### PR TITLE
feat(annotations)!: multi-mode @ScrollingPreview

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -485,13 +485,13 @@ class DiscoveryFunctionalTest {
             """
             package ee.schimke.composeai.preview
 
-            enum class ScrollMode { END, LONG }
+            enum class ScrollMode { TOP, END, LONG }
             enum class ScrollAxis { VERTICAL, HORIZONTAL }
 
             @Retention(AnnotationRetention.BINARY)
             @Target(AnnotationTarget.FUNCTION)
             annotation class ScrollingPreview(
-                val mode: ScrollMode,
+                val modes: Array<ScrollMode> = [ScrollMode.END],
                 val maxScrollPx: Int = 0,
                 val reduceMotion: Boolean = true,
                 val axis: ScrollAxis = ScrollAxis.VERTICAL,
@@ -523,7 +523,7 @@ class DiscoveryFunctionalTest {
             annotation class LightAndDark
 
             @LightAndDark
-            @ScrollingPreview(mode = ScrollMode.END)
+            @ScrollingPreview(modes = [ScrollMode.END])
             @Composable
             fun EndScrollPreview() {
                 Box(modifier = Modifier.size(50.dp).background(Color.Red))
@@ -531,7 +531,7 @@ class DiscoveryFunctionalTest {
 
             @Preview
             @ScrollingPreview(
-                mode = ScrollMode.LONG,
+                modes = [ScrollMode.LONG],
                 maxScrollPx = 4000,
                 reduceMotion = false,
                 axis = ScrollAxis.HORIZONTAL,
@@ -539,6 +539,16 @@ class DiscoveryFunctionalTest {
             @Composable
             fun LongScrollPreview() {
                 Box(modifier = Modifier.size(50.dp).background(Color.Blue))
+            }
+
+            // Multi-mode fan-out: one preview function emits both an
+            // unscrolled initial capture and a scroll-to-end capture,
+            // disambiguated on disk by a _SCROLL_<mode> suffix.
+            @Preview(name = "Scroll")
+            @ScrollingPreview(modes = [ScrollMode.TOP, ScrollMode.END])
+            @Composable
+            fun TopAndEndScrollPreview() {
+                Box(modifier = Modifier.size(50.dp).background(Color.Magenta))
             }
 
             @Preview
@@ -591,6 +601,19 @@ class DiscoveryFunctionalTest {
 
         val plain = manifest.previews.single { it.functionName == "PlainPreview" }
         assertThat(plain.captures.single().scroll).isNull()
+
+        // Multi-mode: one preview yields two captures, one per mode, with
+        // distinct `_SCROLL_<mode>` filenames. Modes sort by enum ordinal
+        // (TOP, END, LONG) so the renderer captures the initial frame
+        // before driving the scroller.
+        val topAndEnd = manifest.previews.single { it.functionName == "TopAndEndScrollPreview" }
+        assertThat(topAndEnd.captures).hasSize(2)
+        assertThat(topAndEnd.captures.map { it.scroll?.mode })
+            .containsExactly(ScrollMode.TOP, ScrollMode.END).inOrder()
+        assertThat(topAndEnd.captures.map { it.renderOutput }).containsExactly(
+            "renders/${topAndEnd.id}_SCROLL_top.png",
+            "renders/${topAndEnd.id}_SCROLL_end.png",
+        ).inOrder()
     }
 
     @Test

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -161,8 +161,9 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         if (timings.isNotEmpty()) {
             parts.add("${preview.captures.size} captures @ ${timings.joinToString(",") { "${it}ms" }}")
         }
-        preview.captures.firstNotNullOfOrNull { it.scroll }?.let { s ->
-            parts.add("scroll=${s.mode.name.lowercase()}")
+        val scrollModes = preview.captures.mapNotNull { it.scroll?.mode }.distinct()
+        if (scrollModes.isNotEmpty()) {
+            parts.add("scroll=" + scrollModes.joinToString(",") { it.name.lowercase() })
         }
         return if (parts.isEmpty()) "" else "  [" + parts.joinToString(" · ") + "]"
     }
@@ -176,9 +177,10 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     ) {
         // @PreviewWrapper and @ScrollingPreview are both non-repeatable and apply
         // to every @Preview on the function (including expansions from
-        // multi-preview meta-annotations).
+        // multi-preview meta-annotations). `@ScrollingPreview.modes` fans out
+        // one capture per entry — see [buildCaptures].
         val wrapperFqn = extractWrapperFqn(annotations)
-        val scrollSpec = extractScrollSpec(annotations)
+        val scrollSpecs = extractScrollSpecs(annotations)
         // @RoboComposePreviewOptions, similarly, applies to the function as a
         // whole — each timing fans out into its own manifest entry, orthogonal
         // to any multi-preview expansion.
@@ -187,7 +189,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         val directPreviews = collectDirectPreviews(annotations)
         if (directPreviews.isNotEmpty()) {
             for (ann in directPreviews) {
-                previews.add(makePreview(classInfo, method, ann, wrapperFqn, scrollSpec, timings))
+                previews.add(makePreview(classInfo, method, ann, wrapperFqn, scrollSpecs, timings))
             }
             return
         }
@@ -195,7 +197,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         for (ann in annotations) {
             val resolved = resolveMultiPreview(ann, scanResult, mutableSetOf())
             for (resolvedAnn in resolved) {
-                previews.add(makePreview(classInfo, method, resolvedAnn, wrapperFqn, scrollSpec, timings))
+                previews.add(makePreview(classInfo, method, resolvedAnn, wrapperFqn, scrollSpecs, timings))
             }
         }
     }
@@ -207,35 +209,34 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     private fun buildCaptures(
         ann: AnnotationInfo,
         previewId: String,
-        scroll: ScrollCapture?,
+        scrolls: List<ScrollCapture>,
         timings: List<Long>,
     ): List<Capture> {
         val isTile = ann.name == TILE_PREVIEW_FQN
         val effectiveTimings = if (isTile) emptyList() else timings
-        val effectiveScroll = scroll.takeUnless { isTile }
+        val effectiveScrolls = if (isTile) emptyList() else scrolls
 
-        if (effectiveTimings.isEmpty()) {
-            // Single capture — either a static preview (all dims null) or a
-            // scrolled-only preview (scroll set, time null).
-            return listOf(
-                Capture(
-                    advanceTimeMillis = null,
-                    scroll = effectiveScroll,
-                    renderOutput = "renders/${previewId}.png",
-                ),
-            )
+        // Single-mode scroll keeps the plain filename so migrations from the
+        // old single-valued `mode = …` annotation land on identical paths.
+        // Multi-mode adds `_SCROLL_<mode>` to disambiguate siblings, same
+        // pattern as `_TIME_<ms>ms` for the time dimension.
+        val scrollRows: List<Pair<ScrollCapture?, String>> = when {
+            effectiveScrolls.isEmpty() -> listOf(null to "")
+            effectiveScrolls.size == 1 -> listOf(effectiveScrolls[0] to "")
+            else -> effectiveScrolls.map { it to "_SCROLL_${it.mode.name.lowercase()}" }
         }
-        // Time-dimensional fan-out. Filename suffix matches Roborazzi's
-        // compose-preview-scanner-support convention (`_TIME_<ms>ms`) so
-        // PNGs coexist on disk under a single preview id. Scroll applies
-        // to every time-frame when both annotations are present (today we
-        // only fan out along time, not scroll).
-        return effectiveTimings.map { ms ->
-            Capture(
-                advanceTimeMillis = ms,
-                scroll = effectiveScroll,
-                renderOutput = "renders/${previewId}_TIME_${ms}ms.png",
-            )
+        val timeRows: List<Pair<Long?, String>> =
+            if (effectiveTimings.isEmpty()) listOf(null to "")
+            else effectiveTimings.map { ms -> ms to "_TIME_${ms}ms" }
+
+        return scrollRows.flatMap { (scroll, scrollSuffix) ->
+            timeRows.map { (ms, timeSuffix) ->
+                Capture(
+                    advanceTimeMillis = ms,
+                    scroll = scroll,
+                    renderOutput = "renders/${previewId}${scrollSuffix}${timeSuffix}.png",
+                )
+            }
         }
     }
 
@@ -272,14 +273,16 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         }
     }
 
-    private fun extractScrollSpec(annotations: List<AnnotationInfo>): ScrollCapture? {
-        val ann = annotations.firstOrNull { it.name == SCROLLING_PREVIEW_FQN } ?: return null
+    private fun extractScrollSpecs(annotations: List<AnnotationInfo>): List<ScrollCapture> {
+        val ann = annotations.firstOrNull { it.name == SCROLLING_PREVIEW_FQN } ?: return emptyList()
         val pv = ann.parameterValues
-        // Enum constants come through as AnnotationEnumValue; compare by .valueName so
-        // we never force-load the annotation's classes.
-        val mode = (pv.getValue("mode") as? AnnotationEnumValue)?.valueName
-            ?.let { runCatching { ScrollMode.valueOf(it) }.getOrNull() }
-            ?: return null
+        // ClassGraph surfaces the `modes: Array<ScrollMode>` field as an
+        // Object[] of AnnotationEnumValue; same shape as `manualClockOptions`
+        // above. Enum constants are compared by `.valueName` so we never
+        // force-load the annotation's classes.
+        val rawModes = pv.getValue("modes")
+        val modes = readEnumArray(rawModes) { ScrollMode.valueOf(it) }
+        if (modes.isEmpty()) return emptyList()
         val axis = (pv.getValue("axis") as? AnnotationEnumValue)?.valueName
             ?.let { runCatching { ScrollAxis.valueOf(it) }.getOrNull() }
             ?: ScrollAxis.VERTICAL
@@ -287,13 +290,37 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         val reduceMotion = (pv.getValue("reduceMotion") as? Boolean) ?: true
         // Result fields (atEnd, reachedPx) default to "not reported" — the
         // renderer would fill them in post-capture; discovery knows only the
-        // intent.
-        return ScrollCapture(
-            mode = mode,
-            axis = axis,
-            maxScrollPx = maxScrollPx,
-            reduceMotion = reduceMotion,
-        )
+        // intent. De-dup to guard against `modes = [END, END]` producing
+        // colliding PNG paths. Sort by enum ordinal (TOP→END→LONG) so the
+        // renderer captures the initial frame before driving the scroller —
+        // otherwise `modes = [END, TOP]` would produce a "TOP" PNG at the
+        // scrolled-end position.
+        return modes.distinct().sortedBy { it.ordinal }.map { mode ->
+            ScrollCapture(
+                mode = mode,
+                axis = axis,
+                maxScrollPx = maxScrollPx,
+                reduceMotion = reduceMotion,
+            )
+        }
+    }
+
+    // Reads an annotation's Array<EnumT> parameter and maps each entry by
+    // `.valueName` through [parse]. ClassGraph can hand this back as a plain
+    // array, a single AnnotationEnumValue (single-entry arrays), or a typed
+    // array we need to walk reflectively — same cases as
+    // [extractRoboTimings].
+    private fun <T> readEnumArray(raw: Any?, parse: (String) -> T): List<T> {
+        if (raw == null) return emptyList()
+        val items = when (raw) {
+            is Array<*> -> raw.filterIsInstance<AnnotationEnumValue>()
+            is AnnotationEnumValue -> listOf(raw)
+            else -> {
+                val len = runCatching { java.lang.reflect.Array.getLength(raw) }.getOrNull() ?: 0
+                (0 until len).mapNotNull { java.lang.reflect.Array.get(raw, it) as? AnnotationEnumValue }
+            }
+        }
+        return items.mapNotNull { runCatching { parse(it.valueName) }.getOrNull() }
     }
 
     private fun isDirectPreview(ann: AnnotationInfo): Boolean =
@@ -351,7 +378,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         method: MethodInfo,
         ann: AnnotationInfo,
         wrapperClassName: String?,
-        scroll: ScrollCapture?,
+        scrolls: List<ScrollCapture>,
         timings: List<Long>,
     ): PreviewInfo {
         val params = extractPreviewParams(ann, wrapperClassName)
@@ -364,7 +391,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             className = classInfo.name,
             sourceFile = packageQualifiedSourcePath(classInfo),
             params = params,
-            captures = buildCaptures(ann, id, scroll, timings),
+            captures = buildCaptures(ann, id, scrolls, timings),
         )
     }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -22,6 +22,7 @@ enum class PreviewKind {
  * renderer modules.
  */
 enum class ScrollMode {
+    TOP,
     END,
     LONG,
 }

--- a/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/ScrollingPreview.kt
+++ b/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/ScrollingPreview.kt
@@ -9,19 +9,29 @@ package ee.schimke.composeai.preview
  * annotation in their own code depend on
  * `ee.schimke.composeai:preview-annotations`.
  *
- * The annotation only records *intent* in `previews.json` — renderer support
- * for [ScrollMode.END] and [ScrollMode.LONG] lands in subsequent changes.
+ * Each entry in [modes] fans out into its own capture (and its own PNG on
+ * disk). Shared knobs — [axis], [maxScrollPx], [reduceMotion] — apply to
+ * every capture produced by a single annotation instance. A single-mode
+ * annotation (e.g. `modes = [ScrollMode.END]`) keeps the plain
+ * `renders/<id>.png` filename; multi-mode annotations disambiguate siblings
+ * with a `_SCROLL_<mode>` suffix (`renders/<id>_SCROLL_top.png`,
+ * `renders/<id>_SCROLL_end.png`, …).
  */
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.FUNCTION)
 @MustBeDocumented
 annotation class ScrollingPreview(
-    /** Capture strategy for the scrollable content. */
-    val mode: ScrollMode,
+    /**
+     * Capture strategies for the scrollable content. Each mode produces one
+     * PNG. Defaults to `[END]` so migrating from the pre-0.7 single-mode
+     * shape (`mode = ScrollMode.END`) is a one-line edit.
+     */
+    val modes: Array<ScrollMode> = [ScrollMode.END],
     /**
      * Upper bound on how far we'll scroll, in pixels. `0` means unbounded —
      * drive to the content's natural end. Use a positive value on infinite
-     * or very tall scrollers to cap capture size.
+     * or very tall scrollers to cap capture size. Applies to [ScrollMode.END]
+     * and [ScrollMode.LONG]; ignored for [ScrollMode.TOP].
      */
     val maxScrollPx: Int = 0,
     /**
@@ -36,6 +46,13 @@ annotation class ScrollingPreview(
 )
 
 enum class ScrollMode {
+    /**
+     * Capture the initial (unscrolled) frame. Equivalent to a plain
+     * `@Preview` but lets you emit a top-state capture alongside END/LONG
+     * from one function.
+     */
+    TOP,
+
     /** Scroll to the end of the content, then capture a single frame. */
     END,
 

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -13,6 +13,7 @@ enum class PreviewKind {
  * renderer can read `previews.json` without depending on the annotation artifact.
  */
 enum class ScrollMode {
+    TOP,
     END,
     LONG,
 }

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -265,7 +265,7 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                 // can suppress transient UI (e.g. Wear's `ScreenScaffold` scroll
                 // indicator) by reading `LocalScrollCaptureInProgress.current`.
                 //
-                // Only set for `@ScrollingPreview(mode = LONG)`: stitched
+                // Only set for `@ScrollingPreview(modes = [LONG])`: stitched
                 // captures composite many frames into one tall PNG, and a
                 // fading indicator at arbitrary opacity per slice dominates
                 // the diff. END mode is a single frame at the natural
@@ -397,7 +397,11 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                         )
 
                     if (!longHandled) {
-                        if (scroll != null) {
+                        // TOP mode is the unscrolled initial frame — no
+                        // drive, just a capture. END mode drives the first
+                        // scrollable on the requested axis to its content
+                        // end before capturing.
+                        if (scroll != null && scroll.mode == ScrollMode.END) {
                             val result = driveScrollToEnd(
                                 rule = rule,
                                 axis = scroll.axis,
@@ -575,7 +579,7 @@ private fun cropPngTopLeft(
 }
 
 /**
- * Handles `@ScrollingPreview(mode = LONG)` captures. Drives the first
+ * Handles `@ScrollingPreview(modes = [LONG])` captures. Drives the first
  * scrollable on [ScrollCapture.axis] by one viewport-height per step via
  * [driveScrollByViewport], captures each slice to a temp PNG with per-slice
  * round crop DISABLED, and Java2D-stitches them via [stitchSlices].

--- a/sample-android/src/main/kotlin/com/example/sampleandroid/ScrollPreviews.kt
+++ b/sample-android/src/main/kotlin/com/example/sampleandroid/ScrollPreviews.kt
@@ -38,21 +38,16 @@ fun RedToBlueList() {
     }
 }
 
-/** Baseline — captures the initial (unscrolled) frame. Mostly red. */
-@Preview(name = "Top", showBackground = true)
-@Composable
-fun RedToBlueTopPreview() {
-    RedToBlueList()
-}
-
 /**
- * Same fixture with `@ScrollingPreview(mode = END)` — the renderer drives the
- * LazyColumn to the end of its content before the capture, so this frame is
- * mostly blue.
+ * Multi-mode scroll capture from a single preview function. Produces two
+ * PNGs — `..._SCROLL_top.png` (initial unscrolled frame, mostly red) and
+ * `..._SCROLL_end.png` (after driving the LazyColumn to its content end,
+ * mostly blue). Pixel assertions in [ScrollPreviewPixelTest] key off this
+ * gradient to prove both captures land on disk distinctly.
  */
-@Preview(name = "End", showBackground = true)
-@ScrollingPreview(mode = ScrollMode.END)
+@Preview(name = "Scroll", showBackground = true)
+@ScrollingPreview(modes = [ScrollMode.TOP, ScrollMode.END])
 @Composable
-fun RedToBlueEndPreview() {
+fun RedToBlueScrollPreview() {
     RedToBlueList()
 }

--- a/sample-android/src/test/kotlin/com/example/sampleandroid/ScrollPreviewPixelTest.kt
+++ b/sample-android/src/test/kotlin/com/example/sampleandroid/ScrollPreviewPixelTest.kt
@@ -6,8 +6,9 @@ import javax.imageio.ImageIO
 import org.junit.Test
 
 /**
- * End-to-end verification that `@ScrollingPreview(mode = END)` drives the
- * LazyColumn to the bottom before capturing. Reads the PNGs produced by
+ * End-to-end verification that `@ScrollingPreview(modes = [TOP, END])`
+ * produces two distinct captures from one preview function: an unscrolled
+ * top frame and a scrolled-to-end frame. Reads the PNGs produced by
  * `:sample-android:renderAllPreviews` and asserts colour dominance matches
  * the expected top (red) / bottom (blue) of [RedToBlueList].
  *
@@ -18,6 +19,7 @@ import org.junit.Test
 class ScrollPreviewPixelTest {
 
     private val rendersDir = File("build/compose-previews/renders")
+    private val baseName = "com.example.sampleandroid.ScrollPreviewsKt.RedToBlueScrollPreview_Scroll"
 
     private data class Avg(val r: Double, val g: Double, val b: Double) {
         fun dominant(): Char = when {
@@ -45,8 +47,8 @@ class ScrollPreviewPixelTest {
     }
 
     @Test
-    fun `Top preview (no ScrollingPreview) is red-dominant`() {
-        val file = File(rendersDir, "com.example.sampleandroid.ScrollPreviewsKt.RedToBlueTopPreview_Top.png")
+    fun `TOP capture is red-dominant`() {
+        val file = File(rendersDir, "${baseName}_SCROLL_top.png")
         assertThat(file.exists()).isTrue()
         val avg = averageColor(file)
         assertThat(avg.dominant()).isEqualTo('R')
@@ -55,8 +57,8 @@ class ScrollPreviewPixelTest {
     }
 
     @Test
-    fun `End preview (ScrollingPreview END) is blue-dominant`() {
-        val file = File(rendersDir, "com.example.sampleandroid.ScrollPreviewsKt.RedToBlueEndPreview_End.png")
+    fun `END capture is blue-dominant`() {
+        val file = File(rendersDir, "${baseName}_SCROLL_end.png")
         assertThat(file.exists()).isTrue()
         val avg = averageColor(file)
         // If scroll-to-end silently fails, the image is red-dominant — this

--- a/sample-wear/src/main/kotlin/com/example/samplewear/Previews.kt
+++ b/sample-wear/src/main/kotlin/com/example/samplewear/Previews.kt
@@ -210,7 +210,7 @@ fun BadWearButtonPreview() {
  * `TransformingLazyColumn` + `EdgeButton` layout as [ActivityListScreen],
  * but with 15 items so the content overflows the viewport. The
  * `scrollIndicator` slot reads [LocalScrollCaptureInProgress] so the
- * `@ScrollingPreview(mode = LONG)` capture doesn't pick up a fading
+ * `@ScrollingPreview(modes = [LONG])` capture doesn't pick up a fading
  * indicator at random opacities. The screen does NOT compose its own
  * `MaterialTheme` / `AppScaffold` — its caller (the preview, or production)
  * does, which keeps the preview free to swap in a [FixedTimeSource].
@@ -290,7 +290,7 @@ fun LongActivityListScreen() {
 }
 
 @WearPreviewLargeRound
-@ScrollingPreview(mode = ScrollMode.LONG)
+@ScrollingPreview(modes = [ScrollMode.LONG])
 @Composable
 fun ActivityListLongPreview() {
     MaterialTheme {

--- a/sample-wear/src/test/kotlin/com/example/samplewear/LongScrollPreviewPixelTest.kt
+++ b/sample-wear/src/test/kotlin/com/example/samplewear/LongScrollPreviewPixelTest.kt
@@ -6,7 +6,7 @@ import javax.imageio.ImageIO
 import org.junit.Test
 
 /**
- * End-to-end regression for `@ScrollingPreview(mode = LONG)` — drives the
+ * End-to-end regression for `@ScrollingPreview(modes = [LONG])` — drives the
  * renderer to produce a stitched tall PNG of the `ActivityListLongPreview`
  * (`TransformingLazyColumn` + `EdgeButton`) and asserts:
  *  - Output height > viewport height (proves multi-slice stitching ran,

--- a/skills/compose-preview/SKILL.md
+++ b/skills/compose-preview/SKILL.md
@@ -266,33 +266,53 @@ import ee.schimke.composeai.preview.ScrollMode
 import ee.schimke.composeai.preview.ScrollingPreview
 
 @Preview(name = "End", showBackground = true)
-@ScrollingPreview(mode = ScrollMode.END)
+@ScrollingPreview(modes = [ScrollMode.END])
 @Composable
 fun MyListEndPreview() { MyList() }
 
+// One function → two captures. Produces `..._SCROLL_top.png` (initial
+// frame) and `..._SCROLL_end.png` (scrolled to content end).
+@Preview(name = "Scroll", showBackground = true)
+@ScrollingPreview(modes = [ScrollMode.TOP, ScrollMode.END])
+@Composable
+fun MyListTopAndEndPreview() { MyList() }
+
 @WearPreviewLargeRound
-@ScrollingPreview(mode = ScrollMode.LONG)
+@ScrollingPreview(modes = [ScrollMode.LONG])
 @Composable
 fun MyListLongPreview() { MyList() }
 ```
 
+- `ScrollMode.TOP` captures the initial (unscrolled) frame. Equivalent to a
+  plain `@Preview`, but lets a single function emit a top-state capture
+  alongside END/LONG — no sibling preview needed.
 - `ScrollMode.END` drives the scroller to its content end and captures one
-  frame. Pair with a static `@Preview` of the same composable to diff the
-  top and bottom states.
+  frame.
 - `ScrollMode.LONG` stitches multiple slices into a single tall PNG covering
   the whole scrollable extent. On round Wear faces the output is clipped to a
   capsule shape — top half-circle, rectangular middle, bottom half-circle —
   so the watch edge is preserved at the first and last slices.
 - `maxScrollPx` caps how far the renderer scrolls (use it on infinite or
-  pathologically long scrollers; `0` means unbounded).
+  pathologically long scrollers; `0` means unbounded). Applies to END/LONG;
+  ignored for TOP.
 - `reduceMotion = true` (default) wraps the body in
   `LocalReduceMotion provides ReduceMotion(true)` — important for Wear
   `TransformingLazyColumn`, where item transforms otherwise vary slice-to-slice
   and produce noisy diffs.
 - Only `ScrollAxis.VERTICAL` is rendered today.
 
+### Filenames
+
+Single-mode annotations keep the plain `renders/<id>.png` path (so migrating
+from the pre-0.7 `mode = ScrollMode.END` shape to `modes = [ScrollMode.END]`
+lands on the same output). Multi-mode annotations disambiguate siblings with
+a `_SCROLL_<mode>` suffix — e.g. `renders/<id>_SCROLL_top.png` and
+`renders/<id>_SCROLL_end.png`. Captures are emitted in enum order
+(TOP, END, LONG) regardless of how they appear in the `modes` array, so the
+renderer captures the unscrolled frame before driving the scroller.
+
 Each scroll capture is a separate entry in the CLI's `captures[]` with
-`scroll` set (`{mode: "END"}` or `{mode: "LONG", index, total, heightPx, …}`).
+`scroll` set (`{mode: "TOP"}`, `{mode: "END"}`, or `{mode: "LONG"}`).
 
 `@ScrollingPreview` is Android-only at present; CMP Desktop ignores the
 annotation.

--- a/skills/compose-preview/design/WEAR_UI.md
+++ b/skills/compose-preview/design/WEAR_UI.md
@@ -106,7 +106,7 @@ Implications when designing previews:
   clipped away.
 - Place primary content within the inscribed circle. The corners of the
   preview canvas are *not* a usable design area.
-- Stitched `@ScrollingPreview(mode = LONG)` round captures use a capsule
+- Stitched `@ScrollingPreview(modes = [LONG])` round captures use a capsule
   mask (top half-circle + rectangle + bottom half-circle), not per-slice
   circles, so vertical content in the middle remains visible.
 - Square Wear devices (`id:wearos_square`) are rendered without the clip.
@@ -132,12 +132,12 @@ hundreds of pixel-different PNGs. Pin these things:
 - **Suppress the scroll indicator during stitched captures via
   `LocalScrollCaptureInProgress`.** `ScreenScaffold` draws a transient scroll
   indicator that fades in/out as the list scrolls; on stitched
-  `@ScrollingPreview(mode = LONG)` captures it lands at arbitrary opacities
+  `@ScrollingPreview(modes = [LONG])` captures it lands at arbitrary opacities
   per slice and dominates the diff. The renderer mirrors Compose's
   long-screenshot signal — it provides
   `androidx.compose.ui.platform.LocalScrollCaptureInProgress = true` only
   for `LONG`-mode previews, `false` everywhere else (including
-  `@ScrollingPreview(mode = END)`, regular `@Preview`, and the running app).
+  `@ScrollingPreview(modes = [END])`, regular `@Preview`, and the running app).
   END mode is a single frame at the scroll-to-end position, so showing the
   indicator there matches what a real app renders. Read the local inside
   the `scrollIndicator` slot so production behaviour is unchanged but
@@ -169,7 +169,7 @@ hundreds of pixel-different PNGs. Pin these things:
 
   ```kotlin
   @WearPreviewLargeRound
-  @ScrollingPreview(mode = ScrollMode.LONG)
+  @ScrollingPreview(modes = [ScrollMode.LONG])
   @Composable
   fun MyScreenLongPreview() {
       MaterialTheme {
@@ -186,7 +186,7 @@ hundreds of pixel-different PNGs. Pin these things:
   `ScreenScaffold`).
 
 - **Reduce motion for `TransformingLazyColumn` scroll captures.**
-  `@ScrollingPreview(mode = LONG, reduceMotion = true)` (default) wraps the
+  `@ScrollingPreview(modes = [LONG], reduceMotion = true)` (default) wraps the
   body in `LocalReduceMotion provides ReduceMotion(true)` so item
   shape-morphing and scaling don't vary slice-to-slice. Without it, each
   stitched slice picks up a different transform state and the resulting
@@ -194,7 +194,7 @@ hundreds of pixel-different PNGs. Pin these things:
 
 - **`EdgeButton` revealed only at end-of-list.** `ScreenScaffold` reveals
   the `EdgeButton` only when the list is pinned to its bottom — so for a
-  `@ScrollingPreview(mode = LONG)` the button shows up in the final slice
+  `@ScrollingPreview(modes = [LONG])` the button shows up in the final slice
   only. That's intended behaviour, not a regression; the top-state
   `@Preview` of the same composable will not include it.
 

--- a/vscode-extension/src/captureLabels.ts
+++ b/vscode-extension/src/captureLabels.ts
@@ -30,7 +30,9 @@ function scrollLabel(scroll: NonNullable<Capture['scroll']>): string {
     // Prefer the outcome when the renderer has reported it; fall back to
     // the declared intent. `atEnd` wins over `reachedPx` so "scrolled end"
     // stays stable even when the renderer reports e.g. `reachedPx: 1200`
-    // with content actually exhausted at that offset.
+    // with content actually exhausted at that offset. TOP has no outcome
+    // — the renderer doesn't drive any scrollable for it.
+    if (scroll.mode === 'TOP') return 'scroll top';
     if (scroll.atEnd) return 'scrolled end';
     if (scroll.reachedPx != null) return `scrolled ${scroll.reachedPx}px`;
     if (scroll.mode === 'END') return 'scroll end';

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -18,7 +18,7 @@ export interface PreviewParams {
  * reachedPx) are populated by the renderer post-capture.
  */
 export interface ScrollCapture {
-    mode: 'END' | 'LONG' | string;
+    mode: 'TOP' | 'END' | 'LONG' | string;
     axis: 'VERTICAL' | 'HORIZONTAL' | string;
     maxScrollPx: number;
     reduceMotion: boolean;


### PR DESCRIPTION
## Summary

- Replace `@ScrollingPreview(mode: ScrollMode)` with `modes: Array<ScrollMode> = [ScrollMode.END]` and add `ScrollMode.TOP` so one annotation can fan out into multiple captures (e.g. top + end) from a single preview function.
- Discovery emits one `Capture` per mode, sorted TOP → END → LONG so the renderer grabs the unscrolled frame before driving any scroller. Multi-mode previews disambiguate PNGs with a `_SCROLL_<mode>` suffix; single-mode keeps the existing `renders/<id>.png` path (drop-in migration from `mode = X` to `modes = [X]`).
- `sample-android` now demonstrates the new shape end-to-end — `RedToBlueScrollPreview` annotated with `modes = [TOP, END]` produces both the red-dominant top frame and the blue-dominant end frame, asserted by the updated pixel test.

**BREAKING CHANGE** on `ee.schimke.composeai:preview-annotations`: `mode = ScrollMode.X` ⇒ `modes = [ScrollMode.X]`. No deprecation shim.

## Test plan

- [x] `./gradlew :preview-annotations:build :gradle-plugin:test`
- [x] `./gradlew :gradle-plugin:functionalTest` — includes a new multi-mode case asserting the two-capture fan-out and `_SCROLL_<mode>` filenames.
- [x] `./gradlew :sample-android:test` — renders `RedToBlueScrollPreview` and verifies `..._SCROLL_top.png` is red-dominant / `..._SCROLL_end.png` is blue-dominant.
- [x] `./gradlew :sample-wear:test` — existing `LongScrollPreviewPixelTest` still passes (single-mode filename unchanged).
- [x] `:renderer-android:test`
- [x] `vscode-extension`: `npm run compile` clean with the widened `ScrollCapture.mode` union + `'scroll top'` label branch.