### PR TITLE
ci: shrink release.yml + share install-cli + drop --no-daemon

### DIFF
--- a/.github/actions/install-cli/action.yml
+++ b/.github/actions/install-cli/action.yml
@@ -1,0 +1,23 @@
+name: 'Install compose-preview CLI'
+description: >
+  Download the latest tagged compose-preview release tarball and put its
+  `bin/` on $GITHUB_PATH. Shared by the preview-baselines and
+  preview-comment composite actions — identical logic previously lived in
+  both.
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install CLI
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        VERSION=$(gh release view --repo yschimke/compose-ai-tools --json tagName -q .tagName | sed 's/^v//')
+        echo "Downloading compose-preview ${VERSION}..."
+        gh release download "v${VERSION}" --repo yschimke/compose-ai-tools \
+          --pattern "compose-preview-${VERSION}.tar.gz" --dir /tmp
+        mkdir -p /opt/compose-preview
+        tar -xzf "/tmp/compose-preview-${VERSION}.tar.gz" -C /opt/compose-preview --strip-components=1
+        echo "/opt/compose-preview/bin" >> "$GITHUB_PATH"

--- a/.github/actions/preview-baselines/action.yml
+++ b/.github/actions/preview-baselines/action.yml
@@ -16,19 +16,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Install CLI
-      shell: bash
-      run: |
-        set -euo pipefail
-        VERSION=$(gh release view --repo yschimke/compose-ai-tools --json tagName -q .tagName | sed 's/^v//')
-        echo "Downloading compose-preview ${VERSION}..."
-        gh release download "v${VERSION}" --repo yschimke/compose-ai-tools \
-          --pattern "compose-preview-${VERSION}.tar.gz" --dir /tmp
-        mkdir -p /opt/compose-preview
-        tar -xzf "/tmp/compose-preview-${VERSION}.tar.gz" -C /opt/compose-preview --strip-components=1
-        echo "/opt/compose-preview/bin" >> "$GITHUB_PATH"
-      env:
-        GH_TOKEN: ${{ github.token }}
+    - uses: ./.github/actions/install-cli
 
     - name: Render previews
       shell: bash

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -18,19 +18,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Install CLI
-      shell: bash
-      run: |
-        set -euo pipefail
-        VERSION=$(gh release view --repo yschimke/compose-ai-tools --json tagName -q .tagName | sed 's/^v//')
-        echo "Downloading compose-preview ${VERSION}..."
-        gh release download "v${VERSION}" --repo yschimke/compose-ai-tools \
-          --pattern "compose-preview-${VERSION}.tar.gz" --dir /tmp
-        mkdir -p /opt/compose-preview
-        tar -xzf "/tmp/compose-preview-${VERSION}.tar.gz" -C /opt/compose-preview --strip-components=1
-        echo "/opt/compose-preview/bin" >> "$GITHUB_PATH"
-      env:
-        GH_TOKEN: ${{ github.token }}
+    - uses: ./.github/actions/install-cli
 
     - name: Render previews
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Run unit tests
-        run: ./gradlew :gradle-plugin:test --no-daemon
+        run: ./gradlew :gradle-plugin:test
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -43,7 +43,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Run functional tests
-        run: ./gradlew :gradle-plugin:functionalTest --no-daemon
+        run: ./gradlew :gradle-plugin:functionalTest
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -60,9 +60,9 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Build CMP sample and discover previews
-        run: ./gradlew :sample-cmp:discoverPreviews --no-daemon
+        run: ./gradlew :sample-cmp:discoverPreviews
       - name: Build Android sample and discover previews
-        run: ./gradlew :sample-android:discoverPreviews --no-daemon
+        run: ./gradlew :sample-android:discoverPreviews
       - name: Upload preview manifests
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -80,4 +80,4 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Build CLI
-        run: ./gradlew :cli:build --no-daemon
+        run: ./gradlew :cli:build

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,10 +47,10 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Publish plugin to mavenLocal
-        run: ./gradlew :gradle-plugin:publishToMavenLocal --no-daemon --stacktrace
+        run: ./gradlew :gradle-plugin:publishToMavenLocal --stacktrace
 
       - name: Install CLI
-        run: ./gradlew :cli:installDist --no-daemon --stacktrace
+        run: ./gradlew :cli:installDist --stacktrace
 
       - name: Bundle artifacts
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,15 +23,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  version:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.extract.outputs.version }}
-    steps:
-      - id: extract
-        # Strip leading `v` from tag, e.g. v0.1.0 → 0.1.0
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
   # Run gradle publish AFTER the other builds succeed so we don't orphan a
   # published Maven artifact if the VSIX or CLI build fails (GitHub Packages
   # refuses to overwrite an already-published release version — see #409).
@@ -39,67 +30,61 @@ jobs:
   # that apply the plugin via GitHub Packages also get the Robolectric-based
   # Android renderer AAR — the plugin resolves it via matching version.
   publish-gradle-plugin:
-    needs: [version, build-cli, build-vscode-extension]
+    needs: [build-cli, build-vscode-extension]
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write   # push to GitHub Packages
+    env:
+      # Signing creds are shared by both publish steps. vanniktech's
+      # `signAllPublications()` wires the `sign*` tasks as dependencies of
+      # every publish task — including the GH Packages publication — so
+      # "no configured signatory" errors out either publish without them.
+      ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
+      ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Derive plugin version from tag
+        # Strip leading `v` from tag, e.g. v0.1.0 → 0.1.0. $PLUGIN_VERSION is
+        # then inherited by every subsequent step in this job.
+        run: echo "PLUGIN_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
       - name: Publish plugin and renderer-android to GitHub Packages
-        # Signing credentials are required here too: vanniktech's
-        # `signAllPublications()` wires the `sign*` tasks as dependencies of
-        # every publish task — including `publishAllPublicationsToGitHubPackagesRepository`
-        # — so this step fails with "no configured signatory" without them.
-        # The resulting `.asc` sidecars on GH Packages are harmless.
         env:
-          PLUGIN_VERSION: ${{ needs.version.outputs.version }}
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
         run: |
           ./gradlew \
             :gradle-plugin:publishAllPublicationsToGitHubPackagesRepository \
-            :renderer-android:publishAllPublicationsToGitHubPackagesRepository \
-            --no-daemon
+            :renderer-android:publishAllPublicationsToGitHubPackagesRepository
       - name: Publish plugin and renderer-android to Maven Central
         env:
-          PLUGIN_VERSION: ${{ needs.version.outputs.version }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
         run: |
           ./gradlew \
             :gradle-plugin:publishAndReleaseToMavenCentral \
-            :renderer-android:publishAndReleaseToMavenCentral \
-            --no-daemon
-          # `--no-configuration-cache` is rejected when
-          # `org.gradle.unsafe.isolated-projects=true` (see gradle.properties).
+            :renderer-android:publishAndReleaseToMavenCentral
 
   build-cli:
-    needs: version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Derive plugin version from tag
+        run: echo "PLUGIN_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
       - name: Build CLI distribution
-        env:
-          PLUGIN_VERSION: ${{ needs.version.outputs.version }}
-        run: ./gradlew :cli:distZip :cli:distTar --no-daemon
+        run: ./gradlew :cli:distZip :cli:distTar
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cli-dist
@@ -109,7 +94,6 @@ jobs:
           retention-days: 1
 
   build-vscode-extension:
-    needs: version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -125,11 +109,10 @@ jobs:
         run: npm ci
       - name: Set version
         working-directory: vscode-extension
-        # Pass the version via env so the tag value (attacker-influenceable
-        # through the git tag name) can't inject arguments into `npm version`.
-        env:
-          PKG_VERSION: ${{ needs.version.outputs.version }}
-        run: npm version --no-git-tag-version --allow-same-version "$PKG_VERSION"
+        # Read tag from $GITHUB_REF_NAME (runner-set, not templated into the
+        # script) so the tag name — attacker-influenceable through git — can't
+        # inject arguments into `npm version`.
+        run: npm version --no-git-tag-version --allow-same-version "${GITHUB_REF_NAME#v}"
       - name: Build VSIX
         working-directory: vscode-extension
         run: npm run package
@@ -140,7 +123,7 @@ jobs:
           retention-days: 1
 
   release:
-    needs: [version, publish-gradle-plugin]
+    needs: publish-gradle-plugin
     runs-on: ubuntu-latest
     permissions:
       contents: write   # create release, upload assets
@@ -153,15 +136,13 @@ jobs:
           path: artifacts
           merge-multiple: true
       - name: Create GitHub Release
-        # Pass the resolved version through env, not inline ${{ }}, so the
-        # tag name (attacker-controllable in theory) can't break out of the
-        # quotation and inject extra arguments to `gh release create`.
+        # $GITHUB_REF_NAME is runner-set (not templated into the script), so
+        # the tag name can't break out of the quotation and inject extra args.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_VERSION: ${{ needs.version.outputs.version }}
         run: |
           gh release create "${GITHUB_REF_NAME}" \
-            --title "compose-ai-tools ${RELEASE_VERSION}" \
+            --title "compose-ai-tools ${GITHUB_REF_NAME#v}" \
             --generate-notes \
             artifacts/*.zip \
             artifacts/*.tar.gz \

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -52,8 +52,7 @@ jobs:
         run: |
           ./gradlew \
             :gradle-plugin:publishToMavenCentral \
-            :renderer-android:publishToMavenCentral \
-            --no-daemon
+            :renderer-android:publishToMavenCentral
           # Note: `--no-configuration-cache` is incompatible with
           # `org.gradle.unsafe.isolated-projects=true` set in gradle.properties
           # (Gradle fails with "Configuration Cache cannot be disabled when


### PR DESCRIPTION
## Summary
Four cleanups from the earlier workflow review, rolled into one PR. Each is small and reviewable on its own — kept together because they all touch the same release / preview paths.

### New composite: `.github/actions/install-cli`
- Extracts the identical ~12-line \"download latest compose-preview release tarball and put its bin/ on \$PATH\" block that lived in both [preview-baselines/action.yml](.github/actions/preview-baselines/action.yml) and [preview-comment/action.yml](.github/actions/preview-comment/action.yml).
- Both composites now do `uses: ./.github/actions/install-cli`.

### release.yml: kill the `version` job
- The `version` job existed only to do `echo \"version=\${GITHUB_REF_NAME#v}\"`. Spinning a whole runner for one substitution. Gone.
- Three Gradle-consuming jobs now add a one-line \"derive plugin version from tag\" step that writes `PLUGIN_VERSION` to `\$GITHUB_ENV`; subsequent steps pick it up automatically.
- `build-vscode-extension` and the final `release` job use `\${GITHUB_REF_NAME#v}` inline — `\$GITHUB_REF_NAME` is runner-set, not templated, so the existing zizmor template-injection hardening still applies.
- Removed `needs: version` from all four dependents.

### release.yml: lift shared signing creds to job-level env
- Both publish steps on `publish-gradle-plugin` were setting the same three `ORG_GRADLE_PROJECT_signingInMemoryKey*` secrets. Promoted them to the job's `env:` block; each step only keeps the creds unique to it (GH Packages vs Maven Central).

### release.yml: drop orphaned comment
- The trailing `# --no-configuration-cache is rejected when ...` comment under the Maven Central publish step was left behind by a prior edit — the command above it doesn't pass that flag.

### Drop `--no-daemon` everywhere
- `ci.yml` × 4 gradlew invocations
- `integration.yml` × 2 (publishToMavenLocal + installDist ran back-to-back, paying the JVM startup tax twice)
- `release.yml` × 3
- `snapshot.yml` × 1
- `gradle/actions/setup-gradle`'s caching model assumes the daemon is reused across invocations; `--no-daemon` forces a fresh JVM per command and defeats that.

## Test plan
- [ ] `CI` workflow still green.
- [ ] `Integration` workflow green — in particular verify the back-to-back `publishToMavenLocal` + `installDist` sequence is faster (daemon reused).
- [ ] Tag a throwaway `vX.Y.Z` pre-release to validate the `version`-job removal: `PLUGIN_VERSION` reaches gradle, the VSIX is versioned correctly, and the GH Release is created with the stripped title.
- [ ] `zizmor` workflow passes against the refactored release.yml (no new template-injection sinks).
- [ ] `snapshot` workflow publishes cleanly after merge.

## Notes
- Independent of PR #39 (snapshot.yml action-version drift) and PR #40 (shared setup composite). Will conflict on release.yml + snapshot.yml + ci.yml with #40, but auto-resolves in either merge order.