### PR TITLE
feat(ext): two-tier preview rendering + fix stuck "Building…" banner

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -774,6 +774,24 @@ internal object AndroidPreviewSupport {
                     debug = project.providers.gradleProperty("composeai.a11y.debug").orElse("false"),
                 ),
             )
+            // Render-tier filter — fed via the same lazy `@Input` provider
+            // pattern so VS Code can flip `-PcomposePreview.tier=fast` on
+            // every save without paying a config-cache reconfigure. Renderer
+            // reads `composeai.render.tier` in [PreviewManifestLoader.loadShard]
+            // to drop HEAVY captures from each entry before sharding.
+            val tierProvider = resolveTier(project)
+            jvmArgumentProviders.add(TierSystemPropProvider(tier = tierProvider))
+            // Disable build-cache participation for `tier=fast` runs. A cache
+            // hit restores the cached `renders/` snapshot, which on a fast
+            // run only contains the cheap captures — heavy outputs from a
+            // previous full run would get wiped, breaking the "stale image"
+            // story VS Code shows on heavy cards. Up-to-date checks still
+            // apply, so a `tier=fast` re-run with no input changes is a
+            // no-op and the renders dir stays as-is. Full-tier runs cache
+            // normally.
+            outputs.cacheIf("renderPreviews caches tier=full runs only") {
+                tierProvider.get().equals("full", ignoreCase = true)
+            }
             // Per-preview dir is always an output — the feature being off just
             // means no files get written there. Declaring it unconditionally
             // lets the config cache key stay stable across toggles.
@@ -900,6 +918,39 @@ internal object AndroidPreviewSupport {
             .gradleProperty("composePreview.accessibilityChecks.annotateScreenshots")
             .map { it.toBooleanStrictOrNull() ?: true }
             .orElse(extension.accessibilityChecks.annotateScreenshots)
+
+    /**
+     * Resolve the active render tier from `-PcomposePreview.tier=<fast|full>`.
+     * `fast` tells the renderer to skip captures classified as
+     * [ee.schimke.composeai.plugin.CaptureCost.HEAVY] (`@AnimatedPreview` and
+     * non-TOP `@ScrollingPreview` modes); `full` (the default) renders
+     * everything as before.
+     *
+     * Returned as a `Provider<String>` for the same reason as
+     * [resolveA11yEnabled]: feeding `.get()` to a `CommandLineArgumentProvider`
+     * means the tier is resolved at task-execution time, so VS Code flipping
+     * the property between saves doesn't invalidate the configuration cache.
+     */
+    internal fun resolveTier(
+        project: org.gradle.api.Project,
+    ): org.gradle.api.provider.Provider<String> =
+        project.providers
+            .gradleProperty("composePreview.tier")
+            .map { v -> if (v.equals("fast", ignoreCase = true)) "fast" else "full" }
+            .orElse("full")
+
+    /**
+     * Lazy holder for the render-tier system property on the `renderPreviews`
+     * `Test` task. Same pattern as [AccessibilitySystemPropsProvider] — the
+     * Provider is `@Input`, so flipping `-PcomposePreview.tier` re-runs the
+     * task without invalidating the configuration cache.
+     */
+    internal class TierSystemPropProvider(
+        @get:org.gradle.api.tasks.Input val tier: org.gradle.api.provider.Provider<String>,
+    ) : org.gradle.process.CommandLineArgumentProvider {
+        override fun asArguments(): Iterable<String> =
+            listOf("-Dcomposeai.render.tier=${tier.get()}")
+    }
 
     private fun copyAttributes(target: AttributeContainer, source: AttributeContainer) {
         source.keySet().forEach { key ->

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -62,6 +62,7 @@ internal object ComposePreviewTasks {
                 outputDir.set(previewOutputDir.map { it.dir("renders") })
                 renderBackend.set("desktop")
                 useComposeRenderer.set(true)
+                tier.set(tierProperty(project))
                 renderClasspath.from(sourceClassDirs)
                 project.configurations.findByName(dependencyConfigName)?.let { renderClasspath.from(it) }
                 renderClasspath.from(rendererConfig)
@@ -74,6 +75,20 @@ internal object ComposePreviewTasks {
             registerStubRenderTask(project, previewOutputDir, sourceClassDirs, dependencyConfigName, discoverTask, extension)
         }
     }
+
+    /**
+     * Shared `Provider<String>` for the `composePreview.tier` Gradle property.
+     * `"fast"` (case-insensitive) tells the renderer to skip captures whose
+     * `cost` exceeds [HEAVY_COST_THRESHOLD]; anything else maps to `"full"`.
+     * Lazy + cacheable through `project.providers`, so reading `.get()` at
+     * task-execution time doesn't invalidate the configuration cache when
+     * the Gradle property flips between runs.
+     */
+    internal fun tierProperty(project: Project): Provider<String> =
+        project.providers
+            .gradleProperty("composePreview.tier")
+            .map { v -> if (v.equals("fast", ignoreCase = true)) "fast" else "full" }
+            .orElse("full")
 
     fun registerDiscoverTask(
         project: Project,
@@ -139,6 +154,7 @@ internal object ComposePreviewTasks {
             outputDir.set(previewOutputDir.map { it.dir("renders") })
             renderBackend.set("stub")
             useComposeRenderer.set(false)
+            tier.set(tierProperty(project))
             renderClasspath.from(sourceClassDirs)
             project.configurations.findByName(dependencyConfigName)?.let { renderClasspath.from(it) }
             group = "compose preview"
@@ -193,6 +209,14 @@ internal object ComposePreviewTasks {
         // check the failure surfaces only in downstream tools (CLI / VSCode).
         val manifestFile = previewOutputDir.map { it.file("previews.json") }
         val rendersDir = previewOutputDir.map { it.dir("renders") }
+        // Captured at config time so the `doLast` body doesn't reach for
+        // `project` at execution (config-cache safe). Resolves at execution
+        // to "fast" or "full"; "fast" tells the post-condition to tolerate
+        // heavy captures that legitimately weren't rendered this run.
+        val tierProvider = project.providers
+            .gradleProperty("composePreview.tier")
+            .map { v -> if (v.equals("fast", ignoreCase = true)) "fast" else "full" }
+            .orElse("full")
         project.tasks.register("renderAllPreviews", DefaultTask::class.java) {
             group = "compose preview"
             dependsOn(extension.historyEnabled.map { enabled -> if (enabled) historizeTask else renderTask })
@@ -202,6 +226,7 @@ internal object ComposePreviewTasks {
             // inspect when the a11y threshold trips the build.
             verifyAccessibilityTask?.let { finalizedBy(it) }
             doLast {
+                val isFastTier = tierProvider.get() == "fast"
                 val manifestOnDisk = manifestFile.get().asFile
                 if (!manifestOnDisk.exists()) return@doLast
                 val manifest = previewManifestJson
@@ -243,6 +268,13 @@ internal object ComposePreviewTasks {
                 val missing = manifest.previews
                     .filter { p ->
                         p.captures.any { c ->
+                            // `tier=fast` legitimately skips heavy captures —
+                            // their PNG/GIF either still exists on disk from a
+                            // prior full run (and stays usable as the "stale"
+                            // image) or hasn't been produced yet. Either way,
+                            // it isn't a wiring bug worth failing the build
+                            // over, so exclude them from the must-exist check.
+                            if (isFastTier && isHeavyCost(c.cost)) return@any false
                             val rel = c.renderOutput.ifEmpty { "renders/${p.id}.png" }
                             // `@PreviewParameter` previews fan out at render
                             // time: manifest carries a `<stem>.png` template,

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -523,6 +523,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
                 Capture(
                     animation = effectiveAnimation,
                     renderOutput = "renders/${previewId}${suffix}.gif",
+                    cost = ANIMATION_COST,
                 ),
             )
         }
@@ -556,10 +557,26 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
                     // keeps multi-mode annotations like `modes = [TOP, GIF]`
                     // producing one PNG + one GIF from the same function.
                     val ext = if (scroll?.mode == ScrollMode.GIF) "gif" else "png"
+                    // Cost is normalised to a static @Preview = 1.0. The mode
+                    // ladder (TOP < END ≪ LONG < GIF) reflects how much extra
+                    // work each scroll variant adds on top of the baseline
+                    // compose pass. `advanceTimeMillis` alone is still one
+                    // pass at a specific virtual time, so it doesn't bump the
+                    // per-capture cost — the wall-time of a multi-timing
+                    // fan-out is in the *count*, which lives in the captures
+                    // list itself.
+                    val captureCost = when (scroll?.mode) {
+                        null -> STATIC_COST
+                        ScrollMode.TOP -> SCROLL_TOP_COST
+                        ScrollMode.END -> SCROLL_END_COST
+                        ScrollMode.LONG -> SCROLL_LONG_COST
+                        ScrollMode.GIF -> SCROLL_GIF_COST
+                    }
                     Capture(
                         advanceTimeMillis = ms,
                         scroll = scroll,
                         renderOutput = "renders/${previewId}${scrollSuffix}${timeSuffix}.${ext}",
+                        cost = captureCost,
                     )
                 }
             }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -84,6 +84,46 @@ data class AnimationCapture(
     val showCurves: Boolean = false,
 )
 
+/**
+ * Cost catalogue, normalised so a static `@Preview` (single compose pass +
+ * one screenshot) is `1.0`. The discovery task stamps the right value onto
+ * each [Capture]; tooling reads them back to throttle interactive renders.
+ *
+ * Values are wall-time approximations (relative, not absolute):
+ *
+ *  - [STATIC_COST] / [SCROLL_TOP_COST] = 1 — one compose pass, one PNG.
+ *  - [SCROLL_END_COST] ≈ 3 — single capture plus a scroll-drive prelude.
+ *  - [SCROLL_LONG_COST] ≈ 20 — multi-slice stitched into a tall PNG.
+ *  - [SCROLL_GIF_COST] ≈ 40 — many frames + GIF encode.
+ *  - [ANIMATION_COST] ≈ 50 — `@AnimatedPreview` window: frame loop +
+ *    optional curve strip + GIF encode. Frame counts vary slightly with
+ *    the auto-detected duration, but the wall-time is dominated by the
+ *    GIF encode, so a flat figure approximates well enough for tiering.
+ *  - [ACCESSIBILITY_COST_PER_CAPTURE] = 4 — flat per-capture overhead
+ *    when ATF runs (not stored on the manifest because it's a global
+ *    runtime toggle; tooling adds it in when computing effective cost).
+ *
+ * [HEAVY_COST_THRESHOLD] sits above END (3) and below LONG (20), so the
+ * cheap-enough-for-every-save bucket includes static + TOP + END, and
+ * LONG / GIF / animated captures fall into the on-demand "heavy" bucket.
+ */
+const val STATIC_COST: Float = 1.0f
+const val SCROLL_TOP_COST: Float = 1.0f
+const val SCROLL_END_COST: Float = 3.0f
+const val SCROLL_LONG_COST: Float = 20.0f
+const val SCROLL_GIF_COST: Float = 40.0f
+const val ANIMATION_COST: Float = 50.0f
+const val ACCESSIBILITY_COST_PER_CAPTURE: Float = 4.0f
+const val HEAVY_COST_THRESHOLD: Float = 5.0f
+
+/**
+ * Returns `true` when [cost] exceeds [HEAVY_COST_THRESHOLD]. Single seam so
+ * the plugin, renderer, and VS Code extension all agree on which captures
+ * the interactive save loop should skip — there's no separate enum field
+ * on the manifest, just the numeric cost.
+ */
+fun isHeavyCost(cost: Float): Boolean = cost > HEAVY_COST_THRESHOLD
+
 @Serializable
 data class PreviewParams(
     val name: String? = null,
@@ -155,6 +195,15 @@ data class Capture(
     val animation: AnimationCapture? = null,
     /** Module-relative PNG path, e.g. `renders/<preview id>_TIME_500ms.png`. */
     val renderOutput: String = "",
+    /**
+     * Estimated render cost, normalised so a static `@Preview` is `1.0`.
+     * See the cost catalogue at the top of this file ([STATIC_COST],
+     * [SCROLL_LONG_COST], [ANIMATION_COST], …) for the figures the
+     * discovery task stamps in. Defaults to `1.0` so older manifests
+     * (pre-cost field) parse as cheap-everywhere and older tooling keeps
+     * its historical "render everything on every save" behaviour.
+     */
+    val cost: Float = STATIC_COST,
 )
 
 @Serializable

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -31,6 +31,16 @@ abstract class RenderPreviewsTask : DefaultTask() {
     @get:Input
     abstract val useComposeRenderer: Property<Boolean>
 
+    /**
+     * Render-tier filter. When `"fast"` the desktop / stub path skips any
+     * preview whose representative capture is heavier than
+     * [HEAVY_COST_THRESHOLD] (TOP / static stay in; LONG / GIF / animated
+     * fall out). Default `"full"` keeps the historical behaviour (every
+     * preview rendered).
+     */
+    @get:Input
+    abstract val tier: Property<String>
+
     @get:Classpath
     abstract val renderClasspath: ConfigurableFileCollection
 
@@ -43,10 +53,38 @@ abstract class RenderPreviewsTask : DefaultTask() {
     @get:Inject
     abstract val workerExecutor: WorkerExecutor
 
+    init {
+        // Caching is intentionally gated on `tier=full`: a `tier=fast` run
+        // only writes a subset of captures (fast ones), so a build-cache
+        // restore from a fast snapshot would *wipe* the previous full run's
+        // heavy outputs from `outputDir` — exactly the stale images the
+        // interactive UI relies on. Up-to-date checks still apply, so a
+        // re-run with no input changes is a no-op and the renders directory
+        // stays as-is regardless of tier.
+        outputs.cacheIf("renderPreviews caches tier=full runs only") {
+            tier.get().equals("full", ignoreCase = true)
+        }
+    }
+
     @TaskAction
     fun render() {
         val json = Json { ignoreUnknownKeys = true }
-        val manifest = json.decodeFromString<PreviewManifest>(previewsJson.get().asFile.readText())
+        val rawManifest = json.decodeFromString<PreviewManifest>(previewsJson.get().asFile.readText())
+
+        // Tier filter — drop previews whose representative capture is heavy
+        // when running in `fast` mode. The desktop / stub path renders just
+        // the first capture per preview, so the decision is per-preview
+        // rather than per-capture (unlike the Robolectric path which can
+        // pick and choose among an entry's captures). Skipped previews keep
+        // their previous PNG on disk (referenced by the manifest, untouched
+        // by `cleanStaleRenders`) so VS Code can still display the stale
+        // image with its badge.
+        val isFastTier = tier.get().equals("fast", ignoreCase = true)
+        val previews = if (!isFastTier) rawManifest.previews else rawManifest.previews.filter {
+            val firstCost = it.captures.firstOrNull()?.cost ?: STATIC_COST
+            !isHeavyCost(firstCost)
+        }
+        val manifest = if (isFastTier) rawManifest.copy(previews = previews) else rawManifest
 
         if (manifest.previews.isEmpty()) {
             logger.lifecycle("No previews to render.")
@@ -62,7 +100,8 @@ abstract class RenderPreviewsTask : DefaultTask() {
             renderWithStub(manifest, outDir)
         }
 
-        logger.lifecycle("Rendered ${manifest.previews.size} preview(s)")
+        val tierTag = if (isFastTier) " (fast tier; ${rawManifest.previews.size - manifest.previews.size} heavy skipped)" else ""
+        logger.lifecycle("Rendered ${manifest.previews.size} preview(s)$tierTag")
     }
 
     private fun renderWithCompose(manifest: PreviewManifest, outDir: java.io.File) {

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -49,6 +49,15 @@ data class AnimationCapture(
     val showCurves: Boolean = false,
 )
 
+/**
+ * Heavy/fast threshold for [RenderPreviewCapture.cost]. Mirrors the plugin's
+ * `HEAVY_COST_THRESHOLD` — anything strictly greater is considered "heavy"
+ * and gets dropped when `composeai.render.tier=fast`. Single source of truth
+ * for the renderer; the plugin enforces the same threshold over the same
+ * cost numbers it stamped at discovery.
+ */
+const val HEAVY_COST_THRESHOLD: Float = 5.0f
+
 @Serializable
 data class RenderManifest(
     val module: String,
@@ -160,6 +169,12 @@ data class RenderPreviewCapture(
     val scroll: ScrollCapture? = null,
     val animation: AnimationCapture? = null,
     val renderOutput: String = "",
+    /**
+     * Estimated render cost normalised so a static `@Preview` is `1.0`. See
+     * the plugin's `Capture.cost` for the full catalogue. Defaults to `1.0`
+     * so older manifests parse as cheap-everywhere.
+     */
+    val cost: Float = 1.0f,
 )
 
 @Serializable

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -66,7 +66,21 @@ object PreviewManifestLoader {
         // manifest: provider values can be arbitrary runtime objects, often
         // not JSON-representable.
         val expanded = manifest.previews.flatMap { expandParameterProvider(it) }
-        return expanded
+        // Tier filter (set by the plugin via TierSystemPropProvider). When
+        // `fast`, drop captures classified HEAVY (`@AnimatedPreview` and
+        // non-TOP `@ScrollingPreview`) — the interactive save loop only
+        // re-renders cheap captures; heavy ones keep their previous PNG/GIF
+        // on disk and stay reachable via VS Code's per-card refresh action.
+        // Entries left with zero captures are dropped from sharding entirely
+        // so shards don't allocate a row for a no-op render.
+        val isFast = System.getProperty("composeai.render.tier", "full")
+            .equals("fast", ignoreCase = true)
+        val filtered = if (!isFast) expanded else expanded.mapNotNull { row ->
+            val keep = row.entry.captures.filter { it.cost <= HEAVY_COST_THRESHOLD }
+            if (keep.isEmpty()) null
+            else PreviewRow(row.entry.copy(captures = keep), row.previewArgs)
+        }
+        return filtered
             .withIndex()
             .filter { (i, _) -> i % shardCount == shardIndex }
             .map { (_, row) -> arrayOf<Any>(row.entry, row.previewArgs) }

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -390,6 +390,20 @@ body {
     border-color: var(--vscode-errorForeground);
 }
 
+/* Stale heavy capture: dim the rendered image so the user notices it isn't
+   fresh, and tint the warning icon. The badge button itself is the only
+   click target — clicking re-runs render at tier=full for this module. */
+.preview-card.is-stale .image-container img {
+    opacity: 0.7;
+}
+.card-stale-btn {
+    color: var(--vscode-editorWarning-foreground, #cca700);
+}
+.card-stale-btn:hover {
+    color: var(--vscode-editorWarning-foreground, #cca700);
+    background: var(--vscode-toolbar-hoverBackground, rgba(255, 255, 255, 0.08));
+}
+
 /* Persistent variant summary — sits below the preview image so it never
    overlaps content, while still letting sibling previews (e.g.
    @WearPreviewFontScales × 6) read as distinct without a hover header. */

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -12,7 +12,7 @@ import { PreviewCodeLensProvider } from './previewCodeLensProvider';
 import { PreviewA11yDiagnostics } from './previewA11yDiagnostics';
 import { PreviewDoctorDiagnostics } from './previewDoctorDiagnostics';
 import { packageQualifiedSourcePath } from './sourcePath';
-import { PreviewInfo } from './types';
+import { HEAVY_COST_THRESHOLD, PreviewInfo } from './types';
 import { captureLabel } from './captureLabels';
 
 const DEBOUNCE_MS = 1500;
@@ -434,11 +434,16 @@ function maybeFirePendingRefresh(): void {
 
 /** Runs {@link refresh} with the `refreshInFlight` gate so the debounce queue
  *  can tell whether to defer. On completion picks up anything that arrived
- *  during the run, re-applying the debounce-elapsed check. */
+ *  during the run, re-applying the debounce-elapsed check.
+ *
+ *  Save-driven: always `tier='fast'`. Heavy captures (LONG / GIF / animated)
+ *  keep their previous PNG/GIF on disk and surface as stale in the panel —
+ *  the user re-renders them on demand via the refresh command, which uses
+ *  `tier='full'`. Keeps every save in the cheap interactive loop. */
 async function runRefreshExclusive(filePath: string): Promise<void> {
     refreshInFlight = true;
     try {
-        await refresh(true, filePath);
+        await refresh(true, filePath, 'fast');
     } finally {
         refreshInFlight = false;
         maybeFirePendingRefresh();
@@ -452,11 +457,28 @@ function sendModuleList() {
 }
 
 /**
+ * Modules where the most recent render was `tier='fast'` — heavy captures
+ * (LONG / GIF / animated) are stale on disk relative to the user's source.
+ * The webview reads this to decorate heavy cards with a "stale, click to
+ * refresh" badge. Cleared per module on a successful `tier='full'` render.
+ */
+const fastTierModules = new Set<string>();
+
+/**
  * Main refresh entry point.
  * @param forceRender  If true, runs renderAllPreviews (not just discover).
  * @param forFilePath  If set, scopes to the module owning this file.
+ * @param tier         Which render tier to request when `forceRender` is true.
+ *                     Defaults to `'full'` so explicit user-triggered refreshes
+ *                     produce up-to-date heavy captures; the save-driven path
+ *                     overrides to `'fast'` (see {@link runRefreshExclusive}).
+ *                     Ignored when `forceRender` is false (discover-only).
  */
-async function refresh(forceRender: boolean, forFilePath?: string) {
+async function refresh(
+    forceRender: boolean,
+    forFilePath?: string,
+    tier: 'fast' | 'full' = 'full',
+) {
     if (!gradleService || !panel) { return; }
 
     // Cancel any in-flight refresh
@@ -525,8 +547,19 @@ async function refresh(forceRender: boolean, forFilePath?: string) {
             if (abort.signal.aborted) { return; }
 
             const manifest = forceRender
-                ? await gradleService.renderPreviews(mod)
+                ? await gradleService.renderPreviews(mod, tier)
                 : await gradleService.discoverPreviews(mod);
+
+            // Track tier so the webview can mark heavy cards as stale after a
+            // fast save. A successful full render clears the flag for this
+            // module (heavy captures are now fresh on disk).
+            if (forceRender && manifest) {
+                if (tier === 'fast') {
+                    fastTierModules.add(mod);
+                } else {
+                    fastTierModules.delete(mod);
+                }
+            }
 
             const perModule: PreviewInfo[] = [];
             if (manifest) {
@@ -577,20 +610,38 @@ async function refresh(forceRender: boolean, forFilePath?: string) {
             return;
         }
 
+        // A preview is "heavyStale" when this module's most recent render was
+        // tier=fast AND the preview has at least one heavy capture. The
+        // webview decorates these cards with a stale badge so the user knows
+        // the GIF/long-scroll image is from a previous full render.
+        const moduleIsFastTier = modules.some(mod => fastTierModules.has(mod));
+        const heavyStaleIds = moduleIsFastTier
+            ? visiblePreviews
+                .filter(p => p.captures.some(c => (c.cost ?? 1) > HEAVY_COST_THRESHOLD))
+                .map(p => p.id)
+            : [];
+
         panel.postMessage({
             command: 'setPreviews',
             previews: visiblePreviews,
             moduleDir: modules.join(','),
+            heavyStaleIds,
         });
         hasPreviewsLoaded = true;
         logLine(`rendered ${visiblePreviews.length} preview(s) for ${path.basename(activeFile)}`);
 
-        // Load images asynchronously. Animated previews have multiple captures
+        // Load images in parallel. Animated previews have multiple captures
         // in `preview.captures`; one updateImage message per capture. The
         // registry (used for CodeLens / hover) keeps only the representative
         // (first) capture's PNG.
+        //
+        // Sequential awaits here used to be the long pole on a 16-preview
+        // module with @AnimatedPreview GIFs — each capture is a 1-5MB read +
+        // base64 encode. Streaming them concurrently lets each card paint
+        // as soon as its bytes arrive rather than waiting for an arbitrary
+        // serial position.
+        const imageJobs: Promise<void>[] = [];
         for (const preview of visiblePreviews) {
-            if (abort.signal.aborted) { return; }
             const captures = preview.captures;
             if (captures.length === 0) { continue; }
 
@@ -598,47 +649,50 @@ async function refresh(forceRender: boolean, forFilePath?: string) {
             if (!mod) { continue; }
 
             for (let captureIndex = 0; captureIndex < captures.length; captureIndex++) {
-                if (abort.signal.aborted) { return; }
                 const capture = captures[captureIndex];
                 if (!capture.renderOutput) { continue; }
-                const imageData = await gradleService.readPreviewImage(mod, capture.renderOutput);
-                if (abort.signal.aborted) { return; }
+                const idx = captureIndex;
+                imageJobs.push((async () => {
+                    if (abort.signal.aborted) { return; }
+                    const imageData = await gradleService!.readPreviewImage(mod, capture.renderOutput);
+                    if (abort.signal.aborted || !panel) { return; }
 
-                if (imageData) {
-                    if (captureIndex === 0) {
-                        registry.setImage(preview.id, imageData);
+                    if (imageData) {
+                        if (idx === 0) {
+                            registry.setImage(preview.id, imageData);
+                        }
+                        panel.postMessage({
+                            command: 'updateImage',
+                            previewId: preview.id,
+                            captureIndex: idx,
+                            imageData,
+                        });
+                    } else if (forceRender) {
+                        // Render task completed but produced no PNG for this
+                        // capture — a per-capture failure that didn't fail the
+                        // whole task. Surface it on the card; root-cause log is
+                        // in Output ▸ Compose Preview.
+                        panel.postMessage({
+                            command: 'setImageError',
+                            previewId: preview.id,
+                            captureIndex: idx,
+                            message: 'Render failed — see Output ▸ Compose Preview',
+                        });
                     }
-                    panel.postMessage({
-                        command: 'updateImage',
-                        previewId: preview.id,
-                        captureIndex,
-                        imageData,
-                    });
-                } else if (forceRender) {
-                    // Render task completed but produced no PNG for this
-                    // capture — a per-capture failure that didn't fail the
-                    // whole task. Surface it on the card; root-cause log is
-                    // in Output ▸ Compose Preview.
-                    panel.postMessage({
-                        command: 'setImageError',
-                        previewId: preview.id,
-                        captureIndex,
-                        message: 'Render failed — see Output ▸ Compose Preview',
-                    });
-                }
-                // else: discover-only pass, PNG not produced yet. Leave the
-                // skeleton in place; the next save-triggered render will
-                // populate it.
+                    // else: discover-only pass, PNG not produced yet. Leave
+                    // the skeleton in place; the next save-triggered render
+                    // will populate it.
+                })());
             }
         }
+        await Promise.all(imageJobs);
 
         // NOTE: intentionally do NOT send `showMessage: ''` here. The webview's
-        // renderPreviews() already hides the "Building…" message when cards
-        // populate, so this used to be a no-op for the happy path — but it
-        // *did* clobber legitimate messages (e.g. "No previews match the
-        // current filters" set by applyFilters, or the empty-file notice
-        // above), which is what produced the "populate then go blank with
-        // nothing in the logs" symptom.
+        // renderPreviews() clears the 'loading' Building… banner the moment
+        // cards arrive, so the happy path is already covered. Posting a blank
+        // showMessage would also clobber legitimate extension-set messages
+        // (filter empty notice, build errors), which was the original
+        // "populate then go blank" regression.
     } catch (err: unknown) {
         if (abort.signal.aborted) { return; }
         if (err instanceof JdkImageError) {
@@ -681,10 +735,24 @@ function handleWebviewMessage(msg: WebviewToExtensionMessage) {
                 sendHistoryImage(msg.previewId, msg.filename);
             }
             break;
+        case 'refreshHeavy':
+            // Click on the stale badge → full-tier render of the owning
+            // module. Once we have a `-PcomposePreview.previewIds=` filter
+            // we can scope this to just the requested capture; for now the
+            // user pays a full-module render for the freshness guarantee.
+            if (msg.previewId) {
+                const mod = previewModuleMap.get(msg.previewId);
+                if (mod) {
+                    void refresh(true, currentScopeFile ?? undefined, 'full');
+                }
+            }
+            break;
     }
 }
 
-// Loose type for incoming webview messages (validated per-case above)
+// Loose type for incoming webview messages (validated per-case above).
+// Field union accommodates every case in handleWebviewMessage so no cast
+// gymnastics are needed at the use site.
 interface WebviewToExtensionMessage {
     command: string;
     className?: string;

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -132,9 +132,32 @@ export class GradleService {
         return manifest;
     }
 
-    async renderPreviews(module: string): Promise<PreviewManifest | null> {
+    /**
+     * Runs `:<module>:renderAllPreviews` and returns the parsed manifest.
+     *
+     * `tier` controls which captures the renderer produces:
+     *
+     *   - `'fast'` — append `-PcomposePreview.tier=fast`; the plugin's
+     *     `RobolectricRenderTest` and `RenderPreviewsTask` skip captures
+     *     whose `cost` exceeds `HEAVY_COST_THRESHOLD` (LONG / GIF /
+     *     animated). Cheap interactive loop on every save.
+     *   - `'full'` — explicit `-PcomposePreview.tier=full`; renders
+     *     everything. The user-triggered "Render All Previews" path.
+     *
+     * Same task name in either case so Gradle's up-to-date check still
+     * applies — the tier is an `@Input` on the underlying task, so flipping
+     * tier between calls correctly invalidates the up-to-date cache without
+     * burning a config-cache reconfigure (see `TierSystemPropProvider`).
+     */
+    async renderPreviews(
+        module: string,
+        tier: 'fast' | 'full' = 'full',
+    ): Promise<PreviewManifest | null> {
         this.manifestCache.delete(module);
-        await this.runTask(`:${module}:renderAllPreviews`);
+        await this.runTask(
+            `:${module}:renderAllPreviews`,
+            [`-PcomposePreview.tier=${tier}`],
+        );
         const manifest = this.readManifest(module);
         if (manifest) {
             this.manifestCache.set(module, { manifest, timestamp: Date.now() });
@@ -424,7 +447,7 @@ export class GradleService {
         this.cancel();
     }
 
-    private runTask(task: string): Promise<void> {
+    private runTask(task: string, extraArgs: ReadonlyArray<string> = []): Promise<void> {
         const cancellationKey = `compose-preview-${++this.taskCounter}|${task}`;
         this.activeKeys.add(cancellationKey);
         this.logger.appendLine(`> ${task}`);
@@ -445,7 +468,7 @@ export class GradleService {
         const taskPromise = this.gradleApi.runTask({
             projectFolder: this.workspaceRoot,
             taskName: task,
-            args: this.argsProvider(),
+            args: [...this.argsProvider(), ...extraArgs],
             showOutputColors: false,
             cancellationKey,
             onOutput: (output) => {

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -378,6 +378,12 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 titleRow.appendChild(historyBtn);
             }
 
+            // Stale-tier refresh button — only attached up front for cards
+            // already known to be stale at setPreviews time. updateStaleBadges
+            // also adds/removes it on subsequent renders. Placed before the
+            // header is appended so its DOM order stays predictable.
+            applyStaleBadge(card, false);
+
             header.appendChild(titleRow);
             card.appendChild(header);
 
@@ -842,9 +848,12 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 setMessage('No @Preview functions found', 'empty');
                 return;
             }
-            // Only clear a message we own (filter/empty/fallback) — leave
-            // extension-set messages like "Building…" alone; the extension
-            // will drive its own lifecycle.
+            // Clear transient owner messages now that we have cards. The
+            // 'loading' Building… banner gets clobbered here so cards aren't
+            // hidden under it while images stream in. 'extension'-owned
+            // messages (build errors, empty-state notices) are left alone —
+            // those are terminal states the extension is asserting and the
+            // caller wouldn't be sending setPreviews alongside them anyway.
             if (message.dataset.owner && message.dataset.owner !== 'extension') {
                 setMessage('', message.dataset.owner);
             }
@@ -899,6 +908,57 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     lastInsertedCard = card;
                 }
             }
+        }
+
+        /**
+         * Toggles the "stale render — click to refresh" affordance on a card.
+         *
+         * Called both at card creation time (so cards born stale have the
+         * badge from the start) and from updateStaleBadges after each
+         * setPreviews (state can flip when the user toggles between fast
+         * and full saves). Idempotent: skips if the desired state already
+         * matches the DOM, so re-running on an unchanged card is cheap.
+         *
+         * Why a button rather than a static badge: clicking it is the only
+         * way the user can recover a fresh GIF/long-scroll image without
+         * editing source. Keeping it inside the title row puts it in the
+         * same affordance band as history / open-source buttons.
+         */
+        function applyStaleBadge(card, isStale) {
+            const titleRow = card.querySelector('.card-title-row');
+            if (!titleRow) return;
+            const existing = card.querySelector('.card-stale-btn');
+            if (isStale && !existing) {
+                const btn = document.createElement('button');
+                btn.className = 'icon-button card-stale-btn';
+                btn.title = 'Stale heavy capture — click to render at full tier';
+                btn.setAttribute('aria-label', 'Refresh stale capture');
+                btn.innerHTML = '<i class="codicon codicon-warning" aria-hidden="true"></i>';
+                btn.addEventListener('click', () => {
+                    vscode.postMessage({
+                        command: 'refreshHeavy',
+                        previewId: card.dataset.previewId,
+                    });
+                });
+                titleRow.appendChild(btn);
+                card.classList.add('is-stale');
+            } else if (!isStale && existing) {
+                existing.remove();
+                card.classList.remove('is-stale');
+            }
+        }
+
+        /**
+         * Apply the heavy-stale badge state across all cards after
+         * setPreviews fires. The extension passes a list of preview IDs
+         * whose heavy captures weren't refreshed this run; everything else
+         * gets its badge cleared.
+         */
+        function updateStaleBadges(heavyStaleIds) {
+            const stale = new Set(heavyStaleIds || []);
+            grid.querySelectorAll('.preview-card').forEach(card => {
+                applyStaleBadge(card, stale.has(card.dataset.previewId));
+            });
         }
 
         /** Add a subtle spinner overlay to every card during a stealth refresh. */
@@ -1054,6 +1114,12 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     moduleDir = msg.moduleDir;
                     renderPreviews(msg.previews);
                     applyRelativeSizing(msg.previews);
+                    // Stale-tier badges depend on the latest render's tier
+                    // (sent from the extension as heavyStaleIds). Apply
+                    // *after* renderPreviews so the badge attaches to cards
+                    // that were just inserted, not stripped by a stale-state
+                    // diff from the previous setPreviews.
+                    updateStaleBadges(msg.heavyStaleIds);
 
                     const fns = [...new Set(msg.previews.map(p => p.functionName))].sort();
                     const groups = [...new Set(msg.previews.map(p => p.params.group).filter(Boolean))].sort();
@@ -1120,7 +1186,11 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                             }
                         }
                     } else {
-                        setMessage('Building…', 'extension');
+                        // 'loading' (not 'extension') so renderPreviews can
+                        // clear it the moment cards arrive — otherwise the
+                        // banner sits on top of skeleton cards while images
+                        // stream in, which looks like the build is stuck.
+                        setMessage('Building…', 'loading');
                     }
                     break;
 

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -41,6 +41,14 @@ export interface ScrollCapture {
 }
 
 /**
+ * Threshold above which a capture's `cost` is considered "heavy" — dropped
+ * from `composePreview.tier=fast` renders, surfaces in VS Code with a
+ * stale-state badge, refreshed only on explicit user action. Mirrors the
+ * plugin's `HEAVY_COST_THRESHOLD` in `PreviewData.kt`.
+ */
+export const HEAVY_COST_THRESHOLD = 5;
+
+/**
  * One rendered snapshot of a preview. Non-null dimensional fields
  * (advanceTimeMillis, scroll) are the coordinates that distinguish this
  * capture from its siblings. A static preview has a single capture with
@@ -56,6 +64,14 @@ export interface Capture {
      *  [captureLabels.captureLabel]) before sending to the webview so the
      *  carousel markup stays free of dimension logic. */
     label?: string;
+    /**
+     * Estimated render cost, normalised so a static `@Preview` is `1.0`.
+     * Catalogue: TOP=1, END=3, LONG=20, GIF=40, animation=50. Tooling
+     * thresholds on `cost > HEAVY_COST_THRESHOLD` to decide what to skip
+     * during interactive saves. Defaults to `1` when missing (older
+     * manifests pre-cost-field).
+     */
+    cost?: number;
 }
 
 export interface PreviewInfo {
@@ -144,7 +160,18 @@ export interface HistoryEntry {
 
 /** Messages from extension to webview */
 export type ExtensionToWebview =
-    | { command: 'setPreviews'; previews: PreviewInfo[]; moduleDir: string }
+    | {
+          command: 'setPreviews';
+          previews: PreviewInfo[];
+          moduleDir: string;
+          /**
+           * IDs of previews whose heavy captures (LONG / GIF / animated)
+           * were skipped this render — the on-disk PNG/GIF is from a
+           * previous full run. Drives the "stale, click to refresh" badge.
+           * Empty when the module was last rendered with `tier=full`.
+           */
+          heavyStaleIds?: string[];
+      }
     /** `captureIndex` addresses which capture within an animated preview the
      *  image belongs to. Static previews have a single capture at index 0. */
     | { command: 'updateImage'; previewId: string; captureIndex: number; imageData: string }
@@ -164,4 +191,11 @@ export type WebviewToExtension =
     | { command: 'openFile'; className: string; functionName: string }
     | { command: 'selectModule'; value: string }
     | { command: 'showHistory'; previewId: string }
-    | { command: 'loadHistoryImage'; previewId: string; filename: string };
+    | { command: 'loadHistoryImage'; previewId: string; filename: string }
+    /**
+     * User clicked the stale-badge refresh icon on a heavy card. Triggers a
+     * `tier='full'` render of the owning module so the heavy capture is
+     * re-rendered. (A future per-preview filter would scope this to the
+     * single previewId; today it falls back to a full-module render.)
+     */
+    | { command: 'refreshHeavy'; previewId: string };


### PR DESCRIPTION
## Summary

- **Fix:** "Building…" banner no longer sits on top of skeleton cards while images stream in. The webview now uses a distinct `'loading'` owner that `renderPreviews()` clears the moment cards arrive.
- **Fix:** image reads run in parallel via `Promise.all` instead of awaiting in a serial loop — a 16-preview module with multi-MB GIFs paints as soon as each capture's bytes arrive (it was the long pole on the "stuck at building" symptom in 0.8.0).
- **Feat:** every `Capture` carries a normalised `cost` (static = 1.0; END = 3, LONG = 20, GIF = 40, animated = 50; a11y is +4 at runtime), stamped at discovery and shipped in `previews.json`. Mirrored on `RenderManifest.kt` and the TS `Capture` type.
- **Feat:** save-driven refreshes pass `-PcomposePreview.tier=fast`, which the plugin uses to skip captures whose cost exceeds `HEAVY_COST_THRESHOLD` (5). The `composePreview.refresh` command and the new per-card stale-badge button both pass `tier=full` so heavy captures (LONG / GIF / animated) only re-render on explicit user action. Heavy cards display a stale-state badge and dim their image when the module's most recent render was tier=fast.

### Caching notes
- `tier` is fed via `CommandLineArgumentProvider` (Robolectric Test task) and a Property `@Input` (`RenderPreviewsTask`) so flipping it doesn't invalidate the configuration cache.
- Output caching is gated `cacheIf("full only")` on both render task implementations: a tier=fast cache restore would wipe the heavy outputs from a previous full run, breaking the stale-image story. Up-to-date checks still apply, so tier=fast re-runs with no input changes are no-ops and the renders directory stays as-is.
- The `renderAllPreviews` post-condition check tolerates missing files for heavy captures when tier=fast.

### Out of scope (follow-up)
- Per-preview / visible-only `previewIds=` filter for even tighter interactive loops (regenerate only what's on screen, with cost-budget heuristics).
- Focus-mode auto-refresh for stale heavy captures.
- @vscode/test-electron integration tests covering the full message contract (next PR).

## Test plan

- [x] `./gradlew :gradle-plugin:test` passes (existing functional tests unchanged).
- [x] `./gradlew :renderer-android:compileDebugKotlin` succeeds.
- [x] `npm run compile && mocha out/test/**/*.test.js` — 65 tests pass.
- [ ] Manual smoke in `cadence` (or another sample project on 0.8.x): edit a `.kt` with mixed static + animated previews, confirm static cards repaint within ~1s of save while animated cards keep their previous GIF + show the stale badge; click the badge to verify a full-tier render kicks in.
- [ ] Verify `tier=fast` and `tier=full` get separate cache entries (`./gradlew :app:renderAllPreviews -PcomposePreview.tier=fast --info` then re-run with `tier=full`, look for cache miss / re-execution log).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxHvPDB1fMwp478kNPXXoU)_