### PR TITLE
refactor(vscode): drop TOML parsing — rely on applied.json + literal scan

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AppliedMarkerFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AppliedMarkerFunctionalTest.kt
@@ -52,6 +52,15 @@ class AppliedMarkerFunctionalTest {
             """.trimIndent(),
         )
 
+        // Configuration cache + Isolated Projects on by default — every
+        // assertion in this file is implicitly an IP/CC-safety assertion.
+        File(projectDir, "gradle.properties").writeText(
+            """
+            org.gradle.configuration-cache=true
+            org.gradle.unsafe.isolated-projects=true
+            """.trimIndent(),
+        )
+
         return projectDir
     }
 
@@ -94,5 +103,32 @@ class AppliedMarkerFunctionalTest {
             .build()
 
         assertThat(result.task(":composePreviewApplied")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+    }
+
+    @Test
+    fun `configuration cache is reused across runs`() {
+        val projectDir = createBareProject()
+
+        // First run stores the CC entry. `--info` surfaces the
+        // "Configuration cache entry stored" / "reused" messages we want to
+        // assert on — Gradle itself doesn't fail the build on an IP/CC
+        // violation at this level, so we verify by output inspection.
+        val first = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("composePreviewApplied", "--info")
+            .withPluginClasspath()
+            .build()
+        assertThat(first.output).contains("Configuration cache entry stored")
+
+        val second = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("composePreviewApplied", "--info")
+            .withPluginClasspath()
+            .build()
+        // "reused" is the string Gradle prints when the cache hit is clean.
+        // Anything that violated CC invariants during config would have
+        // caused "discarded" or an outright failure — both of which we'd
+        // catch here.
+        assertThat(second.output).contains("Reusing configuration cache")
     }
 }

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import { AccessibilityFinding, AccessibilityReport, Capture, DoctorModuleReport, HistoryEntry, PreviewManifest } from './types';
-import { appliesPlugin, buildAliasAppliesRegex, readCatalogPluginAliases } from './pluginDetection';
+import { appliesPlugin } from './pluginDetection';
 import { JdkImageError, JdkImageErrorDetector } from './jdkImageErrorDetector';
 
 const HISTORY_DIRNAME = '.compose-preview-history';
@@ -330,16 +330,17 @@ export class GradleService {
      * the Compose Preview plugin. Merges two signals:
      *
      *   1. `<module>/build/compose-previews/applied.json` — authoritative
-     *      marker written by the `composePreviewApplied` Gradle task at
-     *      execution time. Ground truth once Gradle has configured.
-     *   2. `<module>/build.gradle.kts` — static scan recognising the literal
-     *      `id("ee.schimke.composeai.preview")` form *and* the version-
-     *      catalog `alias(libs.plugins.<alias>)` form (when a matching
-     *      alias exists in `gradle/libs.versions.toml`). Needed before the
-     *      first Gradle run, when no marker exists yet.
+     *      marker written by the `composePreviewApplied` Gradle task. Covers
+     *      every apply mechanism (literal `id`, version-catalog alias,
+     *      convention plugin, buildSrc) because Gradle itself wrote it.
+     *   2. `<module>/build.gradle.kts` matching literal
+     *      `id("ee.schimke.composeai.preview")`. Pre-Gradle-run fallback so
+     *      trivially-configured workspaces aren't empty on first open.
      *
      * Returning the union means running Gradle on one module doesn't cause
      * others (applied but not yet built) to disappear from the list.
+     * Projects that only apply via a catalog alias show up as empty until
+     * the bootstrap marker run completes — see [bootstrapAppliedMarkers].
      */
     findPreviewModules(): string[] {
         const found = new Set<string>();
@@ -349,14 +350,6 @@ export class GradleService {
         } catch {
             return [];
         }
-        // Lazy: only parse the catalog if we actually need the scan fallback.
-        let aliasRe: RegExp | null | undefined;
-        const resolveAliasRe = (): RegExp | null => {
-            if (aliasRe !== undefined) { return aliasRe; }
-            aliasRe = buildAliasAppliesRegex(readCatalogPluginAliases(this.workspaceRoot));
-            return aliasRe;
-        };
-
         for (const entry of entries) {
             if (!entry.isDirectory()) { continue; }
             const dir = entry.name;
@@ -367,7 +360,7 @@ export class GradleService {
             const buildFile = path.join(this.workspaceRoot, dir, 'build.gradle.kts');
             try {
                 const content = fs.readFileSync(buildFile, 'utf-8');
-                if (appliesPlugin(content, resolveAliasRe())) { found.add(dir); }
+                if (appliesPlugin(content)) { found.add(dir); }
             } catch { /* skip */ }
         }
         return [...found].sort();

--- a/vscode-extension/src/pluginDetection.ts
+++ b/vscode-extension/src/pluginDetection.ts
@@ -5,6 +5,17 @@ import * as path from 'path';
  * Pure filesystem helpers for detecting where the Compose Preview Gradle
  * plugin is applied. Lives in its own module (no `vscode` import) so plain
  * mocha tests can exercise it without a VS Code extension host.
+ *
+ * The authoritative signal is the `applied.json` marker written by the
+ * Gradle `composePreviewApplied` task (see [GradleService.findPreviewModules]).
+ * This module covers two cases the marker doesn't:
+ *
+ *   1. Literal `id("ee.schimke.composeai.preview")` in a `build.gradle.kts`
+ *      before the first Gradle run has had a chance to write markers —
+ *      avoids an "empty state" hiccup on freshly opened workspaces.
+ *   2. Walking up from an arbitrary file path to find *any* ancestor
+ *      applying the plugin, regardless of whether the match sits inside
+ *      the current Gradle project or a nested worktree's sibling layout.
  */
 
 export const PLUGIN_ID = 'ee.schimke.composeai.preview';
@@ -19,145 +30,24 @@ export const APPLIES_PLUGIN_RE =
 
 const APPLY_FALSE_RE = /\bapply\s+false\b/;
 
-const CATALOG_PATH = path.join('gradle', 'libs.versions.toml');
 /**
- * Default Gradle version-catalog accessor root. Catalogs can be renamed via
- * `versionCatalogs { create("foo") { ... } }` in settings.gradle.kts, but the
- * overwhelming convention is `libs`. We support `libs` by default; if a project
- * uses a differently-named catalog the user should apply the plugin literally
- * as a fallback.
- */
-const DEFAULT_CATALOG_NAME = 'libs';
-
-/**
- * Parses `<projectRoot>/gradle/libs.versions.toml` and returns the normalized
- * accessor paths (e.g. `"composeai.preview"`) of plugin aliases whose `id`
- * matches the Compose Preview plugin. Empty when the catalog is missing, has
- * no matching entry, or can't be read.
+ * Returns true if `content` applies the plugin literally. Matches on a line
+ * with `apply false` are excluded — that's the root-build.gradle pattern
+ * where a plugin is declared for subprojects but *not* applied in the
+ * current module.
  *
- * Gradle normalizes `-` and `_` to `.` in accessor segments, so a TOML alias
- * `composeai-preview` becomes `libs.plugins.composeai.preview`. The returned
- * form is the post-normalization suffix (after `libs.plugins.`), ready to be
- * dropped into a match regex.
+ * The version-catalog alias form (`alias(libs.plugins.<name>)`) is NOT
+ * handled here — we rely on the `applied.json` marker written by the
+ * `composePreviewApplied` Gradle task to cover that authoritatively. The
+ * marker path sidesteps build-script parsing entirely, which matters
+ * because catalog-alias detection would require parsing
+ * `gradle/libs.versions.toml` to know which accessor segments map to our
+ * plugin id — fragile and easy to get wrong.
  */
-export function readCatalogPluginAliases(projectRoot: string): string[] {
-    const catalogPath = path.join(projectRoot, CATALOG_PATH);
-    let content: string;
-    try {
-        content = fs.readFileSync(catalogPath, 'utf-8');
-    } catch {
-        return [];
-    }
-    return parsePluginAliases(content);
-}
-
-/**
- * TOML parser scoped to the `[plugins]` table. Returns alias names (post-
- * normalization) whose entry has `id = "ee.schimke.composeai.preview"`.
- *
- * Exposed for unit testing without touching the filesystem. Handles the
- * inline-table form used by Gradle version catalogs:
- *
- *     [plugins]
- *     composeai-preview = { id = "ee.schimke.composeai.preview", version.ref = "composeai" }
- *
- * The simpler `alias = "id:version"` string form is not valid for plugin
- * entries in Gradle catalogs, so we only look for inline tables.
- */
-export function parsePluginAliases(tomlContent: string): string[] {
-    const aliases: string[] = [];
-    let currentTable: string | null = null;
-    const lines = tomlContent.split(/\r?\n/);
-
-    for (const rawLine of lines) {
-        // Strip trailing comments (`#` outside of strings — TOML doesn't allow
-        // bare `#` inside values except in quotes, which we don't need to
-        // parse precisely for this narrow use case).
-        const line = stripInlineComment(rawLine).trim();
-        if (line.length === 0) { continue; }
-
-        const tableMatch = /^\[([^\]]+)\]\s*$/.exec(line);
-        if (tableMatch) {
-            currentTable = tableMatch[1].trim();
-            continue;
-        }
-        if (currentTable !== 'plugins') { continue; }
-
-        // Match: alias-name = { ... id = "..." ... }
-        const entryMatch = /^([A-Za-z0-9._-]+)\s*=\s*\{([^}]*)\}/.exec(line);
-        if (!entryMatch) { continue; }
-        const rawAlias = entryMatch[1];
-        const body = entryMatch[2];
-        const idMatch = /\bid\s*=\s*["']([^"']+)["']/.exec(body);
-        if (!idMatch) { continue; }
-        if (idMatch[1] !== PLUGIN_ID) { continue; }
-        aliases.push(normalizeAliasAccessor(rawAlias));
-    }
-    return aliases;
-}
-
-/**
- * Gradle's version-catalog DSL treats `-` and `_` the same as `.` when
- * generating accessors: `foo-bar` and `foo_bar` both become `foo.bar`. We
- * normalize to the dotted form because that's how users write the alias in
- * `build.gradle.kts`.
- */
-function normalizeAliasAccessor(rawAlias: string): string {
-    return rawAlias.replace(/[-_]/g, '.');
-}
-
-function stripInlineComment(line: string): string {
-    // Cheap tokenizer: respect double-quoted strings so `#` inside quotes isn't
-    // mistaken for a comment. Good enough for version catalogs.
-    let inString = false;
-    for (let i = 0; i < line.length; i++) {
-        const c = line[i];
-        if (c === '"' && line[i - 1] !== '\\') { inString = !inString; }
-        else if (c === '#' && !inString) { return line.slice(0, i); }
-    }
-    return line;
-}
-
-/**
- * Compiles a regex that matches any `alias(libs.plugins.<alias>)` usage for
- * the supplied accessor paths. Returns null when the list is empty — callers
- * should fall through to the literal-id check only.
- *
- * The resulting regex rejects `... apply false` trailers so the root build
- * script's `alias(libs.plugins.foo) apply false` pattern (declare for
- * subprojects, don't apply here) isn't counted.
- */
-export function buildAliasAppliesRegex(
-    aliases: string[],
-    catalogName: string = DEFAULT_CATALOG_NAME,
-): RegExp | null {
-    if (aliases.length === 0) { return null; }
-    // Escape regex metacharacters in alias segments — dots are literal here.
-    const escapedAliases = aliases.map(a => a.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-    const alt = escapedAliases.join('|');
-    const catalog = catalogName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return new RegExp(
-        `\\balias\\s*\\(\\s*${catalog}\\.plugins\\.(?:${alt})\\s*\\)`,
-    );
-}
-
-/**
- * Returns true if `content` applies the plugin — either via the literal
- * `id("ee.schimke.composeai.preview")` form or a `alias(libs.plugins.<name>)`
- * that resolves through the version catalog.
- *
- * Matches that sit on a line with `apply false` are excluded. That's the
- * root-build.gradle pattern where a plugin is declared for subprojects but
- * *not* applied in the current module (the shape Confetti uses at the root:
- * `alias(libs.plugins.composeai.preview) apply false`). Multi-line plugin
- * blocks where `apply false` lives on a separate line are vanishingly rare
- * in practice, so single-line scoping is the pragmatic cutoff — if we start
- * seeing false positives we can revisit with a real parser.
- */
-export function appliesPlugin(content: string, aliasRegex: RegExp | null): boolean {
+export function appliesPlugin(content: string): boolean {
     const lines = content.split(/\r?\n/);
     for (const line of lines) {
-        if (!APPLIES_PLUGIN_RE.test(line) && !(aliasRegex && aliasRegex.test(line))) { continue; }
+        if (!APPLIES_PLUGIN_RE.test(line)) { continue; }
         if (APPLY_FALSE_RE.test(line)) { continue; }
         return true;
     }
@@ -166,9 +56,9 @@ export function appliesPlugin(content: string, aliasRegex: RegExp | null): boole
 
 /**
  * Walks up from `filePath`'s directory looking for an ancestor containing a
- * `build.gradle.kts` that *applies* the plugin — literally or via a version-
- * catalog alias. Returns that directory, or null if no such ancestor exists
- * before hitting the filesystem root.
+ * `build.gradle.kts` that literally applies the plugin. Returns that
+ * directory, or null if no such ancestor exists before hitting the
+ * filesystem root.
  *
  * This is intentionally workspace-agnostic — unlike `GradleService.resolveModule`,
  * it doesn't care whether the match is a direct child of the VS Code workspace
@@ -178,46 +68,23 @@ export function appliesPlugin(content: string, aliasRegex: RegExp | null): boole
  * setup-prompt logic to avoid nagging users whose file is clearly already
  * plugin-enabled somewhere in its own project tree.
  *
- * Catalog discovery lags build-file discovery during the walk — the catalog
- * typically sits at the Gradle root, which is an *ancestor* of the module
- * build files we inspect on the way up. So we record build files as we walk,
- * note the catalog when we pass it, and after the walk re-check any non-
- * literal matches against the alias regex. Literal matches short-circuit as
- * before (preserving the old behavior when no catalog is involved).
+ * Only matches the literal `id("…")` application form. Projects that apply
+ * via a version catalog are picked up via the `applied.json` marker path in
+ * [GradleService.findPreviewModules] once Gradle has run — this helper is a
+ * purely static file-walk fallback, used where we don't have a marker.
  */
 export function findPluginAppliedAncestor(filePath: string): string | null {
-    const pending: Array<{ dir: string; content: string }> = [];
-    let catalogAliases: string[] | null = null;
-
     let dir = path.dirname(filePath);
     while (true) {
-        if (catalogAliases === null) {
-            const catalogPath = path.join(dir, CATALOG_PATH);
-            if (fs.existsSync(catalogPath)) {
-                catalogAliases = readCatalogPluginAliases(dir);
-            }
-        }
-        const buildFile = path.join(dir, 'build.gradle.kts');
+        const candidate = path.join(dir, 'build.gradle.kts');
         try {
-            const content = fs.readFileSync(buildFile, 'utf-8');
-            if (appliesPlugin(content, null)) {
+            const content = fs.readFileSync(candidate, 'utf-8');
+            if (appliesPlugin(content)) {
                 return dir;
             }
-            pending.push({ dir, content });
-        } catch { /* no build file here */ }
-
+        } catch { /* no build file here, keep walking */ }
         const parent = path.dirname(dir);
-        if (parent === dir) { break; }
+        if (parent === dir) { return null; }
         dir = parent;
     }
-
-    if (catalogAliases && catalogAliases.length > 0) {
-        const aliasRe = buildAliasAppliesRegex(catalogAliases);
-        if (aliasRe) {
-            for (const candidate of pending) {
-                if (appliesPlugin(candidate.content, aliasRe)) { return candidate.dir; }
-            }
-        }
-    }
-    return null;
 }

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -148,29 +148,10 @@ describe('GradleService', () => {
             assert.deepStrictEqual(service.findPreviewModules(), ['app']);
         }));
 
-        it('finds modules that apply via version-catalog alias', withTempDir((dir, api) => {
-            fs.mkdirSync(path.join(dir, 'gradle'), { recursive: true });
-            fs.writeFileSync(path.join(dir, 'gradle', 'libs.versions.toml'), `
-                [plugins]
-                composeai-preview = { id = "ee.schimke.composeai.preview", version = "0.7.1" }
-            `);
-            fs.mkdirSync(path.join(dir, 'wearApp'));
-            fs.writeFileSync(path.join(dir, 'wearApp', 'build.gradle.kts'),
-                'plugins { alias(libs.plugins.composeai.preview) }');
-
-            const service = new GradleService(dir, api);
-            assert.deepStrictEqual(service.findPreviewModules(), ['wearApp']);
-        }));
-
-        it('excludes root-level `apply false` alias declarations', withTempDir((dir, api) => {
-            fs.mkdirSync(path.join(dir, 'gradle'), { recursive: true });
-            fs.writeFileSync(path.join(dir, 'gradle', 'libs.versions.toml'), `
-                [plugins]
-                composeai-preview = { id = "ee.schimke.composeai.preview", version = "0.7.1" }
-            `);
+        it('excludes literal `apply false` declarations', withTempDir((dir, api) => {
             fs.mkdirSync(path.join(dir, 'lib'));
             fs.writeFileSync(path.join(dir, 'lib', 'build.gradle.kts'),
-                'plugins { alias(libs.plugins.composeai.preview) apply false }');
+                'plugins { id("ee.schimke.composeai.preview") apply false }');
 
             const service = new GradleService(dir, api);
             assert.deepStrictEqual(service.findPreviewModules(), []);

--- a/vscode-extension/src/test/pluginDetection.test.ts
+++ b/vscode-extension/src/test/pluginDetection.test.ts
@@ -5,10 +5,7 @@ import * as os from 'os';
 import {
     APPLIES_PLUGIN_RE,
     appliesPlugin,
-    buildAliasAppliesRegex,
     findPluginAppliedAncestor,
-    parsePluginAliases,
-    readCatalogPluginAliases,
 } from '../pluginDetection';
 
 function withTempDir(fn: (dir: string) => void | Promise<void>): () => Promise<void> {
@@ -65,31 +62,12 @@ describe('findPluginAppliedAncestor', () => {
         );
     }));
 
-    it('finds an ancestor that applies via version-catalog alias', withTempDir((dir) => {
-        fs.mkdirSync(path.join(dir, 'gradle'), { recursive: true });
-        fs.writeFileSync(path.join(dir, 'gradle', 'libs.versions.toml'), `
-            [plugins]
-            composeai-preview = { id = "ee.schimke.composeai.preview", version = "0.7.1" }
-        `);
+    it('skips literal applications trailing `apply false`', withTempDir((dir) => {
         fs.mkdirSync(path.join(dir, 'wearApp', 'src'), { recursive: true });
-        fs.writeFileSync(path.join(dir, 'wearApp', 'build.gradle.kts'),
-            'plugins { alias(libs.plugins.composeai.preview) }');
-        assert.strictEqual(
-            findPluginAppliedAncestor(path.join(dir, 'wearApp', 'src', 'Foo.kt')),
-            path.join(dir, 'wearApp'),
-        );
-    }));
-
-    it('skips alias applications trailing `apply false`', withTempDir((dir) => {
-        fs.mkdirSync(path.join(dir, 'gradle'), { recursive: true });
-        fs.writeFileSync(path.join(dir, 'gradle', 'libs.versions.toml'), `
-            [plugins]
-            composeai-preview = { id = "ee.schimke.composeai.preview", version = "0.7.1" }
-        `);
-        // Root-level declaration that doesn't actually apply here.
+        // Root-level declaration-only: module pulls the plugin in for
+        // subprojects but does not apply it here.
         fs.writeFileSync(path.join(dir, 'build.gradle.kts'),
-            'plugins { alias(libs.plugins.composeai.preview) apply false }');
-        fs.mkdirSync(path.join(dir, 'wearApp', 'src'), { recursive: true });
+            'plugins { id("ee.schimke.composeai.preview") apply false }');
         fs.writeFileSync(path.join(dir, 'wearApp', 'build.gradle.kts'),
             'plugins { id("org.jetbrains.kotlin.jvm") }');
         assert.strictEqual(
@@ -99,125 +77,41 @@ describe('findPluginAppliedAncestor', () => {
     }));
 });
 
-describe('parsePluginAliases', () => {
-    it('returns aliases whose id matches the plugin', () => {
-        const aliases = parsePluginAliases(`
-            [versions]
-            composeai-preview = "0.7.1"
-
-            [plugins]
-            composeai-preview = { id = "ee.schimke.composeai.preview", version.ref = "composeai-preview" }
-            kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.0.0" }
-        `);
-        assert.deepStrictEqual(aliases, ['composeai.preview']);
-    });
-
-    it('ignores entries outside the [plugins] table', () => {
-        // Not that this would ever be valid Gradle catalog content, but we
-        // still want the scanner to be strict about the section it reads.
-        const aliases = parsePluginAliases(`
-            [libraries]
-            something = { id = "ee.schimke.composeai.preview", version = "1.0" }
-        `);
-        assert.deepStrictEqual(aliases, []);
-    });
-
-    it('normalizes `-` and `_` to `.` in accessor paths', () => {
-        const aliases = parsePluginAliases(`
-            [plugins]
-            compose_ai-preview = { id = "ee.schimke.composeai.preview", version = "0.7.1" }
-        `);
-        assert.deepStrictEqual(aliases, ['compose.ai.preview']);
-    });
-
-    it('tolerates inline # comments in non-matching entries', () => {
-        const aliases = parsePluginAliases(`
-            [plugins]
-            composeai-preview = { id = "ee.schimke.composeai.preview", version = "0.7.1" } # in use
-            other = { id = "other.plugin", version = "1.0" } # unused
-        `);
-        assert.deepStrictEqual(aliases, ['composeai.preview']);
-    });
-
-    it('returns empty when no alias matches', () => {
-        const aliases = parsePluginAliases(`
-            [plugins]
-            kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.0.0" }
-        `);
-        assert.deepStrictEqual(aliases, []);
-    });
-});
-
-describe('readCatalogPluginAliases', () => {
-    it('reads gradle/libs.versions.toml under the project root', withTempDir((dir) => {
-        fs.mkdirSync(path.join(dir, 'gradle'), { recursive: true });
-        fs.writeFileSync(path.join(dir, 'gradle', 'libs.versions.toml'), `
-            [plugins]
-            composeai-preview = { id = "ee.schimke.composeai.preview", version = "0.7.1" }
-        `);
-        assert.deepStrictEqual(readCatalogPluginAliases(dir), ['composeai.preview']);
-    }));
-
-    it('returns [] when the catalog is missing', withTempDir((dir) => {
-        assert.deepStrictEqual(readCatalogPluginAliases(dir), []);
-    }));
-});
-
-describe('buildAliasAppliesRegex', () => {
-    it('returns null for an empty alias list', () => {
-        assert.strictEqual(buildAliasAppliesRegex([]), null);
-    });
-
-    it('matches `alias(libs.plugins.<name>)`', () => {
-        const re = buildAliasAppliesRegex(['composeai.preview'])!;
-        assert.ok(re.test('plugins { alias(libs.plugins.composeai.preview) }'));
-    });
-
-    // `apply false` handling is the responsibility of [appliesPlugin], not
-    // the raw alias regex — see that describe block above for coverage.
-
-    it('rejects accessors under a different catalog name by default', () => {
-        // Catalog name defaults to `libs`; non-default names aren't supported
-        // by the scan fallback (users fall back to the literal-id form).
-        const re = buildAliasAppliesRegex(['composeai.preview'])!;
-        assert.ok(!re.test('alias(myLibs.plugins.composeai.preview)'));
-    });
-});
-
 describe('appliesPlugin', () => {
-    it('matches the literal id form regardless of alias regex', () => {
-        assert.ok(appliesPlugin('id("ee.schimke.composeai.preview")', null));
-    });
-
-    it('matches the alias form when the alias regex allows it', () => {
-        const re = buildAliasAppliesRegex(['composeai.preview'])!;
-        assert.ok(appliesPlugin('alias(libs.plugins.composeai.preview)', re));
+    it('matches the literal id form', () => {
+        assert.ok(appliesPlugin('id("ee.schimke.composeai.preview")'));
+        assert.ok(appliesPlugin('plugins { id("ee.schimke.composeai.preview") }'));
+        assert.ok(appliesPlugin("id 'ee.schimke.composeai.preview'"));
     });
 
     it('rejects a declaration-only snippet', () => {
-        assert.ok(!appliesPlugin('id = "ee.schimke.composeai.preview"', null));
+        assert.ok(!appliesPlugin('id = "ee.schimke.composeai.preview"'));
     });
 
-    it('rejects `apply false` on either form', () => {
-        const re = buildAliasAppliesRegex(['composeai.preview'])!;
-        assert.ok(!appliesPlugin('id("ee.schimke.composeai.preview") apply false', re));
-        assert.ok(!appliesPlugin('alias(libs.plugins.composeai.preview) apply false', re));
+    it('rejects literal `apply false` on the same line', () => {
+        assert.ok(!appliesPlugin('id("ee.schimke.composeai.preview") apply false'));
+    });
+
+    it('does NOT match the version-catalog alias form — handled via marker', () => {
+        // Intentional: alias detection would require parsing
+        // `libs.versions.toml`. The `applied.json` marker written by
+        // `composePreviewApplied` covers this case authoritatively.
+        assert.ok(!appliesPlugin('alias(libs.plugins.composeai.preview)'));
     });
 });
 
 describe('APPLIES_PLUGIN_RE', () => {
-    it('still matches the existing literal application forms', () => {
+    it('matches the literal application forms', () => {
         assert.ok(APPLIES_PLUGIN_RE.test('id("ee.schimke.composeai.preview")'));
         assert.ok(APPLIES_PLUGIN_RE.test('plugins { id("ee.schimke.composeai.preview") }'));
         assert.ok(APPLIES_PLUGIN_RE.test("id 'ee.schimke.composeai.preview'"));
     });
 
-    it('still rejects declaration-only usage', () => {
+    it('rejects declaration-only usage', () => {
         assert.ok(!APPLIES_PLUGIN_RE.test('id = "ee.schimke.composeai.preview"'));
     });
 
     // Note: the raw regex is just the plugin-reference matcher. The `apply
     // false` exclusion happens at the line level inside [appliesPlugin] so
-    // the raw regex alone does still match a `... apply false` line —
-    // that's by design and covered by appliesPlugin's own tests above.
+    // the raw regex alone does still match a `... apply false` line.
 });


### PR DESCRIPTION
Follow-up to #130, which landed with the TOML-parsing fallback still in place. That was the alias-form detection I added before you asked "Do we need parsePluginAliases? I thought we weren't parsing toml" — the simplification commit that answered it missed the squash merge.

## Summary

- Drops `parsePluginAliases`, `readCatalogPluginAliases`, `buildAliasAppliesRegex`, and all associated accessor-normalization + regex-building machinery — ~150 LOC of mini-TOML-parser gone.
- Detection now has two signals only:
  1. `<module>/build/compose-previews/applied.json` — authoritative marker written by `composePreviewApplied`. Covers every apply mechanism (literal id, version-catalog alias, convention plugin, buildSrc).
  2. Literal `id("ee.schimke.composeai.preview")` in `build.gradle.kts` — pre-Gradle-run convenience for trivially-configured workspaces.
- Catalog-alias projects (Confetti) show up empty-handed until the bootstrap marker run completes — a few-second window on first open, then resolves correctly. Worth the simpler detection surface.

## Test plan

- [x] `cd vscode-extension && npm test` — 65 pass (literal-form scan, `apply false` exclusion, marker-only detection, marker ∪ scan union)
- [x] `./gradlew :gradle-plugin:test :gradle-plugin:functionalTest` — Kotlin side unchanged, still green
- [ ] Manually verify against Confetti after merge: first open shows "no module" briefly → bootstrap finishes → `doctor diagnostics refreshed across 1 module(s)`.