### PR TITLE
Streamline first-run setup: install.sh + compose-preview doctor

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -1,0 +1,215 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URI
+import java.util.Base64
+import java.util.Properties
+import kotlin.system.exitProcess
+
+/**
+ * `compose-preview doctor`
+ *
+ * Verifies the prerequisites for using the plugin before the user edits any
+ * Gradle files:
+ *
+ *   1. Java 21+ is reachable.
+ *   2. GitHub Packages credentials (`composeAiTools.githubUser` / `...Token`)
+ *      are set in ~/.gradle/gradle.properties, or `GITHUB_ACTOR` /
+ *      `GITHUB_TOKEN` are set in the environment.
+ *   3. The credentials actually resolve a package — a HEAD against the plugin
+ *      POM on `maven.pkg.github.com`. A 200 means auth is good and
+ *      `read:packages` is effective (fine-grained tokens don't expose scopes
+ *      via the REST API, so we probe instead of introspecting).
+ *   4. If token looks like a classic PAT, also surfaces the `x-oauth-scopes`
+ *      header so the user can see what scopes are actually granted.
+ *
+ * Exits 0 when everything checks out, 1 otherwise. Designed to be safe to run
+ * outside a Gradle project — it never touches the filesystem.
+ */
+class DoctorCommand(args: List<String>) {
+    private val verbose = "--verbose" in args || "-v" in args
+    private val pluginVersion = args.flagValue("--plugin-version") ?: DEFAULT_PLUGIN_VERSION
+
+    private var errors = 0
+    private var warnings = 0
+
+    fun run() {
+        println("compose-preview doctor")
+        println()
+
+        checkJava()
+        val creds = checkCredentials()
+        if (creds != null) probeMaven(creds)
+
+        println()
+        when {
+            errors > 0 -> {
+                println("✗ $errors problem(s) found" + if (warnings > 0) ", $warnings warning(s)" else "")
+                println()
+                println("Fix the errors above before applying the plugin to your build.")
+                exitProcess(1)
+            }
+            warnings > 0 -> println("✓ ok ($warnings warning(s))")
+            else -> println("✓ all checks passed")
+        }
+    }
+
+    // --- Checks -------------------------------------------------------------
+
+    private fun checkJava() {
+        val version = System.getProperty("java.specification.version")
+        val major = version?.substringBefore('.')?.toIntOrNull()
+        if (major != null && major >= 21) {
+            ok("Java $version on PATH")
+        } else {
+            err("Java 21+ required, got ${version ?: "unknown"}")
+            hint("Install a JDK 21 and put it on PATH, or set JAVA_HOME.")
+        }
+    }
+
+    private fun checkCredentials(): Credentials? {
+        val propsFile = File(System.getProperty("user.home"), ".gradle/gradle.properties")
+        val props = loadProperties(propsFile)
+
+        val user = props["composeAiTools.githubUser"]
+            ?: System.getenv("GITHUB_ACTOR")
+        val token = props["composeAiTools.githubToken"]
+            ?: System.getenv("GITHUB_TOKEN")
+
+        when {
+            user == null && token == null -> {
+                err("no GitHub Packages credentials found")
+                hint("Store a token in ${propsFile.path}:")
+                hint("    composeAiTools.githubUser=<your-github-username>")
+                hint("    composeAiTools.githubToken=<PAT with read:packages>")
+                hint("Or: gh auth refresh -h github.com -s read:packages && gh auth token")
+                return null
+            }
+            token == null -> {
+                err("composeAiTools.githubToken is not set")
+                return null
+            }
+            user == null -> {
+                warn("composeAiTools.githubUser not set; falling back to 'x' for BASIC auth")
+            }
+        }
+
+        val source = when {
+            props["composeAiTools.githubToken"] != null -> propsFile.path
+            else -> "\$GITHUB_TOKEN env var"
+        }
+        ok("credentials found ($source)")
+
+        return Credentials(user ?: "x", token!!)
+    }
+
+    private fun probeMaven(creds: Credentials) {
+        // Probe the plugin POM on GitHub Packages. 200 = auth works + read:packages
+        // is effective. 401/403 = bad creds or missing scope. 404 = auth worked but
+        // the specific version doesn't exist (still good news for the auth check).
+        val path = "ee/schimke/composeai/gradle-plugin/$pluginVersion/gradle-plugin-$pluginVersion.pom"
+        val url = "$MAVEN_BASE/$path"
+
+        val (code, headers) = head(url, creds)
+
+        when (code) {
+            in 200..299 -> ok("GitHub Packages auth works (HEAD $pluginVersion → $code)")
+            404 -> {
+                // 404 from maven.pkg.github.com with valid auth still means auth+scope
+                // worked — GitHub returns 401 if the token can't see the package at all.
+                ok("GitHub Packages auth works (plugin v$pluginVersion not published, but token can see the repo)")
+                warn("pinned plugin version $pluginVersion not found; check https://github.com/$REPO/releases")
+            }
+            401 -> {
+                err("GitHub Packages rejected credentials (HTTP 401)")
+                surfaceScopes(headers)
+                hint("The token is missing 'read:packages' or is invalid.")
+                hint("Fix: gh auth refresh -h github.com -s read:packages")
+                hint("  or: create a classic PAT with 'read:packages' at https://github.com/settings/tokens/new")
+            }
+            403 -> {
+                err("GitHub Packages refused (HTTP 403) — token likely lacks 'read:packages'")
+                surfaceScopes(headers)
+            }
+            else -> {
+                err("unexpected HTTP $code from $url")
+                if (verbose) headers.forEach { (k, v) -> System.err.println("  $k: $v") }
+            }
+        }
+    }
+
+    // --- Helpers ------------------------------------------------------------
+
+    private fun head(url: String, creds: Credentials): Pair<Int, Map<String, String>> {
+        val conn = (URI(url).toURL().openConnection() as HttpURLConnection).apply {
+            requestMethod = "HEAD"
+            connectTimeout = 10_000
+            readTimeout = 10_000
+            instanceFollowRedirects = true
+            val auth = Base64.getEncoder()
+                .encodeToString("${creds.user}:${creds.token}".toByteArray())
+            setRequestProperty("Authorization", "Basic $auth")
+            setRequestProperty("User-Agent", "compose-preview-doctor")
+        }
+        return try {
+            val code = conn.responseCode
+            val headers = conn.headerFields
+                .filterKeys { it != null }
+                .mapValues { it.value.joinToString(", ") }
+            code to headers
+        } catch (e: Exception) {
+            err("network probe failed: ${e.message}")
+            -1 to emptyMap()
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    private fun surfaceScopes(headers: Map<String, String>) {
+        val scopes = headers.entries.firstOrNull { it.key.equals("x-oauth-scopes", true) }?.value
+        if (scopes != null) {
+            hint("token scopes reported by GitHub: ${scopes.ifBlank { "(none)" }}")
+            if ("read:packages" !in scopes) {
+                hint("missing 'read:packages'.")
+            }
+        } else {
+            hint("(no x-oauth-scopes header — fine-grained tokens don't expose scopes this way)")
+        }
+    }
+
+    private fun loadProperties(file: File): Map<String, String> {
+        if (!file.exists()) return emptyMap()
+        return try {
+            Properties().apply { file.inputStream().use { load(it) } }
+                .entries.associate { it.key.toString() to it.value.toString() }
+        } catch (e: Exception) {
+            warn("could not read ${file.path}: ${e.message}")
+            emptyMap()
+        }
+    }
+
+    private fun ok(msg: String) = println("  ✓ $msg")
+    private fun warn(msg: String) {
+        warnings++
+        println("  ! $msg")
+    }
+    private fun err(msg: String) {
+        errors++
+        println("  ✗ $msg")
+    }
+    private fun hint(msg: String) = println("      $msg")
+
+    private data class Credentials(val user: String, val token: String)
+
+    companion object {
+        private const val REPO = "yschimke/compose-ai-tools"
+        private const val MAVEN_BASE = "https://maven.pkg.github.com/$REPO"
+        private const val DEFAULT_PLUGIN_VERSION = "0.3.1"
+    }
+}
+
+private fun List<String>.flagValue(flag: String): String? {
+    val idx = indexOf(flag)
+    return if (idx >= 0 && idx + 1 < size) this[idx + 1] else null
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -9,9 +9,11 @@ fun main(args: Array<String>) {
     }
 
     // Find the command — first non-flag argument that isn't a flag's value.
-    // Flags that take values: --module, --variant, --filter, --id, --output, --timeout
-    val valuedFlags = setOf("--module", "--variant", "--filter", "--id", "--output", "--timeout")
-    val commands = setOf("show", "list", "render", "help")
+    // Flags that take values: --module, --variant, --filter, --id, --output, --timeout, --plugin-version
+    val valuedFlags = setOf(
+        "--module", "--variant", "--filter", "--id", "--output", "--timeout", "--plugin-version",
+    )
+    val commands = setOf("show", "list", "render", "doctor", "help")
 
     var commandIndex = -1
     var i = 0
@@ -46,6 +48,7 @@ fun main(args: Array<String>) {
         "show" -> ShowCommand(allArgs).run()
         "list" -> ListCommand(allArgs).run()
         "render" -> RenderCommand(allArgs).run()
+        "doctor" -> DoctorCommand(allArgs).run()
         "help" -> printUsage()
         else -> {
             System.err.println("Unknown command: $command")
@@ -66,6 +69,7 @@ private fun printUsage() {
           show    Discover and render previews; print id, path, sha256, changed flag
           list    List discovered previews
           render  Render previews; with --output copies a single match to disk
+          doctor  Verify Java 21 + GitHub Packages credentials before editing Gradle files
           help    Show this help message
 
         Options:

--- a/docs/PACKAGING_SKILL.md
+++ b/docs/PACKAGING_SKILL.md
@@ -1,0 +1,190 @@
+# Packaging this repo as a Claude Code skill
+
+Notes for making the Compose Preview skill trivially installable from a fresh
+Claude Code environment. The goal: a single command that gives an agent both
+the skill instructions *and* a working CLI, without the agent having to
+improvise install paths, translate Kotlin→Groovy, or diagnose GitHub Packages
+401s on its own.
+
+The recommendations below move the repo from "docs + binary, figure it out"
+to "an agent can run through Setup mechanically."
+
+## Anatomy of a Claude Code skill
+
+Claude Code discovers skills by scanning these locations, in order:
+
+1. **Plugin marketplaces** the user has added via `/plugin`.
+2. **`.claude/skills/<name>/SKILL.md`** inside a project (project-scoped; the
+   most common shape).
+3. **`~/.claude/skills/<name>/SKILL.md`** (user-scoped; available in every
+   project).
+
+A "skill" is just a directory whose `SKILL.md` has YAML frontmatter with at
+least `name:` and `description:`. The description is what Claude uses to
+decide whether the skill is relevant to the current turn, so it must be
+specific and trigger-oriented (verbs, file types, task descriptions).
+
+A skill directory may also contain:
+- **`scripts/`** — helper scripts the skill instructs the agent to run.
+  These are plain files; there is no special format.
+- **Reference docs** — anything the skill's prose points to (markdown,
+  JSON, images).
+
+There is no build step. Agents read `SKILL.md`, follow its instructions, and
+invoke the helpers.
+
+## Current state and gaps
+
+Today, [docs/SKILL.md](SKILL.md) is a well-written skill file that lives
+inside the source tree, but to actually *use* it an agent has to:
+
+1. Find it (not on a standard skill path).
+2. Download a release tarball and guess an install location.
+3. Write Gradle credentials to the right file.
+4. Translate Kotlin DSL snippets to Groovy for projects that use
+   `settings.gradle`.
+
+With the install script and `compose-preview doctor` added in this change,
+steps 2 and 3 are now scripted. Step 4 is addressed with dual snippets in
+`SKILL.md`. Step 1 is what this doc is about.
+
+## Option A — "copy this directory into `.claude/skills/`"
+
+Simplest shape; no tooling required. Recommended starting point.
+
+### Layout
+
+Publish the skill as a standalone directory in this repo:
+
+```
+.claude-skill/
+├── SKILL.md                 # copy/symlink of docs/SKILL.md
+├── install.sh               # copy of scripts/install.sh
+└── design/
+    └── WEAR_UI.md           # the Wear guidance that SKILL.md references
+```
+
+Users install it with one command:
+
+```sh
+mkdir -p ~/.claude/skills/compose-preview
+curl -fsSL https://codeload.github.com/yschimke/compose-ai-tools/tar.gz/refs/heads/main \
+  | tar -xz --strip-components=2 -C ~/.claude/skills/compose-preview \
+      compose-ai-tools-main/.claude-skill
+```
+
+Or, pinned to a release:
+
+```sh
+curl -fsSL https://github.com/yschimke/compose-ai-tools/releases/download/v0.3.1/compose-preview-skill.tar.gz \
+  | tar -xz -C ~/.claude/skills/
+```
+
+Implement by adding a `compose-preview-skill.tar.gz` to the release pipeline
+— a one-line `tar czf` over the `.claude-skill/` directory. No new
+dependencies.
+
+### Why a copy, not a symlink
+
+`SKILL.md` is referenced by the README (for humans) and needs to live under
+`docs/` to remain linkable there. A release build can either `cp` or
+`ln -s` it into `.claude-skill/` before packaging; a symlink is fine on
+Linux/macOS tarballs.
+
+### Keep the two in sync
+
+Add a CI check:
+
+```yaml
+- name: Skill mirror is in sync
+  run: diff -u docs/SKILL.md .claude-skill/SKILL.md
+```
+
+Or, cleaner: make `.claude-skill/SKILL.md` the source of truth and have
+`docs/SKILL.md` be a one-line include ("See the skill file at
+`.claude-skill/SKILL.md`."). The README stays linkable, humans still find
+their docs, and the skill shape is the canonical home.
+
+## Option B — plugin marketplace entry
+
+Claude Code's plugin system lets a user run `/plugin install <name>` to
+subscribe to a marketplace. Marketplaces are git repos whose root contains a
+`marketplace.json` listing available skills. If `yschimke/compose-ai-tools`
+exposes one directly, the install sequence becomes:
+
+```
+/plugin marketplace add yschimke/compose-ai-tools
+/plugin install compose-preview
+```
+
+Minimum files:
+
+```
+marketplace.json                   # { "name": "...", "skills": [{ "path": ".claude-skill" }] }
+.claude-skill/SKILL.md
+.claude-skill/install.sh
+```
+
+Users get automatic update prompts and no manual `tar` step. Best UX, but
+introduces a second file (`marketplace.json`) the release pipeline has to
+keep valid.
+
+## Option C — fully self-contained: bundle the CLI in the skill
+
+For users who don't want to run `install.sh` separately, the skill directory
+can ship the CLI binaries directly:
+
+```
+.claude-skill/
+├── SKILL.md
+├── bin/compose-preview           # thin launcher wrapper
+└── lib/*.jar                     # same contents as the release tarball's lib/
+```
+
+`SKILL.md` then points at `bin/compose-preview` using `${CLAUDE_SKILL_DIR}`
+(an env var Claude Code sets when running skill helpers) — the agent never
+touches `~/.local/bin`, and there's no PATH setup.
+
+Trade-off: the skill tarball grows to match the CLI tarball size (~6.4 MB
+for 0.3.1). Still small in absolute terms, but it means every skill update
+re-ships the whole CLI. The upside is that `install.sh` becomes truly
+optional; `compose-preview doctor` runs directly from the skill.
+
+## Recommendation
+
+Ship **Option A first** (it's five lines of release pipeline and a mirror
+check) and evaluate Option B once the skill has real users. Hold off on
+Option C unless install friction turns out to be the binding constraint
+— the versioned CLI + `install.sh` already collapses install to one
+command, which is usually good enough.
+
+## Release pipeline changes, concretely
+
+1. **Mirror the skill file.** Add a release step (or commit-time pre-push
+   hook) that copies `docs/SKILL.md` → `.claude-skill/SKILL.md`, and CI
+   that fails if they diverge.
+2. **Bundle the scripts.** In the same release workflow that produces
+   `compose-preview-<ver>.tar.gz`, add:
+   ```sh
+   tar czf compose-preview-skill-<ver>.tar.gz -C .claude-skill .
+   ```
+   Attach it to the GitHub release alongside the CLI tarball and VSIX.
+3. **Pin the skill to a CLI version.** `SKILL.md` already pins the plugin
+   version in its `Setup` snippets. Have the release step template that
+   version into the skill tarball so there's no drift — e.g. replace a
+   `@CLI_VERSION@` token at package time.
+4. **Document both install flows in README.** One section each:
+   "Install the CLI" (what's already there) and "Install as a Claude Code
+   skill" (the one-liner from Option A).
+
+## Naming notes
+
+- The `name:` field in the current `SKILL.md` frontmatter is `preview`.
+  For a standalone skill directory named `compose-preview`, rename it to
+  `compose-preview` so `/skills` listings don't collide with other
+  "preview" skills (the web, any IDE, etc.).
+- The `description:` is what Claude uses to decide to trigger. It already
+  lists the concrete triggers ("Render Compose @Preview functions to PNG…
+  Use this to verify UI changes, iterate on designs, and compare
+  before/after states"). Keep that specificity; don't reduce it to
+  "preview helper" or similar.

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -42,6 +42,7 @@ Commands:
   show     Discover + render previews; print id, path, sha256, changed flag
   list     List discovered previews
   render   Render previews; with --output copies a single match to disk
+  doctor   Verify Java 21 + GitHub Packages credentials (run before Setup)
 
 Options:
   --module <name>      Target a single module (default: auto-detect)
@@ -98,7 +99,55 @@ extension provides:
 
 ## Setup
 
-### 1. Register the plugin repository in `settings.gradle.kts`
+Run the steps in order. Step 0 is a precheck — if it fails, **stop** and fix
+credentials before editing any Gradle files. The plugin is hosted on GitHub
+Packages, which requires authentication even for public repos, so a missing
+token produces an `HTTP 401` that is easy to misdiagnose once Gradle is in
+the mix.
+
+### 0. Install the CLI and run `doctor`
+
+Bootstrap the CLI, then verify Java 21 and GitHub Packages credentials are in
+place:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/scripts/install.sh | bash
+
+compose-preview doctor
+```
+
+The install script is idempotent, pulls the latest release into
+`~/.local/opt/compose-preview/<version>/`, and symlinks
+`~/.local/bin/compose-preview`. If that directory isn't on your `PATH`, the
+script prints the exact command to add it (`fish_add_path …` or a `PATH=`
+line for bash/zsh).
+
+`compose-preview doctor` verifies:
+
+1. Java 21 on `PATH`.
+2. `composeAiTools.githubToken` in `~/.gradle/gradle.properties`, or
+   `GITHUB_TOKEN` in the environment.
+3. The token actually resolves a package on `maven.pkg.github.com` (HEAD
+   probe). This catches the most common failure mode: a `gh` CLI token
+   reused as `GITHUB_TOKEN` that doesn't have the `read:packages` scope.
+
+If doctor reports missing credentials, fix them before continuing:
+
+```properties
+# ~/.gradle/gradle.properties
+composeAiTools.githubUser=your-github-username
+composeAiTools.githubToken=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Or refresh the `gh` CLI token with the right scope:
+
+```sh
+gh auth refresh -h github.com -s read:packages
+```
+
+### 1. Register the plugin repository
+
+**Kotlin DSL — `settings.gradle.kts`:**
 
 ```kotlin
 pluginManagement {
@@ -127,18 +176,39 @@ pluginManagement {
 }
 ```
 
-Credentials live in `~/.gradle/gradle.properties` (a GitHub PAT with
-`read:packages` is enough):
+**Groovy DSL — `settings.gradle`** (used by many Android sample projects
+including the AOSP `wear-os-samples`):
 
-```properties
-composeAiTools.githubUser=your-github-username
-composeAiTools.githubToken=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```groovy
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+        maven {
+            name = 'composeAiTools'
+            url = uri('https://maven.pkg.github.com/yschimke/compose-ai-tools')
+            credentials {
+                username = providers.gradleProperty('composeAiTools.githubUser').orNull ?: System.getenv('GITHUB_ACTOR')
+                password = providers.gradleProperty('composeAiTools.githubToken').orNull ?: System.getenv('GITHUB_TOKEN')
+            }
+        }
+    }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == 'ee.schimke.composeai.preview') {
+                useModule("ee.schimke.composeai:gradle-plugin:${requested.version}")
+            }
+        }
+    }
+}
 ```
 
 ### 2. Apply the plugin
 
+**Kotlin DSL — `<module>/build.gradle.kts`:**
+
 ```kotlin
-// <module>/build.gradle.kts
 plugins {
     id("ee.schimke.composeai.preview") version "0.3.1"
 }
@@ -147,6 +217,20 @@ composePreview {
     variant.set("debug")   // Android build variant (default: "debug")
     sdkVersion.set(35)     // Robolectric SDK version (default: 35)
     enabled.set(true)      // set false to skip task registration
+}
+```
+
+**Groovy DSL — `<module>/build.gradle`:**
+
+```groovy
+plugins {
+    id 'ee.schimke.composeai.preview' version '0.3.1'
+}
+
+composePreview {
+    variant = 'debug'
+    sdkVersion = 35
+    enabled = true
 }
 ```
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# Bootstrap installer for the compose-preview CLI.
+#
+# Downloads a pinned (or latest) release tarball from GitHub, verifies the
+# sha256 against the GitHub release API, installs into a versioned directory
+# under ~/.local/opt/compose-preview, and symlinks ~/.local/bin/compose-preview
+# to the new launcher. Idempotent: rerunning with the same version is a no-op.
+#
+# Usage:
+#   scripts/install.sh               # install latest release
+#   scripts/install.sh 0.3.1         # install a specific version
+#   VERSION=0.3.1 scripts/install.sh # same, via env
+#
+# Override locations:
+#   PREFIX=$HOME/.local scripts/install.sh
+#   REPO=yschimke/compose-ai-tools scripts/install.sh
+#
+# Requires: bash, curl, tar, sha256sum (or shasum), and Java 21 on PATH at
+# run time (not install time).
+
+set -euo pipefail
+
+REPO="${REPO:-yschimke/compose-ai-tools}"
+PREFIX="${PREFIX:-$HOME/.local}"
+VERSION="${1:-${VERSION:-}}"
+
+BIN_DIR="$PREFIX/bin"
+OPT_DIR="$PREFIX/opt/compose-preview"
+
+die() { echo "error: $*" >&2; exit 1; }
+log() { echo "==> $*"; }
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required tool: $1"
+}
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    die "neither sha256sum nor shasum available"
+  fi
+}
+
+require curl
+require tar
+
+# ---- Resolve version ------------------------------------------------------
+
+if [[ -z "$VERSION" ]]; then
+  log "resolving latest release of $REPO"
+  VERSION="$(
+    curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" |
+      sed -n 's/.*"tag_name":[[:space:]]*"v\{0,1\}\([^"]*\)".*/\1/p' |
+      head -n1
+  )"
+  [[ -n "$VERSION" ]] || die "could not resolve latest version from GitHub API"
+fi
+
+ASSET="compose-preview-${VERSION}.tar.gz"
+DEST="$OPT_DIR/$VERSION"
+LAUNCHER="$DEST/compose-preview-${VERSION}/bin/compose-preview"
+
+# ---- Idempotent short-circuit --------------------------------------------
+
+if [[ -x "$LAUNCHER" && "$(readlink "$BIN_DIR/compose-preview" 2>/dev/null || true)" == "$LAUNCHER" ]]; then
+  log "compose-preview $VERSION already installed and linked"
+  "$LAUNCHER" --help >/dev/null 2>&1 || die "installed launcher is broken: $LAUNCHER"
+  exit 0
+fi
+
+# ---- Fetch release metadata ----------------------------------------------
+
+log "fetching release metadata for v$VERSION"
+META="$(curl -fsSL \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$REPO/releases/tags/v$VERSION")" \
+  || die "release v$VERSION not found on $REPO"
+
+ASSET_URL="$(printf '%s' "$META" |
+  sed -n 's/.*"browser_download_url":[[:space:]]*"\([^"]*'"$ASSET"'\)".*/\1/p' |
+  head -n1)"
+ASSET_DIGEST="$(printf '%s' "$META" |
+  awk -v asset="$ASSET" '
+    /"name":/ { in_asset = ($0 ~ asset) }
+    in_asset && /"digest":/ {
+      sub(/.*"digest":[[:space:]]*"sha256:/, "")
+      sub(/".*/, "")
+      print
+      exit
+    }
+  ')"
+
+[[ -n "$ASSET_URL" ]] || die "asset $ASSET not found in release v$VERSION"
+
+# ---- Download + verify ----------------------------------------------------
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+log "downloading $ASSET_URL"
+curl -fL --progress-bar -o "$TMP/$ASSET" "$ASSET_URL"
+
+if [[ -n "${ASSET_DIGEST:-}" ]]; then
+  got="$(sha256_of "$TMP/$ASSET")"
+  [[ "$got" == "$ASSET_DIGEST" ]] \
+    || die "sha256 mismatch: expected $ASSET_DIGEST, got $got"
+  log "verified sha256 $got"
+else
+  log "warning: no sha256 digest advertised in release metadata; skipping verification"
+fi
+
+# ---- Install --------------------------------------------------------------
+
+log "installing to $DEST"
+mkdir -p "$DEST"
+tar -xzf "$TMP/$ASSET" -C "$DEST"
+
+[[ -x "$LAUNCHER" ]] || die "launcher not found after extract: $LAUNCHER"
+
+mkdir -p "$BIN_DIR"
+ln -sf "$LAUNCHER" "$BIN_DIR/compose-preview"
+log "symlinked $BIN_DIR/compose-preview -> $LAUNCHER"
+
+# ---- Smoke test -----------------------------------------------------------
+
+if ! "$LAUNCHER" --help >/dev/null 2>&1; then
+  die "launcher failed smoke test (needs Java 21 on PATH or JAVA_HOME)"
+fi
+
+# ---- PATH advice ----------------------------------------------------------
+
+case ":$PATH:" in
+  *":$BIN_DIR:"*) ;;
+  *)
+    cat >&2 <<EOF
+
+note: $BIN_DIR is not on your PATH.
+
+  bash/zsh:  echo 'export PATH="$BIN_DIR:\$PATH"' >> ~/.bashrc  # or ~/.zshrc
+  fish:      fish_add_path $BIN_DIR
+
+EOF
+    ;;
+esac
+
+log "installed compose-preview $VERSION"
+log "next: run 'compose-preview doctor' in your project to verify Gradle + GitHub Packages access"


### PR DESCRIPTION
## Summary

- **`scripts/install.sh`** — idempotent bootstrap that resolves latest (or pinned) release, verifies sha256 against the GitHub release API, installs to `~/.local/opt/compose-preview/<version>/`, symlinks `~/.local/bin/compose-preview`, and prints shell-specific `PATH` advice (bash/zsh/fish).
- **`compose-preview doctor`** — new CLI subcommand that checks Java 21, reads `~/.gradle/gradle.properties` (falling back to `GITHUB_ACTOR`/`GITHUB_TOKEN`), and HEADs the plugin POM on `maven.pkg.github.com`. 200/404 confirm auth; 401/403 surface `x-oauth-scopes` and point at `gh auth refresh -s read:packages`.
- **`docs/SKILL.md`** — reordered. New **Step 0** runs install + doctor *before* any Gradle edits, so the common `HTTP 401` (from a `gh` CLI token lacking `read:packages`) is caught up front. Steps 1 and 2 now include both Kotlin DSL and Groovy DSL variants.
- **`docs/PACKAGING_SKILL.md`** — guide for publishing this repo as a Claude Code skill (three options: copy-into-`~/.claude/skills/`, plugin marketplace, bundled-CLI), plus the concrete release-pipeline changes to keep the skill shape in sync.

## Motivation

Bootstrapping this skill on a fresh machine currently requires three manual steps before anything builds: improvise a CLI install path, paste Kotlin DSL into `settings.gradle` (which might be Groovy), and discover the `read:packages` scope requirement only after Gradle fails with a cryptic 401 half-way through resolution. After this PR, the install is one command and the failure is caught by `doctor` before any files are edited.

## Test plan

- [x] `./gradlew :cli:check` passes
- [x] `bash -n scripts/install.sh` parses clean
- [x] `compose-preview doctor` end-to-end on a machine with no creds — correctly fails with actionable hint
- [ ] Manual: run `scripts/install.sh` in a clean VM and confirm `compose-preview --help` works
- [ ] Manual: `compose-preview doctor` on a machine with a valid PAT — confirm HEAD probe hits 200
- [ ] Manual: `compose-preview doctor` with a `gh` CLI token lacking `read:packages` — confirm 401 path surfaces scopes and hint