### PR TITLE
security: clear Dependabot + zizmor alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,13 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
-    # Let a new version sit on the registry for a few days before we pull it
+    # Let a new version sit on the registry for a week before we pull it
     # in, so typosquat/supply-chain compromises published and then pulled
-    # don't auto-land as a Dependabot PR. (zizmor: dependabot-cooldown)
+    # don't auto-land as a Dependabot PR. (zizmor: dependabot-cooldown
+    # requires at least 7 days of cooldown across the board.)
     cooldown:
-      default-days: 3
-      semver-major-days: 7
+      default-days: 7
+      semver-major-days: 14
     groups:
       # Bundle routine patch/minor bumps into a single PR to reduce noise.
       actions-minor:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,11 +115,13 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      # Do not cache `npm` here: release builds produce artifacts that get
+      # published, and a poisoned cache from an unrelated branch/run could
+      # influence the installed dependency tree (zizmor: cache-poisoning).
+      # `npm ci` on a clean runner is fast enough for a once-per-release job.
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 20
-          cache: npm
-          cache-dependency-path: vscode-extension/package-lock.json
       - name: Install dependencies
         working-directory: vscode-extension
         run: npm ci

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -3500,16 +3500,6 @@
             ],
             "license": "MIT"
         },
-        "node_modules/randombytes": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "^5.1.0"
-            }
-        },
         "node_modules/rc": {
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -3768,13 +3758,13 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+            "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/shebang-command": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -87,5 +87,8 @@
         "@vscode/vsce": "^3.0.0",
         "mocha": "^10.7.0",
         "typescript": "^5.3.0"
+    },
+    "overrides": {
+        "serialize-javascript": "^7.0.5"
     }
 }


### PR DESCRIPTION
## Summary

Clears all four open alerts on main:

- **Dependabot #1 / #2** — `serialize-javascript` 6.0.2 (GHSA-5c6j-r48x-rmvq RCE, high; GHSA-qj8w-gfj5-8c6v DoS, moderate). Only reachable through `mocha` (dev-only), whose pin is `^6.0.2`. Forced to `^7.0.5` via an npm `overrides` block so the transitive resolution jumps past both fixes without downgrading mocha.
- **Code scanning #82** — zizmor `cache-poisoning` on `release.yml:118`. The `setup-node` step in the release workflow was configured with `cache: npm`; release artifacts get published, so they shouldn't trust a cache that unrelated branches/runs can poison. Dropped the cache config — `npm ci` on a clean runner is cheap for a once-per-release job.
- **Code scanning #101** — zizmor `dependabot-cooldown` on `dependabot.yml:18`. Bumped `default-days` 3 → 7 and `semver-major-days` 7 → 14 to meet zizmor's ≥7-day threshold.

`npm audit` in `vscode-extension/` reports `found 0 vulnerabilities` after the change.

## Test plan
- [x] `npm install` in `vscode-extension/` resolves `serialize-javascript@7.0.5`
- [x] `npm audit` — 0 vulnerabilities
- [x] `npm test` — 40/40 passing
- [ ] zizmor workflow green on this PR (will run in CI)