### PR TITLE
feat(renderer): honour reduceMotion for @ScrollingPreview LONG captures

### DIFF
--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -274,11 +274,29 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                 @Suppress("UNCHECKED_CAST")
                 val scrollCaptureProvidable =
                     LocalScrollCaptureInProgress as ProvidableCompositionLocal<Boolean>
+                // Wear-only: flatten `TransformingLazyColumn` item scaling for
+                // `@ScrollingPreview(..., reduceMotion = true)` captures.
+                // Without this, items mid-transform at a viewport edge get
+                // captured at non-1.0 scale, then the stitcher paints that
+                // same item again (at its next-slice scale) one viewport
+                // down — producing the ghost/duplicate rows at slice seams
+                // the user sees on long Wear previews. `LocalReduceMotion`
+                // is looked up reflectively so this file stays free of a
+                // Wear Compose compile dep; on non-Wear modules the lookup
+                // returns null and the flag is a no-op.
+                val reduceMotion =
+                    preview.captures.any { it.scroll?.reduceMotion == true }
+                val reduceMotionLocal =
+                    if (reduceMotion) WearReduceMotionLocal.get() else null
+                val providedValues = buildList {
+                    add(LocalInspectionMode provides !a11yEnabled)
+                    add(scrollCaptureProvidable provides scrollCaptureInProgress)
+                    if (reduceMotionLocal != null) {
+                        add(reduceMotionLocal provides true)
+                    }
+                }.toTypedArray()
                 rule.setContent {
-                    CompositionLocalProvider(
-                        LocalInspectionMode provides !a11yEnabled,
-                        scrollCaptureProvidable provides scrollCaptureInProgress,
-                    ) {
+                    CompositionLocalProvider(values = providedValues) {
                         if (wrapWidth || wrapHeight) {
                             // AS-parity wrap-to-content: measure the strategy's
                             // composable with unbounded constraints on wrapped

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/WearReduceMotionLocal.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/WearReduceMotionLocal.kt
@@ -1,0 +1,37 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+
+/**
+ * Resolves Wear Compose's `LocalReduceMotion` by reflection so the renderer can
+ * honour `@ScrollingPreview(..., reduceMotion = true)` without taking a
+ * compile-time dependency on `androidx.wear.compose:compose-foundation`.
+ *
+ * Wear Compose Foundation 1.5+ exposes it as:
+ *
+ * ```
+ * package androidx.wear.compose.foundation
+ * val LocalReduceMotion: ProvidableCompositionLocal<Boolean>
+ * ```
+ *
+ * The backing JVM member is `CompositionLocalsKt.getLocalReduceMotion()`.
+ * When the consumer module isn't a Wear module (class not on the test JVM
+ * classpath) the lookup returns `null` and the caller skips the provider —
+ * reduceMotion becomes a no-op, which is harmless for non-Wear scrollables
+ * where `TransformingLazyColumn`-style edge scaling doesn't apply.
+ *
+ * Cached after the first call: reflection lookup cost amortises across every
+ * preview in the shard.
+ */
+internal object WearReduceMotionLocal {
+    private val cached: ProvidableCompositionLocal<Boolean>? by lazy { resolve() }
+
+    fun get(): ProvidableCompositionLocal<Boolean>? = cached
+
+    @Suppress("UNCHECKED_CAST")
+    private fun resolve(): ProvidableCompositionLocal<Boolean>? = runCatching {
+        val clazz = Class.forName("androidx.wear.compose.foundation.CompositionLocalsKt")
+        val method = clazz.getDeclaredMethod("getLocalReduceMotion")
+        method.invoke(null) as ProvidableCompositionLocal<Boolean>
+    }.getOrNull()
+}

--- a/sample-wear/src/main/kotlin/com/example/samplewear/Previews.kt
+++ b/sample-wear/src/main/kotlin/com/example/samplewear/Previews.kt
@@ -290,7 +290,7 @@ fun LongActivityListScreen() {
 }
 
 @WearPreviewLargeRound
-@ScrollingPreview(mode = ScrollMode.LONG, reduceMotion = true)
+@ScrollingPreview(mode = ScrollMode.LONG)
 @Composable
 fun ActivityListLongPreview() {
     MaterialTheme {

--- a/skills/compose-preview/SKILL.md
+++ b/skills/compose-preview/SKILL.md
@@ -271,7 +271,7 @@ import ee.schimke.composeai.preview.ScrollingPreview
 fun MyListEndPreview() { MyList() }
 
 @WearPreviewLargeRound
-@ScrollingPreview(mode = ScrollMode.LONG, reduceMotion = true)
+@ScrollingPreview(mode = ScrollMode.LONG)
 @Composable
 fun MyListLongPreview() { MyList() }
 ```


### PR DESCRIPTION
## Summary

- `@ScrollingPreview(reduceMotion = true)` (the annotation default) was wired through discovery and the manifest but never applied by the renderer — the flag was pure placebo. Long-scroll captures of Wear `TransformingLazyColumn` content left edge-scaled items at slice seams, which the stitcher then painted into adjacent viewports as narrower ghost rows (visibly: "Sleep day 3", "Timer 6", etc. appearing twice at reduced width in `ActivityListLongPreview`).
- `RobolectricRenderTest` now reflectively looks up `LocalReduceMotion` in `androidx.wear.compose.foundation.CompositionLocalsKt` and provides `true` whenever any capture on the preview opts in. Lookup is cached and returns `null` on non-Wear modules — no Wear compile dependency leaks into `renderer-android`.
- Drops the now-redundant `reduceMotion = true` from the sample-wear LONG preview and the SKILL.md example, since the annotation default now actually does what the docstring always promised.

## Before / after

Same preview (`ActivityListLongPreview`, 15-item TLC). Before: items 3, 6, 9, 13 appear as scaled ghost rows at slice seams. After: all 15 items render at full width.

## Test plan

- [x] `./gradlew :renderer-android:compileDebugKotlin` — compiles.
- [x] `./gradlew :sample-wear:renderPreviews --rerun-tasks` — produces a clean stitched PNG with no seam ghosts.
- [ ] `./gradlew check` on CI.
- [ ] Follow-up: pixel regression test locking in the full-width invariant for LONG captures (measuring now, will post in a follow-up PR).