### PR TITLE
ci: add Renovate config for Gradle and npm dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits"
+  ],
+  "schedule": [
+    "before 9am on Monday"
+  ],
+  "timezone": "UTC",
+  "prConcurrentLimit": 10,
+  "minimumReleaseAge": "7 days",
+  "github-actions": {
+    "enabled": false
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "minimumReleaseAge": "14 days"
+    },
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "{{manager}} minor/patch"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `.github/renovate.json` so Renovate manages Gradle (`libs.versions.toml`) and npm (`vscode-extension/`) updates.
- Schedules weekly PRs (before 9am Monday UTC) with a 7-day release cooldown — 14 days for majors — mirroring the supply-chain guard already in `.github/dependabot.yml`.
- Groups minor/patch updates per manager to keep PR volume manageable.
- Sets `github-actions.enabled = false` so Dependabot stays the single source of truth for SHA-pinned actions; the two tools won't race on the same pins.

Activation requires installing the Renovate GitHub App at https://github.com/apps/renovate and granting it access to this repo. Renovate will then open an onboarding PR.

## Test plan

- [ ] Install/authorise the Renovate GitHub App for `yschimke/compose-ai-tools`.
- [ ] Confirm Renovate opens its onboarding PR and the dependency dashboard issue.
- [ ] Verify the first scheduled run produces grouped Gradle / npm PRs and leaves GitHub Actions to Dependabot.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jg67Eagj3bxvKgjnRFZSxw)_