### PR TITLE
ci: enforce conventional-commit format on PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,49 @@
+name: PR Title
+
+# Enforces conventional-commit format on pull request titles. Matters because
+# PRs are squash-merged with the PR title as the commit headline, and
+# release-please only bumps the version / populates the changelog from commits
+# whose headline matches `<type>(<scope>)?: <subject>`. A non-conforming title
+# is how #94 slipped past the 0.6.0 release PR (#93) until we pushed a
+# manually-crafted marker commit.
+#
+# The allowed types mirror what release-please understands: `feat` and `fix`
+# drive minor/patch bumps; the rest (`chore`, `docs`, `refactor`, …) still land
+# in the changelog under their section and keep history scannable.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Conventional Commit title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Subset release-please recognises. Keep in sync with any custom
+          # release-please commit-types config (none currently — defaults).
+          types: |
+            feat
+            fix
+            chore
+            docs
+            refactor
+            perf
+            test
+            build
+            ci
+            style
+            revert
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            should start with a lowercase character.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,6 +13,10 @@ In **Settings → Actions → General → Workflow permissions**, tick **"Allow 
 [release-please](https://github.com/googleapis/release-please) watches `main` for conventional-commit history and keeps a release PR up to date. Merging the PR is the only manual step.
 
 1. **Land conventional-commit PRs to `main`.** `fix:`, `feat:`, and `feat!:` / `BREAKING CHANGE` trigger a release. `chore:`, `docs:`, `ci:`, `refactor:`, and `test:` do not. To force a bump, add a `Release-As: 0.3.4` footer to any commit, or run the `Release PR` workflow via `workflow_dispatch`.
+
+   > **PR titles are the commit headlines.** Squash-merge uses the PR title as the commit headline, which is what release-please parses. The [PR Title](../.github/workflows/pr-title.yml) workflow enforces conventional-commit format on every PR so mis-titled PRs can't silently skip a release (as PR #94 did before the 0.6.0 cut). If you _do_ ever end up with a non-conforming commit on `main`, push an empty conventional-commit marker with `git commit --allow-empty -m "feat(...)…"` and release-please will re-scan.
+
+   Requires repo setting **Settings → General → Pull Requests → "Default to pull request title for squash merges"**. The repo-level API field is `squash_merge_commit_title=PR_TITLE` (not the default `COMMIT_OR_PR_TITLE`, which reuses the first commit's headline on single-commit PRs — that's the gap that let #94 through).
 2. **Review the release PR.** Titled `chore(main): release X.Y.Z`. Check the proposed `CHANGELOG.md`, the version bumps in `README.md`, `docs/*.md`, `DoctorCommand.kt`, and `.release-please-manifest.json`. Amend commit messages on `main` if the bump isn't right — the PR updates itself.
 3. **Merge the release PR.** On the next `release-please.yml` run (fires immediately on the merge commit), it creates the `vX.Y.Z` tag + GitHub Release, then invokes `release.yml` to build and upload the artifacts.
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pr-title.yml` running [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request) on every PR. Blocks non-conforming titles as a required check.
- Documents the companion repo setting in [docs/RELEASING.md](docs/RELEASING.md).

## Why

Squash-merge uses the PR title as the commit headline, and release-please only bumps the version from conventional-commit headlines. #94 squash-merged with a plain-English title (`Make Wear preview rendering robust for real-world consumers`), so release-please skipped it and PR #93 didn't mention it. We recovered with a manual empty marker commit on main (ec36863); this check prevents the next recurrence.

There's a second half to the fix that I can't do from here: the repo currently has `squash_merge_commit_title=COMMIT_OR_PR_TITLE`, which falls back to the commit's own title on single-commit PRs (exactly what happened with #94). Flipping it to `PR_TITLE` makes the enforced PR titles actually reach main. See RELEASING.md for the UI path.

## Test plan

- [ ] This PR's own title satisfies the check
- [ ] Renaming the PR to something non-conforming (e.g. `test bad title`) fails the check