### PR TITLE
ci: add WearTilesKotlin to integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -89,6 +89,13 @@ jobs:
               -Dorg.gradle.unsafe.isolated-projects=false
               -Dorg.gradle.isolated-projects=false
               --no-configuration-cache
+          - name: wear-os-samples (WearTilesKotlin)
+            slug: wear-tiles
+            repo: android/wear-os-samples
+            ref: main
+            workdir: WearTilesKotlin
+            module: app
+            extra_gradle_args: ""
           # Confetti: dropped for now. :androidApp has @Preview functions but
           # discovery returned 0 (same bug we see in PeopleInSpace — track as a
           # follow-up). Render also fails on a :common:car KMP variant


### PR DESCRIPTION
## Summary

- Adds `wear-os-samples (WearTilesKotlin)` as a new matrix entry in the integration workflow, alongside the existing `ComposeStarter` entry
- Exercises tile-preview discovery against a real Wear Tiles project from `android/wear-os-samples`
- Uses the same `app` module and `--walk .` patch strategy as the other entries

## Test plan

- [ ] Integration workflow runs the new `wear-os-samples (WearTilesKotlin)` job successfully
- [ ] `discoverPreviews` finds at least one tile preview in the `app` module