### PR TITLE
fix(plugin): declare renders dir as output of Android renderPreviews

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -185,7 +185,8 @@ internal object AndroidPreviewSupport {
         }
 
         val manifestFile = previewOutputDir.map { it.file("previews.json").asFile.absolutePath }
-        val rendersDir = previewOutputDir.map { it.dir("renders").asFile.absolutePath }
+        val rendersDirectory = previewOutputDir.map { it.dir("renders") }
+        val rendersDir = rendersDirectory.map { it.asFile.absolutePath }
 
         val shardCount = resolveShardCount(project, extension, previewOutputDir.get().file("previews.json").asFile)
         val shardsEnabled = shardCount > 1
@@ -284,6 +285,15 @@ internal object AndroidPreviewSupport {
 
             systemProperty("composeai.render.manifest", manifestFile.get())
             systemProperty("composeai.render.outputDir", rendersDir.get())
+
+            // The PNG files are written to `rendersDirectory` via the
+            // `composeai.render.outputDir` system property, not through any
+            // Gradle-managed output. Declare the directory as an additional
+            // output so the build cache round-trips the PNGs alongside the
+            // test reports; without this the task gets a cache hit on a fresh
+            // checkout but the renders are never restored, which is exactly
+            // how previous modules silently vanished from `preview_main`.
+            outputs.dir(rendersDirectory).withPropertyName("rendersDir")
 
             dependsOn(discoverTask)
             if (useLocalRenderer) {


### PR DESCRIPTION
## Summary

- Android `renderPreviews` (a plain `Test` task) writes PNGs to `build/compose-previews/renders/` via a system property but never declared that directory as a task output. Gradle's build cache stored/restored only the test reports, so cache hits on CI left the renders directory empty.
- `preview-baselines.yml` force-pushes an orphan `preview_main` branch with only the PNGs present on disk. With `sample-android` and `sample-wear` silently missing their renders, `preview_main` ended up containing only `sample-cmp` (whose desktop `RenderPreviewsTask` already has `@OutputDirectory`), and every PR comment (e.g. #41) treated those modules as "new".
- Fix: `outputs.dir(rendersDirectory).withPropertyName(\"rendersDir\")` on the Test task so the build cache round-trips the PNGs alongside the reports. Audited the other 7 task registrations in the plugin — all already use correct cache annotations.

## Test plan

- [x] `./gradlew :gradle-plugin:test`
- [x] `./gradlew :gradle-plugin:functionalTest`
- [x] `rm -rf */build/compose-previews/renders && compose-preview show --json` → all 26 previews restored (9 android + 3 cmp + 14 wear) via FROM-CACHE, vs. 3 (cmp only) before the fix
- [ ] Next push to `main` should produce a `preview_main` baseline containing all three modules