### PR TITLE
Fallback to Consumer Test Classes in renderPreviews

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -226,10 +226,11 @@ internal object AndroidPreviewSupport {
         val renderTask = project.tasks.register("renderPreviews", Test::class.java) {
             group = "compose preview"
             description = "Render Android previews via Robolectric"
+            val agpTestTask = project.tasks.findByName("test${capVariant}UnitTest") as? Test
             testClassesDirs = if (compileShardsTask != null) {
-                rendererClassDirs + project.files(compileShardsTask.map { it.destinationDirectory })
+                rendererClassDirs + project.files(compileShardsTask.map { it.destinationDirectory }) + (agpTestTask?.testClassesDirs ?: project.files())
             } else {
-                rendererClassDirs
+                rendererClassDirs + (agpTestTask?.testClassesDirs ?: project.files())
             }
             classpath = if (compileShardsTask != null) {
                 resolvedClasspath + project.files(compileShardsTask.map { it.destinationDirectory })
@@ -248,7 +249,6 @@ internal object AndroidPreviewSupport {
             // lambda (rather than called at registration time) so AGP has had
             // a chance to register `test${capVariant}UnitTest` by the time this
             // runs — onVariants fires before unit-test tasks are wired.
-            val agpTestTask = project.tasks.findByName("test${capVariant}UnitTest") as? Test
             jvmArgs(agpTestTask?.jvmArgs ?: emptyList<String>())
             jvmArgs(
                 "--add-opens=java.base/java.lang=ALL-UNNAMED",


### PR DESCRIPTION
## Goal
The goal of this change is to ensure that the `renderPreviews` task can discover test classes defined in the consumer project (such as fallback classes or specific test runners) when running in external mode (consuming the plugin without `includeBuild`).

## Context / Why it's necessary for my use case
In our integration with [WearWidgetKotlin](https://github.com/ithinkihaveacat/wear-os-samples/tree/wear-widgets/WearWidgetKotlin), we encountered an issue where the `renderPreviews` task failed with `NO-SOURCE` because it could not find the `RobolectricRenderTest` class inside the resolved AAR via the artifact view. Investigation showed that the artifact view returned a JAR file rather than an extracted classes directory in our environment, and Gradle's `Test` task failed to discover tests within it.

We attempted to fix this within the plugin by using `zipTree` to extract the JAR content for `testClassesDirs`, but while this prevented the `NO-SOURCE` error, it failed to actually execute the tests.

To unblock screenshot generation, we created a [local RobolectricRenderTest](https://github.com/ithinkihaveacat/wear-os-samples/blob/wear-widgets/WearWidgetKotlin/app/src/test/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt) in the consumer project (under the same package expected by the plugin) to drive the rendering. However, because the plugin explicitly restricted `testClassesDirs` to only look at the resolved artifact from the AAR, it ignored our local test class.

By appending the consumer project's unit test classes directory to `testClassesDirs`, we allow the task to find and execute these local tests as a fallback when AAR resolution does not yield runnable tests.

## Why it is safe
This change is safe because it only *appends* the consumer's test classes directory to the existing `testClassesDirs`. It does not remove the functionality of searching the AAR. If the classes are found in the AAR (as intended by the maintainer), they will still be executed. This change merely provides a fallback or extension point for cases where the AAR resolution behaves differently or local customizations are needed.

## Why we aren't adding tests
We are not adding new tests for this change because it is a targeted fix for a specific integration issue in external consumer environments. The existing functional tests in the plugin cover the standard flow, and reproducing this specific resolution failure in a test environment would require setting up a full external consumption flow which is complex and likely overkill for this small fallback addition.
