### PR TITLE
ci: add preview diff comments on PRs

### DIFF
--- a/.github/ci/compare-previews.py
+++ b/.github/ci/compare-previews.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Generate preview baselines or compare renders against them.
+
+Works with ``compose-preview show --json`` output, so it's portable to any
+project that uses the ee.schimke.composeai.preview Gradle plugin + CLI.
+
+Modes
+-----
+generate
+    Read CLI JSON output, hash rendered PNGs, and emit ``baselines.json``
+    plus a browsable ``README.md`` with inline images.
+
+compare
+    Read CLI JSON output and a previously-generated ``baselines.json``,
+    then emit a Markdown PR comment body to stdout.
+
+copy-changed
+    Copy only new/changed PNGs to an output directory (for the PR renders
+    branch).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import shutil
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def load_cli_output(cli_json_path: Path) -> dict[str, dict]:
+    """Parse ``compose-preview show --json`` output into a keyed dict.
+
+    The CLI emits a JSON array of PreviewResult objects.  We key them as
+    ``<module>/<id>`` for stable cross-run comparison.
+    """
+    entries = json.loads(cli_json_path.read_text())
+    result: dict[str, dict] = {}
+    for entry in entries:
+        key = f"{entry['module']}/{entry['id']}"
+        result[key] = {
+            "sha256": entry.get("sha256") or "",
+            "functionName": entry["functionName"],
+            "sourceFile": entry.get("sourceFile", ""),
+            "module": entry["module"],
+            "previewId": entry["id"],
+            "pngPath": entry.get("pngPath", ""),
+        }
+    return result
+
+
+# ---------------------------------------------------------------------------
+# generate mode
+# ---------------------------------------------------------------------------
+
+def cmd_generate(args: argparse.Namespace) -> int:
+    cli_json = Path(args.cli_json)
+    out_dir = Path(args.output_dir)
+    repo = args.repo
+    branch = args.branch
+
+    previews = load_cli_output(cli_json)
+    if not previews:
+        print("No previews in CLI output.", file=sys.stderr)
+        return 1
+
+    # --- baselines.json ---
+    baselines = {
+        key: {
+            "sha256": info["sha256"],
+            "functionName": info["functionName"],
+            "sourceFile": info["sourceFile"],
+        }
+        for key, info in previews.items()
+        if info["sha256"]  # skip entries without a rendered PNG
+    }
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "baselines.json").write_text(
+        json.dumps(baselines, indent=2, sort_keys=True) + "\n")
+
+    # --- copy PNGs into renders/<module>/<id>.png ---
+    renders_out = out_dir / "renders"
+    if renders_out.exists():
+        shutil.rmtree(renders_out)
+    for info in previews.values():
+        png = Path(info["pngPath"])
+        if not png.exists():
+            continue
+        dest = renders_out / info["module"] / f"{info['previewId']}.png"
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(png, dest)
+
+    # --- README.md (browsable gallery) ---
+    lines = [
+        "# Preview Baselines",
+        "",
+        "Auto-generated from `main`. Browse inline or compare against PR branches.",
+        "",
+    ]
+    by_module: dict[str, list[tuple[str, dict]]] = {}
+    for key, info in sorted(previews.items()):
+        if not info["sha256"]:
+            continue
+        by_module.setdefault(info["module"], []).append((key, info))
+
+    for module, entries in sorted(by_module.items()):
+        lines.append(f"## {module}")
+        lines.append("")
+        lines.append("| Preview | Image |")
+        lines.append("|---------|-------|")
+        for _, info in entries:
+            fn = info["functionName"]
+            img_path = f"renders/{info['module']}/{info['previewId']}.png"
+            raw_url = f"https://raw.githubusercontent.com/{repo}/{branch}/{img_path}"
+            lines.append(
+                f"| `{fn}` | <img src=\"{raw_url}\" width=\"150\" /> |"
+            )
+        lines.append("")
+
+    (out_dir / "README.md").write_text("\n".join(lines) + "\n")
+
+    print(f"Generated baselines for {len(baselines)} preview(s) in {out_dir}",
+          file=sys.stderr)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# compare mode
+# ---------------------------------------------------------------------------
+
+def cmd_compare(args: argparse.Namespace) -> int:
+    cli_json = Path(args.cli_json)
+    baselines_path = Path(args.baselines)
+    repo = args.repo
+    base_branch = args.base_branch
+    head_branch = args.head_branch
+
+    current = load_cli_output(cli_json)
+    baselines = json.loads(baselines_path.read_text()) if baselines_path.exists() else {}
+
+    new: list[tuple[str, dict]] = []
+    changed: list[tuple[str, dict, dict]] = []
+    removed: list[tuple[str, dict]] = []
+    unchanged: list[tuple[str, dict]] = []
+
+    for key, info in sorted(current.items()):
+        if not info["sha256"]:
+            continue
+        if key not in baselines:
+            new.append((key, info))
+        elif info["sha256"] != baselines[key]["sha256"]:
+            changed.append((key, info, baselines[key]))
+        else:
+            unchanged.append((key, info))
+
+    for key, bl_info in sorted(baselines.items()):
+        if key not in current:
+            removed.append((key, bl_info))
+
+    # --- generate markdown ---
+    marker = "<!-- preview-diff -->"
+    lines = [marker, "## Preview Changes", ""]
+
+    if not new and not changed and not removed:
+        lines.append("No visual changes detected.")
+        lines.append("")
+        if unchanged:
+            lines.append(f"_{len(unchanged)} preview(s) unchanged._")
+        print("\n".join(lines))
+        return 0
+
+    if changed:
+        lines.append(f"### Changed ({len(changed)})")
+        lines.append("")
+        for key, cur, bl in changed:
+            module, preview_id = key.split("/", 1)
+            fn = cur["functionName"]
+            before_url = (
+                f"https://raw.githubusercontent.com/{repo}/{base_branch}"
+                f"/renders/{module}/{preview_id}.png"
+            )
+            after_url = (
+                f"https://raw.githubusercontent.com/{repo}/{head_branch}"
+                f"/renders/{module}/{preview_id}.png"
+            )
+            lines.append(f"**`{fn}`** ({module})")
+            lines.append("")
+            lines.append("| Before | After |")
+            lines.append("|--------|-------|")
+            lines.append(
+                f"| <img src=\"{before_url}\" width=\"200\" /> "
+                f"| <img src=\"{after_url}\" width=\"200\" /> |"
+            )
+            lines.append("")
+
+    if new:
+        lines.append(f"### New ({len(new)})")
+        lines.append("")
+        lines.append("| Preview | Render |")
+        lines.append("|---------|--------|")
+        for key, info in new:
+            module, preview_id = key.split("/", 1)
+            fn = info["functionName"]
+            after_url = (
+                f"https://raw.githubusercontent.com/{repo}/{head_branch}"
+                f"/renders/{module}/{preview_id}.png"
+            )
+            lines.append(
+                f"| `{fn}` ({module}) "
+                f"| <img src=\"{after_url}\" width=\"200\" /> |"
+            )
+        lines.append("")
+
+    if removed:
+        lines.append(f"### Removed ({len(removed)})")
+        lines.append("")
+        for _, bl_info in removed:
+            fn = bl_info.get("functionName", "unknown")
+            lines.append(f"- ~`{fn}`~")
+        lines.append("")
+
+    if unchanged:
+        lines.append(f"<details><summary>Unchanged ({len(unchanged)})</summary>")
+        lines.append("")
+        for _, info in unchanged:
+            lines.append(f"- `{info['functionName']}`")
+        lines.append("")
+        lines.append("</details>")
+
+    print("\n".join(lines))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# copy-changed mode
+# ---------------------------------------------------------------------------
+
+def cmd_copy_changed(args: argparse.Namespace) -> int:
+    """Copy new/changed PNGs to an output directory for the PR renders branch."""
+    cli_json = Path(args.cli_json)
+    baselines_path = Path(args.baselines)
+    out_dir = Path(args.output_dir)
+
+    current = load_cli_output(cli_json)
+    baselines = json.loads(baselines_path.read_text()) if baselines_path.exists() else {}
+
+    copied = 0
+    for key, info in current.items():
+        if not info["sha256"]:
+            continue
+        png = Path(info["pngPath"])
+        if not png.exists():
+            continue
+        is_new = key not in baselines
+        is_changed = not is_new and info["sha256"] != baselines[key]["sha256"]
+        if is_new or is_changed:
+            dest = out_dir / "renders" / info["module"] / f"{info['previewId']}.png"
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(png, dest)
+            copied += 1
+
+    print(f"Copied {copied} changed/new preview(s) to {out_dir}", file=sys.stderr)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = ap.add_subparsers(dest="command", required=True)
+
+    gen = sub.add_parser("generate", help="Generate baselines from CLI output")
+    gen.add_argument("cli_json", help="Path to compose-preview show --json output")
+    gen.add_argument("--output-dir", required=True)
+    gen.add_argument("--repo", required=True, help="owner/repo")
+    gen.add_argument("--branch", default="preview_main")
+
+    cmp = sub.add_parser("compare", help="Compare CLI output against baselines")
+    cmp.add_argument("cli_json", help="Path to compose-preview show --json output")
+    cmp.add_argument("--baselines", required=True, help="Path to baselines.json")
+    cmp.add_argument("--repo", required=True)
+    cmp.add_argument("--pr", required=True)
+    cmp.add_argument("--base-branch", default="preview_main")
+    cmp.add_argument("--head-branch", required=True, help="e.g. preview_pr/42")
+
+    cp = sub.add_parser("copy-changed", help="Copy new/changed PNGs to output dir")
+    cp.add_argument("cli_json", help="Path to compose-preview show --json output")
+    cp.add_argument("--baselines", required=True)
+    cp.add_argument("--output-dir", required=True)
+
+    args = ap.parse_args()
+    handlers = {
+        "generate": cmd_generate,
+        "compare": cmd_compare,
+        "copy-changed": cmd_copy_changed,
+    }
+    return handlers[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Render previews
         run: |
           cli/build/install/compose-preview/bin/compose-preview show --json \
-            > _previews.json
+            --timeout 600 > _previews.json
 
       - name: Generate baselines
         run: |

--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -1,0 +1,68 @@
+name: Preview Baselines
+
+# Renders all previews on main via the compose-preview CLI and publishes
+# the PNGs + baselines.json (preview ID -> SHA-256) to the `preview_main`
+# orphan branch.
+#
+# The branch is browsable on GitHub (README.md with inline image gallery)
+# and serves as the "before" state for PR preview-diff comments.
+#
+# Works for any project that applies ee.schimke.composeai.preview — modules
+# are auto-discovered by the CLI.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: preview-baselines
+  cancel-in-progress: true
+
+jobs:
+  update:
+    name: Update preview_main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Install CLI
+        run: ./gradlew :cli:installDist --no-daemon
+
+      - name: Render previews
+        run: |
+          cli/build/install/compose-preview/bin/compose-preview show --json \
+            > _previews.json
+
+      - name: Generate baselines
+        run: |
+          python3 .github/ci/compare-previews.py generate _previews.json \
+            --output-dir _baselines \
+            --repo "${{ github.repository }}" \
+            --branch preview_main
+
+      - name: Push to preview_main
+        run: |
+          set -euo pipefail
+          cd _baselines
+
+          git init
+          git checkout -b preview_main
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Update preview baselines from ${GITHUB_SHA::8}"
+
+          git remote add origin \
+            "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          git push --force origin preview_main

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Render previews
         run: |
           cli/build/install/compose-preview/bin/compose-preview show --json \
-            > _previews.json
+            --timeout 600 > _previews.json
 
       - name: Fetch baselines
         run: |

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -1,0 +1,139 @@
+name: Preview Comment
+
+# Renders previews on a PR via the compose-preview CLI, compares against
+# the baselines on preview_main, and posts a before/after comment.
+# Changed PNGs are pushed to a per-PR branch (preview_pr/<number>) so both
+# images are URL-accessible in the comment via raw.githubusercontent.com.
+#
+# Works for any project that applies ee.schimke.composeai.preview — modules
+# are auto-discovered by the CLI.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: preview-comment-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  compare:
+    name: Compare previews
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Install CLI
+        run: ./gradlew :cli:installDist --no-daemon
+
+      - name: Render previews
+        run: |
+          cli/build/install/compose-preview/bin/compose-preview show --json \
+            > _previews.json
+
+      - name: Fetch baselines
+        run: |
+          mkdir -p _baselines
+          if git ls-remote --exit-code origin preview_main >/dev/null 2>&1; then
+            git fetch origin preview_main
+            git show origin/preview_main:baselines.json \
+              > _baselines/baselines.json 2>/dev/null || true
+          else
+            echo "No preview_main branch yet — treating all previews as new."
+          fi
+
+      - name: Copy changed PNGs
+        run: |
+          python3 .github/ci/compare-previews.py copy-changed _previews.json \
+            --baselines _baselines/baselines.json \
+            --output-dir _pr_renders
+
+      - name: Push PR renders
+        run: |
+          set -euo pipefail
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          BRANCH="preview_pr/${PR_NUMBER}"
+
+          # Nothing to push if no renders changed
+          if [ ! -d _pr_renders/renders ] || \
+             [ -z "$(ls -A _pr_renders/renders 2>/dev/null)" ]; then
+            echo "No changed renders to push."
+            exit 0
+          fi
+
+          cd _pr_renders
+          git init
+          git checkout -b "$BRANCH"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Preview renders for PR #${PR_NUMBER} (${GITHUB_SHA::8})"
+
+          git remote add origin \
+            "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          git push --force origin "$BRANCH"
+
+      - name: Generate comment
+        run: |
+          set -euo pipefail
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          python3 .github/ci/compare-previews.py compare _previews.json \
+            --baselines _baselines/baselines.json \
+            --repo "${{ github.repository }}" \
+            --pr "$PR_NUMBER" \
+            --base-branch preview_main \
+            --head-branch "preview_pr/${PR_NUMBER}" \
+            > _comment_body.md
+
+      - name: Post or update PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          BODY=$(cat _comment_body.md)
+          MARKER="<!-- preview-diff -->"
+
+          # Find existing comment by marker
+          COMMENT_ID=$(gh api \
+            "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
+            | head -1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -f body="$BODY"
+          else
+            gh pr comment "$PR_NUMBER" --body "$BODY"
+          fi
+
+  # Clean up the per-PR renders branch when the PR is closed or merged.
+  cleanup:
+    name: Clean up PR renders
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete preview branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="preview_pr/${{ github.event.pull_request.number }}"
+          gh api "repos/${{ github.repository }}/git/refs/heads/${BRANCH}" \
+            -X DELETE 2>/dev/null || true


### PR DESCRIPTION
## Summary

- **preview-baselines.yml** — on push to main, renders all previews via `compose-preview show --json` and publishes to a `preview_main` orphan branch with a browsable README gallery + `baselines.json` (ID → SHA-256)
- **preview-comment.yml** — on PRs, renders previews, compares SHAs against `preview_main`, pushes changed PNGs to `preview_pr/<number>`, and posts a comment with before/after image tables. Cleans up on PR close.
- **compare-previews.py** — comparison script with three modes (`generate`, `compare`, `copy-changed`), driven entirely by CLI JSON output so it's portable to any consumer project

## How it works

```
push to main → render → baselines.json + PNGs → preview_main branch (browsable gallery)

PR opened/updated → render → compare SHAs → push changed PNGs → post/update comment
PR closed → delete preview_pr/<number> branch
```

## Test plan

- [ ] Merge and verify `preview-baselines.yml` populates `preview_main` with README + renders
- [ ] Open a test PR with a UI change and verify the comment appears with before/after images
- [ ] Verify comment updates on subsequent pushes (not duplicated)
- [ ] Verify `preview_pr/<number>` branch is deleted on PR close