### PR TITLE
feat(renderer): support @PreviewParameter fan-out across Android + Desktop

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -30,6 +30,15 @@ data class PreviewParams(
     val locale: String? = null,
     val group: String? = null,
     val wrapperClassName: String? = null,
+    /**
+     * FQN of the `PreviewParameterProvider` harvested from `@PreviewParameter`
+     * on one of the preview function's parameters, if any. Discovery records
+     * this but does NOT expand captures — the renderer fans out on disk as
+     * `<id>_PARAM_<idx>.<ext>` and the CLI globs those files in [buildResults].
+     */
+    val previewParameterProviderClassName: String? = null,
+    /** Mirrors `@PreviewParameter.limit`. `Int.MAX_VALUE` = take every value. */
+    val previewParameterLimit: Int = Int.MAX_VALUE,
     /** "COMPOSE" or "TILE". Free-form string so unknown future kinds round-trip. */
     val kind: String = "COMPOSE",
 )
@@ -369,7 +378,19 @@ abstract class Command(protected val args: List<String>) {
             val updated = mutableMapOf<String, String>()
 
             for (p in manifest.previews) {
-                val captureResults = p.captures.mapIndexed { index, capture ->
+                // `@PreviewParameter`-driven previews render at
+                // `<renderOutput_base>_PARAM_<idx>.<ext>`, one file per
+                // provider value. The manifest carries a single template
+                // capture; here we glob the actual fan-out and synthesize a
+                // `CaptureResult` per file on disk — keeps the manifest shape
+                // a pure discovery artifact while the CLI reports one entry
+                // per rendered PNG.
+                val captures = if (p.params.previewParameterProviderClassName != null) {
+                    p.captures.flatMap { capture -> expandParamCaptures(module, capture) }
+                } else {
+                    p.captures
+                }
+                val captureResults = captures.mapIndexed { index, capture ->
                     val pngFile = capture.renderOutput
                         .takeIf { it.isNotEmpty() }
                         ?.let { projectDir.resolve("$module/build/compose-previews/$it").canonicalFile }
@@ -424,6 +445,48 @@ abstract class Command(protected val args: List<String>) {
     /** True if the preview has at least one capture with `changed = true`. */
     protected fun PreviewResult.anyChanged(): Boolean =
         captures.any { it.changed == true } || changed == true
+
+    /**
+     * Globs the on-disk `_PARAM_<idx>.<ext>` fan-out for a parameterized
+     * preview capture. The manifest carries one template capture (e.g.
+     * `renders/foo.png`); the renderer writes `renders/foo_PARAM_0.png`,
+     * `renders/foo_PARAM_1.png`, … one per provider value. Returns synthetic
+     * `Capture` rows pointing at each file, or an empty list when nothing
+     * matched — the plugin's `renderAllPreviews` verification already fails
+     * loudly when a parameterized preview rendered no files at all, so we
+     * don't duplicate the error surface here.
+     */
+    private fun expandParamCaptures(module: String, template: Capture): List<Capture> {
+        val rel = template.renderOutput.ifEmpty { return listOf(template) }
+        val file = projectDir.resolve("$module/build/compose-previews/$rel").canonicalFile
+        val dir = file.parentFile ?: return listOf(template)
+        val prefix = file.nameWithoutExtension + "_PARAM_"
+        val ext = ".${file.extension}"
+        val matches = (dir.listFiles() ?: emptyArray())
+            .filter { it.name.startsWith(prefix) && it.name.endsWith(ext) }
+            .sortedBy {
+                // Sort by the numeric index between `_PARAM_` and the
+                // extension so PARAM_10 sorts after PARAM_2 (not before,
+                // which lexicographic ordering would produce). Unparseable
+                // suffixes fall through to Int.MAX_VALUE so they land at
+                // the end deterministically.
+                it.name.removePrefix(prefix).removeSuffix(ext).toIntOrNull() ?: Int.MAX_VALUE
+            }
+        if (matches.isEmpty()) return emptyList()
+        // Preserve the template's time/scroll coordinates — a parameterized
+        // preview is orthogonal to those dimensions. Each fan-out file
+        // points back at the same conceptual capture, just at a different
+        // provider value.
+        val templateDir = rel.substringBeforeLast('/', "")
+        val dirPrefix = if (templateDir.isEmpty()) "" else "$templateDir/"
+        return matches.map { f ->
+            Capture(
+                advanceTimeMillis = template.advanceTimeMillis,
+                scroll = template.scroll,
+                renderOutput = dirPrefix + f.name,
+            )
+        }
+    }
 
     /** Filters by `--id` / `--filter` and (optionally) `--changed-only`. */
     protected fun applyFilters(all: List<PreviewResult>): List<PreviewResult> =

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -671,6 +671,82 @@ class DiscoveryFunctionalTest {
     }
 
     @Test
+    fun `discoverPreviews records @PreviewParameter provider FQN`() {
+        val projectDir = createCmpTestProject()
+
+        val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+        srcFile.writeText(
+            """
+            package test
+
+            import androidx.compose.foundation.background
+            import androidx.compose.foundation.layout.Box
+            import androidx.compose.foundation.layout.size
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+            import androidx.compose.ui.graphics.Color
+            import androidx.compose.ui.tooling.preview.Preview
+            import androidx.compose.ui.tooling.preview.PreviewParameter
+            import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+            import androidx.compose.ui.unit.dp
+
+            class ColorProvider : PreviewParameterProvider<Long> {
+                override val values: Sequence<Long>
+                    get() = sequenceOf(0xFFFF0000L, 0xFF00FF00L, 0xFF0000FFL)
+            }
+
+            @Preview(name = "Swatch")
+            @Composable
+            fun SwatchPreview(
+                @PreviewParameter(ColorProvider::class) color: Long,
+            ) {
+                Box(modifier = Modifier.size(50.dp).background(Color(color.toInt())))
+            }
+
+            // Limit arg: annotation takes only the first entry.
+            @Preview(name = "Limited")
+            @Composable
+            fun LimitedPreview(
+                @PreviewParameter(ColorProvider::class, limit = 1) color: Long,
+            ) {
+                Box(modifier = Modifier.size(50.dp).background(Color(color.toInt())))
+            }
+
+            // No provider — must not surface a previewParameterProviderClassName.
+            @Preview
+            @Composable
+            fun PlainPreview() {
+                Box(modifier = Modifier.size(50.dp).background(Color.Gray))
+            }
+            """.trimIndent()
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("discoverPreviews", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+
+        assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+        val manifest = json.decodeFromString<PreviewManifest>(
+            File(projectDir, "build/compose-previews/previews.json").readText()
+        )
+
+        val swatch = manifest.previews.single { it.functionName == "SwatchPreview" }
+        assertThat(swatch.params.previewParameterProviderClassName).isEqualTo("test.ColorProvider")
+        assertThat(swatch.params.previewParameterLimit).isEqualTo(Int.MAX_VALUE)
+
+        val limited = manifest.previews.single { it.functionName == "LimitedPreview" }
+        assertThat(limited.params.previewParameterProviderClassName).isEqualTo("test.ColorProvider")
+        assertThat(limited.params.previewParameterLimit).isEqualTo(1)
+
+        val plain = manifest.previews.single { it.functionName == "PlainPreview" }
+        assertThat(plain.params.previewParameterProviderClassName).isNull()
+        assertThat(plain.params.previewParameterLimit).isEqualTo(Int.MAX_VALUE)
+    }
+
+    @Test
     fun `discoverPreviews re-runs when source changes`() {
         val projectDir = createCmpTestProject()
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -207,7 +207,23 @@ internal object ComposePreviewTasks {
                     .filter { p ->
                         p.captures.any { c ->
                             val rel = c.renderOutput.ifEmpty { "renders/${p.id}.png" }
-                            !outDir.resolve(rel).exists()
+                            // `@PreviewParameter` previews fan out at render
+                            // time: manifest carries a `<id>.png` template,
+                            // but the actual files live at
+                            // `<id>_PARAM_<idx>.png` (one per provider value).
+                            // Check that at least ONE matching fan-out file
+                            // exists instead of demanding the template itself.
+                            if (p.params.previewParameterProviderClassName != null) {
+                                val file = outDir.resolve(rel)
+                                val dir = file.parentFile ?: outDir
+                                val prefix = file.nameWithoutExtension + "_PARAM_"
+                                val ext = ".${file.extension}"
+                                !(dir.listFiles()?.any { f ->
+                                    f.name.startsWith(prefix) && f.name.endsWith(ext)
+                                } ?: false)
+                            } else {
+                                !outDir.resolve(rel).exists()
+                            }
                         }
                     }
                     .map { it.id }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -73,6 +73,11 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         // Our own opt-in for scrolling-screenshot capture. Matched by FQN so projects
         // that don't depend on `ee.schimke.composeai:preview-annotations` are unaffected.
         private const val SCROLLING_PREVIEW_FQN = "ee.schimke.composeai.preview.ScrollingPreview"
+        // The stable FQN is shared by both Android's ui-tooling-preview and CMP's
+        // `org.jetbrains.compose.components:components-ui-tooling-preview` — Kotlin
+        // `expect`/`actual` collapses onto the same `androidx...` class name on
+        // every target we care about.
+        private const val PREVIEW_PARAMETER_FQN = "androidx.compose.ui.tooling.preview.PreviewParameter"
 
         internal const val TILE_PREVIEW_FQN = "androidx.wear.tiles.tooling.preview.Preview"
 
@@ -185,11 +190,17 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         // whole — each timing fans out into its own manifest entry, orthogonal
         // to any multi-preview expansion.
         val timings = extractRoboTimings(annotations)
+        // @PreviewParameter lives on a method PARAMETER, not the method itself,
+        // so it's sourced from `parameterInfo` rather than the method
+        // annotation list. Extracted once per function and applied to every
+        // multi-preview expansion — the provider is the same no matter which
+        // @Preview drove the fan-out.
+        val previewParameter = extractPreviewParameter(method)
 
         val directPreviews = collectDirectPreviews(annotations)
         if (directPreviews.isNotEmpty()) {
             for (ann in directPreviews) {
-                previews.add(makePreview(classInfo, method, ann, wrapperFqn, scrollSpecs, timings))
+                previews.add(makePreview(classInfo, method, ann, wrapperFqn, scrollSpecs, timings, previewParameter))
             }
             return
         }
@@ -197,9 +208,39 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         for (ann in annotations) {
             val resolved = resolveMultiPreview(ann, scanResult, mutableSetOf())
             for (resolvedAnn in resolved) {
-                previews.add(makePreview(classInfo, method, resolvedAnn, wrapperFqn, scrollSpecs, timings))
+                previews.add(makePreview(classInfo, method, resolvedAnn, wrapperFqn, scrollSpecs, timings, previewParameter))
             }
         }
+    }
+
+    /**
+     * Scans [method]'s parameters for `@PreviewParameter`. Returns the provider
+     * FQN + `limit` of the FIRST parameter that carries the annotation; `null`
+     * when none do. Supporting a single parameter mirrors the current upstream
+     * (Studio/Layoutlib) semantic — multi-param preview functions require
+     * explicit wiring in tooling code, which our renderer doesn't expose.
+     *
+     * ClassGraph surfaces parameter annotations on `MethodParameterInfo.annotationInfo`.
+     * The `value` field on `@PreviewParameter` carries the provider KClass, which
+     * comes back as an [AnnotationClassRef] — we pull its FQN without triggering
+     * classloading (matches how [extractWrapperFqn] handles `@PreviewWrapper`).
+     */
+    private fun extractPreviewParameter(method: MethodInfo): Pair<String, Int>? {
+        val params = method.parameterInfo ?: return null
+        for (param in params) {
+            val anns = param.annotationInfo ?: continue
+            val ann = anns.firstOrNull { it.name == PREVIEW_PARAMETER_FQN } ?: continue
+            val provider = when (val value = ann.parameterValues.getValue("provider")) {
+                is AnnotationClassRef -> value.name
+                is String -> value
+                else -> null
+            } ?: continue
+            val limit = (ann.parameterValues.getValue("limit") as? Int)
+                ?.coerceAtLeast(0)
+                ?: Int.MAX_VALUE
+            return provider to limit
+        }
+        return null
     }
 
     // Tile previews don't go through `mainClock` and can't scroll (the
@@ -392,8 +433,9 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         wrapperClassName: String?,
         scrolls: List<ScrollCapture>,
         timings: List<Long>,
+        previewParameter: Pair<String, Int>?,
     ): PreviewInfo {
-        val params = extractPreviewParams(ann, wrapperClassName)
+        val params = extractPreviewParams(ann, wrapperClassName, previewParameter)
         val fqn = "${classInfo.name}.${method.name}"
         val suffix = buildVariantSuffix(params)
         val id = fqn + suffix
@@ -444,6 +486,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     private fun extractPreviewParams(
         ann: AnnotationInfo,
         wrapperClassName: String?,
+        previewParameter: Pair<String, Int>?,
     ): PreviewParams {
         val pv = ann.parameterValues
         val kind = if (ann.name == TILE_PREVIEW_FQN) PreviewKind.TILE else PreviewKind.COMPOSE
@@ -497,6 +540,12 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             // so even if the annotation happened to be present on the function,
             // the wrapper's `Wrap(content)` would never wrap the tile View.
             wrapperClassName = if (kind == PreviewKind.TILE) null else wrapperClassName,
+            // @PreviewParameter targets composables too. Tile preview functions
+            // return `TilePreviewData`; the renderer reflects them directly and
+            // has no code path for injecting a provider value.
+            previewParameterProviderClassName =
+                if (kind == PreviewKind.TILE) null else previewParameter?.first,
+            previewParameterLimit = previewParameter?.second ?: Int.MAX_VALUE,
             kind = kind,
             // @ScrollingPreview is applied by `makePreview` via `.copy(scroll = …)` so
             // the timings fan-out and scroll spec live side-by-side in one place.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GenerateRenderShardsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GenerateRenderShardsTask.kt
@@ -51,7 +51,10 @@ abstract class GenerateRenderShardsTask : DefaultTask() {
                 | */
                 |@RunWith(ParameterizedRobolectricTestRunner.class)
                 |public class $className extends RobolectricRenderTestBase {
-                |    public $className(RenderPreviewEntry preview) { super(preview); }
+                |    @SuppressWarnings({"unchecked", "rawtypes"})
+                |    public $className(RenderPreviewEntry preview, List previewArgs) {
+                |        super(preview, (List<Object>) previewArgs);
+                |    }
                 |
                 |    @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
                 |    public static List<Object[]> previews() {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -96,6 +96,26 @@ data class PreviewParams(
     val group: String? = null,
     /** FQN of the `PreviewWrapperProvider` from `@PreviewWrapper`, if any. */
     val wrapperClassName: String? = null,
+    /**
+     * FQN of a `PreviewParameterProvider` from `@PreviewParameter` on one of the
+     * preview function's parameters, if any. Discovery only records the spec —
+     * the renderer instantiates the provider, enumerates its `values` (capped
+     * by [previewParameterLimit]), and fans out one rendered file per value
+     * with a `_PARAM_<idx>` suffix inserted before the extension.
+     *
+     * We intentionally do not expand at discovery time: the plugin's own
+     * classpath doesn't have the consumer's Compose dependencies, so loading
+     * the provider would require rebuilding the consumer's classloader from
+     * scratch. Leaving fan-out to the renderer keeps discovery classpath-cheap.
+     */
+    val previewParameterProviderClassName: String? = null,
+    /**
+     * Mirrors `@PreviewParameter.limit`. `Int.MAX_VALUE` is the annotation
+     * default — the renderer takes every value the provider yields. Applied
+     * via `values.take(limit)` so providers backed by infinite sequences stay
+     * bounded.
+     */
+    val previewParameterLimit: Int = Int.MAX_VALUE,
     val kind: PreviewKind = PreviewKind.COMPOSE,
 )
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -107,6 +107,15 @@ abstract class RenderPreviewsTask : DefaultTask() {
                     // the intrinsic bounds on that axis.
                     spec.wrapWidth.toString(),
                     spec.wrapHeight.toString(),
+                    // 12th/13th — @PreviewParameter spec. Empty string signals
+                    // "no provider"; otherwise the renderer enumerates the
+                    // provider's values.take(limit) in-process and writes one
+                    // `<id>_PARAM_<idx>.png` per value. Plugin-side can't know
+                    // the count (consumer's classpath isn't loaded here), so
+                    // fan-out is delegated to the renderer process that already
+                    // has everything on its classpath.
+                    preview.params.previewParameterProviderClassName.orEmpty(),
+                    preview.params.previewParameterLimit.toString(),
                 )
             }
         }

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewRenderStrategy.kt
@@ -15,7 +15,7 @@ import androidx.compose.runtime.reflect.getDeclaredComposableMethod
  */
 internal interface PreviewRenderStrategy {
     @Composable
-    fun Render(preview: RenderPreviewEntry, widthDp: Int, heightDp: Int)
+    fun Render(preview: RenderPreviewEntry, widthDp: Int, heightDp: Int, previewArgs: List<Any?>)
 }
 
 private val STRATEGIES: Map<PreviewKind, PreviewRenderStrategy> = mapOf(
@@ -40,9 +40,18 @@ internal fun strategyFor(kind: PreviewKind): PreviewRenderStrategy =
  */
 private object ComposePreviewStrategy : PreviewRenderStrategy {
     @Composable
-    override fun Render(preview: RenderPreviewEntry, widthDp: Int, heightDp: Int) {
+    override fun Render(preview: RenderPreviewEntry, widthDp: Int, heightDp: Int, previewArgs: List<Any?>) {
         val clazz = Class.forName(preview.className)
-        val composableMethod = clazz.getDeclaredComposableMethod(preview.functionName)
+        // For previews with a `@PreviewParameter` argument, look up the
+        // overload whose Composable-visible parameters match the supplied
+        // values. The pipeline only injects one value today (Studio-parity:
+        // multi-@PreviewParameter functions aren't supported), but passing
+        // the full list keeps the lookup shape honest with the invocation.
+        val composableMethod = if (previewArgs.isEmpty()) {
+            clazz.getDeclaredComposableMethod(preview.functionName)
+        } else {
+            findComposableMethodWithArgs(clazz, preview.functionName, previewArgs)
+        }
         // Top-level `@Preview` functions compile into static methods on the
         // file's synthetic `FooKt` class, so `receiver = null` works. Google's
         // `com.android.compose.screenshot` tool (and Paparazzi-style tests)
@@ -56,7 +65,7 @@ private object ComposePreviewStrategy : PreviewRenderStrategy {
         // constructor, else fall back to null for static methods.
         val receiver = resolvePreviewReceiver(clazz)
         val body: @Composable () -> Unit = {
-            composableMethod.invoke(currentComposer, receiver)
+            composableMethod.invoke(currentComposer, receiver, *previewArgs.toTypedArray())
         }
         val wrapperFqn = preview.params.wrapperClassName
         if (wrapperFqn != null) {
@@ -66,6 +75,60 @@ private object ComposePreviewStrategy : PreviewRenderStrategy {
             body()
         }
     }
+}
+
+/**
+ * Resolves the `ComposableMethod` for a preview function that declares
+ * `@PreviewParameter` arguments, where parameter types aren't known
+ * statically. Walks `declaredMethods`, picks the overload whose leading
+ * JVM parameter types line up with `previewArgs` (receiver types match the
+ * runtime class of each value, plus the usual trailing Composer + changed
+ * int-bits), then hands that shape to
+ * `Class<*>.getDeclaredComposableMethod(name, vararg parameterTypes)` —
+ * the only officially supported way to produce a `ComposableMethod`.
+ *
+ * Null entries in [previewArgs] are matched against the declared parameter's
+ * box type (Kotlin nullable types already compile to boxed reference types).
+ * Primitive-typed non-null values are auto-boxed in [previewArgs], so we
+ * check both box and primitive forms.
+ */
+internal fun findComposableMethodWithArgs(
+    clazz: Class<*>,
+    name: String,
+    previewArgs: List<Any?>,
+): androidx.compose.runtime.reflect.ComposableMethod {
+    val argCount = previewArgs.size
+    // Compose compiler emits `(…args, Composer, changed[, defaultBits…])`
+    // at the JVM level, so a method with N composable-visible params has at
+    // least N + 2 JVM params. The default-bits tail is emitted when the
+    // preview function declares default arguments we didn't supply.
+    val candidate = clazz.declaredMethods.firstOrNull { m ->
+        m.name == name && m.parameterCount >= argCount + 2 && argsMatch(m, previewArgs)
+    } ?: throw NoSuchMethodException(
+        "Couldn't find composable method $name on ${clazz.name} taking ${previewArgs.size} parameter(s); " +
+            "check that the @PreviewParameter provider's value type matches the preview's parameter type.",
+    )
+    val declaredTypes = candidate.parameterTypes.take(argCount).toTypedArray()
+    return clazz.getDeclaredComposableMethod(name, *declaredTypes)
+}
+
+private fun argsMatch(method: java.lang.reflect.Method, previewArgs: List<Any?>): Boolean {
+    for ((i, arg) in previewArgs.withIndex()) {
+        val expected = method.parameterTypes[i]
+        if (arg == null) {
+            // A null argument can satisfy any reference parameter; a primitive
+            // JVM parameter can't accept null, so it's an immediate mismatch.
+            if (expected.isPrimitive) return false
+            continue
+        }
+        val actual = arg.javaClass
+        if (expected.isAssignableFrom(actual)) continue
+        // Auto-boxing: `int` vs `Integer`, etc. `expected.kotlin.javaObjectType`
+        // is the box class for primitives; for reference types it's itself.
+        if (expected.kotlin.javaObjectType.isAssignableFrom(actual)) continue
+        return false
+    }
+    return true
 }
 
 /**
@@ -104,7 +167,10 @@ internal fun resolvePreviewReceiver(clazz: Class<*>): Any? {
  */
 private object TilePreviewStrategy : PreviewRenderStrategy {
     @Composable
-    override fun Render(preview: RenderPreviewEntry, widthDp: Int, heightDp: Int) {
+    override fun Render(preview: RenderPreviewEntry, widthDp: Int, heightDp: Int, previewArgs: List<Any?>) {
+        // `@PreviewParameter` doesn't apply to tile previews — discovery
+        // drops the provider FQN for `PreviewKind.TILE`, so this list is
+        // always empty here.
         TilePreviewComposable(preview, widthDp, heightDp)
     }
 }

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -139,5 +139,16 @@ data class RenderPreviewParams(
     val group: String? = null,
     /** FQN of the `PreviewWrapperProvider` from `@PreviewWrapper`, if any. */
     val wrapperClassName: String? = null,
+    /**
+     * FQN of a `PreviewParameterProvider` harvested from `@PreviewParameter`
+     * on one of the preview function's parameters, if any. When non-null the
+     * renderer enumerates the provider's `values` (capped by
+     * [previewParameterLimit]) and emits one file per value with a
+     * `_PARAM_<idx>` suffix. `null` means the preview has no parameter
+     * provider — the default single-capture path applies.
+     */
+    val previewParameterProviderClassName: String? = null,
+    /** Mirrors `@PreviewParameter.limit`. `Int.MAX_VALUE` = take every value. */
+    val previewParameterLimit: Int = Int.MAX_VALUE,
     val kind: PreviewKind = PreviewKind.COMPOSE,
 )

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -58,10 +58,93 @@ object PreviewManifestLoader {
         if (!file.exists()) return emptyList()
 
         val manifest = json.decodeFromString<RenderManifest>(file.readText())
-        return manifest.previews
+        // Expand `@PreviewParameter` providers into one row per value BEFORE
+        // sharding, so one preview's values never span multiple shards — each
+        // (preview, value) row carries an already-suffixed id / renderOutput
+        // ready for the test runner. Values are kept alongside the entry
+        // (Array<Any>[entry, args]) instead of being serialised back into the
+        // manifest: provider values can be arbitrary runtime objects, often
+        // not JSON-representable.
+        val expanded = manifest.previews.flatMap { expandParameterProvider(it) }
+        return expanded
             .withIndex()
             .filter { (i, _) -> i % shardCount == shardIndex }
-            .map { (_, p) -> arrayOf<Any>(p) }
+            .map { (_, row) -> arrayOf<Any>(row.entry, row.previewArgs) }
+    }
+
+    internal data class PreviewRow(val entry: RenderPreviewEntry, val previewArgs: List<Any?>)
+
+    internal fun expandParameterProvider(entry: RenderPreviewEntry): List<PreviewRow> {
+        val providerFqn = entry.params.previewParameterProviderClassName
+            ?: return listOf(PreviewRow(entry, emptyList()))
+        val limit = entry.params.previewParameterLimit.coerceAtLeast(0)
+        if (limit == 0) return emptyList()
+        val values = loadProviderValues(providerFqn, limit)
+        if (values.isEmpty()) {
+            System.err.println(
+                "@PreviewParameter(provider = $providerFqn) on '${entry.id}' produced no values — skipping.",
+            )
+            return emptyList()
+        }
+        return values.mapIndexed { idx, value ->
+            val paramSuffix = "_PARAM_$idx"
+            val newCaptures = entry.captures.map { c ->
+                c.copy(renderOutput = insertBeforeExtension(c.renderOutput, paramSuffix))
+            }
+            val newId = entry.id + paramSuffix
+            PreviewRow(entry.copy(id = newId, captures = newCaptures), listOf(value))
+        }
+    }
+
+    /**
+     * Inserts [suffix] before the extension of a `renders/<id>.<ext>` path.
+     * `renders/foo.png` + `_PARAM_0` → `renders/foo_PARAM_0.png`. Leaves
+     * paths without an extension untouched (appended at the end) so the
+     * mapping stays a pure string transformation.
+     */
+    internal fun insertBeforeExtension(path: String, suffix: String): String {
+        if (path.isEmpty()) return path
+        val dot = path.lastIndexOf('.')
+        val slash = path.lastIndexOf('/')
+        return if (dot > slash) path.substring(0, dot) + suffix + path.substring(dot)
+        else path + suffix
+    }
+
+    private fun loadProviderValues(providerFqn: String, limit: Int): List<Any?> {
+        val clazz = try {
+            Class.forName(providerFqn)
+        } catch (e: ClassNotFoundException) {
+            System.err.println("@PreviewParameter: provider class $providerFqn not found on test classpath — skipping.")
+            return emptyList()
+        }
+        val instance = runCatching {
+            val ctor = clazz.getDeclaredConstructor()
+            ctor.isAccessible = true
+            ctor.newInstance()
+        }.getOrElse { e ->
+            System.err.println(
+                "@PreviewParameter: couldn't instantiate $providerFqn via nullary constructor: ${e.message}",
+            )
+            return emptyList()
+        }
+        // `PreviewParameterProvider<T>` exposes `values: Sequence<T>` as a Kotlin
+        // property — its JVM signature is `getValues(): Sequence`. Look up the
+        // method by name to avoid taking a compile-time dependency on the
+        // provider interface (which lives in the consumer's Compose artifact).
+        val getValues = runCatching { clazz.getMethod("getValues") }.getOrElse {
+            System.err.println("@PreviewParameter: $providerFqn has no getValues() — not a PreviewParameterProvider?")
+            return emptyList()
+        }
+        @Suppress("UNCHECKED_CAST")
+        val sequence = getValues.invoke(instance) as? Sequence<Any?>
+            ?: return emptyList()
+        // `Sequence.take(Int).toList()` is the Kotlin stdlib contract —
+        // drives the sequence lazily up to `limit` without requiring
+        // reflective access into package-private iterator implementations
+        // (`kotlin.jvm.internal.ArrayIterator`, which `Method.invoke`
+        // rejects with IllegalAccessException from outside the stdlib
+        // module).
+        return sequence.take(limit).toList()
     }
 }
 
@@ -94,7 +177,17 @@ object PreviewManifestLoader {
  */
 @Config(sdk = [35])
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
-abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry) {
+abstract class RobolectricRenderTestBase(
+    private val preview: RenderPreviewEntry,
+    /**
+     * Values supplied to the preview composable — non-empty only when the
+     * preview's `@PreviewParameter` fan-out produced a row. The test-runner
+     * row carries `(entry, args)` so values never round-trip through JSON;
+     * the loader enumerates the provider on the test JVM and passes the raw
+     * objects straight through.
+     */
+    private val previewArgs: List<Any?>,
+) {
 
     @OptIn(ExperimentalRoborazziApi::class)
     @Test
@@ -346,10 +439,10 @@ abstract class RobolectricRenderTestBase(private val preview: RenderPreviewEntry
                                     }
                                 },
                             ) {
-                                strategyFor(params.kind).Render(preview, widthDp, heightDp)
+                                strategyFor(params.kind).Render(preview, widthDp, heightDp, previewArgs)
                             }
                         } else {
-                            strategyFor(params.kind).Render(preview, widthDp, heightDp)
+                            strategyFor(params.kind).Render(preview, widthDp, heightDp, previewArgs)
                         }
                     }
                 }
@@ -837,7 +930,10 @@ internal fun resolveWrapper(wrapperFqn: String): Pair<ComposableMethod, Any> {
  * `composeAiPreview.shards > 1`.
  */
 @RunWith(ParameterizedRobolectricTestRunner::class)
-class RobolectricRenderTest(preview: RenderPreviewEntry) : RobolectricRenderTestBase(preview) {
+class RobolectricRenderTest(
+    preview: RenderPreviewEntry,
+    @Suppress("UNCHECKED_CAST") previewArgs: List<Any?>,
+) : RobolectricRenderTestBase(preview, previewArgs) {
     companion object {
         @JvmStatic
         @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")

--- a/renderer-desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderer-desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -26,7 +26,7 @@ import kotlin.system.exitProcess
 /**
  * Standalone entry point for rendering Compose Desktop previews to PNG.
  *
- * Args: className functionName widthPx heightPx density showBackground backgroundColor outputFile [wrapperClassName] [wrapWidth] [wrapHeight]
+ * Args: className functionName widthPx heightPx density showBackground backgroundColor outputFile [wrapperClassName] [wrapWidth] [wrapHeight] [previewParameterProviderFqn] [previewParameterLimit]
  *
  * The optional 9th argument is the FQN of a `PreviewWrapperProvider` (Compose 1.11+);
  * pass an empty string or omit to skip wrapping.
@@ -36,10 +36,18 @@ import kotlin.system.exitProcess
  * measures its intrinsic size, and crops the final PNG to that size on the
  * wrapped axis. Defaults to `false` when omitted so older callers keep the
  * full-frame behaviour.
+ *
+ * Args 12 and 13 are the `@PreviewParameter` provider FQN + limit. When
+ * arg 12 is non-empty the renderer instantiates the provider, iterates its
+ * `values.take(limit)`, and writes one file per value using `outputFile` as
+ * a template (`_PARAM_<idx>` inserted before the extension). Looping inside
+ * a single JVM — instead of spawning one subprocess per value — avoids N×
+ * Compose cold-start cost; the same `ImageComposeScene` is reused across
+ * values.
  */
 fun main(args: Array<String>) {
     if (args.size < 8) {
-        System.err.println("Usage: DesktopRendererMain <className> <functionName> <widthPx> <heightPx> <density> <showBackground> <backgroundColor> <outputFile> [wrapperClassName] [wrapWidth] [wrapHeight]")
+        System.err.println("Usage: DesktopRendererMain <className> <functionName> <widthPx> <heightPx> <density> <showBackground> <backgroundColor> <outputFile> [wrapperClassName] [wrapWidth] [wrapHeight] [previewParameterProviderFqn] [previewParameterLimit]")
         exitProcess(1)
     }
 
@@ -66,18 +74,87 @@ fun main(args: Array<String>) {
     val wrapperClassName = args.getOrNull(8)?.takeIf { it.isNotBlank() }
     val wrapWidth = args.getOrNull(9)?.toBoolean() ?: false
     val wrapHeight = args.getOrNull(10)?.toBoolean() ?: false
+    val previewParameterProviderFqn = args.getOrNull(11)?.takeIf { it.isNotBlank() }
+    val previewParameterLimit = args.getOrNull(12)?.toIntOrNull()?.coerceAtLeast(0) ?: Int.MAX_VALUE
 
     try {
-        renderPreview(
-            className, functionName, widthPx, heightPx, density,
-            showBackground, backgroundColor, outputFile, wrapperClassName,
-            wrapWidth, wrapHeight,
-        )
+        val values: List<Any?> = if (previewParameterProviderFqn != null && previewParameterLimit > 0) {
+            loadProviderValues(previewParameterProviderFqn, previewParameterLimit).also { vs ->
+                if (vs.isEmpty()) {
+                    System.err.println(
+                        "@PreviewParameter(provider = $previewParameterProviderFqn) on $functionName produced no values — skipping.",
+                    )
+                }
+            }
+        } else {
+            listOf(NO_PARAM)
+        }
+
+        for ((idx, value) in values.withIndex()) {
+            val targetFile = if (value === NO_PARAM) outputFile
+            else File(insertBeforeExtension(outputFile.path, "_PARAM_$idx"))
+            val previewArgs = if (value === NO_PARAM) emptyList() else listOf(value)
+            renderPreview(
+                className, functionName, widthPx, heightPx, density,
+                showBackground, backgroundColor, targetFile, wrapperClassName,
+                wrapWidth, wrapHeight, previewArgs,
+            )
+        }
     } catch (e: Exception) {
         System.err.println("Render failed for $className.$functionName: ${e.message}")
         e.printStackTrace()
         exitProcess(2)
     }
+}
+
+// Sentinel: distinguishes "no @PreviewParameter fan-out" from "provider yielded null".
+// A null value from the provider is a legitimate case we want to render; NO_PARAM
+// short-circuits the file-path suffix logic instead.
+private val NO_PARAM = Any()
+
+private fun insertBeforeExtension(path: String, suffix: String): String {
+    if (path.isEmpty()) return path
+    val dot = path.lastIndexOf('.')
+    val slash = path.lastIndexOf(File.separatorChar).coerceAtLeast(path.lastIndexOf('/'))
+    return if (dot > slash) path.substring(0, dot) + suffix + path.substring(dot)
+    else path + suffix
+}
+
+/**
+ * Loads and enumerates a `PreviewParameterProvider` reflectively — same
+ * strategy the Android renderer uses in `PreviewManifestLoader.loadProviderValues`.
+ * Keeping this renderer-local avoids a shared module dependency and the
+ * lookup stays limited to the method shapes the interface guarantees
+ * (`getValues(): Sequence`).
+ */
+private fun loadProviderValues(providerFqn: String, limit: Int): List<Any?> {
+    val clazz = try {
+        Class.forName(providerFqn)
+    } catch (e: ClassNotFoundException) {
+        System.err.println("@PreviewParameter: provider class $providerFqn not found — skipping.")
+        return emptyList()
+    }
+    val instance = runCatching {
+        val ctor = clazz.getDeclaredConstructor()
+        ctor.isAccessible = true
+        ctor.newInstance()
+    }.getOrElse { e ->
+        System.err.println("@PreviewParameter: couldn't instantiate $providerFqn via nullary ctor: ${e.message}")
+        return emptyList()
+    }
+    val getValues = runCatching { clazz.getMethod("getValues") }.getOrElse {
+        System.err.println("@PreviewParameter: $providerFqn has no getValues() — not a PreviewParameterProvider?")
+        return emptyList()
+    }
+    @Suppress("UNCHECKED_CAST")
+    val sequence = getValues.invoke(instance) as? Sequence<Any?> ?: return emptyList()
+    // `Sequence.take(Int)` is lazy and `.toList()` drives it — bounds the
+    // enumeration for infinite providers without requiring an explicit
+    // counter. Calling through the typed Kotlin API avoids reflective
+    // access into `kotlin.jvm.internal.ArrayIterator`, whose visibility is
+    // package-private and throws `IllegalAccessException` from outside the
+    // stdlib's own module.
+    return sequence.take(limit).toList()
 }
 
 private fun renderPreview(
@@ -92,9 +169,14 @@ private fun renderPreview(
     wrapperClassName: String?,
     wrapWidth: Boolean,
     wrapHeight: Boolean,
+    previewArgs: List<Any?>,
 ) {
     val clazz = Class.forName(className)
-    val composableMethod = clazz.getDeclaredComposableMethod(functionName)
+    val composableMethod = if (previewArgs.isEmpty()) {
+        clazz.getDeclaredComposableMethod(functionName)
+    } else {
+        findComposableMethodWithArgs(clazz, functionName, previewArgs)
+    }
 
     val scene = ImageComposeScene(
         width = widthPx,
@@ -154,11 +236,11 @@ private fun renderPreview(
                             }
                             .background(bgColor),
                     ) {
-                        InvokeComposable(composableMethod, null)
+                        InvokeComposable(composableMethod, null, previewArgs)
                     }
                 } else {
                     Box(modifier = Modifier.fillMaxSize().background(bgColor)) {
-                        InvokeComposable(composableMethod, null)
+                        InvokeComposable(composableMethod, null, previewArgs)
                     }
                 }
             }
@@ -213,8 +295,46 @@ private fun renderPreview(
 private fun InvokeComposable(
     composableMethod: ComposableMethod,
     instance: Any?,
+    previewArgs: List<Any?>,
 ) {
-    composableMethod.invoke(currentComposer, instance)
+    composableMethod.invoke(currentComposer, instance, *previewArgs.toTypedArray())
+}
+
+/**
+ * Desktop mirror of the Android renderer's lookup for `@PreviewParameter`
+ * functions — see [ee.schimke.composeai.renderer.findComposableMethodWithArgs]
+ * for the full commentary. Kept local (not shared via a common module) so the
+ * two renderer artefacts stay independently buildable.
+ */
+private fun findComposableMethodWithArgs(
+    clazz: Class<*>,
+    name: String,
+    previewArgs: List<Any?>,
+): ComposableMethod {
+    val argCount = previewArgs.size
+    val candidate = clazz.declaredMethods.firstOrNull { m ->
+        m.name == name && m.parameterCount >= argCount + 2 && argsMatch(m, previewArgs)
+    } ?: throw NoSuchMethodException(
+        "Couldn't find composable method $name on ${clazz.name} taking $argCount parameter(s); " +
+            "check that the @PreviewParameter provider's value type matches the preview's parameter type.",
+    )
+    val declaredTypes = candidate.parameterTypes.take(argCount).toTypedArray()
+    return clazz.getDeclaredComposableMethod(name, *declaredTypes)
+}
+
+private fun argsMatch(method: java.lang.reflect.Method, previewArgs: List<Any?>): Boolean {
+    for ((i, arg) in previewArgs.withIndex()) {
+        val expected = method.parameterTypes[i]
+        if (arg == null) {
+            if (expected.isPrimitive) return false
+            continue
+        }
+        val actual = arg.javaClass
+        if (expected.isAssignableFrom(actual)) continue
+        if (expected.kotlin.javaObjectType.isAssignableFrom(actual)) continue
+        return false
+    }
+    return true
 }
 
 /**

--- a/sample-android/src/main/kotlin/com/example/sampleandroid/PreviewParameterPreviews.kt
+++ b/sample-android/src/main/kotlin/com/example/sampleandroid/PreviewParameterPreviews.kt
@@ -1,0 +1,98 @@
+package com.example.sampleandroid
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+
+/**
+ * Demo data for the `@PreviewParameter` samples below. Shape mirrors what a
+ * typical list-cell or detail-screen composable would receive from a ViewModel
+ * — a handful of fields, each value visually distinct, so the rendered PNGs
+ * make the fan-out obvious at a glance.
+ */
+data class UserCardData(
+    val name: String,
+    val role: String,
+    val active: Boolean,
+)
+
+/**
+ * Minimal `@PreviewParameter` demo: one preview function, one provider, N
+ * rendered PNGs. The plugin's discovery pass records the provider FQN on
+ * `PreviewParams`; the Robolectric renderer instantiates the provider at
+ * test-load time, enumerates `values`, and emits one file per value with a
+ * `_PARAM_<idx>` suffix before the extension.
+ *
+ * Kept intentionally simple (no `@PreviewWrapper`, no device, no fan-out
+ * dimensions other than the provider) so the output diff reviewing the
+ * parameter path is unambiguous.
+ */
+class UserCardProvider : PreviewParameterProvider<UserCardData> {
+    override val values: Sequence<UserCardData> = sequenceOf(
+        UserCardData("Ada Lovelace", "Principal Engineer", active = true),
+        UserCardData("Grace Hopper", "Distinguished Engineer", active = true),
+        UserCardData("Alan Turing", "Research Fellow", active = false),
+    )
+}
+
+@Preview(name = "User Card", showBackground = true, backgroundColor = 0xFFFFFFFF, widthDp = 260)
+@Composable
+fun UserCardPreview(
+    @PreviewParameter(UserCardProvider::class) user: UserCardData,
+) {
+    MaterialTheme {
+        Card(modifier = Modifier.padding(12.dp)) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(user.name, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.SemiBold)
+                Text(user.role, style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    if (user.active) "● Active" else "○ Inactive",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (user.active) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Demonstrates `limit = N` on `@PreviewParameter`: the provider exposes seven
+ * values, but the annotation takes only the first three. Good smoke test for
+ * the `limit` handling — without it the plugin would render seven PNGs here,
+ * one of which (`status = "unknown"`) would look odd next to the rest.
+ */
+class TextSampleProvider : PreviewParameterProvider<String> {
+    override val values: Sequence<String> = sequenceOf(
+        "The quick brown fox",
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+        "Short",
+        "A moderately long line of body text, wrapping naturally across the available width.",
+        "ALL CAPS FOR EMPHASIS",
+        "Line with a trailing ellipsis…",
+        "unused — beyond the limit",
+    )
+}
+
+@Preview(name = "Body Text", showBackground = true, backgroundColor = 0xFFFFFFFF, widthDp = 320)
+@Composable
+fun BodyTextPreview(
+    @PreviewParameter(TextSampleProvider::class, limit = 3) body: String,
+) {
+    MaterialTheme {
+        Text(
+            text = body,
+            modifier = Modifier.padding(16.dp),
+            style = MaterialTheme.typography.bodyLarge,
+        )
+    }
+}

--- a/sample-cmp/src/main/kotlin/com/example/samplecmp/PreviewParameterPreviews.kt
+++ b/sample-cmp/src/main/kotlin/com/example/samplecmp/PreviewParameterPreviews.kt
@@ -1,0 +1,65 @@
+package com.example.samplecmp
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+
+/**
+ * Demo data for the CMP Desktop `@PreviewParameter` sample. Each value has a
+ * distinct label + colour, so the fan-out (`<id>_PARAM_0.png`,
+ * `<id>_PARAM_1.png`, …) lands on visually different PNGs.
+ */
+data class SwatchData(val label: String, val color: Long)
+
+class SwatchProvider : PreviewParameterProvider<SwatchData> {
+    override val values: Sequence<SwatchData> = sequenceOf(
+        SwatchData("Crimson", 0xFFDC143C),
+        SwatchData("Teal", 0xFF008B8B),
+        SwatchData("Amber", 0xFFFFBF00),
+        SwatchData("Violet", 0xFF7F00FF),
+    )
+}
+
+/**
+ * Desktop (CMP) `@PreviewParameter` smoke test. The JVM renderer consumes
+ * the provider FQN + limit passed on the command line, loops over
+ * `values.take(limit)` inside a single process, and emits one PNG per
+ * value with `_PARAM_<idx>` inserted before the extension.
+ */
+@Preview(name = "Color Swatch", backgroundColor = 0xFFFFFFFF, showBackground = true)
+@Composable
+fun SwatchPreview(
+    @PreviewParameter(SwatchProvider::class) swatch: SwatchData,
+) {
+    MaterialTheme {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Box(
+                modifier = Modifier
+                    .size(160.dp, 80.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Color(swatch.color.toInt())),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = swatch.label,
+                    color = Color.White,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+        }
+    }
+}

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -1,11 +1,54 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { AccessibilityFinding, AccessibilityReport, DoctorModuleReport, HistoryEntry, PreviewManifest } from './types';
+import { AccessibilityFinding, AccessibilityReport, Capture, DoctorModuleReport, HistoryEntry, PreviewManifest } from './types';
 import { APPLIES_PLUGIN_RE } from './pluginDetection';
 import { JdkImageError, JdkImageErrorDetector } from './jdkImageErrorDetector';
 
 const HISTORY_DIRNAME = '.compose-preview-history';
 const TIMESTAMP_RE = /^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})(?:-\d+)?$/;
+
+/**
+ * Expands a parameterized preview's single template capture into N captures
+ * pointing at the actual `_PARAM_<idx>` files on disk. Returns the original
+ * list unchanged when no matching files exist (rare — the plugin's
+ * `renderAllPreviews` check would have already failed loudly), or when the
+ * template has no `renderOutput` to key off.
+ *
+ * Sorted by the numeric suffix (`PARAM_0`, `PARAM_1`, …, `PARAM_10`) so
+ * `PARAM_10` doesn't sort before `PARAM_2` — lexicographic ordering on the
+ * raw filename would produce that order.
+ */
+function expandParamCaptures(rendersDir: string, templates: Capture[]): Capture[] {
+    if (!fs.existsSync(rendersDir)) { return templates; }
+    const expanded: Capture[] = [];
+    for (const template of templates) {
+        if (!template.renderOutput) { expanded.push(template); continue; }
+        const base = path.basename(template.renderOutput);
+        const dot = base.lastIndexOf('.');
+        const stem = dot > 0 ? base.slice(0, dot) : base;
+        const ext = dot > 0 ? base.slice(dot) : '';
+        const prefix = stem + '_PARAM_';
+        const templateDir = path.dirname(template.renderOutput);
+        const dirPrefix = templateDir && templateDir !== '.' ? `${templateDir}/` : '';
+        const matches = fs.readdirSync(rendersDir)
+            .filter(name => name.startsWith(prefix) && name.endsWith(ext))
+            .map(name => {
+                const idxStr = name.slice(prefix.length, name.length - ext.length);
+                const idx = parseInt(idxStr, 10);
+                return { name, idx: Number.isNaN(idx) ? Number.MAX_SAFE_INTEGER : idx };
+            })
+            .sort((a, b) => a.idx - b.idx);
+        if (matches.length === 0) { continue; }
+        for (const match of matches) {
+            expanded.push({
+                advanceTimeMillis: template.advanceTimeMillis,
+                scroll: template.scroll,
+                renderOutput: dirPrefix + match.name,
+            });
+        }
+    }
+    return expanded;
+}
 
 const TASK_TIMEOUT_MS = 5 * 60 * 1000;
 const MANIFEST_CACHE_TTL_MS = 30_000;
@@ -133,6 +176,19 @@ export class GradleService {
             if (!manifest.previews || !Array.isArray(manifest.previews)) {
                 this.logger.appendLine(`Malformed manifest at ${manifestPath}`);
                 return null;
+            }
+            // `@PreviewParameter` previews ship a single template capture on
+            // the manifest (`renders/<id>.<ext>`). The renderer fans out to
+            // `renders/<id>_PARAM_<idx>.<ext>` on disk — one file per
+            // provider value. Substitute the template with the actual files
+            // before any downstream consumer (carousel, hover, image loader)
+            // sees the preview, so the UI walks N files instead of trying to
+            // read the template path (which never exists).
+            const rendersDir = path.join(this.workspaceRoot, module, 'build', 'compose-previews', 'renders');
+            for (const p of manifest.previews) {
+                if (p.params?.previewParameterProviderClassName) {
+                    p.captures = expandParamCaptures(rendersDir, p.captures);
+                }
             }
             // Enrich each preview with a11y findings when the module has the
             // sidecar report. Always follow the manifest's pointer rather than

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -10,6 +10,15 @@ export interface PreviewParams {
     uiMode: number;
     locale: string | null;
     group: string | null;
+    /**
+     * FQN of the `PreviewParameterProvider` harvested from `@PreviewParameter`,
+     * when the discovery pass saw one on this preview's function signature.
+     * Extension uses this to know to glob for `<id>_PARAM_<idx>.<ext>` files
+     * (one per provider value) rather than expecting the manifest's single
+     * template capture to exist on disk verbatim.
+     */
+    previewParameterProviderClassName?: string | null;
+    previewParameterLimit?: number | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Discover `@PreviewParameter` on method parameters — record provider FQN + `limit` on `PreviewParams` (plugin and renderer mirrors).
- Renderers enumerate the provider's `Sequence.take(limit)` and emit one file per value with a `_PARAM_<idx>` suffix before the extension.
  - **Android**: `PreviewManifestLoader` expands each preview into one parameterized Robolectric row per value, so every value renders in its own Compose rule. `ComposePreviewStrategy` finds the matching overload reflectively.
  - **Desktop**: two new CLI args on `DesktopRendererMain` (provider FQN + limit) let it loop in-process — avoids N× Compose cold-start cost.
  - `renderAllPreviews` verification accepts any matching `<id>_PARAM_*` fan-out instead of the literal template.
- Samples ship a `UserCard` demo (3 values) and a `BodyText` demo with `limit = 3` against a 7-value provider in `sample-android`, plus a 4-swatch demo in `sample-cmp`.
- New discovery functional test for provider FQN + `limit` round-tripping.

## Test plan

- [x] `./gradlew :gradle-plugin:check` — unit + functional tests green (including new `@PreviewParameter` discovery test).
- [x] `./gradlew :renderer-android:check` — renderer unit tests green.
- [x] `./gradlew :sample-android:check` — pixel test + lint green.
- [x] `./gradlew :sample-cmp:renderAllPreviews` — emits 4 `SwatchPreview_PARAM_*.png` (one per swatch).
- [x] `./gradlew :sample-android:renderAllPreviews` — emits 3 `UserCardPreview_PARAM_*.png` + 3 `BodyTextPreview_PARAM_*.png` (limit-capped at 3 of 7).
- [x] Visually inspected output PNGs — correct per-value content ("Ada Lovelace / Principal Engineer / Active", "Alan Turing / Research Fellow / Inactive", "Teal" swatch, etc.).