### PR TITLE
feat(renderer): ANI legend with matched colours, skip dynamic previews

### DIFF
--- a/.github/actions/lib/a11y-report.py
+++ b/.github/actions/lib/a11y-report.py
@@ -97,6 +97,25 @@ def load_previews(build_dir: Path) -> tuple[dict, dict]:
     return manifest, a11y_by_id
 
 
+def is_dynamic_preview(preview: dict) -> bool:
+    """Returns True for `@ScrollingPreview` / `@AnimatedPreview` variants.
+
+    Dynamic captures move during the render — `scroll != null` covers TOP,
+    END, LONG, and GIF scroll modes, and a `.gif` extension catches
+    `@AnimatedPreview`'s frame-strip output. Including them in the a11y
+    report would mean overlaying the legend onto a tall stitched scroll or
+    a single animation frame, neither of which is a useful "what TalkBack
+    sees" picture. The static variant of the same function (when it
+    exists) carries the a11y signal.
+    """
+    for capture in preview.get("captures", []):
+        if capture.get("scroll") is not None:
+            return True
+        if (capture.get("renderOutput") or "").endswith(".gif"):
+            return True
+    return False
+
+
 def select_variants(manifest: dict, a11y_by_id: dict) -> list[dict]:
     """Pick one variant per (functionName) and merge in a11y data.
 
@@ -104,16 +123,22 @@ def select_variants(manifest: dict, a11y_by_id: dict) -> list[dict]:
     module, functionName, sourceFile, previewId, variant, renderOutput
     (module-relative), annotatedPath (module-relative), findings.
 
-    Tile previews (``params.kind == "TILE"``) are filtered out — ATF runs
-    against the Robolectric View tree, but Wear Tiles render through
-    `TilePreviewRenderer`, so listing them with empty findings would falsely
-    imply they were checked.
+    Filtered out:
+    * Tile previews (``params.kind == "TILE"``) — ATF runs against the
+      Robolectric View tree, but Wear Tiles render through
+      `TilePreviewRenderer`, so listing them with empty findings would
+      falsely imply they were checked.
+    * Scroll / animation captures (``@ScrollingPreview`` /
+      ``@AnimatedPreview``) — see [is_dynamic_preview]. Functions whose
+      ONLY variants are dynamic drop out of the report entirely.
     """
     module = manifest["module"]
     by_fn: dict[str, list[dict]] = {}
     for preview in manifest.get("previews", []):
         kind = (preview.get("params") or {}).get("kind", "COMPOSE")
         if kind != "COMPOSE":
+            continue
+        if is_dynamic_preview(preview):
             continue
         by_fn.setdefault(preview["functionName"], []).append(preview)
 

--- a/.github/actions/lib/test_a11y_report.py
+++ b/.github/actions/lib/test_a11y_report.py
@@ -125,6 +125,36 @@ class SelectVariantsTest(unittest.TestCase):
         rows = ar.select_variants(manifest, {})
         self.assertEqual([r["functionName"] for r in rows], ["Button"])
 
+    def test_filters_out_scroll_captures(self):
+        scroll_preview = _preview(
+            id="x.LongList_1", function="LongList",
+            device="id:wearos_large_round",
+        )
+        scroll_preview["captures"] = [
+            {"renderOutput": "renders/LongList.png", "scroll": {"mode": "LONG"}},
+        ]
+        manifest = {
+            "module": "sample-wear",
+            "previews": [
+                scroll_preview,
+                _preview(id="x.Button_1", function="Button",
+                         device="id:wearos_large_round"),
+            ],
+        }
+        rows = ar.select_variants(manifest, {})
+        # The scroll-only function drops; the static button stays.
+        self.assertEqual([r["functionName"] for r in rows], ["Button"])
+
+    def test_filters_out_gif_animations(self):
+        gif_preview = _preview(
+            id="x.Anim_1", function="Anim",
+            device="id:phone",
+        )
+        gif_preview["captures"] = [{"renderOutput": "renders/Anim.gif"}]
+        manifest = {"module": "app", "previews": [gif_preview]}
+        rows = ar.select_variants(manifest, {})
+        self.assertEqual(rows, [])
+
     def test_merges_a11y_for_chosen_variant(self):
         manifest = {
             "module": "sample-wear",

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/VerifyAccessibilityTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/VerifyAccessibilityTask.kt
@@ -56,9 +56,22 @@ abstract class VerifyAccessibilityTask : DefaultTask() {
     )
 
     @Serializable
+    private data class A11yNode(
+        val label: String,
+        val role: String? = null,
+        val states: List<String> = emptyList(),
+        val boundsInScreen: String,
+    )
+
+    @Serializable
     private data class A11yEntry(
         val previewId: String,
         val findings: List<A11yFinding>,
+        // Mirror of [renderer-android/RenderManifest.AccessibilityNode] —
+        // round-trips through the aggregate JSON so downstream tools (CLI,
+        // VS Code, the python report lib) can read the ANI overlay data
+        // without going through the renderer's classpath.
+        val nodes: List<A11yNode> = emptyList(),
         val annotatedPath: String? = null,
     )
 

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityChecker.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityChecker.kt
@@ -31,7 +31,19 @@ internal object AccessibilityChecker {
 
     private val json = Json { prettyPrint = true; encodeDefaults = true }
 
-    fun check(previewId: String, root: View): List<AccessibilityFinding> {
+    /**
+     * Output of a single a11y pass over the rendered View tree. Both
+     * fields are populated unconditionally (so the Paparazzi-style overlay
+     * can render even when nothing's wrong), but consumers usually treat
+     * empty [findings] as "no ATF problems" and empty [nodes] as "a11y
+     * was disabled or the View has no labelled content".
+     */
+    data class Result(
+        val findings: List<AccessibilityFinding>,
+        val nodes: List<AccessibilityNode>,
+    )
+
+    fun analyze(previewId: String, root: View): Result {
         val originalFingerprint = Build.FINGERPRINT
         val needsSwap = originalFingerprint == "robolectric"
         if (needsSwap) {
@@ -49,12 +61,68 @@ internal object AccessibilityChecker {
                 val typeCounts = allResults.groupingBy { it.type?.name ?: "null" }.eachCount()
                 println("[compose-a11y] $previewId: ran ${checks.size} check(s), got ${allResults.size} raw result(s) on ${root.javaClass.simpleName} (attached=${root.isAttachedToWindow}) types=$typeCounts")
             }
-            return allResults.mapNotNull { it.toFinding() }
+            val findings = allResults.mapNotNull { it.toFinding() }
+            val nodes = extractNodes(hierarchy)
+            return Result(findings = findings, nodes = nodes)
         } finally {
             if (needsSwap) {
                 ShadowBuild.setFingerprint(originalFingerprint)
             }
         }
+    }
+
+    /** Back-compat shim — most call sites only care about findings. */
+    fun check(previewId: String, root: View): List<AccessibilityFinding> =
+        analyze(previewId, root).findings
+
+    private fun extractNodes(hierarchy: AccessibilityHierarchyAndroid): List<AccessibilityNode> {
+        val views = hierarchy.activeWindow.allViews
+        val out = mutableListOf<AccessibilityNode>()
+        for (v in views) {
+            val bounds = v.boundsInScreen
+            if (bounds == null || bounds.width <= 0 || bounds.height <= 0) continue
+            // Prefer contentDescription (what TalkBack actually announces);
+            // fall back to visible text. Both are SpannableStrings — toString()
+            // strips ATF's spans so we get plain UI copy.
+            val label = (v.contentDescription?.toString()?.trim().orEmpty())
+                .ifEmpty { v.text?.toString()?.trim().orEmpty() }
+            val role = simplifyRole(v.accessibilityClassName?.toString() ?: v.className?.toString())
+            val states = buildList {
+                if (v.isCheckable == true) {
+                    add(if (v.isChecked == true) "checked" else "unchecked")
+                }
+            }
+            // Drop nodes that wouldn't carry weight in the legend: a label,
+            // a role beyond plain View, an actionable state, or clickability
+            // is enough to keep them. Clickable-but-empty containers (a card
+            // with text inside it that's already its own node) drop out.
+            val keep = label.isNotEmpty() ||
+                states.isNotEmpty() ||
+                (role != null && v.isClickable)
+            if (!keep) continue
+            // The label is what reviewers scan for first; an unlabelled
+            // clickable element with a known role still surfaces, but with
+            // an empty `label` field — the overlay caller decides how to
+            // render that (we draw the role on its own line in the legend).
+            out += AccessibilityNode(
+                label = label,
+                role = role,
+                states = states,
+                boundsInScreen = "${bounds.left},${bounds.top},${bounds.right},${bounds.bottom}",
+            )
+        }
+        return out
+    }
+
+    /**
+     * Strip the package off TalkBack's class name and drop the generic
+     * `android.view.View` so the legend doesn't fill up with `View` chips.
+     */
+    private fun simplifyRole(fqn: String?): String? {
+        if (fqn.isNullOrEmpty()) return null
+        val short = fqn.substringAfterLast('.')
+        if (short.isEmpty() || short == "View" || short == "ViewGroup") return null
+        return short
     }
 
     private val DEBUG = System.getProperty("composeai.a11y.debug") == "true"
@@ -65,22 +133,26 @@ internal object AccessibilityChecker {
      * per-preview avoids concurrent-writer issues when previews are sharded
      * across JVMs.
      *
-     * When [screenshot] is non-null and [findings] is non-empty, also
-     * generates an annotated PNG next to the screenshot and records the
-     * relative path back to the aggregate JSON in [AccessibilityEntry.annotatedPath].
+     * Always writes the JSON entry, even when both lists are empty (so
+     * `accessibility.json` covers every preview). The annotated PNG is
+     * generated whenever there's at least one finding OR one ANI node and
+     * a screenshot is available — that way the Paparazzi-style "what
+     * TalkBack sees" overlay shows up on clean previews too.
      */
     fun writePerPreviewReport(
         outputDir: File,
         previewId: String,
         findings: List<AccessibilityFinding>,
+        nodes: List<AccessibilityNode>,
         screenshot: File? = null,
     ) {
         outputDir.mkdirs()
-        val annotated = if (screenshot != null && findings.isNotEmpty()) {
-            AccessibilityOverlay.generate(screenshot, findings)
+        val hasContent = findings.isNotEmpty() || nodes.isNotEmpty()
+        val annotated = if (screenshot != null && hasContent) {
+            AccessibilityOverlay.generate(screenshot, findings, nodes)
         } else null
-        if (findings.isNotEmpty() && annotated == null) {
-            // Findings present but no overlay landed — log the precondition
+        if (hasContent && annotated == null) {
+            // Content present but no overlay landed — log the precondition
             // that wasn't met so the cause is visible in CI logs without
             // having to enable the verbose `composeai.a11y.debug` flag.
             // [AccessibilityOverlay.generate] logs the more specific reason
@@ -91,7 +163,8 @@ internal object AccessibilityChecker {
                 else -> "AccessibilityOverlay.generate returned null (see preceding stderr)"
             }
             System.err.println(
-                "[compose-a11y] $previewId: ${findings.size} finding(s) but no overlay — $reason",
+                "[compose-a11y] $previewId: ${findings.size} finding(s) / " +
+                    "${nodes.size} node(s) but no overlay — $reason",
             )
         }
 
@@ -108,6 +181,7 @@ internal object AccessibilityChecker {
         val entry = AccessibilityEntry(
             previewId = previewId,
             findings = findings,
+            nodes = nodes,
             annotatedPath = relative,
         )
         outputDir.resolve("$previewId.json").writeText(

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityOverlay.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityOverlay.kt
@@ -9,93 +9,107 @@ import android.graphics.Rect
 import android.graphics.RectF
 import android.graphics.Typeface
 import java.io.File
+import kotlin.math.max
 
 /**
- * Generates an annotated screenshot alongside each preview when accessibility
- * checks produce findings.
+ * Generates an annotated screenshot for each preview that has either ATF
+ * findings or accessibility-relevant nodes.
  *
- * The input PNG is left untouched — the overlay is written as a sibling
- * `<id>.a11y.png` so downstream tools can show either the clean render or the
- * annotated one. The composite has the original screenshot on the left with
- * numbered badges + coloured outlines at each finding's `boundsInScreen`, and
- * a legend panel on the right listing rule + message for each badge.
+ * Visual language matches Cash App's Paparazzi a11y snapshots: every node
+ * ATF tracks (label / role / state) gets a translucent pastel fill on the
+ * screenshot and a swatched legend row in matching colour, so reviewers can
+ * map "what TalkBack sees" without counting overlays. ATF findings layer on
+ * top with the louder red/orange/blue numbered badges they've always had.
  *
- * Drawn with native Canvas instead of a second Compose render pass because
- * the annotation is pure data — boxes and text over an existing bitmap. A
- * Compose pass would need another `ActivityScenario`, double the capture
- * latency, and deal with inspection-mode quirks; Canvas sidesteps all of it.
+ * Layout adapts to aspect ratio:
+ *  - **Tall** previews (h/w ≥ [TALL_ASPECT]) keep the side-by-side shape —
+ *    screenshot left, legend right, ANI rows y-aligned to their element's
+ *    top edge so the eye can scan straight across.
+ *  - **Non-tall** (Wear, landscape) stack the legend vertically: findings
+ *    above the screenshot, ANI rows below it, so the small round Wear face
+ *    isn't squeezed by a fixed-width side panel.
  */
 internal object AccessibilityOverlay {
 
-    /** Width of the legend panel when laid out beside a portrait screenshot. */
-    private const val LEGEND_WIDTH = 520
+    /** Width of the legend panel when laid out beside a tall screenshot. */
+    private const val LEGEND_WIDTH = 540
 
     /** Vertical padding between legend rows. */
-    private const val ROW_PADDING = 12
+    private const val ROW_PADDING = 10
 
     /** Outer margin inside the legend panel. */
     private const val LEGEND_MARGIN = 24
 
-    /** Badge radius (px). Small enough not to obscure the element, big enough to read. */
+    /** Badge radius (px) for finding numbers. */
     private const val BADGE_RADIUS = 22f
 
-    /**
-     * Outline stroke width (px). The whole point of the overlay is to draw
-     * attention to the offending element without smothering the UI it sits
-     * on top of, so we keep the stroke thin and translucent
-     * ([OUTLINE_ALPHA]) and let the badge carry the colour weight.
-     */
+    /** Side of the colour swatch drawn next to each ANI legend row. */
+    private const val SWATCH_SIDE = 28f
+
+    /** Outline stroke width (px) on a finding's element bounds. */
     private const val OUTLINE_STROKE = 2f
 
-    /**
-     * Outline stroke alpha (0–255). Picks up the level colour but at ~60%
-     * opacity so backgrounds, text, and small targets behind the stroke
-     * still read clearly. Earlier full-opacity 4f borders crowded out the
-     * UI on tiny Wear bounds.
-     */
+    /** Outline alpha (0–255). Translucent so UI behind still reads. */
     private const val OUTLINE_ALPHA = 150
 
     /**
-     * Minimum side length (px) for the screenshot panel. Sources smaller
-     * than this on both axes — Wear small/large round at 192–227 — are
-     * upscaled (preserving aspect) so they don't look dwarfed next to the
-     * fixed-width legend. Phones / tablets / desktop already comfortably
-     * exceed this on at least one axis and pass through unchanged.
+     * Alpha (0–255) for the translucent fill drawn over each ANI element.
+     * ~30% opacity — enough to identify the region in the legend mapping,
+     * not enough to obscure the underlying control. Findings still get the
+     * full-strength outline + badge on top.
      */
+    private const val NODE_FILL_ALPHA = 80
+
+    /** Aspect at which we switch from stacked-legend to side-by-side. */
+    private const val TALL_ASPECT = 1.3f
+
+    /** Wear sources upscale to this short side so the legend doesn't dwarf them. */
     private const val MIN_SCREENSHOT_DIM = 400
 
     /**
-     * Writes the annotated PNG next to [sourcePng]. If [findings] is empty,
-     * does nothing (keeps the build cache tidy — zero findings means nothing
-     * to show, and the CLI/VSCode treat the absence of the file accordingly).
-     *
-     * Layout matches Paparazzi's a11y snapshots: screenshot on the left,
-     * fixed-width legend on the right — for every device. Wear previews
-     * end up looking proportionally narrow next to the legend, but a
-     * consistent shape makes batches of reports easier to skim than a
-     * Wear-specific stacked layout would.
-     *
-     * @return the destination [File] when written, `null` otherwise.
+     * Pastel palette for ANI nodes. Cycled by index, so consecutive nodes get
+     * adjacent hues — easier to disambiguate two close-together elements than
+     * a random palette would be. Saturated enough that the swatch reads on a
+     * white legend background; light enough that the [NODE_FILL_ALPHA] fill
+     * doesn't darken the screenshot much.
      */
-    fun generate(sourcePng: File, findings: List<AccessibilityFinding>): File? {
-        if (findings.isEmpty()) return null
+    private val NODE_PALETTE = intArrayOf(
+        Color.rgb(0xF8, 0xBB, 0xD0), // pink
+        Color.rgb(0xB3, 0xE5, 0xFC), // light blue
+        Color.rgb(0xFF, 0xE0, 0xB2), // peach
+        Color.rgb(0xC8, 0xE6, 0xC9), // mint
+        Color.rgb(0xE1, 0xBE, 0xE7), // lavender
+        Color.rgb(0xFF, 0xF5, 0x9D), // pale yellow
+        Color.rgb(0xFF, 0xCC, 0xBC), // coral
+        Color.rgb(0xB2, 0xEB, 0xF2), // cyan
+    )
+
+    /**
+     * Writes the annotated PNG next to [sourcePng]. No-op when [findings] and
+     * [nodes] are both empty. Returns the destination [File] when written.
+     */
+    fun generate(
+        sourcePng: File,
+        findings: List<AccessibilityFinding>,
+        nodes: List<AccessibilityNode>,
+    ): File? {
+        if (findings.isEmpty() && nodes.isEmpty()) return null
         if (!sourcePng.exists()) {
-            // The render pipeline is supposed to write outputFile before
-            // calling us, so a missing source means the wiring shifted —
-            // worth surfacing rather than silently dropping the overlay.
+            // The render pipeline writes outputFile before calling us; a
+            // missing source means the wiring shifted — surface it rather
+            // than silently dropping the overlay.
             System.err.println(
                 "[compose-a11y] overlay skipped: source PNG missing at ${sourcePng.absolutePath}",
             )
             return null
         }
         return try {
-            generateInternal(sourcePng, findings)
+            generateInternal(sourcePng, findings, nodes)
         } catch (t: Throwable) {
-            // Without this catch, an exception inside Canvas / Bitmap.createBitmap
-            // would propagate through writePerPreviewReport and skip the JSON
-            // report too — masking the original failure as "no a11y data".
-            // Logging the stack here keeps the report intact and tells CI logs
-            // exactly what to fix.
+            // Without this catch, a Canvas / Bitmap.createBitmap blow-up
+            // would propagate through writePerPreviewReport and skip the
+            // JSON report too — masking the original failure as "no a11y
+            // data". Logging the stack here keeps the report intact.
             System.err.println(
                 "[compose-a11y] overlay failed for ${sourcePng.name}: " +
                     "${t.javaClass.simpleName}: ${t.message}",
@@ -105,7 +119,11 @@ internal object AccessibilityOverlay {
         }
     }
 
-    private fun generateInternal(sourcePng: File, findings: List<AccessibilityFinding>): File? {
+    private fun generateInternal(
+        sourcePng: File,
+        findings: List<AccessibilityFinding>,
+        nodes: List<AccessibilityNode>,
+    ): File? {
         val source = BitmapFactory.decodeFile(sourcePng.absolutePath)
         if (source == null) {
             System.err.println(
@@ -114,9 +132,7 @@ internal object AccessibilityOverlay {
             )
             return null
         }
-
-        val composite = drawSideBySide(source, findings)
-
+        val composite = compose(source, findings, nodes)
         val dest = File(sourcePng.parentFile, "${sourcePng.nameWithoutExtension}.a11y.png")
         dest.outputStream().use { composite.compress(Bitmap.CompressFormat.PNG, 100, it) }
         source.recycle()
@@ -124,96 +140,196 @@ internal object AccessibilityOverlay {
         return dest
     }
 
-    /**
-     * Side-by-side composition: screenshot on the left, fixed-width legend
-     * on the right. The canvas height is `max(screenshotHeight, legendHeight)`
-     * so both panes fit without cropping; the screenshot is centred
-     * vertically in its column when the legend is taller, and Wear-sized
-     * sources are upscaled to [MIN_SCREENSHOT_DIM] so they don't look
-     * dwarfed next to the legend.
-     */
-    private fun drawSideBySide(source: Bitmap, findings: List<AccessibilityFinding>): Bitmap {
+    private fun compose(
+        source: Bitmap,
+        findings: List<AccessibilityFinding>,
+        nodes: List<AccessibilityNode>,
+    ): Bitmap {
         val scale = screenshotScale(source)
         val drawn = if (scale > 1f) {
-            // ARGB_8888 + filter=true so the upscale stays smooth on the
-            // round-clipped Wear edges — nearest-neighbour produced
-            // distracting jaggies on the alpha boundary.
             Bitmap.createScaledBitmap(
                 source,
                 (source.width * scale).toInt(),
                 (source.height * scale).toInt(),
-                true,
+                /* filter = */ true,
             )
         } else source
-
-        val legendHeight = estimateLegendHeight(findings, LEGEND_WIDTH)
-        val canvasHeight = maxOf(drawn.height, legendHeight)
-        val composite = Bitmap.createBitmap(
-            drawn.width + LEGEND_WIDTH,
-            canvasHeight,
-            Bitmap.Config.ARGB_8888,
-        )
-        val canvas = Canvas(composite)
-        canvas.drawColor(Color.WHITE)
-
-        val imageTop = (canvasHeight - drawn.height) / 2
-        canvas.drawBitmap(drawn, 0f, imageTop.toFloat(), null)
-        findings.forEachIndexed { i, f ->
-            drawBadgeAndOutline(canvas, i + 1, f, 0f, imageTop.toFloat(), scale)
+        // Stable per-node colour assignment; both the screenshot fill and the
+        // legend swatch read the same index, so they always match.
+        val nodeColors = IntArray(nodes.size) { NODE_PALETTE[it % NODE_PALETTE.size] }
+        val isTall = drawn.height.toFloat() / drawn.width.toFloat() >= TALL_ASPECT
+        val composite = if (isTall) {
+            composeTall(drawn, findings, nodes, nodeColors)
+        } else {
+            composeStacked(drawn, findings, nodes, nodeColors)
         }
-
-        drawLegend(
-            canvas = canvas,
-            findings = findings,
-            originX = drawn.width.toFloat(),
-            originY = 0f,
-            width = LEGEND_WIDTH,
-            height = canvasHeight,
-        )
-        // [drawn] is either [source] (scale = 1) or a fresh upscaled bitmap.
-        // The caller recycles [source] separately; only the scaled copy
-        // needs releasing here.
         if (drawn !== source) drawn.recycle()
         return composite
     }
 
     /**
-     * Returns the upscale factor for [source] when both dimensions are
-     * smaller than [MIN_SCREENSHOT_DIM] (i.e. Wear). Larger sources get
-     * `1f` and pass through Bitmap.createScaledBitmap unchanged.
+     * Tall layout: screenshot on the left, legend on the right. Findings are
+     * stacked at the top of the legend; ANI rows below them, each y-anchored
+     * at the element's `bounds.top` (with overlap prevention so adjacent
+     * elements don't trample each other).
      */
-    private fun screenshotScale(source: Bitmap): Float {
-        if (source.width >= MIN_SCREENSHOT_DIM || source.height >= MIN_SCREENSHOT_DIM) {
-            return 1f
+    private fun composeTall(
+        screenshot: Bitmap,
+        findings: List<AccessibilityFinding>,
+        nodes: List<AccessibilityNode>,
+        nodeColors: IntArray,
+    ): Bitmap {
+        val findingsBlock = measureFindingsBlock(findings, LEGEND_WIDTH)
+        val nodesBlockMin = measureNodesBlockMin(nodes)
+        val legendMin = LEGEND_MARGIN + findingsBlock + nodesBlockMin + LEGEND_MARGIN
+        val canvasHeight = max(screenshot.height, legendMin)
+        val composite = Bitmap.createBitmap(
+            screenshot.width + LEGEND_WIDTH,
+            canvasHeight,
+            Bitmap.Config.ARGB_8888,
+        )
+        val canvas = Canvas(composite).apply { drawColor(Color.WHITE) }
+        val imageTopOffset = (canvasHeight - screenshot.height) / 2
+
+        // Translucent pastel fills first so finding outlines layer on top.
+        drawNodeFills(canvas, nodes, nodeColors, offsetX = 0f, offsetY = imageTopOffset.toFloat())
+        canvas.drawBitmap(screenshot, 0f, imageTopOffset.toFloat(), null)
+        // Re-draw fills *over* the bitmap with their full stroke — the bitmap
+        // we just drew covers the pre-fill, so we paint the fill again and
+        // add a thin border so each region reads as a region, not a tint.
+        drawNodeFills(canvas, nodes, nodeColors, offsetX = 0f, offsetY = imageTopOffset.toFloat())
+        drawNodeBorders(canvas, nodes, nodeColors, offsetX = 0f, offsetY = imageTopOffset.toFloat())
+        findings.forEachIndexed { i, f ->
+            drawFindingBadge(canvas, i + 1, f, offsetX = 0f, offsetY = imageTopOffset.toFloat())
         }
-        // Use the larger dimension so the screenshot exactly hits MIN on
-        // its long side and stays inside it on the short side — preserves
-        // the round/square shape Wear ships with.
-        return MIN_SCREENSHOT_DIM.toFloat() / maxOf(source.width, source.height)
+
+        val legendX = screenshot.width.toFloat()
+        drawLegendBackground(canvas, legendX, 0f, LEGEND_WIDTH, canvasHeight)
+        var y = LEGEND_MARGIN.toFloat()
+        y = drawHeader(canvas, findings.size, nodes.size, legendX + LEGEND_MARGIN, y)
+        y = drawFindingsRows(canvas, findings, legendX, y, LEGEND_WIDTH)
+        drawNodeRowsAligned(
+            canvas = canvas,
+            nodes = nodes,
+            nodeColors = nodeColors,
+            originX = legendX,
+            top = y,
+            bottom = canvasHeight - LEGEND_MARGIN.toFloat(),
+            panelWidth = LEGEND_WIDTH,
+            imageTopOffset = imageTopOffset.toFloat(),
+        )
+        return composite
     }
 
-    private fun drawBadgeAndOutline(
+    /**
+     * Non-tall layout (Wear, landscape): findings stacked above the
+     * screenshot, ANI rows stacked below it. Screenshot is centred
+     * horizontally inside the wider of the two rails.
+     */
+    private fun composeStacked(
+        screenshot: Bitmap,
+        findings: List<AccessibilityFinding>,
+        nodes: List<AccessibilityNode>,
+        nodeColors: IntArray,
+    ): Bitmap {
+        // Stacked legend wants more elbow room than the side-by-side one —
+        // a Wear screenshot is ~400px wide, so we let rows fill that plus a
+        // margin instead of clipping to LEGEND_WIDTH.
+        val panelWidth = max(screenshot.width, LEGEND_WIDTH) + LEGEND_MARGIN * 2
+        val findingsBlock = if (findings.isEmpty()) 0 else
+            measureFindingsBlock(findings, panelWidth) + LEGEND_MARGIN
+        val nodesBlock = if (nodes.isEmpty()) 0 else
+            measureNodesStackedBlock(nodes, panelWidth) + LEGEND_MARGIN
+        val headerBlock = LEGEND_MARGIN + 28 + ROW_PADDING + 16
+        val canvasWidth = panelWidth
+        val canvasHeight = headerBlock + findingsBlock + screenshot.height + nodesBlock + LEGEND_MARGIN
+        val composite = Bitmap.createBitmap(canvasWidth, canvasHeight, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(composite).apply { drawColor(Color.WHITE) }
+
+        var y = LEGEND_MARGIN.toFloat()
+        y = drawHeader(canvas, findings.size, nodes.size, LEGEND_MARGIN.toFloat(), y)
+        if (findings.isNotEmpty()) {
+            y = drawFindingsRows(canvas, findings, originX = 0f, top = y, panelWidth = canvasWidth)
+            y += LEGEND_MARGIN
+        }
+        // Centre the screenshot horizontally; record its origin so finding /
+        // node draws line up with the same coordinates.
+        val imageX = ((canvasWidth - screenshot.width) / 2).toFloat()
+        val imageY = y
+        drawNodeFills(canvas, nodes, nodeColors, imageX, imageY)
+        canvas.drawBitmap(screenshot, imageX, imageY, null)
+        drawNodeFills(canvas, nodes, nodeColors, imageX, imageY)
+        drawNodeBorders(canvas, nodes, nodeColors, imageX, imageY)
+        findings.forEachIndexed { i, f ->
+            drawFindingBadge(canvas, i + 1, f, imageX, imageY)
+        }
+        y = imageY + screenshot.height
+        if (nodes.isNotEmpty()) {
+            y += LEGEND_MARGIN
+            drawNodeRowsStacked(canvas, nodes, nodeColors, originX = 0f, top = y, panelWidth = canvasWidth)
+        }
+        return composite
+    }
+
+    private fun screenshotScale(source: Bitmap): Float {
+        if (source.width >= MIN_SCREENSHOT_DIM || source.height >= MIN_SCREENSHOT_DIM) return 1f
+        return MIN_SCREENSHOT_DIM.toFloat() / max(source.width, source.height)
+    }
+
+    // ---------- screenshot layer ----------
+
+    private fun drawNodeFills(
+        canvas: Canvas,
+        nodes: List<AccessibilityNode>,
+        nodeColors: IntArray,
+        offsetX: Float,
+        offsetY: Float,
+    ) {
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL }
+        nodes.forEachIndexed { i, node ->
+            val r = parseBounds(node.boundsInScreen) ?: return@forEachIndexed
+            paint.color = nodeColors[i]
+            paint.alpha = NODE_FILL_ALPHA
+            canvas.drawRect(
+                offsetX + r.left, offsetY + r.top, offsetX + r.right, offsetY + r.bottom,
+                paint,
+            )
+        }
+    }
+
+    private fun drawNodeBorders(
+        canvas: Canvas,
+        nodes: List<AccessibilityNode>,
+        nodeColors: IntArray,
+        offsetX: Float,
+        offsetY: Float,
+    ) {
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.STROKE
+            strokeWidth = 1.5f
+            alpha = 200
+        }
+        nodes.forEachIndexed { i, node ->
+            val r = parseBounds(node.boundsInScreen) ?: return@forEachIndexed
+            paint.color = nodeColors[i]
+            paint.alpha = 200
+            canvas.drawRect(
+                offsetX + r.left + 0.5f, offsetY + r.top + 0.5f,
+                offsetX + r.right - 0.5f, offsetY + r.bottom - 0.5f,
+                paint,
+            )
+        }
+    }
+
+    private fun drawFindingBadge(
         canvas: Canvas,
         number: Int,
         finding: AccessibilityFinding,
         offsetX: Float,
         offsetY: Float,
-        scale: Float,
     ) {
-        val bounds = parseBounds(finding.boundsInScreen) ?: return
+        val r = parseBounds(finding.boundsInScreen) ?: return
         val color = levelColor(finding.level)
-        // boundsInScreen are in the source bitmap's pixel space; when we
-        // upscale Wear screenshots the badge / outline have to follow.
-        val left = bounds.left * scale
-        val top = bounds.top * scale
-        val right = bounds.right * scale
-        val bottom = bounds.bottom * scale
-
-        // Outline around the finding. Inset by half [OUTLINE_STROKE] so the
-        // stroke sits *inside* the element's touch bounds — useful for tiny
-        // targets where a full-thickness outline would otherwise render
-        // entirely outside the visible box. Translucent so the original UI
-        // still reads through; the badge carries the loud colour.
         val outline = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             style = Paint.Style.STROKE
             strokeWidth = OUTLINE_STROKE
@@ -223,89 +339,90 @@ internal object AccessibilityOverlay {
         val inset = OUTLINE_STROKE / 2f
         canvas.drawRect(
             RectF(
-                offsetX + left + inset,
-                offsetY + top + inset,
-                offsetX + right - inset,
-                offsetY + bottom - inset,
+                offsetX + r.left + inset, offsetY + r.top + inset,
+                offsetX + r.right - inset, offsetY + r.bottom - inset,
             ),
             outline,
         )
-
-        // Badge anchored at the top-left corner of the element so it stays
-        // next to the offending control even when bounds clip the edge of
-        // the image.
-        val cx = offsetX + left.coerceAtLeast(BADGE_RADIUS)
-        val cy = offsetY + top.coerceAtLeast(BADGE_RADIUS)
-
-        val badgeBg = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-            style = Paint.Style.FILL
-            this.color = color
-        }
-        canvas.drawCircle(cx, cy, BADGE_RADIUS, badgeBg)
-
-        val badgeText = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        // Badge anchored at the top-left so it stays next to the offending
+        // control even when bounds clip the edge of the image.
+        val cx = offsetX + r.left.toFloat().coerceAtLeast(BADGE_RADIUS)
+        val cy = offsetY + r.top.toFloat().coerceAtLeast(BADGE_RADIUS)
+        val bg = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL; this.color = color }
+        canvas.drawCircle(cx, cy, BADGE_RADIUS, bg)
+        val text = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             this.color = Color.WHITE
             textSize = 24f
             textAlign = Paint.Align.CENTER
             typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
         }
-        val fm = badgeText.fontMetrics
-        canvas.drawText(
-            number.toString(),
-            cx,
-            cy - (fm.ascent + fm.descent) / 2f,
-            badgeText,
-        )
+        val fm = text.fontMetrics
+        canvas.drawText(number.toString(), cx, cy - (fm.ascent + fm.descent) / 2f, text)
     }
 
-    private fun drawLegend(
-        canvas: Canvas,
-        findings: List<AccessibilityFinding>,
-        originX: Float,
-        originY: Float,
-        width: Int,
-        height: Int,
-    ) {
-        val bg = Paint().apply { color = Color.rgb(0xF6, 0xF6, 0xF8); style = Paint.Style.FILL }
-        canvas.drawRect(originX, originY, originX + width, originY + height, bg)
+    // ---------- legend layer ----------
 
-        // Header
-        val headerPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+    private fun drawLegendBackground(
+        canvas: Canvas,
+        x: Float, y: Float, w: Int, h: Int,
+    ) {
+        val bg = Paint().apply { color = Color.rgb(0xFA, 0xFA, 0xFC); style = Paint.Style.FILL }
+        canvas.drawRect(x, y, x + w, y + h, bg)
+        val divider = Paint().apply { color = Color.rgb(0xE3, 0xE3, 0xE8); strokeWidth = 1f }
+        canvas.drawLine(x, y, x, y + h, divider)
+    }
+
+    private fun drawHeader(
+        canvas: Canvas,
+        findingCount: Int,
+        nodeCount: Int,
+        x: Float,
+        y: Float,
+    ): Float {
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             color = Color.BLACK
             textSize = 28f
             typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
         }
-        val headerY = originY + LEGEND_MARGIN + headerPaint.textSize
-        canvas.drawText(
-            "Accessibility (${findings.size})",
-            originX + LEGEND_MARGIN,
-            headerY,
-            headerPaint,
-        )
-
-        // Rows
-        var y = headerY + ROW_PADDING + 20f
-        findings.forEachIndexed { index, finding ->
-            y = drawLegendRow(canvas, index + 1, finding, originX, y, width)
+        val baseline = y + paint.textSize
+        val title = buildString {
+            append("Accessibility")
+            val parts = mutableListOf<String>()
+            if (findingCount > 0) parts += "$findingCount finding${if (findingCount == 1) "" else "s"}"
+            if (nodeCount > 0) parts += "$nodeCount element${if (nodeCount == 1) "" else "s"}"
+            if (parts.isNotEmpty()) append(" · ").append(parts.joinToString(", "))
         }
+        canvas.drawText(title, x, baseline, paint)
+        return baseline + ROW_PADDING + 6f
     }
 
-    /** Draws a single legend row; returns the next row's top Y. */
-    private fun drawLegendRow(
+    private fun drawFindingsRows(
+        canvas: Canvas,
+        findings: List<AccessibilityFinding>,
+        originX: Float,
+        top: Float,
+        panelWidth: Int,
+    ): Float {
+        var y = top
+        findings.forEachIndexed { i, f ->
+            y = drawFindingRow(canvas, i + 1, f, originX, y, panelWidth)
+        }
+        return y
+    }
+
+    private fun drawFindingRow(
         canvas: Canvas,
         number: Int,
         finding: AccessibilityFinding,
-        offsetX: Float,
+        originX: Float,
         top: Float,
         panelWidth: Int,
     ): Float {
         val color = levelColor(finding.level)
-
-        // Badge — same visual language as the overlay so the mapping is obvious.
-        val badgeX = offsetX + LEGEND_MARGIN + BADGE_RADIUS
+        val badgeX = originX + LEGEND_MARGIN + BADGE_RADIUS
         val badgeY = top + BADGE_RADIUS
-        val badgeBg = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL; this.color = color }
-        canvas.drawCircle(badgeX, badgeY, BADGE_RADIUS, badgeBg)
+        val bg = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL; this.color = color }
+        canvas.drawCircle(badgeX, badgeY, BADGE_RADIUS, bg)
         val badgeText = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             this.color = Color.WHITE
             textSize = 24f
@@ -315,57 +432,187 @@ internal object AccessibilityOverlay {
         val bfm = badgeText.fontMetrics
         canvas.drawText(number.toString(), badgeX, badgeY - (bfm.ascent + bfm.descent) / 2f, badgeText)
 
-        // Rule name (bold)
         val titlePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             this.color = Color.BLACK
             textSize = 22f
             typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
         }
-        val titleX = badgeX + BADGE_RADIUS + 14f
+        val textX = badgeX + BADGE_RADIUS + 14f
         val titleY = top + 24f
-        canvas.drawText("${finding.level} · ${finding.type}", titleX, titleY, titlePaint)
+        canvas.drawText("${finding.level} · ${finding.type}", textX, titleY, titlePaint)
 
-        // Message (wrapped)
-        val messagePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        val msgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             this.color = Color.rgb(0x30, 0x30, 0x33)
             textSize = 20f
         }
-        val textWidth = (panelWidth - LEGEND_MARGIN - (BADGE_RADIUS * 2 + 14f) - LEGEND_MARGIN).toInt()
-        val lines = wrap(finding.message, messagePaint, textWidth)
+        val rightMargin = LEGEND_MARGIN
+        val textWidth = (panelWidth - (textX - originX) - rightMargin).toInt()
+        val lines = wrap(finding.message, msgPaint, textWidth)
         var lineY = titleY + 28f
         for (line in lines) {
-            canvas.drawText(line, titleX, lineY, messagePaint)
+            canvas.drawText(line, textX, lineY, msgPaint)
             lineY += 26f
         }
-
-        // Element description (small, muted)
-        val elementDesc = finding.viewDescription
-        if (!elementDesc.isNullOrBlank()) {
-            val descPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                this.color = Color.rgb(0x70, 0x70, 0x76)
-                textSize = 18f
-                isAntiAlias = true
-            }
-            val truncated = if (elementDesc.length > 64) elementDesc.take(61) + "…" else elementDesc
-            canvas.drawText(truncated, titleX, lineY + 4f, descPaint)
-            lineY += 24f
-        }
-
         return lineY + ROW_PADDING.toFloat()
     }
 
-    private fun estimateLegendHeight(findings: List<AccessibilityFinding>, width: Int): Int {
-        // Rough upper-bound estimate. A wider panel wraps long messages into
-        // fewer lines, so we linearly scale the assumed "lines per row" by
-        // the panel width relative to the default (narrow) LEGEND_WIDTH.
-        // Overshooting here is safe — the composite sizes to this estimate
-        // and the final draw just paints within it. Undershooting clips
-        // the last row.
-        val headerHeight = LEGEND_MARGIN * 2 + 28
-        val assumedMessageLines = if (width >= LEGEND_WIDTH * 2) 1 else 2
-        val rowHeight = 24 + 28 + 26 * assumedMessageLines + 24 + ROW_PADDING
-        return headerHeight + findings.size * rowHeight + LEGEND_MARGIN
+    /**
+     * Y-aligned ANI rows for the tall layout. Each row's preferred top is the
+     * element's `bounds.top` in canvas space; we walk top-down and push any
+     * row that would collide with the previous one downward by a row
+     * height + padding, so the relative ordering matches the screenshot
+     * even if some elements are stacked too tightly to align exactly.
+     */
+    private fun drawNodeRowsAligned(
+        canvas: Canvas,
+        nodes: List<AccessibilityNode>,
+        nodeColors: IntArray,
+        originX: Float,
+        top: Float,
+        bottom: Float,
+        panelWidth: Int,
+        imageTopOffset: Float,
+    ) {
+        if (nodes.isEmpty()) return
+        // Index-color pairs sorted by anchor Y. Sorting is stable on tied
+        // anchors so left-to-right reading order survives.
+        data class Anchored(val node: AccessibilityNode, val color: Int, val anchor: Float)
+        val anchored = nodes.mapIndexedNotNull { i, n ->
+            val r = parseBounds(n.boundsInScreen) ?: return@mapIndexedNotNull null
+            Anchored(n, nodeColors[i], imageTopOffset + r.top)
+        }.sortedBy { it.anchor }
+
+        var prevBottom = top
+        for (a in anchored) {
+            val rowTop = max(a.anchor, prevBottom + ROW_PADDING)
+            val rowBottom = drawNodeRow(canvas, a.node, a.color, originX, rowTop, panelWidth)
+            if (rowBottom > bottom) break
+            prevBottom = rowBottom
+        }
     }
+
+    private fun drawNodeRowsStacked(
+        canvas: Canvas,
+        nodes: List<AccessibilityNode>,
+        nodeColors: IntArray,
+        originX: Float,
+        top: Float,
+        panelWidth: Int,
+    ): Float {
+        var y = top
+        nodes.forEachIndexed { i, n ->
+            y = drawNodeRow(canvas, n, nodeColors[i], originX, y, panelWidth)
+        }
+        return y
+    }
+
+    /**
+     * One ANI legend row: solid swatch (matching the screenshot fill) +
+     * label, with role / states as a smaller second line. Returns the next
+     * row's top Y.
+     */
+    private fun drawNodeRow(
+        canvas: Canvas,
+        node: AccessibilityNode,
+        color: Int,
+        originX: Float,
+        top: Float,
+        panelWidth: Int,
+    ): Float {
+        // Swatch — full opacity in the legend so the colour is unambiguous,
+        // even though its on-screenshot counterpart is translucent.
+        val swatchX = originX + LEGEND_MARGIN
+        val swatchY = top + 4f
+        val swatchPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.FILL; this.color = color }
+        canvas.drawRoundRect(
+            RectF(swatchX, swatchY, swatchX + SWATCH_SIDE, swatchY + SWATCH_SIDE),
+            6f, 6f, swatchPaint,
+        )
+        val swatchBorder = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.STROKE
+            strokeWidth = 1f
+            this.color = Color.rgb(0x60, 0x60, 0x66)
+            alpha = 120
+        }
+        canvas.drawRoundRect(
+            RectF(swatchX, swatchY, swatchX + SWATCH_SIDE, swatchY + SWATCH_SIDE),
+            6f, 6f, swatchBorder,
+        )
+
+        val textX = swatchX + SWATCH_SIDE + 14f
+        val labelPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            this.color = Color.BLACK
+            textSize = 20f
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+        }
+        val rightMargin = LEGEND_MARGIN
+        val textWidth = (panelWidth - (textX - originX) - rightMargin).toInt()
+        val labelText = node.label.ifEmpty { node.role ?: "(unlabelled)" }
+        val labelLines = wrap(labelText, labelPaint, textWidth)
+        var y = top + 22f
+        for (line in labelLines) {
+            canvas.drawText(line, textX, y, labelPaint)
+            y += 24f
+        }
+
+        // Subtitle: role + states separated by ' · ', skipped when both
+        // empty (purely-textual nodes don't need a subtitle line).
+        val subtitleParts = buildList {
+            node.role?.let { add(it) }
+            addAll(node.states)
+        }
+        if (subtitleParts.isNotEmpty()) {
+            val sub = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                this.color = Color.rgb(0x60, 0x60, 0x66)
+                textSize = 17f
+            }
+            canvas.drawText(subtitleParts.joinToString(" · "), textX, y, sub)
+            y += 20f
+        }
+        return y + ROW_PADDING.toFloat()
+    }
+
+    // ---------- measurement ----------
+
+    /** Total height a findings block (rows only, no header) consumes. */
+    private fun measureFindingsBlock(findings: List<AccessibilityFinding>, panelWidth: Int): Int {
+        if (findings.isEmpty()) return 0
+        val msgPaint = Paint().apply { textSize = 20f }
+        val textWidth = panelWidth - LEGEND_MARGIN * 2 - (BADGE_RADIUS * 2 + 14f).toInt()
+        var total = 0
+        for (f in findings) {
+            val lines = wrap(f.message, msgPaint, textWidth).size.coerceAtLeast(1)
+            total += 24 + 28 + 26 * lines + ROW_PADDING
+        }
+        return total
+    }
+
+    /**
+     * Lower bound on tall-layout ANI block height — assumes each row is one
+     * line of label + one subtitle line. Y-alignment may push some rows
+     * further down, but those overflow into the canvas's bottom margin
+     * rather than getting clipped.
+     */
+    private fun measureNodesBlockMin(nodes: List<AccessibilityNode>): Int {
+        if (nodes.isEmpty()) return 0
+        return nodes.size * (22 + 24 + 20 + ROW_PADDING)
+    }
+
+    private fun measureNodesStackedBlock(nodes: List<AccessibilityNode>, panelWidth: Int): Int {
+        if (nodes.isEmpty()) return 0
+        val labelPaint = Paint().apply { textSize = 20f }
+        val textWidth = panelWidth - LEGEND_MARGIN * 2 - (SWATCH_SIDE + 14f).toInt()
+        var total = 0
+        for (n in nodes) {
+            val labelText = n.label.ifEmpty { n.role ?: "(unlabelled)" }
+            val lines = wrap(labelText, labelPaint, textWidth).size.coerceAtLeast(1)
+            val hasSubtitle = n.role != null || n.states.isNotEmpty()
+            total += 22 + 24 * lines + (if (hasSubtitle) 20 else 0) + ROW_PADDING
+        }
+        return total
+    }
+
+    // ---------- shared helpers ----------
 
     private fun levelColor(level: String): Int = when (level) {
         "ERROR" -> Color.rgb(0xD3, 0x2F, 0x2F)
@@ -383,6 +630,7 @@ internal object AccessibilityOverlay {
 
     /** Greedy word-wrap fitting [text] into [maxWidth] pixels using [paint]'s metrics. */
     private fun wrap(text: String, paint: Paint, maxWidth: Int): List<String> {
+        if (text.isEmpty()) return listOf("")
         val words = text.split(' ')
         val out = mutableListOf<String>()
         var current = StringBuilder()

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -80,6 +80,14 @@ data class AccessibilityEntry(
     val previewId: String,
     val findings: List<AccessibilityFinding>,
     /**
+     * Every accessibility-relevant node ATF saw on the rendered tree.
+     * Populated whether or not [findings] is empty so consumers can render
+     * a Paparazzi-style "what TalkBack sees" overlay even when there's
+     * nothing to fix. Empty list ≈ a11y disabled or the View has no
+     * labelled / actionable content.
+     */
+    val nodes: List<AccessibilityNode> = emptyList(),
+    /**
      * Relative path (from the aggregated `accessibility.json`) to an
      * annotated screenshot showing each finding as a numbered badge + legend.
      * `null` when there were no findings, or when overlay generation was
@@ -87,6 +95,34 @@ data class AccessibilityEntry(
      * pointer — fall back to the clean render.
      */
     val annotatedPath: String? = null,
+)
+
+/**
+ * One accessibility-relevant node from the rendered View tree, captured for
+ * the Paparazzi-style overlay (translucent colour fill on the screenshot
+ * matched against a swatched legend). The shape is deliberately small — we
+ * keep only what TalkBack would announce and what the overlay needs to
+ * draw, not the full ATF [ViewHierarchyElement][com.google.android.apps.common.testing.accessibility.framework.uielement.ViewHierarchyElement]
+ * graph.
+ */
+@Serializable
+data class AccessibilityNode(
+    /** Visible text or contentDescription. Always non-empty for emitted nodes. */
+    val label: String,
+    /**
+     * TalkBack's class announcement (`Button`, `Image`, `TextView`, …).
+     * `null` for plain Views that only carry a label, so the legend can
+     * skip the role chip and avoid the noisy `View` everyone gets.
+     */
+    val role: String? = null,
+    /**
+     * Extra semantic state (`selected`, `checked`, `unchecked`). Empty for
+     * stateless nodes. Heading isn't here — ATF's hierarchy doesn't expose
+     * it cleanly enough to detect Compose-side `Modifier.semantics { heading() }`.
+     */
+    val states: List<String> = emptyList(),
+    /** `left,top,right,bottom` in source-bitmap pixels — same shape as [AccessibilityFinding.boundsInScreen]. */
+    val boundsInScreen: String,
 )
 
 @Serializable

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -631,7 +631,10 @@ abstract class RobolectricRenderTestBase(
                         // produces populated AccessibilityNodeInfo. DecorView
                         // here returns all NOT_RUN.
                         val view = (onRoot.fetchSemanticsNode().root as ViewRootForTest).view
-                        val findings = AccessibilityChecker.check(preview.id, view)
+                        // analyze() runs ATF and walks the hierarchy in one
+                        // pass — the overlay needs both findings (red badge
+                        // layer) and ANI nodes (the colour-swatched legend).
+                        val result = AccessibilityChecker.analyze(preview.id, view)
                         val a11yDir = File(
                             System.getProperty("composeai.a11y.outputDir")
                                 ?: "build/compose-previews/accessibility-per-preview",
@@ -639,7 +642,8 @@ abstract class RobolectricRenderTestBase(
                         AccessibilityChecker.writePerPreviewReport(
                             outputDir = a11yDir,
                             previewId = preview.id,
-                            findings = findings,
+                            findings = result.findings,
+                            nodes = result.nodes,
                             screenshot = outputFile.takeIf { annotate },
                         )
                     }


### PR DESCRIPTION
## Summary
- Every ATF-tracked element gets a translucent pastel fill on the screenshot and a swatched legend row in the matching colour; findings keep their red/orange/blue numbered badges on top.
- Tall previews use side-by-side layout with ANI rows y-anchored to each element's `bounds.top` (with overlap prevention); non-tall (Wear) stacks findings above + ANI rows below so the round face isn't squeezed by a 540 px side panel.
- Report layer skips scrolling/animated previews (`@ScrollingPreview LONG/GIF`, `@AnimatedPreview`) — the captured frame is one moment of motion, not the static state worth checking.

## Implementation notes
- `AccessibilityChecker.analyze()` returns findings + nodes in a single ATF pass; the new `extractNodes()` filters to labelled / actionable elements and skips the noisy generic `View`s.
- `AccessibilityOverlay.generate(findings, nodes)` runs whenever either list is non-empty, so clean previews still get the legend.
- `RenderManifest.AccessibilityNode` and the plugin-side mirror in `VerifyAccessibilityTask` round-trip the ANI data through `accessibility.json`.
- `.github/actions/lib/a11y-report.py` gains `is_dynamic_preview()` to drop scroll / GIF variants from the report; 2 new tests in `test_a11y_report.py`.

## Test plan
- [ ] Run `:sample-wear:renderAllPreviews -PcomposePreview.accessibilityChecks.enabled=true` and inspect a clean Wear preview's `.a11y.png` — legend should show ANI rows even when there are no findings.
- [ ] Inspect `BadWearButtonPreview`'s `.a11y.png` — finding badge layered on top of the node fill, both colours matched in the legend.
- [ ] Render a tall phone preview and confirm legend rows align with their elements (with overlap prevention when stacked tightly).
- [ ] Confirm `@ScrollingPreview(LONG)` and `@AnimatedPreview` rows are absent from the published a11y report.
- [ ] CI must pass `:renderer-android:compileDebugKotlin` — local build was not run before push.

---
_Generated by [Claude Code](https://claude.ai/code/session_011dKWi46ZbEweckt6xWDRrp)_