### PR TITLE
docs(vscode-extension): include plugin-apply snippet in Marketplace README

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,7 @@
       "include-component-in-tag": false,
       "extra-files": [
         "README.md",
+        "vscode-extension/README.md",
         "skills/compose-preview/SKILL.md",
         "docs/RELEASING.md",
         {

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -20,11 +20,6 @@ renders them to PNG, and the extension loads those PNGs into a webview.
 
 ## Prerequisites
 
-- The
-  [`ee.schimke.composeai.preview`](https://central.sonatype.com/artifact/ee.schimke.composeai/compose-preview-plugin)
-  Gradle plugin applied in your module. See the
-  [project README](https://github.com/yschimke/compose-ai-tools#setup) for
-  apply instructions.
 - Java 21 on `PATH` or `JAVA_HOME`.
 - Gradle 9.4.1+ (the bundled wrapper in your project is fine).
 - The
@@ -34,6 +29,26 @@ renders them to PNG, and the extension loads those PNGs into a webview.
   `implementation(compose.components.uiToolingPreview)` — the bundled
   `@Preview` annotation has `SOURCE` retention and is otherwise invisible to
   the discovery step.
+
+## Apply the Gradle plugin
+
+Add
+[`ee.schimke.composeai.preview`](https://central.sonatype.com/artifact/ee.schimke.composeai/compose-preview-plugin)
+to the module whose previews you want to render:
+
+<!-- x-release-please-start-version -->
+```kotlin
+// <module>/build.gradle.kts
+plugins {
+    id("ee.schimke.composeai.preview") version "0.4.0"
+}
+```
+<!-- x-release-please-end -->
+
+The plugin is on Maven Central, so no extra repository setup is needed when
+`mavenCentral()` is already in your `pluginManagement.repositories`. See the
+[project README](https://github.com/yschimke/compose-ai-tools#setup) for
+snapshot builds.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Marketplace listing (`vscode-extension/README.md`) now includes the `plugins { id(\"ee.schimke.composeai.preview\") version \"…\" }` snippet in its own **Apply the Gradle plugin** section, instead of pointing readers at the repo README for apply instructions.
- Version string is wrapped in `x-release-please-start-version` / `-end` markers and the file is registered as an `extra-files` entry in `release-please-config.json`, so it bumps alongside the other pinned versions.

## Test plan

- [ ] Eyeball the rendered README on GitHub — snippet renders, markers stay invisible.
- [ ] On next release, confirm release-please rewrites `0.4.0` in `vscode-extension/README.md` along with the other tracked files.