### PR TITLE
revert: re-enable Roborazzi ActionBar workaround (#79)

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -359,15 +359,6 @@ internal object AndroidPreviewSupport {
             // unless the expected baseline exists). Force "record" so every run
             // writes fresh PNGs.
             systemProperty("roborazzi.test.record", "true")
-            // `ui-test-manifest` declares ComponentActivity with the framework
-            // default theme, which on compileSdk >= 35 still includes an
-            // ActionBar. Roborazzi 1.59+ detects this and applies a runtime
-            // hide-ActionBar workaround per render (layout invalidation plus a
-            // noisy warning on every preview). We capture via `onRoot()` — the
-            // compose tree, not the decor view — so the ActionBar never ends
-            // up in output PNGs regardless of whether it's hidden. Opt out of
-            // the workaround entirely.
-            systemProperty("roborazzi.compose.actionbar.overlap.fix", "false")
 
             systemProperty("composeai.render.manifest", manifestFile.get())
             systemProperty("composeai.render.outputDir", rendersDir.get())


### PR DESCRIPTION
## Summary
Reverts the systemProperty added in #79. My reasoning there — that captures via `onRoot()` exclude the decor view, so the workaround was pure overhead — was wrong. The ActionBar **is** composited into the captured PNG, and disabling the workaround caused visible ActionBar bleed-through in every preview render on `compileSdk >= 35` (as the preview-bot before/after on #79 showed).

Re-enable the workaround. The layout-invalidation cost and the log warning are the price for correct images.

If we want to remove the warning long-term, the correct fix is a no-ActionBar theme on the host activity **before its window is inflated** — that means either a custom `ui-test-manifest` override or our own `Activity` subclass registered in the test manifest. #79 tried neither.

## Test plan
- [x] `./gradlew :sample-android:renderPreviews --rerun-tasks` — renders are clean (e.g. BlueBoxPreview is solid blue again, no "Sample Android" header bleed)
- [ ] CI preview-bot comparison on this PR confirms the restore