### PR TITLE
ci: pass signing creds to GH Packages publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,11 +59,19 @@ jobs:
           # end up with poisoned inputs. (zizmor: cache-poisoning)
           cache-read-only: true
       - name: Publish plugin and renderer-android to GitHub Packages
+        # Signing credentials are required here too: vanniktech's
+        # `signAllPublications()` wires the `sign*` tasks as dependencies of
+        # every publish task — including `publishAllPublicationsToGitHubPackagesRepository`
+        # — so this step fails with "no configured signatory" without them.
+        # The resulting `.asc` sidecars on GH Packages are harmless.
         env:
           PLUGIN_VERSION: ${{ needs.version.outputs.version }}
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
         run: |
           ./gradlew \
             :gradle-plugin:publishAllPublicationsToGitHubPackagesRepository \


### PR DESCRIPTION
## Summary
- Fixes the `publish-gradle-plugin` job of `release.yml`, which failed on v0.3.3 ([run 24557724476](https://github.com/yschimke/compose-ai-tools/actions/runs/24557724476)) with `no configured signatory`.
- Root cause: #20's `signAllPublications()` wires `sign*` as a dependency of every publish task — including `publishAllPublicationsToGitHubPackagesRepository` — but the GH Packages step only had `GITHUB_TOKEN`, not signing env vars. v0.3.2 succeeded only because it predated that commit.
- Fix: pass the same `ORG_GRADLE_PROJECT_signingInMemoryKey*` env vars that the Maven Central step already has. The resulting `.asc` sidecars on GH Packages are harmless.

## Test plan
- [ ] Merge, then cut `v0.3.4` and verify both `publishAllPublicationsToGitHubPackagesRepository` and `publishAndReleaseToMavenCentral` succeed.
- [ ] Confirm plugin + renderer-android appear on Central (`https://repo1.maven.org/maven2/ee/schimke/composeai/`).