### PR TITLE
chore(deps): apply Renovate PRs #205 and #199 with toolchain fixes

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -78,7 +78,7 @@ The CLI ([cli/](cli/src/main/kotlin/ee/schimke/composeai/cli/)) and VS Code exte
 
 - **Configuration cache is strict** (`problems=fail` in [gradle.properties](gradle.properties)). Changes to plugin code must resolve classpaths/JVM args at configuration time via lazy providers — never call `.files` inside a task action or touch `project.*` at execution time.
 - **CMP Desktop previews require `implementation(compose.components.uiToolingPreview)`** — the bundled `@Preview` has `SOURCE` retention and is invisible to ClassGraph otherwise.
-- **Toolchain:** Java 17, Kotlin 2.2.21, Gradle 9.4.1+, AGP 9.1.0, CMP 1.10.3. Always use the bundled `./gradlew` wrapper. Don't loosen the toolchain to a newer JDK to avoid the install — AGP 9.1.0 / Robolectric still target 17, and bumping silently produces classes-vs-resources skew on the consumer's unit-test classpath.
+- **Toolchain:** Java 17, Kotlin 2.3.20, Gradle 9.4.1+, AGP 9.1.1, CMP 1.10.3. Always use the bundled `./gradlew` wrapper. Don't loosen the toolchain to a newer JDK to avoid the install — AGP 9.1.0 / Robolectric still target 17, and bumping silently produces classes-vs-resources skew on the consumer's unit-test classpath.
 - **Bringing up a fresh sandbox.** When `./gradlew` fails with "Unable to download toolchain": `sudo apt-get install -y openjdk-17-jdk-headless` — Gradle's auto-detection picks it up from `/usr/lib/jvm/`. When an Android-flavoured sample then fails with "SDK location not found", install the SDK manually (no apt package covers `compileSdk = 36`):
   ```
   curl -fsSL -o /tmp/cmdline-tools.zip \

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin = "2.2.21"
-agp = "9.1.0"
+kotlin = "2.3.20"
+agp = "9.1.1"
 robolectric = "4.16.1"
 classgraph = "4.8.184"
 compose-bom = "2026.03.01"
@@ -15,28 +15,25 @@ compose-bom = "2026.03.01"
 compose-bom-compat = "2026.03.01"
 compose-multiplatform = "1.10.3"
 activity-compose = "1.13.0"
-wear-compose = "1.6.0"
+wear-compose = "1.6.1"
 wear-tiles = "1.6.0"
 wear-protolayout = "1.4.0"
 wear-tooling-preview = "1.0.0"
 # Remote Compose — alpha artifacts, used only by `:sample-remotecompose` to
 # demonstrate `RemotePreview` + `@PreviewWrapper(RemotePreviewWrapper::class)`.
-# Version pins, chosen for AGP 9.1.0 / compileSdk 36 compatibility:
-#  * compose-remote alpha07 requires minCompileSdk=35 / AGP 8.6.0 (alpha08
-#    bumps both to 37 / 9.1).
-#  * wear-compose-remote alpha01 requires minCompileSdk=35 / AGP 8.6.0
-#    (alpha02 bumps to 37 / 9.1).
+# Re-check minCompileSdk / AGP requirements when bumping these — the alpha
+# line has historically tightened them between releases.
 #  * ui-tooling-preview 1.11.0-rc01 is the first released artifact that
 #    contains `PreviewWrapper` / `PreviewWrapperProvider` — 1.10.x (the
 #    current BOM) doesn't have them. Declared explicitly because the
 #    sample doesn't depend on compose-bom.
-compose-remote = "1.0.0-alpha07"
-wear-compose-remote = "1.0.0-alpha01"
+compose-remote = "1.0.0-alpha08"
+wear-compose-remote = "1.0.0-alpha02"
 compose-ui-tooling-preview-wrapper = "1.11.0-rc01"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.11.0"
 junit = "4.13.2"
-truth = "1.4.4"
+truth = "1.4.5"
 maven-publish = "0.36.0"
 # Google's host-side screenshot testing plugin (Layoutlib-backed). Used only
 # by `:sample-android-screenshot-test`, which exercises our co-existence

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -18,7 +18,7 @@
                 "@vscode/vsce": "^3.0.0",
                 "glob": "^13.0.0",
                 "mocha": "^11.0.0",
-                "typescript": "^5.3.0"
+                "typescript": "^6.0.0"
             },
             "engines": {
                 "vscode": "^1.85.0"
@@ -4812,9 +4812,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -122,7 +122,7 @@
         "@vscode/vsce": "^3.0.0",
         "glob": "^13.0.0",
         "mocha": "^11.0.0",
-        "typescript": "^5.3.0"
+        "typescript": "^6.0.0"
     },
     "overrides": {
         "serialize-javascript": "^7.0.5"

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -3,6 +3,7 @@
         "module": "commonjs",
         "target": "ES2022",
         "lib": ["ES2022"],
+        "types": ["node", "mocha"],
         "outDir": "out",
         "rootDir": "src",
         "strict": true,


### PR DESCRIPTION
## Summary

Applies the changes from #205 (typescript v6) and #199 (gradle minor/patch bumps) and resolves the CI failures each one triggered.

**TypeScript v6 (#205)** — TypeScript 6 stopped auto-including every `@types/*` package, so node and mocha globals (`__dirname`, `process`, `setTimeout`, `Buffer`, …) stopped resolving in the VS Code extension and tests. Fixed by declaring `"types": ["node", "mocha"]` in `vscode-extension/tsconfig.json`. `npm test` now passes (65/65).

**Gradle bumps (#199)** — kotlin 2.2.21 → 2.3.20, agp 9.1.0 → 9.1.1, wear-compose 1.6.0 → 1.6.1, compose-remote alpha07 → alpha08, wear-compose-remote alpha01 → alpha02, truth 1.4.4 → 1.4.5. The libs.versions.toml comment that justified pinning compose-remote at alpha07 ("alpha08 requires minCompileSdk=37 / AGP 9.1") is no longer accurate — alpha08 builds against compileSdk=36 / AGP 9.1.1 in the upstream Renovate PR's CI. Replaced the stale rationale with a generic reminder to re-check minCompileSdk on each bump and bumped the toolchain reference in `docs/AGENTS.md`.

## Test plan
- [x] `cd vscode-extension && npm install && npm run compile && npm test` — 65/65 passing locally
- [ ] CI: Plugin Unit Tests
- [ ] CI: Plugin Functional Tests
- [ ] CI: Build Samples
- [ ] CI: Build CLI
- [ ] CI: VS Code Extension Tests
- [ ] CI: Compare previews

---
_Generated by [Claude Code](https://claude.ai/code/session_01CV1mHG8WyNBQ9qwwcgJKN9)_