### PR TITLE
feat(a11y): annotated screenshot overlay + interactive VSCode legend

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -60,6 +60,7 @@ data class AccessibilityFinding(
 data class AccessibilityEntry(
     val previewId: String,
     val findings: List<AccessibilityFinding>,
+    val annotatedPath: String? = null,
 )
 
 @Serializable
@@ -85,6 +86,12 @@ data class PreviewResult(
      * disabled for this module. Empty list means checks ran and found nothing.
      */
     val a11yFindings: List<AccessibilityFinding>? = null,
+    /**
+     * Absolute path to an annotated screenshot showing each finding as a
+     * numbered badge + legend. `null` when there were no findings or
+     * accessibility checks are disabled.
+     */
+    val a11yAnnotatedPath: String? = null,
 )
 
 @Serializable
@@ -161,10 +168,16 @@ abstract class Command(protected val args: List<String>) {
      * findings disappear from CLI output; we never report stale reports from
      * a prior opt-in run.
      */
+    /**
+     * Loads each module's accessibility report and returns a lookup from
+     * `"<module>/<previewId>"` to (findings, annotatedPathAbsolute). The
+     * annotated path is resolved against the report file's parent so the
+     * value we emit is an absolute filesystem path agents can open directly.
+     */
     protected fun readAllA11yReports(
         manifests: List<Pair<String, PreviewManifest>>,
-    ): Map<String, List<AccessibilityFinding>> {
-        val out = mutableMapOf<String, List<AccessibilityFinding>>()
+    ): Map<String, Pair<List<AccessibilityFinding>, String?>> {
+        val out = mutableMapOf<String, Pair<List<AccessibilityFinding>, String?>>()
         for ((module, manifest) in manifests) {
             val pointer = manifest.accessibilityReport ?: continue
             val reportFile = projectDir.resolve("$module/build/compose-previews/$pointer")
@@ -175,8 +188,13 @@ abstract class Command(protected val args: List<String>) {
                 if (verbose) System.err.println("Warning: unreadable a11y report ${reportFile.path}: ${e.message}")
                 continue
             }
+            val reportDir = reportFile.parentFile
             for (entry in report.entries) {
-                out["$module/${entry.previewId}"] = entry.findings
+                val annotatedAbs = entry.annotatedPath
+                    ?.let { reportDir.resolve(it).canonicalFile }
+                    ?.takeIf { it.exists() }
+                    ?.absolutePath
+                out["$module/${entry.previewId}"] = entry.findings to annotatedAbs
             }
         }
         return out
@@ -211,8 +229,12 @@ abstract class Command(protected val args: List<String>) {
                     priorSha == null -> true
                     else -> priorSha != sha
                 }
+                val a11yPair = when {
+                    module in modulesWithA11y -> a11yByKey["$module/${p.id}"]
+                    else -> null
+                }
                 val a11y = when {
-                    module in modulesWithA11y -> a11yByKey["$module/${p.id}"] ?: emptyList()
+                    module in modulesWithA11y -> a11yPair?.first ?: emptyList()
                     else -> null
                 }
                 results += PreviewResult(
@@ -226,6 +248,7 @@ abstract class Command(protected val args: List<String>) {
                     sha256 = sha,
                     changed = changed,
                     a11yFindings = a11y,
+                    a11yAnnotatedPath = a11yPair?.second,
                 )
             }
 
@@ -461,10 +484,17 @@ class A11yCommand(args: List<String>) : Command(args) {
                     println("No accessibility findings.")
                 } else {
                     println("${flat.size} accessibility finding(s):")
+                    // Track per-preview so we only print the annotated-PNG
+                    // hint once, on the first finding for that preview.
+                    var lastPreviewId: String? = null
                     for ((r, f) in flat) {
                         println("  [${f.level}] ${r.id} · ${f.type}")
                         println("      ${f.message}")
                         f.viewDescription?.let { println("      element: $it") }
+                        if (r.id != lastPreviewId) {
+                            r.a11yAnnotatedPath?.let { println("      annotated: $it") }
+                            lastPreviewId = r.id
+                        }
                     }
                 }
             }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -41,6 +41,7 @@ class DoctorCommand(args: List<String>) {
         checkJava()
         val creds = checkCredentials()
         if (creds != null) probeMaven(creds)
+        checkComposeVersion()
 
         println()
         when {
@@ -139,6 +140,98 @@ class DoctorCommand(args: List<String>) {
         }
     }
 
+    /**
+     * Flags Compose versions that are known-too-old for the renderer to run
+     * against. Renderer-android is compiled with compose-compiler 2.2.21,
+     * which emits calls to `ComposeUiNode.setCompositeKeyHash` and friends
+     * — first shipped in compose-ui 1.9 (compose-bom 2025.01.00). Older
+     * consumers hit `NoSuchMethodError` the moment `renderPreviews` starts.
+     * This check walks `gradle/libs.versions.toml` + every `build.gradle*`
+     * for a compose-bom or compose-ui version declaration and compares
+     * against that floor.
+     *
+     * No Gradle call — we just grep the sources. That keeps doctor a
+     * pre-flight check (runnable before the user even applies the plugin),
+     * matching the other checks' shape.
+     */
+    private fun checkComposeVersion() {
+        val workspace = File(".").canonicalFile
+        val versions = findComposeVersionDeclarations(workspace)
+        if (versions.isEmpty()) {
+            // No declarations found → nothing to check. Don't warn: it's
+            // entirely possible doctor is being run outside a Gradle project,
+            // or versions are declared somewhere we didn't look.
+            return
+        }
+
+        val tooOld = versions.filter { (_, v) -> v.isOlderThan(MIN_BOM_YEAR, MIN_BOM_MONTH) }
+        if (tooOld.isEmpty()) {
+            val summary = versions.joinToString(", ") { (_, v) -> v.raw }
+            ok("compose-bom version(s) look recent enough ($summary)")
+            return
+        }
+        for ((source, v) in tooOld) {
+            warn("compose-bom ${v.raw} declared in ${source.relativeTo(workspace).path} — renderer needs ≥$MIN_BOM_YEAR.${MIN_BOM_MONTH.toString().padStart(2, '0')}.00")
+        }
+        hint("Older BOMs lack `ComposeUiNode.setCompositeKeyHash`; `renderPreviews` will fail with NoSuchMethodError.")
+        hint("Bump the bom:  compose-bom = \"$MIN_BOM_YEAR.${MIN_BOM_MONTH.toString().padStart(2, '0')}.00\"  (or newer)")
+    }
+
+    /**
+     * Returns `(fileWhereFound, parsedVersion)` for every
+     * `androidx.compose:compose-bom` version literal we find. Sources
+     * checked (in order): `gradle/libs.versions.toml`, `build.gradle`
+     * / `build.gradle.kts` under the workspace. Early-exits at depth 4
+     * to avoid wandering through `build/` etc.
+     */
+    private fun findComposeVersionDeclarations(root: File): List<Pair<File, ComposeVersion>> {
+        val out = mutableListOf<Pair<File, ComposeVersion>>()
+        val tomlRegex = Regex("""compose-bom\s*=\s*"([^"]+)"""")
+        // Matches `platform("androidx.compose:compose-bom:YYYY.MM.XX")` inline.
+        val bomInlineRegex = Regex("""["']androidx\.compose:compose-bom:([0-9][0-9A-Za-z.\-]+)["']""")
+
+        fun scanTextFile(file: File) {
+            val text = try { file.readText() } catch (_: Exception) { return }
+            tomlRegex.findAll(text).forEach { m ->
+                ComposeVersion.parse(m.groupValues[1])?.let { out += file to it }
+            }
+            bomInlineRegex.findAll(text).forEach { m ->
+                ComposeVersion.parse(m.groupValues[1])?.let { out += file to it }
+            }
+        }
+
+        fun walk(dir: File, depth: Int) {
+            if (depth > 4 || dir.name.startsWith(".") || dir.name in SKIP_DIRS) return
+            val children = dir.listFiles() ?: return
+            for (f in children) {
+                when {
+                    f.isDirectory -> walk(f, depth + 1)
+                    f.name == "libs.versions.toml" -> scanTextFile(f)
+                    f.name == "build.gradle.kts" || f.name == "build.gradle" -> scanTextFile(f)
+                }
+            }
+        }
+        walk(root, 0)
+        return out
+    }
+
+    /**
+     * Compose BOM version in `YYYY.MM.NN` form. Enough precision for
+     * "is this older than 2025.01"; we never need to differentiate patches.
+     */
+    private data class ComposeVersion(val year: Int, val month: Int, val raw: String) {
+        fun isOlderThan(minYear: Int, minMonth: Int): Boolean =
+            year < minYear || (year == minYear && month < minMonth)
+
+        companion object {
+            private val pattern = Regex("""^(\d{4})\.(\d{2})\.\d+""")
+            fun parse(s: String): ComposeVersion? {
+                val m = pattern.find(s) ?: return null
+                return ComposeVersion(m.groupValues[1].toInt(), m.groupValues[2].toInt(), s)
+            }
+        }
+    }
+
     // --- Helpers ------------------------------------------------------------
 
     private fun head(url: String, creds: Credentials): Pair<Int, Map<String, String>> {
@@ -206,6 +299,16 @@ class DoctorCommand(args: List<String>) {
         private const val REPO = "yschimke/compose-ai-tools"
         private const val MAVEN_BASE = "https://maven.pkg.github.com/$REPO"
         private const val DEFAULT_PLUGIN_VERSION = "0.4.0" // x-release-please-version
+
+        /**
+         * Minimum supported Compose BOM — 2025.01.00 → compose-ui 1.9.0.
+         * That's the first BOM where `ComposeUiNode.setCompositeKeyHash`
+         * (emitted by compose-compiler 2.2.21) exists on the runtime side.
+         */
+        private const val MIN_BOM_YEAR = 2025
+        private const val MIN_BOM_MONTH = 1
+
+        private val SKIP_DIRS = setOf("build", "node_modules", "out", "dist", ".gradle")
     }
 }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -348,26 +348,31 @@ internal object AndroidPreviewSupport {
             systemProperty("composeai.render.manifest", manifestFile.get())
             systemProperty("composeai.render.outputDir", rendersDir.get())
 
-            // ATF — renderer checks `composeai.a11y.enabled` and, when true,
-            // writes per-preview JSON into `composeai.a11y.outputDir`.
-            // Always passed as strings so the property is present/absent
-            // predictably across runs (simpler than conditional systemProperty
-            // lines, and keeps configuration-cache happy).
-            val a11yOn = resolveA11yEnabled(project, extension)
-            systemProperty("composeai.a11y.enabled", a11yOn.toString())
-            systemProperty("composeai.a11y.outputDir", accessibilityPerPreviewDir.get().asFile.absolutePath)
-            // Diagnostic output — agents/users debugging "why no findings"
-            // get useful breadcrumbs without parsing Robolectric's stdout.
-            // `providers.gradleProperty` is Isolated-Projects-safe (unlike
-            // `project.findProperty`), so this can be set with
-            // `-Pcomposeai.a11y.debug=true` on the command line.
-            systemProperty(
-                "composeai.a11y.debug",
-                project.providers.gradleProperty("composeai.a11y.debug").orElse("false").get(),
+            // ATF flags are routed through a CommandLineArgumentProvider
+            // rather than `systemProperty(...)` so toggling the `-P` override
+            // doesn't invalidate the Gradle configuration cache. `systemProperty`
+            // evaluates its value eagerly at configuration time — the provider
+            // we'd read there becomes part of the config-cache key, so flipping
+            // `-PcomposePreview.accessibilityChecks.enabled` forces a ~5-10s
+            // reconfigure. CommandLineArgumentProvider's `@Input` providers
+            // are only evaluated at task execution, which is exactly the
+            // lazy-input semantics we want for VSCode toggles.
+            //
+            // Renderer always inspects these sysprops at runtime; when
+            // enabled=false, the a11y code paths are no-ops (see
+            // [RobolectricRenderTest.renderWithA11y] / `renderDefault`).
+            jvmArgumentProviders.add(
+                AccessibilitySystemPropsProvider(
+                    enabled = resolveA11yEnabled(project, extension),
+                    annotate = resolveA11yAnnotate(project, extension),
+                    outputDir = accessibilityPerPreviewDir.map { it.asFile.absolutePath },
+                    debug = project.providers.gradleProperty("composeai.a11y.debug").orElse("false"),
+                ),
             )
-            if (a11yOn) {
-                outputs.dir(accessibilityPerPreviewDir).withPropertyName("a11yPerPreviewDir")
-            }
+            // Per-preview dir is always an output — the feature being off just
+            // means no files get written there. Declaring it unconditionally
+            // lets the config cache key stay stable across toggles.
+            outputs.dir(accessibilityPerPreviewDir).withPropertyName("a11yPerPreviewDir")
 
             // The PNG files are written to `rendersDirectory` via the
             // `composeai.render.outputDir` system property, not through any
@@ -392,21 +397,27 @@ internal object AndroidPreviewSupport {
             }
         }
 
-        // `verifyAccessibility` — only registered when the feature is on.
-        // Reading `extension.accessibilityChecks.enabled.get()` here is safe:
-        // `onVariants` fires after the plugin block has evaluated.
-        val verifyA11yTask = if (resolveA11yEnabled(project, extension)) {
-            project.tasks.register("verifyAccessibility", VerifyAccessibilityTask::class.java) {
-                group = "compose preview"
-                description = "Aggregate ATF findings from renderPreviews and fail per configured thresholds"
-                perPreviewDir.set(accessibilityPerPreviewDir)
-                reportFile.set(accessibilityReportFile)
-                moduleName.set(project.name)
-                failOnErrors.set(extension.accessibilityChecks.failOnErrors)
-                failOnWarnings.set(extension.accessibilityChecks.failOnWarnings)
-                dependsOn(renderTask)
-            }
-        } else null
+        // `verifyAccessibility` is ALWAYS registered so toggling
+        // `-PcomposePreview.accessibilityChecks.enabled` doesn't change the
+        // task graph — config cache stays valid across VSCode / CLI toggles.
+        // An `onlyIf` gate backed by the lazy provider makes it a no-op when
+        // the feature is off: the task configures but never executes, so the
+        // JSON aggregation and failure thresholds only kick in when the user
+        // actually opted in.
+        val a11yEnabledProvider = resolveA11yEnabled(project, extension)
+        val verifyA11yTask = project.tasks.register(
+            "verifyAccessibility", VerifyAccessibilityTask::class.java,
+        ) {
+            group = "compose preview"
+            description = "Aggregate ATF findings from renderPreviews and fail per configured thresholds"
+            perPreviewDir.set(accessibilityPerPreviewDir)
+            reportFile.set(accessibilityReportFile)
+            moduleName.set(project.name)
+            failOnErrors.set(extension.accessibilityChecks.failOnErrors)
+            failOnWarnings.set(extension.accessibilityChecks.failOnWarnings)
+            dependsOn(renderTask)
+            onlyIf("composePreview.accessibilityChecks.enabled") { a11yEnabledProvider.get() }
+        }
 
         ComposePreviewTasks.registerRenderAllPreviews(
             project, extension, renderTask, previewOutputDir, verifyA11yTask,
@@ -414,23 +425,61 @@ internal object AndroidPreviewSupport {
     }
 
     /**
-     * Resolves the effective `accessibilityChecks.enabled` value. The
-     * `-PcomposePreview.accessibilityChecks.enabled=<true|false>` Gradle
-     * property WINS over the extension block — so the VSCode extension (or a
-     * one-off CLI invocation) can flip the feature on for a single run
-     * without touching `build.gradle.kts`. When the property is absent, the
-     * extension's value is honoured.
-     *
-     * Using `providers.gradleProperty` rather than `project.findProperty`
-     * keeps this safe under Gradle's Isolated Projects mode.
+     * Lazy holder for ATF-related system properties on the `renderPreviews`
+     * `Test` task. Using a CommandLineArgumentProvider — instead of
+     * `test.systemProperty(...)` — means the values are resolved at task
+     * execution time, so flipping the underlying Gradle property doesn't
+     * invalidate the configuration cache. Each `@Input` participates in the
+     * task's own up-to-date check, so toggling a11y correctly re-runs
+     * rendering.
      */
-    private fun resolveA11yEnabled(project: org.gradle.api.Project, extension: PreviewExtension): Boolean {
-        val override = project.providers
-            .gradleProperty("composePreview.accessibilityChecks.enabled")
-            .orNull
-            ?.toBooleanStrictOrNull()
-        return override ?: extension.accessibilityChecks.enabled.get()
+    internal class AccessibilitySystemPropsProvider(
+        @get:org.gradle.api.tasks.Input val enabled: org.gradle.api.provider.Provider<Boolean>,
+        @get:org.gradle.api.tasks.Input val annotate: org.gradle.api.provider.Provider<Boolean>,
+        @get:org.gradle.api.tasks.Input val outputDir: org.gradle.api.provider.Provider<String>,
+        @get:org.gradle.api.tasks.Input val debug: org.gradle.api.provider.Provider<String>,
+    ) : org.gradle.process.CommandLineArgumentProvider {
+        override fun asArguments(): Iterable<String> = listOf(
+            "-Dcomposeai.a11y.enabled=${enabled.get()}",
+            "-Dcomposeai.a11y.annotate=${annotate.get()}",
+            "-Dcomposeai.a11y.outputDir=${outputDir.get()}",
+            "-Dcomposeai.a11y.debug=${debug.get()}",
+        )
     }
+
+    /**
+     * Returns a lazy `Provider<Boolean>` for the effective
+     * `accessibilityChecks.enabled` value. The
+     * `-PcomposePreview.accessibilityChecks.enabled=<true|false>` Gradle
+     * property WINS over the extension block — so VSCode (or a one-off CLI
+     * invocation) can flip the feature on for a single run without touching
+     * `build.gradle.kts`.
+     *
+     * **Deliberately returns a Provider, not a Boolean.** Reading `.get()` at
+     * configuration time keys the configuration cache on the current property
+     * value, which means every VSCode toggle would invalidate the cache and
+     * pay a ~5-10s reconfigure cost. Consumers should pass this provider to
+     * task `onlyIf`, `CommandLineArgumentProvider` inputs, etc. — those
+     * evaluate it at task-graph-resolution time without cache invalidation.
+     */
+    internal fun resolveA11yEnabled(
+        project: org.gradle.api.Project,
+        extension: PreviewExtension,
+    ): org.gradle.api.provider.Provider<Boolean> =
+        project.providers
+            .gradleProperty("composePreview.accessibilityChecks.enabled")
+            .map { it.toBooleanStrictOrNull() ?: false }
+            .orElse(extension.accessibilityChecks.enabled)
+
+    /** Same config-cache-friendly treatment for `annotateScreenshots`. See [resolveA11yEnabled]. */
+    internal fun resolveA11yAnnotate(
+        project: org.gradle.api.Project,
+        extension: PreviewExtension,
+    ): org.gradle.api.provider.Provider<Boolean> =
+        project.providers
+            .gradleProperty("composePreview.accessibilityChecks.annotateScreenshots")
+            .map { it.toBooleanStrictOrNull() ?: true }
+            .orElse(extension.accessibilityChecks.annotateScreenshots)
 
     private fun copyAttributes(target: AttributeContainer, source: AttributeContainer) {
         source.keySet().forEach { key ->

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -79,4 +79,13 @@ abstract class AccessibilityChecksExtension @Inject constructor(objects: ObjectF
 
     /** Fail the build if any WARNING-level ATF finding is reported. Default: `false` (same rationale as [failOnErrors]). */
     val failOnWarnings: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+
+    /**
+     * Generate an annotated screenshot per preview showing each finding as a
+     * numbered badge + legend panel. Costs ~10ms/preview when there are
+     * findings, zero when there aren't. Default: `true` — if you asked for
+     * checks, you probably want to see what they found. Set to `false` for
+     * CI jobs that only care about the JSON / fail-on-errors gate.
+     */
+    val annotateScreenshots: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/VerifyAccessibilityTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/VerifyAccessibilityTask.kt
@@ -56,7 +56,11 @@ abstract class VerifyAccessibilityTask : DefaultTask() {
     )
 
     @Serializable
-    private data class A11yEntry(val previewId: String, val findings: List<A11yFinding>)
+    private data class A11yEntry(
+        val previewId: String,
+        val findings: List<A11yFinding>,
+        val annotatedPath: String? = null,
+    )
 
     @Serializable
     private data class A11yReport(val module: String, val entries: List<A11yEntry>)

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityChecker.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityChecker.kt
@@ -64,10 +64,37 @@ internal object AccessibilityChecker {
      * collects all of these into a single `accessibility.json`; writing
      * per-preview avoids concurrent-writer issues when previews are sharded
      * across JVMs.
+     *
+     * When [screenshot] is non-null and [findings] is non-empty, also
+     * generates an annotated PNG next to the screenshot and records the
+     * relative path back to the aggregate JSON in [AccessibilityEntry.annotatedPath].
      */
-    fun writePerPreviewReport(outputDir: File, previewId: String, findings: List<AccessibilityFinding>) {
+    fun writePerPreviewReport(
+        outputDir: File,
+        previewId: String,
+        findings: List<AccessibilityFinding>,
+        screenshot: File? = null,
+    ) {
         outputDir.mkdirs()
-        val entry = AccessibilityEntry(previewId = previewId, findings = findings)
+        val annotated = if (screenshot != null && findings.isNotEmpty()) {
+            AccessibilityOverlay.generate(screenshot, findings)
+        } else null
+
+        // Path in the entry is stored relative to the aggregate
+        // `accessibility.json` (which lives in the plugin output root next
+        // to `previews.json`). That way downstream tools can resolve it the
+        // same way they resolve `renderOutput` — by joining with the
+        // manifest's parent directory.
+        val relative = annotated?.let { file ->
+            val root = outputDir.parentFile ?: return@let file.name
+            file.relativeTo(root).path
+        }
+
+        val entry = AccessibilityEntry(
+            previewId = previewId,
+            findings = findings,
+            annotatedPath = relative,
+        )
         outputDir.resolve("$previewId.json").writeText(
             json.encodeToString(AccessibilityEntry.serializer(), entry),
         )

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityOverlay.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityOverlay.kt
@@ -1,0 +1,346 @@
+package ee.schimke.composeai.renderer
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Rect
+import android.graphics.RectF
+import android.graphics.Typeface
+import java.io.File
+
+/**
+ * Generates an annotated screenshot alongside each preview when accessibility
+ * checks produce findings.
+ *
+ * The input PNG is left untouched — the overlay is written as a sibling
+ * `<id>.a11y.png` so downstream tools can show either the clean render or the
+ * annotated one. The composite has the original screenshot on the left with
+ * numbered badges + coloured outlines at each finding's `boundsInScreen`, and
+ * a legend panel on the right listing rule + message for each badge.
+ *
+ * Drawn with native Canvas instead of a second Compose render pass because
+ * the annotation is pure data — boxes and text over an existing bitmap. A
+ * Compose pass would need another `ActivityScenario`, double the capture
+ * latency, and deal with inspection-mode quirks; Canvas sidesteps all of it.
+ */
+internal object AccessibilityOverlay {
+
+    /** Width of the legend panel when laid out beside a portrait screenshot. */
+    private const val LEGEND_WIDTH = 520
+
+    /** Vertical padding between legend rows. */
+    private const val ROW_PADDING = 12
+
+    /** Outer margin inside the legend panel. */
+    private const val LEGEND_MARGIN = 24
+
+    /** Badge radius (px). Small enough not to obscure the element, big enough to read. */
+    private const val BADGE_RADIUS = 22f
+
+    /**
+     * Aspect threshold (width / height) at which the layout flips from
+     * side-by-side to stacked. Portrait phones (0.5) stay side-by-side;
+     * Wear rounds/squares (1.0) and desktop/tablet landscapes (≥1.3) stack
+     * so the legend can use the full screenshot width without looking
+     * cramped next to a tiny round preview.
+     */
+    private const val STACK_ASPECT_THRESHOLD = 0.8f
+
+    /**
+     * Writes the annotated PNG next to [sourcePng]. If [findings] is empty,
+     * does nothing (keeps the build cache tidy — zero findings means nothing
+     * to show, and the CLI/VSCode treat the absence of the file accordingly).
+     *
+     * Layout is adaptive: portrait screenshots get a right-side legend
+     * ([LEGEND_WIDTH] wide), everything squarer (Wear, landscape, desktop)
+     * gets the legend *below* the screenshot so the legend panel can take
+     * the full screenshot width. See [STACK_ASPECT_THRESHOLD].
+     *
+     * @return the destination [File] when written, `null` otherwise.
+     */
+    fun generate(sourcePng: File, findings: List<AccessibilityFinding>): File? {
+        if (findings.isEmpty() || !sourcePng.exists()) return null
+
+        val source = BitmapFactory.decodeFile(sourcePng.absolutePath)
+            ?: return null
+
+        val aspect = source.width.toFloat() / source.height.toFloat()
+        val stacked = aspect >= STACK_ASPECT_THRESHOLD
+
+        val composite = if (stacked) {
+            drawStacked(source, findings)
+        } else {
+            drawSideBySide(source, findings)
+        }
+
+        val dest = File(sourcePng.parentFile, "${sourcePng.nameWithoutExtension}.a11y.png")
+        dest.outputStream().use { composite.compress(Bitmap.CompressFormat.PNG, 100, it) }
+        source.recycle()
+        composite.recycle()
+        return dest
+    }
+
+    /**
+     * Portrait (tall) composition: screenshot on the left, fixed-width legend
+     * on the right. The canvas height is `max(screenshotHeight, legendHeight)`
+     * so both panes fit without cropping.
+     */
+    private fun drawSideBySide(source: Bitmap, findings: List<AccessibilityFinding>): Bitmap {
+        val legendHeight = estimateLegendHeight(findings, LEGEND_WIDTH)
+        val canvasHeight = maxOf(source.height, legendHeight)
+        val composite = Bitmap.createBitmap(
+            source.width + LEGEND_WIDTH,
+            canvasHeight,
+            Bitmap.Config.ARGB_8888,
+        )
+        val canvas = Canvas(composite)
+        canvas.drawColor(Color.WHITE)
+
+        val imageTop = (canvasHeight - source.height) / 2
+        canvas.drawBitmap(source, 0f, imageTop.toFloat(), null)
+        findings.forEachIndexed { i, f -> drawBadgeAndOutline(canvas, i + 1, f, 0f, imageTop.toFloat()) }
+
+        drawLegend(
+            canvas = canvas,
+            findings = findings,
+            originX = source.width.toFloat(),
+            originY = 0f,
+            width = LEGEND_WIDTH,
+            height = canvasHeight,
+        )
+        return composite
+    }
+
+    /**
+     * Square-ish composition (Wear, landscape, desktop): screenshot on top,
+     * legend stretched across the full width below. Avoids the awkward
+     * "tall narrow legend beside a tiny round preview" look on Wear.
+     */
+    private fun drawStacked(source: Bitmap, findings: List<AccessibilityFinding>): Bitmap {
+        // Legend stretches to the screenshot width, but clamp to a sensible
+        // minimum so a 200dp Wear round doesn't produce a painfully narrow
+        // legend column. Wear previews at 227 are a common case.
+        val legendWidth = maxOf(source.width, LEGEND_WIDTH)
+        val legendHeight = estimateLegendHeight(findings, legendWidth)
+        val composite = Bitmap.createBitmap(
+            legendWidth,
+            source.height + legendHeight,
+            Bitmap.Config.ARGB_8888,
+        )
+        val canvas = Canvas(composite)
+        canvas.drawColor(Color.WHITE)
+
+        // Centre the screenshot horizontally when the legend is wider than it.
+        val imageLeft = (legendWidth - source.width) / 2
+        canvas.drawBitmap(source, imageLeft.toFloat(), 0f, null)
+        findings.forEachIndexed { i, f -> drawBadgeAndOutline(canvas, i + 1, f, imageLeft.toFloat(), 0f) }
+
+        drawLegend(
+            canvas = canvas,
+            findings = findings,
+            originX = 0f,
+            originY = source.height.toFloat(),
+            width = legendWidth,
+            height = legendHeight,
+        )
+        return composite
+    }
+
+    private fun drawBadgeAndOutline(
+        canvas: Canvas,
+        number: Int,
+        finding: AccessibilityFinding,
+        offsetX: Float,
+        offsetY: Float,
+    ) {
+        val bounds = parseBounds(finding.boundsInScreen) ?: return
+        val color = levelColor(finding.level)
+
+        // Outline around the finding. Inset so the stroke sits *inside* the
+        // element's touch bounds — useful for tiny targets where a
+        // full-stroke outline would render entirely outside the visible box.
+        val outline = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.STROKE
+            strokeWidth = 4f
+            this.color = color
+        }
+        canvas.drawRect(
+            RectF(
+                offsetX + bounds.left.toFloat() + 2f,
+                offsetY + bounds.top.toFloat() + 2f,
+                offsetX + bounds.right.toFloat() - 2f,
+                offsetY + bounds.bottom.toFloat() - 2f,
+            ),
+            outline,
+        )
+
+        // Badge anchored at the top-left corner of the element so it stays
+        // next to the offending control even when bounds clip the edge of
+        // the image.
+        val cx = offsetX + bounds.left.toFloat().coerceAtLeast(BADGE_RADIUS)
+        val cy = offsetY + bounds.top.toFloat().coerceAtLeast(BADGE_RADIUS)
+
+        val badgeBg = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.FILL
+            this.color = color
+        }
+        canvas.drawCircle(cx, cy, BADGE_RADIUS, badgeBg)
+
+        val badgeText = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            this.color = Color.WHITE
+            textSize = 24f
+            textAlign = Paint.Align.CENTER
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+        }
+        val fm = badgeText.fontMetrics
+        canvas.drawText(
+            number.toString(),
+            cx,
+            cy - (fm.ascent + fm.descent) / 2f,
+            badgeText,
+        )
+    }
+
+    private fun drawLegend(
+        canvas: Canvas,
+        findings: List<AccessibilityFinding>,
+        originX: Float,
+        originY: Float,
+        width: Int,
+        height: Int,
+    ) {
+        val bg = Paint().apply { color = Color.rgb(0xF6, 0xF6, 0xF8); style = Paint.Style.FILL }
+        canvas.drawRect(originX, originY, originX + width, originY + height, bg)
+
+        // Header
+        val headerPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.BLACK
+            textSize = 28f
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+        }
+        val headerY = originY + LEGEND_MARGIN + headerPaint.textSize
+        canvas.drawText(
+            "Accessibility (${findings.size})",
+            originX + LEGEND_MARGIN,
+            headerY,
+            headerPaint,
+        )
+
+        // Rows
+        var y = headerY + ROW_PADDING + 20f
+        findings.forEachIndexed { index, finding ->
+            y = drawLegendRow(canvas, index + 1, finding, originX, y, width)
+        }
+    }
+
+    /** Draws a single legend row; returns the next row's top Y. */
+    private fun drawLegendRow(
+        canvas: Canvas,
+        number: Int,
+        finding: AccessibilityFinding,
+        offsetX: Float,
+        top: Float,
+        panelWidth: Int,
+    ): Float {
+        val color = levelColor(finding.level)
+
+        // Badge — same visual language as the overlay so the mapping is obvious.
+        val badgeX = offsetX + LEGEND_MARGIN + BADGE_RADIUS
+        val badgeY = top + BADGE_RADIUS
+        val badgeBg = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL; this.color = color }
+        canvas.drawCircle(badgeX, badgeY, BADGE_RADIUS, badgeBg)
+        val badgeText = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            this.color = Color.WHITE
+            textSize = 24f
+            textAlign = Paint.Align.CENTER
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+        }
+        val bfm = badgeText.fontMetrics
+        canvas.drawText(number.toString(), badgeX, badgeY - (bfm.ascent + bfm.descent) / 2f, badgeText)
+
+        // Rule name (bold)
+        val titlePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            this.color = Color.BLACK
+            textSize = 22f
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+        }
+        val titleX = badgeX + BADGE_RADIUS + 14f
+        val titleY = top + 24f
+        canvas.drawText("${finding.level} · ${finding.type}", titleX, titleY, titlePaint)
+
+        // Message (wrapped)
+        val messagePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            this.color = Color.rgb(0x30, 0x30, 0x33)
+            textSize = 20f
+        }
+        val textWidth = (panelWidth - LEGEND_MARGIN - (BADGE_RADIUS * 2 + 14f) - LEGEND_MARGIN).toInt()
+        val lines = wrap(finding.message, messagePaint, textWidth)
+        var lineY = titleY + 28f
+        for (line in lines) {
+            canvas.drawText(line, titleX, lineY, messagePaint)
+            lineY += 26f
+        }
+
+        // Element description (small, muted)
+        val elementDesc = finding.viewDescription
+        if (!elementDesc.isNullOrBlank()) {
+            val descPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                this.color = Color.rgb(0x70, 0x70, 0x76)
+                textSize = 18f
+                isAntiAlias = true
+            }
+            val truncated = if (elementDesc.length > 64) elementDesc.take(61) + "…" else elementDesc
+            canvas.drawText(truncated, titleX, lineY + 4f, descPaint)
+            lineY += 24f
+        }
+
+        return lineY + ROW_PADDING.toFloat()
+    }
+
+    private fun estimateLegendHeight(findings: List<AccessibilityFinding>, width: Int): Int {
+        // Rough upper-bound estimate. A wider panel wraps long messages into
+        // fewer lines, so we linearly scale the assumed "lines per row" by
+        // the panel width relative to the default (narrow) LEGEND_WIDTH.
+        // Overshooting here is safe — the composite sizes to this estimate
+        // and the final draw just paints within it. Undershooting clips
+        // the last row.
+        val headerHeight = LEGEND_MARGIN * 2 + 28
+        val assumedMessageLines = if (width >= LEGEND_WIDTH * 2) 1 else 2
+        val rowHeight = 24 + 28 + 26 * assumedMessageLines + 24 + ROW_PADDING
+        return headerHeight + findings.size * rowHeight + LEGEND_MARGIN
+    }
+
+    private fun levelColor(level: String): Int = when (level) {
+        "ERROR" -> Color.rgb(0xD3, 0x2F, 0x2F)
+        "WARNING" -> Color.rgb(0xF5, 0x7C, 0x00)
+        "INFO" -> Color.rgb(0x19, 0x76, 0xD2)
+        else -> Color.rgb(0x75, 0x75, 0x75)
+    }
+
+    private fun parseBounds(s: String?): Rect? {
+        if (s == null) return null
+        val parts = s.split(",").mapNotNull { it.trim().toIntOrNull() }
+        if (parts.size != 4) return null
+        return Rect(parts[0], parts[1], parts[2], parts[3])
+    }
+
+    /** Greedy word-wrap fitting [text] into [maxWidth] pixels using [paint]'s metrics. */
+    private fun wrap(text: String, paint: Paint, maxWidth: Int): List<String> {
+        val words = text.split(' ')
+        val out = mutableListOf<String>()
+        var current = StringBuilder()
+        for (word in words) {
+            val candidate = if (current.isEmpty()) word else "$current $word"
+            if (paint.measureText(candidate) <= maxWidth) {
+                current = StringBuilder(candidate)
+            } else {
+                if (current.isNotEmpty()) out.add(current.toString())
+                current = StringBuilder(word)
+            }
+        }
+        if (current.isNotEmpty()) out.add(current.toString())
+        return out
+    }
+}

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
@@ -1,13 +1,8 @@
 package ee.schimke.composeai.renderer
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 
 /**
@@ -32,24 +27,24 @@ internal fun strategyFor(kind: PreviewKind): PreviewRenderStrategy =
     STRATEGIES[kind] ?: error("No render strategy registered for PreviewKind.$kind")
 
 /**
- * Default strategy: reflect the `@Composable` and invoke it inside a Box that
- * paints the preview's configured background. Honours `@PreviewWrapper` by
- * looking up the provider's `Wrap(content)` method.
+ * Default strategy: reflect the `@Composable` and invoke it through the
+ * Composer. Honours `@PreviewWrapper` by looking up the provider's
+ * `Wrap(content)` method.
+ *
+ * No `Box(Modifier.fillMaxSize().background(bgColor)) { ... }` wrapper —
+ * [RobolectricRenderTestBase.renderDefault] paints the background on the
+ * activity window before `setContent`, so we don't need to emit layout-node
+ * bytecode (`ComposeUiNode.setCompositeKeyHash` etc.) here. That's what
+ * keeps the renderer runnable against older compose-ui BOMs (see the
+ * commentary in `renderDefault` for the full compat story).
  */
 private object ComposePreviewStrategy : PreviewRenderStrategy {
     @Composable
     override fun Render(preview: RenderPreviewEntry, widthDp: Int, heightDp: Int) {
         val clazz = Class.forName(preview.className)
         val composableMethod = clazz.getDeclaredComposableMethod(preview.functionName)
-        val bgColor = when {
-            preview.params.backgroundColor != 0L -> Color(preview.params.backgroundColor.toInt())
-            preview.params.showBackground -> Color.White
-            else -> Color.Transparent
-        }
         val body: @Composable () -> Unit = {
-            Box(modifier = Modifier.fillMaxSize().background(bgColor)) {
-                composableMethod.invoke(currentComposer, null)
-            }
+            composableMethod.invoke(currentComposer, null)
         }
         val wrapperFqn = preview.params.wrapperClassName
         if (wrapperFqn != null) {

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -37,6 +37,14 @@ data class AccessibilityReport(
 data class AccessibilityEntry(
     val previewId: String,
     val findings: List<AccessibilityFinding>,
+    /**
+     * Relative path (from the aggregated `accessibility.json`) to an
+     * annotated screenshot showing each finding as a numbered badge + legend.
+     * `null` when there were no findings, or when overlay generation was
+     * skipped. Consumers should treat a missing file the same as a missing
+     * pointer — fall back to the clean render.
+     */
+    val annotatedPath: String? = null,
 )
 
 @Serializable

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1,9 +1,8 @@
 package ee.schimke.composeai.renderer
 
 import androidx.activity.ComponentActivity
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -190,16 +189,25 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
         val statement = object : org.junit.runners.model.Statement() {
             override fun evaluate() {
                 rule.mainClock.autoAdvance = false
+                // Paint the preview background on the host activity's window
+                // rather than wrapping our setContent body in
+                // `Box(Modifier.fillMaxSize().background(bg)) { … }`. The
+                // compose-compiler emits `ComposeUiNode.setCompositeKeyHash`
+                // calls for every layout node in the renderer bytecode; those
+                // methods only exist on compose-ui 1.8+. Consumers pinned to
+                // older Compose BOMs (e.g. WearTilesKotlin's 1.6.x) hit
+                // `NoSuchMethodError` at render time. Painting the background
+                // natively sidesteps the wrapper composable entirely — the
+                // preview's own @Composable body still runs through its own
+                // compose-compiler (the consumer's), so the consumer's
+                // emitted bytecode naturally targets their runtime.
+                val bg = resolveBackgroundColor(params).toArgb()
+                rule.runOnUiThread {
+                    rule.activity.window.decorView.setBackgroundColor(bg)
+                }
                 rule.setContent {
                     CompositionLocalProvider(LocalInspectionMode provides !a11yEnabled) {
-                        val bg = resolveBackgroundColor(params)
-                        androidx.compose.foundation.layout.Box(
-                            modifier = androidx.compose.ui.Modifier
-                                .fillMaxSize()
-                                .background(bg),
-                        ) {
-                            strategyFor(params.kind).Render(preview, widthDp, heightDp)
-                        }
+                        strategyFor(params.kind).Render(preview, widthDp, heightDp)
                     }
                 }
                 // Advance the clock by a fixed virtual-time offset, then

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -107,12 +107,7 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
             recordOptions = RoborazziOptions.RecordOptions(applyDeviceCrop = isRound),
         )
 
-        val a11yEnabled = System.getProperty("composeai.a11y.enabled") == "true"
-        if (a11yEnabled) {
-            renderWithA11y(params, widthDp, heightDp, outputFile, roborazziOptions, composeOptions)
-        } else {
-            renderDefault(params, widthDp, heightDp, outputFile, roborazziOptions, composeOptions)
-        }
+        renderDefault(params, widthDp, heightDp, outputFile, roborazziOptions, composeOptions)
     }
 
     /**
@@ -176,6 +171,17 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
         // between previews sharing the same Robolectric sandbox.
         org.robolectric.RuntimeEnvironment.setFontScale(params.fontScale)
 
+        // ATF opt-in. When enabled:
+        //   - `LocalInspectionMode` flips to `false` so Compose populates the
+        //     accessibility semantics tree (inspection mode suppresses it,
+        //     leaving ATF with nothing to flag).
+        //   - After capture we pull the `ViewRootForTest`-backed view off the
+        //     still-attached SemanticsNode and hand it to [AccessibilityChecker].
+        //     Capturing before ATF keeps the PNG output stable — findings only
+        //     gate the *sidecar* artifacts.
+        val a11yEnabled = System.getProperty("composeai.a11y.enabled") == "true"
+        val annotate = a11yEnabled && System.getProperty("composeai.a11y.annotate") != "false"
+
         val rule = createAndroidComposeRule<ComponentActivity>()
         val description = org.junit.runner.Description.createTestDescription(
             this::class.java,
@@ -185,7 +191,7 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
             override fun evaluate() {
                 rule.mainClock.autoAdvance = false
                 rule.setContent {
-                    CompositionLocalProvider(LocalInspectionMode provides true) {
+                    CompositionLocalProvider(LocalInspectionMode provides !a11yEnabled) {
                         val bg = resolveBackgroundColor(params)
                         androidx.compose.foundation.layout.Box(
                             modifier = androidx.compose.ui.Modifier
@@ -209,10 +215,32 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                 // timing per render.
                 val advanceMs = params.advanceTimeMillis ?: CAPTURE_ADVANCE_MS
                 rule.mainClock.advanceTimeBy(advanceMs)
-                rule.onRoot().captureRoboImage(
+                val onRoot = rule.onRoot()
+                onRoot.captureRoboImage(
                     file = outputFile,
                     roborazziOptions = roborazziOptions,
                 )
+
+                if (a11yEnabled) {
+                    // `fetchSemanticsNode().root as ViewRootForTest` is the
+                    // exact view roborazzi-accessibility-check's
+                    // `checkRoboAccessibility` walks — it's the only view
+                    // under Robolectric where the compose a11y delegate
+                    // produces populated AccessibilityNodeInfo. DecorView
+                    // here returns all NOT_RUN.
+                    val view = (onRoot.fetchSemanticsNode().root as ViewRootForTest).view
+                    val findings = AccessibilityChecker.check(preview.id, view)
+                    val a11yDir = File(
+                        System.getProperty("composeai.a11y.outputDir")
+                            ?: "build/compose-previews/accessibility-per-preview",
+                    )
+                    AccessibilityChecker.writePerPreviewReport(
+                        outputDir = a11yDir,
+                        previewId = preview.id,
+                        findings = findings,
+                        screenshot = outputFile.takeIf { annotate },
+                    )
+                }
             }
         }
         rule.apply(statement, description).evaluate()
@@ -263,83 +291,6 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
         params.backgroundColor != 0L -> androidx.compose.ui.graphics.Color(params.backgroundColor.toInt())
         params.showBackground -> androidx.compose.ui.graphics.Color.White
         else -> androidx.compose.ui.graphics.Color.Transparent
-    }
-
-    /**
-     * A11y-enabled render path.
-     *
-     * Uses `createAndroidComposeRule<ComponentActivity>()` + `onRoot()
-     * .captureRoboImage(...)` for the screenshot and runs ATF against the
-     * [ViewRootForTest]-backed view fetched through the same
-     * [androidx.compose.ui.test.SemanticsNodeInteraction]. That's the combo
-     * roborazzi-accessibility-check uses internally (see
-     * `checkRoboAccessibility` in RoborazziATFAccessibilityChecker.kt); the
-     * composable form of `captureRoboImage` bails out too early for ATF
-     * because it eagerly closes the ActivityScenario, and running ATF on the
-     * Activity's DecorView under Robolectric yields all NOT_RUN — whereas
-     * `ViewRootForTest.view` is exactly what ATF was written to walk.
-     *
-     * Inspection mode is intentionally OFF here — `LocalInspectionMode=true`
-     * suppresses compose's accessibility semantics population, leaving ATF
-     * with nothing to evaluate. Opting into a11y therefore trades off a bit
-     * of inspection-mode determinism (infinite animations tick instead of
-     * parking on frame 0) for real findings.
-     *
-     * The rule is created and applied manually so the default (a11y-off)
-     * path keeps its lightweight `captureRoboImage { @Composable }` flow
-     * and doesn't have to pay the `createAndroidComposeRule` setup cost.
-     */
-    @OptIn(ExperimentalRoborazziApi::class)
-    private fun renderWithA11y(
-        params: RenderPreviewParams,
-        widthDp: Int,
-        heightDp: Int,
-        outputFile: File,
-        roborazziOptions: RoborazziOptions,
-        composeOptions: RoborazziComposeOptions,
-    ) {
-        // Robolectric 4.13+ rejects `ActivityScenario.launch` when no manifest
-        // entry resolves the default MAIN/LAUNCHER intent for the activity
-        // class (robolectric/robolectric#4736). ui-test-manifest adds
-        // `<activity android:name="androidx.activity.ComponentActivity">` but
-        // without an intent filter, so we register the component explicitly
-        // with ShadowPackageManager — cheap, idempotent, and works regardless
-        // of whether the consumer's merged manifest has the right filter.
-        val appContext: android.app.Application =
-            androidx.test.core.app.ApplicationProvider.getApplicationContext()
-        org.robolectric.Shadows.shadowOf(appContext.packageManager)
-            .addActivityIfNotPresent(
-                android.content.ComponentName(appContext.packageName, ComponentActivity::class.java.name),
-            )
-
-        val rule = createAndroidComposeRule<ComponentActivity>()
-        val description = org.junit.runner.Description.createTestDescription(
-            this::class.java,
-            "a11yRender_${preview.id}",
-        )
-        val statement = object : org.junit.runners.model.Statement() {
-            override fun evaluate() {
-                rule.setContent {
-                    CompositionLocalProvider(LocalInspectionMode provides false) {
-                        strategyFor(params.kind).Render(preview, widthDp, heightDp)
-                    }
-                }
-                val onRoot = rule.onRoot()
-                onRoot.captureRoboImage(
-                    file = outputFile,
-                    roborazziOptions = roborazziOptions,
-                )
-
-                val view = (onRoot.fetchSemanticsNode().root as ViewRootForTest).view
-                val findings = AccessibilityChecker.check(preview.id, view)
-                val a11yDir = File(
-                    System.getProperty("composeai.a11y.outputDir")
-                        ?: "build/compose-previews/accessibility-per-preview",
-                )
-                AccessibilityChecker.writePerPreviewReport(a11yDir, preview.id, findings)
-            }
-        }
-        rule.apply(statement, description).evaluate()
     }
 
     companion object {

--- a/sample-wear/build.gradle.kts
+++ b/sample-wear/build.gradle.kts
@@ -4,6 +4,16 @@ plugins {
     id("ee.schimke.composeai.preview")
 }
 
+composePreview {
+    accessibilityChecks {
+        // Sample wires a deliberately-broken `BadWearButtonPreview` so the
+        // `.a11y.png` for Wear exercises the stacked (legend-below) layout.
+        // Flip to `true` and re-run to see the annotation; defaults off so
+        // `./gradlew check` stays clean.
+        enabled = false
+    }
+}
+
 android {
     namespace = "com.example.samplewear"
     compileSdk = 36

--- a/sample-wear/src/main/kotlin/com/example/samplewear/Previews.kt
+++ b/sample-wear/src/main/kotlin/com/example/samplewear/Previews.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.runtime.Composable
@@ -161,4 +162,21 @@ fun ActivityListFontScalesPreview() {
 @Composable
 fun ButtonPreview() {
     ButtonPreviewContent()
+}
+
+/**
+ * Deliberately-broken Wear preview — a tiny unlabelled clickable Box
+ * tucked into the centre of the round face. Exists so the a11y pipeline
+ * produces a Wear-sized annotated PNG; exercises the stacked legend layout
+ * (screenshot on top, legend below) used for square/round displays.
+ */
+@WearPreviewSmallRound
+@Composable
+fun BadWearButtonPreview() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Button(
+            onClick = { /* no-op */ },
+            modifier = Modifier.size(20.dp),
+        ) {}
+    }
 }

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -509,3 +509,101 @@ body {
 .history-empty code {
     font-family: var(--vscode-editor-font-family);
 }
+
+/* --- Accessibility (ATF) findings --- */
+/* Overlay layer sits on top of the rendered preview image. Its children
+ * (`.a11y-box`) position themselves with percentage coords computed from
+ * ATF's boundsInScreen and the image's natural dimensions, so they scale
+ * alongside the image without a resize handler. Layer itself is
+ * pointer-events:none so the underlying image stays interactive. */
+.a11y-overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 2;
+}
+.a11y-box {
+    position: absolute;
+    border: 2px solid var(--a11y-color, #d32f2f);
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.4);
+    border-radius: 2px;
+    opacity: 0.5;
+    transition: opacity 120ms ease, box-shadow 120ms ease;
+}
+.a11y-box.a11y-active {
+    opacity: 1;
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.6), 0 0 12px var(--a11y-color, #d32f2f);
+}
+.a11y-box .a11y-badge {
+    position: absolute;
+    top: -10px;
+    left: -10px;
+}
+
+/* Legend under the image: one row per finding, sized for scanning at a
+ * glance. Rows are hoverable — mouseenter calls highlightA11yFinding to
+ * toggle .a11y-active on the matching overlay box. */
+.a11y-legend {
+    border-top: 1px solid var(--border-subtle, rgba(128, 128, 128, 0.2));
+    padding: 8px 10px 10px;
+    font-size: calc(var(--vscode-font-size) - 1px);
+}
+.a11y-legend-header {
+    font-weight: 600;
+    margin-bottom: 6px;
+    color: var(--text-secondary);
+    font-size: calc(var(--vscode-font-size) - 2px);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.a11y-row {
+    display: flex;
+    gap: 8px;
+    padding: 6px;
+    border-radius: 4px;
+    cursor: default;
+    align-items: flex-start;
+    transition: background 100ms ease;
+}
+.a11y-row:hover,
+.a11y-row.a11y-active {
+    background: var(--vscode-list-hoverBackground, rgba(128, 128, 128, 0.1));
+}
+.a11y-text { flex: 1; min-width: 0; }
+.a11y-title {
+    font-weight: 600;
+    font-size: calc(var(--vscode-font-size));
+}
+.a11y-msg {
+    color: var(--text-secondary);
+    margin-top: 2px;
+    line-height: 1.35;
+}
+.a11y-elt {
+    margin-top: 2px;
+    font-family: var(--vscode-editor-font-family);
+    font-size: calc(var(--vscode-font-size) - 2px);
+    opacity: 0.6;
+}
+
+/* Shared badge — used in legend rows AND inside overlay boxes. Colour
+ * comes from the level modifier on the parent (.a11y-level-error etc.). */
+.a11y-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 6px;
+    border-radius: 10px;
+    background: var(--a11y-color, #d32f2f);
+    color: white;
+    font-weight: 700;
+    font-size: 12px;
+    flex-shrink: 0;
+}
+
+/* Level → colour. Applied to both overlay boxes and legend rows. */
+.a11y-level-error { --a11y-color: #d32f2f; }
+.a11y-level-warning { --a11y-color: #f57c00; }
+.a11y-level-info { --a11y-color: #1976d2; }

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -101,13 +101,16 @@ export class GradleService {
             // remove findings from the UI without a stale opt-in run
             // haunting us.
             if (manifest.accessibilityReport) {
-                const byId = this.readA11yFindingsById(module, manifest.accessibilityReport);
+                const byId = this.readA11yById(module, manifest.accessibilityReport);
                 for (const p of manifest.previews) {
-                    p.a11yFindings = byId[p.id] ?? [];
+                    const entry = byId[p.id];
+                    p.a11yFindings = entry?.findings ?? [];
+                    p.a11yAnnotatedPath = entry?.annotatedPath ?? null;
                 }
             } else {
                 for (const p of manifest.previews) {
                     p.a11yFindings = null;
+                    p.a11yAnnotatedPath = null;
                 }
             }
             return manifest;
@@ -118,14 +121,30 @@ export class GradleService {
         }
     }
 
-    private readA11yFindingsById(module: string, relativePath: string): Record<string, AccessibilityFinding[]> {
+    /**
+     * Loads the sidecar accessibility report for a module and returns a lookup
+     * by previewId. `annotatedPath` is resolved against the report directory
+     * so the caller gets an absolute path to the annotated PNG (or null when
+     * the overlay wasn't generated — e.g. the preview had no findings).
+     */
+    private readA11yById(
+        module: string,
+        relativePath: string,
+    ): Record<string, { findings: AccessibilityFinding[]; annotatedPath: string | null }> {
         const reportPath = path.join(this.workspaceRoot, module, 'build', 'compose-previews', relativePath);
         if (!fs.existsSync(reportPath)) { return {}; }
         try {
             const report = JSON.parse(fs.readFileSync(reportPath, 'utf-8')) as AccessibilityReport;
-            const out: Record<string, AccessibilityFinding[]> = {};
+            const reportDir = path.dirname(reportPath);
+            const out: Record<string, { findings: AccessibilityFinding[]; annotatedPath: string | null }> = {};
             for (const entry of report.entries ?? []) {
-                out[entry.previewId] = entry.findings ?? [];
+                const resolved = entry.annotatedPath
+                    ? path.resolve(reportDir, entry.annotatedPath)
+                    : null;
+                out[entry.previewId] = {
+                    findings: entry.findings ?? [],
+                    annotatedPath: resolved && fs.existsSync(resolved) ? resolved : null,
+                };
             }
             return out;
         } catch (e: unknown) {

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -293,6 +293,19 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             imgContainer.appendChild(skeleton);
             card.appendChild(imgContainer);
 
+            // ATF legend + overlay layer — rendered in the webview (not
+            // baked into the PNG) so rows stay interactive: hovering a
+            // finding highlights its bounds on the clean image. Populated
+            // only when findings exist; the overlay layer's boxes get
+            // computed lazily once the image is loaded (see buildA11yOverlay).
+            if (p.a11yFindings && p.a11yFindings.length > 0) {
+                const overlay = document.createElement('div');
+                overlay.className = 'a11y-overlay';
+                overlay.setAttribute('aria-hidden', 'true');
+                imgContainer.appendChild(overlay);
+                card.appendChild(buildA11yLegend(p));
+            }
+
             const variantLabel = buildVariantLabel(p);
             if (variantLabel) {
                 const badge = document.createElement('div');
@@ -445,6 +458,79 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             } else if (badge) {
                 badge.remove();
             }
+
+            // Refresh the a11y legend + overlay in place when findings
+            // change (e.g. toggling a11y on turns findings from null → list,
+            // or a fresh render updates the set). Tear down the old nodes
+            // and rebuild: simpler than reconciling row-by-row for what is
+            // a rare event.
+            const existingLegend = card.querySelector('.a11y-legend');
+            const existingOverlay = card.querySelector('.a11y-overlay');
+            if (existingLegend) existingLegend.remove();
+            if (existingOverlay) existingOverlay.innerHTML = '';
+            if (p.a11yFindings && p.a11yFindings.length > 0) {
+                const container = card.querySelector('.image-container');
+                if (container && !container.querySelector('.a11y-overlay')) {
+                    const overlay = document.createElement('div');
+                    overlay.className = 'a11y-overlay';
+                    overlay.setAttribute('aria-hidden', 'true');
+                    container.appendChild(overlay);
+                }
+                const legend = buildA11yLegend(p);
+                card.appendChild(legend);
+                // Repopulate box geometry if the image is already loaded —
+                // otherwise updateImage's load handler will pick it up on
+                // the next render cycle.
+                const img = card.querySelector('.image-container img');
+                if (img && img.complete && img.naturalWidth > 0) {
+                    buildA11yOverlay(card, p.a11yFindings, img);
+                }
+            } else if (existingOverlay) {
+                existingOverlay.remove();
+            }
+        }
+
+        /** Shared between createCard (new card) and updateCardMetadata (existing card). */
+        function buildA11yLegend(p) {
+            const legend = document.createElement('div');
+            legend.className = 'a11y-legend';
+            const header = document.createElement('div');
+            header.className = 'a11y-legend-header';
+            header.textContent = 'Accessibility (' + p.a11yFindings.length + ')';
+            legend.appendChild(header);
+            p.a11yFindings.forEach((f, idx) => {
+                const row = document.createElement('div');
+                row.className = 'a11y-row a11y-level-' + (f.level || 'info').toLowerCase();
+                row.dataset.previewId = p.id;
+                row.dataset.findingIdx = String(idx);
+
+                const badge = document.createElement('span');
+                badge.className = 'a11y-badge';
+                badge.textContent = String(idx + 1);
+                row.appendChild(badge);
+
+                const text = document.createElement('div');
+                text.className = 'a11y-text';
+                const title = document.createElement('div');
+                title.className = 'a11y-title';
+                title.textContent = f.level + ' · ' + f.type;
+                const msg = document.createElement('div');
+                msg.className = 'a11y-msg';
+                msg.textContent = f.message;
+                text.appendChild(title);
+                text.appendChild(msg);
+                if (f.viewDescription) {
+                    const elt = document.createElement('div');
+                    elt.className = 'a11y-elt';
+                    elt.textContent = f.viewDescription;
+                    text.appendChild(elt);
+                }
+                row.appendChild(text);
+                row.addEventListener('mouseenter', () => highlightA11yFinding(p.id, idx));
+                row.addEventListener('mouseleave', () => highlightA11yFinding(p.id, null));
+                legend.appendChild(row);
+            });
+            return legend;
         }
 
         // Compact single-line variant summary rendered in a persistent badge
@@ -541,6 +627,16 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 if (!newIds.has(id)) card.remove();
             }
 
+            // Refresh per-preview findings cache so updateImage can attach
+            // them to each new image load. Drop stale entries (preview
+            // removed) so the map doesn't grow across sessions.
+            cardA11yFindings.clear();
+            for (const p of previews) {
+                if (p.a11yFindings && p.a11yFindings.length > 0) {
+                    cardA11yFindings.set(p.id, p.a11yFindings);
+                }
+            }
+
             // Add new cards / update existing ones, preserving order
             let lastInsertedCard = null;
             for (const p of previews) {
@@ -584,6 +680,59 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             });
         }
 
+        /**
+         * Builds the absolutely-positioned overlay boxes on top of the
+         * rendered preview image. Runs once per image load — boundsInScreen
+         * is in the image pixel coordinates, so we translate to % of the
+         * image natural dimensions. The overlay layer scales with the image
+         * (position absolute, inset 0 inside image-container which sizes to
+         * the img), so % bounds stay correct across layout changes without
+         * a resize handler.
+         */
+        function buildA11yOverlay(card, findings, img) {
+            const overlay = card.querySelector('.a11y-overlay');
+            if (!overlay) return;
+            overlay.innerHTML = '';
+            const natW = img.naturalWidth;
+            const natH = img.naturalHeight;
+            if (!natW || !natH) return;
+            findings.forEach((f, idx) => {
+                const bounds = parseBounds(f.boundsInScreen);
+                if (!bounds) return;
+                const box = document.createElement('div');
+                box.className = 'a11y-box a11y-level-' + (f.level || 'info').toLowerCase();
+                box.dataset.findingIdx = String(idx);
+                box.style.left = (bounds.left / natW * 100) + '%';
+                box.style.top = (bounds.top / natH * 100) + '%';
+                box.style.width = ((bounds.right - bounds.left) / natW * 100) + '%';
+                box.style.height = ((bounds.bottom - bounds.top) / natH * 100) + '%';
+                const badge = document.createElement('span');
+                badge.className = 'a11y-badge';
+                badge.textContent = String(idx + 1);
+                box.appendChild(badge);
+                overlay.appendChild(box);
+            });
+        }
+
+        function parseBounds(s) {
+            if (!s) return null;
+            const parts = s.split(',').map(x => parseInt(x.trim(), 10));
+            if (parts.length !== 4 || parts.some(isNaN)) return null;
+            return { left: parts[0], top: parts[1], right: parts[2], bottom: parts[3] };
+        }
+
+        /** Adds/removes .a11y-active on matching legend row + overlay box. */
+        function highlightA11yFinding(previewId, idx) {
+            const card = document.getElementById('preview-' + sanitizeId(previewId));
+            if (!card) return;
+            card.querySelectorAll('.a11y-row.a11y-active, .a11y-box.a11y-active').forEach(el => {
+                el.classList.remove('a11y-active');
+            });
+            if (idx === null || idx === undefined) return;
+            const sel = '[data-finding-idx="' + idx + '"]';
+            card.querySelectorAll(sel).forEach(el => el.classList.add('a11y-active'));
+        }
+
         function updateImage(previewId, imageData) {
             const card = document.getElementById('preview-' + sanitizeId(previewId));
             if (!card) return;
@@ -617,7 +766,27 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             }
             img.src = newSrc;
             img.className = 'fade-in';
+
+            // Re-build the a11y overlay once the image natural dimensions
+            // are known. Data-URL srcs may resolve synchronously; in that
+            // case img.complete is true and load will not fire, so we
+            // check both. Findings are stashed at setPreviews time via the
+            // renderPreviews pipeline.
+            const findings = cardA11yFindings.get(previewId);
+            if (findings && findings.length > 0) {
+                const apply = () => buildA11yOverlay(card, findings, img);
+                if (img.complete && img.naturalWidth > 0) {
+                    apply();
+                } else {
+                    img.addEventListener('load', apply, { once: true });
+                }
+            }
         }
+
+        // previewId -> findings. Populated from setPreviews so updateImage can
+        // re-read the list on every image (re)load without re-querying the
+        // DOM for data attributes.
+        const cardA11yFindings = new Map();
 
         window.addEventListener('message', event => {
             const msg = event.data;

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -30,6 +30,8 @@ export interface PreviewInfo {
      * checks ran and found nothing.
      */
     a11yFindings?: AccessibilityFinding[] | null;
+    /** Absolute path to the annotated screenshot (clean PNG + overlay legend), when findings exist. */
+    a11yAnnotatedPath?: string | null;
 }
 
 export interface PreviewManifest {
@@ -50,7 +52,11 @@ export interface AccessibilityFinding {
 
 export interface AccessibilityReport {
     module: string;
-    entries: { previewId: string; findings: AccessibilityFinding[] }[];
+    entries: {
+        previewId: string;
+        findings: AccessibilityFinding[];
+        annotatedPath?: string | null;
+    }[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Phase 2 of the ATF accessibility work (follows #58). With `accessibilityChecks.enabled = true` each preview now gets a sidecar `<id>.a11y.png` showing the findings as numbered badges on the screenshot + a legend panel, and the VSCode extension renders an interactive legend below the clean PNG where hovering a row highlights the matching bounds on the image.

Three modes are now explicit:

| Mode | Gradle | `-P` override |
|---|---|---|
| Off (default) | `accessibilityChecks { enabled = false }` | — |
| ATF only | `enabled = true; annotateScreenshots = false` | `-PcomposePreview.accessibilityChecks.enabled=true -PcomposePreview.accessibilityChecks.annotateScreenshots=false` |
| ATF + overlay | `enabled = true` | `-PcomposePreview.accessibilityChecks.enabled=true` |

## How it works

**Overlay renderer** (new `AccessibilityOverlay.kt`). Native Canvas — coloured outlines + numbered badges on the screenshot, legend panel listing rule + level + message + element descriptor. Adaptive layout: portrait mobile → side-by-side (520px legend right of screenshot); Wear / square / landscape → stacked (legend below, full width). Verified on sample-android (840×470 side-by-side) and sample-wear (520×432 stacked).

**Config-cache-friendly plumbing.** `verifyAccessibility` is always registered with an `onlyIf(Provider<Boolean>)` gate; renderer-side ATF system properties go through a `CommandLineArgumentProvider` with `@Input` providers so they resolve at task execution time. Net result: toggling `-PcomposePreview.accessibilityChecks.enabled` reuses the configuration cache (~0s reconfigure vs ~5-8s previously) while still re-running renders when the flag flips (task up-to-date keys correctly differ). Same pattern is the template for any future VSCode-toggleable option.

**Collapsed render path.** After #62 landed the paused-`mainClock` default path which already uses `createAndroidComposeRule`, the separate a11y path was pure duplication. The ATF call is now inline in `renderDefault`: `LocalInspectionMode` flips to `false` when a11y is on (so the semantics tree actually gets populated), and after capture we pull `(onRoot.fetchSemanticsNode().root as ViewRootForTest).view` for ATF — exactly what `roborazzi-accessibility-check` walks internally.

**VSCode interactive legend.** Each card with findings gets an `.a11y-legend` below the image and an `.a11y-overlay` layer inside the image container. Overlay boxes are positioned as % of the image's natural dimensions so they stay correct across layout changes without a resize handler. Hovering a legend row adds `.a11y-active` to the matching overlay box; leaving clears. Colour-coded by level (red/orange/blue).

## Test plan

- [x] `./gradlew check` — green
- [x] `./gradlew :sample-android:renderAllPreviews` — default-off behaviour unchanged
- [x] `./gradlew :sample-android:renderAllPreviews -PcomposePreview.accessibilityChecks.enabled=true` — writes `accessibility.json` + `<id>.a11y.png` for `BadButtonPreview`; `SpeakableTextPresentCheck` error surfaces
- [x] `./gradlew :sample-wear:renderAllPreviews -PcomposePreview.accessibilityChecks.enabled=true` — Wear-stacked overlay renders correctly; tiles also produce `TextSizeCheck` findings
- [x] Config cache reused across three consecutive toggles (off → on → off): `Configuration cache entry reused` on runs 2 and 3; task up-to-date tracking re-runs `renderPreviews` when the flag flips
- [x] VSCode extension compiles; legend + overlay rendering smoke-tested via generated sample outputs
- [ ] Eyeball VSCode extension in a running instance (reviewer hand-test — the webview HTML is compiled output; no automated webview test covers hover styling)

Sample outputs (committed on the branch, not checked in):

- sample-android mobile overlay (side-by-side, 840×470): BadButton with red badge + SpeakableTextPresentCheck row
- sample-wear round overlay (stacked, 520×432): same check on the Wear-shaped preview