### PR TITLE
ci: add a11y report workflow demoed on sample-wear

### DIFF
--- a/.github/actions/a11y-report/action.yml
+++ b/.github/actions/a11y-report/action.yml
@@ -1,0 +1,198 @@
+name: 'Compose A11y Report'
+description: >
+  Render @Preview functions with ATF accessibility checks enabled, generate
+  an annotated screenshot + finding table per preview, and publish to a
+  shared branch (`a11y_main` for `push`, `a11y_pr` for `pull_request`). For
+  PRs, also upserts a comment with finding counts and SHA-pinned image
+  links. Mirrors the push-and-retry / comment-upsert pattern used by
+  preview-comment, but is a separate action so a11y churn doesn't block the
+  pixel-diff hot path.
+
+inputs:
+  mode:
+    description: "'baseline' (push to `a11y_main`) or 'comment' (push to `a11y_pr` + upsert PR comment)"
+    required: true
+  module:
+    description: 'Gradle module path to render (e.g. `sample-wear`)'
+    default: 'sample-wear'
+  baseline-branch:
+    description: 'Long-lived branch holding the baseline a11y report'
+    default: 'a11y_main'
+  pr-branch:
+    description: 'Shared branch that accumulates per-PR a11y renders'
+    default: 'a11y_pr'
+  pr-number:
+    description: 'Pull request number (auto-detected from context if omitted)'
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Render previews with a11y checks enabled
+      shell: bash
+      env:
+        MODULE: ${{ inputs.module }}
+      run: |
+        set -euo pipefail
+        # `-PcomposePreview.accessibilityChecks.enabled=true` overrides the
+        # module DSL default so `./gradlew check` stays clean while CI still
+        # exercises the a11y path. The module's `verifyAccessibility` task is
+        # always registered; the property flips its `onlyIf` predicate.
+        ./gradlew ":${MODULE}:renderAllPreviews" \
+          -PcomposePreview.accessibilityChecks.enabled=true \
+          --no-daemon
+
+    - name: Copy annotated PNGs and emit findings.json
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        MODULE: ${{ inputs.module }}
+      run: |
+        set -euo pipefail
+        python3 "$ACTION_PATH/../lib/a11y-report.py" copy-annotated \
+          --build-dir "${MODULE}/build/compose-previews" \
+          --output-dir _a11y_renders
+
+    - name: Generate README for target branch
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        REPO: ${{ github.repository }}
+        TARGET_BRANCH: ${{ inputs.mode == 'baseline' && inputs.baseline-branch || inputs.pr-branch }}
+      run: |
+        set -euo pipefail
+        # Image URLs reference the branch name rather than a SHA — same
+        # contract preview-baselines uses for the on-branch README. The PR
+        # comment (generated separately below) is what pins to a SHA so it
+        # survives the PR merge.
+        python3 "$ACTION_PATH/../lib/a11y-report.py" readme \
+          _a11y_renders/findings.json \
+          --repo "$REPO" \
+          --branch "$TARGET_BRANCH" \
+          --output _a11y_renders/README.md
+
+    - name: Push a11y renders branch
+      id: push
+      shell: bash
+      env:
+        # Route every templated value through env so a malicious branch /
+        # PR-number input can't expand inside the shell body. (zizmor:
+        # template-injection)
+        MODE: ${{ inputs.mode }}
+        BASELINE_BRANCH: ${{ inputs.baseline-branch }}
+        PR_BRANCH: ${{ inputs.pr-branch }}
+        PR_INPUT_NUMBER: ${{ inputs.pr-number }}
+        EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+        GITHUB_TOKEN_INLINE: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        if [ "$MODE" = "baseline" ]; then
+          TARGET_BRANCH="$BASELINE_BRANCH"
+        else
+          TARGET_BRANCH="$PR_BRANCH"
+        fi
+
+        cd _a11y_renders
+        git init -q
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git remote add origin \
+          "https://x-access-token:${GITHUB_TOKEN_INLINE}@github.com/${REPO}.git"
+
+        git add -A
+        TREE=$(git write-tree)
+
+        PR_NUMBER="${PR_INPUT_NUMBER:-$EVENT_PR_NUMBER}"
+        if [ "$MODE" = "baseline" ]; then
+          MSG="Update accessibility baseline from ${GITHUB_SHA::8}"
+        else
+          MSG="A11y report for PR #${PR_NUMBER} (${GITHUB_SHA::8})"
+        fi
+
+        # Append commit on top of existing tip so older PR comments pinned
+        # to past SHAs stay reachable. Retry loop handles the push race
+        # when two PRs finish concurrently against the shared `a11y_pr`
+        # branch — same recipe as preview-comment/action.yml.
+        attempt=1
+        while :; do
+          PARENT=""
+          if git fetch --depth=1 --quiet origin "$TARGET_BRANCH" 2>/dev/null; then
+            PARENT=$(git rev-parse FETCH_HEAD)
+            PARENT_TREE=$(git rev-parse "${PARENT}^{tree}")
+            if [ "$MODE" = "baseline" ] && [ "$TREE" = "$PARENT_TREE" ]; then
+              # Nothing changed vs the current baseline — skip the no-op
+              # commit so the branch history doesn't grow on every CI run.
+              echo "A11y baseline unchanged; skipping push."
+              echo "head_sha=" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          if [ -n "$PARENT" ]; then
+            COMMIT=$(git commit-tree "$TREE" -p "$PARENT" -m "$MSG")
+          else
+            COMMIT=$(git commit-tree "$TREE" -m "$MSG")
+          fi
+
+          if git push --quiet origin "${COMMIT}:refs/heads/${TARGET_BRANCH}" 2>&1; then
+            echo "head_sha=${COMMIT}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$attempt" -ge 5 ]; then
+            echo "Push to ${TARGET_BRANCH} failed after ${attempt} attempts." >&2
+            exit 1
+          fi
+          delay=$((attempt * 2 + RANDOM % 3))
+          echo "Push to ${TARGET_BRANCH} lost the race; retry ${attempt}/5 in ${delay}s…" >&2
+          attempt=$((attempt + 1))
+          sleep "$delay"
+        done
+
+    - name: Generate PR comment body
+      if: inputs.mode == 'comment'
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        REPO: ${{ github.repository }}
+        PR_BRANCH: ${{ inputs.pr-branch }}
+        HEAD_SHA: ${{ steps.push.outputs.head_sha }}
+      run: |
+        set -euo pipefail
+        # Fall back to the branch name when no commit was pushed (e.g. the
+        # baseline-equivalent skip path landed). The body still resolves —
+        # branch URLs follow the tip until something else moves it.
+        HEAD_REF="${HEAD_SHA:-$PR_BRANCH}"
+        python3 "$ACTION_PATH/../lib/a11y-report.py" comment \
+          _a11y_renders/findings.json \
+          --repo "$REPO" \
+          --head-ref "$HEAD_REF" \
+          > _a11y_comment.md
+
+    - name: Upsert PR comment
+      if: inputs.mode == 'comment'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_INPUT_NUMBER: ${{ inputs.pr-number }}
+        EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        PR_NUMBER="${PR_INPUT_NUMBER:-$EVENT_PR_NUMBER}"
+        BODY=$(cat _a11y_comment.md)
+        MARKER="<!-- a11y-report -->"
+
+        COMMENT_ID=$(gh api \
+          "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+          --paginate \
+          --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
+          | head -1)
+
+        if [ -n "$COMMENT_ID" ]; then
+          gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
+            -X PATCH -f body="$BODY"
+        else
+          gh pr comment "$PR_NUMBER" --body "$BODY"
+        fi

--- a/.github/actions/lib/a11y-report.py
+++ b/.github/actions/lib/a11y-report.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""Generate accessibility reports from compose-preview output.
+
+Reads the per-module ``previews.json`` (from the Gradle plugin) and its
+sidecar ``accessibility.json`` (written by ``verifyAccessibility``), filters
+each preview function down to a single canonical Wear variant, and emits
+either a browsable ``README.md`` for the ``a11y_main`` baseline branch or a
+Markdown PR comment body for the ``a11y_pr`` branch.
+
+Subcommands
+-----------
+copy-annotated
+    Read the two manifests, pick one variant per (module, function), and
+    copy the rendered PNG plus the annotated ``<id>.a11y.png`` into the
+    output directory. Also writes ``findings.json``, a flat per-preview
+    summary the readme/comment subcommands consume.
+
+readme
+    Render ``findings.json`` to a browsable Markdown gallery with inline
+    images (raw.githubusercontent SHA-pinned).
+
+comment
+    Render ``findings.json`` to a PR-comment Markdown body with the
+    ``<!-- a11y-report -->`` marker the action upserts on.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Variant filter
+# ---------------------------------------------------------------------------
+
+# Wear meta-annotations (`@WearPreviewDevices`, `@WearPreviewLargeRound`, …)
+# fan a single function out into multiple previews, each with a different
+# `params.device`. The README would get noisy if we listed every variant,
+# so for each function we keep just the variant whose device sits earliest
+# in this global priority. Devices not listed here fall through to a
+# stable id-sort tiebreaker, so non-Wear modules still produce output.
+_DEVICE_PRIORITY: tuple[str, ...] = (
+    "id:wearos_large_round",
+    "id:wearos_small_round",
+)
+
+
+def device_priority(device: str | None) -> int:
+    """Index of ``device`` in [_DEVICE_PRIORITY]; sentinel when absent/unknown."""
+    if not device:
+        return len(_DEVICE_PRIORITY) + 1
+    try:
+        return _DEVICE_PRIORITY.index(device)
+    except ValueError:
+        return len(_DEVICE_PRIORITY) + 1
+
+
+def variant_label(device: str | None) -> str:
+    """Short human-readable label for ``device``.
+
+    Strips the ``id:`` prefix Compose uses for known device ids
+    (``id:wearos_large_round`` → ``wearos_large_round``); returns the empty
+    string for ``None`` so the README header drops the trailing dot when
+    there's no device to show.
+    """
+    if not device:
+        return ""
+    return device.removeprefix("id:")
+
+
+# ---------------------------------------------------------------------------
+# Manifest loading
+# ---------------------------------------------------------------------------
+
+def load_previews(build_dir: Path) -> tuple[dict, dict]:
+    """Return ``(manifest, a11y_by_id)`` for one module's build output.
+
+    ``manifest`` is the raw ``previews.json`` dict. ``a11y_by_id`` maps each
+    previewId to its accessibility entry (findings + relative annotatedPath),
+    or ``None`` when ``accessibility.json`` is absent (a11y not enabled).
+    """
+    manifest_path = build_dir / "previews.json"
+    if not manifest_path.exists():
+        raise SystemExit(f"previews.json not found at {manifest_path}")
+    manifest = json.loads(manifest_path.read_text())
+
+    a11y_by_id: dict = {}
+    a11y_path = build_dir / "accessibility.json"
+    if a11y_path.exists():
+        report = json.loads(a11y_path.read_text())
+        for entry in report.get("entries", []):
+            a11y_by_id[entry["previewId"]] = entry
+    return manifest, a11y_by_id
+
+
+def select_variants(manifest: dict, a11y_by_id: dict) -> list[dict]:
+    """Pick one variant per (functionName) and merge in a11y data.
+
+    Returns a list of flat dicts with everything readme/comment need:
+    module, functionName, sourceFile, previewId, variant, renderOutput
+    (module-relative), annotatedPath (module-relative), findings.
+
+    Tile previews (``params.kind == "TILE"``) are filtered out — ATF runs
+    against the Robolectric View tree, but Wear Tiles render through
+    `TilePreviewRenderer`, so listing them with empty findings would falsely
+    imply they were checked.
+    """
+    module = manifest["module"]
+    by_fn: dict[str, list[dict]] = {}
+    for preview in manifest.get("previews", []):
+        kind = (preview.get("params") or {}).get("kind", "COMPOSE")
+        if kind != "COMPOSE":
+            continue
+        by_fn.setdefault(preview["functionName"], []).append(preview)
+
+    rows: list[dict] = []
+    for fn, group in sorted(by_fn.items()):
+        chosen = min(
+            group,
+            key=lambda p: (
+                device_priority((p.get("params") or {}).get("device")),
+                p["id"],
+            ),
+        )
+        # `captures[0].renderOutput` is the canonical PNG for a static preview.
+        # Multi-capture previews (scroll/time fan-outs) collapse to the first
+        # capture for the report — a Wear a11y demo doesn't need the full
+        # animation strip; the annotated PNG already pins one frame.
+        captures = chosen.get("captures") or []
+        render_rel = captures[0]["renderOutput"] if captures else ""
+        a11y = a11y_by_id.get(chosen["id"])
+        chosen_device = (chosen.get("params") or {}).get("device")
+        rows.append({
+            "module": module,
+            "functionName": fn,
+            "sourceFile": chosen.get("sourceFile"),
+            "previewId": chosen["id"],
+            "variant": variant_label(chosen_device),
+            "renderOutput": render_rel,
+            "annotatedPath": (a11y or {}).get("annotatedPath"),
+            "findings": (a11y or {}).get("findings", []),
+        })
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# copy-annotated
+# ---------------------------------------------------------------------------
+
+def cmd_copy_annotated(args: argparse.Namespace) -> int:
+    build_dir = Path(args.build_dir)
+    out_dir = Path(args.output_dir)
+    manifest, a11y_by_id = load_previews(build_dir)
+    rows = select_variants(manifest, a11y_by_id)
+
+    module = manifest["module"]
+    renders_out = out_dir / "renders" / module
+    if renders_out.exists():
+        shutil.rmtree(renders_out)
+    renders_out.mkdir(parents=True, exist_ok=True)
+
+    findings_summary: list[dict] = []
+    for row in rows:
+        # Copy the clean render (always — the README links it for previews
+        # without findings so the gallery still shows what was checked).
+        clean_basename = ""
+        if row["renderOutput"]:
+            src = build_dir / row["renderOutput"]
+            if src.exists():
+                clean_basename = src.name
+                shutil.copy2(src, renders_out / clean_basename)
+        # Copy the annotated PNG when present.
+        annotated_basename = ""
+        if row["annotatedPath"]:
+            src = build_dir / row["annotatedPath"]
+            if src.exists():
+                annotated_basename = src.name
+                shutil.copy2(src, renders_out / annotated_basename)
+        findings_summary.append({
+            "module": row["module"],
+            "functionName": row["functionName"],
+            "sourceFile": row["sourceFile"],
+            "previewId": row["previewId"],
+            "variant": row["variant"],
+            "cleanBasename": clean_basename,
+            "annotatedBasename": annotated_basename,
+            "findings": row["findings"],
+        })
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "findings.json").write_text(
+        json.dumps({"entries": findings_summary}, indent=2, sort_keys=True) + "\n"
+    )
+
+    total_findings = sum(len(r["findings"]) for r in findings_summary)
+    print(
+        f"Copied {len(findings_summary)} preview(s) with "
+        f"{total_findings} finding(s) to {out_dir}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# readme / comment shared rendering
+# ---------------------------------------------------------------------------
+
+def _level_counts(entries: list[dict]) -> tuple[int, int, int]:
+    err = warn = info = 0
+    for entry in entries:
+        for f in entry["findings"]:
+            level = f.get("level")
+            if level == "ERROR":
+                err += 1
+            elif level == "WARNING":
+                warn += 1
+            elif level == "INFO":
+                info += 1
+    return err, warn, info
+
+
+def _image_url(repo: str, ref: str, module: str, basename: str) -> str:
+    return (
+        f"https://raw.githubusercontent.com/{repo}/{ref}"
+        f"/renders/{module}/{basename}"
+    )
+
+
+def _findings_table(findings: list[dict]) -> list[str]:
+    """Markdown table of one preview's findings. Returns lines (no trailing blank)."""
+    lines = [
+        "| # | Level | Rule | Element | Message |",
+        "|--:|---|---|---|---|",
+    ]
+    for idx, f in enumerate(findings, start=1):
+        element = (f.get("viewDescription") or "").replace("|", "\\|")
+        # Messages from ATF can contain backticks and newlines; collapse to
+        # a single line so the table cell renders correctly.
+        message = (f.get("message") or "").replace("\n", " ").replace("|", "\\|")
+        lines.append(
+            f"| {idx} | {f.get('level', '')} | {f.get('type', '')} "
+            f"| {element} | {message} |"
+        )
+    return lines
+
+
+def _entry_block(entry: dict, ref: str, repo: str, image_width: int) -> list[str]:
+    fn = entry["functionName"]
+    module = entry["module"]
+    variant = entry["variant"]
+    findings = entry["findings"]
+
+    # Prefer the annotated PNG when there are findings (it visually flags
+    # the issues); fall back to the clean render so the gallery still has
+    # an image even for clean previews.
+    image_basename = entry["annotatedBasename"] or entry["cleanBasename"]
+    lines: list[str] = []
+    header_suffix = f" · `{variant}`" if variant else ""
+    lines.append(f"### `{fn}`{header_suffix}")
+    lines.append("")
+    if image_basename:
+        url = _image_url(repo, ref, module, image_basename)
+        lines.append(f'<img src="{url}" width="{image_width}" />')
+        lines.append("")
+    if findings:
+        lines.extend(_findings_table(findings))
+    else:
+        lines.append("_No findings._")
+    lines.append("")
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# readme
+# ---------------------------------------------------------------------------
+
+def cmd_readme(args: argparse.Namespace) -> int:
+    findings_path = Path(args.findings)
+    payload = json.loads(findings_path.read_text())
+    entries: list[dict] = payload.get("entries", [])
+
+    err, warn, info = _level_counts(entries)
+    findings_count = err + warn + info
+
+    by_module: dict[str, list[dict]] = {}
+    for entry in entries:
+        by_module.setdefault(entry["module"], []).append(entry)
+
+    lines = [
+        "# Accessibility Report",
+        "",
+        f"_Auto-generated from `{args.branch}`. "
+        f"{len(entries)} preview(s) across {len(by_module)} module(s) · "
+        f"{err} error(s) · {warn} warning(s) · {info} info._",
+        "",
+        "Browse inline; image URLs are pinned to the commit SHA on the "
+        "baseline branch so links keep resolving after merge.",
+        "",
+    ]
+    if findings_count == 0:
+        lines.append("No accessibility findings.")
+        lines.append("")
+
+    for module, module_entries in sorted(by_module.items()):
+        lines.append(f"## {module}")
+        lines.append("")
+        for entry in sorted(module_entries, key=lambda e: e["functionName"]):
+            lines.extend(_entry_block(entry, args.branch, args.repo, image_width=400))
+
+    out_path = Path(args.output) if args.output else None
+    body = "\n".join(lines).rstrip() + "\n"
+    if out_path:
+        out_path.write_text(body)
+    else:
+        sys.stdout.write(body)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# comment
+# ---------------------------------------------------------------------------
+
+def cmd_comment(args: argparse.Namespace) -> int:
+    findings_path = Path(args.findings)
+    payload = json.loads(findings_path.read_text())
+    entries: list[dict] = payload.get("entries", [])
+
+    err, warn, info = _level_counts(entries)
+    findings_count = err + warn + info
+
+    by_module: dict[str, list[dict]] = {}
+    for entry in entries:
+        by_module.setdefault(entry["module"], []).append(entry)
+
+    marker = "<!-- a11y-report -->"
+    lines = [
+        marker,
+        "## Accessibility Report",
+        "",
+        f"{err} error(s) · {warn} warning(s) · {info} info "
+        f"across {len(entries)} preview(s).",
+        "",
+    ]
+
+    if findings_count == 0:
+        lines.append("No accessibility findings.")
+        lines.append("")
+        # Still link the gallery thumbnails so reviewers can spot-check
+        # what was actually rendered — same data the readme would show,
+        # without the table.
+        for module, module_entries in sorted(by_module.items()):
+            lines.append(f"### {module}")
+            lines.append("")
+            for entry in sorted(module_entries, key=lambda e: e["functionName"]):
+                image = entry["annotatedBasename"] or entry["cleanBasename"]
+                if not image:
+                    continue
+                url = _image_url(args.repo, args.head_ref, module, image)
+                lines.append(
+                    f"- `{entry['functionName']}` "
+                    f'<img src="{url}" width="120" />'
+                )
+            lines.append("")
+        sys.stdout.write("\n".join(lines).rstrip() + "\n")
+        return 0
+
+    for module, module_entries in sorted(by_module.items()):
+        lines.append(f"### {module}")
+        lines.append("")
+        for entry in sorted(module_entries, key=lambda e: e["functionName"]):
+            lines.extend(_entry_block(entry, args.head_ref, args.repo, image_width=240))
+
+    sys.stdout.write("\n".join(lines).rstrip() + "\n")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = ap.add_subparsers(dest="command", required=True)
+
+    cp = sub.add_parser(
+        "copy-annotated",
+        help="Copy chosen-variant PNGs and emit findings.json",
+    )
+    cp.add_argument(
+        "--build-dir", required=True,
+        help="Path to the module's build/compose-previews directory",
+    )
+    cp.add_argument("--output-dir", required=True)
+
+    rd = sub.add_parser("readme", help="Render findings.json to README.md")
+    rd.add_argument("findings", help="Path to findings.json")
+    rd.add_argument("--repo", required=True, help="owner/repo")
+    rd.add_argument("--branch", required=True, help="Branch hosting the renders")
+    rd.add_argument(
+        "--output", default=None,
+        help="Output README path (default: stdout)",
+    )
+
+    cm = sub.add_parser("comment", help="Render findings.json to PR comment body")
+    cm.add_argument("findings", help="Path to findings.json")
+    cm.add_argument("--repo", required=True)
+    cm.add_argument(
+        "--head-ref", required=True,
+        help="a11y_pr commit SHA (or branch) for image URLs",
+    )
+
+    args = ap.parse_args()
+    handlers = {
+        "copy-annotated": cmd_copy_annotated,
+        "readme": cmd_readme,
+        "comment": cmd_comment,
+    }
+    return handlers[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/lib/test_a11y_report.py
+++ b/.github/actions/lib/test_a11y_report.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Tests for a11y-report.py.
+
+Pure stdlib (unittest) — same shape as test_compare_previews.py. Run:
+
+    python3 -m unittest .github/actions/lib/test_a11y_report.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_SPEC = importlib.util.spec_from_file_location(
+    "a11y_report", _HERE / "a11y-report.py"
+)
+ar = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(ar)
+
+
+def _preview(*, id: str, function: str, render: str = "",
+             device: str | None = None, kind: str = "COMPOSE") -> dict:
+    params: dict = {"kind": kind}
+    if device is not None:
+        params["device"] = device
+    return {
+        "id": id,
+        "functionName": function,
+        "className": "K",
+        "sourceFile": "f.kt",
+        "params": params,
+        "captures": [{"renderOutput": render}] if render else [{"renderOutput": ""}],
+    }
+
+
+def _finding(*, level: str = "WARNING", rule: str = "TouchTargetSizeCheck",
+             message: str = "Too small.") -> dict:
+    return {
+        "level": level,
+        "type": rule,
+        "message": message,
+        "viewDescription": "ComposeView",
+        "boundsInScreen": "0,0,40,40",
+    }
+
+
+class DevicePriorityTest(unittest.TestCase):
+    def test_large_round_wins(self):
+        self.assertLess(
+            ar.device_priority("id:wearos_large_round"),
+            ar.device_priority("id:wearos_small_round"),
+        )
+
+    def test_unknown_device_falls_through(self):
+        # Anything not in _DEVICE_PRIORITY scores worse than every listed
+        # device, so listed previews always win the tiebreak.
+        self.assertGreater(
+            ar.device_priority("id:phone_xl"),
+            ar.device_priority("id:wearos_small_round"),
+        )
+
+    def test_missing_device_falls_through(self):
+        self.assertGreater(
+            ar.device_priority(None),
+            ar.device_priority("id:wearos_small_round"),
+        )
+
+    def test_label_strips_id_prefix(self):
+        self.assertEqual(ar.variant_label("id:wearos_large_round"), "wearos_large_round")
+        self.assertEqual(ar.variant_label(None), "")
+
+
+class SelectVariantsTest(unittest.TestCase):
+    def test_collapses_to_one_per_function(self):
+        manifest = {
+            "module": "sample-wear",
+            "previews": [
+                _preview(id="x.ButtonPreview_1", function="ButtonPreview",
+                         device="id:wearos_small_round"),
+                _preview(id="x.ButtonPreview_2", function="ButtonPreview",
+                         device="id:wearos_large_round"),
+                _preview(id="x.BadPreview_1", function="BadPreview",
+                         device="id:wearos_small_round"),
+            ],
+        }
+        rows = ar.select_variants(manifest, {})
+        self.assertEqual(len(rows), 2)
+        # Function names sort: BadPreview, ButtonPreview.
+        self.assertEqual(rows[0]["functionName"], "BadPreview")
+        self.assertEqual(rows[0]["variant"], "wearos_small_round")
+        self.assertEqual(rows[1]["functionName"], "ButtonPreview")
+        # Large round wins over small round per the global ordering.
+        self.assertEqual(rows[1]["variant"], "wearos_large_round")
+        self.assertEqual(rows[1]["previewId"], "x.ButtonPreview_2")
+
+    def test_unknown_devices_fall_back_to_id_sort(self):
+        manifest = {
+            "module": "app",
+            "previews": [
+                _preview(id="x.Foo_b", function="Foo", device="id:phone"),
+                _preview(id="x.Foo_a", function="Foo", device="id:tablet"),
+            ],
+        }
+        rows = ar.select_variants(manifest, {})
+        # Both devices are unlisted → tied on priority, so the id-sort
+        # tiebreaker picks `Foo_a`.
+        self.assertEqual(rows[0]["previewId"], "x.Foo_a")
+
+    def test_filters_out_tile_previews(self):
+        manifest = {
+            "module": "sample-wear",
+            "previews": [
+                _preview(id="x.HelloTile_1", function="HelloTile",
+                         device="id:wearos_small_round", kind="TILE"),
+                _preview(id="x.Button_1", function="Button",
+                         device="id:wearos_large_round"),
+            ],
+        }
+        rows = ar.select_variants(manifest, {})
+        self.assertEqual([r["functionName"] for r in rows], ["Button"])
+
+    def test_merges_a11y_for_chosen_variant(self):
+        manifest = {
+            "module": "sample-wear",
+            "previews": [
+                _preview(id="x.Bad_small_round", function="Bad",
+                         render="renders/Bad_small.png"),
+            ],
+        }
+        a11y_by_id = {
+            "x.Bad_small_round": {
+                "previewId": "x.Bad_small_round",
+                "findings": [_finding()],
+                "annotatedPath": "accessibility-per-preview/Bad_small.a11y.png",
+            },
+        }
+        rows = ar.select_variants(manifest, a11y_by_id)
+        self.assertEqual(len(rows[0]["findings"]), 1)
+        self.assertEqual(
+            rows[0]["annotatedPath"],
+            "accessibility-per-preview/Bad_small.a11y.png",
+        )
+        self.assertEqual(rows[0]["renderOutput"], "renders/Bad_small.png")
+
+
+class CopyAnnotatedTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+        self.build = self.tmp / "build"
+        self.build.mkdir()
+        # Lay out the on-disk shape the plugin produces.
+        (self.build / "renders").mkdir()
+        (self.build / "renders" / "Bad_small.png").write_bytes(b"clean")
+        (self.build / "accessibility-per-preview").mkdir()
+        (self.build / "accessibility-per-preview" / "Bad_small.a11y.png").write_bytes(b"annotated")
+        (self.build / "previews.json").write_text(json.dumps({
+            "module": "sample-wear",
+            "variant": "debug",
+            "previews": [
+                _preview(id="x.Bad_small_round", function="Bad",
+                         render="renders/Bad_small.png"),
+            ],
+            "accessibilityReport": "accessibility.json",
+        }))
+        (self.build / "accessibility.json").write_text(json.dumps({
+            "module": "sample-wear",
+            "entries": [{
+                "previewId": "x.Bad_small_round",
+                "findings": [_finding()],
+                "annotatedPath": "accessibility-per-preview/Bad_small.a11y.png",
+            }],
+        }))
+
+    def test_copies_clean_and_annotated(self):
+        out = self.tmp / "out"
+        import argparse
+        ar.cmd_copy_annotated(argparse.Namespace(
+            build_dir=str(self.build),
+            output_dir=str(out),
+        ))
+        self.assertTrue((out / "renders" / "sample-wear" / "Bad_small.png").exists())
+        self.assertTrue((out / "renders" / "sample-wear" / "Bad_small.a11y.png").exists())
+        findings = json.loads((out / "findings.json").read_text())
+        self.assertEqual(len(findings["entries"]), 1)
+        entry = findings["entries"][0]
+        self.assertEqual(entry["cleanBasename"], "Bad_small.png")
+        self.assertEqual(entry["annotatedBasename"], "Bad_small.a11y.png")
+        self.assertEqual(len(entry["findings"]), 1)
+
+
+class ReadmeTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def _write_findings(self, entries: list[dict]) -> Path:
+        path = self.tmp / "findings.json"
+        path.write_text(json.dumps({"entries": entries}))
+        return path
+
+    def test_readme_with_findings_lists_them(self):
+        findings_path = self._write_findings([{
+            "module": "sample-wear",
+            "functionName": "BadWearButtonPreview",
+            "sourceFile": "Previews.kt",
+            "previewId": "x.Bad_small_round",
+            "variant": "small_round",
+            "cleanBasename": "Bad_small.png",
+            "annotatedBasename": "Bad_small.a11y.png",
+            "findings": [_finding(level="WARNING")],
+        }])
+        out = self.tmp / "README.md"
+        import argparse
+        ar.cmd_readme(argparse.Namespace(
+            findings=str(findings_path),
+            repo="org/repo",
+            branch="a11y_main",
+            output=str(out),
+        ))
+        body = out.read_text()
+        self.assertIn("Accessibility Report", body)
+        self.assertIn("BadWearButtonPreview", body)
+        # The annotated PNG wins over the clean one when there are findings.
+        self.assertIn("Bad_small.a11y.png", body)
+        self.assertIn("a11y_main", body)
+        self.assertIn("WARNING", body)
+        self.assertIn("TouchTargetSizeCheck", body)
+
+    def test_readme_clean_preview_uses_clean_render(self):
+        findings_path = self._write_findings([{
+            "module": "sample-wear",
+            "functionName": "ButtonPreview",
+            "sourceFile": "Previews.kt",
+            "previewId": "x.Button_large_round",
+            "variant": "large_round",
+            "cleanBasename": "Button_large.png",
+            "annotatedBasename": "",
+            "findings": [],
+        }])
+        out = self.tmp / "README.md"
+        import argparse
+        ar.cmd_readme(argparse.Namespace(
+            findings=str(findings_path),
+            repo="org/repo",
+            branch="a11y_main",
+            output=str(out),
+        ))
+        body = out.read_text()
+        self.assertIn("Button_large.png", body)
+        self.assertIn("No findings", body)
+
+
+class CommentTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def test_comment_carries_marker(self):
+        findings_path = self.tmp / "findings.json"
+        findings_path.write_text(json.dumps({"entries": [{
+            "module": "sample-wear",
+            "functionName": "Bad",
+            "sourceFile": "Previews.kt",
+            "previewId": "x.Bad_small_round",
+            "variant": "small_round",
+            "cleanBasename": "Bad.png",
+            "annotatedBasename": "Bad.a11y.png",
+            "findings": [_finding(level="ERROR")],
+        }]}))
+        import argparse, io, contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            ar.cmd_comment(argparse.Namespace(
+                findings=str(findings_path),
+                repo="org/repo",
+                head_ref="abc123",
+            ))
+        body = buf.getvalue()
+        self.assertTrue(body.startswith("<!-- a11y-report -->"))
+        self.assertIn("ERROR", body)
+        self.assertIn("abc123", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/a11y-report.yml
+++ b/.github/workflows/a11y-report.yml
@@ -1,0 +1,62 @@
+name: A11y Report
+
+# Demo of the accessibility-checking pipeline on `sample-wear`. Mirrors the
+# preview-baselines / preview-comment split: pushes to `main` refresh the
+# `a11y_main` baseline branch; PRs render their own report on the shared
+# `a11y_pr` branch and post a comment with the findings table. Wired only
+# for `sample-wear` for now — the deliberately-broken `BadWearButtonPreview`
+# is what makes the annotated overlay non-empty.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # `push` runs serialise on a single group so two main commits can't race
+  # the baseline branch; PR runs each get their own group so concurrent PRs
+  # don't cancel each other.
+  group: a11y-report-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  baseline:
+    name: Update a11y baseline
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      # Composite action appends a commit to the long-lived `a11y_main`
+      # branch.
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/a11y-report
+        with:
+          mode: baseline
+
+  report:
+    name: Render a11y report for PR
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      # Push annotated PNGs to the shared `a11y_pr` branch and upsert a
+      # comment on the PR.
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - uses: ./.github/actions/a11y-report
+        with:
+          mode: comment


### PR DESCRIPTION
## Summary

Adds a standalone GitHub Actions workflow that mirrors `preview-comment` but for accessibility findings.

- **Trigger:** `push` to `main` refreshes the `a11y_main` baseline branch (annotated PNGs + browsable `README.md`); `pull_request` pushes per-PR renders to `a11y_pr` and upserts a comment with the findings table (marker `<!-- a11y-report -->`).
- **Demo scope:** `sample-wear` only. The composite action runs `:sample-wear:renderAllPreviews` with `-PcomposePreview.accessibilityChecks.enabled=true` so `./gradlew check` stays clean while CI still exercises ATF against the deliberately-broken `BadWearButtonPreview` fixture.
- **Variant filter:** small Python lib in `.github/actions/lib/a11y-report.py` collapses each function to a single variant using a global device-id ordering (`id:wearos_large_round` → `id:wearos_small_round` → unlisted devices fall back to id-sort) so the report isn't drowned in fan-out variants. Tile previews are filtered out — ATF runs against the Robolectric View tree, not the Tile renderer.
- **Branch hygiene:** push step uses the same append-and-retry recipe as `preview-comment/action.yml` so concurrent PRs don't drop renders, and old comments stay resolvable via SHA-pinned image URLs.

## Test plan

- [x] `python3 -m unittest discover -s .github/actions/lib -p 'test_a11y_report.py'` — 12 unit tests covering device priority, variant selection, tile filter, copy step, README/comment rendering.
- [ ] Workflow dry-run on this PR posts a comment + pushes to `a11y_pr` against the `BadWearButtonPreview` fixture.
- [ ] After merge to `main`, baseline job populates `a11y_main` with the README gallery.
- [ ] Confirm `large_round` is the variant rendered for previews that have both small and large round annotations.

---
_Generated by [Claude Code](https://claude.ai/code/session_011dKWi46ZbEweckt6xWDRrp)_