### PR TITLE
docs: point VS Code install at the Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,17 +180,12 @@ Requires Java 21 on `PATH` (or `JAVA_HOME`).
 
 ## Install the VS Code extension
 
-<!-- x-release-please-start-version -->
-Download `compose-preview-0.3.5.vsix` from the
-[v0.3.5 release](https://github.com/yschimke/compose-ai-tools/releases/tag/v0.3.4)
-and install it:
+Install [Compose Preview](https://marketplace.visualstudio.com/items?itemName=yuri-schimke.compose-preview)
+from the VS Code Marketplace, or from the command line:
 
 ```sh
-code --install-extension compose-preview-0.3.5.vsix
+code --install-extension yuri-schimke.compose-preview
 ```
-<!-- x-release-please-end -->
-
-Or in VS Code: **Extensions → ⋯ → Install from VSIX…** and pick the file.
 
 The extension uses the Gradle plugin to render previews, so apply
 `ee.schimke.composeai.preview` version `0.3.5` <!-- x-release-please-version --> in your project as shown above.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -137,13 +137,14 @@ tar xzf compose-preview.tar.gz
 
 ### VS Code extension
 
-Download the `.vsix` from the Releases page and install:
+Install [Compose Preview](https://marketplace.visualstudio.com/items?itemName=yuri-schimke.compose-preview)
+from the VS Code Marketplace, or from the command line:
 
-<!-- x-release-please-start-version -->
 ```bash
-code --install-extension compose-preview-0.3.5.vsix
+code --install-extension yuri-schimke.compose-preview
 ```
-<!-- x-release-please-end -->
+
+The `.vsix` is also attached to each GitHub Release as a fallback.
 
 ## Future: publishing to public registries
 
@@ -154,7 +155,7 @@ consumers:
 | Artifact | Current | Public registry | Migration |
 |----------|---------|-----------------|-----------|
 | Gradle plugin | **Maven Central** (+ GH Packages mirror) | Gradle Plugin Portal | Apply `com.gradle.plugin-publish` plugin; add `publishPlugins` task to the workflow with `GRADLE_PUBLISH_KEY`/`GRADLE_PUBLISH_SECRET` secrets |
-| VS Code extension | Release .vsix | VS Code Marketplace + Open VSX | Add `vsce publish` and `ovsx publish` steps with `VSCE_PAT` / `OVSX_PAT` secrets |
+| VS Code extension | **VS Code Marketplace** (+ Release .vsix fallback) | Open VSX | Add an `ovsx publish` step with an `OVSX_PAT` secret |
 | CLI | Release .zip/.tar | Homebrew tap | Add a `dispatches` step that updates a separate `homebrew-tap` repo |
 
 Existing GitHub Release artifacts remain as a fallback and don't need to go away.


### PR DESCRIPTION
## Summary

- The [Compose Preview](https://marketplace.visualstudio.com/items?itemName=yuri-schimke.compose-preview) extension is live on the VS Code Marketplace, so drop the `.vsix` download dance from README.md and docs/RELEASING.md in favour of a Marketplace link + `code --install-extension yuri-schimke.compose-preview`.
- Remove the `x-release-please-start-version` markers around that block — the install command no longer carries a version number.
- Update the "future public registries" table in RELEASING.md: only Open VSX remains as future work.

## Test plan

- [x] `git diff` reviewed; only docs changed.
- [ ] Render README.md on GitHub after merge and confirm the Marketplace badge/link resolves.