### PR TITLE
ci: publish preview-annotations alongside plugin and renderer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
   # `renderer-android` is published alongside the plugin so external consumers
   # that apply the plugin via GitHub Packages also get the Robolectric-based
   # Android renderer AAR — the plugin resolves it via matching version.
+  # `preview-annotations` ships the `@ScrollingPreview` marker that Compose
+  # apps add to their compileOnly classpath, so it must publish in lockstep.
   publish-gradle-plugin:
     needs: [build-cli, build-vscode-extension]
     runs-on: ubuntu-latest
@@ -82,7 +84,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
-      - name: Publish plugin and renderer-android to GitHub Packages
+      - name: Publish plugin, renderer-android and preview-annotations to GitHub Packages
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -90,15 +92,17 @@ jobs:
         run: |
           ./gradlew \
             :gradle-plugin:publishAllPublicationsToGitHubPackagesRepository \
-            :renderer-android:publishAllPublicationsToGitHubPackagesRepository
-      - name: Publish plugin and renderer-android to Maven Central
+            :renderer-android:publishAllPublicationsToGitHubPackagesRepository \
+            :preview-annotations:publishAllPublicationsToGitHubPackagesRepository
+      - name: Publish plugin, renderer-android and preview-annotations to Maven Central
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         run: |
           ./gradlew \
             :gradle-plugin:publishAndReleaseToMavenCentral \
-            :renderer-android:publishAndReleaseToMavenCentral
+            :renderer-android:publishAndReleaseToMavenCentral \
+            :preview-annotations:publishAndReleaseToMavenCentral
 
   build-cli:
     runs-on: ubuntu-latest

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -52,7 +52,8 @@ jobs:
         run: |
           ./gradlew \
             :gradle-plugin:publishToMavenCentral \
-            :renderer-android:publishToMavenCentral
+            :renderer-android:publishToMavenCentral \
+            :preview-annotations:publishToMavenCentral
           # Note: `--no-configuration-cache` is incompatible with
           # `org.gradle.unsafe.isolated-projects=true` set in gradle.properties
           # (Gradle fails with "Configuration Cache cannot be disabled when

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -33,7 +33,7 @@ Both fallbacks share the same concurrency group as the primary path, so they can
 
 ### What the `release.yml` workflow does
 
-1. Publishes the **Gradle plugin** (`ee.schimke.composeai:compose-preview-plugin`) and the **Android renderer AAR** (`ee.schimke.composeai:renderer-android`) to **Maven Central** via the Central Portal, and mirrors them to GitHub Packages.
+1. Publishes the **Gradle plugin** (`ee.schimke.composeai:compose-preview-plugin`), the **Android renderer AAR** (`ee.schimke.composeai:renderer-android`), and the **preview annotations** (`ee.schimke.composeai:preview-annotations`) to **Maven Central** via the Central Portal, and mirrors them to GitHub Packages.
 2. Builds the **CLI** as `.zip` and `.tar.gz` distributions.
 3. Packages the **VS Code extension** as a `.vsix` file.
 4. Uploads all three artifacts onto the GitHub Release that release-please created (falling back to creating the Release itself if invoked outside the release-please path, e.g. from a manual tag push).


### PR DESCRIPTION
## Summary

- `preview-annotations/build.gradle.kts` is fully configured for publishing (vanniktech, Maven Central + GH Packages mirror, signing, POM metadata) but neither `release.yml` nor `snapshot.yml` ever invoked its publish tasks.
- Consumers that put `@ScrollingPreview` on the `compileOnly` classpath can't resolve `ee.schimke.composeai:preview-annotations` from Maven Central as a result.
- Add `:preview-annotations` to the same Gradle task lists already used for `:gradle-plugin` and `:renderer-android` in both the release (GH Packages + Maven Central) and snapshot (Maven Central snapshots) workflows, and update the RELEASING doc.

## Test plan

- [ ] Next snapshot run on `main` publishes `ee.schimke.composeai:preview-annotations:<next>-SNAPSHOT` to https://central.sonatype.com/repository/maven-snapshots/
- [ ] Next tagged release publishes `ee.schimke.composeai:preview-annotations:<vX.Y.Z>` to Maven Central and to GitHub Packages