### PR TITLE
ci: publish plugin and renderer-android to Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,19 @@ jobs:
             :gradle-plugin:publishAllPublicationsToGitHubPackagesRepository \
             :renderer-android:publishAllPublicationsToGitHubPackagesRepository \
             --no-daemon
+      - name: Publish plugin and renderer-android to Maven Central
+        env:
+          PLUGIN_VERSION: ${{ needs.version.outputs.version }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        run: |
+          ./gradlew \
+            :gradle-plugin:publishAndReleaseToMavenCentral \
+            :renderer-android:publishAndReleaseToMavenCentral \
+            --no-daemon --no-configuration-cache
 
   build-cli:
     needs: version

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,54 @@
+name: Publish snapshot
+
+# Publish a -SNAPSHOT build to the Maven Central snapshots repo
+# (https://central.sonatype.com/repository/maven-snapshots/) on every push to
+# main. The vanniktech plugin routes `-SNAPSHOT` versions to that URL
+# automatically; snapshots are unsigned.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: snapshot-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need tags to compute the next snapshot version.
+          fetch-depth: 0
+      - id: version
+        name: Compute snapshot version from last tag
+        # Take the latest `v*` tag, strip leading `v`, bump the patch digit,
+        # append `-SNAPSHOT`. Falls back to 0.0.1-SNAPSHOT if no tag exists yet.
+        run: |
+          last_tag="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo v0.0.0)"
+          base="${last_tag#v}"
+          major="${base%%.*}"
+          rest="${base#*.}"
+          minor="${rest%%.*}"
+          patch="${rest#*.}"
+          patch="${patch%%-*}"                    # drop any pre-release suffix
+          next="${major}.${minor}.$((patch + 1))-SNAPSHOT"
+          echo "Last tag: $last_tag → snapshot version: $next"
+          echo "version=$next" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Publish -SNAPSHOT to Maven Central snapshots
+        env:
+          PLUGIN_VERSION: ${{ steps.version.outputs.version }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        run: |
+          ./gradlew \
+            :gradle-plugin:publishToMavenCentral \
+            :renderer-android:publishToMavenCentral \
+            --no-daemon --no-configuration-cache

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -4,7 +4,8 @@ plugins {
     application
 }
 
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.1.0-SNAPSHOT"
+// See gradle-plugin/build.gradle.kts for how CI sets PLUGIN_VERSION.
+version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.3.3-SNAPSHOT"
 
 base {
     archivesName.set("compose-preview")

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -3,10 +3,14 @@ plugins {
     `kotlin-dsl`
     `maven-publish`
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.1.0-SNAPSHOT"
+// CI sets PLUGIN_VERSION: release.yml passes the git tag (stripped of `v`);
+// snapshot.yml passes `<last-tag-patch+1>-SNAPSHOT`. The string below is only
+// used for local `publishToMavenLocal`; bump it when the release version drifts.
+version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.3.3-SNAPSHOT"
 
 gradlePlugin {
     website.set("https://github.com/yschimke/compose-ai-tools")
@@ -22,9 +26,9 @@ gradlePlugin {
     }
 }
 
-// Publish to GitHub Packages by default.
-// To switch to Gradle Plugin Portal later: apply the `com.gradle.plugin-publish`
-// plugin and remove the publishing block below — it wraps this config automatically.
+// Publish to both GitHub Packages (legacy / CI convenience) and Maven Central
+// via the new Central Portal. Snapshots (version ending in `-SNAPSHOT`) route
+// automatically to `https://central.sonatype.com/repository/maven-snapshots/`.
 publishing {
     repositories {
         maven {
@@ -38,6 +42,54 @@ publishing {
                 username = providers.environmentVariable("GITHUB_ACTOR").orNull
                 password = providers.environmentVariable("GITHUB_TOKEN").orNull
             }
+        }
+    }
+}
+
+mavenPublishing {
+    // Central Portal (https://central.sonatype.com) is the only target in
+    // vanniktech ≥ 0.34. `automaticRelease = true` promotes to the central
+    // repo without a manual "release" click in the Portal UI. Snapshots route
+    // to https://central.sonatype.com/repository/maven-snapshots/ automatically.
+    publishToMavenCentral(automaticRelease = true)
+    // Vanniktech auto-detects `java-gradle-plugin` and publishes the plugin +
+    // marker artifacts with sources/javadoc jars. (If we ever apply the
+    // `com.gradle.plugin-publish` plugin for Plugin Portal, swap in
+    // `configure(GradlePublishPlugin())`.)
+    // Only require signing for non-snapshot builds — snapshots are unsigned on
+    // the Central snapshots repo, which is convenient for local/dev publishes.
+    if (!version.toString().endsWith("SNAPSHOT")) {
+        signAllPublications()
+    }
+
+    coordinates("ee.schimke.composeai", "compose-preview-plugin", version.toString())
+
+    pom {
+        name.set("Compose Preview Gradle Plugin")
+        description.set(
+            "Gradle plugin to discover and render Jetpack Compose / Compose Multiplatform " +
+                "@Preview functions to PNG outside Android Studio.",
+        )
+        url.set("https://github.com/yschimke/compose-ai-tools")
+        inceptionYear.set("2025")
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("repo")
+            }
+        }
+        developers {
+            developer {
+                id.set("yschimke")
+                name.set("Yuri Schimke")
+                url.set("https://github.com/yschimke")
+            }
+        }
+        scm {
+            url.set("https://github.com/yschimke/compose-ai-tools")
+            connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+            developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
         }
     }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GenerateRenderShardsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GenerateRenderShardsTask.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.plugin
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
@@ -18,6 +19,7 @@ import org.gradle.api.tasks.TaskAction
  * generated-source path. `javac --release 21` is enough since the base class is a plain
  * JVM class from the plugin's perspective.
  */
+@CacheableTask
 abstract class GenerateRenderShardsTask : DefaultTask() {
     @get:Input
     abstract val shards: Property<Int>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.11.0"
 junit = "4.13.2"
 truth = "1.4.4"
+maven-publish = "0.36.0"
 
 [libraries]
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
@@ -54,3 +55,4 @@ kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref 
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -1,12 +1,19 @@
+@file:Suppress("DEPRECATION") // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
+// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
+
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.serialization)
     `maven-publish`
+    alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.1.0-SNAPSHOT"
+// See gradle-plugin/build.gradle.kts for how CI sets PLUGIN_VERSION.
+version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.3.3-SNAPSHOT"
 
 android {
     namespace = "ee.schimke.composeai.renderer"
@@ -26,10 +33,8 @@ android {
             isIncludeAndroidResources = true
         }
     }
-
-    publishing {
-        singleVariant("release")
-    }
+    // `AndroidSingleVariantLibrary` in `mavenPublishing {}` below wires the
+    // `singleVariant("release")` publication for us — don't declare it twice.
 }
 
 dependencies {
@@ -57,6 +62,9 @@ dependencies {
     compileOnly(libs.wear.protolayout.expression)
 }
 
+// GitHub Packages repo kept alongside Maven Central for internal/CI convenience.
+// Vanniktech's `AndroidSingleVariantLibrary` creates the release publication
+// (with sources + javadoc jar) — do not create one manually; it clashes.
 publishing {
     repositories {
         maven {
@@ -74,13 +82,41 @@ publishing {
     }
 }
 
-afterEvaluate {
-    publishing {
-        publications {
-            create<MavenPublication>("release") {
-                from(components["release"])
-                artifactId = "renderer-android"
+mavenPublishing {
+    publishToMavenCentral(automaticRelease = true)
+    configure(AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true))
+    if (!version.toString().endsWith("SNAPSHOT")) {
+        signAllPublications()
+    }
+
+    coordinates("ee.schimke.composeai", "renderer-android", version.toString())
+
+    pom {
+        name.set("Compose Preview — Android Renderer")
+        description.set(
+            "Robolectric-based renderer for Jetpack Compose @Preview functions, " +
+                "used by the compose-preview Gradle plugin to produce PNGs off-device.",
+        )
+        url.set("https://github.com/yschimke/compose-ai-tools")
+        inceptionYear.set("2025")
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("repo")
             }
+        }
+        developers {
+            developer {
+                id.set("yschimke")
+                name.set("Yuri Schimke")
+                url.set("https://github.com/yschimke")
+            }
+        }
+        scm {
+            url.set("https://github.com/yschimke/compose-ai-tools")
+            connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+            developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
         }
     }
 }


### PR DESCRIPTION
## Summary

- Configures Maven Central publishing via the vanniktech maven-publish plugin for `gradle-plugin` and `renderer-android`, alongside the existing GitHub Packages repo.
- Adds `.github/workflows/snapshot.yml`: on every push to `main`, derives the next version (`<last-tag patch+1>-SNAPSHOT`) from `git describe` and publishes to the Central snapshots repo.
- Adds a "Publish to Maven Central" step to `release.yml` that runs `publishAndReleaseToMavenCentral` on a `v*` tag (signed; auto-releases without a manual Portal click).
- Plugin artifact id renamed `gradle-plugin` → `compose-preview-plugin`. Plugin DSL consumers (`plugins { id("ee.schimke.composeai.preview") }`) are unaffected — they resolve via the marker POM.
- Drive-by: fixes a pre-existing `validatePlugins` failure by annotating `GenerateRenderShardsTask` with `@CacheableTask` so `./gradlew check` passes again.

## Required GitHub secrets

| Secret | Source |
|---|---|
| `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` | User token from https://central.sonatype.com/account |
| `SIGNING_KEY` | `gpg --armor --export-secret-keys <FPR>` (full ASCII-armored block) |
| `SIGNING_KEY_ID` | Short 8-hex ID from `gpg --list-secret-keys --keyid-format=short` |
| `SIGNING_KEY_PASSWORD` | GPG passphrase |

Also requires claiming the `ee.schimke` namespace on Central Portal (DNS TXT verification).

## Test plan

- [x] `./gradlew :gradle-plugin:publishToMavenLocal :renderer-android:publishToMavenLocal` produces valid POMs with all Central-required metadata (name, description, url, licenses, developers, scm) plus sources + javadoc jars.
- [x] `./gradlew :gradle-plugin:check` passes (previously failed on `validatePlugins`).
- [x] Plugin marker POM (`ee.schimke.composeai.preview:ee.schimke.composeai.preview.gradle.plugin`) correctly redirects to the renamed main artifact.
- [ ] Dry-run snapshot publish against Central Portal once namespace is verified.
- [ ] Tag `v0.3.3` and confirm full release flow (GH Packages + Central + CLI/VSIX assets) succeeds end-to-end.