### PR TITLE
fix(doctor): print concise findings from composePreviewDoctor task

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.plugin.tooling
 
+import java.time.YearMonth
+
 /**
  * Plugin-side compat-check rules. Single source of truth used by both
  * [ComposePreviewModelBuilder] (Tooling API path, consumed by the CLI) and
@@ -160,9 +162,21 @@ internal object CompatRules {
             message = "no Compose BOM declared",
             detail = "Without a BOM, compose-ui / compose-runtime / compose-foundation can end up on non-lockstep versions. Most consumer failure reports we see start here.",
             remediationSummary = "Declare a Compose BOM to align all compose-* artifact versions.",
-            remediationCommands = listOf("implementation(platform(\"androidx.compose:compose-bom:2024.09.00\"))"),
+            remediationCommands = listOf("implementation(platform(\"androidx.compose:compose-bom:${suggestedComposeBom()}\"))"),
             docsUrl = null,
         )
+    }
+
+    /**
+     * Suggest the previous calendar month's BOM (`YYYY.MM.00`). Compose BOM
+     * publishes monthly with the `.00` as the initial release, so "last
+     * month's BOM" is both a real version and a safe, conservative choice —
+     * it always exists, and we're never recommending a literal that will
+     * age out the moment this file is committed.
+     */
+    internal fun suggestedComposeBom(today: YearMonth = YearMonth.now()): String {
+        val ym = today.minusMonths(1)
+        return "%04d.%02d.00".format(ym.year, ym.monthValue)
     }
 
     private fun parseVersions(raw: Map<String, String>): Map<String, Semver> {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewDoctorTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewDoctorTask.kt
@@ -14,6 +14,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
+import java.io.File
 
 /**
  * Writes [CompatRules] findings for the current module to a sidecar JSON.
@@ -77,7 +78,36 @@ abstract class ComposePreviewDoctorTask : DefaultTask() {
         val out = outputFile.get().asFile
         out.parentFile.mkdirs()
         out.writeText(JSON.encodeToString(report))
-        logger.lifecycle("Wrote compose-preview doctor report for ${modulePath.get()}: ${findings.size} finding(s) → ${out.path}")
+        printSummary(report, out)
+    }
+
+    /**
+     * Mirror the CLI's `emitText` shape at module scope: header, one marker
+     * line per finding, optional remediation. The JSON file is authoritative
+     * for tooling; this is purely for the human watching the Gradle output.
+     */
+    private fun printSummary(report: DoctorModuleReport, out: File) {
+        logger.lifecycle("compose-preview doctor — ${report.module} (variant: ${report.variant})")
+        if (report.findings.isEmpty()) {
+            logger.lifecycle("  ✓ no compatibility issues found")
+        } else {
+            for (f in report.findings) {
+                val marker = when (f.severity) {
+                    "error" -> "✗"
+                    "warning" -> "!"
+                    "info" -> "∙"
+                    else -> "?"
+                }
+                logger.lifecycle("  $marker [${f.severity}] ${f.message}")
+                f.remediationSummary?.let { logger.lifecycle("      → $it") }
+                for (cmd in f.remediationCommands) logger.lifecycle("        \$ $cmd")
+                f.docsUrl?.let { logger.lifecycle("        docs: $it") }
+            }
+            val errors = report.findings.count { it.severity == "error" }
+            val warnings = report.findings.count { it.severity == "warning" }
+            logger.lifecycle("  ${report.findings.size} finding(s): $errors error(s), $warnings warning(s)")
+        }
+        logger.lifecycle("  report: ${out.path}")
     }
 
     private fun collectModuleVersions(root: ResolvedComponentResult?): Map<String, String> {


### PR DESCRIPTION
## Summary
- `composePreviewDoctor` now prints a human-readable per-module summary to the Gradle console (header, `✗`/`!`/`∙` marker per finding, remediation + commands + docs link, totals) in addition to writing the JSON sidecar. Previously the task logged only the output file path, forcing users to open the JSON to see what was wrong.
- Replace the hard-coded `compose-bom:2024.09.00` recommendation in the "no Compose BOM declared" finding with `YearMonth.now().minusMonths(1)` formatted as `YYYY.MM.00`. The old literal was already below the CLI's own 2025.01.00 floor, so following the advice would have tripped the CLI's "too old" warning. Last month's BOM always exists (the `.00` is Compose BOM's monthly initial release) and the recommendation stays fresh without file churn.

## Test plan
- [x] `./gradlew :gradle-plugin:test` — existing CompatRules tests pass (they assert on id/severity, not the literal version).
- [ ] Run `./gradlew composePreviewDoctor` against a consumer project and eyeball the new console output.