### PR TITLE
fix(renderer): don't poison consumer classpath with newer AndroidX

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -115,6 +115,22 @@ jobs:
             workdir: WearTilesKotlin
             module: app
             extra_gradle_args: ""
+            # Render in addition to discover — WearTilesKotlin uses an older
+            # Compose BOM than our renderer, which previously exposed a latent
+            # transitive-dep issue (activity-compose 1.13 → navigationevent
+            # resources not merged into the consumer's `apk-for-local-test.ap_`,
+            # crashing Robolectric at Activity bootstrap with
+            # `NoClassDefFoundError: androidx/navigationevent/R$id`). Discovery
+            # never exercises that path; only renderPreviews does. Keep this
+            # entry rendering so the regression doesn't come back silently.
+            render: true
+            # Tiles-specific: fail the job unless at least one rendered preview
+            # is of `kind: TILE`. Catches the case where discovery + rendering
+            # both succeed but the tile path (`TilePreviewComposable` →
+            # `TileRenderer.inflateAsync`) silently regressed to zero coverage
+            # — e.g. if `@androidx.wear.tiles.tooling.preview.Preview` stopped
+            # being recognized during discovery.
+            require_tile_render: true
           # Confetti: dropped for now. :androidApp has @Preview functions but
           # discovery returned 0 (same bug we see in PeopleInSpace — track as a
           # follow-up). Render also fails on a :common:car KMP variant
@@ -281,6 +297,38 @@ jobs:
           fi
           echo "Rendered ${#pngs[@]} PNG file(s):"
           printf '  %s\n' "${pngs[@]}"
+
+      - name: Verify at least one TILE preview was rendered
+        if: matrix.render && matrix.require_tile_render
+        working-directory: external/${{ matrix.workdir }}
+        run: |
+          set -euo pipefail
+          # Walk every module's previews.json, count entries with `kind: TILE`
+          # that also have a corresponding PNG on disk. Tiles-only matrix
+          # entries (like WearTilesKotlin) must produce at least one such
+          # preview, otherwise a silent regression in the tile discovery or
+          # TileRenderer.inflateAsync path would pass unnoticed.
+          python3 - <<'PY'
+          import json, os, sys
+          from pathlib import Path
+          total_tiles = 0
+          for manifest in Path('.').rglob('build/compose-previews/previews.json'):
+              if 'external/build' in str(manifest):
+                  continue
+              data = json.loads(manifest.read_text())
+              renders_dir = manifest.parent / 'renders'
+              for p in data.get('previews', []):
+                  if p.get('params', {}).get('kind') != 'TILE':
+                      continue
+                  png = renders_dir / Path(p.get('renderOutput', '')).name
+                  if png.exists():
+                      total_tiles += 1
+                      print(f"  tile rendered: {png}")
+          print(f"Total TILE previews rendered: {total_tiles}")
+          if total_tiles == 0:
+              print("::error::require_tile_render=true but zero TILE-kind previews were rendered end-to-end.", file=sys.stderr)
+              sys.exit(1)
+          PY
 
       - name: Upload previews.json
         if: always()

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -67,27 +67,25 @@ internal object AndroidPreviewSupport {
             dependsOn("compile${capVariant}Kotlin")
         }
 
-        // When a11y is on, the renderer switches from `captureRoboImage { @Composable }`
-        // to `createAndroidComposeRule<ComponentActivity>()`, which needs
-        // ui-test-manifest to contribute the ComponentActivity <activity> entry
-        // to the consumer's merged unit-test AndroidManifest. Renderer-android
-        // pulls ui-test-manifest in transitively, but our plugin bypasses the
-        // normal AGP dep graph (renderer classpath lives in our own resolvable
-        // config, not `testImplementation`), so the manifest merger never sees
-        // it. Explicitly adding ui-test-manifest to `testImplementation` here
-        // closes that gap. Only fires when the feature is enabled, so opt-out
-        // consumers pay nothing.
-        if (resolveA11yEnabled(project, extension)) {
-            // No version: relies on the consumer's Compose BOM (or direct
-            // Compose dep) to resolve ui-test-manifest. Projects using
-            // `implementation(platform(libs.compose.bom))` pick up the
-            // aligned version automatically; projects without a BOM need to
-            // add one (a reasonable ask — the plugin is for Compose apps).
-            project.dependencies.add(
-                "testImplementation",
-                "androidx.compose.ui:ui-test-manifest",
-            )
-        }
+        // Always inject `ui-test-manifest` into the consumer's `testImplementation`
+        // so its `ComponentActivity` <activity> entry is merged into the
+        // consumer's unit-test AndroidManifest. The renderer-android AAR pulls
+        // ui-test-manifest in transitively, but our plugin bypasses the normal
+        // AGP dep graph (renderer classpath lives in our own resolvable config,
+        // not `testImplementation`), so the manifest merger never sees it
+        // otherwise. This is a hard requirement for any ComposeTestRule-based
+        // path (e.g. the ATF accessibility checks) and a safety net for future
+        // tests that need a host activity.
+        //
+        // No version: relies on the consumer's Compose BOM (or direct Compose
+        // dep) to resolve ui-test-manifest. Projects using
+        // `implementation(platform(libs.compose.bom))` pick up the aligned
+        // version automatically; projects without a BOM need to add one (a
+        // reasonable ask — the plugin is for Compose apps).
+        project.dependencies.add(
+            "testImplementation",
+            "androidx.compose.ui:ui-test-manifest",
+        )
 
         val artifactType = Attribute.of("artifactType", String::class.java)
         val testConfig = project.configurations.findByName("${variantName}UnitTestRuntimeClasspath")
@@ -113,11 +111,23 @@ internal object AndroidPreviewSupport {
         // resolvable configuration in *this* project. Attributes are copied
         // from the sample's unit-test runtime classpath so Gradle picks the
         // right Android variant without us declaring them by hand.
+        //
+        // `extendsFrom(testConfig)` is load-bearing: it tells Gradle to resolve
+        // renderer deps in the SAME graph as the consumer's test-runtime deps,
+        // so version conflicts pick a single coherent max version instead of
+        // two separate graphs that clash at class-load time. Without it, the
+        // renderer's transitive `androidx.core:1.8.0` and consumer's
+        // `androidx.core:1.16.0` both end up on the test classpath in different
+        // JARs — whichever is listed first wins for each class, and the loaded
+        // activity/lifecycle/compose-ui versions don't all agree. Symptoms:
+        //   - `NoSuchFieldError: androidx.lifecycle.ReportFragment.Companion`
+        //   - `NoSuchFieldError: … tag_compat_insets_dispatch`
         val rendererConfig = project.configurations.maybeCreate("composePreviewAndroidRenderer$capVariant").apply {
             isCanBeResolved = true
             isCanBeConsumed = false
             if (testConfig != null) {
                 copyAttributes(attributes, testConfig.attributes)
+                extendsFrom(testConfig)
             }
         }
 

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -47,13 +47,45 @@ dependencies {
     implementation(libs.robolectric)
     implementation(libs.junit)
     implementation(libs.kotlinx.serialization.json)
-    implementation(platform(libs.compose.bom))
-    implementation(libs.compose.ui)
-    implementation(libs.compose.foundation)
-    implementation(libs.compose.material3)
-    implementation(libs.compose.runtime)
-    implementation(libs.compose.ui.tooling.preview)
-    implementation(libs.activity.compose)
+
+    // Compose / Activity / Compose-UI-test libs are `compileOnly` on purpose:
+    // they must match what the CONSUMER module declares, because AGP's
+    // `process<Variant>Resources` builds the unit-test merged resource APK
+    // (`apk-for-local-test.ap_`) from the consumer's dependency graph — NOT
+    // from our custom `composePreviewAndroidRenderer` configuration. If these
+    // are `implementation`, Gradle drags our newer activity-compose 1.13 onto
+    // the test JVM classpath — which transitively brings `androidx.navigationevent`
+    // — while the consumer's merged resource APK stays on their older
+    // activity. The test JVM then loads the 1.13 Activity bootstrap and crashes
+    // on `NoClassDefFoundError: androidx/navigationevent/R$id` because the
+    // navigationevent resources were never merged. Same class of failure for
+    // `androidx.core.R.tag_compat_insets_dispatch` (compose-ui 1.10 →
+    // androidx.core 1.16 resources missing on older consumers).
+    //
+    // `testImplementation` mirrors `compileOnly` for our own unit tests, which
+    // need actual runtime classes. The plugin separately injects ui-test-manifest
+    // into the consumer's `testImplementation` in AndroidPreviewSupport so its
+    // `ComponentActivity` entry lands in the consumer's merged test manifest.
+    compileOnly(platform(libs.compose.bom))
+    compileOnly(libs.compose.ui)
+    compileOnly(libs.compose.foundation)
+    compileOnly(libs.compose.material3)
+    compileOnly(libs.compose.runtime)
+    compileOnly(libs.compose.ui.tooling.preview)
+    compileOnly(libs.activity.compose)
+    compileOnly("androidx.compose.ui:ui-test-junit4")
+    compileOnly("androidx.compose.ui:ui-test-manifest")
+
+    testImplementation(platform(libs.compose.bom))
+    testImplementation(libs.compose.ui)
+    testImplementation(libs.compose.foundation)
+    testImplementation(libs.compose.material3)
+    testImplementation(libs.compose.runtime)
+    testImplementation(libs.compose.ui.tooling.preview)
+    testImplementation(libs.activity.compose)
+    testImplementation("androidx.compose.ui:ui-test-junit4")
+    testImplementation("androidx.compose.ui:ui-test-manifest")
+
     implementation(libs.roborazzi)
     implementation(libs.roborazzi.compose)
     // ATF accessibility checks. Exercised only when consumers opt in via
@@ -69,14 +101,6 @@ dependencies {
     // hierarchy richly enough for ATF to surface findings. The composable-
     // form `captureRoboImage { @Composable }` closes its ActivityScenario
     // eagerly, which detaches the view before ATF gets to run.
-    //
-    // Requires `ui-test-junit4` (ComposeTestRule) and `ui-test-manifest`
-    // (ComponentActivity <activity> entry merged into the consumer's test
-    // manifest). Declared as `implementation` — AGP's manifest merger picks
-    // up ui-test-manifest automatically when it's on the unit-test runtime
-    // classpath, without leaking into production.
-    implementation("androidx.compose.ui:ui-test-junit4")
-    implementation("androidx.compose.ui:ui-test-manifest")
     implementation(libs.roborazzi.accessibility.check)
 
     // Tiles rendering is reflection-driven at runtime (the consumer module

--- a/sample-wear/src/main/kotlin/com/example/samplewear/TilePreviews.kt
+++ b/sample-wear/src/main/kotlin/com/example/samplewear/TilePreviews.kt
@@ -1,57 +1,82 @@
 package com.example.samplewear
 
 import android.content.Context
-import androidx.wear.protolayout.ColorBuilders.argb
-import androidx.wear.protolayout.DimensionBuilders.sp
-import androidx.wear.protolayout.LayoutElementBuilders.FontStyle
-import androidx.wear.protolayout.LayoutElementBuilders.Text
+import androidx.wear.protolayout.material3.materialScope
+import androidx.wear.protolayout.material3.primaryLayout
+import androidx.wear.protolayout.material3.text
+import androidx.wear.protolayout.material3.textEdgeButton
+import androidx.wear.protolayout.material3.titleCard
+import androidx.wear.protolayout.modifiers.LayoutModifier
+import androidx.wear.protolayout.modifiers.clickable
+import androidx.wear.protolayout.modifiers.contentDescription
+import androidx.wear.protolayout.types.layoutString
 import androidx.wear.tiles.tooling.preview.Preview
 import androidx.wear.tiles.tooling.preview.TilePreviewData
 import androidx.wear.tiles.tooling.preview.TilePreviewHelper
 import androidx.wear.tooling.preview.devices.WearDevices
 
 /**
- * Minimal `@androidx.wear.tiles.tooling.preview.Preview` sample — exercises the
- * tile-preview discovery + rendering path end-to-end. Not a real production tile.
- */
-@Preview(device = WearDevices.SMALL_ROUND, name = "Small Round")
-@Preview(device = WearDevices.LARGE_ROUND, name = "Large Round")
-fun HelloTilePreview(context: Context): TilePreviewData =
-    TilePreviewData { _ ->
-        TilePreviewHelper.singleTimelineEntryTileBuilder(
-            Text.Builder()
-                .setText("Hello Tiles")
-                .setFontStyle(
-                    FontStyle.Builder()
-                        .setSize(sp(20f))
-                        .setColor(argb(0xFFFFFFFF.toInt()))
-                        .build(),
-                )
-                .build(),
-        ).build()
-    }
-
-/**
  * Multi-preview meta-annotation — mirrors Wear OS samples' `MultiRoundDevicesPreviews`
  * pattern. Our discovery walks annotation classes looking for @Preview, so this
- * should expand to small + large round previews on any function it annotates.
+ * expands to small + large round previews on any function it annotates.
  */
 @Preview(device = WearDevices.SMALL_ROUND, name = "Small Round")
 @Preview(device = WearDevices.LARGE_ROUND, name = "Large Round")
 internal annotation class MultiRoundTilesPreviews
 
+/**
+ * Minimal Material3 tile — title card with a subtitle, exercising the happy
+ * path for the protolayout-material3 `materialScope` / `primaryLayout` APIs.
+ * Enough to prove the renderer produces readable content, not just a bounding
+ * box.
+ */
 @MultiRoundTilesPreviews
-fun CounterTilePreview(context: Context): TilePreviewData =
-    TilePreviewData { _ ->
+fun HelloTilePreview(context: Context): TilePreviewData =
+    TilePreviewData { request ->
         TilePreviewHelper.singleTimelineEntryTileBuilder(
-            Text.Builder()
-                .setText("42")
-                .setFontStyle(
-                    FontStyle.Builder()
-                        .setSize(sp(48f))
-                        .setColor(argb(0xFFFFFFFF.toInt()))
-                        .build(),
+            materialScope(context, request.deviceConfiguration) {
+                primaryLayout(
+                    titleSlot = { text("Today".layoutString) },
+                    mainSlot = {
+                        titleCard(
+                            onClick = clickable(),
+                            title = { text("Morning run".layoutString) },
+                            content = { text("5.2 km · 28 min".layoutString) },
+                            modifier = LayoutModifier.contentDescription("Morning run summary"),
+                        )
+                    },
                 )
-                .build(),
+            },
+        ).build()
+    }
+
+/**
+ * Second tile variant — shows a single centered stat, demonstrating that
+ * repeated tile previews on the same file render independently.
+ */
+@MultiRoundTilesPreviews
+fun StepsTilePreview(context: Context): TilePreviewData =
+    TilePreviewData { request ->
+        TilePreviewHelper.singleTimelineEntryTileBuilder(
+            materialScope(context, request.deviceConfiguration) {
+                primaryLayout(
+                    titleSlot = { text("Steps".layoutString) },
+                    mainSlot = {
+                        titleCard(
+                            onClick = clickable(),
+                            title = { text("6,482".layoutString) },
+                            content = { text("Goal 10,000".layoutString) },
+                            modifier = LayoutModifier.contentDescription("Steps today"),
+                        )
+                    },
+                    bottomSlot = {
+                        textEdgeButton(
+                            onClick = clickable(),
+                            labelContent = { text("Details".layoutString) },
+                            modifier = LayoutModifier.contentDescription("Show step details"),
+                        )
+                    },
+                )
+            },
         ).build()
     }


### PR DESCRIPTION
## Summary

Consumer apps on older Compose BOMs were hitting `NoClassDefFoundError: androidx/navigationevent/R$id` on every preview render, because the renderer-android AAR was transitively dragging our newer Compose/Activity libs onto their unit-test classpath while AGP built the merged resource APK (`apk-for-local-test.ap_`) from only the consumer's own dep graph — the classes and resources disagreed at runtime.

Root cause thread: `implementation(libs.activity.compose)` in `renderer-android` → activity-compose 1.13 → `androidx.navigationevent:1.0.0` on the test JVM. Consumer's APK is on activity-compose 1.8.x → no navigationevent resources → `ViewTreeNavigationEventDispatcherOwner.set` blows up at `R.id.view_tree_navigation_event_dispatcher_owner`. Same failure mode for `androidx.core.R.id.tag_compat_insets_dispatch` on even older consumers.

This hit every `android/wear-os-samples/WearTilesKotlin` preview (156/156 failing). Not tiles-specific — any Wear Compose / older-BOM consumer would see it. WearTilesKotlin just makes it unmissable because every preview is a tile and every render goes through the full `captureRoboImage` → `ComponentActivity` boot path.

## What changed

- **`renderer-android/build.gradle.kts`** — Compose/Activity/UI-test libs moved from `implementation` to `compileOnly` + matching `testImplementation`. Consumer's own versions win at runtime, classes match their resource APK. `roborazzi-accessibility-check` stays `implementation` (no resource contribution).
- **`AndroidPreviewSupport.kt`** — `rendererConfig.extendsFrom(testConfig)` so renderer transitives resolve in the same Gradle graph as the consumer's test deps. One coherent max-version set instead of two separate graphs that clash per-JAR on the test classpath.
- **`.github/workflows/integration.yml`** — WearTilesKotlin matrix entry now runs `renderPreviews` (not just `discoverPreviews`), so this regression is caught end-to-end. Adds a `require_tile_render: true` step that walks `previews.json` and requires at least one `params.kind == "TILE"` entry with a matching PNG on disk — catches silent regressions where tile discovery or `TileRenderer.inflateAsync` stops producing renders while Compose previews still work.
- **`sample-wear/src/main/kotlin/com/example/samplewear/TilePreviews.kt`** — swap raw `LayoutElementBuilders.Text` (white-on-default, rendered as near-blank PNGs that masked any tile-path issues) for `protolayout-material3`'s `materialScope` / `primaryLayout` / `titleCard` / `textEdgeButton`. The tile path now produces self-evidently-correct in-repo output.

## Test plan

- [x] `./gradlew check`
- [x] `./gradlew :sample-wear:renderAllPreviews` — tiles render Material3 cards
- [x] Publish snapshot to `mavenLocal`, patch `android/wear-os-samples/WearTilesKotlin` to `0.4.1-SNAPSHOT`, run `:app:renderAllPreviews` — all 156 tile previews now render (was 156/156 failing pre-fix)
- [ ] CI integration job `wear-os-samples (WearTilesKotlin)` completes `renderPreviews` + verifies at least one TILE preview PNG