### PR TITLE
ci: extract shared JDK+Gradle setup into composite action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,24 @@
+name: 'Setup JDK + Gradle'
+description: >
+  Install Temurin JDK 21 and configure gradle/actions/setup-gradle with the
+  action versions pinned consistently across this repo. Centralised so
+  dependabot only has to bump these in one place.
+
+inputs:
+  cache-read-only:
+    description: >
+      Pass 'true' in release/publish jobs to prevent Gradle cache writes —
+      avoids cache poisoning from untrusted PR runs reading those entries
+      on subsequent workflow invocations. (zizmor: cache-poisoning)
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      with:
+        distribution: temurin
+        java-version: 21
+    - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      with:
+        cache-read-only: ${{ inputs.cache-read-only }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      - uses: ./.github/actions/setup
       - name: Run unit tests
         run: ./gradlew :gradle-plugin:test --no-daemon
       - name: Upload test results
@@ -45,11 +41,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      - uses: ./.github/actions/setup
       - name: Run functional tests
         run: ./gradlew :gradle-plugin:functionalTest --no-daemon
       - name: Upload test results
@@ -66,11 +58,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      - uses: ./.github/actions/setup
       - name: Build CMP sample and discover previews
         run: ./gradlew :sample-cmp:discoverPreviews --no-daemon
       - name: Build Android sample and discover previews
@@ -90,10 +78,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      - uses: ./.github/actions/setup
       - name: Build CLI
         run: ./gradlew :cli:build --no-daemon

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,12 +44,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: 21
-
-      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      - uses: ./.github/actions/setup
 
       - name: Publish plugin to mavenLocal
         run: ./gradlew :gradle-plugin:publishToMavenLocal --no-daemon --stacktrace

--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -23,9 +23,5 @@ jobs:
           # URL (see `preview-baselines/action.yml`), so we don't need the
           # default git credentials persisted here.
           persist-credentials: false
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      - uses: ./.github/actions/setup
       - uses: ./.github/actions/preview-baselines

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -28,11 +28,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+      - uses: ./.github/actions/setup
       - uses: ./.github/actions/preview-comment
 
   cleanup:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,16 +48,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: ./.github/actions/setup
         with:
-          distribution: temurin
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-        with:
-          # Don't populate the Gradle cache from release builds — untrusted
-          # PR runs could read those entries on subsequent workflow runs and
-          # end up with poisoned inputs. (zizmor: cache-poisoning)
-          cache-read-only: true
+          cache-read-only: 'true'
       - name: Publish plugin and renderer-android to GitHub Packages
         # Signing credentials are required here too: vanniktech's
         # `signAllPublications()` wires the `sign*` tasks as dependencies of
@@ -100,13 +93,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - uses: ./.github/actions/setup
         with:
-          distribution: temurin
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-        with:
-          cache-read-only: true
+          cache-read-only: 'true'
       - name: Build CLI distribution
         env:
           PLUGIN_VERSION: ${{ needs.version.outputs.version }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -43,11 +43,7 @@ jobs:
           next="${major}.${minor}.$((patch + 1))-SNAPSHOT"
           echo "Last tag: $last_tag → snapshot version: $next"
           echo "version=$next" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: temurin
-          java-version: 21
-      - uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+      - uses: ./.github/actions/setup
       - name: Publish -SNAPSHOT to Maven Central snapshots
         env:
           PLUGIN_VERSION: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary
- New composite action at `.github/actions/setup` installs Temurin JDK 21 and configures `gradle/actions/setup-gradle`, with pinned SHAs in one place.
- Jobs in `ci.yml` (×4), `integration.yml` (build-plugin), `preview-baselines.yml`, `preview-comment.yml`, `release.yml` (publish-gradle-plugin, build-cli), and `snapshot.yml` replace their setup-java+setup-gradle pair with `uses: ./.github/actions/setup`.
- `cache-read-only: 'true'` stays exposed as an input so release/publish jobs keep their zizmor cache-poisoning hardening.

## Notes
- The integration matrix job stays inline — it only checks out the external repo, so `./.github/actions/setup` wouldn't resolve in its working directory.
- Does not update the checkout action in `snapshot.yml` — that's PR #39 (independent). This PR rebases cleanly after either merge order.

## Test plan
- [ ] `CI` workflow green on this PR (all four jobs still run tests/build and upload artifacts).
- [ ] `Integration` workflow green (build-plugin step publishes plugin + CLI bundle; matrix jobs still work).
- [ ] `zizmor` workflow passes (composite action inputs correctly routed, no new template injection sinks).
- [ ] Verify on a real release and a snapshot push post-merge that publish jobs still succeed with the composite.