### PR TITLE
test(vscode): decouple GradleService from vscode module

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -87,7 +87,15 @@ export async function activate(context: vscode.ExtensionContext) {
     }
     const gradleApi = (await gradleExt.activate()) as GradleApi;
 
-    gradleService = new GradleService(workspaceRoot, gradleApi, outputChannel);
+    gradleService = new GradleService(workspaceRoot, gradleApi, outputChannel, () => {
+        // Read config lazily on each run so user toggles take effect without a reload.
+        const args: string[] = [];
+        const config = vscode.workspace.getConfiguration('composePreview');
+        if (config.get<boolean>('accessibilityChecks.enabled')) {
+            args.push('-PcomposePreview.accessibilityChecks.enabled=true');
+        }
+        return args;
+    });
 
     panel = new PreviewPanel(context.extensionUri, handleWebviewMessage);
     context.subscriptions.push(

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import * as vscode from 'vscode';
 import { AccessibilityFinding, AccessibilityReport, DoctorModuleReport, HistoryEntry, PreviewManifest } from './types';
 import { APPLIES_PLUGIN_RE } from './pluginDetection';
 
@@ -45,14 +44,21 @@ export class GradleService {
     private workspaceRoot: string;
     private logger: Logger;
     private gradleApi: GradleApi;
+    private argsProvider: () => string[];
     private manifestCache = new Map<string, { manifest: PreviewManifest; timestamp: number }>();
     private taskCounter = 0;
     private activeKeys = new Set<string>();
 
-    constructor(workspaceRoot: string, gradleApi: GradleApi, logger?: Logger) {
+    constructor(
+        workspaceRoot: string,
+        gradleApi: GradleApi,
+        logger?: Logger,
+        argsProvider?: () => string[],
+    ) {
         this.workspaceRoot = workspaceRoot;
         this.gradleApi = gradleApi;
         this.logger = logger ?? nullLogger;
+        this.argsProvider = argsProvider ?? (() => []);
     }
 
     async discoverPreviews(module: string): Promise<PreviewManifest | null> {
@@ -296,20 +302,6 @@ export class GradleService {
         this.cancel();
     }
 
-    /**
-     * Reads workspace settings and builds the `-P` override list passed to
-     * every Gradle invocation. Keeps the mapping in one place so settings
-     * changes take effect the next time `runTask` fires, no reload required.
-     */
-    private buildGradleArgs(): string[] {
-        const args: string[] = [];
-        const config = vscode.workspace.getConfiguration('composePreview');
-        if (config.get<boolean>('accessibilityChecks.enabled')) {
-            args.push('-PcomposePreview.accessibilityChecks.enabled=true');
-        }
-        return args;
-    }
-
     private runTask(task: string): Promise<void> {
         const cancellationKey = `compose-preview-${++this.taskCounter}|${task}`;
         this.activeKeys.add(cancellationKey);
@@ -329,7 +321,7 @@ export class GradleService {
         const taskPromise = this.gradleApi.runTask({
             projectFolder: this.workspaceRoot,
             taskName: task,
-            args: this.buildGradleArgs(),
+            args: this.argsProvider(),
             showOutputColors: false,
             cancellationKey,
             onOutput: (output) => {


### PR DESCRIPTION
## Summary
- `gradleService.test.ts` failed to load under plain mocha because `gradleService.ts` imported `vscode` just to read `composePreview.accessibilityChecks.enabled` inside `buildGradleArgs()`.
- Removed the `vscode` import from `gradleService.ts` and replaced `buildGradleArgs()` with an injected `argsProvider: () => string[]` constructor parameter.
- `extension.ts` now supplies the callback, which reads the config lazily on each `runTask` call — same behavior, no reload required on toggle.

## Test plan
- [x] `npm test` in `vscode-extension/` — all 44 tests pass, including the previously-blocked `gradleService` suite.