### PR TITLE
feat(scroll): @ScrollingPreview annotation with scroll-to-end capture

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -459,6 +459,124 @@ class DiscoveryFunctionalTest {
     }
 
     @Test
+    fun `discoverPreviews picks up @ScrollingPreview`() {
+        val projectDir = createCmpTestProject()
+
+        // Stub out @ScrollingPreview at its canonical FQN inside the synthetic
+        // project — mirrors the @PreviewWrapper test above so the functional
+        // test doesn't need the preview-annotations artifact on its classpath.
+        val scrollingFqnDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/preview")
+        scrollingFqnDir.mkdirs()
+        File(scrollingFqnDir, "ScrollingPreview.kt").writeText(
+            """
+            package ee.schimke.composeai.preview
+
+            enum class ScrollMode { END, LONG }
+            enum class ScrollAxis { VERTICAL, HORIZONTAL }
+
+            @Retention(AnnotationRetention.BINARY)
+            @Target(AnnotationTarget.FUNCTION)
+            annotation class ScrollingPreview(
+                val mode: ScrollMode,
+                val maxScrollPx: Int = 0,
+                val reduceMotion: Boolean = true,
+                val axis: ScrollAxis = ScrollAxis.VERTICAL,
+            )
+            """.trimIndent()
+        )
+
+        val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+        srcFile.writeText(
+            """
+            package test
+
+            import androidx.compose.foundation.background
+            import androidx.compose.foundation.layout.Box
+            import androidx.compose.foundation.layout.size
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+            import androidx.compose.ui.graphics.Color
+            import androidx.compose.ui.tooling.preview.Preview
+            import androidx.compose.ui.unit.dp
+            import ee.schimke.composeai.preview.ScrollAxis
+            import ee.schimke.composeai.preview.ScrollMode
+            import ee.schimke.composeai.preview.ScrollingPreview
+
+            // Multi-preview meta-annotation to prove the scroll spec propagates to
+            // every expansion, same pattern as the PreviewWrapper test.
+            @Preview(name = "Light", backgroundColor = 0xFFFFFFFF, showBackground = true)
+            @Preview(name = "Dark", backgroundColor = 0xFF000000, showBackground = true)
+            annotation class LightAndDark
+
+            @LightAndDark
+            @ScrollingPreview(mode = ScrollMode.END)
+            @Composable
+            fun EndScrollPreview() {
+                Box(modifier = Modifier.size(50.dp).background(Color.Red))
+            }
+
+            @Preview
+            @ScrollingPreview(
+                mode = ScrollMode.LONG,
+                maxScrollPx = 4000,
+                reduceMotion = false,
+                axis = ScrollAxis.HORIZONTAL,
+            )
+            @Composable
+            fun LongScrollPreview() {
+                Box(modifier = Modifier.size(50.dp).background(Color.Blue))
+            }
+
+            @Preview
+            @Composable
+            fun PlainPreview() {
+                Box(modifier = Modifier.size(50.dp).background(Color.Green))
+            }
+            """.trimIndent()
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("discoverPreviews", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+
+        assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+        val manifest = json.decodeFromString<PreviewManifest>(
+            File(projectDir, "build/compose-previews/previews.json").readText()
+        )
+
+        val endPreviews = manifest.previews.filter { it.functionName == "EndScrollPreview" }
+        assertThat(endPreviews).hasSize(2)
+        // @ScrollingPreview propagates identically to every @LightAndDark expansion,
+        // using its declared-in-source defaults (reduceMotion=true, axis=VERTICAL).
+        for (p in endPreviews) {
+            assertThat(p.params.scroll).isEqualTo(
+                ScrollSpec(
+                    mode = ScrollMode.END,
+                    maxScrollPx = 0,
+                    reduceMotion = true,
+                    axis = ScrollAxis.VERTICAL,
+                )
+            )
+        }
+
+        val longPreview = manifest.previews.single { it.functionName == "LongScrollPreview" }
+        assertThat(longPreview.params.scroll).isEqualTo(
+            ScrollSpec(
+                mode = ScrollMode.LONG,
+                maxScrollPx = 4000,
+                reduceMotion = false,
+                axis = ScrollAxis.HORIZONTAL,
+            )
+        )
+
+        val plain = manifest.previews.single { it.functionName == "PlainPreview" }
+        assertThat(plain.params.scroll).isNull()
+    }
+
+    @Test
     fun `discoverPreviews re-runs when source changes`() {
         val projectDir = createCmpTestProject()
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import io.github.classgraph.AnnotationClassRef
+import io.github.classgraph.AnnotationEnumValue
 import io.github.classgraph.AnnotationInfo
 import io.github.classgraph.ClassGraph
 import io.github.classgraph.ClassInfo
@@ -69,6 +70,9 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         // PreviewWrapperProvider. Matched by FQN so older apps (no such class on classpath)
         // simply never surface the annotation and discovery is a no-op.
         private const val PREVIEW_WRAPPER_FQN = "androidx.compose.ui.tooling.preview.PreviewWrapper"
+        // Our own opt-in for scrolling-screenshot capture. Matched by FQN so projects
+        // that don't depend on `ee.schimke.composeai:preview-annotations` are unaffected.
+        private const val SCROLLING_PREVIEW_FQN = "ee.schimke.composeai.preview.ScrollingPreview"
 
         internal const val TILE_PREVIEW_FQN = "androidx.wear.tiles.tooling.preview.Preview"
 
@@ -161,9 +165,11 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         scanResult: ScanResult,
         previews: MutableList<PreviewInfo>,
     ) {
-        // @PreviewWrapper is non-repeatable and applies to every @Preview on the
-        // function (including expansions from multi-preview meta-annotations).
+        // @PreviewWrapper and @ScrollingPreview are both non-repeatable and apply
+        // to every @Preview on the function (including expansions from
+        // multi-preview meta-annotations).
         val wrapperFqn = extractWrapperFqn(annotations)
+        val scrollSpec = extractScrollSpec(annotations)
         // @RoboComposePreviewOptions, similarly, applies to the function as a
         // whole — each timing fans out into its own manifest entry, orthogonal
         // to any multi-preview expansion.
@@ -172,7 +178,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         val directPreviews = collectDirectPreviews(annotations)
         if (directPreviews.isNotEmpty()) {
             for (ann in directPreviews) {
-                addPreviewsForTimings(classInfo, method, ann, wrapperFqn, timings, previews)
+                addPreviewsForTimings(classInfo, method, ann, wrapperFqn, scrollSpec, timings, previews)
             }
             return
         }
@@ -180,7 +186,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         for (ann in annotations) {
             val resolved = resolveMultiPreview(ann, scanResult, mutableSetOf())
             for (resolvedAnn in resolved) {
-                addPreviewsForTimings(classInfo, method, resolvedAnn, wrapperFqn, timings, previews)
+                addPreviewsForTimings(classInfo, method, resolvedAnn, wrapperFqn, scrollSpec, timings, previews)
             }
         }
     }
@@ -190,6 +196,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         method: MethodInfo,
         ann: AnnotationInfo,
         wrapperFqn: String?,
+        scrollSpec: ScrollSpec?,
         timings: List<Long>,
         previews: MutableList<PreviewInfo>,
     ) {
@@ -199,10 +206,10 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         // the annotation as a no-op on tiles.
         val applicable = timings.takeIf { ann.name != TILE_PREVIEW_FQN }.orEmpty()
         if (applicable.isEmpty()) {
-            previews.add(makePreview(classInfo, method, ann, wrapperFqn, advanceTimeMillis = null))
+            previews.add(makePreview(classInfo, method, ann, wrapperFqn, scrollSpec, advanceTimeMillis = null))
         } else {
             for (ms in applicable) {
-                previews.add(makePreview(classInfo, method, ann, wrapperFqn, advanceTimeMillis = ms))
+                previews.add(makePreview(classInfo, method, ann, wrapperFqn, scrollSpec, advanceTimeMillis = ms))
             }
         }
     }
@@ -238,6 +245,27 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             is String -> value
             else -> null
         }
+    }
+
+    private fun extractScrollSpec(annotations: List<AnnotationInfo>): ScrollSpec? {
+        val ann = annotations.firstOrNull { it.name == SCROLLING_PREVIEW_FQN } ?: return null
+        val pv = ann.parameterValues
+        // Enum constants come through as AnnotationEnumValue; compare by .valueName so
+        // we never force-load the annotation's classes.
+        val mode = (pv.getValue("mode") as? AnnotationEnumValue)?.valueName
+            ?.let { runCatching { ScrollMode.valueOf(it) }.getOrNull() }
+            ?: return null
+        val axis = (pv.getValue("axis") as? AnnotationEnumValue)?.valueName
+            ?.let { runCatching { ScrollAxis.valueOf(it) }.getOrNull() }
+            ?: ScrollAxis.VERTICAL
+        val maxScrollPx = (pv.getValue("maxScrollPx") as? Int)?.coerceAtLeast(0) ?: 0
+        val reduceMotion = (pv.getValue("reduceMotion") as? Boolean) ?: true
+        return ScrollSpec(
+            mode = mode,
+            maxScrollPx = maxScrollPx,
+            reduceMotion = reduceMotion,
+            axis = axis,
+        )
     }
 
     private fun isDirectPreview(ann: AnnotationInfo): Boolean =
@@ -295,10 +323,17 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         method: MethodInfo,
         ann: AnnotationInfo,
         wrapperClassName: String?,
+        scrollSpec: ScrollSpec?,
         advanceTimeMillis: Long?,
     ): PreviewInfo {
+        // Tile previews can't scroll — same reasoning as the timings fan-out above.
+        // Null out the scroll spec at the manifest level so renderers don't branch on it.
+        val applicableScroll = scrollSpec.takeIf { ann.name != TILE_PREVIEW_FQN }
         val params = extractPreviewParams(ann, wrapperClassName)
-            .copy(advanceTimeMillis = advanceTimeMillis)
+            .copy(
+                advanceTimeMillis = advanceTimeMillis,
+                scroll = applicableScroll,
+            )
         val fqn = "${classInfo.name}.${method.name}"
         val baseSuffix = buildVariantSuffix(params)
         // Match Roborazzi's own compose-preview-scanner-support filename
@@ -350,7 +385,10 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     private fun sanitizeForPath(s: String): String =
         s.replace(Regex("""[/\\:*?"<>|]"""), "_")
 
-    private fun extractPreviewParams(ann: AnnotationInfo, wrapperClassName: String?): PreviewParams {
+    private fun extractPreviewParams(
+        ann: AnnotationInfo,
+        wrapperClassName: String?,
+    ): PreviewParams {
         val pv = ann.parameterValues
         val kind = if (ann.name == TILE_PREVIEW_FQN) PreviewKind.TILE else PreviewKind.COMPOSE
         val device = (pv.getValue("device") as? String)?.ifBlank { null }
@@ -378,6 +416,8 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             // the wrapper's `Wrap(content)` would never wrap the tile View.
             wrapperClassName = if (kind == PreviewKind.TILE) null else wrapperClassName,
             kind = kind,
+            // @ScrollingPreview is applied by `makePreview` via `.copy(scroll = …)` so
+            // the timings fan-out and scroll spec live side-by-side in one place.
         )
     }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -14,6 +14,36 @@ enum class PreviewKind {
     TILE,
 }
 
+/**
+ * Mirrors `ee.schimke.composeai.preview.ScrollMode` from the `preview-annotations`
+ * artifact. Duplicated here so the Gradle plugin can serialize the value into
+ * `previews.json` without pulling the annotation artifact onto the plugin's
+ * compile classpath — same split we use for [PreviewKind] across plugin /
+ * renderer modules.
+ */
+enum class ScrollMode {
+    END,
+    LONG,
+}
+
+/** Mirrors `ee.schimke.composeai.preview.ScrollAxis`. */
+enum class ScrollAxis {
+    VERTICAL,
+    HORIZONTAL,
+}
+
+/**
+ * Captured settings from `@ScrollingPreview`. `null` on [PreviewParams.scroll]
+ * means the preview opted out of scrolling capture (the default).
+ */
+@Serializable
+data class ScrollSpec(
+    val mode: ScrollMode,
+    val maxScrollPx: Int = 0,
+    val reduceMotion: Boolean = true,
+    val axis: ScrollAxis = ScrollAxis.VERTICAL,
+)
+
 @Serializable
 data class PreviewParams(
     val name: String? = null,
@@ -39,6 +69,8 @@ data class PreviewParams(
      * values — one render per variant.
      */
     val advanceTimeMillis: Long? = null,
+    /** Scrolling-capture settings from `@ScrollingPreview`, if any. */
+    val scroll: ScrollSpec? = null,
 )
 
 @Serializable

--- a/preview-annotations/build.gradle.kts
+++ b/preview-annotations/build.gradle.kts
@@ -1,0 +1,78 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    `maven-publish`
+    alias(libs.plugins.maven.publish)
+}
+
+group = "ee.schimke.composeai"
+// See gradle-plugin/build.gradle.kts for how CI sets PLUGIN_VERSION. Local
+// builds derive the SNAPSHOT version from `.release-please-manifest.json`.
+version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: run {
+    val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+    val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+    val (major, minor, patch) = current.split(".").map { it.toInt() }
+    "$major.$minor.${patch + 1}-SNAPSHOT"
+}
+
+java {
+    toolchain { languageVersion.set(JavaLanguageVersion.of(21)) }
+}
+
+// Annotation-only artifact — deliberately no runtime deps so adding it to a
+// Compose app classpath never drags anything else in.
+
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri(
+                providers.environmentVariable("GITHUB_REPOSITORY")
+                    .map { "https://maven.pkg.github.com/$it" }
+                    .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools"),
+            )
+            credentials {
+                username = providers.environmentVariable("GITHUB_ACTOR").orNull
+                password = providers.environmentVariable("GITHUB_TOKEN").orNull
+            }
+        }
+    }
+}
+
+mavenPublishing {
+    publishToMavenCentral(automaticRelease = true)
+    if (!version.toString().endsWith("SNAPSHOT")) {
+        signAllPublications()
+    }
+
+    coordinates("ee.schimke.composeai", "preview-annotations", version.toString())
+
+    pom {
+        name.set("Compose Preview — Annotations")
+        description.set(
+            "Annotations consumed by the compose-preview Gradle plugin — e.g. " +
+                "@ScrollingPreview for opting @Preview composables into scrolling " +
+                "screenshot capture.",
+        )
+        url.set("https://github.com/yschimke/compose-ai-tools")
+        inceptionYear.set("2025")
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                distribution.set("repo")
+            }
+        }
+        developers {
+            developer {
+                id.set("yschimke")
+                name.set("Yuri Schimke")
+                url.set("https://github.com/yschimke")
+            }
+        }
+        scm {
+            url.set("https://github.com/yschimke/compose-ai-tools")
+            connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+            developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+        }
+    }
+}

--- a/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/ScrollingPreview.kt
+++ b/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/ScrollingPreview.kt
@@ -1,0 +1,52 @@
+package ee.schimke.composeai.preview
+
+/**
+ * Opts a `@Preview` composable into scrolling-screenshot capture.
+ *
+ * The compose-preview Gradle plugin's discovery task picks this up by FQN,
+ * independently of whether the annotation artifact is on the consumer's
+ * compile classpath at plugin-apply time. Consumers that want to use the
+ * annotation in their own code depend on
+ * `ee.schimke.composeai:preview-annotations`.
+ *
+ * The annotation only records *intent* in `previews.json` — renderer support
+ * for [ScrollMode.END] and [ScrollMode.LONG] lands in subsequent changes.
+ */
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+@MustBeDocumented
+annotation class ScrollingPreview(
+    /** Capture strategy for the scrollable content. */
+    val mode: ScrollMode,
+    /**
+     * Upper bound on how far we'll scroll, in pixels. `0` means unbounded —
+     * drive to the content's natural end. Use a positive value on infinite
+     * or very tall scrollers to cap capture size.
+     */
+    val maxScrollPx: Int = 0,
+    /**
+     * If true, scrolling captures wrap the preview body in a
+     * `LocalReduceMotion provides ReduceMotion(true)` to flatten Wear
+     * `TransformingLazyColumn` item transforms so slices / end-state
+     * captures look consistent.
+     */
+    val reduceMotion: Boolean = true,
+    /** Which axis to drive. Only [ScrollAxis.VERTICAL] is rendered today. */
+    val axis: ScrollAxis = ScrollAxis.VERTICAL,
+)
+
+enum class ScrollMode {
+    /** Scroll to the end of the content, then capture a single frame. */
+    END,
+
+    /**
+     * Capture the full scrollable content, stitching multiple frames into
+     * one tall (or wide) PNG.
+     */
+    LONG,
+}
+
+enum class ScrollAxis {
+    VERTICAL,
+    HORIZONTAL,
+}

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -7,6 +7,31 @@ enum class PreviewKind {
     TILE,
 }
 
+/**
+ * Mirrors `ee.schimke.composeai.preview.ScrollMode` from the `preview-annotations`
+ * artifact. Duplicated on the renderer side (same split as [PreviewKind]) so the
+ * renderer can read `previews.json` without depending on the annotation artifact.
+ */
+enum class ScrollMode {
+    END,
+    LONG,
+}
+
+/** Mirrors `ee.schimke.composeai.preview.ScrollAxis`. */
+enum class ScrollAxis {
+    VERTICAL,
+    HORIZONTAL,
+}
+
+/** Renderer-side mirror of the plugin's `ScrollSpec`. */
+@Serializable
+data class ScrollSpec(
+    val mode: ScrollMode,
+    val maxScrollPx: Int = 0,
+    val reduceMotion: Boolean = true,
+    val axis: ScrollAxis = ScrollAxis.VERTICAL,
+)
+
 @Serializable
 data class RenderManifest(
     val module: String,
@@ -93,4 +118,6 @@ data class RenderPreviewParams(
      * is emitted at discovery time.
      */
     val advanceTimeMillis: Long? = null,
+    /** Scrolling-capture settings from `@ScrollingPreview`, if any. */
+    val scroll: ScrollSpec? = null,
 )

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -230,6 +230,25 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                 // timing per render.
                 val advanceMs = params.advanceTimeMillis ?: CAPTURE_ADVANCE_MS
                 rule.mainClock.advanceTimeBy(advanceMs)
+
+                // @ScrollingPreview: drive the first scrollable on the annotated
+                // axis to the end of its content before the snapshot. Both ScrollMode
+                // values capture the end-state for now — true long-scroll stitching
+                // lands in a follow-up; the manifest field stays stable across the
+                // transition.
+                params.scroll?.let { spec ->
+                    val result = driveScrollToEnd(
+                        rule = rule,
+                        axis = spec.axis,
+                        maxScrollPx = spec.maxScrollPx,
+                    )
+                    if (result is ScrollDriveResult.NoScrollable) {
+                        System.err.println(
+                            "@ScrollingPreview on '${preview.id}' but no scrollable composable found on axis ${spec.axis} — capturing initial frame.",
+                        )
+                    }
+                }
+
                 val onRoot = rule.onRoot()
                 onRoot.captureRoboImage(
                     file = outputFile,

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollDriver.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollDriver.kt
@@ -1,0 +1,96 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.ui.semantics.ScrollAxisRange
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+
+/**
+ * Drives the first scrollable composable matching [axis] to the end of its
+ * content, by repeatedly calling `SemanticsActions.ScrollBy` with the
+ * remaining delta and advancing the paused [AndroidComposeTestRule.mainClock].
+ *
+ * Loops because:
+ *  - `LazyList` / `LazyColumn` reports `maxValue` progressively as items
+ *    materialize — the first `ScrollBy` call doesn't know the final extent.
+ *  - `Modifier.verticalScroll` with a `ScrollState` reports the total content
+ *    extent up front, but its `animateScrollBy` under the hood still takes
+ *    multiple frames of virtual time to settle on the target.
+ *
+ * Returns when the remaining delta is ≈ 0 or when [maxScrollPx] (if > 0) is
+ * exhausted. Safe no-op if no scrollable is found — caller captures whatever
+ * the composition has drawn.
+ */
+@Suppress("LongParameterList")
+internal fun driveScrollToEnd(
+    rule: AndroidComposeTestRule<*, *>,
+    axis: ScrollAxis,
+    maxScrollPx: Int,
+    maxIterations: Int = DEFAULT_MAX_ITERATIONS,
+    advanceMsPerStep: Long = DEFAULT_ADVANCE_MS_PER_STEP,
+): ScrollDriveResult {
+    val axisKey = when (axis) {
+        ScrollAxis.VERTICAL -> SemanticsProperties.VerticalScrollAxisRange
+        ScrollAxis.HORIZONTAL -> SemanticsProperties.HorizontalScrollAxisRange
+    }
+    val scrollables = rule.onAllNodes(SemanticsMatcher.keyIsDefined(axisKey)).fetchSemanticsNodes()
+    if (scrollables.isEmpty()) return ScrollDriveResult.NoScrollable
+
+    // Match the first scrollable — same node across iterations via the
+    // SemanticsNodeInteraction, so config reads see up-to-date maxValue.
+    val interaction = rule.onAllNodes(SemanticsMatcher.keyIsDefined(axisKey))[0]
+
+    val cap = if (maxScrollPx > 0) maxScrollPx.toFloat() else Float.POSITIVE_INFINITY
+    var scrolledPx = 0f
+
+    repeat(maxIterations) {
+        val node = interaction.fetchSemanticsNode()
+        val range: ScrollAxisRange = node.config.getOrNull(axisKey)
+            ?: return ScrollDriveResult.Completed(scrolledPx)
+        val scrollByAction = node.config.getOrNull(SemanticsActions.ScrollBy)?.action
+            ?: return ScrollDriveResult.Completed(scrolledPx)
+
+        val remaining = (range.maxValue() - range.value()).coerceAtLeast(0f)
+        if (remaining <= SETTLED_EPSILON_PX) return ScrollDriveResult.Completed(scrolledPx)
+
+        val headroom = (cap - scrolledPx).coerceAtLeast(0f)
+        if (headroom <= SETTLED_EPSILON_PX) return ScrollDriveResult.CapReached(scrolledPx)
+
+        val step = minOf(remaining, headroom)
+        val (dx, dy) = when (axis) {
+            ScrollAxis.VERTICAL -> 0f to step
+            ScrollAxis.HORIZONTAL -> step to 0f
+        }
+        scrollByAction.invoke(dx, dy)
+        scrolledPx += step
+
+        // ScrollBy dispatches animateScrollBy — the scroll doesn't land until
+        // virtual time advances enough for the animation to complete.
+        rule.mainClock.advanceTimeBy(advanceMsPerStep)
+    }
+    return ScrollDriveResult.IterationCapReached(scrolledPx)
+}
+
+internal sealed interface ScrollDriveResult {
+    /** No scrollable composable found on the requested axis. */
+    data object NoScrollable : ScrollDriveResult
+
+    /** Reached `value == maxValue` (± epsilon). */
+    data class Completed(val scrolledPx: Float) : ScrollDriveResult
+
+    /** Annotation's `maxScrollPx` cap hit before the content ended. */
+    data class CapReached(val scrolledPx: Float) : ScrollDriveResult
+
+    /** [DEFAULT_MAX_ITERATIONS] reached without the scroll settling — usually a runaway LazyList. */
+    data class IterationCapReached(val scrolledPx: Float) : ScrollDriveResult
+}
+
+// 30 iterations × 250ms of virtual time = 7.5s budget, enough for 100-ish
+// LazyColumn items' worth of progressive materialization without runaway.
+private const val DEFAULT_MAX_ITERATIONS = 30
+private const val DEFAULT_ADVANCE_MS_PER_STEP = 250L
+
+// Sub-pixel remainder from fractional density scaling shouldn't keep us spinning.
+private const val SETTLED_EPSILON_PX = 0.5f

--- a/sample-android/build.gradle.kts
+++ b/sample-android/build.gradle.kts
@@ -43,6 +43,23 @@ android {
     }
 }
 
+// `ScrollPreviewPixelTest` reads PNGs under `build/compose-previews/renders/`
+// produced by `renderAllPreviews`. Wire the AGP unit-test tasks to depend on
+// it so `./gradlew :sample-android:check` renders the PNGs first then
+// pixel-asserts against them. Targeting the `test{Debug,Release}UnitTest`
+// tasks by name — `tasks.withType<Test>()` would also grab the plugin's own
+// `renderPreviews` Test task and create a circular dependency.
+afterEvaluate {
+    listOf("testDebugUnitTest", "testReleaseUnitTest").forEach { name ->
+        tasks.findByName(name)?.dependsOn("renderAllPreviews")
+    }
+}
+
+dependencies {
+    testImplementation(libs.junit)
+    testImplementation(libs.truth)
+}
+
 dependencies {
     implementation(platform(libs.compose.bom))
     implementation(libs.compose.ui)
@@ -54,5 +71,8 @@ dependencies {
     // metadata read by `DiscoverPreviewsTask` — the annotation itself has no
     // runtime behaviour in production builds.
     implementation(libs.roborazzi.annotations)
+    // Our `@ScrollingPreview` lives here — same role as above, read by FQN
+    // at discovery time; no runtime behaviour.
+    implementation(project(":preview-annotations"))
     debugImplementation("androidx.compose.ui:ui-tooling")
 }

--- a/sample-android/src/main/kotlin/com/example/sampleandroid/ScrollPreviews.kt
+++ b/sample-android/src/main/kotlin/com/example/sampleandroid/ScrollPreviews.kt
@@ -1,0 +1,58 @@
+package com.example.sampleandroid
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
+
+/**
+ * Demo fixture for `@ScrollingPreview`. 40 stacked bands going red (top)
+ * → blue (bottom), each taller than the preview viewport so the top-of-list
+ * capture is dominantly red and the scrolled-to-end capture is dominantly
+ * blue. Pixel assertions in `:gradle-plugin:functionalTest` / manual eyes
+ * both key off this gradient.
+ */
+@Composable
+fun RedToBlueList() {
+    val count = 40
+    LazyColumn(modifier = Modifier.fillMaxWidth()) {
+        items((0 until count).toList()) { index ->
+            val t = index.toFloat() / (count - 1).toFloat()
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(60.dp)
+                    .background(lerp(Color.Red, Color.Blue, t)),
+            )
+        }
+    }
+}
+
+/** Baseline — captures the initial (unscrolled) frame. Mostly red. */
+@Preview(name = "Top", showBackground = true)
+@Composable
+fun RedToBlueTopPreview() {
+    RedToBlueList()
+}
+
+/**
+ * Same fixture with `@ScrollingPreview(mode = END)` — the renderer drives the
+ * LazyColumn to the end of its content before the capture, so this frame is
+ * mostly blue.
+ */
+@Preview(name = "End", showBackground = true)
+@ScrollingPreview(mode = ScrollMode.END)
+@Composable
+fun RedToBlueEndPreview() {
+    RedToBlueList()
+}

--- a/sample-android/src/test/kotlin/com/example/sampleandroid/ScrollPreviewPixelTest.kt
+++ b/sample-android/src/test/kotlin/com/example/sampleandroid/ScrollPreviewPixelTest.kt
@@ -1,0 +1,68 @@
+package com.example.sampleandroid
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Test
+
+/**
+ * End-to-end verification that `@ScrollingPreview(mode = END)` drives the
+ * LazyColumn to the bottom before capturing. Reads the PNGs produced by
+ * `:sample-android:renderAllPreviews` and asserts colour dominance matches
+ * the expected top (red) / bottom (blue) of [RedToBlueList].
+ *
+ * The `renderAllPreviews` task is wired into this module's `test` task
+ * dependency graph in build.gradle.kts so running `:sample-android:test` (or
+ * `:check`) renders the PNGs first.
+ */
+class ScrollPreviewPixelTest {
+
+    private val rendersDir = File("build/compose-previews/renders")
+
+    private data class Avg(val r: Double, val g: Double, val b: Double) {
+        fun dominant(): Char = when {
+            r > g && r > b -> 'R'
+            g > r && g > b -> 'G'
+            else -> 'B'
+        }
+    }
+
+    private fun averageColor(file: File): Avg {
+        val img = ImageIO.read(file)
+        var rs = 0L
+        var gs = 0L
+        var bs = 0L
+        val w = img.width
+        val h = img.height
+        for (y in 0 until h) for (x in 0 until w) {
+            val argb = img.getRGB(x, y)
+            rs += (argb shr 16) and 0xff
+            gs += (argb shr 8) and 0xff
+            bs += argb and 0xff
+        }
+        val n = (w * h).toDouble()
+        return Avg(rs / n, gs / n, bs / n)
+    }
+
+    @Test
+    fun `Top preview (no ScrollingPreview) is red-dominant`() {
+        val file = File(rendersDir, "com.example.sampleandroid.ScrollPreviewsKt.RedToBlueTopPreview_Top.png")
+        assertThat(file.exists()).isTrue()
+        val avg = averageColor(file)
+        assertThat(avg.dominant()).isEqualTo('R')
+        assertThat(avg.r).isGreaterThan(150.0)
+        assertThat(avg.b).isLessThan(120.0)
+    }
+
+    @Test
+    fun `End preview (ScrollingPreview END) is blue-dominant`() {
+        val file = File(rendersDir, "com.example.sampleandroid.ScrollPreviewsKt.RedToBlueEndPreview_End.png")
+        assertThat(file.exists()).isTrue()
+        val avg = averageColor(file)
+        // If scroll-to-end silently fails, the image is red-dominant — this
+        // is exactly the regression this test guards against.
+        assertThat(avg.dominant()).isEqualTo('B')
+        assertThat(avg.b).isGreaterThan(150.0)
+        assertThat(avg.r).isLessThan(120.0)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ rootProject.name = "compose-ai-tools"
 
 includeBuild("gradle-plugin")
 include(":cli")
+include(":preview-annotations")
 include(":sample-android")
 include(":sample-wear")
 include(":sample-cmp")


### PR DESCRIPTION
## Summary

- New `@ScrollingPreview` annotation (published as `ee.schimke.composeai:preview-annotations`) that opts a `@Preview` into driving its first scrollable composable to the end of its content before the screenshot is taken.
- Discovery picks the annotation up by FQN, threads a `ScrollSpec?` through the manifest alongside the existing `@RoboComposePreviewOptions` timings fan-out.
- `renderer-android` gains `ScrollDriver.kt`, which loops `ScrollBy(remaining) + mainClock.advanceTimeBy(250)` against the node's `VerticalScrollAxisRange` until settled or the `maxScrollPx` cap trips. Handles `LazyColumn`'s progressive `maxValue` revelation as items materialize.

## Demo fixture

`sample-android` ships a 40-item red→blue `LazyColumn` with paired previews:

- `RedToBlueTopPreview` (baseline, no annotation) — captures the top; avg colour `(219, 55, 78)` → red-dominant.
- `RedToBlueEndPreview` (`@ScrollingPreview(mode = END)`) — captures the bottom; avg colour `(54, 53, 226)` → blue-dominant.

`ScrollPreviewPixelTest` reads both PNGs and asserts colour dominance; wired as a dependency of `testDebugUnitTest` so `./gradlew check` renders then pixel-asserts, catching silent regressions.

## Explicitly not in this PR

- `ScrollMode.LONG` currently behaves identically to `END`. True tall-stitched capture lands in a follow-up; annotation shape stays stable.
- `reduceMotion` is plumbed through the manifest but not yet honoured — the Wear `LocalReduceMotion` wrap arrives with the `TransformingLazyColumn` sample.

## Test plan

- [x] `./gradlew :preview-annotations:build`
- [x] `./gradlew :gradle-plugin:test :gradle-plugin:functionalTest`
- [x] `./gradlew :renderer-android:test`
- [x] `./gradlew :sample-android:test` — 2/2 `ScrollPreviewPixelTest` assertions pass
- [x] `./gradlew :sample-android:renderAllPreviews :sample-cmp:renderAllPreviews :sample-wear:renderAllPreviews` — unchanged preview counts + 2 new scrolling previews
- [x] `./gradlew check`