### PR TITLE
test(samples): update pixel-test filenames for #140 package-prefix stripping

### DIFF
--- a/sample-android/src/test/kotlin/com/example/sampleandroid/ScrollPreviewPixelTest.kt
+++ b/sample-android/src/test/kotlin/com/example/sampleandroid/ScrollPreviewPixelTest.kt
@@ -20,7 +20,7 @@ import org.junit.Test
 class ScrollPreviewPixelTest {
 
     private val rendersDir = File("build/compose-previews/renders")
-    private val baseName = "com.example.sampleandroid.ScrollPreviewsKt.RedToBlueScrollPreview_Scroll"
+    private val baseName = "ScrollPreviewsKt.RedToBlueScrollPreview_Scroll"
 
     private data class Avg(val r: Double, val g: Double, val b: Double) {
         fun dominant(): Char = when {
@@ -81,7 +81,7 @@ class ScrollPreviewPixelTest {
      */
     @Test
     fun `GIF capture animates red to blue`() {
-        val gifName = "com.example.sampleandroid.ScrollPreviewsKt.RedToBlueScrollGifPreview_ScrollGif.gif"
+        val gifName = "ScrollPreviewsKt.RedToBlueScrollGifPreview_ScrollGif.gif"
         val file = File(rendersDir, gifName)
         assertThat(file.exists()).isTrue()
 

--- a/sample-wear/src/test/kotlin/com/example/samplewear/LongScrollPreviewPixelTest.kt
+++ b/sample-wear/src/test/kotlin/com/example/samplewear/LongScrollPreviewPixelTest.kt
@@ -20,7 +20,7 @@ import org.junit.Test
 class LongScrollPreviewPixelTest {
 
     private val longPng = File(
-        "build/compose-previews/renders/com.example.samplewear.PreviewsKt.ActivityListLongPreview_Devices - Large Round.png",
+        "build/compose-previews/renders/PreviewsKt.ActivityListLongPreview_Devices_-_Large_Round.png",
     )
 
     @Test


### PR DESCRIPTION
## Summary

`ScrollPreviewPixelTest` and `LongScrollPreviewPixelTest` still pointed at pre-#140 filenames, which carried the full dotted package prefix and unescaped spaces:

```
com.example.sampleandroid.ScrollPreviewsKt.RedToBlueScrollPreview_Scroll_SCROLL_top.png
com.example.samplewear.PreviewsKt.ActivityListLongPreview_Devices - Large Round.png
```

Since #140 the plugin normalises `renderOutput` by stripping the common dotted prefix across every preview in the module and sanitising shell-unfriendly characters, so the on-disk names are now:

```
ScrollPreviewsKt.RedToBlueScrollPreview_Scroll_SCROLL_top.png
PreviewsKt.ActivityListLongPreview_Devices_-_Large_Round.png
```

Both pixel tests fail on `--rerun-tasks` because of the mismatch; they only pass from build cache if their results were captured pre-#140. Point them at the current filenames.

Pure test-fixture update, no behaviour change.

## Test plan

- [ ] `./gradlew :sample-android:testDebugUnitTest --rerun-tasks` — `ScrollPreviewPixelTest` passes.
- [ ] `./gradlew :sample-wear:testDebugUnitTest --rerun-tasks` — `LongScrollPreviewPixelTest` passes.