### PR TITLE
chore: clean up doc drift and dead code

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,20 +67,24 @@ Launch a subprocess with the module's full classpath plus the renderer-desktop m
 
 ### Rendering (Android)
 
-Launch a subprocess inside a Robolectric sandbox with native graphics.
+Launch a Gradle `Test` task inside a Robolectric sandbox with native graphics
+(`graphicsMode=NATIVE`, `pixelCopyRenderMode=hardware`).
 
 ```
-1. Bootstrap a ComponentActivity through Robolectric's activity lifecycle.
-   Configure the shadow display to match the target dimensions.
+1. Bootstrap a ComponentActivity through `createAndroidComposeRule`.
+   Apply the @Preview qualifiers (size, density, locale, uiMode, round,
+   orientation) via `RuntimeEnvironment.setQualifiers` and `setFontScale`.
 
-2. Set the activity content to the composable (same as Desktop:
-   background fill + reflected composable invocation + inspection mode).
+2. Set the activity content to a background fill + reflected composable
+   invocation, with `LocalInspectionMode = true`.
 
-3. Advance the main looper frame-by-frame (16ms per frame, up to 20 frames).
-   After each frame, sample ~64 pixels and compute a checksum.
-   Stop when the checksum is stable for 2 consecutive frames.
+3. Pause Compose's main clock (`autoAdvance = false`) and step it by a
+   fixed amount so infinite animations terminate deterministically instead
+   of hanging the idling resource.
 
-4. Draw the activity's root view to a bitmap, compress as PNG, write to file.
+4. Capture the root view via `captureRoboImage`, which routes ShadowPixelCopy
+   through HardwareRenderer + ImageReader to replay Compose's RenderNodes,
+   compress as PNG, write to file.
 ```
 
 ### Caching
@@ -163,12 +167,12 @@ The snapshot version is the next patch ahead of the latest release
 
 <!-- x-release-please-start-version -->
 Download `compose-preview-0.4.0.tar.gz` (or `.zip`) from the
-[v0.4.0 release](https://github.com/yschimke/compose-ai-tools/releases/tag/v0.3.4)
+[v0.4.0 release](https://github.com/yschimke/compose-ai-tools/releases/tag/v0.4.0)
 and put the `bin/` directory on your `PATH`:
 
 ```sh
 curl -L -o compose-preview.tar.gz \
-  https://github.com/yschimke/compose-ai-tools/releases/download/v0.4.0/compose-preview-0.3.4.tar.gz
+  https://github.com/yschimke/compose-ai-tools/releases/download/v0.4.0/compose-preview-0.4.0.tar.gz
 tar -xzf compose-preview.tar.gz
 export PATH="$PWD/compose-preview-0.4.0/bin:$PATH"
 
@@ -216,7 +220,7 @@ composePreview {
 | `gradle-plugin/` | Gradle plugin — discovery, rendering task orchestration |
 | `renderer-desktop/` | Desktop renderer — `ImageComposeScene` + Skia PNG capture |
 | `renderer-android/` | Android renderer — Robolectric harness |
-| `cli/` | CLI with GraalVM native-image support |
+| `cli/` | CLI — Tooling-API driver over `discoverPreviews` / `renderAllPreviews` |
 | `sample-android/` | Android sample with colored box `@Preview` composables |
 | `sample-cmp/` | CMP Desktop sample with colored box `@Preview` composables |
 

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -34,7 +34,6 @@ tasks.named<Tar>("distTar") {
 }
 
 dependencies {
-    implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
     implementation("org.gradle:gradle-tooling-api:9.3.1")
     runtimeOnly("org.slf4j:slf4j-nop:2.0.16")

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -165,20 +165,15 @@ abstract class Command(protected val args: List<String>) {
 
     /**
      * Reads each module's accessibility report IF the manifest points at one
-     * (i.e. the feature is enabled in Gradle). Returns a map keyed by
-     * `"$module/$previewId"` so `buildResults` can look up findings without a
-     * second filesystem probe.
+     * (i.e. the feature is enabled in Gradle), and returns a lookup from
+     * `"<module>/<previewId>"` to (findings, annotatedPathAbsolute). The
+     * annotated path is resolved against the report file's parent so the
+     * value we emit is an absolute filesystem path agents can open directly.
      *
      * Following the manifest pointer — rather than hard-coding
      * `accessibility.json` — means disabling checks in Gradle cleanly makes
      * findings disappear from CLI output; we never report stale reports from
      * a prior opt-in run.
-     */
-    /**
-     * Loads each module's accessibility report and returns a lookup from
-     * `"<module>/<previewId>"` to (findings, annotatedPathAbsolute). The
-     * annotated path is resolved against the report file's parent so the
-     * value we emit is an absolute filesystem path agents can open directly.
      */
     protected fun readAllA11yReports(
         manifests: List<Pair<String, PreviewManifest>>,

--- a/skills/compose-preview/SKILL.md
+++ b/skills/compose-preview/SKILL.md
@@ -13,8 +13,8 @@ Desktop (via `ImageComposeScene` + Skia).
 
 - A Gradle plugin (`ee.schimke.composeai.preview`) that discovers `@Preview`
   annotations from compiled classes and registers rendering tasks.
-- A `compose-preview` CLI (GraalVM native-image) that drives the Gradle build via the
-  Tooling API and surfaces rendered PNG paths.
+- A `compose-preview` CLI that drives the Gradle build via the Tooling API
+  and surfaces rendered PNG paths.
 - A VS Code extension with a preview panel, CodeLens and hover actions on
   `@Preview` functions, and commands for rendering all or a single file.
 
@@ -42,7 +42,8 @@ Commands:
   show     Discover + render previews; print id, path, sha256, changed flag
   list     List discovered previews
   render   Render previews; with --output copies a single match to disk
-  doctor   Verify Java 21 and plugin-repo connectivity (run before Setup)
+  a11y     Render previews and print ATF accessibility findings
+  doctor   Verify Java 21 + project compatibility (run before Setup)
 
 Options:
   --module <name>      Target a single module (default: auto-detect)


### PR DESCRIPTION
## Summary

Six small fixes for refactor leftovers — pure docs/dead-code, no behaviour change.

- **README "Rendering (Android)"** — rewrite to match the current Robolectric + paused-clock pipeline. The old description (per-frame stabilizer loop sampling 64 pixels) refers to a renderer that no longer exists; the current path uses \`mainClock.autoAdvance = false\` + \`captureRoboImage\` + hardware \`PixelCopy\`.
- **README CLI install snippet** — fix interleaved \`0.4.0\` / \`0.3.4\` version strings inside the \`x-release-please-start-version\` block (release-please updated some occurrences and not others, leaving a broken curl URL).
- **README + SKILL.md** — drop the "GraalVM native-image" claim. The CLI module is a plain \`application\` plugin build (\`installDist\`); there's no \`org.graalvm.buildtools.native\` anywhere.
- **SKILL.md** — add the \`a11y\` command to the CLI command table (it ships in \`Main.kt\` and \`Commands.kt\` but the skill never mentioned it).
- **\`Commands.kt\`** — collapse the duplicated KDoc block on \`readAllA11yReports\`.
- **\`cli/build.gradle.kts\`** — drop \`kotlinx-coroutines-core\`. Nothing in \`cli/src/main/kotlin\` imports it; it just bloated the distribution.

## Test plan

- [x] \`./gradlew :cli:compileKotlin :cli:test\` — green.