### PR TITLE
fix(renderer): stretch GIF scroll to ~2s for a typical Wear app

### DIFF
--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -914,10 +914,12 @@ private fun handleGifCapture(
 
     val frameFiles = mutableListOf<File>()
     try {
-        // 20% of viewport per step → ~5 frames per viewport of scrolled
-        // content. With 80ms default cadence that's ~0.4s of animation
-        // per viewport — smooth scroll without an explosive frame count
-        // on tall lists. Too small jitters, too large stutters.
+        // 10% of viewport per step → 10 frames per viewport. With the 80ms
+        // default cadence that's 800ms of animation per viewport scrolled;
+        // a typical Wear screen scrolls ~2–3 viewports of content, landing
+        // the resulting GIF at ~1.5–2.5s — long enough to read motion,
+        // short enough to embed in a PR body. Smaller fraction = smoother
+        // but explosive frame count on tall lists.
         val result = driveScrollByViewport(
             rule = rule,
             axis = scroll.axis,
@@ -963,8 +965,10 @@ private fun handleGifCapture(
     }
 }
 
-// 20% of viewport per step balances smoothness against frame count.
-private const val GIF_STEP_FRACTION = 0.2f
+// 10% of viewport per step → 10 frames per viewport. Tuned so a typical
+// Wear scroll (2–3 viewports of content at the default 80ms cadence) lands
+// at roughly 2 seconds of animation. Lower = smoother but more frames.
+private const val GIF_STEP_FRACTION = 0.1f
 
 /**
  * Adds Robolectric's `+round` qualifier so `Configuration.isScreenRound` becomes

--- a/sample-wear/src/main/kotlin/com/example/samplewear/Previews.kt
+++ b/sample-wear/src/main/kotlin/com/example/samplewear/Previews.kt
@@ -301,3 +301,16 @@ fun ActivityListLongPreview() {
         }
     }
 }
+
+@WearPreviewLargeRound
+@ScrollingPreview(modes = [ScrollMode.GIF], reduceMotion = false)
+@Composable
+fun ActivityListGifPreview() {
+    MaterialTheme {
+        AppScaffold(
+            timeText = { TimeText(timeSource = FixedTimeSource) },
+        ) {
+            LongActivityListScreen()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Halve `GIF_STEP_FRACTION` (0.2 → 0.1) so animated scroll captures run 10 frames per viewport at the default 80 ms cadence. A typical Wear screen (2–3 viewports of scrollable content) now lands at ~1.5–2.5 s of animation, up from ~0.4–1.2 s — long enough for a reviewer to read the scroll without ballooning file size.
- Scope is `ScrollMode.GIF` only; TOP / END / LONG have no scroll-duration knob and are untouched.
- Add `ActivityListGifPreview` to `sample-wear` as a Wear-shaped fixture (`WearPreviewLargeRound` + `ScreenScaffold` + `EdgeButton` + `TransformingLazyColumn`) so we have direct coverage of the exact scaffold the #154 reporter uses.

## Context: #154

#154 reports `ScrollMode.GIF` producing a single-frame GIF on a Wear `TransformingLazyColumn` preview. The new Wear fixture renders the same scaffold shape on plugin HEAD and produces a healthy 31-frame / 2.48 s GIF, which narrows the reported breakage to something specific to the Confetti preview setup (outer scrollable wrapper, stale build output, or a version axis) rather than a defect in the driver/encoder. That investigation is separate from this PR — this is just the timing tweak the reporter asked for.

## Measured durations (default 80 ms cadence)

| Preview | Frames | Duration |
|---|---|---|
| `ActivityListGifPreview` (Wear, large round) | 31 | 2.48 s |
| `SettingsListScrollGifPreview` (Android, 220×440) | 27 | 2.16 s |
| `RedToBlueScrollGifPreview` (Android, 200×400) | 22 | 1.76 s |

## Test plan

- [x] `./gradlew :sample-wear:renderAllPreviews` and `./gradlew :sample-android:renderAllPreviews` produce multi-frame GIFs at the timings above (verified via `ffprobe`).
- [ ] CI: `./gradlew check` on the affected sample modules.

Refs #154