### PR TITLE
ci: fix snapshot publish failing on main (isolated-projects)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,9 @@ jobs:
           ./gradlew \
             :gradle-plugin:publishAndReleaseToMavenCentral \
             :renderer-android:publishAndReleaseToMavenCentral \
-            --no-daemon --no-configuration-cache
+            --no-daemon
+          # `--no-configuration-cache` is rejected when
+          # `org.gradle.unsafe.isolated-projects=true` (see gradle.properties).
 
   build-cli:
     needs: version

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -18,10 +18,11 @@ jobs:
   publish-snapshot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # Need tags to compute the next snapshot version.
           fetch-depth: 0
+          persist-credentials: false
       - id: version
         name: Compute snapshot version from last tag
         # Take the latest `v*` tag, strip leading `v`, bump the patch digit,
@@ -37,11 +38,11 @@ jobs:
           next="${major}.${minor}.$((patch + 1))-SNAPSHOT"
           echo "Last tag: $last_tag → snapshot version: $next"
           echo "version=$next" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
       - name: Publish -SNAPSHOT to Maven Central snapshots
         env:
           PLUGIN_VERSION: ${{ steps.version.outputs.version }}
@@ -51,4 +52,9 @@ jobs:
           ./gradlew \
             :gradle-plugin:publishToMavenCentral \
             :renderer-android:publishToMavenCentral \
-            --no-daemon --no-configuration-cache
+            --no-daemon
+          # Note: `--no-configuration-cache` is incompatible with
+          # `org.gradle.unsafe.isolated-projects=true` set in gradle.properties
+          # (Gradle fails with "Configuration Cache cannot be disabled when
+          # Isolated Projects is enabled"). Vanniktech's publish tasks work
+          # with config-cache, so just let it run normally.


### PR DESCRIPTION
## Summary

Main has been red since #20 merged: the new \`Publish snapshot\` workflow fails with \`Configuration Cache cannot be disabled when Isolated Projects is enabled\`. I had added \`--no-configuration-cache\` to the snapshot + release Maven Central steps defensively, but it conflicts with \`org.gradle.unsafe.isolated-projects=true\` in gradle.properties.

Vanniktech's publish tasks work fine with the config cache on (verified locally with \`publishToMavenLocal\`), so the flag just comes out.

Also pins the three unpinned \`@v4\` action references in \`snapshot.yml\` (lines 21, 40, 44 per zizmor's \`unpinned-uses\` rule) and sets \`persist-credentials: false\` on its checkout.

## Scope

Fixes only the pipeline breakage and the unpinned-action findings specific to \`snapshot.yml\`. The broader zizmor findings on main are tracked separately:

- \`artipacked\` × 17 (other checkouts missing \`persist-credentials: false\`)
- \`excessive-permissions\` × 13 (workflows/jobs without explicit \`permissions:\`)
- \`template-injection\` × 15 (in preview composite actions and release.yml)
- \`cache-poisoning\` × 3 (release.yml gradle cache writes)
- \`dependabot-cooldown\` × 1 (minor)
- Pre-existing \`Preview Baselines\` failure (Python TypeError in composite action — unrelated to anything I've touched)

## Test plan

- [x] \`./gradlew :gradle-plugin:publishToMavenLocal :renderer-android:publishToMavenLocal --no-daemon\` succeeds and stores a config cache entry (verified locally).
- [ ] \`Publish snapshot\` goes green on merge to main.