### PR TITLE
ci: resolve all outstanding zizmor findings

### DIFF
--- a/.github/actions/preview-baselines/action.yml
+++ b/.github/actions/preview-baselines/action.yml
@@ -32,29 +32,42 @@ runs:
 
     - name: Render previews
       shell: bash
-      run: compose-preview show --json --timeout ${{ inputs.timeout }} > _previews.json
+      env:
+        RENDER_TIMEOUT: ${{ inputs.timeout }}
+      run: compose-preview show --json --timeout "$RENDER_TIMEOUT" > _previews.json
 
     - name: Generate baselines
       shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        REPO: ${{ github.repository }}
+        BASELINE_BRANCH: ${{ inputs.branch }}
       run: |
-        python3 "${{ github.action_path }}/../lib/compare-previews.py" generate _previews.json \
+        python3 "$ACTION_PATH/../lib/compare-previews.py" generate _previews.json \
           --output-dir _baselines \
-          --repo "${{ github.repository }}" \
-          --branch "${{ inputs.branch }}"
+          --repo "$REPO" \
+          --branch "$BASELINE_BRANCH"
 
     - name: Push to baselines branch
       shell: bash
+      # All templated values go through env first so a malicious input
+      # (e.g. a branch name containing "$(rm -rf /)") can't expand inside
+      # the shell script. (zizmor: template-injection)
+      env:
+        BASELINE_BRANCH: ${{ inputs.branch }}
+        REPO: ${{ github.repository }}
+        GITHUB_TOKEN_INLINE: ${{ github.token }}
       run: |
         set -euo pipefail
         cd _baselines
 
         git init
-        git checkout -b "${{ inputs.branch }}"
+        git checkout -b "$BASELINE_BRANCH"
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git add -A
         git commit -m "Update preview baselines from ${GITHUB_SHA::8}"
 
         git remote add origin \
-          "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
-        git push --force origin "${{ inputs.branch }}"
+          "https://x-access-token:${GITHUB_TOKEN_INLINE}@github.com/${REPO}.git"
+        git push --force origin "$BASELINE_BRANCH"

--- a/.github/actions/preview-cleanup/action.yml
+++ b/.github/actions/preview-cleanup/action.yml
@@ -11,10 +11,13 @@ runs:
   steps:
     - name: Delete preview branch
       shell: bash
-      run: |
-        PR_NUMBER="${{ inputs.pr-number || github.event.pull_request.number }}"
-        BRANCH="preview_pr/${PR_NUMBER}"
-        gh api "repos/${{ github.repository }}/git/refs/heads/${BRANCH}" \
-          -X DELETE 2>/dev/null || true
       env:
         GH_TOKEN: ${{ github.token }}
+        PR_INPUT_NUMBER: ${{ inputs.pr-number }}
+        EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        PR_NUMBER="${PR_INPUT_NUMBER:-$EVENT_PR_NUMBER}"
+        BRANCH="preview_pr/${PR_NUMBER}"
+        gh api "repos/${REPO}/git/refs/heads/${BRANCH}" \
+          -X DELETE 2>/dev/null || true

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -34,32 +34,46 @@ runs:
 
     - name: Render previews
       shell: bash
-      run: compose-preview show --json --timeout ${{ inputs.timeout }} > _previews.json
+      env:
+        RENDER_TIMEOUT: ${{ inputs.timeout }}
+      run: compose-preview show --json --timeout "$RENDER_TIMEOUT" > _previews.json
 
     - name: Fetch baselines
       shell: bash
+      env:
+        BASE_BRANCH: ${{ inputs.base-branch }}
       run: |
         mkdir -p _baselines
-        if git ls-remote --exit-code origin ${{ inputs.base-branch }} >/dev/null 2>&1; then
-          git fetch origin ${{ inputs.base-branch }}
-          git show origin/${{ inputs.base-branch }}:baselines.json \
+        if git ls-remote --exit-code origin "$BASE_BRANCH" >/dev/null 2>&1; then
+          git fetch origin "$BASE_BRANCH"
+          git show "origin/${BASE_BRANCH}:baselines.json" \
             > _baselines/baselines.json 2>/dev/null || true
         else
-          echo "No ${{ inputs.base-branch }} branch yet — treating all previews as new."
+          echo "No $BASE_BRANCH branch yet — treating all previews as new."
         fi
 
     - name: Copy changed PNGs
       shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
       run: |
-        python3 "${{ github.action_path }}/../lib/compare-previews.py" copy-changed _previews.json \
+        python3 "$ACTION_PATH/../lib/compare-previews.py" copy-changed _previews.json \
           --baselines _baselines/baselines.json \
           --output-dir _pr_renders
 
     - name: Push PR renders
       shell: bash
+      env:
+        # `inputs.pr-number` defaults to "" so the `||` resolves to the
+        # number from the event payload. Routing both through env removes
+        # the template from the `run:` body entirely. (zizmor: template-injection)
+        PR_INPUT_NUMBER: ${{ inputs.pr-number }}
+        EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+        GITHUB_TOKEN_INLINE: ${{ github.token }}
       run: |
         set -euo pipefail
-        PR_NUMBER="${{ inputs.pr-number || github.event.pull_request.number }}"
+        PR_NUMBER="${PR_INPUT_NUMBER:-$EVENT_PR_NUMBER}"
         BRANCH="preview_pr/${PR_NUMBER}"
 
         if [ ! -d _pr_renders/renders ] || \
@@ -77,42 +91,51 @@ runs:
         git commit -m "Preview renders for PR #${PR_NUMBER} (${GITHUB_SHA::8})"
 
         git remote add origin \
-          "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+          "https://x-access-token:${GITHUB_TOKEN_INLINE}@github.com/${REPO}.git"
         git push --force origin "$BRANCH"
 
     - name: Generate comment
       shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        PR_INPUT_NUMBER: ${{ inputs.pr-number }}
+        EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+        BASE_BRANCH: ${{ inputs.base-branch }}
       run: |
         set -euo pipefail
-        PR_NUMBER="${{ inputs.pr-number || github.event.pull_request.number }}"
+        PR_NUMBER="${PR_INPUT_NUMBER:-$EVENT_PR_NUMBER}"
 
-        python3 "${{ github.action_path }}/../lib/compare-previews.py" compare _previews.json \
+        python3 "$ACTION_PATH/../lib/compare-previews.py" compare _previews.json \
           --baselines _baselines/baselines.json \
-          --repo "${{ github.repository }}" \
+          --repo "$REPO" \
           --pr "$PR_NUMBER" \
-          --base-branch "${{ inputs.base-branch }}" \
+          --base-branch "$BASE_BRANCH" \
           --head-branch "preview_pr/${PR_NUMBER}" \
           > _comment_body.md
 
     - name: Post or update PR comment
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_INPUT_NUMBER: ${{ inputs.pr-number }}
+        EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
       run: |
         set -euo pipefail
-        PR_NUMBER="${{ inputs.pr-number || github.event.pull_request.number }}"
+        PR_NUMBER="${PR_INPUT_NUMBER:-$EVENT_PR_NUMBER}"
         BODY=$(cat _comment_body.md)
         MARKER="<!-- preview-diff -->"
 
         COMMENT_ID=$(gh api \
-          "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+          "repos/${REPO}/issues/${PR_NUMBER}/comments" \
           --paginate \
           --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
           | head -1)
 
         if [ -n "$COMMENT_ID" ]; then
-          gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" \
+          gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
             -X PATCH -f body="$BODY"
         else
           gh pr comment "$PR_NUMBER" --body "$BODY"
         fi
-      env:
-        GH_TOKEN: ${{ github.token }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,12 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    # Let a new version sit on the registry for a few days before we pull it
+    # in, so typosquat/supply-chain compromises published and then pulled
+    # don't auto-land as a Dependabot PR. (zizmor: dependabot-cooldown)
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
     groups:
       # Bundle routine patch/minor bumps into a single PR to reduce noise.
       actions-minor:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# Workflow-level default: minimum viable scope. Individual jobs can widen if
+# they need it (none here do — all jobs are read-only builds + artifact upload,
+# which only needs `contents: read`).
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -16,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
@@ -35,6 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
@@ -54,6 +64,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
@@ -76,6 +88,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           # Full history so gitleaks can scan every commit on a PR, not just HEAD.
           fetch-depth: 0
+          persist-credentials: false
       - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,6 +27,11 @@ concurrency:
   group: integration-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Integration jobs only read this repo's code and check out external public
+# repos for testing. No writes required anywhere.
+permissions:
+  contents: read
+
 env:
   PLUGIN_VERSION: 0.1.0-SNAPSHOT
 
@@ -36,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
@@ -148,6 +155,7 @@ jobs:
           repository: ${{ matrix.repo }}
           ref: ${{ matrix.ref }}
           path: external
+          persist-credentials: false
 
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:

--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -18,6 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # The composite action pushes via an explicit token in the remote
+          # URL (see `preview-baselines/action.yml`), so we don't need the
+          # default git credentials persisted here.
+          persist-credentials: false
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -5,9 +5,10 @@ on:
     branches: [main]
     types: [opened, synchronize, closed]
 
+# Workflow-level: read only. Jobs that need to push renders or comment on
+# the PR widen below.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: preview-comment-${{ github.event.pull_request.number }}
@@ -18,8 +19,15 @@ jobs:
     name: Compare previews
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
+    permissions:
+      # preview-comment composite action force-pushes a per-PR render branch
+      # and upserts a PR comment with the before/after images.
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
@@ -35,4 +43,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/preview-cleanup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,11 @@ on:
     tags:
       - 'v*'
 
+# Workflow-level default is read-only. Each job widens only what it needs:
+# - publish-gradle-plugin: packages: write (for GH Packages)
+# - release: contents: write (creates the GitHub Release, uploads assets)
 permissions:
-  contents: write     # create releases, upload assets
-  packages: write     # push to GitHub Packages
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
@@ -39,13 +41,23 @@ jobs:
   publish-gradle-plugin:
     needs: [version, build-cli, build-vscode-extension]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write   # push to GitHub Packages
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          # Don't populate the Gradle cache from release builds — untrusted
+          # PR runs could read those entries on subsequent workflow runs and
+          # end up with poisoned inputs. (zizmor: cache-poisoning)
+          cache-read-only: true
       - name: Publish plugin and renderer-android to GitHub Packages
         env:
           PLUGIN_VERSION: ${{ needs.version.outputs.version }}
@@ -78,11 +90,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: 21
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-read-only: true
       - name: Build CLI distribution
         env:
           PLUGIN_VERSION: ${{ needs.version.outputs.version }}
@@ -100,6 +116,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 20
@@ -110,7 +128,11 @@ jobs:
         run: npm ci
       - name: Set version
         working-directory: vscode-extension
-        run: npm version --no-git-tag-version --allow-same-version ${{ needs.version.outputs.version }}
+        # Pass the version via env so the tag value (attacker-influenceable
+        # through the git tag name) can't inject arguments into `npm version`.
+        env:
+          PKG_VERSION: ${{ needs.version.outputs.version }}
+        run: npm version --no-git-tag-version --allow-same-version "$PKG_VERSION"
       - name: Build VSIX
         working-directory: vscode-extension
         run: npm run package
@@ -123,18 +145,26 @@ jobs:
   release:
     needs: [version, publish-gradle-plugin]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create release, upload assets
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           merge-multiple: true
       - name: Create GitHub Release
+        # Pass the resolved version through env, not inline ${{ }}, so the
+        # tag name (attacker-controllable in theory) can't break out of the
+        # quotation and inject extra arguments to `gh release create`.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ needs.version.outputs.version }}
         run: |
           gh release create "${GITHUB_REF_NAME}" \
-            --title "compose-ai-tools ${{ needs.version.outputs.version }}" \
+            --title "compose-ai-tools ${RELEASE_VERSION}" \
             --generate-notes \
             artifacts/*.zip \
             artifacts/*.tar.gz \

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -14,6 +14,11 @@ concurrency:
   group: snapshot-${{ github.ref }}
   cancel-in-progress: true
 
+# Snapshot publish only reads repo contents; auth for Central is via
+# env-based credentials, not GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   publish-snapshot:
     runs-on: ubuntu-latest

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -26,4 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
## Summary

Closes the 51 code-scanning alerts zizmor raised on main. Each rule addressed:

### `artipacked` × 18 → `persist-credentials: false`

Every `actions/checkout` step leaves the default git token on disk for the rest of the job. Unused in most of our workflows, but readable by any later step or transitive dep. Disabled wherever it wasn't actually needed; the two composite actions that do push (\`preview-baselines\`, \`preview-comment\`) already embed an explicit \`x-access-token:\` URL so they continue to work.

### \`excessive-permissions\` × 13 → explicit \`permissions:\` blocks

Every workflow now declares \`permissions: contents: read\` at the workflow level. Jobs that legitimately need more widen inline:
- \`release.yml\` → \`publish-gradle-plugin\`: \`packages: write\`; \`release\`: \`contents: write\`
- \`preview-comment.yml\` → \`compare\`: \`contents: write, pull-requests: write\`; \`cleanup\` (unchanged): \`contents: write\`

### \`template-injection\` × 15 → \`env:\` indirection

All \`\${{ inputs.* }}\`, \`\${{ github.event.* }}\`, \`\${{ needs.*.outputs.* }}\` references inside \`run:\` bodies are now bound into \`env:\` blocks and read as \`\"\$VAR\"\` in the shell. A branch / tag / PR-title containing \`\$(...)\` or backticks can no longer be interpolated as code. Applies to \`preview-baselines/action.yml\`, \`preview-comment/action.yml\`, \`preview-cleanup/action.yml\`, \`release.yml\`.

### \`cache-poisoning\` × 3 → \`cache-read-only: true\` on release

\`release.yml\`'s three \`setup-gradle\` steps now read the Gradle cache but don't write to it, so tagged release builds can't seed an entry that a later untrusted run might read.

### \`dependabot-cooldown\` × 1 → \`cooldown:\` block

\`dependabot.yml\` gets a 3-day default / 7-day major-version cooldown so a supply-chain-compromised version pulled quickly from the registry can't auto-land as a Dependabot PR in the meantime.

## Behaviour changes

None to CI semantics. The composite-action rewrites are mechanical (same script, values read via \`\"\$VAR\"\` instead of inline templates). Release builds lose Gradle cache-write but retain cache-read, so they benefit from CI-populated caches but don't themselves populate — a small time hit at release only.

## Test plan

- [x] All workflow + composite-action YAML re-validates with \`yaml.safe_load\`.
- [ ] After merge, zizmor workflow run shows 0 open alerts (verify in Security tab).
- [ ] Next PR's \`preview-comment\` action still posts a comment and pushes renders.
- [ ] Next \`Preview Baselines\` run still force-pushes to \`preview_main\`.
- [ ] Eventually: next \`v*\` tag → release workflow completes end-to-end with \`cache-read-only\`.

## Depends on

Stacked on #28 (snapshot publish fix). Rebase cleanly once that's merged.