### PR TITLE
discover: surface private @Preview functions

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -967,6 +967,70 @@ class DiscoveryFunctionalTest {
     }
 
     @Test
+    fun `discoverPreviews finds private and internal previews`() {
+        // Teams that don't want @Preview functions to leak into their public
+        // API mark them `private` (or `internal`). Kotlin compiles `private
+        // fun` to JVM `private` and ClassGraph's default visibility filter
+        // drops them; `internal fun` compiles to JVM `public` (with the
+        // `name$module` mangle) so it has always been visible. Asserting both
+        // shapes so the visibility regression doesn't return on either axis.
+        val projectDir = createCmpTestProject()
+
+        val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+        srcFile.writeText(
+            """
+            package test
+
+            import androidx.compose.ui.tooling.preview.Preview
+            import androidx.compose.foundation.background
+            import androidx.compose.foundation.layout.Box
+            import androidx.compose.foundation.layout.size
+            import androidx.compose.runtime.Composable
+            import androidx.compose.ui.Modifier
+            import androidx.compose.ui.graphics.Color
+            import androidx.compose.ui.unit.dp
+
+            @Preview
+            @Composable
+            fun PublicPreview() {
+                Box(modifier = Modifier.size(50.dp).background(Color.Red))
+            }
+
+            @Preview
+            @Composable
+            internal fun InternalPreview() {
+                Box(modifier = Modifier.size(50.dp).background(Color.Green))
+            }
+
+            @Preview
+            @Composable
+            private fun PrivatePreview() {
+                Box(modifier = Modifier.size(50.dp).background(Color.Blue))
+            }
+            """.trimIndent()
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments("discoverPreviews", "--stacktrace")
+            .withPluginClasspath()
+            .build()
+
+        assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+        val manifest = json.decodeFromString<PreviewManifest>(
+            File(projectDir, "build/compose-previews/previews.json").readText()
+        )
+        // `internal fun` has its JVM name mangled to `InternalPreview$<module>`
+        // so we match by prefix rather than exact equality.
+        val names = manifest.previews.map { it.functionName }
+        assertThat(names).contains("PublicPreview")
+        assertThat(names).contains("PrivatePreview")
+        assertThat(names.any { it.startsWith("InternalPreview") }).isTrue()
+        assertThat(manifest.previews).hasSize(3)
+    }
+
+    @Test
     fun `failOnEmpty fails the build and emits diagnostics when no previews exist`() {
         val projectDir = createCmpTestProject()
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -146,6 +146,13 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
             ClassGraph()
                 .enableMethodInfo()
                 .enableAnnotationInfo()
+                // Kotlin `private fun` compiles to a JVM `private` method and
+                // ClassGraph's default visibility filter drops it; `internal
+                // fun` compiles to JVM `public` (with the `name$module` mangle)
+                // so it slips through. Without this flag, projects that follow
+                // the "private @Preview to keep them out of the namespace"
+                // convention silently surface zero previews.
+                .ignoreMethodVisibility()
                 .overrideClasspath(classpath.map { it.absolutePath })
                 .ignoreParentClassLoaders()
                 .scan().use { scanResult ->


### PR DESCRIPTION
## Summary

- ClassGraph's default visibility filter dropped Kotlin `private fun` previews (JVM `private`) while `internal fun` (JVM `public` with `name$module` mangling) slipped through, so teams that mark previews `private` to keep them out of the public namespace saw zero previews discovered.
- Enables `ignoreMethodVisibility()` on the ClassGraph builder in `DiscoverPreviewsTask`. Annotation-FQN filtering is unchanged, so non-preview private methods don't pollute the manifest. No new dependency, no opt-in flag.
- Adds a `DiscoveryFunctionalTest` case asserting public, internal, and private `@Preview` functions all land in `previews.json`.

## Test plan

- [x] `./gradlew :gradle-plugin:functionalTest --tests "ee.schimke.composeai.plugin.DiscoveryFunctionalTest.discoverPreviews finds private and internal previews"` — passes locally
- [ ] Full `./gradlew check` in CI
- [ ] `./gradlew :sample-cmp:renderAllPreviews` / `:sample-android:renderAllPreviews` end-to-end (verifies the renderer can also invoke a private preview, not just discover it)


---
_Generated by [Claude Code](https://claude.ai/code/session_014myWrRZgm2554h5bhY2w3d)_