### PR TITLE
ci(integration): publish + exercise renderer-android snapshot end-to-end

### DIFF
--- a/.github/ci/apply-compose-ai.init.gradle.kts
+++ b/.github/ci/apply-compose-ai.init.gradle.kts
@@ -1,11 +1,26 @@
 // Gradle init script for integration tests.
 //
-// Adds mavenLocal() to the settings-level pluginManagement repositories so the
-// `ee.schimke.composeai.preview` plugin marker published by the build-plugin
-// CI job can be resolved. This is the ONLY responsibility of the init script:
-// actually applying the plugin happens via a `plugins { }` entry in the
-// consumer module's build.gradle(.kts), patched in by .github/ci/patch-consumer.py
-// before Gradle runs.
+// Adds mavenLocal() to two repository lists in the consumer's settings so
+// everything the plugin needs at runtime resolves from the bundle seeded into
+// $HOME/.m2 by the build-plugin CI job:
+//
+//   1. pluginManagement.repositories — for the `ee.schimke.composeai.preview`
+//      plugin marker itself, resolved through the consumer's plugin classpath.
+//      Actually applying the plugin happens via a `plugins { }` entry in the
+//      consumer module's build.gradle(.kts), patched in by
+//      .github/ci/patch-consumer.py before Gradle runs.
+//
+//   2. dependencyResolutionManagement.repositories — for the
+//      `ee.schimke.composeai:renderer-android:<version>` AAR that the plugin
+//      wires into a `composePreviewAndroidRenderer<Variant>` configuration in
+//      the consumer project at render time. Consumer projects often set
+//      `RepositoriesMode.FAIL_ON_PROJECT_REPOS`, which blocks
+//      `allprojects { repositories { mavenLocal() } }`, so the addition has to
+//      happen at the settings level here. Without this, `renderPreviews`
+//      fails to resolve the renderer AAR even though the plugin itself loads
+//      fine. Adding mavenLocal at the settings level is compatible with
+//      FAIL_ON_PROJECT_REPOS (the ban is on project-level `repositories {}`
+//      blocks, not settings-level additions).
 //
 // Loading the plugin through the consumer's plugin classpath (rather than via
 // this init script's classpath) is important: it puts the plugin's classes in
@@ -16,4 +31,5 @@
 
 gradle.settingsEvaluated {
     pluginManagement.repositories.mavenLocal()
+    dependencyResolutionManagement.repositories.mavenLocal()
 }

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,8 +46,20 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: Publish plugin to mavenLocal
-        run: ./gradlew :gradle-plugin:publishToMavenLocal --stacktrace
+      - name: Publish plugin + renderer-android to mavenLocal
+        # Both artifacts are needed end-to-end: the plugin resolves through
+        # pluginManagement when the consumer's `plugins { }` block is patched,
+        # and it then wires `ee.schimke.composeai:renderer-android:<version>`
+        # into the consumer's `composePreviewAndroidRenderer<Variant>`
+        # configuration at render time. Publishing only the plugin here would
+        # mean the render path silently falls back to whatever's on the
+        # consumer's remote repos (or fails resolution) — exactly the kind of
+        # release-vs-source drift these tests are supposed to catch.
+        run: |
+          ./gradlew \
+            :gradle-plugin:publishToMavenLocal \
+            :renderer-android:publishToMavenLocal \
+            --stacktrace
 
       - name: Install CLI
         run: ./gradlew :cli:installDist --stacktrace
@@ -91,6 +103,11 @@ jobs:
               -Dorg.gradle.unsafe.isolated-projects=false
               -Dorg.gradle.isolated-projects=false
               --no-configuration-cache
+            # Exercise the full render pipeline on at least one matrix entry
+            # so the `renderer-android` AAR resolution + Robolectric launch
+            # path is covered against the locally-published snapshot. The
+            # other entries stay at discovery-only to keep the matrix fast.
+            render: true
           - name: wear-os-samples (WearTilesKotlin)
             slug: wear-tiles
             repo: android/wear-os-samples
@@ -237,11 +254,48 @@ jobs:
             exit 1
           fi
 
+      - name: Render previews via Gradle
+        if: matrix.render
+        working-directory: external/${{ matrix.workdir }}
+        env:
+          COMPOSE_AI_PLUGIN_VERSION: ${{ env.PLUGIN_VERSION }}
+          GRADLE_OPTS: -Xmx4g -Dfile.encoding=UTF-8
+        run: |
+          # renderPreviews depends on discoverPreviews, so we get both in one
+          # invocation. This is the step that exercises renderer-android AAR
+          # resolution from mavenLocal — the artifact path external consumers
+          # hit at runtime.
+          ./gradlew renderPreviews \
+            ${{ matrix.extra_gradle_args }} \
+            --stacktrace
+
+      - name: Verify PNGs were produced
+        if: matrix.render
+        working-directory: external/${{ matrix.workdir }}
+        run: |
+          set -euo pipefail
+          mapfile -t pngs < <(find . -path '*/build/compose-previews/renders/*.png' -not -path '*/external/build/*' 2>/dev/null)
+          if [ "${#pngs[@]}" -eq 0 ]; then
+            echo "::error::renderPreviews ran but no PNG files were produced."
+            exit 1
+          fi
+          echo "Rendered ${#pngs[@]} PNG file(s):"
+          printf '  %s\n' "${pngs[@]}"
+
       - name: Upload previews.json
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: previews-${{ matrix.slug }}
           path: external/**/build/compose-previews/previews.json
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload rendered PNGs
+        if: always() && matrix.render
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: renders-${{ matrix.slug }}
+          path: external/**/build/compose-previews/renders/*.png
           if-no-files-found: warn
           retention-days: 7


### PR DESCRIPTION
## Summary

The external-repo integration matrix was only exercising the plugin side of our published artifacts. Two gaps let release-vs-source drift through:

- `renderer-android` was never published into the mavenLocal bundle, and no matrix entry ran `renderPreviews`, so the Maven-artifact branch in [AndroidPreviewSupport.kt:109-113](gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt) (the one external consumers actually hit) was never covered by CI — it only ran against the `includeBuild` sibling-project fallback used by in-repo samples.
- The init script added `mavenLocal()` only to `pluginManagement.repositories`. Consumers with `RepositoriesMode.FAIL_ON_PROJECT_REPOS` (common on modern Android projects) could not have resolved the renderer AAR from mavenLocal even if it had been published.

Changes:

- `:renderer-android:publishToMavenLocal` is now published alongside the plugin in `build-plugin` and ends up in the bundle tarball that seeds each consumer job's mavenLocal.
- The init script also adds `mavenLocal()` to `dependencyResolutionManagement.repositories` so the renderer AAR resolves at render time on repos that ban project-level repository blocks.
- `wear-os-samples (ComposeStarter)` is flagged `render: true`; a new step runs `renderPreviews`, fails if no PNGs land in `build/compose-previews/renders/`, and uploads the PNGs as CI artifacts. Other matrix entries stay at discovery-only to keep the fan-out fast.

`PLUGIN_VERSION=0.1.0-SNAPSHOT` is set at workflow level, so the plugin jar is built with that version baked into `plugin-version.properties` and `renderer-android` is published under the same coords — the runtime lookup `ee.schimke.composeai:renderer-android:${PluginVersion.value}` now hits the locally-published snapshot.

## Test plan

- [ ] `Integration / Build plugin + CLI` — publishes both artifacts to mavenLocal, bundle tarball contains `ee/schimke/composeai/gradle-plugin/` and `ee/schimke/composeai/renderer-android/`
- [ ] `Integration / wear-os-samples (ComposeStarter)` — `renderPreviews` runs; `renders-wear-os-samples` artifact contains PNG(s)
- [ ] `Integration / wear-os-samples (WearTilesKotlin)` and `Integration / androidify` — unchanged (discovery only)