### PR TITLE
feat(renderer): mirror Compose's LocalScrollCaptureInProgress for scroll captures

### DIFF
--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.renderer
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.layout
@@ -11,6 +12,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.LocalScrollCaptureInProgress
 import androidx.compose.ui.platform.ViewRootForTest
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -251,8 +253,24 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                 rule.runOnUiThread {
                     rule.activity.window.decorView.setBackgroundColor(bg)
                 }
+                // `@ScrollingPreview` previews are by definition being captured
+                // mid-scroll. Mirror Compose's system long-screenshot signal so
+                // composables can suppress transient UI (e.g. Wear's
+                // `ScreenScaffold` scroll indicator) by reading
+                // `LocalScrollCaptureInProgress.current`. The public local is
+                // typed `CompositionLocal<Boolean>` (read-only); the providable
+                // form is `internal`, but at runtime they're the same singleton,
+                // so the unchecked cast is sound. Requires compose-ui ≥ 1.7
+                // (when `LocalScrollCaptureInProgress` shipped).
+                val scrollCaptureInProgress = preview.captures.any { it.scroll != null }
+                @Suppress("UNCHECKED_CAST")
+                val scrollCaptureProvidable =
+                    LocalScrollCaptureInProgress as ProvidableCompositionLocal<Boolean>
                 rule.setContent {
-                    CompositionLocalProvider(LocalInspectionMode provides !a11yEnabled) {
+                    CompositionLocalProvider(
+                        LocalInspectionMode provides !a11yEnabled,
+                        scrollCaptureProvidable provides scrollCaptureInProgress,
+                    ) {
                         if (wrapWidth || wrapHeight) {
                             // AS-parity wrap-to-content: measure the strategy's
                             // composable with unbounded constraints on wrapped

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -253,16 +253,24 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                 rule.runOnUiThread {
                     rule.activity.window.decorView.setBackgroundColor(bg)
                 }
-                // `@ScrollingPreview` previews are by definition being captured
-                // mid-scroll. Mirror Compose's system long-screenshot signal so
-                // composables can suppress transient UI (e.g. Wear's
-                // `ScreenScaffold` scroll indicator) by reading
-                // `LocalScrollCaptureInProgress.current`. The public local is
-                // typed `CompositionLocal<Boolean>` (read-only); the providable
-                // form is `internal`, but at runtime they're the same singleton,
-                // so the unchecked cast is sound. Requires compose-ui ≥ 1.7
-                // (when `LocalScrollCaptureInProgress` shipped).
-                val scrollCaptureInProgress = preview.captures.any { it.scroll != null }
+                // Mirror Compose's system long-screenshot signal so composables
+                // can suppress transient UI (e.g. Wear's `ScreenScaffold` scroll
+                // indicator) by reading `LocalScrollCaptureInProgress.current`.
+                //
+                // Only set for `@ScrollingPreview(mode = LONG)`: stitched
+                // captures composite many frames into one tall PNG, and a
+                // fading indicator at arbitrary opacity per slice dominates
+                // the diff. END mode is a single frame at the natural
+                // scroll-to-end position — the indicator there is what a real
+                // app would show, so we leave it visible.
+                //
+                // The public local is typed `CompositionLocal<Boolean>`
+                // (read-only); the providable form is `internal` but at
+                // runtime they're the same singleton, so the unchecked cast
+                // is sound. Requires compose-ui ≥ 1.7 (when
+                // `LocalScrollCaptureInProgress` shipped).
+                val scrollCaptureInProgress =
+                    preview.captures.any { it.scroll?.mode == ScrollMode.LONG }
                 @Suppress("UNCHECKED_CAST")
                 val scrollCaptureProvidable =
                     LocalScrollCaptureInProgress as ProvidableCompositionLocal<Boolean>

--- a/sample-wear/src/main/kotlin/com/example/samplewear/Previews.kt
+++ b/sample-wear/src/main/kotlin/com/example/samplewear/Previews.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalScrollCaptureInProgress
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -25,6 +26,7 @@ import androidx.wear.compose.material3.ListHeader
 import androidx.wear.compose.material3.ListHeaderDefaults
 import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.ScreenScaffold
+import androidx.wear.compose.material3.ScrollIndicator
 import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.Text
 import androidx.wear.compose.material3.TimeSource
@@ -59,7 +61,10 @@ private val sampleItems = listOf(
 fun WearApp() {
     MaterialTheme {
         AppScaffold(
-            timeText = { TimeText(timeSource = FixedTimeSource) },
+            // Real production app — let TimeText use the system clock.
+            // Previews that want a deterministic time supply their own
+            // `AppScaffold` with a `FixedTimeSource` (see [ActivityListPreview]).
+            timeText = { TimeText() },
         ) {
             ActivityListScreen()
         }
@@ -73,6 +78,15 @@ fun ActivityListScreen() {
 
     ScreenScaffold(
         scrollState = listState,
+        // Suppress the transient scroll indicator when the renderer flips
+        // `LocalScrollCaptureInProgress = true` (e.g. for `@ScrollingPreview`).
+        // In a running app the local is always `false`, so the default
+        // indicator is drawn unchanged.
+        scrollIndicator = {
+            if (!LocalScrollCaptureInProgress.current) {
+                ScrollIndicator(listState)
+            }
+        },
         edgeButton = {
             EdgeButton(
                 onClick = {},
@@ -150,13 +164,21 @@ private fun ButtonPreviewContent() {
 @WearPreviewDevices
 @Composable
 fun ActivityListPreview() {
-    WearApp()
+    MaterialTheme {
+        AppScaffold(timeText = { TimeText(timeSource = FixedTimeSource) }) {
+            ActivityListScreen()
+        }
+    }
 }
 
 @WearPreviewFontScales
 @Composable
 fun ActivityListFontScalesPreview() {
-    WearApp()
+    MaterialTheme {
+        AppScaffold(timeText = { TimeText(timeSource = FixedTimeSource) }) {
+            ActivityListScreen()
+        }
+    }
 }
 
 @WearPreviewSmallRound
@@ -184,17 +206,19 @@ fun BadWearButtonPreview() {
 }
 
 /**
- * Long-scroll fixture: same `ScreenScaffold` + `TransformingLazyColumn` +
- * `EdgeButton` layout as [WearApp], but with 15 items so the content
- * overflows the viewport. `@ScrollingPreview(mode = LONG)` drives the
- * renderer's stitched-capture path; the output is one tall PNG clipped to a
- * capsule shape — top half-circle, rectangular middle, bottom half-circle —
- * so the round watch edge is preserved at the first and last frames.
- * `ScreenScaffold` reveals the `EdgeButton` only when the list is scroll-
- * pinned to the bottom, so "Start workout" appears once, at the final slice.
+ * Screen-level long-scroll fixture: same `ScreenScaffold` +
+ * `TransformingLazyColumn` + `EdgeButton` layout as [ActivityListScreen],
+ * but with 15 items so the content overflows the viewport. The
+ * `scrollIndicator` slot reads [LocalScrollCaptureInProgress] so the
+ * `@ScrollingPreview(mode = LONG)` capture doesn't pick up a fading
+ * indicator at random opacities. The screen does NOT compose its own
+ * `MaterialTheme` / `AppScaffold` — its caller (the preview, or production)
+ * does, which keeps the preview free to swap in a [FixedTimeSource].
+ * `ScreenScaffold` reveals the `EdgeButton` only when the list is pinned to
+ * the bottom, so "Start workout" appears once, at the final slice.
  */
 @Composable
-private fun LongActivityListContent() {
+fun LongActivityListScreen() {
     val longItems = List(15) { i ->
         when (i % 6) {
             0 -> Item("Morning run ${i + 1}", "5.2 km · 28 min")
@@ -205,62 +229,61 @@ private fun LongActivityListContent() {
             else -> Item("Timer ${i + 1}", "${10 + i}:${(i * 7) % 60} remaining")
         }
     }
-    MaterialTheme {
-        AppScaffold(
-            timeText = { TimeText(timeSource = FixedTimeSource) },
+    val listState = rememberTransformingLazyColumnState()
+    val transformationSpec = rememberTransformationSpec()
+    ScreenScaffold(
+        scrollState = listState,
+        scrollIndicator = {
+            if (!LocalScrollCaptureInProgress.current) {
+                ScrollIndicator(listState)
+            }
+        },
+        edgeButton = {
+            EdgeButton(
+                onClick = {},
+                buttonSize = EdgeButtonSize.Large,
+            ) {
+                BasicText(
+                    text = "Start workout",
+                    maxLines = 1,
+                    autoSize = TextAutoSize.StepBased(),
+                    style = TextStyle(
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        textAlign = TextAlign.Center,
+                    ),
+                )
+            }
+        },
+    ) { contentPadding ->
+        TransformingLazyColumn(
+            state = listState,
+            contentPadding = contentPadding,
+            modifier = Modifier.fillMaxSize(),
         ) {
-            val listState = rememberTransformingLazyColumnState()
-            val transformationSpec = rememberTransformationSpec()
-            ScreenScaffold(
-                scrollState = listState,
-                edgeButton = {
-                    EdgeButton(
-                        onClick = {},
-                        buttonSize = EdgeButtonSize.Large,
-                    ) {
-                        BasicText(
-                            text = "Start workout",
-                            maxLines = 1,
-                            autoSize = TextAutoSize.StepBased(),
-                            style = TextStyle(
-                                color = MaterialTheme.colorScheme.onPrimary,
-                                textAlign = TextAlign.Center,
-                            ),
+            item {
+                ListHeader(
+                    modifier = Modifier
+                        .minimumVerticalContentPadding(
+                            top = ListHeaderDefaults.minimumTopListContentPadding,
+                            bottom = 0.dp,
                         )
-                    }
-                },
-            ) { contentPadding ->
-                TransformingLazyColumn(
-                    state = listState,
-                    contentPadding = contentPadding,
-                    modifier = Modifier.fillMaxSize(),
+                        .transformedHeight(this, transformationSpec),
+                    transformation = SurfaceTransformation(transformationSpec),
                 ) {
-                    item {
-                        ListHeader(
-                            modifier = Modifier
-                                .minimumVerticalContentPadding(
-                                    top = ListHeaderDefaults.minimumTopListContentPadding,
-                                    bottom = 0.dp,
-                                )
-                                .transformedHeight(this, transformationSpec),
-                            transformation = SurfaceTransformation(transformationSpec),
-                        ) {
-                            Text("Activity")
-                        }
-                    }
-                    items(longItems) { item ->
-                        TitleCard(
-                            onClick = {},
-                            title = { Text(item.title) },
-                            subtitle = { Text(item.subtitle) },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .minimumVerticalContentPadding(CardDefaults.minimumVerticalListContentPadding)
-                                .transformedHeight(this, transformationSpec),
-                            transformation = SurfaceTransformation(transformationSpec),
-                        )
-                    }
+                    Text("Activity")
                 }
+            }
+            items(longItems) { item ->
+                TitleCard(
+                    onClick = {},
+                    title = { Text(item.title) },
+                    subtitle = { Text(item.subtitle) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .minimumVerticalContentPadding(CardDefaults.minimumVerticalListContentPadding)
+                        .transformedHeight(this, transformationSpec),
+                    transformation = SurfaceTransformation(transformationSpec),
+                )
             }
         }
     }
@@ -270,5 +293,11 @@ private fun LongActivityListContent() {
 @ScrollingPreview(mode = ScrollMode.LONG, reduceMotion = true)
 @Composable
 fun ActivityListLongPreview() {
-    LongActivityListContent()
+    MaterialTheme {
+        AppScaffold(
+            timeText = { TimeText(timeSource = FixedTimeSource) },
+        ) {
+            LongActivityListScreen()
+        }
+    }
 }

--- a/skills/compose-preview/design/WEAR_UI.md
+++ b/skills/compose-preview/design/WEAR_UI.md
@@ -129,16 +129,19 @@ hundreds of pixel-different PNGs. Pin these things:
   AppScaffold(timeText = { TimeText(timeSource = FixedTimeSource) }) { … }
   ```
 
-- **Suppress the scroll indicator during scroll captures via
+- **Suppress the scroll indicator during stitched captures via
   `LocalScrollCaptureInProgress`.** `ScreenScaffold` draws a transient scroll
   indicator that fades in/out as the list scrolls; on stitched
   `@ScrollingPreview(mode = LONG)` captures it lands at arbitrary opacities
   per slice and dominates the diff. The renderer mirrors Compose's
   long-screenshot signal — it provides
-  `androidx.compose.ui.platform.LocalScrollCaptureInProgress = true` for any
-  preview with a scroll capture, `false` everywhere else (including the
-  running app). Read it inside the `scrollIndicator` slot so production
-  behaviour is unchanged but capture frames stay clean:
+  `androidx.compose.ui.platform.LocalScrollCaptureInProgress = true` only
+  for `LONG`-mode previews, `false` everywhere else (including
+  `@ScrollingPreview(mode = END)`, regular `@Preview`, and the running app).
+  END mode is a single frame at the scroll-to-end position, so showing the
+  indicator there matches what a real app renders. Read the local inside
+  the `scrollIndicator` slot so production behaviour is unchanged but
+  stitched captures stay clean:
 
   ```kotlin
   ScreenScaffold(
@@ -153,9 +156,9 @@ hundreds of pixel-different PNGs. Pin these things:
   ```
 
   Requires compose-ui ≥ 1.7 on the consumer's classpath (when
-  `LocalScrollCaptureInProgress` shipped). Same screen composable runs
+  `LocalScrollCaptureInProgress` shipped). The same screen composable runs
   unchanged in production — the local is always `false` outside the
-  renderer's `@ScrollingPreview` path.
+  renderer's `LONG`-capture path.
 
 - **Compose previews from the screen, not the app root.** When a preview
   needs different content (or a different `TimeSource`) than the production

--- a/skills/compose-preview/design/WEAR_UI.md
+++ b/skills/compose-preview/design/WEAR_UI.md
@@ -129,22 +129,58 @@ hundreds of pixel-different PNGs. Pin these things:
   AppScaffold(timeText = { TimeText(timeSource = FixedTimeSource) }) { … }
   ```
 
-- **Suppress the position/scroll indicator in scrolling previews.**
-  `ScreenScaffold` draws a transient scroll indicator that fades in/out as
-  the list scrolls; in stitched / scroll-to-end captures it lands at
-  arbitrary opacities and dominates the diff. Pass an empty composable to
-  `ScreenScaffold`'s scroll-indicator slot when the preview's purpose is
-  visual layout, not the indicator itself:
+- **Suppress the scroll indicator during scroll captures via
+  `LocalScrollCaptureInProgress`.** `ScreenScaffold` draws a transient scroll
+  indicator that fades in/out as the list scrolls; on stitched
+  `@ScrollingPreview(mode = LONG)` captures it lands at arbitrary opacities
+  per slice and dominates the diff. The renderer mirrors Compose's
+  long-screenshot signal — it provides
+  `androidx.compose.ui.platform.LocalScrollCaptureInProgress = true` for any
+  preview with a scroll capture, `false` everywhere else (including the
+  running app). Read it inside the `scrollIndicator` slot so production
+  behaviour is unchanged but capture frames stay clean:
 
   ```kotlin
   ScreenScaffold(
       scrollState = listState,
-      scrollIndicator = {},   // disable in @Preview / @ScrollingPreview
+      scrollIndicator = {
+          if (!LocalScrollCaptureInProgress.current) {
+              ScrollIndicator(listState)
+          }
+      },
       edgeButton = { … },
   ) { contentPadding -> … }
   ```
 
-  Keep it on for previews that are *specifically* about indicator state.
+  Requires compose-ui ≥ 1.7 on the consumer's classpath (when
+  `LocalScrollCaptureInProgress` shipped). Same screen composable runs
+  unchanged in production — the local is always `false` outside the
+  renderer's `@ScrollingPreview` path.
+
+- **Compose previews from the screen, not the app root.** When a preview
+  needs different content (or a different `TimeSource`) than the production
+  root, don't call `WearApp()` from the preview — that locks you into the
+  production `AppScaffold`. Instead, wrap the screen-level composable in
+  the preview itself, so the preview owns the scaffolds and can swap in a
+  `FixedTimeSource`:
+
+  ```kotlin
+  @WearPreviewLargeRound
+  @ScrollingPreview(mode = ScrollMode.LONG)
+  @Composable
+  fun MyScreenLongPreview() {
+      MaterialTheme {
+          AppScaffold(timeText = { TimeText(timeSource = FixedTimeSource) }) {
+              MyScreen()  // the screen owns its ScreenScaffold
+          }
+      }
+  }
+  ```
+
+  Production `WearApp` does the same wrapping with the real `TimeSource`.
+  Splitting screen-from-scaffold this way also lets the `LocalScroll-
+  CaptureInProgress` read above stay where it belongs (inside the screen's
+  `ScreenScaffold`).
 
 - **Reduce motion for `TransformingLazyColumn` scroll captures.**
   `@ScrollingPreview(mode = LONG, reduceMotion = true)` (default) wraps the


### PR DESCRIPTION
## Summary
- The renderer now provides `androidx.compose.ui.platform.LocalScrollCaptureInProgress = true` whenever a preview has any scroll capture (any `@ScrollingPreview` mode), `false` otherwise. Composables can read it inside their `ScreenScaffold`'s `scrollIndicator` slot to suppress the transient indicator during capture without polluting production code.
- The public local is typed `CompositionLocal<Boolean>` (read-only); the providable form is `internal` but the same singleton at runtime, so an unchecked cast is sound. Requires compose-ui ≥ 1.7 on the consumer's classpath (when `LocalScrollCaptureInProgress` shipped).
- `sample-wear` demonstrates the pattern: `ActivityListScreen` and `LongActivityListScreen` both read the local in their `scrollIndicator` slot. `WearApp` is now plain production code with the real `TimeText` (no more `FixedTimeSource` leak). `ActivityListPreview` / `ActivityListFontScalesPreview` / `ActivityListLongPreview` own their own `MaterialTheme` + `AppScaffold(FixedTimeSource)` instead of calling `WearApp()`.
- WEAR_UI.md guidance updated: replace the `scrollIndicator = {}` bullet with the `LocalScrollCaptureInProgress.current` pattern, and add a "Compose previews from the screen, not the app root" bullet.

Follow-up to PR #83 (which only landed the docs portion of the original branch).

## Test plan
- [x] `./gradlew :renderer-android:test :sample-wear:renderAllPreviews :sample-android:renderAllPreviews` — all green
- [x] `ActivityListLongPreview` PNG inspected: scroll indicator suppressed throughout the stitched capture
- [x] `ActivityListPreview` PNG inspected: scroll indicator still visible (production behaviour unchanged)