### PR TITLE
fix: keep .a11y.png siblings during stale-render cleanup

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -78,7 +78,20 @@ The CLI ([cli/](cli/src/main/kotlin/ee/schimke/composeai/cli/)) and VS Code exte
 
 - **Configuration cache is strict** (`problems=fail` in [gradle.properties](gradle.properties)). Changes to plugin code must resolve classpaths/JVM args at configuration time via lazy providers — never call `.files` inside a task action or touch `project.*` at execution time.
 - **CMP Desktop previews require `implementation(compose.components.uiToolingPreview)`** — the bundled `@Preview` has `SOURCE` retention and is invisible to ClassGraph otherwise.
-- **Toolchain:** Java 17, Kotlin 2.2.21, Gradle 9.4.1+, AGP 9.1.0, CMP 1.10.3. Always use the bundled `./gradlew` wrapper.
+- **Toolchain:** Java 17, Kotlin 2.2.21, Gradle 9.4.1+, AGP 9.1.0, CMP 1.10.3. Always use the bundled `./gradlew` wrapper. Don't loosen the toolchain to a newer JDK to avoid the install — AGP 9.1.0 / Robolectric still target 17, and bumping silently produces classes-vs-resources skew on the consumer's unit-test classpath.
+- **Bringing up a fresh sandbox.** When `./gradlew` fails with "Unable to download toolchain": `sudo apt-get install -y openjdk-17-jdk-headless` — Gradle's auto-detection picks it up from `/usr/lib/jvm/`. When an Android-flavoured sample then fails with "SDK location not found", install the SDK manually (no apt package covers `compileSdk = 36`):
+  ```
+  curl -fsSL -o /tmp/cmdline-tools.zip \
+    https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip
+  sudo unzip -q /tmp/cmdline-tools.zip -d /tmp && \
+    sudo mkdir -p /opt/android-sdk/cmdline-tools && \
+    sudo mv /tmp/cmdline-tools /opt/android-sdk/cmdline-tools/latest
+  yes | sudo /opt/android-sdk/cmdline-tools/latest/bin/sdkmanager --licenses
+  sudo /opt/android-sdk/cmdline-tools/latest/bin/sdkmanager \
+    "platforms;android-36" "platform-tools" "build-tools;36.0.0"
+  echo "sdk.dir=/opt/android-sdk" > local.properties
+  ```
+  `local.properties` is `.gitignore`d; CI uses `ANDROID_HOME` instead. Re-running `:sample-wear:renderAllPreviews` after this end-to-end takes ~3 min cold.
 - **Do not run `collectPreviewInfo` / other internal plugin tasks by hand** — the plugin wires them as dependencies of `renderAllPreviews`.
 - **Plugin version** is driven by `.release-please-manifest.json` at the repo root (single source of truth, maintained by release-please). The three `build.gradle.kts` files read that manifest and compute next-patch `-SNAPSHOT` for local builds; CI overrides with the `PLUGIN_VERSION` env var from the git tag or `snapshot.yml`. See [docs/RELEASING.md](RELEASING.md).
 - **Android renderer is pinned to Robolectric SDK 35** via `@Config(sdk = [35])` in [RobolectricRenderTest.kt](renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt) (`renderer-android` itself is on `compileSdk = 36`). Capture depends on Robolectric's shadowed `ImageReader` / `PixelCopy` path, historically fragile across SDK × Robolectric combinations (e.g. `ShadowNativeImageReaderSurfaceImage.nativeCreatePlanes` is `maxSdk`-gated). Re-run `:sample-android:renderAllPreviews` end-to-end when bumping either the SDK level or Robolectric.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -287,14 +287,19 @@ internal object ComposePreviewTasks {
     /**
      * Deletes files inside [rendersDir] that aren't referenced by [manifest].
      *
-     * Keeps three kinds of files:
+     * Keeps four kinds of files:
      * 1. Exact `renderOutput` matches from non-parameterized previews.
      * 2. `<stem>_*.<ext>` fan-out files where `<stem>` belongs to a
      *    `@PreviewParameter` preview — the renderer itself cleans up its
      *    own stale fan-outs (it knows the exact filenames), so the Gradle
      *    side deliberately stays conservative and doesn't delete files it
      *    can't be sure are stale.
-     * 3. Non-PNG/GIF files that aren't in the plugin's output domain.
+     * 3. `<stem>.a11y.png` siblings of registered renders. The renderer's
+     *    `AccessibilityOverlay` writes these next to the clean PNG when
+     *    a preview produces ATF findings; the manifest doesn't list them
+     *    (the pointer lives in `accessibility.json` instead), so without
+     *    this exemption they'd be deleted between writing and publishing.
+     * 4. Non-PNG/GIF files that aren't in the plugin's output domain.
      *
      * Anything else (PNGs or GIFs that were produced for a now-removed
      * preview) gets removed so downstream tools compare the manifest
@@ -339,10 +344,25 @@ internal object ComposePreviewTasks {
                 val rel = f.relativeTo(rendersDir).invariantSeparatorsPath
                 if (rel in expectedRelPaths) return@forEach
                 if (paramStems.any { it.matches(rel, f.name) }) return@forEach
+                if (isA11ySiblingOfExpected(rel, expectedRelPaths)) return@forEach
                 if (!f.delete()) {
                     logger.warn("compose-preview: couldn't delete stale render $f")
                 }
             }
+    }
+
+    // `<stem>.a11y.png` lives next to the clean `<stem>.png` registered in
+    // the manifest. Match by mechanical suffix-strip rather than scanning
+    // accessibility.json: the cleanup runs whether a11y is enabled or not,
+    // and a stale `.a11y.png` whose clean sibling has been removed is still
+    // garbage we want gone.
+    internal fun isA11ySiblingOfExpected(
+        rel: String,
+        expectedRelPaths: Set<String>,
+    ): Boolean {
+        if (!rel.endsWith(".a11y.png")) return false
+        val cleanSibling = rel.removeSuffix(".a11y.png") + ".png"
+        return cleanSibling in expectedRelPaths
     }
 
     private fun String.stripRendersPrefix(): String? {

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
@@ -1,0 +1,44 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class CleanStaleRendersTest {
+
+    private val expected = setOf(
+        "Foo.png",
+        "sub/Bar.png",
+        "Baz_TIME_500ms.png",
+    )
+
+    @Test
+    fun `keeps a11y sibling of registered render`() {
+        assertThat(ComposePreviewTasks.isA11ySiblingOfExpected("Foo.a11y.png", expected)).isTrue()
+        assertThat(ComposePreviewTasks.isA11ySiblingOfExpected("sub/Bar.a11y.png", expected)).isTrue()
+    }
+
+    @Test
+    fun `keeps a11y sibling of fan-out capture`() {
+        // Multi-capture previews encode dimensions in the basename
+        // (`_TIME_500ms`); the a11y overlay sits next to the same basename.
+        assertThat(
+            ComposePreviewTasks.isA11ySiblingOfExpected("Baz_TIME_500ms.a11y.png", expected),
+        ).isTrue()
+    }
+
+    @Test
+    fun `drops a11y png with no clean sibling`() {
+        assertThat(
+            ComposePreviewTasks.isA11ySiblingOfExpected("Removed.a11y.png", expected),
+        ).isFalse()
+    }
+
+    @Test
+    fun `ignores non-a11y png entirely`() {
+        // Plain renders are handled by the exact-match branch in
+        // cleanStaleRenders; this helper should pass them through (false)
+        // so the caller decides.
+        assertThat(ComposePreviewTasks.isA11ySiblingOfExpected("Foo.png", expected)).isFalse()
+        assertThat(ComposePreviewTasks.isA11ySiblingOfExpected("Foo.gif", expected)).isFalse()
+    }
+}


### PR DESCRIPTION
## Summary

Root-causes the missing `.a11y.png` overlay observed in #182 / #184. With JDK 17 + Android SDK 36 wired into the sandbox, `:sample-wear:renderAllPreviews -PcomposePreview.accessibilityChecks.enabled=true` reproduces the bug locally — and the new diagnostic logging from #184 does NOT fire. The renderer happily writes a 33KB annotated PNG and `accessibility.json` correctly records its `annotatedPath`. The file just doesn't survive to publish.

`cleanStaleRenders` (in `ComposePreviewTasks.kt`) walks `build/compose-previews/renders/` at the end of `renderAllPreviews` and deletes any `.png`/`.gif` that isn't referenced by a `Capture.renderOutput` in the manifest. Annotated overlays live next to the clean PNG as `<stem>.a11y.png` siblings, but the manifest doesn't list them — the pointer lives in `accessibility.json` instead — so the cleanup pass treats them as stale and removes them.

The fix adds a fourth exemption to the cleanup rule: keep `<stem>.a11y.png` whenever `<stem>.png` is in `expectedRelPaths`. Stale a11y files for removed previews still get collected because the clean sibling is gone too.

Also documents the JDK 17 + Android SDK install steps in `docs/AGENTS.md`, since the dead-ends getting them set up in a fresh sandbox are exactly how I ended up identifying this bug. Saves the next agent the same scavenger hunt.

## Test plan

- [x] `:gradle-plugin:test --tests "ee.schimke.composeai.plugin.CleanStaleRendersTest"` — 4 new unit tests for the helper (a11y sibling kept, fan-out a11y sibling kept, orphan a11y dropped, plain `.png` not classified as a11y).
- [x] `:sample-wear:renderAllPreviews -PcomposePreview.accessibilityChecks.enabled=true` locally with JDK 17 + Android SDK 36 — `BadWearButtonPreview_Devices_-_Small_Round.a11y.png` now exists in `build/compose-previews/renders/` after the build (33989 bytes).
- [ ] After merge, `a11y-report` workflow on `sample-wear` should publish the annotated overlay and the PR-comment image link should resolve to the badge+legend image rather than the clean PNG.

---
_Generated by [Claude Code](https://claude.ai/code/session_011dKWi46ZbEweckt6xWDRrp)_