### PR TITLE
ci: compact PR preview comments, fix CLI install, document baselines

### DIFF
--- a/.github/ci/compare-previews.py
+++ b/.github/ci/compare-previews.py
@@ -137,6 +137,34 @@ def cmd_generate(args: argparse.Namespace) -> int:
 # compare mode
 # ---------------------------------------------------------------------------
 
+def _variant_label(preview_id: str) -> str:
+    """Extract the variant label from a preview ID (suffix after the last ``_``)."""
+    # e.g. "com.example.PreviewsKt.ConfigProbePreview_German" -> "German"
+    parts = preview_id.rsplit("_", 1)
+    return parts[1] if len(parts) == 2 else ""
+
+
+def _is_default_variant(preview_id: str) -> bool:
+    label = _variant_label(preview_id).lower()
+    return label in ("", "default")
+
+
+def _render_url(repo: str, branch: str, module: str, preview_id: str) -> str:
+    return (
+        f"https://raw.githubusercontent.com/{repo}/{branch}"
+        f"/renders/{module}/{preview_id}.png"
+    )
+
+
+def _pick_hero(entries: list) -> tuple[int, object]:
+    """Pick the best variant to show inline (prefer Default, else first)."""
+    for i, entry in enumerate(entries):
+        pid = entry[0].split("/", 1)[1]  # key -> preview_id
+        if _is_default_variant(pid):
+            return i, entry
+    return 0, entries[0]
+
+
 def cmd_compare(args: argparse.Namespace) -> int:
     cli_json = Path(args.cli_json)
     baselines_path = Path(args.baselines)
@@ -179,60 +207,88 @@ def cmd_compare(args: argparse.Namespace) -> int:
         return 0
 
     if changed:
-        lines.append(f"### Changed ({len(changed)})")
-        lines.append("")
+        # Group changed variants by (module, functionName).
+        groups: dict[tuple[str, str], list[tuple[str, dict, dict]]] = {}
         for key, cur, bl in changed:
-            module, preview_id = key.split("/", 1)
-            fn = cur["functionName"]
-            before_url = (
-                f"https://raw.githubusercontent.com/{repo}/{base_branch}"
-                f"/renders/{module}/{preview_id}.png"
-            )
-            after_url = (
-                f"https://raw.githubusercontent.com/{repo}/{head_branch}"
-                f"/renders/{module}/{preview_id}.png"
-            )
+            gk = (cur["module"], cur["functionName"])
+            groups.setdefault(gk, []).append((key, cur, bl))
+
+        lines.append(f"### Changed ({len(changed)} variant(s) across {len(groups)} function(s))")
+        lines.append("")
+
+        for (module, fn), entries in sorted(groups.items()):
+            hero_idx, (hero_key, hero_cur, hero_bl) = _pick_hero(entries)
+            hero_pid = hero_key.split("/", 1)[1]
+            before = _render_url(repo, base_branch, module, hero_pid)
+            after = _render_url(repo, head_branch, module, hero_pid)
+
             lines.append(f"**`{fn}`** ({module})")
             lines.append("")
             lines.append("| Before | After |")
             lines.append("|--------|-------|")
             lines.append(
-                f"| <img src=\"{before_url}\" width=\"200\" /> "
-                f"| <img src=\"{after_url}\" width=\"200\" /> |"
+                f"| <img src=\"{before}\" width=\"200\" /> "
+                f"| <img src=\"{after}\" width=\"200\" /> |"
             )
+
+            # Link remaining variants
+            others = [e for i, e in enumerate(entries) if i != hero_idx]
+            if others:
+                variant_links = []
+                for okey, ocur, obl in others:
+                    opid = okey.split("/", 1)[1]
+                    label = _variant_label(opid) or opid
+                    link = _render_url(repo, head_branch, module, opid)
+                    variant_links.append(f"[{label}]({link})")
+                lines.append("")
+                lines.append(f"Other variants: {', '.join(variant_links)}")
             lines.append("")
 
     if new:
-        lines.append(f"### New ({len(new)})")
-        lines.append("")
-        lines.append("| Preview | Render |")
-        lines.append("|---------|--------|")
+        # Group new previews similarly.
+        groups_new: dict[tuple[str, str], list[tuple[str, dict]]] = {}
         for key, info in new:
-            module, preview_id = key.split("/", 1)
-            fn = info["functionName"]
-            after_url = (
-                f"https://raw.githubusercontent.com/{repo}/{head_branch}"
-                f"/renders/{module}/{preview_id}.png"
-            )
-            lines.append(
-                f"| `{fn}` ({module}) "
-                f"| <img src=\"{after_url}\" width=\"200\" /> |"
-            )
+            gk = (info["module"], info["functionName"])
+            groups_new.setdefault(gk, []).append((key, info))
+
+        lines.append(f"### New ({len(new)} variant(s) across {len(groups_new)} function(s))")
         lines.append("")
 
+        for (module, fn), entries in sorted(groups_new.items()):
+            hero_idx, (hero_key, hero_info) = _pick_hero(entries)
+            hero_pid = hero_key.split("/", 1)[1]
+            after = _render_url(repo, head_branch, module, hero_pid)
+
+            lines.append(
+                f"**`{fn}`** ({module}) "
+                f"<img src=\"{after}\" width=\"200\" />"
+            )
+
+            others = [e for i, e in enumerate(entries) if i != hero_idx]
+            if others:
+                variant_links = []
+                for okey, oinfo in others:
+                    opid = okey.split("/", 1)[1]
+                    label = _variant_label(opid) or opid
+                    link = _render_url(repo, head_branch, module, opid)
+                    variant_links.append(f"[{label}]({link})")
+                lines.append(f"Variants: {', '.join(variant_links)}")
+            lines.append("")
+
     if removed:
-        lines.append(f"### Removed ({len(removed)})")
+        fn_set = {bl_info.get("functionName", "?") for _, bl_info in removed}
+        lines.append(f"### Removed ({len(removed)} variant(s))")
         lines.append("")
-        for _, bl_info in removed:
-            fn = bl_info.get("functionName", "unknown")
+        for fn in sorted(fn_set):
             lines.append(f"- ~`{fn}`~")
         lines.append("")
 
     if unchanged:
-        lines.append(f"<details><summary>Unchanged ({len(unchanged)})</summary>")
+        fn_set = {info["functionName"] for _, info in unchanged}
+        lines.append(f"<details><summary>Unchanged ({len(fn_set)} function(s), {len(unchanged)} variant(s))</summary>")
         lines.append("")
-        for _, info in unchanged:
-            lines.append(f"- `{info['functionName']}`")
+        for fn in sorted(fn_set):
+            lines.append(f"- `{fn}`")
         lines.append("")
         lines.append("</details>")
 

--- a/.github/ci/compare-previews.py
+++ b/.github/ci/compare-previews.py
@@ -144,25 +144,11 @@ def _variant_label(preview_id: str) -> str:
     return parts[1] if len(parts) == 2 else ""
 
 
-def _is_default_variant(preview_id: str) -> bool:
-    label = _variant_label(preview_id).lower()
-    return label in ("", "default")
-
-
 def _render_url(repo: str, branch: str, module: str, preview_id: str) -> str:
     return (
         f"https://raw.githubusercontent.com/{repo}/{branch}"
         f"/renders/{module}/{preview_id}.png"
     )
-
-
-def _pick_hero(entries: list) -> tuple[int, object]:
-    """Pick the best variant to show inline (prefer Default, else first)."""
-    for i, entry in enumerate(entries):
-        pid = entry[0].split("/", 1)[1]  # key -> preview_id
-        if _is_default_variant(pid):
-            return i, entry
-    return 0, entries[0]
 
 
 def cmd_compare(args: argparse.Namespace) -> int:
@@ -217,7 +203,7 @@ def cmd_compare(args: argparse.Namespace) -> int:
         lines.append("")
 
         for (module, fn), entries in sorted(groups.items()):
-            hero_idx, (hero_key, hero_cur, hero_bl) = _pick_hero(entries)
+            hero_key, hero_cur, hero_bl = entries[0]
             hero_pid = hero_key.split("/", 1)[1]
             before = _render_url(repo, base_branch, module, hero_pid)
             after = _render_url(repo, head_branch, module, hero_pid)
@@ -232,10 +218,9 @@ def cmd_compare(args: argparse.Namespace) -> int:
             )
 
             # Link remaining variants
-            others = [e for i, e in enumerate(entries) if i != hero_idx]
-            if others:
+            if len(entries) > 1:
                 variant_links = []
-                for okey, ocur, obl in others:
+                for okey, ocur, obl in entries[1:]:
                     opid = okey.split("/", 1)[1]
                     label = _variant_label(opid) or opid
                     link = _render_url(repo, head_branch, module, opid)
@@ -255,7 +240,7 @@ def cmd_compare(args: argparse.Namespace) -> int:
         lines.append("")
 
         for (module, fn), entries in sorted(groups_new.items()):
-            hero_idx, (hero_key, hero_info) = _pick_hero(entries)
+            hero_key, hero_info = entries[0]
             hero_pid = hero_key.split("/", 1)[1]
             after = _render_url(repo, head_branch, module, hero_pid)
 
@@ -264,10 +249,9 @@ def cmd_compare(args: argparse.Namespace) -> int:
                 f"<img src=\"{after}\" width=\"200\" />"
             )
 
-            others = [e for i, e in enumerate(entries) if i != hero_idx]
-            if others:
+            if len(entries) > 1:
                 variant_links = []
-                for okey, oinfo in others:
+                for okey, oinfo in entries[1:]:
                     opid = okey.split("/", 1)[1]
                     label = _variant_label(opid) or opid
                     link = _render_url(repo, head_branch, module, opid)

--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -37,12 +37,16 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
 
       - name: Install CLI
-        run: ./gradlew :cli:installDist --no-daemon
+        run: |
+          gh release download --pattern 'compose-preview-*.tar.gz' --dir /tmp
+          tar -xzf /tmp/compose-preview-*.tar.gz -C /tmp
+          echo "/tmp/compose-preview-$(gh release view --json tagName -q .tagName | sed 's/^v//')/bin" \
+            >> "$GITHUB_PATH"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Render previews
-        run: |
-          cli/build/install/compose-preview/bin/compose-preview show --json \
-            --timeout 600 > _previews.json
+        run: compose-preview show --json --timeout 600 > _previews.json
 
       - name: Generate baselines
         run: |

--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -38,10 +38,13 @@ jobs:
 
       - name: Install CLI
         run: |
-          gh release download --pattern 'compose-preview-*.tar.gz' --dir /tmp
-          tar -xzf /tmp/compose-preview-*.tar.gz -C /tmp
-          echo "/tmp/compose-preview-$(gh release view --json tagName -q .tagName | sed 's/^v//')/bin" \
-            >> "$GITHUB_PATH"
+          set -euo pipefail
+          VERSION=$(gh release view --json tagName -q .tagName | sed 's/^v//')
+          echo "Downloading compose-preview ${VERSION}..."
+          gh release download "v${VERSION}" --pattern "compose-preview-${VERSION}.tar.gz" --dir /tmp
+          mkdir -p /opt/compose-preview
+          tar -xzf "/tmp/compose-preview-${VERSION}.tar.gz" -C /opt/compose-preview --strip-components=1
+          echo "/opt/compose-preview/bin" >> "$GITHUB_PATH"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -37,12 +37,16 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
 
       - name: Install CLI
-        run: ./gradlew :cli:installDist --no-daemon
+        run: |
+          gh release download --pattern 'compose-preview-*.tar.gz' --dir /tmp
+          tar -xzf /tmp/compose-preview-*.tar.gz -C /tmp
+          echo "/tmp/compose-preview-$(gh release view --json tagName -q .tagName | sed 's/^v//')/bin" \
+            >> "$GITHUB_PATH"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Render previews
-        run: |
-          cli/build/install/compose-preview/bin/compose-preview show --json \
-            --timeout 600 > _previews.json
+        run: compose-preview show --json --timeout 600 > _previews.json
 
       - name: Fetch baselines
         run: |

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -38,10 +38,13 @@ jobs:
 
       - name: Install CLI
         run: |
-          gh release download --pattern 'compose-preview-*.tar.gz' --dir /tmp
-          tar -xzf /tmp/compose-preview-*.tar.gz -C /tmp
-          echo "/tmp/compose-preview-$(gh release view --json tagName -q .tagName | sed 's/^v//')/bin" \
-            >> "$GITHUB_PATH"
+          set -euo pipefail
+          VERSION=$(gh release view --json tagName -q .tagName | sed 's/^v//')
+          echo "Downloading compose-preview ${VERSION}..."
+          gh release download "v${VERSION}" --pattern "compose-preview-${VERSION}.tar.gz" --dir /tmp
+          mkdir -p /opt/compose-preview
+          tar -xzf "/tmp/compose-preview-${VERSION}.tar.gz" -C /opt/compose-preview --strip-components=1
+          echo "/opt/compose-preview/bin" >> "$GITHUB_PATH"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -178,6 +178,51 @@ When creating or iterating on Wear OS designs, refer to the
 - Proper **System UI** integration (e.g., `TimeText`, `AppScaffold`).
 - **Responsive layout** strategies across screen sizes.
 
+## CI preview baselines (`preview_main` branch)
+
+Projects that use the Gradle plugin can set up CI workflows to maintain a
+`preview_main` branch with rendered PNGs and a `baselines.json` file (preview
+ID → SHA-256). This serves two purposes:
+
+1. **Browsable gallery** — the branch has a `README.md` with inline images,
+   viewable directly on GitHub.
+2. **PR diff comments** — a companion workflow renders previews on each PR,
+   compares against the baselines, and posts a before/after comment.
+
+### Checking if baselines are available
+
+```bash
+git ls-remote --exit-code origin preview_main
+```
+
+### Fetching current main previews
+
+```bash
+# Get the baselines manifest
+git fetch origin preview_main
+git show origin/preview_main:baselines.json
+
+# Get a specific rendered PNG
+git show origin/preview_main:renders/<module>/<preview-id>.png > preview.png
+```
+
+Or via raw URL:
+```
+https://raw.githubusercontent.com/<owner>/<repo>/preview_main/renders/<module>/<preview-id>.png
+```
+
+### Setting up the workflows
+
+Copy these files from `compose-ai-tools` into your project:
+
+- `.github/workflows/preview-baselines.yml` — updates `preview_main` on push
+  to main
+- `.github/workflows/preview-comment.yml` — posts before/after comments on PRs
+- `.github/ci/compare-previews.py` — comparison script (used by both workflows)
+
+The workflows download the `compose-preview` CLI from the latest release and
+auto-discover all modules that apply the plugin.
+
 ## Tips
 
 - First render is slow (module compile + renderer bootstrap); later renders


### PR DESCRIPTION
## Summary

- **Compact PR comments**: group preview variants by function — show one inline before/after image (first variant), link remaining variants instead of showing all inline
- **Fix CLI install**: use `--strip-components=1` to extract to `/opt/compose-preview` with `set -euo pipefail` for proper error visibility
- **Download CLI from releases** instead of building from source — faster and portable to consumer projects
- **Document** `preview_main` branch and PR workflows in SKILL.md (how to detect availability, fetch baselines, set up in a new project)

## Test plan

- [ ] Preview Comment workflow installs CLI from release and renders successfully
- [ ] PR comment is compact (one image per function, variant links for the rest)