### PR TITLE
fix(discovery): pin DEFAULT_DENSITY on wrap-content previews

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -430,11 +430,16 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         } else {
             effectiveWidth = rawWidth
             effectiveHeight = rawHeight
-            // `null` → renderer falls back to its built-in default (AS's
-            // xxhdpi-ish `DEFAULT_DENSITY`). Avoid pinning the density here so
-            // a wrap-content preview behaves the same as AS's default-phone
-            // preview without baking a specific dpi into `previews.json`.
-            effectiveDensity = null
+            // Pin Android Studio's default preview density (xxhdpi-ish, 420dpi
+            // → 2.625x). Without this the Robolectric renderer defaults to
+            // mdpi (1.0x), which is fine at the PNG level but fuzzy in the VS
+            // Code tile grid: tiles have a `max-width: 180px`, so a 100-dp
+            // composable that produced a 100-px PNG under mdpi gets upscaled
+            // and looks blurry next to device-based previews rendered at
+            // their native densities. Pinning here keeps wrap-content
+            // previews at the same pixel density as both the Desktop
+            // renderer and Studio's own preview pane.
+            effectiveDensity = DeviceDimensions.DEFAULT_DENSITY
         }
         return PreviewParams(
             name = (pv.getValue("name") as? String)?.ifBlank { null },


### PR DESCRIPTION
## Summary

Fixes the fuzzy tile rendering introduced by #74. Wrap-content previews now render at Android Studio's default xxhdpi-ish density (2.625x) instead of Robolectric's mdpi (1.0x), matching both the Desktop renderer and Studio's own preview pane.

## Root cause

- #70 wired a `density` qualifier into the Robolectric renderer — [RobolectricRenderTest.kt:439](renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt:439) emits `<n>dpi` when `params.density != null`.
- #74 left `params.density = null` for bare `@Preview` (no device, no showSystemUi), with the comment "renderer falls back to its built-in default."
- But the Robolectric fallback isn't `DEFAULT_DENSITY` — it's whatever Robolectric's `Configuration` defaults to, which is mdpi.
- Downstream: VS Code tiles have `max-width: 180px` ([preview.css:41](vscode-extension/media/preview.css:41)). A 100-dp composable → 100-px PNG gets upscaled by the browser to fit the slot, conspicuously blurry next to device-based previews that render at their real densities.

The Desktop renderer wasn't affected because [RenderPreviewsTask.kt:84](gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt:84) already falls back to `spec.density` (DEFAULT_DENSITY for the wrap case).

## Fix

Pin `DEFAULT_DENSITY = 2.625f` in [DiscoverPreviewsTask.kt](gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt) for the wrap-content branch. Single-line change; the rest of the pipeline was already in place.

## Before / after (sample-android)

| Preview | Before | After |
|---|---|---|
| RedBoxPreview (100 dp) | 100×100 | 263×263 |
| BlueBoxPreview (100 dp) | 100×100 | 263×263 |
| GreenBoxPreview (100 dp) | 100×100 | 263×263 |
| ConfigProbe (220×120 dp) | 220×120 | 578×315 |
| GreetingPreview | 107×24 | 282×63 |
| LoadingPreview | 76×64 | 197×168 |
| BadButtonPreview (20 dp) | 20×20 | 53×53 |
| ScrollPreviews (fillMaxSize) | 400×800 | 1050×2100 |
| PhoneGreetingPreview (device=spec) | 336×147 | 336×147 (unchanged) |

Desktop samples unchanged — they already rendered at the right density.

## Test plan

- [ ] `./gradlew check` passes — plugin unit + functional tests, renderer tests, samples all green.
- [ ] `./gradlew :sample-android:renderAllPreviews` produces PNGs at the pixel dimensions above; eyeball them in the VS Code extension panel — tiles crisp instead of fuzzy.
- [ ] Device-based previews (`PhoneGreetingPreview`, Wear samples) are byte-identical to the pre-PR renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)