### PR TITLE
fix(annotations): new ScrollMode.GIF — animated scroll captures

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -485,7 +485,7 @@ class DiscoveryFunctionalTest {
             """
             package ee.schimke.composeai.preview
 
-            enum class ScrollMode { TOP, END, LONG }
+            enum class ScrollMode { TOP, END, LONG, GIF }
             enum class ScrollAxis { VERTICAL, HORIZONTAL }
 
             @Retention(AnnotationRetention.BINARY)
@@ -495,6 +495,7 @@ class DiscoveryFunctionalTest {
                 val maxScrollPx: Int = 0,
                 val reduceMotion: Boolean = true,
                 val axis: ScrollAxis = ScrollAxis.VERTICAL,
+                val frameIntervalMs: Int = 80,
             )
             """.trimIndent()
         )
@@ -551,6 +552,23 @@ class DiscoveryFunctionalTest {
                 Box(modifier = Modifier.size(50.dp).background(Color.Magenta))
             }
 
+            // GIF-mode capture: single-mode annotation lands at .gif, not .png.
+            @Preview(name = "Gif")
+            @ScrollingPreview(modes = [ScrollMode.GIF], frameIntervalMs = 120)
+            @Composable
+            fun GifScrollPreview() {
+                Box(modifier = Modifier.size(50.dp).background(Color.Cyan))
+            }
+
+            // Multi-mode with GIF sibling: each capture keeps its own
+            // extension — .png for END, .gif for GIF.
+            @Preview(name = "EndAndGif")
+            @ScrollingPreview(modes = [ScrollMode.END, ScrollMode.GIF])
+            @Composable
+            fun EndAndGifScrollPreview() {
+                Box(modifier = Modifier.size(50.dp).background(Color.Yellow))
+            }
+
             @Preview
             @Composable
             fun PlainPreview() {
@@ -577,6 +595,11 @@ class DiscoveryFunctionalTest {
         // using its declared-in-source defaults (reduceMotion=true, axis=VERTICAL).
         // Scroll state lives on each capture now (Capture.scroll) — single-capture
         // previews carry it on the first element.
+        // `frameIntervalMs` on the annotation applies to every capture in
+        // the manifest even though it's only meaningful for GIF mode —
+        // discovery reads the field unconditionally for a uniform shape.
+        // Test stub declares 80 as the default (matches the real
+        // annotation's DEFAULT_GIF_FRAME_INTERVAL_MS).
         for (p in endPreviews) {
             assertThat(p.captures).hasSize(1)
             assertThat(p.captures.first().scroll).isEqualTo(
@@ -585,6 +608,7 @@ class DiscoveryFunctionalTest {
                     axis = ScrollAxis.VERTICAL,
                     maxScrollPx = 0,
                     reduceMotion = true,
+                    frameIntervalMs = 80,
                 )
             )
         }
@@ -596,6 +620,7 @@ class DiscoveryFunctionalTest {
                 axis = ScrollAxis.HORIZONTAL,
                 maxScrollPx = 4000,
                 reduceMotion = false,
+                frameIntervalMs = 80,
             )
         )
 
@@ -604,7 +629,7 @@ class DiscoveryFunctionalTest {
 
         // Multi-mode: one preview yields two captures, one per mode, with
         // distinct `_SCROLL_<mode>` filenames. Modes sort by enum ordinal
-        // (TOP, END, LONG) so the renderer captures the initial frame
+        // (TOP, END, LONG, GIF) so the renderer captures the initial frame
         // before driving the scroller.
         val topAndEnd = manifest.previews.single { it.functionName == "TopAndEndScrollPreview" }
         assertThat(topAndEnd.captures).hasSize(2)
@@ -613,6 +638,35 @@ class DiscoveryFunctionalTest {
         assertThat(topAndEnd.captures.map { it.renderOutput }).containsExactly(
             "renders/${topAndEnd.id}_SCROLL_top.png",
             "renders/${topAndEnd.id}_SCROLL_end.png",
+        ).inOrder()
+
+        // Single-mode GIF: keeps the plain `renders/<id>.gif` name (no
+        // `_SCROLL_gif` suffix) and round-trips `frameIntervalMs` onto the
+        // manifest so the renderer can honour it.
+        val gifOnly = manifest.previews.single { it.functionName == "GifScrollPreview" }
+        assertThat(gifOnly.captures).hasSize(1)
+        assertThat(gifOnly.captures.single().scroll).isEqualTo(
+            ScrollCapture(
+                mode = ScrollMode.GIF,
+                axis = ScrollAxis.VERTICAL,
+                maxScrollPx = 0,
+                reduceMotion = true,
+                frameIntervalMs = 120,
+            )
+        )
+        assertThat(gifOnly.captures.single().renderOutput)
+            .isEqualTo("renders/${gifOnly.id}.gif")
+
+        // Multi-mode with GIF sibling: each capture gets its mode's
+        // extension (PNG for END, GIF for GIF) — the extension branches
+        // per-capture rather than per-preview.
+        val endAndGif = manifest.previews.single { it.functionName == "EndAndGifScrollPreview" }
+        assertThat(endAndGif.captures).hasSize(2)
+        assertThat(endAndGif.captures.map { it.scroll?.mode })
+            .containsExactly(ScrollMode.END, ScrollMode.GIF).inOrder()
+        assertThat(endAndGif.captures.map { it.renderOutput }).containsExactly(
+            "renders/${endAndGif.id}_SCROLL_end.png",
+            "renders/${endAndGif.id}_SCROLL_gif.gif",
         ).inOrder()
     }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -231,10 +231,15 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
 
         return scrollRows.flatMap { (scroll, scrollSuffix) ->
             timeRows.map { (ms, timeSuffix) ->
+                // GIF captures land on `.gif`; everything else is `.png`.
+                // Branching the extension per-capture (rather than per-preview)
+                // keeps multi-mode annotations like `modes = [TOP, GIF]`
+                // producing one PNG + one GIF from the same function.
+                val ext = if (scroll?.mode == ScrollMode.GIF) "gif" else "png"
                 Capture(
                     advanceTimeMillis = ms,
                     scroll = scroll,
-                    renderOutput = "renders/${previewId}${scrollSuffix}${timeSuffix}.png",
+                    renderOutput = "renders/${previewId}${scrollSuffix}${timeSuffix}.${ext}",
                 )
             }
         }
@@ -288,10 +293,16 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             ?: ScrollAxis.VERTICAL
         val maxScrollPx = (pv.getValue("maxScrollPx") as? Int)?.coerceAtLeast(0) ?: 0
         val reduceMotion = (pv.getValue("reduceMotion") as? Boolean) ?: true
+        // `frameIntervalMs` only meaningful for GIF mode; we still read it
+        // unconditionally and carry it into every ScrollCapture so the
+        // manifest shape stays uniform. `0` (or negative, coerced) signals
+        // "use the renderer's default" — matching the annotation-side
+        // DEFAULT_GIF_FRAME_INTERVAL_MS without duplicating the literal here.
+        val frameIntervalMs = (pv.getValue("frameIntervalMs") as? Int)?.coerceAtLeast(0) ?: 0
         // Result fields (atEnd, reachedPx) default to "not reported" — the
         // renderer would fill them in post-capture; discovery knows only the
         // intent. De-dup to guard against `modes = [END, END]` producing
-        // colliding PNG paths. Sort by enum ordinal (TOP→END→LONG) so the
+        // colliding paths. Sort by enum ordinal (TOP→END→LONG→GIF) so the
         // renderer captures the initial frame before driving the scroller —
         // otherwise `modes = [END, TOP]` would produce a "TOP" PNG at the
         // scrolled-end position.
@@ -301,6 +312,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
                 axis = axis,
                 maxScrollPx = maxScrollPx,
                 reduceMotion = reduceMotion,
+                frameIntervalMs = frameIntervalMs,
             )
         }
     }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -25,6 +25,7 @@ enum class ScrollMode {
     TOP,
     END,
     LONG,
+    GIF,
 }
 
 /** Mirrors `ee.schimke.composeai.preview.ScrollAxis`. */
@@ -51,6 +52,12 @@ data class ScrollCapture(
     val axis: ScrollAxis = ScrollAxis.VERTICAL,
     val maxScrollPx: Int = 0,
     val reduceMotion: Boolean = true,
+    /**
+     * Per-frame delay for [ScrollMode.GIF] output, in milliseconds. Ignored
+     * by other modes. `0` means "use the renderer's built-in default"
+     * (matches the annotation default).
+     */
+    val frameIntervalMs: Int = 0,
     // Outcome
     /**
      * `true` when the scrollable reported it was already at the end of its

--- a/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/ScrollingPreview.kt
+++ b/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/ScrollingPreview.kt
@@ -9,13 +9,15 @@ package ee.schimke.composeai.preview
  * annotation in their own code depend on
  * `ee.schimke.composeai:preview-annotations`.
  *
- * Each entry in [modes] fans out into its own capture (and its own PNG on
- * disk). Shared knobs — [axis], [maxScrollPx], [reduceMotion] — apply to
- * every capture produced by a single annotation instance. A single-mode
+ * Each entry in [modes] fans out into its own capture. TOP / END / LONG
+ * produce a single PNG per capture; GIF produces an animated `.gif`.
+ * Shared knobs — [axis], [maxScrollPx], [reduceMotion] — apply to every
+ * capture produced by a single annotation instance. A single-mode
  * annotation (e.g. `modes = [ScrollMode.END]`) keeps the plain
- * `renders/<id>.png` filename; multi-mode annotations disambiguate siblings
- * with a `_SCROLL_<mode>` suffix (`renders/<id>_SCROLL_top.png`,
- * `renders/<id>_SCROLL_end.png`, …).
+ * `renders/<id>.<ext>` filename; multi-mode annotations disambiguate
+ * siblings with a `_SCROLL_<mode>` suffix
+ * (`renders/<id>_SCROLL_top.png`, `renders/<id>_SCROLL_end.png`,
+ * `renders/<id>_SCROLL_gif.gif`, …).
  */
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.FUNCTION)
@@ -30,8 +32,8 @@ annotation class ScrollingPreview(
     /**
      * Upper bound on how far we'll scroll, in pixels. `0` means unbounded —
      * drive to the content's natural end. Use a positive value on infinite
-     * or very tall scrollers to cap capture size. Applies to [ScrollMode.END]
-     * and [ScrollMode.LONG]; ignored for [ScrollMode.TOP].
+     * or very tall scrollers to cap capture size. Applies to [ScrollMode.END],
+     * [ScrollMode.LONG], and [ScrollMode.GIF]; ignored for [ScrollMode.TOP].
      */
     val maxScrollPx: Int = 0,
     /**
@@ -43,7 +45,22 @@ annotation class ScrollingPreview(
     val reduceMotion: Boolean = true,
     /** Which axis to drive. Only [ScrollAxis.VERTICAL] is rendered today. */
     val axis: ScrollAxis = ScrollAxis.VERTICAL,
+    /**
+     * Per-frame delay for [ScrollMode.GIF] output, in milliseconds. Snaps to
+     * GIF's 10ms timing resolution at encode time. Default 80ms ≈ 12.5fps —
+     * smooth enough for a UI scroll, small enough to keep file size
+     * reasonable. Ignored by all other modes.
+     */
+    val frameIntervalMs: Int = DEFAULT_GIF_FRAME_INTERVAL_MS,
 )
+
+/**
+ * Default per-frame delay, in milliseconds, for `@ScrollingPreview(modes = [ScrollMode.GIF])`.
+ * Exposed as a top-level const because Kotlin annotation classes can't carry a
+ * companion object. Referenced as the default for
+ * [ScrollingPreview.frameIntervalMs].
+ */
+const val DEFAULT_GIF_FRAME_INTERVAL_MS: Int = 80
 
 enum class ScrollMode {
     /**
@@ -61,6 +78,14 @@ enum class ScrollMode {
      * one tall (or wide) PNG.
      */
     LONG,
+
+    /**
+     * Capture the full scrollable content as an animated GIF showing the
+     * scroll from top to bottom. Output lands at `renders/<id>.gif` (or
+     * `renders/<id>_SCROLL_gif.gif` for a multi-mode annotation). Frame
+     * cadence is controlled by [ScrollingPreview.frameIntervalMs].
+     */
+    GIF,
 }
 
 enum class ScrollAxis {

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -16,6 +16,7 @@ enum class ScrollMode {
     TOP,
     END,
     LONG,
+    GIF,
 }
 
 /** Mirrors `ee.schimke.composeai.preview.ScrollAxis`. */
@@ -31,6 +32,11 @@ data class ScrollCapture(
     val axis: ScrollAxis = ScrollAxis.VERTICAL,
     val maxScrollPx: Int = 0,
     val reduceMotion: Boolean = true,
+    /**
+     * Per-frame delay for [ScrollMode.GIF] captures, in milliseconds. `0`
+     * means "renderer default" ([ScrollGifEncoder.DEFAULT_FRAME_DELAY_MS]).
+     */
+    val frameIntervalMs: Int = 0,
     val atEnd: Boolean = false,
     val reachedPx: Int? = null,
 )

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -395,8 +395,25 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                                 (params.showSystemUi || params.kind == PreviewKind.TILE),
                             outputFile = outputFile,
                         )
+                    // @ScrollingPreview(GIF): drive the scroller by small
+                    // steps and encode the sequence as an animated GIF.
+                    // Same multi-frame shape as LONG, but encodes into a
+                    // GIF container instead of stitching one tall PNG.
+                    val gifHandled = !longHandled &&
+                        scroll != null &&
+                        scroll.mode == ScrollMode.GIF &&
+                        scroll.axis == ScrollAxis.VERTICAL &&
+                        handleGifCapture(
+                            rule = rule,
+                            scroll = scroll,
+                            previewId = preview.id,
+                            heightDp = heightDp,
+                            isRound = isRoundDevice(params.device) &&
+                                (params.showSystemUi || params.kind == PreviewKind.TILE),
+                            outputFile = outputFile,
+                        )
 
-                    if (!longHandled) {
+                    if (!longHandled && !gifHandled) {
                         // TOP mode is the unscrolled initial frame — no
                         // drive, just a capture. END mode drives the first
                         // scrollable on the requested axis to its content
@@ -422,9 +439,10 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
 
                     // AS-parity: crop the PNG down to the composable's
                     // intrinsic size on wrapped axes. Skipped for stitched
-                    // LONG output — that PNG's dimensions are the stitched
-                    // scroll extent, not the composable's intrinsic box.
-                    if (!longHandled && (wrapWidth || wrapHeight) && measured != null) {
+                    // LONG output and animated GIF output — those files'
+                    // dimensions are the full scrollable extent / frame
+                    // size, not the composable's intrinsic box.
+                    if (!longHandled && !gifHandled && (wrapWidth || wrapHeight) && measured != null) {
                         cropPngTopLeft(
                             file = outputFile,
                             wrapWidth = wrapWidth,
@@ -693,6 +711,97 @@ private fun settlePostScrollAnimations(rule: AndroidComposeTestRule<*, *>) {
  * writing) with comfortable headroom for overshoot / chained animations.
  */
 private const val POST_SCROLL_SETTLE_MS = 1000L
+
+/**
+ * Handles `@ScrollingPreview(modes = [GIF])` captures. Drives the scroller
+ * by a small fraction of the viewport per step via [driveScrollByViewport],
+ * captures each step to a temp PNG, then encodes the sequence as an
+ * animated GIF at [outputFile] via [ScrollGifEncoder].
+ *
+ * Unlike LONG, every frame is a full viewport-sized image — the GIF shows
+ * the scroll as an animation rather than stitching frames into one tall
+ * still. Per-frame round crop stays ON (each GIF frame should show a
+ * proper watch-shaped viewport), so we reuse the default
+ * `RoborazziOptions` the caller wired for single-frame captures.
+ *
+ * Returns `true` when [outputFile] was written; `false` to fall through
+ * to the default single-capture path (e.g. when no scrollable matched, or
+ * when the encoder declines).
+ */
+@OptIn(ExperimentalRoborazziApi::class)
+private fun handleGifCapture(
+    rule: AndroidComposeTestRule<*, ComponentActivity>,
+    scroll: ScrollCapture,
+    previewId: String,
+    heightDp: Int,
+    isRound: Boolean,
+    outputFile: File,
+): Boolean {
+    val density = rule.activity.resources.displayMetrics.density
+    val viewportLayoutPx = (heightDp * density).toInt().coerceAtLeast(1)
+    val framesDir = File(outputFile.parentFile, "${outputFile.nameWithoutExtension}_gif_frames")
+    framesDir.deleteRecursively()
+    framesDir.mkdirs()
+
+    // Per-frame crop matches END mode: each GIF frame should look like a
+    // normal single capture, circle-clipped on round devices included.
+    val frameRoborazziOptions = RoborazziOptions(
+        recordOptions = RoborazziOptions.RecordOptions(applyDeviceCrop = isRound),
+    )
+
+    val frameFiles = mutableListOf<File>()
+    try {
+        // 20% of viewport per step → ~5 frames per viewport of scrolled
+        // content. With 80ms default cadence that's ~0.4s of animation
+        // per viewport — smooth scroll without an explosive frame count
+        // on tall lists. Too small jitters, too large stutters.
+        val result = driveScrollByViewport(
+            rule = rule,
+            axis = scroll.axis,
+            stepPx = viewportLayoutPx * GIF_STEP_FRACTION,
+            maxScrollPx = scroll.maxScrollPx,
+        ) { _ ->
+            val frameFile = File(framesDir, "frame_${frameFiles.size}.png")
+            rule.onRoot().captureRoboImage(file = frameFile, roborazziOptions = frameRoborazziOptions)
+            frameFiles += frameFile
+        }
+        if (result is ScrollDriveResult.NoScrollable) {
+            System.err.println(
+                "@ScrollingPreview(GIF) on '$previewId': no scrollable composable — falling through.",
+            )
+            return false
+        }
+        if (frameFiles.isEmpty()) return false
+
+        // Mirror [handleLongCapture]'s post-scroll settle: re-capture the
+        // final frame after advancing the clock so animations that begin
+        // once the scroll lands (Wear `EdgeButton` reveal, spring overshoot)
+        // show their resting state at the end of the GIF rather than a
+        // caught-mid-reveal transient. Previous frames stay as captured —
+        // they represent the scroll-in-progress state, which is what a
+        // user would see while scrolling.
+        settlePostScrollAnimations(rule)
+        val lastFrameFile = frameFiles.last()
+        lastFrameFile.delete()
+        rule.onRoot().captureRoboImage(file = lastFrameFile, roborazziOptions = frameRoborazziOptions)
+
+        val frames = frameFiles.map {
+            javax.imageio.ImageIO.read(it) ?: error("Failed to read GIF frame PNG: $it")
+        }
+        val delay = if (scroll.frameIntervalMs > 0) scroll.frameIntervalMs
+                    else ScrollGifEncoder.DEFAULT_FRAME_DELAY_MS
+        val written = ScrollGifEncoder.encode(frames, outputFile, delay) ?: return false
+        System.err.println(
+            "@ScrollingPreview(GIF) on '$previewId': encoded ${frames.size} frames → ${written.name}.",
+        )
+        return true
+    } finally {
+        framesDir.deleteRecursively()
+    }
+}
+
+// 20% of viewport per step balances smoothness against frame count.
+private const val GIF_STEP_FRACTION = 0.2f
 
 /**
  * Adds Robolectric's `+round` qualifier so `Configuration.isScreenRound` becomes

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollGifEncoder.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollGifEncoder.kt
@@ -1,0 +1,129 @@
+package ee.schimke.composeai.renderer
+
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.IIOImage
+import javax.imageio.ImageIO
+import javax.imageio.ImageTypeSpecifier
+import javax.imageio.ImageWriteParam
+import javax.imageio.ImageWriter
+import javax.imageio.metadata.IIOMetadata
+import javax.imageio.metadata.IIOMetadataNode
+import javax.imageio.stream.FileImageOutputStream
+
+/**
+ * Encodes a sequence of same-sized `BufferedImage` frames as an animated
+ * GIF at [outputFile], looping forever at [frameDelayMs] per frame.
+ *
+ * Built on `javax.imageio`'s standard GIF writer plugin — no extra deps.
+ * Two GIF-specific knobs are driven through the metadata tree that
+ * `ImageWriter` exposes:
+ *
+ *  - `GraphicControlExtension` per frame carries the `delayTime`
+ *    (hundredths of a second) and a `disposalMethod=none` so consecutive
+ *    frames composite atop each other without flicker.
+ *  - One `ApplicationExtensions / NETSCAPE2.0` record on the first frame
+ *    signals infinite looping (`loopCount=0`). Without it most viewers
+ *    play once and stop.
+ *
+ * GIF's palette is 256 colours per frame; for the UI-scroll case (flat
+ * colours, anti-aliased text) the default `ImageIO` quantiser produces
+ * acceptable output. If we ever need higher fidelity, NeuQuant / octree
+ * dithering sits behind the same metadata plumbing.
+ *
+ * [ScrollMode.GIF] captures call this with one BufferedImage per scroll
+ * step. Returns the written file, or `null` if [frames] is empty or the
+ * GIF writer plugin isn't registered (never, on a standard JRE).
+ */
+internal object ScrollGifEncoder {
+    const val DEFAULT_FRAME_DELAY_MS: Int = 80
+    const val MIN_FRAME_DELAY_MS: Int = 20
+
+    fun encode(
+        frames: List<BufferedImage>,
+        outputFile: File,
+        frameDelayMs: Int = DEFAULT_FRAME_DELAY_MS,
+    ): File? {
+        if (frames.isEmpty()) return null
+        val writer = ImageIO.getImageWritersByFormatName("gif").asSequence().firstOrNull()
+            ?: return null
+
+        // GIF timing resolution is 1/100s. Rounding down to the nearest 10ms
+        // keeps our nominal delay honest; clamped to 20ms because many
+        // browsers treat <20ms as "use default ~100ms", which silently breaks
+        // fast-cadence encodes.
+        val delayCentiseconds = (frameDelayMs.coerceAtLeast(MIN_FRAME_DELAY_MS) / 10).coerceAtLeast(2)
+
+        outputFile.parentFile?.mkdirs()
+        FileImageOutputStream(outputFile).use { stream ->
+            writer.output = stream
+            val param: ImageWriteParam = writer.defaultWriteParam
+            val first = frames.first()
+            val imageType = ImageTypeSpecifier.createFromRenderedImage(first)
+            val meta = writer.getDefaultImageMetadata(imageType, param)
+            configureFrameMetadata(meta, delayCentiseconds, loopForever = true)
+
+            writer.prepareWriteSequence(null)
+            writer.writeToSequence(IIOImage(first, null, meta), param)
+
+            for (i in 1 until frames.size) {
+                val frameMeta = writer.getDefaultImageMetadata(imageType, param)
+                configureFrameMetadata(frameMeta, delayCentiseconds, loopForever = false)
+                writer.writeToSequence(IIOImage(frames[i], null, frameMeta), param)
+            }
+            writer.endWriteSequence()
+        }
+        writer.dispose()
+        return outputFile
+    }
+
+    /**
+     * Writes the per-frame `GraphicControlExtension` (delay + disposal) and,
+     * on the first frame only, the `ApplicationExtensions / NETSCAPE2.0`
+     * sub-block that switches on infinite looping.
+     *
+     * `IIOMetadata` is navigated through `javax_imageio_gif_image_1.0`'s tree
+     * shape — the names and attribute keys here are what
+     * `GIFImageMetadata` declares, not invented by us.
+     */
+    private fun configureFrameMetadata(
+        meta: IIOMetadata,
+        delayCentiseconds: Int,
+        loopForever: Boolean,
+    ) {
+        val format = meta.nativeMetadataFormatName
+        val root = meta.getAsTree(format) as IIOMetadataNode
+
+        val gce = getOrCreateChild(root, "GraphicControlExtension")
+        gce.setAttribute("disposalMethod", "none")
+        gce.setAttribute("userInputFlag", "FALSE")
+        gce.setAttribute("transparentColorFlag", "FALSE")
+        gce.setAttribute("delayTime", delayCentiseconds.toString())
+        gce.setAttribute("transparentColorIndex", "0")
+
+        if (loopForever) {
+            val appExts = getOrCreateChild(root, "ApplicationExtensions")
+            val appExt = IIOMetadataNode("ApplicationExtension")
+            appExt.setAttribute("applicationID", "NETSCAPE")
+            appExt.setAttribute("authenticationCode", "2.0")
+            // 3-byte sub-block: { 0x01, loopCount_lo, loopCount_hi } — 0 = forever.
+            appExt.userObject = byteArrayOf(0x1, 0x0, 0x0)
+            appExts.appendChild(appExt)
+        }
+
+        meta.setFromTree(format, root)
+    }
+
+    private fun getOrCreateChild(parent: IIOMetadataNode, name: String): IIOMetadataNode {
+        var child = parent.firstChild
+        while (child != null) {
+            if (child.nodeName.equals(name, ignoreCase = true)) {
+                return child as IIOMetadataNode
+            }
+            child = child.nextSibling
+        }
+        val created = IIOMetadataNode(name)
+        parent.appendChild(created)
+        return created
+    }
+}

--- a/sample-android/src/main/kotlin/com/example/sampleandroid/ScrollPreviews.kt
+++ b/sample-android/src/main/kotlin/com/example/sampleandroid/ScrollPreviews.kt
@@ -16,15 +16,19 @@ import ee.schimke.composeai.preview.ScrollMode
 import ee.schimke.composeai.preview.ScrollingPreview
 
 /**
- * Demo fixture for `@ScrollingPreview`. 40 stacked bands going red (top)
- * → blue (bottom), each taller than the preview viewport so the top-of-list
- * capture is dominantly red and the scrolled-to-end capture is dominantly
- * blue. Pixel assertions in `:gradle-plugin:functionalTest` / manual eyes
- * both key off this gradient.
+ * Demo fixture for `@ScrollingPreview`. Stacked bands going red (top)
+ * → blue (bottom), each taller than the preview viewport so the
+ * top-of-list capture is dominantly red and the scrolled-to-end capture
+ * is dominantly blue. Pixel assertions in `:gradle-plugin:functionalTest`
+ * / manual eyes both key off this gradient.
+ *
+ * [count] defaults to 40 for the full-viewport TOP/END fixture; callers
+ * driving a smaller viewport (e.g. the GIF preview below) can pass a
+ * smaller value so the scroll extent fits inside the renderer's default
+ * iteration budget.
  */
 @Composable
-fun RedToBlueList() {
-    val count = 40
+fun RedToBlueList(count: Int = 40) {
     LazyColumn(modifier = Modifier.fillMaxWidth()) {
         items((0 until count).toList()) { index ->
             val t = index.toFloat() / (count - 1).toFloat()
@@ -50,4 +54,27 @@ fun RedToBlueList() {
 @Composable
 fun RedToBlueScrollPreview() {
     RedToBlueList()
+}
+
+/**
+ * Animated-GIF capture of the same scroll. Produces a single `.gif`
+ * showing the scroll from top (mostly red) to end (mostly blue). The
+ * pixel test in [ScrollPreviewPixelTest] decodes the GIF and asserts
+ * that frame 0 is red-dominant while the last frame is blue-dominant —
+ * proving both that we scroll, and that frames round-trip through the
+ * GIF encoder/decoder intact.
+ *
+ * Sized down via `widthDp`/`heightDp`: the default sandbox (400×800dp,
+ * ≈1050×2100px at 2.625×) produces a ~600KB demo GIF, which is more
+ * than this fixture needs. A 160×320dp viewport still shows 5 bands
+ * per frame — plenty to prove the scroll moves through the gradient —
+ * at ~1/6 the pixel budget. List length drops to 16 so the total scroll
+ * extent fits inside [driveScrollByViewport]'s default iteration budget;
+ * the animation therefore terminates at a fully blue-dominant last frame.
+ */
+@Preview(name = "ScrollGif", showBackground = true, widthDp = 160, heightDp = 320)
+@ScrollingPreview(modes = [ScrollMode.GIF])
+@Composable
+fun RedToBlueScrollGifPreview() {
+    RedToBlueList(count = 16)
 }

--- a/sample-android/src/main/kotlin/com/example/sampleandroid/SettingsListScrollGifPreview.kt
+++ b/sample-android/src/main/kotlin/com/example/sampleandroid/SettingsListScrollGifPreview.kt
@@ -1,0 +1,210 @@
+package com.example.sampleandroid
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import ee.schimke.composeai.preview.ScrollMode
+import ee.schimke.composeai.preview.ScrollingPreview
+
+/**
+ * A realistic scrolling-GIF demo: a 24-row settings-style list with a
+ * leading colour-chip avatar + two-line text, and a right-aligned scroll
+ * position indicator that tracks the visible window.
+ *
+ * This is the "what you'd actually screenshot in docs" fixture, sized
+ * close to a small phone viewport (220×440dp ≈ 580×1155px at 2.625×). The
+ * red-to-blue pixel-test fixture in [RedToBlueScrollGifPreview] stays
+ * minimal; this one is the visual showcase for PRs / READMEs.
+ */
+@Preview(name = "SettingsListScrollGif", showBackground = true, widthDp = 220, heightDp = 440)
+@ScrollingPreview(modes = [ScrollMode.GIF])
+@Composable
+fun SettingsListScrollGifPreview() {
+    val state = rememberLazyListState()
+    Box(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            state = state,
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            items(SETTINGS_ROWS) { row ->
+                SettingsRow(row = row)
+                HorizontalDivider(
+                    thickness = 0.5.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                )
+            }
+        }
+        ScrollPositionIndicator(
+            state = state,
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(vertical = 8.dp, horizontal = 3.dp)
+                .width(3.dp)
+                .fillMaxHeight(),
+        )
+    }
+}
+
+@Composable
+private fun SettingsRow(row: SettingsRowData) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(28.dp)
+                .background(row.tint, CircleShape),
+        )
+        Column(
+            modifier = Modifier
+                .padding(start = 12.dp)
+                .weight(1f),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(row.title, style = MaterialTheme.typography.titleSmall, maxLines = 1)
+            Text(
+                row.subtitle,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+/**
+ * A thin scrollbar-style indicator that shows the visible window as a
+ * rounded thumb on a faint track. Derives the thumb's top / height
+ * fractions directly from [LazyListState.layoutInfo] — wrapping in
+ * [derivedStateOf] so recomposition only triggers when the thumb actually
+ * moves, not on every scroll frame.
+ *
+ * Rolled by hand rather than pulled from a library because (a) Compose
+ * Material3 doesn't ship a `Scrollbar` today and (b) a few composables'
+ * worth of code avoids pulling `accompanist` / `scrollbar` deps into the
+ * sample module.
+ */
+@Composable
+private fun ScrollPositionIndicator(
+    state: LazyListState,
+    modifier: Modifier = Modifier,
+) {
+    val thumb by remember {
+        derivedStateOf {
+            val info = state.layoutInfo
+            val visible = info.visibleItemsInfo
+            if (visible.isEmpty() || info.totalItemsCount == 0) {
+                0f to 0f
+            } else {
+                val total = info.totalItemsCount.toFloat()
+                val first = visible.first().index.toFloat()
+                val last = visible.last().index.toFloat()
+                (first / total) to ((last + 1f) / total)
+            }
+        }
+    }
+    val (start, end) = thumb
+    Box(modifier = modifier) {
+        // Track — faint, always visible so the indicator has a stable
+        // geometry reference even on a preview where nothing is being
+        // dragged.
+        Box(
+            Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.06f), RoundedCornerShape(2.dp)),
+        )
+        // Thumb — positioned via BoxWithConstraints so the dp math uses
+        // the parent's actual measured height. `offset(y = ...)` and
+        // `height(...)` both accept Dp, so we do the Dp arithmetic
+        // inside the constraints scope.
+        BoxWithConstraints(Modifier.fillMaxSize()) {
+            val h = maxHeight
+            Box(
+                Modifier
+                    .offset(y = h * start)
+                    .fillMaxWidth()
+                    .height(h * (end - start))
+                    .background(
+                        Color(0xFF6750A4).copy(alpha = 0.65f),
+                        RoundedCornerShape(2.dp),
+                    ),
+            )
+        }
+    }
+}
+
+private data class SettingsRowData(
+    val title: String,
+    val subtitle: String,
+    val tint: Color,
+)
+
+/**
+ * 24 rows, enough that a 220×440dp viewport shows ~7 at a time and the
+ * scroll spans ~3 viewports — comfortably inside
+ * `driveScrollByViewport`'s default 30-iteration budget even at GIF's
+ * 20%-per-step cadence, so the last frame lands at the real end of the
+ * list rather than getting clipped.
+ *
+ * Tint palette walks through the hue wheel so consecutive rows are
+ * visually distinct and the scroll animation reads as actual motion (if
+ * every row looked the same, the scroll would feel static).
+ */
+private val SETTINGS_ROWS: List<SettingsRowData> = listOf(
+    SettingsRowData("Wi-Fi", "HomeNet · 5 GHz", Color(0xFF1E88E5)),
+    SettingsRowData("Bluetooth", "Off", Color(0xFF3949AB)),
+    SettingsRowData("Mobile network", "Vodafone · 4G", Color(0xFF8E24AA)),
+    SettingsRowData("Hotspot", "Not sharing", Color(0xFFD81B60)),
+    SettingsRowData("Notifications", "3 apps silenced", Color(0xFFE53935)),
+    SettingsRowData("Sound", "Ring 80% · Media 60%", Color(0xFFFB8C00)),
+    SettingsRowData("Display", "Adaptive brightness", Color(0xFFFDD835)),
+    SettingsRowData("Wallpaper", "Mountain at dusk", Color(0xFFC0CA33)),
+    SettingsRowData("Accessibility", "Large text · high contrast", Color(0xFF7CB342)),
+    SettingsRowData("Storage", "127 GB free of 256 GB", Color(0xFF43A047)),
+    SettingsRowData("Battery", "74% · 8h 12m left", Color(0xFF00897B)),
+    SettingsRowData("Privacy", "Location off", Color(0xFF00ACC1)),
+    SettingsRowData("Security", "Fingerprint · Face", Color(0xFF039BE5)),
+    SettingsRowData("Google services", "Play Store · Drive", Color(0xFF5E35B1)),
+    SettingsRowData("Accounts", "yuri@example.com", Color(0xFFAB47BC)),
+    SettingsRowData("Backup", "Last: yesterday", Color(0xFFEC407A)),
+    SettingsRowData("System updates", "Up to date", Color(0xFFEF5350)),
+    SettingsRowData("Apps", "128 installed", Color(0xFFFF7043)),
+    SettingsRowData("Digital wellbeing", "4h 12m screen time", Color(0xFFFFCA28)),
+    SettingsRowData("Date & time", "Automatic", Color(0xFF9CCC65)),
+    SettingsRowData("Language", "English (UK)", Color(0xFF26A69A)),
+    SettingsRowData("Keyboard", "Gboard", Color(0xFF29B6F6)),
+    SettingsRowData("Developer options", "USB debugging on", Color(0xFF7E57C2)),
+    SettingsRowData("About phone", "Pixel 9 Pro · build TQ3A", Color(0xFFBDBDBD)),
+)

--- a/sample-android/src/test/kotlin/com/example/sampleandroid/ScrollPreviewPixelTest.kt
+++ b/sample-android/src/test/kotlin/com/example/sampleandroid/ScrollPreviewPixelTest.kt
@@ -1,6 +1,7 @@
 package com.example.sampleandroid
 
 import com.google.common.truth.Truth.assertThat
+import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO
 import org.junit.Test
@@ -66,5 +67,69 @@ class ScrollPreviewPixelTest {
         assertThat(avg.dominant()).isEqualTo('B')
         assertThat(avg.b).isGreaterThan(150.0)
         assertThat(avg.r).isLessThan(120.0)
+    }
+
+    /**
+     * End-to-end check of the [ScrollMode.GIF] pipeline: driver captures
+     * each frame, encoder lays them into a NETSCAPE-looping GIF, and a
+     * standard `ImageIO` reader on the other side can decode the frames
+     * back out.
+     *
+     * Keyed off the single-mode `GIF` annotation on [RedToBlueScrollGifPreview],
+     * so the output file is `...RedToBlueScrollGifPreview_ScrollGif.gif`
+     * without the `_SCROLL_gif` suffix multi-mode would add.
+     */
+    @Test
+    fun `GIF capture animates red to blue`() {
+        val gifName = "com.example.sampleandroid.ScrollPreviewsKt.RedToBlueScrollGifPreview_ScrollGif.gif"
+        val file = File(rendersDir, gifName)
+        assertThat(file.exists()).isTrue()
+
+        val frames = readGifFrames(file)
+        // Need at least two frames for an animation, and the driver should
+        // typically produce many more (several per viewport).
+        assertThat(frames.size).isAtLeast(2)
+
+        val first = avgOfImage(frames.first())
+        val last = avgOfImage(frames.last())
+        // Frame 0 is the unscrolled top → red-dominant.
+        assertThat(first.dominant()).isEqualTo('R')
+        // Final frame is at (or near) the end → blue-dominant. Wider
+        // tolerances than the PNG END test because GIF quantisation shifts
+        // per-channel averages by a few points.
+        assertThat(last.dominant()).isEqualTo('B')
+        assertThat(last.b).isGreaterThan(130.0)
+        assertThat(last.r).isLessThan(140.0)
+    }
+
+    private fun avgOfImage(img: BufferedImage): Avg {
+        var rs = 0L
+        var gs = 0L
+        var bs = 0L
+        val w = img.width
+        val h = img.height
+        for (y in 0 until h) for (x in 0 until w) {
+            val argb = img.getRGB(x, y)
+            rs += (argb shr 16) and 0xff
+            gs += (argb shr 8) and 0xff
+            bs += argb and 0xff
+        }
+        val n = (w * h).toDouble()
+        return Avg(rs / n, gs / n, bs / n)
+    }
+
+    /**
+     * Reads every frame of an animated GIF into a list of [BufferedImage].
+     * Uses the standard `javax.imageio` GIF reader plugin — same plugin
+     * [ScrollGifEncoder] writes against, so this doubles as a round-trip
+     * check on the encoder's metadata tree.
+     */
+    private fun readGifFrames(file: File): List<BufferedImage> {
+        val reader = ImageIO.getImageReadersByFormatName("gif").next()
+        javax.imageio.stream.FileImageInputStream(file).use { input ->
+            reader.input = input
+            val count = reader.getNumImages(true)
+            return List(count) { reader.read(it) }
+        }
     }
 }

--- a/vscode-extension/src/captureLabels.ts
+++ b/vscode-extension/src/captureLabels.ts
@@ -37,6 +37,7 @@ function scrollLabel(scroll: NonNullable<Capture['scroll']>): string {
     if (scroll.reachedPx != null) return `scrolled ${scroll.reachedPx}px`;
     if (scroll.mode === 'END') return 'scroll end';
     if (scroll.mode === 'LONG') return 'scroll long';
+    if (scroll.mode === 'GIF') return 'scroll gif';
     return `scroll ${scroll.mode.toLowerCase()}`;
 }
 

--- a/vscode-extension/src/previewHoverProvider.ts
+++ b/vscode-extension/src/previewHoverProvider.ts
@@ -28,8 +28,15 @@ export class PreviewHoverProvider implements vscode.HoverProvider {
             md.appendMarkdown(`**${det.functionName}** — Compose Preview\n\n`);
 
             if (entry?.imageBase64) {
+                // Derive MIME from the primary capture's renderOutput so
+                // GIF-mode previews hover as animated GIFs instead of a
+                // static first frame interpreted as PNG.
+                const primary = entry.preview.captures?.[0]?.renderOutput ?? '';
+                const mime = typeof primary === 'string' && primary.toLowerCase().endsWith('.gif')
+                    ? 'image/gif'
+                    : 'image/png';
                 md.appendMarkdown(
-                    `<img src="data:image/png;base64,${entry.imageBase64}" `
+                    `<img src="data:${mime};base64,${entry.imageBase64}" `
                     + `width="${HOVER_IMG_MAX}" height="${HOVER_IMG_MAX}" />`,
                 );
             } else {

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -281,6 +281,19 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             return id.replace(/[^a-zA-Z0-9_-]/g, '_');
         }
 
+        // Data-URL MIME for a preview image, derived from its renderOutput
+        // extension. @ScrollingPreview(GIF) captures land at .gif; all
+        // other captures are PNG. Browsers sniff magic bytes and would
+        // actually render a GIF served as image/png — but declaring the
+        // right type matters for the webview's img fallback/accessibility
+        // paths and avoids a console warning when saving the preview.
+        function mimeFor(renderOutput) {
+            return typeof renderOutput === 'string' &&
+                renderOutput.toLowerCase().endsWith('.gif')
+                ? 'image/gif'
+                : 'image/png';
+        }
+
         // Per-preview carousel runtime state — imageData / errorMessage per
         // capture. Populated from updateImage / setImageError messages so
         // prev/next navigation can swap the visible <img> without a fresh
@@ -315,6 +328,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             card.dataset.currentIndex = '0';
             cardCaptures.set(p.id, captures.map(c => ({
                 label: c.label || '',
+                renderOutput: c.renderOutput || '',
                 imageData: null,
                 errorMessage: null,
             })));
@@ -477,7 +491,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     img.alt = card.dataset.function + ' preview';
                     container.appendChild(img);
                 }
-                img.src = 'data:image/png;base64,' + capture.imageData;
+                img.src = 'data:' + mimeFor(capture.renderOutput) + ';base64,' + capture.imageData;
                 img.className = 'fade-in';
             } else if (capture.errorMessage) {
                 container.innerHTML = '<div class="error-message" role="alert">' + escapeHtml(capture.errorMessage) + '</div>';
@@ -647,6 +661,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             // annotation). Mismatched positions just reset to null-image.
             const mergedCaps = newCaps.map((nc, i) => ({
                 label: nc.label,
+                renderOutput: nc.renderOutput || '',
                 imageData: prior[i]?.imageData ?? null,
                 errorMessage: prior[i]?.errorMessage ?? null,
             }));
@@ -989,7 +1004,8 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             if (errorMsg) errorMsg.remove();
             card.classList.remove('has-error');
 
-            const newSrc = 'data:image/png;base64,' + imageData;
+            const ro = caps && caps[captureIndex] ? caps[captureIndex].renderOutput : '';
+            const newSrc = 'data:' + mimeFor(ro) + ';base64,' + imageData;
 
             // If the user is viewing a history snapshot, don't clobber it —
             // stash the new latest so closing the drawer reveals the update.


### PR DESCRIPTION
## Goal

Build a scroll mode that generates an animated GIF of scrolling from top to bottom (or MP4 / other video if that's a better choice). Build on top of anthropics/compose-ai-tools#104 — the multi-mode `@ScrollingPreview` — after pulling main.

Follow-up ask: add a more typical scrolling demo (a LazyColumn with a position indicator) as a **new** preview rather than replacing the pixel-test fixture.

## Summary

### Format choice — GIF, not MP4

Picked animated GIF. `javax.imageio` ships a GIF writer plugin (no new deps vs. a JCodec / FFmpeg MP4 path), GIFs embed inline in GitHub PR comments / VSCode webview / IDE hover without a player, and scroll content compresses well under LZW. MP4 can be added behind the same `driveScrollByViewport` → encoder seam later if GIF size ever becomes a problem.

### Changes

- **Annotation** — new `ScrollMode.GIF` + `frameIntervalMs: Int = 80` knob in [ScrollingPreview.kt](preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/ScrollingPreview.kt). `DEFAULT_GIF_FRAME_INTERVAL_MS` exposed as a top-level const (Kotlin annotations can't carry a companion object).
- **Manifest plumbing** — `ScrollMode.GIF` mirrored on plugin-side [PreviewData.kt](gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt) and renderer-side [RenderManifest.kt](renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt); `frameIntervalMs` added to `ScrollCapture`.
- **Discovery** — [DiscoverPreviewsTask.kt:237](gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt:237) branches the capture extension per-mode (`.gif` for GIF, `.png` otherwise) so multi-mode annotations like `modes = [END, GIF]` produce one PNG + one GIF from the same function. `frameIntervalMs` round-trips onto every capture even for non-GIF modes (uniform JSON shape; non-GIF modes ignore it).
- **Renderer** — new `handleGifCapture` in [RobolectricRenderTest.kt](renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt) reuses `driveScrollByViewport` at 20% step (≈5 frames per viewport), captures each step to a temp PNG, encodes via `ScrollGifEncoder`. Mirrors the post-scroll `settlePostScrollAnimations` + last-frame re-capture that main added for LONG (#105-ish), so Wear `EdgeButton` reveals / spring overshoots land settled in the final GIF frame.
- **Encoder** — new [ScrollGifEncoder.kt](renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollGifEncoder.kt) using `javax.imageio`'s `ImageWriter.prepareWriteSequence` with per-frame `GraphicControlExtension` (delay, disposal=none) and a one-shot `ApplicationExtensions/NETSCAPE2.0` record for infinite looping.
- **Sample + pixel test** — `RedToBlueScrollGifPreview` as the test fixture (160×320dp, 16 bands; the viewport change is why the list count drops from 40 — default iteration budget otherwise clips the scroll short of blue). `ScrollPreviewPixelTest` decodes the GIF frame-by-frame via `javax.imageio` and asserts frame 0 red-dominant, last frame blue-dominant — covers both the scroll drive and the encoder/decoder round-trip.
- **New visual demo** — [SettingsListScrollGifPreview.kt](sample-android/src/main/kotlin/com/example/sampleandroid/SettingsListScrollGifPreview.kt): 24-row settings-style LazyColumn with coloured avatar chips, two-line text, and a hand-rolled `ScrollPositionIndicator` (derivedStateOf over `LazyListState.layoutInfo`, no `accompanist` dep). 220×440dp viewport.
- **VSCode extension** — `mimeFor(renderOutput)` helper in [previewPanel.ts](vscode-extension/src/previewPanel.ts) picks `image/gif` vs `image/png` from the file extension for three `data:` URL sites (carousel image, update path, history); same logic in [previewHoverProvider.ts](vscode-extension/src/previewHoverProvider.ts) for the CodeLens hover. Carousel capture map now carries `renderOutput` so it reaches the webview runtime. `captureLabels.ts` gets a `'scroll gif'` branch.
- **Functional test** — [DiscoveryFunctionalTest.kt](gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt) stub grows `ScrollMode.GIF` + `frameIntervalMs` and asserts (a) single-mode GIF lands at `renders/<id>.gif`, (b) `frameIntervalMs` round-trips onto the manifest, (c) a mixed `modes = [END, GIF]` preview emits both `.png` + `.gif` under the existing `_SCROLL_<mode>` naming convention.

### Things tried and abandoned

- **`maxFrames: Int` knob on `@ScrollingPreview`** — considered for capping GIF size on infinite lists. Dropped after user input: `maxScrollPx` already caps scroll distance, and a second cap isn't worth the API surface for a first pass.
- **MP4 via JCodec** — rejected upfront (see Format choice).
- **Settling per-frame in the GIF loop** — too expensive and bends the "this is what the user would see mid-scroll" semantics. Only the final frame gets the settle, same as LONG.

### Known gaps

- **HistorizePreviewsTask is still `.png`-only** ([HistorizePreviewsTask.kt:59](gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/HistorizePreviewsTask.kt:59)). It also only handles single-capture previews (already misses multi-mode TOP/END, LONG, and TIME variants today), so GIF non-historization is consistent with existing behaviour. Scope-creep to fix here.
- **`javax.imageio`'s GIF writer doesn't do interframe delta-encoding.** Each frame carries its own full-image LZW record. Acceptable for short scrolls (demo fixtures come in at ~600KB–1MB); tall lists will be chunky. A `gifsicle` post-pass or a hand-rolled delta encoder could shrink this later.
- **Horizontal axis untouched for GIF** — same pre-existing limitation as LONG; guarded with the same `axis == VERTICAL` gate.

### Verification

- `./gradlew check` — full suite green after rebase onto main (which had just merged the LONG post-scroll settle fix; resolved the conflict by keeping both + reusing the settle helper for GIF).
- `./gradlew :gradle-plugin:functionalTest` — new GIF discovery assertions pass.
- `./gradlew :sample-android:test` — new `GIF capture animates red to blue` test passes; decodes 18 GIF frames and verifies colour dominance at head + tail.
- `vscode-extension` — `npm run compile` + `npm test` (55 passing).
- **Rendered previews read locally:**
  - `com.example.sampleandroid.ScrollPreviewsKt.RedToBlueScrollGifPreview_ScrollGif.gif` — red → blue, 18 frames, 420×840.
  - `com.example.sampleandroid.SettingsListScrollGifPreviewKt.SettingsListScrollGifPreview_SettingsListScrollGif.gif` — Wi-Fi → About phone, 26 frames, 577×1155, scroll thumb tracks visible window correctly.