### PR TITLE
docs: document how to test plugin snapshots in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,39 @@ CMP Desktop projects additionally need
 `@Preview` annotation has `SOURCE` retention and is invisible to ClassGraph.
 
 Check [Releases](https://github.com/yschimke/compose-ai-tools/releases) for
-the latest version. Snapshots publish to the Central snapshots repo on
-every push to `main` — see [docs/RELEASING.md](docs/RELEASING.md) if you
-want to consume pre-release builds.
+the latest version.
+
+### Testing against a snapshot
+
+Every push to `main` publishes a `-SNAPSHOT` build to the Central snapshots
+repository. To try an unreleased change, add the snapshots repo to
+`pluginManagement` and bump the plugin version to the next patch
+`-SNAPSHOT`:
+
+```kotlin
+// settings.gradle.kts
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+        maven("https://central.sonatype.com/repository/maven-snapshots/") {
+            mavenContent { snapshotsOnly() }
+        }
+    }
+}
+```
+
+```kotlin
+// <module>/build.gradle.kts
+plugins {
+    id("ee.schimke.composeai.preview") version "0.3.5-SNAPSHOT"
+}
+```
+
+The snapshot version is the next patch ahead of the latest release
+(e.g. last tag `v0.3.4` → `0.3.5-SNAPSHOT`). Snapshots are unsigned. See
+[docs/RELEASING.md](docs/RELEASING.md) for more detail.
 
 ## Install the CLI
 


### PR DESCRIPTION
## Summary
- Adds a "Testing against a snapshot" subsection under Setup in `README.md`
- Inlines the Central snapshots `pluginManagement` block and the next-patch `-SNAPSHOT` version scheme so users don't have to open `docs/RELEASING.md` for the common case
- Intentionally does not wrap the snapshot version in an `x-release-please-start-version` marker — release-please would rewrite `0.3.5-SNAPSHOT` to the next release version and break it

## Test plan
- [ ] Render the README on GitHub and confirm the new section displays correctly and the link to `docs/RELEASING.md` still resolves