### PR TITLE
refactor(cli): dedupe flagValue extension into shared Args.kt

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Args.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Args.kt
@@ -1,0 +1,14 @@
+package ee.schimke.composeai.cli
+
+/**
+ * Returns the value of `flag` from a positional argv (e.g. `--module foo`),
+ * or `null` if the flag is missing or unaccompanied.
+ *
+ * Trivial parser shared by every command. If we ever grow more flag types
+ * (repeatable, comma-list, equals-form), promote this file to a real argv
+ * helper rather than duplicating the parser per call-site.
+ */
+internal fun List<String>.flagValue(flag: String): String? {
+    val idx = indexOf(flag)
+    return if (idx >= 0 && idx + 1 < size) this[idx + 1] else null
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -773,8 +773,3 @@ private fun sha256(bytes: ByteArray): String {
     val md = MessageDigest.getInstance("SHA-256")
     return md.digest(bytes).joinToString("") { "%02x".format(it) }
 }
-
-private fun List<String>.flagValue(flag: String): String? {
-    val idx = indexOf(flag)
-    return if (idx >= 0 && idx + 1 < size) this[idx + 1] else null
-}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -624,7 +624,3 @@ data class DoctorSummary(
     val skipped: Int,
 )
 
-private fun List<String>.flagValue(flag: String): String? {
-    val idx = indexOf(flag)
-    return if (idx >= 0 && idx + 1 < size) this[idx + 1] else null
-}


### PR DESCRIPTION
## Summary

Both `Commands.kt` and `DoctorCommand.kt` declared a private `List<String>.flagValue(String): String?` with identical bodies — pure copy-paste. Move it to a one-function `Args.kt` and drop the duplicates.

The kdoc on `Args.flagValue` notes the upgrade path: if we ever grow more flag types (repeatable, comma-list, equals-form), this is the right place to evolve, rather than re-duplicating per call-site.

## Test plan

- [x] `./gradlew :cli:test` — green.