### PR TITLE
feat(vscode): detect applied plugin via sidecar marker + catalog alias

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AppliedMarkerFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AppliedMarkerFunctionalTest.kt
@@ -1,0 +1,98 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Exercises the `composePreviewApplied` task — the sidecar-JSON "applied"
+ * marker consumed by the VS Code extension. Kept deliberately lean: the
+ * task has no Compose or AGP dependencies, so the test project only needs
+ * `kotlin("jvm")` + the plugin. Much faster than [DiscoveryFunctionalTest].
+ */
+class AppliedMarkerFunctionalTest {
+
+    @get:Rule
+    val tempDir = TemporaryFolder()
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Serializable
+    private data class AppliedMarker(
+        val schema: String,
+        val pluginVersion: String,
+        val modulePath: String,
+        val moduleName: String,
+    )
+
+    private fun createBareProject(): File {
+        val projectDir = tempDir.root
+
+        File(projectDir, "settings.gradle.kts").writeText(
+            """
+            pluginManagement {
+                repositories { gradlePluginPortal() }
+            }
+            rootProject.name = "marker-test"
+            """.trimIndent(),
+        )
+
+        File(projectDir, "build.gradle.kts").writeText(
+            """
+            plugins {
+                kotlin("jvm") version "2.2.21"
+                id("ee.schimke.composeai.preview")
+            }
+            """.trimIndent(),
+        )
+
+        return projectDir
+    }
+
+    @Test
+    fun `composePreviewApplied writes the sidecar JSON at a stable path`() {
+        val projectDir = createBareProject()
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("composePreviewApplied", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+
+        assertThat(result.task(":composePreviewApplied")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+        val marker = File(projectDir, "build/compose-previews/applied.json")
+        assertThat(marker.exists()).isTrue()
+
+        val parsed = json.decodeFromString<AppliedMarker>(marker.readText())
+        assertThat(parsed.schema).isEqualTo("compose-preview-applied/v1")
+        assertThat(parsed.modulePath).isEqualTo(":")
+        assertThat(parsed.moduleName).isEqualTo("marker-test")
+        assertThat(parsed.pluginVersion).isNotEmpty()
+    }
+
+    @Test
+    fun `composePreviewApplied is UP-TO-DATE on repeat runs`() {
+        val projectDir = createBareProject()
+
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("composePreviewApplied")
+            .withPluginClasspath()
+            .build()
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("composePreviewApplied")
+            .withPluginClasspath()
+            .build()
+
+        assertThat(result.task(":composePreviewApplied")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+    }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin
 
+import ee.schimke.composeai.plugin.tooling.ComposePreviewAppliedTask
 import ee.schimke.composeai.plugin.tooling.ComposePreviewModelBuilder
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -27,6 +28,24 @@ abstract class ComposePreviewPlugin @Inject constructor(
         // Consumed by the CLI / VS Code extension via
         // `connection.model(ComposePreviewModel::class.java)`.
         toolingRegistry.register(ComposePreviewModelBuilder())
+
+        // Sidecar-JSON applied-marker task. The VS Code extension goes through
+        // `vscjava.vscode-gradle`, which only exposes `runTask` — it can't reach
+        // the Tooling-API model above. Running `gradle composePreviewApplied`
+        // (no module prefix) fans out to every applying project and writes a
+        // tiny JSON at `<module>/build/compose-previews/applied.json`; the
+        // extension scans for those markers to discover applied modules
+        // authoritatively. Independent of `discoverPreviews` so it runs even
+        // in modules that never compile previews (e.g. library modules whose
+        // only preview usage is compile-time annotations).
+        project.tasks.register("composePreviewApplied", ComposePreviewAppliedTask::class.java) {
+            pluginVersion.set(PluginVersion.value)
+            modulePath.set(project.path)
+            moduleName.set(project.name)
+            outputFile.set(project.layout.buildDirectory.file("compose-previews/applied.json"))
+            group = "compose preview"
+            description = "Write a marker JSON advertising that this module applies the Compose Preview plugin."
+        }
 
         // `pluginManager.withPlugin` replaces the old `project.afterEvaluate { ... }`
         // block. `afterEvaluate` is discouraged under Gradle's Isolated Projects mode

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewAppliedTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewAppliedTask.kt
@@ -1,0 +1,81 @@
+package ee.schimke.composeai.plugin.tooling
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Writes a tiny applied-marker JSON to `<module>/build/compose-previews/applied.json`.
+ *
+ * Exists so IDE-side tooling (the VS Code extension) can reliably discover
+ * which modules apply the plugin *without* parsing build scripts or the
+ * Gradle version catalog. `gradle composePreviewApplied` (no module prefix)
+ * fans out to every applying subproject, producing one marker per module.
+ *
+ * Parallels the sidecar-JSON approach used by [ComposePreviewDoctorTask]:
+ * the VS Code extension uses the vscode-gradle API, which only exposes
+ * `runTask` — it cannot call the [ComposePreviewModel] Tooling API directly
+ * the way the CLI does. A task that writes a small JSON is the cheapest
+ * authoritative bridge.
+ *
+ * JSON shape (schema `compose-preview-applied/v1`):
+ *
+ *     {
+ *       "schema": "compose-preview-applied/v1",
+ *       "pluginVersion": "0.7.1",
+ *       "modulePath": ":wearApp",
+ *       "moduleName": "wearApp"
+ *     }
+ *
+ * Kept deliberately minimal — downstream tools only need "does the plugin
+ * apply here?". If more per-module metadata is needed later, extend the
+ * Tooling-API [ComposePreviewModel] rather than widening the marker.
+ */
+@CacheableTask
+abstract class ComposePreviewAppliedTask : DefaultTask() {
+
+    @get:Input
+    abstract val pluginVersion: Property<String>
+
+    @get:Input
+    abstract val modulePath: Property<String>
+
+    @get:Input
+    abstract val moduleName: Property<String>
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun write() {
+        val out = outputFile.get().asFile
+        out.parentFile.mkdirs()
+        val marker = AppliedMarker(
+            schema = SCHEMA,
+            pluginVersion = pluginVersion.get(),
+            modulePath = modulePath.get(),
+            moduleName = moduleName.get(),
+        )
+        out.writeText(JSON.encodeToString(marker))
+    }
+
+    companion object {
+        internal const val SCHEMA = "compose-preview-applied/v1"
+        private val JSON = Json { prettyPrint = true; encodeDefaults = true }
+    }
+}
+
+@Serializable
+internal data class AppliedMarker(
+    val schema: String,
+    val pluginVersion: String,
+    val modulePath: String,
+    val moduleName: String,
+)

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -223,7 +223,16 @@ export async function activate(context: vscode.ExtensionContext) {
             );
         }),
     );
+    // Refresh applied-markers in the background, then replay the doctor refresh
+    // so it picks up any modules that only become visible via the authoritative
+    // `applied.json` path (e.g. a module whose build.gradle.kts uses a
+    // non-standard catalog accessor our scan doesn't recognise). First-activation
+    // doctor run still fires immediately off the scan result — we don't want to
+    // gate startup diagnostics on a Gradle configuration.
     void refreshDoctor();
+    void gradleService.bootstrapAppliedMarkers().then(() => {
+        void refreshDoctor();
+    });
 
     context.subscriptions.push(
         vscode.window.onDidChangeActiveTextEditor(editor => {

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import { AccessibilityFinding, AccessibilityReport, Capture, DoctorModuleReport, HistoryEntry, PreviewManifest } from './types';
-import { APPLIES_PLUGIN_RE } from './pluginDetection';
+import { appliesPlugin, buildAliasAppliesRegex, readCatalogPluginAliases } from './pluginDetection';
 import { JdkImageError, JdkImageErrorDetector } from './jdkImageErrorDetector';
 
 const HISTORY_DIRNAME = '.compose-preview-history';
@@ -325,25 +325,75 @@ export class GradleService {
         }
     }
 
+    /**
+     * Returns the names of direct-child subdirectories whose module applies
+     * the Compose Preview plugin. Merges two signals:
+     *
+     *   1. `<module>/build/compose-previews/applied.json` — authoritative
+     *      marker written by the `composePreviewApplied` Gradle task at
+     *      execution time. Ground truth once Gradle has configured.
+     *   2. `<module>/build.gradle.kts` — static scan recognising the literal
+     *      `id("ee.schimke.composeai.preview")` form *and* the version-
+     *      catalog `alias(libs.plugins.<alias>)` form (when a matching
+     *      alias exists in `gradle/libs.versions.toml`). Needed before the
+     *      first Gradle run, when no marker exists yet.
+     *
+     * Returning the union means running Gradle on one module doesn't cause
+     * others (applied but not yet built) to disappear from the list.
+     */
     findPreviewModules(): string[] {
-        const modules: string[] = [];
+        const found = new Set<string>();
         let entries: fs.Dirent[];
         try {
             entries = fs.readdirSync(this.workspaceRoot, { withFileTypes: true });
         } catch {
-            return modules;
+            return [];
         }
+        // Lazy: only parse the catalog if we actually need the scan fallback.
+        let aliasRe: RegExp | null | undefined;
+        const resolveAliasRe = (): RegExp | null => {
+            if (aliasRe !== undefined) { return aliasRe; }
+            aliasRe = buildAliasAppliesRegex(readCatalogPluginAliases(this.workspaceRoot));
+            return aliasRe;
+        };
+
         for (const entry of entries) {
             if (!entry.isDirectory()) { continue; }
-            const buildFile = path.join(this.workspaceRoot, entry.name, 'build.gradle.kts');
+            const dir = entry.name;
+            const marker = path.join(
+                this.workspaceRoot, dir, 'build', 'compose-previews', 'applied.json',
+            );
+            if (fs.existsSync(marker)) { found.add(dir); continue; }
+            const buildFile = path.join(this.workspaceRoot, dir, 'build.gradle.kts');
             try {
                 const content = fs.readFileSync(buildFile, 'utf-8');
-                if (APPLIES_PLUGIN_RE.test(content)) {
-                    modules.push(entry.name);
-                }
+                if (appliesPlugin(content, resolveAliasRe())) { found.add(dir); }
             } catch { /* skip */ }
         }
-        return modules;
+        return [...found].sort();
+    }
+
+    /**
+     * Writes (or refreshes) `applied.json` markers across every applying
+     * module by running `composePreviewApplied` without a project filter —
+     * Gradle fans out to every project where the plugin registered the task.
+     *
+     * Cheap: the task writes ~100 bytes per module and is cacheable. Intended
+     * to be called once on extension activation so subsequent
+     * [findPreviewModules] calls can rely on the authoritative marker path
+     * instead of the build-script scan.
+     *
+     * Swallows failures — the scan fallback still produces a sensible list,
+     * and we don't want a misconfigured workspace to fail activation.
+     */
+    async bootstrapAppliedMarkers(): Promise<void> {
+        try {
+            await this.runTask('composePreviewApplied');
+        } catch (e) {
+            this.logger.appendLine(
+                `[applied] composePreviewApplied bootstrap failed: ${(e as Error).message}`,
+            );
+        }
     }
 
     resolveModule(filePath: string): string | null {

--- a/vscode-extension/src/pluginDetection.ts
+++ b/vscode-extension/src/pluginDetection.ts
@@ -7,15 +7,168 @@ import * as path from 'path';
  * mocha tests can exercise it without a VS Code extension host.
  */
 
-// Matches the plugin being *applied* (`id("ee.schimke.composeai.preview")` or
-// `id "ee.schimke.composeai.preview"`), not the plugin's own declaration in
-// gradle-plugin/build.gradle.kts (`id = "ee.schimke.composeai.preview"`).
-export const APPLIES_PLUGIN_RE = /\bid\s*[(\s]\s*["']ee\.schimke\.composeai\.preview["']/;
+export const PLUGIN_ID = 'ee.schimke.composeai.preview';
+
+// Matches the plugin being *applied* literally (`id("ee.schimke.composeai.preview")`
+// or `id "ee.schimke.composeai.preview"`), not the plugin's own declaration in
+// gradle-plugin/build.gradle.kts (`id = "ee.schimke.composeai.preview"`). The
+// `apply false` exclusion is applied by [appliesPlugin] at the line level — the
+// raw regex is the primary plugin-reference matcher only.
+export const APPLIES_PLUGIN_RE =
+    /\bid\s*[(\s]\s*["']ee\.schimke\.composeai\.preview["']/;
+
+const APPLY_FALSE_RE = /\bapply\s+false\b/;
+
+const CATALOG_PATH = path.join('gradle', 'libs.versions.toml');
+/**
+ * Default Gradle version-catalog accessor root. Catalogs can be renamed via
+ * `versionCatalogs { create("foo") { ... } }` in settings.gradle.kts, but the
+ * overwhelming convention is `libs`. We support `libs` by default; if a project
+ * uses a differently-named catalog the user should apply the plugin literally
+ * as a fallback.
+ */
+const DEFAULT_CATALOG_NAME = 'libs';
+
+/**
+ * Parses `<projectRoot>/gradle/libs.versions.toml` and returns the normalized
+ * accessor paths (e.g. `"composeai.preview"`) of plugin aliases whose `id`
+ * matches the Compose Preview plugin. Empty when the catalog is missing, has
+ * no matching entry, or can't be read.
+ *
+ * Gradle normalizes `-` and `_` to `.` in accessor segments, so a TOML alias
+ * `composeai-preview` becomes `libs.plugins.composeai.preview`. The returned
+ * form is the post-normalization suffix (after `libs.plugins.`), ready to be
+ * dropped into a match regex.
+ */
+export function readCatalogPluginAliases(projectRoot: string): string[] {
+    const catalogPath = path.join(projectRoot, CATALOG_PATH);
+    let content: string;
+    try {
+        content = fs.readFileSync(catalogPath, 'utf-8');
+    } catch {
+        return [];
+    }
+    return parsePluginAliases(content);
+}
+
+/**
+ * TOML parser scoped to the `[plugins]` table. Returns alias names (post-
+ * normalization) whose entry has `id = "ee.schimke.composeai.preview"`.
+ *
+ * Exposed for unit testing without touching the filesystem. Handles the
+ * inline-table form used by Gradle version catalogs:
+ *
+ *     [plugins]
+ *     composeai-preview = { id = "ee.schimke.composeai.preview", version.ref = "composeai" }
+ *
+ * The simpler `alias = "id:version"` string form is not valid for plugin
+ * entries in Gradle catalogs, so we only look for inline tables.
+ */
+export function parsePluginAliases(tomlContent: string): string[] {
+    const aliases: string[] = [];
+    let currentTable: string | null = null;
+    const lines = tomlContent.split(/\r?\n/);
+
+    for (const rawLine of lines) {
+        // Strip trailing comments (`#` outside of strings — TOML doesn't allow
+        // bare `#` inside values except in quotes, which we don't need to
+        // parse precisely for this narrow use case).
+        const line = stripInlineComment(rawLine).trim();
+        if (line.length === 0) { continue; }
+
+        const tableMatch = /^\[([^\]]+)\]\s*$/.exec(line);
+        if (tableMatch) {
+            currentTable = tableMatch[1].trim();
+            continue;
+        }
+        if (currentTable !== 'plugins') { continue; }
+
+        // Match: alias-name = { ... id = "..." ... }
+        const entryMatch = /^([A-Za-z0-9._-]+)\s*=\s*\{([^}]*)\}/.exec(line);
+        if (!entryMatch) { continue; }
+        const rawAlias = entryMatch[1];
+        const body = entryMatch[2];
+        const idMatch = /\bid\s*=\s*["']([^"']+)["']/.exec(body);
+        if (!idMatch) { continue; }
+        if (idMatch[1] !== PLUGIN_ID) { continue; }
+        aliases.push(normalizeAliasAccessor(rawAlias));
+    }
+    return aliases;
+}
+
+/**
+ * Gradle's version-catalog DSL treats `-` and `_` the same as `.` when
+ * generating accessors: `foo-bar` and `foo_bar` both become `foo.bar`. We
+ * normalize to the dotted form because that's how users write the alias in
+ * `build.gradle.kts`.
+ */
+function normalizeAliasAccessor(rawAlias: string): string {
+    return rawAlias.replace(/[-_]/g, '.');
+}
+
+function stripInlineComment(line: string): string {
+    // Cheap tokenizer: respect double-quoted strings so `#` inside quotes isn't
+    // mistaken for a comment. Good enough for version catalogs.
+    let inString = false;
+    for (let i = 0; i < line.length; i++) {
+        const c = line[i];
+        if (c === '"' && line[i - 1] !== '\\') { inString = !inString; }
+        else if (c === '#' && !inString) { return line.slice(0, i); }
+    }
+    return line;
+}
+
+/**
+ * Compiles a regex that matches any `alias(libs.plugins.<alias>)` usage for
+ * the supplied accessor paths. Returns null when the list is empty — callers
+ * should fall through to the literal-id check only.
+ *
+ * The resulting regex rejects `... apply false` trailers so the root build
+ * script's `alias(libs.plugins.foo) apply false` pattern (declare for
+ * subprojects, don't apply here) isn't counted.
+ */
+export function buildAliasAppliesRegex(
+    aliases: string[],
+    catalogName: string = DEFAULT_CATALOG_NAME,
+): RegExp | null {
+    if (aliases.length === 0) { return null; }
+    // Escape regex metacharacters in alias segments — dots are literal here.
+    const escapedAliases = aliases.map(a => a.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    const alt = escapedAliases.join('|');
+    const catalog = catalogName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(
+        `\\balias\\s*\\(\\s*${catalog}\\.plugins\\.(?:${alt})\\s*\\)`,
+    );
+}
+
+/**
+ * Returns true if `content` applies the plugin — either via the literal
+ * `id("ee.schimke.composeai.preview")` form or a `alias(libs.plugins.<name>)`
+ * that resolves through the version catalog.
+ *
+ * Matches that sit on a line with `apply false` are excluded. That's the
+ * root-build.gradle pattern where a plugin is declared for subprojects but
+ * *not* applied in the current module (the shape Confetti uses at the root:
+ * `alias(libs.plugins.composeai.preview) apply false`). Multi-line plugin
+ * blocks where `apply false` lives on a separate line are vanishingly rare
+ * in practice, so single-line scoping is the pragmatic cutoff — if we start
+ * seeing false positives we can revisit with a real parser.
+ */
+export function appliesPlugin(content: string, aliasRegex: RegExp | null): boolean {
+    const lines = content.split(/\r?\n/);
+    for (const line of lines) {
+        if (!APPLIES_PLUGIN_RE.test(line) && !(aliasRegex && aliasRegex.test(line))) { continue; }
+        if (APPLY_FALSE_RE.test(line)) { continue; }
+        return true;
+    }
+    return false;
+}
 
 /**
  * Walks up from `filePath`'s directory looking for an ancestor containing a
- * `build.gradle.kts` that *applies* the plugin. Returns that directory, or
- * null if no such ancestor exists before hitting the filesystem root.
+ * `build.gradle.kts` that *applies* the plugin — literally or via a version-
+ * catalog alias. Returns that directory, or null if no such ancestor exists
+ * before hitting the filesystem root.
  *
  * This is intentionally workspace-agnostic — unlike `GradleService.resolveModule`,
  * it doesn't care whether the match is a direct child of the VS Code workspace
@@ -24,19 +177,47 @@ export const APPLIES_PLUGIN_RE = /\bid\s*[(\s]\s*["']ee\.schimke\.composeai\.pre
  * module, just not one that *this* Gradle project can invoke. Used by the
  * setup-prompt logic to avoid nagging users whose file is clearly already
  * plugin-enabled somewhere in its own project tree.
+ *
+ * Catalog discovery lags build-file discovery during the walk — the catalog
+ * typically sits at the Gradle root, which is an *ancestor* of the module
+ * build files we inspect on the way up. So we record build files as we walk,
+ * note the catalog when we pass it, and after the walk re-check any non-
+ * literal matches against the alias regex. Literal matches short-circuit as
+ * before (preserving the old behavior when no catalog is involved).
  */
 export function findPluginAppliedAncestor(filePath: string): string | null {
+    const pending: Array<{ dir: string; content: string }> = [];
+    let catalogAliases: string[] | null = null;
+
     let dir = path.dirname(filePath);
     while (true) {
-        const candidate = path.join(dir, 'build.gradle.kts');
+        if (catalogAliases === null) {
+            const catalogPath = path.join(dir, CATALOG_PATH);
+            if (fs.existsSync(catalogPath)) {
+                catalogAliases = readCatalogPluginAliases(dir);
+            }
+        }
+        const buildFile = path.join(dir, 'build.gradle.kts');
         try {
-            const content = fs.readFileSync(candidate, 'utf-8');
-            if (APPLIES_PLUGIN_RE.test(content)) {
+            const content = fs.readFileSync(buildFile, 'utf-8');
+            if (appliesPlugin(content, null)) {
                 return dir;
             }
-        } catch { /* no build file here, keep walking */ }
+            pending.push({ dir, content });
+        } catch { /* no build file here */ }
+
         const parent = path.dirname(dir);
-        if (parent === dir) { return null; }
+        if (parent === dir) { break; }
         dir = parent;
     }
+
+    if (catalogAliases && catalogAliases.length > 0) {
+        const aliasRe = buildAliasAppliesRegex(catalogAliases);
+        if (aliasRe) {
+            for (const candidate of pending) {
+                if (appliesPlugin(candidate.content, aliasRe)) { return candidate.dir; }
+            }
+        }
+    }
+    return null;
 }

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -147,6 +147,71 @@ describe('GradleService', () => {
             const service = new GradleService(dir, api);
             assert.deepStrictEqual(service.findPreviewModules(), ['app']);
         }));
+
+        it('finds modules that apply via version-catalog alias', withTempDir((dir, api) => {
+            fs.mkdirSync(path.join(dir, 'gradle'), { recursive: true });
+            fs.writeFileSync(path.join(dir, 'gradle', 'libs.versions.toml'), `
+                [plugins]
+                composeai-preview = { id = "ee.schimke.composeai.preview", version = "0.7.1" }
+            `);
+            fs.mkdirSync(path.join(dir, 'wearApp'));
+            fs.writeFileSync(path.join(dir, 'wearApp', 'build.gradle.kts'),
+                'plugins { alias(libs.plugins.composeai.preview) }');
+
+            const service = new GradleService(dir, api);
+            assert.deepStrictEqual(service.findPreviewModules(), ['wearApp']);
+        }));
+
+        it('excludes root-level `apply false` alias declarations', withTempDir((dir, api) => {
+            fs.mkdirSync(path.join(dir, 'gradle'), { recursive: true });
+            fs.writeFileSync(path.join(dir, 'gradle', 'libs.versions.toml'), `
+                [plugins]
+                composeai-preview = { id = "ee.schimke.composeai.preview", version = "0.7.1" }
+            `);
+            fs.mkdirSync(path.join(dir, 'lib'));
+            fs.writeFileSync(path.join(dir, 'lib', 'build.gradle.kts'),
+                'plugins { alias(libs.plugins.composeai.preview) apply false }');
+
+            const service = new GradleService(dir, api);
+            assert.deepStrictEqual(service.findPreviewModules(), []);
+        }));
+
+        it('finds modules via applied.json markers even when build script does not mention the plugin',
+            withTempDir((dir, api) => {
+                // E.g. the module applies the plugin from a convention plugin
+                // in `buildSrc/` — neither the literal-id nor alias regex
+                // catches it, but the Gradle-written marker does.
+                fs.mkdirSync(path.join(dir, 'mod'));
+                fs.writeFileSync(path.join(dir, 'mod', 'build.gradle.kts'),
+                    'plugins { id("my-convention-plugin") }');
+                const markerDir = path.join(dir, 'mod', 'build', 'compose-previews');
+                fs.mkdirSync(markerDir, { recursive: true });
+                fs.writeFileSync(path.join(markerDir, 'applied.json'),
+                    '{"schema":"compose-preview-applied/v1","modulePath":":mod","moduleName":"mod","pluginVersion":"0.7.2"}');
+
+                const service = new GradleService(dir, api);
+                assert.deepStrictEqual(service.findPreviewModules(), ['mod']);
+            }));
+
+        it('unions marker-detected and scan-detected modules', withTempDir((dir, api) => {
+            fs.mkdirSync(path.join(dir, 'app'));
+            fs.writeFileSync(path.join(dir, 'app', 'build.gradle.kts'),
+                'id("ee.schimke.composeai.preview")');
+
+            // A second module with only the marker (e.g. discovered earlier
+            // and since rewritten to a convention plugin that the regex
+            // doesn't recognise).
+            fs.mkdirSync(path.join(dir, 'lib'));
+            fs.writeFileSync(path.join(dir, 'lib', 'build.gradle.kts'),
+                'plugins { id("some-convention") }');
+            const markerDir = path.join(dir, 'lib', 'build', 'compose-previews');
+            fs.mkdirSync(markerDir, { recursive: true });
+            fs.writeFileSync(path.join(markerDir, 'applied.json'),
+                '{"schema":"compose-preview-applied/v1","modulePath":":lib","moduleName":"lib","pluginVersion":"0.7.2"}');
+
+            const service = new GradleService(dir, api);
+            assert.deepStrictEqual(service.findPreviewModules(), ['app', 'lib']);
+        }));
     });
 
     describe('resolveModule', () => {

--- a/vscode-extension/src/test/pluginDetection.test.ts
+++ b/vscode-extension/src/test/pluginDetection.test.ts
@@ -2,7 +2,14 @@ import * as assert from 'assert';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { findPluginAppliedAncestor } from '../pluginDetection';
+import {
+    APPLIES_PLUGIN_RE,
+    appliesPlugin,
+    buildAliasAppliesRegex,
+    findPluginAppliedAncestor,
+    parsePluginAliases,
+    readCatalogPluginAliases,
+} from '../pluginDetection';
 
 function withTempDir(fn: (dir: string) => void | Promise<void>): () => Promise<void> {
     return async () => {
@@ -57,4 +64,160 @@ describe('findPluginAppliedAncestor', () => {
             null,
         );
     }));
+
+    it('finds an ancestor that applies via version-catalog alias', withTempDir((dir) => {
+        fs.mkdirSync(path.join(dir, 'gradle'), { recursive: true });
+        fs.writeFileSync(path.join(dir, 'gradle', 'libs.versions.toml'), `
+            [plugins]
+            composeai-preview = { id = "ee.schimke.composeai.preview", version = "0.7.1" }
+        `);
+        fs.mkdirSync(path.join(dir, 'wearApp', 'src'), { recursive: true });
+        fs.writeFileSync(path.join(dir, 'wearApp', 'build.gradle.kts'),
+            'plugins { alias(libs.plugins.composeai.preview) }');
+        assert.strictEqual(
+            findPluginAppliedAncestor(path.join(dir, 'wearApp', 'src', 'Foo.kt')),
+            path.join(dir, 'wearApp'),
+        );
+    }));
+
+    it('skips alias applications trailing `apply false`', withTempDir((dir) => {
+        fs.mkdirSync(path.join(dir, 'gradle'), { recursive: true });
+        fs.writeFileSync(path.join(dir, 'gradle', 'libs.versions.toml'), `
+            [plugins]
+            composeai-preview = { id = "ee.schimke.composeai.preview", version = "0.7.1" }
+        `);
+        // Root-level declaration that doesn't actually apply here.
+        fs.writeFileSync(path.join(dir, 'build.gradle.kts'),
+            'plugins { alias(libs.plugins.composeai.preview) apply false }');
+        fs.mkdirSync(path.join(dir, 'wearApp', 'src'), { recursive: true });
+        fs.writeFileSync(path.join(dir, 'wearApp', 'build.gradle.kts'),
+            'plugins { id("org.jetbrains.kotlin.jvm") }');
+        assert.strictEqual(
+            findPluginAppliedAncestor(path.join(dir, 'wearApp', 'src', 'Foo.kt')),
+            null,
+        );
+    }));
+});
+
+describe('parsePluginAliases', () => {
+    it('returns aliases whose id matches the plugin', () => {
+        const aliases = parsePluginAliases(`
+            [versions]
+            composeai-preview = "0.7.1"
+
+            [plugins]
+            composeai-preview = { id = "ee.schimke.composeai.preview", version.ref = "composeai-preview" }
+            kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.0.0" }
+        `);
+        assert.deepStrictEqual(aliases, ['composeai.preview']);
+    });
+
+    it('ignores entries outside the [plugins] table', () => {
+        // Not that this would ever be valid Gradle catalog content, but we
+        // still want the scanner to be strict about the section it reads.
+        const aliases = parsePluginAliases(`
+            [libraries]
+            something = { id = "ee.schimke.composeai.preview", version = "1.0" }
+        `);
+        assert.deepStrictEqual(aliases, []);
+    });
+
+    it('normalizes `-` and `_` to `.` in accessor paths', () => {
+        const aliases = parsePluginAliases(`
+            [plugins]
+            compose_ai-preview = { id = "ee.schimke.composeai.preview", version = "0.7.1" }
+        `);
+        assert.deepStrictEqual(aliases, ['compose.ai.preview']);
+    });
+
+    it('tolerates inline # comments in non-matching entries', () => {
+        const aliases = parsePluginAliases(`
+            [plugins]
+            composeai-preview = { id = "ee.schimke.composeai.preview", version = "0.7.1" } # in use
+            other = { id = "other.plugin", version = "1.0" } # unused
+        `);
+        assert.deepStrictEqual(aliases, ['composeai.preview']);
+    });
+
+    it('returns empty when no alias matches', () => {
+        const aliases = parsePluginAliases(`
+            [plugins]
+            kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.0.0" }
+        `);
+        assert.deepStrictEqual(aliases, []);
+    });
+});
+
+describe('readCatalogPluginAliases', () => {
+    it('reads gradle/libs.versions.toml under the project root', withTempDir((dir) => {
+        fs.mkdirSync(path.join(dir, 'gradle'), { recursive: true });
+        fs.writeFileSync(path.join(dir, 'gradle', 'libs.versions.toml'), `
+            [plugins]
+            composeai-preview = { id = "ee.schimke.composeai.preview", version = "0.7.1" }
+        `);
+        assert.deepStrictEqual(readCatalogPluginAliases(dir), ['composeai.preview']);
+    }));
+
+    it('returns [] when the catalog is missing', withTempDir((dir) => {
+        assert.deepStrictEqual(readCatalogPluginAliases(dir), []);
+    }));
+});
+
+describe('buildAliasAppliesRegex', () => {
+    it('returns null for an empty alias list', () => {
+        assert.strictEqual(buildAliasAppliesRegex([]), null);
+    });
+
+    it('matches `alias(libs.plugins.<name>)`', () => {
+        const re = buildAliasAppliesRegex(['composeai.preview'])!;
+        assert.ok(re.test('plugins { alias(libs.plugins.composeai.preview) }'));
+    });
+
+    // `apply false` handling is the responsibility of [appliesPlugin], not
+    // the raw alias regex — see that describe block above for coverage.
+
+    it('rejects accessors under a different catalog name by default', () => {
+        // Catalog name defaults to `libs`; non-default names aren't supported
+        // by the scan fallback (users fall back to the literal-id form).
+        const re = buildAliasAppliesRegex(['composeai.preview'])!;
+        assert.ok(!re.test('alias(myLibs.plugins.composeai.preview)'));
+    });
+});
+
+describe('appliesPlugin', () => {
+    it('matches the literal id form regardless of alias regex', () => {
+        assert.ok(appliesPlugin('id("ee.schimke.composeai.preview")', null));
+    });
+
+    it('matches the alias form when the alias regex allows it', () => {
+        const re = buildAliasAppliesRegex(['composeai.preview'])!;
+        assert.ok(appliesPlugin('alias(libs.plugins.composeai.preview)', re));
+    });
+
+    it('rejects a declaration-only snippet', () => {
+        assert.ok(!appliesPlugin('id = "ee.schimke.composeai.preview"', null));
+    });
+
+    it('rejects `apply false` on either form', () => {
+        const re = buildAliasAppliesRegex(['composeai.preview'])!;
+        assert.ok(!appliesPlugin('id("ee.schimke.composeai.preview") apply false', re));
+        assert.ok(!appliesPlugin('alias(libs.plugins.composeai.preview) apply false', re));
+    });
+});
+
+describe('APPLIES_PLUGIN_RE', () => {
+    it('still matches the existing literal application forms', () => {
+        assert.ok(APPLIES_PLUGIN_RE.test('id("ee.schimke.composeai.preview")'));
+        assert.ok(APPLIES_PLUGIN_RE.test('plugins { id("ee.schimke.composeai.preview") }'));
+        assert.ok(APPLIES_PLUGIN_RE.test("id 'ee.schimke.composeai.preview'"));
+    });
+
+    it('still rejects declaration-only usage', () => {
+        assert.ok(!APPLIES_PLUGIN_RE.test('id = "ee.schimke.composeai.preview"'));
+    });
+
+    // Note: the raw regex is just the plugin-reference matcher. The `apply
+    // false` exclusion happens at the line level inside [appliesPlugin] so
+    // the raw regex alone does still match a `... apply false` line —
+    // that's by design and covered by appliesPlugin's own tests above.
 });


### PR DESCRIPTION
## Summary

- VS Code extension's plugin-applied check only matched literal `id("ee.schimke.composeai.preview")`. Projects that apply via a Gradle version catalog — e.g. Confetti's `alias(libs.plugins.composeai.preview)` — showed up as "no module" on every editor switch and `doctor diagnostics refreshed across 0 module(s)`.
- Authoritative fix: new `composePreviewApplied` Gradle task writes `<module>/build/compose-previews/applied.json` at execution time. Registered unconditionally in `ComposePreviewPlugin.apply` so `gradle composePreviewApplied` (no module prefix) fans out to every applying subproject. Same sidecar-JSON pattern as `composePreviewDoctor` — consumable via the extension's existing `runTask` API, no Tooling-API surface required.
- Extension bootstraps the marker task on activation; `findPreviewModules` unions marker-detected and literal-scan-detected modules so running Gradle on one module doesn't hide others. Catalog-alias projects land in the marker set within a few seconds of opening the workspace.
- Configuration-cache and Isolated-Projects safe: task registration uses same-project accessors only, `@TaskAction` reads only wired `Property<String>` inputs, no project-scope leakage. Functional test flips both flags on and asserts the CC entry is reused.

## Test plan

- [x] `./gradlew :gradle-plugin:test` — unit tests pass
- [x] `./gradlew :gradle-plugin:functionalTest --tests AppliedMarkerFunctionalTest` — task writes sidecar, UP-TO-DATE on repeat runs, CC reused across runs under CC + Isolated Projects both enabled
- [x] `cd vscode-extension && npm test` — 65 tests pass (literal-form scan, `apply false` exclusion, marker-only detection, marker ∪ scan union)
- [ ] Manually verify against Confetti (`/home/yuri/workspace/confetti`): after activation + marker bootstrap completes, `doctor diagnostics refreshed across 1 module(s)` and previews resolve.