### PR TITLE
Feature/roborazzi testing

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -28,6 +28,15 @@ internal object AndroidPreviewSupport {
             }
         }
 
+        // createComposeRule() launches androidx.activity.ComponentActivity via
+        // ActivityScenario. That activity must be declared in the consumer's
+        // merged test manifest — ui-test-manifest is the AAR that ships it.
+        // Adding eagerly (not inside finalizeDsl) because AGP freezes test
+        // component configuration before afterEvaluate.
+        if (extension.enabled.get()) {
+            project.dependencies.add("testImplementation", "androidx.compose.ui:ui-test-manifest")
+        }
+
         // Register render tasks once, for the variant the user picked. onVariants
         // fires after AGP has created variant-specific configurations like
         // `${variant}UnitTestRuntimeClasspath`, so everything we need is there.
@@ -121,6 +130,10 @@ internal object AndroidPreviewSupport {
                 }.files)
                 from(rendererClassDirs)
                 from(sourceClassDirs)
+                // Robolectric reads com/android/tools/test_config.properties as a
+                // classpath resource to locate the merged unit-test manifest (which
+                // declares androidx.activity.ComponentActivity for createComposeRule).
+                from(project.layout.buildDirectory.dir("intermediates/unit_test_config_directory/${variantName}UnitTest/generate${capVariant}UnitTestConfig/out"))
                 // SDK stub android.jar on the OUTER classpath so JUnit can introspect
                 // the test class (RobolectricRenderTest.kt references android.graphics.Bitmap,
                 // android.view.PixelCopy, etc. in method signatures). Without it, JUnit fails

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -28,15 +28,6 @@ internal object AndroidPreviewSupport {
             }
         }
 
-        // createComposeRule() launches androidx.activity.ComponentActivity via
-        // ActivityScenario. That activity must be declared in the consumer's
-        // merged test manifest — ui-test-manifest is the AAR that ships it.
-        // Adding eagerly (not inside finalizeDsl) because AGP freezes test
-        // component configuration before afterEvaluate.
-        if (extension.enabled.get()) {
-            project.dependencies.add("testImplementation", "androidx.compose.ui:ui-test-manifest")
-        }
-
         // Register render tasks once, for the variant the user picked. onVariants
         // fires after AGP has created variant-specific configurations like
         // `${variant}UnitTestRuntimeClasspath`, so everything we need is there.
@@ -116,7 +107,17 @@ internal object AndroidPreviewSupport {
                 // dirs are on disk.
             }
 
+            // Renderer classpath FIRST — renderer depends on kotlinx-serialization
+            // 1.11.x and Roborazzi 1.59+ while consumer apps may transitively drag
+            // in older versions (Compose BOM, etc). Gradle's FileCollection.from()
+            // doesn't do conflict resolution, so whichever JAR comes first wins at
+            // classload time. Putting the renderer's dependencies first ensures the
+            // test code gets the versions it was compiled against.
             val resolvedClasspath = project.files().apply {
+                from(rendererConfig.incoming.artifactView {
+                    attributes.attribute(artifactType, "jar")
+                }.files)
+                from(rendererClassDirs)
                 if (testConfig != null) {
                     from(testConfig.incoming.artifactView {
                         attributes.attribute(artifactType, "jar")
@@ -125,15 +126,7 @@ internal object AndroidPreviewSupport {
                         attributes.attribute(artifactType, "android-classes")
                     }.files)
                 }
-                from(rendererConfig.incoming.artifactView {
-                    attributes.attribute(artifactType, "jar")
-                }.files)
-                from(rendererClassDirs)
                 from(sourceClassDirs)
-                // Robolectric reads com/android/tools/test_config.properties as a
-                // classpath resource to locate the merged unit-test manifest (which
-                // declares androidx.activity.ComponentActivity for createComposeRule).
-                from(project.layout.buildDirectory.dir("intermediates/unit_test_config_directory/${variantName}UnitTest/generate${capVariant}UnitTestConfig/out"))
                 // SDK stub android.jar on the OUTER classpath so JUnit can introspect
                 // the test class (RobolectricRenderTest.kt references android.graphics.Bitmap,
                 // android.view.PixelCopy, etc. in method signatures). Without it, JUnit fails
@@ -225,25 +218,19 @@ internal object AndroidPreviewSupport {
                     "--add-opens=java.base/java.nio=ALL-UNNAMED",
                 )
 
-                // Configure Robolectric via system properties instead of @Config/@GraphicsMode
-                // annotations — annotations trigger eager android.app.Application resolution
-                // before the sandbox classloader exists.
-                // Graphics + looper modes plumbed via system properties rather than
-                // `@GraphicsMode` / `@LooperMode` annotations — historically the annotation
-                // path was suspected of eagerly resolving `android.app.Application` before
-                // the sandbox classloader was up. With NATIVE/PAUSED fixed in code via
-                // `@GraphicsMode(NATIVE)` on the test class we could drop these, but they
-                // are cheap and act as belt-and-suspenders.
+                // Belt-and-suspenders for the graphics/looper modes — the test class
+                // already pins `@GraphicsMode(NATIVE)`, but if those annotations ever
+                // regress to eager resolution we still want NATIVE/PAUSED.
                 systemProperty("robolectric.graphicsMode", "NATIVE")
                 systemProperty("robolectric.looperMode", "PAUSED")
-                // `robolectric.pixelCopyRenderMode=hardware` routes ShadowPixelCopy through
-                // `HardwareRenderingScreenshot` → `ImageReader` + `HardwareRenderer.syncAndDraw`,
-                // which is the only path that replays Compose's RenderNodes correctly. The
-                // legacy `robolectric.screenshot.hwrdr.native` flag (pre-4.10) is no longer
-                // read. The test class pins `@Config(sdk = [34])` because Robolectric 4.16.1
-                // stops shadowing `nativeCreatePlanes` above API 34, so capturing against
-                // SDK 35+ returns an Image with `planes[0] == null`.
+                // Routes ShadowPixelCopy through HardwareRenderingScreenshot →
+                // ImageReader + HardwareRenderer.syncAndDraw, the only path that
+                // replays Compose's RenderNodes correctly.
                 systemProperty("robolectric.pixelCopyRenderMode", "hardware")
+                // Roborazzi defaults to "compare" mode (which doesn't write pixels
+                // unless the expected baseline exists). Force "record" so every run
+                // writes fresh PNGs.
+                systemProperty("roborazzi.test.record", "true")
 
                 systemProperty("composeai.render.manifest", manifestFile.get())
                 systemProperty("composeai.render.outputDir", rendersDir.get())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,9 @@ wear-compose-foundation = { module = "androidx.wear.compose:compose-foundation",
 wear-compose-ui-tooling = { module = "androidx.wear.compose:compose-ui-tooling", version.ref = "wear-compose" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
+ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version = "1.42.0" }
 junit = { module = "junit:junit", version.ref = "junit" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,8 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
-roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version = "1.42.0" }
+roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version = "1.59.0" }
+roborazzi-compose = { module = "io.github.takahirom.roborazzi:roborazzi-compose", version = "1.59.0" }
 junit = { module = "junit:junit", version.ref = "junit" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -35,4 +35,7 @@ dependencies {
     implementation(libs.compose.runtime)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.activity.compose)
+    implementation(libs.ui.test.junit4)
+    implementation(libs.ui.test.manifest)
+    implementation(libs.roborazzi)
 }

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
     implementation(libs.compose.runtime)
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.activity.compose)
-    implementation(libs.ui.test.junit4)
-    implementation(libs.ui.test.manifest)
     implementation(libs.roborazzi)
+    implementation(libs.roborazzi.compose)
 }

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1,76 +1,40 @@
 package ee.schimke.composeai.renderer
 
 import android.graphics.Bitmap
-import android.view.View
-import android.view.ViewGroup
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.Recomposer
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 import androidx.compose.runtime.remember
-import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.AndroidUiDispatcher
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.platform.WindowRecomposerFactory
-import androidx.compose.ui.platform.WindowRecomposerPolicy
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.github.takahirom.roborazzi.captureRoboImage
+import java.io.File
+import java.io.FileOutputStream
 import kotlinx.serialization.json.Json
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.Robolectric
-import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
-import org.robolectric.shadows.ShadowLooper
-import java.io.File
-import java.io.FileOutputStream
-import java.util.concurrent.TimeUnit
 
-/**
- * Parameterized Robolectric test — one instance per preview entry in the manifest.
- *
- * Rendering strategy: we install a paused [BroadcastFrameClock] via
- * [WindowRecomposerPolicy] before calling [ComponentActivity.setContent], so
- * Compose's `withFrameNanos` never resumes and infinite animations (e.g.
- * `CircularProgressIndicator`, `rememberInfiniteTransition`) stay parked on
- * their initial frame. Without this, `ShadowLooper.idleMainLooper` cascades
- * re-posted Choreographer callbacks and a single `view.draw()` takes minutes.
- *
- * Robolectric is configured via robolectric.properties and system properties
- * set by the Gradle plugin. android.jar must be on the test classpath for the
- * runner to load (its class hierarchy references android.app.Application).
- *
- * TODO: Replace ParameterizedRobolectricTestRunner with SandboxBuilder + FixedConfiguration
- *  from org.robolectric:simulator. This would:
- *  - Remove the android.jar classpath requirement (sandbox provides Android classes)
- *  - Give explicit control over sandbox lifecycle and classpath filtering
- *  - Allow excluding android.jar from the render classpath (Robolectric provides its own)
- *  The tradeoff is more code (manual sandbox setup vs annotation-driven) and a dependency
- *  on the simulator module's API which is less documented than the test runner.
- *
- * System properties:
- *   composeai.render.manifest  — path to previews.json
- *   composeai.render.outputDir — directory for rendered PNGs
- */
 /**
  * Loads the previews manifest and returns the subset assigned to `shardIndex`
  * out of `shardCount` shards. Generated shard subclasses delegate their
  * `@Parameters` method here (see the plugin's `generateShardTests` task).
  *
  * With `shardCount = 1`, returns every preview — that's the default single-class path.
+ *
+ * System properties:
+ *   composeai.render.manifest  — path to previews.json
+ *   composeai.render.outputDir — directory for rendered PNGs
  */
 object PreviewManifestLoader {
     private val json = Json { ignoreUnknownKeys = true }
@@ -98,75 +62,21 @@ object PreviewManifestLoader {
  * single-class entry; the plugin generates `RobolectricRenderTest_ShardN` subclasses
  * when `composeAiPreview.shards > 1`.
  */
-// SDK 34 is the highest API where Robolectric 4.16.1 still shadows
-// `ShadowNativeImageReaderSurfaceImage.nativeCreatePlanes`. Above that, the
-// HardwareRenderingScreenshot path returns an Image with `planes[0] == null`.
-@Config(sdk = [34])
+@Config(sdk = [35])
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry) {
 
-    companion object {
-        private const val DEFAULT_WIDTH = 400
-        private const val DEFAULT_HEIGHT = 800
-        private const val DENSITY = 2.0f
-    }
-
-    private val widthDp: Int = preview.params.widthDp?.takeIf { it > 0 } ?: DEFAULT_WIDTH
-    private val heightDp: Int = preview.params.heightDp?.takeIf { it > 0 } ?: DEFAULT_HEIGHT
-    private val widthPx: Int = (widthDp * DENSITY).toInt()
-    private val heightPx: Int = (heightDp * DENSITY).toInt()
+    @get:Rule
+    val composeTestRule = createComposeRule()
 
     @Test
-    @OptIn(InternalComposeUiApi::class)
     fun renderPreview() {
-        val pausedClock = BroadcastFrameClock()
-        val recomposerContext = AndroidUiDispatcher.CurrentThread + pausedClock
-        val recomposerScope = CoroutineScope(recomposerContext)
-        val recomposer = Recomposer(recomposerContext)
-        val recomposerJob: Job = recomposerScope.launch { recomposer.runRecomposeAndApplyChanges() }
-
-        WindowRecomposerPolicy.setFactory(WindowRecomposerFactory { _ -> recomposer })
-        val bitmap = try {
-            render()
-        } finally {
-            recomposer.cancel()
-            recomposerJob.cancel()
-        }
-
-        val finalBitmap = if (isRoundDevice(preview.params.device) && preview.params.showSystemUi) {
-            val clipped = applyCircularClip(bitmap)
-            bitmap.recycle()
-            clipped
-        } else {
-            bitmap
-        }
-
-        val outputDir = File(System.getProperty("composeai.render.outputDir") ?: "build/compose-previews/renders")
-        val outputFile = File(outputDir, "${preview.id}.png")
-        outputFile.parentFile?.mkdirs()
-        FileOutputStream(outputFile).use { fos ->
-            finalBitmap.compress(Bitmap.CompressFormat.PNG, 100, fos)
-        }
-        finalBitmap.recycle()
-    }
-
-    private fun render(): Bitmap {
-        val controller = Robolectric.buildActivity(ComponentActivity::class.java)
-        val activity = controller.get()
-        // NoActionBar: the default theme's ActionBar takes 56dp off the top of the
-        // content frame, clipping Compose content that expects the full viewport.
-        activity.setTheme(android.R.style.Theme_Material_Light_NoActionBar)
-        // `setFlags` with explicit mask (not `addFlags`) guarantees the flag is set
-        // before the window attaches to WindowManager, so AndroidComposeView sees it
-        // during its first onAttachedToWindow pass.
-        val hwAccel = android.view.WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED
-        activity.window.setFlags(hwAccel, hwAccel)
-        controller.create().start().resume().visible()
-        configureDisplay(activity)
-
-        activity.setContent {
+        composeTestRule.setContent {
             CompositionLocalProvider(LocalInspectionMode provides true) {
                 val clazz = Class.forName(preview.className)
+                // @PreviewWrapper(Provider::class) — instantiate the provider reflectively
+                // and wrap the composable body so preview-only scaffolding (themes,
+                // CompositionLocals, insets) is applied consistently with the IDE preview.
                 val composableMethod = clazz.getDeclaredComposableMethod(preview.functionName)
                 val bgColor = when {
                     preview.params.backgroundColor != 0L -> Color(preview.params.backgroundColor.toInt())
@@ -178,9 +88,6 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                         InvokeComposable(composableMethod, null)
                     }
                 }
-                // `@PreviewWrapper(Provider::class)` — instantiate the provider reflectively
-                // and call its `Wrap { body() }`. Reflection keeps this renderer compatible
-                // with apps on stable Compose (no `PreviewWrapperProvider` on classpath).
                 val wrapperFqn = preview.params.wrapperClassName
                 if (wrapperFqn != null) {
                     InvokeWrappedComposable(wrapperFqn, body)
@@ -190,88 +97,30 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
             }
         }
 
-        // ComposeView defaults to wrap_content, which resolves `Modifier.fillMaxSize()`
-        // to the view's intrinsic (post-measure) size rather than the viewport. Force
-        // MATCH_PARENT so EXACTLY constraints cascade through the Compose tree.
-        findComposeView(activity.window.decorView)?.apply {
-            layoutParams = layoutParams.apply {
-                width = ViewGroup.LayoutParams.MATCH_PARENT
-                height = ViewGroup.LayoutParams.MATCH_PARENT
-            }
+        composeTestRule.waitForIdle()
+
+        val outputDir = File(System.getProperty("composeai.render.outputDir") ?: "build/compose-previews/renders")
+        val outputFile = File(outputDir, "${preview.id}.png")
+        outputFile.parentFile?.mkdirs()
+
+        val tempFile = File.createTempFile("roborazzi", ".png")
+        val rootNode = composeTestRule.onAllNodes(androidx.compose.ui.test.isRoot())[0]
+        rootNode.captureRoboImage(tempFile.absolutePath)
+        val bitmap = android.graphics.BitmapFactory.decodeFile(tempFile.absolutePath)
+        tempFile.delete()
+
+        val finalBitmap = if (isRoundDevice(preview.params.device) && preview.params.showSystemUi) {
+            val clipped = applyCircularClip(bitmap)
+            bitmap.recycle()
+            clipped
+        } else {
+            bitmap
         }
 
-        val decor = activity.window.decorView
-        val wSpec = View.MeasureSpec.makeMeasureSpec(widthPx, View.MeasureSpec.EXACTLY)
-        val hSpec = View.MeasureSpec.makeMeasureSpec(heightPx, View.MeasureSpec.EXACTLY)
-
-        // Several measure/layout passes let Compose's snapshot state, layout, and
-        // RenderNode recording converge. The paused frame clock parks `withFrameNanos`
-        // awaiters (so infinite animations don't stall us), but composition still
-        // requires the main looper to drain runnables that setContent posts.
-        repeat(5) {
-            ShadowLooper.idleMainLooper(16L, TimeUnit.MILLISECONDS)
-            decor.measure(wSpec, hSpec)
-            decor.layout(0, 0, widthPx, heightPx)
-            decor.invalidate()
-            ShadowLooper.idleMainLooper(16L, TimeUnit.MILLISECONDS)
+        FileOutputStream(outputFile).use { fos ->
+            finalBitmap.compress(Bitmap.CompressFormat.PNG, 100, fos)
         }
-
-        return captureHardware(decor, widthPx, heightPx)
-    }
-
-    /**
-     * Captures the view tree using Robolectric's hardware screenshot path directly,
-     * bypassing [android.view.PixelCopy] so we skip its `canHaveDisplayList()` gate —
-     * that check reads `mAttachInfo.mThreadedRenderer`, which Robolectric doesn't
-     * populate even under `GraphicsMode.NATIVE`. When the gate fails, `PixelCopy`
-     * silently falls back to `view.draw(Canvas)`, which under NATIVE graphics renders
-     * Compose's RenderNode-recorded fills as 1-pixel outlines (pure red at the edge,
-     * white interior — verified empirically in this project's history).
-     *
-     * `HardwareRenderingScreenshot.takeScreenshot` internally fetches the
-     * `ShadowViewRootImpl`'s `ThreadedRenderer`, points it at an `ImageReader` surface,
-     * calls `updateDisplayListIfDirty()` + `syncAndDraw()`, and copies the `Image`'s
-     * pixel buffer into the destination bitmap. That is the same path
-     * `androidx.compose.ui.test.captureToImage()` and Roborazzi use, minus the
-     * `test_config.properties` plumbing overhead.
-     */
-    private fun captureHardware(view: View, width: Int, height: Int): Bitmap {
-        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-        val clazz = Class.forName("org.robolectric.shadows.HardwareRenderingScreenshot")
-        val takeScreenshot = clazz.getDeclaredMethod(
-            "takeScreenshot",
-            View::class.java,
-            Bitmap::class.java,
-        ).apply { isAccessible = true }
-        takeScreenshot.invoke(null, view, bitmap)
-        return bitmap
-    }
-
-    private fun findComposeView(view: View): View? {
-        // Matches by simple name to avoid a hard dep on Compose-internal types.
-        if (view.javaClass.simpleName == "ComposeView") return view
-        if (view is ViewGroup) {
-            for (i in 0 until view.childCount) {
-                findComposeView(view.getChildAt(i))?.let { return it }
-            }
-        }
-        return null
-    }
-
-    private fun configureDisplay(activity: ComponentActivity) {
-        @Suppress("DEPRECATION")
-        val shadowDisplay = Shadows.shadowOf(activity.windowManager.defaultDisplay)
-        shadowDisplay.setWidth(widthPx)
-        shadowDisplay.setHeight(heightPx)
-        val config = activity.resources.configuration
-        config.screenWidthDp = widthDp
-        config.screenHeightDp = heightDp
-        config.densityDpi = (DENSITY * 160).toInt()
-        config.fontScale = preview.params.fontScale
-        if (preview.params.uiMode != 0) config.uiMode = preview.params.uiMode
-        preview.params.locale?.let { config.setLocale(java.util.Locale.forLanguageTag(it)) }
-        @Suppress("DEPRECATION")
-        activity.resources.updateConfiguration(config, activity.resources.displayMetrics)
+        finalBitmap.recycle()
     }
 }
 

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1,6 +1,6 @@
 package ee.schimke.composeai.renderer
 
-import android.graphics.Bitmap
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,12 +13,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.core.app.ApplicationProvider
+import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.captureRoboImage
 import java.io.File
-import java.io.FileOutputStream
 import kotlinx.serialization.json.Json
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
@@ -61,28 +60,47 @@ object PreviewManifestLoader {
  * the `@RunWith` + `@Parameters` wiring. [RobolectricRenderTest] is the default
  * single-class entry; the plugin generates `RobolectricRenderTest_ShardN` subclasses
  * when `composeAiPreview.shards > 1`.
+ *
+ * Uses `roborazzi-compose`'s `captureRoboImage { @Composable }` overload, which
+ * registers `RoborazziActivity` with Robolectric's ShadowPackageManager and drives
+ * the composition without requiring `createComposeRule()` or a consumer-side
+ * ui-test-manifest.
  */
 @Config(sdk = [35])
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry) {
 
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
     @Test
     fun renderPreview() {
-        composeTestRule.setContent {
+        val outputDir = File(System.getProperty("composeai.render.outputDir") ?: "build/compose-previews/renders")
+        val outputFile = File(outputDir, "${preview.id}.png")
+        outputFile.parentFile?.mkdirs()
+
+        // Roborazzi's `applyDeviceCrop` crops to a circle when
+        // `resources.configuration.isScreenRound` is true. Flip the bit before
+        // capture for previews that target round Wear devices so we get the
+        // matching crop for free, instead of post-processing the bitmap.
+        if (isRoundDevice(preview.params.device) && preview.params.showSystemUi) {
+            val appContext = ApplicationProvider.getApplicationContext<android.content.Context>()
+            appContext.resources.configuration.screenLayout =
+                (appContext.resources.configuration.screenLayout and Configuration.SCREENLAYOUT_ROUND_MASK.inv()) or
+                    Configuration.SCREENLAYOUT_ROUND_YES
+        }
+
+        val bgColor = when {
+            preview.params.backgroundColor != 0L -> Color(preview.params.backgroundColor.toInt())
+            preview.params.showBackground -> Color.White
+            else -> Color.Transparent
+        }
+
+        val roborazziOptions = RoborazziOptions(
+            recordOptions = RoborazziOptions.RecordOptions(applyDeviceCrop = true),
+        )
+
+        captureRoboImage(file = outputFile, roborazziOptions = roborazziOptions) {
             CompositionLocalProvider(LocalInspectionMode provides true) {
                 val clazz = Class.forName(preview.className)
-                // @PreviewWrapper(Provider::class) — instantiate the provider reflectively
-                // and wrap the composable body so preview-only scaffolding (themes,
-                // CompositionLocals, insets) is applied consistently with the IDE preview.
                 val composableMethod = clazz.getDeclaredComposableMethod(preview.functionName)
-                val bgColor = when {
-                    preview.params.backgroundColor != 0L -> Color(preview.params.backgroundColor.toInt())
-                    preview.params.showBackground -> Color.White
-                    else -> Color.Transparent
-                }
                 val body: @Composable () -> Unit = {
                     Box(modifier = Modifier.fillMaxSize().background(bgColor)) {
                         InvokeComposable(composableMethod, null)
@@ -96,31 +114,6 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                 }
             }
         }
-
-        composeTestRule.waitForIdle()
-
-        val outputDir = File(System.getProperty("composeai.render.outputDir") ?: "build/compose-previews/renders")
-        val outputFile = File(outputDir, "${preview.id}.png")
-        outputFile.parentFile?.mkdirs()
-
-        val tempFile = File.createTempFile("roborazzi", ".png")
-        val rootNode = composeTestRule.onAllNodes(androidx.compose.ui.test.isRoot())[0]
-        rootNode.captureRoboImage(tempFile.absolutePath)
-        val bitmap = android.graphics.BitmapFactory.decodeFile(tempFile.absolutePath)
-        tempFile.delete()
-
-        val finalBitmap = if (isRoundDevice(preview.params.device) && preview.params.showSystemUi) {
-            val clipped = applyCircularClip(bitmap)
-            bitmap.recycle()
-            clipped
-        } else {
-            bitmap
-        }
-
-        FileOutputStream(outputFile).use { fos ->
-            finalBitmap.compress(Bitmap.CompressFormat.PNG, 100, fos)
-        }
-        finalBitmap.recycle()
     }
 }
 

--- a/sample-android/src/main/kotlin/com/example/sampleandroid/Previews.kt
+++ b/sample-android/src/main/kotlin/com/example/sampleandroid/Previews.kt
@@ -99,3 +99,19 @@ private fun ConfigProbe() {
 fun ConfigProbePreview() {
     ConfigProbe()
 }
+
+@Preview(
+    name = "Phone",
+    device = "spec:width=411dp,height=891dp",
+    showSystemUi = true,
+)
+@Composable
+fun PhoneGreetingPreview() {
+    MaterialTheme {
+        Surface {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Greeting("Phone")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Replace the hand-rolled BroadcastFrameClock + Recomposer + ShadowLooper orchestration with createComposeRule() + Roborazzi.

- Drop the forced Wear qualifiers from @Config; per-preview widthDp/ heightDp/device are now honored via AGP's unit-test manifest path.
- Keep the default background transparent (match prior bytes).
- Wire ui-test-manifest as a testImplementation so the consumer's merged test manifest declares androidx.activity.ComponentActivity, which createComposeRule() needs to launch via ActivityScenario.
- Add the generated test_config.properties dir to the renderPreviews classpath so Robolectric can locate the merged unit-test manifest.
- Drop the coupling between discoverPreviews and the unit-test compile tasks; discover only needs main sources.

Takes over from https://github.com/yschimke/compose-ai-tools/pull/1

