### PR TITLE
docs: update for 0.3.3 and Maven Central publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,95 +91,53 @@ Configuration caching is strict (`problems=fail`).
 
 ## Setup
 
-The plugin is published to [GitHub Packages](https://github.com/yschimke/compose-ai-tools/packages). GitHub
-requires authentication for reading Maven artifacts even from public repos,
-so you need a Personal Access Token.
+The plugin is published to [Maven Central](https://central.sonatype.com/artifact/ee.schimke.composeai/compose-preview-plugin).
+No authentication, no PAT — just apply it.
 
-### 1. Create a GitHub PAT
-
-You need a Personal Access Token to read Maven artifacts from GitHub Packages
-(authentication is required even for public repos). You only need the
-**`read:packages`** scope — nothing else.
-
-**Classic token (simplest):**
-
-1. Go to <https://github.com/settings/tokens/new>.
-2. Name: e.g. `compose-ai-tools`. Expiration: whatever you prefer.
-3. Tick only **`read:packages`**.
-4. Click **Generate token** and copy the value (starts with `ghp_`).
-
-**Fine-grained token:** at
-<https://github.com/settings/personal-access-tokens/new> grant **Account
-permissions → Packages: Read-only**. Repository access can stay at "Public
-repositories (read-only)".
-
-**Or reuse your `gh` CLI token** if you're already signed in:
-
-```sh
-gh auth token   # prints a token with read:packages by default
-```
-
-### 2. Store credentials (not in the repo)
-
-Add to `~/.gradle/gradle.properties` so they apply to every build on your machine:
-
-```properties
-composeAiTools.githubUser=your-github-username
-composeAiTools.githubToken=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-```
-
-On CI, pass them via environment variables `GITHUB_ACTOR` / `GITHUB_TOKEN`
-(both are pre-populated in GitHub Actions — no config needed).
-
-### 3. Register the plugin repository
-
-In `settings.gradle.kts`:
+### 1. Apply the plugin
 
 ```kotlin
+// <module>/build.gradle.kts
+plugins {
+    id("ee.schimke.composeai.preview") version "0.3.3"
+}
+```
+
+Most projects already have `mavenCentral()` in their
+`pluginManagement.repositories` (AGP and the Kotlin Gradle Plugin are both
+on Central). If yours doesn't, add it:
+
+```kotlin
+// settings.gradle.kts
 pluginManagement {
     repositories {
         gradlePluginPortal()
         google()
         mavenCentral()
-        maven {
-            name = "composeAiTools"
-            url = uri("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-            credentials {
-                username = providers.gradleProperty("composeAiTools.githubUser").orNull
-                    ?: System.getenv("GITHUB_ACTOR")
-                password = providers.gradleProperty("composeAiTools.githubToken").orNull
-                    ?: System.getenv("GITHUB_TOKEN")
-            }
-        }
     }
 }
 ```
 
-### 4. Apply the plugin
-
-```kotlin
-// <module>/build.gradle.kts
-plugins {
-    id("ee.schimke.composeai.preview") version "0.3.2"
-}
-```
-
-Check [Releases](https://github.com/yschimke/compose-ai-tools/releases) for the
-latest version. CMP Desktop projects also need
+CMP Desktop projects additionally need
 `implementation(compose.components.uiToolingPreview)` — the bundled
 `@Preview` annotation has `SOURCE` retention and is invisible to ClassGraph.
 
+Check [Releases](https://github.com/yschimke/compose-ai-tools/releases) for
+the latest version. Snapshots publish to the Central snapshots repo on
+every push to `main` — see [docs/RELEASING.md](docs/RELEASING.md) if you
+want to consume pre-release builds.
+
 ## Install the CLI
 
-Download `compose-preview-0.3.2.tar.gz` (or `.zip`) from the
-[v0.3.2 release](https://github.com/yschimke/compose-ai-tools/releases/tag/v0.3.2)
+Download `compose-preview-0.3.3.tar.gz` (or `.zip`) from the
+[v0.3.3 release](https://github.com/yschimke/compose-ai-tools/releases/tag/v0.3.3)
 and put the `bin/` directory on your `PATH`:
 
 ```sh
 curl -L -o compose-preview.tar.gz \
-  https://github.com/yschimke/compose-ai-tools/releases/download/v0.3.2/compose-preview-0.3.2.tar.gz
+  https://github.com/yschimke/compose-ai-tools/releases/download/v0.3.3/compose-preview-0.3.3.tar.gz
 tar -xzf compose-preview.tar.gz
-export PATH="$PWD/compose-preview-0.3.2/bin:$PATH"
+export PATH="$PWD/compose-preview-0.3.3/bin:$PATH"
 
 compose-preview --help
 ```
@@ -188,18 +146,18 @@ Requires Java 21 on `PATH` (or `JAVA_HOME`).
 
 ## Install the VS Code extension
 
-Download `compose-preview-0.3.2.vsix` from the
-[v0.3.2 release](https://github.com/yschimke/compose-ai-tools/releases/tag/v0.3.2)
+Download `compose-preview-0.3.3.vsix` from the
+[v0.3.3 release](https://github.com/yschimke/compose-ai-tools/releases/tag/v0.3.3)
 and install it:
 
 ```sh
-code --install-extension compose-preview-0.3.2.vsix
+code --install-extension compose-preview-0.3.3.vsix
 ```
 
 Or in VS Code: **Extensions → ⋯ → Install from VSIX…** and pick the file.
 
 The extension uses the Gradle plugin to render previews, so apply
-`ee.schimke.composeai.preview` version `0.3.2` in your project as shown above.
+`ee.schimke.composeai.preview` version `0.3.3` in your project as shown above.
 
 ## Usage
 

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 // See gradle-plugin/build.gradle.kts for how CI sets PLUGIN_VERSION.
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.3.3-SNAPSHOT"
+version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.3.4-SNAPSHOT"
 
 base {
     archivesName.set("compose-preview")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -205,7 +205,7 @@ class DoctorCommand(args: List<String>) {
     companion object {
         private const val REPO = "yschimke/compose-ai-tools"
         private const val MAVEN_BASE = "https://maven.pkg.github.com/$REPO"
-        private const val DEFAULT_PLUGIN_VERSION = "0.3.2"
+        private const val DEFAULT_PLUGIN_VERSION = "0.3.3"
     }
 }
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -69,7 +69,7 @@ The CLI ([cli/](cli/src/main/kotlin/ee/schimke/composeai/cli/)) and VS Code exte
 - **CMP Desktop previews require `implementation(compose.components.uiToolingPreview)`** — the bundled `@Preview` has `SOURCE` retention and is invisible to ClassGraph otherwise.
 - **Toolchain:** Java 21, Kotlin 2.2.21, Gradle 9.4.1+, AGP 9.1.0, CMP 1.10.3. Always use the bundled `./gradlew` wrapper.
 - **Do not run `collectPreviewInfo` / other internal plugin tasks by hand** — the plugin wires them as dependencies of `renderAllPreviews`.
-- **Plugin version** defaults to `0.1.0-SNAPSHOT` unless `PLUGIN_VERSION` env var is set (see [gradle-plugin/build.gradle.kts:9](gradle-plugin/build.gradle.kts#L9)).
+- **Plugin version** defaults to the next-patch `-SNAPSHOT` (e.g. `0.3.4-SNAPSHOT` when `v0.3.3` is the last tag) unless `PLUGIN_VERSION` env var is set (see [gradle-plugin/build.gradle.kts](gradle-plugin/build.gradle.kts)). Bump the fallback in the build files after each tag so local `publishToMavenLocal` yields a meaningful version.
 - **Android renderer is pinned to Robolectric SDK 34** via `@Config(sdk = [34])` in [RobolectricRenderTest.kt](renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt). Robolectric 4.16.1's `ShadowNativeImageReaderSurfaceImage.nativeCreatePlanes` is gated `maxSdk=UPSIDE_DOWN_CAKE`; on API 35+ the un-shadowed AOSP native yields `Image.planes[0] == null` and capture fails. Re-test and remove the pin when bumping Robolectric.
 
 ## Tests

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,7 +1,7 @@
 # Development
 
 Instructions for building the project from source and running it locally against
-the bundled samples, without going through GitHub Packages or the VS Code
+the bundled samples, without going through Maven Central or the VS Code
 Marketplace.
 
 There are three shipping artifacts, each with its own local install story:
@@ -67,9 +67,8 @@ can't reach the plugin sources (e.g. Docker build, other machine via rsync).
 ./gradlew :gradle-plugin:publishToMavenLocal
 ```
 
-Then in the consumer's `settings.gradle.kts`, swap the GitHub Packages block
-from the [README](../README.md#3-register-the-plugin-repository) for
-`mavenLocal()`:
+Then in the consumer's `settings.gradle.kts`, add `mavenLocal()` to the
+plugin repositories:
 
 ```kotlin
 pluginManagement {
@@ -79,19 +78,22 @@ pluginManagement {
         mavenCentral()
         mavenLocal()
     }
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id == "ee.schimke.composeai.preview") {
-                useModule("ee.schimke.composeai:gradle-plugin:${requested.version}")
-            }
-        }
-    }
+}
+```
+
+And apply the plugin with whatever version the local build produced:
+
+```kotlin
+plugins {
+    id("ee.schimke.composeai.preview") version "0.3.4-SNAPSHOT"
 }
 ```
 
 The version string must match the one in
-[gradle-plugin/build.gradle.kts](../gradle-plugin/build.gradle.kts#L9) — default
-is `0.1.0-SNAPSHOT` unless `PLUGIN_VERSION` is set.
+[gradle-plugin/build.gradle.kts](../gradle-plugin/build.gradle.kts) — the
+local fallback (used when `PLUGIN_VERSION` is not set) tracks the next
+upcoming release (e.g. after tagging `v0.3.3`, the fallback is
+`0.3.4-SNAPSHOT`).
 
 ### Smoke test
 
@@ -184,7 +186,7 @@ Closest to what a real user gets:
 
 ```
 npm run package
-code --install-extension compose-preview-0.1.0.vsix
+code --install-extension compose-preview-0.3.3.vsix
 ```
 
 The `package` script runs `vsce package --no-dependencies`, which requires

--- a/docs/PACKAGING_SKILL.md
+++ b/docs/PACKAGING_SKILL.md
@@ -3,8 +3,9 @@
 Notes for making the Compose Preview skill trivially installable from a fresh
 Claude Code environment. The goal: a single command that gives an agent both
 the skill instructions *and* a working CLI, without the agent having to
-improvise install paths, translate Kotlin→Groovy, or diagnose GitHub Packages
-401s on its own.
+improvise install paths or translate Kotlin→Groovy on its own. Now that the
+plugin is published to Maven Central, no credentials or PAT are needed —
+one less class of setup failure to diagnose.
 
 The recommendations below move the repo from "docs + binary, figure it out"
 to "an agent can run through Setup mechanically."
@@ -40,13 +41,14 @@ inside the source tree, but to actually *use* it an agent has to:
 
 1. Find it (not on a standard skill path).
 2. Download a release tarball and guess an install location.
-3. Write Gradle credentials to the right file.
-4. Translate Kotlin DSL snippets to Groovy for projects that use
+3. Translate Kotlin DSL snippets to Groovy for projects that use
    `settings.gradle`.
 
-With the install script and `compose-preview doctor` added in this change,
-steps 2 and 3 are now scripted. Step 4 is addressed with dual snippets in
-`SKILL.md`. Step 1 is what this doc is about.
+With the install script added in this change, step 2 is now scripted. Step
+3 is addressed with dual snippets in `SKILL.md`. Maven Central publishing
+eliminated a previous "write Gradle credentials" step entirely — apply
+the plugin by id/version and it resolves from the default `mavenCentral()`
+repo. Step 1 is what this doc is about.
 
 ## Option A — "copy this directory into `.claude/skills/`"
 
@@ -76,7 +78,7 @@ curl -fsSL https://codeload.github.com/yschimke/compose-ai-tools/tar.gz/refs/hea
 Or, pinned to a release:
 
 ```sh
-curl -fsSL https://github.com/yschimke/compose-ai-tools/releases/download/v0.3.2/compose-preview-skill.tar.gz \
+curl -fsSL https://github.com/yschimke/compose-ai-tools/releases/download/v0.3.3/compose-preview-skill.tar.gz \
   | tar -xz -C ~/.claude/skills/
 ```
 
@@ -145,9 +147,9 @@ can ship the CLI binaries directly:
 (an env var Claude Code sets when running skill helpers) — the agent never
 touches `~/.local/bin`, and there's no PATH setup.
 
-Trade-off: the skill tarball grows to match the CLI tarball size (~6.4 MB
-for 0.3.2). Still small in absolute terms, but it means every skill update
-re-ships the whole CLI. The upside is that `install.sh` becomes truly
+Trade-off: the skill tarball grows to match the CLI tarball size (roughly
+6–7 MB at current). Still small in absolute terms, but it means every
+skill update re-ships the whole CLI. The upside is that `install.sh` becomes truly
 optional; `compose-preview doctor` runs directly from the skill.
 
 ## Recommendation

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -11,18 +11,55 @@ git push origin v<version>
 
 The `release.yml` workflow then:
 
-1. Publishes the **Gradle plugin** to GitHub Packages (`maven.pkg.github.com/yschimke/compose-ai-tools`)
-2. Builds the **CLI** as `.zip` and `.tar.gz` distributions
-3. Packages the **VS Code extension** as a `.vsix` file
-4. Creates a GitHub Release with auto-generated notes and all three artifacts attached
+1. Publishes the **Gradle plugin** (`ee.schimke.composeai:compose-preview-plugin`)
+   and the **Android renderer AAR** (`ee.schimke.composeai:renderer-android`)
+   to **Maven Central** via the Central Portal, and mirrors them to GitHub
+   Packages.
+2. Builds the **CLI** as `.zip` and `.tar.gz` distributions.
+3. Packages the **VS Code extension** as a `.vsix` file.
+4. Creates a GitHub Release with auto-generated notes and all three artifacts attached.
 
-No secrets or accounts required beyond `GITHUB_TOKEN`, which is provided automatically.
+Required secrets on the repository:
+
+| Secret | Purpose |
+|---|---|
+| `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` | User token for https://central.sonatype.com |
+| `SIGNING_KEY` | ASCII-armored GPG private key (Maven Central requires signed artifacts) |
+| `SIGNING_KEY_ID` | Short (8-hex) key ID |
+| `SIGNING_KEY_PASSWORD` | Passphrase for the GPG key |
+
+`GITHUB_TOKEN` is provided automatically and is used for the GH Packages mirror.
+
+## Snapshots
+
+Every push to `main` triggers `snapshot.yml`, which computes the next
+patch-SNAPSHOT version from `git describe` (e.g. last tag `v0.3.3` →
+`0.3.4-SNAPSHOT`) and publishes to the Central snapshots repository:
+
+```
+https://central.sonatype.com/repository/maven-snapshots/
+```
+
+Snapshots are unsigned, so they only need `MAVEN_CENTRAL_USERNAME` /
+`MAVEN_CENTRAL_PASSWORD`.
 
 ## Consuming the artifacts
 
-### Gradle plugin (GitHub Packages)
+### Gradle plugin (Maven Central)
 
-Consumers need to authenticate to GitHub Packages. In their `settings.gradle.kts`:
+No authentication, no repository configuration, no PAT. If your project
+already includes `mavenCentral()` in `pluginManagement.repositories` (the
+typical Android/KMP setup does — AGP and the Kotlin Gradle Plugin both
+live there), just apply the plugin:
+
+```kotlin
+// <module>/build.gradle.kts
+plugins {
+    id("ee.schimke.composeai.preview") version "0.3.3"
+}
+```
+
+If `mavenCentral()` is missing from `settings.gradle.kts`, add it:
 
 ```kotlin
 pluginManagement {
@@ -30,36 +67,39 @@ pluginManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
-        maven {
-            url = uri("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-            credentials {
-                username = providers.gradleProperty("composeAiTools.githubUser").orNull
-                    ?: System.getenv("GITHUB_ACTOR")
-                password = providers.gradleProperty("composeAiTools.githubToken").orNull
-                    ?: System.getenv("GITHUB_TOKEN")
-            }
-        }
     }
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id == "ee.schimke.composeai.preview") {
-                useModule("ee.schimke.composeai:gradle-plugin:${requested.version}")
-            }
+}
+```
+
+**Consuming snapshots:** add the Central snapshots repo:
+
+```kotlin
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+        maven("https://central.sonatype.com/repository/maven-snapshots/") {
+            mavenContent { snapshotsOnly() }
         }
     }
 }
 ```
 
-Then in a consumer `build.gradle.kts`:
+Then reference a `-SNAPSHOT` version:
 
 ```kotlin
 plugins {
-    id("ee.schimke.composeai.preview") version "0.3.2"
+    id("ee.schimke.composeai.preview") version "0.3.4-SNAPSHOT"
 }
 ```
 
-The GitHub token needs `read:packages` scope. Create a PAT at
-<https://github.com/settings/tokens> or use `GITHUB_TOKEN` in CI.
+### Gradle plugin (GitHub Packages — fallback)
+
+The release workflow also publishes to GitHub Packages for users who
+prefer it. This path requires a PAT with `read:packages` scope; see git
+history for the repository+credentials setup if you need it. Maven
+Central is the supported default.
 
 ### CLI
 
@@ -67,9 +107,9 @@ Download from the [Releases page](https://github.com/yschimke/compose-ai-tools/r
 
 ```bash
 curl -L -o compose-preview.tar.gz \
-    https://github.com/yschimke/compose-ai-tools/releases/latest/download/compose-preview-0.3.2.tar.gz
+    https://github.com/yschimke/compose-ai-tools/releases/latest/download/compose-preview-0.3.3.tar.gz
 tar xzf compose-preview.tar.gz
-./compose-preview-0.3.2/bin/compose-preview list
+./compose-preview-0.3.3/bin/compose-preview list
 ```
 
 ### VS Code extension
@@ -77,17 +117,18 @@ tar xzf compose-preview.tar.gz
 Download the `.vsix` from the Releases page and install:
 
 ```bash
-code --install-extension compose-preview-0.3.2.vsix
+code --install-extension compose-preview-0.3.3.vsix
 ```
 
 ## Future: publishing to public registries
 
-The current workflow is GitHub-only. Each artifact can be added to its public
-registry without changing existing consumers:
+The Gradle plugin is now on Maven Central. The other artifacts could
+similarly move to their public registries without breaking existing
+consumers:
 
 | Artifact | Current | Public registry | Migration |
 |----------|---------|-----------------|-----------|
-| Gradle plugin | GitHub Packages | Gradle Plugin Portal | Apply `com.gradle.plugin-publish` plugin; add `publishPlugins` task to the workflow with `GRADLE_PUBLISH_KEY`/`GRADLE_PUBLISH_SECRET` secrets |
+| Gradle plugin | **Maven Central** (+ GH Packages mirror) | Gradle Plugin Portal | Apply `com.gradle.plugin-publish` plugin; add `publishPlugins` task to the workflow with `GRADLE_PUBLISH_KEY`/`GRADLE_PUBLISH_SECRET` secrets |
 | VS Code extension | Release .vsix | VS Code Marketplace + Open VSX | Add `vsce publish` and `ovsx publish` steps with `VSCE_PAT` / `OVSX_PAT` secrets |
 | CLI | Release .zip/.tar | Homebrew tap | Add a `release-please` or `dispatches` step that updates a separate `homebrew-tap` repo |
 
@@ -95,6 +136,8 @@ Existing GitHub Release artifacts remain as a fallback and don't need to go away
 
 ## Versioning
 
-`PLUGIN_VERSION` is set from the tag name (`v0.1.0` → `0.1.0`) by the workflow
-and threaded into all three build scripts via environment variable. Local builds
-default to `0.1.0-SNAPSHOT`.
+`PLUGIN_VERSION` is set from the tag name (`v0.3.3` → `0.3.3`) by the
+release workflow and threaded into all three build scripts via environment
+variable. The snapshot workflow computes its version from the last tag.
+Local builds default to a forward-looking `-SNAPSHOT` string (see the
+fallback in each module's `build.gradle.kts`).

--- a/docs/SKILL.md
+++ b/docs/SKILL.md
@@ -42,7 +42,7 @@ Commands:
   show     Discover + render previews; print id, path, sha256, changed flag
   list     List discovered previews
   render   Render previews; with --output copies a single match to disk
-  doctor   Verify Java 21 + GitHub Packages credentials (run before Setup)
+  doctor   Verify Java 21 and plugin-repo connectivity (run before Setup)
 
 Options:
   --module <name>      Target a single module (default: auto-detect)
@@ -99,16 +99,17 @@ extension provides:
 
 ## Setup
 
-Run the steps in order. Step 0 is a precheck — if it fails, **stop** and fix
-credentials before editing any Gradle files. The plugin is hosted on GitHub
-Packages, which requires authentication even for public repos, so a missing
-token produces an `HTTP 401` that is easy to misdiagnose once Gradle is in
-the mix.
+The plugin is published to Maven Central, so no credentials, PAT, or
+registry configuration is required. Most projects already have
+`mavenCentral()` in their plugin repositories (AGP and the Kotlin Gradle
+Plugin are both hosted there).
+
+Run the steps in order. Step 0 is a precheck — if it fails, **stop** and
+fix the environment before editing any Gradle files.
 
 ### 0. Install the CLI and run `doctor`
 
-Bootstrap the CLI, then verify Java 21 and GitHub Packages credentials are in
-place:
+Bootstrap the CLI, then verify the environment:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/scripts/install.sh | bash
@@ -122,30 +123,13 @@ The install script is idempotent, pulls the latest release into
 script prints the exact command to add it (`fish_add_path …` or a `PATH=`
 line for bash/zsh).
 
-`compose-preview doctor` verifies:
+`compose-preview doctor` verifies Java 21 is on `PATH` (the only hard
+prereq for the plugin now that Maven Central resolution needs no auth).
 
-1. Java 21 on `PATH`.
-2. `composeAiTools.githubToken` in `~/.gradle/gradle.properties`, or
-   `GITHUB_TOKEN` in the environment.
-3. The token actually resolves a package on `maven.pkg.github.com` (HEAD
-   probe). This catches the most common failure mode: a `gh` CLI token
-   reused as `GITHUB_TOKEN` that doesn't have the `read:packages` scope.
+### 1. Register the plugin repository (only if mavenCentral is missing)
 
-If doctor reports missing credentials, fix them before continuing:
-
-```properties
-# ~/.gradle/gradle.properties
-composeAiTools.githubUser=your-github-username
-composeAiTools.githubToken=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-```
-
-Or refresh the `gh` CLI token with the right scope:
-
-```sh
-gh auth refresh -h github.com -s read:packages
-```
-
-### 1. Register the plugin repository
+Most Android/KMP projects already include `mavenCentral()` in
+`pluginManagement.repositories`. If yours doesn't, add it.
 
 **Kotlin DSL — `settings.gradle.kts`:**
 
@@ -155,29 +139,11 @@ pluginManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
-        maven {
-            name = "composeAiTools"
-            url = uri("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-            credentials {
-                username = providers.gradleProperty("composeAiTools.githubUser").orNull
-                    ?: System.getenv("GITHUB_ACTOR")
-                password = providers.gradleProperty("composeAiTools.githubToken").orNull
-                    ?: System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id == "ee.schimke.composeai.preview") {
-                useModule("ee.schimke.composeai:gradle-plugin:${requested.version}")
-            }
-        }
     }
 }
 ```
 
-**Groovy DSL — `settings.gradle`** (used by many Android sample projects
-including the AOSP `wear-os-samples`):
+**Groovy DSL — `settings.gradle`:**
 
 ```groovy
 pluginManagement {
@@ -185,21 +151,6 @@ pluginManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
-        maven {
-            name = 'composeAiTools'
-            url = uri('https://maven.pkg.github.com/yschimke/compose-ai-tools')
-            credentials {
-                username = providers.gradleProperty('composeAiTools.githubUser').orNull ?: System.getenv('GITHUB_ACTOR')
-                password = providers.gradleProperty('composeAiTools.githubToken').orNull ?: System.getenv('GITHUB_TOKEN')
-            }
-        }
-    }
-    resolutionStrategy {
-        eachPlugin {
-            if (requested.id.id == 'ee.schimke.composeai.preview') {
-                useModule("ee.schimke.composeai:gradle-plugin:${requested.version}")
-            }
-        }
     }
 }
 ```
@@ -210,7 +161,7 @@ pluginManagement {
 
 ```kotlin
 plugins {
-    id("ee.schimke.composeai.preview") version "0.3.2"
+    id("ee.schimke.composeai.preview") version "0.3.3"
 }
 
 composePreview {
@@ -224,7 +175,7 @@ composePreview {
 
 ```groovy
 plugins {
-    id 'ee.schimke.composeai.preview' version '0.3.2'
+    id 'ee.schimke.composeai.preview' version '0.3.3'
 }
 
 composePreview {

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -9,8 +9,9 @@ plugins {
 group = "ee.schimke.composeai"
 // CI sets PLUGIN_VERSION: release.yml passes the git tag (stripped of `v`);
 // snapshot.yml passes `<last-tag-patch+1>-SNAPSHOT`. The string below is only
-// used for local `publishToMavenLocal`; bump it when the release version drifts.
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.3.3-SNAPSHOT"
+// used for local `publishToMavenLocal`; bump it after each tag so local
+// builds produce a version ahead of the last release.
+version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.3.4-SNAPSHOT"
 
 gradlePlugin {
     website.set("https://github.com/yschimke/compose-ai-tools")

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 group = "ee.schimke.composeai"
 // See gradle-plugin/build.gradle.kts for how CI sets PLUGIN_VERSION.
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.3.3-SNAPSHOT"
+version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.3.4-SNAPSHOT"
 
 android {
     namespace = "ee.schimke.composeai.renderer"


### PR DESCRIPTION
## Summary

All markdown now describes the simpler Maven Central flow — no PAT, no credential plumbing, no custom repo block. Applying the plugin is a one-line change for most projects.

- **README.md**, **docs/SKILL.md**: replace multi-step GH Packages setup with a minimal \`id(\"...\") version \"0.3.3\"\` block.
- **docs/RELEASING.md**: Maven Central as primary target; documents required secrets, snapshot repo URL, how to consume snapshots.
- **docs/DEVELOPMENT.md**: remove stale cross-reference to the old GH Packages block; simplify local-consumption example.
- **docs/PACKAGING_SKILL.md**, **docs/AGENTS.md**: minor wording / version refs.
- Version refs 0.3.2 → 0.3.3 across all markdown.
- \`cli/DoctorCommand.kt\`: bump \`DEFAULT_PLUGIN_VERSION\` constant.
- \`{gradle-plugin,renderer-android,cli}/build.gradle.kts\`: bump local fallback 0.3.3-SNAPSHOT → 0.3.4-SNAPSHOT.

## Test plan

- [x] \`./gradlew :gradle-plugin:check\` passes.
- [ ] On merge, tag \`v0.3.3\` → release workflow publishes to Maven Central + GH Packages + Release page.