### PR TITLE
ci: gate a11y PR comment on findings actually changing

### DIFF
--- a/.github/actions/a11y-report/action.yml
+++ b/.github/actions/a11y-report/action.yml
@@ -53,7 +53,55 @@ runs:
           --build-dir "${MODULE}/build/compose-previews" \
           --output-dir _a11y_renders
 
+    - name: Fetch baseline findings
+      if: inputs.mode == 'comment'
+      shell: bash
+      env:
+        BASELINE_BRANCH: ${{ inputs.baseline-branch }}
+      run: |
+        set -euo pipefail
+        # Pull `findings.json` from a11y_main so the comment subcommand can
+        # compare and stay silent when nothing changed. Default to an empty
+        # entries list when the branch hasn't been seeded yet — the python
+        # treats a missing baseline the same as an empty one.
+        if git ls-remote --exit-code origin "$BASELINE_BRANCH" >/dev/null 2>&1; then
+          git fetch origin "$BASELINE_BRANCH"
+          git show "origin/${BASELINE_BRANCH}:findings.json" \
+            > _baseline_findings.json 2>/dev/null \
+            || echo '{"entries":[]}' > _baseline_findings.json
+        else
+          echo '{"entries":[]}' > _baseline_findings.json
+        fi
+
+    - name: Generate PR comment body (and detect change vs baseline)
+      id: comment
+      if: inputs.mode == 'comment'
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+        REPO: ${{ github.repository }}
+        PR_BRANCH: ${{ inputs.pr-branch }}
+      run: |
+        set -euo pipefail
+        # The python writes nothing when findings match the baseline, so an
+        # empty file is the signal to skip both the push and the upsert.
+        # `--head-ref` here is provisional (the SHA we'll push isn't known
+        # yet); if we DO end up pushing, the next step rewrites it.
+        python3 "$ACTION_PATH/../lib/a11y-report.py" comment \
+          _a11y_renders/findings.json \
+          --repo "$REPO" \
+          --head-ref "$PR_BRANCH" \
+          --baseline _baseline_findings.json \
+          > _a11y_comment.md
+        if [ -s _a11y_comment.md ]; then
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          echo "No a11y changes vs ${PR_BRANCH}; skipping push + comment."
+        fi
+
     - name: Generate README for target branch
+      if: inputs.mode == 'baseline' || steps.comment.outputs.changed == 'true'
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
@@ -63,8 +111,8 @@ runs:
         set -euo pipefail
         # Image URLs reference the branch name rather than a SHA — same
         # contract preview-baselines uses for the on-branch README. The PR
-        # comment (generated separately below) is what pins to a SHA so it
-        # survives the PR merge.
+        # comment (regenerated below with the just-pushed SHA) is what pins
+        # the URLs that need to survive the PR merge.
         python3 "$ACTION_PATH/../lib/a11y-report.py" readme \
           _a11y_renders/findings.json \
           --repo "$REPO" \
@@ -73,6 +121,7 @@ runs:
 
     - name: Push a11y renders branch
       id: push
+      if: inputs.mode == 'baseline' || steps.comment.outputs.changed == 'true'
       shell: bash
       env:
         # Route every templated value through env so a malicious branch /
@@ -150,8 +199,8 @@ runs:
           sleep "$delay"
         done
 
-    - name: Generate PR comment body
-      if: inputs.mode == 'comment'
+    - name: Re-render PR comment body with pushed SHA
+      if: inputs.mode == 'comment' && steps.comment.outputs.changed == 'true'
       shell: bash
       env:
         ACTION_PATH: ${{ github.action_path }}
@@ -160,9 +209,10 @@ runs:
         HEAD_SHA: ${{ steps.push.outputs.head_sha }}
       run: |
         set -euo pipefail
-        # Fall back to the branch name when no commit was pushed (e.g. the
-        # baseline-equivalent skip path landed). The body still resolves —
-        # branch URLs follow the tip until something else moves it.
+        # The earlier comment-generation step used the branch name as a
+        # provisional ref because the SHA wasn't known yet. Now that push
+        # has run, swap in the actual SHA so the comment's image URLs stay
+        # resolvable after a11y_pr advances or the PR merges.
         HEAD_REF="${HEAD_SHA:-$PR_BRANCH}"
         python3 "$ACTION_PATH/../lib/a11y-report.py" comment \
           _a11y_renders/findings.json \
@@ -171,7 +221,7 @@ runs:
           > _a11y_comment.md
 
     - name: Upsert PR comment
-      if: inputs.mode == 'comment'
+      if: inputs.mode == 'comment' && steps.comment.outputs.changed == 'true'
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/actions/lib/a11y-report.py
+++ b/.github/actions/lib/a11y-report.py
@@ -324,10 +324,54 @@ def cmd_readme(args: argparse.Namespace) -> int:
 # comment
 # ---------------------------------------------------------------------------
 
+def _findings_fingerprint(entries: list[dict]) -> tuple:
+    """Stable representation of (preview, findings) used for change detection.
+
+    Compares only the data a reviewer would care about — module, previewId,
+    and the findings list itself. Filenames (`cleanBasename`,
+    `annotatedBasename`) are excluded because identical findings can move
+    around between files when the renderer renames variants, and we don't
+    want to wake the PR comment for that. Findings are tuple-ified so the
+    comparison is hash-stable and order-insensitive (sorted below).
+    """
+    def finding_tuple(f: dict) -> tuple:
+        return (
+            f.get("level"),
+            f.get("type"),
+            f.get("message"),
+            f.get("viewDescription"),
+            f.get("boundsInScreen"),
+        )
+    return tuple(
+        (
+            e["module"],
+            e["previewId"],
+            tuple(sorted(finding_tuple(f) for f in e.get("findings", []))),
+        )
+        for e in sorted(entries, key=lambda e: (e["module"], e["previewId"]))
+    )
+
+
 def cmd_comment(args: argparse.Namespace) -> int:
     findings_path = Path(args.findings)
     payload = json.loads(findings_path.read_text())
     entries: list[dict] = payload.get("entries", [])
+
+    # When a baseline (the on-`a11y_main` findings.json) is provided, stay
+    # silent if nothing has changed — the workflow runs on every PR and a
+    # comment that says "no findings" on PRs that don't touch a11y was
+    # noted as distracting in user feedback. Empty stdout signals the
+    # action to skip both the push and the upsert.
+    if args.baseline:
+        baseline_path = Path(args.baseline)
+        if baseline_path.exists():
+            try:
+                baseline_payload = json.loads(baseline_path.read_text())
+            except json.JSONDecodeError:
+                baseline_payload = {"entries": []}
+            baseline_entries = baseline_payload.get("entries", [])
+            if _findings_fingerprint(entries) == _findings_fingerprint(baseline_entries):
+                return 0  # silent
 
     err, warn, info = _level_counts(entries)
     findings_count = err + warn + info
@@ -414,6 +458,12 @@ def main() -> int:
     cm.add_argument(
         "--head-ref", required=True,
         help="a11y_pr commit SHA (or branch) for image URLs",
+    )
+    cm.add_argument(
+        "--baseline", default=None,
+        help="Optional baseline findings.json (from a11y_main). When set, "
+             "the comment subcommand emits empty stdout if findings haven't "
+             "changed vs the baseline — the action takes that as 'skip'.",
     )
 
     args = ap.parse_args()

--- a/.github/actions/lib/test_a11y_report.py
+++ b/.github/actions/lib/test_a11y_report.py
@@ -262,18 +262,26 @@ class CommentTest(unittest.TestCase):
         self.tmp = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, self.tmp)
 
-    def test_comment_carries_marker(self):
-        findings_path = self.tmp / "findings.json"
-        findings_path.write_text(json.dumps({"entries": [{
+    def _entry(self, *, findings: list[dict] | None = None) -> dict:
+        return {
             "module": "sample-wear",
             "functionName": "Bad",
             "sourceFile": "Previews.kt",
             "previewId": "x.Bad_small_round",
             "variant": "small_round",
             "cleanBasename": "Bad.png",
-            "annotatedBasename": "Bad.a11y.png",
-            "findings": [_finding(level="ERROR")],
-        }]}))
+            "annotatedBasename": "Bad.a11y.png" if findings else "",
+            "findings": findings or [],
+        }
+
+    def _run_comment(self, current_entries, *, baseline_entries=None):
+        findings_path = self.tmp / "findings.json"
+        findings_path.write_text(json.dumps({"entries": current_entries}))
+        baseline_path = None
+        if baseline_entries is not None:
+            baseline_path = self.tmp / "baseline.json"
+            baseline_path.write_text(json.dumps({"entries": baseline_entries}))
+
         import argparse, io, contextlib
         buf = io.StringIO()
         with contextlib.redirect_stdout(buf):
@@ -281,11 +289,44 @@ class CommentTest(unittest.TestCase):
                 findings=str(findings_path),
                 repo="org/repo",
                 head_ref="abc123",
+                baseline=str(baseline_path) if baseline_path else None,
             ))
-        body = buf.getvalue()
+        return buf.getvalue()
+
+    def test_comment_carries_marker(self):
+        body = self._run_comment([self._entry(findings=[_finding(level="ERROR")])])
         self.assertTrue(body.startswith("<!-- a11y-report -->"))
         self.assertIn("ERROR", body)
         self.assertIn("abc123", body)
+
+    def test_silent_when_findings_match_baseline(self):
+        # Identical findings on both sides → no comment body, the action
+        # uses the empty stdout to skip the upsert and the branch push.
+        entry = self._entry(findings=[_finding(level="ERROR")])
+        body = self._run_comment([entry], baseline_entries=[entry])
+        self.assertEqual(body, "")
+
+    def test_emits_when_finding_added(self):
+        baseline_entry = self._entry(findings=[])
+        current_entry = self._entry(findings=[_finding(level="ERROR")])
+        body = self._run_comment([current_entry], baseline_entries=[baseline_entry])
+        self.assertIn("<!-- a11y-report -->", body)
+
+    def test_emits_when_finding_removed(self):
+        baseline_entry = self._entry(findings=[_finding(level="ERROR")])
+        current_entry = self._entry(findings=[])
+        body = self._run_comment([current_entry], baseline_entries=[baseline_entry])
+        # Different finding count on the baseline side → fingerprint diverges.
+        self.assertIn("<!-- a11y-report -->", body)
+
+    def test_silent_when_baseline_missing_but_no_findings(self):
+        # No baseline file at all behaves like an empty baseline; so a PR
+        # that introduces zero findings on a fresh repo still goes silent.
+        body = self._run_comment(
+            [self._entry(findings=[])],
+            baseline_entries=[self._entry(findings=[])],
+        )
+        self.assertEqual(body, "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Pivots the a11y-report PR comment from "post on every PR" to "post only when findings actually change vs `a11y_main`". A fresh full-report comment landing on #188 (a discovery-task PR) was flagged as distracting noise — this skips the comment and the `a11y_pr` push when the current run's findings match the baseline.

How it works:
- The python `comment` subcommand grows a `--baseline` arg pointing at `a11y_main`'s `findings.json`.
- It computes a stable fingerprint per preview (`module`, `previewId`, sorted findings tuple — filenames excluded) and exits with empty stdout when the current and baseline fingerprints match.
- The composite action fetches the baseline before generating the comment body. Empty body ⇒ `outputs.changed=false` ⇒ both the push to `a11y_pr` and the upsert step are skipped.
- Push-to-main / `workflow_dispatch` baseline runs are unaffected — they always update `a11y_main`.

The first comment-generation pass uses the branch name as a provisional `--head-ref`; if push runs, a second pass rewrites the body with the just-pushed SHA so image URLs survive merge — matching the `preview-comment` SHA-pinning behaviour.

## Test plan

- [x] `python3 -m unittest discover -s .github/actions/lib -p 'test_a11y_report.py'` — 16 tests, including 4 new comment cases (match, finding added, finding removed, no-finding baseline).
- [ ] Open a doc-only PR after merge; the a11y-report job runs but no comment lands.
- [ ] Open a PR that flips `accessibilityChecks.enabled` or breaks a Wear preview's a11y; the comment lands with the new findings.
- [ ] Verify `Update a11y baseline` job on main keeps refreshing `a11y_main` after the PR-side gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_011dKWi46ZbEweckt6xWDRrp)_