### PR TITLE
feat(plugin): derive human-readable filenames for @PreviewParameter fan-outs

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -377,16 +377,26 @@ abstract class Command(protected val args: List<String>) {
             val prior = readState(module).shas
             val updated = mutableMapOf<String, String>()
 
+            // Files owned by non-parameterized siblings — exclude them from
+            // the `<stem>_*` glob so a `Foo_header.png` that belongs to a
+            // different preview never gets attributed to `Foo`'s fan-out.
+            val siblingRenderOutputs = manifest.previews
+                .filter { it.params.previewParameterProviderClassName == null }
+                .flatMap { it.captures.map { c -> c.renderOutput } }
+                .filter { it.isNotEmpty() }
+                .toSet()
+
             for (p in manifest.previews) {
                 // `@PreviewParameter`-driven previews render at
-                // `<renderOutput_base>_PARAM_<idx>.<ext>`, one file per
-                // provider value. The manifest carries a single template
-                // capture; here we glob the actual fan-out and synthesize a
-                // `CaptureResult` per file on disk — keeps the manifest shape
-                // a pure discovery artifact while the CLI reports one entry
-                // per rendered PNG.
+                // `<stem>_<suffix>.<ext>`, one file per provider value. The
+                // manifest carries a single template capture; here we glob
+                // the actual fan-out and synthesize a `CaptureResult` per
+                // file on disk — keeps the manifest shape a pure discovery
+                // artifact while the CLI reports one entry per rendered PNG.
                 val captures = if (p.params.previewParameterProviderClassName != null) {
-                    p.captures.flatMap { capture -> expandParamCaptures(module, capture) }
+                    p.captures.flatMap { capture ->
+                        expandParamCaptures(module, capture, siblingRenderOutputs)
+                    }
                 } else {
                     p.captures
                 }
@@ -447,38 +457,40 @@ abstract class Command(protected val args: List<String>) {
         captures.any { it.changed == true } || changed == true
 
     /**
-     * Globs the on-disk `_PARAM_<idx>.<ext>` fan-out for a parameterized
+     * Globs the on-disk `<stem>_<suffix>.<ext>` fan-out for a parameterized
      * preview capture. The manifest carries one template capture (e.g.
-     * `renders/foo.png`); the renderer writes `renders/foo_PARAM_0.png`,
-     * `renders/foo_PARAM_1.png`, … one per provider value. Returns synthetic
-     * `Capture` rows pointing at each file, or an empty list when nothing
-     * matched — the plugin's `renderAllPreviews` verification already fails
-     * loudly when a parameterized preview rendered no files at all, so we
-     * don't duplicate the error surface here.
+     * `renders/foo.png`); the renderer writes one file per provider value,
+     * keying each by a derived label (`renders/foo_on.png`) or by numeric
+     * index (`renders/foo_PARAM_0.png`) when the label can't be derived.
+     * Returns synthetic `Capture` rows pointing at each file, or an empty
+     * list when nothing matched — the plugin's `renderAllPreviews`
+     * verification already fails loudly when a parameterized preview
+     * rendered no files at all, so we don't duplicate the error surface here.
      */
-    private fun expandParamCaptures(module: String, template: Capture): List<Capture> {
+    private fun expandParamCaptures(
+        module: String,
+        template: Capture,
+        siblingRenderOutputs: Set<String>,
+    ): List<Capture> {
         val rel = template.renderOutput.ifEmpty { return listOf(template) }
         val file = projectDir.resolve("$module/build/compose-previews/$rel").canonicalFile
         val dir = file.parentFile ?: return listOf(template)
-        val prefix = file.nameWithoutExtension + "_PARAM_"
+        val prefix = file.nameWithoutExtension + "_"
         val ext = ".${file.extension}"
+        val templateDir = rel.substringBeforeLast('/', "")
+        val dirPrefix = if (templateDir.isEmpty()) "" else "$templateDir/"
         val matches = (dir.listFiles() ?: emptyArray())
-            .filter { it.name.startsWith(prefix) && it.name.endsWith(ext) }
-            .sortedBy {
-                // Sort by the numeric index between `_PARAM_` and the
-                // extension so PARAM_10 sorts after PARAM_2 (not before,
-                // which lexicographic ordering would produce). Unparseable
-                // suffixes fall through to Int.MAX_VALUE so they land at
-                // the end deterministically.
-                it.name.removePrefix(prefix).removeSuffix(ext).toIntOrNull() ?: Int.MAX_VALUE
+            .filter { f ->
+                f.name.startsWith(prefix) &&
+                    f.name.endsWith(ext) &&
+                    (dirPrefix + f.name) !in siblingRenderOutputs
             }
+            .sortedWith(paramFanoutOrder(prefix, ext))
         if (matches.isEmpty()) return emptyList()
         // Preserve the template's time/scroll coordinates — a parameterized
         // preview is orthogonal to those dimensions. Each fan-out file
         // points back at the same conceptual capture, just at a different
         // provider value.
-        val templateDir = rel.substringBeforeLast('/', "")
-        val dirPrefix = if (templateDir.isEmpty()) "" else "$templateDir/"
         return matches.map { f ->
             Capture(
                 advanceTimeMillis = template.advanceTimeMillis,
@@ -487,6 +499,28 @@ abstract class Command(protected val args: List<String>) {
             )
         }
     }
+
+    /**
+     * Stable ordering for a fan-out's on-disk files. Numeric `_PARAM_<idx>`
+     * entries come first, sorted by index (so `PARAM_10` lands after
+     * `PARAM_2` rather than before it as lexicographic ordering would
+     * produce). Label-based entries sort alphabetically by their suffix —
+     * provider order isn't recoverable from the filename alone, but
+     * alphabetical is stable and readable.
+     */
+    private fun paramFanoutOrder(prefix: String, ext: String): Comparator<java.io.File> =
+        Comparator { a, b ->
+            val sa = a.name.removePrefix(prefix).removeSuffix(ext)
+            val sb = b.name.removePrefix(prefix).removeSuffix(ext)
+            val ia = sa.removePrefix("PARAM_").toIntOrNull()?.takeIf { sa.startsWith("PARAM_") }
+            val ib = sb.removePrefix("PARAM_").toIntOrNull()?.takeIf { sb.startsWith("PARAM_") }
+            when {
+                ia != null && ib != null -> ia.compareTo(ib)
+                ia != null -> -1
+                ib != null -> 1
+                else -> sa.compareTo(sb)
+            }
+        }
 
     /** Filters by `--id` / `--filter` and (optionally) `--changed-only`. */
     protected fun applyFilters(all: List<PreviewResult>): List<PreviewResult> =

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -66,9 +66,7 @@ Four-stage pipeline, spread across the modules:
 
 4. **History (optional)** — [HistorizePreviewsTask.kt](gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/HistorizePreviewsTask.kt) archives changed PNGs into `.compose-preview-history/` (outside `build/`, survives `clean`). Enabled via `composePreview.historyEnabled`.
 
-**`build/compose-previews/renders/` is ephemeral.** Every `renderAllPreviews` run deletes PNG/GIF files that aren't referenced by the current manifest (see `cleanStaleRenders` in [ComposePreviewTasks.kt](gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt)), and the Android/Desktop renderers themselves delete stale `@PreviewParameter` fan-out siblings before writing a new fan-out. If you need to preserve a specific render for comparison or debugging, copy it out of `renders/` or enable `composePreview.historyEnabled` before running — don't rely on files persisting across runs.
-
-**Filenames are normalized.** `renderOutput` paths in the manifest use `[A-Za-z0-9._-]` only — any preview name or `@PreviewParameter` value label that would otherwise contain spaces, parens, or shell-hostile characters gets those characters replaced with `_`. The common package prefix across all previews in a module is stripped too, so `ee.schimke.ha.previews.CardPreviewsKt.Tile_Light_States_tile light (light).png` renders to `CardPreviewsKt.Tile_Light_States_tile_light_light.png`. The `id` field keeps the full FQN — only the on-disk filename is shortened.
+`renders/` is ephemeral: rewritten every run, stale files deleted. Filenames are normalized — see [docs/RENDER_FILENAMES.md](RENDER_FILENAMES.md).
 
 The CLI ([cli/](cli/src/main/kotlin/ee/schimke/composeai/cli/)) and VS Code extension ([vscode-extension/](vscode-extension/src/)) are thin drivers over the Gradle tasks — they shell out via the Tooling API (`GradleConnector.kt`, `gradleService.ts`) and read the resulting `previews.json` / PNG files. The CLI also ships a `compose-preview` binary with `installDist` for use as an agent/MCP backend.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -66,6 +66,10 @@ Four-stage pipeline, spread across the modules:
 
 4. **History (optional)** — [HistorizePreviewsTask.kt](gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/HistorizePreviewsTask.kt) archives changed PNGs into `.compose-preview-history/` (outside `build/`, survives `clean`). Enabled via `composePreview.historyEnabled`.
 
+**`build/compose-previews/renders/` is ephemeral.** Every `renderAllPreviews` run deletes PNG/GIF files that aren't referenced by the current manifest (see `cleanStaleRenders` in [ComposePreviewTasks.kt](gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt)), and the Android/Desktop renderers themselves delete stale `@PreviewParameter` fan-out siblings before writing a new fan-out. If you need to preserve a specific render for comparison or debugging, copy it out of `renders/` or enable `composePreview.historyEnabled` before running — don't rely on files persisting across runs.
+
+**Filenames are normalized.** `renderOutput` paths in the manifest use `[A-Za-z0-9._-]` only — any preview name or `@PreviewParameter` value label that would otherwise contain spaces, parens, or shell-hostile characters gets those characters replaced with `_`. The common package prefix across all previews in a module is stripped too, so `ee.schimke.ha.previews.CardPreviewsKt.Tile_Light_States_tile light (light).png` renders to `CardPreviewsKt.Tile_Light_States_tile_light_light.png`. The `id` field keeps the full FQN — only the on-disk filename is shortened.
+
 The CLI ([cli/](cli/src/main/kotlin/ee/schimke/composeai/cli/)) and VS Code extension ([vscode-extension/](vscode-extension/src/)) are thin drivers over the Gradle tasks — they shell out via the Tooling API (`GradleConnector.kt`, `gradleService.ts`) and read the resulting `previews.json` / PNG files. The CLI also ships a `compose-preview` binary with `installDist` for use as an agent/MCP backend.
 
 ## Git conventions

--- a/docs/RENDER_FILENAMES.md
+++ b/docs/RENDER_FILENAMES.md
@@ -1,0 +1,27 @@
+# Render output layout
+
+## `build/compose-previews/renders/` is ephemeral
+
+Each `renderAllPreviews` run rewrites this directory and deletes stale files:
+
+- The renderer (`RobolectricRenderTest` / `DesktopRendererMain`) deletes its own stale `@PreviewParameter` fan-out siblings before writing a new fan-out — it's the only code that knows the exact filenames the provider will produce.
+- `renderAllPreviews` deletes any PNG/GIF not referenced by the current manifest (`cleanStaleRenders` in `ComposePreviewTasks.kt`). Parameterized `<stem>_*<ext>` matches are preserved — the plugin side can't enumerate provider values, so it trusts the renderer's own cleanup.
+
+To keep a specific render across runs, enable `composePreview.historyEnabled` or copy the file somewhere outside `build/`.
+
+## Filename normalization
+
+`renderOutput` paths use `[A-Za-z0-9._-]` only. Any other character (spaces, parens, commas, Unicode dashes, emoji) collapses to `_`. A whitelist is deliberate: enumerating a blacklist of shell-hostile characters is a losing game across shells and CI systems.
+
+The common dotted package prefix across all previews in a module is stripped too, so `ee.schimke.ha.previews.CardPreviewsKt.Foo.png` lands as `CardPreviewsKt.Foo.png`. `PreviewInfo.id` keeps the full FQN — consumers keying by id (history folders, CLI state, JUnit test names) are unaffected.
+
+## `@PreviewParameter` fan-out labels
+
+Per-value suffix derivation (`PreviewParameterLabels` in each renderer module):
+
+1. `Pair.first` → label.
+2. `name` / `label` / `id` property (Kotlin property or Java-bean getter returning `String`) → label.
+3. `toString()`, unless it's the default `ClassName@hash` form → label.
+4. Otherwise `_PARAM_<idx>`.
+
+Labels are sanitized against the same whitelist and capped at 32 chars. If two values produce the same sanitized label, every value in the fan-out falls back to `_PARAM_<idx>` so the filenames stay internally consistent.

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ColorValidationTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ColorValidationTest.kt
@@ -141,7 +141,10 @@ class ColorValidationTest {
         assertThat(redPreview).isNotNull()
         assertThat(redPreview!!.params.backgroundColor).isEqualTo(0xFFFF0000)
 
-        val pngFile = File(projectDir, "build/compose-previews/renders/${redPreview.id}.png")
+        val pngFile = File(
+            projectDir,
+            "build/compose-previews/${redPreview.captures.first().renderOutput}",
+        )
         assertThat(pngFile.exists()).isTrue()
 
         val img: BufferedImage = ImageIO.read(pngFile)
@@ -167,7 +170,10 @@ class ColorValidationTest {
         val bluePreview = manifest.previews.find { it.params.name == "Blue" }
         assertThat(bluePreview).isNotNull()
 
-        val pngFile = File(projectDir, "build/compose-previews/renders/${bluePreview!!.id}.png")
+        val pngFile = File(
+            projectDir,
+            "build/compose-previews/${bluePreview!!.captures.first().renderOutput}",
+        )
         assertThat(pngFile.exists()).isTrue()
 
         val img: BufferedImage = ImageIO.read(pngFile)
@@ -192,7 +198,10 @@ class ColorValidationTest {
         val greenPreview = manifest.previews.find { it.params.name == "Green" }
         assertThat(greenPreview).isNotNull()
 
-        val pngFile = File(projectDir, "build/compose-previews/renders/${greenPreview!!.id}.png")
+        val pngFile = File(
+            projectDir,
+            "build/compose-previews/${greenPreview!!.captures.first().renderOutput}",
+        )
         assertThat(pngFile.exists()).isTrue()
 
         val img: BufferedImage = ImageIO.read(pngFile)

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -635,9 +635,13 @@ class DiscoveryFunctionalTest {
         assertThat(topAndEnd.captures).hasSize(2)
         assertThat(topAndEnd.captures.map { it.scroll?.mode })
             .containsExactly(ScrollMode.TOP, ScrollMode.END).inOrder()
+        // renderOutput strips the common `test.` package prefix from every
+        // preview id — the full FQN is retained on `preview.id` itself (and
+        // also stays addressable in `renderOutput`'s basename), but the
+        // on-disk filename drops the shared prefix.
         assertThat(topAndEnd.captures.map { it.renderOutput }).containsExactly(
-            "renders/${topAndEnd.id}_SCROLL_top.png",
-            "renders/${topAndEnd.id}_SCROLL_end.png",
+            "renders/TopAndEndScrollPreview_Scroll_SCROLL_top.png",
+            "renders/TopAndEndScrollPreview_Scroll_SCROLL_end.png",
         ).inOrder()
 
         // Single-mode GIF: keeps the plain `renders/<id>.gif` name (no
@@ -655,7 +659,7 @@ class DiscoveryFunctionalTest {
             )
         )
         assertThat(gifOnly.captures.single().renderOutput)
-            .isEqualTo("renders/${gifOnly.id}.gif")
+            .isEqualTo("renders/GifScrollPreview_Gif.gif")
 
         // Multi-mode with GIF sibling: each capture gets its mode's
         // extension (PNG for END, GIF for GIF) — the extension branches
@@ -665,8 +669,8 @@ class DiscoveryFunctionalTest {
         assertThat(endAndGif.captures.map { it.scroll?.mode })
             .containsExactly(ScrollMode.END, ScrollMode.GIF).inOrder()
         assertThat(endAndGif.captures.map { it.renderOutput }).containsExactly(
-            "renders/${endAndGif.id}_SCROLL_end.png",
-            "renders/${endAndGif.id}_SCROLL_gif.gif",
+            "renders/EndAndGifScrollPreview_EndAndGif_SCROLL_end.png",
+            "renders/EndAndGifScrollPreview_EndAndGif_SCROLL_gif.gif",
         ).inOrder()
     }
 
@@ -744,6 +748,64 @@ class DiscoveryFunctionalTest {
         val plain = manifest.previews.single { it.functionName == "PlainPreview" }
         assertThat(plain.params.previewParameterProviderClassName).isNull()
         assertThat(plain.params.previewParameterLimit).isEqualTo(Int.MAX_VALUE)
+    }
+
+    @Test
+    fun `renderOutput strips common package prefix and sanitises spaces and parens`() {
+        val projectDir = createCmpTestProject()
+
+        val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+        srcFile.writeText(
+            """
+            package test
+
+            import androidx.compose.foundation.background
+            import androidx.compose.foundation.layout.Box
+            import androidx.compose.foundation.layout.size
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+            import androidx.compose.ui.graphics.Color
+            import androidx.compose.ui.tooling.preview.Preview
+            import androidx.compose.ui.unit.dp
+
+            @Preview(name = "tile light (light)")
+            @Composable
+            fun TileLightStates() {
+                Box(modifier = Modifier.size(50.dp).background(Color.Red))
+            }
+
+            @Preview(name = "plain")
+            @Composable
+            fun TileDarkStates() {
+                Box(modifier = Modifier.size(50.dp).background(Color.Blue))
+            }
+            """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("discoverPreviews", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+
+        val manifest = json.decodeFromString<PreviewManifest>(
+            File(projectDir, "build/compose-previews/previews.json").readText()
+        )
+
+        val light = manifest.previews.single { it.functionName == "TileLightStates" }
+        // `id` stays as the full FQN — consumers key by it. Top-level
+        // Kotlin functions land on the synthetic `<File>Kt` class, so
+        // the id is `test.PreviewsKt.TileLightStates_tile light (light)`.
+        assertThat(light.id).isEqualTo("test.PreviewsKt.TileLightStates_tile light (light)")
+        // `renderOutput` drops the shared `test.PreviewsKt.` dotted
+        // prefix and sanitises the awkward `tile light (light)` variant
+        // suffix down to shell-safe `tile_light_light`.
+        assertThat(light.captures.single().renderOutput)
+            .isEqualTo("renders/TileLightStates_tile_light_light.png")
+
+        val dark = manifest.previews.single { it.functionName == "TileDarkStates" }
+        assertThat(dark.captures.single().renderOutput)
+            .isEqualTo("renders/TileDarkStates_plain.png")
     }
 
     @Test

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -198,28 +198,60 @@ internal object ComposePreviewTasks {
                 val manifest = previewManifestJson
                     .decodeFromString(PreviewManifest.serializer(), manifestOnDisk.readText())
                 if (manifest.previews.isEmpty()) return@doLast
+
+                // `build/compose-previews/renders/` is a derived artefact —
+                // the renderer rewrites it every run, and downstream tools
+                // (VS Code, CLI, history) compare the CURRENT manifest
+                // against on-disk state. Files left over from deleted or
+                // renamed previews confuse that comparison, so we delete
+                // anything that isn't referenced by a current manifest
+                // entry.
+                //
+                // Parameterized (`@PreviewParameter`) previews are special:
+                // the Gradle side only knows the stem (e.g.
+                // `Foo_PARAM_template.png`), not which fan-out filenames
+                // the provider will produce. The renderer itself cleans up
+                // its own stale fan-out before writing (see
+                // `deleteStaleFanoutFiles` in the renderer modules), so
+                // here we keep every `<stem>_*<ext>` match rather than
+                // second-guessing the provider values.
+                cleanStaleRenders(previewOutputDir.get().asFile.resolve("renders"), manifest, logger)
                 // Each preview can produce multiple captures (`@RoboComposePreviewOptions`
                 // time fan-out, future scroll / dimension fan-outs). Verify each
                 // capture's renderOutput lands on disk — report back one missing
                 // entry per preview with at least one missing capture.
                 val outDir = previewOutputDir.get().asFile
+                // Files owned by non-parameterized siblings — exclude them
+                // from the `<stem>_*` glob so a `Foo_header.png` that
+                // belongs to a different preview never gets treated as
+                // part of `Foo`'s fan-out.
+                val siblingNames = manifest.previews
+                    .filter { it.params.previewParameterProviderClassName == null }
+                    .flatMap { it.captures.map { c -> c.renderOutput } }
+                    .filter { it.isNotEmpty() }
+                    .map { java.io.File(outDir, it).name }
+                    .toSet()
                 val missing = manifest.previews
                     .filter { p ->
                         p.captures.any { c ->
                             val rel = c.renderOutput.ifEmpty { "renders/${p.id}.png" }
                             // `@PreviewParameter` previews fan out at render
-                            // time: manifest carries a `<id>.png` template,
+                            // time: manifest carries a `<stem>.png` template,
                             // but the actual files live at
-                            // `<id>_PARAM_<idx>.png` (one per provider value).
-                            // Check that at least ONE matching fan-out file
-                            // exists instead of demanding the template itself.
+                            // `<stem>_<label>.png` (one per provider value,
+                            // or `_PARAM_<idx>` when the label can't be
+                            // derived). Check that at least ONE matching
+                            // fan-out file exists instead of demanding the
+                            // template itself.
                             if (p.params.previewParameterProviderClassName != null) {
                                 val file = outDir.resolve(rel)
                                 val dir = file.parentFile ?: outDir
-                                val prefix = file.nameWithoutExtension + "_PARAM_"
+                                val prefix = file.nameWithoutExtension + "_"
                                 val ext = ".${file.extension}"
                                 !(dir.listFiles()?.any { f ->
-                                    f.name.startsWith(prefix) && f.name.endsWith(ext)
+                                    f.name.startsWith(prefix) &&
+                                        f.name.endsWith(ext) &&
+                                        f.name !in siblingNames
                                 } ?: false)
                             } else {
                                 !outDir.resolve(rel).exists()
@@ -240,6 +272,79 @@ internal object ComposePreviewTasks {
                     )
                 }
             }
+        }
+    }
+
+    /**
+     * Deletes files inside [rendersDir] that aren't referenced by [manifest].
+     *
+     * Keeps three kinds of files:
+     * 1. Exact `renderOutput` matches from non-parameterized previews.
+     * 2. `<stem>_*.<ext>` fan-out files where `<stem>` belongs to a
+     *    `@PreviewParameter` preview — the renderer itself cleans up its
+     *    own stale fan-outs (it knows the exact filenames), so the Gradle
+     *    side deliberately stays conservative and doesn't delete files it
+     *    can't be sure are stale.
+     * 3. Non-PNG/GIF files that aren't in the plugin's output domain.
+     *
+     * Anything else (PNGs or GIFs that were produced for a now-removed
+     * preview) gets removed so downstream tools compare the manifest
+     * against a clean directory.
+     */
+    private fun cleanStaleRenders(
+        rendersDir: java.io.File,
+        manifest: PreviewManifest,
+        logger: org.gradle.api.logging.Logger,
+    ) {
+        if (!rendersDir.isDirectory) return
+
+        val expectedRelPaths = manifest.previews
+            .filter { it.params.previewParameterProviderClassName == null }
+            .flatMap { it.captures.mapNotNull { c -> c.renderOutput.stripRendersPrefix() } }
+            .toSet()
+
+        // `<stem>_` / `.<ext>` pairs we MUST leave alone — each one is the
+        // template filename of a `@PreviewParameter` preview. Any file in
+        // [rendersDir] whose leaf name starts with one of these prefixes
+        // and ends with the matching extension is treated as a fan-out
+        // sibling and preserved.
+        val paramStems = manifest.previews
+            .filter { it.params.previewParameterProviderClassName != null }
+            .flatMap { it.captures }
+            .mapNotNull { c ->
+                val rel = c.renderOutput.stripRendersPrefix() ?: return@mapNotNull null
+                val leaf = rel.substringAfterLast('/')
+                val dot = leaf.lastIndexOf('.')
+                if (dot <= 0) null
+                else FanoutKey(
+                    relDir = rel.substringBeforeLast('/', missingDelimiterValue = ""),
+                    prefix = leaf.substring(0, dot) + "_",
+                    ext = leaf.substring(dot),
+                )
+            }
+            .toSet()
+
+        rendersDir.walkBottomUp()
+            .filter { it.isFile && (it.extension == "png" || it.extension == "gif") }
+            .forEach { f ->
+                val rel = f.relativeTo(rendersDir).invariantSeparatorsPath
+                if (rel in expectedRelPaths) return@forEach
+                if (paramStems.any { it.matches(rel, f.name) }) return@forEach
+                if (!f.delete()) {
+                    logger.warn("compose-preview: couldn't delete stale render $f")
+                }
+            }
+    }
+
+    private fun String.stripRendersPrefix(): String? {
+        if (isEmpty()) return null
+        return substringAfter("renders/", missingDelimiterValue = this).takeIf { it.isNotEmpty() }
+    }
+
+    private data class FanoutKey(val relDir: String, val prefix: String, val ext: String) {
+        fun matches(rel: String, leaf: String): Boolean {
+            val dir = rel.substringBeforeLast('/', missingDelimiterValue = "")
+            return dir == relDir && leaf.startsWith(prefix) && leaf.endsWith(ext)
         }
     }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -127,10 +127,20 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         // dedup by id alone. Two identical preview variants on the same function collapse.
         val deduped = previews.distinctBy { it.id }
 
+        // Rewrite each capture's renderOutput to a normalized, shell-safe
+        // filename: drop the package prefix shared by every preview in the
+        // module so `renders/ee.schimke.ha.previews.CardPreviewsKt.Foo.png`
+        // lands at `renders/CardPreviewsKt.Foo.png`; sanitize spaces, parens,
+        // and other awkward shell characters inherited from `@Preview(name =
+        // "tile light (light)")`. Keeps `PreviewInfo.id` untouched — consumers
+        // that key by id (history folders, CLI state, test names) are
+        // unaffected.
+        val normalized = normalizeRenderOutputs(deduped)
+
         val manifest = PreviewManifest(
             module = moduleName.get(),
             variant = variantName.get(),
-            previews = deduped,
+            previews = normalized,
             accessibilityReport = "accessibility.json".takeIf { accessibilityChecksEnabled.get() },
         )
 
@@ -138,11 +148,83 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         outFile.parentFile.mkdirs()
         outFile.writeText(json.encodeToString(manifest))
 
-        logger.lifecycle("Discovered ${deduped.size} preview(s) in module '${moduleName.get()}':")
-        for (preview in deduped) {
+        logger.lifecycle("Discovered ${normalized.size} preview(s) in module '${moduleName.get()}':")
+        for (preview in normalized) {
             logger.lifecycle("  ${preview.className}.${preview.functionName}${describeVariant(preview)}")
         }
     }
+
+    /**
+     * Computes the common dotted prefix shared by every preview id (up to and
+     * including the last matched `.`) and strips it from each capture's
+     * `renderOutput` filename. Also runs every stem through [sanitizeFileStem]
+     * so spaces and shell-unfriendly characters inherited from `@Preview(name
+     * = "tile light (light)")` don't end up in the PNG filename.
+     *
+     * `preview.id` itself is deliberately left untouched — it's the stable
+     * identity consumers key by (history folders, CLI state, JUnit test
+     * names). The renderOutput is purely the on-disk filename, and that's
+     * what benefits from a shorter, quoted-free form.
+     *
+     * No-op on a single-preview module (empty prefix) or when sanitization
+     * would collapse two distinct ids to the same stem — in that case we
+     * keep the un-stripped, un-sanitized id for everyone so the pretty
+     * rename never introduces a filename collision.
+     */
+    private fun normalizeRenderOutputs(previews: List<PreviewInfo>): List<PreviewInfo> {
+        if (previews.isEmpty()) return previews
+        val commonPrefix = commonDottedPrefix(previews.map { it.id })
+        val stems = previews.map { sanitizeFileStem(it.id.removePrefix(commonPrefix)) }
+        val safe = stems.toSet().size == previews.size &&
+            stems.none { it.isEmpty() }
+        return previews.mapIndexed { i, preview ->
+            val newStem = if (safe) stems[i] else preview.id
+            val rewritten = preview.captures.map { c ->
+                c.copy(renderOutput = rewriteRenderStem(c.renderOutput, preview.id, newStem))
+            }
+            preview.copy(captures = rewritten)
+        }
+    }
+
+    /** `renders/<oldStem><tail>.<ext>` → `renders/<newStem><tail>.<ext>`. */
+    private fun rewriteRenderStem(renderOutput: String, oldStem: String, newStem: String): String {
+        if (renderOutput.isEmpty() || oldStem == newStem) return renderOutput
+        val dir = renderOutput.substringBeforeLast('/', missingDelimiterValue = "")
+        val leaf = renderOutput.substringAfterLast('/')
+        if (!leaf.startsWith(oldStem)) return renderOutput
+        val rewritten = newStem + leaf.removePrefix(oldStem)
+        return if (dir.isEmpty()) rewritten else "$dir/$rewritten"
+    }
+
+    private fun commonDottedPrefix(ids: List<String>): String {
+        if (ids.size < 2) return ""
+        var prefix = ids.first()
+        for (id in ids.drop(1)) {
+            var i = 0
+            val limit = minOf(prefix.length, id.length)
+            while (i < limit && prefix[i] == id[i]) i++
+            prefix = prefix.substring(0, i)
+            if (prefix.isEmpty()) return ""
+        }
+        val lastDot = prefix.lastIndexOf('.')
+        return if (lastDot < 0) "" else prefix.substring(0, lastDot + 1)
+    }
+
+    /**
+     * Sanitizes a filename stem to an ASCII-safe whitelist
+     * (`[A-Za-z0-9._-]`). Every other character collapses to `_`, runs of
+     * `_` collapse to a single `_`, and leading/trailing `_`, `.`, `-` are
+     * trimmed. A whitelist is deliberate: we can't enumerate every awkward
+     * character a preview name might contain (Unicode dashes, NBSP, RTL
+     * marks, emoji), and any one of them can break a downstream tool that
+     * expects a POSIX-plain filename. `.` is preserved so FQN-shaped stems
+     * (`CardPreviewsKt.Tile_Light_States`) survive intact when the package
+     * prefix strip can't flatten them further.
+     */
+    private fun sanitizeFileStem(s: String): String =
+        s.replace(Regex("""[^A-Za-z0-9._-]"""), "_")
+            .replace(Regex("""_+"""), "_")
+            .trim('_', '.', '-')
 
     // Renders the distinguishing bits of a preview variant for the discovery log
     // so sibling expansions (e.g. @WearPreviewFontScales × 6) aren't visually

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/HistorizePreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/HistorizePreviewsTask.kt
@@ -56,7 +56,16 @@ abstract class HistorizePreviewsTask : DefaultTask() {
 
         var archived = 0
         for (preview in manifest.previews) {
-            val currentRender = rendersRoot.resolve("${preview.id}.png")
+            // Use the capture's renderOutput (module-relative, e.g.
+            // `renders/Foo.png`) rather than inferring from `preview.id`.
+            // Since discovery normalizes stems (strips package prefix,
+            // sanitizes shell-unsafe characters), the on-disk filename no
+            // longer matches `${id}.png`.
+            val relRender = preview.captures.firstOrNull()?.renderOutput
+                ?.substringAfter("renders/", missingDelimiterValue = "")
+                ?.takeIf { it.isNotEmpty() }
+                ?: continue
+            val currentRender = rendersRoot.resolve(relRender)
             if (!currentRender.exists()) continue
 
             val previewFolder = historyRoot.resolve(sanitize(preview.id)).apply { mkdirs() }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -86,7 +86,16 @@ abstract class RenderPreviewsTask : DefaultTask() {
             val density = preview.params.density ?: spec.density
             val widthPx = (spec.widthDp * density).toInt().coerceAtLeast(1)
             val heightPx = (spec.heightDp * density).toInt().coerceAtLeast(1)
-            val outputFile = outDir.resolve("${preview.id}.png")
+            // The discovery task writes a normalized `renderOutput` (package
+            // prefix stripped, unsafe chars sanitized) into each capture;
+            // honour it rather than rebuilding the path from `preview.id`
+            // so the file actually lands where the manifest claims it will.
+            val relRender = preview.captures.firstOrNull()
+                ?.renderOutput
+                ?.substringAfter("renders/", missingDelimiterValue = "")
+                ?.takeIf { it.isNotEmpty() }
+                ?: "${preview.id}.png"
+            val outputFile = outDir.resolve(relRender)
 
             execOperations.javaexec {
                 classpath = renderClasspath
@@ -131,6 +140,11 @@ abstract class RenderPreviewsTask : DefaultTask() {
                 heightDp = preview.params.heightDp,
                 showSystemUi = preview.params.showSystemUi,
             )
+            val relRender = preview.captures.firstOrNull()
+                ?.renderOutput
+                ?.substringAfter("renders/", missingDelimiterValue = "")
+                ?.takeIf { it.isNotEmpty() }
+                ?: "${preview.id}.png"
             workQueue.submit(PreviewRenderWorkAction::class.java) {
                 className.set(preview.className)
                 functionName.set(preview.functionName)
@@ -140,7 +154,7 @@ abstract class RenderPreviewsTask : DefaultTask() {
                 fontScale.set(preview.params.fontScale)
                 showBackground.set(preview.params.showBackground)
                 backgroundColor.set(preview.params.backgroundColor)
-                outputFile.set(outDir.resolve("${preview.id}.png"))
+                outputFile.set(outDir.resolve(relRender))
                 backend.set(renderBackend.get())
             }
         }

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterLabels.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterLabels.kt
@@ -1,0 +1,97 @@
+package ee.schimke.composeai.renderer
+
+/**
+ * Derives a human-readable filename suffix from a `@PreviewParameter`
+ * provider's values so the fan-out lands on `<id>_on.png` / `<id>_off.png`
+ * instead of `<id>_PARAM_0.png` / `<id>_PARAM_1.png`. Falls back to
+ * `_PARAM_<idx>` per value when no label can be derived, or across the whole
+ * fan-out when any two values would collide after sanitization — keeping the
+ * output directory unambiguous is more important than pretty names when the
+ * provider makes labeling awkward.
+ *
+ * Recognised shapes:
+ * - `Pair<*, *>` — takes `first.toString()` as the label (matches the common
+ *   `"on" to snapshot(...)` provider idiom).
+ * - Any value exposing a `name`, `label`, or `id` Kotlin property (or the
+ *   corresponding Java bean getter) returning a `String` — covers data class
+ *   conventions without pinning us to a specific base interface.
+ * - Otherwise the value's `toString()`, provided it's not the default
+ *   `ClassName@hash` form.
+ *
+ * Duplicated between the Android and Desktop renderers so neither pulls the
+ * other's artifact onto the classpath — matches the existing split for
+ * `loadProviderValues` and `insertBeforeExtension`.
+ */
+internal object PreviewParameterLabels {
+
+    fun suffixesFor(values: List<Any?>): List<String> {
+        val labels = values.map { rawLabel(it)?.let(::sanitize)?.takeIf { s -> s.isNotEmpty() } }
+        // Duplicate labels would clobber each other on disk. When any two
+        // values produce the same label, fall back to `_PARAM_<idx>` for
+        // every value in the fan-out (not just the colliders) so the
+        // filenames stay internally consistent: either every entry is a
+        // label or every entry is a numbered PARAM.
+        val nonNull = labels.filterNotNull()
+        val hasCollision = nonNull.size != nonNull.toSet().size
+        return labels.mapIndexed { idx, label ->
+            when {
+                label == null || hasCollision -> "_PARAM_$idx"
+                else -> "_$label"
+            }
+        }
+    }
+
+    private fun rawLabel(value: Any?): String? {
+        if (value == null) return null
+        if (value is Pair<*, *>) {
+            val first = value.first ?: return null
+            return (first as? String) ?: first.toString()
+        }
+        val fromProperty = propertyLabel(value)
+        if (fromProperty != null) return fromProperty
+        val str = runCatching { value.toString() }.getOrNull() ?: return null
+        // `Object.toString()` default shape — `ClassName@hexHash`. That's
+        // never useful as a filename, so treat it as no label and fall back
+        // to `_PARAM_<idx>`.
+        val defaultPrefix = value.javaClass.name + "@"
+        return if (str.startsWith(defaultPrefix)) null else str
+    }
+
+    private fun propertyLabel(value: Any?): String? {
+        val v = value ?: return null
+        for (candidate in listOf("name", "label", "id")) {
+            val getter = "get" + candidate.replaceFirstChar { it.uppercase() }
+            val method = runCatching {
+                v.javaClass.methods.firstOrNull {
+                    it.name == getter &&
+                        it.parameterCount == 0 &&
+                        it.returnType == String::class.java
+                }
+            }.getOrNull() ?: continue
+            val result = runCatching { method.invoke(v) as? String }.getOrNull()
+            if (!result.isNullOrBlank()) return result
+        }
+        return null
+    }
+
+    private fun sanitize(label: String): String {
+        // Whitelist the POSIX-plain character set `[A-Za-z0-9._-]`. Every
+        // other character (Unicode dashes, parens, punctuation, whitespace,
+        // emoji…) collapses to `_`. Enumerating a blacklist is a losing
+        // game — a whitelist keeps the output predictable across shells,
+        // URL consumers, and CI systems that reject non-ASCII paths.
+        val replaced = label.trim().replace(Regex("""[^A-Za-z0-9._-]"""), "_")
+        val collapsed = replaced.replace(Regex("""_+"""), "_").trim('_', '.', '-')
+        // Cap length so an accidental long `toString()` doesn't blow up
+        // filesystem path limits. 32 chars is enough for human-readable
+        // labels and matches the stem-sanitization budget on the plugin
+        // side.
+        return if (collapsed.length > MAX_LABEL_LEN) {
+            collapsed.substring(0, MAX_LABEL_LEN).trim('_', '.', '-')
+        } else {
+            collapsed
+        }
+    }
+
+    private const val MAX_LABEL_LEN = 32
+}

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -86,14 +86,59 @@ object PreviewManifestLoader {
             )
             return emptyList()
         }
-        return values.mapIndexed { idx, value ->
-            val paramSuffix = "_PARAM_$idx"
+        val suffixes = PreviewParameterLabels.suffixesFor(values)
+        val rows = values.mapIndexed { idx, value ->
+            val paramSuffix = suffixes[idx]
             val newCaptures = entry.captures.map { c ->
                 c.copy(renderOutput = insertBeforeExtension(c.renderOutput, paramSuffix))
             }
             val newId = entry.id + paramSuffix
             PreviewRow(entry.copy(id = newId, captures = newCaptures), listOf(value))
         }
+        // The renderer is authoritative about which fan-out files will exist
+        // for this preview — delete any `<stem>_*<ext>` files from prior runs
+        // that aren't in this run's expected output. Guards against provider
+        // renames ("loading" → "busy") and the `_PARAM_<idx>` → `_<label>`
+        // migration leaving a mix of old-shape and new-shape PNGs on disk.
+        // Runs at shard-load time so it fires once per parameterized preview,
+        // before any test body writes to the directory.
+        deleteStaleFanoutFiles(entry.captures, rows)
+        return rows
+    }
+
+    private fun deleteStaleFanoutFiles(
+        templateCaptures: List<RenderPreviewCapture>,
+        expanded: List<PreviewRow>,
+    ) {
+        val outDirPath = System.getProperty("composeai.render.outputDir") ?: return
+        val outDir = File(outDirPath)
+        if (!outDir.isDirectory) return
+        val expectedNames = expanded.flatMap { it.entry.captures }
+            .mapNotNull { fanoutLeaf(it.renderOutput) }
+            .toSet()
+        for (template in templateCaptures) {
+            val templateFile = File(outDir, template.renderOutput.substringAfter("renders/"))
+            val dir = templateFile.parentFile ?: continue
+            val stem = templateFile.nameWithoutExtension
+            val ext = ".${templateFile.extension}"
+            val prefix = stem + "_"
+            dir.listFiles()
+                ?.filter { f ->
+                    f.name.startsWith(prefix) &&
+                        f.name.endsWith(ext) &&
+                        f.name !in expectedNames
+                }
+                ?.forEach { f ->
+                    if (!f.delete()) {
+                        System.err.println("Failed to delete stale fan-out file: ${f.absolutePath}")
+                    }
+                }
+        }
+    }
+
+    private fun fanoutLeaf(renderOutput: String): String? {
+        if (renderOutput.isEmpty()) return null
+        return renderOutput.substringAfterLast('/').ifEmpty { renderOutput }
     }
 
     /**

--- a/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterLabelsTest.kt
+++ b/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterLabelsTest.kt
@@ -1,0 +1,89 @@
+package ee.schimke.composeai.renderer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PreviewParameterLabelsTest {
+
+    @Test
+    fun `pair uses first as label`() {
+        val suffixes = PreviewParameterLabels.suffixesFor(
+            listOf("on" to Any(), "off" to Any(), "unavailable" to Any()),
+        )
+        assertEquals(listOf("_on", "_off", "_unavailable"), suffixes)
+    }
+
+    data class Named(val name: String, val value: Int)
+
+    @Test
+    fun `data class with name property derives label`() {
+        val suffixes = PreviewParameterLabels.suffixesFor(
+            listOf(Named("alpha", 1), Named("beta", 2)),
+        )
+        assertEquals(listOf("_alpha", "_beta"), suffixes)
+    }
+
+    data class Labeled(val label: String)
+
+    @Test
+    fun `label property is recognised`() {
+        val suffixes = PreviewParameterLabels.suffixesFor(listOf(Labeled("red"), Labeled("blue")))
+        assertEquals(listOf("_red", "_blue"), suffixes)
+    }
+
+    data class WithId(val id: String)
+
+    @Test
+    fun `id property is recognised when name and label absent`() {
+        val suffixes = PreviewParameterLabels.suffixesFor(listOf(WithId("a1"), WithId("b2")))
+        assertEquals(listOf("_a1", "_b2"), suffixes)
+    }
+
+    @Test
+    fun `toString fallback is used when no property matches`() {
+        val suffixes = PreviewParameterLabels.suffixesFor(listOf("hello", "world"))
+        assertEquals(listOf("_hello", "_world"), suffixes)
+    }
+
+    @Test
+    fun `default object toString falls back to PARAM_idx`() {
+        val suffixes = PreviewParameterLabels.suffixesFor(listOf(Any(), Any()))
+        assertEquals(listOf("_PARAM_0", "_PARAM_1"), suffixes)
+    }
+
+    @Test
+    fun `null values fall back to PARAM_idx`() {
+        val suffixes = PreviewParameterLabels.suffixesFor(listOf<Any?>(null, "ok"))
+        assertEquals(listOf("_PARAM_0", "_ok"), suffixes)
+    }
+
+    @Test
+    fun `spaces and parens are sanitized`() {
+        val suffixes = PreviewParameterLabels.suffixesFor(
+            listOf("tile light (light)" to Any(), "tile dark (dark)" to Any()),
+        )
+        assertEquals(listOf("_tile_light_light", "_tile_dark_dark"), suffixes)
+    }
+
+    @Test
+    fun `shell-hostile characters are replaced with underscore`() {
+        val suffixes = PreviewParameterLabels.suffixesFor(listOf("a&b/c", "x|y*z"))
+        assertEquals(listOf("_a_b_c", "_x_y_z"), suffixes)
+    }
+
+    @Test
+    fun `colliding labels fall back to PARAM_idx across the whole fan-out`() {
+        val suffixes = PreviewParameterLabels.suffixesFor(
+            listOf("dup" to Any(), "dup" to Any(), "unique" to Any()),
+        )
+        assertEquals(listOf("_PARAM_0", "_PARAM_1", "_PARAM_2"), suffixes)
+    }
+
+    @Test
+    fun `long labels are truncated`() {
+        val long = "x".repeat(64)
+        val suffixes = PreviewParameterLabels.suffixesFor(listOf(long to Any()))
+        val expected = "_" + "x".repeat(32)
+        assertEquals(listOf(expected), suffixes)
+    }
+}

--- a/renderer-desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderer-desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -90,9 +90,24 @@ fun main(args: Array<String>) {
             listOf(NO_PARAM)
         }
 
+        val suffixes: List<String> = if (values.size == 1 && values[0] === NO_PARAM) {
+            listOf("")
+        } else {
+            PreviewParameterLabels.suffixesFor(values)
+        }
+        val targetFiles = values.mapIndexed { idx, value ->
+            if (value === NO_PARAM) outputFile
+            else File(insertBeforeExtension(outputFile.path, suffixes[idx]))
+        }
+        // Renderer is authoritative about the fan-out — delete any
+        // `<stem>_*<ext>` files from prior runs that aren't in this run's
+        // expected output. Guards against provider renames and the
+        // `_PARAM_<idx>` → `_<label>` migration leaving stale PNGs behind.
+        if (values.any { it !== NO_PARAM }) {
+            deleteStaleFanoutFiles(outputFile, targetFiles.map { it.name }.toSet())
+        }
         for ((idx, value) in values.withIndex()) {
-            val targetFile = if (value === NO_PARAM) outputFile
-            else File(insertBeforeExtension(outputFile.path, "_PARAM_$idx"))
+            val targetFile = targetFiles[idx]
             val previewArgs = if (value === NO_PARAM) emptyList() else listOf(value)
             renderPreview(
                 className, functionName, widthPx, heightPx, density,
@@ -111,6 +126,21 @@ fun main(args: Array<String>) {
 // A null value from the provider is a legitimate case we want to render; NO_PARAM
 // short-circuits the file-path suffix logic instead.
 private val NO_PARAM = Any()
+
+private fun deleteStaleFanoutFiles(template: File, expectedNames: Set<String>) {
+    val dir = template.parentFile ?: return
+    if (!dir.isDirectory) return
+    val stem = template.nameWithoutExtension
+    val ext = ".${template.extension}"
+    val prefix = stem + "_"
+    dir.listFiles()
+        ?.filter { it.name.startsWith(prefix) && it.name.endsWith(ext) && it.name !in expectedNames }
+        ?.forEach { f ->
+            if (!f.delete()) {
+                System.err.println("Failed to delete stale fan-out file: ${f.absolutePath}")
+            }
+        }
+}
 
 private fun insertBeforeExtension(path: String, suffix: String): String {
     if (path.isEmpty()) return path

--- a/renderer-desktop/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterLabels.kt
+++ b/renderer-desktop/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterLabels.kt
@@ -1,0 +1,64 @@
+package ee.schimke.composeai.renderer
+
+/**
+ * Desktop mirror of the Android renderer's [PreviewParameterLabels] — see
+ * that file for the full commentary on label derivation and fallback rules.
+ * Duplicated here (not shared via a common module) so the two renderer
+ * artefacts stay independently buildable.
+ */
+internal object PreviewParameterLabels {
+
+    fun suffixesFor(values: List<Any?>): List<String> {
+        val labels = values.map { rawLabel(it)?.let(::sanitize)?.takeIf { s -> s.isNotEmpty() } }
+        val nonNull = labels.filterNotNull()
+        val hasCollision = nonNull.size != nonNull.toSet().size
+        return labels.mapIndexed { idx, label ->
+            when {
+                label == null || hasCollision -> "_PARAM_$idx"
+                else -> "_$label"
+            }
+        }
+    }
+
+    private fun rawLabel(value: Any?): String? {
+        if (value == null) return null
+        if (value is Pair<*, *>) {
+            val first = value.first ?: return null
+            return (first as? String) ?: first.toString()
+        }
+        val fromProperty = propertyLabel(value)
+        if (fromProperty != null) return fromProperty
+        val str = runCatching { value.toString() }.getOrNull() ?: return null
+        val defaultPrefix = value.javaClass.name + "@"
+        return if (str.startsWith(defaultPrefix)) null else str
+    }
+
+    private fun propertyLabel(value: Any?): String? {
+        val v = value ?: return null
+        for (candidate in listOf("name", "label", "id")) {
+            val getter = "get" + candidate.replaceFirstChar { it.uppercase() }
+            val method = runCatching {
+                v.javaClass.methods.firstOrNull {
+                    it.name == getter &&
+                        it.parameterCount == 0 &&
+                        it.returnType == String::class.java
+                }
+            }.getOrNull() ?: continue
+            val result = runCatching { method.invoke(v) as? String }.getOrNull()
+            if (!result.isNullOrBlank()) return result
+        }
+        return null
+    }
+
+    private fun sanitize(label: String): String {
+        val replaced = label.trim().replace(Regex("""[^A-Za-z0-9._-]"""), "_")
+        val collapsed = replaced.replace(Regex("""_+"""), "_").trim('_', '.', '-')
+        return if (collapsed.length > MAX_LABEL_LEN) {
+            collapsed.substring(0, MAX_LABEL_LEN).trim('_', '.', '-')
+        } else {
+            collapsed
+        }
+    }
+
+    private const val MAX_LABEL_LEN = 32
+}

--- a/sample-android/src/main/kotlin/com/example/sampleandroid/PreviewParameterPreviews.kt
+++ b/sample-android/src/main/kotlin/com/example/sampleandroid/PreviewParameterPreviews.kt
@@ -29,8 +29,10 @@ data class UserCardData(
  * Minimal `@PreviewParameter` demo: one preview function, one provider, N
  * rendered PNGs. The plugin's discovery pass records the provider FQN on
  * `PreviewParams`; the Robolectric renderer instantiates the provider at
- * test-load time, enumerates `values`, and emits one file per value with a
- * `_PARAM_<idx>` suffix before the extension.
+ * test-load time, enumerates `values`, and emits one file per value. The
+ * filename suffix is derived from the value's `name` property
+ * (`..._Ada_Lovelace.png`, `..._Grace_Hopper.png`, …); the renderer falls
+ * back to `_PARAM_<idx>` only when no label can be recovered.
  *
  * Kept intentionally simple (no `@PreviewWrapper`, no device, no fan-out
  * dimensions other than the provider) so the output diff reviewing the

--- a/sample-cmp/src/main/kotlin/com/example/samplecmp/PreviewParameterPreviews.kt
+++ b/sample-cmp/src/main/kotlin/com/example/samplecmp/PreviewParameterPreviews.kt
@@ -20,8 +20,10 @@ import androidx.compose.ui.unit.dp
 
 /**
  * Demo data for the CMP Desktop `@PreviewParameter` sample. Each value has a
- * distinct label + colour, so the fan-out (`<id>_PARAM_0.png`,
- * `<id>_PARAM_1.png`, …) lands on visually different PNGs.
+ * distinct label + colour, so the fan-out lands on visually different PNGs —
+ * and since [SwatchData] exposes a [label] property, the renderer derives
+ * filename suffixes from it (`<id>_Crimson.png`, `<id>_Teal.png`, …) instead
+ * of opaque `_PARAM_<idx>` indices.
  */
 data class SwatchData(val label: String, val color: Long)
 
@@ -38,7 +40,9 @@ class SwatchProvider : PreviewParameterProvider<SwatchData> {
  * Desktop (CMP) `@PreviewParameter` smoke test. The JVM renderer consumes
  * the provider FQN + limit passed on the command line, loops over
  * `values.take(limit)` inside a single process, and emits one PNG per
- * value with `_PARAM_<idx>` inserted before the extension.
+ * value — keyed by the value's derived label (from a `name`/`label`/`id`
+ * property or a `Pair`'s `first`) and falling back to `_PARAM_<idx>` when
+ * no label can be derived.
  */
 @Preview(name = "Color Swatch", backgroundColor = 0xFFFFFFFF, showBackground = true)
 @Composable

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -9,16 +9,23 @@ const TIMESTAMP_RE = /^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})(?:-\d+)?$/;
 
 /**
  * Expands a parameterized preview's single template capture into N captures
- * pointing at the actual `_PARAM_<idx>` files on disk. Returns the original
- * list unchanged when no matching files exist (rare — the plugin's
- * `renderAllPreviews` check would have already failed loudly), or when the
- * template has no `renderOutput` to key off.
+ * pointing at the actual `<stem>_<suffix>.<ext>` files on disk. The suffix
+ * is either a human-readable label derived from the provider value (`_on`,
+ * `_off`), or a numeric `_PARAM_<idx>` when no label could be derived.
+ * Returns the original list unchanged when no matching files exist (rare —
+ * the plugin's `renderAllPreviews` check would have already failed loudly),
+ * or when the template has no `renderOutput` to key off.
  *
- * Sorted by the numeric suffix (`PARAM_0`, `PARAM_1`, …, `PARAM_10`) so
- * `PARAM_10` doesn't sort before `PARAM_2` — lexicographic ordering on the
- * raw filename would produce that order.
+ * Numeric `_PARAM_<idx>` entries sort before label-based entries and among
+ * themselves by index (so `PARAM_10` lands after `PARAM_2`, not before).
+ * Labels sort alphabetically — provider order isn't recoverable from the
+ * filename alone, but alphabetical is stable and readable.
  */
-function expandParamCaptures(rendersDir: string, templates: Capture[]): Capture[] {
+function expandParamCaptures(
+    rendersDir: string,
+    templates: Capture[],
+    siblingRenderOutputs: Set<string>,
+): Capture[] {
     if (!fs.existsSync(rendersDir)) { return templates; }
     const expanded: Capture[] = [];
     for (const template of templates) {
@@ -27,17 +34,24 @@ function expandParamCaptures(rendersDir: string, templates: Capture[]): Capture[
         const dot = base.lastIndexOf('.');
         const stem = dot > 0 ? base.slice(0, dot) : base;
         const ext = dot > 0 ? base.slice(dot) : '';
-        const prefix = stem + '_PARAM_';
+        const prefix = stem + '_';
         const templateDir = path.dirname(template.renderOutput);
         const dirPrefix = templateDir && templateDir !== '.' ? `${templateDir}/` : '';
         const matches = fs.readdirSync(rendersDir)
-            .filter(name => name.startsWith(prefix) && name.endsWith(ext))
+            .filter(name => name.startsWith(prefix) && name.endsWith(ext)
+                && !siblingRenderOutputs.has(dirPrefix + name))
             .map(name => {
-                const idxStr = name.slice(prefix.length, name.length - ext.length);
-                const idx = parseInt(idxStr, 10);
-                return { name, idx: Number.isNaN(idx) ? Number.MAX_SAFE_INTEGER : idx };
+                const suffix = name.slice(prefix.length, name.length - ext.length);
+                const paramIdxStr = suffix.startsWith('PARAM_') ? suffix.slice('PARAM_'.length) : null;
+                const paramIdx = paramIdxStr !== null ? parseInt(paramIdxStr, 10) : NaN;
+                return { name, suffix, paramIdx: Number.isNaN(paramIdx) ? null : paramIdx };
             })
-            .sort((a, b) => a.idx - b.idx);
+            .sort((a, b) => {
+                if (a.paramIdx !== null && b.paramIdx !== null) { return a.paramIdx - b.paramIdx; }
+                if (a.paramIdx !== null) { return -1; }
+                if (b.paramIdx !== null) { return 1; }
+                return a.suffix.localeCompare(b.suffix);
+            });
         if (matches.length === 0) { continue; }
         for (const match of matches) {
             expanded.push({
@@ -185,9 +199,17 @@ export class GradleService {
             // sees the preview, so the UI walks N files instead of trying to
             // read the template path (which never exists).
             const rendersDir = path.join(this.workspaceRoot, module, 'build', 'compose-previews', 'renders');
+            const siblingRenderOutputs = new Set<string>();
+            for (const p of manifest.previews) {
+                if (!p.params?.previewParameterProviderClassName) {
+                    for (const c of p.captures) {
+                        if (c.renderOutput) { siblingRenderOutputs.add(c.renderOutput); }
+                    }
+                }
+            }
             for (const p of manifest.previews) {
                 if (p.params?.previewParameterProviderClassName) {
-                    p.captures = expandParamCaptures(rendersDir, p.captures);
+                    p.captures = expandParamCaptures(rendersDir, p.captures, siblingRenderOutputs);
                 }
             }
             // Enrich each preview with a11y findings when the module has the

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -13,9 +13,11 @@ export interface PreviewParams {
     /**
      * FQN of the `PreviewParameterProvider` harvested from `@PreviewParameter`,
      * when the discovery pass saw one on this preview's function signature.
-     * Extension uses this to know to glob for `<id>_PARAM_<idx>.<ext>` files
-     * (one per provider value) rather than expecting the manifest's single
-     * template capture to exist on disk verbatim.
+     * Extension uses this to know to glob for `<stem>_<suffix>.<ext>` files
+     * (one per provider value — `<suffix>` is a human-readable label derived
+     * from the value, or `PARAM_<idx>` when no label can be derived) rather
+     * than expecting the manifest's single template capture to exist on disk
+     * verbatim.
      */
     previewParameterProviderClassName?: string | null;
     previewParameterLimit?: number | null;


### PR DESCRIPTION
Resolves #139.

## Summary

- `@PreviewParameter` fan-outs now land on `..._on.png` / `..._off.png` / `..._unavailable.png` — labels are derived from `Pair.first`, a `name` / `label` / `id` property on the value, or a non-default `toString()`. Falls back to `_PARAM_<idx>` only when no label is derivable or two values collide.
- Render filenames strip the common dotted package prefix across all previews in a module (`ee.schimke.ha.previews.CardPreviewsKt.Foo.png` → `CardPreviewsKt.Foo.png`) and are sanitized against a `[A-Za-z0-9._-]` whitelist (spaces, parens, commas, other shell-awkward or non-ASCII characters become `_`). `PreviewInfo.id` stays the full FQN — only the on-disk filename is shortened.
- `build/compose-previews/renders/` is now treated as ephemeral. Each renderer deletes stale `<stem>_*<ext>` fan-out siblings before writing; `renderAllPreviews` deletes PNG/GIF files not referenced by the current manifest (but preserves `<stem>_*<ext>` matches of parameterized previews since the plugin side can't enumerate their exact filenames). Documented in [AGENTS.md](docs/AGENTS.md).

## Before / after

Before, for a provider yielding `"on" to snapshot`, `"off" to snapshot`, `"unavailable" to snapshot`:

```
ee.schimke.ha.previews.CardPreviewsKt.Tile_Light_States_tile light (light)_PARAM_0.png
ee.schimke.ha.previews.CardPreviewsKt.Tile_Light_States_tile light (light)_PARAM_1.png
ee.schimke.ha.previews.CardPreviewsKt.Tile_Light_States_tile light (light)_PARAM_2.png
```

After:

```
CardPreviewsKt.Tile_Light_States_tile_light_light_on.png
CardPreviewsKt.Tile_Light_States_tile_light_light_off.png
CardPreviewsKt.Tile_Light_States_tile_light_light_unavailable.png
```

## Test plan

- [x] `./gradlew check` — green (274 tasks)
- [x] `./gradlew :sample-android:renderAllPreviews :sample-cmp:renderAllPreviews --rerun-tasks` — end-to-end clean render verified label-based filenames land on disk and no stale PNGs remain
- [x] `vscode-extension` Mocha — 65/65 passing
- [x] New coverage: `PreviewParameterLabelsTest` (pair / name property / label property / id property / toString fallback / default-object fallback / null handling / whitespace + parens sanitization / collision fallback / length cap) and a functional test locking in `tile light (light)` → `tile_light_light` end-to-end.
- [x] Existing functional tests updated to the new `renderOutput` shape (`ColorValidationTest`, `DiscoveryFunctionalTest` scroll + device-dim cases).