### PR TITLE
renderer: surface why a11y overlay is skipped

### DIFF
--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityChecker.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityChecker.kt
@@ -79,6 +79,21 @@ internal object AccessibilityChecker {
         val annotated = if (screenshot != null && findings.isNotEmpty()) {
             AccessibilityOverlay.generate(screenshot, findings)
         } else null
+        if (findings.isNotEmpty() && annotated == null) {
+            // Findings present but no overlay landed — log the precondition
+            // that wasn't met so the cause is visible in CI logs without
+            // having to enable the verbose `composeai.a11y.debug` flag.
+            // [AccessibilityOverlay.generate] logs the more specific reason
+            // when it gets to run; this branch covers the case where it
+            // wasn't called at all (annotation disabled or no screenshot).
+            val reason = when {
+                screenshot == null -> "screenshot=null (annotation disabled or capture not wired)"
+                else -> "AccessibilityOverlay.generate returned null (see preceding stderr)"
+            }
+            System.err.println(
+                "[compose-a11y] $previewId: ${findings.size} finding(s) but no overlay — $reason",
+            )
+        }
 
         // Path in the entry is stored relative to the aggregate
         // `accessibility.json` (which lives in the plugin output root next

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityOverlay.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityOverlay.kt
@@ -61,10 +61,42 @@ internal object AccessibilityOverlay {
      * @return the destination [File] when written, `null` otherwise.
      */
     fun generate(sourcePng: File, findings: List<AccessibilityFinding>): File? {
-        if (findings.isEmpty() || !sourcePng.exists()) return null
+        if (findings.isEmpty()) return null
+        if (!sourcePng.exists()) {
+            // The render pipeline is supposed to write outputFile before
+            // calling us, so a missing source means the wiring shifted —
+            // worth surfacing rather than silently dropping the overlay.
+            System.err.println(
+                "[compose-a11y] overlay skipped: source PNG missing at ${sourcePng.absolutePath}",
+            )
+            return null
+        }
+        return try {
+            generateInternal(sourcePng, findings)
+        } catch (t: Throwable) {
+            // Without this catch, an exception inside Canvas / Bitmap.createBitmap
+            // would propagate through writePerPreviewReport and skip the JSON
+            // report too — masking the original failure as "no a11y data".
+            // Logging the stack here keeps the report intact and tells CI logs
+            // exactly what to fix.
+            System.err.println(
+                "[compose-a11y] overlay failed for ${sourcePng.name}: " +
+                    "${t.javaClass.simpleName}: ${t.message}",
+            )
+            t.printStackTrace(System.err)
+            null
+        }
+    }
 
+    private fun generateInternal(sourcePng: File, findings: List<AccessibilityFinding>): File? {
         val source = BitmapFactory.decodeFile(sourcePng.absolutePath)
-            ?: return null
+        if (source == null) {
+            System.err.println(
+                "[compose-a11y] overlay skipped: BitmapFactory could not decode " +
+                    "${sourcePng.absolutePath} (size=${sourcePng.length()} bytes)",
+            )
+            return null
+        }
 
         val aspect = source.width.toFloat() / source.height.toFloat()
         val stacked = aspect >= STACK_ASPECT_THRESHOLD


### PR DESCRIPTION
## Summary

Follow-up to #182. The sample-wear demo surfaced an ATF finding on `BadWearButtonPreview` but the comment fell back to the clean PNG — the annotated `.a11y.png` was never produced. Inspecting the `a11y_pr` branch confirmed that `accessibility.json` had `annotatedPath: null` for that preview, so the publishing pipeline had nothing to copy.

`AccessibilityOverlay.generate` has three silent null-returning paths (no findings, missing source, `BitmapFactory.decodeFile` returning null) and `AccessibilityChecker.writePerPreviewReport` has a fourth (`screenshot == null`). Today none of them log anything, so CI gives no signal about which case fired. This change makes each path log a one-line stderr message that pinpoints the cause without needing the verbose `composeai.a11y.debug` flag, and adds a try/catch around the `Canvas`/`Bitmap` pipeline so an unexpected exception inside `drawStacked` / `drawSideBySide` doesn't also take the JSON report down with it.

No behaviour change when overlays succeed.

## Test plan

- [ ] Confirm `:gradle-plugin:test`, `:renderer-android:test`, and the existing CI green.
- [ ] Re-run the `a11y-report` workflow on this PR and read the `Render a11y report for PR` job log for the new `[compose-a11y]` line — that tells us the precondition that fails for `BadWearButtonPreview`.
- [ ] Once the cause is known, follow up with the actual fix in this PR (or a child commit).

---
_Generated by [Claude Code](https://claude.ai/code/session_011dKWi46ZbEweckt6xWDRrp)_