### PR TITLE
fix(renderer): settle post-scroll animations before final LONG slice

### DIFF
--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -638,6 +638,25 @@ private fun handleLongCapture(
             return false
         }
         if (slices.isEmpty()) return false
+
+        // Settle post-scroll animations (Wear `EdgeButton` reveal, spring
+        // snaps, AnimatedVisibility fade-ins that only start once the list
+        // has landed) before composing the final stitched frame. The
+        // per-step 250ms advance inside `driveScrollByViewport` is tuned
+        // for scroll settling, not for animations that START when the
+        // scroll reaches its end — without this step the last slice
+        // captures the EdgeButton mid-reveal and the stitched PNG shows a
+        // thin pill at the bottom instead of the fully-expanded button.
+        //
+        // Tick one frame at a time so any withFrameNanos-driven animation
+        // gets each cycle it's waiting on. Bounded (POST_SCROLL_SETTLE_MS
+        // / 16ms frames) so infinite animations can't run away — they keep
+        // the paused-clock semantics of the rest of the render path.
+        settlePostScrollAnimations(rule)
+        val lastSlice = slices.last()
+        lastSlice.file.delete()
+        rule.onRoot().captureRoboImage(file = lastSlice.file, roborazziOptions = sliceRoborazziOptions)
+
         stitchSlices(slices, viewportLayoutPx, outputFile) ?: return false
         if (isRound) applyWearPillClip(outputFile)
         System.err.println(
@@ -648,6 +667,32 @@ private fun handleLongCapture(
         slicesDir.deleteRecursively()
     }
 }
+
+/**
+ * Advance the paused `mainClock` one frame at a time up to
+ * [POST_SCROLL_SETTLE_MS], letting animations that begin once the scroll
+ * lands (e.g. Wear `ScreenScaffold`'s `EdgeButton` reveal) run to their
+ * resting state before the final slice is captured.
+ *
+ * Bounded so infinite animations (`rememberInfiniteTransition`, etc.)
+ * don't turn the settle step into an open-ended render. 1000ms is ~4×
+ * Wear Material3's 250ms EdgeButton reveal spec — enough headroom for
+ * chained animations or a spring overshoot, still cheap per preview.
+ */
+private fun settlePostScrollAnimations(rule: AndroidComposeTestRule<*, *>) {
+    val frameMs = 16L
+    val frames = POST_SCROLL_SETTLE_MS / frameMs
+    repeat(frames.toInt()) {
+        rule.mainClock.advanceTimeByFrame()
+    }
+}
+
+/**
+ * Total virtual-time budget for [settlePostScrollAnimations]. Sized for
+ * Wear Material3's `EdgeButton` expand spec (~250ms at the time of
+ * writing) with comfortable headroom for overshoot / chained animations.
+ */
+private const val POST_SCROLL_SETTLE_MS = 1000L
 
 /**
  * Adds Robolectric's `+round` qualifier so `Configuration.isScreenRound` becomes

--- a/sample-wear/src/test/kotlin/com/example/samplewear/LongScrollPreviewPixelTest.kt
+++ b/sample-wear/src/test/kotlin/com/example/samplewear/LongScrollPreviewPixelTest.kt
@@ -132,4 +132,65 @@ class LongScrollPreviewPixelTest {
         val scaledRatio = scaledCardRows.toDouble() / contentRows
         assertThat(scaledRatio).isLessThan(0.10)
     }
+
+    /**
+     * Regression for the EdgeButton reveal animation at the bottom of a
+     * scroll-to-end stitch: without a post-scroll settle pass, the final
+     * slice captures `ScreenScaffold`'s `EdgeButton` mid-reveal, and the
+     * stitched PNG shows a narrow pill at the very bottom instead of the
+     * fully-expanded "Start workout" button. Once the renderer advances
+     * the paused `mainClock` enough for the expand spec to complete
+     * (`settlePostScrollAnimations` in `handleLongCapture`), the bottom
+     * band contains a near-full-width run of primary-coloured pixels.
+     *
+     * Measured on the fixed render: widest primary-colour run spans
+     * ~85 % of the viewport width. With the settle disabled the same
+     * run collapses to ~30 %. Gate at 0.60 — ~1.4× headroom above the
+     * passing value, ~2× above the failing value.
+     */
+    @Test
+    fun `LONG preview final frame shows fully-expanded EdgeButton`() {
+        val img = ImageIO.read(longPng)
+        val w = img.width
+        val h = img.height
+
+        // EdgeButton Large is ~46 dp tall ≈ 92 px at 2x density. Scan the
+        // bottom 120 px so the whole button (plus the round-face pill
+        // curvature below it) is in range regardless of exact Material3
+        // sizing changes. For each row find the widest continuous run of
+        // bright pixels; the expanded button sits as one wide horizontal
+        // stripe, a mid-reveal button as a short centred pill.
+        val scanFromY = (h - 120).coerceAtLeast(0)
+        var maxRunWidth = 0
+        for (y in scanFromY until h) {
+            var bestRun = 0
+            var currentRun = 0
+            for (x in 0 until w) {
+                val argb = img.getRGB(x, y)
+                val alpha = (argb ushr 24) and 0xff
+                if (alpha == 0) {
+                    // Pill-clip curvature: gap in the run.
+                    currentRun = 0
+                    continue
+                }
+                val r = (argb shr 16) and 0xff
+                val g = (argb shr 8) and 0xff
+                val b = argb and 0xff
+                // Button container is Material3 primary (bright, saturated);
+                // scaffold background is pure black. Sum > 120 isolates the
+                // coloured button from the 0-summed background and from any
+                // dark card surfaces that might stray into the band.
+                if (r + g + b > 120) {
+                    currentRun++
+                    if (currentRun > bestRun) bestRun = currentRun
+                } else {
+                    currentRun = 0
+                }
+            }
+            if (bestRun > maxRunWidth) maxRunWidth = bestRun
+        }
+
+        val extent = maxRunWidth.toDouble() / w
+        assertThat(extent).isGreaterThan(0.60)
+    }
 }


### PR DESCRIPTION
## Summary

- `@ScrollingPreview(modes = [LONG])` captures each slice 250ms after its scroll step — fine for the scroll itself, but not for animations that *start* once the list lands at the bottom. Most visible culprit: Wear `ScreenScaffold`'s `EdgeButton` reveal, which expands on `scrollState.canScrollForward -> false`. The stitched PNG shipped with #104 showed the button as a narrow pill at the bottom instead of the fully-expanded "Start workout".
- Fix: after `driveScrollByViewport` completes, advance the paused `mainClock` by up to 1000ms in frame-sized steps (`settlePostScrollAnimations`), then re-capture the final slice in place. Bounded so `rememberInfiniteTransition` / `withFrameNanos` loops keep their paused-clock semantics. Not gated on Wear — spring snaps, parallax headers, and any other post-scroll settling benefit too.
- Not a Wear-specific heuristic ([WearReduceMotionLocal.kt](renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/WearReduceMotionLocal.kt) and [LocalScrollCaptureInProgress](renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt:281) already cover the Wear-only concerns); this is a general scroll-capture correction.

## Test plan

- Added `LONG preview final frame shows fully-expanded EdgeButton` in `LongScrollPreviewPixelTest`. Scans the bottom 120 px for the widest contiguous bright-pixel run; gates at 60 % of viewport width. Verified separation locally:
  - Settle disabled: extent = 0.21 (narrow pill) — test fails as expected.
  - Settle enabled: extent ≈ 0.85 — test passes.
- [x] `./gradlew :sample-wear:renderAllPreviews :sample-wear:testDebugUnitTest`
- [x] `./gradlew :renderer-android:test`
- Visual check: `ActivityListLongPreview_Devices - Large Round.png` now shows the expanded "Start workout" button at the bottom instead of the thin pill.