### PR TITLE
feat(renderer): deterministic frame budget via paused mainClock

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -67,24 +67,38 @@ internal object AndroidPreviewSupport {
             dependsOn("compile${capVariant}Kotlin")
         }
 
-        // Always inject `ui-test-manifest` into the consumer's `testImplementation`
-        // so its `ComponentActivity` <activity> entry is merged into the
-        // consumer's unit-test AndroidManifest. The renderer-android AAR pulls
-        // ui-test-manifest in transitively, but our plugin bypasses the normal
-        // AGP dep graph (renderer classpath lives in our own resolvable config,
-        // not `testImplementation`), so the manifest merger never sees it
-        // otherwise. This is a hard requirement for any ComposeTestRule-based
-        // path (e.g. the ATF accessibility checks) and a safety net for future
-        // tests that need a host activity.
+        // Always inject `ui-test-manifest` + `ui-test-junit4` into the consumer's
+        // `testImplementation`:
+        //
+        //  * `ui-test-manifest` contributes the `<activity android:name=
+        //    "androidx.activity.ComponentActivity">` entry that has to land in
+        //    the consumer's merged unit-test AndroidManifest before
+        //    `createAndroidComposeRule<ComponentActivity>()` can launch its
+        //    ActivityScenario. Our plugin bypasses the normal AGP dep graph
+        //    (renderer classpath lives in our own resolvable config, not
+        //    `testImplementation`), so the manifest merger never sees it
+        //    otherwise.
+        //  * `ui-test-junit4` is where `createAndroidComposeRule` /
+        //    `ComposeTestRule` / `mainClock` live. The renderer test references
+        //    these unconditionally from its default `renderDefault` path (we
+        //    use `mainClock.autoAdvance = false` + explicit frame pumping to
+        //    make infinite animations terminate deterministically — see
+        //    RobolectricRenderTest.renderDefault), so the consumer's test
+        //    classpath needs these classes too, not just the resource/manifest
+        //    half of the story.
         //
         // No version: relies on the consumer's Compose BOM (or direct Compose
-        // dep) to resolve ui-test-manifest. Projects using
+        // dep) to resolve these artifacts. Projects using
         // `implementation(platform(libs.compose.bom))` pick up the aligned
         // version automatically; projects without a BOM need to add one (a
         // reasonable ask — the plugin is for Compose apps).
         project.dependencies.add(
             "testImplementation",
             "androidx.compose.ui:ui-test-manifest",
+        )
+        project.dependencies.add(
+            "testImplementation",
+            "androidx.compose.ui:ui-test-junit4",
         )
 
         val artifactType = Attribute.of("artifactType", String::class.java)

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.renderer
 
 import androidx.activity.ComponentActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
@@ -113,6 +115,36 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
         }
     }
 
+    /**
+     * Default render path — paused `mainClock`, pump [FRAME_BUDGET] frames, capture.
+     *
+     * Replaces the earlier `captureRoboImage { @Composable }` flow. The
+     * composable overload drives the composition to idle before capturing,
+     * which hangs on infinite animations (`CircularProgressIndicator()`,
+     * `rememberInfiniteTransition`, hand-rolled `withFrameNanos` loops) and
+     * was the root cause of the 12-minute / OOM runs that PR #14 papered
+     * over. With `mainClock.autoAdvance = false` we never wait for idle —
+     * each `advanceTimeByFrame()` deterministically dispatches one frame
+     * cycle, and after [FRAME_BUDGET] frames we just capture whatever the
+     * composition has drawn.
+     *
+     * `ui-test-manifest` (injected into the consumer's `testImplementation`
+     * by the plugin) supplies the `ComponentActivity` entry
+     * `createAndroidComposeRule` needs; we still register the component
+     * explicitly with `ShadowPackageManager` to satisfy Robolectric 4.13+'s
+     * intent-resolution check (robolectric/robolectric#4736).
+     *
+     * Options (size, locale, uiMode, round, fontScale, background,
+     * inspectionMode) are applied by hand here rather than through
+     * [RoborazziComposeOptions], because the option chain wants an
+     * [ActivityScenario] it owns and that's awkward to share with a
+     * [ComposeTestRule]. size/locale/uiMode/round go through Robolectric
+     * resource qualifiers; fontScale goes through
+     * `RuntimeEnvironment.setFontScale` (matching Roborazzi's own
+     * `RoborazziComposeFontScaleOption`) since fontScale is a Configuration
+     * field, not a qualifier; background/inspection go through composition
+     * locals.
+     */
     @OptIn(ExperimentalRoborazziApi::class)
     private fun renderDefault(
         params: RenderPreviewParams,
@@ -122,15 +154,110 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
         roborazziOptions: RoborazziOptions,
         composeOptions: RoborazziComposeOptions,
     ) {
-        captureRoboImage(
-            file = outputFile,
-            roborazziOptions = roborazziOptions,
-            roborazziComposeOptions = composeOptions,
-        ) {
-            CompositionLocalProvider(LocalInspectionMode provides true) {
-                strategyFor(params.kind).Render(preview, widthDp, heightDp)
+        val appContext: android.app.Application =
+            androidx.test.core.app.ApplicationProvider.getApplicationContext()
+        org.robolectric.Shadows.shadowOf(appContext.packageManager)
+            .addActivityIfNotPresent(
+                android.content.ComponentName(appContext.packageName, ComponentActivity::class.java.name),
+            )
+
+        applyPreviewQualifiers(
+            widthDp = widthDp,
+            heightDp = heightDp,
+            isRound = isRoundDevice(params.device) && params.showSystemUi,
+            locale = params.locale,
+            uiMode = params.uiMode,
+        )
+        // fontScale isn't a Robolectric resource qualifier — it's a
+        // Configuration field. `RuntimeEnvironment.setFontScale(Float)` is the
+        // Robolectric API that updates Configuration before the activity
+        // launches; Roborazzi's own `RoborazziComposeFontScaleOption` uses the
+        // same entrypoint. Applied unconditionally (default 1f) so it resets
+        // between previews sharing the same Robolectric sandbox.
+        org.robolectric.RuntimeEnvironment.setFontScale(params.fontScale)
+
+        val rule = createAndroidComposeRule<ComponentActivity>()
+        val description = org.junit.runner.Description.createTestDescription(
+            this::class.java,
+            "renderDefault_${preview.id}",
+        )
+        val statement = object : org.junit.runners.model.Statement() {
+            override fun evaluate() {
+                rule.mainClock.autoAdvance = false
+                rule.setContent {
+                    CompositionLocalProvider(LocalInspectionMode provides true) {
+                        val bg = resolveBackgroundColor(params)
+                        androidx.compose.foundation.layout.Box(
+                            modifier = androidx.compose.ui.Modifier
+                                .fillMaxSize()
+                                .background(bg),
+                        ) {
+                            strategyFor(params.kind).Render(preview, widthDp, heightDp)
+                        }
+                    }
+                }
+                // Pump a fixed number of frames. With mainClock paused, each
+                // advanceTimeByFrame() deterministically dispatches one frame
+                // (layout, draw, animations advance by frameInterval).
+                // Infinite animations park at t = FRAME_BUDGET * frameInterval
+                // regardless of wall clock — repeated captures are byte-identical.
+                repeat(FRAME_BUDGET) {
+                    rule.mainClock.advanceTimeByFrame()
+                }
+                rule.onRoot().captureRoboImage(
+                    file = outputFile,
+                    roborazziOptions = roborazziOptions,
+                )
             }
         }
+        rule.apply(statement, description).evaluate()
+    }
+
+    /**
+     * Match how Roborazzi's `RoborazziComposeSizeOption` / `LocaleOption` /
+     * `UiModeOption` express themselves as Robolectric qualifiers — applied
+     * before the ComposeTestRule's ActivityScenario launches so the
+     * Configuration the activity picks up has our intended dimensions / locale
+     * / night bits.
+     *
+     * Order matters: Robolectric's parser (and Android's underlying grammar —
+     * https://developer.android.com/guide/topics/resources/providing-resources#QualifierRules)
+     * is strict about the sequence. Locale comes before width/height, which
+     * come before orientation, which comes before night-mode, which comes
+     * before density. Out-of-order qualifiers produce
+     * `IllegalArgumentException: failed to parse qualifiers` at runtime.
+     */
+    private fun applyPreviewQualifiers(
+        widthDp: Int,
+        heightDp: Int,
+        isRound: Boolean,
+        locale: String?,
+        uiMode: Int,
+    ) {
+        val qualifiers = buildList {
+            if (!locale.isNullOrBlank()) add(locale)
+            if (widthDp > 0) add("w${widthDp}dp")
+            if (heightDp > 0) add("h${heightDp}dp")
+            if (isRound) add("round")
+            if (widthDp > 0 && heightDp > 0) {
+                add(if (widthDp > heightDp) "land" else "port")
+            }
+            if (uiMode != 0) {
+                when (uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK) {
+                    android.content.res.Configuration.UI_MODE_NIGHT_YES -> add("night")
+                    android.content.res.Configuration.UI_MODE_NIGHT_NO -> add("notnight")
+                }
+            }
+        }
+        if (qualifiers.isNotEmpty()) {
+            org.robolectric.RuntimeEnvironment.setQualifiers("+${qualifiers.joinToString("-")}")
+        }
+    }
+
+    private fun resolveBackgroundColor(params: RenderPreviewParams): androidx.compose.ui.graphics.Color = when {
+        params.backgroundColor != 0L -> androidx.compose.ui.graphics.Color(params.backgroundColor.toInt())
+        params.showBackground -> androidx.compose.ui.graphics.Color.White
+        else -> androidx.compose.ui.graphics.Color.Transparent
     }
 
     /**
@@ -213,6 +340,16 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
     companion object {
         private const val DEFAULT_WIDTH = 400
         private const val DEFAULT_HEIGHT = 800
+
+        /**
+         * Frames to drive before capture in the paused-`mainClock` path.
+         * Small on purpose: with [ui-test-manifest]'s ComposeTestRule we own
+         * the clock, so "settled" is `autoAdvance = false` + however many
+         * frames we explicitly pump. 2 is enough for static previews (initial
+         * composition + one settle pass for `LaunchedEffect`s); for infinite
+         * animations it defines the deterministic snapshot point.
+         */
+        private const val FRAME_BUDGET = 2
     }
 }
 

--- a/sample-android/src/main/kotlin/com/example/sampleandroid/Previews.kt
+++ b/sample-android/src/main/kotlin/com/example/sampleandroid/Previews.kt
@@ -72,7 +72,7 @@ fun GreetingPreview() {
 fun LoadingPreview() {
     MaterialTheme {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            CircularProgressIndicator(progress = { 0.5f })
+            CircularProgressIndicator()
             Text("Loading...")
         }
     }


### PR DESCRIPTION
## Summary
- Replace `renderDefault`'s `captureRoboImage { @Composable }` flow with `createAndroidComposeRule<ComponentActivity>()` + `mainClock.autoAdvance = false` + pump `FRAME_BUDGET = 2` frames before capture. Infinite animations now park at a fixed virtual time instead of hanging Compose's idling resource (the 12-minute / OOM failure that PR #14 papered over).
- Plugin injects `ui-test-junit4` into the consumer's `testImplementation` alongside `ui-test-manifest` — the default path now uses `ComposeTestRule`/`mainClock` unconditionally, so those classes have to be on the consumer's test classpath.
- Revert PR #14's `LoadingPreview` change — `CircularProgressIndicator()` (infinite indeterminate) is back, now caught and captured deterministically.

## Option-plumbing notes
`RoborazziComposeOptions`'s chain wants an `ActivityScenario` it owns and doesn't share cleanly with a `ComposeTestRule`, so options are applied manually:
- **size/locale/uiMode/round/orientation** → `RuntimeEnvironment.setQualifiers`, ordered per Android's qualifier grammar. Wrong ordering fails loud at `Qualifiers.parse` (locale before width before orientation before night — got caught by `ConfigProbePreview_German` mid-review).
- **fontScale** → `RuntimeEnvironment.setFontScale(Float)`. Not a qualifier — it's a `Configuration` field, same knob Roborazzi's own `RoborazziComposeFontScaleOption` uses.
- **background/inspection** → `CompositionLocalProvider` inside `setContent`.

`renderWithA11y` left alone — it already uses `createAndroidComposeRule` for its own reasons and relies on `LocalInspectionMode = false`.

## Test plan
- [x] `./gradlew :sample-android:renderAllPreviews` — 10/10 pass in ~14s (was 12min+ / OOM for the infinite-animation case)
- [x] Re-run `:sample-android:renderPreviews --rerun-tasks` and byte-diff the PNGs — all 10 SHA-256s identical across runs, including the reverted `LoadingPreview`
- [x] `./gradlew :sample-wear:renderAllPreviews` — `ActivityListFontScalesPreview` variants have distinct hashes again (fontScale honoured)
- [x] `./gradlew :sample-cmp:renderAllPreviews` — unchanged
- [x] `./gradlew :gradle-plugin:test :gradle-plugin:functionalTest` — pass