### PR TITLE
ci: fix preview baselines crash on null pngPath

### DIFF
--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -53,7 +53,7 @@ def load_cli_output(cli_json_path: Path) -> dict[str, dict]:
             "sourceFile": entry.get("sourceFile", ""),
             "module": entry["module"],
             "previewId": entry["id"],
-            "pngPath": entry.get("pngPath", ""),
+            "pngPath": entry.get("pngPath") or "",
         }
     return result
 
@@ -92,6 +92,8 @@ def cmd_generate(args: argparse.Namespace) -> int:
     if renders_out.exists():
         shutil.rmtree(renders_out)
     for info in previews.values():
+        if not info["pngPath"]:
+            continue
         png = Path(info["pngPath"])
         if not png.exists():
             continue
@@ -296,6 +298,8 @@ def cmd_copy_changed(args: argparse.Namespace) -> int:
     copied = 0
     for key, info in current.items():
         if not info["sha256"]:
+            continue
+        if not info["pngPath"]:
             continue
         png = Path(info["pngPath"])
         if not png.exists():


### PR DESCRIPTION
## Summary
- `compose-preview show --json` emits `pngPath: null` for previews that didn't render, which made `Path(info["pngPath"])` raise `TypeError` in `.github/actions/lib/compare-previews.py:95` and failed the `Update preview_main` job ([run 24557710446](https://github.com/yschimke/compose-ai-tools/actions/runs/24557710446/job/71798264380)).
- `dict.get("pngPath", "")` only returns the default when the key is *absent*; when the key exists with value `null` it returns `None`.
- Normalize to `""` via `entry.get("pngPath") or ""` and skip empty paths in the two copy loops (`Path("")` would resolve to `Path(".")` and `shutil.copy2` on a directory would fail).

## Test plan
- [ ] Re-run the `Update preview_main` workflow on `main` and confirm it completes successfully.