### PR TITLE
docs(cloud): lead with 4-host allowlist + install.sh; doctor flags Claude cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,38 @@ Also provides a VS Code plugin that displays them
 
 <img height="400" alt="image" src="https://github.com/user-attachments/assets/fe9be596-13d9-4880-9e20-cedd6992f650" />
 
+## Cloud sandboxes (Claude Code on the web, etc.)
+
+If you're running this in a cloud agent sandbox, two things are required:
+
+1. **Allowlist the four Google hosts** the Android + downloadable-fonts render
+   paths pull from. In the Claude Code web UI, switch **Network access** from
+   *Trusted* to **Custom**, keep *"include Trusted defaults"* on, and add:
+
+   | Host | Used for |
+   | --- | --- |
+   | `maven.google.com` | AGP + AndroidX resolution |
+   | `dl.google.com` | Android SDK cmdline-tools / Google Maven mirror |
+   | `fonts.googleapis.com` | Google Fonts API (downloadable fonts) |
+   | `fonts.gstatic.com` | Google Fonts static assets |
+
+   Pure CMP Desktop / JVM consumers can stay on *Trusted* — the four hosts
+   are Android-specific.
+
+2. **Drop the install script into your environment setup.** It installs
+   JDK 17, the CLI, and the skill bundle (at `~/.claude/skills/compose-preview/`),
+   and appends `JAVA_HOME` / `PATH` to `$CLAUDE_ENV_FILE` so every subsequent
+   tool invocation in the session inherits them:
+
+   ```sh
+   curl -fsSL https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/scripts/install.sh | bash
+   ```
+
+`compose-preview doctor` probes all four hosts and, when it sees
+`$CLAUDE_CODE_SESSION_ID` / `$CLAUDE_ENV_FILE`, tailors its remediation to the
+Claude Code UI (Trusted → Custom, add the missing host). Full walk-through
+including Gradle pre-warming, Android SDK install, and proxy gotchas:
+[skills/compose-preview/design/CLAUDE_CLOUD.md](skills/compose-preview/design/CLAUDE_CLOUD.md).
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ If you're running this in a cloud agent sandbox, two things are required:
    Pure CMP Desktop / JVM consumers can stay on *Trusted* — the four hosts
    are Android-specific.
 
+   Building the `:cli` module *from source* (not using `install.sh`) also
+   needs `repo.gradle.org` — it hosts `gradle-tooling-api` and isn't on the
+   Trusted defaults. If you consume the released CLI tarball this doesn't
+   apply.
+
 2. **Drop the install script into your environment setup.** It installs
    JDK 17, the CLI, and the skill bundle (at `~/.claude/skills/compose-preview/`),
    and appends `JAVA_HOME` / `PATH` to `$CLAUDE_ENV_FILE` so every subsequent

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -51,11 +51,23 @@ class DoctorCommand(args: List<String>) {
 
     private val checks = mutableListOf<DoctorCheck>()
 
+    /**
+     * Claude Code cloud sandbox detection. Same signal `scripts/install.sh`
+     * uses (see `CLAUDE_CLOUD` auto-detection). When true, network-reach
+     * remediations call out Claude Code's Custom network mode directly and
+     * `checkClaudeCloud` emits a top-line `env.claude-cloud` check so the
+     * rest of the report reads in that context.
+     */
+    private val inClaudeCloud: Boolean =
+        !System.getenv("CLAUDE_CODE_SESSION_ID").isNullOrBlank() ||
+            !System.getenv("CLAUDE_ENV_FILE").isNullOrBlank()
+
     fun run() {
         // Environment checks always run.
         checkOs()
         checkJava()
         checkPathJava()
+        checkClaudeCloud()
 
         val projectDir = resolveProjectDir()
 
@@ -190,6 +202,43 @@ class DoctorCommand(args: List<String>) {
                 status = "ok",
                 message = "`java` on PATH → $path",
                 detail = summary,
+            ),
+        )
+    }
+
+    /**
+     * Surfaces Claude Code cloud sandbox detection as an info-style check so
+     * agents and humans reading the report know the four `env.network.*`
+     * probes below are load-bearing (Google hosts aren't on the Trusted
+     * allowlist — they only resolve in Custom mode) and that
+     * `scripts/install.sh` is the intended bootstrap path. Suppressed when
+     * no Claude cloud env vars are set.
+     */
+    private fun checkClaudeCloud() {
+        if (!inClaudeCloud) return
+        val sessionId = System.getenv("CLAUDE_CODE_SESSION_ID").orEmpty()
+        val envFile = System.getenv("CLAUDE_ENV_FILE").orEmpty()
+        addCheck(
+            DoctorCheck(
+                id = "env.claude-cloud",
+                category = "env",
+                status = "ok",
+                message = "Claude Code cloud sandbox detected",
+                detail = buildString {
+                    append("session=${sessionId.ifBlank { "(unset)" }}")
+                    append("; env-file=${envFile.ifBlank { "(unset)" }}")
+                    append(". Cloud renders need network level = Custom with ")
+                    append(NETWORK_HOSTS.joinToString(", ") { it.host })
+                    append(" allowlisted (keep 'include Trusted defaults' on). ")
+                    append("`scripts/install.sh` handles the JDK 17 + bundle install.")
+                },
+                remediation = DoctorRemediation(
+                    summary = "Bootstrap the CLI + skill bundle and write JAVA_HOME/PATH to \$CLAUDE_ENV_FILE.",
+                    commands = listOf(
+                        "curl -fsSL https://raw.githubusercontent.com/$REPO/main/scripts/install.sh | bash",
+                    ),
+                    docs = "https://github.com/$REPO/blob/main/skills/compose-preview/design/CLAUDE_CLOUD.md",
+                ),
             ),
         )
     }
@@ -726,6 +775,11 @@ class DoctorCommand(args: List<String>) {
                     message = "${probe.host} reachable (HTTP $code)",
                 )
             } else {
+                val summary = if (inClaudeCloud) {
+                    "Claude Code cloud session detected — switch the session's network level from Trusted to **Custom**, keep 'include Trusted defaults' on, and add `${probe.host}` (plus the other three Google hosts probed here) to the allowlist."
+                } else {
+                    "Allow ${probe.host} in your sandbox / proxy configuration. In Claude Code cloud sessions this means switching network access to Custom and adding the host (keep 'include Trusted defaults' on)."
+                }
                 DoctorCheck(
                     id = id,
                     category = "env",
@@ -733,7 +787,7 @@ class DoctorCommand(args: List<String>) {
                     message = "${probe.host} unreachable",
                     detail = "${probe.purpose}. Error: ${headers["error"] ?: "unknown"}.",
                     remediation = DoctorRemediation(
-                        summary = "Allow ${probe.host} in your sandbox / proxy configuration. In Claude Code cloud sessions this means switching network access to Custom and adding the host (keep 'include Trusted defaults' on).",
+                        summary = summary,
                         docs = "https://code.claude.com/docs/en/claude-code-on-the-web#network-access",
                     ),
                 )

--- a/skills/compose-preview/design/CLAUDE_CLOUD.md
+++ b/skills/compose-preview/design/CLAUDE_CLOUD.md
@@ -2,32 +2,54 @@
 
 Notes for running this project's tooling inside Claude Code's cloud sandbox
 (claude.ai/code / "Claude on the web"). The default network level handles
-the common case; Android-consumer builds need one extra step.
+CMP Desktop / pure-JVM; Android-consumer builds need one extra step.
 
 ## TL;DR
 
-- One-step install for both the skill bundle and the CLI:
-  ```
-  curl -fsSL https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/scripts/install.sh | bash
-  ```
-  Lands the skill at `~/.claude/skills/compose-preview/` (where Claude Code
-  discovers it) with the CLI extracted as a sibling under `cli/` and a
-  `bin/compose-preview` launcher inside the bundle. Also symlinks
-  `~/.local/bin/compose-preview` for direct CLI use.
-- **CMP Desktop / pure-JVM consumers**: works on the default **Trusted**
-  network level. No allowlist changes needed.
-- **Android consumers** (anything pulling AGP / AndroidX / Robolectric):
-  switch the session to **Custom** and add `dl.google.com` and
-  `maven.google.com`, with the "include Trusted defaults" checkbox kept on.
-  Don't use **Full** — it's broader than needed.
-- `install.sh` auto-detects the Claude Code cloud sandbox (via
-  `$CLAUDE_ENV_FILE` / `$CLAUDE_CODE_SESSION_ID`) and handles the two things
-  the default image is missing: it apt-installs `openjdk-17-jdk-headless`
-  (the Gradle toolchain pin is 17; only 21 is pre-installed) and appends
-  `JAVA_HOME` + `PATH` to `$CLAUDE_ENV_FILE` so every subsequent tool
-  invocation sees them.
-- Put any project-specific Gradle pre-warm in the **environment setup
-  script** after the install line — what to render is yours to fill in.
+Two things, in order:
+
+1. **Network level → Custom** with these four hosts allowlisted (keep
+   "include Trusted defaults" on):
+
+   | Host | Why |
+   | --- | --- |
+   | `maven.google.com` | AGP + AndroidX |
+   | `dl.google.com` | Android SDK cmdline-tools / Google Maven mirror |
+   | `fonts.googleapis.com` | Google Fonts API (downloadable fonts) |
+   | `fonts.gstatic.com` | Google Fonts static assets |
+
+   CMP Desktop / pure-JVM consumers can stay on **Trusted** — the four hosts
+   are Android + downloadable-fonts specific. Don't use **Full**; it's broader
+   than needed.
+
+2. **Drop the install script into the environment setup script:**
+
+   ```
+   curl -fsSL https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/scripts/install.sh | bash
+   ```
+
+   Auto-detects the Claude Code cloud sandbox (via `$CLAUDE_ENV_FILE` /
+   `$CLAUDE_CODE_SESSION_ID`) and handles the two things the default image is
+   missing: apt-installs `openjdk-17-jdk-headless` (the Gradle toolchain pin
+   is 17; only 21 is pre-installed) and appends `JAVA_HOME` + `PATH` to
+   `$CLAUDE_ENV_FILE` so every subsequent tool invocation sees them. Lands
+   the skill at `~/.claude/skills/compose-preview/` (where Claude Code
+   discovers it) with the CLI as a sibling under `cli/`, and symlinks
+   `~/.local/bin/compose-preview` for direct CLI use.
+
+Verify in a fresh session:
+
+```
+compose-preview doctor
+```
+
+When it sees `$CLAUDE_CODE_SESSION_ID` / `$CLAUDE_ENV_FILE`, doctor emits an
+`env.claude-cloud` info check at the top, probes the four hosts above, and
+tailors its remediation to the Claude Code UI (Trusted → Custom, add the
+missing host) rather than generic "allow in your proxy" text.
+
+Put project-specific Gradle pre-warm in the **environment setup script**
+after the install line — what to render is yours to fill in.
 
 ## Cloud sandbox network levels
 

--- a/skills/compose-preview/design/CLAUDE_CLOUD.md
+++ b/skills/compose-preview/design/CLAUDE_CLOUD.md
@@ -22,6 +22,14 @@ Two things, in order:
    are Android + downloadable-fonts specific. Don't use **Full**; it's broader
    than needed.
 
+   Extra conditional hosts, covered in detail further down:
+   - `repo.gradle.org` — only if building `:cli` from source (hosts
+     `gradle-tooling-api`); skipped by the release-tarball path.
+   - `api.adoptium.net` — only if you let Gradle auto-provision a JDK
+     instead of using `install.sh`'s pinned `JAVA_HOME`.
+   - `api.github.com` — rate-limited on shared sandbox IPs;
+     `install.sh` deliberately avoids it.
+
 2. **Drop the install script into the environment setup script:**
 
    ```


### PR DESCRIPTION
## Summary

Makes cloud-sandbox configuration a first-class topic in the docs and teaches `compose-preview doctor` to recognise the Claude Code sandbox and tailor its remediation.

### README.md
New "Cloud sandboxes (Claude Code on the web, etc.)" section placed high on the page. Two numbered actions:
1. Network level → Custom with a four-row table of the required hosts (`maven.google.com`, `dl.google.com`, `fonts.googleapis.com`, `fonts.gstatic.com`).
2. `scripts/install.sh` one-liner for JDK 17 + CLI + skill bundle + `$CLAUDE_ENV_FILE` wiring.

Adds a conditional note for `repo.gradle.org` (only needed when building `:cli` from source).

### skills/compose-preview/design/CLAUDE_CLOUD.md
TL;DR rewritten: two-step numbered list with the four hosts in a table (instead of scattered bullets) and `install.sh` as the second step. Adds a short "extra conditional hosts" bullet list pointing at `repo.gradle.org`, `api.adoptium.net`, and `api.github.com` with the one-line condition that makes each matter — detail remains in the "Cloud sandbox network levels" section further down.

### cli/.../DoctorCommand.kt
- Detects the Claude Code cloud sandbox via `$CLAUDE_CODE_SESSION_ID` / `$CLAUDE_ENV_FILE` (same signal `scripts/install.sh` uses).
- New top-line `env.claude-cloud` info check announcing the detection and pointing at the install script, so the rest of the report reads in that context.
- Per-host `env.network.*` remediations branch on the detection: Claude-cloud sessions get a direct "Trusted → Custom, add `<host>`" instruction referencing the Claude Code UI; non-Claude callers keep the generic "allow in your proxy" wording.

Small, additive change: one new private val, one new private method, one remediation-string branch. No new serialization surface, so the existing `DoctorCommandTest` still covers the schema.

## Test plan

- [ ] `compose-preview doctor` in a Claude Code cloud session emits the new `env.claude-cloud` check and tailored network-reach remediations.
- [ ] `compose-preview doctor --json` still validates against `compose-preview-doctor/v1` (covered by `DoctorReportSerializationTest`).
- [ ] `compose-preview doctor` outside a Claude Code session keeps the existing generic remediation wording (no regression).
- [ ] README renders cleanly on GitHub — four-host table, code fence, relative link to `skills/compose-preview/design/CLAUDE_CLOUD.md` resolves.
- [ ] CLAUDE_CLOUD.md TL;DR renders with the table and the "extra conditional hosts" list as a nested list under step 1.

Note: I couldn't run `./gradlew :cli:test` end-to-end from the Claude Code sandbox I authored this in — `repo.gradle.org/gradle/libs-releases` (which hosts `gradle-tooling-api`) returns 403 through the sandbox proxy, even with the Google hosts allowlisted. That's exactly the situation the new docs describe. CI should have no trouble.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hcfWedSQWmkpZhavqtJwD)_