### PR TITLE
fix(doctor): flag Gradle versions below AGP 9.1.x's floor

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -100,11 +100,17 @@ internal object AndroidPreviewSupport {
         val testRuntimeRoot = project.configurations.findByName("${variantName}UnitTestRuntimeClasspath")
             ?.incoming?.resolutionResult?.rootComponent
 
+        // Capture the running Gradle version at configuration time so the
+        // task action stays config-cache safe (GradleVersion.current() is a
+        // static call but keeping the read out of `@TaskAction` avoids
+        // surprises if Gradle ever namespaces it differently).
+        val currentGradleVersion = org.gradle.util.GradleVersion.current().version
         project.tasks.register("composePreviewDoctor", ee.schimke.composeai.plugin.tooling.ComposePreviewDoctorTask::class.java) {
             group = "compose preview"
             description = "Write compose-preview doctor findings to build/compose-previews/doctor.json"
             this.variant.set(variantName)
             this.modulePath.set(project.path)
+            this.gradleVersion.set(currentGradleVersion)
             this.outputFile.set(previewOutputDir.map { it.file("doctor.json") })
             mainRuntimeRoot?.let { this.mainRuntimeRoot.set(it) }
             testRuntimeRoot?.let { this.testRuntimeRoot.set(it) }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
@@ -16,6 +16,26 @@ import java.time.YearMonth
 internal object CompatRules {
 
     /**
+     * Effective minimum Gradle version for consumers applying the plugin.
+     *
+     * The binding constraint is **AGP's own floor**, not any API we use:
+     * AGP 9.1.x requires Gradle 9.3.1+ (per the AGP release notes), and
+     * AGP itself rejects older Gradle at its own version check — long
+     * before our `apply()` runs. The plugin's own code only reaches
+     * Gradle APIs that have been stable since the 8.x line, so there's
+     * no floor we set independently of AGP.
+     *
+     * Keep this in lockstep with AGP's documented minimum when bumping
+     * `libs.versions.toml`:
+     *   AGP 9.0.x → Gradle 9.1.0
+     *   AGP 9.1.x → Gradle 9.3.1
+     *
+     * The repo wrapper (currently 9.4.1) is the dev/test toolchain — not
+     * a floor we impose on consumers. Don't conflate the two.
+     */
+    internal val GRADLE_MIN = Semver(9, 3, 1)
+
+    /**
      * activity 1.11+ transitively brought `androidx.navigationevent:1.0.0`.
      * Consumers whose main variant has older activity end up with the
      * `ComponentActivity` classes expecting `R.id.view_tree_…` resources
@@ -56,16 +76,55 @@ internal object CompatRules {
      * ordered by severity. Pure — safe to call from tests and from the
      * serialisation path.
      */
-    fun evaluate(main: Map<String, String>, test: Map<String, String>): List<ModuleFindingData> {
+    fun evaluate(
+        main: Map<String, String>,
+        test: Map<String, String>,
+        gradleVersion: String? = null,
+    ): List<ModuleFindingData> {
         val findings = mutableListOf<ModuleFindingData>()
         val mainV = parseVersions(main)
         val testV = parseVersions(test)
+        checkGradleVersion(gradleVersion)?.let(findings::add)
         checkUiTestManifest(testV)?.let(findings::add)
         checkNavigationEvent(mainV, testV, main)?.let(findings::add)
         checkComposeUiVsCore(mainV, testV, main)?.let(findings::add)
         checkComposeBom(main)?.let(findings::add)
         findings += checkOldDeps(mainV, testV, main, test)
         return findings
+    }
+
+    /**
+     * Flags Gradle versions below [GRADLE_MIN]. Parameter is the raw version
+     * string from `GradleVersion.current().version` (e.g. `"9.3.1"`,
+     * `"9.4.1"`, `"9.5.0-rc-1"`). `null` means the caller didn't plumb the
+     * version through — keeps the pre-existing call sites and tests working
+     * without forcing every path to know about Gradle's runtime.
+     *
+     * On paper this is unreachable in an AGP build — AGP's own compat check
+     * fails the build before `apply()` runs. In practice the rule is still
+     * worth keeping for two reasons: CMP Desktop builds don't have AGP
+     * guarding the gate, and a clear "gradle-too-old" finding beats the
+     * Tooling API's opaque `Could not execute build using connection to
+     * Gradle distribution …` wrapper when something does slip through.
+     */
+    private fun checkGradleVersion(gradleVersion: String?): ModuleFindingData? {
+        val raw = gradleVersion ?: return null
+        val parsed = Semver.parseOrNull(raw) ?: return null
+        if (parsed >= GRADLE_MIN) return null
+        return ModuleFindingData(
+            id = "gradle-too-old",
+            severity = "error",
+            message = "Gradle $raw is below AGP 9.1.x's minimum ($GRADLE_MIN)",
+            detail = "AGP 9.1.x requires Gradle >= $GRADLE_MIN. The plugin itself only uses APIs " +
+                "stable since Gradle 8.x, so the floor comes from AGP — on an Android build AGP's " +
+                "own compat check fails before this rule even fires. The finding is still emitted " +
+                "for CMP Desktop projects (no AGP gate) and to give a clear remediation when the " +
+                "Tooling API wraps the real cause in a generic `Could not execute build using " +
+                "connection to Gradle distribution …` message.",
+            remediationSummary = "Upgrade the project's Gradle wrapper to >= $GRADLE_MIN.",
+            remediationCommands = listOf("./gradlew wrapper --gradle-version $GRADLE_MIN"),
+            docsUrl = null,
+        )
     }
 
     private fun checkUiTestManifest(test: Map<String, Semver>): ModuleFindingData? {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewDoctorTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewDoctorTask.kt
@@ -44,6 +44,16 @@ abstract class ComposePreviewDoctorTask : DefaultTask() {
     @get:Input
     abstract val modulePath: Property<String>
 
+    /**
+     * Gradle runtime version, e.g. `"9.4.1"`. Wired at task-registration
+     * time from `GradleVersion.current().version` so [CompatRules] can
+     * flag consumers on older wrappers than the plugin supports. Kept as
+     * a plain [Property<String>] rather than a non-serialisable Gradle
+     * object so the configuration-cache image round-trips cleanly.
+     */
+    @get:Input
+    abstract val gradleVersion: Property<String>
+
     @get:Internal
     abstract val mainRuntimeRoot: Property<ResolvedComponentResult>
 
@@ -58,7 +68,7 @@ abstract class ComposePreviewDoctorTask : DefaultTask() {
         val variantName = variant.get()
         val main = collectModuleVersions(mainRuntimeRoot.orNull)
         val test = collectModuleVersions(testRuntimeRoot.orNull)
-        val findings = CompatRules.evaluate(main, test)
+        val findings = CompatRules.evaluate(main, test, gradleVersion.orNull)
         val report = DoctorModuleReport(
             schema = SCHEMA,
             module = modulePath.get(),

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
@@ -36,7 +36,8 @@ internal class ComposePreviewModelBuilder : ToolingModelBuilder {
         val variant = resolveVariant(project)
         val main = resolveConfiguration(project, "${variant}RuntimeClasspath")
         val test = resolveConfiguration(project, "${variant}UnitTestRuntimeClasspath")
-        val findings: List<ModuleFinding> = CompatRules.evaluate(main, test)
+        val gradleVersion = org.gradle.util.GradleVersion.current().version
+        val findings: List<ModuleFinding> = CompatRules.evaluate(main, test, gradleVersion)
         val info: ModuleInfo = ModuleInfoData(variant, main, test, findings)
         return ComposePreviewModelData(PluginVersion.value, mapOf(project.path to info))
     }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
@@ -126,6 +126,47 @@ class CompatRulesTest {
         assertNull(findings.firstOrNull { it.id.startsWith("old-dep-androidx.activity") })
     }
 
+    @Test fun `old gradle fires error`() {
+        val findings = CompatRules.evaluate(
+            mainWithBom(),
+            mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
+            gradleVersion = "9.2.1",
+        )
+        val f = findings.single { it.id == "gradle-too-old" }
+        assertEquals("error", f.severity)
+        assertTrue("9.2.1" in f.message)
+        assertTrue(f.remediationCommands.any { "gradle-version" in it })
+    }
+
+    @Test fun `minimum gradle is quiet`() {
+        val findings = CompatRules.evaluate(
+            mainWithBom(),
+            mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
+            gradleVersion = CompatRules.GRADLE_MIN.toString(),
+        )
+        assertNull(findings.firstOrNull { it.id == "gradle-too-old" })
+    }
+
+    @Test fun `newer gradle is quiet`() {
+        val findings = CompatRules.evaluate(
+            mainWithBom(),
+            mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
+            gradleVersion = "9.9.0",
+        )
+        assertNull(findings.firstOrNull { it.id == "gradle-too-old" })
+    }
+
+    @Test fun `absent gradle version emits no finding`() {
+        // Back-compat: callers that don't plumb the running Gradle version
+        // still get the dependency checks without a bogus "unknown version"
+        // finding.
+        val findings = CompatRules.evaluate(
+            mainWithBom(),
+            mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
+        )
+        assertNull(findings.firstOrNull { it.id == "gradle-too-old" })
+    }
+
     @Test fun `semver parses and compares`() {
         assertEquals(Semver(1, 16, 0), Semver.parseOrNull("1.16.0"))
         assertEquals(Semver(1, 16, 0), Semver.parseOrNull("1.16"))


### PR DESCRIPTION
## Summary

- New `gradle-too-old` rule in `CompatRules` — flags consumers running below AGP 9.1.x's documented Gradle minimum (**9.3.1**), with a concrete `./gradlew wrapper --gradle-version 9.3.1` remediation. Surfaces in both the CLI (`compose-preview doctor`) and the VS Code Problems panel, with no changes needed in either tool (both already render every `ModuleFinding`).
- Plumb `GradleVersion.current().version` through the two doctor paths: `ComposePreviewDoctorTask` (task path, consumed by VS Code) and `ComposePreviewModelBuilder` (Tooling API path, consumed by the CLI). Configuration-cache safe — version is captured at task-registration time into an `@Input Property<String>`.

## Why 9.3.1, not 9.4.1

The plugin's own code only reaches Gradle APIs stable since the 8.x line; there's no floor we impose independently of AGP. AGP 9.1.x requires Gradle 9.3.1+ per the [AGP release notes](https://developer.android.com/build/releases/past-releases/agp-9-1-0-release-notes), and AGP rejects older Gradle at its own version check — before `apply()` runs. The repo wrapper being on 9.4.1 is the dev/test toolchain, not a consumer floor.

The rule still earns its keep for CMP Desktop projects (no AGP gate) and whenever the Tooling API buries the real cause under the generic `Could not execute build using connection to Gradle distribution …` wrapper.

## Test plan

- [x] `./gradlew :gradle-plugin:test --tests "ee.schimke.composeai.plugin.tooling.CompatRulesTest"` — 4 new cases (old fires, minimum quiet, newer quiet, absent-version back-compat) pass alongside the existing suite.
- [x] `./gradlew :gradle-plugin:functionalTest` — green; plugin apply / task wiring unchanged for the live-Gradle paths.
- [x] `./gradlew :sample-android:composePreviewDoctor` — emits `doctor.json` with no findings on the repo's 9.4.1 wrapper (regression check: nothing fires spuriously on a supported version).