### PR TITLE
docs(skill): minimal Remote Compose and Wear Tiles guides

### DIFF
--- a/skills/compose-preview/SKILL.md
+++ b/skills/compose-preview/SKILL.md
@@ -412,6 +412,27 @@ When creating or iterating on Wear OS designs, refer to the
 - Proper **System UI** integration (e.g., `TimeText`, `AppScaffold`).
 - **Responsive layout** strategies across screen sizes.
 
+## Wear Tiles
+
+Tiles are a separate Wear surface — protolayout, not Compose. Preview
+functions return `TilePreviewData` instead of emitting composables, and the
+renderer invokes them via `TileRenderer` rather than `ComposeTestRule`. See
+**[design/WEAR_TILES.md](./design/WEAR_TILES.md)** for the authoring
+primitives (`materialScope`, `primaryLayout`, `titleCard`, `textEdgeButton`),
+the dependency wiring, and the `TilePreviewData` / `TilePreviewHelper`
+pattern for building a single-timeline-entry tile from a preview function.
+
+## Remote Compose
+
+For previews against Remote Compose — a Compose dialect with its own applier
+and `@RemoteComposable` target marker that captures the tree into a
+replayable `RemoteDocument` — see the
+**[Remote Compose guide](./design/REMOTE_COMPOSE.md)**. Covers the two
+preview shapes (`RemotePreview { … }` inside a `@Preview` composable vs.
+`@PreviewWrapper(RemotePreviewWrapper::class)`), the creation/tooling
+artifact split, and how Wear's `remote-material3` builds on
+`remote-creation-compose` for Material 3 components inside a remote tree.
+
 ## CI and PR workflows
 
 - **[design/CI_PREVIEWS.md](design/CI_PREVIEWS.md)** — setting up the

--- a/skills/compose-preview/design/REMOTE_COMPOSE.md
+++ b/skills/compose-preview/design/REMOTE_COMPOSE.md
@@ -1,0 +1,163 @@
+# Remote Compose
+
+Remote Compose is a Compose dialect that compiles your `@Composable` tree into
+a portable **RemoteDocument** byte stream — a serialisable description of the
+UI that a remote player (a watch face, tile, widget, or another surface that
+can't host a full Compose runtime) replays at display time. Same `@Composable`
+authoring model, but the output is a document, not an Android view tree.
+
+Two things that matter for anyone writing previews against it:
+
+- **Different applier.** Remote Compose uses its own applier that emits into a
+  RemoteDocument capture buffer, not into Android's layout/draw tree. A plain
+  `Text("hello")` from `androidx.compose.material` won't work inside a Remote
+  Compose tree — you need the remote-aware equivalents (`RemoteText`,
+  `RemoteBox`, `RemoteButton`, …). Mixing the two inside a single capture
+  produces a document with gaps.
+- **Different target marker.** Remote-aware composables are annotated with
+  `@RemoteComposable` (a `@ComposableTargetMarker`) instead of the usual
+  `@UiComposable`. The Compose compiler uses target markers to flag "wrong
+  dialect" usage at compile time, so the compiler — not runtime — tells you
+  when you reach for a UI composable inside a remote subtree.
+
+## Library layout
+
+The group is `androidx.compose.remote` (plus the Wear add-on
+`androidx.wear.compose.remote`). For previews the interesting pieces are:
+
+| Purpose | Artifact |
+| :--- | :--- |
+| **Authoring primitives** (`RemoteBox`, `RemoteModifier`, state like `RemoteString`/`RemoteColor`, the `.rs`/`.rdp`/`.rb`/`.rf` conversion helpers, `HostAction`) | `androidx.compose.remote:remote-creation-compose` |
+| **Core creation runtime** (capture buffer, profiles) | `androidx.compose.remote:remote-creation` |
+| **Preview tooling** (`RemotePreview`, `RemotePreviewWrapper`) | `androidx.compose.remote:remote-tooling-preview` |
+| **Wear Material 3 remote components** (`RemoteButton`, `RemoteText`, `RemoteButtonDefaults`, `buttonSizeModifier`, …) | `androidx.wear.compose.remote:remote-material3` |
+
+`remote-material3` builds on top of `remote-creation-compose` — it gives you
+Material 3 components that emit remote layout/draw commands, so you get M3
+styling inside a RemoteDocument without reinventing button colours, shapes,
+and typography. Same role `compose-material3` plays for a normal app.
+
+### Dependency wiring
+
+`remote-tooling-preview`'s POM declares its creation deps at **`runtime`**
+scope, so a project that only lists it on `implementation` won't see the
+creation types on its compile classpath. Add them explicitly:
+
+```kotlin
+dependencies {
+    implementation("androidx.compose.remote:remote-tooling-preview:…")
+    implementation("androidx.compose.remote:remote-creation:…")
+    implementation("androidx.compose.remote:remote-creation-compose:…")
+    implementation("androidx.wear.compose.remote:remote-material3:…")
+}
+```
+
+Most Remote Compose APIs are `@RestrictTo(LIBRARY_GROUP)`. You'll get lint
+failures (`RestrictedApi`) and IDE red squigglies without either
+`@file:Suppress("RestrictedApiAndroidX")` at the top of each file *and* a
+`lint { disable += "RestrictedApi" }` block in the module's `build.gradle.kts`.
+
+## Previewing: two shapes, same output
+
+### 1. `RemotePreview` wrapper inside a `@Preview` composable
+
+```kotlin
+@Preview(showBackground = true, widthDp = 200, heightDp = 200)
+@Composable
+fun RemoteButtonEnabledPreview() {
+    RemotePreview(profile = RcPlatformProfiles.ANDROIDX) {
+        Container { RemoteButtonEnabled() }
+    }
+}
+```
+
+`RemotePreview` captures the inner `@RemoteComposable` tree into a
+RemoteDocument, then plays it back into the regular Compose preview surface.
+This is the shape used in `wear/compose/remote/remote-material3/samples` in
+AOSP and works on any Android Studio that can render `@Preview` — no
+dependency on the newer `PreviewWrapper` annotation.
+
+### 2. `@PreviewWrapper(RemotePreviewWrapper::class)`
+
+```kotlin
+@Preview(showBackground = true, widthDp = 200, heightDp = 200)
+@PreviewWrapper(RemotePreviewWrapper::class)
+@Composable
+fun RemoteButtonWithBorderPreview() {
+    Container { RemoteButtonWithBorder() }
+}
+```
+
+Tooling applies `RemotePreviewWrapper.Wrap { … }` around the function body, so
+the preview function itself only contains remote content. `PreviewWrapper`
+landed in `androidx.compose.ui:ui-tooling-preview` 1.11.0-beta+ — older
+Compose releases don't ship the annotation class, so this shape is newer than
+approach 1.
+
+`RemotePreviewWrapper` itself lives in `remote-tooling-preview`:
+
+```kotlin
+class RemotePreviewWrapper : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) {
+        RemotePreview(profile = RcPlatformProfiles.ANDROIDX, content = content)
+    }
+}
+```
+
+> [!NOTE]
+> If your `remote-tooling-preview` alpha predates the published
+> `RemotePreviewWrapper` class, drop a local copy into the sample module —
+> signature is identical, swap to the upstream one once it ships.
+
+Both approaches render the same pixels — pick the one that suits your
+preview density. Approach 1 scales well when previews need different profiles
+or framing per case; approach 2 keeps many same-shaped previews terse.
+
+## Component previews, not device previews
+
+Remote Compose components don't care about device chrome (bezel, status bar,
+system time) — they're rendered by a host surface that owns those details.
+Size previews by the component's own footprint, not by a device:
+
+```kotlin
+@Preview(showBackground = true, widthDp = 200, heightDp = 200)
+```
+
+Skip `@WearPreviewDevices` / `@PreviewScreenSizes` here. A 200×200 canvas
+frames a single `RemoteButton` cleanly; stretch when you add components that
+need more room, or split into multiple previews rather than packing a whole
+screen.
+
+Give the remote tree a centered container so the component isn't jammed into
+the top-left corner of the canvas:
+
+```kotlin
+@Composable
+@RemoteComposable
+fun Container(content: @Composable @RemoteComposable () -> Unit) {
+    RemoteBox(
+        modifier = RemoteModifier.fillMaxSize(),
+        contentAlignment = RemoteAlignment.Center,
+        content = content,
+    )
+}
+```
+
+## Reference sample
+
+A working end-to-end example lives in [`sample-remotecompose/`](../../../sample-remotecompose/):
+
+- `RemoteComponents.kt` — three `@RemoteComposable` button variants + the
+  `Container` helper.
+- `Previews.kt` — both preview shapes side by side.
+- `RemotePreviewWrapper.kt` — local copy of the wrapper until the upstream
+  alpha catches up.
+- `build.gradle.kts` — explicit dependency wiring, `lint { disable +=
+  "RestrictedApi" }`, and a note on why this module doesn't use the Compose
+  BOM (Remote Compose alphas pull in a newer Compose runtime than the BOM
+  currently pins).
+
+`./gradlew :sample-remotecompose:renderAllPreviews` produces PNGs for both
+shapes, so you can see that the capture-and-replay path works end-to-end in
+the plugin's renderer.

--- a/skills/compose-preview/design/WEAR_TILES.md
+++ b/skills/compose-preview/design/WEAR_TILES.md
@@ -1,0 +1,144 @@
+# Wear Tiles
+
+Tiles are the *glanceable* Wear surface — the horizontal swipe-layer next to
+the watch face. They are **not** Compose. A tile is a `protolayout` tree
+(proto-backed layout primitives) built on a background thread, serialised,
+and rendered by the system. The preview pipeline treats them as a separate
+kind of preview: different annotation, different entry-point signature,
+different renderer.
+
+## What's different from Compose previews
+
+- **Not a composable.** A tile preview is a top-level function returning
+  `TilePreviewData`, optionally taking a `Context`:
+  ```kotlin
+  fun HelloTilePreview(context: Context): TilePreviewData = …
+  ```
+  It does not use `@Composable`. Discovery recognises this shape by the
+  return type, not by a target marker.
+- **Different `@Preview`.** The annotation lives under
+  `androidx.wear.tiles.tooling.preview`, not
+  `androidx.compose.ui.tooling.preview`. Importing the wrong one silently
+  produces zero tile previews.
+- **No Compose runtime at play.** The renderer skips `ComposeTestRule` /
+  `captureRoboImage` for tiles and uses `TileRenderer` to turn the
+  protolayout into a view, which is then captured. Nothing about Compose
+  dispatchers, `LaunchedEffect`, or `LocalInspectionMode` applies here.
+- **Timeline-based output.** A tile emits a `Timeline` of entries. For
+  previews we always pick the single-entry helper so the captured PNG
+  corresponds to a stable snapshot rather than whichever entry happens to
+  be active when the timer fires.
+
+## Dependencies
+
+| Purpose | Artifact |
+| :--- | :--- |
+| **Tile core primitives** (`TileBuilders`, `RequestBuilders`, `ResourceBuilders`) | `androidx.wear.tiles:tiles` |
+| **Tile preview tooling** (`@Preview`, `TilePreviewData`, `TilePreviewHelper`) | `androidx.wear.tiles:tiles-tooling-preview` |
+| **Protolayout layout/modifier types** | `androidx.wear.protolayout:protolayout` |
+| **Dynamic expressions** (state, arithmetic, formatters) | `androidx.wear.protolayout:protolayout-expression` |
+| **Material 3 components for protolayout** (`materialScope`, `primaryLayout`, `titleCard`, `textEdgeButton`) | `androidx.wear.protolayout:protolayout-material3` |
+| **Preview device metadata** (`WearDevices.SMALL_ROUND`, `LARGE_ROUND`, `SQUARE`) | `androidx.wear:wear-tooling-preview` |
+
+The Gradle plugin injects `androidx.wear.tiles:tiles-renderer` into the
+renderer's classpath on demand — consumer apps do *not* need to list
+`tiles-renderer` in their own dependencies. Keep the list above; leave
+rendering infrastructure to the plugin.
+
+## Authoring a tile preview
+
+```kotlin
+import android.content.Context
+import androidx.wear.protolayout.material3.materialScope
+import androidx.wear.protolayout.material3.primaryLayout
+import androidx.wear.protolayout.material3.text
+import androidx.wear.protolayout.material3.textEdgeButton
+import androidx.wear.protolayout.material3.titleCard
+import androidx.wear.protolayout.modifiers.LayoutModifier
+import androidx.wear.protolayout.modifiers.clickable
+import androidx.wear.protolayout.modifiers.contentDescription
+import androidx.wear.protolayout.types.layoutString
+import androidx.wear.tiles.tooling.preview.Preview
+import androidx.wear.tiles.tooling.preview.TilePreviewData
+import androidx.wear.tiles.tooling.preview.TilePreviewHelper
+import androidx.wear.tooling.preview.devices.WearDevices
+
+@Preview(device = WearDevices.LARGE_ROUND)
+fun StepsTilePreview(context: Context): TilePreviewData =
+    TilePreviewData { request ->
+        TilePreviewHelper.singleTimelineEntryTileBuilder(
+            materialScope(context, request.deviceConfiguration) {
+                primaryLayout(
+                    titleSlot = { text("Steps".layoutString) },
+                    mainSlot = {
+                        titleCard(
+                            onClick = clickable(),
+                            title = { text("6,482".layoutString) },
+                            content = { text("Goal 10,000".layoutString) },
+                            modifier = LayoutModifier.contentDescription("Steps today"),
+                        )
+                    },
+                    bottomSlot = {
+                        textEdgeButton(
+                            onClick = clickable(),
+                            labelContent = { text("Details".layoutString) },
+                            modifier = LayoutModifier.contentDescription("Show step details"),
+                        )
+                    },
+                )
+            },
+        ).build()
+    }
+```
+
+Things to notice:
+
+- **`TilePreviewData { request -> … }`** — the lambda receives a
+  `TileRequest`; extract `request.deviceConfiguration` to pass into
+  `materialScope` so sizes and colours match the target device.
+- **`TilePreviewHelper.singleTimelineEntryTileBuilder(...)`** — wraps a
+  single layout into a `TileBuilders.Tile` with a trivial timeline. Call
+  `.build()` at the end.
+- **`materialScope(context, deviceConfiguration) { … }`** — opens the
+  Material 3 scope. Components inside are the protolayout analogues of
+  Compose widgets, not Compose composables.
+- **`primaryLayout(titleSlot = …, mainSlot = …, bottomSlot = …)`** — the
+  Material 3 scaffold for tiles. Slot-based, similar in intent to
+  `ScreenScaffold` on the Compose side.
+- **`.layoutString`** — the extension that lifts a Kotlin `String` into a
+  `protolayout` `LayoutString`. Use it everywhere text is set.
+- **`LayoutModifier.clickable()` / `.contentDescription(…)`** — modifiers
+  apply to protolayout elements, not to Compose modifiers. Different
+  import path, different type.
+
+## Multi-preview
+
+The same multi-preview pattern used for Compose works here — any annotation
+class stacked with multiple `@Preview` entries fans out when applied:
+
+```kotlin
+@Preview(device = WearDevices.SMALL_ROUND, name = "Small Round")
+@Preview(device = WearDevices.LARGE_ROUND, name = "Large Round")
+internal annotation class MultiRoundTilesPreviews
+```
+
+Apply `@MultiRoundTilesPreviews` to a tile preview function and discovery
+expands it to both devices. The plugin's discovery walks the annotation
+class looking for `@Preview` (with cycle detection), so nested meta-preview
+annotations work identically to the Compose side.
+
+## Reference sample
+
+Working examples live in
+[`sample-wear/src/main/kotlin/com/example/samplewear/TilePreviews.kt`](../../../sample-wear/src/main/kotlin/com/example/samplewear/TilePreviews.kt):
+
+- `HelloTilePreview` — minimal `titleCard` inside `primaryLayout`,
+  exercising `materialScope` + `.layoutString`.
+- `StepsTilePreview` — adds a `textEdgeButton` in `bottomSlot`, proving the
+  M3 scaffold slots render independently.
+- `MultiRoundTilesPreviews` — multi-preview fan-out across small and large
+  round devices.
+
+`./gradlew :sample-wear:renderAllPreviews` produces the tile PNGs alongside
+the Compose ones; the preview manifest tags tile entries with
+`kind = TILE` so tooling can treat them differently if needed.


### PR DESCRIPTION
## Summary

- **`design/REMOTE_COMPOSE.md`** — minimal companion to `WEAR_UI.md` for Remote Compose. Explains what it actually is (different applier, `@RemoteComposable` target marker instead of `@UiComposable`, captures into a replayable `RemoteDocument`), the creation/tooling artifact layout, and the two preview shapes (`RemotePreview { … }` inside a `@Preview` vs. `@PreviewWrapper(RemotePreviewWrapper::class)`). Mentions that Wear's `remote-material3` builds on top of `remote-creation-compose` for Material 3 components inside a remote tree, and points at `sample-remotecompose/` as the runnable reference.

- **`design/WEAR_TILES.md`** — same treatment for Wear Tiles. Tiles are protolayout, not Compose; preview functions return `TilePreviewData` rather than being composables; the renderer routes through `TileRenderer` rather than `ComposeTestRule`. Covers the dependency wiring, `materialScope` / `primaryLayout` / `titleCard` / `textEdgeButton` authoring, and multi-preview fan-out. Points at `sample-wear/src/main/kotlin/com/example/samplewear/TilePreviews.kt` for a working example.

- **`SKILL.md`** — new short sections that link to both guides from the existing Wear design guidance block.

## Test plan

- [x] Inline file paths in both guides resolve (`sample-remotecompose/`, `sample-wear/.../TilePreviews.kt`)
- [x] Dependency lists match what the sample modules actually declare
- [x] Render the samples to confirm the referenced APIs still exist: `./gradlew :sample-remotecompose:renderAllPreviews` and `./gradlew :sample-wear:renderAllPreviews`