### PR TITLE
feat(doctor): warn when tracked AndroidX libs are behind head

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
@@ -31,6 +31,25 @@ internal object CompatRules {
     private val CORE_1_16 = Semver(1, 16, 0)
 
     /**
+     * Generic "you're well behind head" minimums for libraries whose
+     * version commonly shapes renderer behaviour. Threshold policy:
+     * roughly the second-to-last known stable at time of writing —
+     * recent enough to flag genuinely stale stacks, lenient enough that
+     * a consumer one release behind head doesn't get nagged. Bump when
+     * the paired upstream line ships a new stable minor.
+     *
+     * The specific compat rules above (navigationevent, core-vs-compose)
+     * still fire on their own when they apply — this list is the
+     * catch-all for "nothing's actively broken, but you're old".
+     */
+    private val OLD_DEP_MINIMUMS: List<Pair<String, Semver>> = listOf(
+        "androidx.compose.ui:ui" to Semver(1, 9, 0),
+        "androidx.activity:activity" to Semver(1, 10, 0),
+        "androidx.core:core" to Semver(1, 15, 0),
+        "androidx.lifecycle:lifecycle-runtime" to Semver(2, 8, 0),
+    )
+
+    /**
      * Runs every rule against the given dep snapshot and returns findings
      * ordered by severity. Pure — safe to call from tests and from the
      * serialisation path.
@@ -43,6 +62,7 @@ internal object CompatRules {
         checkNavigationEvent(mainV, testV, main)?.let(findings::add)
         checkComposeUiVsCore(mainV, testV, main)?.let(findings::add)
         checkComposeBom(main)?.let(findings::add)
+        findings += checkOldDeps(mainV, testV, main, test)
         return findings
     }
 
@@ -100,6 +120,36 @@ internal object CompatRules {
             remediationCommands = emptyList(),
             docsUrl = DOCS_COMPOSE_UI_VS_CORE,
         )
+    }
+
+    /**
+     * Emits one warning per [OLD_DEP_MINIMUMS] entry whose highest resolved
+     * version (main or test classpath) is below the minimum. Libraries
+     * absent from both classpaths are silently skipped — the consumer
+     * isn't using them, so there's nothing to warn about.
+     */
+    private fun checkOldDeps(
+        main: Map<String, Semver>,
+        test: Map<String, Semver>,
+        rawMain: Map<String, String>,
+        rawTest: Map<String, String>,
+    ): List<ModuleFindingData> {
+        val out = mutableListOf<ModuleFindingData>()
+        for ((artifact, minVersion) in OLD_DEP_MINIMUMS) {
+            val resolved = listOfNotNull(main[artifact], test[artifact]).maxOrNull() ?: continue
+            if (resolved >= minVersion) continue
+            val rawVersion = rawMain[artifact] ?: rawTest[artifact] ?: resolved.toString()
+            out += ModuleFindingData(
+                id = "old-dep-$artifact",
+                severity = "warning",
+                message = "$artifact is on $rawVersion; recommended >= $minVersion",
+                detail = "Resolved $artifact:$rawVersion is several releases behind. Renderer compat issues tend to cluster around older Compose / Activity / Core / Lifecycle versions; upgrading clears a class of bugs before they hit.",
+                remediationSummary = "Upgrade $artifact to at least $minVersion.",
+                remediationCommands = listOf("implementation(\"$artifact:$minVersion\")"),
+                docsUrl = null,
+            )
+        }
+        return out
     }
 
     private fun checkComposeBom(rawMain: Map<String, String>): ModuleFindingData? {

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
@@ -94,6 +94,38 @@ class CompatRulesTest {
         }
     }
 
+    @Test fun `old activity fires old-dep warning`() {
+        val main = mainWithBom() + ("androidx.activity:activity" to "1.8.0")
+        val test = main + ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
+        val findings = CompatRules.evaluate(main, test)
+        val f = findings.single { it.id == "old-dep-androidx.activity:activity" }
+        assertEquals("warning", f.severity)
+        assertTrue("1.8.0" in f.message)
+        assertTrue(f.remediationCommands.any { "androidx.activity:activity" in it })
+    }
+
+    @Test fun `current activity is quiet`() {
+        val main = mainWithBom() + ("androidx.activity:activity" to "1.13.0")
+        val test = main + ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
+        val findings = CompatRules.evaluate(main, test)
+        assertNull(findings.firstOrNull { it.id.startsWith("old-dep-androidx.activity") })
+    }
+
+    @Test fun `absent library emits no old-dep finding`() {
+        // lifecycle-runtime isn't on the classpath at all — silently skipped.
+        val findings = CompatRules.evaluate(mainWithBom(), mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"))
+        assertNull(findings.firstOrNull { it.id.startsWith("old-dep-androidx.lifecycle") })
+    }
+
+    @Test fun `test-classpath higher than main is taken as resolved`() {
+        // Main has old activity, test classpath has newer — we take the max.
+        val main = mainWithBom() + ("androidx.activity:activity" to "1.8.0")
+        val test = main + ("androidx.activity:activity" to "1.13.0") +
+            ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
+        val findings = CompatRules.evaluate(main, test)
+        assertNull(findings.firstOrNull { it.id.startsWith("old-dep-androidx.activity") })
+    }
+
     @Test fun `semver parses and compares`() {
         assertEquals(Semver(1, 16, 0), Semver.parseOrNull("1.16.0"))
         assertEquals(Semver(1, 16, 0), Semver.parseOrNull("1.16"))


### PR DESCRIPTION
## Summary

- Adds a generic old-dep doctor rule alongside the existing targeted ones in `CompatRules`.
- Minimums are roughly *second-to-last known stable* at time of writing — recent enough to flag genuinely stale stacks, lenient enough that one-release-behind doesn't nag.
- Existing targeted rules (`navigationevent`, `compose-ui-vs-core`) continue to fire independently as `error`s when they apply; the new rule is the `warning`-severity catch-all for "nothing's actively broken, but you're old".

Tracked:

| artifact | min |
|---|---|
| `androidx.compose.ui:ui` | 1.9.0 |
| `androidx.activity:activity` | 1.10.0 |
| `androidx.core:core` | 1.15.0 |
| `androidx.lifecycle:lifecycle-runtime` | 2.8.0 |

Behaviour:

- One `warning` finding per offender, with `id = old-dep-<artifact>` and a `remediationCommands` entry pointing at the minimum.
- Library absent from both classpaths → silently skipped (consumer isn't using it).
- Takes the max of main and test classpath resolutions so an older main + newer test doesn't double-warn.

## Test plan

- [x] `./gradlew :gradle-plugin:test --tests ".*CompatRulesTest"` — four new cases (old fires, current quiet, absent skipped, test-higher-than-main takes max)
- [x] Existing stacked "all findings actionable" test still passes — old-dep findings carry remediation commands