### PR TITLE
feat(renderer): per-preview clock control via @RoboComposePreviewOptions

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -71,6 +71,19 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         private const val PREVIEW_WRAPPER_FQN = "androidx.compose.ui.tooling.preview.PreviewWrapper"
 
         internal const val TILE_PREVIEW_FQN = "androidx.wear.tiles.tooling.preview.Preview"
+
+        // Roborazzi's per-preview clock control. Opt-in: presence of the
+        // annotation on a @Preview method fans out one extra manifest entry
+        // per `ManualClockOptions.advanceTimeMillis` value, with filename
+        // suffix `_TIME_<ms>ms`. Absent → single entry with null timing
+        // (renderer falls back to its default CAPTURE_ADVANCE_MS).
+        //
+        // Shipped by `io.github.takahirom.roborazzi:roborazzi-annotations`.
+        // We never load the class — ClassGraph reads the annotation and its
+        // nested `ManualClockOptions` entries by descriptor, so the plugin
+        // itself doesn't need a compile-time dep.
+        private const val ROBO_COMPOSE_PREVIEW_OPTIONS_FQN =
+            "com.github.takahirom.roborazzi.annotations.RoboComposePreviewOptions"
     }
 
     @TaskAction
@@ -137,6 +150,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         if (p.uiMode != 0) parts.add("uiMode=${p.uiMode}")
         p.locale?.let(parts::add)
         p.group?.let { parts.add("group=$it") }
+        p.advanceTimeMillis?.let { parts.add("t=${it}ms") }
         return if (parts.isEmpty()) "" else "  [" + parts.joinToString(" · ") + "]"
     }
 
@@ -150,11 +164,15 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         // @PreviewWrapper is non-repeatable and applies to every @Preview on the
         // function (including expansions from multi-preview meta-annotations).
         val wrapperFqn = extractWrapperFqn(annotations)
+        // @RoboComposePreviewOptions, similarly, applies to the function as a
+        // whole — each timing fans out into its own manifest entry, orthogonal
+        // to any multi-preview expansion.
+        val timings = extractRoboTimings(annotations)
 
         val directPreviews = collectDirectPreviews(annotations)
         if (directPreviews.isNotEmpty()) {
             for (ann in directPreviews) {
-                previews.add(makePreview(classInfo, method, ann, wrapperFqn))
+                addPreviewsForTimings(classInfo, method, ann, wrapperFqn, timings, previews)
             }
             return
         }
@@ -162,9 +180,53 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         for (ann in annotations) {
             val resolved = resolveMultiPreview(ann, scanResult, mutableSetOf())
             for (resolvedAnn in resolved) {
-                previews.add(makePreview(classInfo, method, resolvedAnn, wrapperFqn))
+                addPreviewsForTimings(classInfo, method, resolvedAnn, wrapperFqn, timings, previews)
             }
         }
+    }
+
+    private fun addPreviewsForTimings(
+        classInfo: ClassInfo,
+        method: MethodInfo,
+        ann: AnnotationInfo,
+        wrapperFqn: String?,
+        timings: List<Long>,
+        previews: MutableList<PreviewInfo>,
+    ) {
+        // Tile previews don't go through `mainClock` — the renderer inflates a
+        // View via `TileRenderer` and has no Compose animation clock to advance.
+        // Applying a clock-time fan-out would produce N identical PNGs. Treat
+        // the annotation as a no-op on tiles.
+        val applicable = timings.takeIf { ann.name != TILE_PREVIEW_FQN }.orEmpty()
+        if (applicable.isEmpty()) {
+            previews.add(makePreview(classInfo, method, ann, wrapperFqn, advanceTimeMillis = null))
+        } else {
+            for (ms in applicable) {
+                previews.add(makePreview(classInfo, method, ann, wrapperFqn, advanceTimeMillis = ms))
+            }
+        }
+    }
+
+    // Reads `@RoboComposePreviewOptions(manualClockOptions = [...])` on the
+    // preview function and returns the `advanceTimeMillis` of each entry.
+    // Empty list if the annotation is absent OR present with no entries — the
+    // latter is equivalent to "default" per Roborazzi's own scanner-support
+    // behaviour. ClassGraph surfaces `manualClockOptions` as an
+    // Object[] of `AnnotationInfo` because the field type is `Array<ManualClockOptions>`.
+    private fun extractRoboTimings(annotations: List<AnnotationInfo>): List<Long> {
+        val ann = annotations.firstOrNull { it.name == ROBO_COMPOSE_PREVIEW_OPTIONS_FQN } ?: return emptyList()
+        val raw = ann.parameterValues.getValue("manualClockOptions") ?: return emptyList()
+        val items = when (raw) {
+            is Array<*> -> raw.filterIsInstance<AnnotationInfo>()
+            is AnnotationInfo -> listOf(raw)
+            else -> {
+                // Some ClassGraph versions hand back a typed primitive array or
+                // Kotlin wrapper — fall back to reflective iteration.
+                val len = runCatching { java.lang.reflect.Array.getLength(raw) }.getOrNull() ?: 0
+                (0 until len).mapNotNull { java.lang.reflect.Array.get(raw, it) as? AnnotationInfo }
+            }
+        }
+        return items.mapNotNull { it.parameterValues.getValue("advanceTimeMillis") as? Long }
     }
 
     private fun extractWrapperFqn(annotations: List<AnnotationInfo>): String? {
@@ -233,17 +295,24 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         method: MethodInfo,
         ann: AnnotationInfo,
         wrapperClassName: String?,
+        advanceTimeMillis: Long?,
     ): PreviewInfo {
         val params = extractPreviewParams(ann, wrapperClassName)
+            .copy(advanceTimeMillis = advanceTimeMillis)
         val fqn = "${classInfo.name}.${method.name}"
-        val suffix = buildVariantSuffix(params)
+        val baseSuffix = buildVariantSuffix(params)
+        // Match Roborazzi's own compose-preview-scanner-support filename
+        // convention (`_TIME_<ms>ms`) so tooling that sits on top of either
+        // pipeline groups variants the same way.
+        val timeSuffix = advanceTimeMillis?.let { "_TIME_${it}ms" }.orEmpty()
+        val id = fqn + baseSuffix + timeSuffix
         return PreviewInfo(
-            id = fqn + suffix,
+            id = id,
             functionName = method.name,
             className = classInfo.name,
             sourceFile = packageQualifiedSourcePath(classInfo),
             params = params,
-            renderOutput = "renders/${fqn}${suffix}.png",
+            renderOutput = "renders/${id}.png",
         )
     }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -30,6 +30,15 @@ data class PreviewParams(
     /** FQN of the `PreviewWrapperProvider` from `@PreviewWrapper`, if any. */
     val wrapperClassName: String? = null,
     val kind: PreviewKind = PreviewKind.COMPOSE,
+    /**
+     * Virtual-time offset to advance `mainClock` by before capture, sourced from
+     * Roborazzi's `@RoboComposePreviewOptions(manualClockOptions = [...])`. `null`
+     * means "use the renderer's default" (a small fixed step). A preview with
+     * `manualClockOptions = [ManualClockOptions(500L), ManualClockOptions(1000L)]`
+     * expands at discovery time into two entries, each carrying one of these
+     * values — one render per variant.
+     */
+    val advanceTimeMillis: Long? = null,
 )
 
 @Serializable

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,7 @@ ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version = "1.59.0" }
 roborazzi-compose = { module = "io.github.takahirom.roborazzi:roborazzi-compose", version = "1.59.0" }
 roborazzi-accessibility-check = { module = "io.github.takahirom.roborazzi:roborazzi-accessibility-check", version = "1.59.0" }
+roborazzi-annotations = { module = "io.github.takahirom.roborazzi:roborazzi-annotations", version = "1.59.0" }
 junit = { module = "junit:junit", version.ref = "junit" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -78,4 +78,11 @@ data class RenderPreviewParams(
     /** FQN of the `PreviewWrapperProvider` from `@PreviewWrapper`, if any. */
     val wrapperClassName: String? = null,
     val kind: PreviewKind = PreviewKind.COMPOSE,
+    /**
+     * Virtual-time offset to advance `mainClock` by before capture, sourced from
+     * Roborazzi's `@RoboComposePreviewOptions(manualClockOptions = [...])`. `null`
+     * means use the renderer's default. One entry per `ManualClockOptions` value
+     * is emitted at discovery time.
+     */
+    val advanceTimeMillis: Long? = null,
 )

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -197,13 +197,18 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                     }
                 }
                 // Advance the clock by a fixed virtual-time offset, then
-                // capture. Expressing the budget in milliseconds (rather than
-                // a frame count) matches Roborazzi's `@RoboComposePreviewOptions`
-                // / `ManualClockOptions.advanceTimeMillis` convention, so a
-                // future per-preview override can drop in without changing the
-                // primitive. Infinite animations park at exactly this virtual
-                // time across runs — repeated captures are byte-identical.
-                rule.mainClock.advanceTimeBy(CAPTURE_ADVANCE_MS)
+                // capture. With `mainClock.autoAdvance = false` this is the
+                // only clock motion Compose sees, so infinite animations park
+                // at exactly this virtual time across runs — repeated captures
+                // are byte-identical.
+                //
+                // If the preview carries `@RoboComposePreviewOptions`, the
+                // per-entry `advanceTimeMillis` overrides the default;
+                // `DiscoverPreviewsTask` has already fanned each timing out
+                // into its own manifest entry, so this value is one specific
+                // timing per render.
+                val advanceMs = params.advanceTimeMillis ?: CAPTURE_ADVANCE_MS
+                rule.mainClock.advanceTimeBy(advanceMs)
                 rule.onRoot().captureRoboImage(
                     file = outputFile,
                     roborazziOptions = roborazziOptions,

--- a/sample-android/build.gradle.kts
+++ b/sample-android/build.gradle.kts
@@ -50,5 +50,9 @@ dependencies {
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.foundation)
     implementation(libs.activity.compose)
+    // Roborazzi's per-preview clock control annotation. Source-retained
+    // metadata read by `DiscoverPreviewsTask` — the annotation itself has no
+    // runtime behaviour in production builds.
+    implementation(libs.roborazzi.annotations)
     debugImplementation("androidx.compose.ui:ui-tooling")
 }

--- a/sample-android/src/main/kotlin/com/example/sampleandroid/Previews.kt
+++ b/sample-android/src/main/kotlin/com/example/sampleandroid/Previews.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.github.takahirom.roborazzi.annotations.ManualClockOptions
+import com.github.takahirom.roborazzi.annotations.RoboComposePreviewOptions
 
 @Composable
 fun Greeting(name: String, modifier: Modifier = Modifier) {
@@ -70,6 +72,32 @@ fun GreetingPreview() {
 @Preview(name = "Loading Spinner", showBackground = true, backgroundColor = 0xFFFFFFFF)
 @Composable
 fun LoadingPreview() {
+    MaterialTheme {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            CircularProgressIndicator()
+            Text("Loading...")
+        }
+    }
+}
+
+/**
+ * Demonstrates `@RoboComposePreviewOptions`: the same preview captured at three
+ * distinct points along the infinite animation timeline. Each entry in
+ * `manualClockOptions` fans out into its own manifest entry / PNG, suffixed
+ * `_TIME_<ms>ms`. Useful for reviewing how a spinner looks at frame 0 vs
+ * mid-rotation vs a settled-ish point — the kind of thing you'd want a
+ * reviewer to see in a diff.
+ */
+@Preview(name = "Spinner Timeline", showBackground = true, backgroundColor = 0xFFFFFFFF)
+@RoboComposePreviewOptions(
+    manualClockOptions = [
+        ManualClockOptions(advanceTimeMillis = 0L),
+        ManualClockOptions(advanceTimeMillis = 500L),
+        ManualClockOptions(advanceTimeMillis = 1500L),
+    ],
+)
+@Composable
+fun SpinnerTimelinePreview() {
     MaterialTheme {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             CircularProgressIndicator()


### PR DESCRIPTION
Layer 2 of the animation-handling roadmap (following #62's default-path frame budget and #65's ms-primitive rename): per-preview opt-in to custom capture times, reusing Roborazzi's own annotation rather than rolling our own.

## Summary
A preview annotated with \`@RoboComposePreviewOptions(manualClockOptions = [...])\` fans out at discovery time into one manifest entry per \`ManualClockOptions.advanceTimeMillis\`, each rendered with that exact virtual-time offset and filed under \`_TIME_<ms>ms.png\`. Filename convention matches takahirom/roborazzi's own \`compose-preview-scanner-support\` library so downstream tooling aligns.

## Pipeline wiring
- **\`DiscoverPreviewsTask\`** picks up \`@RoboComposePreviewOptions\` by FQN — no compile-time dep on the annotation class, ClassGraph reads everything through descriptors. Empty / absent → single entry with \`advanceTimeMillis = null\`. Tile previews ignore the annotation (no Compose clock to advance).
- **\`PreviewParams\` / \`RenderPreviewParams\`** gain an optional \`advanceTimeMillis: Long?\`. \`null\` means \"use the renderer default\" (\`CAPTURE_ADVANCE_MS\` from #65).
- **\`RobolectricRenderTest.renderDefault\`** reads the field and passes it to \`mainClock.advanceTimeBy(...)\`.
- **\`@RoboComposePreviewOptions\` × multi-\`@Preview\`** is a cross-product by natural construction — each \`@Preview\` expansion runs through the same timing fan-out.

## Sample
\`sample-android\` gains \`SpinnerTimelinePreview\` — the same indeterminate \`CircularProgressIndicator\` captured at t=0ms / 500ms / 1500ms. Exercises the happy path end-to-end and produces three visibly-different frames of the same spinner for reviewers.

## Test plan
- [x] \`:sample-android:renderAllPreviews\` — 13 previews rendered; 3 \`SpinnerTimeline_TIME_*ms.png\` have distinct SHA-256s
- [x] \`--rerun-tasks\` — byte-identical across runs (deterministic)
- [x] \`:sample-wear:renderAllPreviews\` — unaffected
- [x] \`:sample-cmp:renderAllPreviews\` — unaffected
- [x] \`:gradle-plugin:test\` + \`:gradle-plugin:functionalTest\` — pass

## Follow-ups (separate PRs)
- CLI / VS Code grouping of \`_TIME_*\` variants as one preview with multiple frames — today each variant surfaces as an independent entry, which is fine but not ideal UX.
- \`roborazzi-compose-preview-scanner-support\` full adoption vs annotation-only — exploration brief lives outside this PR (to be picked up by a separate agent per request).