### PR TITLE
feat(renderer): realistic scroll shape for ScrollMode.GIF

### DIFF
--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/GifScrollScript.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/GifScrollScript.kt
@@ -1,0 +1,128 @@
+package ee.schimke.composeai.renderer
+
+/**
+ * One planned frame in the scripted `ScrollMode.GIF` walk.
+ *
+ * [scrollPx] is the delta to scroll before capturing — `0f` means "no
+ * scroll, just capture the current state" (used for inter-fling dwells
+ * inside the plan). [delayMs] is the per-frame GIF delay this capture
+ * should render with.
+ *
+ * Hold-start and hold-end frames are synthesised by the runtime around
+ * the scripted sequence (see `handleGifCapture`) rather than appearing
+ * here, so the script is purely the in-motion portion.
+ */
+internal data class GifScrollStep(val scrollPx: Float, val delayMs: Int)
+
+/**
+ * Shapes a "realistic user" scroll for `ScrollMode.GIF`: the playback is
+ * a brief finger-drag ramp, then one or more fling bursts with geometric
+ * velocity decay, with short dwells between flings when the content runs
+ * long enough to warrant a second swipe.
+ *
+ * The returned steps cover only the in-motion portion of the GIF. Callers
+ * prepend a hold-start frame (long dwell at position 0) and append a
+ * hold-end frame (long dwell on the settled final state) around the
+ * walk so the viewer has time to read the top and bottom.
+ *
+ * Per-frame step sizes are calibrated against GIF *playback* time rather
+ * than virtual time: at the default [frameIntervalMs] of 80 ms, a peak
+ * fling step of `120 dp` displays as ~1500 dp/s — roughly the velocity
+ * of an intentional user swipe on Android. Slower than a blur, faster
+ * than a crawl.
+ *
+ * [contentExtentPxHint] is a best-effort upfront estimate; the runtime
+ * still clips each step to the live remaining extent so a LazyList that
+ * materialises more items mid-walk won't over-scroll. Tiny content
+ * (<= one slow-ramp's worth) collapses the plan to a few gentle steps
+ * with no fling.
+ */
+@Suppress("LongParameterList")
+internal fun buildGifScrollScript(
+    contentExtentPxHint: Float,
+    viewportPx: Float,
+    density: Float,
+    frameIntervalMs: Int,
+    slowRampStepDp: Float = SLOW_RAMP_STEP_DP,
+    slowRampFrames: Int = SLOW_RAMP_FRAMES,
+    flingPeakDpPerFrame: Float = FLING_PEAK_DP_PER_FRAME,
+    flingDecay: Float = FLING_DECAY,
+    flingMinStepDp: Float = FLING_MIN_STEP_DP,
+    flingMaxDistanceViewports: Float = FLING_MAX_DISTANCE_VIEWPORTS,
+    interFlingHoldMs: Int = INTER_FLING_HOLD_MS,
+): List<GifScrollStep> {
+    if (contentExtentPxHint <= 0f || viewportPx <= 0f || density <= 0f) {
+        return emptyList()
+    }
+
+    val slowStepPx = slowRampStepDp * density
+    val flingPeakPx = flingPeakDpPerFrame * density
+    val flingMinPx = flingMinStepDp * density
+    val flingCapPx = flingMaxDistanceViewports * viewportPx
+
+    val steps = mutableListOf<GifScrollStep>()
+    var scrolled = 0f
+
+    // Slow ramp: mimics a user's finger touching and starting to drag
+    // before the fling. At 30 dp/frame × 80 ms cadence that's ~375 dp/s —
+    // visibly slower than the fling peak so the acceleration reads as
+    // deliberate motion rather than a uniform slide.
+    repeat(slowRampFrames) {
+        if (scrolled >= contentExtentPxHint) return@repeat
+        val step = minOf(slowStepPx, contentExtentPxHint - scrolled)
+        if (step <= 0f) return@repeat
+        steps += GifScrollStep(step, frameIntervalMs)
+        scrolled += step
+    }
+
+    // Fling bursts. Each fling decays geometrically from peak down to min
+    // step; a per-fling distance cap (`flingMaxDistanceViewports`) cuts
+    // long flings off mid-decay so tall content shows as a sequence of
+    // swipes rather than one endless deceleration. Stops when content
+    // runs out.
+    while (scrolled < contentExtentPxHint) {
+        var step = flingPeakPx
+        var distanceInFling = 0f
+        while (step >= flingMinPx &&
+            scrolled < contentExtentPxHint &&
+            distanceInFling < flingCapPx
+        ) {
+            val remainingContent = contentExtentPxHint - scrolled
+            val remainingCap = flingCapPx - distanceInFling
+            val emit = minOf(step, remainingContent, remainingCap)
+            if (emit <= 0f) break
+            steps += GifScrollStep(emit, frameIntervalMs)
+            scrolled += emit
+            distanceInFling += emit
+            step *= flingDecay
+        }
+        if (scrolled < contentExtentPxHint) {
+            // Short dwell between flings — reads as "user released, about
+            // to swipe again" rather than a continuous glide.
+            steps += GifScrollStep(0f, interFlingHoldMs)
+        }
+    }
+
+    return steps
+}
+
+// -----------------------------------------------------------------------------
+// Calibration constants. Chosen for "feels like a typical user" at the default
+// 80 ms GIF frame interval; all tunable in one place. Values in dp so they
+// stay consistent across densities.
+// -----------------------------------------------------------------------------
+
+internal const val HOLD_START_MS: Int = 1000
+internal const val HOLD_END_MS: Int = 1000
+
+internal const val SLOW_RAMP_STEP_DP: Float = 30f
+internal const val SLOW_RAMP_FRAMES: Int = 4
+
+// 120 dp/frame at 80 ms cadence ≈ 1500 dp/s peak fling velocity — the
+// high end of a deliberate Android swipe.
+internal const val FLING_PEAK_DP_PER_FRAME: Float = 120f
+internal const val FLING_DECAY: Float = 0.85f
+internal const val FLING_MIN_STEP_DP: Float = 12f
+internal const val FLING_MAX_DISTANCE_VIEWPORTS: Float = 1.5f
+
+internal const val INTER_FLING_HOLD_MS: Int = 240

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -890,16 +890,16 @@ private fun settlePostScrollAnimations(rule: AndroidComposeTestRule<*, *>) {
 private const val POST_SCROLL_SETTLE_MS = 1000L
 
 /**
- * Handles `@ScrollingPreview(modes = [GIF])` captures. Drives the scroller
- * by a small fraction of the viewport per step via [driveScrollByViewport],
- * captures each step to a temp PNG, then encodes the sequence as an
- * animated GIF at [outputFile] via [ScrollGifEncoder].
+ * Handles `@ScrollingPreview(modes = [GIF])` captures with a "realistic
+ * user" scroll shape: 1 s hold at the top, a slow finger-drag ramp, one
+ * or more fling bursts sized for the content, then a 1 s hold on the
+ * settled final frame. See [buildGifScrollScript] for the plan shape.
  *
- * Unlike LONG, every frame is a full viewport-sized image — the GIF shows
- * the scroll as an animation rather than stitching frames into one tall
- * still. Per-frame round crop stays ON (each GIF frame should show a
- * proper watch-shaped viewport), so we reuse the default
- * `RoborazziOptions` the caller wired for single-frame captures.
+ * Every frame is a full viewport-sized image — the GIF shows the scroll
+ * as an animation rather than stitching frames into one tall still.
+ * Per-frame round crop stays ON (each GIF frame should show a proper
+ * watch-shaped viewport), so we reuse the default `RoborazziOptions`
+ * the caller wired for single-frame captures.
  *
  * Returns `true` when [outputFile] was written; `false` to fall through
  * to the default single-capture path (e.g. when no scrollable matched, or
@@ -926,7 +926,18 @@ private fun handleGifCapture(
         recordOptions = RoborazziOptions.RecordOptions(applyDeviceCrop = isRound),
     )
 
+    val frameIntervalMs = if (scroll.frameIntervalMs > 0) scroll.frameIntervalMs
+                          else ScrollGifEncoder.DEFAULT_FRAME_DELAY_MS
     val frameFiles = mutableListOf<File>()
+    val frameDelays = mutableListOf<Int>()
+
+    fun captureFrame(delayMs: Int) {
+        val frameFile = File(framesDir, "frame_${frameFiles.size}.png")
+        rule.onRoot().captureRoboImage(file = frameFile, roborazziOptions = frameRoborazziOptions)
+        frameFiles += frameFile
+        frameDelays += delayMs
+    }
+
     try {
         // Multi-mode annotations (`modes = [..., GIF]`) run captures in
         // enum ordinal order against the same composition, so an earlier
@@ -934,50 +945,92 @@ private fun handleGifCapture(
         // would animate "from end to end" — a single frame indistinguishable
         // from the END capture. Reset to the top before the frame walk
         // starts. Fix for #154.
-        driveScrollToStart(rule, scroll.axis)
-
-        // 10% of viewport per step → 10 frames per viewport. With the 80ms
-        // default cadence that's 800ms of animation per viewport scrolled;
-        // a typical Wear screen scrolls ~2–3 viewports of content, landing
-        // the resulting GIF at ~1.5–2.5s — long enough to read motion,
-        // short enough to embed in a PR body. Smaller fraction = smoother
-        // but explosive frame count on tall lists.
-        val result = driveScrollByViewport(
-            rule = rule,
-            axis = scroll.axis,
-            stepPx = viewportLayoutPx * GIF_STEP_FRACTION,
-            maxScrollPx = scroll.maxScrollPx,
-        ) { _ ->
-            val frameFile = File(framesDir, "frame_${frameFiles.size}.png")
-            rule.onRoot().captureRoboImage(file = frameFile, roborazziOptions = frameRoborazziOptions)
-            frameFiles += frameFile
-        }
-        if (result is ScrollDriveResult.NoScrollable) {
+        val resetResult = driveScrollToStart(rule, scroll.axis)
+        if (resetResult is ScrollDriveResult.NoScrollable) {
             System.err.println(
                 "@ScrollingPreview(GIF) on '$previewId': no scrollable composable — falling through.",
             )
             return false
         }
-        if (frameFiles.isEmpty()) return false
 
-        // Mirror [handleLongCapture]'s post-scroll settle: re-capture the
-        // final frame after advancing the clock so animations that begin
-        // once the scroll lands (Wear `EdgeButton` reveal, spring overshoot)
-        // show their resting state at the end of the GIF rather than a
-        // caught-mid-reveal transient. Previous frames stay as captured —
-        // they represent the scroll-in-progress state, which is what a
-        // user would see while scrolling.
+        // Hold-start: the viewer needs a beat to read the top of the
+        // screen before motion begins. 1 s dwell.
+        captureFrame(HOLD_START_MS)
+
+        // Upfront extent hint — capped to `maxScrollPx` when the
+        // annotation sets one. Runtime clamps each step to live remaining
+        // anyway, so LazyList's progressive maxValue doesn't over-scroll.
+        val liveRemaining = remainingScrollPx(rule, scroll.axis)
+        val cap = if (scroll.maxScrollPx > 0) scroll.maxScrollPx.toFloat() else Float.POSITIVE_INFINITY
+        val extentHint = minOf(liveRemaining, cap)
+
+        val script = buildGifScrollScript(
+            contentExtentPxHint = extentHint,
+            viewportPx = viewportLayoutPx.toFloat(),
+            density = density,
+            frameIntervalMs = frameIntervalMs,
+        )
+
+        var scrolledPx = 0f
+        var scriptHitEnd = false
+        for (step in script) {
+            if (step.scrollPx > 0f) {
+                val headroom = (cap - scrolledPx).coerceAtLeast(0f)
+                val target = minOf(step.scrollPx, headroom)
+                if (target <= 0f) {
+                    scriptHitEnd = true
+                    break
+                }
+                val actual = driveScrollBy(rule, scroll.axis, target)
+                if (actual <= 0f) {
+                    scriptHitEnd = true
+                    break
+                }
+                scrolledPx += actual
+            } else {
+                // Inter-fling dwell: no scroll, just a pause frame. Advance
+                // virtual time a little so animations mid-composition keep
+                // ticking honestly across the hold.
+                rule.mainClock.advanceTimeBy(frameIntervalMs.toLong())
+            }
+            captureFrame(step.delayMs)
+        }
+
+        // Tail flings: LazyList reports `maxValue` progressively, so the
+        // upfront `extentHint` can under-cover — the script finishes with
+        // the scroll still mid-content. Keep emitting fling bursts against
+        // the *live* remaining until the scrollable is exhausted (or the
+        // `cap` / safety cap kicks in). Without this the final frame of
+        // the GIF can land in the middle of the gradient on tall lists.
+        if (!scriptHitEnd) {
+            emitTailFlings(
+                rule = rule,
+                axis = scroll.axis,
+                density = density,
+                viewportPx = viewportLayoutPx.toFloat(),
+                frameIntervalMs = frameIntervalMs,
+                cap = cap,
+                alreadyScrolledPx = scrolledPx,
+                captureFrame = ::captureFrame,
+            )
+        }
+
+        // Settle + hold-end: let animations that start when the scroll
+        // lands (Wear `EdgeButton` reveal, spring overshoot) reach their
+        // resting state, then capture one final frame with a long dwell.
         settlePostScrollAnimations(rule)
-        val lastFrameFile = frameFiles.last()
-        lastFrameFile.delete()
-        rule.onRoot().captureRoboImage(file = lastFrameFile, roborazziOptions = frameRoborazziOptions)
+        captureFrame(HOLD_END_MS)
+
+        if (frameFiles.isEmpty()) return false
 
         val frames = frameFiles.map {
             javax.imageio.ImageIO.read(it) ?: error("Failed to read GIF frame PNG: $it")
         }
-        val delay = if (scroll.frameIntervalMs > 0) scroll.frameIntervalMs
-                    else ScrollGifEncoder.DEFAULT_FRAME_DELAY_MS
-        val written = ScrollGifEncoder.encode(frames, outputFile, delay) ?: return false
+        val written = ScrollGifEncoder.encode(
+            frames = frames,
+            outputFile = outputFile,
+            frameDelaysMs = frameDelays.toIntArray(),
+        ) ?: return false
         System.err.println(
             "@ScrollingPreview(GIF) on '$previewId': encoded ${frames.size} frames → ${written.name}.",
         )
@@ -987,10 +1040,76 @@ private fun handleGifCapture(
     }
 }
 
-// 10% of viewport per step → 10 frames per viewport. Tuned so a typical
-// Wear scroll (2–3 viewports of content at the default 80ms cadence) lands
-// at roughly 2 seconds of animation. Lower = smoother but more frames.
-private const val GIF_STEP_FRACTION = 0.1f
+/**
+ * Drives the remaining scroll to content end in fling-shaped bursts,
+ * capturing one frame per step. Used after the scripted plan runs out
+ * of steps on content taller than the initial extent hint — the common
+ * LazyList progressive-materialisation case where the first
+ * [remainingScrollPx] read under-reports the true scroll extent.
+ *
+ * Each iteration emits one fling (geometric decay from peak to min
+ * step, capped at [FLING_MAX_DISTANCE_VIEWPORTS] of a viewport) preceded
+ * by a short inter-fling hold so the continuation reads as "user
+ * swiped again" rather than one endless glide. Bounded by
+ * [MAX_TAIL_FLINGS] so a runaway `maxValue` (infinite LazyList with a
+ * no-op `ScrollBy`) can't spin forever.
+ */
+@Suppress("LongParameterList")
+private fun emitTailFlings(
+    rule: AndroidComposeTestRule<*, *>,
+    axis: ScrollAxis,
+    density: Float,
+    viewportPx: Float,
+    frameIntervalMs: Int,
+    cap: Float,
+    alreadyScrolledPx: Float,
+    captureFrame: (delayMs: Int) -> Unit,
+) {
+    val flingPeakPx = FLING_PEAK_DP_PER_FRAME * density
+    val flingMinPx = FLING_MIN_STEP_DP * density
+    val flingCapPx = FLING_MAX_DISTANCE_VIEWPORTS * viewportPx
+    var scrolledPx = alreadyScrolledPx
+
+    repeat(MAX_TAIL_FLINGS) {
+        val remaining = remainingScrollPx(rule, axis)
+        if (remaining <= TAIL_FLING_EPSILON_PX) return
+        val headroom = (cap - scrolledPx).coerceAtLeast(0f)
+        if (headroom <= TAIL_FLING_EPSILON_PX) return
+
+        // Inter-fling hold frame: short dwell + no scroll. Makes the
+        // follow-up read as a distinct swipe.
+        rule.mainClock.advanceTimeBy(frameIntervalMs.toLong())
+        captureFrame(INTER_FLING_HOLD_MS)
+
+        var step = flingPeakPx
+        var distanceInFling = 0f
+        while (step >= flingMinPx && distanceInFling < flingCapPx) {
+            val live = remainingScrollPx(rule, axis)
+            val remainingHeadroom = (cap - scrolledPx).coerceAtLeast(0f)
+            val cappedRemaining = minOf(live, remainingHeadroom)
+            if (cappedRemaining <= TAIL_FLING_EPSILON_PX) return
+            val emit = minOf(step, cappedRemaining, flingCapPx - distanceInFling)
+            if (emit <= 0f) return
+            val actual = driveScrollBy(rule, axis, emit)
+            if (actual <= 0f) return
+            distanceInFling += actual
+            scrolledPx += actual
+            captureFrame(frameIntervalMs)
+            step *= FLING_DECAY
+        }
+    }
+}
+
+// Safety cap on continuation flings so an infinite or pathological
+// LazyList can't spin. Four flings × 1.5 viewports/fling covers six more
+// viewports beyond the initial scripted walk — enough for any reasonable
+// real-world preview.
+private const val MAX_TAIL_FLINGS = 4
+
+// Slightly looser than SETTLED_EPSILON_PX in ScrollDriver: LazyList's
+// maxValue can wobble a pixel or two as items recompose, and we don't
+// want a sub-pixel remainder to keep us spinning in the tail loop.
+private const val TAIL_FLING_EPSILON_PX = 1f
 
 /**
  * Adds Robolectric's `+round` qualifier so `Configuration.isScreenRound` becomes

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollDriver.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollDriver.kt
@@ -189,6 +189,70 @@ internal fun driveScrollToStart(
     return ScrollDriveResult.IterationCapReached(scrolledPx)
 }
 
+/**
+ * Single-step scroll helper used by the scripted `ScrollMode.GIF` walk.
+ * Scrolls by `min(deltaPx, remaining)` on the first scrollable matching
+ * [axis], advances virtual time so `animateScrollBy` settles, and returns
+ * the pixels actually consumed (0 if no scrollable or already at end).
+ *
+ * Unlike [driveScrollByViewport], this does not emit intermediate callbacks
+ * or iterate — the caller owns per-step capture and timing. Kept tiny so
+ * the GIF script builder can shape the sequence (slow ramp, fling decay,
+ * inter-fling holds) without fighting the driver.
+ */
+internal fun driveScrollBy(
+    rule: AndroidComposeTestRule<*, *>,
+    axis: ScrollAxis,
+    deltaPx: Float,
+    advanceMsPerStep: Long = DEFAULT_ADVANCE_MS_PER_STEP,
+): Float {
+    if (deltaPx <= 0f) return 0f
+    val axisKey = when (axis) {
+        ScrollAxis.VERTICAL -> SemanticsProperties.VerticalScrollAxisRange
+        ScrollAxis.HORIZONTAL -> SemanticsProperties.HorizontalScrollAxisRange
+    }
+    val scrollables = rule.onAllNodes(SemanticsMatcher.keyIsDefined(axisKey)).fetchSemanticsNodes()
+    if (scrollables.isEmpty()) return 0f
+
+    val interaction = rule.onAllNodes(SemanticsMatcher.keyIsDefined(axisKey))[0]
+    val node = interaction.fetchSemanticsNode()
+    val range: ScrollAxisRange = node.config.getOrNull(axisKey) ?: return 0f
+    val scrollByAction = node.config.getOrNull(SemanticsActions.ScrollBy)?.action ?: return 0f
+
+    val remaining = (range.maxValue() - range.value()).coerceAtLeast(0f)
+    if (remaining <= SETTLED_EPSILON_PX) return 0f
+
+    val step = minOf(deltaPx, remaining)
+    val (dx, dy) = when (axis) {
+        ScrollAxis.VERTICAL -> 0f to step
+        ScrollAxis.HORIZONTAL -> step to 0f
+    }
+    scrollByAction.invoke(dx, dy)
+    rule.mainClock.advanceTimeBy(advanceMsPerStep)
+    return step
+}
+
+/**
+ * Returns the remaining scrollable extent on [axis] — `maxValue - value`
+ * — or `0` if no scrollable is mounted. Used as an up-front hint when
+ * building the GIF scroll script; final length is still adaptive at
+ * runtime because LazyList reports its max progressively.
+ */
+internal fun remainingScrollPx(
+    rule: AndroidComposeTestRule<*, *>,
+    axis: ScrollAxis,
+): Float {
+    val axisKey = when (axis) {
+        ScrollAxis.VERTICAL -> SemanticsProperties.VerticalScrollAxisRange
+        ScrollAxis.HORIZONTAL -> SemanticsProperties.HorizontalScrollAxisRange
+    }
+    val scrollables = rule.onAllNodes(SemanticsMatcher.keyIsDefined(axisKey)).fetchSemanticsNodes()
+    if (scrollables.isEmpty()) return 0f
+    val node = rule.onAllNodes(SemanticsMatcher.keyIsDefined(axisKey))[0].fetchSemanticsNode()
+    val range: ScrollAxisRange = node.config.getOrNull(axisKey) ?: return 0f
+    return (range.maxValue() - range.value()).coerceAtLeast(0f)
+}
+
 internal sealed interface ScrollDriveResult {
     /** No scrollable composable found on the requested axis. */
     data object NoScrollable : ScrollDriveResult

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollGifEncoder.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ScrollGifEncoder.kt
@@ -43,16 +43,27 @@ internal object ScrollGifEncoder {
         frames: List<BufferedImage>,
         outputFile: File,
         frameDelayMs: Int = DEFAULT_FRAME_DELAY_MS,
+    ): File? = encode(frames, outputFile, IntArray(frames.size) { frameDelayMs })
+
+    /**
+     * Variable per-frame cadence: [frameDelaysMs] must have one entry per
+     * image in [frames]. Used by the scripted `ScrollMode.GIF` walk to give
+     * hold-start / hold-end frames a longer dwell (e.g. 1000ms) than the
+     * in-motion scroll frames (80ms) within a single GIF. Each frame's GCE
+     * already gets its own `delayTime` attribute, so variable delay is just
+     * a matter of plumbing the per-frame value through.
+     */
+    fun encode(
+        frames: List<BufferedImage>,
+        outputFile: File,
+        frameDelaysMs: IntArray,
     ): File? {
         if (frames.isEmpty()) return null
+        require(frameDelaysMs.size == frames.size) {
+            "frameDelaysMs size ${frameDelaysMs.size} != frames size ${frames.size}"
+        }
         val writer = ImageIO.getImageWritersByFormatName("gif").asSequence().firstOrNull()
             ?: return null
-
-        // GIF timing resolution is 1/100s. Rounding down to the nearest 10ms
-        // keeps our nominal delay honest; clamped to 20ms because many
-        // browsers treat <20ms as "use default ~100ms", which silently breaks
-        // fast-cadence encodes.
-        val delayCentiseconds = (frameDelayMs.coerceAtLeast(MIN_FRAME_DELAY_MS) / 10).coerceAtLeast(2)
 
         outputFile.parentFile?.mkdirs()
         FileImageOutputStream(outputFile).use { stream ->
@@ -61,14 +72,14 @@ internal object ScrollGifEncoder {
             val first = frames.first()
             val imageType = ImageTypeSpecifier.createFromRenderedImage(first)
             val meta = writer.getDefaultImageMetadata(imageType, param)
-            configureFrameMetadata(meta, delayCentiseconds, loopForever = true)
+            configureFrameMetadata(meta, toCentiseconds(frameDelaysMs[0]), loopForever = true)
 
             writer.prepareWriteSequence(null)
             writer.writeToSequence(IIOImage(first, null, meta), param)
 
             for (i in 1 until frames.size) {
                 val frameMeta = writer.getDefaultImageMetadata(imageType, param)
-                configureFrameMetadata(frameMeta, delayCentiseconds, loopForever = false)
+                configureFrameMetadata(frameMeta, toCentiseconds(frameDelaysMs[i]), loopForever = false)
                 writer.writeToSequence(IIOImage(frames[i], null, frameMeta), param)
             }
             writer.endWriteSequence()
@@ -76,6 +87,13 @@ internal object ScrollGifEncoder {
         writer.dispose()
         return outputFile
     }
+
+    // GIF timing resolution is 1/100s. Rounding down to the nearest 10ms
+    // keeps our nominal delay honest; clamped to 20ms because many browsers
+    // treat <20ms as "use default ~100ms", which silently breaks fast-cadence
+    // encodes.
+    private fun toCentiseconds(delayMs: Int): Int =
+        (delayMs.coerceAtLeast(MIN_FRAME_DELAY_MS) / 10).coerceAtLeast(2)
 
     /**
      * Writes the per-frame `GraphicControlExtension` (delay + disposal) and,

--- a/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/GifScrollScriptTest.kt
+++ b/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/GifScrollScriptTest.kt
@@ -1,0 +1,142 @@
+package ee.schimke.composeai.renderer
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the shape of the scripted `ScrollMode.GIF` plan produced by
+ * [buildGifScrollScript]. These assertions aren't pixel-exact — they
+ * cover the invariants the runtime relies on:
+ *
+ *  - slow ramp frames appear first, at the calibrated slow step size;
+ *  - fling frames decay geometrically from peak down to min;
+ *  - the plan respects the per-fling distance cap and emits an
+ *    inter-fling hold between swipes on tall content;
+ *  - total scrolled distance never exceeds the content extent hint.
+ *
+ * Values are chosen so `density = 1f` and inputs are dp-equivalent,
+ * which keeps the arithmetic easy to cross-check by hand.
+ */
+class GifScrollScriptTest {
+
+    private val frameIntervalMs = 80
+    private val viewportPx = 400f
+    private val density = 1f
+
+    @Test
+    fun `empty content emits no steps`() {
+        val script = buildGifScrollScript(
+            contentExtentPxHint = 0f,
+            viewportPx = viewportPx,
+            density = density,
+            frameIntervalMs = frameIntervalMs,
+        )
+        assertTrue("expected no steps, got $script", script.isEmpty())
+    }
+
+    @Test
+    fun `short content uses slow ramp only`() {
+        // 50 dp of scrollable content — fits inside the 4-frame × 30 dp
+        // slow ramp (120 dp) with room to spare, so no fling should be
+        // emitted at all.
+        val script = buildGifScrollScript(
+            contentExtentPxHint = 50f,
+            viewportPx = viewportPx,
+            density = density,
+            frameIntervalMs = frameIntervalMs,
+        )
+        // No inter-fling holds (all steps have stepPx > 0).
+        assertTrue("expected no holds in $script", script.all { it.scrollPx > 0f })
+        // All scrolls are slow-ramp-sized (<= 30 dp/frame).
+        assertTrue(
+            "some step exceeded slow ramp limit: $script",
+            script.all { it.scrollPx <= SLOW_RAMP_STEP_DP * density + 0.01f },
+        )
+        assertEquals(50f, script.sumOf { it.scrollPx.toDouble() }.toFloat(), 0.01f)
+    }
+
+    @Test
+    fun `medium content ramps then flings once`() {
+        // 600 dp content ≈ 1.5 viewports. Enough to trigger a fling after
+        // the ramp but well under the `FLING_MAX_DISTANCE_VIEWPORTS` cap
+        // (1.5 × 400 dp = 600 dp) — so no inter-fling hold, just one
+        // continuous decay.
+        val script = buildGifScrollScript(
+            contentExtentPxHint = 600f,
+            viewportPx = viewportPx,
+            density = density,
+            frameIntervalMs = frameIntervalMs,
+        )
+
+        val slowStepPx = SLOW_RAMP_STEP_DP * density
+        val rampSteps = script.takeWhile { it.scrollPx <= slowStepPx + 0.01f && it.scrollPx > 0f }
+        assertEquals(SLOW_RAMP_FRAMES, rampSteps.size)
+
+        val flingSteps = script.drop(rampSteps.size)
+        assertFalse("unexpected hold in single-fling plan: $flingSteps", flingSteps.any { it.scrollPx == 0f })
+        assertTrue(
+            "fling peak exceeded expected: ${flingSteps.first()}",
+            flingSteps.first().scrollPx <= FLING_PEAK_DP_PER_FRAME * density + 0.01f,
+        )
+        val total = script.sumOf { it.scrollPx.toDouble() }.toFloat()
+        assertEquals(600f, total, 0.1f)
+    }
+
+    @Test
+    fun `tall content emits multiple flings with holds between`() {
+        // 2000 dp content ≫ 1 × `flingCap` (600 dp) — should produce
+        // several fling bursts with inter-fling holds (scrollPx == 0).
+        val script = buildGifScrollScript(
+            contentExtentPxHint = 2000f,
+            viewportPx = viewportPx,
+            density = density,
+            frameIntervalMs = frameIntervalMs,
+        )
+
+        val holds = script.filter { it.scrollPx == 0f }
+        assertTrue("expected at least one inter-fling hold, got $script", holds.isNotEmpty())
+        assertTrue(
+            "hold delay should be INTER_FLING_HOLD_MS: $holds",
+            holds.all { it.delayMs == INTER_FLING_HOLD_MS },
+        )
+        // With 2000 dp at a 600 dp cap per fling, expect at least 2 holds
+        // (between 3 flings' worth of travel), though the tail fling
+        // covers the remainder without reaching the cap.
+        assertTrue("expected at least 2 holds, got ${holds.size}", holds.size >= 2)
+
+        val totalScrolled = script.sumOf { it.scrollPx.toDouble() }.toFloat()
+        assertTrue("overshot extent: $totalScrolled", totalScrolled <= 2000f + 0.1f)
+        assertEquals(2000f, totalScrolled, 0.1f)
+    }
+
+    @Test
+    fun `scroll frames carry the supplied frame interval`() {
+        val script = buildGifScrollScript(
+            contentExtentPxHint = 800f,
+            viewportPx = viewportPx,
+            density = density,
+            frameIntervalMs = 120,
+        )
+        val scrolling = script.filter { it.scrollPx > 0f }
+        assertTrue("no scrolling frames emitted", scrolling.isNotEmpty())
+        assertTrue(
+            "scroll frames should use supplied cadence: $scrolling",
+            scrolling.all { it.delayMs == 120 },
+        )
+    }
+
+    @Test
+    fun `density scales step sizes`() {
+        val hi = buildGifScrollScript(
+            contentExtentPxHint = 600f,
+            viewportPx = viewportPx,
+            density = 2f,
+            frameIntervalMs = frameIntervalMs,
+        )
+        // First ramp frame should be ~60 px (30 dp × 2), not 30 px.
+        val firstRamp = hi.first { it.scrollPx > 0f }
+        assertEquals(60f, firstRamp.scrollPx, 0.01f)
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the uniform 10%-of-viewport / 80 ms metronome in `ScrollMode.GIF` with a scripted walk: **1 s hold at top → slow finger-drag ramp → fling bursts with geometric velocity decay → short inter-fling dwells on tall content → 1 s hold on the settled final frame**.
- Peak fling lands at ~1500 dp/s (120 dp per 80 ms frame) — deliberate-swipe pace, not a blur.
- Per-frame delays threaded through `ScrollGifEncoder` using the existing per-frame `GraphicControlExtension`: holds = 1000 ms, scroll frames = 80 ms, inter-fling dwells = 240 ms.

## How it's built
- [`GifScrollScript.kt`](../blob/claude/objective-perlman/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/GifScrollScript.kt) — pure-JVM `buildGifScrollScript` helper plus one set of calibration constants (`HOLD_*`, `SLOW_RAMP_*`, `FLING_*`, `INTER_FLING_HOLD_MS`). All tunable in one place.
- `ScrollGifEncoder.encode` now has a per-frame `IntArray` overload (old `Int` overload delegates through, backward compatible).
- `ScrollDriver` grows a single-step `driveScrollBy` and a `remainingScrollPx` probe so the GIF path can work step-by-step without fighting the uniform-step loop used by LONG.
- `handleGifCapture` runs the script against live remaining scroll and then emits tail flings until the scrollable is actually exhausted — LazyList reports `maxValue` progressively, so an upfront hint under-covers by design. `MAX_TAIL_FLINGS = 4` caps runaway.

## Shape in practice
Sample GIFs produced by this PR:
- **Wear `ActivityListGifPreview`** (227 dp viewport): 18 frames, 3.6 s total, delays `[1000, 80×7, 240, 80×4, 240, 80×2, 1000]`.
- **Phone `SettingsListScrollGifPreview`** (440 dp viewport): 38 frames, 5.4 s total — three fling bursts separated by 240 ms dwells, flanked by 1 s holds.
- **`RedToBlueScrollGifPreview`**: 26 frames, 4.2 s total.

## Test plan
- [x] `:renderer-android:testDebugUnitTest --tests GifScrollScriptTest` — 6/6 pass (empty / short / medium / tall content, frame-interval propagation, density scaling).
- [x] `:sample-android:testDebugUnitTest --tests ScrollPreviewPixelTest` — 4/4 pass (first frame red-dominant, last frame blue-dominant round-trip through the encoder).
- [x] `:sample-wear:testDebugUnitTest` — pass.
- [x] `:gradle-plugin:functionalTest --tests *ScrollingPreview*` — pass.
- [ ] Visual sanity of the produced GIFs (reviewer).

`ScrollSliceStitcherTest` / `LongScrollGhostOverlayTest` have pre-existing failures on `main` (verified by stashing this change and re-running). Unrelated to GIF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)