### PR TITLE
fix(renderer): stitch LONG scroll slices by pixel content, not reported offsets

### DIFF
--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -613,10 +613,14 @@ private fun handleLongCapture(
 
     val slices = mutableListOf<SliceCapture>()
     try {
+        // Drive at 80% of the viewport so each consecutive slice pair has a
+        // ~20% physical overlap for the content-aware stitcher to lock onto.
+        // The stitcher uses scrolledPx only as a hint — the actual vertical
+        // placement is decided by pixel matching.
         val result = driveScrollByViewport(
             rule = rule,
             axis = scroll.axis,
-            stepPx = viewportLayoutPx.toFloat(),
+            stepPx = viewportLayoutPx * 0.8f,
             maxScrollPx = scroll.maxScrollPx,
         ) { scrolledPx ->
             val sliceFile = File(slicesDir, "slice_${slices.size}.png")

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollSliceStitcher.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollSliceStitcher.kt
@@ -9,35 +9,51 @@ import java.awt.geom.Rectangle2D
 import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO
+import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
+import kotlin.math.sqrt
 
 /**
  * One captured slice — the on-disk PNG plus the cumulative scroll offset
- * (in layout pixels) the scrollable reported at the time of capture.
+ * (in layout pixels) the scrollable reported at the time of capture. The
+ * offset is now used only as a **hint** to narrow the overlap search; the
+ * actual alignment is driven by pixel content ([findOverlapShift]).
  */
 internal data class SliceCapture(val scrolledLayoutPx: Float, val file: File)
 
 /**
- * Stitches per-viewport slices (see [driveScrollByViewport]) into a single
+ * Stitches per-viewport slices (see `driveScrollByViewport`) into a single
  * tall PNG at [outputFile].
  *
- * Geometry:
+ * Content-aware alignment: each slice's vertical placement is decided by
+ * comparing pixel rows against the previous slice, not by trusting the
+ * scroller's reported offset. We've seen `TransformingLazyColumn` and
+ * spring-settled scrolls advance their semantic `ScrollAxisRange.value`
+ * faster or slower than the visible content actually moves — a stitcher
+ * keyed on semantics prints duplicated or dropped bands at each seam. The
+ * matcher here locks onto whatever the images actually show.
  *
- * Slice 0 was captured at scroll offset 0 — it covers output rows
- * `[0, sliceH)`. For each subsequent slice at offset `s_i`:
- *  - delta = round((s_i - s_{i-1}) × pxPerLayoutPx)
- *  - Source rows `[sliceH - delta, sliceH)` (the bottom `delta` rows).
- *  - Dest rows `[y_prev, y_prev + delta)`, where `y_prev` starts at
- *    `sliceH` and advances by `delta` per slice.
+ * The caller should drive the scroller at less than one full viewport per
+ * step (e.g. 80 %) so consecutive slice pairs have a physical overlap the
+ * matcher can lock onto.
  *
- * `pxPerLayoutPx` is the ratio between captured PNG pixel height and the
- * layout-pixel viewport height — `captureRoboImage` under Roborazzi writes
- * at the Robolectric qualifier density, which often equals layout units 1:1
- * but can diverge. Computing the ratio from slice 0 keeps the stitcher
- * honest about any difference.
+ * Per slice pair `(prev, next)`:
+ *  - Compute per-row luminance and per-row horizontal stddev (a cheap
+ *    "interestingness" signal — a blank row has stddev ≈ 0, a row cutting
+ *    through text or button edges has a large stddev).
+ *  - For each candidate shift `d` in `[hint × 0.5, hint × 1.2]` (clipped to
+ *    `[1, sliceH)`), score `Σ w_k · rowSAD(prev[d+k], next[k]) / Σ w_k`
+ *    with `w_k = max(prevStddev[d+k], nextStddev[k])`.
+ *  - Pick the `d` with the lowest score. The weighting means alignment is
+ *    decided by varied rows (text, edges, icons) — vast tracts of matching
+ *    blank background can't dominate the match.
  *
- * Output height = `sliceH + lastOffsetInImagePx`.
+ * `pxPerLayoutPx` converts the scroller's layout-pixel delta to image pixels
+ * to seed the search window. Robolectric's qualifier density often makes this
+ * 1.0, but we compute it from slice 0 to stay honest.
+ *
+ * Output height = `sliceH + Σ d_i` (sum of measured per-pair shifts).
  *
  * Returns the written file, or `null` if [slices] is empty.
  */
@@ -54,32 +70,63 @@ internal fun stitchSlices(
     val sliceH = firstImage.height
     val pxPerLayoutPx = sliceH.toDouble() / viewportLayoutPx.toDouble()
 
-    val imageOffsets = slices.map { (it.scrolledLayoutPx * pxPerLayoutPx).roundToInt() }
-    val lastOffsetPx = imageOffsets.last()
-    val totalHeight = sliceH + lastOffsetPx
+    // Load every slice up-front — we need each pixel set twice (alignment +
+    // blit) and the slice count is one per viewport (handful per preview).
+    val images = List(slices.size) { i ->
+        val img = if (i == 0) {
+            firstImage
+        } else {
+            ImageIO.read(slices[i].file)
+                ?: error("Failed to read slice PNG: ${slices[i].file}")
+        }
+        require(img.width == width && img.height == sliceH) {
+            "Slice dimensions drifted: expected ${width}x$sliceH, got ${img.width}x${img.height} at index $i"
+        }
+        img
+    }
+    val luminance = images.map { readLuminanceRows(it) }
+    val weights = luminance.map { rowStddevs(it) }
 
+    // Measured pixel shift for each transition i-1 -> i.
+    val shifts = IntArray(slices.size - 1)
+    for (i in 1 until slices.size) {
+        val reportedDelta = slices[i].scrolledLayoutPx - slices[i - 1].scrolledLayoutPx
+        if (reportedDelta <= 0f) {
+            // Framework reported no motion — treat as a duplicate capture
+            // and skip it; keeps parity with the old behaviour.
+            shifts[i - 1] = 0
+            continue
+        }
+        val hintPx = (reportedDelta * pxPerLayoutPx).roundToInt()
+        shifts[i - 1] = findOverlapShift(
+            prevLum = luminance[i - 1],
+            nextLum = luminance[i],
+            prevW = weights[i - 1],
+            nextW = weights[i],
+            sliceH = sliceH,
+            hintPx = hintPx,
+        )
+    }
+
+    val totalHeight = sliceH + shifts.sum()
     val stitched = BufferedImage(width, totalHeight, BufferedImage.TYPE_INT_ARGB)
     val g = stitched.createGraphics()
     try {
-        g.drawImage(firstImage, 0, 0, null)
-
+        g.drawImage(images[0], 0, 0, null)
         var yPrev = sliceH
-        for (i in 1 until slices.size) {
-            val img = ImageIO.read(slices[i].file)
-                ?: error("Failed to read slice PNG: ${slices[i].file}")
-            require(img.width == width && img.height == sliceH) {
-                "Slice dimensions drifted: expected ${width}x$sliceH, got ${img.width}x${img.height} at index $i"
-            }
-            val delta = imageOffsets[i] - imageOffsets[i - 1]
-            if (delta <= 0) continue // duplicate capture — framework reported no motion
-
+        for (i in 1 until images.size) {
+            val d = shifts[i - 1]
+            if (d <= 0) continue
+            // Copy the bottom `d` rows of the next slice directly beneath the
+            // previously written content — the top `sliceH - d` rows already
+            // overlap with what was drawn for the previous slice.
             g.drawImage(
-                img,
-                0, yPrev, width, yPrev + delta,
-                0, sliceH - delta, width, sliceH,
+                images[i],
+                0, yPrev, width, yPrev + d,
+                0, sliceH - d, width, sliceH,
                 null,
             )
-            yPrev += delta
+            yPrev += d
         }
     } finally {
         g.dispose()
@@ -88,6 +135,140 @@ internal fun stitchSlices(
     outputFile.parentFile?.mkdirs()
     ImageIO.write(stitched, "PNG", outputFile)
     return outputFile
+}
+
+/**
+ * Finds the vertical shift `d` that best aligns `prev[d..sliceH)` with
+ * `next[0..sliceH-d)`. Uses [hintPx] (the semantic reported delta converted
+ * to image pixels) to loosely narrow the search window; we keep the window
+ * generous because the scroller's reported offset can be wildly inaccurate
+ * (that's the bug we're fixing).
+ *
+ * Rows are weighted by their horizontal stddev so blank rows contribute
+ * ~nothing — the alignment is decided by text, edges, and varied-colour
+ * rows that can't accidentally match at the wrong offset. If the weighted
+ * signal is degenerate (every candidate overlap region is uniformly blank),
+ * we fall back to a plain rowSAD score so the matcher still produces a
+ * sensible answer.
+ */
+private fun findOverlapShift(
+    prevLum: Array<IntArray>,
+    nextLum: Array<IntArray>,
+    prevW: DoubleArray,
+    nextW: DoubleArray,
+    sliceH: Int,
+    hintPx: Int,
+): Int {
+    val maxShift = sliceH - 1
+    if (maxShift < 1) return 0
+
+    // Generous window around the hint — the framework can under- or over-
+    // report motion by a wide margin (e.g. TransformingLazyColumn), and
+    // search cost scales with sliceH × w, which is cheap.
+    val lo: Int
+    val hi: Int
+    if (hintPx > 0) {
+        lo = (hintPx / 3).coerceIn(1, maxShift)
+        hi = (hintPx * 3).coerceIn(lo, maxShift)
+    } else {
+        lo = 1
+        hi = maxShift
+    }
+
+    var bestWeightedD = -1
+    var bestWeightedScore = Double.POSITIVE_INFINITY
+    // Fallback: plain (unweighted) SAD per row, in case every candidate
+    // overlap region is uniformly blank (all per-row stddevs = 0) so the
+    // weighted score is undefined for every d.
+    var bestPlainD = hintPx.coerceIn(lo, hi)
+    var bestPlainScore = Double.POSITIVE_INFINITY
+
+    for (d in lo..hi) {
+        val n = sliceH - d
+        if (n <= 0) break
+        var weightSum = 0.0
+        var weightedCost = 0.0
+        var plainCost = 0.0
+        for (k in 0 until n) {
+            val w = max(prevW[d + k], nextW[k])
+            val sad = rowSad(prevLum[d + k], nextLum[k])
+            plainCost += sad
+            if (w > 0.0) {
+                weightedCost += w * sad
+                weightSum += w
+            }
+        }
+        val plainScore = plainCost / n
+        if (plainScore < bestPlainScore) {
+            bestPlainScore = plainScore
+            bestPlainD = d
+        }
+        if (weightSum > 0.0) {
+            val score = weightedCost / weightSum
+            if (score < bestWeightedScore) {
+                bestWeightedScore = score
+                bestWeightedD = d
+            }
+        }
+    }
+
+    return if (bestWeightedD >= 0) bestWeightedD else bestPlainD
+}
+
+/**
+ * Converts each row of [img] into an `IntArray` of 0..255 luminance values
+ * (Rec. 601 weighting). Luminance — rather than raw ARGB — makes the row
+ * SAD dominated by perceived brightness differences, which lines up with
+ * "interesting rows" as a human reads them.
+ */
+private fun readLuminanceRows(img: BufferedImage): Array<IntArray> {
+    val w = img.width
+    val h = img.height
+    val rgb = IntArray(w)
+    return Array(h) { y ->
+        img.getRGB(0, y, w, 1, rgb, 0, w)
+        IntArray(w) { x ->
+            val p = rgb[x]
+            val r = (p ushr 16) and 0xFF
+            val gg = (p ushr 8) and 0xFF
+            val b = p and 0xFF
+            (r * 299 + gg * 587 + b * 114) / 1000
+        }
+    }
+}
+
+/**
+ * Horizontal standard deviation of each row — the per-row "interestingness"
+ * weight. A blank row (black/white/single-colour background) scores ≈ 0;
+ * a row cutting through text, a chip border, or an icon scores high.
+ */
+private fun rowStddevs(rows: Array<IntArray>): DoubleArray {
+    return DoubleArray(rows.size) { y ->
+        val row = rows[y]
+        if (row.isEmpty()) {
+            return@DoubleArray 0.0
+        }
+        var sum = 0L
+        for (v in row) sum += v
+        val mean = sum.toDouble() / row.size
+        var varSum = 0.0
+        for (v in row) {
+            val d = v - mean
+            varSum += d * d
+        }
+        sqrt(varSum / row.size)
+    }
+}
+
+/** Sum of absolute per-pixel luminance differences between two rows. */
+private fun rowSad(a: IntArray, b: IntArray): Long {
+    val w = min(a.size, b.size)
+    var sum = 0L
+    for (i in 0 until w) {
+        val d = a[i] - b[i]
+        sum += if (d < 0) -d.toLong() else d.toLong()
+    }
+    return sum
 }
 
 /**

--- a/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/ScrollSliceStitcherTest.kt
+++ b/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/ScrollSliceStitcherTest.kt
@@ -1,0 +1,217 @@
+package ee.schimke.composeai.renderer
+
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pure-JVM tests for [stitchSlices]. Builds a tall synthetic "source" image
+ * with a unique colour band per horizontal row, carves viewport-sized windows
+ * out of it at known positions, and verifies the stitcher recomposes the
+ * source from the slices — byte-exact.
+ *
+ * The `overreported` test simulates the real-world bug we've seen on
+ * `TransformingLazyColumn` (see the duplicated "Allow LTE" row on the Wear
+ * settings screen): the framework's semantic `scrolledLayoutPx` advances
+ * faster than the image content actually moves, so a stitcher that trusts
+ * that value re-prints a band of pixels at the seam. A content-aware stitcher
+ * locks onto the real overlap instead.
+ */
+class ScrollSliceStitcherTest {
+    @get:Rule
+    val tmp: TemporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `reconstructs source when scroll offsets honestly match pixel motion`() {
+        val source = buildSource(width = 40, height = 500)
+        val viewport = 100
+        val offsets = listOf(0, 80, 160, 240, 320, 400)
+
+        val slices = offsets.mapIndexed { i, off ->
+            SliceCapture(off.toFloat(), writeSlice(source, off, viewport, "honest_$i"))
+        }
+
+        val out = tmp.newFile("stitched_honest.png")
+        val written = stitchSlices(slices, viewport, out)
+        assertTrue("stitchSlices returned null", written != null)
+
+        val stitched = ImageIO.read(out)
+        assertEquals(500, stitched.height)
+        assertPixelsEqual(source, stitched)
+    }
+
+    @Test
+    fun `reconstructs source even when scroll offsets overreport motion`() {
+        val source = buildSource(width = 40, height = 500)
+        val viewport = 100
+        // Actual pixel motion per step: 80 (20% overlap between consecutive slices).
+        val actualOffsets = listOf(0, 80, 160, 240, 320, 400)
+        // Framework claims it advanced a full viewport (100) each time — a lie.
+        // A naïve stitcher keying on scrolledLayoutPx will skip over real content.
+        val reportedOffsets = listOf(0, 100, 200, 300, 400, 500)
+
+        val slices = actualOffsets.zip(reportedOffsets).mapIndexed { i, (actual, reported) ->
+            SliceCapture(reported.toFloat(), writeSlice(source, actual, viewport, "lied_$i"))
+        }
+
+        val out = tmp.newFile("stitched_lied.png")
+        val written = stitchSlices(slices, viewport, out)
+        assertTrue("stitchSlices returned null", written != null)
+
+        val stitched = ImageIO.read(out)
+        // viewport (100) + 5 × measured overlap delta (80) = 500.
+        assertEquals(500, stitched.height)
+        assertPixelsEqual(source, stitched)
+    }
+
+    @Test
+    fun `reconstructs source when scroll offsets underreport motion`() {
+        val source = buildSource(width = 40, height = 600)
+        val viewport = 100
+        // Slice was actually advanced 80 px per step, but framework claims 50.
+        val actualOffsets = listOf(0, 80, 160, 240, 320, 400, 480)
+        val reportedOffsets = listOf(0, 50, 100, 150, 200, 250, 300)
+
+        val slices = actualOffsets.zip(reportedOffsets).mapIndexed { i, (actual, reported) ->
+            SliceCapture(reported.toFloat(), writeSlice(source, actual, viewport, "low_$i"))
+        }
+
+        val out = tmp.newFile("stitched_low.png")
+        stitchSlices(slices, viewport, out) ?: error("stitchSlices returned null")
+
+        val stitched = ImageIO.read(out)
+        assertEquals(100 + 6 * 80, stitched.height)
+        val expected = source.getSubimage(0, 0, source.width, 100 + 6 * 80)
+        assertPixelsEqual(expected, stitched)
+    }
+
+    @Test
+    fun `alignment is driven by interesting rows, not blank background`() {
+        // Source: mostly-uniform grey background (low-but-nonzero stddev) with a
+        // single very distinctive high-contrast "text" row placed inside every
+        // slice-pair's overlap region. A naive matcher could align anywhere in
+        // the grey; the weighted matcher should lock onto the distinctive rows.
+        val width = 40
+        val height = 500
+        val source = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        // Grey-ish background with tiny horizontal jitter — stddev is small
+        // but non-zero, so these rows contribute to the weighted score only
+        // mildly.
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                val v = 0x40 + ((x + y) and 0x07) // 64..71
+                source.setRGB(x, y, (0xFF shl 24) or (v shl 16) or (v shl 8) or v)
+            }
+        }
+        // High-variance "text-like" rows at y ≡ 8 (mod 20) — guaranteed to
+        // appear inside every 80-px shift's 20-px overlap.
+        for (y in 0 until height) {
+            if (y % 20 == 8) {
+                for (x in 0 until width) {
+                    // Large amplitude chequered pattern → huge horizontal stddev.
+                    val on = ((x + y) and 1) != 0
+                    val v = if (on) 0xEE else 0x11
+                    source.setRGB(
+                        x,
+                        y,
+                        (0xFF shl 24) or ((v xor ((y * 7) and 0xFF)) shl 16) or
+                            (v shl 8) or ((v xor 0x5A) and 0xFF),
+                    )
+                }
+            }
+        }
+
+        val viewport = 100
+        // Actual physical scroll = 80 px per step (20 px overlap).
+        // Reported offsets lie about the step size.
+        val actualOffsets = listOf(0, 80, 160, 240, 320, 400)
+        val reportedOffsets = listOf(0, 100, 200, 300, 400, 500)
+
+        val slices = actualOffsets.zip(reportedOffsets).mapIndexed { i, (actual, reported) ->
+            SliceCapture(reported.toFloat(), writeSlice(source, actual, viewport, "text_$i"))
+        }
+
+        val out = tmp.newFile("stitched_text.png")
+        stitchSlices(slices, viewport, out) ?: error("stitchSlices returned null")
+
+        val stitched = ImageIO.read(out)
+        assertEquals(500, stitched.height)
+        assertPixelsEqual(source, stitched)
+    }
+
+    @Test
+    fun `single slice round-trips unchanged`() {
+        val source = buildSource(width = 40, height = 100)
+        val slices = listOf(
+            SliceCapture(0f, writeSlice(source, 0, 100, "single")),
+        )
+        val out = tmp.newFile("stitched_single.png")
+        stitchSlices(slices, 100, out) ?: error("stitchSlices returned null")
+        assertPixelsEqual(source, ImageIO.read(out))
+    }
+
+    @Test
+    fun `empty slice list returns null without writing a file`() {
+        val out = tmp.newFile("should_not_exist.png")
+        out.delete()
+        val result = stitchSlices(emptyList(), viewportLayoutPx = 100, outputFile = out)
+        assertEquals(null, result)
+        assertEquals(false, out.exists())
+    }
+
+    /**
+     * Build a tall "source" image where every pixel has a pseudo-random
+     * colour derived from both (x, y). Two properties matter for the test:
+     *  - Each row has high horizontal variation (non-zero stddev), mimicking
+     *    real screenshots where there's always *some* content per row — so
+     *    the weighted matcher has a signal to grip onto.
+     *  - Two rows at different y never accidentally share a pixel pattern,
+     *    so no two shifts look equally plausible to the matcher.
+     */
+    private fun buildSource(width: Int, height: Int): BufferedImage {
+        val img = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                // Integer hash of (x, y) → pseudo-random 24-bit colour. The
+                // bit-mixing makes neighbouring rows visually distinct and
+                // keeps per-row horizontal stddev high.
+                var h = y * -1640531535 xor (x * 1597334677)
+                h = h xor (h ushr 13)
+                h *= 5
+                val rgb = h and 0x00FFFFFF
+                img.setRGB(x, y, (0xFF shl 24) or rgb)
+            }
+        }
+        return img
+    }
+
+    private fun writeSlice(source: BufferedImage, y0: Int, viewport: Int, label: String): File {
+        val slice = source.getSubimage(0, y0, source.width, viewport)
+        val file = tmp.newFile("slice_${label}.png")
+        ImageIO.write(slice, "PNG", file)
+        return file
+    }
+
+    private fun assertPixelsEqual(expected: BufferedImage, actual: BufferedImage) {
+        assertEquals("width", expected.width, actual.width)
+        assertEquals("height", expected.height, actual.height)
+        for (y in 0 until expected.height) {
+            for (x in 0 until expected.width) {
+                val e = expected.getRGB(x, y)
+                val a = actual.getRGB(x, y)
+                if (e != a) {
+                    throw AssertionError(
+                        "pixel mismatch at ($x, $y): expected 0x${Integer.toHexString(e)}, " +
+                            "got 0x${Integer.toHexString(a)}",
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Goal

The LONG @ScrollingPreview stitching is producing duplicate rows at slice seams (e.g. an `Allow LTE` row rendered twice on a Wear settings preview). Find the overlap by comparing pixel rows rather than trusting the scroller's reported offset, and stitch ~80% of the viewport per step so there's always a margin for error. Consider weighting rows by how "interesting" they are — varied content (text, edges) is much less likely to be a false match than blank background.

## Summary

**Changes made**

- [ScrollSliceStitcher.kt](renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollSliceStitcher.kt) — per slice pair, scan a shift `d` and pick the one minimising per-row luminance SAD. Each row contributes with weight = its horizontal stddev, so text/edges/varied rows dominate the alignment and matching blank background can't drift the shift. The scroller's reported offset is kept only as a hint that narrows the search window; a plain-SAD fallback covers the all-blank-overlap degenerate case.
- [RobolectricRenderTest.kt:619](renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt:619) — drive scrolling at 80% of the viewport per step so consecutive slices always have a ~20% physical overlap for the matcher.
- [ScrollSliceStitcherTest.kt](renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/ScrollSliceStitcherTest.kt) — new pure-JVM unit tests: byte-exact reconstruction for honest / over-reported / under-reported offsets, plus a mostly-blank source with a high-variance "text" row to exercise the weighting. Over/under cases fail against the old stitcher; all six pass against the new one.

**Things tried and abandoned**

- Keeping a tight `[hint × 0.5, hint × 1.2]` search window — passed the over-report case but missed the under-report case (actual shift > hint × 1.2). Widened to `[hint / 3, hint × 3]`.
- A per-row scalar feature (row luminance sum) as the alignment signal — degenerates on uniform-per-row test data; unreliable in general. Went straight to weighted per-pixel SAD.

**Known gaps**

- The realistic-screenshot regression ("render the `Allow LTE` Settings preview and assert no duplicate rows at the seams") is skipped per your call; the unit-level byte-exact tests plus an eye-check of `ActivityListLongPreview` (items 1 → 15 in clean sequence, no duplicates) are the coverage.

**Verification**

- `./gradlew :renderer-android:testDebugUnitTest` — 6/6 new tests pass; no regressions.
- `./gradlew :sample-wear:renderAllPreviews` + `:sample-wear:test` — `ActivityListLongPreview` stitches cleanly, existing `LongScrollPreviewPixelTest` still passes.
- Microbench on a realistic Wear-large-round scenario (5 slices × 454×454, 6 alignment pairs): **~370 ms median**. Amortised inside the Gradle + Robolectric render budget (seconds), not a bottleneck.