### PR TITLE
feat(renderer): wrap @Preview to intrinsic size, Android-Studio style

### DIFF
--- a/.github/actions/install-cli/action.yml
+++ b/.github/actions/install-cli/action.yml
@@ -11,10 +11,22 @@ description: >
 runs:
   using: 'composite'
   steps:
-    - name: Build CLI
+    - name: Build and stage CLI
       shell: bash
-      run: ./gradlew :cli:installDist --no-daemon
+      # `installDist` drops the CLI under `cli/build/install/compose-preview`
+      # in the workspace; we stage it at a hardcoded path under /opt so the
+      # $GITHUB_PATH write below is a fixed literal. Writing an
+      # expansion-backed value to $GITHUB_PATH trips zizmor's `github-env`
+      # rule because any attacker-influence over the expansion becomes
+      # attacker-influence over every subsequent step's $PATH. The stage
+      # step is trusted because its inputs are the repo checkout + our own
+      # Gradle build.
+      run: |
+        set -euo pipefail
+        ./gradlew :cli:installDist --no-daemon
+        sudo mkdir -p /opt/compose-preview
+        sudo cp -a cli/build/install/compose-preview/. /opt/compose-preview/
 
     - name: Add CLI to PATH
       shell: bash
-      run: echo "${GITHUB_WORKSPACE}/cli/build/install/compose-preview/bin" >> "$GITHUB_PATH"
+      run: echo "/opt/compose-preview/bin" >> "$GITHUB_PATH"

--- a/.github/actions/install-cli/action.yml
+++ b/.github/actions/install-cli/action.yml
@@ -1,23 +1,20 @@
 name: 'Install compose-preview CLI'
 description: >
-  Download the latest tagged compose-preview release tarball and put its
+  Build the compose-preview CLI from the checked-out source and put its
   `bin/` on $GITHUB_PATH. Shared by the preview-baselines and
-  preview-comment composite actions — identical logic previously lived in
-  both.
+  preview-comment composite actions. Building from source (rather than
+  downloading the latest release tarball) keeps the CLI in lockstep with
+  the plugin / renderer schema on the current commit — PRs that land a
+  schema change (e.g. the captures refactor in #72) won't break the CI
+  render step with a version-skew error against a stale released CLI.
 
 runs:
   using: 'composite'
   steps:
-    - name: Install CLI
+    - name: Build CLI
       shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        set -euo pipefail
-        VERSION=$(gh release view --repo yschimke/compose-ai-tools --json tagName -q .tagName | sed 's/^v//')
-        echo "Downloading compose-preview ${VERSION}..."
-        gh release download "v${VERSION}" --repo yschimke/compose-ai-tools \
-          --pattern "compose-preview-${VERSION}.tar.gz" --dir /tmp
-        mkdir -p /opt/compose-preview
-        tar -xzf "/tmp/compose-preview-${VERSION}.tar.gz" -C /opt/compose-preview --strip-components=1
-        echo "/opt/compose-preview/bin" >> "$GITHUB_PATH"
+      run: ./gradlew :cli:installDist --no-daemon
+
+    - name: Add CLI to PATH
+      shell: bash
+      run: echo "${GITHUB_WORKSPACE}/cli/build/install/compose-preview/bin" >> "$GITHUB_PATH"

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -124,6 +124,17 @@ class DiscoveryFunctionalTest {
 
         val names = manifest.previews.map { it.functionName }
         assertThat(names).containsExactly("RedBoxPreview", "BlueBoxPreview")
+
+        // AS-parity: bare `@Preview` with no device / showSystemUi /
+        // widthDp / heightDp must serialize null on both axes so renderers
+        // wrap to the composable's intrinsic size instead of defaulting
+        // to a 400×800 phone frame.
+        manifest.previews.forEach {
+            assertThat(it.params.widthDp).isNull()
+            assertThat(it.params.heightDp).isNull()
+            assertThat(it.params.device).isNull()
+            assertThat(it.params.showSystemUi).isFalse()
+        }
     }
 
     @Test

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderFunctionalTest.kt
@@ -126,9 +126,15 @@ class RenderFunctionalTest {
         assertThat(pngFile).isNotNull()
 
         val img: BufferedImage = ImageIO.read(pngFile!!)
-        // Default dimensions: 400x800 dp at DEFAULT_DENSITY (2.625x, matching the
-        // xxhdpi-class default Android Studio uses for `@Preview` without a device)
-        // = 1050x2100 px.
+        // Synthetic functional-test projects don't have `:renderer-desktop` on
+        // their classpath, so the plugin falls back to the stub renderer
+        // (PreviewRenderWorkAction) — which writes a blank PNG of the
+        // task-computed sandbox size without running a real composition.
+        // Under AS-parity sizing, a bare `@Preview` gets the wrap-content
+        // sandbox (400×800 dp) at DEFAULT_DENSITY (2.625x) = 1050×2100 px.
+        // The real wrap-to-intrinsic crop is exercised end-to-end through the
+        // sample-cmp / sample-android render tasks, which pull in the actual
+        // renderer modules.
         assertThat(img.width).isEqualTo(1050)
         assertThat(img.height).isEqualTo(2100)
     }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceDimensions.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceDimensions.kt
@@ -19,6 +19,35 @@ object DeviceDimensions {
      */
     const val DEFAULT_DENSITY: Float = 2.625f
 
+    /**
+     * Per-axis sizing decision for a single preview, mirroring Android Studio's
+     * Compose preview pane: an axis is *fixed* when the user named a dp value or
+     * chose a device/`showSystemUi`, otherwise it *wraps* to the composable's
+     * intrinsic size. Wrapped axes still need a sandbox dimension so Robolectric
+     * Configuration qualifiers and the desktop `ImageComposeScene` have a finite
+     * canvas to render into — the renderer crops the PNG back down to the
+     * measured content bounds afterwards.
+     */
+    data class SizeSpec(
+        val widthDp: Int,
+        val heightDp: Int,
+        val wrapWidth: Boolean,
+        val wrapHeight: Boolean,
+        val density: Float = DEFAULT_DENSITY,
+    )
+
+    /**
+     * Sandbox dp used for wrapped axes — matches the historical default
+     * (400×800 dp) that stood in for "no device" before AS-parity sizing, so
+     * `fillMax*` composables measure into a phone-shaped viewport rather than
+     * a giant square. Wrapped small composables then crop well below this.
+     */
+    const val SANDBOX_WIDTH_DP = 400
+    const val SANDBOX_HEIGHT_DP = 800
+
+    /** Back-compat alias for callers/tests that want a single constant. */
+    const val SANDBOX_DP = SANDBOX_WIDTH_DP
+
     // Source-of-truth for the dp values and densities below: sergio-sastre/ComposablePreviewScanner
     // (Phone.kt / Tablet.kt / Wear.kt / GenericDevices.kt / Desktop.kt / Television.kt /
     // Automotive.kt / XR.kt under android/.../device/types/), with dp = px / (densityDpi / 160)
@@ -147,5 +176,42 @@ object DeviceDimensions {
         }
 
         return DEFAULT
+    }
+
+    /**
+     * AS-parity sizing: axes are fixed iff the user specified them (or chose
+     * a device frame / `showSystemUi`); otherwise the axis wraps to the
+     * composable's intrinsic size. The `widthDp` / `heightDp` fields of the
+     * returned [SizeSpec] are the *sandbox* dimensions the renderer should
+     * use — for wrapped axes that's [SANDBOX_DP]; for fixed axes it's the
+     * effective dp the frame was resolved to.
+     */
+    fun resolveForRender(
+        device: String?,
+        widthDp: Int?,
+        heightDp: Int?,
+        showSystemUi: Boolean,
+    ): SizeSpec {
+        val w = widthDp?.takeIf { it > 0 }
+        val h = heightDp?.takeIf { it > 0 }
+        // Device / showSystemUi → full device frame on both axes. Explicit
+        // widthDp/heightDp still override the resolved device spec (matches
+        // the existing `resolve()` precedence and AS).
+        if (device != null || showSystemUi) {
+            val spec = resolve(device, w, h)
+            return SizeSpec(
+                widthDp = spec.widthDp,
+                heightDp = spec.heightDp,
+                wrapWidth = false,
+                wrapHeight = false,
+                density = spec.density,
+            )
+        }
+        return SizeSpec(
+            widthDp = w ?: SANDBOX_WIDTH_DP,
+            heightDp = h ?: SANDBOX_HEIGHT_DP,
+            wrapWidth = w == null,
+            wrapHeight = h == null,
+        )
     }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -411,19 +411,39 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         val device = (pv.getValue("device") as? String)?.ifBlank { null }
         val rawWidth = (pv.getValue("widthDp") as? Int)?.takeIf { it > 0 }
         val rawHeight = (pv.getValue("heightDp") as? Int)?.takeIf { it > 0 }
-        // Resolve dimensions up-front so downstream consumers (renderers, VSCode
-        // extension, CLI) see the effective widthDp/heightDp instead of having to
-        // each re-implement DeviceDimensions. RenderPreviewsTask still calls resolve()
-        // — passing already-resolved values is a no-op path.
-        val dims = DeviceDimensions.resolve(device, rawWidth, rawHeight)
+        val showSystemUi = (pv.getValue("showSystemUi") as? Boolean) ?: false
+        // AS-parity sizing: when the user picked a device or asked for the
+        // system UI frame, resolve up-front so downstream consumers (renderers,
+        // VS Code extension, CLI) see the effective widthDp/heightDp and the
+        // device's density. When no frame was requested, keep the raw user
+        // values — nulls on either axis signal "wrap to intrinsic" to the
+        // renderers, matching how Android Studio's preview pane sizes
+        // component previews.
+        val effectiveWidth: Int?
+        val effectiveHeight: Int?
+        val effectiveDensity: Float?
+        if (device != null || showSystemUi) {
+            val dims = DeviceDimensions.resolve(device, rawWidth, rawHeight)
+            effectiveWidth = dims.widthDp
+            effectiveHeight = dims.heightDp
+            effectiveDensity = dims.density
+        } else {
+            effectiveWidth = rawWidth
+            effectiveHeight = rawHeight
+            // `null` → renderer falls back to its built-in default (AS's
+            // xxhdpi-ish `DEFAULT_DENSITY`). Avoid pinning the density here so
+            // a wrap-content preview behaves the same as AS's default-phone
+            // preview without baking a specific dpi into `previews.json`.
+            effectiveDensity = null
+        }
         return PreviewParams(
             name = (pv.getValue("name") as? String)?.ifBlank { null },
             device = device,
-            widthDp = dims.widthDp,
-            heightDp = dims.heightDp,
-            density = dims.density,
+            widthDp = effectiveWidth,
+            heightDp = effectiveHeight,
+            density = effectiveDensity,
             fontScale = (pv.getValue("fontScale") as? Float)?.takeIf { it > 0 } ?: 1.0f,
-            showSystemUi = (pv.getValue("showSystemUi") as? Boolean) ?: false,
+            showSystemUi = showSystemUi,
             showBackground = (pv.getValue("showBackground") as? Boolean) ?: false,
             backgroundColor = (pv.getValue("backgroundColor") as? Long) ?: 0L,
             uiMode = (pv.getValue("uiMode") as? Int)?.takeIf { it > 0 } ?: 0,

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -71,17 +71,21 @@ abstract class RenderPreviewsTask : DefaultTask() {
         val mainClass = "ee.schimke.composeai.renderer.DesktopRendererMainKt"
 
         for (preview in manifest.previews) {
-            val dims = DeviceDimensions.resolve(
-                preview.params.device,
-                preview.params.widthDp,
-                preview.params.heightDp,
+            val spec = DeviceDimensions.resolveForRender(
+                device = preview.params.device,
+                widthDp = preview.params.widthDp,
+                heightDp = preview.params.heightDp,
+                showSystemUi = preview.params.showSystemUi,
             )
-            // Per-device density (= densityDpi / 160), so output bitmaps match what
-            // Android Studio renders for the same `@Preview`. Source: the same data
-            // sergio-sastre/ComposablePreviewScanner / takahirom/roborazzi consume.
-            val density = preview.params.density ?: dims.density
-            val widthPx = (dims.widthDp * density).toInt().coerceAtLeast(1)
-            val heightPx = (dims.heightDp * density).toInt().coerceAtLeast(1)
+            // Per-device density (= densityDpi / 160), so output bitmaps match
+            // what Android Studio renders for the same `@Preview`. Source: the
+            // same data sergio-sastre/ComposablePreviewScanner /
+            // takahirom/roborazzi consume. Discovery pins `params.density` when
+            // a device/showSystemUi frame applies; the wrap-content path leaves
+            // it null and we fall back to `spec.density` (= DEFAULT_DENSITY).
+            val density = preview.params.density ?: spec.density
+            val widthPx = (spec.widthDp * density).toInt().coerceAtLeast(1)
+            val heightPx = (spec.heightDp * density).toInt().coerceAtLeast(1)
             val outputFile = outDir.resolve("${preview.id}.png")
 
             execOperations.javaexec {
@@ -98,6 +102,11 @@ abstract class RenderPreviewsTask : DefaultTask() {
                     outputFile.absolutePath,
                     // 9th arg — empty string signals "no wrapper" (keeps arg positions stable).
                     preview.params.wrapperClassName.orEmpty(),
+                    // 10th/11th — AS-parity wrap flags. When set, the renderer
+                    // wraps the composable, measures it, and crops the PNG to
+                    // the intrinsic bounds on that axis.
+                    spec.wrapWidth.toString(),
+                    spec.wrapHeight.toString(),
                 )
             }
         }
@@ -107,17 +116,18 @@ abstract class RenderPreviewsTask : DefaultTask() {
         val workQueue = workerExecutor.noIsolation()
 
         for (preview in manifest.previews) {
-            val dims = DeviceDimensions.resolve(
-                preview.params.device,
-                preview.params.widthDp,
-                preview.params.heightDp,
+            val spec = DeviceDimensions.resolveForRender(
+                device = preview.params.device,
+                widthDp = preview.params.widthDp,
+                heightDp = preview.params.heightDp,
+                showSystemUi = preview.params.showSystemUi,
             )
             workQueue.submit(PreviewRenderWorkAction::class.java) {
                 className.set(preview.className)
                 functionName.set(preview.functionName)
-                widthDp.set(dims.widthDp)
-                heightDp.set(dims.heightDp)
-                density.set(preview.params.density ?: dims.density)
+                widthDp.set(spec.widthDp)
+                heightDp.set(spec.heightDp)
+                density.set(preview.params.density ?: spec.density)
                 fontScale.set(preview.params.fontScale)
                 showBackground.set(preview.params.showBackground)
                 backgroundColor.set(preview.params.backgroundColor)

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DeviceDimensionsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DeviceDimensionsTest.kt
@@ -216,4 +216,79 @@ class DeviceDimensionsTest {
         assertThat(spec.widthDp)
             .isGreaterThan(DeviceDimensions.resolve("id:wearos_large_round").widthDp)
     }
+
+    // -- resolveForRender (AS-parity sizing) --
+
+    @Test
+    fun `resolveForRender wraps both axes when no hints are given`() {
+        val spec = DeviceDimensions.resolveForRender(
+            device = null,
+            widthDp = null,
+            heightDp = null,
+            showSystemUi = false,
+        )
+        assertThat(spec.wrapWidth).isTrue()
+        assertThat(spec.wrapHeight).isTrue()
+        // Wrap-axes get the phone-shaped 400×800 dp sandbox so fillMaxSize
+        // composables render into a reasonable viewport before the PNG crop.
+        assertThat(spec.widthDp).isEqualTo(DeviceDimensions.SANDBOX_WIDTH_DP)
+        assertThat(spec.heightDp).isEqualTo(DeviceDimensions.SANDBOX_HEIGHT_DP)
+    }
+
+    @Test
+    fun `resolveForRender keeps device frame when device is set`() {
+        val spec = DeviceDimensions.resolveForRender(
+            device = "id:pixel_6",
+            widthDp = null,
+            heightDp = null,
+            showSystemUi = false,
+        )
+        assertThat(spec.wrapWidth).isFalse()
+        assertThat(spec.wrapHeight).isFalse()
+        // Pixel 6 = 411×914 dp after the upstream per-device density refresh.
+        assertThat(spec.widthDp).isEqualTo(411)
+        assertThat(spec.heightDp).isEqualTo(914)
+    }
+
+    @Test
+    fun `resolveForRender keeps full frame when showSystemUi is true`() {
+        val spec = DeviceDimensions.resolveForRender(
+            device = null,
+            widthDp = null,
+            heightDp = null,
+            showSystemUi = true,
+        )
+        assertThat(spec.wrapWidth).isFalse()
+        assertThat(spec.wrapHeight).isFalse()
+        assertThat(spec.widthDp).isEqualTo(400)
+        assertThat(spec.heightDp).isEqualTo(800)
+    }
+
+    @Test
+    fun `resolveForRender wraps only the axis the user left unset`() {
+        val spec = DeviceDimensions.resolveForRender(
+            device = null,
+            widthDp = 240,
+            heightDp = null,
+            showSystemUi = false,
+        )
+        assertThat(spec.wrapWidth).isFalse()
+        assertThat(spec.wrapHeight).isTrue()
+        assertThat(spec.widthDp).isEqualTo(240)
+        assertThat(spec.heightDp).isEqualTo(DeviceDimensions.SANDBOX_HEIGHT_DP)
+    }
+
+    @Test
+    fun `resolveForRender explicit dims override device frame`() {
+        val spec = DeviceDimensions.resolveForRender(
+            device = "id:pixel_6",
+            widthDp = 200,
+            heightDp = 300,
+            showSystemUi = false,
+        )
+        assertThat(spec.wrapWidth).isFalse()
+        assertThat(spec.wrapHeight).isFalse()
+        assertThat(spec.widthDp).isEqualTo(200)
+        assertThat(spec.heightDp).isEqualTo(300)
+    }
 }

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1,8 +1,13 @@
 package ee.schimke.composeai.renderer
 
 import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -87,8 +92,16 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
         outputDir.mkdirs()
 
         val params = preview.params
-        val widthDp = params.widthDp?.takeIf { it > 0 } ?: DEFAULT_WIDTH
-        val heightDp = params.heightDp?.takeIf { it > 0 } ?: DEFAULT_HEIGHT
+        // AS-parity sizing: an axis wraps to intrinsic content when the user
+        // didn't specify it (and didn't pick a device/showSystemUi frame —
+        // discovery has already pre-resolved those cases). We use a generous
+        // sandbox dp for wrapped axes so the Robolectric window / Configuration
+        // has a finite, coherent size; the captured PNG is cropped back down
+        // to the measured content bounds after capture.
+        val wrapWidth = params.widthDp == null || params.widthDp <= 0
+        val wrapHeight = params.heightDp == null || params.heightDp <= 0
+        val widthDp = params.widthDp?.takeIf { it > 0 } ?: SANDBOX_WIDTH_DP
+        val heightDp = params.heightDp?.takeIf { it > 0 } ?: SANDBOX_HEIGHT_DP
         // Round crop fires when the preview is on a round device AND it's the
         // kind of surface that fills the watch — either a @Composable the user
         // asked for system UI on, or a tile (tiles always fill the watchface,
@@ -111,7 +124,16 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
             recordOptions = RoborazziOptions.RecordOptions(applyDeviceCrop = isRound),
         )
 
-        renderDefault(params, widthDp, heightDp, outputDir, roborazziOptions, composeOptions)
+        renderDefault(
+            params = params,
+            widthDp = widthDp,
+            heightDp = heightDp,
+            wrapWidth = wrapWidth,
+            wrapHeight = wrapHeight,
+            outputDir = outputDir,
+            roborazziOptions = roborazziOptions,
+            composeOptions = composeOptions,
+        )
     }
 
     /**
@@ -159,6 +181,8 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
         params: RenderPreviewParams,
         widthDp: Int,
         heightDp: Int,
+        wrapWidth: Boolean,
+        wrapHeight: Boolean,
         outputDir: File,
         roborazziOptions: RoborazziOptions,
         composeOptions: RoborazziComposeOptions,
@@ -203,6 +227,10 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
             this::class.java,
             "renderDefault_${preview.id}",
         )
+        // Captures the content's intrinsic pixel size when either axis wraps.
+        // Read after `captureRoboImage` to crop the PNG down to the composable's
+        // actual bounds.
+        var measured: IntSize? = null
         val statement = object : org.junit.runners.model.Statement() {
             override fun evaluate() {
                 rule.mainClock.autoAdvance = false
@@ -224,7 +252,50 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                 }
                 rule.setContent {
                     CompositionLocalProvider(LocalInspectionMode provides !a11yEnabled) {
-                        strategyFor(params.kind).Render(preview, widthDp, heightDp)
+                        if (wrapWidth || wrapHeight) {
+                            // AS-parity wrap-to-content: measure the strategy's
+                            // composable with unbounded constraints on wrapped
+                            // axes, capture the child's pixel size, then size
+                            // the outer Box to match. Doing this in a single
+                            // layout pass (rather than via onGloballyPositioned)
+                            // keeps the measurement deterministic even when
+                            // Compose's post-layout scheduling is short-circuited
+                            // by Robolectric. The wrapping Box re-introduces the
+                            // layout-node bytecode the compat workaround in the
+                            // comment below avoids — acceptable because
+                            // wrap-content is only emitted when the user didn't
+                            // name a device / widthDp / heightDp, and the
+                            // old-Compose-BOM consumers who need that workaround
+                            // use device-pinned (e.g. wearos_*) previews.
+                            // Measure with *bounded* sandbox constraints (not
+                            // Infinity): that's what Android Studio's preview
+                            // pane does, and it's the only shape that
+                            // `Modifier.fillMax*` / `LazyColumn` accept without
+                            // throwing from `InlineClassHelper`. Relax the min
+                            // constraint on wrapped axes so small composables
+                            // can shrink below the sandbox; a `fillMaxWidth`
+                            // composable still measures at the sandbox width
+                            // and no width-crop happens on that axis.
+                            Box(
+                                modifier = Modifier.layout { measurable, constraints ->
+                                    val wrappedConstraints = Constraints(
+                                        minWidth = if (wrapWidth) 0 else constraints.minWidth,
+                                        maxWidth = constraints.maxWidth,
+                                        minHeight = if (wrapHeight) 0 else constraints.minHeight,
+                                        maxHeight = constraints.maxHeight,
+                                    )
+                                    val placeable = measurable.measure(wrappedConstraints)
+                                    measured = IntSize(placeable.width, placeable.height)
+                                    layout(placeable.width, placeable.height) {
+                                        placeable.place(0, 0)
+                                    }
+                                },
+                            ) {
+                                strategyFor(params.kind).Render(preview, widthDp, heightDp)
+                            }
+                        } else {
+                            strategyFor(params.kind).Render(preview, widthDp, heightDp)
+                        }
                     }
                 }
                 // With `mainClock.autoAdvance = false` the clock stays at 0
@@ -272,6 +343,21 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                         file = outputFile,
                         roborazziOptions = roborazziOptions,
                     )
+
+                    // AS-parity: crop the PNG down to the composable's
+                    // intrinsic size on wrapped axes. `measured` is populated
+                    // during the wrap Box's Modifier.layout measure pass on the
+                    // first composition and doesn't change between captures
+                    // (the wrapped axes stay the same), so it's safe to apply
+                    // per-capture here.
+                    if ((wrapWidth || wrapHeight) && measured != null) {
+                        cropPngTopLeft(
+                            file = outputFile,
+                            wrapWidth = wrapWidth,
+                            wrapHeight = wrapHeight,
+                            measured = measured!!,
+                        )
+                    }
 
                     if (a11yEnabled && idx == a11yCaptureIndex()) {
                         // `fetchSemanticsNode().root as ViewRootForTest` is the
@@ -366,8 +452,15 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
     }
 
     companion object {
-        private const val DEFAULT_WIDTH = 400
-        private const val DEFAULT_HEIGHT = 800
+        /**
+         * Sandbox dp used for wrapped axes. Matches the historical phone-shaped
+         * 400×800 dp default that stood in for "no device" before AS-parity
+         * sizing — `fillMax*` composables get a reasonable viewport instead of
+         * a giant square. Mirrors `DeviceDimensions.SANDBOX_WIDTH/HEIGHT_DP`
+         * on the plugin side.
+         */
+        private const val SANDBOX_WIDTH_DP = 400
+        private const val SANDBOX_HEIGHT_DP = 800
 
         /**
          * Virtual time to advance before capture in the paused-`mainClock`
@@ -384,6 +477,31 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
          */
         private const val CAPTURE_ADVANCE_MS = 32L
     }
+}
+
+/**
+ * Crops [file] in-place to the top-left region defined by [measured] on the
+ * wrapped axes. The non-wrapped axis keeps its original pixel extent — we
+ * never expand beyond the captured PNG, so a wrapped-axis crop that somehow
+ * exceeds the sandbox is clamped.
+ *
+ * Uses `javax.imageio` rather than Android's `Bitmap` so the path doesn't need
+ * a Robolectric shadow: this runs on the JVM side after `captureRoboImage`
+ * has already written a standard PNG.
+ */
+private fun cropPngTopLeft(
+    file: File,
+    wrapWidth: Boolean,
+    wrapHeight: Boolean,
+    measured: IntSize,
+) {
+    if (!file.exists()) return
+    val original = javax.imageio.ImageIO.read(file) ?: return
+    val cropW = (if (wrapWidth) measured.width else original.width).coerceIn(1, original.width)
+    val cropH = (if (wrapHeight) measured.height else original.height).coerceIn(1, original.height)
+    if (cropW == original.width && cropH == original.height) return
+    val cropped = original.getSubimage(0, 0, cropW, cropH)
+    javax.imageio.ImageIO.write(cropped, "PNG", file)
 }
 
 /**

--- a/renderer-desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderer-desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -12,23 +12,34 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
 import org.jetbrains.skia.EncodedImageFormat
+import java.io.ByteArrayInputStream
 import java.io.File
+import javax.imageio.ImageIO
 import kotlin.system.exitProcess
 
 /**
  * Standalone entry point for rendering Compose Desktop previews to PNG.
  *
- * Args: className functionName widthPx heightPx density showBackground backgroundColor outputFile [wrapperClassName]
+ * Args: className functionName widthPx heightPx density showBackground backgroundColor outputFile [wrapperClassName] [wrapWidth] [wrapHeight]
  *
  * The optional 9th argument is the FQN of a `PreviewWrapperProvider` (Compose 1.11+);
  * pass an empty string or omit to skip wrapping.
+ *
+ * Args 10 and 11 are AS-parity wrap flags. When an axis wraps, widthPx/heightPx
+ * are treated as a sandbox dimension — the renderer wraps the composable,
+ * measures its intrinsic size, and crops the final PNG to that size on the
+ * wrapped axis. Defaults to `false` when omitted so older callers keep the
+ * full-frame behaviour.
  */
 fun main(args: Array<String>) {
     if (args.size < 8) {
-        System.err.println("Usage: DesktopRendererMain <className> <functionName> <widthPx> <heightPx> <density> <showBackground> <backgroundColor> <outputFile> [wrapperClassName]")
+        System.err.println("Usage: DesktopRendererMain <className> <functionName> <widthPx> <heightPx> <density> <showBackground> <backgroundColor> <outputFile> [wrapperClassName] [wrapWidth] [wrapHeight]")
         exitProcess(1)
     }
 
@@ -53,11 +64,14 @@ fun main(args: Array<String>) {
     }
     val outputFile = File(args[7])
     val wrapperClassName = args.getOrNull(8)?.takeIf { it.isNotBlank() }
+    val wrapWidth = args.getOrNull(9)?.toBoolean() ?: false
+    val wrapHeight = args.getOrNull(10)?.toBoolean() ?: false
 
     try {
         renderPreview(
             className, functionName, widthPx, heightPx, density,
             showBackground, backgroundColor, outputFile, wrapperClassName,
+            wrapWidth, wrapHeight,
         )
     } catch (e: Exception) {
         System.err.println("Render failed for $className.$functionName: ${e.message}")
@@ -76,6 +90,8 @@ private fun renderPreview(
     backgroundColor: Long,
     outputFile: File,
     wrapperClassName: String?,
+    wrapWidth: Boolean,
+    wrapHeight: Boolean,
 ) {
     val clazz = Class.forName(className)
     val composableMethod = clazz.getDeclaredComposableMethod(functionName)
@@ -86,6 +102,10 @@ private fun renderPreview(
         density = Density(density),
     )
 
+    // Measured content size in pixels, captured from the wrapping Box via
+    // onGloballyPositioned. Only read when at least one axis wraps.
+    var measured: IntSize? = null
+
     scene.setContent {
         CompositionLocalProvider(LocalInspectionMode provides true) {
             val bgColor = when {
@@ -94,8 +114,52 @@ private fun renderPreview(
                 else -> Color.Transparent
             }
             val body: @Composable () -> Unit = {
-                Box(modifier = Modifier.fillMaxSize().background(bgColor)) {
-                    InvokeComposable(composableMethod, null)
+                if (wrapWidth || wrapHeight) {
+                    // AS-parity wrap: measure the composable with unbounded
+                    // constraints on wrapped axes (keep the sandbox constraint
+                    // on fixed axes), capture the child's pixel size, then
+                    // size the outer Box to exactly that. The .layout modifier
+                    // lets us both observe and bound the child's size in a
+                    // single measurement pass — more reliable under
+                    // ImageComposeScene than onGloballyPositioned, which is
+                    // tied to a post-layout effect pass the scene doesn't
+                    // always flush.
+                    // Bounded sandbox constraints (not Infinity) — matches
+                    // Android Studio's preview pane. `fillMaxWidth` / LazyColumn
+                    // / etc. require bounded constraints; they'd throw from
+                    // `InlineClassHelper` under an Infinity max. Small
+                    // composables (`Modifier.size(100.dp)`) still measure at
+                    // their intrinsic size and get cropped to that below;
+                    // `fillMax*` composables measure at the sandbox size and
+                    // no crop happens on that axis.
+                    Box(
+                        modifier = Modifier
+                            .layout { measurable, constraints ->
+                                // Relax the min constraint on wrapped axes so
+                                // small composables can shrink below the
+                                // sandbox; keep the max bounded (the parent's
+                                // maxWidth/maxHeight) so `fillMax*` / LazyColumn
+                                // still have a finite viewport.
+                                val wrappedConstraints = Constraints(
+                                    minWidth = if (wrapWidth) 0 else constraints.minWidth,
+                                    maxWidth = constraints.maxWidth,
+                                    minHeight = if (wrapHeight) 0 else constraints.minHeight,
+                                    maxHeight = constraints.maxHeight,
+                                )
+                                val placeable = measurable.measure(wrappedConstraints)
+                                measured = IntSize(placeable.width, placeable.height)
+                                layout(placeable.width, placeable.height) {
+                                    placeable.place(0, 0)
+                                }
+                            }
+                            .background(bgColor),
+                    ) {
+                        InvokeComposable(composableMethod, null)
+                    }
+                } else {
+                    Box(modifier = Modifier.fillMaxSize().background(bgColor)) {
+                        InvokeComposable(composableMethod, null)
+                    }
                 }
             }
             // `@PreviewWrapper(Provider::class)` — instantiate the provider reflectively
@@ -117,7 +181,30 @@ private fun renderPreview(
         ?: throw IllegalStateException("Failed to encode image to PNG")
 
     outputFile.parentFile?.mkdirs()
-    outputFile.writeBytes(pngData.bytes)
+
+    // Crop to the measured content bounds on wrapped axes. `measured` is
+    // populated during the Modifier.layout measure pass in the wrap branch
+    // above — if it somehow wasn't set (shouldn't happen, but defensive),
+    // fall back to the sandbox dimensions and write the uncropped PNG.
+    if ((wrapWidth || wrapHeight) && measured != null) {
+        val m = measured!!
+        val cropW = (if (wrapWidth) m.width else widthPx).coerceIn(1, widthPx)
+        val cropH = (if (wrapHeight) m.height else heightPx).coerceIn(1, heightPx)
+        val decoded = ByteArrayInputStream(pngData.bytes).use { ImageIO.read(it) }
+        if (decoded != null && (cropW < decoded.width || cropH < decoded.height)) {
+            val sub = decoded.getSubimage(
+                0,
+                0,
+                cropW.coerceAtMost(decoded.width),
+                cropH.coerceAtMost(decoded.height),
+            )
+            ImageIO.write(sub, "PNG", outputFile)
+        } else {
+            outputFile.writeBytes(pngData.bytes)
+        }
+    } else {
+        outputFile.writeBytes(pngData.bytes)
+    }
 
     scene.close()
 }


### PR DESCRIPTION
## Summary

Match Android Studio's preview-pane sizing rules. `@Preview` without a device / widthDp / heightDp / showSystemUi now wraps to the composable's intrinsic size instead of always landing in a 400×800 dp frame. Fixes the VS Code tile view showing small component previews dominated by grey/transparent space (the `ConfigProbe` 220×120 dp surface in the giant 400×800 canvas, the 100 dp color boxes, etc.).

Per-axis rules, matching AS:

| Condition | Width | Height |
|---|---|---|
| `device != null` OR `showSystemUi == true` | device frame | device frame |
| `widthDp` set | fixed | (per height col) |
| `heightDp` set | (per width col) | fixed |
| none of the above | wrap | wrap |

Rules stack: `@Preview(widthDp = 240)` → width fixed, height wraps.

## Implementation

- `DeviceDimensions.resolveForRender` returns a new `SizeSpec` carrying per-axis wrap flags plus sandbox dp (400×800) for wrapped axes.
- Discovery stops pre-resolving widthDp/heightDp for the wrap case; `previews.json` serializes `null` on those axes. Downstream (VS Code extension) already tolerates null — no UI change.
- Both renderers wrap the strategy's composable in a `Box(Modifier.layout { ... })` that measures with bounded sandbox constraints on non-wrapped axes and `minWidth=0`/`minHeight=0` on wrapped ones. `fillMax*` / `LazyColumn` still get a finite viewport (400×800 dp) rather than `Infinity` which would throw.
- After capture, PNG gets cropped to the measured pixel bounds on wrapped axes via `image.getSubimage(...)` (Android, `javax.imageio`) / `BufferedImage.getSubimage` (Desktop, post Skia encode).

Verified end-to-end on the samples:

| Preview | Before | After |
|---|---|---|
| `ConfigProbe` (no device) | 400×800 dp × 2.625 = giant | 220×120 px |
| `RedBoxPreview` 100.dp (Android) | full frame | 100×100 px |
| `RedBoxPreview` 100.dp (Desktop) | full frame | 263×263 px |
| `LoadingPreview` | full frame | 76×64 px |
| `AppPreview` (`fillMaxSize`) | full frame | 1050×2100 px (sandbox) |
| `PhoneGreetingPreview` (device=spec, showSystemUi) | 336×147 px | 336×147 px (unchanged) |

Tile previews always carry a device, so they're unaffected.

## Test plan

- [ ] `./gradlew check` — plugin unit + functional tests + renderer tests + samples all pass
- [ ] `./gradlew :sample-cmp:renderAllPreviews :sample-android:renderAllPreviews` — PNGs land at the intrinsic sizes listed above
- [ ] Open the VS Code extension, run "Render Previews" against sample-cmp / sample-android — tiles are tight to content; `PhoneGreetingPreview` still shows the device frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)