### PR TITLE
feat(vscode): detect JRE-without-jlink and suggest a real JDK

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import { GradleService, GradleApi } from './gradleService';
+import { JdkImageError } from './jdkImageErrorDetector';
 import { findPluginAppliedAncestor } from './pluginDetection';
 import { PreviewPanel } from './previewPanel';
 import { PreviewRegistry } from './previewRegistry';
@@ -58,6 +59,9 @@ let logLine: (msg: string) => void = () => { /* noop pre-activate */ };
 /** Guard against firing the "plugin not applied" notification more than once
  *  per session — users shouldn't see it on every refresh tick. */
 let warnedMissingPluginThisSession = false;
+/** Same idea for the jlink-missing notification: save-driven refreshes would
+ *  otherwise re-surface it on every build after the user dismissed it. */
+let warnedJdkImageThisSession = false;
 // Decide whether a file "probably wants previews" with the plugin off. Kept
 // deliberately loose: the file just needs to contain the substring "Preview"
 // (covers `@Preview`, `@PreviewLightDark`, preview-tooling imports, and
@@ -65,6 +69,34 @@ let warnedMissingPluginThisSession = false;
 // False positives are cheap — an extra informational message. False
 // negatives (silence when the user wanted a nudge) are the worse outcome.
 const SETUP_DOCS_URL = 'https://github.com/yschimke/compose-ai-tools/tree/main/vscode-extension#readme';
+const JDK_DOCS_URL = 'https://github.com/yschimke/compose-ai-tools/blob/main/docs/AGENTS.md#important-constraints';
+
+/**
+ * Show the remediation notification for a detected JdkImageError. The offered
+ * "Open JDK setting" action reveals `java.import.gradle.java.home` — the
+ * setting that `vscjava.vscode-gradle` actually reads when launching Gradle.
+ * De-duped per session so save-driven rebuilds don't re-open it.
+ */
+function showJdkImageRemediation(err: JdkImageError): void {
+    if (warnedJdkImageThisSession) { return; }
+    warnedJdkImageThisSession = true;
+    const reason = err.finding.reason ? ` (${err.finding.reason})` : '';
+    const message = `Compose Preview: Gradle is using a JRE without jlink${reason}. `
+        + 'Point it at a full JDK to build Android modules. '
+        + `Path: ${err.finding.jlinkPath}`;
+    const OPEN_SETTING = 'Open JDK setting';
+    const DOCS = 'Learn more';
+    void vscode.window.showErrorMessage(message, OPEN_SETTING, DOCS).then(action => {
+        if (action === OPEN_SETTING) {
+            void vscode.commands.executeCommand(
+                'workbench.action.openSettings',
+                'java.import.gradle.java.home',
+            );
+        } else if (action === DOCS) {
+            void vscode.env.openExternal(vscode.Uri.parse(JDK_DOCS_URL));
+        }
+    });
+}
 
 export async function activate(context: vscode.ExtensionContext) {
     const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -553,6 +585,15 @@ async function refresh(forceRender: boolean, forFilePath?: string) {
         // nothing in the logs" symptom.
     } catch (err: unknown) {
         if (abort.signal.aborted) { return; }
+        if (err instanceof JdkImageError) {
+            logLine(`FAILED (jlink missing): ${err.finding.jlinkPath}`);
+            panel.postMessage({
+                command: 'showMessage',
+                text: 'Gradle is running on a JRE without jlink. Configure a full JDK to render previews.',
+            });
+            showJdkImageRemediation(err);
+            return;
+        }
         const message = err instanceof Error ? err.message.slice(0, 300) : 'Build failed';
         logLine(`FAILED: ${message}`);
         panel.postMessage({

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { AccessibilityFinding, AccessibilityReport, DoctorModuleReport, HistoryEntry, PreviewManifest } from './types';
 import { APPLIES_PLUGIN_RE } from './pluginDetection';
+import { JdkImageError, JdkImageErrorDetector } from './jdkImageErrorDetector';
 
 const HISTORY_DIRNAME = '.compose-preview-history';
 const TIMESTAMP_RE = /^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})(?:-\d+)?$/;
@@ -315,6 +316,8 @@ export class GradleService {
         this.activeKeys.add(cancellationKey);
         this.logger.appendLine(`> ${task}`);
 
+        const detector = new JdkImageErrorDetector();
+
         const timeoutPromise = new Promise<never>((_, reject) => {
             setTimeout(() => {
                 this.gradleApi.cancelRunTask({
@@ -334,13 +337,20 @@ export class GradleService {
             cancellationKey,
             onOutput: (output) => {
                 try {
-                    this.logger.append(new TextDecoder().decode(output.getOutputBytes()));
+                    const decoded = new TextDecoder().decode(output.getOutputBytes());
+                    this.logger.append(decoded);
+                    detector.consume(decoded);
                 } catch { /* ignore */ }
             },
         }).then(
             () => { this.logger.appendLine(`> ${task} completed`); },
             (err) => {
                 this.logger.appendLine(`> ${task} FAILED: ${err?.message ?? err}`);
+                detector.end();
+                const finding = detector.getFinding();
+                if (finding) {
+                    throw new JdkImageError(finding, task);
+                }
                 throw new Error(`Gradle task ${task} failed. See Output > Compose Preview.`);
             },
         ).finally(() => {

--- a/vscode-extension/src/jdkImageErrorDetector.ts
+++ b/vscode-extension/src/jdkImageErrorDetector.ts
@@ -1,0 +1,119 @@
+/**
+ * Scans Gradle output for the AGP `JdkImageTransform` failure that fires when
+ * Gradle is launched with a JRE that has no `jlink` binary — typically an
+ * IDE-bundled runtime (Antigravity / VS Code Java language server) pointed at
+ * via `org.gradle.java.home` or the Gradle extension's setting.
+ *
+ * The decisive signature in the output is:
+ *
+ *     jlink executable <abs-path> does not exist.
+ *
+ * Corroborating signatures (`Failed to transform core-for-system-modules.jar`,
+ * `Execution failed for JdkImageTransform`) are common to other JDK-image
+ * issues too, so we match on the jlink line and treat the rest as context.
+ *
+ * Feed each `onOutput` chunk through {@link consume}. At the end of the build
+ * read {@link getFinding}; it returns `null` unless a jlink line was seen.
+ */
+
+export interface JdkImageFinding {
+    /** Absolute path Gradle tried to execute (always ends in `/bin/jlink` or similar). */
+    jlinkPath: string;
+    /**
+     * Short human-readable reason identifying the likely culprit from the path,
+     * e.g. "Red Hat Java extension bundled runtime" or "bundled JRE (no JDK)".
+     * Empty when the path doesn't match any known pattern.
+     */
+    reason: string;
+}
+
+const JLINK_RE = /jlink executable (\S+(?:\/bin\/jlink|\\bin\\jlink(?:\.exe)?))\s+does not exist/;
+
+/**
+ * Best-effort diagnosis of *why* the path is a JRE and not a JDK. Keyed off
+ * path fragments we've seen in the wild. Order matters — the more specific
+ * vendors match before the generic `/jre/` fallback.
+ */
+function diagnose(jlinkPath: string): string {
+    const p = jlinkPath.replace(/\\/g, '/');
+    if (/\/\.antigravity\/extensions\/redhat\.java-/.test(p)) {
+        return 'Red Hat Java extension bundled runtime (Antigravity)';
+    }
+    if (/\/\.vscode(?:-server|-insiders)?\/extensions\/redhat\.java-/.test(p)) {
+        return 'Red Hat Java extension bundled runtime (VS Code)';
+    }
+    if (/\/redhat\.java-[^/]+\/jre\//.test(p)) {
+        return 'Red Hat Java extension bundled runtime';
+    }
+    if (/\/jre\/|\/jre$/.test(p)) {
+        return 'bundled JRE (no JDK)';
+    }
+    return '';
+}
+
+export class JdkImageErrorDetector {
+    private buffer = '';
+    private finding: JdkImageFinding | null = null;
+
+    /**
+     * Accept a chunk of decoded stdout/stderr. Safe to call with partial
+     * lines — they're buffered until a newline arrives. No-op once a finding
+     * has been recorded (avoids paying the regex cost for the rest of the
+     * build output).
+     */
+    consume(chunk: string): void {
+        if (this.finding) { return; }
+        this.buffer += chunk;
+        let nl = this.buffer.indexOf('\n');
+        while (nl !== -1) {
+            const line = this.buffer.slice(0, nl);
+            this.buffer = this.buffer.slice(nl + 1);
+            if (this.scanLine(line)) { return; }
+            nl = this.buffer.indexOf('\n');
+        }
+        // Bound the buffer so a pathological producer emitting megabytes
+        // without newlines can't grow it without limit. 16 KiB is far
+        // larger than any single Gradle log line we care about.
+        if (this.buffer.length > 16 * 1024) {
+            this.scanLine(this.buffer);
+            this.buffer = '';
+        }
+    }
+
+    /** Flush the residual buffer. Call once after the stream ends. */
+    end(): void {
+        if (this.finding || this.buffer.length === 0) {
+            this.buffer = '';
+            return;
+        }
+        this.scanLine(this.buffer);
+        this.buffer = '';
+    }
+
+    getFinding(): JdkImageFinding | null {
+        return this.finding;
+    }
+
+    private scanLine(line: string): boolean {
+        const m = JLINK_RE.exec(line);
+        if (!m) { return false; }
+        this.finding = { jlinkPath: m[1], reason: diagnose(m[1]) };
+        return true;
+    }
+}
+
+/**
+ * Thrown by {@link GradleService} when the task failed AND the output
+ * contained the jlink-missing signature. Carries the finding so the
+ * extension can offer a targeted remediation instead of the generic
+ * "Gradle task failed" message.
+ */
+export class JdkImageError extends Error {
+    constructor(readonly finding: JdkImageFinding, readonly task: string) {
+        super(
+            `Gradle task ${task} failed: jlink not found at ${finding.jlinkPath}. ` +
+            `Gradle needs a full JDK (with jlink), not a JRE.`,
+        );
+        this.name = 'JdkImageError';
+    }
+}

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -3,19 +3,27 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
 import { GradleService, GradleApi } from '../gradleService';
+import { JdkImageError } from '../jdkImageErrorDetector';
 
 /** Stub GradleApi that records invocations and allows test control. */
 class StubGradleApi implements GradleApi {
     public runCalls: Array<{ taskName: string; cancellationKey?: string }> = [];
     public cancelCalls: Array<{ taskName: string; cancellationKey?: string }> = [];
     public nextRunResult: 'success' | Error = 'success';
+    /** Bytes to feed through onOutput before resolving/rejecting. */
+    public nextRunOutput: string = '';
 
     async runTask(opts: {
         projectFolder: string;
         taskName: string;
         cancellationKey?: string;
+        onOutput?: (output: { getOutputBytes(): Uint8Array; getOutputType(): number }) => void;
     }): Promise<void> {
         this.runCalls.push({ taskName: opts.taskName, cancellationKey: opts.cancellationKey });
+        if (this.nextRunOutput && opts.onOutput) {
+            const bytes = new TextEncoder().encode(this.nextRunOutput);
+            opts.onOutput({ getOutputBytes: () => bytes, getOutputType: () => 0 });
+        }
         if (this.nextRunResult !== 'success') {
             throw this.nextRunResult;
         }
@@ -223,6 +231,24 @@ describe('GradleService', () => {
                 /Gradle task .* failed/,
             );
         }));
+
+        it('throws JdkImageError when the failure output contains the jlink signature',
+            withTempDir(async (dir, api) => {
+                api.nextRunOutput =
+                    '> jlink executable /home/u/.antigravity/extensions/redhat.java-1.54.0-linux-x64'
+                    + '/jre/21.0.10-linux-x86_64/bin/jlink does not exist.\n';
+                api.nextRunResult = new Error('build failed');
+
+                const service = new GradleService(dir, api);
+                await assert.rejects(
+                    service.discoverPreviews('mod'),
+                    (err: unknown) => {
+                        assert.ok(err instanceof JdkImageError, 'expected JdkImageError');
+                        assert.match((err as JdkImageError).finding.jlinkPath, /\/bin\/jlink$/);
+                        return true;
+                    },
+                );
+            }));
     });
 
     describe('listHistory', () => {

--- a/vscode-extension/src/test/jdkImageErrorDetector.test.ts
+++ b/vscode-extension/src/test/jdkImageErrorDetector.test.ts
@@ -1,0 +1,106 @@
+import * as assert from 'assert';
+import { JdkImageErrorDetector } from '../jdkImageErrorDetector';
+
+const ANTIGRAVITY_FIXTURE = [
+    '[Incubating] Problems report is available at: file:///tmp/problems-report.html',
+    '',
+    'FAILURE: Build failed with an exception.',
+    '',
+    '* What went wrong:',
+    'Configuration cache state could not be cached: field `generatedModuleFile` of `com.android.build.gradle.tasks.JdkImageInput` bean [...]',
+    '> Could not resolve all files for configuration \':app:androidJdkImage\'.',
+    '   > Failed to transform core-for-system-modules.jar to match attributes {artifactType=_internal_android_jdk_image, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}.',
+    '      > Execution failed for JdkImageTransform: /home/yuri/Android/Sdk/platforms/android-36/core-for-system-modules.jar.',
+    '         > jlink executable /home/yuri/.antigravity/extensions/redhat.java-1.54.0-linux-x64/jre/21.0.10-linux-x86_64/bin/jlink does not exist.',
+    '',
+].join('\n');
+
+describe('JdkImageErrorDetector', () => {
+    it('detects the jlink-missing signature from the Antigravity fixture', () => {
+        const d = new JdkImageErrorDetector();
+        d.consume(ANTIGRAVITY_FIXTURE);
+        d.end();
+        const f = d.getFinding();
+        assert.notStrictEqual(f, null);
+        assert.strictEqual(
+            f!.jlinkPath,
+            '/home/yuri/.antigravity/extensions/redhat.java-1.54.0-linux-x64/jre/21.0.10-linux-x86_64/bin/jlink',
+        );
+        assert.strictEqual(f!.reason, 'Red Hat Java extension bundled runtime (Antigravity)');
+    });
+
+    it('detects the VS Code Red Hat Java bundled runtime', () => {
+        const d = new JdkImageErrorDetector();
+        d.consume(
+            '> jlink executable /home/user/.vscode/extensions/redhat.java-1.54.0-linux-x64/jre/21.0.10/bin/jlink does not exist.\n',
+        );
+        const f = d.getFinding();
+        assert.strictEqual(f!.reason, 'Red Hat Java extension bundled runtime (VS Code)');
+    });
+
+    it('falls back to "bundled JRE" for generic /jre/ paths', () => {
+        const d = new JdkImageErrorDetector();
+        d.consume('> jlink executable /opt/runtime/jre/bin/jlink does not exist.\n');
+        assert.strictEqual(d.getFinding()!.reason, 'bundled JRE (no JDK)');
+    });
+
+    it('returns empty reason for unrecognised paths', () => {
+        const d = new JdkImageErrorDetector();
+        d.consume('> jlink executable /custom/path/bin/jlink does not exist.\n');
+        const f = d.getFinding()!;
+        assert.strictEqual(f.jlinkPath, '/custom/path/bin/jlink');
+        assert.strictEqual(f.reason, '');
+    });
+
+    it('handles Windows-style paths', () => {
+        const d = new JdkImageErrorDetector();
+        d.consume('> jlink executable C:\\Users\\x\\jre\\bin\\jlink.exe does not exist.\n');
+        const f = d.getFinding();
+        assert.strictEqual(f!.jlinkPath, 'C:\\Users\\x\\jre\\bin\\jlink.exe');
+        // `/jre/` normalisation kicks in after backslash->slash replacement.
+        assert.strictEqual(f!.reason, 'bundled JRE (no JDK)');
+    });
+
+    it('survives chunks that split mid-line', () => {
+        const d = new JdkImageErrorDetector();
+        d.consume('> jlink executable /opt/jre/bin/jlink');
+        assert.strictEqual(d.getFinding(), null);
+        d.consume(' does not exist.\n');
+        assert.notStrictEqual(d.getFinding(), null);
+    });
+
+    it('catches the line at end-of-stream without a trailing newline', () => {
+        const d = new JdkImageErrorDetector();
+        d.consume('> jlink executable /opt/jre/bin/jlink does not exist.');
+        assert.strictEqual(d.getFinding(), null);
+        d.end();
+        assert.notStrictEqual(d.getFinding(), null);
+    });
+
+    it('returns null when the output is unrelated', () => {
+        const d = new JdkImageErrorDetector();
+        d.consume('FAILURE: compilation failed\n> error: cannot find symbol\n');
+        d.end();
+        assert.strictEqual(d.getFinding(), null);
+    });
+
+    it('returns null for the corroborating messages alone (no jlink line)', () => {
+        const d = new JdkImageErrorDetector();
+        d.consume([
+            '> Failed to transform core-for-system-modules.jar to match attributes {...}',
+            '> Execution failed for JdkImageTransform: /path/to/core.jar',
+            '',
+        ].join('\n'));
+        d.end();
+        assert.strictEqual(d.getFinding(), null);
+    });
+
+    it('is idempotent after the first match', () => {
+        const d = new JdkImageErrorDetector();
+        d.consume('> jlink executable /a/jre/bin/jlink does not exist.\n');
+        const first = d.getFinding();
+        d.consume('> jlink executable /b/jre/bin/jlink does not exist.\n');
+        const second = d.getFinding();
+        assert.strictEqual(second!.jlinkPath, first!.jlinkPath);
+    });
+});


### PR DESCRIPTION
## Summary

- AGP's `JdkImageTransform` fails with `jlink executable <path> does not exist` when Gradle is launched on a JRE (Antigravity's / VS Code's Red Hat Java extension bundles one). The failure happens during configuration, so `composePreviewDoctor` never runs.
- Added a line-buffered `JdkImageErrorDetector` that scans Gradle output for the signature; `GradleService` feeds every `onOutput` chunk through it and, on rejection, throws a typed `JdkImageError` carrying the bad path.
- The refresh handler special-cases that error and pops a notification with **Open JDK setting** (reveals `java.import.gradle.java.home`, the setting `vscjava.vscode-gradle` actually reads) and **Learn more**. De-duped per session so save-driven rebuilds don't respawn it.
- Path-based diagnosis identifies common culprits: Antigravity Red Hat Java bundle, VS Code Red Hat Java bundle, and generic `/jre/` paths.

## Test plan

- [x] `tsc -p ./` clean.
- [x] `mocha out/test/jdkImageErrorDetector.test.js` — 10/10 pass (Antigravity fixture, VS Code variant, generic JRE, Windows paths, chunk-split output, end-of-stream flush, unrelated output, corroborating-only output, idempotency).
- [x] New `GradleService` test: stub emits the jlink line + rejects → asserts `JdkImageError` is thrown with the parsed path.
- [ ] Manual: launch the extension against a module with Gradle pointed at a JRE; confirm the notification appears once and the **Open JDK setting** button reveals `java.import.gradle.java.home`.