### PR TITLE
docs(claude): promote no-coauthor rule into CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,5 @@
 See [docs/AGENTS.md](docs/AGENTS.md) for project context, architecture, commands, constraints, and conventions.
+
+## Git conventions (must follow)
+
+- **No `Co-Authored-By` trailers** in commit messages or PR bodies. Commits are attributed solely to the committer — do not add a Claude/AI co-author line, even by default.


### PR DESCRIPTION
The rule already exists in `docs/AGENTS.md` but is one indirection away from what Claude sees first. Surfacing it in `CLAUDE.md` makes it harder to miss when composing commit messages and PR bodies.