### PR TITLE
fix(tiles): put unit_test_config_directory on renderPreviews classpath

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -107,6 +107,20 @@ internal object AndroidPreviewSupport {
                 // dirs are on disk.
             }
 
+            // AGP's `generate${Variant}UnitTestConfig` task emits
+            // `com/android/tools/test_config.properties` under
+            // `intermediates/unit_test_config_directory/<variant>UnitTest/.../out/`.
+            // Robolectric loads it from the classpath and uses it to find the merged
+            // resource APK (`apk-for-local-test.ap_`) — the one that contains every
+            // AAR's merged resources (protolayout-renderer's `ProtoLayoutBaseTheme`
+            // etc.). Without this directory on the classpath, `getIdentifier` returns
+            // 0 for any library-provided style and TileRenderer's theme construction
+            // explodes on `Unknown resource value type 0`. Compose-only previews
+            // don't read AAR resources, which is why this only surfaced with tiles.
+            val unitTestConfigDir = project.layout.buildDirectory.dir(
+                "intermediates/unit_test_config_directory/${variantName}UnitTest/generate${capVariant}UnitTestConfig/out"
+            )
+
             // Renderer classpath FIRST — renderer depends on kotlinx-serialization
             // 1.11.x and Roborazzi 1.59+ while consumer apps may transitively drag
             // in older versions (Compose BOM, etc). Gradle's FileCollection.from()
@@ -127,6 +141,7 @@ internal object AndroidPreviewSupport {
                     }.files)
                 }
                 from(sourceClassDirs)
+                from(unitTestConfigDir)
                 // SDK stub android.jar on the OUTER classpath so JUnit can introspect
                 // the test class (RobolectricRenderTest.kt references android.graphics.Bitmap,
                 // android.view.PixelCopy, etc. in method signatures). Without it, JUnit fails

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
@@ -1,7 +1,7 @@
 package ee.schimke.composeai.renderer
 
 import android.content.Context
-import android.view.ContextThemeWrapper
+import android.view.Gravity
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.compose.foundation.layout.fillMaxSize
@@ -83,37 +83,31 @@ private fun renderTileInto(
         ?.layout
         ?: error("TilePreview '${preview.functionName}' produced no layout (empty timeline)")
 
-    // `TileRenderer.<init>` builds a default `ProtoLayoutTheme` against the passed
-    // context's current theme — and that theme must define the `ProtoLayout*FontFamily`
-    // attrs. The Robolectric host activity uses `Theme_Material_Light_NoActionBar`, which
-    // doesn't; wrap with `ProtoLayoutBaseTheme` (from protolayout-renderer) instead.
-    // This mirrors what `tiles-tooling`'s preview adapter does under the hood.
-    val themedContext = ContextThemeWrapper(context, protoLayoutBaseThemeResId(context))
-
     // Inline executor — Robolectric has the main looper paused, so posting
     // to a background thread and awaiting back on main would deadlock. Inflating
     // on the caller thread completes before the future leaves the method.
-    val renderer = TileRenderer(themedContext, Runnable::run) { _ -> /* no-op loader */ }
-    val future = renderer.inflateAsync(layout, resources, parent)
-    future.get(10, TimeUnit.SECONDS)
+    //
+    // `TileRenderer` builds its default `ProtoLayoutTheme` from
+    // `R.style.ProtoLayoutBaseTheme` via `context.getResources()`. That style
+    // ships with `protolayout-renderer`'s AAR — it resolves correctly here
+    // because the Gradle plugin puts AGP's `unit_test_config_directory` on
+    // the renderer test classpath, so Robolectric loads the merged resource
+    // APK containing every AAR's resources (including the tile theme). Without
+    // that, every `getIdentifier` returns 0 and `TileRenderer` crashes with
+    // `Unknown resource value type 0`.
+    val renderer = TileRenderer(context, Runnable::run) { _ -> /* no-op loader */ }
+    val view = renderer.inflateAsync(layout, resources, parent)
+        .get(10, TimeUnit.SECONDS)
         ?: error("TileRenderer returned no view for preview '${preview.functionName}'")
-}
 
-/**
- * Resolves `ProtoLayoutBaseTheme` by name — avoids a compile-time dep on the
- * `protolayout-renderer` R class. Resources are looked up via `getIdentifier`,
- * which returns 0 if the style isn't present; in that case we fall through to
- * the host theme and let TileRenderer fail loudly with its own error.
- */
-private fun protoLayoutBaseThemeResId(context: Context): Int {
-    val id = context.resources.getIdentifier(
-        "ProtoLayoutBaseTheme",
-        "style",
-        "androidx.wear.protolayout.renderer",
-    )
-    if (id != 0) return id
-    // Fallback — return 0 means ContextThemeWrapper leaves the theme untouched.
-    return 0
+    // Tile inflation defaults to WRAP_CONTENT, which collapses against an
+    // AndroidView that's still measuring. Mirror `TileServiceViewAdapter`:
+    // centre the inflated tile and give it explicit MATCH_PARENT layout.
+    (view.layoutParams as? FrameLayout.LayoutParams)?.apply {
+        width = ViewGroup.LayoutParams.MATCH_PARENT
+        height = ViewGroup.LayoutParams.MATCH_PARENT
+        gravity = Gravity.CENTER
+    }
 }
 
 private fun invokeTilePreviewFunction(


### PR DESCRIPTION
## Summary

The tile preview support that landed in #6 produced the right `kind=TILE` discovery entries but couldn't actually render — every tile failed at `TileRenderer.<init>` with:

```
java.lang.IllegalArgumentException: Unknown resource value type 0
    at androidx.wear.protolayout.renderer.inflater.ProtoLayoutThemeImpl$FontSetImpl.loadTypeface
```

## Root cause

`TileRenderer.<init>` builds its default `ProtoLayoutTheme` from `R.style.ProtoLayoutBaseTheme`, which ships with `protolayout-renderer`'s AAR. Under our custom `renderPreviews` `Test` task, every `Resources.getIdentifier(...)` against that AAR returned 0 (confirmed with diagnostic printouts: `baseThemeId=0x0, titleFontAttrId=0x0, …`), so the typeface lookup fell through to the final `throw` in `loadTypeface`.

The missing piece was `resolvedClasspath`: it pulled JARs + `android-classes` artifacts, but not the AGP-generated `com/android/tools/test_config.properties` file. Robolectric reads that file to locate the merged resource APK produced by `packageDebugUnitTestForUnitTest`, which is what contains every transitive AAR's resources. Without the config on the classpath, Robolectric falls back to stub resources and AAR styles are invisible to `getIdentifier`.

Compose-only previews never read AAR resources, so they worked fine — tiles surfaced the gap.

## Fix

Add `intermediates/unit_test_config_directory/<variant>UnitTest/generate<Variant>UnitTestConfig/out` to `resolvedClasspath` in `AndroidPreviewSupport`. `TilePreviewRenderer` also:

- drops its `ContextThemeWrapper` wrap (a no-op now that the default theme resolves), matching `tiles-tooling`'s `TileServiceViewAdapter`
- sets `MATCH_PARENT` + `Gravity.CENTER` on the inflated tile's `LayoutParams` so it fills the hosting `AndroidView` cell instead of collapsing to 0×0

## Verification

All four `sample-wear` tile previews now render without errors:

```
com.example.samplewear.TilePreviewsKt.HelloTilePreview_Small Round.png
com.example.samplewear.TilePreviewsKt.HelloTilePreview_Large Round.png
com.example.samplewear.TilePreviewsKt.CounterTilePreview_Small Round.png
com.example.samplewear.TilePreviewsKt.CounterTilePreview_Large Round.png
```

## Test plan
- [x] `./gradlew :sample-wear:renderAllPreviews` — all 14 previews (10 compose + 4 tiles) produce PNGs at the correct per-preview size
- [x] Compose preview output unchanged (manually diffed `ButtonPreview_Devices - Large Round.png` — black circle + "Tap me!" button, same as before)
- [ ] The tile PNGs are correctly sized (192×192 / 227×227) but currently render blank — the `TileRenderer` inflation completes without error and the native view tree is attached to the `AndroidView`, but Roborazzi's capture doesn't surface the tile's draw calls. Tracking as a follow-up; this PR unblocks the rest of the tile pipeline.