### PR TITLE
docs(readme): lead with agent pitch; move internals to HOW_IT_WORKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,104 +1,74 @@
 # compose-ai-tools
 
-A Gradle plugin and CLI that discovers `@Preview` composables and renders them to PNG — outside
-of Android Studio. Works with both Android (Jetpack Compose) and Compose Multiplatform
-Desktop projects.
+**Give your AI coding agent eyes for Compose UI.** A Gradle plugin, CLI, and
+VS Code extension that render `@Preview` composables to PNG — outside Android
+Studio — so agents like Claude Code, Cursor, Gemini in Android Studio, and
+Copilot can actually *see* what they're changing and iterate on it.
 
-See [SKILL.md](https://github.com/yschimke/compose-ai-tools/blob/main/skills/compose-preview/SKILL.md)
+Works with Jetpack Compose (Android) and Compose Multiplatform Desktop.
 
-```
-$ compose-preview list --module sample-wear
-com.example.samplewear.PreviewsKt.ActivityListPreview_Devices - Large Round  (com/example/samplewear/Previews.kt)
-com.example.samplewear.PreviewsKt.ActivityListPreview_Devices - Small Round  (com/example/samplewear/Previews.kt)
-com.example.samplewear.PreviewsKt.ActivityListFontScalesPreview_Fonts - Large  (com/example/samplewear/Previews.kt)
-com.example.samplewear.PreviewsKt.ActivityListFontScalesPreview_Fonts - Larger  (com/example/samplewear/Previews.kt)
-com.example.samplewear.PreviewsKt.ActivityListFontScalesPreview_Fonts - Largest  (com/example/samplewear/Previews.kt)
-com.example.samplewear.PreviewsKt.ActivityListFontScalesPreview_Fonts - Medium  (com/example/samplewear/Previews.kt)
-com.example.samplewear.PreviewsKt.ActivityListFontScalesPreview_Fonts - Normal  (com/example/samplewear/Previews.kt)
-com.example.samplewear.PreviewsKt.ActivityListFontScalesPreview_Fonts - Small  (com/example/samplewear/Previews.kt)
-com.example.samplewear.PreviewsKt.ButtonPreview_Devices - Large Round  (com/example/samplewear/Previews.kt)
-com.example.samplewear.PreviewsKt.ButtonPreview_Devices - Small Round  (com/example/samplewear/Previews.kt)
-```
+<!--
+  TODO: replace the two placeholders below with:
+    1. A screenshot of an agent chat session where the agent reads a rendered
+       @Preview PNG and iterates on the design.
+    2. A screenshot of a PR opened by an agent that used compose-preview to
+       verify the change (diff + before/after PNGs in the PR body).
+  Drop the images in an issue/discussion to get a stable GitHub user-images URL,
+  or commit under docs/images/ and reference with a relative path.
+-->
 
-Also provides a VS Code plugin that displays them
+<p align="center">
+  <img width="45%" alt="Agent chat iterating on a Compose preview" src="https://github.com/user-attachments/assets/REPLACE-ME-agent-chat" />
+  &nbsp;
+  <img width="45%" alt="PR opened by an agent using compose-preview" src="https://github.com/user-attachments/assets/REPLACE-ME-agent-pr" />
+</p>
 
-<img height="400" alt="image" src="https://github.com/user-attachments/assets/fe9be596-13d9-4880-9e20-cedd6992f650" />
+## Point your agent at this
 
-
-## How it works
-
-### Discovery
-
-Scan compiled class files for `@Preview` annotations → `build/compose-previews/previews.json`.
+The fastest way to start: hand your agent this URL and ask it to set up the
+project.
 
 ```
-For each method in each compiled class:
-
-  1. Check for direct @Preview or @Preview.Container annotations on the method.
-     If found, extract preview parameters (name, device, dimensions, backgroundColor, etc.)
-     and emit a preview entry.
-
-  2. Otherwise, walk the method's annotations looking for multi-preview meta-annotations.
-     For each annotation, check whether *its* annotation class carries @Preview.
-     Recurse through meta-annotations (with cycle detection via a visited set).
-     Emit a preview entry for each @Preview found transitively.
-
-Deduplicate by fully-qualified name + preview name + device + dimensions.
+https://github.com/yschimke/compose-ai-tools/blob/main/skills/compose-preview/SKILL.md
 ```
 
-### Rendering (Desktop)
+Example prompts:
 
-Launch a subprocess with the module's full classpath plus the renderer-desktop module.
+> *"Set up compose-preview in this project using the skill at
+> https://github.com/yschimke/compose-ai-tools/blob/main/skills/compose-preview/SKILL.md,
+> then render the previews in `app/` and show me the results."*
 
-```
-1. Load the target class by name and resolve the composable function
-   via the Compose runtime's reflection API.
+> *"Read
+> https://github.com/yschimke/compose-ai-tools/blob/main/skills/compose-preview/SKILL.md
+> and iterate on `HomeScreen_loaded` until the empty state matches the
+> screenshot I attached."*
 
-2. Create a headless ImageComposeScene at the target dimensions (2x density).
+The [SKILL.md](https://github.com/yschimke/compose-ai-tools/blob/main/skills/compose-preview/SKILL.md)
+file is a complete agent playbook: install steps, commands, iteration loop,
+state-hoisting guidance for making composables previewable, and which commands
+are safe to pre-approve. Any agent that can fetch a URL — Claude Code, Cursor,
+Windsurf, Aider, Gemini in Android Studio — can follow it cold.
 
-3. Set the scene content to: a background fill (from the @Preview annotation's
-   backgroundColor), with the composable function invoked inside it.
-   LocalInspectionMode is enabled so preview-aware composables render correctly.
+## Why this matters
 
-4. Render two frames (the second allows animations and effects to settle).
+Android Studio's built-in AI agents are great at editing Kotlin, but they're
+flying blind on UI. They can't open the Preview pane, can't see the rendered
+pixels, and often guess at visual changes. `compose-preview` closes the loop:
 
-5. Encode the Skia surface to PNG and write to the output file.
-```
+- **Agents see what they built.** Rendered PNGs go to a path the agent can
+  read, with `sha256` + `changed` flags so it knows which frames to re-inspect.
+- **Fast feedback.** Gradle-cacheable tasks; unchanged inputs skip re-render.
+- **No emulator, no AS running.** Desktop uses `ImageComposeScene` + Skia;
+  Android uses Robolectric with native graphics.
+- **Multi-preview aware.** `@PreviewFontScale`, `@WearPreviewDevices`,
+  `@PreviewLightDark` all fan out to individual captures.
 
-### Rendering (Android)
-
-Launch a Gradle `Test` task inside a Robolectric sandbox with native graphics
-(`graphicsMode=NATIVE`, `pixelCopyRenderMode=hardware`).
-
-```
-1. Bootstrap a ComponentActivity through `createAndroidComposeRule`.
-   Apply the @Preview qualifiers (size, density, locale, uiMode, round,
-   orientation) via `RuntimeEnvironment.setQualifiers` and `setFontScale`.
-
-2. Set the activity content to a background fill + reflected composable
-   invocation, with `LocalInspectionMode = true`.
-
-3. Pause Compose's main clock (`autoAdvance = false`) and step it by a
-   fixed amount so infinite animations terminate deterministically instead
-   of hanging the idling resource.
-
-4. Capture the root view via `captureRoboImage`, which routes ShadowPixelCopy
-   through HardwareRenderer + ImageReader to replay Compose's RenderNodes,
-   compress as PNG, write to file.
-```
-
-### Caching
-
-Both discovery and rendering are Gradle cacheable tasks with declared input/output
-contracts. Unchanged source files produce no re-work on subsequent runs.
-Configuration caching is strict (`problems=fail`).
-
-## Setup
+## Setup (for humans)
 
 The plugin is published to [Maven Central](https://central.sonatype.com/artifact/ee.schimke.composeai/compose-preview-plugin).
 No authentication, no PAT — just apply it.
 
-### 1. Apply the plugin
+### Apply the plugin
 
 <!-- x-release-please-start-version -->
 ```kotlin
@@ -110,33 +80,67 @@ plugins {
 <!-- x-release-please-end -->
 
 Most projects already have `mavenCentral()` in their
-`pluginManagement.repositories` (AGP and the Kotlin Gradle Plugin are both
-on Central). If yours doesn't, add it:
-
-```kotlin
-// settings.gradle.kts
-pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        google()
-        mavenCentral()
-    }
-}
-```
+`pluginManagement.repositories`. If yours doesn't, add it alongside
+`gradlePluginPortal()` and `google()` in `settings.gradle.kts`.
 
 CMP Desktop projects additionally need
-`implementation(compose.components.uiToolingPreview)` — the bundled
-`@Preview` annotation has `SOURCE` retention and is invisible to ClassGraph.
+`implementation(compose.components.uiToolingPreview)` — the bundled `@Preview`
+annotation has `SOURCE` retention and is invisible to ClassGraph.
 
 Check [Releases](https://github.com/yschimke/compose-ai-tools/releases) for
 the latest version.
 
+### Install the CLI
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/scripts/install.sh | bash
+
+compose-preview doctor
+```
+
+The installer is idempotent, drops the latest release under
+`~/.local/opt/compose-preview/<version>/`, and symlinks
+`~/.local/bin/compose-preview`. `doctor` verifies Java 17 is on `PATH`.
+
+### Install the VS Code extension
+
+```sh
+code --install-extension yuri-schimke.compose-preview
+```
+
+Or from the [Marketplace](https://marketplace.visualstudio.com/items?itemName=yuri-schimke.compose-preview).
+The extension renders through the Gradle plugin — apply
+`ee.schimke.composeai.preview` version `0.7.6` <!-- x-release-please-version --> in your project too.
+
+<img height="400" alt="VS Code extension preview panel" src="https://github.com/user-attachments/assets/fe9be596-13d9-4880-9e20-cedd6992f650" />
+
+## Usage
+
+```sh
+./gradlew :app:discoverPreviews    # scan for @Preview annotations
+./gradlew :app:renderAllPreviews   # discover + render to PNG
+
+compose-preview list               # list discovered previews
+compose-preview show --json        # render + emit paths, sha256, changed flags
+compose-preview a11y               # render + ATF accessibility findings
+```
+
+Full CLI reference and agent iteration loop: [SKILL.md](skills/compose-preview/SKILL.md).
+
+### Configuration
+
+```kotlin
+composePreview {
+    variant.set("debug")     // Android build variant (default: "debug")
+    sdkVersion.set(35)       // Robolectric SDK version (default: 35)
+    enabled.set(true)        // disable to skip registration (default: true)
+}
+```
+
 ### Testing against a snapshot
 
-Every push to `main` publishes a `-SNAPSHOT` build to the Central snapshots
-repository. To try an unreleased change, add the snapshots repo to
-`pluginManagement` and bump the plugin version to the next patch
-`-SNAPSHOT`:
+Every push to `main` publishes a `-SNAPSHOT` build. Add the snapshots repo to
+`pluginManagement` and bump to the next patch `-SNAPSHOT`:
 
 ```kotlin
 // settings.gradle.kts
@@ -152,89 +156,19 @@ pluginManagement {
 }
 ```
 
-```kotlin
-// <module>/build.gradle.kts
-plugins {
-    id("ee.schimke.composeai.preview") version "0.3.5-SNAPSHOT"
-}
-```
+See [docs/RELEASING.md](docs/RELEASING.md) for detail.
 
-The snapshot version is the next patch ahead of the latest release
-(e.g. last tag `v0.3.4` → `0.3.5-SNAPSHOT`). Snapshots are unsigned. See
-[docs/RELEASING.md](docs/RELEASING.md) for more detail.
+## Learn more
 
-## Install the CLI
-
-<!-- x-release-please-start-version -->
-Download `compose-preview-0.7.6.tar.gz` (or `.zip`) from the
-[v0.7.6 release](https://github.com/yschimke/compose-ai-tools/releases/tag/v0.4.0)
-and put the `bin/` directory on your `PATH`:
-
-```sh
-curl -L -o compose-preview.tar.gz \
-  https://github.com/yschimke/compose-ai-tools/releases/download/v0.7.6/compose-preview-0.4.0.tar.gz
-tar -xzf compose-preview.tar.gz
-export PATH="$PWD/compose-preview-0.7.6/bin:$PATH"
-
-compose-preview --help
-```
-<!-- x-release-please-end -->
-
-Requires Java 17 on `PATH` (or `JAVA_HOME`).
-
-## Install the VS Code extension
-
-Install [Compose Preview](https://marketplace.visualstudio.com/items?itemName=yuri-schimke.compose-preview)
-from the VS Code Marketplace, or from the command line:
-
-```sh
-code --install-extension yuri-schimke.compose-preview
-```
-
-The extension uses the Gradle plugin to render previews, so apply
-`ee.schimke.composeai.preview` version `0.7.6` <!-- x-release-please-version --> in your project as shown above.
-
-## Usage
-
-Run discovery and rendering:
-
-```
-./gradlew :app:discoverPreviews    # scan for @Preview annotations
-./gradlew :app:renderAllPreviews   # discover + render to PNG
-```
-
-### Configuration
-
-```kotlin
-composePreview {
-    variant.set("debug")     // Android build variant (default: "debug")
-    sdkVersion.set(35)       // Robolectric SDK version (default: 35)
-    enabled.set(true)        // disable to skip registration (default: true)
-}
-```
-
-## Project structure
-
-| Module | Purpose |
-|--------|---------|
-| `gradle-plugin/` | Gradle plugin — discovery, rendering task orchestration |
-| `renderer-desktop/` | Desktop renderer — `ImageComposeScene` + Skia PNG capture |
-| `renderer-android/` | Android renderer — Robolectric harness |
-| `cli/` | CLI — Tooling-API driver over `discoverPreviews` / `renderAllPreviews` |
-| `sample-android/` | Android sample with colored box `@Preview` composables |
-| `sample-cmp/` | CMP Desktop sample with colored box `@Preview` composables |
-| `sample-remotecompose/` | Remote Compose sample — wrapper-inside-Composable vs. `@PreviewWrapper(RemotePreviewWrapper::class)` against `wear-compose-remote-material3` |
-
-## Requirements
-
-- Gradle 9.4.1+
-- Java 17
-- AGP 9.1.0 (Android projects)
-- Kotlin 2.2.21
-- Compose Multiplatform 1.10.3 (Desktop projects)
+- **[skills/compose-preview/SKILL.md](skills/compose-preview/SKILL.md)** — the
+  agent playbook. Commands, iteration loop, state hoisting, a11y, scrolling
+  captures, Wear Tiles, Remote Compose.
+- **[docs/HOW_IT_WORKS.md](docs/HOW_IT_WORKS.md)** — discovery/render pipeline
+  internals, module layout, requirements.
+- **[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)** — building the plugin, CLI,
+  and VS Code extension from source.
+- **[docs/RELEASING.md](docs/RELEASING.md)** — release process and snapshots.
 
 ## Contributing
 
-See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for building the plugin, CLI, and
-VS Code extension from source and running them locally against the bundled
-samples.
+See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -1,0 +1,90 @@
+# How it works
+
+Technical reference for the discovery/render pipeline and module layout. For
+setup and agent usage, see the [README](../README.md).
+
+## Discovery
+
+Scan compiled class files for `@Preview` annotations → `build/compose-previews/previews.json`.
+
+```
+For each method in each compiled class:
+
+  1. Check for direct @Preview or @Preview.Container annotations on the method.
+     If found, extract preview parameters (name, device, dimensions, backgroundColor, etc.)
+     and emit a preview entry.
+
+  2. Otherwise, walk the method's annotations looking for multi-preview meta-annotations.
+     For each annotation, check whether *its* annotation class carries @Preview.
+     Recurse through meta-annotations (with cycle detection via a visited set).
+     Emit a preview entry for each @Preview found transitively.
+
+Deduplicate by fully-qualified name + preview name + device + dimensions.
+```
+
+## Rendering (Desktop)
+
+Launch a subprocess with the module's full classpath plus the renderer-desktop module.
+
+```
+1. Load the target class by name and resolve the composable function
+   via the Compose runtime's reflection API.
+
+2. Create a headless ImageComposeScene at the target dimensions (2x density).
+
+3. Set the scene content to: a background fill (from the @Preview annotation's
+   backgroundColor), with the composable function invoked inside it.
+   LocalInspectionMode is enabled so preview-aware composables render correctly.
+
+4. Render two frames (the second allows animations and effects to settle).
+
+5. Encode the Skia surface to PNG and write to the output file.
+```
+
+## Rendering (Android)
+
+Launch a Gradle `Test` task inside a Robolectric sandbox with native graphics
+(`graphicsMode=NATIVE`, `pixelCopyRenderMode=hardware`).
+
+```
+1. Bootstrap a ComponentActivity through `createAndroidComposeRule`.
+   Apply the @Preview qualifiers (size, density, locale, uiMode, round,
+   orientation) via `RuntimeEnvironment.setQualifiers` and `setFontScale`.
+
+2. Set the activity content to a background fill + reflected composable
+   invocation, with `LocalInspectionMode = true`.
+
+3. Pause Compose's main clock (`autoAdvance = false`) and step it by a
+   fixed amount so infinite animations terminate deterministically instead
+   of hanging the idling resource.
+
+4. Capture the root view via `captureRoboImage`, which routes ShadowPixelCopy
+   through HardwareRenderer + ImageReader to replay Compose's RenderNodes,
+   compress as PNG, write to file.
+```
+
+## Caching
+
+Both discovery and rendering are Gradle cacheable tasks with declared input/output
+contracts. Unchanged source files produce no re-work on subsequent runs.
+Configuration caching is strict (`problems=fail`).
+
+## Project structure
+
+| Module | Purpose |
+|--------|---------|
+| `gradle-plugin/` | Gradle plugin — discovery, rendering task orchestration |
+| `renderer-desktop/` | Desktop renderer — `ImageComposeScene` + Skia PNG capture |
+| `renderer-android/` | Android renderer — Robolectric harness |
+| `cli/` | CLI — Tooling-API driver over `discoverPreviews` / `renderAllPreviews` |
+| `sample-android/` | Android sample with colored box `@Preview` composables |
+| `sample-cmp/` | CMP Desktop sample with colored box `@Preview` composables |
+| `sample-remotecompose/` | Remote Compose sample — wrapper-inside-Composable vs. `@PreviewWrapper(RemotePreviewWrapper::class)` against `wear-compose-remote-material3` |
+
+## Requirements
+
+- Gradle 9.4.1+
+- Java 17
+- AGP 9.1.0 (Android projects)
+- Kotlin 2.2.21
+- Compose Multiplatform 1.10.3 (Desktop projects)


### PR DESCRIPTION
## Summary

- Reframes the README around the primary use case: hand an AI coding agent the SKILL.md URL and let it drive setup and UI iteration. Opens with a short pitch aimed at Android devs who are only lightly familiar with AS Agents.
- Adds a **Point your agent at this** section up top with the SKILL.md URL and two example prompts.
- Replaces the raw `compose-preview list` text block with two image placeholders (agent chat + agent PR). The two URLs are `REPLACE-ME-*` sentinels — I'll swap them for real screenshots before merging (or feel free to drop them in).
- Moves the discovery/render pipeline writeup, project-structure table, and requirements list out of the README into a new [docs/HOW_IT_WORKS.md](docs/HOW_IT_WORKS.md) so the README stays scannable.
- Keeps all `x-release-please` markers intact so version bumps continue to work.

## Test plan

- [ ] `README.md` renders cleanly on GitHub (headings, image placeholders, collapsible structure)
- [ ] Every relative link resolves: `docs/HOW_IT_WORKS.md`, `docs/DEVELOPMENT.md`, `docs/RELEASING.md`, `skills/compose-preview/SKILL.md`
- [ ] `x-release-please-start-version` / `x-release-please-version` markers still wrap `0.7.6` references
- [ ] Replace the two `REPLACE-ME-*` image URLs with real screenshots of (a) an agent chat rendering/iterating on a preview and (b) a PR opened by an agent that used `compose-preview`