### PR TITLE
fix(vscode): stop webview going blank after successful refresh

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -50,6 +50,11 @@ let refreshInFlight = false;
 const DISMISS_KEY = 'composePreview.dismissedMissingPluginWarning';
 /** Captured in activate() so notification helpers can reach workspaceState. */
 let extensionContext: vscode.ExtensionContext | null = null;
+/** Module-scoped logger wired up in activate() so refresh() can trace state
+ *  transitions into the "Compose Preview" output channel. Populate-then-blank
+ *  bugs are hard to diagnose from logs unless we explicitly announce each
+ *  message we send to the webview. */
+let logLine: (msg: string) => void = () => { /* noop pre-activate */ };
 /** Guard against firing the "plugin not applied" notification more than once
  *  per session — users shouldn't see it on every refresh tick. */
 let warnedMissingPluginThisSession = false;
@@ -69,6 +74,7 @@ export async function activate(context: vscode.ExtensionContext) {
     const workspaceRoot = workspaceFolders[0].uri.fsPath;
     const outputChannel = vscode.window.createOutputChannel('Compose Preview');
     context.subscriptions.push(outputChannel);
+    logLine = (msg: string) => outputChannel.appendLine(`[refresh] ${msg}`);
 
     // vscjava.vscode-gradle is declared as an extensionDependency, so it's
     // guaranteed to be installed. Activate it and get its API.
@@ -376,11 +382,12 @@ async function refresh(forceRender: boolean, forFilePath?: string) {
     // empty state rather than falling through to an ambiguous multi-file view.
     // Picks, in priority: caller > active editor > any visible Kotlin editor >
     // last-scoped file. See resolveScopeFile for the full chain.
-    const { file: activeFile } = resolveScopeFile(forFilePath);
+    const { file: activeFile, source: scopeSource } = resolveScopeFile(forFilePath);
     const module = activeFile && isPreviewSourceFile(activeFile)
         ? gradleService.resolveModule(activeFile)
         : null;
     if (!activeFile || !module) {
+        logLine(`no module — activeFile=${activeFile ?? '<none>'} (${scopeSource})`);
         panel.postMessage({ command: 'clearAll' });
         panel.postMessage({ command: 'showMessage', text: emptyStateMessage(activeFile) });
         lastLoadedModules = [];
@@ -391,6 +398,7 @@ async function refresh(forceRender: boolean, forFilePath?: string) {
         }
         return;
     }
+    logLine(`start forceRender=${forceRender} file=${path.basename(activeFile)} (${scopeSource}) module=${module}`);
 
     currentScopeFile = activeFile;
     const modules = [module];
@@ -452,7 +460,12 @@ async function refresh(forceRender: boolean, forFilePath?: string) {
         if (abort.signal.aborted) { return; }
 
         if (allPreviews.length === 0) {
-            panel.postMessage({ command: 'showMessage', text: 'No @Preview functions found' });
+            // Module has no previews at all. Wipe any stale cards so the
+            // message isn't overlaid on old content from a prior scope.
+            panel.postMessage({ command: 'clearAll' });
+            panel.postMessage({ command: 'showMessage', text: 'No @Preview functions found in this module' });
+            hasPreviewsLoaded = false;
+            logLine('done — module has no previews');
             return;
         }
 
@@ -460,12 +473,29 @@ async function refresh(forceRender: boolean, forFilePath?: string) {
         // functions, the panel shows an empty state — never the whole module.
         const visiblePreviews = allPreviews.filter(p => p.sourceFile === filterFile);
 
+        if (visiblePreviews.length === 0) {
+            // The module has previews but this file doesn't. An empty
+            // setPreviews would get silently wiped by applyFilters in the
+            // webview — send an explicit, persistent message instead and
+            // clear the grid so the user sees *why* it's blank.
+            panel.postMessage({ command: 'clearAll' });
+            const otherFiles = allPreviews.length;
+            panel.postMessage({
+                command: 'showMessage',
+                text: `No @Preview functions in this file (${otherFiles} in other files in this module).`,
+            });
+            hasPreviewsLoaded = false;
+            logLine(`done — 0 visible previews in ${path.basename(activeFile)}, module has ${otherFiles}`);
+            return;
+        }
+
         panel.postMessage({
             command: 'setPreviews',
             previews: visiblePreviews,
             moduleDir: modules.join(','),
         });
         hasPreviewsLoaded = true;
+        logLine(`rendered ${visiblePreviews.length} preview(s) for ${path.basename(activeFile)}`);
 
         // Load images asynchronously. Animated previews have multiple captures
         // in `preview.captures`; one updateImage message per capture. The
@@ -514,10 +544,17 @@ async function refresh(forceRender: boolean, forFilePath?: string) {
             }
         }
 
-        panel.postMessage({ command: 'showMessage', text: '' });
+        // NOTE: intentionally do NOT send `showMessage: ''` here. The webview's
+        // renderPreviews() already hides the "Building…" message when cards
+        // populate, so this used to be a no-op for the happy path — but it
+        // *did* clobber legitimate messages (e.g. "No previews match the
+        // current filters" set by applyFilters, or the empty-file notice
+        // above), which is what produced the "populate then go blank with
+        // nothing in the logs" symptom.
     } catch (err: unknown) {
         if (abort.signal.aborted) { return; }
         const message = err instanceof Error ? err.message.slice(0, 300) : 'Build failed';
+        logLine(`FAILED: ${message}`);
         panel.postMessage({
             command: 'showMessage',
             text: message,

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -114,6 +114,13 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         }
         applyLayout();
 
+        // Seed a placeholder so the view isn't blank during the ~1s boot
+        // window before the extension posts its first message. Any real
+        // message (Building…, empty-state notice, cards) will replace it.
+        message.textContent = 'Loading Compose previews…';
+        message.style.display = 'block';
+        message.dataset.owner = 'fallback';
+
         layoutMode.addEventListener('change', () => {
             state.layout = layoutMode.value;
             vscode.setState(state);
@@ -162,13 +169,49 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 if (show) visibleCount++;
             });
 
-            message.textContent = visibleCount === 0 && allPreviews.length > 0
-                ? 'No previews match the current filters'
-                : '';
-            message.style.display = visibleCount === 0 && allPreviews.length > 0 ? 'block' : 'none';
+            // Only own the message when we have a filter-specific thing to
+            // say. When there are no previews at all, the extension owns the
+            // message (e.g. "No @Preview functions in this file") — clearing
+            // it here was how the view went blank after a refresh.
+            if (allPreviews.length > 0 && visibleCount === 0) {
+                setMessage('No previews match the current filters', 'filter');
+            } else if (message.dataset.owner === 'filter') {
+                // We set this earlier; clear it now that it no longer applies.
+                setMessage('', 'filter');
+            }
 
             // Re-apply layout so focus mode updates correctly after filter change
             applyLayout();
+        }
+
+        // Central setter so applyFilters and incoming messages don't fight
+        // over who owns the current text. The owner tag is used only to let
+        // applyFilters clear its own message without touching extension-set
+        // text (empty-file notice, build errors, etc.).
+        function setMessage(text, owner) {
+            message.textContent = text;
+            message.style.display = text ? 'block' : 'none';
+            if (text) {
+                message.dataset.owner = owner || 'extension';
+            } else {
+                delete message.dataset.owner;
+            }
+            ensureNotBlank();
+        }
+
+        // Safety net: if the grid ends up empty *and* no message is showing,
+        // surface a placeholder so the user doesn't stare at a void. This
+        // shouldn't normally trigger — the extension sends an explicit
+        // message for every empty state — but a silent blank view was the
+        // original complaint, so this catches any future regressions.
+        function ensureNotBlank() {
+            const hasCards = grid.querySelector('.preview-card') !== null;
+            const hasMessage = message.style.display !== 'none' && message.textContent;
+            if (!hasCards && !hasMessage) {
+                message.textContent = 'Preparing previews…';
+                message.style.display = 'block';
+                message.dataset.owner = 'fallback';
+            }
         }
 
         function getVisibleCards() {
@@ -776,12 +819,20 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
          */
         function renderPreviews(previews) {
             if (previews.length === 0) {
+                // Defensive fallback — the extension now always sends an
+                // explicit showMessage for empty states, so this branch
+                // shouldn't normally fire. Kept so the view never ends up
+                // with an empty grid + empty message if a bug slips through.
                 grid.innerHTML = '';
-                message.textContent = 'No @Preview functions found';
-                message.style.display = 'block';
+                setMessage('No @Preview functions found', 'empty');
                 return;
             }
-            message.style.display = 'none';
+            // Only clear a message we own (filter/empty/fallback) — leave
+            // extension-set messages like "Building…" alone; the extension
+            // will drive its own lifecycle.
+            if (message.dataset.owner && message.dataset.owner !== 'extension') {
+                setMessage('', message.dataset.owner);
+            }
 
             const newIds = new Set(previews.map(p => p.id));
             const existingCards = new Map();
@@ -1007,8 +1058,11 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 case 'clearAll':
                     allPreviews = [];
                     grid.innerHTML = '';
-                    message.textContent = '';
-                    message.style.display = 'none';
+                    // Don't clear the message here — if it came with a
+                    // follow-up showMessage (the usual pattern) it'll be
+                    // replaced; if not, ensureNotBlank will backstop a
+                    // placeholder so the view never ends up empty+silent.
+                    ensureNotBlank();
                     break;
 
                 case 'updateImage':
@@ -1050,8 +1104,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                             }
                         }
                     } else {
-                        message.textContent = 'Building...';
-                        message.style.display = 'block';
+                        setMessage('Building…', 'extension');
                     }
                     break;
 
@@ -1089,8 +1142,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 }
 
                 case 'showMessage':
-                    message.textContent = msg.text;
-                    message.style.display = msg.text ? 'block' : 'none';
+                    setMessage(msg.text, 'extension');
                     break;
 
                 case 'setHistory':


### PR DESCRIPTION
## Summary

The VS Code extension's preview panel was intermittently going blank after a successful populate — with nothing obvious in the logs.

Root cause: the trailing `panel.postMessage({ command: 'showMessage', text: '' })` at the end of `refresh()` unconditionally clobbered any message the webview had just set (filter status, empty-file notice, per-capture errors). Compounded by `applyFilters` in the webview owning the shared `#message` div and silently clearing it whenever no filter was active, and by the extension sending an empty `setPreviews` when the active file had no `@Preview` functions but the module did.

- Remove the unconditional final `showMessage: ''` from `refresh()`.
- Handle empty `visiblePreviews` explicitly (`clearAll` + a persistent message naming how many previews live in other files of the module) instead of an empty `setPreviews`.
- Add `clearAll` before the empty-module notice so stale cards from a prior scope don't linger underneath it.
- Route webview message paths through a central `setMessage(text, owner)` so `applyFilters` can only clear messages it set itself.
- Add an `ensureNotBlank()` safety net plus an initial placeholder — if the grid ends up empty AND no message is showing, surface "Preparing previews…" rather than a void. Addresses the \"if it does go blank, show a message even if we suspect it's temporary\" ask.
- Log state transitions to the Compose Preview output channel so the next \"it went blank\" report has a trail.

## Test plan

- [ ] Open a Kotlin file with `@Preview` functions → cards populate, no blank flash after images load.
- [ ] Switch to a Kotlin file in the same module that has no `@Preview` → grid clears and a message appears: \"No @Preview functions in this file (N in other files in this module).\"
- [ ] Switch to a Kotlin file in a module without the plugin → existing empty-state guidance still appears.
- [ ] Open a file with previews, set a filter that matches none → \"No previews match the current filters\" persists (previously wiped by the final `showMessage: ''`).
- [ ] Trigger a build failure → error message persists on screen.
- [ ] Confirm Output ▸ Compose Preview now shows `[refresh]` lines for each state transition.