### PR TITLE
chore(renderer): silence Roborazzi ActionBar workaround warning

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -359,6 +359,15 @@ internal object AndroidPreviewSupport {
             // unless the expected baseline exists). Force "record" so every run
             // writes fresh PNGs.
             systemProperty("roborazzi.test.record", "true")
+            // `ui-test-manifest` declares ComponentActivity with the framework
+            // default theme, which on compileSdk >= 35 still includes an
+            // ActionBar. Roborazzi 1.59+ detects this and applies a runtime
+            // hide-ActionBar workaround per render (layout invalidation plus a
+            // noisy warning on every preview). We capture via `onRoot()` — the
+            // compose tree, not the decor view — so the ActionBar never ends
+            // up in output PNGs regardless of whether it's hidden. Opt out of
+            // the workaround entirely.
+            systemProperty("roborazzi.compose.actionbar.overlap.fix", "false")
 
             systemProperty("composeai.render.manifest", manifestFile.get())
             systemProperty("composeai.render.outputDir", rendersDir.get())


### PR DESCRIPTION
## Summary
- Set `roborazzi.compose.actionbar.overlap.fix=false` on the `renderPreviews` Test task.
- `ui-test-manifest` launches `ComponentActivity` with the framework default theme, which on `compileSdk >= 35` still carries an ActionBar, so Roborazzi 1.59+ logged a per-preview warning and paid a layout-invalidation cost to hide it.
- Captures go through `onRoot()` (compose tree, not the activity decor), so the ActionBar was never in output PNGs regardless of whether it was hidden.

## Test plan
- [x] `./gradlew :sample-android:renderPreviews --rerun-tasks` — build succeeds, warning gone from test reports
- [x] `./gradlew :sample-wear:renderPreviews --rerun-tasks` — build succeeds, warning gone
- [x] Configuration cache still valid across runs