### PR TITLE
fix(cli): keep .tar.gz extension without leaking it into dist root

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -15,12 +15,14 @@ application {
     mainClass.set("ee.schimke.composeai.cli.MainKt")
 }
 
-tasks.named<Zip>("distZip") {
-    archiveFileName.set("compose-preview-${project.version}.zip")
-}
-
+// Note: don't set `archiveFileName` directly — Gradle's distribution plugin
+// uses it to derive the root directory inside the archive, so a full filename
+// like `compose-preview-<version>.tar.gz` leaks the `.tar.gz` suffix into the
+// extracted folder name. Setting `archiveExtension` instead lets Gradle compute
+// the file name as `<archivesName>-<version>.<extension>` while keeping the
+// internal root as `<archivesName>-<version>/`.
 tasks.named<Tar>("distTar") {
-    archiveFileName.set("compose-preview-${project.version}.tar.gz")
+    archiveExtension.set("tar.gz")
     compression = Compression.GZIP
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,13 +62,23 @@ fi
 
 ASSET="compose-preview-${VERSION}.tar.gz"
 DEST="$OPT_DIR/$VERSION"
-LAUNCHER="$DEST/compose-preview-${VERSION}/bin/compose-preview"
+
+# Locate the extracted launcher by search rather than by hardcoded path —
+# some release tarballs have a top-level dir named literally
+# `compose-preview-<version>.tar.gz/` instead of `compose-preview-<version>/`.
+find_launcher() {
+  [[ -d "$1" ]] || return 1
+  find "$1" -type f -name compose-preview -path '*/bin/compose-preview' \
+    -print -quit 2>/dev/null
+}
 
 # ---- Idempotent short-circuit --------------------------------------------
 
-if [[ -x "$LAUNCHER" && "$(readlink "$BIN_DIR/compose-preview" 2>/dev/null || true)" == "$LAUNCHER" ]]; then
+EXISTING_LAUNCHER="$(find_launcher "$DEST" || true)"
+if [[ -n "$EXISTING_LAUNCHER" && -x "$EXISTING_LAUNCHER" \
+      && "$(readlink "$BIN_DIR/compose-preview" 2>/dev/null || true)" == "$EXISTING_LAUNCHER" ]]; then
   log "compose-preview $VERSION already installed and linked"
-  "$LAUNCHER" --help >/dev/null 2>&1 || die "installed launcher is broken: $LAUNCHER"
+  "$EXISTING_LAUNCHER" --help >/dev/null 2>&1 || die "installed launcher is broken: $EXISTING_LAUNCHER"
   exit 0
 fi
 
@@ -119,7 +129,9 @@ log "installing to $DEST"
 mkdir -p "$DEST"
 tar -xzf "$TMP/$ASSET" -C "$DEST"
 
-[[ -x "$LAUNCHER" ]] || die "launcher not found after extract: $LAUNCHER"
+LAUNCHER="$(find_launcher "$DEST" || true)"
+[[ -n "$LAUNCHER" && -x "$LAUNCHER" ]] \
+  || die "launcher not found after extract under $DEST (looked for */bin/compose-preview)"
 
 mkdir -p "$BIN_DIR"
 ln -sf "$LAUNCHER" "$BIN_DIR/compose-preview"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,23 +62,13 @@ fi
 
 ASSET="compose-preview-${VERSION}.tar.gz"
 DEST="$OPT_DIR/$VERSION"
-
-# Locate the extracted launcher by search rather than by hardcoded path —
-# some release tarballs have a top-level dir named literally
-# `compose-preview-<version>.tar.gz/` instead of `compose-preview-<version>/`.
-find_launcher() {
-  [[ -d "$1" ]] || return 1
-  find "$1" -type f -name compose-preview -path '*/bin/compose-preview' \
-    -print -quit 2>/dev/null
-}
+LAUNCHER="$DEST/compose-preview-${VERSION}/bin/compose-preview"
 
 # ---- Idempotent short-circuit --------------------------------------------
 
-EXISTING_LAUNCHER="$(find_launcher "$DEST" || true)"
-if [[ -n "$EXISTING_LAUNCHER" && -x "$EXISTING_LAUNCHER" \
-      && "$(readlink "$BIN_DIR/compose-preview" 2>/dev/null || true)" == "$EXISTING_LAUNCHER" ]]; then
+if [[ -x "$LAUNCHER" && "$(readlink "$BIN_DIR/compose-preview" 2>/dev/null || true)" == "$LAUNCHER" ]]; then
   log "compose-preview $VERSION already installed and linked"
-  "$EXISTING_LAUNCHER" --help >/dev/null 2>&1 || die "installed launcher is broken: $EXISTING_LAUNCHER"
+  "$LAUNCHER" --help >/dev/null 2>&1 || die "installed launcher is broken: $LAUNCHER"
   exit 0
 fi
 
@@ -129,9 +119,7 @@ log "installing to $DEST"
 mkdir -p "$DEST"
 tar -xzf "$TMP/$ASSET" -C "$DEST"
 
-LAUNCHER="$(find_launcher "$DEST" || true)"
-[[ -n "$LAUNCHER" && -x "$LAUNCHER" ]] \
-  || die "launcher not found after extract under $DEST (looked for */bin/compose-preview)"
+[[ -x "$LAUNCHER" ]] || die "launcher not found after extract: $LAUNCHER"
 
 mkdir -p "$BIN_DIR"
 ln -sf "$LAUNCHER" "$BIN_DIR/compose-preview"


### PR DESCRIPTION
## Summary
Root cause of the install.sh failure reported for v0.3.2: `distTar` set `archiveFileName` to the full filename `compose-preview-<version>.tar.gz`, and Gradle's distribution plugin uses `archiveFileName` to derive the root directory name inside the archive. Result: the extracted root was literally `compose-preview-0.3.2.tar.gz/` instead of `compose-preview-0.3.2/`.

Fix: set `archiveExtension = "tar.gz"` instead. Gradle then computes the filename as `<archivesName>-<version>.tar.gz` while keeping the internal root as `<archivesName>-<version>/`. The `distZip` override was only there to match the naming convention and is no longer needed — Gradle's default already produces `compose-preview-<version>.zip`.

Supersedes the install.sh find-based workaround from the first commit on this branch (which is reverted in the second commit).

## Verification
Built locally with `PLUGIN_VERSION=0.3.2 ./gradlew :cli:distTar :cli:distZip`:
- Before: tarball root is `compose-preview-0.3.2.tar.gz/`
- After: tarball root is `compose-preview-0.3.2/`, zip root is `compose-preview-0.3.2/`, filenames unchanged

## Test plan
- [ ] Cut a test tag, verify release tarball extracts to `compose-preview-<version>/`
- [ ] `bash scripts/install.sh <version>` succeeds end-to-end
- [ ] Second run no-ops via the idempotent short-circuit

🤖 Generated with [Claude Code](https://claude.com/claude-code)