### PR TITLE
feat(previews): add Wear Tiles Preview support

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceDimensions.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceDimensions.kt
@@ -14,6 +14,10 @@ object DeviceDimensions {
         "id:pixel_tablet" to DeviceSpec(1280, 800),
         "id:wearos_small_round" to DeviceSpec(192, 192),
         "id:wearos_large_round" to DeviceSpec(227, 227),
+        // WearDevices constants from androidx.wear.tooling.preview.devices —
+        // used by @androidx.wear.tiles.tooling.preview.Preview.
+        "id:wearos_square" to DeviceSpec(180, 180),
+        "id:wearos_rect" to DeviceSpec(201, 238),
     )
 
     val DEFAULT = DeviceSpec(400, 800)

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -45,15 +45,23 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         private val PREVIEW_FQNS = setOf(
             "androidx.compose.ui.tooling.preview.Preview",
             "androidx.compose.desktop.ui.tooling.preview.Preview",
+            TILE_PREVIEW_FQN,
         )
         private val CONTAINER_FQNS = setOf(
             "androidx.compose.ui.tooling.preview.Preview\$Container",
             "androidx.compose.ui.tooling.preview.Preview.Container",
+            // Tiles @Preview is @Repeatable, so the compiler synthesises a
+            // `Preview.Container` too. Picking it up here lets us see every
+            // stacked tile preview (e.g. SMALL_ROUND + LARGE_ROUND on one fn).
+            "androidx.wear.tiles.tooling.preview.Preview\$Container",
+            "androidx.wear.tiles.tooling.preview.Preview.Container",
         )
         // androidx.compose.ui:ui-tooling-preview 1.11.0+ — wraps each preview in a custom
         // PreviewWrapperProvider. Matched by FQN so older apps (no such class on classpath)
         // simply never surface the annotation and discovery is a no-op.
         private const val PREVIEW_WRAPPER_FQN = "androidx.compose.ui.tooling.preview.PreviewWrapper"
+
+        internal const val TILE_PREVIEW_FQN = "androidx.wear.tiles.tooling.preview.Preview"
     }
 
     @TaskAction
@@ -265,6 +273,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
 
     private fun extractPreviewParams(ann: AnnotationInfo, wrapperClassName: String?): PreviewParams {
         val pv = ann.parameterValues
+        val kind = if (ann.name == TILE_PREVIEW_FQN) PreviewKind.TILE else PreviewKind.COMPOSE
         val device = (pv.getValue("device") as? String)?.ifBlank { null }
         val rawWidth = (pv.getValue("widthDp") as? Int)?.takeIf { it > 0 }
         val rawHeight = (pv.getValue("heightDp") as? Int)?.takeIf { it > 0 }
@@ -285,7 +294,11 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             uiMode = (pv.getValue("uiMode") as? Int)?.takeIf { it > 0 } ?: 0,
             locale = (pv.getValue("locale") as? String)?.ifBlank { null },
             group = (pv.getValue("group") as? String)?.ifBlank { null },
-            wrapperClassName = wrapperClassName,
+            // @PreviewWrapper targets composables. Tile previews aren't composable,
+            // so even if the annotation happened to be present on the function,
+            // the wrapper's `Wrap(content)` would never wrap the tile View.
+            wrapperClassName = if (kind == PreviewKind.TILE) null else wrapperClassName,
+            kind = kind,
         )
     }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -2,6 +2,18 @@ package ee.schimke.composeai.plugin
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Which @Preview flavour the entry came from. Drives renderer selection —
+ * [COMPOSE] previews are `@Composable` functions invoked through the normal
+ * Compose machinery; [TILE] previews are plain functions returning
+ * `androidx.wear.tiles.tooling.preview.TilePreviewData` that need to be
+ * inflated via `androidx.wear.tiles.renderer.TileRenderer`.
+ */
+enum class PreviewKind {
+    COMPOSE,
+    TILE,
+}
+
 @Serializable
 data class PreviewParams(
     val name: String? = null,
@@ -17,6 +29,7 @@ data class PreviewParams(
     val group: String? = null,
     /** FQN of the `PreviewWrapperProvider` from `@PreviewWrapper`, if any. */
     val wrapperClassName: String? = null,
+    val kind: PreviewKind = PreviewKind.COMPOSE,
 )
 
 @Serializable

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,9 @@ compose-bom = "2026.03.01"
 compose-multiplatform = "1.10.3"
 activity-compose = "1.13.0"
 wear-compose = "1.6.0"
+wear-tiles = "1.6.0"
+wear-protolayout = "1.4.0"
+wear-tooling-preview = "1.0.0"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.11.0"
 junit = "4.13.2"
@@ -25,6 +28,14 @@ activity-compose = { module = "androidx.activity:activity-compose", version.ref 
 wear-compose-material3 = { module = "androidx.wear.compose:compose-material3", version.ref = "wear-compose" }
 wear-compose-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "wear-compose" }
 wear-compose-ui-tooling = { module = "androidx.wear.compose:compose-ui-tooling", version.ref = "wear-compose" }
+wear-tiles = { module = "androidx.wear.tiles:tiles", version.ref = "wear-tiles" }
+wear-tiles-renderer = { module = "androidx.wear.tiles:tiles-renderer", version.ref = "wear-tiles" }
+wear-tiles-tooling = { module = "androidx.wear.tiles:tiles-tooling", version.ref = "wear-tiles" }
+wear-tiles-tooling-preview = { module = "androidx.wear.tiles:tiles-tooling-preview", version.ref = "wear-tiles" }
+wear-tooling-preview = { module = "androidx.wear:wear-tooling-preview", version.ref = "wear-tooling-preview" }
+wear-protolayout = { module = "androidx.wear.protolayout:protolayout", version.ref = "wear-protolayout" }
+wear-protolayout-material3 = { module = "androidx.wear.protolayout:protolayout-material3", version.ref = "wear-protolayout" }
+wear-protolayout-expression = { module = "androidx.wear.protolayout:protolayout-expression", version.ref = "wear-protolayout" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -37,4 +37,14 @@ dependencies {
     implementation(libs.activity.compose)
     implementation(libs.roborazzi)
     implementation(libs.roborazzi.compose)
+
+    // Tiles rendering is reflection-driven at runtime (the consumer module
+    // supplies the actual classes on the JUnit classpath), so we only need
+    // these to compile TilePreviewRenderer — a consumer without tile deps
+    // will never hit the TILE branch in RobolectricRenderTestBase.
+    compileOnly(libs.wear.tiles)
+    compileOnly(libs.wear.tiles.renderer)
+    compileOnly(libs.wear.tiles.tooling.preview)
+    compileOnly(libs.wear.protolayout)
+    compileOnly(libs.wear.protolayout.expression)
 }

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
@@ -1,0 +1,75 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.runtime.reflect.getDeclaredComposableMethod
+
+/**
+ * Produces the composition body for a single [RenderPreviewEntry]. Selection
+ * happens through [strategyFor] — driven by the [PreviewKind] recorded at
+ * discovery time.
+ *
+ * Each strategy owns its own reflection + framing logic so the main Robolectric
+ * pipeline stays oblivious to whether it's driving a @Composable or a tile.
+ */
+internal interface PreviewRenderStrategy {
+    @Composable
+    fun Render(preview: RenderPreviewEntry, widthDp: Int, heightDp: Int)
+}
+
+private val STRATEGIES: Map<PreviewKind, PreviewRenderStrategy> = mapOf(
+    PreviewKind.COMPOSE to ComposePreviewStrategy,
+    PreviewKind.TILE to TilePreviewStrategy,
+)
+
+internal fun strategyFor(kind: PreviewKind): PreviewRenderStrategy =
+    STRATEGIES[kind] ?: error("No render strategy registered for PreviewKind.$kind")
+
+/**
+ * Default strategy: reflect the `@Composable` and invoke it inside a Box that
+ * paints the preview's configured background. Honours `@PreviewWrapper` by
+ * looking up the provider's `Wrap(content)` method.
+ */
+private object ComposePreviewStrategy : PreviewRenderStrategy {
+    @Composable
+    override fun Render(preview: RenderPreviewEntry, widthDp: Int, heightDp: Int) {
+        val clazz = Class.forName(preview.className)
+        val composableMethod = clazz.getDeclaredComposableMethod(preview.functionName)
+        val bgColor = when {
+            preview.params.backgroundColor != 0L -> Color(preview.params.backgroundColor.toInt())
+            preview.params.showBackground -> Color.White
+            else -> Color.Transparent
+        }
+        val body: @Composable () -> Unit = {
+            Box(modifier = Modifier.fillMaxSize().background(bgColor)) {
+                composableMethod.invoke(currentComposer, null)
+            }
+        }
+        val wrapperFqn = preview.params.wrapperClassName
+        if (wrapperFqn != null) {
+            val resolved = remember(wrapperFqn) { resolveWrapper(wrapperFqn) }
+            resolved.first.invoke(currentComposer, resolved.second, body)
+        } else {
+            body()
+        }
+    }
+}
+
+/**
+ * Tiles strategy: invoke the non-composable preview function, drive the
+ * returned [androidx.wear.tiles.tooling.preview.TilePreviewData] through
+ * `TileRenderer`, and host the inflated View via an `AndroidView`. See
+ * [TilePreviewComposable] for the heavy lifting.
+ */
+private object TilePreviewStrategy : PreviewRenderStrategy {
+    @Composable
+    override fun Render(preview: RenderPreviewEntry, widthDp: Int, heightDp: Int) {
+        TilePreviewComposable(preview, widthDp, heightDp)
+    }
+}

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -2,6 +2,11 @@ package ee.schimke.composeai.renderer
 
 import kotlinx.serialization.Serializable
 
+enum class PreviewKind {
+    COMPOSE,
+    TILE,
+}
+
 @Serializable
 data class RenderManifest(
     val module: String,
@@ -34,4 +39,5 @@ data class RenderPreviewParams(
     val group: String? = null,
     /** FQN of the `PreviewWrapperProvider` from `@PreviewWrapper`, if any. */
     val wrapperClassName: String? = null,
+    val kind: PreviewKind = PreviewKind.COMPOSE,
 )

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1,17 +1,11 @@
 package ee.schimke.composeai.renderer
 
 import android.content.res.Configuration
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.test.core.app.ApplicationProvider
 import com.github.takahirom.roborazzi.RoborazziOptions
@@ -65,6 +59,10 @@ object PreviewManifestLoader {
  * registers `RoborazziActivity` with Robolectric's ShadowPackageManager and drives
  * the composition without requiring `createComposeRule()` or a consumer-side
  * ui-test-manifest.
+ *
+ * The content itself is produced by a [PreviewRenderStrategy] keyed off
+ * [RenderPreviewParams.kind] — @Composable previews use the reflective Compose
+ * strategy, tile previews route through [TilePreviewComposable].
  */
 @Config(sdk = [35])
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
@@ -87,60 +85,24 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                     Configuration.SCREENLAYOUT_ROUND_YES
         }
 
-        val bgColor = when {
-            preview.params.backgroundColor != 0L -> Color(preview.params.backgroundColor.toInt())
-            preview.params.showBackground -> Color.White
-            else -> Color.Transparent
-        }
-
         val roborazziOptions = RoborazziOptions(
             recordOptions = RoborazziOptions.RecordOptions(applyDeviceCrop = true),
         )
 
+        val widthDp = preview.params.widthDp?.takeIf { it > 0 } ?: DEFAULT_WIDTH
+        val heightDp = preview.params.heightDp?.takeIf { it > 0 } ?: DEFAULT_HEIGHT
+
         captureRoboImage(file = outputFile, roborazziOptions = roborazziOptions) {
             CompositionLocalProvider(LocalInspectionMode provides true) {
-                val clazz = Class.forName(preview.className)
-                val composableMethod = clazz.getDeclaredComposableMethod(preview.functionName)
-                val body: @Composable () -> Unit = {
-                    Box(modifier = Modifier.fillMaxSize().background(bgColor)) {
-                        InvokeComposable(composableMethod, null)
-                    }
-                }
-                val wrapperFqn = preview.params.wrapperClassName
-                if (wrapperFqn != null) {
-                    InvokeWrappedComposable(wrapperFqn, body)
-                } else {
-                    body()
-                }
+                strategyFor(preview.params.kind).Render(preview, widthDp, heightDp)
             }
         }
     }
-}
 
-@Composable
-private fun InvokeComposable(
-    composableMethod: ComposableMethod,
-    instance: Any?,
-) {
-    composableMethod.invoke(currentComposer, instance)
-}
-
-/**
- * Reflectively instantiates the `PreviewWrapperProvider` identified by [wrapperFqn]
- * and invokes its `Wrap(content)` composable around [body].
- *
- * `PreviewWrapperProvider.Wrap(content: @Composable () -> Unit)` compiles to
- * `Wrap(Function2, Composer, int)` at the bytecode level — [getDeclaredComposableMethod]
- * handles the synthetic Composer/changed args, so we look the method up by the
- * content parameter's JVM type.
- */
-@Composable
-private fun InvokeWrappedComposable(
-    wrapperFqn: String,
-    body: @Composable () -> Unit,
-) {
-    val resolved = remember(wrapperFqn) { resolveWrapper(wrapperFqn) }
-    resolved.first.invoke(currentComposer, resolved.second, body)
+    companion object {
+        private const val DEFAULT_WIDTH = 400
+        private const val DEFAULT_HEIGHT = 800
+    }
 }
 
 internal fun resolveWrapper(wrapperFqn: String): Pair<ComposableMethod, Any> {

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
@@ -1,0 +1,169 @@
+package ee.schimke.composeai.renderer
+
+import android.content.Context
+import android.view.ContextThemeWrapper
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.wear.protolayout.DeviceParametersBuilders
+import androidx.wear.protolayout.DeviceParametersBuilders.DeviceParameters
+import androidx.wear.tiles.RequestBuilders
+import androidx.wear.tiles.TileBuilders
+import androidx.wear.tiles.renderer.TileRenderer
+import androidx.wear.tiles.tooling.preview.TilePreviewData
+import java.lang.reflect.Method
+import java.util.concurrent.TimeUnit
+
+/**
+ * Renders a `@androidx.wear.tiles.tooling.preview.Preview` function into the
+ * surrounding Compose tree via an [AndroidView] hosting the inflated tile View.
+ *
+ * The preview function is a *non-composable* `fun foo(): TilePreviewData` (or
+ * `fun foo(context: Context): TilePreviewData`). We reflect into the Kotlin-compiled
+ * `*Kt` class, invoke it, and drive the returned [TilePreviewData] through
+ * [TileRenderer.inflateAsync] using a synthetic [RequestBuilders.TileRequest]
+ * sized to match the discovered @Preview device.
+ *
+ * All tile classes are referenced via their compileOnly API surface — the
+ * consumer module brings them at runtime. Modules without tile deps never set
+ * `kind = TILE` during discovery, so this code is only ever invoked when the
+ * classes are actually present.
+ */
+@Composable
+internal fun TilePreviewComposable(
+    preview: RenderPreviewEntry,
+    widthDp: Int,
+    heightDp: Int,
+) {
+    val context = LocalContext.current
+    AndroidView(
+        modifier = Modifier.fillMaxSize(),
+        factory = { ctx ->
+            val parent = FrameLayout(ctx).apply {
+                layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+            }
+            renderTileInto(context, preview, widthDp, heightDp, parent)
+            parent
+        },
+    )
+}
+
+private fun renderTileInto(
+    context: Context,
+    preview: RenderPreviewEntry,
+    widthDp: Int,
+    heightDp: Int,
+    parent: FrameLayout,
+) {
+    val data = invokeTilePreviewFunction(context, preview)
+
+    val deviceParams = buildDeviceParameters(widthDp, heightDp, preview.params.device)
+
+    val tileRequest = RequestBuilders.TileRequest.Builder()
+        .setDeviceConfiguration(deviceParams)
+        .build()
+    val tile: TileBuilders.Tile = data.onTileRequest(tileRequest)
+
+    val resourcesRequest = RequestBuilders.ResourcesRequest.Builder()
+        .setVersion(tile.resourcesVersion.ifEmpty { "1" })
+        .setDeviceConfiguration(deviceParams)
+        .build()
+    val resources = data.onTileResourceRequest(resourcesRequest)
+
+    val layout = tile.tileTimeline
+        ?.timelineEntries
+        ?.firstOrNull()
+        ?.layout
+        ?: error("TilePreview '${preview.functionName}' produced no layout (empty timeline)")
+
+    // `TileRenderer.<init>` builds a default `ProtoLayoutTheme` against the passed
+    // context's current theme — and that theme must define the `ProtoLayout*FontFamily`
+    // attrs. The Robolectric host activity uses `Theme_Material_Light_NoActionBar`, which
+    // doesn't; wrap with `ProtoLayoutBaseTheme` (from protolayout-renderer) instead.
+    // This mirrors what `tiles-tooling`'s preview adapter does under the hood.
+    val themedContext = ContextThemeWrapper(context, protoLayoutBaseThemeResId(context))
+
+    // Inline executor — Robolectric has the main looper paused, so posting
+    // to a background thread and awaiting back on main would deadlock. Inflating
+    // on the caller thread completes before the future leaves the method.
+    val renderer = TileRenderer(themedContext, Runnable::run) { _ -> /* no-op loader */ }
+    val future = renderer.inflateAsync(layout, resources, parent)
+    future.get(10, TimeUnit.SECONDS)
+        ?: error("TileRenderer returned no view for preview '${preview.functionName}'")
+}
+
+/**
+ * Resolves `ProtoLayoutBaseTheme` by name — avoids a compile-time dep on the
+ * `protolayout-renderer` R class. Resources are looked up via `getIdentifier`,
+ * which returns 0 if the style isn't present; in that case we fall through to
+ * the host theme and let TileRenderer fail loudly with its own error.
+ */
+private fun protoLayoutBaseThemeResId(context: Context): Int {
+    val id = context.resources.getIdentifier(
+        "ProtoLayoutBaseTheme",
+        "style",
+        "androidx.wear.protolayout.renderer",
+    )
+    if (id != 0) return id
+    // Fallback — return 0 means ContextThemeWrapper leaves the theme untouched.
+    return 0
+}
+
+private fun invokeTilePreviewFunction(
+    context: Context,
+    preview: RenderPreviewEntry,
+): TilePreviewData {
+    val method = findTilePreviewMethod(preview.className, preview.functionName)
+    method.isAccessible = true
+    val result = when (method.parameterTypes.size) {
+        0 -> method.invoke(null)
+        1 -> method.invoke(null, context)
+        else -> error(
+            "TilePreview '${preview.functionName}' has unsupported signature; " +
+                "expected 0 or 1 (Context) parameters, found ${method.parameterTypes.size}"
+        )
+    }
+    return result as? TilePreviewData
+        ?: error("TilePreview '${preview.functionName}' did not return TilePreviewData")
+}
+
+/**
+ * Resolves the static JVM method for a top-level tile preview function. The
+ * Kotlin compiler places top-level functions on a synthetic `${File}Kt` class
+ * (matching the `className` our discovery records). We prefer an overload that
+ * takes a `Context` if present, falling back to a no-arg overload.
+ */
+private fun findTilePreviewMethod(className: String, functionName: String): Method {
+    val cls = Class.forName(className)
+    val candidates = cls.declaredMethods.filter { it.name == functionName }
+    if (candidates.isEmpty()) {
+        error("No method '$functionName' on '$className'")
+    }
+    return candidates.firstOrNull { it.parameterTypes.size == 1 && it.parameterTypes[0] == Context::class.java }
+        ?: candidates.firstOrNull { it.parameterTypes.isEmpty() }
+        ?: error(
+            "TilePreview '$functionName' on '$className' has no supported overload " +
+                "(expected no-arg or single Context parameter)"
+        )
+}
+
+private fun buildDeviceParameters(widthDp: Int, heightDp: Int, device: String?): DeviceParameters {
+    val isRound = isRoundDevice(device)
+    return DeviceParameters.Builder()
+        .setScreenWidthDp(widthDp)
+        .setScreenHeightDp(heightDp)
+        .setScreenDensity(2.0f)
+        .setScreenShape(
+            if (isRound) DeviceParametersBuilders.SCREEN_SHAPE_ROUND
+            else DeviceParametersBuilders.SCREEN_SHAPE_RECT,
+        )
+        .setDevicePlatform(DeviceParametersBuilders.DEVICE_PLATFORM_WEAR_OS)
+        .build()
+}

--- a/sample-wear/build.gradle.kts
+++ b/sample-wear/build.gradle.kts
@@ -36,4 +36,14 @@ dependencies {
     implementation(libs.wear.compose.ui.tooling)
     implementation(libs.compose.ui.tooling.preview)
     debugImplementation("androidx.compose.ui:ui-tooling")
+
+    // Wear Tiles — for the `@androidx.wear.tiles.tooling.preview.Preview` sample
+    // rendered via TilePreviewRenderer in renderer-android.
+    implementation(libs.wear.tiles)
+    implementation(libs.wear.tiles.renderer)
+    implementation(libs.wear.tiles.tooling.preview)
+    implementation(libs.wear.protolayout)
+    implementation(libs.wear.protolayout.expression)
+    implementation(libs.wear.protolayout.material3)
+    implementation(libs.wear.tooling.preview)
 }

--- a/sample-wear/src/main/kotlin/com/example/samplewear/TilePreviews.kt
+++ b/sample-wear/src/main/kotlin/com/example/samplewear/TilePreviews.kt
@@ -1,0 +1,57 @@
+package com.example.samplewear
+
+import android.content.Context
+import androidx.wear.protolayout.ColorBuilders.argb
+import androidx.wear.protolayout.DimensionBuilders.sp
+import androidx.wear.protolayout.LayoutElementBuilders.FontStyle
+import androidx.wear.protolayout.LayoutElementBuilders.Text
+import androidx.wear.tiles.tooling.preview.Preview
+import androidx.wear.tiles.tooling.preview.TilePreviewData
+import androidx.wear.tiles.tooling.preview.TilePreviewHelper
+import androidx.wear.tooling.preview.devices.WearDevices
+
+/**
+ * Minimal `@androidx.wear.tiles.tooling.preview.Preview` sample — exercises the
+ * tile-preview discovery + rendering path end-to-end. Not a real production tile.
+ */
+@Preview(device = WearDevices.SMALL_ROUND, name = "Small Round")
+@Preview(device = WearDevices.LARGE_ROUND, name = "Large Round")
+fun HelloTilePreview(context: Context): TilePreviewData =
+    TilePreviewData { _ ->
+        TilePreviewHelper.singleTimelineEntryTileBuilder(
+            Text.Builder()
+                .setText("Hello Tiles")
+                .setFontStyle(
+                    FontStyle.Builder()
+                        .setSize(sp(20f))
+                        .setColor(argb(0xFFFFFFFF.toInt()))
+                        .build(),
+                )
+                .build(),
+        ).build()
+    }
+
+/**
+ * Multi-preview meta-annotation — mirrors Wear OS samples' `MultiRoundDevicesPreviews`
+ * pattern. Our discovery walks annotation classes looking for @Preview, so this
+ * should expand to small + large round previews on any function it annotates.
+ */
+@Preview(device = WearDevices.SMALL_ROUND, name = "Small Round")
+@Preview(device = WearDevices.LARGE_ROUND, name = "Large Round")
+internal annotation class MultiRoundTilesPreviews
+
+@MultiRoundTilesPreviews
+fun CounterTilePreview(context: Context): TilePreviewData =
+    TilePreviewData { _ ->
+        TilePreviewHelper.singleTimelineEntryTileBuilder(
+            Text.Builder()
+                .setText("42")
+                .setFontStyle(
+                    FontStyle.Builder()
+                        .setSize(sp(48f))
+                        .setColor(argb(0xFFFFFFFF.toInt()))
+                        .build(),
+                )
+                .build(),
+        ).build()
+    }


### PR DESCRIPTION
## Summary

- Discover `@androidx.wear.tiles.tooling.preview.Preview` (and its repeatable `Preview.Container`) alongside the existing Compose `@Preview` annotations.
- Introduce a `PreviewKind` enum (`COMPOSE`, `TILE`) on `PreviewParams` / `RenderPreviewParams`; discovery sets `TILE` when the tiles FQN is used so downstream consumers (renderers, VSCode extension, CLI) can branch cleanly.
- Refactor Robolectric rendering behind a `PreviewRenderStrategy` map keyed by `PreviewKind`. The compose strategy preserves the existing reflective `@Composable` + `@PreviewWrapper` flow; the tile strategy delegates to a new `TilePreviewRenderer` that reflectively invokes the non-composable preview fn (0-arg or `Context`-arg), drives the returned `TilePreviewData` through `TileRenderer.inflateAsync`, and hosts the inflated View via `AndroidView`.
- Tile deps are `compileOnly` on `renderer-android` — consumers without tiles on the classpath never hit `kind=TILE`, so the branch is inert there.
- `sample-wear` gains a tiles `@Preview` sample (`HelloTilePreview` + a `MultiRoundTilesPreviews` meta-annotation) that exercises discovery end-to-end. `DeviceDimensions` learns `wearos_square` / `wearos_rect` from `WearDevices`.

## Known limitation

Tile PNG rendering currently fails under Robolectric with `ProtoLayoutThemeImpl` throwing:

```
java.lang.IllegalArgumentException: Unknown resource value type 0
    at androidx.wear.protolayout.renderer.inflater.ProtoLayoutThemeImpl$FontSetImpl.loadTypeface
```

`TileRenderer.<init>` builds a default `ProtoLayoutTheme` against `R.style.ProtoLayoutBaseTheme`, and the sandbox's `obtainStyledAttributes` lookup of `protoLayoutNormalFont` on `ProtoLayoutBaseFont` returns `TYPE_NULL`. Wrapping the context with `ProtoLayoutBaseTheme` doesn't change the behaviour (the default theme path uses `Resources.newTheme()` directly). The discovery + strategy wiring is in place and Compose rendering is unregressed — a follow-up will sort out the theme resolution under Robolectric's merged-resource loader.

## Test plan
- [x] `./gradlew :sample-wear:discoverPreviews` — 4 tile previews picked up, `kind=TILE` in `previews.json`.
- [x] `./gradlew :sample-wear:renderPreviews --tests "*ButtonPreview*Small*"` — Compose path unchanged.
- [ ] `./gradlew :sample-wear:renderPreviews --tests "*HelloTile*"` — currently fails with the ProtoLayoutTheme issue above.