### PR TITLE
ci: align snapshot workflow to shared action versions

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -23,7 +23,7 @@ jobs:
   publish-snapshot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Need tags to compute the next snapshot version.
           fetch-depth: 0
@@ -47,7 +47,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       - name: Publish -SNAPSHOT to Maven Central snapshots
         env:
           PLUGIN_VERSION: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary
- `snapshot.yml` was pinned to `actions/checkout@v4.3.1` and `gradle/actions/setup-gradle@v4.4.4`; every other workflow uses `v6.0.2` and `v6.1.0`.
- SHA pins kept dependabot from flagging the drift (different hashes, no shared version string).
- Aligns this one file so future bumps only land in one place.

## Test plan
- [ ] `snapshot` workflow run on this PR / post-merge still publishes `-SNAPSHOT` successfully.
- [ ] No change in job output beyond action version.