### PR TITLE
ci: add security audits and pin actions to SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Dependabot keeps SHA-pinned GitHub Actions up to date.
+# Without it, pinning actions to commits means you never get security/bug
+# updates — Dependabot bumps the SHA AND the trailing `# vX.Y.Z` comment
+# so reviewers can see what version the pin represents.
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      # Bundle routine patch/minor bumps into a single PR to reduce noise.
+      actions-minor:
+        update-types: [minor, patch]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,17 @@ jobs:
     name: Plugin Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
       - name: Run unit tests
         run: ./gradlew :gradle-plugin:test --no-daemon
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: unit-test-results
           path: gradle-plugin/build/reports/tests/
@@ -34,17 +34,17 @@ jobs:
     name: Plugin Functional Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
       - name: Run functional tests
         run: ./gradlew :gradle-plugin:functionalTest --no-daemon
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: functional-test-results
           path: gradle-plugin/build/reports/tests/
@@ -53,18 +53,18 @@ jobs:
     name: Build Samples
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
       - name: Build CMP sample and discover previews
         run: ./gradlew :sample-cmp:discoverPreviews --no-daemon
       - name: Build Android sample and discover previews
         run: ./gradlew :sample-android:discoverPreviews --no-daemon
       - name: Upload preview manifests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: preview-manifests
           path: |
@@ -75,11 +75,11 @@ jobs:
     name: Build CLI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
       - name: Build CLI
         run: ./gradlew :cli:build --no-daemon

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,27 @@
+name: dependency-review
+
+# On every PR, diffs the dependency graph and fails if the change introduces
+# a dependency with a known CVE at `fail-on-severity` or higher. This is a
+# defense against drive-by supply-chain attacks where a PR bumps a transitive
+# dep to a compromised version.
+#
+# Requires GitHub's Dependency Graph to be enabled (on by default for public
+# repos).
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          # Comment a summary on the PR. Requires `pull-requests: write` —
+          # add it to `permissions:` above and uncomment if you want the comment.
+          # comment-summary-in-pr: always

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,31 @@
+name: gitleaks
+
+# Scans every PR and every push for accidentally-committed secrets (API keys,
+# private keys, tokens, signing material, etc). Findings fail the job so a
+# leaked secret cannot land on main without an explicit override.
+#
+# Particularly important for this repo because the release/snapshot workflows
+# handle GPG signing keys and Maven Central tokens — a stray paste into a
+# commit message or source file would be exactly the kind of incident this
+# catches before merge.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # Full history so gitleaks can scan every commit on a PR, not just HEAD.
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,14 +35,14 @@ jobs:
     name: Build plugin + CLI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: 21
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
 
       - name: Publish plugin to mavenLocal
         run: ./gradlew :gradle-plugin:publishToMavenLocal --no-daemon --stacktrace
@@ -62,7 +62,7 @@ jobs:
           cp .github/ci/patch-consumer.py bundle/ci/
           tar -czf compose-ai-bundle.tar.gz -C bundle .
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: compose-ai-bundle
           path: compose-ai-bundle.tar.gz
@@ -143,20 +143,20 @@ jobs:
           # Android source sets cleanly.
     steps:
       - name: Checkout ${{ matrix.repo }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: ${{ matrix.repo }}
           ref: ${{ matrix.ref }}
           path: external
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: 21
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: compose-ai-bundle
           path: .
@@ -236,7 +236,7 @@ jobs:
 
       - name: Upload previews.json
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: previews-${{ matrix.slug }}
           path: external/**/build/compose-previews/previews.json

--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -17,10 +17,10 @@ jobs:
     name: Update preview_main
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
       - uses: ./.github/actions/preview-baselines

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -19,12 +19,12 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
       - uses: ./.github/actions/preview-comment
 
   cleanup:
@@ -34,5 +34,5 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/preview-cleanup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,12 @@ jobs:
     needs: [version, build-cli, build-vscode-extension]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
       - name: Publish plugin and renderer-android to GitHub Packages
         env:
           PLUGIN_VERSION: ${{ needs.version.outputs.version }}
@@ -62,17 +62,17 @@ jobs:
     needs: version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
       - name: Build CLI distribution
         env:
           PLUGIN_VERSION: ${{ needs.version.outputs.version }}
         run: ./gradlew :cli:distZip :cli:distTar --no-daemon
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: cli-dist
           path: |
@@ -84,8 +84,8 @@ jobs:
     needs: version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: npm
@@ -99,7 +99,7 @@ jobs:
       - name: Build VSIX
         working-directory: vscode-extension
         run: npm run package
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vscode-extension
           path: vscode-extension/*.vsix
@@ -109,8 +109,8 @@ jobs:
     needs: [version, publish-gradle-plugin]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: zizmor
+
+# Static analysis for GitHub Actions workflows. Catches common-but-dangerous
+# patterns: expression injection via PR titles / branch names, over-permissive
+# `pull_request_target` usage, unpinned third-party actions, missing or
+# excessive `permissions:` blocks, self-hosted-runner misconfiguration, etc.
+#
+# Findings stream into the Security tab via SARIF upload (code scanning),
+# so they show up on PRs as annotated comments and on the dashboard.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Required so the action can upload SARIF to code scanning.
+  security-events: write
+  # Required by zizmor to fetch metadata about referenced actions.
+  actions: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
## Summary

Adds four CI-side security defenses:

1. **`gitleaks`** (`.github/workflows/gitleaks.yml`) — scans every PR and push for committed secrets. Runs on all pushes; full-history scan (`fetch-depth: 0`) so it catches secrets in any commit on a PR, not just the tip.

2. **`zizmor`** (`.github/workflows/zizmor.yml`) — static analysis for GitHub Actions workflows. Catches expression injection via PR titles / branch names, over-permissive `GITHUB_TOKEN` scopes, unsafe `pull_request_target` usage, and unpinned actions. Uploads SARIF to the Security tab.

3. **`dependency-review`** (`.github/workflows/dependency-review.yml`) — on every PR, fails if the change introduces a dep with a known CVE at HIGH severity or above. Closes the drive-by supply-chain PR vector.

4. **SHA-pin every third-party action** in the existing workflows (`ci.yml`, `integration.yml`, `preview-baselines.yml`, `preview-comment.yml`, `release.yml`). Tags are mutable: a compromised maintainer retagging `v4` would run their code on the next workflow run with access to whatever secrets the job can read. Commits are immutable.

   Also added `.github/dependabot.yml` so the pins don't go stale — Dependabot bumps the SHA and updates the trailing `# vX.Y.Z` comment weekly.

Each new workflow declares a minimal `permissions:` block, so the `GITHUB_TOKEN` it receives has only the scopes it needs.

## Note

This PR is based on `main`, so the Maven Central workflows added in #20 (`release.yml` Central step + `snapshot.yml`) aren't pinned here. After #20 merges, pinning those is a quick rebase/cherry-pick or a follow-up PR — Dependabot will do it automatically on its next run regardless.

## Test plan

- [x] All workflow YAML parses with a strict loader.
- [ ] First PR run: gitleaks, zizmor, dependency-review all report green on the current tree (no existing secrets, no unsafe patterns, no vulnerable deps).
- [ ] Confirm SARIF uploads land in the Security tab.
- [ ] Confirm Dependabot opens its first weekly PR within 7 days (verifies config parses).