### PR TITLE
ci: add advanced-setup CodeQL workflow for Kotlin

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,67 @@
+name: CodeQL
+
+# Advanced-setup CodeQL for Java/Kotlin. The default setup's autobuild injects
+# Gradle init scripts that use `allprojects { repositories { ... } }` and
+# `allprojects { tasks... }`, which are rejected by this repo's strict config
+# (`org.gradle.configuration-cache=true` with `problems=fail`, and
+# `org.gradle.unsafe.isolated-projects=true`). Manual build-mode lets us run
+# Gradle with those flags turned off for the scan only.
+#
+# Switch the repo from Default to Advanced setup in
+# Settings → Code security → Code scanning for this workflow to take effect.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, off-peak.
+    - cron: '27 7 * * 3'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (java-kotlin)
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for all workflows
+      security-events: write
+      # Required to fetch internal or private CodeQL packs
+      packages: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          languages: java-kotlin
+          build-mode: manual
+
+      # CodeQL traces the Kotlin/Java compiler to build its database, so we
+      # need a real compile — but with configuration-cache and isolated-projects
+      # disabled, because CodeQL's injected init scripts violate both.
+      # `compileKotlin` covers all Kotlin source sets across the multi-module
+      # build via task-name matching in subprojects.
+      - name: Compile Kotlin for CodeQL
+        run: |
+          ./gradlew compileKotlin compileDebugKotlin compileReleaseKotlin \
+            --no-configuration-cache \
+            -Dorg.gradle.unsafe.isolated-projects=false \
+            --continue
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          category: "/language:java-kotlin"


### PR DESCRIPTION
## Summary

Fixes the failing CodeQL scan on `main` ([run 24557066165](https://github.com/yschimke/compose-ai-tools/actions/runs/24557066165)).

**Root cause:** default-setup autobuild injects Gradle init scripts (`setup-proxy.gradle` + `semmleTempDir/init.gradle`) that call `allprojects { repositories { ... } }` and `allprojects { tasks... }`. Both are rejected by this repo's strict config (`configuration-cache=true` with `problems=fail`, plus `isolated-projects=true`), so every run fails with `Project ':' cannot access 'Project.repositories' functionality on subprojects via 'allprojects'`.

**Why not `build-mode: none`?** Per [GitHub docs](https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/kotlin-detected-in-no-build), Kotlin files are excluded from the database in `none` mode. So `manual` is the only viable build-mode here.

**The fix:** switch to advanced-setup CodeQL with `build-mode: manual` and compile Kotlin with `--no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false`. Those flags are scoped to the scan only — the project keeps its strict defaults for everything else.

## One-time follow-up after merge

CodeQL Default Setup takes priority over workflow files. Flip the repo from Default to Advanced in **Settings → Code security → Code scanning → CodeQL analysis → Set up → Advanced** for this workflow to take effect.

## Test plan

- [x] `./gradlew compileKotlin compileDebugKotlin compileReleaseKotlin --no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false --continue` runs cleanly locally (BUILD SUCCESSFUL, all Kotlin source sets compiled)
- [ ] After merge + Advanced-setup toggle: watch the CodeQL run complete successfully