### PR TITLE
fix(vscode): suppress plugin-not-applied nudge for worktree files

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import { GradleService, GradleApi } from './gradleService';
+import { findPluginAppliedAncestor } from './pluginDetection';
 import { PreviewPanel } from './previewPanel';
 import { PreviewRegistry } from './previewRegistry';
 import { PreviewGutterDecorations } from './previewGutterDecorations';
@@ -578,6 +579,15 @@ function emptyStateMessage(activeFile: string | undefined): string {
             + 'Add id("ee.schimke.composeai.preview") to a module\'s build.gradle.kts to enable previews.';
     }
     if (fileHasPreviewAnnotation(activeFile)) {
+        // File is inside a preview-enabled module, but outside this Gradle
+        // project — typical for a file in a git worktree opened from the main
+        // checkout's workspace. Nothing the user needs to "fix" in the build
+        // script; steer them toward opening the right root instead.
+        if (findPluginAppliedAncestor(activeFile)) {
+            return 'This file is in a preview-enabled module, but outside this VS Code '
+                + 'workspace root (e.g. a git worktree). Open that project root in VS Code '
+                + 'to see its previews.';
+        }
         const topDir = topLevelDirOf(activeFile) ?? '(this module)';
         return `'${topDir}' doesn't apply ee.schimke.composeai.preview. `
             + `Modules with previews in this workspace: ${previewModules.join(', ')}.`;
@@ -601,6 +611,11 @@ function maybeShowSetupPrompt(activeFile: string): void {
     const missingAnywhere = previewModules.length === 0;
     const missingForThisModule = !missingAnywhere && fileHasPreviewAnnotation(activeFile);
     if (!missingAnywhere && !missingForThisModule) { return; }
+    // The file is already inside a plugin-applied module somewhere up its own
+    // path — it just isn't part of *this* Gradle project (e.g. a git worktree
+    // nested under the workspace root). No build-script fix is needed; skip
+    // the nudge rather than point at a module they'd have to invent.
+    if (findPluginAppliedAncestor(activeFile)) { return; }
 
     warnedMissingPluginThisSession = true;
     const message = missingAnywhere

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -2,13 +2,10 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { AccessibilityFinding, AccessibilityReport, DoctorModuleReport, HistoryEntry, PreviewManifest } from './types';
+import { APPLIES_PLUGIN_RE } from './pluginDetection';
 
 const HISTORY_DIRNAME = '.compose-preview-history';
 const TIMESTAMP_RE = /^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})(?:-\d+)?$/;
-// Matches the plugin being *applied* (`id("ee.schimke.composeai.preview")` or
-// `id "ee.schimke.composeai.preview"`), not the plugin's own declaration in
-// gradle-plugin/build.gradle.kts (`id = "ee.schimke.composeai.preview"`).
-const APPLIES_PLUGIN_RE = /\bid\s*[(\s]\s*["']ee\.schimke\.composeai\.preview["']/;
 
 const TASK_TIMEOUT_MS = 5 * 60 * 1000;
 const MANIFEST_CACHE_TTL_MS = 30_000;

--- a/vscode-extension/src/pluginDetection.ts
+++ b/vscode-extension/src/pluginDetection.ts
@@ -1,0 +1,42 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Pure filesystem helpers for detecting where the Compose Preview Gradle
+ * plugin is applied. Lives in its own module (no `vscode` import) so plain
+ * mocha tests can exercise it without a VS Code extension host.
+ */
+
+// Matches the plugin being *applied* (`id("ee.schimke.composeai.preview")` or
+// `id "ee.schimke.composeai.preview"`), not the plugin's own declaration in
+// gradle-plugin/build.gradle.kts (`id = "ee.schimke.composeai.preview"`).
+export const APPLIES_PLUGIN_RE = /\bid\s*[(\s]\s*["']ee\.schimke\.composeai\.preview["']/;
+
+/**
+ * Walks up from `filePath`'s directory looking for an ancestor containing a
+ * `build.gradle.kts` that *applies* the plugin. Returns that directory, or
+ * null if no such ancestor exists before hitting the filesystem root.
+ *
+ * This is intentionally workspace-agnostic — unlike `GradleService.resolveModule`,
+ * it doesn't care whether the match is a direct child of the VS Code workspace
+ * root. That matters for git worktrees nested under the workspace (e.g.
+ * `.claude/worktrees/<name>/sample-android/...`): the file is in a preview
+ * module, just not one that *this* Gradle project can invoke. Used by the
+ * setup-prompt logic to avoid nagging users whose file is clearly already
+ * plugin-enabled somewhere in its own project tree.
+ */
+export function findPluginAppliedAncestor(filePath: string): string | null {
+    let dir = path.dirname(filePath);
+    while (true) {
+        const candidate = path.join(dir, 'build.gradle.kts');
+        try {
+            const content = fs.readFileSync(candidate, 'utf-8');
+            if (APPLIES_PLUGIN_RE.test(content)) {
+                return dir;
+            }
+        } catch { /* no build file here, keep walking */ }
+        const parent = path.dirname(dir);
+        if (parent === dir) { return null; }
+        dir = parent;
+    }
+}

--- a/vscode-extension/src/test/pluginDetection.test.ts
+++ b/vscode-extension/src/test/pluginDetection.test.ts
@@ -1,0 +1,60 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { findPluginAppliedAncestor } from '../pluginDetection';
+
+function withTempDir(fn: (dir: string) => void | Promise<void>): () => Promise<void> {
+    return async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'compose-preview-test-'));
+        try {
+            await fn(dir);
+        } finally {
+            fs.rmSync(dir, { recursive: true });
+        }
+    };
+}
+
+describe('findPluginAppliedAncestor', () => {
+    it('finds a direct ancestor that applies the plugin', withTempDir((dir) => {
+        fs.mkdirSync(path.join(dir, 'app', 'src'), { recursive: true });
+        fs.writeFileSync(path.join(dir, 'app', 'build.gradle.kts'),
+            'id("ee.schimke.composeai.preview")');
+        assert.strictEqual(
+            findPluginAppliedAncestor(path.join(dir, 'app', 'src', 'Foo.kt')),
+            path.join(dir, 'app'),
+        );
+    }));
+
+    it('finds a deeply-nested (worktree-like) ancestor', withTempDir((dir) => {
+        const wt = path.join(dir, '.claude', 'worktrees', 'wt1', 'sample-android');
+        fs.mkdirSync(path.join(wt, 'src', 'main', 'kotlin'), { recursive: true });
+        fs.writeFileSync(path.join(wt, 'build.gradle.kts'),
+            'plugins { id("ee.schimke.composeai.preview") }');
+        assert.strictEqual(
+            findPluginAppliedAncestor(path.join(wt, 'src', 'main', 'kotlin', 'Foo.kt')),
+            wt,
+        );
+    }));
+
+    it('returns null when no ancestor applies the plugin', withTempDir((dir) => {
+        fs.mkdirSync(path.join(dir, 'lib', 'src'), { recursive: true });
+        fs.writeFileSync(path.join(dir, 'lib', 'build.gradle.kts'),
+            'id("org.jetbrains.kotlin.jvm")');
+        assert.strictEqual(
+            findPluginAppliedAncestor(path.join(dir, 'lib', 'src', 'Foo.kt')),
+            null,
+        );
+    }));
+
+    it('skips build scripts that only declare the plugin', withTempDir((dir) => {
+        fs.mkdirSync(path.join(dir, 'gradle-plugin', 'src'), { recursive: true });
+        fs.writeFileSync(path.join(dir, 'gradle-plugin', 'build.gradle.kts'), `
+            gradlePlugin { plugins { create("p") { id = "ee.schimke.composeai.preview" } } }
+        `);
+        assert.strictEqual(
+            findPluginAppliedAncestor(path.join(dir, 'gradle-plugin', 'src', 'Foo.kt')),
+            null,
+        );
+    }));
+});


### PR DESCRIPTION
## Summary
- Setup nudge ("this module doesn't apply the Gradle plugin, but the file uses @Preview") misfired on any file under a git worktree nested in the main-checkout VS Code workspace (e.g. `.claude/worktrees/<wt>/sample-android/...`). `topLevelDirOf` resolved `.claude`, which isn't in `findPreviewModules()`, so the nudge nagged the user about a module they've already configured — just not in *this* Gradle project.
- Before nudging, walk up from the file to find a `build.gradle.kts` that applies `ee.schimke.composeai.preview`. If one exists the file is already plugin-enabled somewhere in its own project tree; suppress the toast and replace the webview empty-state with a worktree-aware message instead.
- `APPLIES_PLUGIN_RE` and the new `findPluginAppliedAncestor` helper moved into a `vscode`-free `pluginDetection.ts` module so they're unit-testable without the extension host.

## Test plan
- [x] `tsc -p ./` clean
- [x] `npx mocha out/test/pluginDetection.test.js out/test/previewFilter.test.js` — 20 passing (4 new cases, including a `.claude/worktrees/.../sample-android/src/Foo.kt` scenario)
- [ ] Manual: open VS Code on the main checkout, edit a Kotlin `@Preview` file inside a `.claude/worktrees/<wt>/sample-android/` tree — confirm the toast no longer appears and the panel empty-state reads "outside this VS Code workspace root…"