### PR TITLE
fix(vscode): stop the jumpy preview render loop

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,3 @@ org.gradle.configuration-cache.unsafe.ignore.unsupported-build-events-listeners=
 # Isolated Projects (accesses :renderer-desktop / :sample-cmp's layout from :).
 # We don't use hot reload, so disable it.
 org.jetbrains.compose.hot.reload.disable=true
-
-org.gradle.unsafe.isolated-projects=true

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -150,9 +150,14 @@ export async function activate(context: vscode.ExtensionContext) {
 
     context.subscriptions.push(
         vscode.window.onDidChangeActiveTextEditor(editor => {
-            if (editor?.document.languageId === 'kotlin') {
-                refresh(false, editor.document.uri.fsPath);
-            }
+            if (editor?.document.languageId !== 'kotlin') { return; }
+            const filePath = editor.document.uri.fsPath;
+            // Focus toggling (editor ↔ webview/terminal ↔ back) fires this
+            // event with the same Kotlin file. Re-running refresh there just
+            // cancels any in-flight render, flashes spinners, and burns a
+            // Gradle invocation — all for a no-op.
+            if (filePath === currentScopeFile) { return; }
+            refresh(false, filePath);
         }),
     );
 
@@ -174,12 +179,19 @@ export async function activate(context: vscode.ExtensionContext) {
         }),
     );
 
-    // External file system changes (git, refactor tools)
+    // External file system changes (git, refactor tools). Gated by
+    // isSourceFile so Gradle-generated files under `<module>/build/**` don't
+    // feed every render back into the refresh queue — that loop is what made
+    // the panel look "jumpy" with spinners reappearing over cards after each
+    // build completed.
+    const onWatcherEvent = (uri: vscode.Uri) => {
+        if (isSourceFile(uri.fsPath)) { enqueueSaveRefresh(uri.fsPath); }
+    };
     for (const glob of ['**/*.kt', '**/res/**/*.xml']) {
         const watcher = vscode.workspace.createFileSystemWatcher(glob);
-        watcher.onDidChange(uri => enqueueSaveRefresh(uri.fsPath));
-        watcher.onDidCreate(uri => enqueueSaveRefresh(uri.fsPath));
-        watcher.onDidDelete(uri => enqueueSaveRefresh(uri.fsPath));
+        watcher.onDidChange(onWatcherEvent);
+        watcher.onDidCreate(onWatcherEvent);
+        watcher.onDidDelete(onWatcherEvent);
         context.subscriptions.push(watcher);
     }
 


### PR DESCRIPTION
## Summary

Two independent fixes for the VS Code extension feeling jumpy and the Gradle "Already watching path" VFS errors in the log.

### 1. Watcher → render loop (`vscode-extension/src/extension.ts`)

The workspace file watcher for `**/*.kt` and `**/res/**/*.xml` piped events straight into `enqueueSaveRefresh` with no path filter. Every Gradle render writes generated Kotlin/resource files under `<module>/build/**`, which the watcher treated as a source edit and queued another render — so a single save produced an endless render → build-output → watcher → render cycle. Visible as loading spinners flashing over cards immediately after a successful render.

Route watcher events through `isSourceFile` (the same `/build/` exclusion the save handler already uses), and short-circuit `onDidChangeActiveTextEditor` when the focused file hasn't changed (focus toggling between the editor and the preview webview was otherwise aborting the in-flight refresh for a no-op).

### 2. Gradle VFS watch collision (`gradle.properties`)

`org.gradle.unsafe.isolated-projects=true` + `includeBuild("gradle-plugin")` made Gradle 9 try to register `gradle-plugin/..` as a watched root, colliding with the main build's own root watch. Gradle then logged `Stopping file watching and invalidating VFS after an error happened`, forcing a full VFS rescan on every subsequent build and compounding #1. Isolated Projects wasn't being relied on anywhere — remove it.

## Test plan

- [ ] `cd vscode-extension && npm run compile` — passes (verified locally)
- [ ] Open a `@Preview`-bearing `.kt` file, save, confirm cards render and stay put (no second spinner burst)
- [ ] Toggle focus to another panel and back, confirm no new Gradle invocation is triggered
- [ ] `./gradlew :sample-android:renderAllPreviews` — no `Already watching path` warning, no VFS invalidation in the log