### PR TITLE
feat(a11y): opt-in ATF accessibility checks for previews

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -39,6 +39,33 @@ data class PreviewManifest(
     val module: String,
     val variant: String,
     val previews: List<PreviewInfo>,
+    /**
+     * Relative path (from this manifest file's parent directory) to the
+     * sidecar ATF accessibility report, when `composePreview.accessibilityChecks`
+     * is enabled on this module. `null` means the feature is off.
+     */
+    val accessibilityReport: String? = null,
+)
+
+@Serializable
+data class AccessibilityFinding(
+    val level: String,
+    val type: String,
+    val message: String,
+    val viewDescription: String? = null,
+    val boundsInScreen: String? = null,
+)
+
+@Serializable
+data class AccessibilityEntry(
+    val previewId: String,
+    val findings: List<AccessibilityFinding>,
+)
+
+@Serializable
+data class AccessibilityReport(
+    val module: String,
+    val entries: List<AccessibilityEntry>,
 )
 
 /** CLI output DTO — enriches manifest entries with runtime data agents need. */
@@ -53,6 +80,11 @@ data class PreviewResult(
     val pngPath: String? = null,
     val sha256: String? = null,
     val changed: Boolean? = null,
+    /**
+     * ATF findings for this preview, or `null` when accessibility checks were
+     * disabled for this module. Empty list means checks ran and found nothing.
+     */
+    val a11yFindings: List<AccessibilityFinding>? = null,
 )
 
 @Serializable
@@ -119,6 +151,38 @@ abstract class Command(protected val args: List<String>) {
     }
 
     /**
+     * Reads each module's accessibility report IF the manifest points at one
+     * (i.e. the feature is enabled in Gradle). Returns a map keyed by
+     * `"$module/$previewId"` so `buildResults` can look up findings without a
+     * second filesystem probe.
+     *
+     * Following the manifest pointer — rather than hard-coding
+     * `accessibility.json` — means disabling checks in Gradle cleanly makes
+     * findings disappear from CLI output; we never report stale reports from
+     * a prior opt-in run.
+     */
+    protected fun readAllA11yReports(
+        manifests: List<Pair<String, PreviewManifest>>,
+    ): Map<String, List<AccessibilityFinding>> {
+        val out = mutableMapOf<String, List<AccessibilityFinding>>()
+        for ((module, manifest) in manifests) {
+            val pointer = manifest.accessibilityReport ?: continue
+            val reportFile = projectDir.resolve("$module/build/compose-previews/$pointer")
+            if (!reportFile.exists()) continue
+            val report = try {
+                json.decodeFromString(AccessibilityReport.serializer(), reportFile.readText())
+            } catch (e: Exception) {
+                if (verbose) System.err.println("Warning: unreadable a11y report ${reportFile.path}: ${e.message}")
+                continue
+            }
+            for (entry in report.entries) {
+                out["$module/${entry.previewId}"] = entry.findings
+            }
+        }
+        return out
+    }
+
+    /**
      * Reads PNGs for every manifest entry, hashes them, compares against the
      * per-module sidecar state file to emit `changed`, and persists the new
      * hashes. Sidecar lives under `build/compose-previews/` so it gets wiped on
@@ -126,6 +190,10 @@ abstract class Command(protected val args: List<String>) {
      */
     protected fun buildResults(manifests: List<Pair<String, PreviewManifest>>): List<PreviewResult> {
         val results = mutableListOf<PreviewResult>()
+        val a11yByKey = readAllA11yReports(manifests)
+        // Track which modules had a11y enabled so we can distinguish "no
+        // findings" (empty list) from "feature off" (null) in `PreviewResult`.
+        val modulesWithA11y = manifests.filter { it.second.accessibilityReport != null }.map { it.first }.toSet()
 
         for ((module, manifest) in manifests) {
             val prior = readState(module).shas
@@ -143,6 +211,10 @@ abstract class Command(protected val args: List<String>) {
                     priorSha == null -> true
                     else -> priorSha != sha
                 }
+                val a11y = when {
+                    module in modulesWithA11y -> a11yByKey["$module/${p.id}"] ?: emptyList()
+                    else -> null
+                }
                 results += PreviewResult(
                     id = p.id,
                     module = module,
@@ -153,6 +225,7 @@ abstract class Command(protected val args: List<String>) {
                     pngPath = pngFile?.absolutePath,
                     sha256 = sha,
                     changed = changed,
+                    a11yFindings = a11y,
                 )
             }
 
@@ -340,6 +413,80 @@ class RenderCommand(args: List<String>) : Command(args) {
                     exitProcess(2)
                 }
             }
+        }
+    }
+}
+
+/**
+ * `compose-preview a11y` — runs `renderAllPreviews` (which pulls in
+ * `verifyAccessibility` when enabled) and prints the findings grouped by
+ * preview. Exits non-zero if the Gradle build failed (i.e. the configured
+ * `failOnErrors`/`failOnWarnings` threshold tripped) or if `--fail-on`
+ * overrides the threshold at the CLI level.
+ */
+class A11yCommand(args: List<String>) : Command(args) {
+    private val jsonOutput = "--json" in args
+    // "errors" | "warnings" | "none". When not set, exit code mirrors Gradle.
+    private val failOn: String? = args.flagValue("--fail-on")
+
+    override fun run() {
+        withGradle { gradle ->
+            val modules = resolveModules(gradle)
+            val tasks = modules.map { ":$it:renderAllPreviews" }.toTypedArray()
+            val buildOk = runGradle(gradle, *tasks)
+
+            val manifests = readAllManifests(modules)
+            val enabledModules = manifests.filter { it.second.accessibilityReport != null }
+            if (enabledModules.isEmpty()) {
+                if (jsonOutput) println("[]") else {
+                    println(
+                        "No module has accessibility checks enabled. Add\n" +
+                            "  composePreview { accessibilityChecks { enabled = true } }\n" +
+                            "to the module's build.gradle.kts."
+                    )
+                }
+                exitProcess(if (buildOk) 0 else 2)
+            }
+
+            val all = buildResults(manifests)
+            val filtered = all.filter { matchesRequest(it) && it.a11yFindings != null }
+
+            if (jsonOutput) {
+                println(json.encodeToString(ListSerializer(PreviewResult.serializer()), filtered))
+            } else {
+                val flat = filtered.flatMap { r ->
+                    (r.a11yFindings ?: emptyList()).map { f -> r to f }
+                }
+                if (flat.isEmpty()) {
+                    println("No accessibility findings.")
+                } else {
+                    println("${flat.size} accessibility finding(s):")
+                    for ((r, f) in flat) {
+                        println("  [${f.level}] ${r.id} · ${f.type}")
+                        println("      ${f.message}")
+                        f.viewDescription?.let { println("      element: $it") }
+                    }
+                }
+            }
+
+            val errorCount = filtered.sumOf { it.a11yFindings?.count { f -> f.level == "ERROR" } ?: 0 }
+            val warnCount = filtered.sumOf { it.a11yFindings?.count { f -> f.level == "WARNING" } ?: 0 }
+            val cliFailed = when (failOn) {
+                "errors" -> errorCount > 0
+                "warnings" -> errorCount > 0 || warnCount > 0
+                "none", null -> false
+                else -> {
+                    System.err.println("Unknown --fail-on value: $failOn (expected errors|warnings|none)")
+                    exitProcess(1)
+                }
+            }
+            exitProcess(
+                when {
+                    cliFailed -> 2
+                    !buildOk -> 2
+                    else -> 0
+                }
+            )
         }
     }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -12,8 +12,9 @@ fun main(args: Array<String>) {
     // Flags that take values: --module, --variant, --filter, --id, --output, --timeout, --plugin-version
     val valuedFlags = setOf(
         "--module", "--variant", "--filter", "--id", "--output", "--timeout", "--plugin-version",
+        "--fail-on",
     )
-    val commands = setOf("show", "list", "render", "doctor", "help")
+    val commands = setOf("show", "list", "render", "a11y", "doctor", "help")
 
     var commandIndex = -1
     var i = 0
@@ -48,6 +49,7 @@ fun main(args: Array<String>) {
         "show" -> ShowCommand(allArgs).run()
         "list" -> ListCommand(allArgs).run()
         "render" -> RenderCommand(allArgs).run()
+        "a11y" -> A11yCommand(allArgs).run()
         "doctor" -> DoctorCommand(allArgs).run()
         "help" -> printUsage()
         else -> {
@@ -69,6 +71,7 @@ private fun printUsage() {
           show    Discover and render previews; print id, path, sha256, changed flag
           list    List discovered previews
           render  Render previews; with --output copies a single match to disk
+          a11y    Render previews and print ATF accessibility findings
           doctor  Verify Java 21 + GitHub Packages credentials before editing Gradle files
           help    Show this help message
 
@@ -82,6 +85,7 @@ private fun printUsage() {
           --progress           Print per-task milestone/heartbeat lines to stderr
           --verbose, -v        Show full Gradle build output (implies --progress)
           --timeout <seconds>  Gradle build timeout (default: 300)
+          --fail-on <level>    a11y: exit non-zero on 'errors' or 'warnings' (default: mirror Gradle)
 
         OSC 9;4 terminal progress (native taskbar/tab progress bar) is on by
         default in a TTY and auto-disables when stdout is piped or redirected.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -67,6 +67,28 @@ internal object AndroidPreviewSupport {
             dependsOn("compile${capVariant}Kotlin")
         }
 
+        // When a11y is on, the renderer switches from `captureRoboImage { @Composable }`
+        // to `createAndroidComposeRule<ComponentActivity>()`, which needs
+        // ui-test-manifest to contribute the ComponentActivity <activity> entry
+        // to the consumer's merged unit-test AndroidManifest. Renderer-android
+        // pulls ui-test-manifest in transitively, but our plugin bypasses the
+        // normal AGP dep graph (renderer classpath lives in our own resolvable
+        // config, not `testImplementation`), so the manifest merger never sees
+        // it. Explicitly adding ui-test-manifest to `testImplementation` here
+        // closes that gap. Only fires when the feature is enabled, so opt-out
+        // consumers pay nothing.
+        if (resolveA11yEnabled(project, extension)) {
+            // No version: relies on the consumer's Compose BOM (or direct
+            // Compose dep) to resolve ui-test-manifest. Projects using
+            // `implementation(platform(libs.compose.bom))` pick up the
+            // aligned version automatically; projects without a BOM need to
+            // add one (a reasonable ask — the plugin is for Compose apps).
+            project.dependencies.add(
+                "testImplementation",
+                "androidx.compose.ui:ui-test-manifest",
+            )
+        }
+
         val artifactType = Attribute.of("artifactType", String::class.java)
         val testConfig = project.configurations.findByName("${variantName}UnitTestRuntimeClasspath")
 
@@ -197,6 +219,13 @@ internal object AndroidPreviewSupport {
         val rendersDirectory = previewOutputDir.map { it.dir("renders") }
         val rendersDir = rendersDirectory.map { it.asFile.absolutePath }
 
+        // Per-preview ATF findings land here. `verifyAccessibility` rolls them
+        // up into a single `accessibility.json` next to `previews.json`. Kept
+        // separate from renders/ so caching treats the two output trees
+        // independently.
+        val accessibilityPerPreviewDir = previewOutputDir.map { it.dir("accessibility-per-preview") }
+        val accessibilityReportFile = previewOutputDir.map { it.file("accessibility.json") }
+
         val shardCount = resolveShardCount(project, extension, previewOutputDir.get().file("previews.json").asFile)
         val shardsEnabled = shardCount > 1
 
@@ -295,6 +324,27 @@ internal object AndroidPreviewSupport {
             systemProperty("composeai.render.manifest", manifestFile.get())
             systemProperty("composeai.render.outputDir", rendersDir.get())
 
+            // ATF — renderer checks `composeai.a11y.enabled` and, when true,
+            // writes per-preview JSON into `composeai.a11y.outputDir`.
+            // Always passed as strings so the property is present/absent
+            // predictably across runs (simpler than conditional systemProperty
+            // lines, and keeps configuration-cache happy).
+            val a11yOn = resolveA11yEnabled(project, extension)
+            systemProperty("composeai.a11y.enabled", a11yOn.toString())
+            systemProperty("composeai.a11y.outputDir", accessibilityPerPreviewDir.get().asFile.absolutePath)
+            // Diagnostic output — agents/users debugging "why no findings"
+            // get useful breadcrumbs without parsing Robolectric's stdout.
+            // `providers.gradleProperty` is Isolated-Projects-safe (unlike
+            // `project.findProperty`), so this can be set with
+            // `-Pcomposeai.a11y.debug=true` on the command line.
+            systemProperty(
+                "composeai.a11y.debug",
+                project.providers.gradleProperty("composeai.a11y.debug").orElse("false").get(),
+            )
+            if (a11yOn) {
+                outputs.dir(accessibilityPerPreviewDir).withPropertyName("a11yPerPreviewDir")
+            }
+
             // The PNG files are written to `rendersDirectory` via the
             // `composeai.render.outputDir` system property, not through any
             // Gradle-managed output. Declare the directory as an additional
@@ -318,7 +368,44 @@ internal object AndroidPreviewSupport {
             }
         }
 
-        ComposePreviewTasks.registerRenderAllPreviews(project, extension, renderTask, previewOutputDir)
+        // `verifyAccessibility` — only registered when the feature is on.
+        // Reading `extension.accessibilityChecks.enabled.get()` here is safe:
+        // `onVariants` fires after the plugin block has evaluated.
+        val verifyA11yTask = if (resolveA11yEnabled(project, extension)) {
+            project.tasks.register("verifyAccessibility", VerifyAccessibilityTask::class.java) {
+                group = "compose preview"
+                description = "Aggregate ATF findings from renderPreviews and fail per configured thresholds"
+                perPreviewDir.set(accessibilityPerPreviewDir)
+                reportFile.set(accessibilityReportFile)
+                moduleName.set(project.name)
+                failOnErrors.set(extension.accessibilityChecks.failOnErrors)
+                failOnWarnings.set(extension.accessibilityChecks.failOnWarnings)
+                dependsOn(renderTask)
+            }
+        } else null
+
+        ComposePreviewTasks.registerRenderAllPreviews(
+            project, extension, renderTask, previewOutputDir, verifyA11yTask,
+        )
+    }
+
+    /**
+     * Resolves the effective `accessibilityChecks.enabled` value. The
+     * `-PcomposePreview.accessibilityChecks.enabled=<true|false>` Gradle
+     * property WINS over the extension block — so the VSCode extension (or a
+     * one-off CLI invocation) can flip the feature on for a single run
+     * without touching `build.gradle.kts`. When the property is absent, the
+     * extension's value is honoured.
+     *
+     * Using `providers.gradleProperty` rather than `project.findProperty`
+     * keeps this safe under Gradle's Isolated Projects mode.
+     */
+    private fun resolveA11yEnabled(project: org.gradle.api.Project, extension: PreviewExtension): Boolean {
+        val override = project.providers
+            .gradleProperty("composePreview.accessibilityChecks.enabled")
+            .orNull
+            ?.toBooleanStrictOrNull()
+        return override ?: extension.accessibilityChecks.enabled.get()
     }
 
     private fun copyAttributes(target: AttributeContainer, source: AttributeContainer) {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -69,7 +69,7 @@ internal object ComposePreviewTasks {
                 description = "Render all previews to PNG"
                 dependsOn(discoverTask)
             }
-            registerRenderAllPreviews(project, extension, renderTask, previewOutputDir)
+            registerRenderAllPreviews(project, extension, renderTask, previewOutputDir, verifyAccessibilityTask = null)
         } else {
             registerStubRenderTask(project, previewOutputDir, sourceClassDirs, dependencyConfigName, discoverTask, extension)
         }
@@ -100,6 +100,15 @@ internal object ComposePreviewTasks {
             }
             moduleName.set(project.name)
             variantName.set(extension.variant)
+            // Gradle property override: `-PcomposePreview.accessibilityChecks.enabled=true`
+            // wins over the extension. Lets VSCode / CLI flip the feature on
+            // for a run without editing build.gradle.kts. Isolated-Projects-
+            // safe because `providers.gradleProperty` is.
+            accessibilityChecksEnabled.set(
+                project.providers.gradleProperty("composePreview.accessibilityChecks.enabled")
+                    .map { it.toBooleanStrictOrNull() ?: false }
+                    .orElse(extension.accessibilityChecks.enabled),
+            )
             outputFile.set(previewOutputDir.map { it.file("previews.json") })
             group = "compose preview"
             description = "Discover @Preview annotations in compiled classes"
@@ -127,7 +136,7 @@ internal object ComposePreviewTasks {
             description = "Render all previews to PNG (stub)"
             dependsOn(discoverTask)
         }
-        registerRenderAllPreviews(project, extension, renderTask, previewOutputDir)
+        registerRenderAllPreviews(project, extension, renderTask, previewOutputDir, verifyAccessibilityTask = null)
     }
 
     /**
@@ -148,6 +157,7 @@ internal object ComposePreviewTasks {
         extension: PreviewExtension,
         renderTask: TaskProvider<*>,
         previewOutputDir: Provider<Directory>,
+        verifyAccessibilityTask: TaskProvider<*>?,
     ) {
         // Default history dir: <project>/.compose-preview-history — outside `build/`
         // so snapshots survive `./gradlew clean`. Users can override via extension.
@@ -177,6 +187,11 @@ internal object ComposePreviewTasks {
         project.tasks.register("renderAllPreviews", DefaultTask::class.java) {
             group = "compose preview"
             dependsOn(extension.historyEnabled.map { enabled -> if (enabled) historizeTask else renderTask })
+            // `verifyAccessibility` runs AFTER rendering so PNGs always exist
+            // even when the check fails. `finalizedBy` (instead of `dependsOn`)
+            // lets the build still produce artefacts for CLI/VSCode to
+            // inspect when the a11y threshold trips the build.
+            verifyAccessibilityTask?.let { finalizedBy(it) }
             doLast {
                 val manifestOnDisk = manifestFile.get().asFile
                 if (!manifestOnDisk.exists()) return@doLast

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -36,6 +36,15 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     @get:Input
     abstract val variantName: Property<String>
 
+    /**
+     * When `true`, [outputFile] is written with a populated
+     * [PreviewManifest.accessibilityReport] pointer so downstream tools can
+     * locate the sidecar report. The file itself is produced later by the
+     * render task / verify task.
+     */
+    @get:Input
+    abstract val accessibilityChecksEnabled: Property<Boolean>
+
     @get:OutputFile
     abstract val outputFile: RegularFileProperty
 
@@ -100,6 +109,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             module = moduleName.get(),
             variant = variantName.get(),
             previews = deduped,
+            accessibilityReport = "accessibility.json".takeIf { accessibilityChecksEnabled.get() },
         )
 
         val outFile = outputFile.get().asFile

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -47,4 +47,12 @@ data class PreviewManifest(
     val module: String,
     val variant: String,
     val previews: List<PreviewInfo>,
+    /**
+     * Relative path (from this manifest's parent directory) to a sidecar
+     * accessibility report JSON, when `composePreview.accessibilityChecks.enabled`
+     * is `true`. `null` signals the feature is off — downstream tools should
+     * treat the absence of this pointer as "no a11y data" rather than probing
+     * for the file on disk.
+     */
+    val accessibilityReport: String? = null,
 )

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -1,11 +1,12 @@
 package ee.schimke.composeai.plugin
 
+import org.gradle.api.Action
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import javax.inject.Inject
 
-abstract class PreviewExtension @Inject constructor(objects: ObjectFactory) {
+abstract class PreviewExtension @Inject constructor(private val objects: ObjectFactory) {
     val variant: Property<String> = objects.property(String::class.java).convention("debug")
     val sdkVersion: Property<Int> = objects.property(Int::class.java).convention(35)
     val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
@@ -40,4 +41,42 @@ abstract class PreviewExtension @Inject constructor(objects: ObjectFactory) {
      * when the module has enough previews to amortise that overhead.
      */
     val shards: Property<Int> = objects.property(Int::class.java).convention(1)
+
+    /**
+     * ATF (Accessibility Test Framework) checks, run against each rendered
+     * preview. Off by default — turning it on surfaces findings in the CLI,
+     * VSCode diagnostics, and `accessibility.json`, but does NOT break the
+     * build. Set `failOnErrors = true` / `failOnWarnings = true` to gate
+     * builds on findings.
+     *
+     *     composePreview {
+     *         accessibilityChecks {
+     *             enabled = true
+     *             failOnErrors = true  // opt in to build gating
+     *         }
+     *     }
+     */
+    val accessibilityChecks: AccessibilityChecksExtension =
+        objects.newInstance(AccessibilityChecksExtension::class.java)
+
+    fun accessibilityChecks(action: Action<AccessibilityChecksExtension>) {
+        action.execute(accessibilityChecks)
+    }
+}
+
+abstract class AccessibilityChecksExtension @Inject constructor(objects: ObjectFactory) {
+    /** Default: `false`. Enabling turns on ATF checks and the `verifyAccessibility` task. */
+    val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+
+    /**
+     * Fail the build if any ERROR-level ATF finding is reported. Default:
+     * `false` — findings are reported (logged, written to the JSON report,
+     * surfaced as CLI/VSCode diagnostics) but do not fail the build unless
+     * the consumer explicitly opts in. That way turning on `enabled` is a
+     * safe, purely additive change.
+     */
+    val failOnErrors: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+
+    /** Fail the build if any WARNING-level ATF finding is reported. Default: `false` (same rationale as [failOnErrors]). */
+    val failOnWarnings: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/VerifyAccessibilityTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/VerifyAccessibilityTask.kt
@@ -1,0 +1,113 @@
+package ee.schimke.composeai.plugin
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Aggregates the per-preview ATF reports emitted by [RobolectricRenderTestBase]
+ * into a single `accessibility.json` keyed by previewId, and fails the build
+ * when findings exceed the thresholds configured on
+ * [AccessibilityChecksExtension].
+ *
+ * Runs once per Android module after `renderPreviews`. Only registered when
+ * `composePreview.accessibilityChecks.enabled = true`.
+ */
+@CacheableTask
+abstract class VerifyAccessibilityTask : DefaultTask() {
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val perPreviewDir: DirectoryProperty
+
+    @get:Input
+    abstract val moduleName: Property<String>
+
+    @get:Input
+    abstract val failOnErrors: Property<Boolean>
+
+    @get:Input
+    abstract val failOnWarnings: Property<Boolean>
+
+    @get:OutputFile
+    abstract val reportFile: RegularFileProperty
+
+    // Serializers duplicated here rather than shared with renderer-android —
+    // the plugin runs on the Gradle JVM and cannot depend on an Android
+    // artifact. Stay in sync with [RenderManifest.kt] in renderer-android.
+    @Serializable
+    private data class A11yFinding(
+        val level: String,
+        val type: String,
+        val message: String,
+        val viewDescription: String? = null,
+        val boundsInScreen: String? = null,
+    )
+
+    @Serializable
+    private data class A11yEntry(val previewId: String, val findings: List<A11yFinding>)
+
+    @Serializable
+    private data class A11yReport(val module: String, val entries: List<A11yEntry>)
+
+    @TaskAction
+    fun verify() {
+        val json = Json { prettyPrint = true; encodeDefaults = true; ignoreUnknownKeys = true }
+
+        val dir = perPreviewDir.get().asFile
+        val entries = if (dir.exists()) {
+            dir.listFiles { f -> f.isFile && f.name.endsWith(".json") }
+                .orEmpty()
+                .sortedBy { it.name }
+                .map { json.decodeFromString(A11yEntry.serializer(), it.readText()) }
+        } else {
+            emptyList()
+        }
+
+        val report = A11yReport(module = moduleName.get(), entries = entries)
+        val out = reportFile.get().asFile
+        out.parentFile?.mkdirs()
+        out.writeText(json.encodeToString(A11yReport.serializer(), report))
+
+        val errorCount = entries.sumOf { it.findings.count { f -> f.level == "ERROR" } }
+        val warningCount = entries.sumOf { it.findings.count { f -> f.level == "WARNING" } }
+
+        logger.lifecycle(
+            "Accessibility: ${entries.size} preview(s), " +
+                "$errorCount error(s), $warningCount warning(s)",
+        )
+        for (entry in entries) {
+            for (finding in entry.findings) {
+                if (finding.level == "INFO") continue
+                logger.lifecycle("  [${finding.level}] ${entry.previewId} · ${finding.type}: ${finding.message}")
+            }
+        }
+
+        val failures = mutableListOf<String>()
+        if (failOnErrors.get() && errorCount > 0) {
+            failures += "$errorCount error(s)"
+        }
+        if (failOnWarnings.get() && warningCount > 0) {
+            failures += "$warningCount warning(s)"
+        }
+        if (failures.isNotEmpty()) {
+            throw GradleException(
+                "Accessibility check failed: ${failures.joinToString(", ")}. " +
+                    "See ${out.absolutePath} for the full report, or disable the " +
+                    "relevant `failOn*` flag in `composePreview.accessibilityChecks` " +
+                    "to downgrade to a warning.",
+            )
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version = "1.59.0" }
 roborazzi-compose = { module = "io.github.takahirom.roborazzi:roborazzi-compose", version = "1.59.0" }
+roborazzi-accessibility-check = { module = "io.github.takahirom.roborazzi:roborazzi-accessibility-check", version = "1.59.0" }
 junit = { module = "junit:junit", version.ref = "junit" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -56,6 +56,28 @@ dependencies {
     implementation(libs.activity.compose)
     implementation(libs.roborazzi)
     implementation(libs.roborazzi.compose)
+    // ATF accessibility checks. Exercised only when consumers opt in via
+    // `composePreview { accessibilityChecks { enabled = true } }`, but always
+    // on the classpath because the renderer test references these types
+    // unconditionally.
+    //
+    // The a11y-enabled path uses `createAndroidComposeRule<ComponentActivity>()`
+    // + `onRoot().captureRoboImage(...)` + ATF against the `ViewRootForTest`
+    // backing the SemanticsNode. That's the same plumbing roborazzi-
+    // accessibility-check's `checkRoboAccessibility` extension uses — it's the
+    // only combination where Robolectric populates the accessibility
+    // hierarchy richly enough for ATF to surface findings. The composable-
+    // form `captureRoboImage { @Composable }` closes its ActivityScenario
+    // eagerly, which detaches the view before ATF gets to run.
+    //
+    // Requires `ui-test-junit4` (ComposeTestRule) and `ui-test-manifest`
+    // (ComponentActivity <activity> entry merged into the consumer's test
+    // manifest). Declared as `implementation` — AGP's manifest merger picks
+    // up ui-test-manifest automatically when it's on the unit-test runtime
+    // classpath, without leaking into production.
+    implementation("androidx.compose.ui:ui-test-junit4")
+    implementation("androidx.compose.ui:ui-test-manifest")
+    implementation(libs.roborazzi.accessibility.check)
 
     // Tiles rendering is reflection-driven at runtime (the consumer module
     // supplies the actual classes on the JUnit classpath), so we only need

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityChecker.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityChecker.kt
@@ -1,0 +1,108 @@
+package ee.schimke.composeai.renderer
+
+import android.os.Build
+import android.view.View
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckPreset
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResult.AccessibilityCheckResultType
+import com.google.android.apps.common.testing.accessibility.framework.AccessibilityHierarchyCheckResult
+import com.google.android.apps.common.testing.accessibility.framework.uielement.AccessibilityHierarchyAndroid
+import java.io.File
+import java.util.Locale
+import kotlinx.serialization.json.Json
+import org.robolectric.shadows.ShadowBuild
+
+/**
+ * Minimal ATF integration for the Robolectric renderer.
+ *
+ * ATF's [AccessibilityHierarchyAndroid] bails out when
+ * `Build.FINGERPRINT == "robolectric"`
+ * ([AccessibilityHierarchyAndroid.java:667](https://github.com/google/Accessibility-Test-Framework-for-Android/blob/c65cab02b2a845c29c3da100d6adefd345a144e3/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/AccessibilityHierarchyAndroid.java#L667)).
+ * The workaround is to swap the fingerprint to something ATF doesn't recognise
+ * for the duration of the check — we mirror what roborazzi's own
+ * `whileAvoidingRobolectricFingerprint` helper does.
+ *
+ * Kept standalone (not using `SemanticsNodeInteraction.checkRoboAccessibility`)
+ * because the renderer uses the lightweight `captureRoboImage { @Composable }`
+ * overload, which doesn't expose a `SemanticsNodeInteraction`. Running ATF
+ * directly against the view we snapshot through [LocalView] avoids paying the
+ * `createComposeRule()` tax on every render.
+ */
+internal object AccessibilityChecker {
+
+    private val json = Json { prettyPrint = true; encodeDefaults = true }
+
+    fun check(previewId: String, root: View): List<AccessibilityFinding> {
+        val originalFingerprint = Build.FINGERPRINT
+        val needsSwap = originalFingerprint == "robolectric"
+        if (needsSwap) {
+            ShadowBuild.setFingerprint("roborazzi")
+        }
+        try {
+            val hierarchy = AccessibilityHierarchyAndroid.newBuilder(root).build()
+            val checks = AccessibilityCheckPreset
+                .getAccessibilityHierarchyChecksForPreset(AccessibilityCheckPreset.LATEST)
+            val allResults = mutableListOf<AccessibilityHierarchyCheckResult>()
+            for (check in checks) {
+                allResults += check.runCheckOnHierarchy(hierarchy)
+            }
+            if (DEBUG) {
+                val typeCounts = allResults.groupingBy { it.type?.name ?: "null" }.eachCount()
+                println("[compose-a11y] $previewId: ran ${checks.size} check(s), got ${allResults.size} raw result(s) on ${root.javaClass.simpleName} (attached=${root.isAttachedToWindow}) types=$typeCounts")
+            }
+            return allResults.mapNotNull { it.toFinding() }
+        } finally {
+            if (needsSwap) {
+                ShadowBuild.setFingerprint(originalFingerprint)
+            }
+        }
+    }
+
+    private val DEBUG = System.getProperty("composeai.a11y.debug") == "true"
+
+    /**
+     * Writes the per-preview report. The plugin's `verifyAccessibility` task
+     * collects all of these into a single `accessibility.json`; writing
+     * per-preview avoids concurrent-writer issues when previews are sharded
+     * across JVMs.
+     */
+    fun writePerPreviewReport(outputDir: File, previewId: String, findings: List<AccessibilityFinding>) {
+        outputDir.mkdirs()
+        val entry = AccessibilityEntry(previewId = previewId, findings = findings)
+        outputDir.resolve("$previewId.json").writeText(
+            json.encodeToString(AccessibilityEntry.serializer(), entry),
+        )
+    }
+
+    private fun AccessibilityHierarchyCheckResult.toFinding(): AccessibilityFinding? {
+        // NOT_RUN is noise in output — the check couldn't evaluate this element.
+        // We still surface INFO so consumers can see what ATF considered.
+        val level = when (type) {
+            AccessibilityCheckResultType.ERROR -> "ERROR"
+            AccessibilityCheckResultType.WARNING -> "WARNING"
+            AccessibilityCheckResultType.INFO -> "INFO"
+            else -> return null // NOT_RUN / SUPPRESSED / RESOLVED / null — noise
+        }
+        val ruleType = sourceCheckClass?.simpleName ?: "UnknownCheck"
+        val message = try {
+            getMessage(Locale.ENGLISH).toString()
+        } catch (e: Throwable) {
+            e.message ?: "no message"
+        }
+        val element = element
+        val bounds = element?.boundsInScreen?.let { "${it.left},${it.top},${it.right},${it.bottom}" }
+        val viewDesc = element?.let { el ->
+            buildString {
+                el.className?.let { append(it).append(' ') }
+                el.resourceName?.let { append('#').append(it.substringAfterLast('/')) }
+                el.contentDescription?.let { append(" desc=\"").append(it).append('"') }
+            }.trim().takeIf { it.isNotEmpty() }
+        }
+        return AccessibilityFinding(
+            level = level,
+            type = ruleType,
+            message = message,
+            viewDescription = viewDesc,
+            boundsInScreen = bounds,
+        )
+    }
+}

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -12,6 +12,44 @@ data class RenderManifest(
     val module: String,
     val variant: String,
     val previews: List<RenderPreviewEntry>,
+    /**
+     * Relative path (from this manifest's parent directory) to a sidecar
+     * [AccessibilityReport] JSON file, when accessibility checks are enabled.
+     * `null` means the feature is off for this module — tools should treat the
+     * absence of this pointer as "no a11y data" rather than probing for the
+     * file on disk.
+     */
+    val accessibilityReport: String? = null,
+)
+
+/**
+ * ATF findings per preview. Written by [RobolectricRenderTestBase] when
+ * accessibility checks are enabled, read by the plugin's post-render verify
+ * task and by downstream tools (CLI, VSCode).
+ */
+@Serializable
+data class AccessibilityReport(
+    val module: String,
+    val entries: List<AccessibilityEntry>,
+)
+
+@Serializable
+data class AccessibilityEntry(
+    val previewId: String,
+    val findings: List<AccessibilityFinding>,
+)
+
+@Serializable
+data class AccessibilityFinding(
+    /** `ERROR`, `WARNING`, `INFO`, or `NOT_RUN` — upper-cased ATF `AccessibilityCheckResultType`. */
+    val level: String,
+    /** Short rule identifier — ATF check class simple name (e.g. `TouchTargetSizeCheck`). */
+    val type: String,
+    val message: String,
+    /** Human-readable description of the offending element, if ATF could resolve one. */
+    val viewDescription: String? = null,
+    /** `left,top,right,bottom` in the preview's pixel space — agents can highlight on the PNG. */
+    val boundsInScreen: String? = null,
 )
 
 @Serializable

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1,9 +1,13 @@
 package ee.schimke.composeai.renderer
 
+import androidx.activity.ComponentActivity
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.ViewRootForTest
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onRoot
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.RoborazziComposeOptions
 import com.github.takahirom.roborazzi.RoborazziComposeSetupOption
@@ -101,6 +105,23 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
             recordOptions = RoborazziOptions.RecordOptions(applyDeviceCrop = isRound),
         )
 
+        val a11yEnabled = System.getProperty("composeai.a11y.enabled") == "true"
+        if (a11yEnabled) {
+            renderWithA11y(params, widthDp, heightDp, outputFile, roborazziOptions, composeOptions)
+        } else {
+            renderDefault(params, widthDp, heightDp, outputFile, roborazziOptions, composeOptions)
+        }
+    }
+
+    @OptIn(ExperimentalRoborazziApi::class)
+    private fun renderDefault(
+        params: RenderPreviewParams,
+        widthDp: Int,
+        heightDp: Int,
+        outputFile: File,
+        roborazziOptions: RoborazziOptions,
+        composeOptions: RoborazziComposeOptions,
+    ) {
         captureRoboImage(
             file = outputFile,
             roborazziOptions = roborazziOptions,
@@ -110,6 +131,83 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                 strategyFor(params.kind).Render(preview, widthDp, heightDp)
             }
         }
+    }
+
+    /**
+     * A11y-enabled render path.
+     *
+     * Uses `createAndroidComposeRule<ComponentActivity>()` + `onRoot()
+     * .captureRoboImage(...)` for the screenshot and runs ATF against the
+     * [ViewRootForTest]-backed view fetched through the same
+     * [androidx.compose.ui.test.SemanticsNodeInteraction]. That's the combo
+     * roborazzi-accessibility-check uses internally (see
+     * `checkRoboAccessibility` in RoborazziATFAccessibilityChecker.kt); the
+     * composable form of `captureRoboImage` bails out too early for ATF
+     * because it eagerly closes the ActivityScenario, and running ATF on the
+     * Activity's DecorView under Robolectric yields all NOT_RUN — whereas
+     * `ViewRootForTest.view` is exactly what ATF was written to walk.
+     *
+     * Inspection mode is intentionally OFF here — `LocalInspectionMode=true`
+     * suppresses compose's accessibility semantics population, leaving ATF
+     * with nothing to evaluate. Opting into a11y therefore trades off a bit
+     * of inspection-mode determinism (infinite animations tick instead of
+     * parking on frame 0) for real findings.
+     *
+     * The rule is created and applied manually so the default (a11y-off)
+     * path keeps its lightweight `captureRoboImage { @Composable }` flow
+     * and doesn't have to pay the `createAndroidComposeRule` setup cost.
+     */
+    @OptIn(ExperimentalRoborazziApi::class)
+    private fun renderWithA11y(
+        params: RenderPreviewParams,
+        widthDp: Int,
+        heightDp: Int,
+        outputFile: File,
+        roborazziOptions: RoborazziOptions,
+        composeOptions: RoborazziComposeOptions,
+    ) {
+        // Robolectric 4.13+ rejects `ActivityScenario.launch` when no manifest
+        // entry resolves the default MAIN/LAUNCHER intent for the activity
+        // class (robolectric/robolectric#4736). ui-test-manifest adds
+        // `<activity android:name="androidx.activity.ComponentActivity">` but
+        // without an intent filter, so we register the component explicitly
+        // with ShadowPackageManager — cheap, idempotent, and works regardless
+        // of whether the consumer's merged manifest has the right filter.
+        val appContext: android.app.Application =
+            androidx.test.core.app.ApplicationProvider.getApplicationContext()
+        org.robolectric.Shadows.shadowOf(appContext.packageManager)
+            .addActivityIfNotPresent(
+                android.content.ComponentName(appContext.packageName, ComponentActivity::class.java.name),
+            )
+
+        val rule = createAndroidComposeRule<ComponentActivity>()
+        val description = org.junit.runner.Description.createTestDescription(
+            this::class.java,
+            "a11yRender_${preview.id}",
+        )
+        val statement = object : org.junit.runners.model.Statement() {
+            override fun evaluate() {
+                rule.setContent {
+                    CompositionLocalProvider(LocalInspectionMode provides false) {
+                        strategyFor(params.kind).Render(preview, widthDp, heightDp)
+                    }
+                }
+                val onRoot = rule.onRoot()
+                onRoot.captureRoboImage(
+                    file = outputFile,
+                    roborazziOptions = roborazziOptions,
+                )
+
+                val view = (onRoot.fetchSemanticsNode().root as ViewRootForTest).view
+                val findings = AccessibilityChecker.check(preview.id, view)
+                val a11yDir = File(
+                    System.getProperty("composeai.a11y.outputDir")
+                        ?: "build/compose-previews/accessibility-per-preview",
+                )
+                AccessibilityChecker.writePerPreviewReport(a11yDir, preview.id, findings)
+            }
+        }
+        rule.apply(statement, description).evaluate()
     }
 
     companion object {

--- a/sample-android/build.gradle.kts
+++ b/sample-android/build.gradle.kts
@@ -4,6 +4,17 @@ plugins {
     id("ee.schimke.composeai.preview")
 }
 
+composePreview {
+    accessibilityChecks {
+        // Sample includes deliberately-broken previews (BadButton,
+        // TinyTapTarget, TinyNativeButton) used as demo data for the CLI /
+        // VSCode surfacing of a11y findings. Flip to `true` to exercise the
+        // opt-in path; defaults off to keep the sample's render build
+        // byte-identical to the non-a11y baseline.
+        enabled = false
+    }
+}
+
 android {
     namespace = "com.example.sampleandroid"
     compileSdk = 36

--- a/sample-android/src/main/kotlin/com/example/sampleandroid/Previews.kt
+++ b/sample-android/src/main/kotlin/com/example/sampleandroid/Previews.kt
@@ -115,3 +115,18 @@ fun PhoneGreetingPreview() {
         }
     }
 }
+
+/**
+ * Deliberately-broken preview — a small Button with no content description
+ * AND a tiny size. Exercises the accessibility pipeline end-to-end: a real
+ * Material Button is important-for-accessibility, so ATF should flag the
+ * TouchTargetSize / SpeakableText rules on it.
+ */
+@Preview(name = "Bad Button", showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+fun BadButtonPreview() {
+    androidx.compose.material3.Button(
+        onClick = { /* no-op */ },
+        modifier = Modifier.size(width = 20.dp, height = 20.dp),
+    ) {}
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -76,6 +76,11 @@
                 "command": "composePreview.openModuleBuildFile",
                 "title": "Open Module build.gradle.kts",
                 "category": "Compose Preview"
+            },
+            {
+                "command": "composePreview.toggleAccessibilityChecks",
+                "title": "Toggle Accessibility Checks",
+                "category": "Compose Preview"
             }
         ],
         "configuration": {
@@ -85,6 +90,11 @@
                     "type": "string",
                     "default": "debug",
                     "description": "Build variant to use for preview rendering"
+                },
+                "composePreview.accessibilityChecks.enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Run ATF accessibility checks on every rendered preview. When on, the extension passes `-PcomposePreview.accessibilityChecks.enabled=true` to each Gradle task; findings surface as diagnostics in the Problems panel and on the `@Preview` line. Overrides the `accessibilityChecks { enabled = ... }` block in build.gradle.kts for this session only."
                 }
             }
         }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -7,6 +7,7 @@ import { PreviewRegistry } from './previewRegistry';
 import { PreviewGutterDecorations } from './previewGutterDecorations';
 import { PreviewHoverProvider } from './previewHoverProvider';
 import { PreviewCodeLensProvider } from './previewCodeLensProvider';
+import { PreviewA11yDiagnostics } from './previewA11yDiagnostics';
 import { packageQualifiedSourcePath } from './sourcePath';
 import { PreviewInfo } from './types';
 
@@ -95,6 +96,27 @@ export async function activate(context: vscode.ExtensionContext) {
         }),
         vscode.commands.registerCommand('composePreview.openModuleBuildFile',
             (filePath?: string) => openModuleBuildFile(workspaceRoot, filePath)),
+        vscode.commands.registerCommand('composePreview.toggleAccessibilityChecks', async () => {
+            // Session-wide toggle — mutates the workspace setting so the
+            // gradleService's `-P` override picks up the new value on the
+            // next task run. We follow up with a refresh so the webview +
+            // diagnostics update immediately; otherwise the new state
+            // would only be visible after the user's next edit.
+            const config = vscode.workspace.getConfiguration('composePreview');
+            const current = config.get<boolean>('accessibilityChecks.enabled') ?? false;
+            await config.update(
+                'accessibilityChecks.enabled',
+                !current,
+                vscode.ConfigurationTarget.Workspace,
+            );
+            vscode.window.showInformationMessage(
+                `Compose Preview: accessibility checks ${!current ? 'ON' : 'OFF'} for this workspace`,
+            );
+            // Force a fresh render — the render task's inputs changed
+            // (different -P arg), so we need to re-resolve findings.
+            gradleService?.invalidateCache();
+            await refresh(true, currentScopeFile ?? undefined);
+        }),
         vscode.commands.registerCommand('composePreview.focusPreview',
             async (functionName: string, filePath?: string) => {
                 if (!panel) { return; }
@@ -115,12 +137,14 @@ export async function activate(context: vscode.ExtensionContext) {
     const gutterDecorations = new PreviewGutterDecorations(context.extensionUri, registry, detectLog);
     const hoverProvider = new PreviewHoverProvider(registry, detectLog);
     const codeLensProvider = new PreviewCodeLensProvider(registry, detectLog);
+    const a11yDiagnostics = new PreviewA11yDiagnostics(registry, detectLog);
     const kotlinFiles: vscode.DocumentSelector = { language: 'kotlin', scheme: 'file' };
     context.subscriptions.push(
         vscode.languages.registerHoverProvider(kotlinFiles, hoverProvider),
         vscode.languages.registerCodeLensProvider(kotlinFiles, codeLensProvider),
         codeLensProvider,
         gutterDecorations,
+        a11yDiagnostics,
         { dispose: () => registry.dispose() },
     );
 

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { HistoryEntry, PreviewManifest } from './types';
+import * as vscode from 'vscode';
+import { AccessibilityFinding, AccessibilityReport, HistoryEntry, PreviewManifest } from './types';
 
 const HISTORY_DIRNAME = '.compose-preview-history';
 const TIMESTAMP_RE = /^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})(?:-\d+)?$/;
@@ -94,11 +95,43 @@ export class GradleService {
                 this.logger.appendLine(`Malformed manifest at ${manifestPath}`);
                 return null;
             }
+            // Enrich each preview with a11y findings when the module has the
+            // sidecar report. Always follow the manifest's pointer rather than
+            // probing for the file: disabling the Gradle option must cleanly
+            // remove findings from the UI without a stale opt-in run
+            // haunting us.
+            if (manifest.accessibilityReport) {
+                const byId = this.readA11yFindingsById(module, manifest.accessibilityReport);
+                for (const p of manifest.previews) {
+                    p.a11yFindings = byId[p.id] ?? [];
+                }
+            } else {
+                for (const p of manifest.previews) {
+                    p.a11yFindings = null;
+                }
+            }
             return manifest;
         } catch (e: unknown) {
             const message = e instanceof Error ? e.message : String(e);
             this.logger.appendLine(`Failed to parse ${manifestPath}: ${message}`);
             return null;
+        }
+    }
+
+    private readA11yFindingsById(module: string, relativePath: string): Record<string, AccessibilityFinding[]> {
+        const reportPath = path.join(this.workspaceRoot, module, 'build', 'compose-previews', relativePath);
+        if (!fs.existsSync(reportPath)) { return {}; }
+        try {
+            const report = JSON.parse(fs.readFileSync(reportPath, 'utf-8')) as AccessibilityReport;
+            const out: Record<string, AccessibilityFinding[]> = {};
+            for (const entry of report.entries ?? []) {
+                out[entry.previewId] = entry.findings ?? [];
+            }
+            return out;
+        } catch (e: unknown) {
+            const message = e instanceof Error ? e.message : String(e);
+            this.logger.appendLine(`Failed to parse ${reportPath}: ${message}`);
+            return {};
         }
     }
 
@@ -212,6 +245,20 @@ export class GradleService {
         this.cancel();
     }
 
+    /**
+     * Reads workspace settings and builds the `-P` override list passed to
+     * every Gradle invocation. Keeps the mapping in one place so settings
+     * changes take effect the next time `runTask` fires, no reload required.
+     */
+    private buildGradleArgs(): string[] {
+        const args: string[] = [];
+        const config = vscode.workspace.getConfiguration('composePreview');
+        if (config.get<boolean>('accessibilityChecks.enabled')) {
+            args.push('-PcomposePreview.accessibilityChecks.enabled=true');
+        }
+        return args;
+    }
+
     private runTask(task: string): Promise<void> {
         const cancellationKey = `compose-preview-${++this.taskCounter}|${task}`;
         this.activeKeys.add(cancellationKey);
@@ -231,6 +278,7 @@ export class GradleService {
         const taskPromise = this.gradleApi.runTask({
             projectFolder: this.workspaceRoot,
             taskName: task,
+            args: this.buildGradleArgs(),
             showOutputColors: false,
             cancellationKey,
             onOutput: (output) => {

--- a/vscode-extension/src/previewA11yDiagnostics.ts
+++ b/vscode-extension/src/previewA11yDiagnostics.ts
@@ -1,0 +1,103 @@
+import * as vscode from 'vscode';
+import { PreviewRegistry } from './previewRegistry';
+import { detectPreviews } from './previewDetection';
+
+/**
+ * Publishes ATF findings collected in the [PreviewRegistry] as VS Code
+ * diagnostics so they show up in the Problems panel and as squigglies on the
+ * `@Preview` annotation line.
+ *
+ * The registry holds the canonical (sourceFile, functionName) → findings
+ * mapping; this class only handles the projection to open documents. It
+ * listens for registry changes (new render completed) and for document
+ * open/edit events so findings re-render against the current annotation
+ * position if the user added lines above.
+ *
+ * Reuses [detectPreviews] rather than doing its own regex scan — that way we
+ * agree with the gutter / code lens / hover providers on where each preview
+ * annotation sits, and we get multi-preview resolution for free.
+ */
+export class PreviewA11yDiagnostics implements vscode.Disposable {
+    private readonly collection: vscode.DiagnosticCollection;
+    private readonly disposables: vscode.Disposable[] = [];
+    /** Per-document debounce so rapid keystrokes collapse into one refresh. */
+    private pending = new Map<string, NodeJS.Timeout>();
+
+    constructor(
+        private readonly registry: PreviewRegistry,
+        private readonly log?: (msg: string) => void,
+    ) {
+        this.collection = vscode.languages.createDiagnosticCollection('compose-preview-a11y');
+        this.disposables.push(this.collection);
+        this.disposables.push(registry.onDidChange(() => this.refreshAll()));
+        this.disposables.push(
+            vscode.workspace.onDidOpenTextDocument((doc) => this.scheduleRefresh(doc)),
+        );
+        this.disposables.push(
+            vscode.workspace.onDidChangeTextDocument((e) => this.scheduleRefresh(e.document)),
+        );
+        this.disposables.push(
+            vscode.workspace.onDidCloseTextDocument((doc) => this.collection.delete(doc.uri)),
+        );
+        // Seed currently-open documents so findings render on first load
+        // without the user having to re-open anything.
+        for (const doc of vscode.workspace.textDocuments) {
+            this.scheduleRefresh(doc);
+        }
+    }
+
+    dispose(): void {
+        for (const t of this.pending.values()) { clearTimeout(t); }
+        this.pending.clear();
+        for (const d of this.disposables) { d.dispose(); }
+    }
+
+    private refreshAll(): void {
+        for (const doc of vscode.workspace.textDocuments) {
+            this.scheduleRefresh(doc);
+        }
+    }
+
+    private scheduleRefresh(doc: vscode.TextDocument): void {
+        if (doc.languageId !== 'kotlin') { return; }
+        const key = doc.uri.toString();
+        const existing = this.pending.get(key);
+        if (existing) { clearTimeout(existing); }
+        this.pending.set(key, setTimeout(() => {
+            this.pending.delete(key);
+            void this.refreshDocument(doc);
+        }, 200));
+    }
+
+    private async refreshDocument(doc: vscode.TextDocument): Promise<void> {
+        if (doc.languageId !== 'kotlin') {
+            this.collection.delete(doc.uri);
+            return;
+        }
+        const detected = await detectPreviews(doc, this.registry, this.log);
+        const diagnostics: vscode.Diagnostic[] = [];
+        for (const det of detected) {
+            const entry = this.registry.find(doc.uri.fsPath, det.functionName);
+            const findings = entry?.preview.a11yFindings;
+            if (!findings || findings.length === 0) { continue; }
+            const line = det.funLineNumber;
+            const range = new vscode.Range(line, 0, line, doc.lineAt(line).text.length);
+            for (const f of findings) {
+                if (f.level === 'INFO') { continue; }
+                const diag = new vscode.Diagnostic(
+                    range,
+                    `${f.type}: ${f.message}`,
+                    f.level === 'ERROR' ? vscode.DiagnosticSeverity.Error : vscode.DiagnosticSeverity.Warning,
+                );
+                diag.source = 'compose-preview-a11y';
+                diag.code = f.type;
+                diagnostics.push(diag);
+            }
+        }
+        if (diagnostics.length === 0) {
+            this.collection.delete(doc.uri);
+        } else {
+            this.collection.set(doc.uri, diagnostics);
+        }
+    }
+}

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -23,12 +23,34 @@ export interface PreviewInfo {
      *  the preview has at least one archived snapshot on disk. The webview
      *  uses this to decide whether to show the history button at all. */
     hasHistory?: boolean;
+    /**
+     * Populated by the extension from the sidecar accessibility.json referenced
+     * in [PreviewManifest.accessibilityReport]. `null`/`undefined` means
+     * accessibility checks were disabled for this module; an empty array means
+     * checks ran and found nothing.
+     */
+    a11yFindings?: AccessibilityFinding[] | null;
 }
 
 export interface PreviewManifest {
     module: string;
     variant: string;
     previews: PreviewInfo[];
+    /** Relative path (from `previews.json`) to the sidecar a11y report, or null. */
+    accessibilityReport?: string | null;
+}
+
+export interface AccessibilityFinding {
+    level: 'ERROR' | 'WARNING' | 'INFO' | string;
+    type: string;
+    message: string;
+    viewDescription?: string | null;
+    boundsInScreen?: string | null;
+}
+
+export interface AccessibilityReport {
+    module: string;
+    entries: { previewId: string; findings: AccessibilityFinding[] }[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds Google's Accessibility Test Framework (ATF) checks to every rendered preview, inspired by [takahirom/roborazzi#557](https://github.com/takahirom/roborazzi/pull/557). Off by default; enabling is purely additive — findings land in `accessibility.json`, surface in the CLI (`compose-preview a11y`, `show --json`) and in VS Code as diagnostics on the `@Preview` line.
- Build gating is also opt-in: `failOnErrors` / `failOnWarnings` both default to `false` so flipping `enabled = true` never breaks a clean build unless the consumer explicitly wants it to.
- VS Code gains a `composePreview.accessibilityChecks.enabled` setting + "Toggle Accessibility Checks" command; the setting passes `-PcomposePreview.accessibilityChecks.enabled=true` to every Gradle invocation so a single-session override works without editing `build.gradle.kts`. Same `-P` works from the CLI.

## How it works

- **Renderer:** when a11y is on, switches from `captureRoboImage { @Composable }` to `createAndroidComposeRule<ComponentActivity>()` + `onRoot().captureRoboImage(...)` + ATF against the `ViewRootForTest`-backed view. That's the same plumbing `roborazzi-accessibility-check` uses internally, and the only combo where the Robolectric-built accessibility hierarchy is rich enough for ATF to produce findings. Applies the `ShadowBuild.setFingerprint(\"roborazzi\")` workaround around every ATF call ([AccessibilityHierarchyAndroid:667](https://github.com/google/Accessibility-Test-Framework-for-Android/blob/c65cab02b2a845c29c3da100d6adefd345a144e3/src/main/java/com/google/android/apps/common/testing/accessibility/framework/uielement/AccessibilityHierarchyAndroid.java#L667) short-circuit).
- **Plugin:** a new `verifyAccessibility` task aggregates per-preview JSON into `accessibility.json` and fails per the configured thresholds. `finalizedBy renderAllPreviews` so PNGs still land even when a11y fails. `previews.json` grows an `accessibilityReport` pointer so downstream tools discover findings through the existing manifest (no separate probing).
- **Sample:** adds one deliberately-broken `BadButtonPreview` (tiny unlabelled Material Button) as demo data.

## Test plan

- [x] `./gradlew check` — all existing unit + functional tests pass
- [x] `./gradlew :sample-android:renderAllPreviews` (default-off) — byte-identical to before: only `previews.json` + `renders/`, no `accessibility*` artefacts, manifest has `accessibilityReport: null`
- [x] `./gradlew :sample-android:renderAllPreviews -PcomposePreview.accessibilityChecks.enabled=true` — produces `accessibility.json`, `verifyAccessibility` reports 1 error on `BadButtonPreview` (`SpeakableTextPresentCheck`), build succeeds because `failOnErrors` defaults off
- [x] Flip `failOnErrors = true` and re-run — build fails with a clear "See …/accessibility.json for the full report" message; all 12 PNGs still rendered
- [x] VS Code extension compiles (`npm run compile`), toggle command flips workspace setting and refreshes

Phase 2 (not in this PR, captured in the plan): annotated screenshot overlay per horologist's [A11ySnapshotTransformer](https://github.com/google/horologist/blob/d9101195432d5d25efb285c7df2daac194fc42bf/roboscreenshots/src/main/java/com/google/android/horologist/screenshots/a11y/A11ySnapshotTransformer.kt#L4).