### PR TITLE
fix(ci): expand multi-capture previews in PR diff bot

### DIFF
--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -37,6 +37,43 @@ def sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def _capture_label(capture: dict) -> str:
+    """Human-readable summary of a capture's non-null dimensions.
+
+    Mirrors the TS `captureLabels.captureLabel` in the VS Code extension so
+    the two surfaces agree on wording. Static captures (no dimensions)
+    return ``""``; time fan-outs read ``"500ms"``; scroll captures read
+    ``"scroll top"`` / ``"scroll end"`` / ``"scroll long"``; the
+    cross-product reads ``"500ms \u00B7 scroll end"``.
+    """
+    parts: list[str] = []
+    ms = capture.get("advanceTimeMillis")
+    if ms is not None:
+        parts.append(f"{ms}ms")
+    scroll = capture.get("scroll")
+    if isinstance(scroll, dict):
+        mode = str(scroll.get("mode") or "").lower()
+        if mode:
+            parts.append(f"scroll {mode}")
+    return " \u00B7 ".join(parts)
+
+
+def _render_basename(png_path: str, preview_id: str) -> str:
+    """File basename the diff bot should use when copying/linking a capture.
+
+    Prefer the basename the renderer actually wrote (it encodes dimension
+    suffixes like ``_SCROLL_end`` / ``_TIME_500ms`` so two captures of the
+    same preview never collide). Fall back to ``<previewId>.png`` when the
+    CLI didn't surface a real path — that matches the legacy behaviour for
+    missing / unrendered rows.
+    """
+    if png_path:
+        name = Path(png_path).name
+        if name:
+            return name
+    return f"{preview_id}.png"
+
+
 def load_cli_output(cli_json_path: Path) -> dict[str, dict]:
     """Parse ``compose-preview show --json`` output into a keyed dict.
 
@@ -45,7 +82,15 @@ def load_cli_output(cli_json_path: Path) -> dict[str, dict]:
     JSON array of PreviewResult objects — accepted as a fallback so this
     action keeps working against older CLI tarballs in CI matrices.
 
-    Entries are keyed as ``<module>/<id>`` for stable cross-run comparison.
+    Previews with multiple captures (``@RoboComposePreviewOptions`` time
+    fan-out, ``@ScrollingPreview(modes = […])`` scroll fan-out) expand into
+    one row per capture. The first capture keeps the bare ``<module>/<id>``
+    key so existing baselines continue matching single-capture previews;
+    subsequent captures are keyed ``<module>/<id>#<n>`` — same convention as
+    the CLI's own per-capture state file.
+
+    Rows carry the render PNG basename (``_SCROLL_end.png`` etc.) and a
+    ``captureLabel`` for downstream markdown / filename handling.
     """
     raw = json.loads(cli_json_path.read_text())
     if isinstance(raw, dict) and "previews" in raw:
@@ -60,15 +105,47 @@ def load_cli_output(cli_json_path: Path) -> dict[str, dict]:
 
     result: dict[str, dict] = {}
     for entry in entries:
-        key = f"{entry['module']}/{entry['id']}"
-        result[key] = {
-            "sha256": entry.get("sha256") or "",
-            "functionName": entry["functionName"],
-            "sourceFile": entry.get("sourceFile", ""),
-            "module": entry["module"],
-            "previewId": entry["id"],
-            "pngPath": entry.get("pngPath") or "",
-        }
+        module = entry["module"]
+        preview_id = entry["id"]
+        fn = entry["functionName"]
+        source = entry.get("sourceFile", "")
+
+        # Legacy / unrendered shape: no per-capture list, fall back to the
+        # top-level sha/png. Produces one row as before.
+        captures = entry.get("captures") or []
+        if not captures:
+            result[f"{module}/{preview_id}"] = {
+                "sha256": entry.get("sha256") or "",
+                "functionName": fn,
+                "sourceFile": source,
+                "module": module,
+                "previewId": preview_id,
+                "pngPath": entry.get("pngPath") or "",
+                "captureIndex": 0,
+                "captureLabel": "",
+                "renderBasename": _render_basename(entry.get("pngPath") or "", preview_id),
+            }
+            continue
+
+        for idx, capture in enumerate(captures):
+            # Index 0 keeps the bare key so pre-fan-out baselines on `main`
+            # keep matching single-capture previews. Additional captures
+            # (#1, #2, …) appear as "new" entries on the first run after
+            # a preview grows a fan-out, which is correct — those PNGs
+            # didn't exist in the baseline.
+            key = f"{module}/{preview_id}" if idx == 0 else f"{module}/{preview_id}#{idx}"
+            png = capture.get("pngPath") or ""
+            result[key] = {
+                "sha256": capture.get("sha256") or "",
+                "functionName": fn,
+                "sourceFile": source,
+                "module": module,
+                "previewId": preview_id,
+                "pngPath": png,
+                "captureIndex": idx,
+                "captureLabel": _capture_label(capture),
+                "renderBasename": _render_basename(png, preview_id),
+            }
     return result
 
 
@@ -88,11 +165,16 @@ def cmd_generate(args: argparse.Namespace) -> int:
         return 1
 
     # --- baselines.json ---
+    # Persist the renderBasename alongside the sha so the compare run can
+    # reconstruct raw-GitHub URLs for removed captures without needing the
+    # CLI output for them.
     baselines = {
         key: {
             "sha256": info["sha256"],
             "functionName": info["functionName"],
             "sourceFile": info["sourceFile"],
+            "renderBasename": info["renderBasename"],
+            "captureLabel": info["captureLabel"],
         }
         for key, info in previews.items()
         if info["sha256"]  # skip entries without a rendered PNG
@@ -101,7 +183,10 @@ def cmd_generate(args: argparse.Namespace) -> int:
     (out_dir / "baselines.json").write_text(
         json.dumps(baselines, indent=2, sort_keys=True) + "\n")
 
-    # --- copy PNGs into renders/<module>/<id>.png ---
+    # --- copy PNGs into renders/<module>/<renderBasename> ---
+    # Using the renderer's on-disk basename (e.g. `Foo_SCROLL_end.png`)
+    # rather than `<previewId>.png` so captures in a multi-mode /
+    # time-fan-out preview don't collide on the baseline branch.
     renders_out = out_dir / "renders"
     if renders_out.exists():
         shutil.rmtree(renders_out)
@@ -111,7 +196,7 @@ def cmd_generate(args: argparse.Namespace) -> int:
         png = Path(info["pngPath"])
         if not png.exists():
             continue
-        dest = renders_out / info["module"] / f"{info['previewId']}.png"
+        dest = renders_out / info["module"] / info["renderBasename"]
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(png, dest)
 
@@ -134,8 +219,9 @@ def cmd_generate(args: argparse.Namespace) -> int:
         lines.append("| Preview | Image |")
         lines.append("|---------|-------|")
         for _, info in entries:
-            fn = info["functionName"]
-            img_path = f"renders/{info['module']}/{info['previewId']}.png"
+            label_suffix = f" · {info['captureLabel']}" if info["captureLabel"] else ""
+            fn = f"{info['functionName']}{label_suffix}"
+            img_path = f"renders/{info['module']}/{info['renderBasename']}"
             raw_url = f"https://raw.githubusercontent.com/{repo}/{branch}/{img_path}"
             lines.append(
                 f"| `{fn}` | <img src=\"{raw_url}\" width=\"150\" /> |"
@@ -160,10 +246,24 @@ def _variant_label(preview_id: str) -> str:
     return parts[1] if len(parts) == 2 else ""
 
 
-def _render_url(repo: str, branch: str, module: str, preview_id: str) -> str:
+def _entry_label(info: dict) -> str:
+    """Display label for one row inside a function group.
+
+    Combines the variant suffix from the preview id (Light/Dark, device
+    name, etc.) with the capture label (``scroll end``, ``500ms``, …).
+    Either half may be empty; the label is used in link text / table
+    headings, so empty strings are filtered out.
+    """
+    variant = _variant_label(info["previewId"])
+    capture = info.get("captureLabel") or ""
+    parts = [p for p in (variant, capture) if p]
+    return " · ".join(parts) or info["previewId"]
+
+
+def _render_url(repo: str, branch: str, module: str, basename: str) -> str:
     return (
         f"https://raw.githubusercontent.com/{repo}/{branch}"
-        f"/renders/{module}/{preview_id}.png"
+        f"/renders/{module}/{basename}"
     )
 
 
@@ -209,7 +309,9 @@ def cmd_compare(args: argparse.Namespace) -> int:
         return 0
 
     if changed:
-        # Group changed variants by (module, functionName).
+        # Group changed variants by (module, functionName) — a function
+        # fans out into (preview variants × captures), so one group can
+        # contain many rows even for a single source function.
         groups: dict[tuple[str, str], list[tuple[str, dict, dict]]] = {}
         for key, cur, bl in changed:
             gk = (cur["module"], cur["functionName"])
@@ -220,9 +322,8 @@ def cmd_compare(args: argparse.Namespace) -> int:
 
         for (module, fn), entries in sorted(groups.items()):
             hero_key, hero_cur, hero_bl = entries[0]
-            hero_pid = hero_key.split("/", 1)[1]
-            before = _render_url(repo, base_branch, module, hero_pid)
-            after = _render_url(repo, head_branch, module, hero_pid)
+            before = _render_url(repo, base_branch, module, hero_cur["renderBasename"])
+            after = _render_url(repo, head_branch, module, hero_cur["renderBasename"])
 
             lines.append(f"**`{fn}`** ({module})")
             lines.append("")
@@ -236,10 +337,9 @@ def cmd_compare(args: argparse.Namespace) -> int:
             # Link remaining variants
             if len(entries) > 1:
                 variant_links = []
-                for okey, ocur, obl in entries[1:]:
-                    opid = okey.split("/", 1)[1]
-                    label = _variant_label(opid) or opid
-                    link = _render_url(repo, head_branch, module, opid)
+                for _okey, ocur, _obl in entries[1:]:
+                    label = _entry_label(ocur)
+                    link = _render_url(repo, head_branch, module, ocur["renderBasename"])
                     variant_links.append(f"[{label}]({link})")
                 lines.append("")
                 lines.append(f"Other variants: {', '.join(variant_links)}")
@@ -257,8 +357,7 @@ def cmd_compare(args: argparse.Namespace) -> int:
 
         for (module, fn), entries in sorted(groups_new.items()):
             hero_key, hero_info = entries[0]
-            hero_pid = hero_key.split("/", 1)[1]
-            after = _render_url(repo, head_branch, module, hero_pid)
+            after = _render_url(repo, head_branch, module, hero_info["renderBasename"])
 
             lines.append(
                 f"**`{fn}`** ({module}) "
@@ -267,10 +366,9 @@ def cmd_compare(args: argparse.Namespace) -> int:
 
             if len(entries) > 1:
                 variant_links = []
-                for okey, oinfo in entries[1:]:
-                    opid = okey.split("/", 1)[1]
-                    label = _variant_label(opid) or opid
-                    link = _render_url(repo, head_branch, module, opid)
+                for _okey, oinfo in entries[1:]:
+                    label = _entry_label(oinfo)
+                    link = _render_url(repo, head_branch, module, oinfo["renderBasename"])
                     variant_links.append(f"[{label}]({link})")
                 lines.append(f"Variants: {', '.join(variant_links)}")
             lines.append("")
@@ -321,7 +419,9 @@ def cmd_copy_changed(args: argparse.Namespace) -> int:
         is_new = key not in baselines
         is_changed = not is_new and info["sha256"] != baselines[key]["sha256"]
         if is_new or is_changed:
-            dest = out_dir / "renders" / info["module"] / f"{info['previewId']}.png"
+            # Use the renderer's on-disk basename so multi-capture previews
+            # don't collide — matches the generate path.
+            dest = out_dir / "renders" / info["module"] / info["renderBasename"]
             dest.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(png, dest)
             copied += 1

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -34,7 +34,7 @@ def _png_with(content: bytes) -> bytes:
 
 def _entry(*, id: str, module: str = "app", function: str = "Fn",
            source: str | None = "f.kt", png: str | None = None,
-           sha: str | None = None) -> dict:
+           sha: str | None = None, captures: list | None = None) -> dict:
     return {
         "id": id,
         "module": module,
@@ -43,6 +43,22 @@ def _entry(*, id: str, module: str = "app", function: str = "Fn",
         "sourceFile": source,
         "pngPath": png,
         "sha256": sha,
+        # CLI always emits `captures[]`; omitting it exercises the legacy
+        # (pre-fan-out) fallback path in load_cli_output. Callers that want
+        # a multi-capture entry pass an explicit list.
+        **({"captures": captures} if captures is not None else {}),
+    }
+
+
+def _capture(*, png: str | None = None, sha: str | None = None,
+             advanceTimeMillis: int | None = None,
+             scroll: dict | None = None) -> dict:
+    """Build a CaptureResult-shaped dict for use in `_entry(captures=[…])`."""
+    return {
+        "pngPath": png,
+        "sha256": sha,
+        "advanceTimeMillis": advanceTimeMillis,
+        "scroll": scroll,
     }
 
 
@@ -116,11 +132,12 @@ class CopyChangedTest(unittest.TestCase):
         self.tmp = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, self.tmp)
 
-        # Two PNGs on disk — `red` is "changed" relative to baselines,
-        # `blue` matches its baseline sha.
-        self.red = self.tmp / "red.png"
+        # Fixture PNGs mirror the filenames the renderer would actually
+        # write — `compare-previews.py` copies under those names so two
+        # captures of a multi-mode preview don't collide on disk.
+        self.red = self.tmp / "Red.png"
         self.red.write_bytes(_png_with(b"red bytes"))
-        self.blue = self.tmp / "blue.png"
+        self.blue = self.tmp / "Blue.png"
         self.blue.write_bytes(_png_with(b"blue bytes"))
 
         cli_payload = {
@@ -176,7 +193,7 @@ class GenerateTest(unittest.TestCase):
         self.tmp = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, self.tmp)
 
-        self.png = self.tmp / "a.png"
+        self.png = self.tmp / "A.png"
         self.png.write_bytes(b"png-bytes")
 
         self.cli_path = self.tmp / "cli.json"
@@ -269,6 +286,254 @@ class CompareMarkdownTest(unittest.TestCase):
         self.assertIn("### Removed", out)
         # Marker comment so subsequent runs can edit-in-place.
         self.assertIn("<!-- preview-diff -->", out)
+
+
+class MultiCaptureLoadTest(unittest.TestCase):
+    """`@ScrollingPreview(modes = [TOP, END])` / time fan-out: one preview
+    must surface as one row per capture so each PNG shows up in the diff."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def _write(self, name: str, payload) -> Path:
+        p = self.tmp / name
+        p.write_text(json.dumps(payload))
+        return p
+
+    def test_multi_capture_preview_expands_to_one_row_per_capture(self):
+        # TOP + END scroll fan-out — two captures under one preview id.
+        path = self._write("e.json", {
+            "previews": [_entry(
+                id="Scroll", function="ScrollFn", png="/top.png", sha="top-sha",
+                captures=[
+                    _capture(png="/top.png", sha="top-sha",
+                             scroll={"mode": "TOP"}),
+                    _capture(png="/end.png", sha="end-sha",
+                             scroll={"mode": "END"}),
+                ],
+            )],
+        })
+        out = cp.load_cli_output(path)
+
+        # Two rows: first keeps the bare key for back-compat with existing
+        # baselines; the second slots in as #1.
+        self.assertEqual(set(out), {"app/Scroll", "app/Scroll#1"})
+
+        first = out["app/Scroll"]
+        self.assertEqual(first["sha256"], "top-sha")
+        self.assertEqual(first["captureLabel"], "scroll top")
+        self.assertEqual(first["renderBasename"], "top.png")
+
+        second = out["app/Scroll#1"]
+        self.assertEqual(second["sha256"], "end-sha")
+        self.assertEqual(second["captureLabel"], "scroll end")
+        self.assertEqual(second["renderBasename"], "end.png")
+
+    def test_time_and_scroll_cross_product_carries_both_dimensions(self):
+        # Combined time × scroll dimension: two captures, each with both
+        # an advanceTimeMillis and a scroll. captureLabel joins them.
+        path = self._write("cross.json", {
+            "previews": [_entry(
+                id="Cross", function="CrossFn", png="/a.png", sha="a",
+                captures=[
+                    _capture(png="/a.png", sha="a",
+                             advanceTimeMillis=500, scroll={"mode": "END"}),
+                ],
+            )],
+        })
+        out = cp.load_cli_output(path)
+        self.assertEqual(out["app/Cross"]["captureLabel"], "500ms \u00B7 scroll end")
+
+    def test_legacy_entry_without_captures_still_loads_as_one_row(self):
+        # Pre-fan-out CLI (no `captures[]` field) falls back to the
+        # top-level sha/png so the action keeps working against older
+        # CLI tarballs pinned in CI matrices.
+        path = self._write("legacy.json", {
+            "previews": [_entry(id="Flat", png="/f.png", sha="s")],
+        })
+        out = cp.load_cli_output(path)
+        self.assertEqual(set(out), {"app/Flat"})
+        self.assertEqual(out["app/Flat"]["captureLabel"], "")
+        self.assertEqual(out["app/Flat"]["renderBasename"], "f.png")
+
+
+class CaptureLabelTest(unittest.TestCase):
+    """Helper that builds the per-capture dimension label."""
+
+    def test_static_capture_has_empty_label(self):
+        self.assertEqual(cp._capture_label({"advanceTimeMillis": None, "scroll": None}), "")
+
+    def test_time_only(self):
+        self.assertEqual(cp._capture_label({"advanceTimeMillis": 500, "scroll": None}), "500ms")
+
+    def test_scroll_only(self):
+        self.assertEqual(
+            cp._capture_label({"advanceTimeMillis": None, "scroll": {"mode": "LONG"}}),
+            "scroll long",
+        )
+
+    def test_time_and_scroll_joined_with_middle_dot(self):
+        self.assertEqual(
+            cp._capture_label({"advanceTimeMillis": 200, "scroll": {"mode": "END"}}),
+            "200ms \u00B7 scroll end",
+        )
+
+
+class MultiCaptureGenerateTest(unittest.TestCase):
+    """`generate` mode must copy every capture (not just the first) onto
+    the baseline branch so PR compares can pair them up by basename."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+        self.top_png = self.tmp / "S_SCROLL_top.png"
+        self.top_png.write_bytes(b"top-bytes")
+        self.end_png = self.tmp / "S_SCROLL_end.png"
+        self.end_png.write_bytes(b"end-bytes")
+
+        self.cli_path = self.tmp / "cli.json"
+        self.cli_path.write_text(json.dumps({
+            "previews": [_entry(
+                id="S", module="m", function="Fn",
+                png=str(self.top_png), sha="top-sha",
+                captures=[
+                    _capture(png=str(self.top_png), sha="top-sha",
+                             scroll={"mode": "TOP"}),
+                    _capture(png=str(self.end_png), sha="end-sha",
+                             scroll={"mode": "END"}),
+                ],
+            )],
+        }))
+        self.out = self.tmp / "preview_main"
+
+    def test_copies_each_capture_under_its_renderer_basename(self):
+        from types import SimpleNamespace
+        rc = cp.cmd_generate(SimpleNamespace(
+            cli_json=str(self.cli_path),
+            output_dir=str(self.out),
+            repo="owner/repo",
+            branch="preview_main",
+        ))
+        self.assertEqual(rc, 0)
+
+        # Both captures land on disk; neither collides on `<id>.png`.
+        copied = sorted(p.name for p in (self.out / "renders" / "m").iterdir())
+        self.assertEqual(copied, ["S_SCROLL_end.png", "S_SCROLL_top.png"])
+
+        # Baselines keyed per-capture; both carry their renderBasename
+        # so a later compare run can build raw-GitHub URLs correctly.
+        baselines = json.loads((self.out / "baselines.json").read_text())
+        self.assertEqual(set(baselines), {"m/S", "m/S#1"})
+        self.assertEqual(baselines["m/S"]["renderBasename"], "S_SCROLL_top.png")
+        self.assertEqual(baselines["m/S#1"]["renderBasename"], "S_SCROLL_end.png")
+
+        # README rows include the capture label so the gallery distinguishes
+        # the top frame from the end frame visually.
+        readme = (self.out / "README.md").read_text()
+        self.assertIn("Fn \u00B7 scroll top", readme)
+        self.assertIn("Fn \u00B7 scroll end", readme)
+
+
+class MultiCaptureCopyChangedTest(unittest.TestCase):
+    """`copy-changed` mode must diff per-capture so a regression on only
+    the END frame copies just the END PNG, not the (unchanged) TOP PNG."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+        self.top_png = self.tmp / "S_SCROLL_top.png"
+        self.top_png.write_bytes(b"top-bytes")
+        self.end_png = self.tmp / "S_SCROLL_end.png"
+        self.end_png.write_bytes(b"end-bytes")
+
+        self.cli_path = self.tmp / "cli.json"
+        self.cli_path.write_text(json.dumps({
+            "previews": [_entry(
+                id="S", module="m", function="Fn",
+                png=str(self.top_png), sha="top-sha",
+                captures=[
+                    _capture(png=str(self.top_png), sha="top-sha",
+                             scroll={"mode": "TOP"}),
+                    _capture(png=str(self.end_png), sha="new-end-sha",
+                             scroll={"mode": "END"}),
+                ],
+            )],
+        }))
+        self.baselines = self.tmp / "baselines.json"
+        self.baselines.write_text(json.dumps({
+            "m/S": {"sha256": "top-sha", "functionName": "Fn"},
+            "m/S#1": {"sha256": "old-end-sha", "functionName": "Fn"},
+        }))
+        self.out_dir = self.tmp / "out"
+
+    def test_only_the_changed_capture_gets_copied(self):
+        from types import SimpleNamespace
+        rc = cp.cmd_copy_changed(SimpleNamespace(
+            cli_json=str(self.cli_path),
+            baselines=str(self.baselines),
+            output_dir=str(self.out_dir),
+        ))
+        self.assertEqual(rc, 0)
+
+        copied = sorted(p.name for p in (self.out_dir / "renders" / "m").iterdir())
+        self.assertEqual(copied, ["S_SCROLL_end.png"])
+
+
+class MultiCaptureCompareTest(unittest.TestCase):
+    """Compare markdown must link every capture of a multi-capture preview
+    — the original regression that prompted this change."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def _run(self, current_payload, baselines_payload) -> str:
+        cli_path = self.tmp / "cli.json"
+        cli_path.write_text(json.dumps(current_payload))
+        bl_path = self.tmp / "baselines.json"
+        bl_path.write_text(json.dumps(baselines_payload))
+
+        import io
+        import contextlib
+        from types import SimpleNamespace
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            cp.cmd_compare(SimpleNamespace(
+                cli_json=str(cli_path),
+                baselines=str(bl_path),
+                repo="owner/repo",
+                pr="42",
+                base_branch="preview_main",
+                head_branch="preview_pr/42",
+            ))
+        return buf.getvalue()
+
+    def test_new_multi_capture_preview_links_every_variant(self):
+        # Preview didn't exist in the baseline — both captures should appear,
+        # the hero inline and the others as linked variants.
+        out = self._run(
+            {"previews": [_entry(
+                id="Scroll", function="ScrollFn",
+                png="/t.png", sha="top-sha",
+                captures=[
+                    _capture(png="/S_SCROLL_top.png", sha="top-sha",
+                             scroll={"mode": "TOP"}),
+                    _capture(png="/S_SCROLL_end.png", sha="end-sha",
+                             scroll={"mode": "END"}),
+                ],
+            )]},
+            {},
+        )
+        self.assertIn("### New (2 variant(s) across 1 function(s))", out)
+        # Hero image: first capture's basename.
+        self.assertIn("S_SCROLL_top.png", out)
+        # Second capture rendered as a variant link with its label.
+        self.assertIn("[scroll end]", out)
+        self.assertIn("S_SCROLL_end.png", out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- The `compare-previews.py` PR diff bot keyed rows by `<module>/<id>` and read only the top-level `sha256`/`pngPath` from the CLI's `show --json`. That top-level pair mirrors the **first capture only** ([Commands.kt:411-412](../blob/main/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt#L411-L412), with a comment explaining it's for pre-fan-out agent back-compat), so previews with multiple captures — `@ScrollingPreview(modes = [TOP, END])`, `@RoboComposePreviewOptions` time fan-outs — showed up as one entry with only the first PNG compared.
- #104 made this visible: the new `RedToBlueScrollPreview` showed only its TOP (red) frame in the PR comment, not the END (blue) one.
- Fix: `load_cli_output` now walks `captures[]` and emits one row per capture. Index 0 keeps the bare `<module>/<id>` key so existing baselines on `preview_main` keep matching single-capture previews; additional captures are keyed `<module>/<id>#<n>` (same convention as the CLI's state file). Rows carry the renderer's on-disk basename (which already encodes `_SCROLL_<mode>` / `_TIME_<ms>ms` suffixes) and a capture label mirroring the VS Code extension's `captureLabels.captureLabel` wording.
- `generate` / `compare` / `copy-changed` switched from `<previewId>.png` to the per-capture basename so captures no longer collide on disk; compare markdown links every capture as its own variant (`[scroll end]`, `[500ms]`, etc.). Legacy pre-fan-out CLI output (no `captures[]` field) still works via a fallback.

## Test plan

- [x] `python3 -m unittest test_compare_previews` — 23 tests pass (13 pre-existing + 10 new covering load/generate/compare/copy-changed under multi-capture input, plus a fallback test for the legacy bare-entry shape).

## Follow-up

First CI run after merge will see every capture index #1+ as "new" against the current `preview_main` baseline (because those PNGs didn't exist in the baseline under the new keys). That self-heals once `preview-baselines.yml` runs on `main` post-merge — same behaviour as when a brand-new `@Preview` lands. Not regressions; just one loud initial diff.