### PR TITLE
ci(release): chain release-please into publish in a single run

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,9 +1,12 @@
 name: Release PR
 
 # Keeps a "chore(main): release X.Y.Z" pull request up to date based on
-# conventional-commit history since the last tag. Does NOT tag or create a
-# GitHub Release — once the release PR is merged, the maintainer pushes the
-# tag manually, which triggers release.yml. See docs/RELEASING.md.
+# conventional-commit history since the last tag. When that PR is merged,
+# release-please creates the tag + GitHub Release, then this workflow calls
+# release.yml to build and publish the three artifacts onto that Release.
+#
+# One button: merging the release PR triggers the full publish. No manual
+# tag push, no dispatch step. See docs/RELEASING.md.
 
 on:
   push:
@@ -11,8 +14,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: release-please-${{ github.ref }}
@@ -21,13 +23,36 @@ concurrency:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write        # create tags + GitHub Releases
+      pull-requests: write   # open/update the release PR
+    outputs:
+      release_created: ${{ steps.rp.outputs.release_created }}
+      tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        id: rp
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          # Do NOT let release-please create the tag/GitHub Release. The
-          # maintainer tags manually after merging the release PR — this keeps
-          # tag creation visible and triggers release.yml (which won't fire
-          # from a GITHUB_TOKEN-created tag anyway).
-          skip-github-release: true
+          # When the release PR is merged, release-please creates the tag and
+          # an empty GitHub Release (populated with the CHANGELOG entry as the
+          # body). The `release` job below then uploads CLI + VSIX assets to
+          # that Release. We used to skip this and tag manually, but chaining
+          # within a single workflow run sidesteps the GITHUB_TOKEN-doesn't-
+          # trigger-workflows limitation that motivated the manual step.
+
+  # Build and publish the artifacts whenever release-please actually cuts a
+  # release. Skipped on "just updating the release PR" runs.
+  release:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.release-please.outputs.tag_name }}
+    # Inherit secrets so the called workflow can reach MAVEN_CENTRAL_* and
+    # SIGNING_*. `secrets: inherit` passes every secret the caller can see.
+    secrets: inherit
+    permissions:
+      contents: write   # needed by the called workflow's `release` job
+      packages: write   # needed by the called workflow's GH Packages publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,53 @@
 name: Release
 
-# Triggered by pushing a tag like `v0.1.0`. Creates a GitHub Release with:
-#   - The CLI distribution (tar + zip) as release assets
-#   - The VS Code extension .vsix as a release asset
-#   - The Gradle plugin published to GitHub Packages
+# Builds and publishes the CLI, VS Code extension, and Gradle plugin +
+# renderer-android for a given tag. Uploads the CLI/VSIX assets onto the
+# GitHub Release (creating it if it doesn't exist yet).
 #
-# Future: adding Plugin Portal / VS Code Marketplace / Open VSX is additive —
-# just add new jobs here. Nothing below would need to change.
+# Entry points:
+#   - workflow_call: called from release-please.yml after release-please
+#     merges the release PR and creates the tag + Release. Primary path.
+#   - workflow_dispatch: re-run the release build for an existing tag (e.g.
+#     after a transient publish failure).
+#   - push: tags (v*): escape hatch for manually-pushed tags.
+#
+# All three paths resolve to `TAG_NAME`, so downstream jobs don't care which
+# fired. See docs/RELEASING.md.
 on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Tag name to release (e.g. v0.3.5).'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to (re)release, e.g. v0.3.5. Must already exist.'
+        required: true
+        type: string
   push:
     tags:
       - 'v*'
 
 # Workflow-level default is read-only. Each job widens only what it needs:
 # - publish-gradle-plugin: packages: write (for GH Packages)
-# - release: contents: write (creates the GitHub Release, uploads assets)
+# - release: contents: write (creates/updates the GitHub Release, uploads assets)
 permissions:
   contents: read
 
+# Both tag-push and workflow_call/dispatch for the same tag serialize through
+# the same concurrency group, so a re-run can't race a fresh release.
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: false
+
+# Every job consumes TAG_NAME (never GITHUB_REF_NAME) so the steps work the
+# same whether triggered by tag push or by workflow_call/dispatch. Templated
+# once here; scripts read it via `$TAG_NAME` from the env, which keeps tag
+# content out of shell arg positions.
+env:
+  TAG_NAME: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   # Run gradle publish AFTER the other builds succeed so we don't orphan a
@@ -46,11 +73,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ env.TAG_NAME }}
           persist-credentials: false
       - name: Derive plugin version from tag
-        # Strip leading `v` from tag, e.g. v0.1.0 → 0.1.0. $PLUGIN_VERSION is
-        # then inherited by every subsequent step in this job.
-        run: echo "PLUGIN_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+        # Strip leading `v` from TAG_NAME, e.g. v0.1.0 → 0.1.0. $PLUGIN_VERSION
+        # is inherited by every subsequent step in this job.
+        run: echo "PLUGIN_VERSION=${TAG_NAME#v}" >> "$GITHUB_ENV"
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
@@ -77,9 +105,10 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ env.TAG_NAME }}
           persist-credentials: false
       - name: Derive plugin version from tag
-        run: echo "PLUGIN_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+        run: echo "PLUGIN_VERSION=${TAG_NAME#v}" >> "$GITHUB_ENV"
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
@@ -98,6 +127,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ env.TAG_NAME }}
           persist-credentials: false
       # Do not cache `npm` here: release builds produce artifacts that get
       # published, and a poisoned cache from an unrelated branch/run could
@@ -111,10 +141,10 @@ jobs:
         run: npm ci
       - name: Set version
         working-directory: vscode-extension
-        # Read tag from $GITHUB_REF_NAME (runner-set, not templated into the
-        # script) so the tag name — attacker-influenceable through git — can't
-        # inject arguments into `npm version`.
-        run: npm version --no-git-tag-version --allow-same-version "${GITHUB_REF_NAME#v}"
+        # Read tag from $TAG_NAME (from env, not templated into the script) so
+        # the tag name — attacker-influenceable through git or the dispatch
+        # input — can't inject arguments into `npm version`.
+        run: npm version --no-git-tag-version --allow-same-version "${TAG_NAME#v}"
       - name: Build VSIX
         working-directory: vscode-extension
         run: npm run package
@@ -128,24 +158,38 @@ jobs:
     needs: publish-gradle-plugin
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # create release, upload assets
+      contents: write   # update the release, upload assets
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           merge-multiple: true
-      - name: Create GitHub Release
-        # $GITHUB_REF_NAME is runner-set (not templated into the script), so
-        # the tag name can't break out of the quotation and inject extra args.
+      - name: Upload or create GitHub Release
+        # $TAG_NAME is read from env (not templated into the script), so the
+        # tag name — attacker-influenceable through git or the dispatch input
+        # — can't break out of the quotation and inject extra args.
+        #
+        # Idempotent: release-please has usually already created the Release
+        # (with the CHANGELOG entry as the body) by the time this runs, so we
+        # just upload assets onto it. Falls back to creating the Release for
+        # tag-push / workflow_dispatch paths where it may not exist yet.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
-          gh release create "${GITHUB_REF_NAME}" \
-            --title "compose-ai-tools ${GITHUB_REF_NAME#v}" \
-            --generate-notes \
-            artifacts/*.zip \
-            artifacts/*.tar.gz \
-            artifacts/*.vsix
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Release $TAG_NAME exists — uploading assets."
+            gh release upload "$TAG_NAME" \
+              --clobber \
+              artifacts/*.zip \
+              artifacts/*.tar.gz \
+              artifacts/*.vsix
+          else
+            echo "Release $TAG_NAME does not exist — creating."
+            gh release create "$TAG_NAME" \
+              --title "compose-ai-tools ${TAG_NAME#v}" \
+              --generate-notes \
+              artifacts/*.zip \
+              artifacts/*.tar.gz \
+              artifacts/*.vsix
+          fi

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,30 +1,42 @@
 # Releasing
 
-All three artifacts ship from a single GitHub Actions workflow triggered by a version tag. The version bump and changelog are prepared by [release-please](https://github.com/googleapis/release-please); the maintainer only needs to merge the release PR and push the tag.
+## TL;DR
 
-## Cutting a release
+**Merge the open `chore(main): release X.Y.Z` PR.** That's it — `release-please.yml` creates the tag and GitHub Release, then chains into `release.yml` to build and publish the CLI, VS Code extension, Gradle plugin, and Android renderer AAR onto that Release.
 
-The flow is:
+## Prerequisites (one-time)
 
-1. **Land conventional-commit PRs to `main`** — e.g. `fix:`, `feat:`, `feat!:` / `BREAKING CHANGE`. Other prefixes (`chore:`, `docs:`, `ci:`, `refactor:`, `test:`) do not trigger a release. Force a bump when needed by adding a `Release-As: 0.3.4` footer to any commit, or run the `Release PR` workflow via `workflow_dispatch`.
-2. **`release-please.yml` opens or updates a release PR** titled `chore(main): release X.Y.Z`. Inspect the proposed `CHANGELOG.md`, version bumps in `README.md` / `docs/*.md` / `DoctorCommand.kt`, and `.release-please-manifest.json`. Adjust commit messages on `main` if the bump isn't what you want; the PR updates automatically.
-3. **Merge the release PR.** `main` now has the bumped files and updated manifest. No tag is created yet — see the box below.
-4. **Tag and push:**
-   ```bash
-   git pull origin main
-   git tag "v$(jq -r '."."' .release-please-manifest.json)"
-   git push origin --tags
-   ```
-   This fires `release.yml`, which publishes all three artifacts and creates the GitHub Release.
+In **Settings → Actions → General → Workflow permissions**, tick **"Allow GitHub Actions to create and approve pull requests"**. Without this, `release-please.yml` fails with `GitHub Actions is not permitted to create or approve pull requests` and no release PR ever appears.
 
-> **Why the tag step is manual:** release-please could create the tag itself, but a tag created by `GITHUB_TOKEN` doesn't trigger other workflows — so `release.yml` (which listens for `push: tags`) would never fire. Keeping the tag push manual sidesteps the need for a PAT.
+## How a release gets cut
+
+[release-please](https://github.com/googleapis/release-please) watches `main` for conventional-commit history and keeps a release PR up to date. Merging the PR is the only manual step.
+
+1. **Land conventional-commit PRs to `main`.** `fix:`, `feat:`, and `feat!:` / `BREAKING CHANGE` trigger a release. `chore:`, `docs:`, `ci:`, `refactor:`, and `test:` do not. To force a bump, add a `Release-As: 0.3.4` footer to any commit, or run the `Release PR` workflow via `workflow_dispatch`.
+2. **Review the release PR.** Titled `chore(main): release X.Y.Z`. Check the proposed `CHANGELOG.md`, the version bumps in `README.md`, `docs/*.md`, `DoctorCommand.kt`, and `.release-please-manifest.json`. Amend commit messages on `main` if the bump isn't right — the PR updates itself.
+3. **Merge the release PR.** On the next `release-please.yml` run (fires immediately on the merge commit), it creates the `vX.Y.Z` tag + GitHub Release, then invokes `release.yml` to build and upload the artifacts.
+
+## Fallback paths
+
+If the automatic chain ever leaves a release half-published (e.g. Maven Central rejected an upload, CLI build failed), you can re-run the build/publish against an existing tag without touching release-please:
+
+- **From the web:** Actions → **Release** → **Run workflow** → enter the tag (e.g. `v0.3.5`) → Run.
+- **From the command line (escape hatch for a manually tagged release):**
+
+  ```bash
+  git tag v0.3.5 && git push origin v0.3.5
+  ```
+
+  The `push: tags` trigger on `release.yml` picks it up. Only use this when you deliberately want to release without a release-please PR.
+
+Both fallbacks share the same concurrency group as the primary path, so they can't race each other. The final upload step is idempotent — it uploads onto an existing Release (or creates one if none exists).
 
 ### What the `release.yml` workflow does
 
 1. Publishes the **Gradle plugin** (`ee.schimke.composeai:compose-preview-plugin`) and the **Android renderer AAR** (`ee.schimke.composeai:renderer-android`) to **Maven Central** via the Central Portal, and mirrors them to GitHub Packages.
 2. Builds the **CLI** as `.zip` and `.tar.gz` distributions.
 3. Packages the **VS Code extension** as a `.vsix` file.
-4. Creates a GitHub Release with auto-generated notes and all three artifacts attached.
+4. Uploads all three artifacts onto the GitHub Release that release-please created (falling back to creating the Release itself if invoked outside the release-please path, e.g. from a manual tag push).
 
 Required secrets on the repository:
 


### PR DESCRIPTION
## Summary

- Merging the `chore(main): release X.Y.Z` PR now tags, releases, builds, and publishes in one workflow run — no separate manual tag push or `workflow_dispatch` step.
- `release-please.yml` now creates the tag + GitHub Release itself and invokes `release.yml` as a reusable workflow for the build/publish jobs.
- `release.yml` gains `workflow_call` and `workflow_dispatch` (tag-input) triggers as recovery paths, keeping `push: tags` as an escape hatch.

## Why

The previous split was to work around a GitHub rule: tags created with `GITHUB_TOKEN` don't trigger other workflows, so `release.yml` (which listened on `push: tags`) would never fire if release-please tagged. Chaining the jobs inside a single run makes that constraint irrelevant.

## Test plan

- [ ] Enable **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** (required for release-please to open its PR at all — previously failing with `GitHub Actions is not permitted to create or approve pull requests`).
- [ ] Merge this PR.
- [ ] Land a `fix:` or `feat:` commit on `main` and wait for release-please to open `chore(main): release X.Y.Z`.
- [ ] Merge the release PR; confirm a single `release-please.yml` run:
  - [ ] Creates tag `vX.Y.Z` and a GitHub Release populated with the CHANGELOG entry as the body.
  - [ ] Invokes `release.yml` (visible as the `release / ...` jobs) which builds CLI + VSIX and publishes plugin + renderer-android to Maven Central and GitHub Packages.
  - [ ] Uploads the `.zip`, `.tar.gz`, and `.vsix` onto the Release.
- [ ] Sanity-check the fallback paths:
  - [ ] Re-run via **Actions → Release → Run workflow** with `tag=vX.Y.Z` — idempotently re-uploads assets onto the existing Release.
  - [ ] `git push origin vX.Y.Z` for a manually-created tag still fires `release.yml` via the `push: tags` trigger.