### PR TITLE
feat(cli): surface multi-capture, brief JSON, --changed-only

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -1,7 +1,8 @@
 package ee.schimke.composeai.cli
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import java.io.File
 import java.security.MessageDigest
@@ -14,6 +15,13 @@ data class PreviewParams(
     val device: String? = null,
     val widthDp: Int? = null,
     val heightDp: Int? = null,
+    /**
+     * Compose density factor (= densityDpi / 160) resolved at discovery from
+     * the @Preview device; null means "use the renderer default". Carried
+     * through so agents can spot per-device fan-outs without re-reading the
+     * Gradle manifest.
+     */
+    val density: Float? = null,
     val fontScale: Float = 1.0f,
     val showSystemUi: Boolean = false,
     val showBackground: Boolean = false,
@@ -22,11 +30,29 @@ data class PreviewParams(
     val locale: String? = null,
     val group: String? = null,
     val wrapperClassName: String? = null,
+    /** "COMPOSE" or "TILE". Free-form string so unknown future kinds round-trip. */
+    val kind: String = "COMPOSE",
+)
+
+/**
+ * Scroll state of a capture. Mirrors `ScrollCapture` in
+ * gradle-plugin/PreviewData.kt — kept as a string-typed mirror so unknown
+ * future modes/axes round-trip cleanly through the CLI.
+ */
+@Serializable
+data class ScrollCapture(
+    val mode: String,
+    val axis: String = "VERTICAL",
+    val maxScrollPx: Int = 0,
+    val reduceMotion: Boolean = true,
+    val atEnd: Boolean = false,
+    val reachedPx: Int? = null,
 )
 
 @Serializable
 data class Capture(
     val advanceTimeMillis: Long? = null,
+    val scroll: ScrollCapture? = null,
     val renderOutput: String = "",
 )
 
@@ -75,6 +101,25 @@ data class AccessibilityReport(
     val entries: List<AccessibilityEntry>,
 )
 
+/**
+ * One rendered snapshot inside a [PreviewResult]. Carries the dimensional
+ * coordinates ([advanceTimeMillis], [scroll]) that distinguish this capture
+ * from its siblings, plus runtime data the agent needs to act on it
+ * ([pngPath], [sha256], [changed]).
+ *
+ * A static preview produces a single `CaptureResult` with both dimensions
+ * null; an animation/scroll fan-out produces N entries — one row per capture
+ * filename on disk.
+ */
+@Serializable
+data class CaptureResult(
+    val advanceTimeMillis: Long? = null,
+    val scroll: ScrollCapture? = null,
+    val pngPath: String? = null,
+    val sha256: String? = null,
+    val changed: Boolean? = null,
+)
+
 /** CLI output DTO — enriches manifest entries with runtime data agents need. */
 @Serializable
 data class PreviewResult(
@@ -84,8 +129,18 @@ data class PreviewResult(
     val className: String,
     val sourceFile: String? = null,
     val params: PreviewParams = PreviewParams(),
+    /**
+     * All rendered snapshots for this preview. Always at least one element.
+     * `length > 1` ⇔ a `@RoboComposePreviewOptions` time fan-out or a
+     * scroll-with-progress capture — agents that need every PNG should
+     * iterate this list rather than reading [pngPath].
+     */
+    val captures: List<CaptureResult> = emptyList(),
+    /** First capture's PNG path. Kept for back-compat with existing agents. */
     val pngPath: String? = null,
+    /** First capture's PNG sha256. Kept for back-compat. */
     val sha256: String? = null,
+    /** First capture's `changed` flag. Kept for back-compat. */
     val changed: Boolean? = null,
     /**
      * ATF findings for this preview, or `null` when accessibility checks were
@@ -100,6 +155,76 @@ data class PreviewResult(
     val a11yAnnotatedPath: String? = null,
 )
 
+/**
+ * Versioned envelope for `compose-preview show|list|a11y --json`. Pinning the
+ * schema lets agents detect format breaks without dispatching on field
+ * shapes — bump [SHOW_LIST_SCHEMA] when the per-row shape changes.
+ *
+ * Top-level [previews] is the same `PreviewResult` list the unwrapped form
+ * used to emit. The [counts] block is filled in by `show`/`a11y` (where
+ * `changed` is meaningful) and lets agents skip downloading every PNG when
+ * they only care about the diff against the previous run.
+ */
+@Serializable
+data class PreviewListResponse(
+    val schema: String = SHOW_LIST_SCHEMA,
+    val previews: List<PreviewResult>,
+    val counts: PreviewCounts? = null,
+)
+
+@Serializable
+data class PreviewCounts(
+    val total: Int,
+    val changed: Int,
+    val unchanged: Int,
+    val missing: Int,
+)
+
+/**
+ * Compact response shape emitted under `--brief`. Drops everything an agent
+ * already had from a prior `show --json` (functionName, className, params,
+ * sourceFile) and shortens field names so the per-row JSON shrinks to ~5x
+ * smaller. Keys are intentionally terse:
+ *   `png` = absolute PNG path, `sha` = first 12 hex chars of sha256,
+ *   `time` = advanceTimeMillis, `scroll` = scroll mode string.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class BriefPreviewListResponse(
+    // Always-encode so brief mode (encodeDefaults=false) still emits the
+    // version pin agents grep for.
+    @EncodeDefault val schema: String = SHOW_LIST_BRIEF_SCHEMA,
+    val previews: List<BriefPreviewResult>,
+    val counts: PreviewCounts? = null,
+)
+
+@Serializable
+data class BriefPreviewResult(
+    val id: String,
+    /** Omitted in single-module output. */
+    val module: String? = null,
+    val captures: List<BriefCapture>,
+    /** Number of ATF findings; null when a11y is off for the module. */
+    val a11y: Int? = null,
+)
+
+@Serializable
+data class BriefCapture(
+    /** Absolute path; null when render didn't produce a PNG. */
+    val png: String? = null,
+    /** sha256 prefix (12 hex chars); null when no PNG. */
+    val sha: String? = null,
+    /** null when first run / unknown. */
+    val changed: Boolean? = null,
+    /** advanceTimeMillis; omitted for static captures. */
+    val time: Long? = null,
+    /** Scroll mode (`END`/`LONG`); omitted when no scroll drive. */
+    val scroll: String? = null,
+)
+
+internal const val SHOW_LIST_SCHEMA = "compose-preview-show/v1"
+internal const val SHOW_LIST_BRIEF_SCHEMA = "compose-preview-show-brief/v1"
+
 @Serializable
 private data class CliState(val shas: Map<String, String> = emptyMap())
 
@@ -107,6 +232,17 @@ private val json = Json {
     ignoreUnknownKeys = true
     prettyPrint = true
     encodeDefaults = true
+}
+
+/**
+ * JSON config for `--brief`: no pretty-print (one-line-per-row encoding is
+ * the common agent consumption pattern) and `encodeDefaults = false` so all
+ * the null/false/0 fields drop out instead of bloating the payload.
+ */
+private val briefJson = Json {
+    ignoreUnknownKeys = true
+    prettyPrint = false
+    encodeDefaults = false
 }
 
 abstract class Command(protected val args: List<String>) {
@@ -117,6 +253,14 @@ abstract class Command(protected val args: List<String>) {
     protected val verbose: Boolean = "--verbose" in args || "-v" in args
     protected val progress: Boolean = verbose || "--progress" in args
     protected val timeoutSeconds: Long = args.flagValue("--timeout")?.toLongOrNull() ?: 300
+    /** When true, drop previews with no `changed=true` capture from JSON output. */
+    protected val changedOnly: Boolean = "--changed-only" in args
+    /**
+     * Compact JSON: drop `functionName`/`className`/`sourceFile`/`module`/`params`
+     * from each row, keep `id` + `captures`. Designed for agent re-render loops
+     * where the full metadata was already cached on first call.
+     */
+    protected val brief: Boolean = "--brief" in args
 
     protected lateinit var projectDir: File
         private set
@@ -202,10 +346,16 @@ abstract class Command(protected val args: List<String>) {
     }
 
     /**
-     * Reads PNGs for every manifest entry, hashes them, compares against the
-     * per-module sidecar state file to emit `changed`, and persists the new
-     * hashes. Sidecar lives under `build/compose-previews/` so it gets wiped on
-     * `./gradlew clean`.
+     * Reads PNGs for every capture of every manifest entry, hashes them,
+     * compares against the per-module sidecar state file to emit per-capture
+     * `changed`, and persists the new hashes. Sidecar lives under
+     * `build/compose-previews/` so it gets wiped on `./gradlew clean`.
+     *
+     * State is keyed `<id>` for the first capture (preserves legacy state
+     * files from before per-capture tracking) and `<id>#<n>` for subsequent
+     * captures of an animation/scroll fan-out. The top-level `pngPath` /
+     * `sha256` / `changed` on [PreviewResult] mirror the first capture
+     * verbatim so existing agents keep working.
      */
     protected fun buildResults(manifests: List<Pair<String, PreviewManifest>>): List<PreviewResult> {
         val results = mutableListOf<PreviewResult>()
@@ -219,21 +369,29 @@ abstract class Command(protected val args: List<String>) {
             val updated = mutableMapOf<String, String>()
 
             for (p in manifest.previews) {
-                // Hash the first capture's PNG as the preview's
-                // representative. Per-capture change tracking is a future
-                // follow-up; today CLI surfaces one row per preview.
-                val pngFile = p.captures.firstOrNull()?.renderOutput
-                    ?.takeIf { it.isNotEmpty() }
-                    ?.let { projectDir.resolve("$module/build/compose-previews/$it").canonicalFile }
-                    ?.takeIf { it.exists() }
-                val sha = pngFile?.let { sha256(it.readBytes()) }
-                if (sha != null) updated[p.id] = sha
-                val priorSha = prior[p.id]
-                val changed = when {
-                    sha == null -> null
-                    priorSha == null -> true
-                    else -> priorSha != sha
+                val captureResults = p.captures.mapIndexed { index, capture ->
+                    val pngFile = capture.renderOutput
+                        .takeIf { it.isNotEmpty() }
+                        ?.let { projectDir.resolve("$module/build/compose-previews/$it").canonicalFile }
+                        ?.takeIf { it.exists() }
+                    val sha = pngFile?.let { sha256(it.readBytes()) }
+                    val stateKey = if (index == 0) p.id else "${p.id}#$index"
+                    if (sha != null) updated[stateKey] = sha
+                    val priorSha = prior[stateKey]
+                    val changed = when {
+                        sha == null -> null
+                        priorSha == null -> true
+                        else -> priorSha != sha
+                    }
+                    CaptureResult(
+                        advanceTimeMillis = capture.advanceTimeMillis,
+                        scroll = capture.scroll,
+                        pngPath = pngFile?.absolutePath,
+                        sha256 = sha,
+                        changed = changed,
+                    )
                 }
+                val first = captureResults.firstOrNull()
                 val a11yPair = when {
                     module in modulesWithA11y -> a11yByKey["$module/${p.id}"]
                     else -> null
@@ -249,9 +407,10 @@ abstract class Command(protected val args: List<String>) {
                     className = p.className,
                     sourceFile = p.sourceFile,
                     params = p.params,
-                    pngPath = pngFile?.absolutePath,
-                    sha256 = sha,
-                    changed = changed,
+                    captures = captureResults,
+                    pngPath = first?.pngPath,
+                    sha256 = first?.sha256,
+                    changed = first?.changed,
                     a11yFindings = a11y,
                     a11yAnnotatedPath = a11yPair?.second,
                 )
@@ -261,6 +420,61 @@ abstract class Command(protected val args: List<String>) {
         }
         return results
     }
+
+    /** True if the preview has at least one capture with `changed = true`. */
+    protected fun PreviewResult.anyChanged(): Boolean =
+        captures.any { it.changed == true } || changed == true
+
+    /** Filters by `--id` / `--filter` and (optionally) `--changed-only`. */
+    protected fun applyFilters(all: List<PreviewResult>): List<PreviewResult> =
+        all.filter { matchesRequest(it) && (!changedOnly || it.anyChanged()) }
+
+    /**
+     * @param results rows to emit (after `--id`/`--filter`/`--changed-only`)
+     * @param countsScope rows the [PreviewCounts] should be computed from —
+     *   typically the unfiltered set so the agent sees totals even when
+     *   `--changed-only` narrows the visible rows. Pass `null` to omit counts.
+     */
+    protected fun encodeResponse(
+        results: List<PreviewResult>,
+        countsScope: List<PreviewResult>?,
+    ): String {
+        val counts = countsScope?.let { countsOf(it) }
+        if (brief) {
+            val multiModule = results.map { it.module }.distinct().size > 1
+            val brief = results.map { r ->
+                BriefPreviewResult(
+                    id = r.id,
+                    module = r.module.takeIf { multiModule },
+                    captures = r.captures.map { c ->
+                        BriefCapture(
+                            png = c.pngPath,
+                            sha = c.sha256?.take(12),
+                            changed = c.changed,
+                            time = c.advanceTimeMillis,
+                            scroll = c.scroll?.mode,
+                        )
+                    },
+                    a11y = r.a11yFindings?.size,
+                )
+            }
+            return briefJson.encodeToString(
+                BriefPreviewListResponse.serializer(),
+                BriefPreviewListResponse(previews = brief, counts = counts),
+            )
+        }
+        return json.encodeToString(
+            PreviewListResponse.serializer(),
+            PreviewListResponse(previews = results, counts = counts),
+        )
+    }
+
+    private fun countsOf(results: List<PreviewResult>) = PreviewCounts(
+        total = results.size,
+        changed = results.count { it.anyChanged() },
+        unchanged = results.count { !it.anyChanged() && it.captures.any { c -> c.pngPath != null } },
+        missing = results.count { it.captures.all { c -> c.pngPath == null } },
+    )
 
     protected fun matchesRequest(result: PreviewResult): Boolean {
         if (exactId != null && result.id != exactId) return false
@@ -313,20 +527,25 @@ class ShowCommand(args: List<String>) : Command(args) {
 
             val manifests = readAllManifests(modules)
             if (manifests.isEmpty() || manifests.all { it.second.previews.isEmpty() }) {
-                if (jsonOutput) println("[]") else println("No previews found.")
+                if (jsonOutput) println(encodeResponse(emptyList(), countsScope = emptyList()))
+                else println("No previews found.")
                 exitProcess(3)
             }
 
             val all = buildResults(manifests)
-            val filtered = all.filter { matchesRequest(it) }
+            val filtered = applyFilters(all)
 
             if (filtered.isEmpty()) {
-                if (jsonOutput) println("[]") else println("No previews matched.")
+                // Counts reflect the full discovered set so an agent using
+                // `--changed-only` can still see "60 unchanged, 0 changed"
+                // and skip a follow-up query.
+                if (jsonOutput) println(encodeResponse(emptyList(), countsScope = all))
+                else println("No previews matched.")
                 exitProcess(3)
             }
 
             if (jsonOutput) {
-                println(json.encodeToString(ListSerializer(PreviewResult.serializer()), filtered))
+                println(encodeResponse(filtered, countsScope = all))
             } else {
                 var lastModule: String? = null
                 for (r in filtered) {
@@ -336,16 +555,32 @@ class ShowCommand(args: List<String>) : Command(args) {
                     }
                     val statusTag = when {
                         r.pngPath == null -> " [no PNG]"
-                        r.changed == true -> " [changed]"
+                        r.anyChanged() -> " [changed]"
                         else -> ""
                     }
                     val shaTag = r.sha256?.let { "  sha=${it.take(12)}" } ?: ""
                     println("${r.functionName} (${r.id})$statusTag$shaTag")
-                    if (r.pngPath != null) println("  ${r.pngPath}")
+                    if (r.captures.size <= 1) {
+                        if (r.pngPath != null) println("  ${r.pngPath}")
+                    } else {
+                        for (c in r.captures) {
+                            val tag = when {
+                                c.pngPath == null -> " [no PNG]"
+                                c.changed == true -> " [changed]"
+                                else -> ""
+                            }
+                            val coord = listOfNotNull(
+                                c.advanceTimeMillis?.let { "${it}ms" },
+                                c.scroll?.let { "scroll ${it.mode.lowercase()}" },
+                            ).joinToString(" · ").ifEmpty { "default" }
+                            println("  [$coord]$tag ${c.pngPath ?: ""}")
+                        }
+                    }
                 }
             }
 
-            val missing = filtered.filter { it.pngPath == null }
+            // "Missing" = at least one capture failed to produce a PNG.
+            val missing = filtered.filter { r -> r.captures.any { it.pngPath == null } }
             if (missing.isNotEmpty()) {
                 System.err.println(
                     "Render task completed but produced no PNG for ${missing.size} of ${filtered.size} preview(s).",
@@ -373,16 +608,18 @@ class ListCommand(args: List<String>) : Command(args) {
 
             val manifests = readAllManifests(modules)
             // List runs discovery only — PNGs may not exist, so sha/changed are null.
+            // `--changed-only` is meaningless without rendering; ignore it here.
             val all = buildResults(manifests)
             val filtered = all.filter { matchesRequest(it) }
 
             if (filtered.isEmpty()) {
-                if (jsonOutput) println("[]") else println("No previews found.")
+                if (jsonOutput) println(encodeResponse(emptyList(), countsScope = null))
+                else println("No previews found.")
                 exitProcess(3)
             }
 
             if (jsonOutput) {
-                println(json.encodeToString(ListSerializer(PreviewResult.serializer()), filtered))
+                println(encodeResponse(filtered, countsScope = null))
             } else {
                 for (r in filtered) {
                     println("${r.id}  (${r.sourceFile ?: "unknown"})")
@@ -404,6 +641,9 @@ class RenderCommand(args: List<String>) : Command(args) {
 
             val manifests = readAllManifests(modules)
             val all = buildResults(manifests)
+            // `render` ignores `--changed-only` so the agent can ask "render
+            // the world, but report only what changed" via a follow-up
+            // `show --changed-only`.
             val filtered = all.filter { matchesRequest(it) }
 
             if (filtered.isEmpty()) {
@@ -411,7 +651,7 @@ class RenderCommand(args: List<String>) : Command(args) {
                 exitProcess(3)
             }
 
-            val missing = filtered.filter { it.pngPath == null }
+            val missing = filtered.filter { r -> r.captures.any { it.pngPath == null } }
 
             if (output != null) {
                 if (filtered.size != 1) {
@@ -431,7 +671,7 @@ class RenderCommand(args: List<String>) : Command(args) {
             } else {
                 val rendered = filtered.size - missing.size
                 println("Rendered $rendered preview(s)")
-                val changedCount = filtered.count { it.changed == true }
+                val changedCount = filtered.count { it.anyChanged() }
                 if (changedCount > 0) println("  $changedCount changed since last run")
                 if (missing.isNotEmpty()) {
                     System.err.println(
@@ -466,7 +706,8 @@ class A11yCommand(args: List<String>) : Command(args) {
             val manifests = readAllManifests(modules)
             val enabledModules = manifests.filter { it.second.accessibilityReport != null }
             if (enabledModules.isEmpty()) {
-                if (jsonOutput) println("[]") else {
+                if (jsonOutput) println(encodeResponse(emptyList(), countsScope = null))
+                else {
                     println(
                         "No module has accessibility checks enabled. Add\n" +
                             "  composePreview { accessibilityChecks { enabled = true } }\n" +
@@ -477,10 +718,12 @@ class A11yCommand(args: List<String>) : Command(args) {
             }
 
             val all = buildResults(manifests)
-            val filtered = all.filter { matchesRequest(it) && it.a11yFindings != null }
+            val filtered = all.filter {
+                matchesRequest(it) && it.a11yFindings != null && (!changedOnly || it.anyChanged())
+            }
 
             if (jsonOutput) {
-                println(json.encodeToString(ListSerializer(PreviewResult.serializer()), filtered))
+                println(encodeResponse(filtered, countsScope = null))
             } else {
                 val flat = filtered.flatMap { r ->
                     (r.a11yFindings ?: emptyList()).map { f -> r to f }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -80,7 +80,9 @@ private fun printUsage() {
           --variant <variant>  Build variant (default: debug)
           --filter <pattern>   Case-insensitive substring match on preview id
           --id <exact>         Exact match on preview id
-          --json               Emit JSON (show, list)
+          --json               Emit JSON (show, list, a11y)
+          --brief              JSON only: drop functionName/className/sourceFile/params
+          --changed-only       JSON only (show, a11y): drop previews with no changed capture
           --output <path>      Copy matched preview PNG to this path (render)
           --progress           Print per-task milestone/heartbeat lines to stderr
           --verbose, -v        Show full Gradle build output (implies --progress)
@@ -90,9 +92,15 @@ private fun printUsage() {
         OSC 9;4 terminal progress (native taskbar/tab progress bar) is on by
         default in a TTY and auto-disables when stdout is piped or redirected.
 
-        JSON output includes sha256 of each rendered PNG and a `changed` flag
-        computed against the previous invocation (state under
-        <module>/build/compose-previews/.cli-state.json; wiped on `clean`).
+        JSON output is wrapped in {schema, previews, counts?} (schema:
+        compose-preview-show/v1). Each preview includes a `captures[]` array
+        with per-capture pngPath/sha256/changed/advanceTimeMillis/scroll.
+        For back-compat the top-level pngPath/sha256/changed mirror the first
+        capture. State persisted per module under
+        <module>/build/compose-previews/.cli-state.json (wiped on `clean`).
+
+        Exit codes: 0 success, 1 build/CLI error, 2 render failure or a11y
+        threshold tripped, 3 no previews found / matched.
         """.trimIndent()
     )
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
@@ -1,0 +1,113 @@
+package ee.schimke.composeai.cli
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PreviewListResponseTest {
+    private val json = Json { prettyPrint = false; encodeDefaults = true; ignoreUnknownKeys = true }
+
+    @Test
+    fun `envelope pins schema and round-trips captures`() {
+        val response = PreviewListResponse(
+            previews = listOf(
+                PreviewResult(
+                    id = "Preview_A",
+                    module = "sample-android",
+                    functionName = "PreviewA",
+                    className = "com.example.PreviewsKt",
+                    sourceFile = "Previews.kt",
+                    captures = listOf(
+                        CaptureResult(
+                            advanceTimeMillis = 0L,
+                            pngPath = "/abs/A_TIME_0ms.png",
+                            sha256 = "deadbeef",
+                            changed = true,
+                        ),
+                        CaptureResult(
+                            advanceTimeMillis = 500L,
+                            pngPath = "/abs/A_TIME_500ms.png",
+                            sha256 = "feedface",
+                            changed = false,
+                        ),
+                    ),
+                    pngPath = "/abs/A_TIME_0ms.png",
+                    sha256 = "deadbeef",
+                    changed = true,
+                ),
+            ),
+            counts = PreviewCounts(total = 1, changed = 1, unchanged = 0, missing = 0),
+        )
+
+        val text = json.encodeToString(PreviewListResponse.serializer(), response)
+        val parsed = json.decodeFromString(PreviewListResponse.serializer(), text)
+        assertEquals(response, parsed)
+
+        // Schema is the agent contract — keep it greppable without parsing.
+        assertTrue("\"schema\":\"$SHOW_LIST_SCHEMA\"" in text)
+        // Multi-capture fan-out is faithfully serialised.
+        assertEquals(2, parsed.previews.single().captures.size)
+        assertEquals(500L, parsed.previews.single().captures[1].advanceTimeMillis)
+    }
+
+    @Test
+    fun `default schema field stays at v1`() {
+        // Bump this test deliberately when rolling to v2 — guards against
+        // accidentally breaking the CLI→agent contract.
+        val response = PreviewListResponse(previews = emptyList())
+        assertEquals("compose-preview-show/v1", response.schema)
+    }
+
+    @Test
+    fun `brief response drops null and default fields`() {
+        // encodeDefaults=false on the brief encoder is the lever that makes
+        // this work — verify it actually fires.
+        val response = BriefPreviewListResponse(
+            previews = listOf(
+                BriefPreviewResult(
+                    id = "P",
+                    captures = listOf(
+                        BriefCapture(png = "/p.png", sha = "abcdef012345", changed = true),
+                    ),
+                ),
+            ),
+            counts = PreviewCounts(total = 1, changed = 1, unchanged = 0, missing = 0),
+        )
+        val brief = Json { prettyPrint = false; encodeDefaults = false }
+            .encodeToString(BriefPreviewListResponse.serializer(), response)
+
+        // Schema and core fields are present.
+        assertTrue(""""schema":"$SHOW_LIST_BRIEF_SCHEMA"""" in brief)
+        assertTrue(""""id":"P"""" in brief)
+        assertTrue(""""png":"/p.png"""" in brief)
+        // Nulls / unspecified optionals are absent.
+        assertTrue("\"module\"" !in brief)
+        assertTrue("\"a11y\"" !in brief)
+        assertTrue("\"time\"" !in brief)
+        assertTrue("\"scroll\"" !in brief)
+    }
+
+    @Test
+    fun `manifest with old-shape renderOutput still parses via ignoreUnknownKeys`() {
+        // Pre-multi-capture manifests had `renderOutput` directly on
+        // `PreviewInfo`. New CLI types don't carry that field; verify they
+        // still parse without throwing (it's just dropped).
+        val legacy = """
+            {
+              "module":"m",
+              "variant":"debug",
+              "previews":[{
+                "id":"X","functionName":"X","className":"K",
+                "params":{"name":null,"group":"g"},
+                "renderOutput":"renders/X.png"
+              }]
+            }
+        """.trimIndent()
+        val parsed = json.decodeFromString(PreviewManifest.serializer(), legacy)
+        assertEquals("X", parsed.previews.single().id)
+        assertEquals("g", parsed.previews.single().params.group)
+        // Default capture list is a single empty capture.
+        assertEquals(1, parsed.previews.single().captures.size)
+    }
+}


### PR DESCRIPTION
## Summary

Three changes to make the agent re-render loop ("render, see what changed, read those PNGs") cheap.

### 1. Multi-capture surfacing

`PreviewResult` gains a `captures: List<CaptureResult>` carrying per-capture pngPath/sha256/changed/advanceTimeMillis/scroll. Previously the CLI only ever surfaced the first capture per preview, so `@RoboComposePreviewOptions` time fan-outs and `@ScrollingPreview` captures were invisible to JSON consumers (the VS Code extension already iterated all captures — CLI was the laggard).

State tracking moves to per-capture too: `<id>` for capture 0, `<id>#<n>` for subsequent captures, so legacy `.cli-state.json` files keep working.

### 2. `--brief` JSON shape

A new `compose-preview-show-brief/v1` schema drops `functionName`/`className`/`sourceFile`/`params` and shortens keys (`png`/`sha`/`time`/`scroll`). Roughly 6× smaller per row — for agent re-render loops where the metadata was cached on the first `show --json` call.

```jsonc
// --json (full) — one preview, ~700 chars
{
  "schema": "compose-preview-show/v1",
  "previews": [{
    "id": "...RedBoxPreview_Red Box",
    "module": "sample-cmp", "functionName": "RedBoxPreview", "className": "...",
    "sourceFile": "...", "params": { …13 fields… },
    "captures": [{ "advanceTimeMillis": null, "scroll": null,
                   "pngPath": "/abs/...", "sha256": "f1f9fce5...", "changed": true }],
    "pngPath": "/abs/...", "sha256": "f1f9fce5...", "changed": true,
    "a11yFindings": null, "a11yAnnotatedPath": null
  }],
  "counts": { "total": 3, "changed": 1, "unchanged": 2, "missing": 0 }
}

// --json --brief — same preview, ~140 chars
{"schema":"compose-preview-show-brief/v1","previews":[{"id":"...RedBoxPreview_Red Box","captures":[{"png":"/abs/...","sha":"f1f9fce59bf7","changed":true}]}],"counts":{"total":3,"changed":1,"unchanged":2,"missing":0}}
```

### 3. `--changed-only` filter

Drops previews with no changed capture from JSON output. Counts are computed over the full set so the agent still sees totals ("3 previews, 0 changed") without a follow-up query — pairs naturally with `--brief` for the minimum-payload case.

### Misc

- Top-level JSON now wrapped in `{schema, previews, counts?}` envelope (`compose-preview-show/v1`) — gives agents a stable contract to detect breaks against, matching what `doctor --json` already does.
- Top-level `pngPath`/`sha256`/`changed` on `PreviewResult` kept as back-compat aliases for `captures[0]`'s values.
- Local CLI data classes synced with the plugin's `PreviewData.kt` — added missing `density`, `kind` to params and `scroll` to capture, so the round-trip no longer silently drops fields.
- `Main.kt` --help reorganised, exit codes documented inline.

## Test plan

- [x] `./gradlew :cli:test` — green (new `PreviewListResponseTest` covers envelope, brief encoding, legacy-shape parse).
- [x] `./gradlew :gradle-plugin:test` — green.
- [x] End-to-end against `:sample-cmp:renderAllPreviews`: full JSON, `--brief`, `--brief --changed-only`, all show expected output and exit codes.