### PR TITLE
refactor(samples): wire renderAllPreviews via lazy matching instead of afterEvaluate

### DIFF
--- a/sample-android/build.gradle.kts
+++ b/sample-android/build.gradle.kts
@@ -49,10 +49,15 @@ android {
 // pixel-asserts against them. Targeting the `test{Debug,Release}UnitTest`
 // tasks by name — `tasks.withType<Test>()` would also grab the plugin's own
 // `renderPreviews` Test task and create a circular dependency.
-afterEvaluate {
-    listOf("testDebugUnitTest", "testReleaseUnitTest").forEach { name ->
-        tasks.findByName(name)?.dependsOn("renderAllPreviews")
-    }
+//
+// `tasks.matching { ... }.configureEach { ... }` is the Isolated-Projects-
+// safe lazy pattern: the matching predicate is evaluated as each task is
+// registered, and the configureEach action only fires for matches. This
+// replaces the discouraged `afterEvaluate { tasks.findByName(...) }` block,
+// which forced eager configuration and isn't IP-friendly.
+val pixelTestUnitTestTasks = setOf("testDebugUnitTest", "testReleaseUnitTest")
+tasks.matching { it.name in pixelTestUnitTestTasks }.configureEach {
+    dependsOn("renderAllPreviews")
 }
 
 dependencies {

--- a/sample-wear/build.gradle.kts
+++ b/sample-wear/build.gradle.kts
@@ -67,8 +67,12 @@ dependencies {
 // Same dependency wiring as sample-android's pixel tests; targets the AGP
 // unit-test tasks by name so we don't include the plugin's own `renderPreviews`
 // Test task (which would create a circular dep).
-afterEvaluate {
-    listOf("testDebugUnitTest", "testReleaseUnitTest").forEach { name ->
-        tasks.findByName(name)?.dependsOn("renderAllPreviews")
-    }
+//
+// `tasks.matching { ... }.configureEach { ... }` is the Isolated-Projects-
+// safe lazy pattern — the predicate fires as each task is registered, so we
+// don't need the discouraged `afterEvaluate` block to wait for AGP to wire
+// the unit-test tasks.
+val pixelTestUnitTestTasks = setOf("testDebugUnitTest", "testReleaseUnitTest")
+tasks.matching { it.name in pixelTestUnitTestTasks }.configureEach {
+    dependsOn("renderAllPreviews")
 }


### PR DESCRIPTION
## Summary

The two Android sample modules wired `renderAllPreviews` into AGP's `test{Debug,Release}UnitTest` via \`afterEvaluate { tasks.findByName(name)?.dependsOn(...) }\`. That works today but is the classic pattern Gradle flags under Isolated Projects — `afterEvaluate` plus `findByName` is eager and cross-project-unsafe.

Swap to \`tasks.matching { it.name in ... }.configureEach { ... }\` in [sample-android/build.gradle.kts](sample-android/build.gradle.kts) and [sample-wear/build.gradle.kts](sample-wear/build.gradle.kts). The predicate evaluates as each task is registered, so the dependency is wired exactly when AGP creates the unit-test task — no `afterEvaluate`, no eager realisation, IP-safe.

## Test plan

- [x] \`./gradlew --dry-run :sample-android:testDebugUnitTest :sample-wear:testDebugUnitTest\` — both samples show \`renderAllPreviews\` (and \`verifyAccessibility\`) ahead of \`testDebugUnitTest\` in the resolved graph
- [x] \`Configuration cache entry stored\` reported on first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)