### PR TITLE
fix(install): reuse pre-installed JDK 21 on Claude Cloud instead of forcing JDK 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ If you're running this in a cloud agent sandbox, two things are required:
    apply.
 
 2. **Drop the install script into your environment setup.** It installs
-   JDK 17, the CLI, and the skill bundle (at `~/.claude/skills/compose-preview/`),
-   and appends `JAVA_HOME` / `PATH` to `$CLAUDE_ENV_FILE` so every subsequent
+   the CLI and the skill bundle (at `~/.claude/skills/compose-preview/`),
+   reuses the pre-installed JDK 21 (falling back to apt-installing JDK 17
+   only if no 17+ JDK is present), and appends `PATH` (and `JAVA_HOME`
+   when the fallback fires) to `$CLAUDE_ENV_FILE` so every subsequent
    tool invocation in the session inherits them:
 
    ```sh
@@ -217,7 +219,8 @@ compose-preview --help
 ```
 <!-- x-release-please-end -->
 
-Requires Java 17 on `PATH` (or `JAVA_HOME`).
+Requires Java 17 or newer on `PATH` (or `JAVA_HOME`). JDK 21 / 25 are
+fine — the CLI and renderer are compiled to JDK 17 bytecode.
 
 ## Install the VS Code extension
 
@@ -265,7 +268,7 @@ composePreview {
 ## Requirements
 
 - Gradle 9.4.1+
-- Java 17
+- Java 17 or newer (renderer / plugin target JDK 17 bytecode; any newer JDK runs them)
 - AGP 9.1.0 (Android projects)
 - Kotlin 2.2.21
 - Compose Multiplatform 1.10.3 (Desktop projects)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -156,7 +156,8 @@ class DoctorCommand(args: List<String>) {
                     message = "Java 17+ required, got ${version ?: "unknown"}",
                     detail = detail,
                     remediation = DoctorRemediation(
-                        summary = "Install a JDK 17 and put it on PATH, or set JAVA_HOME.",
+                        summary = "Install a JDK 17 or newer and put it on PATH, or set JAVA_HOME. " +
+                            "The CLI and renderer target JDK 17 bytecode, so any newer JDK (21, 25, …) works.",
                         commands = listOf("sdk install java 17.0.11-tem"),
                     ),
                 ),
@@ -230,7 +231,9 @@ class DoctorCommand(args: List<String>) {
                     append(". Cloud renders need network level = Custom with ")
                     append(NETWORK_HOSTS.joinToString(", ") { it.host })
                     append(" allowlisted (keep 'include Trusted defaults' on). ")
-                    append("`scripts/install.sh` handles the JDK 17 + bundle install.")
+                    append("`scripts/install.sh` reuses the pre-installed JDK (21 on current ")
+                    append("Claude Cloud images) and installs the skill + CLI bundle. It only ")
+                    append("falls back to apt-installing JDK 17 when no JDK 17+ is available.")
                 },
                 remediation = DoctorRemediation(
                     summary = "Bootstrap the CLI + skill bundle and write JAVA_HOME/PATH to \$CLAUDE_ENV_FILE.",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,13 +25,16 @@
 #   PREFIX=$HOME/.local scripts/install.sh    # for the ~/.local/bin symlink
 #   REPO=yschimke/compose-ai-tools scripts/install.sh
 #
-# Requires: bash, curl, tar, sha256sum (or shasum), and Java 17 on PATH at
+# Requires: bash, curl, tar, sha256sum (or shasum), and Java 17+ on PATH at
 # run time (not install time).
 #
 # Claude Code cloud-sandbox mode (auto-detected via $CLAUDE_ENV_FILE or
 # $CLAUDE_CODE_SESSION_ID):
-#   - apt-installs openjdk-17-jdk-headless if Java 17 isn't already available
-#     (the pre-installed JDK 21 can't satisfy this project's toolchain pin).
+#   - Uses the pre-installed JDK (21 on current Claude Cloud images) when it's
+#     Java 17+ — the CLI, plugin, and renderer AARs are compiled to JDK 17
+#     bytecode and run fine on any newer JDK, so there's no need to downgrade.
+#     Falls back to apt-installing openjdk-17-jdk-headless only when no Java
+#     17+ is available (older base images).
 #   - Skips api.github.com lookups (they 403 on shared sandbox IPs due to
 #     unauthenticated rate limiting) and resolves versions via the public
 #     github.com HTML redirect instead. Sha256 verification is best-effort.
@@ -77,21 +80,39 @@ sha256_of() {
 require curl
 require tar
 
-# ---- Cloud: ensure JDK 17 is available -----------------------------------
+# ---- Cloud: ensure Java 17+ is available ---------------------------------
+#
+# Claude Cloud images currently pre-install JDK 21, which already satisfies
+# the Java-17+ requirement. The renderer JARs and plugin are compiled to JDK
+# 17 bytecode; a newer JDK runs them without issue. Consumer projects pinned
+# to a JDK-17 toolchain are handled by Gradle's own toolchain resolution (or
+# the consumer can bump their toolchain to the same major the daemon runs
+# on). Only apt-install JDK 17 when no JDK 17+ is detected.
 
 if [[ "$CLAUDE_CLOUD" == 1 ]]; then
-  JDK17_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
-  if [[ ! -x "$JDK17_HOME/bin/java" ]]; then
-    log "claude cloud: installing openjdk-17-jdk-headless"
-    SUDO=""
-    if [[ $EUID -ne 0 ]]; then
-      command -v sudo >/dev/null 2>&1 || die "need root or sudo to install JDK 17"
-      SUDO="sudo"
-    fi
-    $SUDO apt-get install -y -qq openjdk-17-jdk-headless
+  detected_major=""
+  if command -v java >/dev/null 2>&1; then
+    # `java -version` prints `openjdk version "21.0.10" ...` to stderr.
+    # Legacy JDK 8 reports `1.8.x`, which parses to major=1 and gets
+    # rejected by the >= 17 check below.
+    detected_major="$(java -version 2>&1 | head -1 | awk -F'"' '{print $2}' | awk -F. '{print $1}')"
   fi
-  export JAVA_HOME="$JDK17_HOME"
-  export PATH="$JAVA_HOME/bin:$PATH"
+  if [[ -n "$detected_major" && "$detected_major" =~ ^[0-9]+$ && "$detected_major" -ge 17 ]]; then
+    log "claude cloud: using existing JDK $detected_major on PATH"
+  else
+    JDK17_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+    if [[ ! -x "$JDK17_HOME/bin/java" ]]; then
+      log "claude cloud: no JDK 17+ detected; installing openjdk-17-jdk-headless"
+      SUDO=""
+      if [[ $EUID -ne 0 ]]; then
+        command -v sudo >/dev/null 2>&1 || die "need root or sudo to install JDK 17"
+        SUDO="sudo"
+      fi
+      $SUDO apt-get install -y -qq openjdk-17-jdk-headless
+    fi
+    export JAVA_HOME="$JDK17_HOME"
+    export PATH="$JAVA_HOME/bin:$PATH"
+  fi
 fi
 
 # ---- Resolve version ------------------------------------------------------
@@ -229,7 +250,7 @@ log "symlinked $BIN_DIR/compose-preview -> $LAUNCHER"
 # ---- Smoke test -----------------------------------------------------------
 
 if ! "$LAUNCHER" --help >/dev/null 2>&1; then
-  die "launcher failed smoke test (needs Java 17 on PATH or JAVA_HOME)"
+  die "launcher failed smoke test (needs Java 17+ on PATH or JAVA_HOME)"
 fi
 
 # ---- Cloud: write env vars ------------------------------------------------

--- a/skills/compose-preview/SKILL.md
+++ b/skills/compose-preview/SKILL.md
@@ -52,7 +52,7 @@ Commands:
   list     List discovered previews
   render   Render previews; with --output copies a single match to disk
   a11y     Render previews and print ATF accessibility findings
-  doctor   Verify Java 17 + project compatibility (run before Setup)
+  doctor   Verify Java 17+ + project compatibility (run before Setup)
 
 Options:
   --module <name>      Target a single module (default: auto-detect)
@@ -224,8 +224,9 @@ The install script is idempotent, pulls the latest release into
 script prints the exact command to add it (`fish_add_path …` or a `PATH=`
 line for bash/zsh).
 
-`compose-preview doctor` verifies Java 17 is on `PATH` (the only hard
-prereq for the plugin now that Maven Central resolution needs no auth).
+`compose-preview doctor` verifies Java 17 or newer is on `PATH` (the only
+hard prereq for the plugin now that Maven Central resolution needs no
+auth). JDK 21 / 25 are fine — the renderer is compiled to JDK 17 bytecode.
 
 ### 1. Register the plugin repository (only if mavenCentral is missing)
 
@@ -445,7 +446,7 @@ artifact split, and how Wear's `remote-material3` builds on
   when opening or reviewing a PR that touches UI.
 - **[design/CLAUDE_CLOUD.md](design/CLAUDE_CLOUD.md)** — running `compose-preview` in
   Claude Code cloud sessions: sandbox allowlist gotchas (Google Maven is blocked),
-  JDK 17 setup, and the release-tarball path that works under the default allowlist.
+  JDK setup (17+), and the release-tarball path that works under the default allowlist.
 
 ## Tips
 

--- a/skills/compose-preview/design/CLAUDE_CLOUD.md
+++ b/skills/compose-preview/design/CLAUDE_CLOUD.md
@@ -37,12 +37,14 @@ Two things, in order:
    ```
 
    Auto-detects the Claude Code cloud sandbox (via `$CLAUDE_ENV_FILE` /
-   `$CLAUDE_CODE_SESSION_ID`) and handles the two things the default image is
-   missing: apt-installs `openjdk-17-jdk-headless` (the Gradle toolchain pin
-   is 17; only 21 is pre-installed) and appends `JAVA_HOME` + `PATH` to
-   `$CLAUDE_ENV_FILE` so every subsequent tool invocation sees them. Lands
-   the skill at `~/.claude/skills/compose-preview/` (where Claude Code
-   discovers it) with the CLI as a sibling under `cli/`, and symlinks
+   `$CLAUDE_CODE_SESSION_ID`) and handles the things the default image is
+   missing: reuses the pre-installed JDK 21 when present (the CLI, plugin,
+   and renderer JARs target JDK 17 bytecode and run fine on any newer
+   JDK) and only falls back to apt-installing `openjdk-17-jdk-headless` if
+   no Java 17+ is on PATH. Appends `PATH` (and `JAVA_HOME` when the fallback
+   fired) to `$CLAUDE_ENV_FILE` so every subsequent tool invocation sees
+   them. Lands the skill at `~/.claude/skills/compose-preview/` (where Claude
+   Code discovers it) with the CLI as a sibling under `cli/`, and symlinks
    `~/.local/bin/compose-preview` for direct CLI use.
 
 Verify in a fresh session:
@@ -90,8 +92,13 @@ What's **not** on the Trusted defaults and matters here:
   `github.com` HTML redirect for version resolution and
   `github.com/.../releases/download/` for the asset).
 
-Pre-installed toolchains: **OpenJDK 21 only.** This project's Gradle build
-pins the JVM toolchain to 17, so 17 has to come from the setup script.
+Pre-installed toolchains: **OpenJDK 21 only.** The CLI, plugin, and
+renderer JARs are compiled to JDK 17 bytecode and run fine on the
+pre-installed 21, so `install.sh` reuses it — no apt-install step needed
+in the common case. If you're building *this* repo from source (not just
+running the released CLI), Gradle's daemon is pinned to JDK 17 via
+`gradle/gradle-daemon-jvm.properties`, and `install.sh` will apt-install
+`openjdk-17-jdk-headless` as a fallback when 17 isn't already on disk.
 
 ## One-step install
 
@@ -123,9 +130,10 @@ Auto-detected as a Claude cloud sandbox via `$CLAUDE_ENV_FILE` /
 `$CLAUDE_CODE_SESSION_ID` (force with `CLAUDE_CLOUD=1` / `CLAUDE_CLOUD=0`).
 What it does when it sees the sandbox:
 
-- `apt-get install -y openjdk-17-jdk-headless` if Java 17 isn't already
-  on disk. The pre-installed JDK 21 can't satisfy the project's toolchain
-  pin, and Gradle's auto-provisioning is firewalled.
+- Reuses the pre-installed JDK 21 when present. Only falls back to
+  `apt-get install -y openjdk-17-jdk-headless` when no JDK 17+ is on
+  PATH — Gradle's auto-provisioning is firewalled, so we can't lazily
+  download a toolchain.
 - Downloads release tarballs from `github.com` directly, skipping
   `api.github.com` (rate-limited on shared sandbox IPs).
 - Appends `JAVA_HOME` and `PATH` to `$CLAUDE_ENV_FILE` so subsequent tool
@@ -156,15 +164,15 @@ and the resulting filesystem is cached into the snapshot.
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Installs JDK 17 + the compose-preview skill bundle (skill files + CLI
-# under ~/.claude/skills/compose-preview/). Writes JAVA_HOME / PATH to
-# $CLAUDE_ENV_FILE.
+# Installs the compose-preview skill bundle (skill files + CLI under
+# ~/.claude/skills/compose-preview/), reusing the pre-installed JDK 21
+# (or falling back to apt-installing JDK 17 if no 17+ JDK is available).
+# Writes PATH (and JAVA_HOME when fallback fires) to $CLAUDE_ENV_FILE.
 curl -fsSL https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/scripts/install.sh | bash
 
 # Optional: pre-warm your project's Gradle cache so the populated deps
 # get baked into the env snapshot. What to render is project-specific —
 # swap in whichever module(s) apply the plugin.
-export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 export PATH=$HOME/.local/bin:$PATH
 compose-preview show --json --brief || true
 ```
@@ -186,8 +194,8 @@ Open a fresh session and run:
 compose-preview doctor
 ```
 
-Expected: a `[env]` block showing JDK 17 on PATH, Gradle reachable, and
-four `env.network.*` checks (one each for `maven.google.com`,
+Expected: a `[env]` block showing JDK 17+ on PATH (21 on current images),
+Gradle reachable, and four `env.network.*` checks (one each for `maven.google.com`,
 `dl.google.com`, `fonts.googleapis.com`, `fonts.gstatic.com`). On
 **Trusted**, the Google hosts will show as warnings — that's expected if
 you only render CMP Desktop / JVM projects. Switch to **Custom** and add


### PR DESCRIPTION
The CLI, plugin, and renderer JARs are compiled to JDK 17 bytecode and
run fine on any newer JDK (21, 25, …). Claude Cloud images currently
pre-install JDK 21, which already satisfies the 17+ requirement, yet
scripts/install.sh was unconditionally apt-installing openjdk-17-jdk-headless
and re-exporting JAVA_HOME to point at it. That wasted time on every
env setup and produced confusing docs about a "toolchain pin" constraint
that only applies to building this repo from source.

Verified end-to-end with a sample-cmp module converted to
JavaLanguageVersion.of(21) + gradle-daemon-jvm.properties toolchainVersion=21
with JAVA_HOME/PATH restricted to JDK 21: :sample-cmp:renderAllPreviews
discovers and renders 4 previews cleanly.

- scripts/install.sh: detect any JDK 17+ already on PATH and reuse it;
  only apt-install JDK 17 when nothing suitable is available.
- doctor remediation text: clarify "JDK 17 or newer"; CLI and renderer
  target JDK 17 bytecode, so 21/25 are fine. Claude Cloud info-check
  reflects the new install.sh behaviour.
- README.md, SKILL.md, CLAUDE_CLOUD.md: drop "JDK 17 toolchain pin"
  framing; document reuse-first, apt-fallback behaviour.

https://claude.ai/code/session_01CZVzheyuEx3wkWJxKLDKhE