### PR TITLE
feat(scroll): stitched capture for @ScrollingPreview(mode = LONG)

### DIFF
--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.ViewRootForTest
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
@@ -317,40 +318,55 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                         currentTime = target
                     }
 
-                    // @ScrollingPreview: drive the first scrollable on the
-                    // requested axis to the end of its content before the
-                    // snapshot. Both ScrollMode values capture the end-state
-                    // for now — true long-scroll stitching lands in a
-                    // follow-up; the manifest field stays stable across that
-                    // transition.
-                    capture.scroll?.let { scroll ->
-                        val result = driveScrollToEnd(
-                            rule = rule,
-                            axis = scroll.axis,
-                            maxScrollPx = scroll.maxScrollPx,
-                        )
-                        if (result is ScrollDriveResult.NoScrollable) {
-                            System.err.println(
-                                "@ScrollingPreview on '${preview.id}' but no scrollable " +
-                                    "composable found on axis ${scroll.axis} — capturing initial frame.",
-                            )
-                        }
-                    }
-
+                    // @ScrollingPreview(END): drive the first scrollable on the
+                    // requested axis to the end of its content before a single
+                    // capture.
+                    // @ScrollingPreview(LONG): stitched capture — one slice per
+                    // viewport-height of scroll, then Java2D-stitched into one
+                    // tall PNG with an optional Wear pill clip. See
+                    // [handleLongCapture].
                     val outputFile = outputFileFor(capture, outputDir)
                     outputFile.parentFile?.mkdirs()
-                    onRoot.captureRoboImage(
-                        file = outputFile,
-                        roborazziOptions = roborazziOptions,
-                    )
+
+                    val scroll = capture.scroll
+                    val longHandled = scroll != null &&
+                        scroll.mode == ScrollMode.LONG &&
+                        scroll.axis == ScrollAxis.VERTICAL &&
+                        handleLongCapture(
+                            rule = rule,
+                            scroll = scroll,
+                            previewId = preview.id,
+                            heightDp = heightDp,
+                            isRound = isRoundDevice(params.device) &&
+                                (params.showSystemUi || params.kind == PreviewKind.TILE),
+                            outputFile = outputFile,
+                        )
+
+                    if (!longHandled) {
+                        if (scroll != null) {
+                            val result = driveScrollToEnd(
+                                rule = rule,
+                                axis = scroll.axis,
+                                maxScrollPx = scroll.maxScrollPx,
+                            )
+                            if (result is ScrollDriveResult.NoScrollable) {
+                                System.err.println(
+                                    "@ScrollingPreview on '${preview.id}' but no scrollable " +
+                                        "composable found on axis ${scroll.axis} — capturing initial frame.",
+                                )
+                            }
+                        }
+                        onRoot.captureRoboImage(
+                            file = outputFile,
+                            roborazziOptions = roborazziOptions,
+                        )
+                    }
 
                     // AS-parity: crop the PNG down to the composable's
-                    // intrinsic size on wrapped axes. `measured` is populated
-                    // during the wrap Box's Modifier.layout measure pass on the
-                    // first composition and doesn't change between captures
-                    // (the wrapped axes stay the same), so it's safe to apply
-                    // per-capture here.
-                    if ((wrapWidth || wrapHeight) && measured != null) {
+                    // intrinsic size on wrapped axes. Skipped for stitched
+                    // LONG output — that PNG's dimensions are the stitched
+                    // scroll extent, not the composable's intrinsic box.
+                    if (!longHandled && (wrapWidth || wrapHeight) && measured != null) {
                         cropPngTopLeft(
                             file = outputFile,
                             wrapWidth = wrapWidth,
@@ -502,6 +518,73 @@ private fun cropPngTopLeft(
     if (cropW == original.width && cropH == original.height) return
     val cropped = original.getSubimage(0, 0, cropW, cropH)
     javax.imageio.ImageIO.write(cropped, "PNG", file)
+}
+
+/**
+ * Handles `@ScrollingPreview(mode = LONG)` captures. Drives the first
+ * scrollable on [ScrollCapture.axis] by one viewport-height per step via
+ * [driveScrollByViewport], captures each slice to a temp PNG with per-slice
+ * round crop DISABLED, and Java2D-stitches them via [stitchSlices].
+ *
+ * For round Wear devices ([isRound] = true), the stitched output gets a
+ * `capsule` clip — half-circle at the very top, rectangular middle,
+ * half-circle at the very bottom ([applyWearPillClip]) — so the captured
+ * scroll preserves the round screen edge at the first and last frames.
+ *
+ * Returns `true` when [outputFile] was written; `false` to let the caller
+ * fall through to END-style single capture (e.g. when no scrollable matched).
+ */
+@OptIn(ExperimentalRoborazziApi::class)
+private fun handleLongCapture(
+    rule: AndroidComposeTestRule<*, ComponentActivity>,
+    scroll: ScrollCapture,
+    previewId: String,
+    heightDp: Int,
+    isRound: Boolean,
+    outputFile: File,
+): Boolean {
+    val density = rule.activity.resources.displayMetrics.density
+    val viewportLayoutPx = (heightDp * density).toInt().coerceAtLeast(1)
+    val slicesDir = File(outputFile.parentFile, "${outputFile.nameWithoutExtension}_slices")
+    slicesDir.deleteRecursively()
+    slicesDir.mkdirs()
+
+    // For stitched capture on round devices, suppress per-slice round crop —
+    // otherwise every slice has a circle cut out of it and the stitched output
+    // has scalloped scallops down the middle. We apply a capsule clip after
+    // stitching instead.
+    val sliceRoborazziOptions = RoborazziOptions(
+        recordOptions = RoborazziOptions.RecordOptions(applyDeviceCrop = false),
+    )
+
+    val slices = mutableListOf<SliceCapture>()
+    try {
+        val result = driveScrollByViewport(
+            rule = rule,
+            axis = scroll.axis,
+            stepPx = viewportLayoutPx.toFloat(),
+            maxScrollPx = scroll.maxScrollPx,
+        ) { scrolledPx ->
+            val sliceFile = File(slicesDir, "slice_${slices.size}.png")
+            rule.onRoot().captureRoboImage(file = sliceFile, roborazziOptions = sliceRoborazziOptions)
+            slices += SliceCapture(scrolledPx, sliceFile)
+        }
+        if (result is ScrollDriveResult.NoScrollable) {
+            System.err.println(
+                "@ScrollingPreview(LONG) on '$previewId': no scrollable composable — falling through.",
+            )
+            return false
+        }
+        if (slices.isEmpty()) return false
+        stitchSlices(slices, viewportLayoutPx, outputFile) ?: return false
+        if (isRound) applyWearPillClip(outputFile)
+        System.err.println(
+            "@ScrollingPreview(LONG) on '$previewId': stitched ${slices.size} slices.",
+        )
+        return true
+    } finally {
+        slicesDir.deleteRecursively()
+    }
 }
 
 /**

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollDriver.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollDriver.kt
@@ -73,6 +73,70 @@ internal fun driveScrollToEnd(
     return ScrollDriveResult.IterationCapReached(scrolledPx)
 }
 
+/**
+ * Drives a scrollable by exactly [stepPx] per iteration and invokes
+ * [onSlice] with the cumulative scrolled pixel count once at offset 0
+ * (before the first scroll) and again after each successful step. Used
+ * by the `LONG` scroll-capture path to take one screenshot per viewport-
+ * height of content, which the caller then stitches into one tall PNG.
+ *
+ * Differs from [driveScrollToEnd] in that each step is a fixed size, not
+ * "all remaining" — the caller wants a slice per viewport, not a single
+ * jump to the bottom.
+ */
+@Suppress("LongParameterList")
+internal fun driveScrollByViewport(
+    rule: AndroidComposeTestRule<*, *>,
+    axis: ScrollAxis,
+    stepPx: Float,
+    maxScrollPx: Int,
+    maxIterations: Int = DEFAULT_MAX_ITERATIONS,
+    advanceMsPerStep: Long = DEFAULT_ADVANCE_MS_PER_STEP,
+    onSlice: (scrolledPx: Float) -> Unit,
+): ScrollDriveResult {
+    require(stepPx > 0f) { "stepPx must be positive, got $stepPx" }
+
+    val axisKey = when (axis) {
+        ScrollAxis.VERTICAL -> SemanticsProperties.VerticalScrollAxisRange
+        ScrollAxis.HORIZONTAL -> SemanticsProperties.HorizontalScrollAxisRange
+    }
+    val scrollables = rule.onAllNodes(SemanticsMatcher.keyIsDefined(axisKey)).fetchSemanticsNodes()
+    if (scrollables.isEmpty()) return ScrollDriveResult.NoScrollable
+
+    val interaction = rule.onAllNodes(SemanticsMatcher.keyIsDefined(axisKey))[0]
+    val cap = if (maxScrollPx > 0) maxScrollPx.toFloat() else Float.POSITIVE_INFINITY
+
+    // First slice captures the initial (unscrolled) frame.
+    onSlice(0f)
+
+    var scrolledPx = 0f
+    repeat(maxIterations) {
+        val node = interaction.fetchSemanticsNode()
+        val range: ScrollAxisRange = node.config.getOrNull(axisKey)
+            ?: return ScrollDriveResult.Completed(scrolledPx)
+        val scrollByAction = node.config.getOrNull(SemanticsActions.ScrollBy)?.action
+            ?: return ScrollDriveResult.Completed(scrolledPx)
+
+        val remaining = (range.maxValue() - range.value()).coerceAtLeast(0f)
+        if (remaining <= SETTLED_EPSILON_PX) return ScrollDriveResult.Completed(scrolledPx)
+
+        val headroom = (cap - scrolledPx).coerceAtLeast(0f)
+        if (headroom <= SETTLED_EPSILON_PX) return ScrollDriveResult.CapReached(scrolledPx)
+
+        val step = minOf(stepPx, remaining, headroom)
+        val (dx, dy) = when (axis) {
+            ScrollAxis.VERTICAL -> 0f to step
+            ScrollAxis.HORIZONTAL -> step to 0f
+        }
+        scrollByAction.invoke(dx, dy)
+        scrolledPx += step
+        rule.mainClock.advanceTimeBy(advanceMsPerStep)
+
+        onSlice(scrolledPx)
+    }
+    return ScrollDriveResult.IterationCapReached(scrolledPx)
+}
+
 internal sealed interface ScrollDriveResult {
     /** No scrollable composable found on the requested axis. */
     data object NoScrollable : ScrollDriveResult

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollSliceStitcher.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollSliceStitcher.kt
@@ -1,0 +1,135 @@
+package ee.schimke.composeai.renderer
+
+import java.awt.AlphaComposite
+import java.awt.Color
+import java.awt.RenderingHints
+import java.awt.geom.Area
+import java.awt.geom.Ellipse2D
+import java.awt.geom.Rectangle2D
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/**
+ * One captured slice — the on-disk PNG plus the cumulative scroll offset
+ * (in layout pixels) the scrollable reported at the time of capture.
+ */
+internal data class SliceCapture(val scrolledLayoutPx: Float, val file: File)
+
+/**
+ * Stitches per-viewport slices (see [driveScrollByViewport]) into a single
+ * tall PNG at [outputFile].
+ *
+ * Geometry:
+ *
+ * Slice 0 was captured at scroll offset 0 — it covers output rows
+ * `[0, sliceH)`. For each subsequent slice at offset `s_i`:
+ *  - delta = round((s_i - s_{i-1}) × pxPerLayoutPx)
+ *  - Source rows `[sliceH - delta, sliceH)` (the bottom `delta` rows).
+ *  - Dest rows `[y_prev, y_prev + delta)`, where `y_prev` starts at
+ *    `sliceH` and advances by `delta` per slice.
+ *
+ * `pxPerLayoutPx` is the ratio between captured PNG pixel height and the
+ * layout-pixel viewport height — `captureRoboImage` under Roborazzi writes
+ * at the Robolectric qualifier density, which often equals layout units 1:1
+ * but can diverge. Computing the ratio from slice 0 keeps the stitcher
+ * honest about any difference.
+ *
+ * Output height = `sliceH + lastOffsetInImagePx`.
+ *
+ * Returns the written file, or `null` if [slices] is empty.
+ */
+internal fun stitchSlices(
+    slices: List<SliceCapture>,
+    viewportLayoutPx: Int,
+    outputFile: File,
+): File? {
+    if (slices.isEmpty()) return null
+
+    val firstImage = ImageIO.read(slices[0].file)
+        ?: error("Failed to read first slice PNG: ${slices[0].file}")
+    val width = firstImage.width
+    val sliceH = firstImage.height
+    val pxPerLayoutPx = sliceH.toDouble() / viewportLayoutPx.toDouble()
+
+    val imageOffsets = slices.map { (it.scrolledLayoutPx * pxPerLayoutPx).roundToInt() }
+    val lastOffsetPx = imageOffsets.last()
+    val totalHeight = sliceH + lastOffsetPx
+
+    val stitched = BufferedImage(width, totalHeight, BufferedImage.TYPE_INT_ARGB)
+    val g = stitched.createGraphics()
+    try {
+        g.drawImage(firstImage, 0, 0, null)
+
+        var yPrev = sliceH
+        for (i in 1 until slices.size) {
+            val img = ImageIO.read(slices[i].file)
+                ?: error("Failed to read slice PNG: ${slices[i].file}")
+            require(img.width == width && img.height == sliceH) {
+                "Slice dimensions drifted: expected ${width}x$sliceH, got ${img.width}x${img.height} at index $i"
+            }
+            val delta = imageOffsets[i] - imageOffsets[i - 1]
+            if (delta <= 0) continue // duplicate capture — framework reported no motion
+
+            g.drawImage(
+                img,
+                0, yPrev, width, yPrev + delta,
+                0, sliceH - delta, width, sliceH,
+                null,
+            )
+            yPrev += delta
+        }
+    } finally {
+        g.dispose()
+    }
+
+    outputFile.parentFile?.mkdirs()
+    ImageIO.write(stitched, "PNG", outputFile)
+    return outputFile
+}
+
+/**
+ * Clips [file]'s image into a pill/stadium shape: half-circle at the top,
+ * rectangular middle, half-circle at the bottom. Width determines the circle
+ * diameter. Pixels outside the shape become transparent.
+ *
+ * Used on stitched `@ScrollingPreview(LONG)` outputs for round Wear devices,
+ * so the rendered scroll visually preserves the round screen edge at the top
+ * of the first frame and the bottom of the last frame.
+ */
+internal fun applyWearPillClip(file: File) {
+    val src = ImageIO.read(file) ?: return
+    val w = src.width
+    val h = src.height
+    if (h <= 0 || w <= 0) return
+
+    val radius = w / 2.0
+
+    // Union of: top half-circle (centred at y=r), middle rectangle, bottom
+    // half-circle (centred at y=h-r). For h < 2r (too short to be a proper
+    // pill), fall back to a single ellipse.
+    val pill: Area = if (h >= 2 * radius) {
+        Area(Ellipse2D.Double(0.0, 0.0, w.toDouble(), 2 * radius)).apply {
+            add(Area(Rectangle2D.Double(0.0, radius, w.toDouble(), h - 2 * radius)))
+            add(Area(Ellipse2D.Double(0.0, h - 2 * radius, w.toDouble(), 2 * radius)))
+        }
+    } else {
+        Area(Ellipse2D.Double(0.0, 0.0, w.toDouble(), min(h.toDouble(), 2 * radius)))
+    }
+
+    val out = BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB)
+    val g = out.createGraphics()
+    try {
+        g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+        g.composite = AlphaComposite.Src
+        g.color = Color(0, 0, 0, 0)
+        g.fillRect(0, 0, w, h)
+        g.clip = pill
+        g.drawImage(src, 0, 0, null)
+    } finally {
+        g.dispose()
+    }
+    ImageIO.write(out, "PNG", file)
+}

--- a/sample-wear/build.gradle.kts
+++ b/sample-wear/build.gradle.kts
@@ -56,4 +56,19 @@ dependencies {
     implementation(libs.wear.protolayout.expression)
     implementation(libs.wear.protolayout.material3)
     implementation(libs.wear.tooling.preview)
+    // `@ScrollingPreview` — read by FQN at discovery time; no runtime cost.
+    implementation(project(":preview-annotations"))
+
+    testImplementation(libs.junit)
+    testImplementation(libs.truth)
+}
+
+// `LongScrollPreviewPixelTest` reads PNGs produced by `renderAllPreviews`.
+// Same dependency wiring as sample-android's pixel tests; targets the AGP
+// unit-test tasks by name so we don't include the plugin's own `renderPreviews`
+// Test task (which would create a circular dep).
+afterEvaluate {
+    listOf("testDebugUnitTest", "testReleaseUnitTest").forEach { name ->
+        tasks.findByName(name)?.dependsOn("renderAllPreviews")
+    }
 }

--- a/sample-wear/src/main/kotlin/com/example/samplewear/Previews.kt
+++ b/sample-wear/src/main/kotlin/com/example/samplewear/Previews.kt
@@ -36,6 +36,8 @@ import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import androidx.wear.compose.ui.tooling.preview.WearPreviewFontScales
 import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
 import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
 
 private object FixedTimeSource : TimeSource {
     @Composable
@@ -179,4 +181,94 @@ fun BadWearButtonPreview() {
             modifier = Modifier.size(20.dp),
         ) {}
     }
+}
+
+/**
+ * Long-scroll fixture: same `ScreenScaffold` + `TransformingLazyColumn` +
+ * `EdgeButton` layout as [WearApp], but with 15 items so the content
+ * overflows the viewport. `@ScrollingPreview(mode = LONG)` drives the
+ * renderer's stitched-capture path; the output is one tall PNG clipped to a
+ * capsule shape — top half-circle, rectangular middle, bottom half-circle —
+ * so the round watch edge is preserved at the first and last frames.
+ * `ScreenScaffold` reveals the `EdgeButton` only when the list is scroll-
+ * pinned to the bottom, so "Start workout" appears once, at the final slice.
+ */
+@Composable
+private fun LongActivityListContent() {
+    val longItems = List(15) { i ->
+        when (i % 6) {
+            0 -> Item("Morning run ${i + 1}", "5.2 km · 28 min")
+            1 -> Item("Heart rate ${i + 1}", "${70 + i} bpm")
+            2 -> Item("Sleep day ${i + 1}", "7h ${(i * 3) % 60}m")
+            3 -> Item("Steps day ${i + 1}", "${6000 + i * 120}")
+            4 -> Item("Calories day ${i + 1}", "${400 + i * 5} kcal")
+            else -> Item("Timer ${i + 1}", "${10 + i}:${(i * 7) % 60} remaining")
+        }
+    }
+    MaterialTheme {
+        AppScaffold(
+            timeText = { TimeText(timeSource = FixedTimeSource) },
+        ) {
+            val listState = rememberTransformingLazyColumnState()
+            val transformationSpec = rememberTransformationSpec()
+            ScreenScaffold(
+                scrollState = listState,
+                edgeButton = {
+                    EdgeButton(
+                        onClick = {},
+                        buttonSize = EdgeButtonSize.Large,
+                    ) {
+                        BasicText(
+                            text = "Start workout",
+                            maxLines = 1,
+                            autoSize = TextAutoSize.StepBased(),
+                            style = TextStyle(
+                                color = MaterialTheme.colorScheme.onPrimary,
+                                textAlign = TextAlign.Center,
+                            ),
+                        )
+                    }
+                },
+            ) { contentPadding ->
+                TransformingLazyColumn(
+                    state = listState,
+                    contentPadding = contentPadding,
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    item {
+                        ListHeader(
+                            modifier = Modifier
+                                .minimumVerticalContentPadding(
+                                    top = ListHeaderDefaults.minimumTopListContentPadding,
+                                    bottom = 0.dp,
+                                )
+                                .transformedHeight(this, transformationSpec),
+                            transformation = SurfaceTransformation(transformationSpec),
+                        ) {
+                            Text("Activity")
+                        }
+                    }
+                    items(longItems) { item ->
+                        TitleCard(
+                            onClick = {},
+                            title = { Text(item.title) },
+                            subtitle = { Text(item.subtitle) },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .minimumVerticalContentPadding(CardDefaults.minimumVerticalListContentPadding)
+                                .transformedHeight(this, transformationSpec),
+                            transformation = SurfaceTransformation(transformationSpec),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@WearPreviewLargeRound
+@ScrollingPreview(mode = ScrollMode.LONG, reduceMotion = true)
+@Composable
+fun ActivityListLongPreview() {
+    LongActivityListContent()
 }

--- a/sample-wear/src/test/kotlin/com/example/samplewear/LongScrollPreviewPixelTest.kt
+++ b/sample-wear/src/test/kotlin/com/example/samplewear/LongScrollPreviewPixelTest.kt
@@ -1,0 +1,81 @@
+package com.example.samplewear
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Test
+
+/**
+ * End-to-end regression for `@ScrollingPreview(mode = LONG)` — drives the
+ * renderer to produce a stitched tall PNG of the `ActivityListLongPreview`
+ * (`TransformingLazyColumn` + `EdgeButton`) and asserts:
+ *  - Output height > viewport height (proves multi-slice stitching ran,
+ *    not a single-frame fallback).
+ *  - Pixels in the top / middle / bottom thirds differ — proves real
+ *    scroll-through content rather than the same frame repeated.
+ *
+ * `testDebugUnitTest.dependsOn("renderAllPreviews")` in sample-wear's
+ * build.gradle.kts guarantees the PNG exists by the time this test runs.
+ */
+class LongScrollPreviewPixelTest {
+
+    private val longPng = File(
+        "build/compose-previews/renders/com.example.samplewear.PreviewsKt.ActivityListLongPreview_Devices - Large Round.png",
+    )
+
+    @Test
+    fun `LONG preview produces a tall stitched PNG`() {
+        assertThat(longPng.exists()).isTrue()
+        val img = ImageIO.read(longPng)
+        // Large round Wear device: 227dp at 2x density ≈ 454 px. LONG output
+        // for 15 items is consistently > 2 viewports tall.
+        val viewportPx = 454
+        assertThat(img.height).isGreaterThan(viewportPx * 2)
+    }
+
+    @Test
+    fun `LONG preview shows different content across vertical thirds`() {
+        val img = ImageIO.read(longPng)
+        val w = img.width
+        val h = img.height
+
+        fun meanRgbFor(startRow: Int, endRow: Int): Triple<Double, Double, Double> {
+            var r = 0L
+            var g = 0L
+            var b = 0L
+            var count = 0L
+            for (y in startRow until endRow) for (x in 0 until w) {
+                val argb = img.getRGB(x, y)
+                val a = (argb ushr 24) and 0xff
+                if (a == 0) continue // skip transparent pill-clip regions
+                r += (argb shr 16) and 0xff
+                g += (argb shr 8) and 0xff
+                b += argb and 0xff
+                count++
+            }
+            val n = count.coerceAtLeast(1L).toDouble()
+            return Triple(r / n, g / n, b / n)
+        }
+
+        val top = meanRgbFor(0, h / 3)
+        val mid = meanRgbFor(h / 3, 2 * h / 3)
+        val bot = meanRgbFor(2 * h / 3, h)
+
+        fun distance(a: Triple<Double, Double, Double>, b: Triple<Double, Double, Double>): Double {
+            val dr = a.first - b.first
+            val dg = a.second - b.second
+            val db = a.third - b.third
+            return dr * dr + dg * dg + db * db
+        }
+
+        // Dark-card-on-black content keeps mean RGB values close, so the
+        // bar is deliberately low — we just need to prove the stitch produced
+        // more than one distinct frame. Any two thirds differing at all
+        // catches a repeat-the-same-frame regression; the full bottom→top
+        // stretch is the strongest signal because the bottom contains the
+        // light-purple EdgeButton that isn't present at the top.
+        assertThat(distance(top, bot)).isGreaterThan(5.0)
+        assertThat(distance(top, mid)).isGreaterThan(0.5)
+        assertThat(distance(mid, bot)).isGreaterThan(0.5)
+    }
+}


### PR DESCRIPTION
## Summary

- `LONG` mode now produces a single tall PNG of the full scrollable content, stitched from viewport-height slices captured via `SemanticsActions.ScrollBy`. Previously aliased to `END`.
- Round-device outputs are clipped into a capsule shape — half-circle at the very top, rectangular middle, half-circle at the very bottom — so the round watch edge is preserved at the first and last frames.
- `ScreenScaffold`'s scroll-state-driven `EdgeButton` visibility means "Start workout" appears only on the final slice of the stitched output — natural consequence of driving the scroll through real Compose state.

## Files

- `renderer-android/.../ScrollDriver.kt` — adds `driveScrollByViewport` alongside the existing `driveScrollToEnd`. Steps by a fixed viewport-height per iteration and invokes `onSlice(scrolledPx)` after each step.
- `renderer-android/.../ScrollSliceStitcher.kt` (new) — Java2D stitcher + `applyWearPillClip` for the capsule shape.
- `renderer-android/.../RobolectricRenderTest.kt` — new `handleLongCapture` branch in the capture loop. `END` + horizontal fallbacks preserved unchanged.
- `sample-wear` — new `ActivityListLongPreview` (15-item `TransformingLazyColumn` + `EdgeButton` on `wearos_large_round`).
- `sample-wear/src/test/.../LongScrollPreviewPixelTest.kt` — asserts output height > 2 viewports and pixel variance across thirds.

## Explicitly *not* in this PR

- `HORIZONTAL + LONG` — vertical-only; falls back to END with a warning.
- Real Android `ScrollCaptureCallback` — a spike against Compose UI's `ComposeScrollCaptureCallback` under Robolectric 4.16.1 at SDK 35 found that the callback wires up correctly, but the framework's `Surface.lockHardwareCanvas` pump returns "Surface has already been released" on first image request. Stitched path via `SemanticsActions.ScrollBy` is the proven substitute; ScrollCapture re-evaluable when Robolectric adds shadow coverage.

## Test plan

- [x] `./gradlew :renderer-android:compileDebugKotlin` — clean
- [x] `./gradlew :sample-wear:test` — 2/2 `LongScrollPreviewPixelTest` assertions pass
- [x] `./gradlew :sample-android:test` — END regression still green
- [x] `./gradlew check` — full sweep green

Output: `sample-wear/build/compose-previews/renders/com.example.samplewear.PreviewsKt.ActivityListLongPreview_Devices - Large Round.png` — ~454 × 2486 px capsule PNG showing all 15 items plus the `Start workout` EdgeButton at the end.