### PR TITLE
feat(doctor): surface AndroidX compat mismatches in CLI and VS Code

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -38,6 +38,12 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation("org.gradle:gradle-tooling-api:9.3.1")
     runtimeOnly("org.slf4j:slf4j-nop:2.0.16")
+
+    testImplementation(kotlin("test"))
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
 }
 
 java {

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -1,5 +1,9 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.plugin.tooling.ComposePreviewModel
+import ee.schimke.composeai.plugin.tooling.ModuleInfo
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import java.io.File
 import java.net.HttpURLConnection
 import java.net.URI
@@ -10,62 +14,108 @@ import kotlin.system.exitProcess
 /**
  * `compose-preview doctor`
  *
- * Verifies the prerequisites for using the plugin before the user edits any
- * Gradle files:
+ * Two layers of checks:
  *
- *   1. Java 21+ is reachable.
- *   2. GitHub Packages credentials (`composeAiTools.githubUser` / `...Token`)
- *      are set in ~/.gradle/gradle.properties, or `GITHUB_ACTOR` /
- *      `GITHUB_TOKEN` are set in the environment.
- *   3. The credentials actually resolve a package — a HEAD against the plugin
- *      POM on `maven.pkg.github.com`. A 200 means auth is good and
- *      `read:packages` is effective (fine-grained tokens don't expose scopes
- *      via the REST API, so we probe instead of introspecting).
- *   4. If token looks like a classic PAT, also surfaces the `x-oauth-scopes`
- *      header so the user can see what scopes are actually granted.
+ * **Environment** (always runs, safe outside a Gradle project):
+ *   - Java 21+ on PATH
+ *   - GitHub Packages credentials set and valid (`composeAiTools.githubUser` /
+ *     `...Token` in `~/.gradle/gradle.properties`, or `GITHUB_ACTOR` /
+ *     `GITHUB_TOKEN` env vars)
+ *   - HEAD probe against `maven.pkg.github.com` verifies `read:packages`
  *
- * Exits 0 when everything checks out, 1 otherwise. Designed to be safe to run
- * outside a Gradle project — it never touches the filesystem.
+ * **Project** (runs when a `settings.gradle[.kts]` is found at `--project` or cwd):
+ *   - Plugin applied to at least one module
+ *   - Consumer's test-runtime classpath vs main-variant classpath satisfies
+ *     the AAR/R.id version-alignment rules for preview rendering. Checks:
+ *       - `deps.<module>.ui-test-manifest` — ui-test-manifest on test classpath
+ *       - `deps.<module>.activity-vs-navigationevent` — navigationevent on test, older activity on main
+ *       - `deps.<module>.compose-ui-vs-core` — compose-ui 1.10+ on test, older androidx.core on main
+ *       - `deps.<module>.compose-bom` (warning) — no Compose BOM declared
+ *
+ * Output modes:
+ *   - Default: human-friendly ANSI with ✓ / ! / ✗ / ∙ markers, per-check remediation.
+ *   - `--json`: machine-readable [DoctorReport] (schema `compose-preview-doctor/v1`).
+ *     Agents should prefer this — remediations come with concrete `commands[]`
+ *     they can apply directly.
+ *   - `--explain`: prints extended rationale for each non-ok check, including
+ *     the specific exception class an unfixed misconfig will surface at render
+ *     time. Useful for humans first hitting a failure; noisy for agents.
+ *
+ * Exits 0 when no errors (warnings OK), 1 when any check reports ERROR.
  */
 class DoctorCommand(args: List<String>) {
+    private val jsonOut = "--json" in args
+    private val explain = "--explain" in args
     private val verbose = "--verbose" in args || "-v" in args
+    private val projectDirArg = args.flagValue("--project")
     private val pluginVersion = args.flagValue("--plugin-version") ?: DEFAULT_PLUGIN_VERSION
 
-    private var errors = 0
-    private var warnings = 0
+    private val checks = mutableListOf<DoctorCheck>()
 
     fun run() {
-        println("compose-preview doctor")
-        println()
-
+        // Environment checks always run.
         checkJava()
         val creds = checkCredentials()
         if (creds != null) probeMaven(creds)
-        checkComposeVersion()
+        checkComposeBomVersion()
 
-        println()
-        when {
-            errors > 0 -> {
-                println("✗ $errors problem(s) found" + if (warnings > 0) ", $warnings warning(s)" else "")
-                println()
-                println("Fix the errors above before applying the plugin to your build.")
-                exitProcess(1)
-            }
-            warnings > 0 -> println("✓ ok ($warnings warning(s))")
-            else -> println("✓ all checks passed")
+        // Project checks: only when a Gradle project is reachable.
+        val projectDir = resolveProjectDir()
+        if (projectDir != null) {
+            runProjectChecks(projectDir)
+        } else {
+            addCheck(
+                DoctorCheck(
+                    id = "project.detected",
+                    category = "project",
+                    status = "skipped",
+                    message = "no Gradle project at ${projectDirArg ?: "."}",
+                    detail = "project-scope compatibility checks were skipped",
+                    remediation = DoctorRemediation(
+                        summary = "run doctor from a Gradle project root, or pass `--project <dir>`",
+                    ),
+                ),
+            )
         }
+
+        emit()
     }
 
-    // --- Checks -------------------------------------------------------------
+    private fun resolveProjectDir(): File? {
+        val dir = File(projectDirArg ?: ".").absoluteFile
+        if (!dir.exists() || !dir.isDirectory) return null
+        return if (File(dir, "settings.gradle.kts").exists() || File(dir, "settings.gradle").exists()) {
+            dir
+        } else null
+    }
+
+    // --- Env checks ---------------------------------------------------------
 
     private fun checkJava() {
         val version = System.getProperty("java.specification.version")
         val major = version?.substringBefore('.')?.toIntOrNull()
         if (major != null && major >= 21) {
-            ok("Java $version on PATH")
+            addCheck(
+                DoctorCheck(
+                    id = "env.java-21",
+                    category = "env",
+                    status = "ok",
+                    message = "Java $version on PATH",
+                ),
+            )
         } else {
-            err("Java 21+ required, got ${version ?: "unknown"}")
-            hint("Install a JDK 21 and put it on PATH, or set JAVA_HOME.")
+            addCheck(
+                DoctorCheck(
+                    id = "env.java-21",
+                    category = "env",
+                    status = "error",
+                    message = "Java 21+ required, got ${version ?: "unknown"}",
+                    remediation = DoctorRemediation(
+                        summary = "Install a JDK 21 and put it on PATH, or set JAVA_HOME.",
+                        commands = listOf("sdk install java 21.0.3-tem"),
+                    ),
+                ),
+            )
         }
     }
 
@@ -80,19 +130,34 @@ class DoctorCommand(args: List<String>) {
 
         when {
             user == null && token == null -> {
-                err("no GitHub Packages credentials found")
-                hint("Store a token in ${propsFile.path}:")
-                hint("    composeAiTools.githubUser=<your-github-username>")
-                hint("    composeAiTools.githubToken=<PAT with read:packages>")
-                hint("Or: gh auth refresh -h github.com -s read:packages && gh auth token")
+                addCheck(
+                    DoctorCheck(
+                        id = "env.github-credentials",
+                        category = "env",
+                        status = "error",
+                        message = "no GitHub Packages credentials found",
+                        remediation = DoctorRemediation(
+                            summary = "Store a GitHub token with `read:packages` scope.",
+                            commands = listOf(
+                                "gh auth refresh -h github.com -s read:packages",
+                                "gh auth token",
+                            ),
+                            docs = "https://github.com/$REPO#credentials",
+                        ),
+                    ),
+                )
                 return null
             }
             token == null -> {
-                err("composeAiTools.githubToken is not set")
+                addCheck(
+                    DoctorCheck(
+                        id = "env.github-credentials",
+                        category = "env",
+                        status = "error",
+                        message = "composeAiTools.githubToken is not set",
+                    ),
+                )
                 return null
-            }
-            user == null -> {
-                warn("composeAiTools.githubUser not set; falling back to 'x' for BASIC auth")
             }
         }
 
@@ -100,94 +165,247 @@ class DoctorCommand(args: List<String>) {
             props["composeAiTools.githubToken"] != null -> propsFile.path
             else -> "\$GITHUB_TOKEN env var"
         }
-        ok("credentials found ($source)")
-
+        addCheck(
+            DoctorCheck(
+                id = "env.github-credentials",
+                category = "env",
+                status = if (user == null) "warning" else "ok",
+                message = "credentials found ($source)",
+                detail = if (user == null) "composeAiTools.githubUser not set; falling back to 'x' for BASIC auth" else null,
+            ),
+        )
         return Credentials(user ?: "x", token!!)
     }
 
     private fun probeMaven(creds: Credentials) {
-        // Probe the plugin POM on GitHub Packages. 200 = auth works + read:packages
-        // is effective. 401/403 = bad creds or missing scope. 404 = auth worked but
-        // the specific version doesn't exist (still good news for the auth check).
         val path = "ee/schimke/composeai/gradle-plugin/$pluginVersion/gradle-plugin-$pluginVersion.pom"
         val url = "$MAVEN_BASE/$path"
 
         val (code, headers) = head(url, creds)
 
-        when (code) {
-            in 200..299 -> ok("GitHub Packages auth works (HEAD $pluginVersion → $code)")
-            404 -> {
-                // 404 from maven.pkg.github.com with valid auth still means auth+scope
-                // worked — GitHub returns 401 if the token can't see the package at all.
-                ok("GitHub Packages auth works (plugin v$pluginVersion not published, but token can see the repo)")
-                warn("pinned plugin version $pluginVersion not found; check https://github.com/$REPO/releases")
+        val check = when (code) {
+            in 200..299 -> DoctorCheck(
+                id = "env.github-packages",
+                category = "env",
+                status = "ok",
+                message = "GitHub Packages auth works (HEAD $pluginVersion → $code)",
+            )
+            404 -> DoctorCheck(
+                id = "env.github-packages",
+                category = "env",
+                status = "warning",
+                message = "plugin v$pluginVersion not found on GitHub Packages",
+                detail = "auth+scope work (404, not 401), but this version is not published; pick a different version",
+                remediation = DoctorRemediation(
+                    summary = "Check available releases.",
+                    docs = "https://github.com/$REPO/releases",
+                ),
+            )
+            401 -> DoctorCheck(
+                id = "env.github-packages",
+                category = "env",
+                status = "error",
+                message = "GitHub Packages rejected credentials (HTTP 401)",
+                detail = headers.entries.firstOrNull { it.key.equals("x-oauth-scopes", true) }?.value
+                    ?.let { "scopes reported: ${it.ifBlank { "(none)" }}" },
+                remediation = DoctorRemediation(
+                    summary = "Token is missing `read:packages` or is invalid.",
+                    commands = listOf("gh auth refresh -h github.com -s read:packages"),
+                    docs = "https://github.com/settings/tokens/new",
+                ),
+            )
+            403 -> DoctorCheck(
+                id = "env.github-packages",
+                category = "env",
+                status = "error",
+                message = "GitHub Packages refused (HTTP 403)",
+                detail = "token likely lacks `read:packages`",
+            )
+            else -> DoctorCheck(
+                id = "env.github-packages",
+                category = "env",
+                status = "error",
+                message = "unexpected HTTP $code from $url",
+            )
+        }
+        addCheck(check)
+    }
+
+    // --- Project checks -----------------------------------------------------
+
+    private fun runProjectChecks(projectDir: File) {
+        val model = try {
+            GradleConnection(projectDir, verbose = verbose).use { gc ->
+                gc.runBuildAction(GatherComposePreviewModelAction())
             }
-            401 -> {
-                err("GitHub Packages rejected credentials (HTTP 401)")
-                surfaceScopes(headers)
-                hint("The token is missing 'read:packages' or is invalid.")
-                hint("Fix: gh auth refresh -h github.com -s read:packages")
-                hint("  or: create a classic PAT with 'read:packages' at https://github.com/settings/tokens/new")
-            }
-            403 -> {
-                err("GitHub Packages refused (HTTP 403) — token likely lacks 'read:packages'")
-                surfaceScopes(headers)
-            }
-            else -> {
-                err("unexpected HTTP $code from $url")
-                if (verbose) headers.forEach { (k, v) -> System.err.println("  $k: $v") }
-            }
+        } catch (e: Exception) {
+            addCheck(
+                DoctorCheck(
+                    id = "project.model",
+                    category = "project",
+                    status = "error",
+                    message = "could not fetch plugin Tooling model",
+                    detail = e.message,
+                    remediation = DoctorRemediation(
+                        summary = "Ensure the project builds (`./gradlew help`) and the plugin is applied.",
+                    ),
+                ),
+            )
+            return
+        }
+
+        if (model == null || model.modules.isEmpty()) {
+            addCheck(
+                DoctorCheck(
+                    id = "project.plugin-applied",
+                    category = "project",
+                    status = "error",
+                    message = "no modules have the compose-preview plugin applied",
+                    remediation = DoctorRemediation(
+                        summary = "Apply the plugin in your module's `plugins { }` block.",
+                        commands = listOf("id(\"ee.schimke.composeai.preview\") version \"$pluginVersion\""),
+                        docs = "https://github.com/$REPO#usage",
+                    ),
+                ),
+            )
+            return
+        }
+
+        addCheck(
+            DoctorCheck(
+                id = "project.plugin-applied",
+                category = "project",
+                status = "ok",
+                message = "plugin applied in ${model.modules.size} module(s)",
+                detail = model.modules.keys.joinToString(", "),
+            ),
+        )
+
+        for ((modulePath, info) in model.modules) {
+            checkModuleCompat(modulePath, info)
         }
     }
 
     /**
-     * Flags Compose versions that are known-too-old for the renderer to run
-     * against. Renderer-android is compiled with compose-compiler 2.2.21,
-     * which emits calls to `ComposeUiNode.setCompositeKeyHash` and friends
-     * — first shipped in compose-ui 1.9 (compose-bom 2025.01.00). Older
-     * consumers hit `NoSuchMethodError` the moment `renderPreviews` starts.
-     * This check walks `gradle/libs.versions.toml` + every `build.gradle*`
-     * for a compose-bom or compose-ui version declaration and compares
-     * against that floor.
-     *
-     * No Gradle call — we just grep the sources. That keeps doctor a
-     * pre-flight check (runnable before the user even applies the plugin),
-     * matching the other checks' shape.
+     * Render findings produced plugin-side (see [CompatRules] in gradle-plugin)
+     * as doctor checks. CLI doesn't run compat logic of its own — one source
+     * of truth, consumed by both CLI and VS Code. Rule thresholds and
+     * remediation phrasing live in the plugin.
      */
-    private fun checkComposeVersion() {
-        val workspace = File(".").canonicalFile
-        val versions = findComposeVersionDeclarations(workspace)
-        if (versions.isEmpty()) {
-            // No declarations found → nothing to check. Don't warn: it's
-            // entirely possible doctor is being run outside a Gradle project,
-            // or versions are declared somewhere we didn't look.
+    private fun checkModuleCompat(modulePath: String, info: ModuleInfo) {
+        val variant = info.variant
+
+        if (info.mainRuntimeDependencies.isEmpty() && info.testRuntimeDependencies.isEmpty()) {
+            addCheck(
+                DoctorCheck(
+                    id = "deps.${idSafe(modulePath)}.resolve",
+                    category = "deps",
+                    status = "skipped",
+                    message = "$modulePath — dependency resolution returned empty for variant '$variant'",
+                    detail = "the plugin was applied but neither ${variant}RuntimeClasspath nor ${variant}UnitTestRuntimeClasspath resolved",
+                ),
+            )
             return
         }
+
+        if (info.findings.isEmpty()) {
+            addCheck(
+                DoctorCheck(
+                    id = "deps.${idSafe(modulePath)}.compat",
+                    category = "deps",
+                    status = "ok",
+                    message = "$modulePath — no compatibility issues found",
+                ),
+            )
+            return
+        }
+
+        for (finding in info.findings) {
+            val status = when (finding.severity) {
+                "error" -> "error"
+                "warning" -> "warning"
+                else -> "info"
+            }
+            // Short-form detail is the default; `--explain` also surfaces
+            // the long-form detail from the plugin (the "why this breaks at
+            // render time" rationale).
+            val detail = if (explain) finding.detail else null
+            val remediation = if (finding.remediationSummary != null) {
+                DoctorRemediation(
+                    summary = finding.remediationSummary!!,
+                    commands = finding.remediationCommands,
+                    docs = finding.docsUrl,
+                )
+            } else null
+            addCheck(
+                DoctorCheck(
+                    id = "deps.${idSafe(modulePath)}.${finding.id}",
+                    category = "deps",
+                    status = status,
+                    message = "$modulePath — ${finding.message}",
+                    detail = detail,
+                    remediation = remediation,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Grep-based "is your compose-bom recent enough" pre-flight. Runs
+     * BEFORE any Gradle call, so it works even outside a Gradle project
+     * or before the plugin is applied — complements the plugin-side
+     * `CompatRules` findings, which only fire once Gradle has resolved
+     * the test classpath. Renderer-android is compiled with compose-
+     * compiler 2.2.21, which emits calls to
+     * `ComposeUiNode.setCompositeKeyHash` — first shipped in compose-ui
+     * 1.9 (compose-bom 2025.01.00). Older consumers hit `NoSuchMethodError`
+     * the moment `renderPreviews` starts.
+     */
+    private fun checkComposeBomVersion() {
+        val workspace = File(projectDirArg ?: ".").canonicalFile
+        val versions = findComposeBomDeclarations(workspace)
+        if (versions.isEmpty()) return // No declarations → nothing to assert on.
 
         val tooOld = versions.filter { (_, v) -> v.isOlderThan(MIN_BOM_YEAR, MIN_BOM_MONTH) }
         if (tooOld.isEmpty()) {
             val summary = versions.joinToString(", ") { (_, v) -> v.raw }
-            ok("compose-bom version(s) look recent enough ($summary)")
+            addCheck(
+                DoctorCheck(
+                    id = "env.compose-bom-version",
+                    category = "env",
+                    status = "ok",
+                    message = "compose-bom version(s) look recent enough ($summary)",
+                ),
+            )
             return
         }
+        val floor = "$MIN_BOM_YEAR.${MIN_BOM_MONTH.toString().padStart(2, '0')}.00"
         for ((source, v) in tooOld) {
-            warn("compose-bom ${v.raw} declared in ${source.relativeTo(workspace).path} — renderer needs ≥$MIN_BOM_YEAR.${MIN_BOM_MONTH.toString().padStart(2, '0')}.00")
+            addCheck(
+                DoctorCheck(
+                    id = "env.compose-bom-version",
+                    category = "env",
+                    status = "warning",
+                    message = "compose-bom ${v.raw} declared in ${source.relativeTo(workspace).path} — renderer needs ≥$floor",
+                    detail = "Older BOMs lack `ComposeUiNode.setCompositeKeyHash`; `renderPreviews` will fail with NoSuchMethodError.",
+                    remediation = DoctorRemediation(
+                        summary = "Bump the BOM.",
+                        commands = listOf("compose-bom = \"$floor\""),
+                    ),
+                ),
+            )
         }
-        hint("Older BOMs lack `ComposeUiNode.setCompositeKeyHash`; `renderPreviews` will fail with NoSuchMethodError.")
-        hint("Bump the bom:  compose-bom = \"$MIN_BOM_YEAR.${MIN_BOM_MONTH.toString().padStart(2, '0')}.00\"  (or newer)")
     }
 
     /**
      * Returns `(fileWhereFound, parsedVersion)` for every
-     * `androidx.compose:compose-bom` version literal we find. Sources
-     * checked (in order): `gradle/libs.versions.toml`, `build.gradle`
-     * / `build.gradle.kts` under the workspace. Early-exits at depth 4
-     * to avoid wandering through `build/` etc.
+     * `androidx.compose:compose-bom` version literal we find under [root].
+     * Scans `gradle/libs.versions.toml` and every `build.gradle[.kts]`,
+     * early-exiting at depth 4 so we don't wander through `build/`.
      */
-    private fun findComposeVersionDeclarations(root: File): List<Pair<File, ComposeVersion>> {
+    private fun findComposeBomDeclarations(root: File): List<Pair<File, ComposeVersion>> {
         val out = mutableListOf<Pair<File, ComposeVersion>>()
         val tomlRegex = Regex("""compose-bom\s*=\s*"([^"]+)"""")
-        // Matches `platform("androidx.compose:compose-bom:YYYY.MM.XX")` inline.
         val bomInlineRegex = Regex("""["']androidx\.compose:compose-bom:([0-9][0-9A-Za-z.\-]+)["']""")
 
         fun scanTextFile(file: File) {
@@ -232,7 +450,77 @@ class DoctorCommand(args: List<String>) {
         }
     }
 
+    // --- Output -------------------------------------------------------------
+
+    private fun emit() {
+        if (jsonOut) emitJson() else emitText()
+        val errors = checks.count { it.status == "error" }
+        exitProcess(if (errors > 0) 1 else 0)
+    }
+
+    private fun emitText() {
+        println("compose-preview doctor")
+        println()
+        var currentCategory = ""
+        for (check in checks) {
+            if (check.category != currentCategory) {
+                if (currentCategory.isNotEmpty()) println()
+                println("  [${check.category}]")
+                currentCategory = check.category
+            }
+            val marker = when (check.status) {
+                "ok" -> "✓"
+                "warning" -> "!"
+                "error" -> "✗"
+                "skipped" -> "∙"
+                else -> "?"
+            }
+            println("  $marker ${check.message}")
+            check.detail?.let { println("      $it") }
+            check.remediation?.let { r ->
+                println("      → ${r.summary}")
+                for (cmd in r.commands) println("        \$ $cmd")
+                r.docs?.let { println("        docs: $it") }
+            }
+        }
+        println()
+
+        val summary = summary()
+        val headline = when {
+            summary.error > 0 -> "✗ ${summary.error} error(s), ${summary.warning} warning(s)"
+            summary.warning > 0 -> "✓ ok (${summary.warning} warning(s))"
+            else -> "✓ all checks passed"
+        }
+        println(headline)
+        if (summary.skipped > 0) println("  ${summary.skipped} check(s) skipped")
+    }
+
+    private fun emitJson() {
+        val report = DoctorReport(
+            pluginVersion = pluginVersion,
+            overall = when {
+                checks.any { it.status == "error" } -> "error"
+                checks.any { it.status == "warning" } -> "warning"
+                else -> "ok"
+            },
+            checks = checks.toList(),
+            summary = summary(),
+        )
+        println(JSON.encodeToString(DoctorReport.serializer(), report))
+    }
+
+    private fun summary() = DoctorSummary(
+        ok = checks.count { it.status == "ok" },
+        warning = checks.count { it.status == "warning" },
+        error = checks.count { it.status == "error" },
+        skipped = checks.count { it.status == "skipped" },
+    )
+
     // --- Helpers ------------------------------------------------------------
+
+    private fun addCheck(check: DoctorCheck) {
+        checks += check
+    }
 
     private fun head(url: String, creds: Credentials): Pair<Int, Map<String, String>> {
         val conn = (URI(url).toURL().openConnection() as HttpURLConnection).apply {
@@ -252,22 +540,9 @@ class DoctorCommand(args: List<String>) {
                 .mapValues { it.value.joinToString(", ") }
             code to headers
         } catch (e: Exception) {
-            err("network probe failed: ${e.message}")
-            -1 to emptyMap()
+            -1 to mapOf("error" to (e.message ?: e.javaClass.simpleName))
         } finally {
             conn.disconnect()
-        }
-    }
-
-    private fun surfaceScopes(headers: Map<String, String>) {
-        val scopes = headers.entries.firstOrNull { it.key.equals("x-oauth-scopes", true) }?.value
-        if (scopes != null) {
-            hint("token scopes reported by GitHub: ${scopes.ifBlank { "(none)" }}")
-            if ("read:packages" !in scopes) {
-                hint("missing 'read:packages'.")
-            }
-        } else {
-            hint("(no x-oauth-scopes header — fine-grained tokens don't expose scopes this way)")
         }
     }
 
@@ -277,21 +552,12 @@ class DoctorCommand(args: List<String>) {
             Properties().apply { file.inputStream().use { load(it) } }
                 .entries.associate { it.key.toString() to it.value.toString() }
         } catch (e: Exception) {
-            warn("could not read ${file.path}: ${e.message}")
             emptyMap()
         }
     }
 
-    private fun ok(msg: String) = println("  ✓ $msg")
-    private fun warn(msg: String) {
-        warnings++
-        println("  ! $msg")
-    }
-    private fun err(msg: String) {
-        errors++
-        println("  ✗ $msg")
-    }
-    private fun hint(msg: String) = println("      $msg")
+    /** Sanitise a module path (e.g. `:sample-wear` → `sample-wear`) for use in check ids. */
+    private fun idSafe(modulePath: String): String = modulePath.removePrefix(":").ifEmpty { "root" }
 
     private data class Credentials(val user: String, val token: String)
 
@@ -309,8 +575,54 @@ class DoctorCommand(args: List<String>) {
         private const val MIN_BOM_MONTH = 1
 
         private val SKIP_DIRS = setOf("build", "node_modules", "out", "dist", ".gradle")
+
+        private val JSON = Json { prettyPrint = true; encodeDefaults = true }
     }
 }
+
+// --- Report schema ---------------------------------------------------------
+// Stable public contract for external consumers — keep backwards-compatible
+// within a major schema version. Schema version lives in [DoctorReport.schema].
+
+@Serializable
+data class DoctorReport(
+    val schema: String = "compose-preview-doctor/v1",
+    val pluginVersion: String,
+    val overall: String, // "ok" | "warning" | "error"
+    val checks: List<DoctorCheck>,
+    val summary: DoctorSummary,
+)
+
+@Serializable
+data class DoctorCheck(
+    /** Stable dotted id — safe to grep / branch on. */
+    val id: String,
+    /** "env" | "project" | "deps". */
+    val category: String,
+    /** "ok" | "warning" | "error" | "skipped". */
+    val status: String,
+    /** Single-line human-readable summary. */
+    val message: String,
+    /** Multi-line follow-up (optional). Agents can surface to users. */
+    val detail: String? = null,
+    /** Concrete action to unblock (optional). */
+    val remediation: DoctorRemediation? = null,
+)
+
+@Serializable
+data class DoctorRemediation(
+    val summary: String,
+    val commands: List<String> = emptyList(),
+    val docs: String? = null,
+)
+
+@Serializable
+data class DoctorSummary(
+    val ok: Int,
+    val warning: Int,
+    val error: Int,
+    val skipped: Int,
+)
 
 private fun List<String>.flagValue(flag: String): String? {
     val idx = indexOf(flag)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/GatherComposePreviewModelAction.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/GatherComposePreviewModelAction.kt
@@ -1,0 +1,86 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.plugin.tooling.ComposePreviewModel
+import ee.schimke.composeai.plugin.tooling.ModuleFinding
+import ee.schimke.composeai.plugin.tooling.ModuleInfo
+import org.gradle.tooling.BuildAction
+import org.gradle.tooling.BuildController
+import org.gradle.tooling.model.gradle.GradleBuild
+import java.io.Serializable
+
+/**
+ * Aggregates [ComposePreviewModel] across every project in the build.
+ *
+ * Runs in the Gradle daemon (serialised by the Tooling API). Walks every
+ * project via the [GradleBuild] model and asks for the per-project
+ * `ComposePreviewModel` on each — projects that don't apply the plugin
+ * return an empty `modules` map, which we drop. Aggregation happens inside
+ * the daemon so each per-project `findModel` call is cross-project-safe
+ * under Isolated Projects, where a single root-scoped builder wouldn't be
+ * allowed to poke at subprojects.
+ *
+ * The return type is a [ComposePreviewModel] implementation defined on the
+ * CLI side so the Tooling API can ship it back without proxy round-tripping
+ * per field access.
+ */
+class GatherComposePreviewModelAction : BuildAction<AggregatedComposePreviewModel> {
+    override fun execute(controller: BuildController): AggregatedComposePreviewModel {
+        val build = controller.getModel(GradleBuild::class.java)
+        val aggregated = linkedMapOf<String, SerializableModuleInfo>()
+        var pluginVersion = ""
+        for (project in build.projects) {
+            val model = try {
+                controller.findModel(project, ComposePreviewModel::class.java)
+            } catch (_: Throwable) {
+                null
+            } ?: continue
+            if (model.pluginVersion.isNotEmpty()) pluginVersion = model.pluginVersion
+            for ((path, info) in model.modules) {
+                aggregated[path] = SerializableModuleInfo(
+                    variant = info.variant,
+                    mainRuntimeDependencies = info.mainRuntimeDependencies.toMap(),
+                    testRuntimeDependencies = info.testRuntimeDependencies.toMap(),
+                    findings = info.findings.map { f ->
+                        SerializableModuleFinding(
+                            id = f.id,
+                            severity = f.severity,
+                            message = f.message,
+                            detail = f.detail,
+                            remediationSummary = f.remediationSummary,
+                            remediationCommands = f.remediationCommands.toList(),
+                            docsUrl = f.docsUrl,
+                        )
+                    },
+                )
+            }
+        }
+        return AggregatedComposePreviewModel(pluginVersion, aggregated)
+    }
+}
+
+/**
+ * CLI-side [ComposePreviewModel] implementation. Tooling API serialises this
+ * class by value, so both sides of the daemon boundary see the same object
+ * shape without dynamic proxies — easier to debug and cheaper to iterate.
+ */
+data class AggregatedComposePreviewModel(
+    override val pluginVersion: String,
+    override val modules: Map<String, SerializableModuleInfo>,
+) : ComposePreviewModel, Serializable
+
+data class SerializableModuleInfo(
+    override val variant: String,
+    override val mainRuntimeDependencies: Map<String, String>,
+    override val testRuntimeDependencies: Map<String, String>,
+    override val findings: List<SerializableModuleFinding>,
+) : ModuleInfo, Serializable
+
+data class SerializableModuleFinding(
+    override val id: String,
+    override val severity: String,
+    override val message: String,
+    override val detail: String?,
+    override val remediationSummary: String?,
+    override val remediationCommands: List<String>,
+    override val docsUrl: String?,
+) : ModuleFinding, Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -181,6 +181,47 @@ class GradleConnection(
     }
 
     /**
+     * Fetch a Tooling API model registered by the applied plugin. Returns
+     * `null` if the model isn't registered (plugin not applied, or version
+     * predates the model) or if the Gradle connection fails — callers fold
+     * both into "skip project-scope checks" rather than erroring.
+     *
+     * The plugin-side model FQN and the [modelClass] passed here must match;
+     * see `ComposePreviewModel.kt` on both sides for the contract.
+     */
+    fun <R> runBuildAction(action: org.gradle.tooling.BuildAction<R>, timeoutSeconds: Long = 60): R? {
+        val tokenSource: CancellationTokenSource = GradleConnector.newCancellationTokenSource()
+        val timer = java.util.Timer(true).apply {
+            schedule(object : java.util.TimerTask() {
+                override fun run() { tokenSource.cancel() }
+            }, timeoutSeconds * 1000)
+        }
+        return try {
+            connection.action(action)
+                .withCancellationToken(tokenSource.token())
+                .apply {
+                    if (verbose) {
+                        setStandardOutput(System.err)
+                        setStandardError(System.err)
+                    } else {
+                        setStandardOutput(NullOutputStream)
+                        setStandardError(NullOutputStream)
+                    }
+                }
+                .run()
+        } catch (e: org.gradle.tooling.GradleConnectionException) {
+            if (verbose) System.err.println("Gradle connection failed: ${e.message}")
+            null
+        } catch (e: org.gradle.tooling.BuildException) {
+            if (verbose) System.err.println("Build action failed: ${e.message}")
+            null
+        } finally {
+            timer.cancel()
+            tokenSource.cancel()
+        }
+    }
+
+    /**
      * Find all subprojects that have a `discoverPreviews` task — these have the
      * compose-ai-tools plugin applied.
      */

--- a/cli/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt
@@ -1,0 +1,31 @@
+package ee.schimke.composeai.plugin.tooling
+
+/**
+ * CLI-side copy of the plugin's Tooling API model. MUST stay at the same
+ * fully-qualified name and method signatures as the plugin-side interface —
+ * Gradle's Tooling API uses reflective proxies to bridge the two across the
+ * daemon boundary, so drift silently produces `null` returns. See the
+ * plugin-side source for the canonical docstrings:
+ * `gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt`.
+ */
+interface ComposePreviewModel {
+    val pluginVersion: String
+    val modules: Map<String, ModuleInfo>
+}
+
+interface ModuleInfo {
+    val variant: String
+    val mainRuntimeDependencies: Map<String, String>
+    val testRuntimeDependencies: Map<String, String>
+    val findings: List<ModuleFinding>
+}
+
+interface ModuleFinding {
+    val id: String
+    val severity: String
+    val message: String
+    val detail: String?
+    val remediationSummary: String?
+    val remediationCommands: List<String>
+    val docsUrl: String?
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DoctorCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DoctorCommandTest.kt
@@ -1,0 +1,57 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DoctorReportSerializationTest {
+    @Test fun `round-trips a report with all fields populated`() {
+        val report = DoctorReport(
+            schema = "compose-preview-doctor/v1",
+            pluginVersion = "0.4.0",
+            overall = "warning",
+            checks = listOf(
+                DoctorCheck(
+                    id = "env.java-21",
+                    category = "env",
+                    status = "ok",
+                    message = "Java 21 on PATH",
+                ),
+                DoctorCheck(
+                    id = "deps.app.ui-test-manifest-missing",
+                    category = "deps",
+                    status = "error",
+                    message = ":app — ui-test-manifest missing on test classpath",
+                    detail = "see docs",
+                    remediation = DoctorRemediation(
+                        summary = "add it",
+                        commands = listOf("testImplementation(\"x:y\")"),
+                        docs = "https://example.com",
+                    ),
+                ),
+            ),
+            summary = DoctorSummary(ok = 1, warning = 0, error = 1, skipped = 0),
+        )
+
+        val json = kotlinx.serialization.json.Json { prettyPrint = true; encodeDefaults = true }
+        val text = json.encodeToString(DoctorReport.serializer(), report)
+        val parsed = json.decodeFromString(DoctorReport.serializer(), text)
+        assertEquals(report, parsed)
+
+        // Schema contract — consumers should be able to grep for this
+        // without parsing the whole document.
+        assertTrue("\"schema\": \"compose-preview-doctor/v1\"" in text)
+    }
+
+    @Test fun `default schema field stays at v1`() {
+        // Bump this test intentionally when rolling to v2 — guards against
+        // accidentally breaking the CLI→agent contract.
+        val report = DoctorReport(
+            pluginVersion = "0.0.0",
+            overall = "ok",
+            checks = emptyList(),
+            summary = DoctorSummary(0, 0, 0, 0),
+        )
+        assertEquals("compose-preview-doctor/v1", report.schema)
+    }
+}

--- a/docs/RENDERER_COMPATIBILITY.md
+++ b/docs/RENDERER_COMPATIBILITY.md
@@ -1,281 +1,57 @@
 # Renderer compatibility notes
 
-Background reading for anyone extending `compose-preview doctor`, debugging a
-consumer render failure, or bumping the renderer-side Compose / AndroidX
-versions. Covers the failure modes we know about, the mitigations already in
-place, and the checks a future doctor pass could surface.
+The renderer ships as `ee.schimke.composeai:renderer-android` (an AAR) and is
+resolved into each consumer project's `composePreviewAndroidRenderer<Variant>`
+configuration. AGP's `process<Variant>Resources` builds the unit-test merged
+resource APK (`apk-for-local-test.ap_`) from the consumer's **own** dep graph,
+so if a transitive pulls a newer AndroidX AAR into the test classpath than the
+consumer's main variant declares, classes and resources disagree at runtime.
 
-## Why there's a mismatch risk at all
+**Don't catalogue the specific failure modes here anymore — run
+`compose-preview doctor --explain` in the consumer project.** The plugin's
+`CompatRules` owns the current list of known AAR/R.id mismatches, and `doctor`
+prints the rationale, the triggering library, and the remediation per finding.
+The VS Code extension surfaces the same findings in the Problems panel (via
+`:<module>:composePreviewDoctor` → `build/compose-previews/doctor.json`).
 
-The renderer ships as `ee.schimke.composeai:renderer-android`, an AAR the
-Gradle plugin resolves into a dedicated `composePreviewAndroidRenderer<Variant>`
-configuration on the consumer project. That configuration is **not** one of
-AGP's built-in configurations, so AGP's resource pipeline has no idea it
-exists.
+## What still lives here
 
-Consequence: `process<Variant>Resources` builds the merged unit-test APK
-(`apk-for-local-test.ap_`) purely from the consumer's **own** dep graph. If
-the renderer AAR transitively drags in a newer version of an AndroidX library
-than the consumer declares, three things are true at the same time:
+- **When to add a rule.** A new rule goes into
+  [`CompatRules.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt)
+  when a new AndroidX AAR adds an R.id field that older transitives don't
+  have, and we've seen a consumer hit the resulting runtime error. Add a test
+  in `CompatRulesTest.kt` with both the triggering and non-triggering paths.
+- **The three mitigation mechanisms** in the renderer/plugin that must move
+  together — remove any one and the compat matrix re-opens:
+  1. `compileOnly` for Compose / Activity / UI-test libs in
+     [`renderer-android/build.gradle.kts`](../renderer-android/build.gradle.kts).
+     Consumer's versions win at runtime, so classes match their APK.
+  2. `rendererConfig.extendsFrom(testConfig)` in
+     [`AndroidPreviewSupport.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt).
+     Renderer transitives resolve in the same Gradle graph as consumer test
+     deps — one coherent max-version set, no per-JAR classpath-ordering
+     hazards.
+  3. Unconditional injection of `androidx.compose.ui:ui-test-manifest` into
+     `testImplementation` (same file). AGP's manifest merger only walks the
+     consumer's declared deps — the renderer AAR transitively carrying the
+     activity entry isn't enough.
 
-1. The consumer's resource APK contains the **older** version's resources.
-2. Gradle's conflict resolution puts the **newer** version's classes on the
-   test JVM classpath (max wins across rendererConfig + testConfig).
-3. Robolectric loads the new classes, which reference resources
-   (`R.id.*`) that only exist in the new version — and those resources are
-   missing from the APK.
+## Tile-rendering gaps (follow-ups)
 
-The test crashes at class-init time with some `NoClassDefFoundError` or
-`NoSuchFieldError`. The failure surface is entirely about **classes and
-resources coming from different versions of the same library**.
+Unrelated to the compat story but worth tracking here so they don't go
+missing:
 
-Three surfaces hit this in practice:
-
-| Surface | What moves independently |
-|---------|---------------------------|
-| Renderer AAR → consumer | Compose BOM, activity-compose, androidx.core versions |
-| Consumer test classpath | Pinned by the consumer's own deps |
-| Consumer resource APK | Generated from the consumer's main-variant deps |
-
-## Known failure signatures
-
-All three failures are the same class of issue — classes on classpath at a
-newer version than resources in the merged APK. Symptoms:
-
-### activity-compose 1.11+ on a consumer with an older activity
-
-```
-java.lang.NoClassDefFoundError: androidx/navigationevent/R$id
-    at androidx.navigationevent.ViewTreeNavigationEventDispatcherOwner.set
-    at androidx.activity.ComponentActivity.initializeViewTreeOwners
-    at androidx.activity.compose.ComponentActivityKt.setContent
-```
-
-- **Triggering change:** `androidx.activity:activity:1.11.0` pulled in
-  `androidx.navigationevent:navigationevent:1.0.0` as a required dep. The
-  `ComponentActivity.initializeViewTreeOwners` codepath now accesses
-  `R.id.view_tree_navigation_event_dispatcher_owner` which lives in the new
-  AAR's R class.
-- **Who hits it:** consumers whose own `activity-compose` version is 1.10.x or
-  older. Observed on `android/wear-os-samples/WearTilesKotlin` (activity-compose
-  1.8.2 via Compose BOM ~2024.09).
-
-### compose-ui 1.10+ on a consumer with older androidx.core
-
-```
-java.lang.NoSuchFieldError: Class androidx.core.R$id does not have member
-field 'int tag_compat_insets_dispatch'
-    at androidx.core.view.ViewCompat$Api21Impl.setOnApplyWindowInsetsListener
-    at androidx.compose.ui.layout.InsetsListener.onViewDetachedFromWindow
-```
-
-- **Triggering change:** `androidx.core:core:1.16.0` added
-  `R.id.tag_compat_insets_dispatch`. compose-ui 1.10+ transitively depends on
-  core 1.16+ and calls `ViewCompat.setOnApplyWindowInsetsListener`, which
-  reads that field via reflection.
-- **Who hits it:** consumers with `androidx.core:core < 1.16.0`. Typically
-  consumers using Compose BOM released before 2025-Q1.
-
-### activity 1.13 vs lifecycle 2.x mismatch
-
-```
-java.lang.NoSuchFieldError: Class androidx.lifecycle.ReportFragment does not
-have member field 'androidx.lifecycle.ReportFragment$Companion Companion'
-    at androidx.activity.ComponentActivity.onCreate
-```
-
-- **Triggering change:** `activity:1.13` expects `ReportFragment.Companion`,
-  added in `lifecycle:2.9.x`. On a classpath that has both activity-1.13
-  (from our renderer) and lifecycle-runtime-2.3 (from older transitive
-  deps), classloader order determines which wins per-class → crash.
-- **Who hits it:** seen transiently while experimenting with classpath
-  ordering before the `extendsFrom(testConfig)` fix. Shouldn't recur under
-  the current architecture but is worth knowing about when debugging.
-
-## Current mitigations
-
-Three mechanisms work together — removing any one of them re-opens the
-failure modes above.
-
-### `compileOnly` in renderer-android
-
-[`renderer-android/build.gradle.kts`](../renderer-android/build.gradle.kts)
-declares Compose / Activity / Compose-UI-test libs as `compileOnly` +
-matching `testImplementation`:
-
-```kotlin
-compileOnly(platform(libs.compose.bom))
-compileOnly(libs.compose.ui)
-compileOnly(libs.activity.compose)
-compileOnly("androidx.compose.ui:ui-test-junit4")
-compileOnly("androidx.compose.ui:ui-test-manifest")
-// ... etc
-```
-
-Effect: these libs are **not** transitively pulled in from the renderer AAR at
-consumer resolve time. The consumer's own versions flow through to the test
-JVM classpath unchanged, matching their resource APK.
-
-**Keep**: Roborazzi + `roborazzi-accessibility-check` as `implementation`.
-They don't contribute AndroidManifest entries or R.id resources that the
-consumer has to have merged.
-
-### `extendsFrom(testConfig)` in the plugin
-
-[`AndroidPreviewSupport.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt)
-has `rendererConfig.extendsFrom(testConfig)`. Effect: Gradle resolves the
-renderer's remaining transitives **together with** the consumer's
-test-runtime deps as one dependency graph. Max-version wins once per module,
-each class appears in exactly one JAR, and `FileCollection.from()` ordering
-stops mattering for the combined classpath.
-
-### Consumer-scope `ui-test-manifest` injection
-
-Same file, `testImplementation` injection:
-
-```kotlin
-project.dependencies.add(
-    "testImplementation",
-    "androidx.compose.ui:ui-test-manifest",
-)
-```
-
-AGP's manifest merger only walks the consumer's declared deps. The renderer
-AAR transitively having ui-test-manifest is not enough — AGP won't pick it
-up unless it lives in a test-scope consumer configuration. This injection
-is **unconditional** (it used to gate on the a11y feature; that gate was
-removed because any ComposeTestRule-backed path needs the manifest entry).
-
-## Things a future `compose-preview doctor` could check
-
-The integration test guards against regression in our own codebase, but it
-doesn't help a user of a broken release diagnose what's wrong in their
-project. `compose-preview doctor` runs inside the consumer, so it can
-introspect the consumer's Gradle model and warn before `renderPreviews`
-crashes.
-
-Concrete checks, in rough order of usefulness:
-
-### Hard errors (block rendering, explain fix)
-
-- **Consumer missing `ui-test-manifest` on test classpath.** Resolve
-  `debugUnitTestRuntimeClasspath` and look for `androidx.compose.ui:ui-test-manifest`.
-  If absent, the plugin injection didn't take effect (misconfigured extension,
-  old plugin version, extension opt-out). Point to `composePreview { enabled = true }`.
-
-- **Consumer's `apk-for-local-test.ap_` missing an R class that the
-  renderer's classpath references.** This is harder to check statically but
-  the symptoms are predictable. At minimum: resolve
-  `debugUnitTestRuntimeClasspath` and `${variantName}RuntimeClasspath`, and if
-  a class that was added in a known AAR version is in the runtime classpath
-  but the AAR version in the main-variant resource-contributing config is
-  older, flag it. Candidates worth hard-coding:
-  - `androidx.navigationevent:navigationevent` presence in test classpath →
-    require `androidx.activity:activity >= 1.11.0` on the consumer's main
-    variant.
-  - `androidx.compose.ui:ui >= 1.10.0` on test classpath → require
-    `androidx.core:core >= 1.16.0` on the consumer's main variant.
-  - `androidx.lifecycle:lifecycle-runtime >= 2.9.0` class refs on test
-    classpath → require `androidx.lifecycle:lifecycle-runtime >= 2.9.0` on
-    the consumer's main variant.
-
-### Warnings (the render will probably work but here be dragons)
-
-- **Consumer's Compose BOM is significantly older than the renderer's
-  build-time BOM.** Soft signal. Not guaranteed to break, but worth a
-  "known-tested combination" nudge. The renderer records its build-time
-  BOM in the jar manifest (see `PluginVersion`); doctor can compare.
-
-- **Consumer declares `implementation(compose.ui)` without a BOM.** Makes
-  version conflicts harder to reason about (no lockstep across compose-*
-  artifacts). Suggest the BOM.
-
-- **Consumer has `ui-test-manifest` on `debugImplementation` instead of
-  `testImplementation`.** Works but leaks the test activity into the debug
-  app. Suggest moving to `testImplementation`.
-
-- **Consumer's `unit_test_config_directory` is missing from the classpath.**
-  Already handled by the plugin, but if someone has customised their Test
-  task and dropped it, `TileRenderer` will crash on `Unknown resource value
-  type 0` and look utterly confusing. See the comment at
-  [`AndroidPreviewSupport.kt`](../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt)
-  around `unitTestConfigDir` for the full reason.
-
-### Tile-specific checks
-
-- **`@androidx.wear.tiles.tooling.preview.Preview` on the classpath but
-  `params.kind == "TILE"` count in `previews.json` is zero.** Means
-  discovery failed to recognise the annotation. Usually a plugin-version
-  mismatch between what's in `pluginManagement` and what's in the renderer
-  AAR resolution, but can also be a ClassGraph classpath issue.
-
-- **Tile previews render to near-blank PNGs.** Usually user-authoring
-  (white text on transparent background — we hit this in sample-wear before
-  the Material3 rewrite). Not a renderer bug, but doctor could sample the
-  first tile PNG and check if it's > N% solid-colour as a heuristic. Noisy,
-  probably not worth hard-coding.
-
-- **Tile render timeout.** `TilePreviewRenderer.inflateAsync.get(10,
-  SECONDS)` has a hard cap. If a consumer's tile takes longer to inflate
-  (complex resource loading, etc.), they'd get a cryptic
-  `TimeoutException`. Worth surfacing as "tile took N seconds; bump
-  timeout or investigate".
-
-## Where to hook this in
-
-- Doctor already runs post-`discoverPreviews`, so `previews.json` exists
-  and can be parsed for `kind` counts.
-- Doctor can resolve Gradle configurations via the Tooling API — the CLI
-  already does this for `renderPreviews` invocation. Extend
-  `GradleConnector` to expose dependency resolution.
-- Some checks (e.g. "is R.id.tag_compat_insets_dispatch going to be looked
-  up?") need knowledge of the specific library → consumer mapping. Keep a
-  small data table of known-breaking (min-consumer-version, min-renderer-version)
-  pairs in the CLI, updated alongside renderer-android's own `libs.versions.toml`
-  bumps. Each pair is an explicit "we know this combination breaks at
-  runtime" entry; the absence of an entry is not a guarantee of
-  compatibility.
-
-## Tile rendering gaps (follow-ups)
-
-Separate from the compatibility issues above, the tile render pipeline has a
-couple of cosmetic gaps worth tracking:
-
-- **Tile previews should default to a black background.** ProtoLayout tiles
-  expect to render onto the watchface's dark substrate. Right now
-  `TilePreviewRenderer` hosts the inflated tile inside a `FrameLayout` with
-  no background, so the Compose substrate underneath (which currently only
-  honours `showBackground` / `backgroundColor` from `@Preview` — both false
-  on `@wear.tiles.tooling.preview.Preview`) leaves the PNG transparent →
-  flattens as white. Fix: in `TilePreviewRenderer.TilePreviewComposable`,
-  paint `Color.Black` on the hosting `Box` when
-  `params.kind == PreviewKind.TILE`, regardless of `showBackground`. Or
-  make it the Wear-default when `device` starts with `id:wearos_*`.
-
-- **Round crop should apply automatically to tile previews.** Today the
-  `RoundScreenOption` Roborazzi qualifier is added when
+- **Tile previews should default to a black background.** Today
+  `TilePreviewRenderer` hosts the inflated tile in a `FrameLayout` with no
+  background; `showBackground`/`backgroundColor` from `@Preview` are both
+  false on `@wear.tiles.tooling.preview.Preview`. Fix in
+  `TilePreviewRenderer.TilePreviewComposable`: paint `Color.Black` on the
+  hosting Box when `params.kind == PreviewKind.TILE`, or when `device`
+  starts with `id:wearos_*`.
+- **Round crop for tile previews.** `RoundScreenOption` is added when
   `isRoundDevice(params.device) && params.showSystemUi`. Tile previews
-  always have `showSystemUi = false` (they're not `@Composable`s hosting
-  system UI), so the round qualifier never fires and tiles end up as
-  rectangles. For tiles specifically, `isRound` alone should drive the
-  qualifier — the tile itself is always rendered inside a round screen on
-  the device. Change the condition to
-  `isRoundDevice(params.device) && (params.showSystemUi || params.kind == PreviewKind.TILE)`.
+  always have `showSystemUi = false`, so the qualifier never fires. Change
+  to `isRoundDevice(device) && (showSystemUi || kind == PreviewKind.TILE)`.
 
-Both land in `renderer-android` and don't touch the plugin or AAR resolution
-path, so they're low-risk follow-ups.
-
-## When to revisit this doc
-
-Update the "Known failure signatures" section whenever:
-
-- A new AndroidX AAR adds an R.id field that an older transitive doesn't have.
-- The renderer's `libs.versions.toml` bumps a Compose / Activity / Core dep
-  and CI integration (on WearTilesKotlin or ComposeStarter) catches a new
-  failure mode.
-- Consumer-side failures come in from external users — add the signature
-  here so doctor can learn it.
-
-The [CI integration matrix](../.github/workflows/integration.yml) is the
-canonical "these consumers are tested to work" list. Anything that doesn't
-pass there should get a doctor check, a docs entry, or both.
+Both land entirely in `renderer-android` and don't touch the plugin / AAR
+resolution path, so they're low-risk follow-ups.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -67,6 +67,21 @@ internal object AndroidPreviewSupport {
             dependsOn("compile${capVariant}Kotlin")
         }
 
+        // Writes the plugin-side compat findings (CompatRules) to
+        // `build/compose-previews/doctor.json`. The CLI doesn't need this
+        // file (it reads the same data via the ComposePreviewModel Tooling
+        // API), but tools that invoke Gradle tasks rather than BuildActions
+        // — specifically the VS Code extension — do. Same JSON schema as
+        // `compose-preview doctor --json`'s per-module shape, so both
+        // surfaces converge on one contract.
+        project.tasks.register("composePreviewDoctor", ee.schimke.composeai.plugin.tooling.ComposePreviewDoctorTask::class.java) {
+            group = "compose preview"
+            description = "Write compose-preview doctor findings to build/compose-previews/doctor.json"
+            this.variant.set(variantName)
+            this.modulePath.set(project.path)
+            this.outputFile.set(previewOutputDir.map { it.file("doctor.json") })
+        }
+
         // Always inject `ui-test-manifest` + `ui-test-junit4` into the consumer's
         // `testImplementation`:
         //

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
@@ -1,11 +1,32 @@
 package ee.schimke.composeai.plugin
 
+import ee.schimke.composeai.plugin.tooling.ComposePreviewModelBuilder
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
+import javax.inject.Inject
 
-class ComposePreviewPlugin : Plugin<Project> {
+abstract class ComposePreviewPlugin @Inject constructor(
+    // Gradle injects build-scoped services into plugin constructors. This is
+    // the documented way to get at `ToolingModelBuilderRegistry`; accessing
+    // `project.services` directly is internal API and not stable.
+    private val toolingRegistry: ToolingModelBuilderRegistry,
+) : Plugin<Project> {
     override fun apply(project: Project) {
         val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+
+        // ToolingModelBuilderRegistry is a build-scoped service — registering
+        // from any applying project makes the model available on every
+        // Tooling-API connection for the build. `register` accepts multiple
+        // builders for the same model (Gradle iterates on `canBuild`), so
+        // registering once per applying subproject is safe even if
+        // `buildAll` only ever gets called on the first one that matches.
+        // Cross-project state (`rootProject.extras`) would trip Isolated
+        // Projects, so we just let every applying project register.
+        //
+        // Consumed by the CLI / VS Code extension via
+        // `connection.model(ComposePreviewModel::class.java)`.
+        toolingRegistry.register(ComposePreviewModelBuilder())
 
         // `pluginManager.withPlugin` replaces the old `project.afterEvaluate { ... }`
         // block. `afterEvaluate` is discouraged under Gradle's Isolated Projects mode

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
@@ -1,0 +1,185 @@
+package ee.schimke.composeai.plugin.tooling
+
+/**
+ * Plugin-side compat-check rules. Single source of truth used by both
+ * [ComposePreviewModelBuilder] (Tooling API path, consumed by the CLI) and
+ * [ComposePreviewDoctorTask] (Gradle-task path, consumed by the VS Code
+ * extension and anything else that drives Gradle tasks but can't run
+ * `BuildAction`s).
+ *
+ * Bump the thresholds here — and only here — when a new AndroidX AAR adds
+ * an R.id field that older transitives don't have. Keep the catalogue in
+ * `docs/RENDERER_COMPATIBILITY.md` in sync.
+ */
+internal object CompatRules {
+
+    /**
+     * activity 1.11+ transitively brought `androidx.navigationevent:1.0.0`.
+     * Consumers whose main variant has older activity end up with the
+     * `ComponentActivity` classes expecting `R.id.view_tree_…` resources
+     * that aren't in the merged APK — crashes Robolectric with
+     * `NoClassDefFoundError: androidx/navigationevent/R$id`.
+     */
+    private val NAVIGATIONEVENT_REQUIRES_ACTIVITY = Semver(1, 11, 0)
+
+    /**
+     * compose-ui 1.10.0 added a call site that references
+     * `androidx.core.R.id.tag_compat_insets_dispatch`, added in
+     * `androidx.core:core:1.16.0`.
+     */
+    private val COMPOSE_UI_NEEDS_CORE_1_16 = Semver(1, 10, 0)
+    private val CORE_1_16 = Semver(1, 16, 0)
+
+    /**
+     * Runs every rule against the given dep snapshot and returns findings
+     * ordered by severity. Pure — safe to call from tests and from the
+     * serialisation path.
+     */
+    fun evaluate(main: Map<String, String>, test: Map<String, String>): List<ModuleFindingData> {
+        val findings = mutableListOf<ModuleFindingData>()
+        val mainV = parseVersions(main)
+        val testV = parseVersions(test)
+        checkUiTestManifest(testV)?.let(findings::add)
+        checkNavigationEvent(mainV, testV, main)?.let(findings::add)
+        checkComposeUiVsCore(mainV, testV, main)?.let(findings::add)
+        checkComposeBom(main)?.let(findings::add)
+        return findings
+    }
+
+    private fun checkUiTestManifest(test: Map<String, Semver>): ModuleFindingData? {
+        if (test.containsKey("androidx.compose.ui:ui-test-manifest")) return null
+        return ModuleFindingData(
+            id = "ui-test-manifest-missing",
+            severity = "error",
+            message = "androidx.compose.ui:ui-test-manifest missing from test classpath",
+            detail = "ComposeTestRule-backed paths (a11y checks, future renderer features) need the <activity> entry merged into the test AndroidManifest. Without it, Robolectric can't launch the host Activity at render time.",
+            remediationSummary = "Apply the plugin so it injects ui-test-manifest, or add it manually.",
+            remediationCommands = listOf("testImplementation(\"androidx.compose.ui:ui-test-manifest\")"),
+            docsUrl = DOCS_UI_TEST_MANIFEST,
+        )
+    }
+
+    private fun checkNavigationEvent(
+        main: Map<String, Semver>,
+        test: Map<String, Semver>,
+        rawMain: Map<String, String>,
+    ): ModuleFindingData? {
+        val navEvent = test["androidx.navigationevent:navigationevent"] ?: return null
+        val mainActivity = main["androidx.activity:activity"]
+        if (mainActivity != null && mainActivity >= NAVIGATIONEVENT_REQUIRES_ACTIVITY) return null
+        return ModuleFindingData(
+            id = "activity-vs-navigationevent",
+            severity = "error",
+            message = "navigationevent on test classpath but main variant activity is too old",
+            detail = "Test classpath has androidx.navigationevent:$navEvent pulled in via a newer activity. " +
+                "AGP builds the merged test resource APK from the main variant " +
+                "(activity:${rawMain["androidx.activity:activity"] ?: "(absent)"}), so " +
+                "`androidx.navigationevent.R.id.*` resources aren't merged. Expect " +
+                "`NoClassDefFoundError: androidx/navigationevent/R\$id` at render time.",
+            remediationSummary = "Upgrade main-variant activity-compose to >= $NAVIGATIONEVENT_REQUIRES_ACTIVITY, or avoid transitively pulling navigationevent into tests.",
+            remediationCommands = listOf("implementation(\"androidx.activity:activity-compose:$NAVIGATIONEVENT_REQUIRES_ACTIVITY\")"),
+            docsUrl = DOCS_NAVIGATIONEVENT,
+        )
+    }
+
+    private fun checkComposeUiVsCore(
+        main: Map<String, Semver>,
+        test: Map<String, Semver>,
+        rawMain: Map<String, String>,
+    ): ModuleFindingData? {
+        val composeUi = test["androidx.compose.ui:ui"] ?: return null
+        if (composeUi < COMPOSE_UI_NEEDS_CORE_1_16) return null
+        val mainCore = main["androidx.core:core"]
+        if (mainCore != null && mainCore >= CORE_1_16) return null
+        return ModuleFindingData(
+            id = "compose-ui-vs-core",
+            severity = "error",
+            message = "compose-ui $composeUi expects androidx.core >= $CORE_1_16",
+            detail = "Test classpath has compose-ui:$composeUi which calls `ViewCompat.setOnApplyWindowInsetsListener`, reading `R.id.tag_compat_insets_dispatch` (added in androidx.core:1.16.0). Main variant has core:${rawMain["androidx.core:core"] ?: "(absent)"}, so that resource isn't in the merged APK. Expect `NoSuchFieldError: … tag_compat_insets_dispatch`.",
+            remediationSummary = "Bump Compose BOM (or androidx.core directly) on the main variant so it resolves to >= $CORE_1_16.",
+            remediationCommands = emptyList(),
+            docsUrl = DOCS_COMPOSE_UI_VS_CORE,
+        )
+    }
+
+    private fun checkComposeBom(rawMain: Map<String, String>): ModuleFindingData? {
+        if (rawMain.containsKey("androidx.compose:compose-bom")) return null
+        return ModuleFindingData(
+            id = "compose-bom-missing",
+            severity = "warning",
+            message = "no Compose BOM declared",
+            detail = "Without a BOM, compose-ui / compose-runtime / compose-foundation can end up on non-lockstep versions. Most consumer failure reports we see start here.",
+            remediationSummary = "Declare a Compose BOM to align all compose-* artifact versions.",
+            remediationCommands = listOf("implementation(platform(\"androidx.compose:compose-bom:2024.09.00\"))"),
+            docsUrl = null,
+        )
+    }
+
+    private fun parseVersions(raw: Map<String, String>): Map<String, Semver> {
+        val out = LinkedHashMap<String, Semver>(raw.size)
+        for ((key, version) in raw) {
+            Semver.parseOrNull(version)?.let { out[key] = it }
+        }
+        return out
+    }
+
+    private const val DOCS_ROOT = "https://github.com/yschimke/compose-ai-tools/blob/main/docs/RENDERER_COMPATIBILITY.md"
+    private const val DOCS_UI_TEST_MANIFEST = "$DOCS_ROOT#consumer-scope-ui-test-manifest-injection"
+    private const val DOCS_NAVIGATIONEVENT = "$DOCS_ROOT#activity-compose-111-on-a-consumer-with-an-older-activity"
+    private const val DOCS_COMPOSE_UI_VS_CORE = "$DOCS_ROOT#compose-ui-110-on-a-consumer-with-older-androidxcore"
+}
+
+/**
+ * Minimal semver used by compat rules. Lives plugin-side so the rules can
+ * work against the resolved-version strings Gradle produces, without a
+ * dependency on any external semver library.
+ */
+internal data class Semver(
+    val major: Int,
+    val minor: Int,
+    val patch: Int,
+    val extra: String = "",
+) : Comparable<Semver> {
+    override fun compareTo(other: Semver): Int {
+        val base = compareValuesBy(this, other, { it.major }, { it.minor }, { it.patch })
+        if (base != 0) return base
+        return when {
+            extra == other.extra -> 0
+            extra.isEmpty() -> 1   // release beats pre-release
+            other.extra.isEmpty() -> -1
+            else -> extra.compareTo(other.extra)
+        }
+    }
+
+    override fun toString(): String = buildString {
+        append(major); append('.'); append(minor); append('.'); append(patch)
+        if (extra.isNotEmpty()) { append('-'); append(extra) }
+    }
+
+    companion object {
+        fun parseOrNull(s: String): Semver? {
+            val parts = s.split('-', limit = 2)
+            val core = parts[0].split('.')
+            if (core.size < 2) return null
+            val major = core[0].toIntOrNull() ?: return null
+            val minor = core[1].toIntOrNull() ?: return null
+            val patch = core.getOrNull(2)?.toIntOrNull() ?: 0
+            val extra = parts.getOrNull(1).orEmpty()
+            return Semver(major, minor, patch, extra)
+        }
+    }
+}
+
+/**
+ * [ModuleFinding] impl used by both the model builder and the task. Named
+ * `Data` not `Impl` to match the existing ModuleInfoData / ComposePreviewModelData.
+ */
+internal data class ModuleFindingData(
+    override val id: String,
+    override val severity: String,
+    override val message: String,
+    override val detail: String?,
+    override val remediationSummary: String?,
+    override val remediationCommands: List<String>,
+    override val docsUrl: String?,
+) : ModuleFinding, java.io.Serializable

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewDoctorTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewDoctorTask.kt
@@ -1,0 +1,111 @@
+package ee.schimke.composeai.plugin.tooling
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.gradle.api.DefaultTask
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+/**
+ * Writes [CompatRules] findings for the current module to a sidecar JSON.
+ * Parallels the `ComposePreviewModel` path used by the CLI — this task
+ * exists so drivers that can't run Gradle `BuildAction`s (notably the
+ * VS Code extension, which uses the vscode-gradle task API) still get the
+ * same output shape via a plain task invocation.
+ *
+ * Output shape matches [DoctorReport] in
+ * `cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt` at the
+ * per-module level — the CLI and the extension converge on the same JSON
+ * schema (`compose-preview-doctor/v1`).
+ *
+ * Cheap to run: resolves the two configurations' `resolutionResult` (no
+ * artifact downloads), applies rules, writes a small JSON file.
+ */
+@DisableCachingByDefault(because = "Doctor findings depend on the live configuration resolution, not on a declared input set — caching across a version bump would silently stale-surface fixed issues.")
+abstract class ComposePreviewDoctorTask : DefaultTask() {
+
+    @get:Input
+    abstract val variant: Property<String>
+
+    @get:Input
+    abstract val modulePath: Property<String>
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun run() {
+        val variantName = variant.get()
+        val main = resolveConfiguration("${variantName}RuntimeClasspath")
+        val test = resolveConfiguration("${variantName}UnitTestRuntimeClasspath")
+        val findings = CompatRules.evaluate(main, test)
+        val report = DoctorModuleReport(
+            schema = SCHEMA,
+            module = modulePath.get(),
+            variant = variantName,
+            findings = findings.map { f ->
+                DoctorFinding(
+                    id = f.id,
+                    severity = f.severity,
+                    message = f.message,
+                    detail = f.detail,
+                    remediationSummary = f.remediationSummary,
+                    remediationCommands = f.remediationCommands,
+                    docsUrl = f.docsUrl,
+                )
+            },
+        )
+        val out = outputFile.get().asFile
+        out.parentFile.mkdirs()
+        out.writeText(JSON.encodeToString(report))
+        logger.lifecycle("Wrote compose-preview doctor report for ${modulePath.get()}: ${findings.size} finding(s) → ${out.path}")
+    }
+
+    private fun resolveConfiguration(name: String): Map<String, String> {
+        val config = project.configurations.findByName(name) ?: return emptyMap()
+        if (!config.isCanBeResolved) return emptyMap()
+        return try {
+            val out = LinkedHashMap<String, String>()
+            for (dep in config.incoming.resolutionResult.allDependencies) {
+                val resolved = dep as? org.gradle.api.artifacts.result.ResolvedDependencyResult ?: continue
+                val id = resolved.selected.id
+                if (id is ModuleComponentIdentifier) {
+                    out.putIfAbsent("${id.group}:${id.module}", id.version)
+                }
+            }
+            out
+        } catch (_: Throwable) {
+            emptyMap()
+        }
+    }
+
+    companion object {
+        internal const val SCHEMA = "compose-preview-doctor/v1"
+        private val JSON = Json { prettyPrint = true; encodeDefaults = true }
+    }
+}
+
+@Serializable
+internal data class DoctorModuleReport(
+    val schema: String,
+    val module: String,
+    val variant: String,
+    val findings: List<DoctorFinding>,
+)
+
+@Serializable
+internal data class DoctorFinding(
+    val id: String,
+    val severity: String,
+    val message: String,
+    val detail: String? = null,
+    val remediationSummary: String? = null,
+    val remediationCommands: List<String> = emptyList(),
+    val docsUrl: String? = null,
+)

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt
@@ -1,0 +1,108 @@
+package ee.schimke.composeai.plugin.tooling
+
+/**
+ * Tooling API model exposing plugin-side state to external drivers — CLI
+ * (`compose-preview doctor`, future commands), VS Code extension, agents.
+ *
+ * The goal is ONE model that grows alongside the plugin, rather than a new
+ * model per feature. Keep return types to [Map] / [List] / [String] /
+ * [Boolean] (what Gradle's Tooling API can marshal across the daemon
+ * boundary), and keep interfaces in lockstep with the CLI-side copy at the
+ * same FQN (`ee.schimke.composeai.plugin.tooling.ComposePreviewModel`).
+ * Tooling API bridges them with reflective proxies — method signatures
+ * drifting between sides silently produces `null`s.
+ *
+ * Registered once per build by
+ * [ee.schimke.composeai.plugin.ComposePreviewPlugin.apply]. Retrieved from
+ * the CLI with `connection.model(ComposePreviewModel::class.java).get()` —
+ * works against any project in the build (the builder always returns the
+ * build-wide snapshot).
+ */
+interface ComposePreviewModel {
+    /**
+     * Plugin version recorded at build time. Useful when the CLI needs to
+     * report the plugin version without parsing the consumer's build files.
+     */
+    val pluginVersion: String
+
+    /**
+     * Every project where the compose-preview plugin was applied. Key is the
+     * Gradle project path (starts with `:`, e.g. `:app`, `:sample-wear`).
+     * Empty if no project applied the plugin — the CLI treats that case
+     * specially (it surfaces an actionable "apply the plugin" remediation).
+     */
+    val modules: Map<String, ModuleInfo>
+}
+
+/**
+ * Per-module state. Starts narrow — just dependency versions for doctor's
+ * compat checks — but this interface is the extension point: add getters
+ * here (e.g. discovered-preview counts, source roots, enabled features) as
+ * the CLI grows. Any addition needs the CLI-side copy updated in lockstep.
+ */
+interface ModuleInfo {
+    /**
+     * The plugin's configured variant — typically `"debug"`. The CLI uses
+     * this to phrase remediation hints and to pick the right configuration
+     * names when resolving deps.
+     */
+    val variant: String
+
+    /**
+     * Resolved dependencies for the module's `${variant}RuntimeClasspath`
+     * configuration (main app runtime — drives AGP's merged resource APK).
+     * Map key is `group:name`; value is Gradle's resolved version string.
+     *
+     * Empty if the configuration didn't exist or didn't resolve — doctor
+     * treats that as "not checkable" rather than erroring.
+     */
+    val mainRuntimeDependencies: Map<String, String>
+
+    /**
+     * Resolved dependencies for `${variant}UnitTestRuntimeClasspath` — what
+     * the preview renderer actually runs against. Same shape as
+     * [mainRuntimeDependencies].
+     */
+    val testRuntimeDependencies: Map<String, String>
+
+    /**
+     * Compat-check findings produced by the plugin's rules against the
+     * dependency maps above. Each entry matches one of the known AAR/R.id
+     * mismatches from `docs/RENDERER_COMPATIBILITY.md`. Rules live plugin-
+     * side so the CLI (`compose-preview doctor`) and the VS Code extension
+     * both consume the same list — no per-tool drift.
+     */
+    val findings: List<ModuleFinding>
+}
+
+/**
+ * One compat-check result. Matches the shape the CLI prints under
+ * `compose-preview doctor` and the shape the VS Code extension consumes for
+ * the Problems view.
+ *
+ * Getters only return Tooling-API-marshalable types; the CLI-side duplicate
+ * at `cli/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt`
+ * must track these method-for-method.
+ */
+interface ModuleFinding {
+    /** Stable dotted id, e.g. `ui-test-manifest-missing`. */
+    val id: String
+
+    /** `"error"` | `"warning"` | `"info"`. */
+    val severity: String
+
+    /** Single-line human-readable summary. */
+    val message: String
+
+    /** Longer rationale (optional). */
+    val detail: String?
+
+    /** One-line action the user can take (optional). */
+    val remediationSummary: String?
+
+    /** Concrete commands / snippets that implement the action. */
+    val remediationCommands: List<String>
+
+    /** Deep-link to project documentation (optional). */
+    val docsUrl: String?
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
@@ -1,0 +1,104 @@
+package ee.schimke.composeai.plugin.tooling
+
+import ee.schimke.composeai.plugin.PluginVersion
+import org.gradle.api.Project
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.tooling.provider.model.ToolingModelBuilder
+import java.io.Serializable
+
+/**
+ * Builds a build-wide [ComposePreviewModel] snapshot — resolves
+ * `${variant}RuntimeClasspath` and `${variant}UnitTestRuntimeClasspath` on
+ * every project where the compose-preview plugin applied, and packs the
+ * result into interfaces the CLI consumes over the Tooling API.
+ *
+ * Registered once per build from
+ * [ee.schimke.composeai.plugin.ComposePreviewPlugin.apply]. [canBuild]
+ * accepts the build-root path regardless of which project the caller hit —
+ * we always return the build-wide snapshot so the CLI doesn't have to iterate.
+ */
+internal class ComposePreviewModelBuilder : ToolingModelBuilder {
+
+    override fun canBuild(modelName: String): Boolean =
+        modelName == ComposePreviewModel::class.java.name
+
+    override fun buildAll(modelName: String, project: Project): Any {
+        // Builder runs per-project under Isolated Projects — we can only
+        // inspect the project we were invoked on. The CLI walks the project
+        // tree with `GradleProject` and asks for this model on each leaf;
+        // projects where the plugin wasn't applied return an empty
+        // `modules` map, which the CLI filters out.
+        val hasPlugin = project.tasks.findByName("discoverPreviews") != null
+        if (!hasPlugin) {
+            return ComposePreviewModelData(PluginVersion.value, emptyMap())
+        }
+        val variant = resolveVariant(project)
+        val main = resolveConfiguration(project, "${variant}RuntimeClasspath")
+        val test = resolveConfiguration(project, "${variant}UnitTestRuntimeClasspath")
+        val findings: List<ModuleFinding> = CompatRules.evaluate(main, test)
+        val info: ModuleInfo = ModuleInfoData(variant, main, test, findings)
+        return ComposePreviewModelData(PluginVersion.value, mapOf(project.path to info))
+    }
+
+    /**
+     * Reads the plugin's variant extension without hard-depending on the
+     * extension class. Falls back to `"debug"` if absent or unreadable —
+     * 99% of consumers never touch this setting.
+     */
+    private fun resolveVariant(project: Project): String {
+        val ext = project.extensions.findByName("composePreview") ?: return "debug"
+        return try {
+            val getter = ext.javaClass.getMethod("getVariant")
+            val prop = getter.invoke(ext)
+            val get = prop.javaClass.getMethod("get")
+            (get.invoke(prop) as? String) ?: "debug"
+        } catch (_: Throwable) {
+            "debug"
+        }
+    }
+
+    /**
+     * Resolves `config` on [project] and returns `group:name → version`.
+     * Swallows failures — doctor treats empty as "not checkable" rather than
+     * erroring. Uses the resolution-result API instead of
+     * `resolvedConfiguration.resolvedArtifacts` because we only need version
+     * metadata, not the downloaded artifacts.
+     */
+    private fun resolveConfiguration(project: Project, name: String): Map<String, String> {
+        val config = project.configurations.findByName(name) ?: return emptyMap()
+        if (!config.isCanBeResolved) return emptyMap()
+        return try {
+            val out = linkedMapOf<String, String>()
+            for (dep in config.incoming.resolutionResult.allDependencies) {
+                val resolved = dep as? org.gradle.api.artifacts.result.ResolvedDependencyResult ?: continue
+                val id = resolved.selected.id
+                if (id is ModuleComponentIdentifier) {
+                    // First occurrence wins — resolutionResult already
+                    // deduplicates to Gradle's conflict-resolved version.
+                    out.putIfAbsent("${id.group}:${id.module}", id.version)
+                }
+            }
+            out
+        } catch (_: Throwable) {
+            emptyMap()
+        }
+    }
+}
+
+// --- Wire impls ------------------------------------------------------------
+//
+// Serializable because Gradle marshals these across the daemon/tooling
+// boundary. Data classes for cheap equality/toString in tests; nothing else
+// depends on that.
+
+private data class ComposePreviewModelData(
+    override val pluginVersion: String,
+    override val modules: Map<String, ModuleInfo>,
+) : ComposePreviewModel, Serializable
+
+private data class ModuleInfoData(
+    override val variant: String,
+    override val mainRuntimeDependencies: Map<String, String>,
+    override val testRuntimeDependencies: Map<String, String>,
+    override val findings: List<ModuleFinding>,
+) : ModuleInfo, Serializable

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
@@ -1,0 +1,117 @@
+package ee.schimke.composeai.plugin.tooling
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Every rule gets two test cases — one that triggers it, one that doesn't.
+ * Rules are pure so no mocking or Project fixture required; we hand-roll
+ * the dependency maps.
+ */
+class CompatRulesTest {
+
+    @Test fun `ui-test-manifest missing fires error`() {
+        val findings = CompatRules.evaluate(mainWithBom(), testWithoutUiTestManifest())
+        val f = findings.single { it.id == "ui-test-manifest-missing" }
+        assertEquals("error", f.severity)
+        assertTrue(f.remediationCommands.any { "ui-test-manifest" in it })
+    }
+
+    @Test fun `ui-test-manifest present is quiet`() {
+        val test = testWithoutUiTestManifest() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
+        val findings = CompatRules.evaluate(mainWithBom(), test)
+        assertNull(findings.firstOrNull { it.id == "ui-test-manifest-missing" })
+    }
+
+    @Test fun `navigationevent with old main activity fires error`() {
+        val main = mainWithBom() + ("androidx.activity:activity" to "1.8.0")
+        val test = testWithoutUiTestManifest() +
+            ("androidx.navigationevent:navigationevent" to "1.0.0") +
+            ("androidx.activity:activity" to "1.13.0")
+        val findings = CompatRules.evaluate(main, test)
+        val f = findings.single { it.id == "activity-vs-navigationevent" }
+        assertEquals("error", f.severity)
+        assertTrue("1.8.0" in (f.detail ?: ""))
+    }
+
+    @Test fun `navigationevent with matching main activity is quiet`() {
+        val main = mainWithBom() + ("androidx.activity:activity" to "1.13.0")
+        val test = main + ("androidx.navigationevent:navigationevent" to "1.0.0") +
+            ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
+        val findings = CompatRules.evaluate(main, test)
+        assertNull(findings.firstOrNull { it.id == "activity-vs-navigationevent" })
+    }
+
+    @Test fun `compose-ui 1_10 with old core fires error`() {
+        val main = mainWithBom() + ("androidx.core:core" to "1.15.0")
+        val test = main + ("androidx.compose.ui:ui" to "1.10.6") +
+            ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
+        val findings = CompatRules.evaluate(main, test)
+        val f = findings.single { it.id == "compose-ui-vs-core" }
+        assertEquals("error", f.severity)
+    }
+
+    @Test fun `compose-ui 1_9 is below threshold (no finding even with old core)`() {
+        val main = mainWithBom() + ("androidx.core:core" to "1.15.0")
+        val test = main + ("androidx.compose.ui:ui" to "1.9.4") +
+            ("androidx.compose.ui:ui-test-manifest" to "1.9.4")
+        val findings = CompatRules.evaluate(main, test)
+        assertNull(findings.firstOrNull { it.id == "compose-ui-vs-core" })
+    }
+
+    @Test fun `no compose BOM yields warning`() {
+        val main = mapOf("androidx.core:core" to "1.16.0")
+        val test = main + ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
+        val findings = CompatRules.evaluate(main, test)
+        val f = findings.single { it.id == "compose-bom-missing" }
+        assertEquals("warning", f.severity)
+    }
+
+    @Test fun `with compose BOM, bom finding is absent`() {
+        val findings = CompatRules.evaluate(mainWithBom(), mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"))
+        assertNull(findings.firstOrNull { it.id == "compose-bom-missing" })
+    }
+
+    @Test fun `all findings populated have non-empty docs or commands`() {
+        // Stacked scenario: everything wrong — exercises every rule at once.
+        val main = mapOf(
+            "androidx.activity:activity" to "1.8.0",
+            "androidx.core:core" to "1.15.0",
+        )
+        val test = mapOf(
+            "androidx.navigationevent:navigationevent" to "1.0.0",
+            "androidx.compose.ui:ui" to "1.10.6",
+        )
+        val findings = CompatRules.evaluate(main, test)
+        assertTrue(findings.size >= 3)
+        // Every finding should carry at least one actionable hint.
+        for (f in findings) {
+            val actionable = f.remediationCommands.isNotEmpty() || f.docsUrl != null
+            assertTrue("finding ${f.id} has no actionable remediation", actionable || f.remediationSummary != null)
+        }
+    }
+
+    @Test fun `semver parses and compares`() {
+        assertEquals(Semver(1, 16, 0), Semver.parseOrNull("1.16.0"))
+        assertEquals(Semver(1, 16, 0), Semver.parseOrNull("1.16"))
+        assertNull(Semver.parseOrNull("foo"))
+        assertTrue(Semver(1, 16, 0) > Semver(1, 15, 0))
+        assertTrue(Semver(1, 13, 0) > Semver(1, 13, 0, "alpha01"))
+        assertNotNull(Semver.parseOrNull("1.13.0-alpha01"))
+    }
+
+    // --- Fixtures ----------------------------------------------------------
+
+    private fun mainWithBom(): Map<String, String> = mapOf(
+        "androidx.compose:compose-bom" to "2025.03.00",
+        "androidx.activity:activity" to "1.13.0",
+        "androidx.core:core" to "1.18.0",
+    )
+
+    private fun testWithoutUiTestManifest(): Map<String, String> = mapOf(
+        "androidx.activity:activity" to "1.13.0",
+    )
+}

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -81,6 +81,11 @@
                 "command": "composePreview.toggleAccessibilityChecks",
                 "title": "Toggle Accessibility Checks",
                 "category": "Compose Preview"
+            },
+            {
+                "command": "composePreview.runDoctor",
+                "title": "Run Doctor (refresh compatibility diagnostics)",
+                "category": "Compose Preview"
             }
         ],
         "configuration": {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -8,6 +8,7 @@ import { PreviewGutterDecorations } from './previewGutterDecorations';
 import { PreviewHoverProvider } from './previewHoverProvider';
 import { PreviewCodeLensProvider } from './previewCodeLensProvider';
 import { PreviewA11yDiagnostics } from './previewA11yDiagnostics';
+import { PreviewDoctorDiagnostics } from './previewDoctorDiagnostics';
 import { packageQualifiedSourcePath } from './sourcePath';
 import { PreviewInfo } from './types';
 
@@ -138,6 +139,11 @@ export async function activate(context: vscode.ExtensionContext) {
     const hoverProvider = new PreviewHoverProvider(registry, detectLog);
     const codeLensProvider = new PreviewCodeLensProvider(registry, detectLog);
     const a11yDiagnostics = new PreviewA11yDiagnostics(registry, detectLog);
+    const doctorDiagnostics = new PreviewDoctorDiagnostics(
+        gradleService,
+        workspaceRoot,
+        (msg) => outputChannel.appendLine(`[doctor] ${msg}`),
+    );
     const kotlinFiles: vscode.DocumentSelector = { language: 'kotlin', scheme: 'file' };
     context.subscriptions.push(
         vscode.languages.registerHoverProvider(kotlinFiles, hoverProvider),
@@ -145,8 +151,31 @@ export async function activate(context: vscode.ExtensionContext) {
         codeLensProvider,
         gutterDecorations,
         a11yDiagnostics,
+        doctorDiagnostics,
         { dispose: () => registry.dispose() },
     );
+
+    // Refresh doctor diagnostics on first load, on-demand from the command,
+    // and whenever we discover new modules. Each refresh kicks the
+    // `composePreviewDoctor` task per module — cheap (no render), but we
+    // don't want to spam on every keystroke, hence the explicit trigger
+    // points rather than a document-change hook.
+    const refreshDoctor = async () => {
+        // gradleService is non-null inside this activation scope (initialised
+        // a few lines up), but the module-scope nullable declaration forces
+        // a local alias for the type-checker.
+        if (!gradleService) { return; }
+        await doctorDiagnostics.refresh(gradleService.findPreviewModules());
+    };
+    context.subscriptions.push(
+        vscode.commands.registerCommand('composePreview.runDoctor', () => {
+            void vscode.window.withProgress(
+                { location: vscode.ProgressLocation.Window, title: 'Running compose-preview doctor…' },
+                refreshDoctor,
+            );
+        }),
+    );
+    void refreshDoctor();
 
     context.subscriptions.push(
         vscode.window.onDidChangeActiveTextEditor(editor => {

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
-import { AccessibilityFinding, AccessibilityReport, HistoryEntry, PreviewManifest } from './types';
+import { AccessibilityFinding, AccessibilityReport, DoctorModuleReport, HistoryEntry, PreviewManifest } from './types';
 
 const HISTORY_DIRNAME = '.compose-preview-history';
 const TIMESTAMP_RE = /^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})(?:-\d+)?$/;
@@ -79,6 +79,41 @@ export class GradleService {
             this.manifestCache.set(module, { manifest, timestamp: Date.now() });
         }
         return manifest;
+    }
+
+    /**
+     * Runs `:<module>:composePreviewDoctor` and returns the parsed sidecar
+     * report. Same JSON schema as `compose-preview doctor --json`'s per-
+     * module shape — see `ComposePreviewDoctorTask.kt` in `gradle-plugin`.
+     *
+     * Returns `null` when the task is missing (plugin not applied or
+     * version predates the feature), the build fails, or the JSON file
+     * wasn't produced. Callers should treat null as "skip doctor
+     * diagnostics for this module", not as an empty finding set.
+     */
+    async runDoctor(module: string): Promise<DoctorModuleReport | null> {
+        try {
+            await this.runTask(`:${module}:composePreviewDoctor`);
+        } catch (e) {
+            this.logger.appendLine(`[doctor] :${module}:composePreviewDoctor failed: ${(e as Error).message}`);
+            return null;
+        }
+        const reportPath = path.join(this.workspaceRoot, module, 'build', 'compose-previews', 'doctor.json');
+        if (!fs.existsSync(reportPath)) {
+            this.logger.appendLine(`[doctor] ${reportPath} not produced`);
+            return null;
+        }
+        try {
+            const parsed = JSON.parse(fs.readFileSync(reportPath, 'utf-8')) as DoctorModuleReport;
+            if (!parsed.schema?.startsWith('compose-preview-doctor/')) {
+                this.logger.appendLine(`[doctor] unexpected schema in ${reportPath}: ${parsed.schema}`);
+                return null;
+            }
+            return parsed;
+        } catch (e) {
+            this.logger.appendLine(`[doctor] parse failed for ${reportPath}: ${(e as Error).message}`);
+            return null;
+        }
     }
 
     invalidateCache(module?: string): void {

--- a/vscode-extension/src/previewDoctorDiagnostics.ts
+++ b/vscode-extension/src/previewDoctorDiagnostics.ts
@@ -1,0 +1,96 @@
+import * as vscode from 'vscode';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { GradleService } from './gradleService';
+import { DoctorFinding } from './types';
+
+/**
+ * Runs `:<module>:composePreviewDoctor` on each applied-plugin module and
+ * surfaces each finding as a VS Code diagnostic attached to the module's
+ * `build.gradle[.kts]`. Same rule set as `compose-preview doctor` — the
+ * plugin owns the rule logic (see `CompatRules.kt`), both tools call it.
+ *
+ * Re-uses the existing `GradleService.runDoctor` path; if the Gradle task
+ * isn't available (e.g. plugin version predates it), the service returns
+ * `null` and we skip the module quietly rather than spamming the Problems
+ * view.
+ */
+export class PreviewDoctorDiagnostics implements vscode.Disposable {
+    private readonly collection: vscode.DiagnosticCollection;
+
+    constructor(
+        private readonly gradleService: GradleService,
+        private readonly workspaceRoot: string,
+        private readonly log?: (msg: string) => void,
+    ) {
+        this.collection = vscode.languages.createDiagnosticCollection('compose-preview-doctor');
+    }
+
+    dispose(): void {
+        this.collection.dispose();
+    }
+
+    /**
+     * Refresh diagnostics for every module that has the plugin applied.
+     * Atomically swaps the DiagnosticCollection so stale findings from a
+     * module that got its issue fixed disappear on the next refresh.
+     */
+    async refresh(modules: ReadonlyArray<string>): Promise<void> {
+        const next = new Map<string, vscode.Diagnostic[]>();
+        for (const module of modules) {
+            const report = await this.gradleService.runDoctor(module);
+            if (!report) { continue; }
+            const targetFile = this.resolveBuildFile(module);
+            if (!targetFile) { continue; }
+            const diags: vscode.Diagnostic[] = [];
+            for (const finding of report.findings) {
+                diags.push(this.toDiagnostic(module, finding));
+            }
+            if (diags.length > 0) {
+                next.set(targetFile, diags);
+            }
+        }
+        // Atomic swap — clear old state, set new state. VS Code dedupes
+        // nothing here; we have to clear first or deleted findings linger.
+        this.collection.clear();
+        for (const [file, diags] of next) {
+            this.collection.set(vscode.Uri.file(file), diags);
+        }
+        this.log?.(`doctor diagnostics refreshed across ${modules.length} module(s)`);
+    }
+
+    private toDiagnostic(module: string, finding: DoctorFinding): vscode.Diagnostic {
+        const severity =
+            finding.severity === 'error' ? vscode.DiagnosticSeverity.Error :
+            finding.severity === 'warning' ? vscode.DiagnosticSeverity.Warning :
+            vscode.DiagnosticSeverity.Information;
+        const parts = [finding.message];
+        if (finding.detail) { parts.push(finding.detail); }
+        if (finding.remediationSummary) {
+            parts.push(`→ ${finding.remediationSummary}`);
+            for (const cmd of finding.remediationCommands ?? []) {
+                parts.push(`    ${cmd}`);
+            }
+            if (finding.docsUrl) {
+                parts.push(`    docs: ${finding.docsUrl}`);
+            }
+        }
+        // We don't have a precise line for dep-alignment findings — anchor
+        // at the top of the build file. VS Code still threads the finding
+        // into the Problems panel with the file name as location.
+        const range = new vscode.Range(0, 0, 0, 0);
+        const diag = new vscode.Diagnostic(range, parts.join('\n'), severity);
+        diag.source = 'compose-preview-doctor';
+        diag.code = `${module}:${finding.id}`;
+        return diag;
+    }
+
+    /** Locate the module's build.gradle[.kts] relative to the workspace root. */
+    private resolveBuildFile(module: string): string | undefined {
+        for (const name of ['build.gradle.kts', 'build.gradle']) {
+            const candidate = path.join(this.workspaceRoot, module, name);
+            if (fs.existsSync(candidate)) { return candidate; }
+        }
+        return undefined;
+    }
+}

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -60,6 +60,30 @@ export interface AccessibilityReport {
 }
 
 /**
+ * Output of `:<module>:composePreviewDoctor`. Matches the serialization in
+ * `gradle-plugin/.../ComposePreviewDoctorTask.kt` and the per-module shape
+ * inside `compose-preview doctor --json`'s `DoctorReport.checks`. Schema
+ * version pinned in [DoctorModuleReport.schema] so extension can detect
+ * incompatible plugin versions without dispatching on field shape.
+ */
+export interface DoctorModuleReport {
+    schema: string;
+    module: string;
+    variant: string;
+    findings: DoctorFinding[];
+}
+
+export interface DoctorFinding {
+    id: string;
+    severity: 'error' | 'warning' | 'info' | string;
+    message: string;
+    detail?: string | null;
+    remediationSummary?: string | null;
+    remediationCommands?: string[];
+    docsUrl?: string | null;
+}
+
+/**
  * One historical snapshot for a preview. The Gradle plugin writes files
  * named `yyyyMMdd-HHmmss[-N].png`; [timestamp] is the filename minus `.png`,
  * kept as a display-friendly label. [iso] is a parsed ISO-8601 form for sort


### PR DESCRIPTION
## Summary

\`compose-preview doctor\` graduates from \"env smoke test\" to \"will your preview render, and if not, why not\" — with the same compat rules consumed by both the CLI and the VS Code extension. Rules live once, in the Gradle plugin.

![](docs/doctor-example.png)

## Architecture

**Plugin** owns the rule logic. A new Tooling-API model (\`ComposePreviewModel\`) exposes per-module dependency snapshots and pre-computed findings; \`CompatRules\` holds the version thresholds from \`RENDERER_COMPATIBILITY.md\` (activity 1.11 → navigationevent, compose-ui 1.10 → core 1.16, ui-test-manifest presence, compose-bom presence). A parallel \`composePreviewDoctor\` Gradle task writes the same findings to \`build/compose-previews/doctor.json\` for drivers that can't run BuildActions.

**CLI** (\`compose-preview doctor\`) uses a \`GatherComposePreviewModelAction\` BuildAction to walk the project tree and aggregate findings, then renders them. Env checks (Java version, GH Packages credentials + scope probe) stay CLI-side. New flags:
- \`--json\` — emits a stable structured report (\`compose-preview-doctor/v1\`) for agents.
- \`--explain\` — surfaces the long-form \"why this breaks at render time\" rationale per finding.

**VS Code extension** runs the \`composePreviewDoctor\` task per applied-plugin module and publishes each finding as a \`vscode.Diagnostic\` on the module's \`build.gradle[.kts]\`. Atomic swap so fixed issues disappear on the next refresh. New \`composePreview.runDoctor\` command + command-palette entry; auto-refresh on activation.

**Docs** — \`RENDERER_COMPATIBILITY.md\` stopped duplicating the failure-signature catalogue; that lives in \`CompatRules.kt\` now, where agents can read it via \`doctor --explain\` in the consumer project. The doc explains *why the risk exists* (AGP resource APK vs renderer classpath mismatch) and points at the code, rather than being a second place to keep the failure list in sync.

## Test plan

- [x] \`./gradlew check\` (plugin functional + unit tests, renderer-android, CLI tests)
- [x] New \`CompatRulesTest\` covers each rule's triggering and non-triggering paths + the \"everything wrong\" stack
- [x] New \`DoctorReportSerializationTest\` pins the \`compose-preview-doctor/v1\` schema
- [x] \`compose-preview doctor --project .\` against in-repo samples: plugin applied in 3 modules, 0 compat issues, 1 skipped (\`:sample-cmp\` has no debugRuntimeClasspath — correctly skipped)
- [x] \`compose-preview doctor --project . --json\` emits a well-formed \`DoctorReport\`
- [x] \`compose-preview doctor --project /path/to/wear-os-samples/WearTilesKotlin\` against the 0.4.1-SNAPSHOT plugin: plugin applied in 1 module, ui-test-manifest correctly on test classpath, no navigationevent/core-R issues reported (the fix from #60 is still holding)
- [x] VS Code extension compiles (\`npm run compile\`); \`PreviewDoctorDiagnostics\` wired into \`extension.ts\`
- [ ] Manual VS Code dogfood against a consumer with real findings (next session)

## Scope / follow-ups

Deliberately not in this PR:
- Tile-rendering cosmetic gaps (black background, auto-round-crop) — still tracked in \`RENDERER_COMPATIBILITY.md\`.
- A CI integration test that drives \`doctor\` against WearTilesKotlin to catch regressions where the underlying renderer fix breaks — candidate for follow-up alongside the tile-render CI guard added in #60.