### PR TITLE
fix(plugin): silence VFS watcher warning and fix doctor task config-cache violation

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -13,7 +13,7 @@ group = "ee.schimke.composeai"
 // at the outer repo root (this project is loaded as an included build, so
 // its own rootDir is `gradle-plugin/` — walk up one level).
 version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: run {
-    val manifest = rootDir.resolve("../.release-please-manifest.json").readText()
+    val manifest = rootDir.parentFile.resolve(".release-please-manifest.json").readText()
     val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
     val (major, minor, patch) = current.split(".").map { it.toInt() }
     "$major.$minor.${patch + 1}-SNAPSHOT"

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -74,12 +74,24 @@ internal object AndroidPreviewSupport {
         // — specifically the VS Code extension — do. Same JSON schema as
         // `compose-preview doctor --json`'s per-module shape, so both
         // surfaces converge on one contract.
+        // Resolve the runtime classpaths' root components at configuration
+        // time so the task action stays config-cache safe (no `task.project`
+        // access at execution). `findByName` may return null on variants that
+        // don't have a paired unit-test classpath; the task tolerates an
+        // unset Property as "no deps to inspect".
+        val mainRuntimeRoot = project.configurations.findByName("${variantName}RuntimeClasspath")
+            ?.incoming?.resolutionResult?.rootComponent
+        val testRuntimeRoot = project.configurations.findByName("${variantName}UnitTestRuntimeClasspath")
+            ?.incoming?.resolutionResult?.rootComponent
+
         project.tasks.register("composePreviewDoctor", ee.schimke.composeai.plugin.tooling.ComposePreviewDoctorTask::class.java) {
             group = "compose preview"
             description = "Write compose-preview doctor findings to build/compose-previews/doctor.json"
             this.variant.set(variantName)
             this.modulePath.set(project.path)
             this.outputFile.set(previewOutputDir.map { it.file("doctor.json") })
+            mainRuntimeRoot?.let { this.mainRuntimeRoot.set(it) }
+            testRuntimeRoot?.let { this.testRuntimeRoot.set(it) }
         }
 
         // Always inject `ui-test-manifest` + `ui-test-junit4` into the consumer's

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewDoctorTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewDoctorTask.kt
@@ -5,9 +5,12 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
@@ -26,6 +29,10 @@ import org.gradle.work.DisableCachingByDefault
  *
  * Cheap to run: resolves the two configurations' `resolutionResult` (no
  * artifact downloads), applies rules, writes a small JSON file.
+ *
+ * Configuration-cache safe: the runtime classpath `ResolutionResult`s are
+ * wired in as `Provider<ResolvedComponentResult>` at registration time so
+ * the action never reaches back to `task.project`.
  */
 @DisableCachingByDefault(because = "Doctor findings depend on the live configuration resolution, not on a declared input set — caching across a version bump would silently stale-surface fixed issues.")
 abstract class ComposePreviewDoctorTask : DefaultTask() {
@@ -36,14 +43,20 @@ abstract class ComposePreviewDoctorTask : DefaultTask() {
     @get:Input
     abstract val modulePath: Property<String>
 
+    @get:Internal
+    abstract val mainRuntimeRoot: Property<ResolvedComponentResult>
+
+    @get:Internal
+    abstract val testRuntimeRoot: Property<ResolvedComponentResult>
+
     @get:OutputFile
     abstract val outputFile: RegularFileProperty
 
     @TaskAction
     fun run() {
         val variantName = variant.get()
-        val main = resolveConfiguration("${variantName}RuntimeClasspath")
-        val test = resolveConfiguration("${variantName}UnitTestRuntimeClasspath")
+        val main = collectModuleVersions(mainRuntimeRoot.orNull)
+        val test = collectModuleVersions(testRuntimeRoot.orNull)
         val findings = CompatRules.evaluate(main, test)
         val report = DoctorModuleReport(
             schema = SCHEMA,
@@ -67,22 +80,25 @@ abstract class ComposePreviewDoctorTask : DefaultTask() {
         logger.lifecycle("Wrote compose-preview doctor report for ${modulePath.get()}: ${findings.size} finding(s) → ${out.path}")
     }
 
-    private fun resolveConfiguration(name: String): Map<String, String> {
-        val config = project.configurations.findByName(name) ?: return emptyMap()
-        if (!config.isCanBeResolved) return emptyMap()
-        return try {
-            val out = LinkedHashMap<String, String>()
-            for (dep in config.incoming.resolutionResult.allDependencies) {
-                val resolved = dep as? org.gradle.api.artifacts.result.ResolvedDependencyResult ?: continue
-                val id = resolved.selected.id
-                if (id is ModuleComponentIdentifier) {
-                    out.putIfAbsent("${id.group}:${id.module}", id.version)
-                }
+    private fun collectModuleVersions(root: ResolvedComponentResult?): Map<String, String> {
+        if (root == null) return emptyMap()
+        val out = LinkedHashMap<String, String>()
+        val seen = HashSet<ResolvedComponentResult>()
+        val stack = ArrayDeque<ResolvedComponentResult>()
+        stack.addLast(root)
+        while (stack.isNotEmpty()) {
+            val node = stack.removeLast()
+            if (!seen.add(node)) continue
+            val id = node.id
+            if (id is ModuleComponentIdentifier) {
+                out.putIfAbsent("${id.group}:${id.module}", id.version)
             }
-            out
-        } catch (_: Throwable) {
-            emptyMap()
+            for (dep in node.dependencies) {
+                val resolved = dep as? ResolvedDependencyResult ?: continue
+                stack.addLast(resolved.selected)
+            }
         }
+        return out
     }
 
     companion object {


### PR DESCRIPTION
## Summary

Two related fixes that surfaced from the same `:sample-android:composePreviewDoctor :sample-wear:discoverPreviews` invocation:

- The included `gradle-plugin` build read `rootDir.resolve(\"../.release-please-manifest.json\")`. The unnormalised `..` made Gradle's file-system watcher try to register `gradle-plugin/..` (the outer repo root) as a watched path, which the outer build was already watching — logging \`Caught exception: Already watching path: …/gradle-plugin/..\` on every configure. Resolving via \`rootDir.parentFile.resolve(...)\` keys the watcher cleanly off the outer root.
- `ComposePreviewDoctorTask.run()` called `project.configurations.findByName(...)` at execution time, which configuration cache forbids. It was hidden until now because the cached graph short-circuited the action; invalidating the cache (via the watcher fix) re-executed it and surfaced the violation. Fixed by wiring each runtime classpath's root `ResolvedComponentResult` into the task as a `Property<ResolvedComponentResult>` at registration time and walking the dep graph from the root in the action — `task.project` is no longer touched at execution.

## Test plan

- [x] `./gradlew :sample-android:composePreviewDoctor :sample-wear:discoverPreviews` — no watcher warning, doctor task succeeds, configuration cache entry stored
- [x] `./gradlew check` inside `gradle-plugin/` (unit + functional tests) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)