### PR TITLE
docs(skill): add upstream source pointer for update checks

### DIFF
--- a/skills/compose-preview/SKILL.md
+++ b/skills/compose-preview/SKILL.md
@@ -9,6 +9,15 @@ Render `@Preview` composables to PNG images without launching Android Studio.
 Works on both Android (Jetpack Compose via Robolectric) and Compose Multiplatform
 Desktop (via `ImageComposeScene` + Skia).
 
+## Source
+
+This skill is maintained at
+[github.com/yschimke/compose-ai-tools](https://github.com/yschimke/compose-ai-tools)
+under `skills/compose-preview/`. To check for updates, compare the installed
+copy against the `main` branch there (e.g. `git ls-remote
+https://github.com/yschimke/compose-ai-tools HEAD` for the latest commit, or
+fetch `skills/compose-preview/SKILL.md` from `main` and diff).
+
 ## What this skill provides
 
 - A Gradle plugin (`ee.schimke.composeai.preview`) that discovers `@Preview`


### PR DESCRIPTION
## Summary

Adds a **Source** section near the top of [skills/compose-preview/SKILL.md](skills/compose-preview/SKILL.md) pointing at `github.com/yschimke/compose-ai-tools` under `skills/compose-preview/`, with a quick recipe for checking for updates (`git ls-remote`, or fetch the `main` copy and diff).

## Why

The skill ships without any in-file hint of where it came from, so neither a user nor an agent can easily answer "is my installed copy up to date?". This gives them a single place to look.

## Notes for reviewer

- Doc-only change, no code impact.
- Section placed right after the intro so it's discoverable without scrolling.