### PR TITLE
fix(cli): resolve nested-module manifests via projectDir (#157)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -271,9 +271,6 @@ abstract class Command(protected val args: List<String>) {
      */
     protected val brief: Boolean = "--brief" in args
 
-    protected lateinit var projectDir: File
-        private set
-
     abstract fun run()
 
     protected fun withGradle(block: (GradleConnection) -> Unit) {
@@ -281,12 +278,21 @@ abstract class Command(protected val args: List<String>) {
             System.err.println("Cannot find Gradle project root (no gradlew found)")
             exitProcess(1)
         }
-        projectDir = root
         GradleConnection(root, verbose, progress).use(block)
     }
 
-    protected fun resolveModules(gradle: GradleConnection): List<String> {
-        if (explicitModule != null) return listOf(explicitModule!!)
+    protected fun resolveModules(gradle: GradleConnection): List<PreviewModule> {
+        if (explicitModule != null) {
+            // Resolve via the Tooling API so --module works with nested
+            // Gradle paths (e.g. `--module auth:composables`) and reflects
+            // any custom `project.projectDir` override.
+            val one = gradle.findPreviewModule(explicitModule!!)
+            if (one == null) {
+                System.err.println("Module '$explicitModule' not found or does not apply the compose-ai-tools plugin.")
+                exitProcess(1)
+            }
+            return listOf(one)
+        }
 
         val modules = gradle.findPreviewModules()
         if (modules.isEmpty()) {
@@ -295,7 +301,7 @@ abstract class Command(protected val args: List<String>) {
             exitProcess(1)
         }
         if (verbose || modules.size > 1) {
-            System.err.println("Found preview modules: ${modules.joinToString(", ")}")
+            System.err.println("Found preview modules: ${modules.joinToString(", ") { it.gradlePath }}")
         }
         return modules
     }
@@ -304,13 +310,13 @@ abstract class Command(protected val args: List<String>) {
         return gradle.runTasks(*tasks, timeoutSeconds = timeoutSeconds)
     }
 
-    protected fun readManifest(module: String): PreviewManifest? {
-        val manifestFile = projectDir.resolve("$module/build/compose-previews/previews.json")
+    protected fun readManifest(module: PreviewModule): PreviewManifest? {
+        val manifestFile = module.projectDir.resolve("build/compose-previews/previews.json")
         if (!manifestFile.exists()) return null
         return json.decodeFromString(manifestFile.readText())
     }
 
-    protected fun readAllManifests(modules: List<String>): List<Pair<String, PreviewManifest>> {
+    protected fun readAllManifests(modules: List<PreviewModule>): List<Pair<PreviewModule, PreviewManifest>> {
         return modules.mapNotNull { module ->
             readManifest(module)?.let { module to it }
         }
@@ -329,12 +335,12 @@ abstract class Command(protected val args: List<String>) {
      * a prior opt-in run.
      */
     protected fun readAllA11yReports(
-        manifests: List<Pair<String, PreviewManifest>>,
+        manifests: List<Pair<PreviewModule, PreviewManifest>>,
     ): Map<String, Pair<List<AccessibilityFinding>, String?>> {
         val out = mutableMapOf<String, Pair<List<AccessibilityFinding>, String?>>()
         for ((module, manifest) in manifests) {
             val pointer = manifest.accessibilityReport ?: continue
-            val reportFile = projectDir.resolve("$module/build/compose-previews/$pointer")
+            val reportFile = module.projectDir.resolve("build/compose-previews/$pointer")
             if (!reportFile.exists()) continue
             val report = try {
                 json.decodeFromString(AccessibilityReport.serializer(), reportFile.readText())
@@ -348,7 +354,7 @@ abstract class Command(protected val args: List<String>) {
                     ?.let { reportDir.resolve(it).canonicalFile }
                     ?.takeIf { it.exists() }
                     ?.absolutePath
-                out["$module/${entry.previewId}"] = entry.findings to annotatedAbs
+                out["${module.gradlePath}/${entry.previewId}"] = entry.findings to annotatedAbs
             }
         }
         return out
@@ -366,12 +372,13 @@ abstract class Command(protected val args: List<String>) {
      * `sha256` / `changed` on [PreviewResult] mirror the first capture
      * verbatim so existing agents keep working.
      */
-    protected fun buildResults(manifests: List<Pair<String, PreviewManifest>>): List<PreviewResult> {
+    protected fun buildResults(manifests: List<Pair<PreviewModule, PreviewManifest>>): List<PreviewResult> {
         val results = mutableListOf<PreviewResult>()
         val a11yByKey = readAllA11yReports(manifests)
         // Track which modules had a11y enabled so we can distinguish "no
         // findings" (empty list) from "feature off" (null) in `PreviewResult`.
-        val modulesWithA11y = manifests.filter { it.second.accessibilityReport != null }.map { it.first }.toSet()
+        val modulesWithA11y = manifests.filter { it.second.accessibilityReport != null }
+            .map { it.first.gradlePath }.toSet()
 
         for ((module, manifest) in manifests) {
             val prior = readState(module).shas
@@ -403,7 +410,7 @@ abstract class Command(protected val args: List<String>) {
                 val captureResults = captures.mapIndexed { index, capture ->
                     val pngFile = capture.renderOutput
                         .takeIf { it.isNotEmpty() }
-                        ?.let { projectDir.resolve("$module/build/compose-previews/$it").canonicalFile }
+                        ?.let { module.projectDir.resolve("build/compose-previews/$it").canonicalFile }
                         ?.takeIf { it.exists() }
                     val sha = pngFile?.let { sha256(it.readBytes()) }
                     val stateKey = if (index == 0) p.id else "${p.id}#$index"
@@ -424,16 +431,16 @@ abstract class Command(protected val args: List<String>) {
                 }
                 val first = captureResults.firstOrNull()
                 val a11yPair = when {
-                    module in modulesWithA11y -> a11yByKey["$module/${p.id}"]
+                    module.gradlePath in modulesWithA11y -> a11yByKey["${module.gradlePath}/${p.id}"]
                     else -> null
                 }
                 val a11y = when {
-                    module in modulesWithA11y -> a11yPair?.first ?: emptyList()
+                    module.gradlePath in modulesWithA11y -> a11yPair?.first ?: emptyList()
                     else -> null
                 }
                 results += PreviewResult(
                     id = p.id,
-                    module = module,
+                    module = module.gradlePath,
                     functionName = p.functionName,
                     className = p.className,
                     sourceFile = p.sourceFile,
@@ -468,12 +475,12 @@ abstract class Command(protected val args: List<String>) {
      * rendered no files at all, so we don't duplicate the error surface here.
      */
     private fun expandParamCaptures(
-        module: String,
+        module: PreviewModule,
         template: Capture,
         siblingRenderOutputs: Set<String>,
     ): List<Capture> {
         val rel = template.renderOutput.ifEmpty { return listOf(template) }
-        val file = projectDir.resolve("$module/build/compose-previews/$rel").canonicalFile
+        val file = module.projectDir.resolve("build/compose-previews/$rel").canonicalFile
         val dir = file.parentFile ?: return listOf(template)
         val prefix = file.nameWithoutExtension + "_"
         val ext = ".${file.extension}"
@@ -579,10 +586,10 @@ abstract class Command(protected val args: List<String>) {
         return true
     }
 
-    private fun stateFile(module: String): File =
-        projectDir.resolve("$module/build/compose-previews/.cli-state.json")
+    private fun stateFile(module: PreviewModule): File =
+        module.projectDir.resolve("build/compose-previews/.cli-state.json")
 
-    private fun readState(module: String): CliState {
+    private fun readState(module: PreviewModule): CliState {
         val f = stateFile(module)
         if (!f.exists()) return CliState()
         return try {
@@ -593,7 +600,7 @@ abstract class Command(protected val args: List<String>) {
         }
     }
 
-    private fun writeState(module: String, state: CliState) {
+    private fun writeState(module: PreviewModule, state: CliState) {
         val f = stateFile(module)
         f.parentFile?.mkdirs()
         f.writeText(json.encodeToString(CliState.serializer(), state))
@@ -615,7 +622,7 @@ class ShowCommand(args: List<String>) : Command(args) {
     override fun run() {
         withGradle { gradle ->
             val modules = resolveModules(gradle)
-            val tasks = modules.map { ":$it:renderAllPreviews" }.toTypedArray()
+            val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
 
             if (!runGradle(gradle, *tasks)) {
                 System.err.println("Render failed")
@@ -699,7 +706,7 @@ class ListCommand(args: List<String>) : Command(args) {
     override fun run() {
         withGradle { gradle ->
             val modules = resolveModules(gradle)
-            val tasks = modules.map { ":$it:discoverPreviews" }.toTypedArray()
+            val tasks = modules.map { ":${it.gradlePath}:discoverPreviews" }.toTypedArray()
 
             if (!runGradle(gradle, *tasks)) exitProcess(1)
 
@@ -732,7 +739,7 @@ class RenderCommand(args: List<String>) : Command(args) {
     override fun run() {
         withGradle { gradle ->
             val modules = resolveModules(gradle)
-            val tasks = modules.map { ":$it:renderAllPreviews" }.toTypedArray()
+            val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
 
             if (!runGradle(gradle, *tasks)) exitProcess(2)
 
@@ -797,7 +804,7 @@ class A11yCommand(args: List<String>) : Command(args) {
     override fun run() {
         withGradle { gradle ->
             val modules = resolveModules(gradle)
-            val tasks = modules.map { ":$it:renderAllPreviews" }.toTypedArray()
+            val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
             val buildOk = runGradle(gradle, *tasks)
 
             val manifests = readAllManifests(modules)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -497,7 +497,13 @@ class DoctorCommand(args: List<String>) {
      * no report on disk (first run, clean checkout) we silently skip.
      */
     private fun checkErrorSignatures(projectDir: File, modulePath: String) {
-        val moduleDir = File(projectDir, idSafe(modulePath)).takeIf { it.isDirectory } ?: return
+        // Gradle path → filesystem path. `:auth:composables` → `auth/composables`
+        // for standard layouts (issue #157). Custom `project.projectDir`
+        // overrides aren't covered here — this is a best-effort triage path;
+        // when the directory doesn't exist we silently skip the signature
+        // scan rather than emit a false "no prior failure" signal.
+        val relative = idSafe(modulePath).replace(':', File.separatorChar)
+        val moduleDir = File(projectDir, relative).takeIf { it.isDirectory } ?: return
         val reportDir = File(moduleDir, "build/reports/tests/renderPreviews")
         if (!reportDir.isDirectory) return
         val htmls = reportDir.walkTopDown()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -11,6 +11,19 @@ import java.io.File
 import java.io.OutputStream
 import java.util.Collections
 
+/**
+ * Handle for a subproject that applies `ee.schimke.composeai.preview`.
+ *
+ * [gradlePath] is the colon-separated project path **without** its leading
+ * colon (e.g. `"app"`, `"auth:composables"`) — used to address Gradle tasks
+ * like `":$gradlePath:renderAllPreviews"` and to identify the module in CLI
+ * output / persisted state. [projectDir] is the actual filesystem directory
+ * of that subproject, resolved via Gradle's Tooling API. Using it instead of
+ * `projectRoot/$gradlePath` is what makes nested subprojects (`:foo:bar`) and
+ * any custom `project.projectDir` override work correctly — see issue #157.
+ */
+data class PreviewModule(val gradlePath: String, val projectDir: File)
+
 class GradleConnection(
     private val projectDir: File,
     private val verbose: Boolean,
@@ -239,17 +252,27 @@ class GradleConnection(
     /**
      * Find all subprojects that have a `discoverPreviews` task — these have the
      * compose-ai-tools plugin applied.
+     *
+     * Each entry carries both the Gradle path (used to build task specs like
+     * `:foo:bar:renderAllPreviews`) and the resolved filesystem `projectDir`.
+     * Nested subprojects (`:foo:bar`) have directory layouts like `foo/bar/`,
+     * so substituting `:` for `/` doesn't always work — and even for standard
+     * layouts a user can point `project.projectDir` anywhere. Reading it from
+     * the Tooling API's [GradleProject.projectDirectory] is the only reliable
+     * way to resolve manifests / PNGs on disk without replicating Gradle's
+     * own project-layout logic.
      */
-    fun findPreviewModules(): List<String> {
+    fun findPreviewModules(): List<PreviewModule> {
         return try {
             val model = connection.model(org.gradle.tooling.model.GradleProject::class.java).get()
-            val modules = mutableListOf<String>()
+            val modules = mutableListOf<PreviewModule>()
             fun visit(project: org.gradle.tooling.model.GradleProject) {
                 val hasPreviewTask = project.tasks.any { it.name == "discoverPreviews" }
                 if (hasPreviewTask) {
-                    // Convert ":sample-android" path to "sample-android"
                     val path = project.path.removePrefix(":")
-                    if (path.isNotEmpty()) modules.add(path)
+                    if (path.isNotEmpty()) {
+                        modules.add(PreviewModule(gradlePath = path, projectDir = project.projectDirectory))
+                    }
                 }
                 for (child in project.children) visit(child)
             }
@@ -259,6 +282,18 @@ class GradleConnection(
             if (verbose) System.err.println("Could not query project model: ${e.message}")
             emptyList()
         }
+    }
+
+    /**
+     * Resolve a single module by its Gradle path (colon-separated, with or
+     * without the leading `:`). Returns `null` when no project with that path
+     * applies the plugin — callers fall back to a user-visible error rather
+     * than silently building an empty task list against a dir that doesn't
+     * exist.
+     */
+    fun findPreviewModule(gradlePath: String): PreviewModule? {
+        val normalized = gradlePath.removePrefix(":")
+        return findPreviewModules().firstOrNull { it.gradlePath == normalized }
     }
 
     override fun close() {

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -848,4 +848,121 @@ class DiscoveryFunctionalTest {
         )
         assertThat(manifest.previews).hasSize(3)
     }
+
+    /**
+     * Regression for issue #157: previews were only surfaced for top-level
+     * modules. Nested Gradle paths (`:auth:composables`) use `:` as a
+     * separator, but the CLI was treating that string as a filesystem path
+     * and looking under `projectRoot/auth:composables/build/...` — which
+     * doesn't exist. The plugin itself always wrote manifests to the real
+     * subproject directory (`auth/composables/build/...`); this test locks
+     * that behaviour in so the CLI fix (`PreviewModule.projectDir` via the
+     * Tooling API) has a stable contract to read against.
+     */
+    @Test
+    fun `discoverPreviews runs in a nested subproject`() {
+        val projectDir = tempDir.root
+
+        // Root settings with a :auth:composables nested subproject.
+        File(projectDir, "settings.gradle.kts").writeText(
+            """
+            pluginManagement {
+                repositories {
+                    gradlePluginPortal()
+                    google()
+                    mavenCentral()
+                }
+            }
+            dependencyResolutionManagement {
+                repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+                repositories {
+                    google()
+                    mavenCentral()
+                }
+            }
+            rootProject.name = "nested-test"
+            include(":auth:composables")
+            """.trimIndent()
+        )
+
+        // Root build.gradle.kts is empty — the plugin is only applied to the
+        // nested subproject to mirror the Horologist-style layout in #157.
+        File(projectDir, "build.gradle.kts").writeText("")
+
+        File(projectDir, "gradle.properties").writeText(
+            "org.gradle.configuration-cache=true\n"
+        )
+
+        val childDir = File(projectDir, "auth/composables")
+        childDir.mkdirs()
+        File(childDir, "build.gradle.kts").writeText(
+            """
+            @file:Suppress("DEPRECATION")
+            plugins {
+                kotlin("jvm") version "2.2.21"
+                kotlin("plugin.compose") version "2.2.21"
+                id("org.jetbrains.compose") version "1.10.3"
+                id("ee.schimke.composeai.preview")
+            }
+            dependencies {
+                implementation(compose.desktop.currentOs)
+                implementation(compose.material3)
+                implementation(compose.uiTooling)
+                implementation(compose.components.uiToolingPreview)
+            }
+            java {
+                toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+            }
+            """.trimIndent()
+        )
+
+        val childSrc = File(childDir, "src/main/kotlin/nested")
+        childSrc.mkdirs()
+        File(childSrc, "Previews.kt").writeText(
+            """
+            package nested
+
+            import androidx.compose.ui.tooling.preview.Preview
+            import androidx.compose.foundation.background
+            import androidx.compose.foundation.layout.Box
+            import androidx.compose.foundation.layout.size
+            import androidx.compose.material3.Text
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+            import androidx.compose.ui.graphics.Color
+            import androidx.compose.ui.unit.dp
+
+            @Preview
+            @Composable
+            fun NestedPreview() {
+                Box(modifier = Modifier.size(80.dp).background(Color.Magenta)) {
+                    Text("nested")
+                }
+            }
+            """.trimIndent()
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments(":auth:composables:discoverPreviews", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+
+        assertThat(result.task(":auth:composables:discoverPreviews")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+
+        // Manifest lives under the real subproject dir (`auth/composables/…`),
+        // not a literal `auth:composables/…` path. This is the invariant the
+        // CLI's `PreviewModule.projectDir` relies on.
+        val manifestFile = File(childDir, "build/compose-previews/previews.json")
+        assertThat(manifestFile.exists()).isTrue()
+
+        // A stray `auth:composables/` directory would mean someone resolved
+        // the Gradle path as a filesystem path — the exact #157 bug.
+        assertThat(File(projectDir, "auth:composables").exists()).isFalse()
+
+        val manifest = json.decodeFromString<PreviewManifest>(manifestFile.readText())
+        assertThat(manifest.previews).hasSize(1)
+        assertThat(manifest.previews[0].functionName).isEqualTo("NestedPreview")
+    }
 }


### PR DESCRIPTION
Fixes #157.

## Summary

The CLI treated each subproject's Gradle path as if it were also a
filesystem path. For a top-level module like `:composables` that
happens to work (`composables/build/…` is a real dir), but for a nested
Gradle path like `:auth:composables` the CLI looked for
`auth:composables/build/compose-previews/previews.json` — a directory
literally containing a colon, which no standard Gradle layout produces.
The plugin itself always wrote the manifest to the real subproject dir
(`auth/composables/build/…`); the CLI just couldn't read it back, so
nested modules silently dropped out of `list` / `show` / `render` /
`a11y` output. Exactly matches the reporter's observation that only
the top-level `composables` module yielded results in the Horologist
rollout.

## Fix

- `GradleConnection.findPreviewModules()` now returns
  `List<PreviewModule>` where each entry carries both the Gradle path
  (for task specs) and the real `projectDir` from the Tooling API's
  `GradleProject.projectDirectory`. That covers both nested Gradle
  paths and any custom `project.projectDir` override.
- Every file-I/O site in `Commands.kt` (`readManifest`,
  `readAllA11yReports`, `buildResults`, `expandParamCaptures`,
  `stateFile`) now resolves against `module.projectDir` instead of
  `projectRoot/$module`. Task specs still use
  `":${module.gradlePath}:…"` — Gradle accepts those for nested paths.
- `--module <name>` looks up the module through the Tooling API so
  explicit-module invocations benefit from the same projectDir
  resolution.
- `DoctorCommand.checkErrorSignatures` converts `:` to the platform
  separator before joining to `projectDir`, so its `renderPreviews`
  HTML-report scan also covers nested modules.

## Test plan

- [x] New `DiscoveryFunctionalTest."discoverPreviews runs in a nested
  subproject"` — applies the plugin only to `:auth:composables`, runs
  `:auth:composables:discoverPreviews`, asserts the manifest is at
  `auth/composables/build/compose-previews/previews.json`, and that no
  stray `auth:composables/` directory was created. Pins the plugin-side
  contract the CLI now reads against.
- [ ] `./gradlew :gradle-plugin:functionalTest --tests
  "ee.schimke.composeai.plugin.DiscoveryFunctionalTest"` — should be
  run in CI; the sandbox I worked in can't reach Google Maven.
- [ ] Manual: apply the plugin to a nested subproject in a
  Horologist-style layout and verify `compose-preview list` / `show`
  return entries for it.

Not covered here: adding `projectDir` to the plugin-side Tooling model
(`ModuleInfo`) so `DoctorCommand`'s per-module project checks also
benefit from first-class path resolution rather than the
`replace(':', File.separatorChar)` best-effort. That's a reasonable
follow-up if we start surfacing more doctor checks that touch per-module
filesystem paths.

---
_Generated by [Claude Code](https://claude.ai/code/session_017CYzj6UpSMvGVMJUsnqjpZ)_