### PR TITLE
fix(install): translate $https_proxy into JAVA_TOOL_OPTIONS in cloud mode

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,6 +37,11 @@
 #     github.com HTML redirect instead. Sha256 verification is best-effort.
 #   - Appends JAVA_HOME and PATH to $CLAUDE_ENV_FILE so subsequent tool
 #     invocations see them.
+#   - If $https_proxy / $http_proxy is set, translates it into
+#     JAVA_TOOL_OPTIONS (-Dhttps.proxyHost / -Dhttp.proxyHost) and writes
+#     that to $CLAUDE_ENV_FILE too. The JVM's HttpURLConnection ignores the
+#     shell proxy env vars, so the Gradle wrapper download otherwise fails
+#     with UnknownHostException (anthropics/claude-code#16222).
 # Force on/off explicitly with CLAUDE_CLOUD=1 / CLAUDE_CLOUD=0.
 
 set -euo pipefail
@@ -122,11 +127,32 @@ SKILL_VERSION_FILE="$SKILL_DIR/.skill-version"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+proxy_java_tool_options() {
+  # Translate $https_proxy / $http_proxy into JVM -D flags. The JVM's
+  # HttpURLConnection (used by the Gradle wrapper) ignores the shell proxy
+  # env vars, so without this the wrapper fails on
+  # `services.gradle.org` (anthropics/claude-code#16222). Prints an empty
+  # string when no proxy URL is set or it lacks an explicit port.
+  local url="${https_proxy:-${HTTPS_PROXY:-${http_proxy:-${HTTP_PROXY:-}}}}"
+  [[ -n "$url" ]] || return 0
+  local hostport="${url#*://}"      # strip scheme
+  hostport="${hostport%%/*}"        # strip path
+  hostport="${hostport##*@}"        # strip optional user:pass@
+  local host="${hostport%:*}"
+  local port="${hostport##*:}"
+  [[ "$host" != "$hostport" ]] || return 0  # no ':' -> no port, skip
+  printf -- '-Dhttps.proxyHost=%s -Dhttps.proxyPort=%s -Dhttp.proxyHost=%s -Dhttp.proxyPort=%s' \
+    "$host" "$port" "$host" "$port"
+}
+
 maybe_write_env_file() {
   if [[ "$CLAUDE_CLOUD" == 1 && -n "${CLAUDE_ENV_FILE:-}" && -w "$(dirname "$CLAUDE_ENV_FILE")" ]]; then
+    local jto
+    jto="$(proxy_java_tool_options)"
     {
       [[ -n "${JAVA_HOME:-}" ]] && echo "JAVA_HOME=$JAVA_HOME"
       echo "PATH=$BIN_DIR:${JAVA_HOME:+$JAVA_HOME/bin:}\$PATH"
+      [[ -n "$jto" ]] && echo "JAVA_TOOL_OPTIONS=$jto"
     } >> "$CLAUDE_ENV_FILE"
     log "wrote env vars to \$CLAUDE_ENV_FILE"
   fi

--- a/skills/compose-preview/design/CLAUDE_CLOUD.md
+++ b/skills/compose-preview/design/CLAUDE_CLOUD.md
@@ -130,6 +130,12 @@ What it does when it sees the sandbox:
   `api.github.com` (rate-limited on shared sandbox IPs).
 - Appends `JAVA_HOME` and `PATH` to `$CLAUDE_ENV_FILE` so subsequent tool
   invocations in the session inherit them.
+- Translates `$https_proxy` / `$http_proxy` into `JAVA_TOOL_OPTIONS`
+  (`-Dhttps.proxyHost` / `-Dhttp.proxyHost`) and writes that to
+  `$CLAUDE_ENV_FILE` as well. The JVM's `HttpURLConnection` ignores the
+  shell proxy env vars, so without this the Gradle wrapper's first-run
+  distribution download fails with `UnknownHostException` on
+  `services.gradle.org` (see the "known gotchas" section below).
 
 Idempotent: rerunning is a fast no-op once things are in place.
 
@@ -254,18 +260,27 @@ Both bite people setting Gradle up in the cloud sandbox for the first time.
 The cloud sandbox routes egress through a proxy and exports `https_proxy`,
 but the JVM's built-in HTTP client ignores it. The Gradle wrapper hits this
 during initial distribution download; downstream `connection.connect()`
-calls in the Tooling API can hit it too.
+calls in the Tooling API can hit it too
+([anthropics/claude-code#16222](https://github.com/anthropics/claude-code/issues/16222)).
 
-Two workarounds, pick one:
+`scripts/install.sh` handles this: when run in cloud mode, it parses the
+shell proxy URL and appends a matching
+`JAVA_TOOL_OPTIONS="-Dhttps.proxyHost=… -Dhttps.proxyPort=… -Dhttp.proxyHost=… -Dhttp.proxyPort=…"`
+line to `$CLAUDE_ENV_FILE`, which the sandbox picks up for every subsequent
+tool invocation.
+
+If you're not using `install.sh` (or you're debugging a different JVM tool
+that hits the same issue), two manual workarounds:
 
 - **Pre-download** the Gradle distribution in the setup script via `curl`
   (which honors `https_proxy`) and stash it under
   `~/.gradle/wrapper/dists/gradle-<ver>-bin/<hash>/` so the wrapper finds it
   locally.
 - **Force the JVM through the proxy** by exporting
-  `JAVA_TOOL_OPTIONS="-Dhttps.proxyHost=<host> -Dhttps.proxyPort=<port>"` in
-  the setup script. See [tschuehly/claude-code-gradle-proxy](https://github.com/tschuehly/claude-code-gradle-proxy)
-  for a worked example.
+  `JAVA_TOOL_OPTIONS="-Dhttps.proxyHost=<host> -Dhttps.proxyPort=<port>"`
+  yourself, or install
+  [tschuehly/claude-code-gradle-proxy](https://github.com/tschuehly/claude-code-gradle-proxy),
+  which does the same thing as a `PreToolUse` hook on `Bash`.
 
 ### Toolchain auto-provisioning is blocked
 


### PR DESCRIPTION
Java's HttpURLConnection ignores $https_proxy, so the Gradle wrapper's
first-run distribution download fails with UnknownHostException on
services.gradle.org even when Trusted network access is enabled
(anthropics/claude-code#16222). install.sh now parses the shell proxy
URL and appends a matching JAVA_TOOL_OPTIONS line to $CLAUDE_ENV_FILE
alongside JAVA_HOME and PATH, so subsequent JVM tool invocations pick
it up automatically. No-ops when no proxy is set.

Updates CLAUDE_CLOUD.md: proxy translation is now a primary install.sh
behavior rather than a "pick one of these two manual workarounds"
gotcha.