### PR TITLE
fix: surface and fail loudly when preview renders don't land

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -233,15 +233,28 @@ class ShowCommand(args: List<String>) : Command(args) {
                         println("[${r.module}]")
                         lastModule = r.module
                     }
-                    val changedTag = when (r.changed) {
-                        true -> " [changed]"
-                        false -> ""
-                        null -> ""
+                    val statusTag = when {
+                        r.pngPath == null -> " [no PNG]"
+                        r.changed == true -> " [changed]"
+                        else -> ""
                     }
                     val shaTag = r.sha256?.let { "  sha=${it.take(12)}" } ?: ""
-                    println("${r.functionName} (${r.id})$changedTag$shaTag")
+                    println("${r.functionName} (${r.id})$statusTag$shaTag")
                     if (r.pngPath != null) println("  ${r.pngPath}")
                 }
+            }
+
+            val missing = filtered.filter { it.pngPath == null }
+            if (missing.isNotEmpty()) {
+                System.err.println(
+                    "Render task completed but produced no PNG for ${missing.size} of ${filtered.size} preview(s).",
+                )
+                System.err.println(
+                    "Check the Gradle output above — a common cause is the `renderPreviews` task " +
+                        "reporting NO-SOURCE, which means the renderer test class wasn't found on " +
+                        "testClassesDirs.",
+                )
+                exitProcess(2)
             }
         }
     }
@@ -297,6 +310,8 @@ class RenderCommand(args: List<String>) : Command(args) {
                 exitProcess(3)
             }
 
+            val missing = filtered.filter { it.pngPath == null }
+
             if (output != null) {
                 if (filtered.size != 1) {
                     System.err.println(
@@ -307,15 +322,23 @@ class RenderCommand(args: List<String>) : Command(args) {
                 }
                 val one = filtered.single()
                 if (one.pngPath == null) {
-                    System.err.println("Match has no rendered PNG: ${one.id}")
+                    System.err.println("Render produced no PNG for: ${one.id}")
                     exitProcess(2)
                 }
                 File(one.pngPath).copyTo(File(output), overwrite = true)
                 println("Rendered ${one.id} to $output")
             } else {
-                println("Rendered ${filtered.size} preview(s)")
+                val rendered = filtered.size - missing.size
+                println("Rendered $rendered preview(s)")
                 val changedCount = filtered.count { it.changed == true }
                 if (changedCount > 0) println("  $changedCount changed since last run")
+                if (missing.isNotEmpty()) {
+                    System.err.println(
+                        "Render task completed but produced no PNG for ${missing.size} preview(s):",
+                    )
+                    for (r in missing) System.err.println("  ${r.id}")
+                    exitProcess(2)
+                }
             }
         }
     }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderFunctionalTest.kt
@@ -132,6 +132,37 @@ class RenderFunctionalTest {
     }
 
     @Test
+    fun `renderAllPreviews fails loudly when render produces no PNGs for a non-empty manifest`() {
+        val projectDir = createTestProject()
+
+        // Discover first so `previews.json` exists with real entries; that's
+        // the precondition for the post-condition check. We run discovery
+        // directly rather than going through renderAllPreviews so no PNGs
+        // get produced as a side-effect.
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("discoverPreviews")
+            .withPluginClasspath()
+            .build()
+
+        val manifest = File(projectDir, "build/compose-previews/previews.json")
+        assertThat(manifest.exists()).isTrue()
+
+        // Force the failure mode: invoke `renderAllPreviews` but exclude the
+        // render task. This mirrors the real-world regression where
+        // `renderPreviews` silently becomes NO-SOURCE — the aggregate task
+        // still fires but no PNGs land on disk.
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("renderAllPreviews", "-x", "renderPreviews", "--stacktrace")
+            .withPluginClasspath()
+            .buildAndFail()
+
+        assertThat(result.output).contains("render produced no PNG")
+        assertThat(result.output).contains("NO-SOURCE")
+    }
+
+    @Test
     fun `renderPreviews is UP-TO-DATE on second run`() {
         val projectDir = createTestProject()
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -112,25 +112,34 @@ internal object AndroidPreviewSupport {
             )
         }
 
-        // Classes directory used for Gradle's test-class scanning. Local mode:
-        // the renderer-android project's compiled output. External mode: the
-        // extracted android-classes artifact (AGP's transform unpacks the AAR's
-        // classes.jar). Either way, Gradle scans this for `@RunWith(…)` classes
-        // to run and finds `RobolectricRenderTest`.
+        // Classes used for Gradle's test-class scanning. Local mode: the
+        // renderer-android project's compiled output directories. External
+        // mode: the AAR's `classes.jar`, expanded via `zipTree` so Gradle's
+        // `Test.include("**/…Test.class")` filter can walk it — the include
+        // filter traverses file trees but does NOT descend into JAR entries,
+        // so feeding a raw JAR here silently produces `renderPreviews NO-SOURCE`
+        // and every preview ends up with no PNG. `android-classes` is AGP's
+        // `ArtifactType.CLASSES_JAR` (a JAR), not the extracted directory
+        // (that would be `android-classes-directory`).
         val rendererClassDirs = if (useLocalRenderer) {
             project.files(
                 rendererProjectDir.resolve("build/intermediates/built_in_kotlinc/$variantName/compile${capVariant}Kotlin/classes"),
                 rendererProjectDir.resolve("build/tmp/kotlin-classes/$variantName"),
             )
         } else {
-            project.files(rendererConfig.incoming.artifactView {
+            val rendererJars = rendererConfig.incoming.artifactView {
                 attributes.attribute(artifactType, "android-classes")
                 componentFilter { id ->
                     id is org.gradle.api.artifacts.component.ModuleComponentIdentifier
                             && id.group == "ee.schimke.composeai"
                             && id.module == "renderer-android"
                 }
-            }.files)
+            }.files
+            // Callable defers `.files` resolution until the Test task queries
+            // this FileCollection, keeping the configuration lazy.
+            project.files(java.util.concurrent.Callable {
+                rendererJars.files.map { project.zipTree(it) }
+            })
         }
 
         // AGP's `generate${Variant}UnitTestConfig` task emits

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -1,12 +1,16 @@
 package ee.schimke.composeai.plugin
 
+import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.Directory
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
+
+private val previewManifestJson = Json { ignoreUnknownKeys = true }
 
 /**
  * AGP-free task wiring shared between the Android and desktop code paths.
@@ -159,9 +163,42 @@ internal object ComposePreviewTasks {
             dependsOn(renderTask)
         }
 
+        // Post-condition check: every entry in the manifest must have a PNG
+        // on disk after the render dependency ran. We ship the renderer
+        // (RobolectricRenderTest on Android, RenderPreviewsTask on desktop)
+        // so we KNOW the task should run for a non-empty manifest — a missing
+        // PNG is a wiring bug, never expected. The most common offender on
+        // Android is `renderPreviews` reporting NO-SOURCE because the AAR's
+        // classes.jar wasn't expanded via `zipTree` before being added to
+        // `testClassesDirs`, which silently skips rendering; without this
+        // check the failure surfaces only in downstream tools (CLI / VSCode).
+        val manifestFile = previewOutputDir.map { it.file("previews.json") }
+        val rendersDir = previewOutputDir.map { it.dir("renders") }
         project.tasks.register("renderAllPreviews", DefaultTask::class.java) {
             group = "compose preview"
             dependsOn(extension.historyEnabled.map { enabled -> if (enabled) historizeTask else renderTask })
+            doLast {
+                val manifestOnDisk = manifestFile.get().asFile
+                if (!manifestOnDisk.exists()) return@doLast
+                val manifest = previewManifestJson
+                    .decodeFromString(PreviewManifest.serializer(), manifestOnDisk.readText())
+                if (manifest.previews.isEmpty()) return@doLast
+                val rd = rendersDir.get().asFile
+                val missing = manifest.previews
+                    .mapNotNull { p -> p.id.takeIf { !rd.resolve("$it.png").exists() } }
+                if (missing.isNotEmpty()) {
+                    val preview = missing.take(3).joinToString(", ")
+                    val andMore = if (missing.size > 3) " (+${missing.size - 3} more)" else ""
+                    throw GradleException(
+                        "renderAllPreviews: render produced no PNG for ${missing.size} of " +
+                            "${manifest.previews.size} preview(s): $preview$andMore. This means " +
+                            "`renderPreviews` was skipped or silently did nothing — on Android " +
+                            "that usually means it reported NO-SOURCE because " +
+                            "RobolectricRenderTest.class wasn't discoverable on its " +
+                            "testClassesDirs. Run with --info to see the task outcome.",
+                    )
+                }
+            }
         }
     }
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -390,13 +390,19 @@ async function refresh(forceRender: boolean, forFilePath?: string) {
             if (imageData) {
                 registry.setImage(preview.id, imageData);
                 panel.postMessage({ command: 'updateImage', previewId: preview.id, imageData });
-            } else {
+            } else if (forceRender) {
+                // Render task completed but produced no PNG for this preview —
+                // a per-preview failure that didn't fail the whole task (e.g.
+                // one parameterized Robolectric test threw). Surface it on the
+                // card; the root-cause log is in Output ▸ Compose Preview.
                 panel.postMessage({
                     command: 'setImageError',
                     previewId: preview.id,
-                    message: 'Render pending — save the file to trigger a render',
+                    message: 'Render failed — see Output ▸ Compose Preview',
                 });
             }
+            // else: discover-only pass, PNG not produced yet. Leave the skeleton
+            // in place; the next save-triggered render will populate it.
         }
 
         panel.postMessage({ command: 'showMessage', text: '' });

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -588,11 +588,16 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             const card = document.getElementById('preview-' + sanitizeId(previewId));
             if (!card) return;
             const container = card.querySelector('.image-container');
-            // Remove skeleton/spinner but keep error state if present
+            // Tear down every prior state before showing the new image.
+            // Leftover .error-message divs here are what caused the
+            // "Render pending — save the file to trigger a render" banner
+            // to stay visible forever even after a successful render.
             const skeleton = container.querySelector('.skeleton');
             const overlay = container.querySelector('.loading-overlay');
+            const errorMsg = container.querySelector('.error-message');
             if (skeleton) skeleton.remove();
             if (overlay) overlay.remove();
+            if (errorMsg) errorMsg.remove();
             card.classList.remove('has-error');
 
             const newSrc = 'data:image/png;base64,' + imageData;


### PR DESCRIPTION
## Summary

A symptom — the VSCode preview panel showing *"Render pending — save the file to trigger a render"* even after a successful save — turned out to be surfacing a real bug: for **external consumers** resolving `renderer-android` via Maven, `:renderPreviews` was silently reporting `NO-SOURCE` and producing zero PNGs. `renderAllPreviews` then reported SUCCESS, the CLI printed `"Rendered N preview(s)"` and exited 0, and the VSCode card-level error was worded as if the user hadn't saved.

In-repo samples all use `useLocalRenderer = true` (points at real class directories), which is why the existing functional tests didn't catch it.

### Root cause — plugin
`AndroidPreviewSupport` put AGP's `android-classes` artifact (= `ArtifactType.CLASSES_JAR`, a JAR) onto `testClassesDirs`. Gradle's `Test.include("**/RobolectricRenderTest.class")` walks file trees but doesn't descend into JAR entries, so the filter matched zero classes and the Test task no-op'd.

Fix: wrap the JAR in `project.zipTree(...)` via a lazy `Callable` so the scan finds the renderer test class.

### Defense — `renderAllPreviews`
Added a `doLast` post-condition: since we ship `RobolectricRenderTest` (Android) and `RenderPreviewsTask` (desktop), any manifest entry without a PNG on disk is a wiring bug. Throws a `GradleException` with the affected ids and the probable cause. New functional test forces the failure via `renderAllPreviews -x renderPreviews` — uses the existing JVM/Compose Desktop scaffolding, no Android SDK required.

### Reporting cleanup
- **CLI**: `render` and `show` now list missing ids on stderr, tag missing rows in `show` text output, and exit `2`. Previously they printed `"Rendered N preview(s)"` even when all N had `pngPath: null`.
- **VSCode extension**: `setImageError` is now only emitted on *forced* renders (so opening a file no longer shows a per-card error), the text is truthful (`Render failed — see Output ▸ Compose Preview`), and `updateImage` strips stale `.error-message` divs so a recovered render fully clears the banner.

## Test plan

- [x] `./gradlew :gradle-plugin:test :gradle-plugin:functionalTest :cli:compileKotlin` — all green locally, new functional test `renderAllPreviews fails loudly when render produces no PNGs for a non-empty manifest` passes.
- [x] VSCode extension TypeScript compiles cleanly (`tsc -p ./`).
- [ ] Manual verification against the external wear starter that triggered this investigation — confirm `compose-preview show --json` now produces non-null `pngPath` for each entry and the VSCode panel shows the rendered images.

## Follow-ups (not in this PR)

A proper Android-path functional test that exercises a published `renderer-android` AAR via `mavenLocal()` would close the last gap (AGP API changes, transform registration regressions). Needs Android SDK in the test environment — separate infra piece.