### PR TITLE
ci(codeql): disable Gradle build cache during scan

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,12 +52,16 @@ jobs:
       # CodeQL traces the Kotlin/Java compiler to build its database, so we
       # need a real compile — but with configuration-cache and isolated-projects
       # disabled, because CodeQL's injected init scripts violate both.
+      # `--no-build-cache` is required: without it the remote Gradle cache
+      # serves `compileKotlin*` as FROM-CACHE, no compiler process runs, and
+      # CodeQL's tracer sees no source (failing with "no source code seen").
       # `compileKotlin` covers all Kotlin source sets across the multi-module
       # build via task-name matching in subprojects.
       - name: Compile Kotlin for CodeQL
         run: |
           ./gradlew compileKotlin compileDebugKotlin compileReleaseKotlin \
             --no-configuration-cache \
+            --no-build-cache \
             -Dorg.gradle.unsafe.isolated-projects=false \
             --continue
 


### PR DESCRIPTION
## Summary
- CodeQL's last run failed with "no source code seen during build" because every `compileKotlin*` task was served `FROM-CACHE` by the remote Gradle cache — no compiler process ran under the `LD_PRELOAD` tracer, so the database was empty.
- Added `--no-build-cache` to the CodeQL workflow's Gradle invocation so the compiler actually executes for the scan, and documented why in the comment.

## Test plan
- [ ] CodeQL workflow run on this PR completes the `Perform CodeQL Analysis` step successfully (compile tasks should now show as executed rather than `FROM-CACHE`).