### PR TITLE
feat(renderer): tile previews get black bg + auto round crop

### DIFF
--- a/docs/RENDERER_COMPATIBILITY.md
+++ b/docs/RENDERER_COMPATIBILITY.md
@@ -36,22 +36,12 @@ The VS Code extension surfaces the same findings in the Problems panel (via
      consumer's declared deps — the renderer AAR transitively carrying the
      activity entry isn't enough.
 
-## Tile-rendering gaps (follow-ups)
+## Tile-rendering defaults
 
-Unrelated to the compat story but worth tracking here so they don't go
-missing:
-
-- **Tile previews should default to a black background.** Today
-  `TilePreviewRenderer` hosts the inflated tile in a `FrameLayout` with no
-  background; `showBackground`/`backgroundColor` from `@Preview` are both
-  false on `@wear.tiles.tooling.preview.Preview`. Fix in
-  `TilePreviewRenderer.TilePreviewComposable`: paint `Color.Black` on the
-  hosting Box when `params.kind == PreviewKind.TILE`, or when `device`
-  starts with `id:wearos_*`.
-- **Round crop for tile previews.** `RoundScreenOption` is added when
-  `isRoundDevice(params.device) && params.showSystemUi`. Tile previews
-  always have `showSystemUi = false`, so the qualifier never fires. Change
-  to `isRoundDevice(device) && (showSystemUi || kind == PreviewKind.TILE)`.
-
-Both land entirely in `renderer-android` and don't touch the plugin / AAR
-resolution path, so they're low-risk follow-ups.
+Tile previews render on an opaque black background and pick up the round
+device crop automatically — both happen unconditionally for
+`params.kind == PreviewKind.TILE` in `TilePreviewRenderer` and
+`RobolectricRenderTest` respectively. Consumers that want something other
+than black can paint inside the tile itself; the hosting FrameLayout's
+background is intentionally not exposed as a knob since it mirrors the
+watchface substrate, not the tile's own surface.

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -90,7 +90,13 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
         val params = preview.params
         val widthDp = params.widthDp?.takeIf { it > 0 } ?: DEFAULT_WIDTH
         val heightDp = params.heightDp?.takeIf { it > 0 } ?: DEFAULT_HEIGHT
-        val isRound = isRoundDevice(params.device) && params.showSystemUi
+        // Round crop fires when the preview is on a round device AND it's the
+        // kind of surface that fills the watch — either a @Composable the user
+        // asked for system UI on, or a tile (tiles always fill the watchface,
+        // so `showSystemUi` is never set for them). Without the tile branch,
+        // tile previews render as rectangles even on wearos_*_round devices.
+        val isRound = isRoundDevice(params.device) &&
+            (params.showSystemUi || params.kind == PreviewKind.TILE)
 
         val composeOptions = RoborazziComposeOptions.Builder().apply {
             size(widthDp, heightDp)
@@ -158,7 +164,8 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
         applyPreviewQualifiers(
             widthDp = widthDp,
             heightDp = heightDp,
-            isRound = isRoundDevice(params.device) && params.showSystemUi,
+            isRound = isRoundDevice(params.device) &&
+                (params.showSystemUi || params.kind == PreviewKind.TILE),
             locale = params.locale,
             uiMode = params.uiMode,
         )

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/TilePreviewRenderer.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.renderer
 
 import android.content.Context
+import android.graphics.Color
 import android.view.Gravity
 import android.view.ViewGroup
 import android.widget.FrameLayout
@@ -48,6 +49,14 @@ internal fun TilePreviewComposable(
                     ViewGroup.LayoutParams.MATCH_PARENT,
                     ViewGroup.LayoutParams.MATCH_PARENT,
                 )
+                // Tiles expect to render onto a dark watchface substrate. Without
+                // an explicit background the inflated ProtoLayout sits on a
+                // transparent parent which flattens to white in the captured
+                // PNG — text that's white-on-expected-black disappears. Paint
+                // opaque black here to match the runtime appearance; consumers
+                // that want a non-black frame can still layer on top inside the
+                // tile itself.
+                setBackgroundColor(Color.BLACK)
             }
             renderTileInto(context, preview, widthDp, heightDp, parent)
             parent


### PR DESCRIPTION
## Summary

Two cosmetic defaults for tile previews, matching what a real Wear OS watchface looks like:

- **Black background.** `TilePreviewRenderer.TilePreviewComposable` now paints opaque `Color.BLACK` on the hosting `FrameLayout`. Previously the inflated ProtoLayout sat on a transparent parent which flattened to white in the captured PNG — white-on-expected-black text (`Text.setColor(argb(0xFFFFFFFF))`, which is the idiomatic tile color usage) disappeared entirely. See \`sample-wear\`'s \`HelloTilePreview\` before/after — the card + "Today" header were invisible on white; now they render correctly on black.

- **Auto round crop.** `RobolectricRenderTest`'s `isRound` check flips from `isRoundDevice(device) && showSystemUi` to `isRoundDevice(device) && (showSystemUi || kind == TILE)`. Tile previews always have `showSystemUi = false` — they're not \`@Composable\`s hosting system UI — so the previous gate never fired and tiles rendered as rectangles on \`wearos_*_round\` devices. Tiles always fill the watchface, so round devices should always crop.

Both land entirely in \`renderer-android\`. No plugin / AAR-resolution changes.

\`docs/RENDERER_COMPATIBILITY.md\` loses its "tile follow-ups" section — both items shipped. Replaced with a one-paragraph note describing the new defaults.

## Test plan

- [x] \`./gradlew check\`
- [x] \`./gradlew :sample-wear:renderAllPreviews --rerun-tasks\`:
  - \`HelloTilePreview_Small Round.png\` — round crop, black background, "Today" + "Morning run / 5.2 km · 28 min" card visible
  - \`StepsTilePreview_Large Round.png\` — round crop, black background, "Steps" + 6,482 count + "Details" button visible
  - Compose previews (\`ActivityListPreview\` etc.) unaffected — still rectangle PNGs when \`showSystemUi = false\`, still round when \`showSystemUi = true\`