### PR TITLE
Append consumer test classes to classpath in renderPreviews

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -233,9 +233,9 @@ internal object AndroidPreviewSupport {
                 rendererClassDirs + (agpTestTask?.testClassesDirs ?: project.files())
             }
             classpath = if (compileShardsTask != null) {
-                resolvedClasspath + project.files(compileShardsTask.map { it.destinationDirectory })
+                resolvedClasspath + project.files(compileShardsTask.map { it.destinationDirectory }) + (agpTestTask?.testClassesDirs ?: project.files())
             } else {
-                resolvedClasspath
+                resolvedClasspath + (agpTestTask?.testClassesDirs ?: project.files())
             }
             if (shardsEnabled) {
                 include("**/RobolectricRenderTest_Shard*.class")


### PR DESCRIPTION
## Goal
The goal of this change is to properly append the consumer project's test classes to the `classpath` in the `renderPreviews` task. This acts as a follow-up to [PR #33](https://github.com/yschimke/compose-ai-tools/pull/33), which added consumer classes to `testClassesDirs` but missed adding them to `classpath`.

## Context / Why it's necessary for my use case
In our integration with [WearWidgetKotlin](https://github.com/ithinkihaveacat/wear-os-samples/tree/wear-widgets/WearWidgetKotlin), PR #33 successfully allowed the `renderPreviews` task to discover the fallback test classes we placed in the consumer project. However, because those classes were not also added to the task's execution `classpath`, Gradle spawned the test worker but encountered a `ClassNotFoundException`, causing the execution to fail instantly.

By appending the same consumer test classes directory (`agpTestTask?.testClassesDirs`) to `classpath`, the fallback tests discovered via `testClassesDirs` can actually be loaded and executed by the JVM during the test run.

## Why it is safe
This change is safe because it merely aligns the `classpath` with the `testClassesDirs` changes introduced in PR #33. It only *appends* the consumer's test classes to the existing resolution, ensuring that if fallback classes are used and discovered, they are fully runnable.

## Why we aren't adding tests
We are not adding tests for the same reason stated in PR #33: it's a targeted fix for a specific integration issue in external consumer environments. Replicating the resolution failure that necessitates this fallback in a standard test environment would be complex and overkill for a small, complementary fix.