### PR TITLE
feat(doctor): surface triage diagnostics for renderPreviews bug reports

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -45,6 +45,7 @@ import kotlin.system.exitProcess
  */
 class DoctorCommand(args: List<String>) {
     private val jsonOut = "--json" in args
+    private val reportOut = "--report" in args
     private val explain = "--explain" in args
     private val verbose = "--verbose" in args || "-v" in args
     private val projectDirArg = args.flagValue("--project")
@@ -54,7 +55,9 @@ class DoctorCommand(args: List<String>) {
 
     fun run() {
         // Environment checks always run.
+        checkOs()
         checkJava()
+        checkPathJava()
         val creds = checkCredentials()
         if (creds != null) probeMaven(creds)
         checkComposeBomVersion()
@@ -91,16 +94,44 @@ class DoctorCommand(args: List<String>) {
 
     // --- Env checks ---------------------------------------------------------
 
+    /**
+     * OS fingerprint. Cheap to collect and has saved several issue rounds —
+     * e.g. #142 was specific to a Linux kernel build not visible from
+     * `os.name` alone. We emit name/version/arch verbatim; doctor never
+     * branches on these.
+     */
+    private fun checkOs() {
+        val name = System.getProperty("os.name") ?: "unknown"
+        val version = System.getProperty("os.version") ?: ""
+        val arch = System.getProperty("os.arch") ?: ""
+        addCheck(
+            DoctorCheck(
+                id = "env.os",
+                category = "env",
+                status = "ok",
+                message = listOf(name, version, arch).filter { it.isNotBlank() }.joinToString(" "),
+            ),
+        )
+    }
+
     private fun checkJava() {
         val version = System.getProperty("java.specification.version")
         val major = version?.substringBefore('.')?.toIntOrNull()
+        // Fingerprint the CLI's own JVM so bug reports carry vendor (often
+        // differentiates the Linux-distro / Google-internal JDK that caused
+        // #142) and java.home (pinpoints SDKMAN vs system-provided installs).
+        val vendor = System.getProperty("java.vendor") ?: "unknown"
+        val runtime = System.getProperty("java.runtime.version") ?: System.getProperty("java.version") ?: "unknown"
+        val home = System.getProperty("java.home") ?: "unknown"
+        val detail = "vendor: $vendor; runtime: $runtime; java.home: $home"
         if (major != null && major >= 17) {
             addCheck(
                 DoctorCheck(
                     id = "env.java-17",
                     category = "env",
                     status = "ok",
-                    message = "Java $version on PATH",
+                    message = "CLI JVM Java $version",
+                    detail = detail,
                 ),
             )
         } else {
@@ -110,6 +141,7 @@ class DoctorCommand(args: List<String>) {
                     category = "env",
                     status = "error",
                     message = "Java 17+ required, got ${version ?: "unknown"}",
+                    detail = detail,
                     remediation = DoctorRemediation(
                         summary = "Install a JDK 17 and put it on PATH, or set JAVA_HOME.",
                         commands = listOf("sdk install java 17.0.11-tem"),
@@ -117,6 +149,48 @@ class DoctorCommand(args: List<String>) {
                 ),
             )
         }
+    }
+
+    /**
+     * Separate check for the `java` on `PATH`. Motivated by #142: the
+     * reporter's Gradle launcher was pinned to JDK 21 via `JAVA_HOME`, but
+     * their system default (`java` on PATH) was JDK 25 — and the forked
+     * `renderPreviews` test worker picked up the system default, because
+     * the Test task's `javaLauncher` wasn't pinned to the project toolchain.
+     * Separating the CLI JVM from the PATH JVM makes that delta visible in
+     * the first line of output.
+     *
+     * Skipped on Windows for now — `java -version` prints to stderr, the
+     * parsing is the same, but nobody is reporting Windows-specific bugs
+     * yet and `sh -c` isn't available there. Add when a Windows-only bug
+     * report needs it.
+     */
+    private fun checkPathJava() {
+        val sameAsCli = System.getProperty("java.home")?.let { home ->
+            // If PATH's `java` resolves to the same install as java.home,
+            // emitting a second check is noise — the cli check already
+            // covers it.
+            val probe = runCommand(listOf("sh", "-c", "command -v java"))
+            probe?.stdout?.trim()?.startsWith(home) == true
+        } ?: false
+        if (sameAsCli) return
+
+        val which = runCommand(listOf("sh", "-c", "command -v java")) ?: return
+        val path = which.stdout.trim().ifBlank { return }
+        val versionOut = runCommand(listOf(path, "-version"))?.stderrOrStdout()?.trim().orEmpty()
+        // `java -version` prints 3 lines to stderr: the version, the
+        // runtime build, and the VM build. We keep the first two, which
+        // carry vendor tagging (e.g. `+-google-release-868188172`).
+        val summary = versionOut.lines().take(2).joinToString(" | ").ifBlank { "unreachable" }
+        addCheck(
+            DoctorCheck(
+                id = "env.path-jvm",
+                category = "env",
+                status = "ok",
+                message = "`java` on PATH → $path",
+                detail = summary,
+            ),
+        )
     }
 
     private fun checkCredentials(): Credentials? {
@@ -233,9 +307,17 @@ class DoctorCommand(args: List<String>) {
 
     // --- Project checks -----------------------------------------------------
 
+    private var daemonGradleVersion: String? = null
+    private var daemonJavaHome: String? = null
+    private var daemonJavaMajor: Int? = null
+
     private fun runProjectChecks(projectDir: File) {
         val model = try {
             GradleConnection(projectDir, verbose = verbose).use { gc ->
+                // Daemon-JVM + Gradle-version snapshot. Runs first so other
+                // project-scope checks can compare against the daemon's JDK
+                // (e.g. flagging test worker mismatch in #142).
+                checkGradleDaemon(gc)
                 gc.runBuildAction(GatherComposePreviewModelAction())
             }
         } catch (e: Exception) {
@@ -282,7 +364,164 @@ class DoctorCommand(args: List<String>) {
         )
 
         for ((modulePath, info) in model.modules) {
+            checkModuleVersions(modulePath, info)
+            checkRenderPreviewsTask(modulePath, info)
             checkModuleCompat(modulePath, info)
+            checkErrorSignatures(projectDir, modulePath)
+        }
+    }
+
+    /**
+     * Emits the daemon's Gradle and JVM fingerprint as two `env` checks.
+     * We stash the JDK major and path on the class so per-module checks
+     * can compare against them (see [checkRenderPreviewsTask]).
+     *
+     * Runs inside the project block because fetching the model requires a
+     * live [GradleConnection]. It's logically an env concern though, so
+     * the check id lives under `env.*`.
+     */
+    private fun checkGradleDaemon(gc: GradleConnection) {
+        val env = gc.buildEnvironment() ?: run {
+            addCheck(
+                DoctorCheck(
+                    id = "env.gradle-daemon",
+                    category = "env",
+                    status = "warning",
+                    message = "could not fetch BuildEnvironment from Gradle daemon",
+                ),
+            )
+            return
+        }
+        daemonGradleVersion = env.gradle.gradleVersion
+        val javaHome = env.java.javaHome
+        daemonJavaHome = javaHome.absolutePath
+        // Derive JDK major from the release file — more reliable than
+        // guessing from `javaHome` path naming. Falls back to null if the
+        // file isn't there or doesn't parse (e.g. a non-standard install).
+        daemonJavaMajor = readJdkMajor(javaHome)
+        val majorStr = daemonJavaMajor?.let { "JDK $it" } ?: "unknown JDK"
+        addCheck(
+            DoctorCheck(
+                id = "env.gradle-daemon",
+                category = "env",
+                status = "ok",
+                message = "Gradle ${daemonGradleVersion} on $majorStr",
+                detail = "daemon java.home: ${daemonJavaHome}",
+            ),
+        )
+    }
+
+    /**
+     * Emits per-module version info — AGP, Kotlin, Robolectric, Compose
+     * runtime. Robolectric/Compose-runtime are read from the resolved test
+     * classpath; AGP/Kotlin are plugin-side reflective reads. All four are
+     * surfaced as an `info`-style ok-status check so `--report` has one
+     * pasteable block with everything a triager needs to see.
+     */
+    private fun checkModuleVersions(modulePath: String, info: ModuleInfo) {
+        val robolectric = info.testRuntimeDependencies["org.robolectric:robolectric"]
+        val composeRuntime = info.testRuntimeDependencies["androidx.compose.runtime:runtime"]
+        val parts = buildList {
+            add("variant=${info.variant}")
+            info.agpVersion?.let { add("agp=$it") }
+            info.kotlinVersion?.let { add("kotlin=$it") }
+            robolectric?.let { add("robolectric=$it") }
+            composeRuntime?.let { add("compose-runtime=$it") }
+        }
+        addCheck(
+            DoctorCheck(
+                id = "project.${idSafe(modulePath)}.versions",
+                category = "project",
+                status = "ok",
+                message = "$modulePath — ${parts.joinToString("  ")}",
+            ),
+        )
+    }
+
+    /**
+     * The check motivated by issue #142. If the test worker's forked JDK
+     * is a different major than the Gradle daemon's, emit a `warning` with
+     * the specific error signature the mismatch typically produces, plus a
+     * remediation pointing at the `javaLauncher` toolchain wiring.
+     *
+     * When the JDK majors match (or when we can't tell), this degrades to
+     * a pure info line — still useful in bug reports because it fingerprints
+     * the launcher vendor and path.
+     */
+    private fun checkRenderPreviewsTask(modulePath: String, info: ModuleInfo) {
+        val task = info.renderPreviewsTask ?: return
+        val launcherMajor = task.javaLauncherVersion?.toIntOrNull()
+        val launcherPath = task.javaLauncherPath ?: "(unknown)"
+        val launcherVendor = task.javaLauncherVendor ?: "unknown"
+        val mismatch = launcherMajor != null && daemonJavaMajor != null && launcherMajor != daemonJavaMajor
+        val detail = buildString {
+            append("launcher: JDK $launcherMajor ($launcherVendor) at $launcherPath")
+            append("; classpath=${task.classpathSize}, bootstrap=${task.bootstrapClasspathSize}")
+        }
+        if (mismatch) {
+            addCheck(
+                DoctorCheck(
+                    id = "project.${idSafe(modulePath)}.render-previews-jvm",
+                    category = "project",
+                    status = "warning",
+                    message = "$modulePath — renderPreviews will fork JDK $launcherMajor, Gradle daemon runs JDK $daemonJavaMajor",
+                    detail = "$detail; symptom on mismatch: `ClassNotFoundException: android.app.Application` during JUnit discovery (see issue #142)",
+                    remediation = DoctorRemediation(
+                        summary = "Pin the renderPreviews Test task to the project's Java toolchain.",
+                        commands = listOf(
+                            "kotlin { jvmToolchain(${daemonJavaMajor ?: 21}) }",
+                            "// or: tasks.named(\"renderPreviews\", Test::class) { javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(${daemonJavaMajor ?: 21})) }) }",
+                        ),
+                        docs = "https://github.com/$REPO/issues/142",
+                    ),
+                ),
+            )
+        } else {
+            addCheck(
+                DoctorCheck(
+                    id = "project.${idSafe(modulePath)}.render-previews-jvm",
+                    category = "project",
+                    status = "ok",
+                    message = "$modulePath — renderPreviews launcher JDK ${launcherMajor ?: "?"}",
+                    detail = detail,
+                ),
+            )
+        }
+    }
+
+    /**
+     * Scans HTML reports under `build/reports/tests/renderPreviews/` for known error
+     * signatures and emits a per-module hint when it spots one. Purely
+     * pattern-based — we only match signatures we've seen in field reports,
+     * so false positives are rare and actionable. Best-effort: if there's
+     * no report on disk (first run, clean checkout) we silently skip.
+     */
+    private fun checkErrorSignatures(projectDir: File, modulePath: String) {
+        val moduleDir = File(projectDir, idSafe(modulePath)).takeIf { it.isDirectory } ?: return
+        val reportDir = File(moduleDir, "build/reports/tests/renderPreviews")
+        if (!reportDir.isDirectory) return
+        val htmls = reportDir.walkTopDown()
+            .maxDepth(4)
+            .filter { it.isFile && it.extension == "html" }
+            .toList()
+        if (htmls.isEmpty()) return
+
+        val haystack = htmls.asSequence().mapNotNull {
+            try { it.readText() } catch (_: Exception) { null }
+        }.joinToString("\n")
+
+        val hint = KNOWN_ERROR_SIGNATURES.firstOrNull { haystack.contains(it.pattern) }
+        if (hint != null) {
+            addCheck(
+                DoctorCheck(
+                    id = "project.${idSafe(modulePath)}.last-error",
+                    category = "project",
+                    status = "warning",
+                    message = "$modulePath — last renderPreviews run failed with a known signature",
+                    detail = "${hint.pattern} — ${hint.hint}",
+                    remediation = hint.remediation,
+                ),
+            )
         }
     }
 
@@ -453,9 +692,59 @@ class DoctorCommand(args: List<String>) {
     // --- Output -------------------------------------------------------------
 
     private fun emit() {
-        if (jsonOut) emitJson() else emitText()
+        when {
+            jsonOut -> emitJson()
+            reportOut -> emitReport()
+            else -> emitText()
+        }
         val errors = checks.count { it.status == "error" }
         exitProcess(if (errors > 0) 1 else 0)
+    }
+
+    /**
+     * Compact, paste-friendly fingerprint block intended for GitHub issue
+     * reports. Prints everything a triager needs upfront so the reporter
+     * doesn't have to re-run `gradlew --version`, `java -version`, etc.
+     * across multiple follow-up comments. Structure is flat key-value so
+     * grep-parsing from an agent is cheap, and the schema string anchors
+     * the v1 contract the same way [DoctorReport.schema] does.
+     *
+     * Each block (env / modules / errors) only prints when we have data —
+     * e.g. module versions are omitted when no project was detected.
+     */
+    private fun emitReport() {
+        println("compose-preview-doctor-report/v1")
+        println()
+        val env = checks.filter { it.category == "env" }
+        val project = checks.filter { it.category == "project" }
+        val deps = checks.filter { it.category == "deps" }
+
+        println("plugin: $pluginVersion")
+        for (c in env) {
+            val tail = c.detail?.let { "  ($it)" } ?: ""
+            println("${c.id}: ${c.message}$tail")
+        }
+        if (project.isNotEmpty()) {
+            println()
+            println("[project]")
+            for (c in project) {
+                println("${c.id} [${c.status}]: ${c.message}")
+                c.detail?.let { println("    $it") }
+            }
+        }
+        if (deps.isNotEmpty()) {
+            println()
+            println("[deps]")
+            for (c in deps) {
+                if (c.status == "ok") continue // compat-clean modules are noise here
+                println("${c.id} [${c.status}]: ${c.message}")
+                c.detail?.let { println("    $it") }
+            }
+        }
+
+        val summary = summary()
+        println()
+        println("summary: ok=${summary.ok} warning=${summary.warning} error=${summary.error} skipped=${summary.skipped}")
     }
 
     private fun emitText() {
@@ -559,7 +848,70 @@ class DoctorCommand(args: List<String>) {
     /** Sanitise a module path (e.g. `:sample-wear` → `sample-wear`) for use in check ids. */
     private fun idSafe(modulePath: String): String = modulePath.removePrefix(":").ifEmpty { "root" }
 
+    /**
+     * Exec a short-lived command and capture its stdout/stderr. Returns
+     * `null` if the executable wasn't found, the process failed to start,
+     * or it didn't finish within 5s — doctor folds all of those into "skip
+     * the check" rather than erroring on what's essentially optional
+     * fingerprinting.
+     */
+    private fun runCommand(cmd: List<String>): CommandResult? {
+        return try {
+            val process = ProcessBuilder(cmd)
+                .redirectErrorStream(false)
+                .start()
+            val stdout = process.inputStream.bufferedReader().use { it.readText() }
+            val stderr = process.errorStream.bufferedReader().use { it.readText() }
+            if (!process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                return null
+            }
+            CommandResult(process.exitValue(), stdout, stderr)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private data class CommandResult(val exitCode: Int, val stdout: String, val stderr: String) {
+        /** `java -version` prints to stderr on most JDKs; fall back to stdout for the occasional one that doesn't. */
+        fun stderrOrStdout(): String = stderr.ifBlank { stdout }
+    }
+
+    /**
+     * Reads the JDK major version from `$javaHome/release`. Most JDK
+     * distributions ship this file with a `JAVA_VERSION=...` line — more
+     * reliable than guessing from the install path, which varies wildly
+     * (`/usr/lib/jvm/temurin-21-jdk-amd64` vs `/opt/homebrew/opt/openjdk@21`
+     * vs `~/.sdkman/candidates/java/21.0.11-tem`). Returns `null` when the
+     * file is missing or malformed.
+     */
+    private fun readJdkMajor(javaHome: File): Int? {
+        val release = File(javaHome, "release").takeIf { it.isFile } ?: return null
+        val line = try {
+            release.readLines().firstOrNull { it.startsWith("JAVA_VERSION=") }
+        } catch (_: Exception) {
+            return null
+        } ?: return null
+        // Format: JAVA_VERSION="21.0.11"  OR  JAVA_VERSION="1.8.0_402"
+        val raw = line.substringAfter("=").trim().trim('"')
+        val major = raw.substringBefore('.').toIntOrNull() ?: return null
+        // Legacy JDK 8 reports as "1.8.x" — normalize to 8.
+        return if (major == 1) raw.split('.').getOrNull(1)?.toIntOrNull() else major
+    }
+
     private data class Credentials(val user: String, val token: String)
+
+    /**
+     * One known `renderPreviews` failure signature. Pattern is a plain
+     * substring we look for in the HTML test report; [hint] is the human
+     * explanation; [remediation] is the same action structure the rest of
+     * doctor emits, so agents get concrete commands out of this too.
+     */
+    private data class ErrorSignature(
+        val pattern: String,
+        val hint: String,
+        val remediation: DoctorRemediation?,
+    )
 
     companion object {
         private const val REPO = "yschimke/compose-ai-tools"
@@ -577,6 +929,42 @@ class DoctorCommand(args: List<String>) {
         private val SKIP_DIRS = setOf("build", "node_modules", "out", "dist", ".gradle")
 
         private val JSON = Json { prettyPrint = true; encodeDefaults = true }
+
+        /**
+         * Failure signatures the CLI recognises from `renderPreviews` HTML
+         * reports. Order matters — the first match wins. Keep the list
+         * curated: only patterns we've traced to a specific, actionable
+         * root cause belong here. Patterns that overlap benign test output
+         * produce false positives.
+         */
+        private val KNOWN_ERROR_SIGNATURES = listOf(
+            ErrorSignature(
+                pattern = "ClassNotFoundException: android.app.Application",
+                hint = "likely test-worker JVM mismatch (see issue #142)",
+                remediation = DoctorRemediation(
+                    summary = "Pin the renderPreviews Test task's javaLauncher to the project toolchain.",
+                    commands = listOf(
+                        "kotlin { jvmToolchain(21) }",
+                    ),
+                    docs = "https://github.com/$REPO/issues/142",
+                ),
+            ),
+            ErrorSignature(
+                pattern = "RuntimeException: Stub!",
+                hint = "android.jar on bootstrap classpath is shadowing Robolectric's instrumented android-all",
+                remediation = DoctorRemediation(
+                    summary = "Don't inject android.jar into bootstrapClasspath — keep it on the outer classpath only.",
+                    docs = "https://github.com/$REPO/blob/main/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt",
+                ),
+            ),
+            ErrorSignature(
+                pattern = "NoSuchMethodError: androidx.compose.runtime.ComposeUiNode",
+                hint = "compose-bom too old — renderer-compiled calls postdate the runtime on the consumer's classpath",
+                remediation = DoctorRemediation(
+                    summary = "Bump compose-bom to at least 2025.01.00.",
+                ),
+            ),
+        )
     }
 }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/GatherComposePreviewModelAction.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/GatherComposePreviewModelAction.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.cli
 import ee.schimke.composeai.plugin.tooling.ComposePreviewModel
 import ee.schimke.composeai.plugin.tooling.ModuleFinding
 import ee.schimke.composeai.plugin.tooling.ModuleInfo
+import ee.schimke.composeai.plugin.tooling.RenderPreviewsTaskInfo
 import org.gradle.tooling.BuildAction
 import org.gradle.tooling.BuildController
 import org.gradle.tooling.model.gradle.GradleBuild
@@ -51,10 +52,41 @@ class GatherComposePreviewModelAction : BuildAction<AggregatedComposePreviewMode
                             docsUrl = f.docsUrl,
                         )
                     },
+                    // New fields — marshalled defensively because older
+                    // plugin versions don't implement the getters. The
+                    // Tooling-API proxy throws `UnsupportedMethodException`
+                    // in that case; catching it here lets a recent CLI
+                    // still read an older plugin's model.
+                    agpVersion = readOptional { info.agpVersion },
+                    kotlinVersion = readOptional { info.kotlinVersion },
+                    renderPreviewsTask = readOptional { info.renderPreviewsTask }?.let { t ->
+                        SerializableRenderPreviewsTaskInfo(
+                            javaLauncherPinned = t.javaLauncherPinned,
+                            javaLauncherVersion = t.javaLauncherVersion,
+                            javaLauncherVendor = t.javaLauncherVendor,
+                            javaLauncherPath = t.javaLauncherPath,
+                            classpathSize = t.classpathSize,
+                            bootstrapClasspathSize = t.bootstrapClasspathSize,
+                            jvmArgs = t.jvmArgs.toList(),
+                        )
+                    },
                 )
             }
         }
         return AggregatedComposePreviewModel(pluginVersion, aggregated)
+    }
+
+    /**
+     * Read an optional getter on a Tooling-API proxy. Getters added to the
+     * model interface after the plugin version the consumer has installed
+     * throw `UnsupportedMethodException` at invocation time — we want those
+     * to surface as `null`, not propagate out as exceptions and kill the
+     * whole `compose-preview doctor` run.
+     */
+    private inline fun <T> readOptional(block: () -> T?): T? = try {
+        block()
+    } catch (_: Throwable) {
+        null
     }
 }
 
@@ -73,7 +105,20 @@ data class SerializableModuleInfo(
     override val mainRuntimeDependencies: Map<String, String>,
     override val testRuntimeDependencies: Map<String, String>,
     override val findings: List<SerializableModuleFinding>,
+    override val agpVersion: String? = null,
+    override val kotlinVersion: String? = null,
+    override val renderPreviewsTask: SerializableRenderPreviewsTaskInfo? = null,
 ) : ModuleInfo, Serializable
+
+data class SerializableRenderPreviewsTaskInfo(
+    override val javaLauncherPinned: Boolean,
+    override val javaLauncherVersion: String?,
+    override val javaLauncherVendor: String?,
+    override val javaLauncherPath: String?,
+    override val classpathSize: Int,
+    override val bootstrapClasspathSize: Int,
+    override val jvmArgs: List<String>,
+) : RenderPreviewsTaskInfo, Serializable
 
 data class SerializableModuleFinding(
     override val id: String,

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -222,6 +222,21 @@ class GradleConnection(
     }
 
     /**
+     * Fetch Gradle's `BuildEnvironment` model — exposes the daemon's Gradle
+     * version and its `javaHome`. Doctor uses both to triage bug reports
+     * where the forked test worker's JVM differs from the daemon's (#142).
+     * Returns `null` on any tooling-API failure; callers fold into "skip".
+     */
+    fun buildEnvironment(): org.gradle.tooling.model.build.BuildEnvironment? {
+        return try {
+            connection.model(org.gradle.tooling.model.build.BuildEnvironment::class.java).get()
+        } catch (e: Exception) {
+            if (verbose) System.err.println("Could not query BuildEnvironment: ${e.message}")
+            null
+        }
+    }
+
+    /**
      * Find all subprojects that have a `discoverPreviews` task — these have the
      * compose-ai-tools plugin applied.
      */

--- a/cli/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt
@@ -18,6 +18,19 @@ interface ModuleInfo {
     val mainRuntimeDependencies: Map<String, String>
     val testRuntimeDependencies: Map<String, String>
     val findings: List<ModuleFinding>
+    val agpVersion: String?
+    val kotlinVersion: String?
+    val renderPreviewsTask: RenderPreviewsTaskInfo?
+}
+
+interface RenderPreviewsTaskInfo {
+    val javaLauncherPinned: Boolean
+    val javaLauncherVersion: String?
+    val javaLauncherVendor: String?
+    val javaLauncherPath: String?
+    val classpathSize: Int
+    val bootstrapClasspathSize: Int
+    val jvmArgs: List<String>
 }
 
 interface ModuleFinding {

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DoctorCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DoctorCommandTest.kt
@@ -54,4 +54,32 @@ class DoctorReportSerializationTest {
         )
         assertEquals("compose-preview-doctor/v1", report.schema)
     }
+
+    @Test fun `renderPreviews task-info serialises round-trip`() {
+        // The nested RenderPreviewsTaskInfo model sits behind the
+        // project.<module>.render-previews-jvm check — verify it
+        // serialises cleanly via the CLI's action type so the JSON
+        // output mode in `doctor --json` stays stable for agents
+        // consuming the new fields.
+        val info = SerializableModuleInfo(
+            variant = "debug",
+            mainRuntimeDependencies = emptyMap(),
+            testRuntimeDependencies = mapOf("org.robolectric:robolectric" to "4.16"),
+            findings = emptyList(),
+            agpVersion = "9.1.0",
+            kotlinVersion = "2.2.21",
+            renderPreviewsTask = SerializableRenderPreviewsTaskInfo(
+                javaLauncherPinned = false,
+                javaLauncherVersion = "25",
+                javaLauncherVendor = "Google Inc.",
+                javaLauncherPath = "/usr/lib/jvm/jdk25",
+                classpathSize = 412,
+                bootstrapClasspathSize = 0,
+                jvmArgs = listOf("--add-opens=java.base/java.nio=ALL-UNNAMED"),
+            ),
+        )
+        assertEquals("9.1.0", info.agpVersion)
+        assertEquals("25", info.renderPreviewsTask?.javaLauncherVersion)
+        assertEquals(412, info.renderPreviewsTask?.classpathSize)
+    }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt
@@ -73,6 +73,68 @@ interface ModuleInfo {
      * both consume the same list — no per-tool drift.
      */
     val findings: List<ModuleFinding>
+
+    /**
+     * Android Gradle Plugin version applied to the module, or `null` if we
+     * couldn't read it (no AGP plugin applied, or AGP internals moved).
+     * Exposed for bug-report triage: issues like #142 depend on the AGP
+     * version the consumer is on.
+     */
+    val agpVersion: String?
+
+    /**
+     * Kotlin Gradle Plugin version applied to the module, or `null` if we
+     * couldn't read it. Same motivation as [agpVersion].
+     */
+    val kotlinVersion: String?
+
+    /**
+     * Diagnostic snapshot of the `renderPreviews` Test task — the Java
+     * launcher it will fork the test worker with, its classpath/bootstrap-
+     * classpath shape, and any JVM args copied from AGP. `null` when the
+     * task wasn't registered (plugin disabled for this module). Introduced
+     * to make bug reports like #142 self-contained: the silent "test worker
+     * falls back to system default JDK" footgun is visible directly here.
+     */
+    val renderPreviewsTask: RenderPreviewsTaskInfo?
+}
+
+/**
+ * Snapshot of the `renderPreviews` Test task's JVM configuration. Taken at
+ * Tooling-model build time, not at task execution — values reflect what
+ * Gradle would use if the task ran now.
+ */
+interface RenderPreviewsTaskInfo {
+    /**
+     * `true` when the task has an explicit toolchain launcher wired (either
+     * by the plugin itself in future, or inherited from AGP's test task).
+     * `false` when Gradle will fall back to the daemon's own JVM — or, worse
+     * on some Linux setups, to the system default `java` on PATH if the
+     * daemon was launched with a different JAVA_HOME override. See #142.
+     */
+    val javaLauncherPinned: Boolean
+
+    /** Effective Java major version the test worker will fork with. */
+    val javaLauncherVersion: String?
+
+    /** Effective JVM vendor (e.g. "Temurin", "Google Inc.") — useful for triage. */
+    val javaLauncherVendor: String?
+
+    /** Effective `java.home` the forked worker will use. */
+    val javaLauncherPath: String?
+
+    /** Number of entries on the task's `classpath`. */
+    val classpathSize: Int
+
+    /**
+     * Number of entries on the task's `bootstrapClasspath`. Non-zero on an
+     * AGP-wired unit-test task (AGP injects `mockable-android.jar`), zero on
+     * `renderPreviews` today. Exposed so doctor can call out the asymmetry.
+     */
+    val bootstrapClasspathSize: Int
+
+    /** JVM args applied to the forked worker (post-`jvmArgs(...)` copies). */
+    val jvmArgs: List<String>
 }
 
 /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
@@ -4,6 +4,7 @@ import ee.schimke.composeai.plugin.PluginVersion
 import ee.schimke.composeai.plugin.PreviewExtension
 import org.gradle.api.Project
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.tasks.testing.Test
 import org.gradle.tooling.provider.model.ToolingModelBuilder
 import java.io.Serializable
 
@@ -38,8 +39,81 @@ internal class ComposePreviewModelBuilder : ToolingModelBuilder {
         val test = resolveConfiguration(project, "${variant}UnitTestRuntimeClasspath")
         val gradleVersion = org.gradle.util.GradleVersion.current().version
         val findings: List<ModuleFinding> = CompatRules.evaluate(main, test, gradleVersion)
-        val info: ModuleInfo = ModuleInfoData(variant, main, test, findings)
+        val info: ModuleInfo = ModuleInfoData(
+            variant = variant,
+            mainRuntimeDependencies = main,
+            testRuntimeDependencies = test,
+            findings = findings,
+            agpVersion = resolveAgpVersion(),
+            kotlinVersion = resolveKotlinVersion(project),
+            renderPreviewsTask = resolveRenderPreviewsTask(project),
+        )
         return ComposePreviewModelData(PluginVersion.value, mapOf(project.path to info))
+    }
+
+    /**
+     * Reads AGP's embedded version constant via reflection so the plugin
+     * doesn't take a hard compile-time dependency on AGP internals. Returns
+     * `null` on any failure — doctor treats that as "unknown" rather than
+     * an error.
+     */
+    private fun resolveAgpVersion(): String? {
+        return try {
+            Class.forName("com.android.Version")
+                .getField("ANDROID_GRADLE_PLUGIN_VERSION")
+                .get(null) as? String
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    /**
+     * Reads the Kotlin Gradle Plugin version via its documented helper
+     * (`KotlinPluginWrapperKt.getKotlinPluginVersion(Project)`). Reflective
+     * call to avoid a hard KGP compile dep on this plugin. Returns `null`
+     * if KGP isn't applied or its API moved.
+     */
+    private fun resolveKotlinVersion(project: Project): String? {
+        return try {
+            Class.forName("org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapperKt")
+                .getMethod("getKotlinPluginVersion", Project::class.java)
+                .invoke(null, project) as? String
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    /**
+     * Snapshots the `renderPreviews` Test task's forked-JVM configuration
+     * so doctor can flag the #142-class footgun (test worker silently
+     * forking on a different JDK than the Gradle daemon).
+     *
+     * `javaLauncher.isPresent` is always `true` at resolution time — Gradle
+     * fills in a convention value from the project toolchain or the daemon
+     * JVM. We can't observe "user never touched this" via the API, so we
+     * report the effective launcher and leave the mismatch check to the
+     * doctor side, which compares against the daemon JVM.
+     */
+    private fun resolveRenderPreviewsTask(project: Project): RenderPreviewsTaskInfo? {
+        val task = project.tasks.findByName("renderPreviews") as? Test ?: return null
+        val launcher = try {
+            task.javaLauncher.orNull
+        } catch (_: Throwable) {
+            null
+        }
+        val metadata = launcher?.metadata
+        val classpathSize = try { task.classpath.files.size } catch (_: Throwable) { -1 }
+        val bootstrapSize = try { task.bootstrapClasspath.files.size } catch (_: Throwable) { -1 }
+        val args = try { task.jvmArgs?.toList() ?: emptyList() } catch (_: Throwable) { emptyList() }
+        return RenderPreviewsTaskInfoData(
+            javaLauncherPinned = launcher != null,
+            javaLauncherVersion = metadata?.languageVersion?.asInt()?.toString(),
+            javaLauncherVendor = metadata?.vendor,
+            javaLauncherPath = metadata?.installationPath?.asFile?.absolutePath,
+            classpathSize = classpathSize,
+            bootstrapClasspathSize = bootstrapSize,
+            jvmArgs = args,
+        )
     }
 
     /**
@@ -97,4 +171,17 @@ private data class ModuleInfoData(
     override val mainRuntimeDependencies: Map<String, String>,
     override val testRuntimeDependencies: Map<String, String>,
     override val findings: List<ModuleFinding>,
+    override val agpVersion: String?,
+    override val kotlinVersion: String?,
+    override val renderPreviewsTask: RenderPreviewsTaskInfo?,
 ) : ModuleInfo, Serializable
+
+private data class RenderPreviewsTaskInfoData(
+    override val javaLauncherPinned: Boolean,
+    override val javaLauncherVersion: String?,
+    override val javaLauncherVendor: String?,
+    override val javaLauncherPath: String?,
+    override val classpathSize: Int,
+    override val bootstrapClasspathSize: Int,
+    override val jvmArgs: List<String>,
+) : RenderPreviewsTaskInfo, Serializable


### PR DESCRIPTION
## Summary

Motivated by [#142](https://github.com/yschimke/compose-ai-tools/issues/142), where three rounds of back-and-forth were needed to extract a test-worker JVM / daemon JVM mismatch from the reporter's environment. Doctor now collects that fingerprint up-front so the next report of this shape is self-contained.

### New env checks
- `env.os` — os.name/version/arch
- `env.java-17` — extended with vendor + java.home
- `env.path-jvm` — separate fingerprint of the `java` on `PATH` when it differs from the CLI's own JVM (catches JAVA_HOME override vs PATH default, which was the hidden axis in #142)
- `env.gradle-daemon` — Gradle version + daemon JDK, via the Tooling API `BuildEnvironment` model

### New project checks per module
- `project.<m>.versions` — AGP, Kotlin, Robolectric, compose-runtime
- `project.<m>.render-previews-jvm` — warns when `renderPreviews` will fork a different JDK major than the daemon, with a concrete `jvmToolchain(...)` / `javaLauncher.set(...)` remediation and a link to #142
- `project.<m>.last-error` — pattern-matches the HTML test report against a curated signature table (`ClassNotFoundException: android.app.Application`, `RuntimeException: Stub!`, `NoSuchMethodError` on `ComposeUiNode`)

### Tooling model extensions
- `ModuleInfo` gained `agpVersion` (reflective via `com.android.Version`), `kotlinVersion` (reflective via `KotlinPluginWrapperKt.getKotlinPluginVersion`), and a new `RenderPreviewsTaskInfo` snapshot capturing javaLauncher version/vendor/path, classpath/bootstrapClasspath sizes, and `jvmArgs`.
- CLI marshalling in `GatherComposePreviewModelAction` guards each new getter with a `readOptional { }` wrapper so a recent CLI keeps working against older plugin versions that don't implement the new interface methods (Tooling API throws `UnsupportedMethodException` in that case).

### New output mode
- `compose-preview doctor --report` emits a `compose-preview-doctor-report/v1` block optimised for pasting into a GitHub issue. `--json` output (schema `compose-preview-doctor/v1`) is unchanged — new checks are additive to the check list.

## Test plan
- [x] `./gradlew :cli:test` green
- [x] `./gradlew :gradle-plugin:test` green
- [ ] Manually invoke `compose-preview doctor --report --project sample-android` and eyeball the fingerprint block (end-to-end smoke not covered by the existing pure-schema tests)
- [ ] Re-run doctor on [ithinkihaveacat/wear-os-samples @ 3f580f66](https://github.com/ithinkihaveacat/wear-os-samples/commit/3f580f66794bde9ac97f235f7525d9cff311593c) (the #142 repro) and confirm the test-worker JVM mismatch warning fires on a clean setup