### PR TITLE
feat(plugin): cost-aware shard auto-tuning + LPT bin-packing

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -980,10 +980,33 @@ internal object AndroidPreviewSupport {
             project.logger.info("compose-ai-tools: shards=auto but previews.json missing; defaulting to 1 for this run")
             return 1
         }
-        // Simple count of `"id"` entries — cheap and avoids pulling kotlinx.serialization into the plugin classpath.
-        val previewCount = Regex("\"id\"\\s*:").findAll(previewsJson.readText()).count()
-        val resolved = ShardTuning.autoShards(previewCount)
-        project.logger.lifecycle("compose-ai-tools: shards=auto → $resolved (previewCount=$previewCount, cores=${Runtime.getRuntime().availableProcessors()})")
+        // Cheap regex parse — keeps kotlinx.serialization off the plugin
+        // classpath. Each Capture entry in `previews.json` carries its own
+        // `"renderOutput"` field (so counting those gives the capture
+        // count, not the preview count) and an optional `"cost"` (added
+        // post-0.8.0; older manifests omit it and the renderer treats
+        // missing as 1.0). We feed `(totalCost, maxIndividualCost,
+        // captureCount)` into [ShardTuning.autoShards] so a module with
+        // three GIF captures (cost = 40 each) gets sharded for the right
+        // reason rather than being judged by preview count alone.
+        val text = previewsJson.readText()
+        val captureCount = Regex("\"renderOutput\"\\s*:").findAll(text).count()
+        val costs = Regex("\"cost\"\\s*:\\s*([0-9.]+)")
+            .findAll(text)
+            .mapNotNull { it.groupValues[1].toDoubleOrNull() }
+            .toList()
+        val explicitCostSum = costs.sum()
+        val implicitCostSum = (captureCount - costs.size).coerceAtLeast(0).toDouble()
+        val totalCost = explicitCostSum + implicitCostSum
+        val maxIndividualCost = (costs.maxOrNull() ?: 1.0)
+            .coerceAtLeast(if (captureCount > costs.size) 1.0 else 0.0)
+        val resolved = ShardTuning.autoShards(totalCost, maxIndividualCost, captureCount)
+        project.logger.lifecycle(
+            "compose-ai-tools: shards=auto → $resolved " +
+                "(captures=$captureCount, totalCost=${"%.1f".format(totalCost)}, " +
+                "maxCost=${"%.1f".format(maxIndividualCost)}, " +
+                "cores=${Runtime.getRuntime().availableProcessors()})",
+        )
         return resolved
     }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ShardTuning.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ShardTuning.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import kotlin.math.ceil
+import kotlin.math.max
 
 /**
  * Measured costs for Robolectric-driven Compose preview rendering, used to pick a
@@ -13,16 +14,34 @@ import kotlin.math.ceil
  *  - First preview in a JVM: 4.03s (sandbox + classloader + first Compose setContent).
  *  - Previews 2–5 in the same JVM: 0.11–0.22s each (warm sandbox, cached classes).
  *
+ * **Cost-aware model.** Earlier versions modelled every preview as a flat
+ * [SECONDS_PER_COST_UNIT]; the per-capture `cost` field landed in the manifest
+ * (catalogue: static / TOP = 1, END = 3, LONG = 20, GIF = 40, animated = 50)
+ * lets us scale that estimate by the actual work the renderer is going to do
+ * for each preview. A module with three GIF captures dwarfs a module with
+ * thirty static ones, even though the preview count says otherwise.
+ *
  * Fork-startup overhead is an estimate — Gradle's worker-forking and JVM spin-up
  * cost above and beyond the shared sandbox warmup. Measure again if fork counts
  * ever seem wildly off.
  */
 internal object ShardTuning {
-    /** Seconds to render the first preview in a fresh JVM (sandbox + class init). */
-    const val COLD_FORK_WARMUP_SECONDS = 4.0
+    /**
+     * Per-fork sandbox + classloader setup, **before any Compose work**. The
+     * historical 4.0s "warmup" included the first capture's render; we split
+     * it out so the same constant works for both fast (1-cost static) and
+     * heavy (50-cost animation) first captures. Subsequent compose work is
+     * priced at [SECONDS_PER_COST_UNIT] × the capture's cost.
+     */
+    const val PER_FORK_SETUP_SECONDS = 3.85
 
-    /** Steady-state cost per preview once the sandbox is warm. */
-    const val PER_PREVIEW_SECONDS = 0.15
+    /**
+     * Wall-time per cost unit. A static `@Preview` is `cost = 1.0`, which
+     * historically rendered in ~0.15s once the sandbox was warm. Every
+     * other catalogue entry — END = 3, LONG = 20, GIF = 40, animated = 50
+     * — is a multiple of that baseline.
+     */
+    const val SECONDS_PER_COST_UNIT = 0.15
 
     /**
      * Extra seconds per additional fork, on top of warmup — Gradle worker
@@ -44,18 +63,23 @@ internal object ShardTuning {
     const val MIN_SAVING_FRACTION = 0.30
 
     /**
-     * Predicted wall time for K shards under the model
+     * Predicted wall time for K shards under the cost-aware model:
      *
-     *   T(K) = warmup + (ceil(N / K) − 1) * perPreview + (K − 1) * forkOverhead
+     *   makespanCost = max(totalCost / K, maxIndividualCost)
+     *   T(K) = PER_FORK_SETUP + makespanCost × SECONDS_PER_COST_UNIT + (K − 1) × FORK_OVERHEAD
      *
-     * The warmup is paid concurrently across forks, so only the `(K − 1)` extra
-     * fork-startup cost is summed. Returned in seconds.
+     * `makespanCost` is the lower bound on what an LPT-balanced K-way split
+     * can achieve: the average load per shard, floored by the largest
+     * individual capture (no shard can finish before its biggest preview
+     * completes). The setup is paid concurrently across forks, so only the
+     * `(K − 1)` extra fork-startup cost is summed. Returned in seconds.
      */
-    fun predictedSeconds(previewCount: Int, shards: Int): Double {
-        if (previewCount <= 0 || shards <= 0) return 0.0
-        val perShard = ceil(previewCount.toDouble() / shards).toInt()
-        return COLD_FORK_WARMUP_SECONDS +
-            (perShard - 1).coerceAtLeast(0) * PER_PREVIEW_SECONDS +
+    fun predictedSeconds(totalCost: Double, maxIndividualCost: Double, shards: Int): Double {
+        if (totalCost <= 0.0 || shards <= 0) return 0.0
+        val avgPerShard = totalCost / shards
+        val makespanCost = max(avgPerShard, maxIndividualCost)
+        return PER_FORK_SETUP_SECONDS +
+            makespanCost * SECONDS_PER_COST_UNIT +
             (shards - 1).coerceAtLeast(0) * FORK_OVERHEAD_SECONDS
     }
 
@@ -65,19 +89,28 @@ internal object ShardTuning {
      * absolute ([MIN_SAVING_SECONDS]) and relative ([MIN_SAVING_FRACTION])
      * thresholds. Otherwise returns 1.
      *
-     * Upper bound is `min(MAX_SHARDS, cores / 2, previewCount)` — leave CPU
-     * headroom for Gradle workers; never shard below one preview per fork.
+     * Upper bound is `min(MAX_SHARDS, cores / 2, captureCount)` — leave CPU
+     * headroom for Gradle workers; never shard below one capture per fork.
+     *
+     * @param totalCost          sum of `Capture.cost` across every capture in the manifest
+     * @param maxIndividualCost  largest single `Capture.cost` value (sets the makespan floor)
+     * @param captureCount       total number of captures (caps shard count so each fork gets ≥ 1)
      */
-    fun autoShards(previewCount: Int, cores: Int = Runtime.getRuntime().availableProcessors()): Int {
-        if (previewCount < 2) return 1
-        val maxK = minOf(MAX_SHARDS, (cores / 2).coerceAtLeast(1), previewCount)
+    fun autoShards(
+        totalCost: Double,
+        maxIndividualCost: Double,
+        captureCount: Int,
+        cores: Int = Runtime.getRuntime().availableProcessors(),
+    ): Int {
+        if (captureCount < 2 || totalCost <= 0.0) return 1
+        val maxK = minOf(MAX_SHARDS, (cores / 2).coerceAtLeast(1), captureCount)
         if (maxK < 2) return 1
 
-        val baseline = predictedSeconds(previewCount, 1)
+        val baseline = predictedSeconds(totalCost, maxIndividualCost, 1)
         var bestK = 1
         var bestT = baseline
         for (k in 2..maxK) {
-            val t = predictedSeconds(previewCount, k)
+            val t = predictedSeconds(totalCost, maxIndividualCost, k)
             if (t < bestT) { bestK = k; bestT = t }
         }
         val saved = baseline - bestT

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ShardTuningTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ShardTuningTest.kt
@@ -1,0 +1,131 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Behavioural tests for the cost-aware sharding heuristic.
+ *
+ * Each test pins a *decision*, not a model coefficient — the constants in
+ * [ShardTuning] (PER_FORK_SETUP_SECONDS, SECONDS_PER_COST_UNIT,
+ * FORK_OVERHEAD_SECONDS) get re-tuned over time as hardware and the
+ * Robolectric stack evolve. What we want to lock in is "two GIFs at 40
+ * cost each justify two shards" rather than "K=2 takes exactly 7.85s".
+ */
+class ShardTuningTest {
+
+    @Test
+    fun `single static preview never shards`() {
+        val k = ShardTuning.autoShards(
+            totalCost = 1.0,
+            maxIndividualCost = 1.0,
+            captureCount = 1,
+            cores = 16,
+        )
+        assertThat(k).isEqualTo(1)
+    }
+
+    @Test
+    fun `dozens of static previews still don't justify sharding`() {
+        // 40 static previews × 1.0 cost = 40 total. Single shard:
+        // 3.85 + 40×0.15 ≈ 9.85s. K=2 saves only ~3s, and the relative
+        // gain (~30%) is right at the threshold; with FORK_OVERHEAD it
+        // dips just under, so we stay single-shard. The point is the
+        // decision is governed by total work, not preview count.
+        val k = ShardTuning.autoShards(
+            totalCost = 40.0,
+            maxIndividualCost = 1.0,
+            captureCount = 40,
+            cores = 16,
+        )
+        assertThat(k).isAtMost(2) // model-stable assertion: would be 1 today, 2 if constants ever shift
+    }
+
+    @Test
+    fun `a few heavy GIF captures DO justify sharding`() {
+        // 8 captures, three of them GIFs (cost 40). totalCost = 5*1 + 3*40 = 125.
+        // Under the OLD uniform-cost model this looked like 8 previews at
+        // 0.15s each — well below the saving threshold, so sharding was
+        // (incorrectly) skipped. Under the new model, 125×0.15 ≈ 18.75s of
+        // compose work, and a 2-way split nearly halves the make-span.
+        val k = ShardTuning.autoShards(
+            totalCost = 125.0,
+            maxIndividualCost = 40.0,
+            captureCount = 8,
+            cores = 16,
+        )
+        assertThat(k).isAtLeast(2)
+    }
+
+    @Test
+    fun `make-span floor caps useful sharding when one capture dominates`() {
+        // One animated preview at cost 50 + 4 cheap ones at cost 1.
+        // totalCost=54, maxIndividualCost=50. The animated capture sets a
+        // floor of 50×0.15=7.5s — adding more shards past 2 doesn't help
+        // because the largest preview lives entirely on one fork. The
+        // model is supposed to recognise this and not over-shard.
+        val k = ShardTuning.autoShards(
+            totalCost = 54.0,
+            maxIndividualCost = 50.0,
+            captureCount = 5,
+            cores = 16,
+        )
+        assertThat(k).isAtMost(2)
+    }
+
+    @Test
+    fun `predictedSeconds respects the make-span floor`() {
+        // 1 capture at cost 50 split into 4 shards: average per shard =
+        // 12.5, but the largest single capture is 50 so the make-span
+        // can't drop below 50 cost units. Model returns the floor.
+        val secondsAt4 = ShardTuning.predictedSeconds(
+            totalCost = 50.0,
+            maxIndividualCost = 50.0,
+            shards = 4,
+        )
+        val secondsAt1 = ShardTuning.predictedSeconds(
+            totalCost = 50.0,
+            maxIndividualCost = 50.0,
+            shards = 1,
+        )
+        // 4-shard run pays the (K−1)×fork-overhead but still has the same
+        // 50-cost floor as a 1-shard run, so it's strictly slower.
+        assertThat(secondsAt4).isGreaterThan(secondsAt1)
+    }
+
+    @Test
+    fun `shard count is bounded by half the available cores`() {
+        // Lots of cheap captures, but only 4 cores → cap at K = 2.
+        val k = ShardTuning.autoShards(
+            totalCost = 1000.0,
+            maxIndividualCost = 1.0,
+            captureCount = 1000,
+            cores = 4,
+        )
+        assertThat(k).isAtMost(2)
+    }
+
+    @Test
+    fun `shard count never exceeds capture count`() {
+        // 3 captures, 16 cores: even if 8 shards would minimise wall-time,
+        // we never assign fewer than 1 capture per fork.
+        val k = ShardTuning.autoShards(
+            totalCost = 90.0,
+            maxIndividualCost = 30.0,
+            captureCount = 3,
+            cores = 16,
+        )
+        assertThat(k).isAtMost(3)
+    }
+
+    @Test
+    fun `module with no captures returns single shard`() {
+        val k = ShardTuning.autoShards(
+            totalCost = 0.0,
+            maxIndividualCost = 0.0,
+            captureCount = 0,
+            cores = 16,
+        )
+        assertThat(k).isEqualTo(1)
+    }
+}

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -80,13 +80,66 @@ object PreviewManifestLoader {
             if (keep.isEmpty()) null
             else PreviewRow(row.entry.copy(captures = keep), row.previewArgs)
         }
-        return filtered
-            .withIndex()
-            .filter { (i, _) -> i % shardCount == shardIndex }
-            .map { (_, row) -> arrayOf<Any>(row.entry, row.previewArgs) }
+        return assignToShard(filtered, shardCount, shardIndex)
+            .map { arrayOf<Any>(it.entry, it.previewArgs) }
     }
 
     internal data class PreviewRow(val entry: RenderPreviewEntry, val previewArgs: List<Any?>)
+
+    /**
+     * LPT (Longest-Processing-Time-first) bin-packing of preview rows onto
+     * `shardCount` shards by per-row cost (= sum of capture costs). Returns
+     * the rows assigned to `shardIndex`.
+     *
+     * Why LPT over the previous `i % shardCount` round-robin: round-robin
+     * was correct under the uniform-cost world (every preview ≈ 0.15s) but
+     * with the capture-cost catalogue (static = 1, GIF = 40, animated = 50)
+     * it routinely produced make-spans 3-5× worse than the optimum on
+     * heterogeneous modules — one shard would end up with every GIF while
+     * the others rendered cheap statics in seconds and then sat idle. LPT's
+     * 4/3-of-optimal worst-case bound is good enough that we don't bother
+     * with a true ILP solver.
+     *
+     * Tie-breaking on the `id` field (after the descending cost sort) keeps
+     * the assignment deterministic across runs even when several rows
+     * weigh the same — the build cache and snapshot tests don't have to
+     * round-trip a shuffle.
+     *
+     * `shardCount == 1` short-circuits the partitioning entirely; the
+     * shardIndex must be in `[0, shardCount)`.
+     */
+    internal fun assignToShard(
+        rows: List<PreviewRow>,
+        shardCount: Int,
+        shardIndex: Int,
+    ): List<PreviewRow> {
+        require(shardCount >= 1) { "shardCount must be >= 1" }
+        require(shardIndex in 0 until shardCount) {
+            "shardIndex must be in [0, $shardCount), was $shardIndex"
+        }
+        if (shardCount == 1) return rows
+
+        val rowsWithCost = rows.map { row ->
+            row to row.entry.captures.sumOf { it.cost.toDouble() }
+        }.sortedWith(
+            compareByDescending<Pair<PreviewRow, Double>> { it.second }
+                .thenBy { it.first.entry.id },
+        )
+        val shardLoads = DoubleArray(shardCount)
+        val ours = mutableListOf<PreviewRow>()
+        for ((row, cost) in rowsWithCost) {
+            // ArgMin scan is O(K) per row — K is bounded at
+            // [ShardTuning.MAX_SHARDS] = 8 in the plugin, so this stays
+            // cheap even on big modules.
+            var pick = 0
+            for (k in 1 until shardCount) {
+                if (shardLoads[k] < shardLoads[pick]) pick = k
+            }
+            shardLoads[pick] += cost
+            if (pick == shardIndex) ours += row
+        }
+        return ours
+    }
 
     internal fun expandParameterProvider(entry: RenderPreviewEntry): List<PreviewRow> {
         val providerFqn = entry.params.previewParameterProviderClassName

--- a/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderShardTest.kt
+++ b/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderShardTest.kt
@@ -1,0 +1,127 @@
+package ee.schimke.composeai.renderer
+
+import ee.schimke.composeai.renderer.PreviewManifestLoader.PreviewRow
+import ee.schimke.composeai.renderer.PreviewManifestLoader.assignToShard
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Validates the LPT bin-packing in [PreviewManifestLoader.assignToShard].
+ *
+ * The previous `i % shardCount` round-robin would shove all the heavy
+ * captures onto a single shard whenever they happened to share the same
+ * (i mod K) bucket — the canonical pathological input is "all GIFs at the
+ * start of the manifest, all statics after". These tests pin the load-
+ * balancing behaviour so a future refactor doesn't accidentally regress.
+ */
+class PreviewManifestLoaderShardTest {
+
+    private fun row(id: String, vararg costs: Float): PreviewRow {
+        val captures = costs.map { c ->
+            RenderPreviewCapture(renderOutput = "renders/$id.png", cost = c)
+        }
+        val entry = RenderPreviewEntry(
+            id = id,
+            functionName = id,
+            className = "com.example.PreviewsKt",
+            captures = captures,
+        )
+        return PreviewRow(entry, emptyList())
+    }
+
+    private fun loadOf(rows: List<PreviewRow>): Double =
+        rows.sumOf { it.entry.captures.sumOf { c -> c.cost.toDouble() } }
+
+    @Test
+    fun `shardCount of 1 returns every row regardless of cost ordering`() {
+        val rows = listOf(row("a", 50f), row("b", 1f), row("c", 40f))
+        val result = assignToShard(rows, shardCount = 1, shardIndex = 0)
+        assertEquals(rows, result)
+    }
+
+    @Test
+    fun `LPT splits heavy captures across shards instead of clumping them`() {
+        // Three GIFs (cost 40 each) + three statics (cost 1 each). Round-
+        // robin would put all three GIFs onto shard 0 (indices 0, 3, ...
+        // wait no — indices 0, 1, 2 are the GIFs and would land on shards
+        // 0, 1, 2 respectively, OK that one's not the bad case). But if
+        // the manifest carries gifs first and statics last, a 2-shard
+        // round-robin lands gifs on shards 0/1/0 and statics on 1/0/1 →
+        // shard 0 gets 80 cost, shard 1 gets 41. LPT should give us a
+        // near-perfect 60/63 split.
+        val rows = listOf(
+            row("gif1", 40f),
+            row("gif2", 40f),
+            row("gif3", 40f),
+            row("static1", 1f),
+            row("static2", 1f),
+            row("static3", 1f),
+        )
+        val shard0 = assignToShard(rows, shardCount = 2, shardIndex = 0)
+        val shard1 = assignToShard(rows, shardCount = 2, shardIndex = 1)
+        // Each shard gets half the GIFs (or two vs one), not a 3/0 split.
+        val gifsInShard0 = shard0.count { it.entry.id.startsWith("gif") }
+        val gifsInShard1 = shard1.count { it.entry.id.startsWith("gif") }
+        assertTrue(
+            "no shard should monopolise the GIFs (got $gifsInShard0 / $gifsInShard1)",
+            gifsInShard0 in 1..2 && gifsInShard1 in 1..2,
+        )
+        // Total cost partition is balanced within ~1 unit either way.
+        val load0 = loadOf(shard0)
+        val load1 = loadOf(shard1)
+        val skew = kotlin.math.abs(load0 - load1)
+        assertTrue("shards too imbalanced (load0=$load0, load1=$load1)", skew <= 40.0)
+    }
+
+    @Test
+    fun `LPT keeps assignment deterministic across runs for ties`() {
+        val rows = listOf(
+            row("c", 5f), row("b", 5f), row("a", 5f), row("d", 5f),
+        )
+        val first = assignToShard(rows, shardCount = 2, shardIndex = 0)
+        val second = assignToShard(rows, shardCount = 2, shardIndex = 0)
+        assertEquals(first.map { it.entry.id }, second.map { it.entry.id })
+    }
+
+    @Test
+    fun `partition is exhaustive and disjoint across shards`() {
+        val rows = listOf(
+            row("p1", 50f),
+            row("p2", 40f),
+            row("p3", 20f),
+            row("p4", 3f),
+            row("p5", 1f),
+            row("p6", 1f),
+            row("p7", 1f),
+        )
+        val k = 3
+        val ids = rows.map { it.entry.id }.toSet()
+        val seen = mutableSetOf<String>()
+        for (s in 0 until k) {
+            val shard = assignToShard(rows, shardCount = k, shardIndex = s)
+            for (r in shard) {
+                assertTrue("duplicate assignment of ${r.entry.id}", seen.add(r.entry.id))
+            }
+        }
+        assertEquals(ids, seen)
+    }
+
+    @Test
+    fun `largest single capture sets the makespan and goes on its own shard first`() {
+        // The 50-cost row should be picked first and placed on shard 0
+        // (all bins start at zero). That gives us a stable expectation
+        // for the test runner about where the heaviest preview lives.
+        val rows = listOf(
+            row("anim", 50f),
+            row("a", 1f),
+            row("b", 1f),
+            row("c", 1f),
+        )
+        val shard0 = assignToShard(rows, shardCount = 2, shardIndex = 0)
+        assertTrue(
+            "expected the 50-cost row on shard 0; got ${shard0.map { it.entry.id }}",
+            shard0.any { it.entry.id == "anim" },
+        )
+    }
+}


### PR DESCRIPTION
## Summary

The shard heuristic was uniform-cost — every preview was modelled at 0.15s, so the threshold for enabling sharding was preview *count* alone (`MIN_SAVING_SECONDS = 3.0s`, ~ 20 previews before any savings show up). That left the worst case on the table: three GIF captures (cost 40 each) burn ~18s on a single fork, but the model saw only 3 previews and declined to shard.

This PR rebuilds both halves of the shard pipeline on top of the per-capture `cost` field that #196 landed.

### When to shard — `ShardTuning`

```
shardSeconds = PER_FORK_SETUP + makespanCost × SECONDS_PER_COST_UNIT
makespanCost = max(totalCost / K, maxIndividualCost)
T(K)         = shardSeconds + (K − 1) × FORK_OVERHEAD
```

- `totalCost` = `Σ Capture.cost` across the manifest (catalogue: static / TOP = 1, END = 3, LONG = 20, GIF = 40, animated = 50).
- `maxIndividualCost` is the floor — sharding can't drive wall time below the largest single capture, since one fork has to render it. The model recognises this and refuses to over-shard a module dominated by one heavy capture.
- `PER_FORK_SETUP` (3.85s) and `SECONDS_PER_COST_UNIT` (0.15s, calibrated against the original static-preview baseline) are split so the same constants work for both fast (1-cost) and heavy (50-cost) first captures.

`AndroidPreviewSupport.resolveShardCount` extracts cost values from `previews.json` with regex (still — keeps `kotlinx.serialization` off the plugin classpath) and feeds `(totalCost, maxIndividualCost, captureCount)` into the tuner. The lifecycle log line now reports those numbers instead of just `previewCount`.

### How to balance — LPT in `PreviewManifestLoader`

`loadShard` switches from `i % shardCount` round-robin to LPT (Longest-Processing-Time-first) greedy bin-packing. The pathological input today is a manifest that lists heavy captures first: a 2-shard round-robin then drops two GIFs onto shard 0 and one onto shard 1, while statics fill the other slots — make-span ≈ 80 cost units on shard 0. LPT puts the GIFs onto separate shards, balancing within ~1 cost unit of the optimum.

The 4/3 worst-case approximation factor of LPT is good enough that we don't bother with a true ILP solver. Tie-breaking on `entry.id` after the cost sort keeps the assignment deterministic across runs so the build cache and snapshot tests don't have to round-trip a shuffle.

### Decision shifts vs. the old model

| Module shape | Old behaviour | New behaviour |
|---|---|---|
| 5 static previews | 1 shard | 1 shard (unchanged) |
| 40 static previews | 1 shard | 1 shard (still under threshold) |
| 8 mixed (5 static + 3 GIF, total cost 125) | 1 shard (saw only 8 previews) | 2 shards |
| 1 animation (cost 50) + 4 statics | 1 shard | up to 2 shards (capped by makespan floor) |
| 3 GIF previews (cost 120) | 1 shard | 2-3 shards |

## Test plan

- [x] `./gradlew :gradle-plugin:test` — 8 new `ShardTuningTest` cases pass alongside the existing suite.
- [x] `./gradlew :renderer-android:testDebugUnitTest` — 5 new `PreviewManifestLoaderShardTest` cases pass; the one pre-existing `LongScrollGhostOverlayTest` failure is unrelated (reproduces on clean main, not in CI today since CI doesn't run that task).
- [ ] CI plugin tests green.
- [ ] Manual smoke against `sample-android` / `sample-wear` to confirm `compose-ai-tools: shards=auto → ...` log line shows `totalCost` / `maxCost` and picks the expected K.