### PR TITLE
fix(renderer): reset scroll before LONG/GIF in multi-mode captures

### DIFF
--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -793,6 +793,14 @@ private fun handleLongCapture(
 
     val slices = mutableListOf<SliceCapture>()
     try {
+        // Multi-mode annotations (e.g. END + LONG) run captures in enum
+        // ordinal order against the same composition, so an earlier END
+        // leaves the scrollable at content end. Reset to the top before
+        // slicing — otherwise the first slice is the end state and
+        // `driveScrollByViewport`'s first iteration bails with
+        // remaining ≈ 0, yielding a single "stitched" slice. See #154.
+        driveScrollToStart(rule, scroll.axis)
+
         // Drive at 80% of the viewport so each consecutive slice pair has a
         // ~20% physical overlap for the content-aware stitcher to lock onto.
         // The stitcher uses scrolledPx only as a hint — the actual vertical
@@ -914,6 +922,14 @@ private fun handleGifCapture(
 
     val frameFiles = mutableListOf<File>()
     try {
+        // Multi-mode annotations (`modes = [..., GIF]`) run captures in
+        // enum ordinal order against the same composition, so an earlier
+        // END / LONG leaves the scrollable at content end and the GIF
+        // would animate "from end to end" — a single frame indistinguishable
+        // from the END capture. Reset to the top before the frame walk
+        // starts. Fix for #154.
+        driveScrollToStart(rule, scroll.axis)
+
         // 10% of viewport per step → 10 frames per viewport. With the 80ms
         // default cadence that's 800ms of animation per viewport scrolled;
         // a typical Wear screen scrolls ~2–3 viewports of content, landing

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollDriver.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollDriver.kt
@@ -137,6 +137,58 @@ internal fun driveScrollByViewport(
     return ScrollDriveResult.IterationCapReached(scrolledPx)
 }
 
+/**
+ * Drives a scrollable back to position 0 on the given axis. Mirrors
+ * [driveScrollToEnd] in the opposite direction.
+ *
+ * Used when a later capture mode in a multi-mode `@ScrollingPreview` needs
+ * to start from the top but an earlier mode (END / LONG / a prior GIF)
+ * left the scrollable at its content end. All captures within one preview
+ * share the same `setContent` composition, so scroll state persists across
+ * them by default — see issue #154.
+ */
+@Suppress("LongParameterList")
+internal fun driveScrollToStart(
+    rule: AndroidComposeTestRule<*, *>,
+    axis: ScrollAxis,
+    maxIterations: Int = DEFAULT_MAX_ITERATIONS,
+    advanceMsPerStep: Long = DEFAULT_ADVANCE_MS_PER_STEP,
+): ScrollDriveResult {
+    val axisKey = when (axis) {
+        ScrollAxis.VERTICAL -> SemanticsProperties.VerticalScrollAxisRange
+        ScrollAxis.HORIZONTAL -> SemanticsProperties.HorizontalScrollAxisRange
+    }
+    val scrollables = rule.onAllNodes(SemanticsMatcher.keyIsDefined(axisKey)).fetchSemanticsNodes()
+    if (scrollables.isEmpty()) return ScrollDriveResult.NoScrollable
+
+    val interaction = rule.onAllNodes(SemanticsMatcher.keyIsDefined(axisKey))[0]
+    var scrolledPx = 0f
+
+    repeat(maxIterations) {
+        val node = interaction.fetchSemanticsNode()
+        val range: ScrollAxisRange = node.config.getOrNull(axisKey)
+            ?: return ScrollDriveResult.Completed(scrolledPx)
+        val scrollByAction = node.config.getOrNull(SemanticsActions.ScrollBy)?.action
+            ?: return ScrollDriveResult.Completed(scrolledPx)
+
+        val current = range.value()
+        if (current <= SETTLED_EPSILON_PX) return ScrollDriveResult.Completed(scrolledPx)
+
+        val (dx, dy) = when (axis) {
+            ScrollAxis.VERTICAL -> 0f to -current
+            ScrollAxis.HORIZONTAL -> -current to 0f
+        }
+        scrollByAction.invoke(dx, dy)
+        scrolledPx += current
+
+        // ScrollBy dispatches animateScrollBy — same timing invariant as
+        // driveScrollToEnd; advance enough virtual time for the animation
+        // to land before we read the axis range again.
+        rule.mainClock.advanceTimeBy(advanceMsPerStep)
+    }
+    return ScrollDriveResult.IterationCapReached(scrolledPx)
+}
+
 internal sealed interface ScrollDriveResult {
     /** No scrollable composable found on the requested axis. */
     data object NoScrollable : ScrollDriveResult

--- a/sample-android/src/main/kotlin/com/example/sampleandroid/ScrollPreviews.kt
+++ b/sample-android/src/main/kotlin/com/example/sampleandroid/ScrollPreviews.kt
@@ -78,3 +78,20 @@ fun RedToBlueScrollPreview() {
 fun RedToBlueScrollGifPreview() {
     RedToBlueList(count = 16)
 }
+
+/**
+ * Regression fixture for #154. All captures in a multi-mode
+ * `@ScrollingPreview` share a single `setContent` composition and run in
+ * enum ordinal order (TOP → END → LONG → GIF), so when GIF follows END
+ * the scrollable is already at content end by the time GIF starts. Before
+ * the fix, the resulting `.gif` was a single frame indistinguishable
+ * from the END capture (scrolled-to-bottom, blue-dominant) — see issue.
+ * The fix scrolls back to the top before the frame walk, so frame 0
+ * should be red-dominant again while the last frame is blue.
+ */
+@Preview(name = "EndThenGif", showBackground = true, widthDp = 160, heightDp = 320)
+@ScrollingPreview(modes = [ScrollMode.END, ScrollMode.GIF])
+@Composable
+fun RedToBlueEndThenGifPreview() {
+    RedToBlueList(count = 16)
+}

--- a/sample-android/src/test/kotlin/com/example/sampleandroid/ScrollPreviewPixelTest.kt
+++ b/sample-android/src/test/kotlin/com/example/sampleandroid/ScrollPreviewPixelTest.kt
@@ -102,6 +102,40 @@ class ScrollPreviewPixelTest {
         assertThat(last.r).isLessThan(140.0)
     }
 
+    /**
+     * Regression guard for issue #154: a `@ScrollingPreview` with
+     * `modes = [END, GIF]` shares one composition across captures, so END
+     * leaves the scrollable at the bottom. Before the fix the follow-up
+     * GIF capture was a single frame indistinguishable from END
+     * (blue-dominant throughout). With the scroll reset, frame 0 should
+     * be red-dominant again.
+     */
+    @Test
+    fun `GIF capture following END resets scroll and still animates`() {
+        val base = "ScrollPreviewsKt.RedToBlueEndThenGifPreview_EndThenGif"
+        val endPng = File(rendersDir, "${base}_SCROLL_end.png")
+        val gif = File(rendersDir, "${base}_SCROLL_gif.gif")
+        assertThat(endPng.exists()).isTrue()
+        assertThat(gif.exists()).isTrue()
+
+        // END still lands on the bottom of the gradient (sanity check the
+        // earlier capture wasn't accidentally disturbed by the reset).
+        val endAvg = averageColor(endPng)
+        assertThat(endAvg.dominant()).isEqualTo('B')
+
+        val frames = readGifFrames(gif)
+        // The driver should produce many frames per viewport scrolled;
+        // a 1-frame GIF is the pre-fix regression signature.
+        assertThat(frames.size).isAtLeast(2)
+
+        val first = avgOfImage(frames.first())
+        val last = avgOfImage(frames.last())
+        // Pre-fix: `first` was blue-dominant because the GIF started from
+        // wherever END left the scrollable.
+        assertThat(first.dominant()).isEqualTo('R')
+        assertThat(last.dominant()).isEqualTo('B')
+    }
+
     private fun avgOfImage(img: BufferedImage): Avg {
         var rs = 0L
         var gs = 0L


### PR DESCRIPTION
Fixes #154.

## Summary

`@ScrollingPreview(modes = [..., ScrollMode.GIF])` was producing a single-frame GIF identical to the `END` capture when any scroll-driving mode ran before it.

## Root cause

All captures in a single `@ScrollingPreview` share one `setContent` composition (the rule calls `setContent` once per preview, then loops over the captures list at [RobolectricRenderTest.kt:466](https://github.com/yschimke/compose-ai-tools/blob/main/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt#L466)). Discovery sorts modes by enum ordinal, so captures run in order `TOP → END → LONG → GIF`. After the `END` capture, the scrollable is left at content end.

When GIF then runs:

- `driveScrollByViewport`'s initial `onSlice(0f)` at [ScrollDriver.kt:110](https://github.com/yschimke/compose-ai-tools/blob/main/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollDriver.kt#L110) captures frame 0 — of the *end* state.
- The first scroll iteration reads `remaining = range.maxValue() - range.value() ≈ 0` and bails with `ScrollDriveResult.Completed(0f)`, so no further `onSlice` calls fire.
- `frameFiles` has one entry; `settlePostScrollAnimations` re-captures it; the encoder writes a 1-frame GIF.

`LONG`-after-`END` has the same defect: a single slice stitched with the final-frame capture produces an image the stitcher collapses back to a single viewport, rather than the tall full-content image users expect.

The existing `ScrollPreviewPixelTest` only covers single-mode GIF (`modes = [ScrollMode.GIF]`) and therefore never exercised the post-END path.

## Fix

New `driveScrollToStart` helper in `ScrollDriver.kt` — mirrors `driveScrollToEnd` with `scrollBy(-range.value())` until the axis range lands at 0 or the iteration budget is exhausted. Called once at the top of both `handleGifCapture` and `handleLongCapture`, before their `driveScrollByViewport` frame walk. Every multi-mode capture now starts from a deterministic top regardless of what earlier modes did to the composition.

## Regression test

- New `RedToBlueEndThenGifPreview` fixture in `ScrollPreviews.kt` with `modes = [END, GIF]`, sized identically to the existing single-mode GIF fixture so render cost is bounded.
- New `GIF capture following END resets scroll and still animates` test in `ScrollPreviewPixelTest.kt`:
  - Asserts `frames.size >= 2` (pre-fix: 1).
  - Asserts frame 0 is red-dominant (pre-fix: blue-dominant, matching END).
  - Asserts the accompanying `_SCROLL_end.png` is still blue-dominant, so the reset doesn't disturb the earlier capture.

## Verification

Couldn't build locally — the sandbox has no Android SDK and installing `cmdline-tools` + `platforms;android-36` + `build-tools` wasn't a good use of bandwidth for this PR. The code change is a narrow parallel of existing `driveScrollToEnd`, and CI runs `:sample-android:renderAllPreviews` + `:sample-android:test` against the new fixture and assertion.

## Test plan

- [ ] CI green on the full matrix, with the new `GIF capture following END` test passing.
- [ ] Manual re-run of the reporter's repro on `joreilly/Confetti#1685` — produced GIF should be multi-frame (`ffprobe -count_frames` ≥ 2) and the first frame should be the unscrolled top of the list, not the EdgeButton-revealed end state.

https://claude.ai/code/session_01JbkS1USxFCJ4TsqtmkVMpa

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbkS1USxFCJ4TsqtmkVMpa)_