### PR TITLE
feat(capture): unify animation / scroll variants as Preview.captures

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -25,13 +25,19 @@ data class PreviewParams(
 )
 
 @Serializable
+data class Capture(
+    val advanceTimeMillis: Long? = null,
+    val renderOutput: String = "",
+)
+
+@Serializable
 data class PreviewInfo(
     val id: String,
     val functionName: String,
     val className: String,
     val sourceFile: String? = null,
     val params: PreviewParams = PreviewParams(),
-    val renderOutput: String? = null,
+    val captures: List<Capture> = listOf(Capture()),
 )
 
 @Serializable
@@ -218,7 +224,11 @@ abstract class Command(protected val args: List<String>) {
             val updated = mutableMapOf<String, String>()
 
             for (p in manifest.previews) {
-                val pngFile = p.renderOutput
+                // Hash the first capture's PNG as the preview's
+                // representative. Per-capture change tracking is a future
+                // follow-up; today CLI surfaces one row per preview.
+                val pngFile = p.captures.firstOrNull()?.renderOutput
+                    ?.takeIf { it.isNotEmpty() }
                     ?.let { projectDir.resolve("$module/build/compose-previews/$it").canonicalFile }
                     ?.takeIf { it.exists() }
                 val sha = pngFile?.let { sha256(it.readBytes()) }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -449,15 +449,16 @@ class DiscoveryFunctionalTest {
         // DeviceDimensions used the Pixel 6 Pro height here.)
         assertThat(phone.params.heightDp).isEqualTo(914)
         assertThat(phone.id).endsWith("_pixel_6")
-        assertThat(phone.renderOutput).endsWith("_pixel_6.png")
+        assertThat(phone.captures.single().renderOutput).endsWith("_pixel_6.png")
 
         val tablet = manifest.previews.single { it.params.device == "id:pixel_tablet" }
         assertThat(tablet.params.widthDp).isEqualTo(1280)
         assertThat(tablet.params.heightDp).isEqualTo(800)
         assertThat(tablet.id).endsWith("_pixel_tablet")
 
-        // The two variants must not collide on renderOutput.
-        assertThat(manifest.previews.map { it.renderOutput }.toSet()).hasSize(2)
+        // The two variants must not collide on their captures' renderOutput.
+        val renderOutputs = manifest.previews.flatMap { it.captures.map { c -> c.renderOutput } }
+        assertThat(renderOutputs.toSet()).hasSize(renderOutputs.size)
     }
 
     @Test
@@ -553,29 +554,32 @@ class DiscoveryFunctionalTest {
         assertThat(endPreviews).hasSize(2)
         // @ScrollingPreview propagates identically to every @LightAndDark expansion,
         // using its declared-in-source defaults (reduceMotion=true, axis=VERTICAL).
+        // Scroll state lives on each capture now (Capture.scroll) — single-capture
+        // previews carry it on the first element.
         for (p in endPreviews) {
-            assertThat(p.params.scroll).isEqualTo(
-                ScrollSpec(
+            assertThat(p.captures).hasSize(1)
+            assertThat(p.captures.first().scroll).isEqualTo(
+                ScrollCapture(
                     mode = ScrollMode.END,
+                    axis = ScrollAxis.VERTICAL,
                     maxScrollPx = 0,
                     reduceMotion = true,
-                    axis = ScrollAxis.VERTICAL,
                 )
             )
         }
 
         val longPreview = manifest.previews.single { it.functionName == "LongScrollPreview" }
-        assertThat(longPreview.params.scroll).isEqualTo(
-            ScrollSpec(
+        assertThat(longPreview.captures.single().scroll).isEqualTo(
+            ScrollCapture(
                 mode = ScrollMode.LONG,
+                axis = ScrollAxis.HORIZONTAL,
                 maxScrollPx = 4000,
                 reduceMotion = false,
-                axis = ScrollAxis.HORIZONTAL,
             )
         )
 
         val plain = manifest.previews.single { it.functionName == "PlainPreview" }
-        assertThat(plain.params.scroll).isNull()
+        assertThat(plain.captures.single().scroll).isNull()
     }
 
     @Test

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -198,9 +198,19 @@ internal object ComposePreviewTasks {
                 val manifest = previewManifestJson
                     .decodeFromString(PreviewManifest.serializer(), manifestOnDisk.readText())
                 if (manifest.previews.isEmpty()) return@doLast
-                val rd = rendersDir.get().asFile
+                // Each preview can produce multiple captures (`@RoboComposePreviewOptions`
+                // time fan-out, future scroll / dimension fan-outs). Verify each
+                // capture's renderOutput lands on disk — report back one missing
+                // entry per preview with at least one missing capture.
+                val outDir = previewOutputDir.get().asFile
                 val missing = manifest.previews
-                    .mapNotNull { p -> p.id.takeIf { !rd.resolve("$it.png").exists() } }
+                    .filter { p ->
+                        p.captures.any { c ->
+                            val rel = c.renderOutput.ifEmpty { "renders/${p.id}.png" }
+                            !outDir.resolve(rel).exists()
+                        }
+                    }
+                    .map { it.id }
                 if (missing.isNotEmpty()) {
                     val preview = missing.take(3).joinToString(", ")
                     val andMore = if (missing.size > 3) " (+${missing.size - 3} more)" else ""

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -135,7 +135,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
 
         logger.lifecycle("Discovered ${deduped.size} preview(s) in module '${moduleName.get()}':")
         for (preview in deduped) {
-            logger.lifecycle("  ${preview.className}.${preview.functionName}${describeVariant(preview.params)}")
+            logger.lifecycle("  ${preview.className}.${preview.functionName}${describeVariant(preview)}")
         }
     }
 
@@ -143,7 +143,8 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     // so sibling expansions (e.g. @WearPreviewFontScales × 6) aren't visually
     // identical. Format mirrors the VSCode tooltip: `name` / `device` /
     // `WxHdp` / `font Nx` / `uiMode=N` / `locale` / `group`.
-    private fun describeVariant(p: PreviewParams): String {
+    private fun describeVariant(preview: PreviewInfo): String {
+        val p = preview.params
         val parts = mutableListOf<String>()
         p.name?.let(parts::add)
         p.device?.let(parts::add)
@@ -154,7 +155,15 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         if (p.uiMode != 0) parts.add("uiMode=${p.uiMode}")
         p.locale?.let(parts::add)
         p.group?.let { parts.add("group=$it") }
-        p.advanceTimeMillis?.let { parts.add("t=${it}ms") }
+        // Summarise capture-level dimensions (time, scroll) on one line so
+        // the log remains a single bullet per preview even for fan-outs.
+        val timings = preview.captures.mapNotNull { it.advanceTimeMillis }
+        if (timings.isNotEmpty()) {
+            parts.add("${preview.captures.size} captures @ ${timings.joinToString(",") { "${it}ms" }}")
+        }
+        preview.captures.firstNotNullOfOrNull { it.scroll }?.let { s ->
+            parts.add("scroll=${s.mode.name.lowercase()}")
+        }
         return if (parts.isEmpty()) "" else "  [" + parts.joinToString(" · ") + "]"
     }
 
@@ -178,7 +187,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         val directPreviews = collectDirectPreviews(annotations)
         if (directPreviews.isNotEmpty()) {
             for (ann in directPreviews) {
-                addPreviewsForTimings(classInfo, method, ann, wrapperFqn, scrollSpec, timings, previews)
+                previews.add(makePreview(classInfo, method, ann, wrapperFqn, scrollSpec, timings))
             }
             return
         }
@@ -186,31 +195,47 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         for (ann in annotations) {
             val resolved = resolveMultiPreview(ann, scanResult, mutableSetOf())
             for (resolvedAnn in resolved) {
-                addPreviewsForTimings(classInfo, method, resolvedAnn, wrapperFqn, scrollSpec, timings, previews)
+                previews.add(makePreview(classInfo, method, resolvedAnn, wrapperFqn, scrollSpec, timings))
             }
         }
     }
 
-    private fun addPreviewsForTimings(
-        classInfo: ClassInfo,
-        method: MethodInfo,
+    // Tile previews don't go through `mainClock` and can't scroll (the
+    // renderer inflates a View via `TileRenderer` and has no Compose
+    // animation clock / scrollable), so both dimensional annotations are
+    // no-ops for tiles.
+    private fun buildCaptures(
         ann: AnnotationInfo,
-        wrapperFqn: String?,
-        scrollSpec: ScrollSpec?,
+        previewId: String,
+        scroll: ScrollCapture?,
         timings: List<Long>,
-        previews: MutableList<PreviewInfo>,
-    ) {
-        // Tile previews don't go through `mainClock` — the renderer inflates a
-        // View via `TileRenderer` and has no Compose animation clock to advance.
-        // Applying a clock-time fan-out would produce N identical PNGs. Treat
-        // the annotation as a no-op on tiles.
-        val applicable = timings.takeIf { ann.name != TILE_PREVIEW_FQN }.orEmpty()
-        if (applicable.isEmpty()) {
-            previews.add(makePreview(classInfo, method, ann, wrapperFqn, scrollSpec, advanceTimeMillis = null))
-        } else {
-            for (ms in applicable) {
-                previews.add(makePreview(classInfo, method, ann, wrapperFqn, scrollSpec, advanceTimeMillis = ms))
-            }
+    ): List<Capture> {
+        val isTile = ann.name == TILE_PREVIEW_FQN
+        val effectiveTimings = if (isTile) emptyList() else timings
+        val effectiveScroll = scroll.takeUnless { isTile }
+
+        if (effectiveTimings.isEmpty()) {
+            // Single capture — either a static preview (all dims null) or a
+            // scrolled-only preview (scroll set, time null).
+            return listOf(
+                Capture(
+                    advanceTimeMillis = null,
+                    scroll = effectiveScroll,
+                    renderOutput = "renders/${previewId}.png",
+                ),
+            )
+        }
+        // Time-dimensional fan-out. Filename suffix matches Roborazzi's
+        // compose-preview-scanner-support convention (`_TIME_<ms>ms`) so
+        // PNGs coexist on disk under a single preview id. Scroll applies
+        // to every time-frame when both annotations are present (today we
+        // only fan out along time, not scroll).
+        return effectiveTimings.map { ms ->
+            Capture(
+                advanceTimeMillis = ms,
+                scroll = effectiveScroll,
+                renderOutput = "renders/${previewId}_TIME_${ms}ms.png",
+            )
         }
     }
 
@@ -247,7 +272,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         }
     }
 
-    private fun extractScrollSpec(annotations: List<AnnotationInfo>): ScrollSpec? {
+    private fun extractScrollSpec(annotations: List<AnnotationInfo>): ScrollCapture? {
         val ann = annotations.firstOrNull { it.name == SCROLLING_PREVIEW_FQN } ?: return null
         val pv = ann.parameterValues
         // Enum constants come through as AnnotationEnumValue; compare by .valueName so
@@ -260,11 +285,14 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             ?: ScrollAxis.VERTICAL
         val maxScrollPx = (pv.getValue("maxScrollPx") as? Int)?.coerceAtLeast(0) ?: 0
         val reduceMotion = (pv.getValue("reduceMotion") as? Boolean) ?: true
-        return ScrollSpec(
+        // Result fields (atEnd, reachedPx) default to "not reported" — the
+        // renderer would fill them in post-capture; discovery knows only the
+        // intent.
+        return ScrollCapture(
             mode = mode,
+            axis = axis,
             maxScrollPx = maxScrollPx,
             reduceMotion = reduceMotion,
-            axis = axis,
         )
     }
 
@@ -323,31 +351,20 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         method: MethodInfo,
         ann: AnnotationInfo,
         wrapperClassName: String?,
-        scrollSpec: ScrollSpec?,
-        advanceTimeMillis: Long?,
+        scroll: ScrollCapture?,
+        timings: List<Long>,
     ): PreviewInfo {
-        // Tile previews can't scroll — same reasoning as the timings fan-out above.
-        // Null out the scroll spec at the manifest level so renderers don't branch on it.
-        val applicableScroll = scrollSpec.takeIf { ann.name != TILE_PREVIEW_FQN }
         val params = extractPreviewParams(ann, wrapperClassName)
-            .copy(
-                advanceTimeMillis = advanceTimeMillis,
-                scroll = applicableScroll,
-            )
         val fqn = "${classInfo.name}.${method.name}"
-        val baseSuffix = buildVariantSuffix(params)
-        // Match Roborazzi's own compose-preview-scanner-support filename
-        // convention (`_TIME_<ms>ms`) so tooling that sits on top of either
-        // pipeline groups variants the same way.
-        val timeSuffix = advanceTimeMillis?.let { "_TIME_${it}ms" }.orEmpty()
-        val id = fqn + baseSuffix + timeSuffix
+        val suffix = buildVariantSuffix(params)
+        val id = fqn + suffix
         return PreviewInfo(
             id = id,
             functionName = method.name,
             className = classInfo.name,
             sourceFile = packageQualifiedSourcePath(classInfo),
             params = params,
-            renderOutput = "renders/${id}.png",
+            captures = buildCaptures(ann, id, scroll, timings),
         )
     }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -33,15 +33,33 @@ enum class ScrollAxis {
 }
 
 /**
- * Captured settings from `@ScrollingPreview`. `null` on [PreviewParams.scroll]
- * means the preview opted out of scrolling capture (the default).
+ * Scroll state of a capture. Combines the intent sourced from
+ * `@ScrollingPreview` ([mode], [axis], [maxScrollPx], [reduceMotion]) with the
+ * outcome recorded by the renderer ([atEnd], [reachedPx]). `null` on
+ * [Capture.scroll] means the capture didn't drive any scrollable.
+ *
+ * Result fields default to "not populated" so the plugin-side initial build
+ * can emit this type before the renderer has run; the renderer overwrites
+ * them post-capture (today it doesn't, pending a manifest-rewrite step —
+ * they're here so the JSON shape is stable in advance).
  */
 @Serializable
-data class ScrollSpec(
+data class ScrollCapture(
+    // Intent
     val mode: ScrollMode,
+    val axis: ScrollAxis = ScrollAxis.VERTICAL,
     val maxScrollPx: Int = 0,
     val reduceMotion: Boolean = true,
-    val axis: ScrollAxis = ScrollAxis.VERTICAL,
+    // Outcome
+    /**
+     * `true` when the scrollable reported it was already at the end of its
+     * content before the renderer stopped. Distinct from `reachedPx ==
+     * maxScrollPx`, which signals the user-set cap was hit without
+     * necessarily exhausting the content.
+     */
+    val atEnd: Boolean = false,
+    /** Pixels actually scrolled. `null` when not yet reported. */
+    val reachedPx: Int? = null,
 )
 
 @Serializable
@@ -71,17 +89,28 @@ data class PreviewParams(
     /** FQN of the `PreviewWrapperProvider` from `@PreviewWrapper`, if any. */
     val wrapperClassName: String? = null,
     val kind: PreviewKind = PreviewKind.COMPOSE,
-    /**
-     * Virtual-time offset to advance `mainClock` by before capture, sourced from
-     * Roborazzi's `@RoboComposePreviewOptions(manualClockOptions = [...])`. `null`
-     * means "use the renderer's default" (a small fixed step). A preview with
-     * `manualClockOptions = [ManualClockOptions(500L), ManualClockOptions(1000L)]`
-     * expands at discovery time into two entries, each carrying one of these
-     * values — one render per variant.
-     */
+)
+
+/**
+ * One rendered snapshot of a preview at a specific point in some dimensional
+ * space. The non-null fields on a [Capture] *are* its dimensions: a static
+ * preview has a single capture with everything null; a
+ * `@RoboComposePreviewOptions`-annotated preview produces N captures differing
+ * only in [advanceTimeMillis]; a `@ScrollingPreview` produces a capture with
+ * [scroll] set; a preview annotated with both produces the cross-product.
+ *
+ * The JSON carries each dimension as a typed field rather than a generic
+ * `dimensions: map` so agent consumers of `previews.json` can read specific
+ * knobs without traversing an untyped structure.
+ */
+@Serializable
+data class Capture(
+    /** `null` → no explicit `mainClock.advanceTimeBy` before capture (renderer applies its default step). */
     val advanceTimeMillis: Long? = null,
-    /** Scrolling-capture settings from `@ScrollingPreview`, if any. */
-    val scroll: ScrollSpec? = null,
+    /** `null` → no scroll drive. */
+    val scroll: ScrollCapture? = null,
+    /** Module-relative PNG path, e.g. `renders/<preview id>_TIME_500ms.png`. */
+    val renderOutput: String = "",
 )
 
 @Serializable
@@ -91,7 +120,12 @@ data class PreviewInfo(
     val className: String,
     val sourceFile: String? = null,
     val params: PreviewParams = PreviewParams(),
-    val renderOutput: String? = null,
+    /**
+     * All snapshots this preview produces. Always at least one element:
+     * a static preview has a single capture with null dimensions; an
+     * animated / scrolled preview can have many.
+     */
+    val captures: List<Capture> = listOf(Capture()),
 )
 
 @Serializable

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewDataTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewDataTest.kt
@@ -25,7 +25,11 @@ class PreviewDataTest {
                         showBackground = true,
                         backgroundColor = 0xFFFF0000,
                     ),
-                    renderOutput = "renders/com.example.PreviewsKt.RedBoxPreview_Red Box.png",
+                    captures = listOf(
+                        Capture(
+                            renderOutput = "renders/com.example.PreviewsKt.RedBoxPreview_Red Box.png",
+                        ),
+                    ),
                 ),
             ),
         )

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -23,13 +23,15 @@ enum class ScrollAxis {
     HORIZONTAL,
 }
 
-/** Renderer-side mirror of the plugin's `ScrollSpec`. */
+/** Renderer-side mirror of the plugin's `ScrollCapture`. */
 @Serializable
-data class ScrollSpec(
+data class ScrollCapture(
     val mode: ScrollMode,
+    val axis: ScrollAxis = ScrollAxis.VERTICAL,
     val maxScrollPx: Int = 0,
     val reduceMotion: Boolean = true,
-    val axis: ScrollAxis = ScrollAxis.VERTICAL,
+    val atEnd: Boolean = false,
+    val reachedPx: Int? = null,
 )
 
 @Serializable
@@ -92,7 +94,20 @@ data class RenderPreviewEntry(
     val className: String,
     val sourceFile: String? = null,
     val params: RenderPreviewParams = RenderPreviewParams(),
-    val renderOutput: String? = null,
+    /**
+     * Rendered snapshots produced by this preview. See the plugin-side
+     * `Capture` docs — each entry carries the dimensional values
+     * (`advanceTimeMillis`, `scroll`) that distinguish it from its siblings
+     * and the PNG path it lands at. Always at least one element.
+     */
+    val captures: List<RenderPreviewCapture> = listOf(RenderPreviewCapture()),
+)
+
+@Serializable
+data class RenderPreviewCapture(
+    val advanceTimeMillis: Long? = null,
+    val scroll: ScrollCapture? = null,
+    val renderOutput: String = "",
 )
 
 @Serializable
@@ -118,13 +133,4 @@ data class RenderPreviewParams(
     /** FQN of the `PreviewWrapperProvider` from `@PreviewWrapper`, if any. */
     val wrapperClassName: String? = null,
     val kind: PreviewKind = PreviewKind.COMPOSE,
-    /**
-     * Virtual-time offset to advance `mainClock` by before capture, sourced from
-     * Roborazzi's `@RoboComposePreviewOptions(manualClockOptions = [...])`. `null`
-     * means use the renderer's default. One entry per `ManualClockOptions` value
-     * is emitted at discovery time.
-     */
-    val advanceTimeMillis: Long? = null,
-    /** Scrolling-capture settings from `@ScrollingPreview`, if any. */
-    val scroll: ScrollSpec? = null,
 )

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -84,8 +84,7 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
     @Test
     fun renderPreview() {
         val outputDir = File(System.getProperty("composeai.render.outputDir") ?: "build/compose-previews/renders")
-        val outputFile = File(outputDir, "${preview.id}.png")
-        outputFile.parentFile?.mkdirs()
+        outputDir.mkdirs()
 
         val params = preview.params
         val widthDp = params.widthDp?.takeIf { it > 0 } ?: DEFAULT_WIDTH
@@ -112,7 +111,17 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
             recordOptions = RoborazziOptions.RecordOptions(applyDeviceCrop = isRound),
         )
 
-        renderDefault(params, widthDp, heightDp, outputFile, roborazziOptions, composeOptions)
+        renderDefault(params, widthDp, heightDp, outputDir, roborazziOptions, composeOptions)
+    }
+
+    /**
+     * Resolve one capture's output file by stripping the module-relative
+     * `renders/` prefix the manifest carries and re-rooting under the
+     * configured output dir.
+     */
+    private fun outputFileFor(capture: RenderPreviewCapture, outputDir: File): File {
+        val leafName = capture.renderOutput.substringAfterLast('/').ifEmpty { "${preview.id}.png" }
+        return File(outputDir, leafName)
     }
 
     /**
@@ -150,7 +159,7 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
         params: RenderPreviewParams,
         widthDp: Int,
         heightDp: Int,
-        outputFile: File,
+        outputDir: File,
         roborazziOptions: RoborazziOptions,
         composeOptions: RoborazziComposeOptions,
     ) {
@@ -218,68 +227,87 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                         strategyFor(params.kind).Render(preview, widthDp, heightDp)
                     }
                 }
-                // Advance the clock by a fixed virtual-time offset, then
-                // capture. With `mainClock.autoAdvance = false` this is the
-                // only clock motion Compose sees, so infinite animations park
-                // at exactly this virtual time across runs — repeated captures
-                // are byte-identical.
-                //
-                // If the preview carries `@RoboComposePreviewOptions`, the
-                // per-entry `advanceTimeMillis` overrides the default;
-                // `DiscoverPreviewsTask` has already fanned each timing out
-                // into its own manifest entry, so this value is one specific
-                // timing per render.
-                val advanceMs = params.advanceTimeMillis ?: CAPTURE_ADVANCE_MS
-                rule.mainClock.advanceTimeBy(advanceMs)
+                // With `mainClock.autoAdvance = false` the clock stays at 0
+                // until we step it, so capturing each frame at its intended
+                // virtual time is a matter of advancing the delta.
+                // `DiscoverPreviewsTask` guarantees `captures` is ordered by
+                // ascending `advanceTimeMillis`, so we accumulate forward-only.
+                var currentTime = 0L
+                val onRoot = rule.onRoot()
+                preview.captures.forEachIndexed { idx, capture ->
+                    val target = capture.advanceTimeMillis ?: CAPTURE_ADVANCE_MS
+                    require(target >= currentTime) {
+                        "Preview ${preview.id}: capture advanceTimeMillis must be ascending " +
+                            "(got $target after clock was at $currentTime)"
+                    }
+                    val delta = target - currentTime
+                    if (delta > 0) {
+                        rule.mainClock.advanceTimeBy(delta)
+                        currentTime = target
+                    }
 
-                // @ScrollingPreview: drive the first scrollable on the annotated
-                // axis to the end of its content before the snapshot. Both ScrollMode
-                // values capture the end-state for now — true long-scroll stitching
-                // lands in a follow-up; the manifest field stays stable across the
-                // transition.
-                params.scroll?.let { spec ->
-                    val result = driveScrollToEnd(
-                        rule = rule,
-                        axis = spec.axis,
-                        maxScrollPx = spec.maxScrollPx,
+                    // @ScrollingPreview: drive the first scrollable on the
+                    // requested axis to the end of its content before the
+                    // snapshot. Both ScrollMode values capture the end-state
+                    // for now — true long-scroll stitching lands in a
+                    // follow-up; the manifest field stays stable across that
+                    // transition.
+                    capture.scroll?.let { scroll ->
+                        val result = driveScrollToEnd(
+                            rule = rule,
+                            axis = scroll.axis,
+                            maxScrollPx = scroll.maxScrollPx,
+                        )
+                        if (result is ScrollDriveResult.NoScrollable) {
+                            System.err.println(
+                                "@ScrollingPreview on '${preview.id}' but no scrollable " +
+                                    "composable found on axis ${scroll.axis} — capturing initial frame.",
+                            )
+                        }
+                    }
+
+                    val outputFile = outputFileFor(capture, outputDir)
+                    outputFile.parentFile?.mkdirs()
+                    onRoot.captureRoboImage(
+                        file = outputFile,
+                        roborazziOptions = roborazziOptions,
                     )
-                    if (result is ScrollDriveResult.NoScrollable) {
-                        System.err.println(
-                            "@ScrollingPreview on '${preview.id}' but no scrollable composable found on axis ${spec.axis} — capturing initial frame.",
+
+                    if (a11yEnabled && idx == a11yCaptureIndex()) {
+                        // `fetchSemanticsNode().root as ViewRootForTest` is the
+                        // exact view roborazzi-accessibility-check's
+                        // `checkRoboAccessibility` walks — it's the only view
+                        // under Robolectric where the compose a11y delegate
+                        // produces populated AccessibilityNodeInfo. DecorView
+                        // here returns all NOT_RUN.
+                        val view = (onRoot.fetchSemanticsNode().root as ViewRootForTest).view
+                        val findings = AccessibilityChecker.check(preview.id, view)
+                        val a11yDir = File(
+                            System.getProperty("composeai.a11y.outputDir")
+                                ?: "build/compose-previews/accessibility-per-preview",
+                        )
+                        AccessibilityChecker.writePerPreviewReport(
+                            outputDir = a11yDir,
+                            previewId = preview.id,
+                            findings = findings,
+                            screenshot = outputFile.takeIf { annotate },
                         )
                     }
-                }
-
-                val onRoot = rule.onRoot()
-                onRoot.captureRoboImage(
-                    file = outputFile,
-                    roborazziOptions = roborazziOptions,
-                )
-
-                if (a11yEnabled) {
-                    // `fetchSemanticsNode().root as ViewRootForTest` is the
-                    // exact view roborazzi-accessibility-check's
-                    // `checkRoboAccessibility` walks — it's the only view
-                    // under Robolectric where the compose a11y delegate
-                    // produces populated AccessibilityNodeInfo. DecorView
-                    // here returns all NOT_RUN.
-                    val view = (onRoot.fetchSemanticsNode().root as ViewRootForTest).view
-                    val findings = AccessibilityChecker.check(preview.id, view)
-                    val a11yDir = File(
-                        System.getProperty("composeai.a11y.outputDir")
-                            ?: "build/compose-previews/accessibility-per-preview",
-                    )
-                    AccessibilityChecker.writePerPreviewReport(
-                        outputDir = a11yDir,
-                        previewId = preview.id,
-                        findings = findings,
-                        screenshot = outputFile.takeIf { annotate },
-                    )
                 }
             }
         }
         rule.apply(statement, description).evaluate()
     }
+
+    /**
+     * ATF runs on a single frame per preview — for animated previews, prefer
+     * the SECOND frame (index 1) when available: frame 0 is often the t=0
+     * pre-settle state (fade-ins still transparent, AnimatedVisibility not on
+     * screen yet) which isn't a representative moment for accessibility.
+     * Static / single-capture previews fall through to index 0.
+     */
+    private fun a11yCaptureIndex(): Int =
+        if (preview.captures.size > 1) 1 else 0
 
     /**
      * Match how Roborazzi's `RoborazziComposeSizeOption` / `LocaleOption` /

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -407,6 +407,46 @@ body {
     font-variant-numeric: tabular-nums;
 }
 
+/* -- Animated card carousel ------------------------------------------ */
+
+/* Icon in the title row telegraphs "this preview has multiple captures"; the
+   carousel strip below the image is the interactive surface. */
+.animation-icon {
+    margin-left: 4px;
+    opacity: 0.75;
+    font-size: 12px;
+    vertical-align: middle;
+    color: var(--text-secondary);
+}
+
+.frame-controls {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    padding: 2px 6px;
+    border-top: 1px solid var(--card-border);
+    background: color-mix(in srgb, var(--vscode-editor-background) 92%, transparent);
+}
+
+.frame-controls:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: -1px;
+}
+
+.frame-indicator {
+    font-size: calc(var(--vscode-font-size) - 1px);
+    color: var(--text-secondary);
+    min-width: 120px;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+}
+
+.frame-controls button[disabled] {
+    opacity: 0.35;
+    cursor: default;
+}
+
 /* -- Card title row + history button --------------------------------- */
 
 .card-title-row {

--- a/vscode-extension/src/captureLabels.ts
+++ b/vscode-extension/src/captureLabels.ts
@@ -1,0 +1,51 @@
+import { Capture, PreviewInfo } from './types';
+
+/**
+ * Human-readable label for one capture of a preview, used in the carousel
+ * frame-indicator. Picks a short summary of whichever non-null dimensions
+ * the capture carries:
+ *
+ *   - static (no dimensions) ⇒ `''`
+ *   - `advanceTimeMillis = 500` ⇒ `'500ms'`
+ *   - `scroll.mode = 'END'` ⇒ `'scrolled end'`
+ *   - both ⇒ `'500ms · scrolled end'`
+ *
+ * Kept here (and imported from the webview's inlined script via the build
+ * output) so the carousel markup stays dumb — if more dimensions land
+ * (motion scale, keyboard focus state, etc.) the addition is confined to
+ * this helper.
+ */
+export function captureLabel(capture: Capture): string {
+    const parts: string[] = [];
+    if (capture.advanceTimeMillis != null) {
+        parts.push(`${capture.advanceTimeMillis}ms`);
+    }
+    if (capture.scroll) {
+        parts.push(scrollLabel(capture.scroll));
+    }
+    return parts.join(' \u00B7 ');
+}
+
+function scrollLabel(scroll: NonNullable<Capture['scroll']>): string {
+    // Prefer the outcome when the renderer has reported it; fall back to
+    // the declared intent. `atEnd` wins over `reachedPx` so "scrolled end"
+    // stays stable even when the renderer reports e.g. `reachedPx: 1200`
+    // with content actually exhausted at that offset.
+    if (scroll.atEnd) return 'scrolled end';
+    if (scroll.reachedPx != null) return `scrolled ${scroll.reachedPx}px`;
+    if (scroll.mode === 'END') return 'scroll end';
+    if (scroll.mode === 'LONG') return 'scroll long';
+    return `scroll ${scroll.mode.toLowerCase()}`;
+}
+
+/** A preview is shown with a carousel when it has >1 capture OR a single
+ *  capture with any non-null dimension (explicit point in dim-space). */
+export function isAnimatedPreview(p: PreviewInfo): boolean {
+    const captures = p.captures;
+    if (captures.length > 1) return true;
+    if (captures.length === 1) {
+        const c = captures[0];
+        return c.advanceTimeMillis != null || c.scroll != null;
+    }
+    return false;
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -12,6 +12,7 @@ import { PreviewA11yDiagnostics } from './previewA11yDiagnostics';
 import { PreviewDoctorDiagnostics } from './previewDoctorDiagnostics';
 import { packageQualifiedSourcePath } from './sourcePath';
 import { PreviewInfo } from './types';
+import { captureLabel } from './captureLabels';
 
 const DEBOUNCE_MS = 1500;
 // Edits to the currently-scoped preview file (e.g. Claude Code's Edit tool
@@ -435,6 +436,11 @@ async function refresh(forceRender: boolean, forFilePath?: string) {
             if (manifest) {
                 for (const p of manifest.previews) {
                     p.hasHistory = gradleService.listHistory(mod, p.id).length > 0;
+                    // Pre-compute carousel labels once so the webview doesn't
+                    // have to know how to render dimension summaries.
+                    for (const capture of p.captures) {
+                        capture.label = captureLabel(capture);
+                    }
                     allPreviews.push(p);
                     previewModuleMap.set(p.id, mod);
                     perModule.push(p);
@@ -461,32 +467,51 @@ async function refresh(forceRender: boolean, forFilePath?: string) {
         });
         hasPreviewsLoaded = true;
 
-        // Load images asynchronously
+        // Load images asynchronously. Animated previews have multiple captures
+        // in `preview.captures`; one updateImage message per capture. The
+        // registry (used for CodeLens / hover) keeps only the representative
+        // (first) capture's PNG.
         for (const preview of visiblePreviews) {
             if (abort.signal.aborted) { return; }
-            if (!preview.renderOutput) { continue; }
+            const captures = preview.captures;
+            if (captures.length === 0) { continue; }
 
             const mod = previewModuleMap.get(preview.id);
             if (!mod) { continue; }
-            const imageData = await gradleService.readPreviewImage(mod, preview.renderOutput);
-            if (abort.signal.aborted) { return; }
 
-            if (imageData) {
-                registry.setImage(preview.id, imageData);
-                panel.postMessage({ command: 'updateImage', previewId: preview.id, imageData });
-            } else if (forceRender) {
-                // Render task completed but produced no PNG for this preview —
-                // a per-preview failure that didn't fail the whole task (e.g.
-                // one parameterized Robolectric test threw). Surface it on the
-                // card; the root-cause log is in Output ▸ Compose Preview.
-                panel.postMessage({
-                    command: 'setImageError',
-                    previewId: preview.id,
-                    message: 'Render failed — see Output ▸ Compose Preview',
-                });
+            for (let captureIndex = 0; captureIndex < captures.length; captureIndex++) {
+                if (abort.signal.aborted) { return; }
+                const capture = captures[captureIndex];
+                if (!capture.renderOutput) { continue; }
+                const imageData = await gradleService.readPreviewImage(mod, capture.renderOutput);
+                if (abort.signal.aborted) { return; }
+
+                if (imageData) {
+                    if (captureIndex === 0) {
+                        registry.setImage(preview.id, imageData);
+                    }
+                    panel.postMessage({
+                        command: 'updateImage',
+                        previewId: preview.id,
+                        captureIndex,
+                        imageData,
+                    });
+                } else if (forceRender) {
+                    // Render task completed but produced no PNG for this
+                    // capture — a per-capture failure that didn't fail the
+                    // whole task. Surface it on the card; root-cause log is
+                    // in Output ▸ Compose Preview.
+                    panel.postMessage({
+                        command: 'setImageError',
+                        previewId: preview.id,
+                        captureIndex,
+                        message: 'Render failed — see Output ▸ Compose Preview',
+                    });
+                }
+                // else: discover-only pass, PNG not produced yet. Leave the
+                // skeleton in place; the next save-triggered render will
+                // populate it.
             }
-            // else: discover-only pass, PNG not produced yet. Leave the skeleton
-            // in place; the next save-triggered render will populate it.
         }
 
         panel.postMessage({ command: 'showMessage', text: '' });

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -238,15 +238,43 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             return id.replace(/[^a-zA-Z0-9_-]/g, '_');
         }
 
+        // Per-preview carousel runtime state — imageData / errorMessage per
+        // capture. Populated from updateImage / setImageError messages so
+        // prev/next navigation can swap the visible <img> without a fresh
+        // extension round-trip.
+        // Map<previewId, [{ label, imageData, errorMessage }]>
+        const cardCaptures = new Map();
+
+        // Preview is shown with a carousel when it has >1 capture or a single
+        // capture with a non-null dimension (e.g. an explicit 500ms snapshot).
+        function isAnimatedPreview(p) {
+            const caps = p.captures;
+            if (caps.length > 1) return true;
+            if (caps.length === 1) {
+                const c = caps[0];
+                return c.advanceTimeMillis != null || c.scroll != null;
+            }
+            return false;
+        }
+
         function createCard(p) {
+            const animated = isAnimatedPreview(p);
+            const captures = p.captures;
+
             const card = document.createElement('div');
-            card.className = 'preview-card';
+            card.className = 'preview-card' + (animated ? ' animated-card' : '');
             card.id = 'preview-' + sanitizeId(p.id);
             card.setAttribute('role', 'listitem');
             card.dataset.function = p.functionName;
             card.dataset.group = p.params.group || '';
             card.dataset.previewId = p.id;
             card.dataset.className = p.className;
+            card.dataset.currentIndex = '0';
+            cardCaptures.set(p.id, captures.map(c => ({
+                label: c.label || '',
+                imageData: null,
+                errorMessage: null,
+            })));
 
             const header = document.createElement('div');
             header.className = 'card-header';
@@ -266,6 +294,17 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 });
             });
             titleRow.appendChild(title);
+
+            if (animated) {
+                // Inline marker so the title row telegraphs "this one has
+                // multiple captures"; the carousel strip under the image is
+                // the interactive surface.
+                const icon = document.createElement('i');
+                icon.className = 'codicon codicon-play-circle animation-icon';
+                icon.title = captures.length + ' captures';
+                icon.setAttribute('aria-label', 'Animated preview (' + captures.length + ' captures)');
+                titleRow.appendChild(icon);
+            }
 
             // History button only appears when the Gradle plugin has been
             // configured with historyEnabled = true and at least one
@@ -314,6 +353,10 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 card.appendChild(badge);
             }
 
+            if (animated) {
+                card.appendChild(buildFrameControls(card));
+            }
+
             // Lazy-built history drawer — only populated when the user clicks
             // the history button and the extension returns entries.
             const drawer = document.createElement('div');
@@ -321,6 +364,108 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             drawer.hidden = true;
             card.appendChild(drawer);
             return card;
+        }
+
+        function buildFrameControls(card) {
+            const bar = document.createElement('div');
+            bar.className = 'frame-controls';
+
+            const prev = document.createElement('button');
+            prev.className = 'icon-button frame-prev';
+            prev.setAttribute('aria-label', 'Previous capture');
+            prev.title = 'Previous capture';
+            prev.innerHTML = '<i class="codicon codicon-chevron-left" aria-hidden="true"></i>';
+            prev.addEventListener('click', () => stepFrame(card, -1));
+
+            const indicator = document.createElement('span');
+            indicator.className = 'frame-indicator';
+            indicator.setAttribute('aria-live', 'polite');
+
+            const next = document.createElement('button');
+            next.className = 'icon-button frame-next';
+            next.setAttribute('aria-label', 'Next capture');
+            next.title = 'Next capture';
+            next.innerHTML = '<i class="codicon codicon-chevron-right" aria-hidden="true"></i>';
+            next.addEventListener('click', () => stepFrame(card, 1));
+
+            bar.appendChild(prev);
+            bar.appendChild(indicator);
+            bar.appendChild(next);
+
+            // Arrow keys when the carousel has focus.
+            bar.tabIndex = 0;
+            bar.addEventListener('keydown', (e) => {
+                if (e.key === 'ArrowLeft') { stepFrame(card, -1); e.preventDefault(); }
+                else if (e.key === 'ArrowRight') { stepFrame(card, 1); e.preventDefault(); }
+            });
+
+            // Seed indicator text so it's not blank before any image arrives.
+            requestAnimationFrame(() => updateFrameIndicator(card));
+            return bar;
+        }
+
+        function stepFrame(card, delta) {
+            const caps = cardCaptures.get(card.dataset.previewId);
+            if (!caps) return;
+            const cur = parseInt(card.dataset.currentIndex || '0', 10);
+            const next = Math.max(0, Math.min(caps.length - 1, cur + delta));
+            if (next === cur) return;
+            card.dataset.currentIndex = String(next);
+            showFrame(card, next);
+        }
+
+        function showFrame(card, index) {
+            const caps = cardCaptures.get(card.dataset.previewId);
+            if (!caps) return;
+            const capture = caps[index];
+            if (!capture) return;
+            const container = card.querySelector('.image-container');
+            if (!container) return;
+
+            if (capture.imageData) {
+                const skeleton = container.querySelector('.skeleton');
+                const errorMsg = container.querySelector('.error-message');
+                if (skeleton) skeleton.remove();
+                if (errorMsg) errorMsg.remove();
+                card.classList.remove('has-error');
+                let img = container.querySelector('img');
+                if (!img) {
+                    img = document.createElement('img');
+                    img.alt = card.dataset.function + ' preview';
+                    container.appendChild(img);
+                }
+                img.src = 'data:image/png;base64,' + capture.imageData;
+                img.className = 'fade-in';
+            } else if (capture.errorMessage) {
+                container.innerHTML = '<div class="error-message" role="alert">' + escapeHtml(capture.errorMessage) + '</div>';
+                card.classList.add('has-error');
+            } else {
+                // No data for this capture yet — render will fill it in later.
+                const existing = container.querySelector('img');
+                if (existing) existing.remove();
+                if (!container.querySelector('.skeleton')) {
+                    const s = document.createElement('div');
+                    s.className = 'skeleton';
+                    s.setAttribute('aria-label', 'Loading capture');
+                    container.appendChild(s);
+                }
+            }
+            updateFrameIndicator(card);
+        }
+
+        function updateFrameIndicator(card) {
+            const indicator = card.querySelector('.frame-indicator');
+            const prevBtn = card.querySelector('.frame-prev');
+            const nextBtn = card.querySelector('.frame-next');
+            if (!indicator) return;
+            const caps = cardCaptures.get(card.dataset.previewId);
+            if (!caps) return;
+            const idx = parseInt(card.dataset.currentIndex || '0', 10);
+            const capture = caps[idx];
+            const label = capture && capture.label ? capture.label : '\u2014';
+            indicator.textContent = (idx + 1) + ' / ' + caps.length + ' \u00B7 ' + label;
+            if (prevBtn) prevBtn.disabled = idx === 0;
+            if (nextBtn) nextBtn.disabled = idx === caps.length - 1;
         }
 
         /**
@@ -446,6 +591,28 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 title.textContent = p.functionName + (p.params.name ? ' — ' + p.params.name : '');
                 title.title = buildTooltip(p);
             }
+            // Refresh capture labels in place. If the capture count changed
+            // (e.g. user edited @RoboComposePreviewOptions) we preserve
+            // already-received imageData for renderOutputs that carry over.
+            const newCaps = p.captures.map(c => ({
+                renderOutput: c.renderOutput,
+                label: c.label || '',
+            }));
+            const prior = cardCaptures.get(p.id) || [];
+            // Match by index rather than renderOutput since filenames may
+            // legitimately change (e.g. a preview gains a @RoboComposePreviewOptions
+            // annotation). Mismatched positions just reset to null-image.
+            const mergedCaps = newCaps.map((nc, i) => ({
+                label: nc.label,
+                imageData: prior[i]?.imageData ?? null,
+                errorMessage: prior[i]?.errorMessage ?? null,
+            }));
+            cardCaptures.set(p.id, mergedCaps);
+            const curIdx = parseInt(card.dataset.currentIndex || '0', 10);
+            if (curIdx >= mergedCaps.length) {
+                card.dataset.currentIndex = String(Math.max(0, mergedCaps.length - 1));
+            }
+            if (isAnimatedPreview(p)) updateFrameIndicator(card);
             const variantLabel = buildVariantLabel(p);
             let badge = card.querySelector('.variant-badge');
             if (variantLabel) {
@@ -622,9 +789,13 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 existingCards.set(card.dataset.previewId, card);
             });
 
-            // Remove cards that no longer exist
+            // Remove cards that no longer exist — drop their cached capture
+            // data so stale entries don't pile up if a preview is renamed.
             for (const [id, card] of existingCards) {
-                if (!newIds.has(id)) card.remove();
+                if (!newIds.has(id)) {
+                    cardCaptures.delete(id);
+                    card.remove();
+                }
             }
 
             // Refresh per-preview findings cache so updateImage can attach
@@ -733,9 +904,27 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             card.querySelectorAll(sel).forEach(el => el.classList.add('a11y-active'));
         }
 
-        function updateImage(previewId, imageData) {
+        function updateImage(previewId, captureIndex, imageData) {
             const card = document.getElementById('preview-' + sanitizeId(previewId));
             if (!card) return;
+
+            // Cache so carousel navigation can restore this capture without
+            // a fresh extension round-trip.
+            const caps = cardCaptures.get(previewId);
+            if (caps && caps[captureIndex]) {
+                caps[captureIndex].imageData = imageData;
+                caps[captureIndex].errorMessage = null;
+            }
+
+            // Only paint the <img> if the currently-displayed capture is the
+            // one that just arrived. Otherwise the cached bytes wait for
+            // prev/next.
+            const cur = parseInt(card.dataset.currentIndex || '0', 10);
+            if (cur !== captureIndex) {
+                if (caps) updateFrameIndicator(card);
+                return;
+            }
+
             const container = card.querySelector('.image-container');
             // Tear down every prior state before showing the new image.
             // Leftover .error-message divs here are what caused the
@@ -766,6 +955,8 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             }
             img.src = newSrc;
             img.className = 'fade-in';
+
+            if (caps) updateFrameIndicator(card);
 
             // Re-build the a11y overlay once the image natural dimensions
             // are known. Data-URL srcs may resolve synchronously; in that
@@ -821,7 +1012,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     break;
 
                 case 'updateImage':
-                    updateImage(msg.previewId, msg.imageData);
+                    updateImage(msg.previewId, msg.captureIndex || 0, msg.imageData);
                     break;
 
                 case 'setModules':
@@ -868,6 +1059,20 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 case 'setImageError': {
                     const errCard = document.getElementById('preview-' + sanitizeId(msg.previewId));
                     if (errCard) {
+                        // Stash per-capture error so carousel navigation
+                        // restores the message when the user returns to
+                        // that specific capture. setError is preview-wide
+                        // (captureIndex defaulted to 0) — applies to the
+                        // representative image container only.
+                        const captureIndex = msg.command === 'setImageError' ? (msg.captureIndex || 0) : 0;
+                        const caps = cardCaptures.get(msg.previewId);
+                        if (caps && caps[captureIndex]) {
+                            caps[captureIndex].errorMessage = msg.message;
+                            caps[captureIndex].imageData = null;
+                        }
+                        const cur = parseInt(errCard.dataset.currentIndex || '0', 10);
+                        if (caps && cur !== captureIndex) break;
+
                         errCard.classList.add('has-error');
                         const container = errCard.querySelector('.image-container');
                         // Keep existing image visible under the error for setImageError

--- a/vscode-extension/src/test/fixtures/previews.json
+++ b/vscode-extension/src/test/fixtures/previews.json
@@ -20,7 +20,13 @@
                 "locale": null,
                 "group": "colors"
             },
-            "renderOutput": "renders/com.example.PreviewsKt.RedBoxPreview_Red Box.png"
+            "captures": [
+                {
+                    "advanceTimeMillis": null,
+                    "scroll": null,
+                    "renderOutput": "renders/com.example.PreviewsKt.RedBoxPreview_Red Box.png"
+                }
+            ]
         },
         {
             "id": "com.example.PreviewsKt.BlueBoxPreview_Blue Box",
@@ -40,7 +46,13 @@
                 "locale": null,
                 "group": "colors"
             },
-            "renderOutput": "renders/com.example.PreviewsKt.BlueBoxPreview_Blue Box.png"
+            "captures": [
+                {
+                    "advanceTimeMillis": null,
+                    "scroll": null,
+                    "renderOutput": "renders/com.example.PreviewsKt.BlueBoxPreview_Blue Box.png"
+                }
+            ]
         },
         {
             "id": "com.example.MainKt.GreetingPreview",
@@ -60,7 +72,13 @@
                 "locale": null,
                 "group": null
             },
-            "renderOutput": "renders/com.example.MainKt.GreetingPreview.png"
+            "captures": [
+                {
+                    "advanceTimeMillis": null,
+                    "scroll": null,
+                    "renderOutput": "renders/com.example.MainKt.GreetingPreview.png"
+                }
+            ]
         },
         {
             "id": "com.example.PreviewsKt.RedBoxPreview_Dark Mode",
@@ -80,7 +98,13 @@
                 "locale": null,
                 "group": "colors"
             },
-            "renderOutput": "renders/com.example.PreviewsKt.RedBoxPreview_Dark Mode.png"
+            "captures": [
+                {
+                    "advanceTimeMillis": null,
+                    "scroll": null,
+                    "renderOutput": "renders/com.example.PreviewsKt.RedBoxPreview_Dark Mode.png"
+                }
+            ]
         }
     ]
 }

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -12,13 +12,49 @@ export interface PreviewParams {
     group: string | null;
 }
 
+/**
+ * Scroll state of a capture. Intent fields (mode, axis, maxScrollPx,
+ * reduceMotion) come from `@ScrollingPreview`; outcome fields (atEnd,
+ * reachedPx) are populated by the renderer post-capture.
+ */
+export interface ScrollCapture {
+    mode: 'END' | 'LONG' | string;
+    axis: 'VERTICAL' | 'HORIZONTAL' | string;
+    maxScrollPx: number;
+    reduceMotion: boolean;
+    /** Scrollable reached the end of its content before the renderer stopped.
+     *  Distinct from `reachedPx === maxScrollPx`, which means the cap fired. */
+    atEnd: boolean;
+    /** Pixels actually scrolled. null when not reported. */
+    reachedPx: number | null;
+}
+
+/**
+ * One rendered snapshot of a preview. Non-null dimensional fields
+ * (advanceTimeMillis, scroll) are the coordinates that distinguish this
+ * capture from its siblings. A static preview has a single capture with
+ * everything null.
+ */
+export interface Capture {
+    advanceTimeMillis: number | null;
+    scroll: ScrollCapture | null;
+    renderOutput: string;
+    /** Human-readable summary of this capture's non-null dimensions —
+     *  e.g. `'500ms'`, `'scrolled end'`, `'500ms · scrolled end'`, or `''`
+     *  for a plain static preview. Populated extension-side (see
+     *  [captureLabels.captureLabel]) before sending to the webview so the
+     *  carousel markup stays free of dimension logic. */
+    label?: string;
+}
+
 export interface PreviewInfo {
     id: string;
     functionName: string;
     className: string;
     sourceFile: string | null;
     params: PreviewParams;
-    renderOutput: string | null;
+    /** Rendered snapshots — always at least one. Length > 1 ⇔ carousel. */
+    captures: Capture[];
     /** Populated by the extension (not the Gradle manifest) — `true` iff
      *  the preview has at least one archived snapshot on disk. The webview
      *  uses this to decide whether to show the history button at all. */
@@ -98,8 +134,10 @@ export interface HistoryEntry {
 /** Messages from extension to webview */
 export type ExtensionToWebview =
     | { command: 'setPreviews'; previews: PreviewInfo[]; moduleDir: string }
-    | { command: 'updateImage'; previewId: string; imageData: string }
-    | { command: 'setImageError'; previewId: string; message: string }
+    /** `captureIndex` addresses which capture within an animated preview the
+     *  image belongs to. Static previews have a single capture at index 0. */
+    | { command: 'updateImage'; previewId: string; captureIndex: number; imageData: string }
+    | { command: 'setImageError'; previewId: string; captureIndex: number; message: string }
     | { command: 'setLoading'; previewId?: string }
     | { command: 'markAllLoading' }
     | { command: 'setError'; previewId: string; message: string }


### PR DESCRIPTION
Each preview can render at multiple points in a dimensional space. On main, two annotation-driven sources of variation surface differently:

| Source | How it surfaced on main | Problem |
|---|---|---|
| \`@RoboComposePreviewOptions(manualClockOptions = [...])\` | N separate \`PreviewInfo\` entries with \`_TIME_<ms>ms\` ID suffix | Duplicated \`params\`, regex'd IDs to understand grouping |
| \`@ScrollingPreview(END)\` | Single \`PreviewInfo\` with \`PreviewParams.scroll\` | Distinct shape from the other dimension; misplaced on params |

Unify under one thing: \`PreviewInfo.captures: List<Capture>\`. Each \`Capture\` is a point in dim-space with typed nullable fields + its PNG.

## Schema

\`\`\`kotlin
data class PreviewInfo(..., val captures: List<Capture> = listOf(Capture()))

data class Capture(
    val advanceTimeMillis: Long? = null,
    val scroll: ScrollCapture? = null,
    val renderOutput: String = \"\",
)

data class ScrollCapture(
    // Intent from @ScrollingPreview
    val mode: ScrollMode,
    val axis: ScrollAxis = ScrollAxis.VERTICAL,
    val maxScrollPx: Int = 0,
    val reduceMotion: Boolean = true,
    // Outcome recorded post-capture (pending renderer feedback step)
    val atEnd: Boolean = false,
    val reachedPx: Int? = null,
)
\`\`\`

- Static preview → one capture, everything null.
- Animated (3 timings) → 3 captures, ascending \`advanceTimeMillis\`.
- Scrolled → capture with \`scroll\` set.
- Combined → cross-product.

\`atEnd\` is a separate field because \`reachedPx == maxScrollPx\` is ambiguous between \"hit the user-supplied cap\" and \"exhausted content\" — consumers that want \"this is the end state\" read \`atEnd\`, consumers that want an offset read \`reachedPx\`.

## Renderer

\`RobolectricRenderTest.renderDefault\` loops \`preview.captures\` inside one test, sharing the \`ComposeTestRule\` / \`setContent\` setup cost across captures of the same preview. For each capture: \`mainClock.advanceTimeBy(delta)\` (monotonic ascending enforced at discovery), then \`ScrollDriver\` if \`capture.scroll != null\`, then \`captureRoboImage\`. ATF runs on capture index 1 for animated previews (capture 0 is often pre-settle t=0) and capture 0 for static.

## VS Code

- \`types.ts\`: new \`Capture\` / \`ScrollCapture\` interfaces; \`captures: Capture[]\` required; \`updateImage\` / \`setImageError\` carry \`captureIndex\`.
- \`captureLabels.ts\` (new): extension-side helper computes per-capture labels like \`'500ms'\`, \`'scrolled end'\`, \`'500ms · scrolled end'\` — webview stays dimension-agnostic.
- \`previewPanel.ts\`: animated cards get a play-circle marker in the title + prev/indicator/next bar below the image. \`cardCaptures\` Map caches per-capture imageData so carousel navigation swaps \`<img>.src\` without a fresh extension round-trip. Keyboard arrow keys navigate when the carousel has focus.

Sample: \`SpinnerTimelinePreview\` now renders as **one** card with a 3-capture carousel (t=0 / 500 / 1500ms) rather than three separate tiles.

## Breaking
No external users — \`PreviewInfo.renderOutput\` removed (captures-only). The \`previews.json\` schema changes shape; CLI + VS Code updated in this PR.

## Test plan
- [x] \`./gradlew :sample-android:renderAllPreviews\` — 13 previews, \`SpinnerTimeline\` producing 3 distinct-hash PNGs
- [x] \`--rerun-tasks\` — byte-identical
- [x] \`:sample-cmp:renderAllPreviews\`, \`:sample-wear:renderAllPreviews\` — unaffected
- [x] \`:gradle-plugin:test\`, \`:gradle-plugin:functionalTest\` — pass
- [x] \`:sample-android:test\` (scroll pixel assertions) — pass
- [x] \`vscode-extension: npm run compile\` — clean; mocha filter tests pass

## Follow-ups (not in this PR)
- Renderer writes back \`atEnd\` / \`reachedPx\` into the manifest post-capture. Today those fields land with defaults (\`false\`, \`null\`); carousel labels fall back to intent (\`mode = END\` → \`'scroll end'\`).
- History archiver: animated previews only archive their first capture. Per-capture history keyed off renderOutput is a small change, deferred.