### PR TITLE
style: apply ktfmt (Google style) across the codebase

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,19 +1,17 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm) apply false
-    alias(libs.plugins.kotlin.android) apply false
-    alias(libs.plugins.kotlin.serialization) apply false
-    alias(libs.plugins.compose.compiler) apply false
-    alias(libs.plugins.compose.multiplatform) apply false
-    alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.ktfmt) apply false
+  alias(libs.plugins.kotlin.jvm) apply false
+  alias(libs.plugins.kotlin.android) apply false
+  alias(libs.plugins.kotlin.serialization) apply false
+  alias(libs.plugins.compose.compiler) apply false
+  alias(libs.plugins.compose.multiplatform) apply false
+  alias(libs.plugins.android.application) apply false
+  alias(libs.plugins.android.library) apply false
+  alias(libs.plugins.ktfmt) apply false
 }
 
 allprojects {
-    apply(plugin = "com.ncorti.ktfmt.gradle")
-    extensions.configure<com.ncorti.ktfmt.gradle.KtfmtExtension>("ktfmt") {
-        googleStyle()
-    }
+  apply(plugin = "com.ncorti.ktfmt.gradle")
+  extensions.configure<com.ncorti.ktfmt.gradle.KtfmtExtension>("ktfmt") { googleStyle() }
 }
 
 // `./gradlew ktfmtCheck` already fans out to every project that applies the
@@ -22,15 +20,15 @@ allprojects {
 fun Project.taskPath(name: String) = if (path == ":") ":$name" else "$path:$name"
 
 tasks.register("ktfmtCheckAll") {
-    group = "verification"
-    description = "Runs ktfmtCheck across this build and the gradle-plugin included build."
-    dependsOn(gradle.includedBuild("gradle-plugin").task(":ktfmtCheck"))
-    allprojects.forEach { dependsOn(it.taskPath("ktfmtCheck")) }
+  group = "verification"
+  description = "Runs ktfmtCheck across this build and the gradle-plugin included build."
+  dependsOn(gradle.includedBuild("gradle-plugin").task(":ktfmtCheck"))
+  allprojects.forEach { dependsOn(it.taskPath("ktfmtCheck")) }
 }
 
 tasks.register("ktfmtFormatAll") {
-    group = "formatting"
-    description = "Runs ktfmtFormat across this build and the gradle-plugin included build."
-    dependsOn(gradle.includedBuild("gradle-plugin").task(":ktfmtFormat"))
-    allprojects.forEach { dependsOn(it.taskPath("ktfmtFormat")) }
+  group = "formatting"
+  description = "Runs ktfmtFormat across this build and the gradle-plugin included build."
+  dependsOn(gradle.includedBuild("gradle-plugin").task(":ktfmtFormat"))
+  allprojects.forEach { dependsOn(it.taskPath("ktfmtFormat")) }
 }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,25 +1,25 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.kotlin.serialization)
-    application
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+  application
 }
 
 // See gradle-plugin/build.gradle.kts for how CI sets PLUGIN_VERSION. Local
 // builds derive the SNAPSHOT version from `.release-please-manifest.json`.
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: run {
-    val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-    val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-    val (major, minor, patch) = current.split(".").map { it.toInt() }
-    "$major.$minor.${patch + 1}-SNAPSHOT"
-}
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
 
-base {
-    archivesName.set("compose-preview")
-}
+base { archivesName.set("compose-preview") }
 
 application {
-    applicationName = "compose-preview"
-    mainClass.set("ee.schimke.composeai.cli.MainKt")
+  applicationName = "compose-preview"
+  mainClass.set("ee.schimke.composeai.cli.MainKt")
 }
 
 // Note: don't set `archiveFileName` directly — Gradle's distribution plugin
@@ -29,22 +29,18 @@ application {
 // the file name as `<archivesName>-<version>.<extension>` while keeping the
 // internal root as `<archivesName>-<version>/`.
 tasks.named<Tar>("distTar") {
-    archiveExtension.set("tar.gz")
-    compression = Compression.GZIP
+  archiveExtension.set("tar.gz")
+  compression = Compression.GZIP
 }
 
 dependencies {
-    implementation(libs.kotlinx.serialization.json)
-    implementation("org.gradle:gradle-tooling-api:9.3.1")
-    runtimeOnly("org.slf4j:slf4j-nop:2.0.16")
+  implementation(libs.kotlinx.serialization.json)
+  implementation("org.gradle:gradle-tooling-api:9.3.1")
+  runtimeOnly("org.slf4j:slf4j-nop:2.0.16")
 
-    testImplementation(kotlin("test"))
+  testImplementation(kotlin("test"))
 }
 
-tasks.withType<Test>().configureEach {
-    useJUnitPlatform()
-}
+tasks.withType<Test>().configureEach { useJUnitPlatform() }
 
-java {
-    toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
-}
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Args.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Args.kt
@@ -1,14 +1,14 @@
 package ee.schimke.composeai.cli
 
 /**
- * Returns the value of `flag` from a positional argv (e.g. `--module foo`),
- * or `null` if the flag is missing or unaccompanied.
+ * Returns the value of `flag` from a positional argv (e.g. `--module foo`), or `null` if the flag
+ * is missing or unaccompanied.
  *
- * Trivial parser shared by every command. If we ever grow more flag types
- * (repeatable, comma-list, equals-form), promote this file to a real argv
- * helper rather than duplicating the parser per call-site.
+ * Trivial parser shared by every command. If we ever grow more flag types (repeatable, comma-list,
+ * equals-form), promote this file to a real argv helper rather than duplicating the parser per
+ * call-site.
  */
 internal fun List<String>.flagValue(flag: String): String? {
-    val idx = indexOf(flag)
-    return if (idx >= 0 && idx + 1 < size) this[idx + 1] else null
+  val idx = indexOf(flag)
+  return if (idx >= 0 && idx + 1 < size) this[idx + 1] else null
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -1,878 +1,880 @@
 package ee.schimke.composeai.cli
 
+import java.io.File
+import java.security.MessageDigest
+import kotlin.system.exitProcess
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import java.io.File
-import java.security.MessageDigest
-import kotlin.system.exitProcess
 
 /** On-disk shape mirrors gradle-plugin/PreviewData.kt (parsed with ignoreUnknownKeys). */
 @Serializable
 data class PreviewParams(
-    val name: String? = null,
-    val device: String? = null,
-    val widthDp: Int? = null,
-    val heightDp: Int? = null,
-    /**
-     * Compose density factor (= densityDpi / 160) resolved at discovery from
-     * the @Preview device; null means "use the renderer default". Carried
-     * through so agents can spot per-device fan-outs without re-reading the
-     * Gradle manifest.
-     */
-    val density: Float? = null,
-    val fontScale: Float = 1.0f,
-    val showSystemUi: Boolean = false,
-    val showBackground: Boolean = false,
-    val backgroundColor: Long = 0,
-    val uiMode: Int = 0,
-    val locale: String? = null,
-    val group: String? = null,
-    val wrapperClassName: String? = null,
-    /**
-     * FQN of the `PreviewParameterProvider` harvested from `@PreviewParameter`
-     * on one of the preview function's parameters, if any. Discovery records
-     * this but does NOT expand captures — the renderer fans out on disk as
-     * `<id>_PARAM_<idx>.<ext>` and the CLI globs those files in [buildResults].
-     */
-    val previewParameterProviderClassName: String? = null,
-    /** Mirrors `@PreviewParameter.limit`. `Int.MAX_VALUE` = take every value. */
-    val previewParameterLimit: Int = Int.MAX_VALUE,
-    /** "COMPOSE" or "TILE". Free-form string so unknown future kinds round-trip. */
-    val kind: String = "COMPOSE",
+  val name: String? = null,
+  val device: String? = null,
+  val widthDp: Int? = null,
+  val heightDp: Int? = null,
+  /**
+   * Compose density factor (= densityDpi / 160) resolved at discovery from the @Preview device;
+   * null means "use the renderer default". Carried through so agents can spot per-device fan-outs
+   * without re-reading the Gradle manifest.
+   */
+  val density: Float? = null,
+  val fontScale: Float = 1.0f,
+  val showSystemUi: Boolean = false,
+  val showBackground: Boolean = false,
+  val backgroundColor: Long = 0,
+  val uiMode: Int = 0,
+  val locale: String? = null,
+  val group: String? = null,
+  val wrapperClassName: String? = null,
+  /**
+   * FQN of the `PreviewParameterProvider` harvested from `@PreviewParameter` on one of the preview
+   * function's parameters, if any. Discovery records this but does NOT expand captures — the
+   * renderer fans out on disk as `<id>_PARAM_<idx>.<ext>` and the CLI globs those files in
+   * [buildResults].
+   */
+  val previewParameterProviderClassName: String? = null,
+  /** Mirrors `@PreviewParameter.limit`. `Int.MAX_VALUE` = take every value. */
+  val previewParameterLimit: Int = Int.MAX_VALUE,
+  /** "COMPOSE" or "TILE". Free-form string so unknown future kinds round-trip. */
+  val kind: String = "COMPOSE",
 )
 
 /**
- * Scroll state of a capture. Mirrors `ScrollCapture` in
- * gradle-plugin/PreviewData.kt — kept as a string-typed mirror so unknown
- * future modes/axes round-trip cleanly through the CLI.
+ * Scroll state of a capture. Mirrors `ScrollCapture` in gradle-plugin/PreviewData.kt — kept as a
+ * string-typed mirror so unknown future modes/axes round-trip cleanly through the CLI.
  */
 @Serializable
 data class ScrollCapture(
-    val mode: String,
-    val axis: String = "VERTICAL",
-    val maxScrollPx: Int = 0,
-    val reduceMotion: Boolean = true,
-    val atEnd: Boolean = false,
-    val reachedPx: Int? = null,
+  val mode: String,
+  val axis: String = "VERTICAL",
+  val maxScrollPx: Int = 0,
+  val reduceMotion: Boolean = true,
+  val atEnd: Boolean = false,
+  val reachedPx: Int? = null,
 )
 
 @Serializable
 data class Capture(
-    val advanceTimeMillis: Long? = null,
-    val scroll: ScrollCapture? = null,
-    val renderOutput: String = "",
+  val advanceTimeMillis: Long? = null,
+  val scroll: ScrollCapture? = null,
+  val renderOutput: String = "",
 )
 
 @Serializable
 data class PreviewInfo(
-    val id: String,
-    val functionName: String,
-    val className: String,
-    val sourceFile: String? = null,
-    val params: PreviewParams = PreviewParams(),
-    val captures: List<Capture> = listOf(Capture()),
+  val id: String,
+  val functionName: String,
+  val className: String,
+  val sourceFile: String? = null,
+  val params: PreviewParams = PreviewParams(),
+  val captures: List<Capture> = listOf(Capture()),
 )
 
 @Serializable
 data class PreviewManifest(
-    val module: String,
-    val variant: String,
-    val previews: List<PreviewInfo>,
-    /**
-     * Relative path (from this manifest file's parent directory) to the
-     * sidecar ATF accessibility report, when `composePreview.accessibilityChecks`
-     * is enabled on this module. `null` means the feature is off.
-     */
-    val accessibilityReport: String? = null,
+  val module: String,
+  val variant: String,
+  val previews: List<PreviewInfo>,
+  /**
+   * Relative path (from this manifest file's parent directory) to the sidecar ATF accessibility
+   * report, when `composePreview.accessibilityChecks` is enabled on this module. `null` means the
+   * feature is off.
+   */
+  val accessibilityReport: String? = null,
 )
 
 @Serializable
 data class AccessibilityFinding(
-    val level: String,
-    val type: String,
-    val message: String,
-    val viewDescription: String? = null,
-    val boundsInScreen: String? = null,
+  val level: String,
+  val type: String,
+  val message: String,
+  val viewDescription: String? = null,
+  val boundsInScreen: String? = null,
 )
 
 @Serializable
 data class AccessibilityEntry(
-    val previewId: String,
-    val findings: List<AccessibilityFinding>,
-    val annotatedPath: String? = null,
+  val previewId: String,
+  val findings: List<AccessibilityFinding>,
+  val annotatedPath: String? = null,
 )
 
 @Serializable
-data class AccessibilityReport(
-    val module: String,
-    val entries: List<AccessibilityEntry>,
-)
+data class AccessibilityReport(val module: String, val entries: List<AccessibilityEntry>)
 
 /**
- * One rendered snapshot inside a [PreviewResult]. Carries the dimensional
- * coordinates ([advanceTimeMillis], [scroll]) that distinguish this capture
- * from its siblings, plus runtime data the agent needs to act on it
- * ([pngPath], [sha256], [changed]).
+ * One rendered snapshot inside a [PreviewResult]. Carries the dimensional coordinates
+ * ([advanceTimeMillis], [scroll]) that distinguish this capture from its siblings, plus runtime
+ * data the agent needs to act on it ([pngPath], [sha256], [changed]).
  *
- * A static preview produces a single `CaptureResult` with both dimensions
- * null; an animation/scroll fan-out produces N entries — one row per capture
- * filename on disk.
+ * A static preview produces a single `CaptureResult` with both dimensions null; an animation/scroll
+ * fan-out produces N entries — one row per capture filename on disk.
  */
 @Serializable
 data class CaptureResult(
-    val advanceTimeMillis: Long? = null,
-    val scroll: ScrollCapture? = null,
-    val pngPath: String? = null,
-    val sha256: String? = null,
-    val changed: Boolean? = null,
+  val advanceTimeMillis: Long? = null,
+  val scroll: ScrollCapture? = null,
+  val pngPath: String? = null,
+  val sha256: String? = null,
+  val changed: Boolean? = null,
 )
 
 /** CLI output DTO — enriches manifest entries with runtime data agents need. */
 @Serializable
 data class PreviewResult(
-    val id: String,
-    val module: String,
-    val functionName: String,
-    val className: String,
-    val sourceFile: String? = null,
-    val params: PreviewParams = PreviewParams(),
-    /**
-     * All rendered snapshots for this preview. Always at least one element.
-     * `length > 1` ⇔ a `@RoboComposePreviewOptions` time fan-out or a
-     * scroll-with-progress capture — agents that need every PNG should
-     * iterate this list rather than reading [pngPath].
-     */
-    val captures: List<CaptureResult> = emptyList(),
-    /** First capture's PNG path. Kept for back-compat with existing agents. */
-    val pngPath: String? = null,
-    /** First capture's PNG sha256. Kept for back-compat. */
-    val sha256: String? = null,
-    /** First capture's `changed` flag. Kept for back-compat. */
-    val changed: Boolean? = null,
-    /**
-     * ATF findings for this preview, or `null` when accessibility checks were
-     * disabled for this module. Empty list means checks ran and found nothing.
-     */
-    val a11yFindings: List<AccessibilityFinding>? = null,
-    /**
-     * Absolute path to an annotated screenshot showing each finding as a
-     * numbered badge + legend. `null` when there were no findings or
-     * accessibility checks are disabled.
-     */
-    val a11yAnnotatedPath: String? = null,
+  val id: String,
+  val module: String,
+  val functionName: String,
+  val className: String,
+  val sourceFile: String? = null,
+  val params: PreviewParams = PreviewParams(),
+  /**
+   * All rendered snapshots for this preview. Always at least one element. `length > 1` ⇔ a
+   * `@RoboComposePreviewOptions` time fan-out or a scroll-with-progress capture — agents that need
+   * every PNG should iterate this list rather than reading [pngPath].
+   */
+  val captures: List<CaptureResult> = emptyList(),
+  /** First capture's PNG path. Kept for back-compat with existing agents. */
+  val pngPath: String? = null,
+  /** First capture's PNG sha256. Kept for back-compat. */
+  val sha256: String? = null,
+  /** First capture's `changed` flag. Kept for back-compat. */
+  val changed: Boolean? = null,
+  /**
+   * ATF findings for this preview, or `null` when accessibility checks were disabled for this
+   * module. Empty list means checks ran and found nothing.
+   */
+  val a11yFindings: List<AccessibilityFinding>? = null,
+  /**
+   * Absolute path to an annotated screenshot showing each finding as a numbered badge + legend.
+   * `null` when there were no findings or accessibility checks are disabled.
+   */
+  val a11yAnnotatedPath: String? = null,
 )
 
 /**
- * Versioned envelope for `compose-preview show|list|a11y --json`. Pinning the
- * schema lets agents detect format breaks without dispatching on field
- * shapes — bump [SHOW_LIST_SCHEMA] when the per-row shape changes.
+ * Versioned envelope for `compose-preview show|list|a11y --json`. Pinning the schema lets agents
+ * detect format breaks without dispatching on field shapes — bump [SHOW_LIST_SCHEMA] when the
+ * per-row shape changes.
  *
- * Top-level [previews] is the same `PreviewResult` list the unwrapped form
- * used to emit. The [counts] block is filled in by `show`/`a11y` (where
- * `changed` is meaningful) and lets agents skip downloading every PNG when
- * they only care about the diff against the previous run.
+ * Top-level [previews] is the same `PreviewResult` list the unwrapped form used to emit. The
+ * [counts] block is filled in by `show`/`a11y` (where `changed` is meaningful) and lets agents skip
+ * downloading every PNG when they only care about the diff against the previous run.
  */
 @Serializable
 data class PreviewListResponse(
-    val schema: String = SHOW_LIST_SCHEMA,
-    val previews: List<PreviewResult>,
-    val counts: PreviewCounts? = null,
+  val schema: String = SHOW_LIST_SCHEMA,
+  val previews: List<PreviewResult>,
+  val counts: PreviewCounts? = null,
 )
 
 @Serializable
-data class PreviewCounts(
-    val total: Int,
-    val changed: Int,
-    val unchanged: Int,
-    val missing: Int,
-)
+data class PreviewCounts(val total: Int, val changed: Int, val unchanged: Int, val missing: Int)
 
 /**
- * Compact response shape emitted under `--brief`. Drops everything an agent
- * already had from a prior `show --json` (functionName, className, params,
- * sourceFile) and shortens field names so the per-row JSON shrinks to ~5x
- * smaller. Keys are intentionally terse:
- *   `png` = absolute PNG path, `sha` = first 12 hex chars of sha256,
- *   `time` = advanceTimeMillis, `scroll` = scroll mode string.
+ * Compact response shape emitted under `--brief`. Drops everything an agent already had from a
+ * prior `show --json` (functionName, className, params, sourceFile) and shortens field names so the
+ * per-row JSON shrinks to ~5x smaller. Keys are intentionally terse: `png` = absolute PNG path,
+ * `sha` = first 12 hex chars of sha256, `time` = advanceTimeMillis, `scroll` = scroll mode string.
  */
 @OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class BriefPreviewListResponse(
-    // Always-encode so brief mode (encodeDefaults=false) still emits the
-    // version pin agents grep for.
-    @EncodeDefault val schema: String = SHOW_LIST_BRIEF_SCHEMA,
-    val previews: List<BriefPreviewResult>,
-    val counts: PreviewCounts? = null,
+  // Always-encode so brief mode (encodeDefaults=false) still emits the
+  // version pin agents grep for.
+  @EncodeDefault val schema: String = SHOW_LIST_BRIEF_SCHEMA,
+  val previews: List<BriefPreviewResult>,
+  val counts: PreviewCounts? = null,
 )
 
 @Serializable
 data class BriefPreviewResult(
-    val id: String,
-    /** Omitted in single-module output. */
-    val module: String? = null,
-    val captures: List<BriefCapture>,
-    /** Number of ATF findings; null when a11y is off for the module. */
-    val a11y: Int? = null,
+  val id: String,
+  /** Omitted in single-module output. */
+  val module: String? = null,
+  val captures: List<BriefCapture>,
+  /** Number of ATF findings; null when a11y is off for the module. */
+  val a11y: Int? = null,
 )
 
 @Serializable
 data class BriefCapture(
-    /** Absolute path; null when render didn't produce a PNG. */
-    val png: String? = null,
-    /** sha256 prefix (12 hex chars); null when no PNG. */
-    val sha: String? = null,
-    /** null when first run / unknown. */
-    val changed: Boolean? = null,
-    /** advanceTimeMillis; omitted for static captures. */
-    val time: Long? = null,
-    /** Scroll mode (`END`/`LONG`); omitted when no scroll drive. */
-    val scroll: String? = null,
+  /** Absolute path; null when render didn't produce a PNG. */
+  val png: String? = null,
+  /** sha256 prefix (12 hex chars); null when no PNG. */
+  val sha: String? = null,
+  /** null when first run / unknown. */
+  val changed: Boolean? = null,
+  /** advanceTimeMillis; omitted for static captures. */
+  val time: Long? = null,
+  /** Scroll mode (`END`/`LONG`); omitted when no scroll drive. */
+  val scroll: String? = null,
 )
 
 internal const val SHOW_LIST_SCHEMA = "compose-preview-show/v1"
 internal const val SHOW_LIST_BRIEF_SCHEMA = "compose-preview-show-brief/v1"
 
-@Serializable
-private data class CliState(val shas: Map<String, String> = emptyMap())
+@Serializable private data class CliState(val shas: Map<String, String> = emptyMap())
 
 private val json = Json {
-    ignoreUnknownKeys = true
-    prettyPrint = true
-    encodeDefaults = true
+  ignoreUnknownKeys = true
+  prettyPrint = true
+  encodeDefaults = true
 }
 
 /**
- * JSON config for `--brief`: no pretty-print (one-line-per-row encoding is
- * the common agent consumption pattern) and `encodeDefaults = false` so all
- * the null/false/0 fields drop out instead of bloating the payload.
+ * JSON config for `--brief`: no pretty-print (one-line-per-row encoding is the common agent
+ * consumption pattern) and `encodeDefaults = false` so all the null/false/0 fields drop out instead
+ * of bloating the payload.
  */
 private val briefJson = Json {
-    ignoreUnknownKeys = true
-    prettyPrint = false
-    encodeDefaults = false
+  ignoreUnknownKeys = true
+  prettyPrint = false
+  encodeDefaults = false
 }
 
 abstract class Command(protected val args: List<String>) {
-    protected val explicitModule: String? = args.flagValue("--module")
-    protected val filter: String? = args.flagValue("--filter")
-    protected val exactId: String? = args.flagValue("--id")
-    protected val verbose: Boolean = "--verbose" in args || "-v" in args
-    protected val progress: Boolean = verbose || "--progress" in args
-    protected val timeoutSeconds: Long = args.flagValue("--timeout")?.toLongOrNull() ?: 300
-    /** When true, drop previews with no `changed=true` capture from JSON output. */
-    protected val changedOnly: Boolean = "--changed-only" in args
-    /**
-     * Compact JSON: drop `functionName`/`className`/`sourceFile`/`module`/`params`
-     * from each row, keep `id` + `captures`. Designed for agent re-render loops
-     * where the full metadata was already cached on first call.
-     */
-    protected val brief: Boolean = "--brief" in args
+  protected val explicitModule: String? = args.flagValue("--module")
+  protected val filter: String? = args.flagValue("--filter")
+  protected val exactId: String? = args.flagValue("--id")
+  protected val verbose: Boolean = "--verbose" in args || "-v" in args
+  protected val progress: Boolean = verbose || "--progress" in args
+  protected val timeoutSeconds: Long = args.flagValue("--timeout")?.toLongOrNull() ?: 300
+  /** When true, drop previews with no `changed=true` capture from JSON output. */
+  protected val changedOnly: Boolean = "--changed-only" in args
+  /**
+   * Compact JSON: drop `functionName`/`className`/`sourceFile`/`module`/`params` from each row,
+   * keep `id` + `captures`. Designed for agent re-render loops where the full metadata was already
+   * cached on first call.
+   */
+  protected val brief: Boolean = "--brief" in args
 
-    abstract fun run()
+  abstract fun run()
 
-    protected fun withGradle(block: (GradleConnection) -> Unit) {
-        val root = findProjectRoot() ?: run {
-            System.err.println("Cannot find Gradle project root (no gradlew found)")
-            exitProcess(1)
+  protected fun withGradle(block: (GradleConnection) -> Unit) {
+    val root =
+      findProjectRoot()
+        ?: run {
+          System.err.println("Cannot find Gradle project root (no gradlew found)")
+          exitProcess(1)
         }
-        GradleConnection(root, verbose, progress).use(block)
-    }
+    GradleConnection(root, verbose, progress).use(block)
+  }
 
-    protected fun resolveModules(gradle: GradleConnection): List<PreviewModule> {
-        if (explicitModule != null) {
-            // Resolve via the Tooling API so --module works with nested
-            // Gradle paths (e.g. `--module auth:composables`) and reflects
-            // any custom `project.projectDir` override.
-            val one = gradle.findPreviewModule(explicitModule!!)
-            if (one == null) {
-                System.err.println("Module '$explicitModule' not found or does not apply the compose-ai-tools plugin.")
-                exitProcess(1)
-            }
-            return listOf(one)
-        }
-
-        val modules = gradle.findPreviewModules()
-        if (modules.isEmpty()) {
-            System.err.println("No modules with compose-ai-tools plugin found.")
-            System.err.println("Apply the plugin: id(\"ee.schimke.composeai.preview\")")
-            exitProcess(1)
-        }
-        if (verbose || modules.size > 1) {
-            System.err.println("Found preview modules: ${modules.joinToString(", ") { it.gradlePath }}")
-        }
-        return modules
-    }
-
-    protected fun runGradle(gradle: GradleConnection, vararg tasks: String): Boolean {
-        return gradle.runTasks(*tasks, timeoutSeconds = timeoutSeconds)
-    }
-
-    protected fun readManifest(module: PreviewModule): PreviewManifest? {
-        val manifestFile = module.projectDir.resolve("build/compose-previews/previews.json")
-        if (!manifestFile.exists()) return null
-        return json.decodeFromString(manifestFile.readText())
-    }
-
-    protected fun readAllManifests(modules: List<PreviewModule>): List<Pair<PreviewModule, PreviewManifest>> {
-        return modules.mapNotNull { module ->
-            readManifest(module)?.let { module to it }
-        }
-    }
-
-    /**
-     * Reads each module's accessibility report IF the manifest points at one
-     * (i.e. the feature is enabled in Gradle), and returns a lookup from
-     * `"<module>/<previewId>"` to (findings, annotatedPathAbsolute). The
-     * annotated path is resolved against the report file's parent so the
-     * value we emit is an absolute filesystem path agents can open directly.
-     *
-     * Following the manifest pointer — rather than hard-coding
-     * `accessibility.json` — means disabling checks in Gradle cleanly makes
-     * findings disappear from CLI output; we never report stale reports from
-     * a prior opt-in run.
-     */
-    protected fun readAllA11yReports(
-        manifests: List<Pair<PreviewModule, PreviewManifest>>,
-    ): Map<String, Pair<List<AccessibilityFinding>, String?>> {
-        val out = mutableMapOf<String, Pair<List<AccessibilityFinding>, String?>>()
-        for ((module, manifest) in manifests) {
-            val pointer = manifest.accessibilityReport ?: continue
-            val reportFile = module.projectDir.resolve("build/compose-previews/$pointer")
-            if (!reportFile.exists()) continue
-            val report = try {
-                json.decodeFromString(AccessibilityReport.serializer(), reportFile.readText())
-            } catch (e: Exception) {
-                if (verbose) System.err.println("Warning: unreadable a11y report ${reportFile.path}: ${e.message}")
-                continue
-            }
-            val reportDir = reportFile.parentFile
-            for (entry in report.entries) {
-                val annotatedAbs = entry.annotatedPath
-                    ?.let { reportDir.resolve(it).canonicalFile }
-                    ?.takeIf { it.exists() }
-                    ?.absolutePath
-                out["${module.gradlePath}/${entry.previewId}"] = entry.findings to annotatedAbs
-            }
-        }
-        return out
-    }
-
-    /**
-     * Reads PNGs for every capture of every manifest entry, hashes them,
-     * compares against the per-module sidecar state file to emit per-capture
-     * `changed`, and persists the new hashes. Sidecar lives under
-     * `build/compose-previews/` so it gets wiped on `./gradlew clean`.
-     *
-     * State is keyed `<id>` for the first capture (preserves legacy state
-     * files from before per-capture tracking) and `<id>#<n>` for subsequent
-     * captures of an animation/scroll fan-out. The top-level `pngPath` /
-     * `sha256` / `changed` on [PreviewResult] mirror the first capture
-     * verbatim so existing agents keep working.
-     */
-    protected fun buildResults(manifests: List<Pair<PreviewModule, PreviewManifest>>): List<PreviewResult> {
-        val results = mutableListOf<PreviewResult>()
-        val a11yByKey = readAllA11yReports(manifests)
-        // Track which modules had a11y enabled so we can distinguish "no
-        // findings" (empty list) from "feature off" (null) in `PreviewResult`.
-        val modulesWithA11y = manifests.filter { it.second.accessibilityReport != null }
-            .map { it.first.gradlePath }.toSet()
-
-        for ((module, manifest) in manifests) {
-            val prior = readState(module).shas
-            val updated = mutableMapOf<String, String>()
-
-            // Files owned by non-parameterized siblings — exclude them from
-            // the `<stem>_*` glob so a `Foo_header.png` that belongs to a
-            // different preview never gets attributed to `Foo`'s fan-out.
-            val siblingRenderOutputs = manifest.previews
-                .filter { it.params.previewParameterProviderClassName == null }
-                .flatMap { it.captures.map { c -> c.renderOutput } }
-                .filter { it.isNotEmpty() }
-                .toSet()
-
-            for (p in manifest.previews) {
-                // `@PreviewParameter`-driven previews render at
-                // `<stem>_<suffix>.<ext>`, one file per provider value. The
-                // manifest carries a single template capture; here we glob
-                // the actual fan-out and synthesize a `CaptureResult` per
-                // file on disk — keeps the manifest shape a pure discovery
-                // artifact while the CLI reports one entry per rendered PNG.
-                val captures = if (p.params.previewParameterProviderClassName != null) {
-                    p.captures.flatMap { capture ->
-                        expandParamCaptures(module, capture, siblingRenderOutputs)
-                    }
-                } else {
-                    p.captures
-                }
-                val captureResults = captures.mapIndexed { index, capture ->
-                    val pngFile = capture.renderOutput
-                        .takeIf { it.isNotEmpty() }
-                        ?.let { module.projectDir.resolve("build/compose-previews/$it").canonicalFile }
-                        ?.takeIf { it.exists() }
-                    val sha = pngFile?.let { sha256(it.readBytes()) }
-                    val stateKey = if (index == 0) p.id else "${p.id}#$index"
-                    if (sha != null) updated[stateKey] = sha
-                    val priorSha = prior[stateKey]
-                    val changed = when {
-                        sha == null -> null
-                        priorSha == null -> true
-                        else -> priorSha != sha
-                    }
-                    CaptureResult(
-                        advanceTimeMillis = capture.advanceTimeMillis,
-                        scroll = capture.scroll,
-                        pngPath = pngFile?.absolutePath,
-                        sha256 = sha,
-                        changed = changed,
-                    )
-                }
-                val first = captureResults.firstOrNull()
-                val a11yPair = when {
-                    module.gradlePath in modulesWithA11y -> a11yByKey["${module.gradlePath}/${p.id}"]
-                    else -> null
-                }
-                val a11y = when {
-                    module.gradlePath in modulesWithA11y -> a11yPair?.first ?: emptyList()
-                    else -> null
-                }
-                results += PreviewResult(
-                    id = p.id,
-                    module = module.gradlePath,
-                    functionName = p.functionName,
-                    className = p.className,
-                    sourceFile = p.sourceFile,
-                    params = p.params,
-                    captures = captureResults,
-                    pngPath = first?.pngPath,
-                    sha256 = first?.sha256,
-                    changed = first?.changed,
-                    a11yFindings = a11y,
-                    a11yAnnotatedPath = a11yPair?.second,
-                )
-            }
-
-            writeState(module, CliState(updated))
-        }
-        return results
-    }
-
-    /** True if the preview has at least one capture with `changed = true`. */
-    protected fun PreviewResult.anyChanged(): Boolean =
-        captures.any { it.changed == true } || changed == true
-
-    /**
-     * Globs the on-disk `<stem>_<suffix>.<ext>` fan-out for a parameterized
-     * preview capture. The manifest carries one template capture (e.g.
-     * `renders/foo.png`); the renderer writes one file per provider value,
-     * keying each by a derived label (`renders/foo_on.png`) or by numeric
-     * index (`renders/foo_PARAM_0.png`) when the label can't be derived.
-     * Returns synthetic `Capture` rows pointing at each file, or an empty
-     * list when nothing matched — the plugin's `renderAllPreviews`
-     * verification already fails loudly when a parameterized preview
-     * rendered no files at all, so we don't duplicate the error surface here.
-     */
-    private fun expandParamCaptures(
-        module: PreviewModule,
-        template: Capture,
-        siblingRenderOutputs: Set<String>,
-    ): List<Capture> {
-        val rel = template.renderOutput.ifEmpty { return listOf(template) }
-        val file = module.projectDir.resolve("build/compose-previews/$rel").canonicalFile
-        val dir = file.parentFile ?: return listOf(template)
-        val prefix = file.nameWithoutExtension + "_"
-        val ext = ".${file.extension}"
-        val templateDir = rel.substringBeforeLast('/', "")
-        val dirPrefix = if (templateDir.isEmpty()) "" else "$templateDir/"
-        val matches = (dir.listFiles() ?: emptyArray())
-            .filter { f ->
-                f.name.startsWith(prefix) &&
-                    f.name.endsWith(ext) &&
-                    (dirPrefix + f.name) !in siblingRenderOutputs
-            }
-            .sortedWith(paramFanoutOrder(prefix, ext))
-        if (matches.isEmpty()) return emptyList()
-        // Preserve the template's time/scroll coordinates — a parameterized
-        // preview is orthogonal to those dimensions. Each fan-out file
-        // points back at the same conceptual capture, just at a different
-        // provider value.
-        return matches.map { f ->
-            Capture(
-                advanceTimeMillis = template.advanceTimeMillis,
-                scroll = template.scroll,
-                renderOutput = dirPrefix + f.name,
-            )
-        }
-    }
-
-    /**
-     * Stable ordering for a fan-out's on-disk files. Numeric `_PARAM_<idx>`
-     * entries come first, sorted by index (so `PARAM_10` lands after
-     * `PARAM_2` rather than before it as lexicographic ordering would
-     * produce). Label-based entries sort alphabetically by their suffix —
-     * provider order isn't recoverable from the filename alone, but
-     * alphabetical is stable and readable.
-     */
-    private fun paramFanoutOrder(prefix: String, ext: String): Comparator<java.io.File> =
-        Comparator { a, b ->
-            val sa = a.name.removePrefix(prefix).removeSuffix(ext)
-            val sb = b.name.removePrefix(prefix).removeSuffix(ext)
-            val ia = sa.removePrefix("PARAM_").toIntOrNull()?.takeIf { sa.startsWith("PARAM_") }
-            val ib = sb.removePrefix("PARAM_").toIntOrNull()?.takeIf { sb.startsWith("PARAM_") }
-            when {
-                ia != null && ib != null -> ia.compareTo(ib)
-                ia != null -> -1
-                ib != null -> 1
-                else -> sa.compareTo(sb)
-            }
-        }
-
-    /** Filters by `--id` / `--filter` and (optionally) `--changed-only`. */
-    protected fun applyFilters(all: List<PreviewResult>): List<PreviewResult> =
-        all.filter { matchesRequest(it) && (!changedOnly || it.anyChanged()) }
-
-    /**
-     * @param results rows to emit (after `--id`/`--filter`/`--changed-only`)
-     * @param countsScope rows the [PreviewCounts] should be computed from —
-     *   typically the unfiltered set so the agent sees totals even when
-     *   `--changed-only` narrows the visible rows. Pass `null` to omit counts.
-     */
-    protected fun encodeResponse(
-        results: List<PreviewResult>,
-        countsScope: List<PreviewResult>?,
-    ): String {
-        val counts = countsScope?.let { countsOf(it) }
-        if (brief) {
-            val multiModule = results.map { it.module }.distinct().size > 1
-            val brief = results.map { r ->
-                BriefPreviewResult(
-                    id = r.id,
-                    module = r.module.takeIf { multiModule },
-                    captures = r.captures.map { c ->
-                        BriefCapture(
-                            png = c.pngPath,
-                            sha = c.sha256?.take(12),
-                            changed = c.changed,
-                            time = c.advanceTimeMillis,
-                            scroll = c.scroll?.mode,
-                        )
-                    },
-                    a11y = r.a11yFindings?.size,
-                )
-            }
-            return briefJson.encodeToString(
-                BriefPreviewListResponse.serializer(),
-                BriefPreviewListResponse(previews = brief, counts = counts),
-            )
-        }
-        return json.encodeToString(
-            PreviewListResponse.serializer(),
-            PreviewListResponse(previews = results, counts = counts),
+  protected fun resolveModules(gradle: GradleConnection): List<PreviewModule> {
+    if (explicitModule != null) {
+      // Resolve via the Tooling API so --module works with nested
+      // Gradle paths (e.g. `--module auth:composables`) and reflects
+      // any custom `project.projectDir` override.
+      val one = gradle.findPreviewModule(explicitModule!!)
+      if (one == null) {
+        System.err.println(
+          "Module '$explicitModule' not found or does not apply the compose-ai-tools plugin."
         )
+        exitProcess(1)
+      }
+      return listOf(one)
     }
 
-    private fun countsOf(results: List<PreviewResult>) = PreviewCounts(
-        total = results.size,
-        changed = results.count { it.anyChanged() },
-        unchanged = results.count { !it.anyChanged() && it.captures.any { c -> c.pngPath != null } },
-        missing = results.count { it.captures.all { c -> c.pngPath == null } },
+    val modules = gradle.findPreviewModules()
+    if (modules.isEmpty()) {
+      System.err.println("No modules with compose-ai-tools plugin found.")
+      System.err.println("Apply the plugin: id(\"ee.schimke.composeai.preview\")")
+      exitProcess(1)
+    }
+    if (verbose || modules.size > 1) {
+      System.err.println("Found preview modules: ${modules.joinToString(", ") { it.gradlePath }}")
+    }
+    return modules
+  }
+
+  protected fun runGradle(gradle: GradleConnection, vararg tasks: String): Boolean {
+    return gradle.runTasks(*tasks, timeoutSeconds = timeoutSeconds)
+  }
+
+  protected fun readManifest(module: PreviewModule): PreviewManifest? {
+    val manifestFile = module.projectDir.resolve("build/compose-previews/previews.json")
+    if (!manifestFile.exists()) return null
+    return json.decodeFromString(manifestFile.readText())
+  }
+
+  protected fun readAllManifests(
+    modules: List<PreviewModule>
+  ): List<Pair<PreviewModule, PreviewManifest>> {
+    return modules.mapNotNull { module -> readManifest(module)?.let { module to it } }
+  }
+
+  /**
+   * Reads each module's accessibility report IF the manifest points at one (i.e. the feature is
+   * enabled in Gradle), and returns a lookup from `"<module>/<previewId>"` to (findings,
+   * annotatedPathAbsolute). The annotated path is resolved against the report file's parent so the
+   * value we emit is an absolute filesystem path agents can open directly.
+   *
+   * Following the manifest pointer — rather than hard-coding `accessibility.json` — means disabling
+   * checks in Gradle cleanly makes findings disappear from CLI output; we never report stale
+   * reports from a prior opt-in run.
+   */
+  protected fun readAllA11yReports(
+    manifests: List<Pair<PreviewModule, PreviewManifest>>
+  ): Map<String, Pair<List<AccessibilityFinding>, String?>> {
+    val out = mutableMapOf<String, Pair<List<AccessibilityFinding>, String?>>()
+    for ((module, manifest) in manifests) {
+      val pointer = manifest.accessibilityReport ?: continue
+      val reportFile = module.projectDir.resolve("build/compose-previews/$pointer")
+      if (!reportFile.exists()) continue
+      val report =
+        try {
+          json.decodeFromString(AccessibilityReport.serializer(), reportFile.readText())
+        } catch (e: Exception) {
+          if (verbose)
+            System.err.println("Warning: unreadable a11y report ${reportFile.path}: ${e.message}")
+          continue
+        }
+      val reportDir = reportFile.parentFile
+      for (entry in report.entries) {
+        val annotatedAbs =
+          entry.annotatedPath
+            ?.let { reportDir.resolve(it).canonicalFile }
+            ?.takeIf { it.exists() }
+            ?.absolutePath
+        out["${module.gradlePath}/${entry.previewId}"] = entry.findings to annotatedAbs
+      }
+    }
+    return out
+  }
+
+  /**
+   * Reads PNGs for every capture of every manifest entry, hashes them, compares against the
+   * per-module sidecar state file to emit per-capture `changed`, and persists the new hashes.
+   * Sidecar lives under `build/compose-previews/` so it gets wiped on `./gradlew clean`.
+   *
+   * State is keyed `<id>` for the first capture (preserves legacy state files from before
+   * per-capture tracking) and `<id>#<n>` for subsequent captures of an animation/scroll fan-out.
+   * The top-level `pngPath` / `sha256` / `changed` on [PreviewResult] mirror the first capture
+   * verbatim so existing agents keep working.
+   */
+  protected fun buildResults(
+    manifests: List<Pair<PreviewModule, PreviewManifest>>
+  ): List<PreviewResult> {
+    val results = mutableListOf<PreviewResult>()
+    val a11yByKey = readAllA11yReports(manifests)
+    // Track which modules had a11y enabled so we can distinguish "no
+    // findings" (empty list) from "feature off" (null) in `PreviewResult`.
+    val modulesWithA11y =
+      manifests.filter { it.second.accessibilityReport != null }.map { it.first.gradlePath }.toSet()
+
+    for ((module, manifest) in manifests) {
+      val prior = readState(module).shas
+      val updated = mutableMapOf<String, String>()
+
+      // Files owned by non-parameterized siblings — exclude them from
+      // the `<stem>_*` glob so a `Foo_header.png` that belongs to a
+      // different preview never gets attributed to `Foo`'s fan-out.
+      val siblingRenderOutputs =
+        manifest.previews
+          .filter { it.params.previewParameterProviderClassName == null }
+          .flatMap { it.captures.map { c -> c.renderOutput } }
+          .filter { it.isNotEmpty() }
+          .toSet()
+
+      for (p in manifest.previews) {
+        // `@PreviewParameter`-driven previews render at
+        // `<stem>_<suffix>.<ext>`, one file per provider value. The
+        // manifest carries a single template capture; here we glob
+        // the actual fan-out and synthesize a `CaptureResult` per
+        // file on disk — keeps the manifest shape a pure discovery
+        // artifact while the CLI reports one entry per rendered PNG.
+        val captures =
+          if (p.params.previewParameterProviderClassName != null) {
+            p.captures.flatMap { capture ->
+              expandParamCaptures(module, capture, siblingRenderOutputs)
+            }
+          } else {
+            p.captures
+          }
+        val captureResults = captures.mapIndexed { index, capture ->
+          val pngFile =
+            capture.renderOutput
+              .takeIf { it.isNotEmpty() }
+              ?.let { module.projectDir.resolve("build/compose-previews/$it").canonicalFile }
+              ?.takeIf { it.exists() }
+          val sha = pngFile?.let { sha256(it.readBytes()) }
+          val stateKey = if (index == 0) p.id else "${p.id}#$index"
+          if (sha != null) updated[stateKey] = sha
+          val priorSha = prior[stateKey]
+          val changed =
+            when {
+              sha == null -> null
+              priorSha == null -> true
+              else -> priorSha != sha
+            }
+          CaptureResult(
+            advanceTimeMillis = capture.advanceTimeMillis,
+            scroll = capture.scroll,
+            pngPath = pngFile?.absolutePath,
+            sha256 = sha,
+            changed = changed,
+          )
+        }
+        val first = captureResults.firstOrNull()
+        val a11yPair =
+          when {
+            module.gradlePath in modulesWithA11y -> a11yByKey["${module.gradlePath}/${p.id}"]
+            else -> null
+          }
+        val a11y =
+          when {
+            module.gradlePath in modulesWithA11y -> a11yPair?.first ?: emptyList()
+            else -> null
+          }
+        results +=
+          PreviewResult(
+            id = p.id,
+            module = module.gradlePath,
+            functionName = p.functionName,
+            className = p.className,
+            sourceFile = p.sourceFile,
+            params = p.params,
+            captures = captureResults,
+            pngPath = first?.pngPath,
+            sha256 = first?.sha256,
+            changed = first?.changed,
+            a11yFindings = a11y,
+            a11yAnnotatedPath = a11yPair?.second,
+          )
+      }
+
+      writeState(module, CliState(updated))
+    }
+    return results
+  }
+
+  /** True if the preview has at least one capture with `changed = true`. */
+  protected fun PreviewResult.anyChanged(): Boolean =
+    captures.any { it.changed == true } || changed == true
+
+  /**
+   * Globs the on-disk `<stem>_<suffix>.<ext>` fan-out for a parameterized preview capture. The
+   * manifest carries one template capture (e.g. `renders/foo.png`); the renderer writes one file
+   * per provider value, keying each by a derived label (`renders/foo_on.png`) or by numeric index
+   * (`renders/foo_PARAM_0.png`) when the label can't be derived. Returns synthetic `Capture` rows
+   * pointing at each file, or an empty list when nothing matched — the plugin's `renderAllPreviews`
+   * verification already fails loudly when a parameterized preview rendered no files at all, so we
+   * don't duplicate the error surface here.
+   */
+  private fun expandParamCaptures(
+    module: PreviewModule,
+    template: Capture,
+    siblingRenderOutputs: Set<String>,
+  ): List<Capture> {
+    val rel =
+      template.renderOutput.ifEmpty {
+        return listOf(template)
+      }
+    val file = module.projectDir.resolve("build/compose-previews/$rel").canonicalFile
+    val dir = file.parentFile ?: return listOf(template)
+    val prefix = file.nameWithoutExtension + "_"
+    val ext = ".${file.extension}"
+    val templateDir = rel.substringBeforeLast('/', "")
+    val dirPrefix = if (templateDir.isEmpty()) "" else "$templateDir/"
+    val matches =
+      (dir.listFiles() ?: emptyArray())
+        .filter { f ->
+          f.name.startsWith(prefix) &&
+            f.name.endsWith(ext) &&
+            (dirPrefix + f.name) !in siblingRenderOutputs
+        }
+        .sortedWith(paramFanoutOrder(prefix, ext))
+    if (matches.isEmpty()) return emptyList()
+    // Preserve the template's time/scroll coordinates — a parameterized
+    // preview is orthogonal to those dimensions. Each fan-out file
+    // points back at the same conceptual capture, just at a different
+    // provider value.
+    return matches.map { f ->
+      Capture(
+        advanceTimeMillis = template.advanceTimeMillis,
+        scroll = template.scroll,
+        renderOutput = dirPrefix + f.name,
+      )
+    }
+  }
+
+  /**
+   * Stable ordering for a fan-out's on-disk files. Numeric `_PARAM_<idx>` entries come first,
+   * sorted by index (so `PARAM_10` lands after `PARAM_2` rather than before it as lexicographic
+   * ordering would produce). Label-based entries sort alphabetically by their suffix — provider
+   * order isn't recoverable from the filename alone, but alphabetical is stable and readable.
+   */
+  private fun paramFanoutOrder(prefix: String, ext: String): Comparator<java.io.File> =
+    Comparator { a, b ->
+      val sa = a.name.removePrefix(prefix).removeSuffix(ext)
+      val sb = b.name.removePrefix(prefix).removeSuffix(ext)
+      val ia = sa.removePrefix("PARAM_").toIntOrNull()?.takeIf { sa.startsWith("PARAM_") }
+      val ib = sb.removePrefix("PARAM_").toIntOrNull()?.takeIf { sb.startsWith("PARAM_") }
+      when {
+        ia != null && ib != null -> ia.compareTo(ib)
+        ia != null -> -1
+        ib != null -> 1
+        else -> sa.compareTo(sb)
+      }
+    }
+
+  /** Filters by `--id` / `--filter` and (optionally) `--changed-only`. */
+  protected fun applyFilters(all: List<PreviewResult>): List<PreviewResult> = all.filter {
+    matchesRequest(it) && (!changedOnly || it.anyChanged())
+  }
+
+  /**
+   * @param results rows to emit (after `--id`/`--filter`/`--changed-only`)
+   * @param countsScope rows the [PreviewCounts] should be computed from — typically the unfiltered
+   *   set so the agent sees totals even when `--changed-only` narrows the visible rows. Pass `null`
+   *   to omit counts.
+   */
+  protected fun encodeResponse(
+    results: List<PreviewResult>,
+    countsScope: List<PreviewResult>?,
+  ): String {
+    val counts = countsScope?.let { countsOf(it) }
+    if (brief) {
+      val multiModule = results.map { it.module }.distinct().size > 1
+      val brief = results.map { r ->
+        BriefPreviewResult(
+          id = r.id,
+          module = r.module.takeIf { multiModule },
+          captures =
+            r.captures.map { c ->
+              BriefCapture(
+                png = c.pngPath,
+                sha = c.sha256?.take(12),
+                changed = c.changed,
+                time = c.advanceTimeMillis,
+                scroll = c.scroll?.mode,
+              )
+            },
+          a11y = r.a11yFindings?.size,
+        )
+      }
+      return briefJson.encodeToString(
+        BriefPreviewListResponse.serializer(),
+        BriefPreviewListResponse(previews = brief, counts = counts),
+      )
+    }
+    return json.encodeToString(
+      PreviewListResponse.serializer(),
+      PreviewListResponse(previews = results, counts = counts),
+    )
+  }
+
+  private fun countsOf(results: List<PreviewResult>) =
+    PreviewCounts(
+      total = results.size,
+      changed = results.count { it.anyChanged() },
+      unchanged = results.count { !it.anyChanged() && it.captures.any { c -> c.pngPath != null } },
+      missing = results.count { it.captures.all { c -> c.pngPath == null } },
     )
 
-    protected fun matchesRequest(result: PreviewResult): Boolean {
-        if (exactId != null && result.id != exactId) return false
-        if (filter != null && !result.id.contains(filter!!, ignoreCase = true)) return false
-        return true
-    }
+  protected fun matchesRequest(result: PreviewResult): Boolean {
+    if (exactId != null && result.id != exactId) return false
+    if (filter != null && !result.id.contains(filter!!, ignoreCase = true)) return false
+    return true
+  }
 
-    private fun stateFile(module: PreviewModule): File =
-        module.projectDir.resolve("build/compose-previews/.cli-state.json")
+  private fun stateFile(module: PreviewModule): File =
+    module.projectDir.resolve("build/compose-previews/.cli-state.json")
 
-    private fun readState(module: PreviewModule): CliState {
-        val f = stateFile(module)
-        if (!f.exists()) return CliState()
-        return try {
-            json.decodeFromString(CliState.serializer(), f.readText())
-        } catch (e: Exception) {
-            if (verbose) System.err.println("Warning: corrupt state file ${f.path}, resetting: ${e.message}")
-            CliState()
-        }
+  private fun readState(module: PreviewModule): CliState {
+    val f = stateFile(module)
+    if (!f.exists()) return CliState()
+    return try {
+      json.decodeFromString(CliState.serializer(), f.readText())
+    } catch (e: Exception) {
+      if (verbose)
+        System.err.println("Warning: corrupt state file ${f.path}, resetting: ${e.message}")
+      CliState()
     }
+  }
 
-    private fun writeState(module: PreviewModule, state: CliState) {
-        val f = stateFile(module)
-        f.parentFile?.mkdirs()
-        f.writeText(json.encodeToString(CliState.serializer(), state))
-    }
+  private fun writeState(module: PreviewModule, state: CliState) {
+    val f = stateFile(module)
+    f.parentFile?.mkdirs()
+    f.writeText(json.encodeToString(CliState.serializer(), state))
+  }
 
-    private fun findProjectRoot(): File? {
-        var dir: File? = File(".").absoluteFile
-        while (dir != null) {
-            if (File(dir, "gradlew").exists()) return dir
-            dir = dir.parentFile
-        }
-        return null
+  private fun findProjectRoot(): File? {
+    var dir: File? = File(".").absoluteFile
+    while (dir != null) {
+      if (File(dir, "gradlew").exists()) return dir
+      dir = dir.parentFile
     }
+    return null
+  }
 }
 
 class ShowCommand(args: List<String>) : Command(args) {
-    private val jsonOutput = "--json" in args
+  private val jsonOutput = "--json" in args
 
-    override fun run() {
-        withGradle { gradle ->
-            val modules = resolveModules(gradle)
-            val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
+  override fun run() {
+    withGradle { gradle ->
+      val modules = resolveModules(gradle)
+      val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
 
-            if (!runGradle(gradle, *tasks)) {
-                System.err.println("Render failed")
-                exitProcess(2)
+      if (!runGradle(gradle, *tasks)) {
+        System.err.println("Render failed")
+        exitProcess(2)
+      }
+
+      val manifests = readAllManifests(modules)
+      if (manifests.isEmpty() || manifests.all { it.second.previews.isEmpty() }) {
+        if (jsonOutput) println(encodeResponse(emptyList(), countsScope = emptyList()))
+        else println("No previews found.")
+        exitProcess(3)
+      }
+
+      val all = buildResults(manifests)
+      val filtered = applyFilters(all)
+
+      if (filtered.isEmpty()) {
+        // Counts reflect the full discovered set so an agent using
+        // `--changed-only` can still see "60 unchanged, 0 changed"
+        // and skip a follow-up query.
+        if (jsonOutput) println(encodeResponse(emptyList(), countsScope = all))
+        else println("No previews matched.")
+        exitProcess(3)
+      }
+
+      if (jsonOutput) {
+        println(encodeResponse(filtered, countsScope = all))
+      } else {
+        var lastModule: String? = null
+        for (r in filtered) {
+          if (modules.size > 1 && r.module != lastModule) {
+            println("[${r.module}]")
+            lastModule = r.module
+          }
+          val statusTag =
+            when {
+              r.pngPath == null -> " [no PNG]"
+              r.anyChanged() -> " [changed]"
+              else -> ""
             }
-
-            val manifests = readAllManifests(modules)
-            if (manifests.isEmpty() || manifests.all { it.second.previews.isEmpty() }) {
-                if (jsonOutput) println(encodeResponse(emptyList(), countsScope = emptyList()))
-                else println("No previews found.")
-                exitProcess(3)
-            }
-
-            val all = buildResults(manifests)
-            val filtered = applyFilters(all)
-
-            if (filtered.isEmpty()) {
-                // Counts reflect the full discovered set so an agent using
-                // `--changed-only` can still see "60 unchanged, 0 changed"
-                // and skip a follow-up query.
-                if (jsonOutput) println(encodeResponse(emptyList(), countsScope = all))
-                else println("No previews matched.")
-                exitProcess(3)
-            }
-
-            if (jsonOutput) {
-                println(encodeResponse(filtered, countsScope = all))
-            } else {
-                var lastModule: String? = null
-                for (r in filtered) {
-                    if (modules.size > 1 && r.module != lastModule) {
-                        println("[${r.module}]")
-                        lastModule = r.module
-                    }
-                    val statusTag = when {
-                        r.pngPath == null -> " [no PNG]"
-                        r.anyChanged() -> " [changed]"
-                        else -> ""
-                    }
-                    val shaTag = r.sha256?.let { "  sha=${it.take(12)}" } ?: ""
-                    println("${r.functionName} (${r.id})$statusTag$shaTag")
-                    if (r.captures.size <= 1) {
-                        if (r.pngPath != null) println("  ${r.pngPath}")
-                    } else {
-                        for (c in r.captures) {
-                            val tag = when {
-                                c.pngPath == null -> " [no PNG]"
-                                c.changed == true -> " [changed]"
-                                else -> ""
-                            }
-                            val coord = listOfNotNull(
-                                c.advanceTimeMillis?.let { "${it}ms" },
-                                c.scroll?.let { "scroll ${it.mode.lowercase()}" },
-                            ).joinToString(" · ").ifEmpty { "default" }
-                            println("  [$coord]$tag ${c.pngPath ?: ""}")
-                        }
-                    }
+          val shaTag = r.sha256?.let { "  sha=${it.take(12)}" } ?: ""
+          println("${r.functionName} (${r.id})$statusTag$shaTag")
+          if (r.captures.size <= 1) {
+            if (r.pngPath != null) println("  ${r.pngPath}")
+          } else {
+            for (c in r.captures) {
+              val tag =
+                when {
+                  c.pngPath == null -> " [no PNG]"
+                  c.changed == true -> " [changed]"
+                  else -> ""
                 }
+              val coord =
+                listOfNotNull(
+                    c.advanceTimeMillis?.let { "${it}ms" },
+                    c.scroll?.let { "scroll ${it.mode.lowercase()}" },
+                  )
+                  .joinToString(" · ")
+                  .ifEmpty { "default" }
+              println("  [$coord]$tag ${c.pngPath ?: ""}")
             }
-
-            // "Missing" = at least one capture failed to produce a PNG.
-            val missing = filtered.filter { r -> r.captures.any { it.pngPath == null } }
-            if (missing.isNotEmpty()) {
-                System.err.println(
-                    "Render task completed but produced no PNG for ${missing.size} of ${filtered.size} preview(s).",
-                )
-                System.err.println(
-                    "Check the Gradle output above — a common cause is the `renderPreviews` task " +
-                        "reporting NO-SOURCE, which means the renderer test class wasn't found on " +
-                        "testClassesDirs.",
-                )
-                exitProcess(2)
-            }
+          }
         }
+      }
+
+      // "Missing" = at least one capture failed to produce a PNG.
+      val missing = filtered.filter { r -> r.captures.any { it.pngPath == null } }
+      if (missing.isNotEmpty()) {
+        System.err.println(
+          "Render task completed but produced no PNG for ${missing.size} of ${filtered.size} preview(s)."
+        )
+        System.err.println(
+          "Check the Gradle output above — a common cause is the `renderPreviews` task " +
+            "reporting NO-SOURCE, which means the renderer test class wasn't found on " +
+            "testClassesDirs."
+        )
+        exitProcess(2)
+      }
     }
+  }
 }
 
 class ListCommand(args: List<String>) : Command(args) {
-    private val jsonOutput = "--json" in args
+  private val jsonOutput = "--json" in args
 
-    override fun run() {
-        withGradle { gradle ->
-            val modules = resolveModules(gradle)
-            val tasks = modules.map { ":${it.gradlePath}:discoverPreviews" }.toTypedArray()
+  override fun run() {
+    withGradle { gradle ->
+      val modules = resolveModules(gradle)
+      val tasks = modules.map { ":${it.gradlePath}:discoverPreviews" }.toTypedArray()
 
-            if (!runGradle(gradle, *tasks)) exitProcess(1)
+      if (!runGradle(gradle, *tasks)) exitProcess(1)
 
-            val manifests = readAllManifests(modules)
-            // List runs discovery only — PNGs may not exist, so sha/changed are null.
-            // `--changed-only` is meaningless without rendering; ignore it here.
-            val all = buildResults(manifests)
-            val filtered = all.filter { matchesRequest(it) }
+      val manifests = readAllManifests(modules)
+      // List runs discovery only — PNGs may not exist, so sha/changed are null.
+      // `--changed-only` is meaningless without rendering; ignore it here.
+      val all = buildResults(manifests)
+      val filtered = all.filter { matchesRequest(it) }
 
-            if (filtered.isEmpty()) {
-                if (jsonOutput) println(encodeResponse(emptyList(), countsScope = null))
-                else println("No previews found.")
-                exitProcess(3)
-            }
+      if (filtered.isEmpty()) {
+        if (jsonOutput) println(encodeResponse(emptyList(), countsScope = null))
+        else println("No previews found.")
+        exitProcess(3)
+      }
 
-            if (jsonOutput) {
-                println(encodeResponse(filtered, countsScope = null))
-            } else {
-                for (r in filtered) {
-                    println("${r.id}  (${r.sourceFile ?: "unknown"})")
-                }
-            }
+      if (jsonOutput) {
+        println(encodeResponse(filtered, countsScope = null))
+      } else {
+        for (r in filtered) {
+          println("${r.id}  (${r.sourceFile ?: "unknown"})")
         }
+      }
     }
+  }
 }
 
 class RenderCommand(args: List<String>) : Command(args) {
-    private val output: String? = args.flagValue("--output")
+  private val output: String? = args.flagValue("--output")
 
-    override fun run() {
-        withGradle { gradle ->
-            val modules = resolveModules(gradle)
-            val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
+  override fun run() {
+    withGradle { gradle ->
+      val modules = resolveModules(gradle)
+      val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
 
-            if (!runGradle(gradle, *tasks)) exitProcess(2)
+      if (!runGradle(gradle, *tasks)) exitProcess(2)
 
-            val manifests = readAllManifests(modules)
-            val all = buildResults(manifests)
-            // `render` ignores `--changed-only` so the agent can ask "render
-            // the world, but report only what changed" via a follow-up
-            // `show --changed-only`.
-            val filtered = all.filter { matchesRequest(it) }
+      val manifests = readAllManifests(modules)
+      val all = buildResults(manifests)
+      // `render` ignores `--changed-only` so the agent can ask "render
+      // the world, but report only what changed" via a follow-up
+      // `show --changed-only`.
+      val filtered = all.filter { matchesRequest(it) }
 
-            if (filtered.isEmpty()) {
-                System.err.println("No previews matched.")
-                exitProcess(3)
-            }
+      if (filtered.isEmpty()) {
+        System.err.println("No previews matched.")
+        exitProcess(3)
+      }
 
-            val missing = filtered.filter { r -> r.captures.any { it.pngPath == null } }
+      val missing = filtered.filter { r -> r.captures.any { it.pngPath == null } }
 
-            if (output != null) {
-                if (filtered.size != 1) {
-                    System.err.println(
-                        "--output requires a single match (got ${filtered.size}). " +
-                            "Narrow with --id <exact> or --filter <substring>.",
-                    )
-                    exitProcess(1)
-                }
-                val one = filtered.single()
-                if (one.pngPath == null) {
-                    System.err.println("Render produced no PNG for: ${one.id}")
-                    exitProcess(2)
-                }
-                File(one.pngPath).copyTo(File(output), overwrite = true)
-                println("Rendered ${one.id} to $output")
-            } else {
-                val rendered = filtered.size - missing.size
-                println("Rendered $rendered preview(s)")
-                val changedCount = filtered.count { it.anyChanged() }
-                if (changedCount > 0) println("  $changedCount changed since last run")
-                if (missing.isNotEmpty()) {
-                    System.err.println(
-                        "Render task completed but produced no PNG for ${missing.size} preview(s):",
-                    )
-                    for (r in missing) System.err.println("  ${r.id}")
-                    exitProcess(2)
-                }
-            }
+      if (output != null) {
+        if (filtered.size != 1) {
+          System.err.println(
+            "--output requires a single match (got ${filtered.size}). " +
+              "Narrow with --id <exact> or --filter <substring>."
+          )
+          exitProcess(1)
         }
+        val one = filtered.single()
+        if (one.pngPath == null) {
+          System.err.println("Render produced no PNG for: ${one.id}")
+          exitProcess(2)
+        }
+        File(one.pngPath).copyTo(File(output), overwrite = true)
+        println("Rendered ${one.id} to $output")
+      } else {
+        val rendered = filtered.size - missing.size
+        println("Rendered $rendered preview(s)")
+        val changedCount = filtered.count { it.anyChanged() }
+        if (changedCount > 0) println("  $changedCount changed since last run")
+        if (missing.isNotEmpty()) {
+          System.err.println(
+            "Render task completed but produced no PNG for ${missing.size} preview(s):"
+          )
+          for (r in missing) System.err.println("  ${r.id}")
+          exitProcess(2)
+        }
+      }
     }
+  }
 }
 
 /**
- * `compose-preview a11y` — runs `renderAllPreviews` (which pulls in
- * `verifyAccessibility` when enabled) and prints the findings grouped by
- * preview. Exits non-zero if the Gradle build failed (i.e. the configured
- * `failOnErrors`/`failOnWarnings` threshold tripped) or if `--fail-on`
+ * `compose-preview a11y` — runs `renderAllPreviews` (which pulls in `verifyAccessibility` when
+ * enabled) and prints the findings grouped by preview. Exits non-zero if the Gradle build failed
+ * (i.e. the configured `failOnErrors`/`failOnWarnings` threshold tripped) or if `--fail-on`
  * overrides the threshold at the CLI level.
  */
 class A11yCommand(args: List<String>) : Command(args) {
-    private val jsonOutput = "--json" in args
-    // "errors" | "warnings" | "none". When not set, exit code mirrors Gradle.
-    private val failOn: String? = args.flagValue("--fail-on")
+  private val jsonOutput = "--json" in args
+  // "errors" | "warnings" | "none". When not set, exit code mirrors Gradle.
+  private val failOn: String? = args.flagValue("--fail-on")
 
-    override fun run() {
-        withGradle { gradle ->
-            val modules = resolveModules(gradle)
-            val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
-            val buildOk = runGradle(gradle, *tasks)
+  override fun run() {
+    withGradle { gradle ->
+      val modules = resolveModules(gradle)
+      val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
+      val buildOk = runGradle(gradle, *tasks)
 
-            val manifests = readAllManifests(modules)
-            val enabledModules = manifests.filter { it.second.accessibilityReport != null }
-            if (enabledModules.isEmpty()) {
-                if (jsonOutput) println(encodeResponse(emptyList(), countsScope = null))
-                else {
-                    println(
-                        "No module has accessibility checks enabled. Add\n" +
-                            "  composePreview { accessibilityChecks { enabled = true } }\n" +
-                            "to the module's build.gradle.kts."
-                    )
-                }
-                exitProcess(if (buildOk) 0 else 2)
-            }
-
-            val all = buildResults(manifests)
-            val filtered = all.filter {
-                matchesRequest(it) && it.a11yFindings != null && (!changedOnly || it.anyChanged())
-            }
-
-            if (jsonOutput) {
-                println(encodeResponse(filtered, countsScope = null))
-            } else {
-                val flat = filtered.flatMap { r ->
-                    (r.a11yFindings ?: emptyList()).map { f -> r to f }
-                }
-                if (flat.isEmpty()) {
-                    println("No accessibility findings.")
-                } else {
-                    println("${flat.size} accessibility finding(s):")
-                    // Track per-preview so we only print the annotated-PNG
-                    // hint once, on the first finding for that preview.
-                    var lastPreviewId: String? = null
-                    for ((r, f) in flat) {
-                        println("  [${f.level}] ${r.id} · ${f.type}")
-                        println("      ${f.message}")
-                        f.viewDescription?.let { println("      element: $it") }
-                        if (r.id != lastPreviewId) {
-                            r.a11yAnnotatedPath?.let { println("      annotated: $it") }
-                            lastPreviewId = r.id
-                        }
-                    }
-                }
-            }
-
-            val errorCount = filtered.sumOf { it.a11yFindings?.count { f -> f.level == "ERROR" } ?: 0 }
-            val warnCount = filtered.sumOf { it.a11yFindings?.count { f -> f.level == "WARNING" } ?: 0 }
-            val cliFailed = when (failOn) {
-                "errors" -> errorCount > 0
-                "warnings" -> errorCount > 0 || warnCount > 0
-                "none", null -> false
-                else -> {
-                    System.err.println("Unknown --fail-on value: $failOn (expected errors|warnings|none)")
-                    exitProcess(1)
-                }
-            }
-            exitProcess(
-                when {
-                    cliFailed -> 2
-                    !buildOk -> 2
-                    else -> 0
-                }
-            )
+      val manifests = readAllManifests(modules)
+      val enabledModules = manifests.filter { it.second.accessibilityReport != null }
+      if (enabledModules.isEmpty()) {
+        if (jsonOutput) println(encodeResponse(emptyList(), countsScope = null))
+        else {
+          println(
+            "No module has accessibility checks enabled. Add\n" +
+              "  composePreview { accessibilityChecks { enabled = true } }\n" +
+              "to the module's build.gradle.kts."
+          )
         }
+        exitProcess(if (buildOk) 0 else 2)
+      }
+
+      val all = buildResults(manifests)
+      val filtered = all.filter {
+        matchesRequest(it) && it.a11yFindings != null && (!changedOnly || it.anyChanged())
+      }
+
+      if (jsonOutput) {
+        println(encodeResponse(filtered, countsScope = null))
+      } else {
+        val flat = filtered.flatMap { r -> (r.a11yFindings ?: emptyList()).map { f -> r to f } }
+        if (flat.isEmpty()) {
+          println("No accessibility findings.")
+        } else {
+          println("${flat.size} accessibility finding(s):")
+          // Track per-preview so we only print the annotated-PNG
+          // hint once, on the first finding for that preview.
+          var lastPreviewId: String? = null
+          for ((r, f) in flat) {
+            println("  [${f.level}] ${r.id} · ${f.type}")
+            println("      ${f.message}")
+            f.viewDescription?.let { println("      element: $it") }
+            if (r.id != lastPreviewId) {
+              r.a11yAnnotatedPath?.let { println("      annotated: $it") }
+              lastPreviewId = r.id
+            }
+          }
+        }
+      }
+
+      val errorCount = filtered.sumOf { it.a11yFindings?.count { f -> f.level == "ERROR" } ?: 0 }
+      val warnCount = filtered.sumOf { it.a11yFindings?.count { f -> f.level == "WARNING" } ?: 0 }
+      val cliFailed =
+        when (failOn) {
+          "errors" -> errorCount > 0
+          "warnings" -> errorCount > 0 || warnCount > 0
+          "none",
+          null -> false
+          else -> {
+            System.err.println("Unknown --fail-on value: $failOn (expected errors|warnings|none)")
+            exitProcess(1)
+          }
+        }
+      exitProcess(
+        when {
+          cliFailed -> 2
+          !buildOk -> 2
+          else -> 0
+        }
+      )
     }
+  }
 }
 
 private fun sha256(bytes: ByteArray): String {
-    val md = MessageDigest.getInstance("SHA-256")
-    return md.digest(bytes).joinToString("") { "%02x".format(it) }
+  val md = MessageDigest.getInstance("SHA-256")
+  return md.digest(bytes).joinToString("") { "%02x".format(it) }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -1,13 +1,12 @@
 package ee.schimke.composeai.cli
 
-import ee.schimke.composeai.plugin.tooling.ComposePreviewModel
 import ee.schimke.composeai.plugin.tooling.ModuleInfo
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import java.io.File
 import java.net.HttpURLConnection
 import java.net.URI
 import kotlin.system.exitProcess
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
 /**
  * `compose-preview doctor`
@@ -15,968 +14,1003 @@ import kotlin.system.exitProcess
  * Two layers of checks:
  *
  * **Environment** (always runs, safe outside a Gradle project):
- *   - Java 17+ on PATH
- *   - HEAD probes of Google-controlled hosts required by Android / downloadable-font
- *     render paths (`maven.google.com`, `dl.google.com`, `fonts.googleapis.com`,
- *     `fonts.gstatic.com`). Warnings only; set `COMPOSE_PREVIEW_DOCTOR_SKIP_NETWORK=1`
- *     to skip.
+ * - Java 17+ on PATH
+ * - HEAD probes of Google-controlled hosts required by Android / downloadable-font render paths
+ *   (`maven.google.com`, `dl.google.com`, `fonts.googleapis.com`, `fonts.gstatic.com`). Warnings
+ *   only; set `COMPOSE_PREVIEW_DOCTOR_SKIP_NETWORK=1` to skip.
  *
  * **Project** (runs when a `settings.gradle[.kts]` is found at `--project` or cwd):
- *   - Plugin applied to at least one module
- *   - Consumer's test-runtime classpath vs main-variant classpath satisfies
- *     the AAR/R.id version-alignment rules for preview rendering. Checks:
- *       - `deps.<module>.ui-test-manifest` — ui-test-manifest on test classpath
- *       - `deps.<module>.activity-vs-navigationevent` — navigationevent on test, older activity on main
- *       - `deps.<module>.compose-ui-vs-core` — compose-ui 1.10+ on test, older androidx.core on main
- *       - `deps.<module>.compose-bom` (warning) — no Compose BOM declared
+ * - Plugin applied to at least one module
+ * - Consumer's test-runtime classpath vs main-variant classpath satisfies the AAR/R.id
+ *   version-alignment rules for preview rendering. Checks:
+ *     - `deps.<module>.ui-test-manifest` — ui-test-manifest on test classpath
+ *     - `deps.<module>.activity-vs-navigationevent` — navigationevent on test, older activity on
+ *       main
+ *     - `deps.<module>.compose-ui-vs-core` — compose-ui 1.10+ on test, older androidx.core on main
+ *     - `deps.<module>.compose-bom` (warning) — no Compose BOM declared
  *
  * Output modes:
- *   - Default: human-friendly ANSI with ✓ / ! / ✗ / ∙ markers, per-check remediation.
- *   - `--json`: machine-readable [DoctorReport] (schema `compose-preview-doctor/v1`).
- *     Agents should prefer this — remediations come with concrete `commands[]`
- *     they can apply directly.
- *   - `--explain`: prints extended rationale for each non-ok check, including
- *     the specific exception class an unfixed misconfig will surface at render
- *     time. Useful for humans first hitting a failure; noisy for agents.
+ * - Default: human-friendly ANSI with ✓ / ! / ✗ / ∙ markers, per-check remediation.
+ * - `--json`: machine-readable [DoctorReport] (schema `compose-preview-doctor/v1`). Agents should
+ *   prefer this — remediations come with concrete `commands[]` they can apply directly.
+ * - `--explain`: prints extended rationale for each non-ok check, including the specific exception
+ *   class an unfixed misconfig will surface at render time. Useful for humans first hitting a
+ *   failure; noisy for agents.
  *
  * Exits 0 when no errors (warnings OK), 1 when any check reports ERROR.
  */
 class DoctorCommand(args: List<String>) {
-    private val jsonOut = "--json" in args
-    private val reportOut = "--report" in args
-    private val explain = "--explain" in args
-    private val verbose = "--verbose" in args || "-v" in args
-    private val projectDirArg = args.flagValue("--project")
-    private val pluginVersion = args.flagValue("--plugin-version") ?: DEFAULT_PLUGIN_VERSION
+  private val jsonOut = "--json" in args
+  private val reportOut = "--report" in args
+  private val explain = "--explain" in args
+  private val verbose = "--verbose" in args || "-v" in args
+  private val projectDirArg = args.flagValue("--project")
+  private val pluginVersion = args.flagValue("--plugin-version") ?: DEFAULT_PLUGIN_VERSION
 
-    private val checks = mutableListOf<DoctorCheck>()
+  private val checks = mutableListOf<DoctorCheck>()
 
-    /**
-     * Claude Code cloud sandbox detection. Same signal `scripts/install.sh`
-     * uses (see `CLAUDE_CLOUD` auto-detection). When true, network-reach
-     * remediations call out Claude Code's Custom network mode directly and
-     * `checkClaudeCloud` emits a top-line `env.claude-cloud` check so the
-     * rest of the report reads in that context.
-     */
-    private val inClaudeCloud: Boolean =
-        !System.getenv("CLAUDE_CODE_SESSION_ID").isNullOrBlank() ||
-            !System.getenv("CLAUDE_ENV_FILE").isNullOrBlank()
+  /**
+   * Claude Code cloud sandbox detection. Same signal `scripts/install.sh` uses (see `CLAUDE_CLOUD`
+   * auto-detection). When true, network-reach remediations call out Claude Code's Custom network
+   * mode directly and `checkClaudeCloud` emits a top-line `env.claude-cloud` check so the rest of
+   * the report reads in that context.
+   */
+  private val inClaudeCloud: Boolean =
+    !System.getenv("CLAUDE_CODE_SESSION_ID").isNullOrBlank() ||
+      !System.getenv("CLAUDE_ENV_FILE").isNullOrBlank()
 
-    fun run() {
-        // Environment checks always run.
-        checkOs()
-        checkJava()
-        checkPathJava()
-        checkClaudeCloud()
+  fun run() {
+    // Environment checks always run.
+    checkOs()
+    checkJava()
+    checkPathJava()
+    checkClaudeCloud()
 
-        val projectDir = resolveProjectDir()
+    val projectDir = resolveProjectDir()
 
-        checkComposeBomVersion()
-        if (System.getenv("COMPOSE_PREVIEW_DOCTOR_SKIP_NETWORK") != "1") {
-            checkNetworkReach()
-        }
-
-        // Project checks: only when a Gradle project is reachable.
-        if (projectDir != null) {
-            runProjectChecks(projectDir)
-        } else {
-            addCheck(
-                DoctorCheck(
-                    id = "project.detected",
-                    category = "project",
-                    status = "skipped",
-                    message = "no Gradle project at ${projectDirArg ?: "."}",
-                    detail = "project-scope compatibility checks were skipped",
-                    remediation = DoctorRemediation(
-                        summary = "run doctor from a Gradle project root, or pass `--project <dir>`",
-                    ),
-                ),
-            )
-        }
-
-        emit()
+    checkComposeBomVersion()
+    if (System.getenv("COMPOSE_PREVIEW_DOCTOR_SKIP_NETWORK") != "1") {
+      checkNetworkReach()
     }
 
-    private fun resolveProjectDir(): File? {
-        val dir = File(projectDirArg ?: ".").absoluteFile
-        if (!dir.exists() || !dir.isDirectory) return null
-        return if (File(dir, "settings.gradle.kts").exists() || File(dir, "settings.gradle").exists()) {
-            dir
-        } else null
-    }
-
-    // --- Env checks ---------------------------------------------------------
-
-    /**
-     * OS fingerprint. Cheap to collect and has saved several issue rounds —
-     * e.g. #142 was specific to a Linux kernel build not visible from
-     * `os.name` alone. We emit name/version/arch verbatim; doctor never
-     * branches on these.
-     */
-    private fun checkOs() {
-        val name = System.getProperty("os.name") ?: "unknown"
-        val version = System.getProperty("os.version") ?: ""
-        val arch = System.getProperty("os.arch") ?: ""
-        addCheck(
-            DoctorCheck(
-                id = "env.os",
-                category = "env",
-                status = "ok",
-                message = listOf(name, version, arch).filter { it.isNotBlank() }.joinToString(" "),
+    // Project checks: only when a Gradle project is reachable.
+    if (projectDir != null) {
+      runProjectChecks(projectDir)
+    } else {
+      addCheck(
+        DoctorCheck(
+          id = "project.detected",
+          category = "project",
+          status = "skipped",
+          message = "no Gradle project at ${projectDirArg ?: "."}",
+          detail = "project-scope compatibility checks were skipped",
+          remediation =
+            DoctorRemediation(
+              summary = "run doctor from a Gradle project root, or pass `--project <dir>`"
             ),
         )
+      )
     }
 
-    private fun checkJava() {
-        val version = System.getProperty("java.specification.version")
-        val major = version?.substringBefore('.')?.toIntOrNull()
-        // Fingerprint the CLI's own JVM so bug reports carry vendor (often
-        // differentiates the Linux-distro / Google-internal JDK that caused
-        // #142) and java.home (pinpoints SDKMAN vs system-provided installs).
-        val vendor = System.getProperty("java.vendor") ?: "unknown"
-        val runtime = System.getProperty("java.runtime.version") ?: System.getProperty("java.version") ?: "unknown"
-        val home = System.getProperty("java.home") ?: "unknown"
-        val detail = "vendor: $vendor; runtime: $runtime; java.home: $home"
-        if (major != null && major >= 17) {
-            addCheck(
-                DoctorCheck(
-                    id = "env.java-17",
-                    category = "env",
-                    status = "ok",
-                    message = "CLI JVM Java $version",
-                    detail = detail,
-                ),
-            )
-        } else {
-            addCheck(
-                DoctorCheck(
-                    id = "env.java-17",
-                    category = "env",
-                    status = "error",
-                    message = "Java 17+ required, got ${version ?: "unknown"}",
-                    detail = detail,
-                    remediation = DoctorRemediation(
-                        summary = "Install a JDK 17 or newer and put it on PATH, or set JAVA_HOME. " +
-                            "The CLI and renderer target JDK 17 bytecode, so any newer JDK (21, 25, …) works.",
-                        commands = listOf("sdk install java 17.0.11-tem"),
-                    ),
-                ),
-            )
-        }
-    }
+    emit()
+  }
 
-    /**
-     * Separate check for the `java` on `PATH`. Motivated by #142: the
-     * reporter's Gradle launcher was pinned to JDK 21 via `JAVA_HOME`, but
-     * their system default (`java` on PATH) was JDK 25 — and the forked
-     * `renderPreviews` test worker picked up the system default, because
-     * the Test task's `javaLauncher` wasn't pinned to the project toolchain.
-     * Separating the CLI JVM from the PATH JVM makes that delta visible in
-     * the first line of output.
-     *
-     * Skipped on Windows for now — `java -version` prints to stderr, the
-     * parsing is the same, but nobody is reporting Windows-specific bugs
-     * yet and `sh -c` isn't available there. Add when a Windows-only bug
-     * report needs it.
-     */
-    private fun checkPathJava() {
-        val sameAsCli = System.getProperty("java.home")?.let { home ->
-            // If PATH's `java` resolves to the same install as java.home,
-            // emitting a second check is noise — the cli check already
-            // covers it.
-            val probe = runCommand(listOf("sh", "-c", "command -v java"))
-            probe?.stdout?.trim()?.startsWith(home) == true
-        } ?: false
-        if (sameAsCli) return
+  private fun resolveProjectDir(): File? {
+    val dir = File(projectDirArg ?: ".").absoluteFile
+    if (!dir.exists() || !dir.isDirectory) return null
+    return if (File(dir, "settings.gradle.kts").exists() || File(dir, "settings.gradle").exists()) {
+      dir
+    } else null
+  }
 
-        val which = runCommand(listOf("sh", "-c", "command -v java")) ?: return
-        val path = which.stdout.trim().ifBlank { return }
-        val versionOut = runCommand(listOf(path, "-version"))?.stderrOrStdout()?.trim().orEmpty()
-        // `java -version` prints 3 lines to stderr: the version, the
-        // runtime build, and the VM build. We keep the first two, which
-        // carry vendor tagging (e.g. `+-google-release-868188172`).
-        val summary = versionOut.lines().take(2).joinToString(" | ").ifBlank { "unreachable" }
-        addCheck(
-            DoctorCheck(
-                id = "env.path-jvm",
-                category = "env",
-                status = "ok",
-                message = "`java` on PATH → $path",
-                detail = summary,
+  // --- Env checks ---------------------------------------------------------
+
+  /**
+   * OS fingerprint. Cheap to collect and has saved several issue rounds — e.g. #142 was specific to
+   * a Linux kernel build not visible from `os.name` alone. We emit name/version/arch verbatim;
+   * doctor never branches on these.
+   */
+  private fun checkOs() {
+    val name = System.getProperty("os.name") ?: "unknown"
+    val version = System.getProperty("os.version") ?: ""
+    val arch = System.getProperty("os.arch") ?: ""
+    addCheck(
+      DoctorCheck(
+        id = "env.os",
+        category = "env",
+        status = "ok",
+        message = listOf(name, version, arch).filter { it.isNotBlank() }.joinToString(" "),
+      )
+    )
+  }
+
+  private fun checkJava() {
+    val version = System.getProperty("java.specification.version")
+    val major = version?.substringBefore('.')?.toIntOrNull()
+    // Fingerprint the CLI's own JVM so bug reports carry vendor (often
+    // differentiates the Linux-distro / Google-internal JDK that caused
+    // #142) and java.home (pinpoints SDKMAN vs system-provided installs).
+    val vendor = System.getProperty("java.vendor") ?: "unknown"
+    val runtime =
+      System.getProperty("java.runtime.version") ?: System.getProperty("java.version") ?: "unknown"
+    val home = System.getProperty("java.home") ?: "unknown"
+    val detail = "vendor: $vendor; runtime: $runtime; java.home: $home"
+    if (major != null && major >= 17) {
+      addCheck(
+        DoctorCheck(
+          id = "env.java-17",
+          category = "env",
+          status = "ok",
+          message = "CLI JVM Java $version",
+          detail = detail,
+        )
+      )
+    } else {
+      addCheck(
+        DoctorCheck(
+          id = "env.java-17",
+          category = "env",
+          status = "error",
+          message = "Java 17+ required, got ${version ?: "unknown"}",
+          detail = detail,
+          remediation =
+            DoctorRemediation(
+              summary =
+                "Install a JDK 17 or newer and put it on PATH, or set JAVA_HOME. " +
+                  "The CLI and renderer target JDK 17 bytecode, so any newer JDK (21, 25, …) works.",
+              commands = listOf("sdk install java 17.0.11-tem"),
             ),
         )
+      )
     }
+  }
 
-    /**
-     * Surfaces Claude Code cloud sandbox detection as an info-style check so
-     * agents and humans reading the report know the four `env.network.*`
-     * probes below are load-bearing (Google hosts aren't on the Trusted
-     * allowlist — they only resolve in Custom mode) and that
-     * `scripts/install.sh` is the intended bootstrap path. Suppressed when
-     * no Claude cloud env vars are set.
-     */
-    private fun checkClaudeCloud() {
-        if (!inClaudeCloud) return
-        val sessionId = System.getenv("CLAUDE_CODE_SESSION_ID").orEmpty()
-        val envFile = System.getenv("CLAUDE_ENV_FILE").orEmpty()
+  /**
+   * Separate check for the `java` on `PATH`. Motivated by #142: the reporter's Gradle launcher was
+   * pinned to JDK 21 via `JAVA_HOME`, but their system default (`java` on PATH) was JDK 25 — and
+   * the forked `renderPreviews` test worker picked up the system default, because the Test task's
+   * `javaLauncher` wasn't pinned to the project toolchain. Separating the CLI JVM from the PATH JVM
+   * makes that delta visible in the first line of output.
+   *
+   * Skipped on Windows for now — `java -version` prints to stderr, the parsing is the same, but
+   * nobody is reporting Windows-specific bugs yet and `sh -c` isn't available there. Add when a
+   * Windows-only bug report needs it.
+   */
+  private fun checkPathJava() {
+    val sameAsCli =
+      System.getProperty("java.home")?.let { home ->
+        // If PATH's `java` resolves to the same install as java.home,
+        // emitting a second check is noise — the cli check already
+        // covers it.
+        val probe = runCommand(listOf("sh", "-c", "command -v java"))
+        probe?.stdout?.trim()?.startsWith(home) == true
+      } ?: false
+    if (sameAsCli) return
+
+    val which = runCommand(listOf("sh", "-c", "command -v java")) ?: return
+    val path =
+      which.stdout.trim().ifBlank {
+        return
+      }
+    val versionOut = runCommand(listOf(path, "-version"))?.stderrOrStdout()?.trim().orEmpty()
+    // `java -version` prints 3 lines to stderr: the version, the
+    // runtime build, and the VM build. We keep the first two, which
+    // carry vendor tagging (e.g. `+-google-release-868188172`).
+    val summary = versionOut.lines().take(2).joinToString(" | ").ifBlank { "unreachable" }
+    addCheck(
+      DoctorCheck(
+        id = "env.path-jvm",
+        category = "env",
+        status = "ok",
+        message = "`java` on PATH → $path",
+        detail = summary,
+      )
+    )
+  }
+
+  /**
+   * Surfaces Claude Code cloud sandbox detection as an info-style check so agents and humans
+   * reading the report know the four `env.network.*` probes below are load-bearing (Google hosts
+   * aren't on the Trusted allowlist — they only resolve in Custom mode) and that
+   * `scripts/install.sh` is the intended bootstrap path. Suppressed when no Claude cloud env vars
+   * are set.
+   */
+  private fun checkClaudeCloud() {
+    if (!inClaudeCloud) return
+    val sessionId = System.getenv("CLAUDE_CODE_SESSION_ID").orEmpty()
+    val envFile = System.getenv("CLAUDE_ENV_FILE").orEmpty()
+    addCheck(
+      DoctorCheck(
+        id = "env.claude-cloud",
+        category = "env",
+        status = "ok",
+        message = "Claude Code cloud sandbox detected",
+        detail =
+          buildString {
+            append("session=${sessionId.ifBlank { "(unset)" }}")
+            append("; env-file=${envFile.ifBlank { "(unset)" }}")
+            append(". Cloud renders need network level = Custom with ")
+            append(NETWORK_HOSTS.joinToString(", ") { it.host })
+            append(" allowlisted (keep 'include Trusted defaults' on). ")
+            append("`scripts/install.sh` reuses the pre-installed JDK (21 on current ")
+            append("Claude Cloud images) and installs the skill + CLI bundle. It only ")
+            append("falls back to apt-installing JDK 17 when no JDK 17+ is available.")
+          },
+        remediation =
+          DoctorRemediation(
+            summary =
+              "Bootstrap the CLI + skill bundle and write JAVA_HOME/PATH to \$CLAUDE_ENV_FILE.",
+            commands =
+              listOf(
+                "curl -fsSL https://raw.githubusercontent.com/$REPO/main/scripts/install.sh | bash"
+              ),
+            docs =
+              "https://github.com/$REPO/blob/main/skills/compose-preview/design/CLAUDE_CLOUD.md",
+          ),
+      )
+    )
+  }
+
+  // --- Project checks -----------------------------------------------------
+
+  private var daemonGradleVersion: String? = null
+  private var daemonJavaHome: String? = null
+  private var daemonJavaMajor: Int? = null
+
+  private fun runProjectChecks(projectDir: File) {
+    val model =
+      try {
+        GradleConnection(projectDir, verbose = verbose).use { gc ->
+          // Daemon-JVM + Gradle-version snapshot. Runs first so other
+          // project-scope checks can compare against the daemon's JDK
+          // (e.g. flagging test worker mismatch in #142).
+          checkGradleDaemon(gc)
+          gc.runBuildAction(GatherComposePreviewModelAction())
+        }
+      } catch (e: Exception) {
         addCheck(
-            DoctorCheck(
-                id = "env.claude-cloud",
-                category = "env",
-                status = "ok",
-                message = "Claude Code cloud sandbox detected",
-                detail = buildString {
-                    append("session=${sessionId.ifBlank { "(unset)" }}")
-                    append("; env-file=${envFile.ifBlank { "(unset)" }}")
-                    append(". Cloud renders need network level = Custom with ")
-                    append(NETWORK_HOSTS.joinToString(", ") { it.host })
-                    append(" allowlisted (keep 'include Trusted defaults' on). ")
-                    append("`scripts/install.sh` reuses the pre-installed JDK (21 on current ")
-                    append("Claude Cloud images) and installs the skill + CLI bundle. It only ")
-                    append("falls back to apt-installing JDK 17 when no JDK 17+ is available.")
-                },
-                remediation = DoctorRemediation(
-                    summary = "Bootstrap the CLI + skill bundle and write JAVA_HOME/PATH to \$CLAUDE_ENV_FILE.",
-                    commands = listOf(
-                        "curl -fsSL https://raw.githubusercontent.com/$REPO/main/scripts/install.sh | bash",
-                    ),
-                    docs = "https://github.com/$REPO/blob/main/skills/compose-preview/design/CLAUDE_CLOUD.md",
-                ),
+          DoctorCheck(
+            id = "project.model",
+            category = "project",
+            status = "error",
+            message = "could not fetch plugin Tooling model",
+            detail = e.message,
+            remediation =
+              DoctorRemediation(
+                summary = "Ensure the project builds (`./gradlew help`) and the plugin is applied."
+              ),
+          )
+        )
+        return
+      }
+
+    if (model == null || model.modules.isEmpty()) {
+      addCheck(
+        DoctorCheck(
+          id = "project.plugin-applied",
+          category = "project",
+          status = "error",
+          message = "no modules have the compose-preview plugin applied",
+          remediation =
+            DoctorRemediation(
+              summary = "Apply the plugin in your module's `plugins { }` block.",
+              commands = listOf("id(\"ee.schimke.composeai.preview\") version \"$pluginVersion\""),
+              docs = "https://github.com/$REPO#usage",
             ),
         )
+      )
+      return
     }
 
-    // --- Project checks -----------------------------------------------------
-
-    private var daemonGradleVersion: String? = null
-    private var daemonJavaHome: String? = null
-    private var daemonJavaMajor: Int? = null
-
-    private fun runProjectChecks(projectDir: File) {
-        val model = try {
-            GradleConnection(projectDir, verbose = verbose).use { gc ->
-                // Daemon-JVM + Gradle-version snapshot. Runs first so other
-                // project-scope checks can compare against the daemon's JDK
-                // (e.g. flagging test worker mismatch in #142).
-                checkGradleDaemon(gc)
-                gc.runBuildAction(GatherComposePreviewModelAction())
-            }
-        } catch (e: Exception) {
-            addCheck(
-                DoctorCheck(
-                    id = "project.model",
-                    category = "project",
-                    status = "error",
-                    message = "could not fetch plugin Tooling model",
-                    detail = e.message,
-                    remediation = DoctorRemediation(
-                        summary = "Ensure the project builds (`./gradlew help`) and the plugin is applied.",
-                    ),
-                ),
-            )
-            return
-        }
-
-        if (model == null || model.modules.isEmpty()) {
-            addCheck(
-                DoctorCheck(
-                    id = "project.plugin-applied",
-                    category = "project",
-                    status = "error",
-                    message = "no modules have the compose-preview plugin applied",
-                    remediation = DoctorRemediation(
-                        summary = "Apply the plugin in your module's `plugins { }` block.",
-                        commands = listOf("id(\"ee.schimke.composeai.preview\") version \"$pluginVersion\""),
-                        docs = "https://github.com/$REPO#usage",
-                    ),
-                ),
-            )
-            return
-        }
-
-        addCheck(
-            DoctorCheck(
-                id = "project.plugin-applied",
-                category = "project",
-                status = "ok",
-                message = "plugin applied in ${model.modules.size} module(s)",
-                detail = model.modules.keys.joinToString(", "),
-            ),
-        )
-
-        for ((modulePath, info) in model.modules) {
-            checkModuleVersions(modulePath, info)
-            checkRenderPreviewsTask(modulePath, info)
-            checkModuleCompat(modulePath, info)
-            checkErrorSignatures(projectDir, modulePath)
-        }
-    }
-
-    /**
-     * Emits the daemon's Gradle and JVM fingerprint as two `env` checks.
-     * We stash the JDK major and path on the class so per-module checks
-     * can compare against them (see [checkRenderPreviewsTask]).
-     *
-     * Runs inside the project block because fetching the model requires a
-     * live [GradleConnection]. It's logically an env concern though, so
-     * the check id lives under `env.*`.
-     */
-    private fun checkGradleDaemon(gc: GradleConnection) {
-        val env = gc.buildEnvironment() ?: run {
-            addCheck(
-                DoctorCheck(
-                    id = "env.gradle-daemon",
-                    category = "env",
-                    status = "warning",
-                    message = "could not fetch BuildEnvironment from Gradle daemon",
-                ),
-            )
-            return
-        }
-        daemonGradleVersion = env.gradle.gradleVersion
-        val javaHome = env.java.javaHome
-        daemonJavaHome = javaHome.absolutePath
-        // Derive JDK major from the release file — more reliable than
-        // guessing from `javaHome` path naming. Falls back to null if the
-        // file isn't there or doesn't parse (e.g. a non-standard install).
-        daemonJavaMajor = readJdkMajor(javaHome)
-        val majorStr = daemonJavaMajor?.let { "JDK $it" } ?: "unknown JDK"
-        addCheck(
-            DoctorCheck(
-                id = "env.gradle-daemon",
-                category = "env",
-                status = "ok",
-                message = "Gradle ${daemonGradleVersion} on $majorStr",
-                detail = "daemon java.home: ${daemonJavaHome}",
-            ),
-        )
-    }
-
-    /**
-     * Emits per-module version info — AGP, Kotlin, Robolectric, Compose
-     * runtime. Robolectric/Compose-runtime are read from the resolved test
-     * classpath; AGP/Kotlin are plugin-side reflective reads. All four are
-     * surfaced as an `info`-style ok-status check so `--report` has one
-     * pasteable block with everything a triager needs to see.
-     */
-    private fun checkModuleVersions(modulePath: String, info: ModuleInfo) {
-        val robolectric = info.testRuntimeDependencies["org.robolectric:robolectric"]
-        val composeRuntime = info.testRuntimeDependencies["androidx.compose.runtime:runtime"]
-        val parts = buildList {
-            add("variant=${info.variant}")
-            info.agpVersion?.let { add("agp=$it") }
-            info.kotlinVersion?.let { add("kotlin=$it") }
-            robolectric?.let { add("robolectric=$it") }
-            composeRuntime?.let { add("compose-runtime=$it") }
-        }
-        addCheck(
-            DoctorCheck(
-                id = "project.${idSafe(modulePath)}.versions",
-                category = "project",
-                status = "ok",
-                message = "$modulePath — ${parts.joinToString("  ")}",
-            ),
-        )
-    }
-
-    /**
-     * The check motivated by issue #142. If the test worker's forked JDK
-     * is a different major than the Gradle daemon's, emit a `warning` with
-     * the specific error signature the mismatch typically produces, plus a
-     * remediation pointing at the `javaLauncher` toolchain wiring.
-     *
-     * When the JDK majors match (or when we can't tell), this degrades to
-     * a pure info line — still useful in bug reports because it fingerprints
-     * the launcher vendor and path.
-     */
-    private fun checkRenderPreviewsTask(modulePath: String, info: ModuleInfo) {
-        val task = info.renderPreviewsTask ?: return
-        val launcherMajor = task.javaLauncherVersion?.toIntOrNull()
-        val launcherPath = task.javaLauncherPath ?: "(unknown)"
-        val launcherVendor = task.javaLauncherVendor ?: "unknown"
-        val mismatch = launcherMajor != null && daemonJavaMajor != null && launcherMajor != daemonJavaMajor
-        val detail = buildString {
-            append("launcher: JDK $launcherMajor ($launcherVendor) at $launcherPath")
-            append("; classpath=${task.classpathSize}, bootstrap=${task.bootstrapClasspathSize}")
-        }
-        if (mismatch) {
-            addCheck(
-                DoctorCheck(
-                    id = "project.${idSafe(modulePath)}.render-previews-jvm",
-                    category = "project",
-                    status = "warning",
-                    message = "$modulePath — renderPreviews will fork JDK $launcherMajor, Gradle daemon runs JDK $daemonJavaMajor",
-                    detail = "$detail; symptom on mismatch: `ClassNotFoundException: android.app.Application` during JUnit discovery (see issue #142)",
-                    remediation = DoctorRemediation(
-                        summary = "Pin the renderPreviews Test task to the project's Java toolchain.",
-                        commands = listOf(
-                            "kotlin { jvmToolchain(${daemonJavaMajor ?: 21}) }",
-                            "// or: tasks.named(\"renderPreviews\", Test::class) { javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(${daemonJavaMajor ?: 21})) }) }",
-                        ),
-                        docs = "https://github.com/$REPO/issues/142",
-                    ),
-                ),
-            )
-        } else {
-            addCheck(
-                DoctorCheck(
-                    id = "project.${idSafe(modulePath)}.render-previews-jvm",
-                    category = "project",
-                    status = "ok",
-                    message = "$modulePath — renderPreviews launcher JDK ${launcherMajor ?: "?"}",
-                    detail = detail,
-                ),
-            )
-        }
-    }
-
-    /**
-     * Scans HTML reports under `build/reports/tests/renderPreviews/` for known error
-     * signatures and emits a per-module hint when it spots one. Purely
-     * pattern-based — we only match signatures we've seen in field reports,
-     * so false positives are rare and actionable. Best-effort: if there's
-     * no report on disk (first run, clean checkout) we silently skip.
-     */
-    private fun checkErrorSignatures(projectDir: File, modulePath: String) {
-        // Gradle path → filesystem path. `:auth:composables` → `auth/composables`
-        // for standard layouts (issue #157). Custom `project.projectDir`
-        // overrides aren't covered here — this is a best-effort triage path;
-        // when the directory doesn't exist we silently skip the signature
-        // scan rather than emit a false "no prior failure" signal.
-        val relative = idSafe(modulePath).replace(':', File.separatorChar)
-        val moduleDir = File(projectDir, relative).takeIf { it.isDirectory } ?: return
-        val reportDir = File(moduleDir, "build/reports/tests/renderPreviews")
-        if (!reportDir.isDirectory) return
-        val htmls = reportDir.walkTopDown()
-            .maxDepth(4)
-            .filter { it.isFile && it.extension == "html" }
-            .toList()
-        if (htmls.isEmpty()) return
-
-        val haystack = htmls.asSequence().mapNotNull {
-            try { it.readText() } catch (_: Exception) { null }
-        }.joinToString("\n")
-
-        val hint = KNOWN_ERROR_SIGNATURES.firstOrNull { haystack.contains(it.pattern) }
-        if (hint != null) {
-            addCheck(
-                DoctorCheck(
-                    id = "project.${idSafe(modulePath)}.last-error",
-                    category = "project",
-                    status = "warning",
-                    message = "$modulePath — last renderPreviews run failed with a known signature",
-                    detail = "${hint.pattern} — ${hint.hint}",
-                    remediation = hint.remediation,
-                ),
-            )
-        }
-    }
-
-    /**
-     * Render findings produced plugin-side (see [CompatRules] in gradle-plugin)
-     * as doctor checks. CLI doesn't run compat logic of its own — one source
-     * of truth, consumed by both CLI and VS Code. Rule thresholds and
-     * remediation phrasing live in the plugin.
-     */
-    private fun checkModuleCompat(modulePath: String, info: ModuleInfo) {
-        val variant = info.variant
-
-        if (info.mainRuntimeDependencies.isEmpty() && info.testRuntimeDependencies.isEmpty()) {
-            addCheck(
-                DoctorCheck(
-                    id = "deps.${idSafe(modulePath)}.resolve",
-                    category = "deps",
-                    status = "skipped",
-                    message = "$modulePath — dependency resolution returned empty for variant '$variant'",
-                    detail = "the plugin was applied but neither ${variant}RuntimeClasspath nor ${variant}UnitTestRuntimeClasspath resolved",
-                ),
-            )
-            return
-        }
-
-        if (info.findings.isEmpty()) {
-            addCheck(
-                DoctorCheck(
-                    id = "deps.${idSafe(modulePath)}.compat",
-                    category = "deps",
-                    status = "ok",
-                    message = "$modulePath — no compatibility issues found",
-                ),
-            )
-            return
-        }
-
-        for (finding in info.findings) {
-            val status = when (finding.severity) {
-                "error" -> "error"
-                "warning" -> "warning"
-                else -> "info"
-            }
-            // Short-form detail is the default; `--explain` also surfaces
-            // the long-form detail from the plugin (the "why this breaks at
-            // render time" rationale).
-            val detail = if (explain) finding.detail else null
-            val remediation = if (finding.remediationSummary != null) {
-                DoctorRemediation(
-                    summary = finding.remediationSummary!!,
-                    commands = finding.remediationCommands,
-                    docs = finding.docsUrl,
-                )
-            } else null
-            addCheck(
-                DoctorCheck(
-                    id = "deps.${idSafe(modulePath)}.${finding.id}",
-                    category = "deps",
-                    status = status,
-                    message = "$modulePath — ${finding.message}",
-                    detail = detail,
-                    remediation = remediation,
-                ),
-            )
-        }
-    }
-
-    /**
-     * Grep-based "is your compose-bom recent enough" pre-flight. Runs
-     * BEFORE any Gradle call, so it works even outside a Gradle project
-     * or before the plugin is applied — complements the plugin-side
-     * `CompatRules` findings, which only fire once Gradle has resolved
-     * the test classpath. Renderer-android is compiled with compose-
-     * compiler 2.2.21, which emits calls to
-     * `ComposeUiNode.setCompositeKeyHash` — first shipped in compose-ui
-     * 1.9 (compose-bom 2025.01.00). Older consumers hit `NoSuchMethodError`
-     * the moment `renderPreviews` starts.
-     */
-    private fun checkComposeBomVersion() {
-        val workspace = File(projectDirArg ?: ".").canonicalFile
-        val versions = findComposeBomDeclarations(workspace)
-        if (versions.isEmpty()) return // No declarations → nothing to assert on.
-
-        val tooOld = versions.filter { (_, v) -> v.isOlderThan(MIN_BOM_YEAR, MIN_BOM_MONTH) }
-        if (tooOld.isEmpty()) {
-            val summary = versions.joinToString(", ") { (_, v) -> v.raw }
-            addCheck(
-                DoctorCheck(
-                    id = "env.compose-bom-version",
-                    category = "env",
-                    status = "ok",
-                    message = "compose-bom version(s) look recent enough ($summary)",
-                ),
-            )
-            return
-        }
-        val floor = "$MIN_BOM_YEAR.${MIN_BOM_MONTH.toString().padStart(2, '0')}.00"
-        for ((source, v) in tooOld) {
-            addCheck(
-                DoctorCheck(
-                    id = "env.compose-bom-version",
-                    category = "env",
-                    status = "warning",
-                    message = "compose-bom ${v.raw} declared in ${source.relativeTo(workspace).path} — renderer needs ≥$floor",
-                    detail = "Older BOMs lack `ComposeUiNode.setCompositeKeyHash`; `renderPreviews` will fail with NoSuchMethodError.",
-                    remediation = DoctorRemediation(
-                        summary = "Bump the BOM.",
-                        commands = listOf("compose-bom = \"$floor\""),
-                    ),
-                ),
-            )
-        }
-    }
-
-    /**
-     * Returns `(fileWhereFound, parsedVersion)` for every
-     * `androidx.compose:compose-bom` version literal we find under [root].
-     * Scans `gradle/libs.versions.toml` and every `build.gradle[.kts]`,
-     * early-exiting at depth 4 so we don't wander through `build/`.
-     */
-    private fun findComposeBomDeclarations(root: File): List<Pair<File, ComposeVersion>> {
-        val out = mutableListOf<Pair<File, ComposeVersion>>()
-        val tomlRegex = Regex("""compose-bom\s*=\s*"([^"]+)"""")
-        val bomInlineRegex = Regex("""["']androidx\.compose:compose-bom:([0-9][0-9A-Za-z.\-]+)["']""")
-
-        fun scanTextFile(file: File) {
-            val text = try { file.readText() } catch (_: Exception) { return }
-            tomlRegex.findAll(text).forEach { m ->
-                ComposeVersion.parse(m.groupValues[1])?.let { out += file to it }
-            }
-            bomInlineRegex.findAll(text).forEach { m ->
-                ComposeVersion.parse(m.groupValues[1])?.let { out += file to it }
-            }
-        }
-
-        fun walk(dir: File, depth: Int) {
-            if (depth > 4 || dir.name.startsWith(".") || dir.name in SKIP_DIRS) return
-            val children = dir.listFiles() ?: return
-            for (f in children) {
-                when {
-                    f.isDirectory -> walk(f, depth + 1)
-                    f.name == "libs.versions.toml" -> scanTextFile(f)
-                    f.name == "build.gradle.kts" || f.name == "build.gradle" -> scanTextFile(f)
-                }
-            }
-        }
-        walk(root, 0)
-        return out
-    }
-
-    /**
-     * Compose BOM version in `YYYY.MM.NN` form. Enough precision for
-     * "is this older than 2025.01"; we never need to differentiate patches.
-     */
-    private data class ComposeVersion(val year: Int, val month: Int, val raw: String) {
-        fun isOlderThan(minYear: Int, minMonth: Int): Boolean =
-            year < minYear || (year == minYear && month < minMonth)
-
-        companion object {
-            private val pattern = Regex("""^(\d{4})\.(\d{2})\.\d+""")
-            fun parse(s: String): ComposeVersion? {
-                val m = pattern.find(s) ?: return null
-                return ComposeVersion(m.groupValues[1].toInt(), m.groupValues[2].toInt(), s)
-            }
-        }
-    }
-
-    // --- Output -------------------------------------------------------------
-
-    private fun emit() {
-        when {
-            jsonOut -> emitJson()
-            reportOut -> emitReport()
-            else -> emitText()
-        }
-        val errors = checks.count { it.status == "error" }
-        exitProcess(if (errors > 0) 1 else 0)
-    }
-
-    /**
-     * Compact, paste-friendly fingerprint block intended for GitHub issue
-     * reports. Prints everything a triager needs upfront so the reporter
-     * doesn't have to re-run `gradlew --version`, `java -version`, etc.
-     * across multiple follow-up comments. Structure is flat key-value so
-     * grep-parsing from an agent is cheap, and the schema string anchors
-     * the v1 contract the same way [DoctorReport.schema] does.
-     *
-     * Each block (env / modules / errors) only prints when we have data —
-     * e.g. module versions are omitted when no project was detected.
-     */
-    private fun emitReport() {
-        println("compose-preview-doctor-report/v1")
-        println()
-        val env = checks.filter { it.category == "env" }
-        val project = checks.filter { it.category == "project" }
-        val deps = checks.filter { it.category == "deps" }
-
-        println("plugin: $pluginVersion")
-        for (c in env) {
-            val tail = c.detail?.let { "  ($it)" } ?: ""
-            println("${c.id}: ${c.message}$tail")
-        }
-        if (project.isNotEmpty()) {
-            println()
-            println("[project]")
-            for (c in project) {
-                println("${c.id} [${c.status}]: ${c.message}")
-                c.detail?.let { println("    $it") }
-            }
-        }
-        if (deps.isNotEmpty()) {
-            println()
-            println("[deps]")
-            for (c in deps) {
-                if (c.status == "ok") continue // compat-clean modules are noise here
-                println("${c.id} [${c.status}]: ${c.message}")
-                c.detail?.let { println("    $it") }
-            }
-        }
-
-        val summary = summary()
-        println()
-        println("summary: ok=${summary.ok} warning=${summary.warning} error=${summary.error} skipped=${summary.skipped}")
-    }
-
-    private fun emitText() {
-        println("compose-preview doctor")
-        println()
-        var currentCategory = ""
-        for (check in checks) {
-            if (check.category != currentCategory) {
-                if (currentCategory.isNotEmpty()) println()
-                println("  [${check.category}]")
-                currentCategory = check.category
-            }
-            val marker = when (check.status) {
-                "ok" -> "✓"
-                "warning" -> "!"
-                "error" -> "✗"
-                "skipped" -> "∙"
-                else -> "?"
-            }
-            println("  $marker ${check.message}")
-            check.detail?.let { println("      $it") }
-            check.remediation?.let { r ->
-                println("      → ${r.summary}")
-                for (cmd in r.commands) println("        \$ $cmd")
-                r.docs?.let { println("        docs: $it") }
-            }
-        }
-        println()
-
-        val summary = summary()
-        val headline = when {
-            summary.error > 0 -> "✗ ${summary.error} error(s), ${summary.warning} warning(s)"
-            summary.warning > 0 -> "✓ ok (${summary.warning} warning(s))"
-            else -> "✓ all checks passed"
-        }
-        println(headline)
-        if (summary.skipped > 0) println("  ${summary.skipped} check(s) skipped")
-    }
-
-    private fun emitJson() {
-        val report = DoctorReport(
-            pluginVersion = pluginVersion,
-            overall = when {
-                checks.any { it.status == "error" } -> "error"
-                checks.any { it.status == "warning" } -> "warning"
-                else -> "ok"
-            },
-            checks = checks.toList(),
-            summary = summary(),
-        )
-        println(JSON.encodeToString(DoctorReport.serializer(), report))
-    }
-
-    private fun summary() = DoctorSummary(
-        ok = checks.count { it.status == "ok" },
-        warning = checks.count { it.status == "warning" },
-        error = checks.count { it.status == "error" },
-        skipped = checks.count { it.status == "skipped" },
+    addCheck(
+      DoctorCheck(
+        id = "project.plugin-applied",
+        category = "project",
+        status = "ok",
+        message = "plugin applied in ${model.modules.size} module(s)",
+        detail = model.modules.keys.joinToString(", "),
+      )
     )
 
-    // --- Helpers ------------------------------------------------------------
-
-    private fun addCheck(check: DoctorCheck) {
-        checks += check
+    for ((modulePath, info) in model.modules) {
+      checkModuleVersions(modulePath, info)
+      checkRenderPreviewsTask(modulePath, info)
+      checkModuleCompat(modulePath, info)
+      checkErrorSignatures(projectDir, modulePath)
     }
+  }
 
-    /**
-     * Probe Google-controlled hosts that the Android render path and Compose's
-     * downloadable-fonts integration depend on at build + render time. Each
-     * host becomes one `env.network.<id>` check; an unreachable host is a
-     * warning (it only matters for specific consumers) and points at the
-     * Claude Code on-the-web Custom-allowlist docs, since this is the most
-     * common place the checks fail.
-     */
-    private fun checkNetworkReach() {
-        NETWORK_HOSTS.forEach { probe ->
-            val (code, headers) = headPlain(probe.url)
-            val id = "env.network.${probe.id}"
-            val check = if (code > 0) {
-                DoctorCheck(
-                    id = id,
-                    category = "env",
-                    status = "ok",
-                    message = "${probe.host} reachable (HTTP $code)",
-                )
-            } else {
-                val summary = if (inClaudeCloud) {
-                    "Claude Code cloud session detected — switch the session's network level from Trusted to **Custom**, keep 'include Trusted defaults' on, and add `${probe.host}` (plus the other three Google hosts probed here) to the allowlist."
-                } else {
-                    "Allow ${probe.host} in your sandbox / proxy configuration. In Claude Code cloud sessions this means switching network access to Custom and adding the host (keep 'include Trusted defaults' on)."
-                }
-                DoctorCheck(
-                    id = id,
-                    category = "env",
-                    status = "warning",
-                    message = "${probe.host} unreachable",
-                    detail = "${probe.purpose}. Error: ${headers["error"] ?: "unknown"}.",
-                    remediation = DoctorRemediation(
-                        summary = summary,
-                        docs = "https://code.claude.com/docs/en/claude-code-on-the-web#network-access",
-                    ),
-                )
-            }
-            addCheck(check)
+  /**
+   * Emits the daemon's Gradle and JVM fingerprint as two `env` checks. We stash the JDK major and
+   * path on the class so per-module checks can compare against them (see
+   * [checkRenderPreviewsTask]).
+   *
+   * Runs inside the project block because fetching the model requires a live [GradleConnection].
+   * It's logically an env concern though, so the check id lives under `env.*`.
+   */
+  private fun checkGradleDaemon(gc: GradleConnection) {
+    val env =
+      gc.buildEnvironment()
+        ?: run {
+          addCheck(
+            DoctorCheck(
+              id = "env.gradle-daemon",
+              category = "env",
+              status = "warning",
+              message = "could not fetch BuildEnvironment from Gradle daemon",
+            )
+          )
+          return
         }
+    daemonGradleVersion = env.gradle.gradleVersion
+    val javaHome = env.java.javaHome
+    daemonJavaHome = javaHome.absolutePath
+    // Derive JDK major from the release file — more reliable than
+    // guessing from `javaHome` path naming. Falls back to null if the
+    // file isn't there or doesn't parse (e.g. a non-standard install).
+    daemonJavaMajor = readJdkMajor(javaHome)
+    val majorStr = daemonJavaMajor?.let { "JDK $it" } ?: "unknown JDK"
+    addCheck(
+      DoctorCheck(
+        id = "env.gradle-daemon",
+        category = "env",
+        status = "ok",
+        message = "Gradle ${daemonGradleVersion} on $majorStr",
+        detail = "daemon java.home: ${daemonJavaHome}",
+      )
+    )
+  }
+
+  /**
+   * Emits per-module version info — AGP, Kotlin, Robolectric, Compose runtime.
+   * Robolectric/Compose-runtime are read from the resolved test classpath; AGP/Kotlin are
+   * plugin-side reflective reads. All four are surfaced as an `info`-style ok-status check so
+   * `--report` has one pasteable block with everything a triager needs to see.
+   */
+  private fun checkModuleVersions(modulePath: String, info: ModuleInfo) {
+    val robolectric = info.testRuntimeDependencies["org.robolectric:robolectric"]
+    val composeRuntime = info.testRuntimeDependencies["androidx.compose.runtime:runtime"]
+    val parts = buildList {
+      add("variant=${info.variant}")
+      info.agpVersion?.let { add("agp=$it") }
+      info.kotlinVersion?.let { add("kotlin=$it") }
+      robolectric?.let { add("robolectric=$it") }
+      composeRuntime?.let { add("compose-runtime=$it") }
     }
+    addCheck(
+      DoctorCheck(
+        id = "project.${idSafe(modulePath)}.versions",
+        category = "project",
+        status = "ok",
+        message = "$modulePath — ${parts.joinToString("  ")}",
+      )
+    )
+  }
 
-    private fun headPlain(url: String): Pair<Int, Map<String, String>> {
-        val conn = (URI(url).toURL().openConnection() as HttpURLConnection).apply {
-            requestMethod = "HEAD"
-            connectTimeout = 3_000
-            readTimeout = 3_000
-            instanceFollowRedirects = true
-            setRequestProperty("User-Agent", "compose-preview-doctor")
-        }
-        return try {
-            val code = conn.responseCode
-            val headers = conn.headerFields
-                .filterKeys { it != null }
-                .mapValues { it.value.joinToString(", ") }
-            code to headers
-        } catch (e: Exception) {
-            -1 to mapOf("error" to (e.message ?: e.javaClass.simpleName))
-        } finally {
-            conn.disconnect()
-        }
+  /**
+   * The check motivated by issue #142. If the test worker's forked JDK is a different major than
+   * the Gradle daemon's, emit a `warning` with the specific error signature the mismatch typically
+   * produces, plus a remediation pointing at the `javaLauncher` toolchain wiring.
+   *
+   * When the JDK majors match (or when we can't tell), this degrades to a pure info line — still
+   * useful in bug reports because it fingerprints the launcher vendor and path.
+   */
+  private fun checkRenderPreviewsTask(modulePath: String, info: ModuleInfo) {
+    val task = info.renderPreviewsTask ?: return
+    val launcherMajor = task.javaLauncherVersion?.toIntOrNull()
+    val launcherPath = task.javaLauncherPath ?: "(unknown)"
+    val launcherVendor = task.javaLauncherVendor ?: "unknown"
+    val mismatch =
+      launcherMajor != null && daemonJavaMajor != null && launcherMajor != daemonJavaMajor
+    val detail = buildString {
+      append("launcher: JDK $launcherMajor ($launcherVendor) at $launcherPath")
+      append("; classpath=${task.classpathSize}, bootstrap=${task.bootstrapClasspathSize}")
     }
+    if (mismatch) {
+      addCheck(
+        DoctorCheck(
+          id = "project.${idSafe(modulePath)}.render-previews-jvm",
+          category = "project",
+          status = "warning",
+          message =
+            "$modulePath — renderPreviews will fork JDK $launcherMajor, Gradle daemon runs JDK $daemonJavaMajor",
+          detail =
+            "$detail; symptom on mismatch: `ClassNotFoundException: android.app.Application` during JUnit discovery (see issue #142)",
+          remediation =
+            DoctorRemediation(
+              summary = "Pin the renderPreviews Test task to the project's Java toolchain.",
+              commands =
+                listOf(
+                  "kotlin { jvmToolchain(${daemonJavaMajor ?: 21}) }",
+                  "// or: tasks.named(\"renderPreviews\", Test::class) { javaLauncher.set(javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(${daemonJavaMajor ?: 21})) }) }",
+                ),
+              docs = "https://github.com/$REPO/issues/142",
+            ),
+        )
+      )
+    } else {
+      addCheck(
+        DoctorCheck(
+          id = "project.${idSafe(modulePath)}.render-previews-jvm",
+          category = "project",
+          status = "ok",
+          message = "$modulePath — renderPreviews launcher JDK ${launcherMajor ?: "?"}",
+          detail = detail,
+        )
+      )
+    }
+  }
 
-    /** Sanitise a module path (e.g. `:sample-wear` → `sample-wear`) for use in check ids. */
-    private fun idSafe(modulePath: String): String = modulePath.removePrefix(":").ifEmpty { "root" }
+  /**
+   * Scans HTML reports under `build/reports/tests/renderPreviews/` for known error signatures and
+   * emits a per-module hint when it spots one. Purely pattern-based — we only match signatures
+   * we've seen in field reports, so false positives are rare and actionable. Best-effort: if
+   * there's no report on disk (first run, clean checkout) we silently skip.
+   */
+  private fun checkErrorSignatures(projectDir: File, modulePath: String) {
+    // Gradle path → filesystem path. `:auth:composables` → `auth/composables`
+    // for standard layouts (issue #157). Custom `project.projectDir`
+    // overrides aren't covered here — this is a best-effort triage path;
+    // when the directory doesn't exist we silently skip the signature
+    // scan rather than emit a false "no prior failure" signal.
+    val relative = idSafe(modulePath).replace(':', File.separatorChar)
+    val moduleDir = File(projectDir, relative).takeIf { it.isDirectory } ?: return
+    val reportDir = File(moduleDir, "build/reports/tests/renderPreviews")
+    if (!reportDir.isDirectory) return
+    val htmls =
+      reportDir.walkTopDown().maxDepth(4).filter { it.isFile && it.extension == "html" }.toList()
+    if (htmls.isEmpty()) return
 
-    /**
-     * Exec a short-lived command and capture its stdout/stderr. Returns
-     * `null` if the executable wasn't found, the process failed to start,
-     * or it didn't finish within 5s — doctor folds all of those into "skip
-     * the check" rather than erroring on what's essentially optional
-     * fingerprinting.
-     */
-    private fun runCommand(cmd: List<String>): CommandResult? {
-        return try {
-            val process = ProcessBuilder(cmd)
-                .redirectErrorStream(false)
-                .start()
-            val stdout = process.inputStream.bufferedReader().use { it.readText() }
-            val stderr = process.errorStream.bufferedReader().use { it.readText() }
-            if (!process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)) {
-                process.destroyForcibly()
-                return null
-            }
-            CommandResult(process.exitValue(), stdout, stderr)
-        } catch (_: Exception) {
+    val haystack =
+      htmls
+        .asSequence()
+        .mapNotNull {
+          try {
+            it.readText()
+          } catch (_: Exception) {
             null
+          }
         }
+        .joinToString("\n")
+
+    val hint = KNOWN_ERROR_SIGNATURES.firstOrNull { haystack.contains(it.pattern) }
+    if (hint != null) {
+      addCheck(
+        DoctorCheck(
+          id = "project.${idSafe(modulePath)}.last-error",
+          category = "project",
+          status = "warning",
+          message = "$modulePath — last renderPreviews run failed with a known signature",
+          detail = "${hint.pattern} — ${hint.hint}",
+          remediation = hint.remediation,
+        )
+      )
+    }
+  }
+
+  /**
+   * Render findings produced plugin-side (see [CompatRules] in gradle-plugin) as doctor checks. CLI
+   * doesn't run compat logic of its own — one source of truth, consumed by both CLI and VS Code.
+   * Rule thresholds and remediation phrasing live in the plugin.
+   */
+  private fun checkModuleCompat(modulePath: String, info: ModuleInfo) {
+    val variant = info.variant
+
+    if (info.mainRuntimeDependencies.isEmpty() && info.testRuntimeDependencies.isEmpty()) {
+      addCheck(
+        DoctorCheck(
+          id = "deps.${idSafe(modulePath)}.resolve",
+          category = "deps",
+          status = "skipped",
+          message = "$modulePath — dependency resolution returned empty for variant '$variant'",
+          detail =
+            "the plugin was applied but neither ${variant}RuntimeClasspath nor ${variant}UnitTestRuntimeClasspath resolved",
+        )
+      )
+      return
     }
 
-    private data class CommandResult(val exitCode: Int, val stdout: String, val stderr: String) {
-        /** `java -version` prints to stderr on most JDKs; fall back to stdout for the occasional one that doesn't. */
-        fun stderrOrStdout(): String = stderr.ifBlank { stdout }
+    if (info.findings.isEmpty()) {
+      addCheck(
+        DoctorCheck(
+          id = "deps.${idSafe(modulePath)}.compat",
+          category = "deps",
+          status = "ok",
+          message = "$modulePath — no compatibility issues found",
+        )
+      )
+      return
     }
 
-    /**
-     * Reads the JDK major version from `$javaHome/release`. Most JDK
-     * distributions ship this file with a `JAVA_VERSION=...` line — more
-     * reliable than guessing from the install path, which varies wildly
-     * (`/usr/lib/jvm/temurin-21-jdk-amd64` vs `/opt/homebrew/opt/openjdk@21`
-     * vs `~/.sdkman/candidates/java/21.0.11-tem`). Returns `null` when the
-     * file is missing or malformed.
-     */
-    private fun readJdkMajor(javaHome: File): Int? {
-        val release = File(javaHome, "release").takeIf { it.isFile } ?: return null
-        val line = try {
-            release.readLines().firstOrNull { it.startsWith("JAVA_VERSION=") }
+    for (finding in info.findings) {
+      val status =
+        when (finding.severity) {
+          "error" -> "error"
+          "warning" -> "warning"
+          else -> "info"
+        }
+      // Short-form detail is the default; `--explain` also surfaces
+      // the long-form detail from the plugin (the "why this breaks at
+      // render time" rationale).
+      val detail = if (explain) finding.detail else null
+      val remediation =
+        if (finding.remediationSummary != null) {
+          DoctorRemediation(
+            summary = finding.remediationSummary!!,
+            commands = finding.remediationCommands,
+            docs = finding.docsUrl,
+          )
+        } else null
+      addCheck(
+        DoctorCheck(
+          id = "deps.${idSafe(modulePath)}.${finding.id}",
+          category = "deps",
+          status = status,
+          message = "$modulePath — ${finding.message}",
+          detail = detail,
+          remediation = remediation,
+        )
+      )
+    }
+  }
+
+  /**
+   * Grep-based "is your compose-bom recent enough" pre-flight. Runs BEFORE any Gradle call, so it
+   * works even outside a Gradle project or before the plugin is applied — complements the
+   * plugin-side `CompatRules` findings, which only fire once Gradle has resolved the test
+   * classpath. Renderer-android is compiled with compose- compiler 2.2.21, which emits calls to
+   * `ComposeUiNode.setCompositeKeyHash` — first shipped in compose-ui 1.9 (compose-bom 2025.01.00).
+   * Older consumers hit `NoSuchMethodError` the moment `renderPreviews` starts.
+   */
+  private fun checkComposeBomVersion() {
+    val workspace = File(projectDirArg ?: ".").canonicalFile
+    val versions = findComposeBomDeclarations(workspace)
+    if (versions.isEmpty()) return // No declarations → nothing to assert on.
+
+    val tooOld = versions.filter { (_, v) -> v.isOlderThan(MIN_BOM_YEAR, MIN_BOM_MONTH) }
+    if (tooOld.isEmpty()) {
+      val summary = versions.joinToString(", ") { (_, v) -> v.raw }
+      addCheck(
+        DoctorCheck(
+          id = "env.compose-bom-version",
+          category = "env",
+          status = "ok",
+          message = "compose-bom version(s) look recent enough ($summary)",
+        )
+      )
+      return
+    }
+    val floor = "$MIN_BOM_YEAR.${MIN_BOM_MONTH.toString().padStart(2, '0')}.00"
+    for ((source, v) in tooOld) {
+      addCheck(
+        DoctorCheck(
+          id = "env.compose-bom-version",
+          category = "env",
+          status = "warning",
+          message =
+            "compose-bom ${v.raw} declared in ${source.relativeTo(workspace).path} — renderer needs ≥$floor",
+          detail =
+            "Older BOMs lack `ComposeUiNode.setCompositeKeyHash`; `renderPreviews` will fail with NoSuchMethodError.",
+          remediation =
+            DoctorRemediation(
+              summary = "Bump the BOM.",
+              commands = listOf("compose-bom = \"$floor\""),
+            ),
+        )
+      )
+    }
+  }
+
+  /**
+   * Returns `(fileWhereFound, parsedVersion)` for every `androidx.compose:compose-bom` version
+   * literal we find under [root]. Scans `gradle/libs.versions.toml` and every `build.gradle[.kts]`,
+   * early-exiting at depth 4 so we don't wander through `build/`.
+   */
+  private fun findComposeBomDeclarations(root: File): List<Pair<File, ComposeVersion>> {
+    val out = mutableListOf<Pair<File, ComposeVersion>>()
+    val tomlRegex = Regex("""compose-bom\s*=\s*"([^"]+)"""")
+    val bomInlineRegex = Regex("""["']androidx\.compose:compose-bom:([0-9][0-9A-Za-z.\-]+)["']""")
+
+    fun scanTextFile(file: File) {
+      val text =
+        try {
+          file.readText()
         } catch (_: Exception) {
-            return null
-        } ?: return null
-        // Format: JAVA_VERSION="21.0.11"  OR  JAVA_VERSION="1.8.0_402"
-        val raw = line.substringAfter("=").trim().trim('"')
-        val major = raw.substringBefore('.').toIntOrNull() ?: return null
-        // Legacy JDK 8 reports as "1.8.x" — normalize to 8.
-        return if (major == 1) raw.split('.').getOrNull(1)?.toIntOrNull() else major
+          return
+        }
+      tomlRegex.findAll(text).forEach { m ->
+        ComposeVersion.parse(m.groupValues[1])?.let { out += file to it }
+      }
+      bomInlineRegex.findAll(text).forEach { m ->
+        ComposeVersion.parse(m.groupValues[1])?.let { out += file to it }
+      }
     }
 
-    /**
-     * One known `renderPreviews` failure signature. Pattern is a plain
-     * substring we look for in the HTML test report; [hint] is the human
-     * explanation; [remediation] is the same action structure the rest of
-     * doctor emits, so agents get concrete commands out of this too.
-     */
-    private data class ErrorSignature(
-        val pattern: String,
-        val hint: String,
-        val remediation: DoctorRemediation?,
-    )
+    fun walk(dir: File, depth: Int) {
+      if (depth > 4 || dir.name.startsWith(".") || dir.name in SKIP_DIRS) return
+      val children = dir.listFiles() ?: return
+      for (f in children) {
+        when {
+          f.isDirectory -> walk(f, depth + 1)
+          f.name == "libs.versions.toml" -> scanTextFile(f)
+          f.name == "build.gradle.kts" || f.name == "build.gradle" -> scanTextFile(f)
+        }
+      }
+    }
+    walk(root, 0)
+    return out
+  }
+
+  /**
+   * Compose BOM version in `YYYY.MM.NN` form. Enough precision for "is this older than 2025.01"; we
+   * never need to differentiate patches.
+   */
+  private data class ComposeVersion(val year: Int, val month: Int, val raw: String) {
+    fun isOlderThan(minYear: Int, minMonth: Int): Boolean =
+      year < minYear || (year == minYear && month < minMonth)
 
     companion object {
-        private const val REPO = "yschimke/compose-ai-tools"
-        private const val DEFAULT_PLUGIN_VERSION = "0.8.1" // x-release-please-version
+      private val pattern = Regex("""^(\d{4})\.(\d{2})\.\d+""")
 
-        /**
-         * Minimum supported Compose BOM — 2025.01.00 → compose-ui 1.9.0.
-         * That's the first BOM where `ComposeUiNode.setCompositeKeyHash`
-         * (emitted by compose-compiler 2.2.21) exists on the runtime side.
-         */
-        private const val MIN_BOM_YEAR = 2025
-        private const val MIN_BOM_MONTH = 1
-
-        private val SKIP_DIRS = setOf("build", "node_modules", "out", "dist", ".gradle")
-
-        private data class NetworkHost(
-            val id: String,
-            val host: String,
-            val url: String,
-            val purpose: String,
-        )
-
-        /**
-         * Google-controlled hosts required by the Android/Compose render
-         * paths. None are on Claude Code's default Trusted allowlist — they
-         * only resolve in Custom mode or in environments with broader egress.
-         */
-        private val NETWORK_HOSTS = listOf(
-            NetworkHost(
-                id = "maven-google",
-                host = "maven.google.com",
-                url = "https://maven.google.com/web/index.html",
-                purpose = "Google Maven — resolves AGP and AndroidX for Android-consumer renders",
-            ),
-            NetworkHost(
-                id = "dl-google",
-                host = "dl.google.com",
-                url = "https://dl.google.com/",
-                purpose = "Android SDK cmdline-tools / platform downloads",
-            ),
-            NetworkHost(
-                id = "fonts-googleapis",
-                host = "fonts.googleapis.com",
-                url = "https://fonts.googleapis.com/",
-                purpose = "Google Fonts API — used by androidx.compose.ui:ui-text-google-fonts at render time",
-            ),
-            NetworkHost(
-                id = "fonts-gstatic",
-                host = "fonts.gstatic.com",
-                url = "https://fonts.gstatic.com/",
-                purpose = "Google Fonts static asset host — downloadable-font binaries",
-            ),
-        )
-
-        private val JSON = Json { prettyPrint = true; encodeDefaults = true }
-
-        /**
-         * Failure signatures the CLI recognises from `renderPreviews` HTML
-         * reports. Order matters — the first match wins. Keep the list
-         * curated: only patterns we've traced to a specific, actionable
-         * root cause belong here. Patterns that overlap benign test output
-         * produce false positives.
-         */
-        private val KNOWN_ERROR_SIGNATURES = listOf(
-            ErrorSignature(
-                pattern = "ClassNotFoundException: android.app.Application",
-                hint = "likely test-worker JVM mismatch (see issue #142)",
-                remediation = DoctorRemediation(
-                    summary = "Pin the renderPreviews Test task's javaLauncher to the project toolchain.",
-                    commands = listOf(
-                        "kotlin { jvmToolchain(21) }",
-                    ),
-                    docs = "https://github.com/$REPO/issues/142",
-                ),
-            ),
-            ErrorSignature(
-                pattern = "RuntimeException: Stub!",
-                hint = "android.jar on bootstrap classpath is shadowing Robolectric's instrumented android-all",
-                remediation = DoctorRemediation(
-                    summary = "Don't inject android.jar into bootstrapClasspath — keep it on the outer classpath only.",
-                    docs = "https://github.com/$REPO/blob/main/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt",
-                ),
-            ),
-            ErrorSignature(
-                pattern = "NoSuchMethodError: androidx.compose.runtime.ComposeUiNode",
-                hint = "compose-bom too old — renderer-compiled calls postdate the runtime on the consumer's classpath",
-                remediation = DoctorRemediation(
-                    summary = "Bump compose-bom to at least 2025.01.00.",
-                ),
-            ),
-        )
+      fun parse(s: String): ComposeVersion? {
+        val m = pattern.find(s) ?: return null
+        return ComposeVersion(m.groupValues[1].toInt(), m.groupValues[2].toInt(), s)
+      }
     }
+  }
+
+  // --- Output -------------------------------------------------------------
+
+  private fun emit() {
+    when {
+      jsonOut -> emitJson()
+      reportOut -> emitReport()
+      else -> emitText()
+    }
+    val errors = checks.count { it.status == "error" }
+    exitProcess(if (errors > 0) 1 else 0)
+  }
+
+  /**
+   * Compact, paste-friendly fingerprint block intended for GitHub issue reports. Prints everything
+   * a triager needs upfront so the reporter doesn't have to re-run `gradlew --version`, `java
+   * -version`, etc. across multiple follow-up comments. Structure is flat key-value so grep-parsing
+   * from an agent is cheap, and the schema string anchors the v1 contract the same way
+   * [DoctorReport.schema] does.
+   *
+   * Each block (env / modules / errors) only prints when we have data — e.g. module versions are
+   * omitted when no project was detected.
+   */
+  private fun emitReport() {
+    println("compose-preview-doctor-report/v1")
+    println()
+    val env = checks.filter { it.category == "env" }
+    val project = checks.filter { it.category == "project" }
+    val deps = checks.filter { it.category == "deps" }
+
+    println("plugin: $pluginVersion")
+    for (c in env) {
+      val tail = c.detail?.let { "  ($it)" } ?: ""
+      println("${c.id}: ${c.message}$tail")
+    }
+    if (project.isNotEmpty()) {
+      println()
+      println("[project]")
+      for (c in project) {
+        println("${c.id} [${c.status}]: ${c.message}")
+        c.detail?.let { println("    $it") }
+      }
+    }
+    if (deps.isNotEmpty()) {
+      println()
+      println("[deps]")
+      for (c in deps) {
+        if (c.status == "ok") continue // compat-clean modules are noise here
+        println("${c.id} [${c.status}]: ${c.message}")
+        c.detail?.let { println("    $it") }
+      }
+    }
+
+    val summary = summary()
+    println()
+    println(
+      "summary: ok=${summary.ok} warning=${summary.warning} error=${summary.error} skipped=${summary.skipped}"
+    )
+  }
+
+  private fun emitText() {
+    println("compose-preview doctor")
+    println()
+    var currentCategory = ""
+    for (check in checks) {
+      if (check.category != currentCategory) {
+        if (currentCategory.isNotEmpty()) println()
+        println("  [${check.category}]")
+        currentCategory = check.category
+      }
+      val marker =
+        when (check.status) {
+          "ok" -> "✓"
+          "warning" -> "!"
+          "error" -> "✗"
+          "skipped" -> "∙"
+          else -> "?"
+        }
+      println("  $marker ${check.message}")
+      check.detail?.let { println("      $it") }
+      check.remediation?.let { r ->
+        println("      → ${r.summary}")
+        for (cmd in r.commands) println("        \$ $cmd")
+        r.docs?.let { println("        docs: $it") }
+      }
+    }
+    println()
+
+    val summary = summary()
+    val headline =
+      when {
+        summary.error > 0 -> "✗ ${summary.error} error(s), ${summary.warning} warning(s)"
+        summary.warning > 0 -> "✓ ok (${summary.warning} warning(s))"
+        else -> "✓ all checks passed"
+      }
+    println(headline)
+    if (summary.skipped > 0) println("  ${summary.skipped} check(s) skipped")
+  }
+
+  private fun emitJson() {
+    val report =
+      DoctorReport(
+        pluginVersion = pluginVersion,
+        overall =
+          when {
+            checks.any { it.status == "error" } -> "error"
+            checks.any { it.status == "warning" } -> "warning"
+            else -> "ok"
+          },
+        checks = checks.toList(),
+        summary = summary(),
+      )
+    println(JSON.encodeToString(DoctorReport.serializer(), report))
+  }
+
+  private fun summary() =
+    DoctorSummary(
+      ok = checks.count { it.status == "ok" },
+      warning = checks.count { it.status == "warning" },
+      error = checks.count { it.status == "error" },
+      skipped = checks.count { it.status == "skipped" },
+    )
+
+  // --- Helpers ------------------------------------------------------------
+
+  private fun addCheck(check: DoctorCheck) {
+    checks += check
+  }
+
+  /**
+   * Probe Google-controlled hosts that the Android render path and Compose's downloadable-fonts
+   * integration depend on at build + render time. Each host becomes one `env.network.<id>` check;
+   * an unreachable host is a warning (it only matters for specific consumers) and points at the
+   * Claude Code on-the-web Custom-allowlist docs, since this is the most common place the checks
+   * fail.
+   */
+  private fun checkNetworkReach() {
+    NETWORK_HOSTS.forEach { probe ->
+      val (code, headers) = headPlain(probe.url)
+      val id = "env.network.${probe.id}"
+      val check =
+        if (code > 0) {
+          DoctorCheck(
+            id = id,
+            category = "env",
+            status = "ok",
+            message = "${probe.host} reachable (HTTP $code)",
+          )
+        } else {
+          val summary =
+            if (inClaudeCloud) {
+              "Claude Code cloud session detected — switch the session's network level from Trusted to **Custom**, keep 'include Trusted defaults' on, and add `${probe.host}` (plus the other three Google hosts probed here) to the allowlist."
+            } else {
+              "Allow ${probe.host} in your sandbox / proxy configuration. In Claude Code cloud sessions this means switching network access to Custom and adding the host (keep 'include Trusted defaults' on)."
+            }
+          DoctorCheck(
+            id = id,
+            category = "env",
+            status = "warning",
+            message = "${probe.host} unreachable",
+            detail = "${probe.purpose}. Error: ${headers["error"] ?: "unknown"}.",
+            remediation =
+              DoctorRemediation(
+                summary = summary,
+                docs = "https://code.claude.com/docs/en/claude-code-on-the-web#network-access",
+              ),
+          )
+        }
+      addCheck(check)
+    }
+  }
+
+  private fun headPlain(url: String): Pair<Int, Map<String, String>> {
+    val conn =
+      (URI(url).toURL().openConnection() as HttpURLConnection).apply {
+        requestMethod = "HEAD"
+        connectTimeout = 3_000
+        readTimeout = 3_000
+        instanceFollowRedirects = true
+        setRequestProperty("User-Agent", "compose-preview-doctor")
+      }
+    return try {
+      val code = conn.responseCode
+      val headers =
+        conn.headerFields.filterKeys { it != null }.mapValues { it.value.joinToString(", ") }
+      code to headers
+    } catch (e: Exception) {
+      -1 to mapOf("error" to (e.message ?: e.javaClass.simpleName))
+    } finally {
+      conn.disconnect()
+    }
+  }
+
+  /** Sanitise a module path (e.g. `:sample-wear` → `sample-wear`) for use in check ids. */
+  private fun idSafe(modulePath: String): String = modulePath.removePrefix(":").ifEmpty { "root" }
+
+  /**
+   * Exec a short-lived command and capture its stdout/stderr. Returns `null` if the executable
+   * wasn't found, the process failed to start, or it didn't finish within 5s — doctor folds all of
+   * those into "skip the check" rather than erroring on what's essentially optional fingerprinting.
+   */
+  private fun runCommand(cmd: List<String>): CommandResult? {
+    return try {
+      val process = ProcessBuilder(cmd).redirectErrorStream(false).start()
+      val stdout = process.inputStream.bufferedReader().use { it.readText() }
+      val stderr = process.errorStream.bufferedReader().use { it.readText() }
+      if (!process.waitFor(5, java.util.concurrent.TimeUnit.SECONDS)) {
+        process.destroyForcibly()
+        return null
+      }
+      CommandResult(process.exitValue(), stdout, stderr)
+    } catch (_: Exception) {
+      null
+    }
+  }
+
+  private data class CommandResult(val exitCode: Int, val stdout: String, val stderr: String) {
+    /**
+     * `java -version` prints to stderr on most JDKs; fall back to stdout for the occasional one
+     * that doesn't.
+     */
+    fun stderrOrStdout(): String = stderr.ifBlank { stdout }
+  }
+
+  /**
+   * Reads the JDK major version from `$javaHome/release`. Most JDK distributions ship this file
+   * with a `JAVA_VERSION=...` line — more reliable than guessing from the install path, which
+   * varies wildly (`/usr/lib/jvm/temurin-21-jdk-amd64` vs `/opt/homebrew/opt/openjdk@21` vs
+   * `~/.sdkman/candidates/java/21.0.11-tem`). Returns `null` when the file is missing or malformed.
+   */
+  private fun readJdkMajor(javaHome: File): Int? {
+    val release = File(javaHome, "release").takeIf { it.isFile } ?: return null
+    val line =
+      try {
+        release.readLines().firstOrNull { it.startsWith("JAVA_VERSION=") }
+      } catch (_: Exception) {
+        return null
+      } ?: return null
+    // Format: JAVA_VERSION="21.0.11"  OR  JAVA_VERSION="1.8.0_402"
+    val raw = line.substringAfter("=").trim().trim('"')
+    val major = raw.substringBefore('.').toIntOrNull() ?: return null
+    // Legacy JDK 8 reports as "1.8.x" — normalize to 8.
+    return if (major == 1) raw.split('.').getOrNull(1)?.toIntOrNull() else major
+  }
+
+  /**
+   * One known `renderPreviews` failure signature. Pattern is a plain substring we look for in the
+   * HTML test report; [hint] is the human explanation; [remediation] is the same action structure
+   * the rest of doctor emits, so agents get concrete commands out of this too.
+   */
+  private data class ErrorSignature(
+    val pattern: String,
+    val hint: String,
+    val remediation: DoctorRemediation?,
+  )
+
+  companion object {
+    private const val REPO = "yschimke/compose-ai-tools"
+    private const val DEFAULT_PLUGIN_VERSION = "0.8.1" // x-release-please-version
+
+    /**
+     * Minimum supported Compose BOM — 2025.01.00 → compose-ui 1.9.0. That's the first BOM where
+     * `ComposeUiNode.setCompositeKeyHash` (emitted by compose-compiler 2.2.21) exists on the
+     * runtime side.
+     */
+    private const val MIN_BOM_YEAR = 2025
+    private const val MIN_BOM_MONTH = 1
+
+    private val SKIP_DIRS = setOf("build", "node_modules", "out", "dist", ".gradle")
+
+    private data class NetworkHost(
+      val id: String,
+      val host: String,
+      val url: String,
+      val purpose: String,
+    )
+
+    /**
+     * Google-controlled hosts required by the Android/Compose render paths. None are on Claude
+     * Code's default Trusted allowlist — they only resolve in Custom mode or in environments with
+     * broader egress.
+     */
+    private val NETWORK_HOSTS =
+      listOf(
+        NetworkHost(
+          id = "maven-google",
+          host = "maven.google.com",
+          url = "https://maven.google.com/web/index.html",
+          purpose = "Google Maven — resolves AGP and AndroidX for Android-consumer renders",
+        ),
+        NetworkHost(
+          id = "dl-google",
+          host = "dl.google.com",
+          url = "https://dl.google.com/",
+          purpose = "Android SDK cmdline-tools / platform downloads",
+        ),
+        NetworkHost(
+          id = "fonts-googleapis",
+          host = "fonts.googleapis.com",
+          url = "https://fonts.googleapis.com/",
+          purpose =
+            "Google Fonts API — used by androidx.compose.ui:ui-text-google-fonts at render time",
+        ),
+        NetworkHost(
+          id = "fonts-gstatic",
+          host = "fonts.gstatic.com",
+          url = "https://fonts.gstatic.com/",
+          purpose = "Google Fonts static asset host — downloadable-font binaries",
+        ),
+      )
+
+    private val JSON = Json {
+      prettyPrint = true
+      encodeDefaults = true
+    }
+
+    /**
+     * Failure signatures the CLI recognises from `renderPreviews` HTML reports. Order matters — the
+     * first match wins. Keep the list curated: only patterns we've traced to a specific, actionable
+     * root cause belong here. Patterns that overlap benign test output produce false positives.
+     */
+    private val KNOWN_ERROR_SIGNATURES =
+      listOf(
+        ErrorSignature(
+          pattern = "ClassNotFoundException: android.app.Application",
+          hint = "likely test-worker JVM mismatch (see issue #142)",
+          remediation =
+            DoctorRemediation(
+              summary = "Pin the renderPreviews Test task's javaLauncher to the project toolchain.",
+              commands = listOf("kotlin { jvmToolchain(21) }"),
+              docs = "https://github.com/$REPO/issues/142",
+            ),
+        ),
+        ErrorSignature(
+          pattern = "RuntimeException: Stub!",
+          hint =
+            "android.jar on bootstrap classpath is shadowing Robolectric's instrumented android-all",
+          remediation =
+            DoctorRemediation(
+              summary =
+                "Don't inject android.jar into bootstrapClasspath — keep it on the outer classpath only.",
+              docs =
+                "https://github.com/$REPO/blob/main/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt",
+            ),
+        ),
+        ErrorSignature(
+          pattern = "NoSuchMethodError: androidx.compose.runtime.ComposeUiNode",
+          hint =
+            "compose-bom too old — renderer-compiled calls postdate the runtime on the consumer's classpath",
+          remediation = DoctorRemediation(summary = "Bump compose-bom to at least 2025.01.00."),
+        ),
+      )
+  }
 }
 
 // --- Report schema ---------------------------------------------------------
@@ -985,41 +1019,35 @@ class DoctorCommand(args: List<String>) {
 
 @Serializable
 data class DoctorReport(
-    val schema: String = "compose-preview-doctor/v1",
-    val pluginVersion: String,
-    val overall: String, // "ok" | "warning" | "error"
-    val checks: List<DoctorCheck>,
-    val summary: DoctorSummary,
+  val schema: String = "compose-preview-doctor/v1",
+  val pluginVersion: String,
+  val overall: String, // "ok" | "warning" | "error"
+  val checks: List<DoctorCheck>,
+  val summary: DoctorSummary,
 )
 
 @Serializable
 data class DoctorCheck(
-    /** Stable dotted id — safe to grep / branch on. */
-    val id: String,
-    /** "env" | "project" | "deps". */
-    val category: String,
-    /** "ok" | "warning" | "error" | "skipped". */
-    val status: String,
-    /** Single-line human-readable summary. */
-    val message: String,
-    /** Multi-line follow-up (optional). Agents can surface to users. */
-    val detail: String? = null,
-    /** Concrete action to unblock (optional). */
-    val remediation: DoctorRemediation? = null,
+  /** Stable dotted id — safe to grep / branch on. */
+  val id: String,
+  /** "env" | "project" | "deps". */
+  val category: String,
+  /** "ok" | "warning" | "error" | "skipped". */
+  val status: String,
+  /** Single-line human-readable summary. */
+  val message: String,
+  /** Multi-line follow-up (optional). Agents can surface to users. */
+  val detail: String? = null,
+  /** Concrete action to unblock (optional). */
+  val remediation: DoctorRemediation? = null,
 )
 
 @Serializable
 data class DoctorRemediation(
-    val summary: String,
-    val commands: List<String> = emptyList(),
-    val docs: String? = null,
+  val summary: String,
+  val commands: List<String> = emptyList(),
+  val docs: String? = null,
 )
 
 @Serializable
-data class DoctorSummary(
-    val ok: Int,
-    val warning: Int,
-    val error: Int,
-    val skipped: Int,
-)
-
+data class DoctorSummary(val ok: Int, val warning: Int, val error: Int, val skipped: Int)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/GatherComposePreviewModelAction.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/GatherComposePreviewModelAction.kt
@@ -4,128 +4,130 @@ import ee.schimke.composeai.plugin.tooling.ComposePreviewModel
 import ee.schimke.composeai.plugin.tooling.ModuleFinding
 import ee.schimke.composeai.plugin.tooling.ModuleInfo
 import ee.schimke.composeai.plugin.tooling.RenderPreviewsTaskInfo
+import java.io.Serializable
 import org.gradle.tooling.BuildAction
 import org.gradle.tooling.BuildController
 import org.gradle.tooling.model.gradle.GradleBuild
-import java.io.Serializable
 
 /**
  * Aggregates [ComposePreviewModel] across every project in the build.
  *
- * Runs in the Gradle daemon (serialised by the Tooling API). Walks every
- * project via the [GradleBuild] model and asks for the per-project
- * `ComposePreviewModel` on each — projects that don't apply the plugin
- * return an empty `modules` map, which we drop. Aggregation happens inside
- * the daemon so each per-project `findModel` call is cross-project-safe
- * under Isolated Projects, where a single root-scoped builder wouldn't be
- * allowed to poke at subprojects.
+ * Runs in the Gradle daemon (serialised by the Tooling API). Walks every project via the
+ * [GradleBuild] model and asks for the per-project `ComposePreviewModel` on each — projects that
+ * don't apply the plugin return an empty `modules` map, which we drop. Aggregation happens inside
+ * the daemon so each per-project `findModel` call is cross-project-safe under Isolated Projects,
+ * where a single root-scoped builder wouldn't be allowed to poke at subprojects.
  *
- * The return type is a [ComposePreviewModel] implementation defined on the
- * CLI side so the Tooling API can ship it back without proxy round-tripping
- * per field access.
+ * The return type is a [ComposePreviewModel] implementation defined on the CLI side so the Tooling
+ * API can ship it back without proxy round-tripping per field access.
  */
 class GatherComposePreviewModelAction : BuildAction<AggregatedComposePreviewModel> {
-    override fun execute(controller: BuildController): AggregatedComposePreviewModel {
-        val build = controller.getModel(GradleBuild::class.java)
-        val aggregated = linkedMapOf<String, SerializableModuleInfo>()
-        var pluginVersion = ""
-        for (project in build.projects) {
-            val model = try {
-                controller.findModel(project, ComposePreviewModel::class.java)
-            } catch (_: Throwable) {
-                null
-            } ?: continue
-            if (model.pluginVersion.isNotEmpty()) pluginVersion = model.pluginVersion
-            for ((path, info) in model.modules) {
-                aggregated[path] = SerializableModuleInfo(
-                    variant = info.variant,
-                    mainRuntimeDependencies = info.mainRuntimeDependencies.toMap(),
-                    testRuntimeDependencies = info.testRuntimeDependencies.toMap(),
-                    findings = info.findings.map { f ->
-                        SerializableModuleFinding(
-                            id = f.id,
-                            severity = f.severity,
-                            message = f.message,
-                            detail = f.detail,
-                            remediationSummary = f.remediationSummary,
-                            remediationCommands = f.remediationCommands.toList(),
-                            docsUrl = f.docsUrl,
-                        )
-                    },
-                    // New fields — marshalled defensively because older
-                    // plugin versions don't implement the getters. The
-                    // Tooling-API proxy throws `UnsupportedMethodException`
-                    // in that case; catching it here lets a recent CLI
-                    // still read an older plugin's model.
-                    agpVersion = readOptional { info.agpVersion },
-                    kotlinVersion = readOptional { info.kotlinVersion },
-                    renderPreviewsTask = readOptional { info.renderPreviewsTask }?.let { t ->
-                        SerializableRenderPreviewsTaskInfo(
-                            javaLauncherPinned = t.javaLauncherPinned,
-                            javaLauncherVersion = t.javaLauncherVersion,
-                            javaLauncherVendor = t.javaLauncherVendor,
-                            javaLauncherPath = t.javaLauncherPath,
-                            classpathSize = t.classpathSize,
-                            bootstrapClasspathSize = t.bootstrapClasspathSize,
-                            jvmArgs = t.jvmArgs.toList(),
-                        )
-                    },
+  override fun execute(controller: BuildController): AggregatedComposePreviewModel {
+    val build = controller.getModel(GradleBuild::class.java)
+    val aggregated = linkedMapOf<String, SerializableModuleInfo>()
+    var pluginVersion = ""
+    for (project in build.projects) {
+      val model =
+        try {
+          controller.findModel(project, ComposePreviewModel::class.java)
+        } catch (_: Throwable) {
+          null
+        } ?: continue
+      if (model.pluginVersion.isNotEmpty()) pluginVersion = model.pluginVersion
+      for ((path, info) in model.modules) {
+        aggregated[path] =
+          SerializableModuleInfo(
+            variant = info.variant,
+            mainRuntimeDependencies = info.mainRuntimeDependencies.toMap(),
+            testRuntimeDependencies = info.testRuntimeDependencies.toMap(),
+            findings =
+              info.findings.map { f ->
+                SerializableModuleFinding(
+                  id = f.id,
+                  severity = f.severity,
+                  message = f.message,
+                  detail = f.detail,
+                  remediationSummary = f.remediationSummary,
+                  remediationCommands = f.remediationCommands.toList(),
+                  docsUrl = f.docsUrl,
                 )
-            }
-        }
-        return AggregatedComposePreviewModel(pluginVersion, aggregated)
+              },
+            // New fields — marshalled defensively because older
+            // plugin versions don't implement the getters. The
+            // Tooling-API proxy throws `UnsupportedMethodException`
+            // in that case; catching it here lets a recent CLI
+            // still read an older plugin's model.
+            agpVersion = readOptional { info.agpVersion },
+            kotlinVersion = readOptional { info.kotlinVersion },
+            renderPreviewsTask =
+              readOptional { info.renderPreviewsTask }
+                ?.let { t ->
+                  SerializableRenderPreviewsTaskInfo(
+                    javaLauncherPinned = t.javaLauncherPinned,
+                    javaLauncherVersion = t.javaLauncherVersion,
+                    javaLauncherVendor = t.javaLauncherVendor,
+                    javaLauncherPath = t.javaLauncherPath,
+                    classpathSize = t.classpathSize,
+                    bootstrapClasspathSize = t.bootstrapClasspathSize,
+                    jvmArgs = t.jvmArgs.toList(),
+                  )
+                },
+          )
+      }
     }
+    return AggregatedComposePreviewModel(pluginVersion, aggregated)
+  }
 
-    /**
-     * Read an optional getter on a Tooling-API proxy. Getters added to the
-     * model interface after the plugin version the consumer has installed
-     * throw `UnsupportedMethodException` at invocation time — we want those
-     * to surface as `null`, not propagate out as exceptions and kill the
-     * whole `compose-preview doctor` run.
-     */
-    private inline fun <T> readOptional(block: () -> T?): T? = try {
-        block()
+  /**
+   * Read an optional getter on a Tooling-API proxy. Getters added to the model interface after the
+   * plugin version the consumer has installed throw `UnsupportedMethodException` at invocation time
+   * — we want those to surface as `null`, not propagate out as exceptions and kill the whole
+   * `compose-preview doctor` run.
+   */
+  private inline fun <T> readOptional(block: () -> T?): T? =
+    try {
+      block()
     } catch (_: Throwable) {
-        null
+      null
     }
 }
 
 /**
- * CLI-side [ComposePreviewModel] implementation. Tooling API serialises this
- * class by value, so both sides of the daemon boundary see the same object
- * shape without dynamic proxies — easier to debug and cheaper to iterate.
+ * CLI-side [ComposePreviewModel] implementation. Tooling API serialises this class by value, so
+ * both sides of the daemon boundary see the same object shape without dynamic proxies — easier to
+ * debug and cheaper to iterate.
  */
 data class AggregatedComposePreviewModel(
-    override val pluginVersion: String,
-    override val modules: Map<String, SerializableModuleInfo>,
+  override val pluginVersion: String,
+  override val modules: Map<String, SerializableModuleInfo>,
 ) : ComposePreviewModel, Serializable
 
 data class SerializableModuleInfo(
-    override val variant: String,
-    override val mainRuntimeDependencies: Map<String, String>,
-    override val testRuntimeDependencies: Map<String, String>,
-    override val findings: List<SerializableModuleFinding>,
-    override val agpVersion: String? = null,
-    override val kotlinVersion: String? = null,
-    override val renderPreviewsTask: SerializableRenderPreviewsTaskInfo? = null,
+  override val variant: String,
+  override val mainRuntimeDependencies: Map<String, String>,
+  override val testRuntimeDependencies: Map<String, String>,
+  override val findings: List<SerializableModuleFinding>,
+  override val agpVersion: String? = null,
+  override val kotlinVersion: String? = null,
+  override val renderPreviewsTask: SerializableRenderPreviewsTaskInfo? = null,
 ) : ModuleInfo, Serializable
 
 data class SerializableRenderPreviewsTaskInfo(
-    override val javaLauncherPinned: Boolean,
-    override val javaLauncherVersion: String?,
-    override val javaLauncherVendor: String?,
-    override val javaLauncherPath: String?,
-    override val classpathSize: Int,
-    override val bootstrapClasspathSize: Int,
-    override val jvmArgs: List<String>,
+  override val javaLauncherPinned: Boolean,
+  override val javaLauncherVersion: String?,
+  override val javaLauncherVendor: String?,
+  override val javaLauncherPath: String?,
+  override val classpathSize: Int,
+  override val bootstrapClasspathSize: Int,
+  override val jvmArgs: List<String>,
 ) : RenderPreviewsTaskInfo, Serializable
 
 data class SerializableModuleFinding(
-    override val id: String,
-    override val severity: String,
-    override val message: String,
-    override val detail: String?,
-    override val remediationSummary: String?,
-    override val remediationCommands: List<String>,
-    override val docsUrl: String?,
+  override val id: String,
+  override val severity: String,
+  override val message: String,
+  override val detail: String?,
+  override val remediationSummary: String?,
+  override val remediationCommands: List<String>,
+  override val docsUrl: String?,
 ) : ModuleFinding, Serializable

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -1,308 +1,330 @@
 package ee.schimke.composeai.cli
 
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.OutputStream
+import java.util.Collections
 import org.gradle.tooling.CancellationTokenSource
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.events.FinishEvent
 import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.events.ProgressEvent
 import org.gradle.tooling.events.StartEvent
-import java.io.ByteArrayOutputStream
-import java.io.File
-import java.io.OutputStream
-import java.util.Collections
 
 /**
  * Handle for a subproject that applies `ee.schimke.composeai.preview`.
  *
- * [gradlePath] is the colon-separated project path **without** its leading
- * colon (e.g. `"app"`, `"auth:composables"`) — used to address Gradle tasks
- * like `":$gradlePath:renderAllPreviews"` and to identify the module in CLI
- * output / persisted state. [projectDir] is the actual filesystem directory
- * of that subproject, resolved via Gradle's Tooling API. Using it instead of
- * `projectRoot/$gradlePath` is what makes nested subprojects (`:foo:bar`) and
- * any custom `project.projectDir` override work correctly — see issue #157.
+ * [gradlePath] is the colon-separated project path **without** its leading colon (e.g. `"app"`,
+ * `"auth:composables"`) — used to address Gradle tasks like `":$gradlePath:renderAllPreviews"` and
+ * to identify the module in CLI output / persisted state. [projectDir] is the actual filesystem
+ * directory of that subproject, resolved via Gradle's Tooling API. Using it instead of
+ * `projectRoot/$gradlePath` is what makes nested subprojects (`:foo:bar`) and any custom
+ * `project.projectDir` override work correctly — see issue #157.
  */
 data class PreviewModule(val gradlePath: String, val projectDir: File)
 
 class GradleConnection(
-    private val projectDir: File,
-    private val verbose: Boolean,
-    private val progress: Boolean = false,
+  private val projectDir: File,
+  private val verbose: Boolean,
+  private val progress: Boolean = false,
 ) : AutoCloseable {
-    private val connector = GradleConnector.newConnector()
-        .forProjectDirectory(projectDir)
-    private val connection = connector.connect()
+  private val connector = GradleConnector.newConnector().forProjectDirectory(projectDir)
+  private val connection = connector.connect()
 
-    fun runTasks(vararg tasks: String, timeoutSeconds: Long = 300): Boolean {
-        val tokenSource: CancellationTokenSource = GradleConnector.newCancellationTokenSource()
-        val startTime = System.currentTimeMillis()
-        val runningTasks = Collections.synchronizedSet(linkedSetOf<String>())
+  fun runTasks(vararg tasks: String, timeoutSeconds: Long = 300): Boolean {
+    val tokenSource: CancellationTokenSource = GradleConnector.newCancellationTokenSource()
+    val startTime = System.currentTimeMillis()
+    val runningTasks = Collections.synchronizedSet(linkedSetOf<String>())
 
-        // Ctrl+C otherwise kills the CLI without going through the cancellation
-        // token — leaving the Gradle daemon still executing and any forked Test
-        // worker (Robolectric, etc.) orphaned. Hook ensures clean cancellation.
-        val shutdownHook = Thread {
-            System.err.println("\nInterrupted — cancelling Gradle build...")
-            tokenSource.cancel()
-            try { connection.close() } catch (_: Exception) {}
-        }
-        Runtime.getRuntime().addShutdownHook(shutdownHook)
-
-        val timer = java.util.Timer(true).apply {
-            schedule(object : java.util.TimerTask() {
-                override fun run() {
-                    System.err.println("Build timed out after ${timeoutSeconds}s, cancelling...")
-                    TerminalProgress.error()
-                    tokenSource.cancel()
-                }
-            }, timeoutSeconds * 1000)
-
-            // Heartbeat so the user can see what is still running (Robolectric
-            // can take minutes on a cold start with no output). Opt-in via
-            // --progress / --verbose so default CLI output stays quiet.
-            if (progress) {
-                val heartbeatMs = 15_000L
-                schedule(object : java.util.TimerTask() {
-                    override fun run() {
-                        val elapsed = (System.currentTimeMillis() - startTime) / 1000
-                        val running = synchronized(runningTasks) { runningTasks.toList() }
-                        if (running.isNotEmpty()) {
-                            System.err.println("  [${elapsed}s] running: ${running.joinToString(", ")}")
-                        }
-                    }
-                }, heartbeatMs, heartbeatMs)
-            }
-        }
-
-        TerminalProgress.indeterminate()
-        var taskCount = 0
-        var tasksFinished = 0
-
-        // Capture stderr for error reporting when not in verbose mode
-        val errorCapture = ByteArrayOutputStream()
-
-        return try {
-            val launcher = connection.newBuild()
-                .forTasks(*tasks)
-                .withCancellationToken(tokenSource.token())
-
-            if (verbose) {
-                launcher.setStandardOutput(System.err)
-                launcher.setStandardError(System.err)
-            } else {
-                launcher.setStandardOutput(NullOutputStream)
-                launcher.setStandardError(errorCapture)
-            }
-
-            val listenerTypes = if (verbose) {
-                setOf(OperationType.TASK, OperationType.TEST)
-            } else {
-                setOf(OperationType.TASK)
-            }
-
-            launcher.addProgressListener({ event: ProgressEvent ->
-                val desc = event.descriptor.name
-                when (event) {
-                    is StartEvent -> {
-                        taskCount++
-                        runningTasks.add(desc)
-                    }
-                    is FinishEvent -> {
-                        runningTasks.remove(desc)
-                        tasksFinished++
-                        if (taskCount > 0) {
-                            TerminalProgress.show((tasksFinished * 100) / taskCount)
-                        }
-                        if (progress && !verbose && (desc.contains("discoverPreviews") ||
-                                desc.contains("renderPreviews") || desc.contains("renderAllPreviews"))
-                        ) {
-                            val elapsed = (System.currentTimeMillis() - startTime) / 1000
-                            System.err.println("  [${elapsed}s] $desc")
-                        }
-                    }
-                    else -> {}
-                }
-            }, listenerTypes)
-
-            launcher.run()
-            TerminalProgress.show(100)
-            true
-        } catch (e: org.gradle.tooling.BuildCancelledException) {
-            TerminalProgress.error()
-            System.err.println("Build cancelled.")
-            false
-        } catch (e: org.gradle.tooling.BuildException) {
-            TerminalProgress.error()
-            printBuildFailure(e, errorCapture)
-            false
-        } catch (e: org.gradle.tooling.GradleConnectionException) {
-            TerminalProgress.error()
-            System.err.println("Gradle connection failed: ${e.message}")
-            false
-        } finally {
-            timer.cancel()
-            tokenSource.cancel()
-            TerminalProgress.hide()
-            try { Runtime.getRuntime().removeShutdownHook(shutdownHook) } catch (_: IllegalStateException) {}
-        }
-    }
-
-    private fun printBuildFailure(e: org.gradle.tooling.BuildException, errorCapture: ByteArrayOutputStream) {
-        // Extract the root cause message
-        var cause: Throwable? = e
-        val messages = mutableListOf<String>()
-        while (cause != null) {
-            cause.message?.let { msg ->
-                if (msg.isNotBlank() && msg !in messages) messages.add(msg)
-            }
-            cause = cause.cause
-        }
-
-        // Show the captured stderr (Gradle's error output)
-        val captured = errorCapture.toString().trim()
-        if (captured.isNotEmpty()) {
-            // Extract actionable lines from Gradle output
-            val lines = captured.lines()
-            val actionable = lines.filter { line ->
-                line.contains("error:", ignoreCase = true) ||
-                    line.contains("FAILURE:") ||
-                    line.contains("What went wrong") ||
-                    line.contains("not found") ||
-                    line.startsWith("e: ") ||
-                    line.startsWith("> ") ||
-                    line.startsWith("* ")
-            }
-            if (actionable.isNotEmpty()) {
-                for (line in actionable) {
-                    System.err.println(line)
-                }
-            } else if (verbose) {
-                System.err.println(captured)
-            }
-        }
-
-        // If no captured output was useful, show exception chain
-        if (captured.isEmpty() || !captured.contains("What went wrong")) {
-            System.err.println("Build failed: ${messages.firstOrNull() ?: "unknown error"}")
-            if (messages.size > 1) {
-                System.err.println("Caused by: ${messages.drop(1).joinToString(" → ")}")
-            }
-        }
-
-        System.err.println()
-        System.err.println("Run with --verbose for full build output.")
-    }
-
-    /**
-     * Fetch a Tooling API model registered by the applied plugin. Returns
-     * `null` if the model isn't registered (plugin not applied, or version
-     * predates the model) or if the Gradle connection fails — callers fold
-     * both into "skip project-scope checks" rather than erroring.
-     *
-     * The plugin-side model FQN and the [modelClass] passed here must match;
-     * see `ComposePreviewModel.kt` on both sides for the contract.
-     */
-    fun <R> runBuildAction(action: org.gradle.tooling.BuildAction<R>, timeoutSeconds: Long = 60): R? {
-        val tokenSource: CancellationTokenSource = GradleConnector.newCancellationTokenSource()
-        val timer = java.util.Timer(true).apply {
-            schedule(object : java.util.TimerTask() {
-                override fun run() { tokenSource.cancel() }
-            }, timeoutSeconds * 1000)
-        }
-        return try {
-            connection.action(action)
-                .withCancellationToken(tokenSource.token())
-                .apply {
-                    if (verbose) {
-                        setStandardOutput(System.err)
-                        setStandardError(System.err)
-                    } else {
-                        setStandardOutput(NullOutputStream)
-                        setStandardError(NullOutputStream)
-                    }
-                }
-                .run()
-        } catch (e: org.gradle.tooling.GradleConnectionException) {
-            if (verbose) System.err.println("Gradle connection failed: ${e.message}")
-            null
-        } catch (e: org.gradle.tooling.BuildException) {
-            if (verbose) System.err.println("Build action failed: ${e.message}")
-            null
-        } finally {
-            timer.cancel()
-            tokenSource.cancel()
-        }
-    }
-
-    /**
-     * Fetch Gradle's `BuildEnvironment` model — exposes the daemon's Gradle
-     * version and its `javaHome`. Doctor uses both to triage bug reports
-     * where the forked test worker's JVM differs from the daemon's (#142).
-     * Returns `null` on any tooling-API failure; callers fold into "skip".
-     */
-    fun buildEnvironment(): org.gradle.tooling.model.build.BuildEnvironment? {
-        return try {
-            connection.model(org.gradle.tooling.model.build.BuildEnvironment::class.java).get()
-        } catch (e: Exception) {
-            if (verbose) System.err.println("Could not query BuildEnvironment: ${e.message}")
-            null
-        }
-    }
-
-    /**
-     * Find all subprojects that have a `discoverPreviews` task — these have the
-     * compose-ai-tools plugin applied.
-     *
-     * Each entry carries both the Gradle path (used to build task specs like
-     * `:foo:bar:renderAllPreviews`) and the resolved filesystem `projectDir`.
-     * Nested subprojects (`:foo:bar`) have directory layouts like `foo/bar/`,
-     * so substituting `:` for `/` doesn't always work — and even for standard
-     * layouts a user can point `project.projectDir` anywhere. Reading it from
-     * the Tooling API's [GradleProject.projectDirectory] is the only reliable
-     * way to resolve manifests / PNGs on disk without replicating Gradle's
-     * own project-layout logic.
-     */
-    fun findPreviewModules(): List<PreviewModule> {
-        return try {
-            val model = connection.model(org.gradle.tooling.model.GradleProject::class.java).get()
-            val modules = mutableListOf<PreviewModule>()
-            fun visit(project: org.gradle.tooling.model.GradleProject) {
-                val hasPreviewTask = project.tasks.any { it.name == "discoverPreviews" }
-                if (hasPreviewTask) {
-                    val path = project.path.removePrefix(":")
-                    if (path.isNotEmpty()) {
-                        modules.add(PreviewModule(gradlePath = path, projectDir = project.projectDirectory))
-                    }
-                }
-                for (child in project.children) visit(child)
-            }
-            visit(model)
-            modules
-        } catch (e: Exception) {
-            if (verbose) System.err.println("Could not query project model: ${e.message}")
-            emptyList()
-        }
-    }
-
-    /**
-     * Resolve a single module by its Gradle path (colon-separated, with or
-     * without the leading `:`). Returns `null` when no project with that path
-     * applies the plugin — callers fall back to a user-visible error rather
-     * than silently building an empty task list against a dir that doesn't
-     * exist.
-     */
-    fun findPreviewModule(gradlePath: String): PreviewModule? {
-        val normalized = gradlePath.removePrefix(":")
-        return findPreviewModules().firstOrNull { it.gradlePath == normalized }
-    }
-
-    override fun close() {
+    // Ctrl+C otherwise kills the CLI without going through the cancellation
+    // token — leaving the Gradle daemon still executing and any forked Test
+    // worker (Robolectric, etc.) orphaned. Hook ensures clean cancellation.
+    val shutdownHook = Thread {
+      System.err.println("\nInterrupted — cancelling Gradle build...")
+      tokenSource.cancel()
+      try {
         connection.close()
+      } catch (_: Exception) {}
     }
+    Runtime.getRuntime().addShutdownHook(shutdownHook)
+
+    val timer =
+      java.util.Timer(true).apply {
+        schedule(
+          object : java.util.TimerTask() {
+            override fun run() {
+              System.err.println("Build timed out after ${timeoutSeconds}s, cancelling...")
+              TerminalProgress.error()
+              tokenSource.cancel()
+            }
+          },
+          timeoutSeconds * 1000,
+        )
+
+        // Heartbeat so the user can see what is still running (Robolectric
+        // can take minutes on a cold start with no output). Opt-in via
+        // --progress / --verbose so default CLI output stays quiet.
+        if (progress) {
+          val heartbeatMs = 15_000L
+          schedule(
+            object : java.util.TimerTask() {
+              override fun run() {
+                val elapsed = (System.currentTimeMillis() - startTime) / 1000
+                val running = synchronized(runningTasks) { runningTasks.toList() }
+                if (running.isNotEmpty()) {
+                  System.err.println("  [${elapsed}s] running: ${running.joinToString(", ")}")
+                }
+              }
+            },
+            heartbeatMs,
+            heartbeatMs,
+          )
+        }
+      }
+
+    TerminalProgress.indeterminate()
+    var taskCount = 0
+    var tasksFinished = 0
+
+    // Capture stderr for error reporting when not in verbose mode
+    val errorCapture = ByteArrayOutputStream()
+
+    return try {
+      val launcher =
+        connection.newBuild().forTasks(*tasks).withCancellationToken(tokenSource.token())
+
+      if (verbose) {
+        launcher.setStandardOutput(System.err)
+        launcher.setStandardError(System.err)
+      } else {
+        launcher.setStandardOutput(NullOutputStream)
+        launcher.setStandardError(errorCapture)
+      }
+
+      val listenerTypes =
+        if (verbose) {
+          setOf(OperationType.TASK, OperationType.TEST)
+        } else {
+          setOf(OperationType.TASK)
+        }
+
+      launcher.addProgressListener(
+        { event: ProgressEvent ->
+          val desc = event.descriptor.name
+          when (event) {
+            is StartEvent -> {
+              taskCount++
+              runningTasks.add(desc)
+            }
+            is FinishEvent -> {
+              runningTasks.remove(desc)
+              tasksFinished++
+              if (taskCount > 0) {
+                TerminalProgress.show((tasksFinished * 100) / taskCount)
+              }
+              if (
+                progress &&
+                  !verbose &&
+                  (desc.contains("discoverPreviews") ||
+                    desc.contains("renderPreviews") ||
+                    desc.contains("renderAllPreviews"))
+              ) {
+                val elapsed = (System.currentTimeMillis() - startTime) / 1000
+                System.err.println("  [${elapsed}s] $desc")
+              }
+            }
+            else -> {}
+          }
+        },
+        listenerTypes,
+      )
+
+      launcher.run()
+      TerminalProgress.show(100)
+      true
+    } catch (e: org.gradle.tooling.BuildCancelledException) {
+      TerminalProgress.error()
+      System.err.println("Build cancelled.")
+      false
+    } catch (e: org.gradle.tooling.BuildException) {
+      TerminalProgress.error()
+      printBuildFailure(e, errorCapture)
+      false
+    } catch (e: org.gradle.tooling.GradleConnectionException) {
+      TerminalProgress.error()
+      System.err.println("Gradle connection failed: ${e.message}")
+      false
+    } finally {
+      timer.cancel()
+      tokenSource.cancel()
+      TerminalProgress.hide()
+      try {
+        Runtime.getRuntime().removeShutdownHook(shutdownHook)
+      } catch (_: IllegalStateException) {}
+    }
+  }
+
+  private fun printBuildFailure(
+    e: org.gradle.tooling.BuildException,
+    errorCapture: ByteArrayOutputStream,
+  ) {
+    // Extract the root cause message
+    var cause: Throwable? = e
+    val messages = mutableListOf<String>()
+    while (cause != null) {
+      cause.message?.let { msg -> if (msg.isNotBlank() && msg !in messages) messages.add(msg) }
+      cause = cause.cause
+    }
+
+    // Show the captured stderr (Gradle's error output)
+    val captured = errorCapture.toString().trim()
+    if (captured.isNotEmpty()) {
+      // Extract actionable lines from Gradle output
+      val lines = captured.lines()
+      val actionable = lines.filter { line ->
+        line.contains("error:", ignoreCase = true) ||
+          line.contains("FAILURE:") ||
+          line.contains("What went wrong") ||
+          line.contains("not found") ||
+          line.startsWith("e: ") ||
+          line.startsWith("> ") ||
+          line.startsWith("* ")
+      }
+      if (actionable.isNotEmpty()) {
+        for (line in actionable) {
+          System.err.println(line)
+        }
+      } else if (verbose) {
+        System.err.println(captured)
+      }
+    }
+
+    // If no captured output was useful, show exception chain
+    if (captured.isEmpty() || !captured.contains("What went wrong")) {
+      System.err.println("Build failed: ${messages.firstOrNull() ?: "unknown error"}")
+      if (messages.size > 1) {
+        System.err.println("Caused by: ${messages.drop(1).joinToString(" → ")}")
+      }
+    }
+
+    System.err.println()
+    System.err.println("Run with --verbose for full build output.")
+  }
+
+  /**
+   * Fetch a Tooling API model registered by the applied plugin. Returns `null` if the model isn't
+   * registered (plugin not applied, or version predates the model) or if the Gradle connection
+   * fails — callers fold both into "skip project-scope checks" rather than erroring.
+   *
+   * The plugin-side model FQN and the [modelClass] passed here must match; see
+   * `ComposePreviewModel.kt` on both sides for the contract.
+   */
+  fun <R> runBuildAction(action: org.gradle.tooling.BuildAction<R>, timeoutSeconds: Long = 60): R? {
+    val tokenSource: CancellationTokenSource = GradleConnector.newCancellationTokenSource()
+    val timer =
+      java.util.Timer(true).apply {
+        schedule(
+          object : java.util.TimerTask() {
+            override fun run() {
+              tokenSource.cancel()
+            }
+          },
+          timeoutSeconds * 1000,
+        )
+      }
+    return try {
+      connection
+        .action(action)
+        .withCancellationToken(tokenSource.token())
+        .apply {
+          if (verbose) {
+            setStandardOutput(System.err)
+            setStandardError(System.err)
+          } else {
+            setStandardOutput(NullOutputStream)
+            setStandardError(NullOutputStream)
+          }
+        }
+        .run()
+    } catch (e: org.gradle.tooling.GradleConnectionException) {
+      if (verbose) System.err.println("Gradle connection failed: ${e.message}")
+      null
+    } catch (e: org.gradle.tooling.BuildException) {
+      if (verbose) System.err.println("Build action failed: ${e.message}")
+      null
+    } finally {
+      timer.cancel()
+      tokenSource.cancel()
+    }
+  }
+
+  /**
+   * Fetch Gradle's `BuildEnvironment` model — exposes the daemon's Gradle version and its
+   * `javaHome`. Doctor uses both to triage bug reports where the forked test worker's JVM differs
+   * from the daemon's (#142). Returns `null` on any tooling-API failure; callers fold into "skip".
+   */
+  fun buildEnvironment(): org.gradle.tooling.model.build.BuildEnvironment? {
+    return try {
+      connection.model(org.gradle.tooling.model.build.BuildEnvironment::class.java).get()
+    } catch (e: Exception) {
+      if (verbose) System.err.println("Could not query BuildEnvironment: ${e.message}")
+      null
+    }
+  }
+
+  /**
+   * Find all subprojects that have a `discoverPreviews` task — these have the compose-ai-tools
+   * plugin applied.
+   *
+   * Each entry carries both the Gradle path (used to build task specs like
+   * `:foo:bar:renderAllPreviews`) and the resolved filesystem `projectDir`. Nested subprojects
+   * (`:foo:bar`) have directory layouts like `foo/bar/`, so substituting `:` for `/` doesn't always
+   * work — and even for standard layouts a user can point `project.projectDir` anywhere. Reading it
+   * from the Tooling API's [GradleProject.projectDirectory] is the only reliable way to resolve
+   * manifests / PNGs on disk without replicating Gradle's own project-layout logic.
+   */
+  fun findPreviewModules(): List<PreviewModule> {
+    return try {
+      val model = connection.model(org.gradle.tooling.model.GradleProject::class.java).get()
+      val modules = mutableListOf<PreviewModule>()
+      fun visit(project: org.gradle.tooling.model.GradleProject) {
+        val hasPreviewTask = project.tasks.any { it.name == "discoverPreviews" }
+        if (hasPreviewTask) {
+          val path = project.path.removePrefix(":")
+          if (path.isNotEmpty()) {
+            modules.add(PreviewModule(gradlePath = path, projectDir = project.projectDirectory))
+          }
+        }
+        for (child in project.children) visit(child)
+      }
+      visit(model)
+      modules
+    } catch (e: Exception) {
+      if (verbose) System.err.println("Could not query project model: ${e.message}")
+      emptyList()
+    }
+  }
+
+  /**
+   * Resolve a single module by its Gradle path (colon-separated, with or without the leading `:`).
+   * Returns `null` when no project with that path applies the plugin — callers fall back to a
+   * user-visible error rather than silently building an empty task list against a dir that doesn't
+   * exist.
+   */
+  fun findPreviewModule(gradlePath: String): PreviewModule? {
+    val normalized = gradlePath.removePrefix(":")
+    return findPreviewModules().firstOrNull { it.gradlePath == normalized }
+  }
+
+  override fun close() {
+    connection.close()
+  }
 }
 
 private object NullOutputStream : OutputStream() {
-    override fun write(b: Int) {}
-    override fun write(b: ByteArray) {}
-    override fun write(b: ByteArray, off: Int, len: Int) {}
+  override fun write(b: Int) {}
+
+  override fun write(b: ByteArray) {}
+
+  override fun write(b: ByteArray, off: Int, len: Int) {}
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -3,103 +3,102 @@ package ee.schimke.composeai.cli
 import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
-    if (args.isEmpty()) {
-        printUsage()
-        exitProcess(0)
+  if (args.isEmpty()) {
+    printUsage()
+    exitProcess(0)
+  }
+
+  // Find the command — first non-flag argument that isn't a flag's value.
+  // Flags that take values: --module, --filter, --id, --output, --timeout, --plugin-version
+  val valuedFlags =
+    setOf("--module", "--filter", "--id", "--output", "--timeout", "--plugin-version", "--fail-on")
+  val commands = setOf("show", "list", "render", "a11y", "doctor", "help")
+
+  var commandIndex = -1
+  var i = 0
+  while (i < args.size) {
+    val arg = args[i]
+    if (arg in valuedFlags) {
+      i += 2 // skip flag and its value
+      continue
     }
-
-    // Find the command — first non-flag argument that isn't a flag's value.
-    // Flags that take values: --module, --filter, --id, --output, --timeout, --plugin-version
-    val valuedFlags = setOf(
-        "--module", "--filter", "--id", "--output", "--timeout", "--plugin-version",
-        "--fail-on",
-    )
-    val commands = setOf("show", "list", "render", "a11y", "doctor", "help")
-
-    var commandIndex = -1
-    var i = 0
-    while (i < args.size) {
-        val arg = args[i]
-        if (arg in valuedFlags) {
-            i += 2 // skip flag and its value
-            continue
-        }
-        if (arg.startsWith("-")) {
-            i++
-            continue
-        }
-        commandIndex = i
-        break
+    if (arg.startsWith("-")) {
+      i++
+      continue
     }
+    commandIndex = i
+    break
+  }
 
-    if (commandIndex < 0) {
-        if ("--help" in args || "-h" in args) {
-            printUsage()
-            exitProcess(0)
-        }
-        System.err.println("No command specified.")
-        printUsage()
-        exitProcess(1)
+  if (commandIndex < 0) {
+    if ("--help" in args || "-h" in args) {
+      printUsage()
+      exitProcess(0)
     }
+    System.err.println("No command specified.")
+    printUsage()
+    exitProcess(1)
+  }
 
-    val command = args[commandIndex]
-    val allArgs = args.toMutableList().apply { removeAt(commandIndex) }
+  val command = args[commandIndex]
+  val allArgs = args.toMutableList().apply { removeAt(commandIndex) }
 
-    when (command) {
-        "show" -> ShowCommand(allArgs).run()
-        "list" -> ListCommand(allArgs).run()
-        "render" -> RenderCommand(allArgs).run()
-        "a11y" -> A11yCommand(allArgs).run()
-        "doctor" -> DoctorCommand(allArgs).run()
-        "help" -> printUsage()
-        else -> {
-            System.err.println("Unknown command: $command")
-            printUsage()
-            exitProcess(1)
-        }
+  when (command) {
+    "show" -> ShowCommand(allArgs).run()
+    "list" -> ListCommand(allArgs).run()
+    "render" -> RenderCommand(allArgs).run()
+    "a11y" -> A11yCommand(allArgs).run()
+    "doctor" -> DoctorCommand(allArgs).run()
+    "help" -> printUsage()
+    else -> {
+      System.err.println("Unknown command: $command")
+      printUsage()
+      exitProcess(1)
     }
+  }
 }
 
 private fun printUsage() {
-    println(
-        """
-        compose-preview — Compose Preview CLI
+  println(
+    """
+    compose-preview — Compose Preview CLI
 
-        Usage: compose-preview [options] <command> [options]
+    Usage: compose-preview [options] <command> [options]
 
-        Commands:
-          show    Discover and render previews; print id, path, sha256, changed flag
-          list    List discovered previews
-          render  Render previews; with --output copies a single match to disk
-          a11y    Render previews and print ATF accessibility findings
-          doctor  Verify Java 17 + Compose/AGP environment before editing Gradle files
-          help    Show this help message
+    Commands:
+      show    Discover and render previews; print id, path, sha256, changed flag
+      list    List discovered previews
+      render  Render previews; with --output copies a single match to disk
+      a11y    Render previews and print ATF accessibility findings
+      doctor  Verify Java 17 + Compose/AGP environment before editing Gradle files
+      help    Show this help message
 
-        Options:
-          --module <name>      Target module (default: auto-detect all)
-          --filter <pattern>   Case-insensitive substring match on preview id
-          --id <exact>         Exact match on preview id
-          --json               Emit JSON (show, list, a11y)
-          --brief              JSON only: drop functionName/className/sourceFile/params
-          --changed-only       JSON only (show, a11y): drop previews with no changed capture
-          --output <path>      Copy matched preview PNG to this path (render)
-          --progress           Print per-task milestone/heartbeat lines to stderr
-          --verbose, -v        Show full Gradle build output (implies --progress)
-          --timeout <seconds>  Gradle build timeout (default: 300)
-          --fail-on <level>    a11y: exit non-zero on 'errors' or 'warnings' (default: mirror Gradle)
+    Options:
+      --module <name>      Target module (default: auto-detect all)
+      --filter <pattern>   Case-insensitive substring match on preview id
+      --id <exact>         Exact match on preview id
+      --json               Emit JSON (show, list, a11y)
+      --brief              JSON only: drop functionName/className/sourceFile/params
+      --changed-only       JSON only (show, a11y): drop previews with no changed capture
+      --output <path>      Copy matched preview PNG to this path (render)
+      --progress           Print per-task milestone/heartbeat lines to stderr
+      --verbose, -v        Show full Gradle build output (implies --progress)
+      --timeout <seconds>  Gradle build timeout (default: 300)
+      --fail-on <level>    a11y: exit non-zero on 'errors' or 'warnings' (default: mirror Gradle)
 
-        OSC 9;4 terminal progress (native taskbar/tab progress bar) is on by
-        default in a TTY and auto-disables when stdout is piped or redirected.
+    OSC 9;4 terminal progress (native taskbar/tab progress bar) is on by
+    default in a TTY and auto-disables when stdout is piped or redirected.
 
-        JSON output is wrapped in {schema, previews, counts?} (schema:
-        compose-preview-show/v1). Each preview includes a `captures[]` array
-        with per-capture pngPath/sha256/changed/advanceTimeMillis/scroll.
-        For back-compat the top-level pngPath/sha256/changed mirror the first
-        capture. State persisted per module under
-        <module>/build/compose-previews/.cli-state.json (wiped on `clean`).
+    JSON output is wrapped in {schema, previews, counts?} (schema:
+    compose-preview-show/v1). Each preview includes a `captures[]` array
+    with per-capture pngPath/sha256/changed/advanceTimeMillis/scroll.
+    For back-compat the top-level pngPath/sha256/changed mirror the first
+    capture. State persisted per module under
+    <module>/build/compose-previews/.cli-state.json (wiped on `clean`).
 
-        Exit codes: 0 success, 1 build/CLI error, 2 render failure or a11y
-        threshold tripped, 3 no previews found / matched.
-        """.trimIndent()
-    )
+    Exit codes: 0 success, 1 build/CLI error, 2 render failure or a11y
+    threshold tripped, 3 no previews found / matched.
+    """
+      .trimIndent()
+  )
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/TerminalProgress.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/TerminalProgress.kt
@@ -3,49 +3,48 @@ package ee.schimke.composeai.cli
 /**
  * OSC 9;4 terminal progress bar protocol.
  *
- * Supported by Windows Terminal, Ghostty, iTerm2, WezTerm, and VTE-based terminals.
- * Displays a native progress bar in the terminal tab and (on Windows) the taskbar.
+ * Supported by Windows Terminal, Ghostty, iTerm2, WezTerm, and VTE-based terminals. Displays a
+ * native progress bar in the terminal tab and (on Windows) the taskbar.
  *
- * Protocol: ESC ] 9 ; 4 ; <state> ; <progress> ST
- *   state: 0=hidden, 1=default, 2=error, 3=indeterminate, 4=warning
- *   progress: 0-100
+ * Protocol: ESC ] 9 ; 4 ; <state> ; <progress> ST state: 0=hidden, 1=default, 2=error,
+ * 3=indeterminate, 4=warning progress: 0-100
  */
 object TerminalProgress {
-    private const val ESC = "\u001b"
-    private const val ST = "$ESC\\"
-    private const val OSC = "${ESC}]"
+  private const val ESC = "\u001b"
+  private const val ST = "$ESC\\"
+  private const val OSC = "${ESC}]"
 
-    // System.console() is null when stdout is redirected to a file or pipe,
-    // so OSC escapes would appear as literal garbage in captured output.
-    // TERM=dumb is the conventional signal to disable terminal styling.
-    private val enabled: Boolean = run {
-        if (System.console() == null) return@run false
-        val term = System.getenv("TERM")
-        term != null && term != "dumb"
-    }
+  // System.console() is null when stdout is redirected to a file or pipe,
+  // so OSC escapes would appear as literal garbage in captured output.
+  // TERM=dumb is the conventional signal to disable terminal styling.
+  private val enabled: Boolean = run {
+    if (System.console() == null) return@run false
+    val term = System.getenv("TERM")
+    term != null && term != "dumb"
+  }
 
-    fun show(percent: Int) {
-        if (!enabled) return
-        val clamped = percent.coerceIn(0, 100)
-        print("${OSC}9;4;1;${clamped}${ST}")
-        System.out.flush()
-    }
+  fun show(percent: Int) {
+    if (!enabled) return
+    val clamped = percent.coerceIn(0, 100)
+    print("${OSC}9;4;1;${clamped}${ST}")
+    System.out.flush()
+  }
 
-    fun indeterminate() {
-        if (!enabled) return
-        print("${OSC}9;4;3;0${ST}")
-        System.out.flush()
-    }
+  fun indeterminate() {
+    if (!enabled) return
+    print("${OSC}9;4;3;0${ST}")
+    System.out.flush()
+  }
 
-    fun error() {
-        if (!enabled) return
-        print("${OSC}9;4;2;100${ST}")
-        System.out.flush()
-    }
+  fun error() {
+    if (!enabled) return
+    print("${OSC}9;4;2;100${ST}")
+    System.out.flush()
+  }
 
-    fun hide() {
-        if (!enabled) return
-        print("${OSC}9;4;0;0${ST}")
-        System.out.flush()
-    }
+  fun hide() {
+    if (!enabled) return
+    print("${OSC}9;4;0;0${ST}")
+    System.out.flush()
+  }
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt
@@ -1,44 +1,43 @@
 package ee.schimke.composeai.plugin.tooling
 
 /**
- * CLI-side copy of the plugin's Tooling API model. MUST stay at the same
- * fully-qualified name and method signatures as the plugin-side interface —
- * Gradle's Tooling API uses reflective proxies to bridge the two across the
- * daemon boundary, so drift silently produces `null` returns. See the
+ * CLI-side copy of the plugin's Tooling API model. MUST stay at the same fully-qualified name and
+ * method signatures as the plugin-side interface — Gradle's Tooling API uses reflective proxies to
+ * bridge the two across the daemon boundary, so drift silently produces `null` returns. See the
  * plugin-side source for the canonical docstrings:
  * `gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt`.
  */
 interface ComposePreviewModel {
-    val pluginVersion: String
-    val modules: Map<String, ModuleInfo>
+  val pluginVersion: String
+  val modules: Map<String, ModuleInfo>
 }
 
 interface ModuleInfo {
-    val variant: String
-    val mainRuntimeDependencies: Map<String, String>
-    val testRuntimeDependencies: Map<String, String>
-    val findings: List<ModuleFinding>
-    val agpVersion: String?
-    val kotlinVersion: String?
-    val renderPreviewsTask: RenderPreviewsTaskInfo?
+  val variant: String
+  val mainRuntimeDependencies: Map<String, String>
+  val testRuntimeDependencies: Map<String, String>
+  val findings: List<ModuleFinding>
+  val agpVersion: String?
+  val kotlinVersion: String?
+  val renderPreviewsTask: RenderPreviewsTaskInfo?
 }
 
 interface RenderPreviewsTaskInfo {
-    val javaLauncherPinned: Boolean
-    val javaLauncherVersion: String?
-    val javaLauncherVendor: String?
-    val javaLauncherPath: String?
-    val classpathSize: Int
-    val bootstrapClasspathSize: Int
-    val jvmArgs: List<String>
+  val javaLauncherPinned: Boolean
+  val javaLauncherVersion: String?
+  val javaLauncherVendor: String?
+  val javaLauncherPath: String?
+  val classpathSize: Int
+  val bootstrapClasspathSize: Int
+  val jvmArgs: List<String>
 }
 
 interface ModuleFinding {
-    val id: String
-    val severity: String
-    val message: String
-    val detail: String?
-    val remediationSummary: String?
-    val remediationCommands: List<String>
-    val docsUrl: String?
+  val id: String
+  val severity: String
+  val message: String
+  val detail: String?
+  val remediationSummary: String?
+  val remediationCommands: List<String>
+  val docsUrl: String?
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DoctorCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DoctorCommandTest.kt
@@ -5,81 +5,94 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class DoctorReportSerializationTest {
-    @Test fun `round-trips a report with all fields populated`() {
-        val report = DoctorReport(
-            schema = "compose-preview-doctor/v1",
-            pluginVersion = "0.4.0",
-            overall = "warning",
-            checks = listOf(
-                DoctorCheck(
-                    id = "env.java-17",
-                    category = "env",
-                    status = "ok",
-                    message = "Java 17 on PATH",
-                ),
-                DoctorCheck(
-                    id = "deps.app.ui-test-manifest-missing",
-                    category = "deps",
-                    status = "error",
-                    message = ":app — ui-test-manifest missing on test classpath",
-                    detail = "see docs",
-                    remediation = DoctorRemediation(
-                        summary = "add it",
-                        commands = listOf("testImplementation(\"x:y\")"),
-                        docs = "https://example.com",
-                    ),
+  @Test
+  fun `round-trips a report with all fields populated`() {
+    val report =
+      DoctorReport(
+        schema = "compose-preview-doctor/v1",
+        pluginVersion = "0.4.0",
+        overall = "warning",
+        checks =
+          listOf(
+            DoctorCheck(
+              id = "env.java-17",
+              category = "env",
+              status = "ok",
+              message = "Java 17 on PATH",
+            ),
+            DoctorCheck(
+              id = "deps.app.ui-test-manifest-missing",
+              category = "deps",
+              status = "error",
+              message = ":app — ui-test-manifest missing on test classpath",
+              detail = "see docs",
+              remediation =
+                DoctorRemediation(
+                  summary = "add it",
+                  commands = listOf("testImplementation(\"x:y\")"),
+                  docs = "https://example.com",
                 ),
             ),
-            summary = DoctorSummary(ok = 1, warning = 0, error = 1, skipped = 0),
-        )
+          ),
+        summary = DoctorSummary(ok = 1, warning = 0, error = 1, skipped = 0),
+      )
 
-        val json = kotlinx.serialization.json.Json { prettyPrint = true; encodeDefaults = true }
-        val text = json.encodeToString(DoctorReport.serializer(), report)
-        val parsed = json.decodeFromString(DoctorReport.serializer(), text)
-        assertEquals(report, parsed)
+    val json =
+      kotlinx.serialization.json.Json {
+        prettyPrint = true
+        encodeDefaults = true
+      }
+    val text = json.encodeToString(DoctorReport.serializer(), report)
+    val parsed = json.decodeFromString(DoctorReport.serializer(), text)
+    assertEquals(report, parsed)
 
-        // Schema contract — consumers should be able to grep for this
-        // without parsing the whole document.
-        assertTrue("\"schema\": \"compose-preview-doctor/v1\"" in text)
-    }
+    // Schema contract — consumers should be able to grep for this
+    // without parsing the whole document.
+    assertTrue("\"schema\": \"compose-preview-doctor/v1\"" in text)
+  }
 
-    @Test fun `default schema field stays at v1`() {
-        // Bump this test intentionally when rolling to v2 — guards against
-        // accidentally breaking the CLI→agent contract.
-        val report = DoctorReport(
-            pluginVersion = "0.0.0",
-            overall = "ok",
-            checks = emptyList(),
-            summary = DoctorSummary(0, 0, 0, 0),
-        )
-        assertEquals("compose-preview-doctor/v1", report.schema)
-    }
+  @Test
+  fun `default schema field stays at v1`() {
+    // Bump this test intentionally when rolling to v2 — guards against
+    // accidentally breaking the CLI→agent contract.
+    val report =
+      DoctorReport(
+        pluginVersion = "0.0.0",
+        overall = "ok",
+        checks = emptyList(),
+        summary = DoctorSummary(0, 0, 0, 0),
+      )
+    assertEquals("compose-preview-doctor/v1", report.schema)
+  }
 
-    @Test fun `renderPreviews task-info serialises round-trip`() {
-        // The nested RenderPreviewsTaskInfo model sits behind the
-        // project.<module>.render-previews-jvm check — verify it
-        // serialises cleanly via the CLI's action type so the JSON
-        // output mode in `doctor --json` stays stable for agents
-        // consuming the new fields.
-        val info = SerializableModuleInfo(
-            variant = "debug",
-            mainRuntimeDependencies = emptyMap(),
-            testRuntimeDependencies = mapOf("org.robolectric:robolectric" to "4.16"),
-            findings = emptyList(),
-            agpVersion = "9.1.0",
-            kotlinVersion = "2.2.21",
-            renderPreviewsTask = SerializableRenderPreviewsTaskInfo(
-                javaLauncherPinned = false,
-                javaLauncherVersion = "25",
-                javaLauncherVendor = "Google Inc.",
-                javaLauncherPath = "/usr/lib/jvm/jdk25",
-                classpathSize = 412,
-                bootstrapClasspathSize = 0,
-                jvmArgs = listOf("--add-opens=java.base/java.nio=ALL-UNNAMED"),
-            ),
-        )
-        assertEquals("9.1.0", info.agpVersion)
-        assertEquals("25", info.renderPreviewsTask?.javaLauncherVersion)
-        assertEquals(412, info.renderPreviewsTask?.classpathSize)
-    }
+  @Test
+  fun `renderPreviews task-info serialises round-trip`() {
+    // The nested RenderPreviewsTaskInfo model sits behind the
+    // project.<module>.render-previews-jvm check — verify it
+    // serialises cleanly via the CLI's action type so the JSON
+    // output mode in `doctor --json` stays stable for agents
+    // consuming the new fields.
+    val info =
+      SerializableModuleInfo(
+        variant = "debug",
+        mainRuntimeDependencies = emptyMap(),
+        testRuntimeDependencies = mapOf("org.robolectric:robolectric" to "4.16"),
+        findings = emptyList(),
+        agpVersion = "9.1.0",
+        kotlinVersion = "2.2.21",
+        renderPreviewsTask =
+          SerializableRenderPreviewsTaskInfo(
+            javaLauncherPinned = false,
+            javaLauncherVersion = "25",
+            javaLauncherVendor = "Google Inc.",
+            javaLauncherPath = "/usr/lib/jvm/jdk25",
+            classpathSize = 412,
+            bootstrapClasspathSize = 0,
+            jvmArgs = listOf("--add-opens=java.base/java.nio=ALL-UNNAMED"),
+          ),
+      )
+    assertEquals("9.1.0", info.agpVersion)
+    assertEquals("25", info.renderPreviewsTask?.javaLauncherVersion)
+    assertEquals(412, info.renderPreviewsTask?.classpathSize)
+  }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
@@ -1,113 +1,126 @@
 package ee.schimke.composeai.cli
 
-import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
 
 class PreviewListResponseTest {
-    private val json = Json { prettyPrint = false; encodeDefaults = true; ignoreUnknownKeys = true }
+  private val json = Json {
+    prettyPrint = false
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+  }
 
-    @Test
-    fun `envelope pins schema and round-trips captures`() {
-        val response = PreviewListResponse(
-            previews = listOf(
-                PreviewResult(
-                    id = "Preview_A",
-                    module = "sample-android",
-                    functionName = "PreviewA",
-                    className = "com.example.PreviewsKt",
-                    sourceFile = "Previews.kt",
-                    captures = listOf(
-                        CaptureResult(
-                            advanceTimeMillis = 0L,
-                            pngPath = "/abs/A_TIME_0ms.png",
-                            sha256 = "deadbeef",
-                            changed = true,
-                        ),
-                        CaptureResult(
-                            advanceTimeMillis = 500L,
-                            pngPath = "/abs/A_TIME_500ms.png",
-                            sha256 = "feedface",
-                            changed = false,
-                        ),
-                    ),
+  @Test
+  fun `envelope pins schema and round-trips captures`() {
+    val response =
+      PreviewListResponse(
+        previews =
+          listOf(
+            PreviewResult(
+              id = "Preview_A",
+              module = "sample-android",
+              functionName = "PreviewA",
+              className = "com.example.PreviewsKt",
+              sourceFile = "Previews.kt",
+              captures =
+                listOf(
+                  CaptureResult(
+                    advanceTimeMillis = 0L,
                     pngPath = "/abs/A_TIME_0ms.png",
                     sha256 = "deadbeef",
                     changed = true,
+                  ),
+                  CaptureResult(
+                    advanceTimeMillis = 500L,
+                    pngPath = "/abs/A_TIME_500ms.png",
+                    sha256 = "feedface",
+                    changed = false,
+                  ),
                 ),
-            ),
-            counts = PreviewCounts(total = 1, changed = 1, unchanged = 0, missing = 0),
-        )
+              pngPath = "/abs/A_TIME_0ms.png",
+              sha256 = "deadbeef",
+              changed = true,
+            )
+          ),
+        counts = PreviewCounts(total = 1, changed = 1, unchanged = 0, missing = 0),
+      )
 
-        val text = json.encodeToString(PreviewListResponse.serializer(), response)
-        val parsed = json.decodeFromString(PreviewListResponse.serializer(), text)
-        assertEquals(response, parsed)
+    val text = json.encodeToString(PreviewListResponse.serializer(), response)
+    val parsed = json.decodeFromString(PreviewListResponse.serializer(), text)
+    assertEquals(response, parsed)
 
-        // Schema is the agent contract — keep it greppable without parsing.
-        assertTrue("\"schema\":\"$SHOW_LIST_SCHEMA\"" in text)
-        // Multi-capture fan-out is faithfully serialised.
-        assertEquals(2, parsed.previews.single().captures.size)
-        assertEquals(500L, parsed.previews.single().captures[1].advanceTimeMillis)
-    }
+    // Schema is the agent contract — keep it greppable without parsing.
+    assertTrue("\"schema\":\"$SHOW_LIST_SCHEMA\"" in text)
+    // Multi-capture fan-out is faithfully serialised.
+    assertEquals(2, parsed.previews.single().captures.size)
+    assertEquals(500L, parsed.previews.single().captures[1].advanceTimeMillis)
+  }
 
-    @Test
-    fun `default schema field stays at v1`() {
-        // Bump this test deliberately when rolling to v2 — guards against
-        // accidentally breaking the CLI→agent contract.
-        val response = PreviewListResponse(previews = emptyList())
-        assertEquals("compose-preview-show/v1", response.schema)
-    }
+  @Test
+  fun `default schema field stays at v1`() {
+    // Bump this test deliberately when rolling to v2 — guards against
+    // accidentally breaking the CLI→agent contract.
+    val response = PreviewListResponse(previews = emptyList())
+    assertEquals("compose-preview-show/v1", response.schema)
+  }
 
-    @Test
-    fun `brief response drops null and default fields`() {
-        // encodeDefaults=false on the brief encoder is the lever that makes
-        // this work — verify it actually fires.
-        val response = BriefPreviewListResponse(
-            previews = listOf(
-                BriefPreviewResult(
-                    id = "P",
-                    captures = listOf(
-                        BriefCapture(png = "/p.png", sha = "abcdef012345", changed = true),
-                    ),
-                ),
-            ),
-            counts = PreviewCounts(total = 1, changed = 1, unchanged = 0, missing = 0),
-        )
-        val brief = Json { prettyPrint = false; encodeDefaults = false }
-            .encodeToString(BriefPreviewListResponse.serializer(), response)
+  @Test
+  fun `brief response drops null and default fields`() {
+    // encodeDefaults=false on the brief encoder is the lever that makes
+    // this work — verify it actually fires.
+    val response =
+      BriefPreviewListResponse(
+        previews =
+          listOf(
+            BriefPreviewResult(
+              id = "P",
+              captures = listOf(BriefCapture(png = "/p.png", sha = "abcdef012345", changed = true)),
+            )
+          ),
+        counts = PreviewCounts(total = 1, changed = 1, unchanged = 0, missing = 0),
+      )
+    val brief =
+      Json {
+          prettyPrint = false
+          encodeDefaults = false
+        }
+        .encodeToString(BriefPreviewListResponse.serializer(), response)
 
-        // Schema and core fields are present.
-        assertTrue(""""schema":"$SHOW_LIST_BRIEF_SCHEMA"""" in brief)
-        assertTrue(""""id":"P"""" in brief)
-        assertTrue(""""png":"/p.png"""" in brief)
-        // Nulls / unspecified optionals are absent.
-        assertTrue("\"module\"" !in brief)
-        assertTrue("\"a11y\"" !in brief)
-        assertTrue("\"time\"" !in brief)
-        assertTrue("\"scroll\"" !in brief)
-    }
+    // Schema and core fields are present.
+    assertTrue(""""schema":"$SHOW_LIST_BRIEF_SCHEMA"""" in brief)
+    assertTrue(""""id":"P"""" in brief)
+    assertTrue(""""png":"/p.png"""" in brief)
+    // Nulls / unspecified optionals are absent.
+    assertTrue("\"module\"" !in brief)
+    assertTrue("\"a11y\"" !in brief)
+    assertTrue("\"time\"" !in brief)
+    assertTrue("\"scroll\"" !in brief)
+  }
 
-    @Test
-    fun `manifest with old-shape renderOutput still parses via ignoreUnknownKeys`() {
-        // Pre-multi-capture manifests had `renderOutput` directly on
-        // `PreviewInfo`. New CLI types don't carry that field; verify they
-        // still parse without throwing (it's just dropped).
-        val legacy = """
-            {
-              "module":"m",
-              "variant":"debug",
-              "previews":[{
-                "id":"X","functionName":"X","className":"K",
-                "params":{"name":null,"group":"g"},
-                "renderOutput":"renders/X.png"
-              }]
-            }
-        """.trimIndent()
-        val parsed = json.decodeFromString(PreviewManifest.serializer(), legacy)
-        assertEquals("X", parsed.previews.single().id)
-        assertEquals("g", parsed.previews.single().params.group)
-        // Default capture list is a single empty capture.
-        assertEquals(1, parsed.previews.single().captures.size)
-    }
+  @Test
+  fun `manifest with old-shape renderOutput still parses via ignoreUnknownKeys`() {
+    // Pre-multi-capture manifests had `renderOutput` directly on
+    // `PreviewInfo`. New CLI types don't carry that field; verify they
+    // still parse without throwing (it's just dropped).
+    val legacy =
+      """
+      {
+        "module":"m",
+        "variant":"debug",
+        "previews":[{
+          "id":"X","functionName":"X","className":"K",
+          "params":{"name":null,"group":"g"},
+          "renderOutput":"renders/X.png"
+        }]
+      }
+      """
+        .trimIndent()
+    val parsed = json.decodeFromString(PreviewManifest.serializer(), legacy)
+    assertEquals("X", parsed.previews.single().id)
+    assertEquals("g", parsed.previews.single().params.group)
+    // Default capture list is a single empty capture.
+    assertEquals(1, parsed.previews.single().captures.size)
+  }
 }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,162 +1,163 @@
 plugins {
-    `java-gradle-plugin`
-    `kotlin-dsl`
-    `maven-publish`
-    alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.maven.publish)
-    alias(libs.plugins.ktfmt)
+  `java-gradle-plugin`
+  `kotlin-dsl`
+  `maven-publish`
+  alias(libs.plugins.kotlin.serialization)
+  alias(libs.plugins.maven.publish)
+  alias(libs.plugins.ktfmt)
 }
 
-ktfmt {
-    googleStyle()
-}
+ktfmt { googleStyle() }
 
 group = "ee.schimke.composeai"
+
 // CI sets PLUGIN_VERSION: release.yml passes the git tag (stripped of `v`);
 // snapshot.yml passes `<last-tag-patch+1>-SNAPSHOT`. Local builds fall back
 // to the next-patch SNAPSHOT derived from `.release-please-manifest.json`
 // at the outer repo root (this project is loaded as an included build, so
 // its own rootDir is `gradle-plugin/` — walk up one level).
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: run {
-    val manifest = rootDir.parentFile.resolve(".release-please-manifest.json").readText()
-    val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-    val (major, minor, patch) = current.split(".").map { it.toInt() }
-    "$major.$minor.${patch + 1}-SNAPSHOT"
-}
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.parentFile.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
 
 gradlePlugin {
-    website.set("https://github.com/yschimke/compose-ai-tools")
-    vcsUrl.set("https://github.com/yschimke/compose-ai-tools.git")
-    plugins {
-        create("composePreview") {
-            id = "ee.schimke.composeai.preview"
-            implementationClass = "ee.schimke.composeai.plugin.ComposePreviewPlugin"
-            displayName = "Compose Preview Plugin"
-            description = "Discover and render Jetpack Compose / Compose Multiplatform @Preview functions to PNG"
-            tags.set(listOf("compose", "preview", "android", "jetpack-compose", "rendering"))
-        }
+  website.set("https://github.com/yschimke/compose-ai-tools")
+  vcsUrl.set("https://github.com/yschimke/compose-ai-tools.git")
+  plugins {
+    create("composePreview") {
+      id = "ee.schimke.composeai.preview"
+      implementationClass = "ee.schimke.composeai.plugin.ComposePreviewPlugin"
+      displayName = "Compose Preview Plugin"
+      description =
+        "Discover and render Jetpack Compose / Compose Multiplatform @Preview functions to PNG"
+      tags.set(listOf("compose", "preview", "android", "jetpack-compose", "rendering"))
     }
+  }
 }
 
 // Publish to both GitHub Packages (legacy / CI convenience) and Maven Central
 // via the new Central Portal. Snapshots (version ending in `-SNAPSHOT`) route
 // automatically to `https://central.sonatype.com/repository/maven-snapshots/`.
 publishing {
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri(
-                providers.environmentVariable("GITHUB_REPOSITORY")
-                    .map { "https://maven.pkg.github.com/$it" }
-                    .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools"),
-            )
-            credentials {
-                username = providers.environmentVariable("GITHUB_ACTOR").orNull
-                password = providers.environmentVariable("GITHUB_TOKEN").orNull
-            }
-        }
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
     }
+  }
 }
 
 mavenPublishing {
-    // Central Portal (https://central.sonatype.com) is the only target in
-    // vanniktech ≥ 0.34. `automaticRelease = true` promotes to the central
-    // repo without a manual "release" click in the Portal UI. Snapshots route
-    // to https://central.sonatype.com/repository/maven-snapshots/ automatically.
-    publishToMavenCentral(automaticRelease = true)
-    // Vanniktech auto-detects `java-gradle-plugin` and publishes the plugin +
-    // marker artifacts with sources/javadoc jars. (If we ever apply the
-    // `com.gradle.plugin-publish` plugin for Plugin Portal, swap in
-    // `configure(GradlePublishPlugin())`.)
-    // Only require signing for non-snapshot builds — snapshots are unsigned on
-    // the Central snapshots repo, which is convenient for local/dev publishes.
-    if (!version.toString().endsWith("SNAPSHOT")) {
-        signAllPublications()
-    }
+  // Central Portal (https://central.sonatype.com) is the only target in
+  // vanniktech ≥ 0.34. `automaticRelease = true` promotes to the central
+  // repo without a manual "release" click in the Portal UI. Snapshots route
+  // to https://central.sonatype.com/repository/maven-snapshots/ automatically.
+  publishToMavenCentral(automaticRelease = true)
+  // Vanniktech auto-detects `java-gradle-plugin` and publishes the plugin +
+  // marker artifacts with sources/javadoc jars. (If we ever apply the
+  // `com.gradle.plugin-publish` plugin for Plugin Portal, swap in
+  // `configure(GradlePublishPlugin())`.)
+  // Only require signing for non-snapshot builds — snapshots are unsigned on
+  // the Central snapshots repo, which is convenient for local/dev publishes.
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
 
-    coordinates("ee.schimke.composeai", "compose-preview-plugin", version.toString())
+  coordinates("ee.schimke.composeai", "compose-preview-plugin", version.toString())
 
-    pom {
-        name.set("Compose Preview Gradle Plugin")
-        description.set(
-            "Gradle plugin to discover and render Jetpack Compose / Compose Multiplatform " +
-                "@Preview functions to PNG outside Android Studio.",
-        )
-        url.set("https://github.com/yschimke/compose-ai-tools")
-        inceptionYear.set("2025")
-        licenses {
-            license {
-                name.set("The Apache License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-                distribution.set("repo")
-            }
-        }
-        developers {
-            developer {
-                id.set("yschimke")
-                name.set("Yuri Schimke")
-                url.set("https://github.com/yschimke")
-            }
-        }
-        scm {
-            url.set("https://github.com/yschimke/compose-ai-tools")
-            connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-            developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-        }
+  pom {
+    name.set("Compose Preview Gradle Plugin")
+    description.set(
+      "Gradle plugin to discover and render Jetpack Compose / Compose Multiplatform " +
+        "@Preview functions to PNG outside Android Studio."
+    )
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2025")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
     }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
 }
 
 dependencies {
-    implementation(libs.classgraph)
-    implementation(libs.kotlinx.serialization.json)
-    compileOnly("com.android.tools.build:gradle:${libs.versions.agp.get()}")
+  implementation(libs.classgraph)
+  implementation(libs.kotlinx.serialization.json)
+  compileOnly("com.android.tools.build:gradle:${libs.versions.agp.get()}")
 
-    testImplementation(libs.junit)
-    testImplementation(libs.truth)
-    testImplementation(gradleTestKit())
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+  testImplementation(gradleTestKit())
 }
 
-java {
-    toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
-}
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 // Functional tests use Gradle TestKit
 val functionalTest by sourceSets.creating {
-    compileClasspath += sourceSets.main.get().output
-    runtimeClasspath += sourceSets.main.get().output
+  compileClasspath += sourceSets.main.get().output
+  runtimeClasspath += sourceSets.main.get().output
 }
 
 val functionalTestImplementation by configurations.getting {
-    extendsFrom(configurations.testImplementation.get())
+  extendsFrom(configurations.testImplementation.get())
 }
 
 val functionalTestRuntimeOnly by configurations.getting {
-    extendsFrom(configurations.testRuntimeOnly.get())
+  extendsFrom(configurations.testRuntimeOnly.get())
 }
 
-val functionalTestTask = tasks.register<Test>("functionalTest") {
+val functionalTestTask =
+  tasks.register<Test>("functionalTest") {
     testClassesDirs = functionalTest.output.classesDirs
     classpath = functionalTest.runtimeClasspath
     useJUnit()
-}
+  }
 
-tasks.check {
-    dependsOn(functionalTestTask)
-}
+tasks.check { dependsOn(functionalTestTask) }
 
 // Bake the plugin's own version into a resource so it can resolve a matching
 // `renderer-android` AAR at runtime for external consumers (who apply the
 // plugin via GitHub Packages rather than includeBuild).
 val generatePluginVersionResource by tasks.registering {
-    val outputDir = layout.buildDirectory.dir("generated/plugin-version-resource")
-    val pluginVersion = project.version.toString()
-    inputs.property("version", pluginVersion)
-    outputs.dir(outputDir)
-    doLast {
-        val file = outputDir.get().file("ee/schimke/composeai/plugin/plugin-version.properties").asFile
-        file.parentFile.mkdirs()
-        file.writeText("version=$pluginVersion\n")
-    }
+  val outputDir = layout.buildDirectory.dir("generated/plugin-version-resource")
+  val pluginVersion = project.version.toString()
+  inputs.property("version", pluginVersion)
+  outputs.dir(outputDir)
+  doLast {
+    val file = outputDir.get().file("ee/schimke/composeai/plugin/plugin-version.properties").asFile
+    file.parentFile.mkdirs()
+    file.writeText("version=$pluginVersion\n")
+  }
 }
 
 sourceSets.main.get().resources.srcDir(generatePluginVersionResource)

--- a/gradle-plugin/settings.gradle.kts
+++ b/gradle-plugin/settings.gradle.kts
@@ -1,17 +1,17 @@
 pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        google()
-        mavenCentral()
-    }
+  repositories {
+    gradlePluginPortal()
+    google()
+    mavenCentral()
+  }
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        google()
-        mavenCentral()
-    }
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    google()
+    mavenCentral()
+  }
 }
 
 rootProject.name = "gradle-plugin"

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AppliedMarkerFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AppliedMarkerFunctionalTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import java.io.File
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.gradle.testkit.runner.GradleRunner
@@ -8,127 +9,134 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import java.io.File
 
 /**
- * Exercises the `composePreviewApplied` task — the sidecar-JSON "applied"
- * marker consumed by the VS Code extension. Kept deliberately lean: the
- * task has no Compose or AGP dependencies, so the test project only needs
- * `kotlin("jvm")` + the plugin. Much faster than [DiscoveryFunctionalTest].
+ * Exercises the `composePreviewApplied` task — the sidecar-JSON "applied" marker consumed by the VS
+ * Code extension. Kept deliberately lean: the task has no Compose or AGP dependencies, so the test
+ * project only needs `kotlin("jvm")` + the plugin. Much faster than [DiscoveryFunctionalTest].
  */
 class AppliedMarkerFunctionalTest {
 
-    @get:Rule
-    val tempDir = TemporaryFolder()
+  @get:Rule val tempDir = TemporaryFolder()
 
-    private val json = Json { ignoreUnknownKeys = true }
+  private val json = Json { ignoreUnknownKeys = true }
 
-    @Serializable
-    private data class AppliedMarker(
-        val schema: String,
-        val pluginVersion: String,
-        val modulePath: String,
-        val moduleName: String,
-    )
+  @Serializable
+  private data class AppliedMarker(
+    val schema: String,
+    val pluginVersion: String,
+    val modulePath: String,
+    val moduleName: String,
+  )
 
-    private fun createBareProject(): File {
-        val projectDir = tempDir.root
+  private fun createBareProject(): File {
+    val projectDir = tempDir.root
 
-        File(projectDir, "settings.gradle.kts").writeText(
-            """
-            pluginManagement {
-                repositories { gradlePluginPortal() }
-            }
-            rootProject.name = "marker-test"
-            """.trimIndent(),
-        )
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories { gradlePluginPortal() }
+        }
+        rootProject.name = "marker-test"
+        """
+          .trimIndent()
+      )
 
-        File(projectDir, "build.gradle.kts").writeText(
-            """
-            plugins {
-                kotlin("jvm") version "2.2.21"
-                id("ee.schimke.composeai.preview")
-            }
-            """.trimIndent(),
-        )
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
+        plugins {
+            kotlin("jvm") version "2.2.21"
+            id("ee.schimke.composeai.preview")
+        }
+        """
+          .trimIndent()
+      )
 
-        // Configuration cache + Isolated Projects on by default — every
-        // assertion in this file is implicitly an IP/CC-safety assertion.
-        File(projectDir, "gradle.properties").writeText(
-            """
-            org.gradle.configuration-cache=true
-            org.gradle.unsafe.isolated-projects=true
-            """.trimIndent(),
-        )
+    // Configuration cache + Isolated Projects on by default — every
+    // assertion in this file is implicitly an IP/CC-safety assertion.
+    File(projectDir, "gradle.properties")
+      .writeText(
+        """
+        org.gradle.configuration-cache=true
+        org.gradle.unsafe.isolated-projects=true
+        """
+          .trimIndent()
+      )
 
-        return projectDir
-    }
+    return projectDir
+  }
 
-    @Test
-    fun `composePreviewApplied writes the sidecar JSON at a stable path`() {
-        val projectDir = createBareProject()
+  @Test
+  fun `composePreviewApplied writes the sidecar JSON at a stable path`() {
+    val projectDir = createBareProject()
 
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("composePreviewApplied", "--stacktrace")
-            .withPluginClasspath()
-            .build()
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewApplied", "--stacktrace")
+        .withPluginClasspath()
+        .build()
 
-        assertThat(result.task(":composePreviewApplied")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(result.task(":composePreviewApplied")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
-        val marker = File(projectDir, "build/compose-previews/applied.json")
-        assertThat(marker.exists()).isTrue()
+    val marker = File(projectDir, "build/compose-previews/applied.json")
+    assertThat(marker.exists()).isTrue()
 
-        val parsed = json.decodeFromString<AppliedMarker>(marker.readText())
-        assertThat(parsed.schema).isEqualTo("compose-preview-applied/v1")
-        assertThat(parsed.modulePath).isEqualTo(":")
-        assertThat(parsed.moduleName).isEqualTo("marker-test")
-        assertThat(parsed.pluginVersion).isNotEmpty()
-    }
+    val parsed = json.decodeFromString<AppliedMarker>(marker.readText())
+    assertThat(parsed.schema).isEqualTo("compose-preview-applied/v1")
+    assertThat(parsed.modulePath).isEqualTo(":")
+    assertThat(parsed.moduleName).isEqualTo("marker-test")
+    assertThat(parsed.pluginVersion).isNotEmpty()
+  }
 
-    @Test
-    fun `composePreviewApplied is UP-TO-DATE on repeat runs`() {
-        val projectDir = createBareProject()
+  @Test
+  fun `composePreviewApplied is UP-TO-DATE on repeat runs`() {
+    val projectDir = createBareProject()
 
-        GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("composePreviewApplied")
-            .withPluginClasspath()
-            .build()
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("composePreviewApplied")
+      .withPluginClasspath()
+      .build()
 
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("composePreviewApplied")
-            .withPluginClasspath()
-            .build()
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewApplied")
+        .withPluginClasspath()
+        .build()
 
-        assertThat(result.task(":composePreviewApplied")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
-    }
+    assertThat(result.task(":composePreviewApplied")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+  }
 
-    @Test
-    fun `configuration cache is reused across runs`() {
-        val projectDir = createBareProject()
+  @Test
+  fun `configuration cache is reused across runs`() {
+    val projectDir = createBareProject()
 
-        // First run stores the CC entry. `--info` surfaces the
-        // "Configuration cache entry stored" / "reused" messages we want to
-        // assert on — Gradle itself doesn't fail the build on an IP/CC
-        // violation at this level, so we verify by output inspection.
-        val first = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("composePreviewApplied", "--info")
-            .withPluginClasspath()
-            .build()
-        assertThat(first.output).contains("Configuration cache entry stored")
+    // First run stores the CC entry. `--info` surfaces the
+    // "Configuration cache entry stored" / "reused" messages we want to
+    // assert on — Gradle itself doesn't fail the build on an IP/CC
+    // violation at this level, so we verify by output inspection.
+    val first =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewApplied", "--info")
+        .withPluginClasspath()
+        .build()
+    assertThat(first.output).contains("Configuration cache entry stored")
 
-        val second = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("composePreviewApplied", "--info")
-            .withPluginClasspath()
-            .build()
-        // "reused" is the string Gradle prints when the cache hit is clean.
-        // Anything that violated CC invariants during config would have
-        // caused "discarded" or an outright failure — both of which we'd
-        // catch here.
-        assertThat(second.output).contains("Reusing configuration cache")
-    }
+    val second =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("composePreviewApplied", "--info")
+        .withPluginClasspath()
+        .build()
+    // "reused" is the string Gradle prints when the cache hit is clean.
+    // Anything that violated CC invariants during config would have
+    // caused "discarded" or an outright failure — both of which we'd
+    // catch here.
+    assertThat(second.output).contains("Reusing configuration cache")
+  }
 }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ColorValidationTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/ColorValidationTest.kt
@@ -1,233 +1,234 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
 import kotlinx.serialization.json.Json
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import java.awt.image.BufferedImage
-import java.io.File
-import javax.imageio.ImageIO
 
 class ColorValidationTest {
 
-    @get:Rule
-    val tempDir = TemporaryFolder()
+  @get:Rule val tempDir = TemporaryFolder()
 
-    private val json = Json { ignoreUnknownKeys = true }
+  private val json = Json { ignoreUnknownKeys = true }
 
-    private fun createColorProject(): File {
-        val projectDir = tempDir.root
+  private fun createColorProject(): File {
+    val projectDir = tempDir.root
 
-        File(projectDir, "settings.gradle.kts").writeText(
-            """
-            pluginManagement {
-                repositories {
-                    gradlePluginPortal()
-                    google()
-                    mavenCentral()
-                }
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                google()
+                mavenCentral()
             }
-            dependencyResolutionManagement {
-                repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-                repositories {
-                    google()
-                    mavenCentral()
-                }
+        }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                google()
+                mavenCentral()
             }
-            rootProject.name = "test-colors"
-            """.trimIndent()
+        }
+        rootProject.name = "test-colors"
+        """
+          .trimIndent()
+      )
+
+    // Uses Android-style @Preview with backgroundColor parameter
+    // For CMP, we use a custom approach since the desktop @Preview doesn't have backgroundColor
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
+        @file:Suppress("DEPRECATION")
+        plugins {
+            kotlin("jvm") version "2.2.21"
+            kotlin("plugin.compose") version "2.2.21"
+            id("org.jetbrains.compose") version "1.10.3"
+            id("ee.schimke.composeai.preview")
+        }
+        dependencies {
+            implementation(compose.desktop.currentOs)
+            implementation(compose.material3)
+            implementation(compose.uiTooling)
+            implementation(compose.components.uiToolingPreview)
+        }
+        java {
+            toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+        }
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "gradle.properties").writeText("org.gradle.configuration-cache=true\n")
+
+    val srcDir = File(projectDir, "src/main/kotlin/test")
+    srcDir.mkdirs()
+    File(srcDir, "ColorPreviews.kt")
+      .writeText(
+        """
+        package test
+
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.foundation.background
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.graphics.Color
+        import androidx.compose.ui.unit.dp
+
+        @Preview(
+            name = "Red",
+            showBackground = true,
+            backgroundColor = 0xFFFF0000,
+            widthDp = 50,
+            heightDp = 50,
         )
+        @Composable
+        fun RedPreview() {
+            Box(modifier = Modifier.size(50.dp).background(Color.Red))
+        }
 
-        // Uses Android-style @Preview with backgroundColor parameter
-        // For CMP, we use a custom approach since the desktop @Preview doesn't have backgroundColor
-        File(projectDir, "build.gradle.kts").writeText(
-            """
-            @file:Suppress("DEPRECATION")
-            plugins {
-                kotlin("jvm") version "2.2.21"
-                kotlin("plugin.compose") version "2.2.21"
-                id("org.jetbrains.compose") version "1.10.3"
-                id("ee.schimke.composeai.preview")
-            }
-            dependencies {
-                implementation(compose.desktop.currentOs)
-                implementation(compose.material3)
-                implementation(compose.uiTooling)
-                implementation(compose.components.uiToolingPreview)
-            }
-            java {
-                toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
-            }
-            """.trimIndent()
+        @Preview(
+            name = "Blue",
+            showBackground = true,
+            backgroundColor = 0xFF0000FF,
+            widthDp = 50,
+            heightDp = 50,
         )
+        @Composable
+        fun BluePreview() {
+            Box(modifier = Modifier.size(50.dp).background(Color.Blue))
+        }
 
-        File(projectDir, "gradle.properties").writeText(
-            "org.gradle.configuration-cache=true\n"
+        @Preview(
+            name = "Green",
+            showBackground = true,
+            backgroundColor = 0xFF00FF00,
+            widthDp = 50,
+            heightDp = 50,
         )
+        @Composable
+        fun GreenPreview() {
+            Box(modifier = Modifier.size(50.dp).background(Color.Green))
+        }
+        """
+          .trimIndent()
+      )
 
-        val srcDir = File(projectDir, "src/main/kotlin/test")
-        srcDir.mkdirs()
-        File(srcDir, "ColorPreviews.kt").writeText(
-            """
-            package test
+    return projectDir
+  }
 
-            import androidx.compose.ui.tooling.preview.Preview
-            import androidx.compose.foundation.background
-            import androidx.compose.foundation.layout.Box
-            import androidx.compose.foundation.layout.size
-            import androidx.compose.runtime.Composable
-            import androidx.compose.ui.Modifier
-            import androidx.compose.ui.graphics.Color
-            import androidx.compose.ui.unit.dp
+  @Test
+  fun `red preview renders with red background color`() {
+    val projectDir = createColorProject()
 
-            @Preview(
-                name = "Red",
-                showBackground = true,
-                backgroundColor = 0xFFFF0000,
-                widthDp = 50,
-                heightDp = 50,
-            )
-            @Composable
-            fun RedPreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Red))
-            }
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("renderAllPreviews", "--stacktrace")
+      .withPluginClasspath()
+      .build()
 
-            @Preview(
-                name = "Blue",
-                showBackground = true,
-                backgroundColor = 0xFF0000FF,
-                widthDp = 50,
-                heightDp = 50,
-            )
-            @Composable
-            fun BluePreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Blue))
-            }
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
 
-            @Preview(
-                name = "Green",
-                showBackground = true,
-                backgroundColor = 0xFF00FF00,
-                widthDp = 50,
-                heightDp = 50,
-            )
-            @Composable
-            fun GreenPreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Green))
-            }
-            """.trimIndent()
-        )
+    val redPreview = manifest.previews.find { it.params.name == "Red" }
+    assertThat(redPreview).isNotNull()
+    assertThat(redPreview!!.params.backgroundColor).isEqualTo(0xFFFF0000)
 
-        return projectDir
-    }
+    val pngFile =
+      File(projectDir, "build/compose-previews/${redPreview.captures.first().renderOutput}")
+    assertThat(pngFile.exists()).isTrue()
 
-    @Test
-    fun `red preview renders with red background color`() {
-        val projectDir = createColorProject()
+    val img: BufferedImage = ImageIO.read(pngFile)
+    // Check center pixel is red (0xFFFF0000)
+    val centerPixel = img.getRGB(img.width / 2, img.height / 2)
+    assertThat(centerPixel).isEqualTo(0xFFFF0000.toInt())
+  }
 
-        GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("renderAllPreviews", "--stacktrace")
-            .withPluginClasspath()
-            .build()
+  @Test
+  fun `blue preview renders with blue background color`() {
+    val projectDir = createColorProject()
 
-        val manifest = json.decodeFromString<PreviewManifest>(
-            File(projectDir, "build/compose-previews/previews.json").readText()
-        )
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("renderAllPreviews")
+      .withPluginClasspath()
+      .build()
 
-        val redPreview = manifest.previews.find { it.params.name == "Red" }
-        assertThat(redPreview).isNotNull()
-        assertThat(redPreview!!.params.backgroundColor).isEqualTo(0xFFFF0000)
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
 
-        val pngFile = File(
-            projectDir,
-            "build/compose-previews/${redPreview.captures.first().renderOutput}",
-        )
-        assertThat(pngFile.exists()).isTrue()
+    val bluePreview = manifest.previews.find { it.params.name == "Blue" }
+    assertThat(bluePreview).isNotNull()
 
-        val img: BufferedImage = ImageIO.read(pngFile)
-        // Check center pixel is red (0xFFFF0000)
-        val centerPixel = img.getRGB(img.width / 2, img.height / 2)
-        assertThat(centerPixel).isEqualTo(0xFFFF0000.toInt())
-    }
+    val pngFile =
+      File(projectDir, "build/compose-previews/${bluePreview!!.captures.first().renderOutput}")
+    assertThat(pngFile.exists()).isTrue()
 
-    @Test
-    fun `blue preview renders with blue background color`() {
-        val projectDir = createColorProject()
+    val img: BufferedImage = ImageIO.read(pngFile)
+    val centerPixel = img.getRGB(img.width / 2, img.height / 2)
+    assertThat(centerPixel).isEqualTo(0xFF0000FF.toInt())
+  }
 
-        GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("renderAllPreviews")
-            .withPluginClasspath()
-            .build()
+  @Test
+  fun `green preview renders with green background color`() {
+    val projectDir = createColorProject()
 
-        val manifest = json.decodeFromString<PreviewManifest>(
-            File(projectDir, "build/compose-previews/previews.json").readText()
-        )
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("renderAllPreviews")
+      .withPluginClasspath()
+      .build()
 
-        val bluePreview = manifest.previews.find { it.params.name == "Blue" }
-        assertThat(bluePreview).isNotNull()
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
 
-        val pngFile = File(
-            projectDir,
-            "build/compose-previews/${bluePreview!!.captures.first().renderOutput}",
-        )
-        assertThat(pngFile.exists()).isTrue()
+    val greenPreview = manifest.previews.find { it.params.name == "Green" }
+    assertThat(greenPreview).isNotNull()
 
-        val img: BufferedImage = ImageIO.read(pngFile)
-        val centerPixel = img.getRGB(img.width / 2, img.height / 2)
-        assertThat(centerPixel).isEqualTo(0xFF0000FF.toInt())
-    }
+    val pngFile =
+      File(projectDir, "build/compose-previews/${greenPreview!!.captures.first().renderOutput}")
+    assertThat(pngFile.exists()).isTrue()
 
-    @Test
-    fun `green preview renders with green background color`() {
-        val projectDir = createColorProject()
+    val img: BufferedImage = ImageIO.read(pngFile)
+    val centerPixel = img.getRGB(img.width / 2, img.height / 2)
+    assertThat(centerPixel).isEqualTo(0xFF00FF00.toInt())
+  }
 
-        GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("renderAllPreviews")
-            .withPluginClasspath()
-            .build()
+  @Test
+  fun `discovered previews have correct backgroundColor params`() {
+    val projectDir = createColorProject()
 
-        val manifest = json.decodeFromString<PreviewManifest>(
-            File(projectDir, "build/compose-previews/previews.json").readText()
-        )
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("discoverPreviews")
+      .withPluginClasspath()
+      .build()
 
-        val greenPreview = manifest.previews.find { it.params.name == "Green" }
-        assertThat(greenPreview).isNotNull()
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
 
-        val pngFile = File(
-            projectDir,
-            "build/compose-previews/${greenPreview!!.captures.first().renderOutput}",
-        )
-        assertThat(pngFile.exists()).isTrue()
+    assertThat(manifest.previews).hasSize(3)
 
-        val img: BufferedImage = ImageIO.read(pngFile)
-        val centerPixel = img.getRGB(img.width / 2, img.height / 2)
-        assertThat(centerPixel).isEqualTo(0xFF00FF00.toInt())
-    }
-
-    @Test
-    fun `discovered previews have correct backgroundColor params`() {
-        val projectDir = createColorProject()
-
-        GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews")
-            .withPluginClasspath()
-            .build()
-
-        val manifest = json.decodeFromString<PreviewManifest>(
-            File(projectDir, "build/compose-previews/previews.json").readText()
-        )
-
-        assertThat(manifest.previews).hasSize(3)
-
-        val colorMap = manifest.previews.associate { it.params.name to it.params.backgroundColor }
-        assertThat(colorMap["Red"]).isEqualTo(0xFFFF0000)
-        assertThat(colorMap["Blue"]).isEqualTo(0xFF0000FF)
-        assertThat(colorMap["Green"]).isEqualTo(0xFF00FF00)
-    }
+    val colorMap = manifest.previews.associate { it.params.name to it.params.backgroundColor }
+    assertThat(colorMap["Red"]).isEqualTo(0xFFFF0000)
+    assertThat(colorMap["Blue"]).isEqualTo(0xFF0000FF)
+    assertThat(colorMap["Green"]).isEqualTo(0xFF00FF00)
+  }
 }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -1,1098 +1,1148 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import java.io.File
 import kotlinx.serialization.json.Json
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import java.io.File
 
 class DiscoveryFunctionalTest {
 
-    @get:Rule
-    val tempDir = TemporaryFolder()
+  @get:Rule val tempDir = TemporaryFolder()
 
-    private val json = Json { ignoreUnknownKeys = true }
+  private val json = Json { ignoreUnknownKeys = true }
 
-    private fun createCmpTestProject(): File {
-        val projectDir = tempDir.root
+  private fun createCmpTestProject(): File {
+    val projectDir = tempDir.root
 
-        // settings.gradle.kts
-        File(projectDir, "settings.gradle.kts").writeText(
-            """
-            pluginManagement {
-                repositories {
-                    gradlePluginPortal()
-                    google()
-                    mavenCentral()
-                }
+    // settings.gradle.kts
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                google()
+                mavenCentral()
             }
-            dependencyResolutionManagement {
-                repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-                repositories {
-                    google()
-                    mavenCentral()
-                }
-            }
-            rootProject.name = "test-project"
-            """.trimIndent()
-        )
-
-        // build.gradle.kts
-        File(projectDir, "build.gradle.kts").writeText(
-            """
-            @file:Suppress("DEPRECATION")
-            plugins {
-                kotlin("jvm") version "2.2.21"
-                kotlin("plugin.compose") version "2.2.21"
-                id("org.jetbrains.compose") version "1.10.3"
-                id("ee.schimke.composeai.preview")
-            }
-            dependencies {
-                implementation(compose.desktop.currentOs)
-                implementation(compose.material3)
-                implementation(compose.uiTooling)
-                implementation(compose.components.uiToolingPreview)
-            }
-            java {
-                toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
-            }
-            """.trimIndent()
-        )
-
-        File(projectDir, "gradle.properties").writeText(
-            "org.gradle.configuration-cache=true\n"
-        )
-
-        // Source file with previews
-        val srcDir = File(projectDir, "src/main/kotlin/test")
-        srcDir.mkdirs()
-        File(srcDir, "Previews.kt").writeText(
-            """
-            package test
-
-            import androidx.compose.ui.tooling.preview.Preview
-            import androidx.compose.foundation.background
-            import androidx.compose.foundation.layout.Box
-            import androidx.compose.foundation.layout.size
-            import androidx.compose.material3.Text
-            import androidx.compose.runtime.Composable
-            import androidx.compose.ui.Modifier
-            import androidx.compose.ui.graphics.Color
-            import androidx.compose.ui.unit.dp
-
-            @Preview
-            @Composable
-            fun RedBoxPreview() {
-                Box(modifier = Modifier.size(100.dp).background(Color.Red)) {
-                    Text("Red")
-                }
-            }
-
-            @Preview
-            @Composable
-            fun BlueBoxPreview() {
-                Box(modifier = Modifier.size(100.dp).background(Color.Blue)) {
-                    Text("Blue")
-                }
-            }
-            """.trimIndent()
-        )
-
-        return projectDir
-    }
-
-    @Test
-    fun `discoverPreviews finds annotated composables`() {
-        val projectDir = createCmpTestProject()
-
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews", "--stacktrace")
-            .withPluginClasspath()
-            .build()
-
-        assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-
-        val manifestFile = File(projectDir, "build/compose-previews/previews.json")
-        assertThat(manifestFile.exists()).isTrue()
-
-        val manifest = json.decodeFromString<PreviewManifest>(manifestFile.readText())
-        assertThat(manifest.previews).hasSize(2)
-
-        val names = manifest.previews.map { it.functionName }
-        assertThat(names).containsExactly("RedBoxPreview", "BlueBoxPreview")
-
-        // AS-parity: bare `@Preview` with no device / showSystemUi /
-        // widthDp / heightDp must serialize null on both axes so renderers
-        // wrap to the composable's intrinsic size instead of defaulting
-        // to a 400×800 phone frame.
-        manifest.previews.forEach {
-            assertThat(it.params.widthDp).isNull()
-            assertThat(it.params.heightDp).isNull()
-            assertThat(it.params.device).isNull()
-            assertThat(it.params.showSystemUi).isFalse()
         }
-    }
-
-    @Test
-    fun `discoverPreviews is UP-TO-DATE on second run`() {
-        val projectDir = createCmpTestProject()
-
-        // First run
-        GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews")
-            .withPluginClasspath()
-            .build()
-
-        // Second run — should be UP-TO-DATE
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews")
-            .withPluginClasspath()
-            .build()
-
-        assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
-    }
-
-    @Test
-    fun `discoverPreviews resolves multi-preview meta-annotations`() {
-        val projectDir = createCmpTestProject()
-
-        // Define a custom meta-annotation that itself carries @Preview,
-        // mirroring the @WearPreviewDevices / @PreviewParameterProvider pattern.
-        val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
-        srcFile.writeText(
-            """
-            package test
-
-            import androidx.compose.ui.tooling.preview.Preview
-            import androidx.compose.foundation.background
-            import androidx.compose.foundation.layout.Box
-            import androidx.compose.foundation.layout.size
-            import androidx.compose.material3.Text
-            import androidx.compose.runtime.Composable
-            import androidx.compose.ui.Modifier
-            import androidx.compose.ui.graphics.Color
-            import androidx.compose.ui.unit.dp
-
-            // Custom multi-preview annotation — applies two @Preview variants
-            @Preview(name = "Light", backgroundColor = 0xFFFFFFFF, showBackground = true)
-            @Preview(name = "Dark", backgroundColor = 0xFF000000, showBackground = true)
-            annotation class LightAndDark
-
-            @LightAndDark
-            @Composable
-            fun ThemedBoxPreview() {
-                Box(modifier = Modifier.size(100.dp).background(Color.Red)) {
-                    Text("Red")
-                }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                google()
+                mavenCentral()
             }
-            """.trimIndent()
-        )
+        }
+        rootProject.name = "test-project"
+        """
+          .trimIndent()
+      )
 
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews", "--stacktrace")
-            .withPluginClasspath()
-            .build()
+    // build.gradle.kts
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
+        @file:Suppress("DEPRECATION")
+        plugins {
+            kotlin("jvm") version "2.2.21"
+            kotlin("plugin.compose") version "2.2.21"
+            id("org.jetbrains.compose") version "1.10.3"
+            id("ee.schimke.composeai.preview")
+        }
+        dependencies {
+            implementation(compose.desktop.currentOs)
+            implementation(compose.material3)
+            implementation(compose.uiTooling)
+            implementation(compose.components.uiToolingPreview)
+        }
+        java {
+            toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+        }
+        """
+          .trimIndent()
+      )
 
-        assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    File(projectDir, "gradle.properties").writeText("org.gradle.configuration-cache=true\n")
 
-        val manifest = json.decodeFromString<PreviewManifest>(
-            File(projectDir, "build/compose-previews/previews.json").readText()
-        )
+    // Source file with previews
+    val srcDir = File(projectDir, "src/main/kotlin/test")
+    srcDir.mkdirs()
+    File(srcDir, "Previews.kt")
+      .writeText(
+        """
+        package test
 
-        // @LightAndDark expands to two previews on the one function
-        assertThat(manifest.previews).hasSize(2)
-        assertThat(manifest.previews.map { it.functionName }).containsExactly(
-            "ThemedBoxPreview", "ThemedBoxPreview",
-        )
-        val labels = manifest.previews.map { it.params.name }
-        assertThat(labels).containsExactly("Light", "Dark")
-    }
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.foundation.background
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.graphics.Color
+        import androidx.compose.ui.unit.dp
 
-    @Test
-    fun `discoverPreviews resolves nested meta-annotations`() {
-        val projectDir = createCmpTestProject()
-
-        // Two levels of meta-annotation: @Outer → @Inner → @Preview
-        val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
-        srcFile.writeText(
-            """
-            package test
-
-            import androidx.compose.ui.tooling.preview.Preview
-            import androidx.compose.foundation.background
-            import androidx.compose.foundation.layout.Box
-            import androidx.compose.foundation.layout.size
-            import androidx.compose.runtime.Composable
-            import androidx.compose.ui.Modifier
-            import androidx.compose.ui.graphics.Color
-            import androidx.compose.ui.unit.dp
-
-            @Preview(name = "Inner")
-            annotation class InnerPreview
-
-            @InnerPreview
-            annotation class OuterPreview
-
-            @OuterPreview
-            @Composable
-            fun NestedPreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Red))
+        @Preview
+        @Composable
+        fun RedBoxPreview() {
+            Box(modifier = Modifier.size(100.dp).background(Color.Red)) {
+                Text("Red")
             }
-            """.trimIndent()
-        )
-
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews", "--stacktrace")
-            .withPluginClasspath()
-            .build()
-
-        assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-
-        val manifest = json.decodeFromString<PreviewManifest>(
-            File(projectDir, "build/compose-previews/previews.json").readText()
-        )
-        assertThat(manifest.previews).hasSize(1)
-        assertThat(manifest.previews[0].functionName).isEqualTo("NestedPreview")
-        assertThat(manifest.previews[0].params.name).isEqualTo("Inner")
-    }
-
-    @Test
-    fun `discoverPreviews handles cycles in meta-annotations without hanging`() {
-        val projectDir = createCmpTestProject()
-
-        // A → B → A cycle. Neither carries @Preview directly.
-        // Expected: no previews, no infinite loop / stack overflow.
-        val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
-        srcFile.writeText(
-            """
-            package test
-
-            import androidx.compose.foundation.background
-            import androidx.compose.foundation.layout.Box
-            import androidx.compose.foundation.layout.size
-            import androidx.compose.runtime.Composable
-            import androidx.compose.ui.Modifier
-            import androidx.compose.ui.graphics.Color
-            import androidx.compose.ui.unit.dp
-
-            @AnnotB
-            annotation class AnnotA
-
-            @AnnotA
-            annotation class AnnotB
-
-            @AnnotA
-            @Composable
-            fun CyclicPreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Red))
-            }
-            """.trimIndent()
-        )
-
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews", "--stacktrace")
-            .withPluginClasspath()
-            .build()
-
-        assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        val manifest = json.decodeFromString<PreviewManifest>(
-            File(projectDir, "build/compose-previews/previews.json").readText()
-        )
-        assertThat(manifest.previews).isEmpty()
-    }
-
-    @Test
-    fun `discoverPreviews captures PreviewWrapper provider FQN`() {
-        val projectDir = createCmpTestProject()
-
-        // Declare our own @PreviewWrapper / PreviewWrapperProvider under the real
-        // androidx FQN. CMP 1.10 (which this test uses) doesn't ship them yet, so
-        // stubbing them locally exercises the discovery path via ClassGraph without
-        // pinning the test to an unreleased dependency. The real 1.11 types are
-        // source-compatible, so production discovery on real apps behaves identically.
-        val previewFqnDir = File(projectDir, "src/main/kotlin/androidx/compose/ui/tooling/preview")
-        previewFqnDir.mkdirs()
-        File(previewFqnDir, "PreviewWrapper.kt").writeText(
-            """
-            package androidx.compose.ui.tooling.preview
-
-            import androidx.compose.runtime.Composable
-            import kotlin.reflect.KClass
-
-            interface PreviewWrapperProvider {
-                @Composable fun Wrap(content: @Composable () -> Unit)
-            }
-
-            @MustBeDocumented
-            @Retention(AnnotationRetention.BINARY)
-            @Target(AnnotationTarget.FUNCTION)
-            annotation class PreviewWrapper(val wrapper: KClass<out PreviewWrapperProvider>)
-            """.trimIndent()
-        )
-
-        // Preview file that uses the wrapper on a function carrying both a direct
-        // @Preview and a multi-preview meta-annotation — assert the wrapper FQN
-        // propagates to every produced preview.
-        val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
-        srcFile.writeText(
-            """
-            package test
-
-            import androidx.compose.foundation.background
-            import androidx.compose.foundation.layout.Box
-            import androidx.compose.foundation.layout.size
-            import androidx.compose.material3.Text
-            import androidx.compose.runtime.Composable
-            import androidx.compose.ui.Modifier
-            import androidx.compose.ui.graphics.Color
-            import androidx.compose.ui.tooling.preview.Preview
-            import androidx.compose.ui.tooling.preview.PreviewWrapper
-            import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
-            import androidx.compose.ui.unit.dp
-
-            class ThemeWrapper : PreviewWrapperProvider {
-                @Composable override fun Wrap(content: @Composable () -> Unit) {
-                    content()
-                }
-            }
-
-            @Preview(name = "Light", backgroundColor = 0xFFFFFFFF, showBackground = true)
-            @Preview(name = "Dark", backgroundColor = 0xFF000000, showBackground = true)
-            annotation class LightAndDark
-
-            @LightAndDark
-            @PreviewWrapper(ThemeWrapper::class)
-            @Composable
-            fun WrappedPreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Red)) {
-                    Text("x")
-                }
-            }
-
-            @Preview
-            @Composable
-            fun PlainPreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Blue))
-            }
-            """.trimIndent()
-        )
-
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews", "--stacktrace")
-            .withPluginClasspath()
-            .build()
-
-        assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-
-        val manifest = json.decodeFromString<PreviewManifest>(
-            File(projectDir, "build/compose-previews/previews.json").readText()
-        )
-
-        val wrapped = manifest.previews.filter { it.functionName == "WrappedPreview" }
-        assertThat(wrapped).hasSize(2)
-        // Every expansion of the multi-preview carries the wrapper FQN.
-        assertThat(wrapped.map { it.params.wrapperClassName })
-            .containsExactly("test.ThemeWrapper", "test.ThemeWrapper")
-
-        // Plain preview (no @PreviewWrapper) reports null.
-        val plain = manifest.previews.single { it.functionName == "PlainPreview" }
-        assertThat(plain.params.wrapperClassName).isNull()
-    }
-
-    @Test
-    fun `discoverPreviews resolves device dimensions and disambiguates ids`() {
-        val projectDir = createCmpTestProject()
-
-        // Multi-preview with two devices, no explicit name — mirrors @WearPreviewDevices.
-        val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
-        srcFile.writeText(
-            """
-            package test
-
-            import androidx.compose.ui.tooling.preview.Preview
-            import androidx.compose.foundation.background
-            import androidx.compose.foundation.layout.Box
-            import androidx.compose.foundation.layout.size
-            import androidx.compose.runtime.Composable
-            import androidx.compose.ui.Modifier
-            import androidx.compose.ui.graphics.Color
-            import androidx.compose.ui.unit.dp
-
-            @Preview(device = "id:pixel_6")
-            @Preview(device = "id:pixel_tablet")
-            annotation class PhoneAndTablet
-
-            @PhoneAndTablet
-            @Composable
-            fun MultiDevicePreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Red))
-            }
-            """.trimIndent()
-        )
-
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews", "--stacktrace")
-            .withPluginClasspath()
-            .build()
-
-        assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-
-        val manifest = json.decodeFromString<PreviewManifest>(
-            File(projectDir, "build/compose-previews/previews.json").readText()
-        )
-
-        assertThat(manifest.previews).hasSize(2)
-
-        val phone = manifest.previews.single { it.params.device == "id:pixel_6" }
-        assertThat(phone.params.widthDp).isEqualTo(411)
-        // Pixel 6 = 1080x2400 px @ 420dpi → 411x914 dp. (Earlier revisions of
-        // DeviceDimensions used the Pixel 6 Pro height here.)
-        assertThat(phone.params.heightDp).isEqualTo(914)
-        assertThat(phone.id).endsWith("_pixel_6")
-        assertThat(phone.captures.single().renderOutput).endsWith("_pixel_6.png")
-
-        val tablet = manifest.previews.single { it.params.device == "id:pixel_tablet" }
-        assertThat(tablet.params.widthDp).isEqualTo(1280)
-        assertThat(tablet.params.heightDp).isEqualTo(800)
-        assertThat(tablet.id).endsWith("_pixel_tablet")
-
-        // The two variants must not collide on their captures' renderOutput.
-        val renderOutputs = manifest.previews.flatMap { it.captures.map { c -> c.renderOutput } }
-        assertThat(renderOutputs.toSet()).hasSize(renderOutputs.size)
-    }
-
-    @Test
-    fun `discoverPreviews picks up @ScrollingPreview`() {
-        val projectDir = createCmpTestProject()
-
-        // Stub out @ScrollingPreview at its canonical FQN inside the synthetic
-        // project — mirrors the @PreviewWrapper test above so the functional
-        // test doesn't need the preview-annotations artifact on its classpath.
-        val scrollingFqnDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/preview")
-        scrollingFqnDir.mkdirs()
-        File(scrollingFqnDir, "ScrollingPreview.kt").writeText(
-            """
-            package ee.schimke.composeai.preview
-
-            enum class ScrollMode { TOP, END, LONG, GIF }
-            enum class ScrollAxis { VERTICAL, HORIZONTAL }
-
-            @Retention(AnnotationRetention.BINARY)
-            @Target(AnnotationTarget.FUNCTION)
-            annotation class ScrollingPreview(
-                val modes: Array<ScrollMode> = [ScrollMode.END],
-                val maxScrollPx: Int = 0,
-                val reduceMotion: Boolean = true,
-                val axis: ScrollAxis = ScrollAxis.VERTICAL,
-                val frameIntervalMs: Int = 80,
-            )
-            """.trimIndent()
-        )
-
-        val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
-        srcFile.writeText(
-            """
-            package test
-
-            import androidx.compose.foundation.background
-            import androidx.compose.foundation.layout.Box
-            import androidx.compose.foundation.layout.size
-            import androidx.compose.runtime.Composable
-            import androidx.compose.ui.Modifier
-            import androidx.compose.ui.graphics.Color
-            import androidx.compose.ui.tooling.preview.Preview
-            import androidx.compose.ui.unit.dp
-            import ee.schimke.composeai.preview.ScrollAxis
-            import ee.schimke.composeai.preview.ScrollMode
-            import ee.schimke.composeai.preview.ScrollingPreview
-
-            // Multi-preview meta-annotation to prove the scroll spec propagates to
-            // every expansion, same pattern as the PreviewWrapper test.
-            @Preview(name = "Light", backgroundColor = 0xFFFFFFFF, showBackground = true)
-            @Preview(name = "Dark", backgroundColor = 0xFF000000, showBackground = true)
-            annotation class LightAndDark
-
-            @LightAndDark
-            @ScrollingPreview(modes = [ScrollMode.END])
-            @Composable
-            fun EndScrollPreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Red))
-            }
-
-            @Preview
-            @ScrollingPreview(
-                modes = [ScrollMode.LONG],
-                maxScrollPx = 4000,
-                reduceMotion = false,
-                axis = ScrollAxis.HORIZONTAL,
-            )
-            @Composable
-            fun LongScrollPreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Blue))
-            }
-
-            // Multi-mode fan-out: one preview function emits both an
-            // unscrolled initial capture and a scroll-to-end capture,
-            // disambiguated on disk by a _SCROLL_<mode> suffix.
-            @Preview(name = "Scroll")
-            @ScrollingPreview(modes = [ScrollMode.TOP, ScrollMode.END])
-            @Composable
-            fun TopAndEndScrollPreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Magenta))
-            }
-
-            // GIF-mode capture: single-mode annotation lands at .gif, not .png.
-            @Preview(name = "Gif")
-            @ScrollingPreview(modes = [ScrollMode.GIF], frameIntervalMs = 120)
-            @Composable
-            fun GifScrollPreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Cyan))
-            }
-
-            // Multi-mode with GIF sibling: each capture keeps its own
-            // extension — .png for END, .gif for GIF.
-            @Preview(name = "EndAndGif")
-            @ScrollingPreview(modes = [ScrollMode.END, ScrollMode.GIF])
-            @Composable
-            fun EndAndGifScrollPreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Yellow))
-            }
-
-            @Preview
-            @Composable
-            fun PlainPreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Green))
-            }
-            """.trimIndent()
-        )
-
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews", "--stacktrace")
-            .withPluginClasspath()
-            .build()
-
-        assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-
-        val manifest = json.decodeFromString<PreviewManifest>(
-            File(projectDir, "build/compose-previews/previews.json").readText()
-        )
-
-        val endPreviews = manifest.previews.filter { it.functionName == "EndScrollPreview" }
-        assertThat(endPreviews).hasSize(2)
-        // @ScrollingPreview propagates identically to every @LightAndDark expansion,
-        // using its declared-in-source defaults (reduceMotion=true, axis=VERTICAL).
-        // Scroll state lives on each capture now (Capture.scroll) — single-capture
-        // previews carry it on the first element.
-        // `frameIntervalMs` on the annotation applies to every capture in
-        // the manifest even though it's only meaningful for GIF mode —
-        // discovery reads the field unconditionally for a uniform shape.
-        // Test stub declares 80 as the default (matches the real
-        // annotation's DEFAULT_GIF_FRAME_INTERVAL_MS).
-        for (p in endPreviews) {
-            assertThat(p.captures).hasSize(1)
-            assertThat(p.captures.first().scroll).isEqualTo(
-                ScrollCapture(
-                    mode = ScrollMode.END,
-                    axis = ScrollAxis.VERTICAL,
-                    maxScrollPx = 0,
-                    reduceMotion = true,
-                    frameIntervalMs = 80,
-                )
-            )
         }
 
-        val longPreview = manifest.previews.single { it.functionName == "LongScrollPreview" }
-        assertThat(longPreview.captures.single().scroll).isEqualTo(
-            ScrollCapture(
-                mode = ScrollMode.LONG,
-                axis = ScrollAxis.HORIZONTAL,
-                maxScrollPx = 4000,
-                reduceMotion = false,
-                frameIntervalMs = 80,
-            )
+        @Preview
+        @Composable
+        fun BlueBoxPreview() {
+            Box(modifier = Modifier.size(100.dp).background(Color.Blue)) {
+                Text("Blue")
+            }
+        }
+        """
+          .trimIndent()
+      )
+
+    return projectDir
+  }
+
+  @Test
+  fun `discoverPreviews finds annotated composables`() {
+    val projectDir = createCmpTestProject()
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("discoverPreviews", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifestFile = File(projectDir, "build/compose-previews/previews.json")
+    assertThat(manifestFile.exists()).isTrue()
+
+    val manifest = json.decodeFromString<PreviewManifest>(manifestFile.readText())
+    assertThat(manifest.previews).hasSize(2)
+
+    val names = manifest.previews.map { it.functionName }
+    assertThat(names).containsExactly("RedBoxPreview", "BlueBoxPreview")
+
+    // AS-parity: bare `@Preview` with no device / showSystemUi /
+    // widthDp / heightDp must serialize null on both axes so renderers
+    // wrap to the composable's intrinsic size instead of defaulting
+    // to a 400×800 phone frame.
+    manifest.previews.forEach {
+      assertThat(it.params.widthDp).isNull()
+      assertThat(it.params.heightDp).isNull()
+      assertThat(it.params.device).isNull()
+      assertThat(it.params.showSystemUi).isFalse()
+    }
+  }
+
+  @Test
+  fun `discoverPreviews is UP-TO-DATE on second run`() {
+    val projectDir = createCmpTestProject()
+
+    // First run
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("discoverPreviews")
+      .withPluginClasspath()
+      .build()
+
+    // Second run — should be UP-TO-DATE
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("discoverPreviews")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+  }
+
+  @Test
+  fun `discoverPreviews resolves multi-preview meta-annotations`() {
+    val projectDir = createCmpTestProject()
+
+    // Define a custom meta-annotation that itself carries @Preview,
+    // mirroring the @WearPreviewDevices / @PreviewParameterProvider pattern.
+    val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+    srcFile.writeText(
+      """
+      package test
+
+      import androidx.compose.ui.tooling.preview.Preview
+      import androidx.compose.foundation.background
+      import androidx.compose.foundation.layout.Box
+      import androidx.compose.foundation.layout.size
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+      import androidx.compose.ui.graphics.Color
+      import androidx.compose.ui.unit.dp
+
+      // Custom multi-preview annotation — applies two @Preview variants
+      @Preview(name = "Light", backgroundColor = 0xFFFFFFFF, showBackground = true)
+      @Preview(name = "Dark", backgroundColor = 0xFF000000, showBackground = true)
+      annotation class LightAndDark
+
+      @LightAndDark
+      @Composable
+      fun ThemedBoxPreview() {
+          Box(modifier = Modifier.size(100.dp).background(Color.Red)) {
+              Text("Red")
+          }
+      }
+      """
+        .trimIndent()
+    )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("discoverPreviews", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+
+    // @LightAndDark expands to two previews on the one function
+    assertThat(manifest.previews).hasSize(2)
+    assertThat(manifest.previews.map { it.functionName })
+      .containsExactly("ThemedBoxPreview", "ThemedBoxPreview")
+    val labels = manifest.previews.map { it.params.name }
+    assertThat(labels).containsExactly("Light", "Dark")
+  }
+
+  @Test
+  fun `discoverPreviews resolves nested meta-annotations`() {
+    val projectDir = createCmpTestProject()
+
+    // Two levels of meta-annotation: @Outer → @Inner → @Preview
+    val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+    srcFile.writeText(
+      """
+      package test
+
+      import androidx.compose.ui.tooling.preview.Preview
+      import androidx.compose.foundation.background
+      import androidx.compose.foundation.layout.Box
+      import androidx.compose.foundation.layout.size
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+      import androidx.compose.ui.graphics.Color
+      import androidx.compose.ui.unit.dp
+
+      @Preview(name = "Inner")
+      annotation class InnerPreview
+
+      @InnerPreview
+      annotation class OuterPreview
+
+      @OuterPreview
+      @Composable
+      fun NestedPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Red))
+      }
+      """
+        .trimIndent()
+    )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("discoverPreviews", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    assertThat(manifest.previews).hasSize(1)
+    assertThat(manifest.previews[0].functionName).isEqualTo("NestedPreview")
+    assertThat(manifest.previews[0].params.name).isEqualTo("Inner")
+  }
+
+  @Test
+  fun `discoverPreviews handles cycles in meta-annotations without hanging`() {
+    val projectDir = createCmpTestProject()
+
+    // A → B → A cycle. Neither carries @Preview directly.
+    // Expected: no previews, no infinite loop / stack overflow.
+    val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+    srcFile.writeText(
+      """
+      package test
+
+      import androidx.compose.foundation.background
+      import androidx.compose.foundation.layout.Box
+      import androidx.compose.foundation.layout.size
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+      import androidx.compose.ui.graphics.Color
+      import androidx.compose.ui.unit.dp
+
+      @AnnotB
+      annotation class AnnotA
+
+      @AnnotA
+      annotation class AnnotB
+
+      @AnnotA
+      @Composable
+      fun CyclicPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Red))
+      }
+      """
+        .trimIndent()
+    )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("discoverPreviews", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    assertThat(manifest.previews).isEmpty()
+  }
+
+  @Test
+  fun `discoverPreviews captures PreviewWrapper provider FQN`() {
+    val projectDir = createCmpTestProject()
+
+    // Declare our own @PreviewWrapper / PreviewWrapperProvider under the real
+    // androidx FQN. CMP 1.10 (which this test uses) doesn't ship them yet, so
+    // stubbing them locally exercises the discovery path via ClassGraph without
+    // pinning the test to an unreleased dependency. The real 1.11 types are
+    // source-compatible, so production discovery on real apps behaves identically.
+    val previewFqnDir = File(projectDir, "src/main/kotlin/androidx/compose/ui/tooling/preview")
+    previewFqnDir.mkdirs()
+    File(previewFqnDir, "PreviewWrapper.kt")
+      .writeText(
+        """
+        package androidx.compose.ui.tooling.preview
+
+        import androidx.compose.runtime.Composable
+        import kotlin.reflect.KClass
+
+        interface PreviewWrapperProvider {
+            @Composable fun Wrap(content: @Composable () -> Unit)
+        }
+
+        @MustBeDocumented
+        @Retention(AnnotationRetention.BINARY)
+        @Target(AnnotationTarget.FUNCTION)
+        annotation class PreviewWrapper(val wrapper: KClass<out PreviewWrapperProvider>)
+        """
+          .trimIndent()
+      )
+
+    // Preview file that uses the wrapper on a function carrying both a direct
+    // @Preview and a multi-preview meta-annotation — assert the wrapper FQN
+    // propagates to every produced preview.
+    val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+    srcFile.writeText(
+      """
+      package test
+
+      import androidx.compose.foundation.background
+      import androidx.compose.foundation.layout.Box
+      import androidx.compose.foundation.layout.size
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+      import androidx.compose.ui.graphics.Color
+      import androidx.compose.ui.tooling.preview.Preview
+      import androidx.compose.ui.tooling.preview.PreviewWrapper
+      import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
+      import androidx.compose.ui.unit.dp
+
+      class ThemeWrapper : PreviewWrapperProvider {
+          @Composable override fun Wrap(content: @Composable () -> Unit) {
+              content()
+          }
+      }
+
+      @Preview(name = "Light", backgroundColor = 0xFFFFFFFF, showBackground = true)
+      @Preview(name = "Dark", backgroundColor = 0xFF000000, showBackground = true)
+      annotation class LightAndDark
+
+      @LightAndDark
+      @PreviewWrapper(ThemeWrapper::class)
+      @Composable
+      fun WrappedPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Red)) {
+              Text("x")
+          }
+      }
+
+      @Preview
+      @Composable
+      fun PlainPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Blue))
+      }
+      """
+        .trimIndent()
+    )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("discoverPreviews", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+
+    val wrapped = manifest.previews.filter { it.functionName == "WrappedPreview" }
+    assertThat(wrapped).hasSize(2)
+    // Every expansion of the multi-preview carries the wrapper FQN.
+    assertThat(wrapped.map { it.params.wrapperClassName })
+      .containsExactly("test.ThemeWrapper", "test.ThemeWrapper")
+
+    // Plain preview (no @PreviewWrapper) reports null.
+    val plain = manifest.previews.single { it.functionName == "PlainPreview" }
+    assertThat(plain.params.wrapperClassName).isNull()
+  }
+
+  @Test
+  fun `discoverPreviews resolves device dimensions and disambiguates ids`() {
+    val projectDir = createCmpTestProject()
+
+    // Multi-preview with two devices, no explicit name — mirrors @WearPreviewDevices.
+    val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+    srcFile.writeText(
+      """
+      package test
+
+      import androidx.compose.ui.tooling.preview.Preview
+      import androidx.compose.foundation.background
+      import androidx.compose.foundation.layout.Box
+      import androidx.compose.foundation.layout.size
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+      import androidx.compose.ui.graphics.Color
+      import androidx.compose.ui.unit.dp
+
+      @Preview(device = "id:pixel_6")
+      @Preview(device = "id:pixel_tablet")
+      annotation class PhoneAndTablet
+
+      @PhoneAndTablet
+      @Composable
+      fun MultiDevicePreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Red))
+      }
+      """
+        .trimIndent()
+    )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("discoverPreviews", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+
+    assertThat(manifest.previews).hasSize(2)
+
+    val phone = manifest.previews.single { it.params.device == "id:pixel_6" }
+    assertThat(phone.params.widthDp).isEqualTo(411)
+    // Pixel 6 = 1080x2400 px @ 420dpi → 411x914 dp. (Earlier revisions of
+    // DeviceDimensions used the Pixel 6 Pro height here.)
+    assertThat(phone.params.heightDp).isEqualTo(914)
+    assertThat(phone.id).endsWith("_pixel_6")
+    assertThat(phone.captures.single().renderOutput).endsWith("_pixel_6.png")
+
+    val tablet = manifest.previews.single { it.params.device == "id:pixel_tablet" }
+    assertThat(tablet.params.widthDp).isEqualTo(1280)
+    assertThat(tablet.params.heightDp).isEqualTo(800)
+    assertThat(tablet.id).endsWith("_pixel_tablet")
+
+    // The two variants must not collide on their captures' renderOutput.
+    val renderOutputs = manifest.previews.flatMap { it.captures.map { c -> c.renderOutput } }
+    assertThat(renderOutputs.toSet()).hasSize(renderOutputs.size)
+  }
+
+  @Test
+  fun `discoverPreviews picks up @ScrollingPreview`() {
+    val projectDir = createCmpTestProject()
+
+    // Stub out @ScrollingPreview at its canonical FQN inside the synthetic
+    // project — mirrors the @PreviewWrapper test above so the functional
+    // test doesn't need the preview-annotations artifact on its classpath.
+    val scrollingFqnDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/preview")
+    scrollingFqnDir.mkdirs()
+    File(scrollingFqnDir, "ScrollingPreview.kt")
+      .writeText(
+        """
+        package ee.schimke.composeai.preview
+
+        enum class ScrollMode { TOP, END, LONG, GIF }
+        enum class ScrollAxis { VERTICAL, HORIZONTAL }
+
+        @Retention(AnnotationRetention.BINARY)
+        @Target(AnnotationTarget.FUNCTION)
+        annotation class ScrollingPreview(
+            val modes: Array<ScrollMode> = [ScrollMode.END],
+            val maxScrollPx: Int = 0,
+            val reduceMotion: Boolean = true,
+            val axis: ScrollAxis = ScrollAxis.VERTICAL,
+            val frameIntervalMs: Int = 80,
         )
+        """
+          .trimIndent()
+      )
 
-        val plain = manifest.previews.single { it.functionName == "PlainPreview" }
-        assertThat(plain.captures.single().scroll).isNull()
+    val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+    srcFile.writeText(
+      """
+      package test
 
-        // Multi-mode: one preview yields two captures, one per mode, with
-        // distinct `_SCROLL_<mode>` filenames. Modes sort by enum ordinal
-        // (TOP, END, LONG, GIF) so the renderer captures the initial frame
-        // before driving the scroller.
-        val topAndEnd = manifest.previews.single { it.functionName == "TopAndEndScrollPreview" }
-        assertThat(topAndEnd.captures).hasSize(2)
-        assertThat(topAndEnd.captures.map { it.scroll?.mode })
-            .containsExactly(ScrollMode.TOP, ScrollMode.END).inOrder()
-        // renderOutput strips the common `test.` package prefix from every
-        // preview id — the full FQN is retained on `preview.id` itself (and
-        // also stays addressable in `renderOutput`'s basename), but the
-        // on-disk filename drops the shared prefix.
-        assertThat(topAndEnd.captures.map { it.renderOutput }).containsExactly(
-            "renders/TopAndEndScrollPreview_Scroll_SCROLL_top.png",
-            "renders/TopAndEndScrollPreview_Scroll_SCROLL_end.png",
-        ).inOrder()
+      import androidx.compose.foundation.background
+      import androidx.compose.foundation.layout.Box
+      import androidx.compose.foundation.layout.size
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+      import androidx.compose.ui.graphics.Color
+      import androidx.compose.ui.tooling.preview.Preview
+      import androidx.compose.ui.unit.dp
+      import ee.schimke.composeai.preview.ScrollAxis
+      import ee.schimke.composeai.preview.ScrollMode
+      import ee.schimke.composeai.preview.ScrollingPreview
 
-        // Single-mode GIF: keeps the plain `renders/<id>.gif` name (no
-        // `_SCROLL_gif` suffix) and round-trips `frameIntervalMs` onto the
-        // manifest so the renderer can honour it.
-        val gifOnly = manifest.previews.single { it.functionName == "GifScrollPreview" }
-        assertThat(gifOnly.captures).hasSize(1)
-        assertThat(gifOnly.captures.single().scroll).isEqualTo(
-            ScrollCapture(
-                mode = ScrollMode.GIF,
-                axis = ScrollAxis.VERTICAL,
-                maxScrollPx = 0,
-                reduceMotion = true,
-                frameIntervalMs = 120,
-            )
+      // Multi-preview meta-annotation to prove the scroll spec propagates to
+      // every expansion, same pattern as the PreviewWrapper test.
+      @Preview(name = "Light", backgroundColor = 0xFFFFFFFF, showBackground = true)
+      @Preview(name = "Dark", backgroundColor = 0xFF000000, showBackground = true)
+      annotation class LightAndDark
+
+      @LightAndDark
+      @ScrollingPreview(modes = [ScrollMode.END])
+      @Composable
+      fun EndScrollPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Red))
+      }
+
+      @Preview
+      @ScrollingPreview(
+          modes = [ScrollMode.LONG],
+          maxScrollPx = 4000,
+          reduceMotion = false,
+          axis = ScrollAxis.HORIZONTAL,
+      )
+      @Composable
+      fun LongScrollPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Blue))
+      }
+
+      // Multi-mode fan-out: one preview function emits both an
+      // unscrolled initial capture and a scroll-to-end capture,
+      // disambiguated on disk by a _SCROLL_<mode> suffix.
+      @Preview(name = "Scroll")
+      @ScrollingPreview(modes = [ScrollMode.TOP, ScrollMode.END])
+      @Composable
+      fun TopAndEndScrollPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Magenta))
+      }
+
+      // GIF-mode capture: single-mode annotation lands at .gif, not .png.
+      @Preview(name = "Gif")
+      @ScrollingPreview(modes = [ScrollMode.GIF], frameIntervalMs = 120)
+      @Composable
+      fun GifScrollPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Cyan))
+      }
+
+      // Multi-mode with GIF sibling: each capture keeps its own
+      // extension — .png for END, .gif for GIF.
+      @Preview(name = "EndAndGif")
+      @ScrollingPreview(modes = [ScrollMode.END, ScrollMode.GIF])
+      @Composable
+      fun EndAndGifScrollPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Yellow))
+      }
+
+      @Preview
+      @Composable
+      fun PlainPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Green))
+      }
+      """
+        .trimIndent()
+    )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("discoverPreviews", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+
+    val endPreviews = manifest.previews.filter { it.functionName == "EndScrollPreview" }
+    assertThat(endPreviews).hasSize(2)
+    // @ScrollingPreview propagates identically to every @LightAndDark expansion,
+    // using its declared-in-source defaults (reduceMotion=true, axis=VERTICAL).
+    // Scroll state lives on each capture now (Capture.scroll) — single-capture
+    // previews carry it on the first element.
+    // `frameIntervalMs` on the annotation applies to every capture in
+    // the manifest even though it's only meaningful for GIF mode —
+    // discovery reads the field unconditionally for a uniform shape.
+    // Test stub declares 80 as the default (matches the real
+    // annotation's DEFAULT_GIF_FRAME_INTERVAL_MS).
+    for (p in endPreviews) {
+      assertThat(p.captures).hasSize(1)
+      assertThat(p.captures.first().scroll)
+        .isEqualTo(
+          ScrollCapture(
+            mode = ScrollMode.END,
+            axis = ScrollAxis.VERTICAL,
+            maxScrollPx = 0,
+            reduceMotion = true,
+            frameIntervalMs = 80,
+          )
         )
-        assertThat(gifOnly.captures.single().renderOutput)
-            .isEqualTo("renders/GifScrollPreview_Gif.gif")
-
-        // Multi-mode with GIF sibling: each capture gets its mode's
-        // extension (PNG for END, GIF for GIF) — the extension branches
-        // per-capture rather than per-preview.
-        val endAndGif = manifest.previews.single { it.functionName == "EndAndGifScrollPreview" }
-        assertThat(endAndGif.captures).hasSize(2)
-        assertThat(endAndGif.captures.map { it.scroll?.mode })
-            .containsExactly(ScrollMode.END, ScrollMode.GIF).inOrder()
-        assertThat(endAndGif.captures.map { it.renderOutput }).containsExactly(
-            "renders/EndAndGifScrollPreview_EndAndGif_SCROLL_end.png",
-            "renders/EndAndGifScrollPreview_EndAndGif_SCROLL_gif.gif",
-        ).inOrder()
     }
 
-    @Test
-    fun `discoverPreviews records @PreviewParameter provider FQN`() {
-        val projectDir = createCmpTestProject()
-
-        val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
-        srcFile.writeText(
-            """
-            package test
-
-            import androidx.compose.foundation.background
-            import androidx.compose.foundation.layout.Box
-            import androidx.compose.foundation.layout.size
-            import androidx.compose.runtime.Composable
-            import androidx.compose.ui.Modifier
-            import androidx.compose.ui.graphics.Color
-            import androidx.compose.ui.tooling.preview.Preview
-            import androidx.compose.ui.tooling.preview.PreviewParameter
-            import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-            import androidx.compose.ui.unit.dp
-
-            class ColorProvider : PreviewParameterProvider<Long> {
-                override val values: Sequence<Long>
-                    get() = sequenceOf(0xFFFF0000L, 0xFF00FF00L, 0xFF0000FFL)
-            }
-
-            @Preview(name = "Swatch")
-            @Composable
-            fun SwatchPreview(
-                @PreviewParameter(ColorProvider::class) color: Long,
-            ) {
-                Box(modifier = Modifier.size(50.dp).background(Color(color.toInt())))
-            }
-
-            // Limit arg: annotation takes only the first entry.
-            @Preview(name = "Limited")
-            @Composable
-            fun LimitedPreview(
-                @PreviewParameter(ColorProvider::class, limit = 1) color: Long,
-            ) {
-                Box(modifier = Modifier.size(50.dp).background(Color(color.toInt())))
-            }
-
-            // No provider — must not surface a previewParameterProviderClassName.
-            @Preview
-            @Composable
-            fun PlainPreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Gray))
-            }
-            """.trimIndent()
+    val longPreview = manifest.previews.single { it.functionName == "LongScrollPreview" }
+    assertThat(longPreview.captures.single().scroll)
+      .isEqualTo(
+        ScrollCapture(
+          mode = ScrollMode.LONG,
+          axis = ScrollAxis.HORIZONTAL,
+          maxScrollPx = 4000,
+          reduceMotion = false,
+          frameIntervalMs = 80,
         )
+      )
 
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews", "--stacktrace")
-            .withPluginClasspath()
-            .build()
+    val plain = manifest.previews.single { it.functionName == "PlainPreview" }
+    assertThat(plain.captures.single().scroll).isNull()
 
-        assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    // Multi-mode: one preview yields two captures, one per mode, with
+    // distinct `_SCROLL_<mode>` filenames. Modes sort by enum ordinal
+    // (TOP, END, LONG, GIF) so the renderer captures the initial frame
+    // before driving the scroller.
+    val topAndEnd = manifest.previews.single { it.functionName == "TopAndEndScrollPreview" }
+    assertThat(topAndEnd.captures).hasSize(2)
+    assertThat(topAndEnd.captures.map { it.scroll?.mode })
+      .containsExactly(ScrollMode.TOP, ScrollMode.END)
+      .inOrder()
+    // renderOutput strips the common `test.` package prefix from every
+    // preview id — the full FQN is retained on `preview.id` itself (and
+    // also stays addressable in `renderOutput`'s basename), but the
+    // on-disk filename drops the shared prefix.
+    assertThat(topAndEnd.captures.map { it.renderOutput })
+      .containsExactly(
+        "renders/TopAndEndScrollPreview_Scroll_SCROLL_top.png",
+        "renders/TopAndEndScrollPreview_Scroll_SCROLL_end.png",
+      )
+      .inOrder()
 
-        val manifest = json.decodeFromString<PreviewManifest>(
-            File(projectDir, "build/compose-previews/previews.json").readText()
+    // Single-mode GIF: keeps the plain `renders/<id>.gif` name (no
+    // `_SCROLL_gif` suffix) and round-trips `frameIntervalMs` onto the
+    // manifest so the renderer can honour it.
+    val gifOnly = manifest.previews.single { it.functionName == "GifScrollPreview" }
+    assertThat(gifOnly.captures).hasSize(1)
+    assertThat(gifOnly.captures.single().scroll)
+      .isEqualTo(
+        ScrollCapture(
+          mode = ScrollMode.GIF,
+          axis = ScrollAxis.VERTICAL,
+          maxScrollPx = 0,
+          reduceMotion = true,
+          frameIntervalMs = 120,
         )
+      )
+    assertThat(gifOnly.captures.single().renderOutput).isEqualTo("renders/GifScrollPreview_Gif.gif")
 
-        val swatch = manifest.previews.single { it.functionName == "SwatchPreview" }
-        assertThat(swatch.params.previewParameterProviderClassName).isEqualTo("test.ColorProvider")
-        assertThat(swatch.params.previewParameterLimit).isEqualTo(Int.MAX_VALUE)
+    // Multi-mode with GIF sibling: each capture gets its mode's
+    // extension (PNG for END, GIF for GIF) — the extension branches
+    // per-capture rather than per-preview.
+    val endAndGif = manifest.previews.single { it.functionName == "EndAndGifScrollPreview" }
+    assertThat(endAndGif.captures).hasSize(2)
+    assertThat(endAndGif.captures.map { it.scroll?.mode })
+      .containsExactly(ScrollMode.END, ScrollMode.GIF)
+      .inOrder()
+    assertThat(endAndGif.captures.map { it.renderOutput })
+      .containsExactly(
+        "renders/EndAndGifScrollPreview_EndAndGif_SCROLL_end.png",
+        "renders/EndAndGifScrollPreview_EndAndGif_SCROLL_gif.gif",
+      )
+      .inOrder()
+  }
 
-        val limited = manifest.previews.single { it.functionName == "LimitedPreview" }
-        assertThat(limited.params.previewParameterProviderClassName).isEqualTo("test.ColorProvider")
-        assertThat(limited.params.previewParameterLimit).isEqualTo(1)
+  @Test
+  fun `discoverPreviews records @PreviewParameter provider FQN`() {
+    val projectDir = createCmpTestProject()
 
-        val plain = manifest.previews.single { it.functionName == "PlainPreview" }
-        assertThat(plain.params.previewParameterProviderClassName).isNull()
-        assertThat(plain.params.previewParameterLimit).isEqualTo(Int.MAX_VALUE)
-    }
+    val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+    srcFile.writeText(
+      """
+      package test
 
-    @Test
-    fun `renderOutput strips common package prefix and sanitises spaces and parens`() {
-        val projectDir = createCmpTestProject()
+      import androidx.compose.foundation.background
+      import androidx.compose.foundation.layout.Box
+      import androidx.compose.foundation.layout.size
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+      import androidx.compose.ui.graphics.Color
+      import androidx.compose.ui.tooling.preview.Preview
+      import androidx.compose.ui.tooling.preview.PreviewParameter
+      import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+      import androidx.compose.ui.unit.dp
 
-        val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
-        srcFile.writeText(
-            """
-            package test
+      class ColorProvider : PreviewParameterProvider<Long> {
+          override val values: Sequence<Long>
+              get() = sequenceOf(0xFFFF0000L, 0xFF00FF00L, 0xFF0000FFL)
+      }
 
-            import androidx.compose.foundation.background
-            import androidx.compose.foundation.layout.Box
-            import androidx.compose.foundation.layout.size
-            import androidx.compose.runtime.Composable
-            import androidx.compose.ui.Modifier
-            import androidx.compose.ui.graphics.Color
-            import androidx.compose.ui.tooling.preview.Preview
-            import androidx.compose.ui.unit.dp
+      @Preview(name = "Swatch")
+      @Composable
+      fun SwatchPreview(
+          @PreviewParameter(ColorProvider::class) color: Long,
+      ) {
+          Box(modifier = Modifier.size(50.dp).background(Color(color.toInt())))
+      }
 
-            @Preview(name = "tile light (light)")
-            @Composable
-            fun TileLightStates() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Red))
+      // Limit arg: annotation takes only the first entry.
+      @Preview(name = "Limited")
+      @Composable
+      fun LimitedPreview(
+          @PreviewParameter(ColorProvider::class, limit = 1) color: Long,
+      ) {
+          Box(modifier = Modifier.size(50.dp).background(Color(color.toInt())))
+      }
+
+      // No provider — must not surface a previewParameterProviderClassName.
+      @Preview
+      @Composable
+      fun PlainPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Gray))
+      }
+      """
+        .trimIndent()
+    )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("discoverPreviews", "--stacktrace")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+
+    val swatch = manifest.previews.single { it.functionName == "SwatchPreview" }
+    assertThat(swatch.params.previewParameterProviderClassName).isEqualTo("test.ColorProvider")
+    assertThat(swatch.params.previewParameterLimit).isEqualTo(Int.MAX_VALUE)
+
+    val limited = manifest.previews.single { it.functionName == "LimitedPreview" }
+    assertThat(limited.params.previewParameterProviderClassName).isEqualTo("test.ColorProvider")
+    assertThat(limited.params.previewParameterLimit).isEqualTo(1)
+
+    val plain = manifest.previews.single { it.functionName == "PlainPreview" }
+    assertThat(plain.params.previewParameterProviderClassName).isNull()
+    assertThat(plain.params.previewParameterLimit).isEqualTo(Int.MAX_VALUE)
+  }
+
+  @Test
+  fun `renderOutput strips common package prefix and sanitises spaces and parens`() {
+    val projectDir = createCmpTestProject()
+
+    val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+    srcFile.writeText(
+      """
+      package test
+
+      import androidx.compose.foundation.background
+      import androidx.compose.foundation.layout.Box
+      import androidx.compose.foundation.layout.size
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+      import androidx.compose.ui.graphics.Color
+      import androidx.compose.ui.tooling.preview.Preview
+      import androidx.compose.ui.unit.dp
+
+      @Preview(name = "tile light (light)")
+      @Composable
+      fun TileLightStates() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Red))
+      }
+
+      @Preview(name = "plain")
+      @Composable
+      fun TileDarkStates() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Blue))
+      }
+      """
+        .trimIndent()
+    )
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("discoverPreviews", "--stacktrace")
+      .withPluginClasspath()
+      .build()
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+
+    val light = manifest.previews.single { it.functionName == "TileLightStates" }
+    // `id` stays as the full FQN — consumers key by it. Top-level
+    // Kotlin functions land on the synthetic `<File>Kt` class, so
+    // the id is `test.PreviewsKt.TileLightStates_tile light (light)`.
+    assertThat(light.id).isEqualTo("test.PreviewsKt.TileLightStates_tile light (light)")
+    // `renderOutput` drops the shared `test.PreviewsKt.` dotted
+    // prefix and sanitises the awkward `tile light (light)` variant
+    // suffix down to shell-safe `tile_light_light`.
+    assertThat(light.captures.single().renderOutput)
+      .isEqualTo("renders/TileLightStates_tile_light_light.png")
+
+    val dark = manifest.previews.single { it.functionName == "TileDarkStates" }
+    assertThat(dark.captures.single().renderOutput).isEqualTo("renders/TileDarkStates_plain.png")
+  }
+
+  @Test
+  fun `discoverPreviews re-runs when source changes`() {
+    val projectDir = createCmpTestProject()
+
+    // First run
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("discoverPreviews")
+      .withPluginClasspath()
+      .build()
+
+    // Add a new preview
+    val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+    srcFile.appendText(
+      """
+
+      @Preview
+      @Composable
+      fun GreenBoxPreview() {
+          Box(modifier = Modifier.size(100.dp).background(Color.Green)) {
+              Text("Green")
+          }
+      }
+      """
+        .trimIndent()
+    )
+
+    // Second run — should re-run and find 3 previews
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("discoverPreviews")
+        .withPluginClasspath()
+        .build()
+
+    assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    assertThat(manifest.previews).hasSize(3)
+  }
+
+  /**
+   * Regression for issue #157: previews were only surfaced for top-level modules. Nested Gradle
+   * paths (`:auth:composables`) use `:` as a separator, but the CLI was treating that string as a
+   * filesystem path and looking under `projectRoot/auth:composables/build/...` — which doesn't
+   * exist. The plugin itself always wrote manifests to the real subproject directory
+   * (`auth/composables/build/...`); this test locks that behaviour in so the CLI fix
+   * (`PreviewModule.projectDir` via the Tooling API) has a stable contract to read against.
+   */
+  @Test
+  fun `discoverPreviews runs in a nested subproject`() {
+    val projectDir = tempDir.root
+
+    // Root settings with a :auth:composables nested subproject.
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                google()
+                mavenCentral()
             }
-
-            @Preview(name = "plain")
-            @Composable
-            fun TileDarkStates() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Blue))
+        }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                google()
+                mavenCentral()
             }
-            """.trimIndent()
-        )
+        }
+        rootProject.name = "nested-test"
+        include(":auth:composables")
+        """
+          .trimIndent()
+      )
 
-        GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews", "--stacktrace")
-            .withPluginClasspath()
-            .build()
+    // Root build.gradle.kts is empty — the plugin is only applied to the
+    // nested subproject to mirror the Horologist-style layout in #157.
+    File(projectDir, "build.gradle.kts").writeText("")
 
-        val manifest = json.decodeFromString<PreviewManifest>(
-            File(projectDir, "build/compose-previews/previews.json").readText()
-        )
+    File(projectDir, "gradle.properties").writeText("org.gradle.configuration-cache=true\n")
 
-        val light = manifest.previews.single { it.functionName == "TileLightStates" }
-        // `id` stays as the full FQN — consumers key by it. Top-level
-        // Kotlin functions land on the synthetic `<File>Kt` class, so
-        // the id is `test.PreviewsKt.TileLightStates_tile light (light)`.
-        assertThat(light.id).isEqualTo("test.PreviewsKt.TileLightStates_tile light (light)")
-        // `renderOutput` drops the shared `test.PreviewsKt.` dotted
-        // prefix and sanitises the awkward `tile light (light)` variant
-        // suffix down to shell-safe `tile_light_light`.
-        assertThat(light.captures.single().renderOutput)
-            .isEqualTo("renders/TileLightStates_tile_light_light.png")
+    val childDir = File(projectDir, "auth/composables")
+    childDir.mkdirs()
+    File(childDir, "build.gradle.kts")
+      .writeText(
+        """
+        @file:Suppress("DEPRECATION")
+        plugins {
+            kotlin("jvm") version "2.2.21"
+            kotlin("plugin.compose") version "2.2.21"
+            id("org.jetbrains.compose") version "1.10.3"
+            id("ee.schimke.composeai.preview")
+        }
+        dependencies {
+            implementation(compose.desktop.currentOs)
+            implementation(compose.material3)
+            implementation(compose.uiTooling)
+            implementation(compose.components.uiToolingPreview)
+        }
+        java {
+            toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+        }
+        """
+          .trimIndent()
+      )
 
-        val dark = manifest.previews.single { it.functionName == "TileDarkStates" }
-        assertThat(dark.captures.single().renderOutput)
-            .isEqualTo("renders/TileDarkStates_plain.png")
-    }
+    val childSrc = File(childDir, "src/main/kotlin/nested")
+    childSrc.mkdirs()
+    File(childSrc, "Previews.kt")
+      .writeText(
+        """
+        package nested
 
-    @Test
-    fun `discoverPreviews re-runs when source changes`() {
-        val projectDir = createCmpTestProject()
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.foundation.background
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.material3.Text
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.graphics.Color
+        import androidx.compose.ui.unit.dp
 
-        // First run
-        GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews")
-            .withPluginClasspath()
-            .build()
-
-        // Add a new preview
-        val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
-        srcFile.appendText(
-            """
-
-            @Preview
-            @Composable
-            fun GreenBoxPreview() {
-                Box(modifier = Modifier.size(100.dp).background(Color.Green)) {
-                    Text("Green")
-                }
+        @Preview
+        @Composable
+        fun NestedPreview() {
+            Box(modifier = Modifier.size(80.dp).background(Color.Magenta)) {
+                Text("nested")
             }
-            """.trimIndent()
-        )
+        }
+        """
+          .trimIndent()
+      )
 
-        // Second run — should re-run and find 3 previews
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews")
-            .withPluginClasspath()
-            .build()
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments(":auth:composables:discoverPreviews", "--stacktrace")
+        .withPluginClasspath()
+        .build()
 
-        assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(result.task(":auth:composables:discoverPreviews")?.outcome)
+      .isEqualTo(TaskOutcome.SUCCESS)
 
-        val manifest = json.decodeFromString<PreviewManifest>(
-            File(projectDir, "build/compose-previews/previews.json").readText()
-        )
-        assertThat(manifest.previews).hasSize(3)
-    }
+    // Manifest lives under the real subproject dir (`auth/composables/…`),
+    // not a literal `auth:composables/…` path. This is the invariant the
+    // CLI's `PreviewModule.projectDir` relies on.
+    val manifestFile = File(childDir, "build/compose-previews/previews.json")
+    assertThat(manifestFile.exists()).isTrue()
 
-    /**
-     * Regression for issue #157: previews were only surfaced for top-level
-     * modules. Nested Gradle paths (`:auth:composables`) use `:` as a
-     * separator, but the CLI was treating that string as a filesystem path
-     * and looking under `projectRoot/auth:composables/build/...` — which
-     * doesn't exist. The plugin itself always wrote manifests to the real
-     * subproject directory (`auth/composables/build/...`); this test locks
-     * that behaviour in so the CLI fix (`PreviewModule.projectDir` via the
-     * Tooling API) has a stable contract to read against.
-     */
-    @Test
-    fun `discoverPreviews runs in a nested subproject`() {
-        val projectDir = tempDir.root
+    // A stray `auth:composables/` directory would mean someone resolved
+    // the Gradle path as a filesystem path — the exact #157 bug.
+    assertThat(File(projectDir, "auth:composables").exists()).isFalse()
 
-        // Root settings with a :auth:composables nested subproject.
-        File(projectDir, "settings.gradle.kts").writeText(
-            """
-            pluginManagement {
-                repositories {
-                    gradlePluginPortal()
-                    google()
-                    mavenCentral()
-                }
-            }
-            dependencyResolutionManagement {
-                repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-                repositories {
-                    google()
-                    mavenCentral()
-                }
-            }
-            rootProject.name = "nested-test"
-            include(":auth:composables")
-            """.trimIndent()
-        )
+    val manifest = json.decodeFromString<PreviewManifest>(manifestFile.readText())
+    assertThat(manifest.previews).hasSize(1)
+    assertThat(manifest.previews[0].functionName).isEqualTo("NestedPreview")
+  }
 
-        // Root build.gradle.kts is empty — the plugin is only applied to the
-        // nested subproject to mirror the Horologist-style layout in #157.
-        File(projectDir, "build.gradle.kts").writeText("")
+  @Test
+  fun `discoverPreviews finds private and internal previews`() {
+    // Teams that don't want @Preview functions to leak into their public
+    // API mark them `private` (or `internal`). Kotlin compiles `private
+    // fun` to JVM `private` and ClassGraph's default visibility filter
+    // drops them; `internal fun` compiles to JVM `public` (with the
+    // `name$module` mangle) so it has always been visible. Asserting both
+    // shapes so the visibility regression doesn't return on either axis.
+    val projectDir = createCmpTestProject()
 
-        File(projectDir, "gradle.properties").writeText(
-            "org.gradle.configuration-cache=true\n"
-        )
+    val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+    srcFile.writeText(
+      """
+      package test
 
-        val childDir = File(projectDir, "auth/composables")
-        childDir.mkdirs()
-        File(childDir, "build.gradle.kts").writeText(
-            """
-            @file:Suppress("DEPRECATION")
-            plugins {
-                kotlin("jvm") version "2.2.21"
-                kotlin("plugin.compose") version "2.2.21"
-                id("org.jetbrains.compose") version "1.10.3"
-                id("ee.schimke.composeai.preview")
-            }
-            dependencies {
-                implementation(compose.desktop.currentOs)
-                implementation(compose.material3)
-                implementation(compose.uiTooling)
-                implementation(compose.components.uiToolingPreview)
-            }
-            java {
-                toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
-            }
-            """.trimIndent()
-        )
+      import androidx.compose.ui.tooling.preview.Preview
+      import androidx.compose.foundation.background
+      import androidx.compose.foundation.layout.Box
+      import androidx.compose.foundation.layout.size
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+      import androidx.compose.ui.graphics.Color
+      import androidx.compose.ui.unit.dp
 
-        val childSrc = File(childDir, "src/main/kotlin/nested")
-        childSrc.mkdirs()
-        File(childSrc, "Previews.kt").writeText(
-            """
-            package nested
+      @Preview
+      @Composable
+      fun PublicPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Red))
+      }
 
-            import androidx.compose.ui.tooling.preview.Preview
-            import androidx.compose.foundation.background
-            import androidx.compose.foundation.layout.Box
-            import androidx.compose.foundation.layout.size
-            import androidx.compose.material3.Text
-            import androidx.compose.runtime.Composable
-            import androidx.compose.ui.Modifier
-            import androidx.compose.ui.graphics.Color
-            import androidx.compose.ui.unit.dp
+      @Preview
+      @Composable
+      internal fun InternalPreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Green))
+      }
 
-            @Preview
-            @Composable
-            fun NestedPreview() {
-                Box(modifier = Modifier.size(80.dp).background(Color.Magenta)) {
-                    Text("nested")
-                }
-            }
-            """.trimIndent()
-        )
+      @Preview
+      @Composable
+      private fun PrivatePreview() {
+          Box(modifier = Modifier.size(50.dp).background(Color.Blue))
+      }
+      """
+        .trimIndent()
+    )
 
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments(":auth:composables:discoverPreviews", "--stacktrace")
-            .withPluginClasspath()
-            .build()
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("discoverPreviews", "--stacktrace")
+        .withPluginClasspath()
+        .build()
 
-        assertThat(result.task(":auth:composables:discoverPreviews")?.outcome)
-            .isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
-        // Manifest lives under the real subproject dir (`auth/composables/…`),
-        // not a literal `auth:composables/…` path. This is the invariant the
-        // CLI's `PreviewModule.projectDir` relies on.
-        val manifestFile = File(childDir, "build/compose-previews/previews.json")
-        assertThat(manifestFile.exists()).isTrue()
+    val manifest =
+      json.decodeFromString<PreviewManifest>(
+        File(projectDir, "build/compose-previews/previews.json").readText()
+      )
+    // `internal fun` has its JVM name mangled to `InternalPreview$<module>`
+    // so we match by prefix rather than exact equality.
+    val names = manifest.previews.map { it.functionName }
+    assertThat(names).contains("PublicPreview")
+    assertThat(names).contains("PrivatePreview")
+    assertThat(names.any { it.startsWith("InternalPreview") }).isTrue()
+    assertThat(manifest.previews).hasSize(3)
+  }
 
-        // A stray `auth:composables/` directory would mean someone resolved
-        // the Gradle path as a filesystem path — the exact #157 bug.
-        assertThat(File(projectDir, "auth:composables").exists()).isFalse()
+  @Test
+  fun `failOnEmpty fails the build and emits diagnostics when no previews exist`() {
+    val projectDir = createCmpTestProject()
 
-        val manifest = json.decodeFromString<PreviewManifest>(manifestFile.readText())
-        assertThat(manifest.previews).hasSize(1)
-        assertThat(manifest.previews[0].functionName).isEqualTo("NestedPreview")
-    }
+    // Replace the preview source file with one that has NO @Preview annotations.
+    // Keeps Compose on the classpath so ClassGraph has real classes to report
+    // about — exactly the diagnostic "scan found classes but no @Preview" path.
+    val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
+    srcFile.writeText(
+      """
+      package test
 
-    @Test
-    fun `discoverPreviews finds private and internal previews`() {
-        // Teams that don't want @Preview functions to leak into their public
-        // API mark them `private` (or `internal`). Kotlin compiles `private
-        // fun` to JVM `private` and ClassGraph's default visibility filter
-        // drops them; `internal fun` compiles to JVM `public` (with the
-        // `name$module` mangle) so it has always been visible. Asserting both
-        // shapes so the visibility regression doesn't return on either axis.
-        val projectDir = createCmpTestProject()
+      import androidx.compose.foundation.background
+      import androidx.compose.foundation.layout.Box
+      import androidx.compose.foundation.layout.size
+      import androidx.compose.material3.Text
+      import androidx.compose.runtime.Composable
+      import androidx.compose.ui.Modifier
+      import androidx.compose.ui.graphics.Color
+      import androidx.compose.ui.unit.dp
 
-        val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
-        srcFile.writeText(
-            """
-            package test
+      @Composable
+      fun NotAPreview() {
+          Box(modifier = Modifier.size(100.dp).background(Color.Red)) {
+              Text("Red")
+          }
+      }
+      """
+        .trimIndent()
+    )
 
-            import androidx.compose.ui.tooling.preview.Preview
-            import androidx.compose.foundation.background
-            import androidx.compose.foundation.layout.Box
-            import androidx.compose.foundation.layout.size
-            import androidx.compose.runtime.Composable
-            import androidx.compose.ui.Modifier
-            import androidx.compose.ui.graphics.Color
-            import androidx.compose.ui.unit.dp
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("discoverPreviews", "-PcomposePreview.failOnEmpty=true", "--stacktrace")
+        .withPluginClasspath()
+        .buildAndFail()
 
-            @Preview
-            @Composable
-            fun PublicPreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Red))
-            }
+    assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.FAILED)
+    // The failure message names the module so CI logs make the regression obvious.
+    assertThat(result.output).contains("discovered 0 previews in module 'test-project'")
+    // Diagnostics block: classDirs listing (directory existence + class counts)
+    // and the ClassGraph summary. These are the two lines users need to see to
+    // disambiguate "wrong class dir" from "wrong @Preview FQN".
+    assertThat(result.output).contains("composePreview: failOnEmpty diagnostics")
+    assertThat(result.output).contains("classDirs (")
+    assertThat(result.output).contains("ClassGraph scan:")
+    // The sample had Compose classes but no @Preview — we should see the
+    // "no known @Preview FQN seen" branch, not the "FQNs WERE seen" branch.
+    assertThat(result.output).contains("no known @Preview FQN seen on any scanned method")
+  }
 
-            @Preview
-            @Composable
-            internal fun InternalPreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Green))
-            }
+  @Test
+  fun `failOnEmpty is quiet when previews exist`() {
+    val projectDir = createCmpTestProject()
 
-            @Preview
-            @Composable
-            private fun PrivatePreview() {
-                Box(modifier = Modifier.size(50.dp).background(Color.Blue))
-            }
-            """.trimIndent()
-        )
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("discoverPreviews", "-PcomposePreview.failOnEmpty=true", "--stacktrace")
+        .withPluginClasspath()
+        .build()
 
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews", "--stacktrace")
-            .withPluginClasspath()
-            .build()
-
-        assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-
-        val manifest = json.decodeFromString<PreviewManifest>(
-            File(projectDir, "build/compose-previews/previews.json").readText()
-        )
-        // `internal fun` has its JVM name mangled to `InternalPreview$<module>`
-        // so we match by prefix rather than exact equality.
-        val names = manifest.previews.map { it.functionName }
-        assertThat(names).contains("PublicPreview")
-        assertThat(names).contains("PrivatePreview")
-        assertThat(names.any { it.startsWith("InternalPreview") }).isTrue()
-        assertThat(manifest.previews).hasSize(3)
-    }
-
-    @Test
-    fun `failOnEmpty fails the build and emits diagnostics when no previews exist`() {
-        val projectDir = createCmpTestProject()
-
-        // Replace the preview source file with one that has NO @Preview annotations.
-        // Keeps Compose on the classpath so ClassGraph has real classes to report
-        // about — exactly the diagnostic "scan found classes but no @Preview" path.
-        val srcFile = File(projectDir, "src/main/kotlin/test/Previews.kt")
-        srcFile.writeText(
-            """
-            package test
-
-            import androidx.compose.foundation.background
-            import androidx.compose.foundation.layout.Box
-            import androidx.compose.foundation.layout.size
-            import androidx.compose.material3.Text
-            import androidx.compose.runtime.Composable
-            import androidx.compose.ui.Modifier
-            import androidx.compose.ui.graphics.Color
-            import androidx.compose.ui.unit.dp
-
-            @Composable
-            fun NotAPreview() {
-                Box(modifier = Modifier.size(100.dp).background(Color.Red)) {
-                    Text("Red")
-                }
-            }
-            """.trimIndent()
-        )
-
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews", "-PcomposePreview.failOnEmpty=true", "--stacktrace")
-            .withPluginClasspath()
-            .buildAndFail()
-
-        assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.FAILED)
-        // The failure message names the module so CI logs make the regression obvious.
-        assertThat(result.output).contains("discovered 0 previews in module 'test-project'")
-        // Diagnostics block: classDirs listing (directory existence + class counts)
-        // and the ClassGraph summary. These are the two lines users need to see to
-        // disambiguate "wrong class dir" from "wrong @Preview FQN".
-        assertThat(result.output).contains("composePreview: failOnEmpty diagnostics")
-        assertThat(result.output).contains("classDirs (")
-        assertThat(result.output).contains("ClassGraph scan:")
-        // The sample had Compose classes but no @Preview — we should see the
-        // "no known @Preview FQN seen" branch, not the "FQNs WERE seen" branch.
-        assertThat(result.output).contains("no known @Preview FQN seen on any scanned method")
-    }
-
-    @Test
-    fun `failOnEmpty is quiet when previews exist`() {
-        val projectDir = createCmpTestProject()
-
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews", "-PcomposePreview.failOnEmpty=true", "--stacktrace")
-            .withPluginClasspath()
-            .build()
-
-        assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
-        // Diagnostics only emit on the empty path; a populated run must not
-        // spam the log with them.
-        assertThat(result.output).doesNotContain("failOnEmpty diagnostics")
-    }
+    assertThat(result.task(":discoverPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    // Diagnostics only emit on the empty path; a populated run must not
+    // spam the log with them.
+    assertThat(result.output).doesNotContain("failOnEmpty diagnostics")
+  }
 }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/HistoryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/HistoryFunctionalTest.kt
@@ -1,50 +1,52 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import java.io.File
+import javax.imageio.ImageIO
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import java.io.File
-import javax.imageio.ImageIO
 
 /**
  * End-to-end coverage for the preview history flow.
  *
- * Uses the CMP renderer (fast + deterministic, same setup as RenderFunctionalTest)
- * rather than the Android path, since the history task itself is backend-agnostic.
+ * Uses the CMP renderer (fast + deterministic, same setup as RenderFunctionalTest) rather than the
+ * Android path, since the history task itself is backend-agnostic.
  */
 class HistoryFunctionalTest {
 
-    @get:Rule
-    val tempDir = TemporaryFolder()
+  @get:Rule val tempDir = TemporaryFolder()
 
-    private fun createProject(historyEnabled: Boolean): File {
-        val projectDir = tempDir.root
+  private fun createProject(historyEnabled: Boolean): File {
+    val projectDir = tempDir.root
 
-        File(projectDir, "settings.gradle.kts").writeText(
-            """
-            pluginManagement {
-                repositories {
-                    gradlePluginPortal()
-                    google()
-                    mavenCentral()
-                }
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                google()
+                mavenCentral()
             }
-            dependencyResolutionManagement {
-                repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-                repositories {
-                    google()
-                    mavenCentral()
-                }
+        }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                google()
+                mavenCentral()
             }
-            rootProject.name = "test-history"
-            """.trimIndent()
-        )
+        }
+        rootProject.name = "test-history"
+        """
+          .trimIndent()
+      )
 
-        File(projectDir, "build.gradle.kts").writeText(
-            """
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
             @file:Suppress("DEPRECATION")
             plugins {
                 kotlin("jvm") version "2.2.21"
@@ -64,31 +66,32 @@ class HistoryFunctionalTest {
             java {
                 toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
             }
-            """.trimIndent()
-        )
-
-        File(projectDir, "gradle.properties").writeText(
-            "org.gradle.configuration-cache=true\n"
-        )
-
-        val srcDir = File(projectDir, "src/main/kotlin/test")
-        srcDir.mkdirs()
-        writePreviewSource(srcDir, color = "Red")
-
-        return projectDir
-    }
-
-    private fun writePreviewSource(srcDir: File, color: String) {
-        // backgroundColor+showBackground fills the full preview so the PNG's centre
-        // pixel tracks the source colour — lets us prove renders differ across edits.
-        val hex = when (color) {
-            "Red" -> "0xFFFF0000"
-            "Blue" -> "0xFF0000FF"
-            "Green" -> "0xFF00FF00"
-            else -> error("unknown colour: $color")
-        }
-        File(srcDir, "ColorBoxes.kt").writeText(
             """
+          .trimIndent()
+      )
+
+    File(projectDir, "gradle.properties").writeText("org.gradle.configuration-cache=true\n")
+
+    val srcDir = File(projectDir, "src/main/kotlin/test")
+    srcDir.mkdirs()
+    writePreviewSource(srcDir, color = "Red")
+
+    return projectDir
+  }
+
+  private fun writePreviewSource(srcDir: File, color: String) {
+    // backgroundColor+showBackground fills the full preview so the PNG's centre
+    // pixel tracks the source colour — lets us prove renders differ across edits.
+    val hex =
+      when (color) {
+        "Red" -> "0xFFFF0000"
+        "Blue" -> "0xFF0000FF"
+        "Green" -> "0xFF00FF00"
+        else -> error("unknown colour: $color")
+      }
+    File(srcDir, "ColorBoxes.kt")
+      .writeText(
+        """
             package test
 
             import androidx.compose.ui.tooling.preview.Preview
@@ -109,113 +112,125 @@ class HistoryFunctionalTest {
             fun BoxPreview() {
                 Box(modifier = Modifier.fillMaxSize().background(Color.$color))
             }
-            """.trimIndent()
-        )
-    }
+            """
+          .trimIndent()
+      )
+  }
 
-    private fun runRenderAllPreviews(projectDir: File) =
-        GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("renderAllPreviews", "--stacktrace")
-            .withPluginClasspath()
-            .build()
+  private fun runRenderAllPreviews(projectDir: File) =
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("renderAllPreviews", "--stacktrace")
+      .withPluginClasspath()
+      .build()
 
-    private fun historyPreviewFolder(projectDir: File): File? =
-        File(projectDir, ".compose-preview-history")
-            .takeIf { it.exists() }
-            ?.listFiles()
-            ?.firstOrNull { it.isDirectory }
+  private fun historyPreviewFolder(projectDir: File): File? =
+    File(projectDir, ".compose-preview-history")
+      .takeIf { it.exists() }
+      ?.listFiles()
+      ?.firstOrNull { it.isDirectory }
 
-    @Test
-    fun `history disabled by default - no historize task is registered`() {
-        val projectDir = createProject(historyEnabled = false)
+  @Test
+  fun `history disabled by default - no historize task is registered`() {
+    val projectDir = createProject(historyEnabled = false)
 
-        val result = runRenderAllPreviews(projectDir)
+    val result = runRenderAllPreviews(projectDir)
 
-        assertThat(result.task(":historizePreviews")).isNull()
-        assertThat(File(projectDir, ".compose-preview-history").exists()).isFalse()
-    }
+    assertThat(result.task(":historizePreviews")).isNull()
+    assertThat(File(projectDir, ".compose-preview-history").exists()).isFalse()
+  }
 
-    @Test
-    fun `first run archives a snapshot per preview`() {
-        val projectDir = createProject(historyEnabled = true)
+  @Test
+  fun `first run archives a snapshot per preview`() {
+    val projectDir = createProject(historyEnabled = true)
 
-        val result = runRenderAllPreviews(projectDir)
+    val result = runRenderAllPreviews(projectDir)
 
-        assertThat(result.task(":historizePreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(result.task(":historizePreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
-        val previewFolder = historyPreviewFolder(projectDir)
-        assertThat(previewFolder).isNotNull()
-        val snapshots = previewFolder!!.listFiles { f -> f.extension == "png" } ?: emptyArray()
-        assertThat(snapshots).hasLength(1)
-        // Timestamp format yyyyMMdd-HHmmss (plus optional -N collision suffix).
-        assertThat(snapshots[0].name).matches("""\d{8}-\d{6}(-\d+)?\.png""")
-    }
+    val previewFolder = historyPreviewFolder(projectDir)
+    assertThat(previewFolder).isNotNull()
+    val snapshots = previewFolder!!.listFiles { f -> f.extension == "png" } ?: emptyArray()
+    assertThat(snapshots).hasLength(1)
+    // Timestamp format yyyyMMdd-HHmmss (plus optional -N collision suffix).
+    assertThat(snapshots[0].name).matches("""\d{8}-\d{6}(-\d+)?\.png""")
+  }
 
-    @Test
-    fun `rerun with identical render does not add a second snapshot`() {
-        val projectDir = createProject(historyEnabled = true)
+  @Test
+  fun `rerun with identical render does not add a second snapshot`() {
+    val projectDir = createProject(historyEnabled = true)
 
-        runRenderAllPreviews(projectDir)
-        val countAfterFirst = historyPreviewFolder(projectDir)!!
-            .listFiles { f -> f.extension == "png" }!!.size
+    runRenderAllPreviews(projectDir)
+    val countAfterFirst =
+      historyPreviewFolder(projectDir)!!.listFiles { f -> f.extension == "png" }!!.size
 
-        // Force the history task to execute again even though renders are UP-TO-DATE:
-        // delete the marker output and invoke via a second argument that bumps the graph.
-        // Since history task has @Internal output dir and depends on renderTask, if
-        // renders are UP-TO-DATE the history task's inputs are unchanged → it also goes
-        // UP-TO-DATE. That alone proves no duplicate snapshot is archived.
-        val secondRun = runRenderAllPreviews(projectDir)
-        val countAfterSecond = historyPreviewFolder(projectDir)!!
-            .listFiles { f -> f.extension == "png" }!!.size
+    // Force the history task to execute again even though renders are UP-TO-DATE:
+    // delete the marker output and invoke via a second argument that bumps the graph.
+    // Since history task has @Internal output dir and depends on renderTask, if
+    // renders are UP-TO-DATE the history task's inputs are unchanged → it also goes
+    // UP-TO-DATE. That alone proves no duplicate snapshot is archived.
+    val secondRun = runRenderAllPreviews(projectDir)
+    val countAfterSecond =
+      historyPreviewFolder(projectDir)!!.listFiles { f -> f.extension == "png" }!!.size
 
-        assertThat(countAfterSecond).isEqualTo(countAfterFirst)
-        // Whether the task is SKIPPED/UP-TO-DATE or re-runs with no-op is fine — the
-        // invariant is "no new file when bytes unchanged".
-        assertThat(secondRun.task(":historizePreviews")?.outcome)
-            .isAnyOf(TaskOutcome.UP_TO_DATE, TaskOutcome.SUCCESS, TaskOutcome.SKIPPED, TaskOutcome.FROM_CACHE)
-    }
+    assertThat(countAfterSecond).isEqualTo(countAfterFirst)
+    // Whether the task is SKIPPED/UP-TO-DATE or re-runs with no-op is fine — the
+    // invariant is "no new file when bytes unchanged".
+    assertThat(secondRun.task(":historizePreviews")?.outcome)
+      .isAnyOf(
+        TaskOutcome.UP_TO_DATE,
+        TaskOutcome.SUCCESS,
+        TaskOutcome.SKIPPED,
+        TaskOutcome.FROM_CACHE,
+      )
+  }
 
-    @Test
-    fun `changed preview content adds a new snapshot`() {
-        val projectDir = createProject(historyEnabled = true)
-        val srcDir = File(projectDir, "src/main/kotlin/test")
+  @Test
+  fun `changed preview content adds a new snapshot`() {
+    val projectDir = createProject(historyEnabled = true)
+    val srcDir = File(projectDir, "src/main/kotlin/test")
 
-        // Preview uses showBackground + backgroundColor so the full PNG takes on the
-        // preview's colour — byte-identity of two consecutive renders is a robust
-        // signal that the render actually changed between source edits.
-        runRenderAllPreviews(projectDir)
-        val firstPng = File(projectDir, "build/compose-previews/renders")
-            .listFiles { f -> f.extension == "png" }!!
-            .first()
-        val firstCenter = ImageIO.read(firstPng).let { img -> img.getRGB(img.width / 2, img.height / 2) }
-        val initial = historyPreviewFolder(projectDir)!!
-            .listFiles { f -> f.extension == "png" }!!
-            .map { it.name }
-            .toSet()
+    // Preview uses showBackground + backgroundColor so the full PNG takes on the
+    // preview's colour — byte-identity of two consecutive renders is a robust
+    // signal that the render actually changed between source edits.
+    runRenderAllPreviews(projectDir)
+    val firstPng =
+      File(projectDir, "build/compose-previews/renders")
+        .listFiles { f -> f.extension == "png" }!!
+        .first()
+    val firstCenter =
+      ImageIO.read(firstPng).let { img -> img.getRGB(img.width / 2, img.height / 2) }
+    val initial =
+      historyPreviewFolder(projectDir)!!
+        .listFiles { f -> f.extension == "png" }!!
+        .map { it.name }
+        .toSet()
 
-        // Change the preview's colour so the PNG bytes differ. Bump mtime explicitly —
-        // on fast test machines two writes within the same second may not invalidate
-        // Gradle's file-change tracking.
-        writePreviewSource(srcDir, color = "Blue")
-        File(srcDir, "ColorBoxes.kt").setLastModified(System.currentTimeMillis() + 2000)
+    // Change the preview's colour so the PNG bytes differ. Bump mtime explicitly —
+    // on fast test machines two writes within the same second may not invalidate
+    // Gradle's file-change tracking.
+    writePreviewSource(srcDir, color = "Blue")
+    File(srcDir, "ColorBoxes.kt").setLastModified(System.currentTimeMillis() + 2000)
 
-        runRenderAllPreviews(projectDir)
-        val secondPng = File(projectDir, "build/compose-previews/renders")
-            .listFiles { f -> f.extension == "png" }!!
-            .first()
-        val secondCenter = ImageIO.read(secondPng).let { img -> img.getRGB(img.width / 2, img.height / 2) }
+    runRenderAllPreviews(projectDir)
+    val secondPng =
+      File(projectDir, "build/compose-previews/renders")
+        .listFiles { f -> f.extension == "png" }!!
+        .first()
+    val secondCenter =
+      ImageIO.read(secondPng).let { img -> img.getRGB(img.width / 2, img.height / 2) }
 
-        // Sanity: the render actually changed — otherwise the history comparison
-        // is vacuous and the test isn't exercising what we think.
-        assertThat(firstCenter).isNotEqualTo(secondCenter)
+    // Sanity: the render actually changed — otherwise the history comparison
+    // is vacuous and the test isn't exercising what we think.
+    assertThat(firstCenter).isNotEqualTo(secondCenter)
 
-        val after = historyPreviewFolder(projectDir)!!
-            .listFiles { f -> f.extension == "png" }!!
-            .map { it.name }
-            .toSet()
+    val after =
+      historyPreviewFolder(projectDir)!!
+        .listFiles { f -> f.extension == "png" }!!
+        .map { it.name }
+        .toSet()
 
-        assertThat(after).containsAtLeastElementsIn(initial)
-        assertThat(after - initial).hasSize(1)
-    }
+    assertThat(after).containsAtLeastElementsIn(initial)
+    assertThat(after - initial).hasSize(1)
+  }
 }

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderFunctionalTest.kt
@@ -1,191 +1,197 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
 import kotlinx.serialization.json.Json
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import java.awt.image.BufferedImage
-import java.io.File
-import javax.imageio.ImageIO
 
 class RenderFunctionalTest {
 
-    @get:Rule
-    val tempDir = TemporaryFolder()
+  @get:Rule val tempDir = TemporaryFolder()
 
-    private val json = Json { ignoreUnknownKeys = true }
+  private val json = Json { ignoreUnknownKeys = true }
 
-    private fun createTestProject(): File {
-        val projectDir = tempDir.root
+  private fun createTestProject(): File {
+    val projectDir = tempDir.root
 
-        File(projectDir, "settings.gradle.kts").writeText(
-            """
-            pluginManagement {
-                repositories {
-                    gradlePluginPortal()
-                    google()
-                    mavenCentral()
-                }
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                google()
+                mavenCentral()
             }
-            dependencyResolutionManagement {
-                repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-                repositories {
-                    google()
-                    mavenCentral()
-                }
+        }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                google()
+                mavenCentral()
             }
-            rootProject.name = "test-render"
-            """.trimIndent()
-        )
+        }
+        rootProject.name = "test-render"
+        """
+          .trimIndent()
+      )
 
-        File(projectDir, "build.gradle.kts").writeText(
-            """
-            @file:Suppress("DEPRECATION")
-            plugins {
-                kotlin("jvm") version "2.2.21"
-                kotlin("plugin.compose") version "2.2.21"
-                id("org.jetbrains.compose") version "1.10.3"
-                id("ee.schimke.composeai.preview")
-            }
-            dependencies {
-                implementation(compose.desktop.currentOs)
-                implementation(compose.material3)
-                implementation(compose.uiTooling)
-                implementation(compose.components.uiToolingPreview)
-            }
-            java {
-                toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
-            }
-            """.trimIndent()
-        )
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
+        @file:Suppress("DEPRECATION")
+        plugins {
+            kotlin("jvm") version "2.2.21"
+            kotlin("plugin.compose") version "2.2.21"
+            id("org.jetbrains.compose") version "1.10.3"
+            id("ee.schimke.composeai.preview")
+        }
+        dependencies {
+            implementation(compose.desktop.currentOs)
+            implementation(compose.material3)
+            implementation(compose.uiTooling)
+            implementation(compose.components.uiToolingPreview)
+        }
+        java {
+            toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+        }
+        """
+          .trimIndent()
+      )
 
-        File(projectDir, "gradle.properties").writeText(
-            "org.gradle.configuration-cache=true\n"
-        )
+    File(projectDir, "gradle.properties").writeText("org.gradle.configuration-cache=true\n")
 
-        val srcDir = File(projectDir, "src/main/kotlin/test")
-        srcDir.mkdirs()
-        File(srcDir, "ColorBoxes.kt").writeText(
-            """
-            package test
+    val srcDir = File(projectDir, "src/main/kotlin/test")
+    srcDir.mkdirs()
+    File(srcDir, "ColorBoxes.kt")
+      .writeText(
+        """
+        package test
 
-            import androidx.compose.ui.tooling.preview.Preview
-            import androidx.compose.foundation.background
-            import androidx.compose.foundation.layout.Box
-            import androidx.compose.foundation.layout.size
-            import androidx.compose.runtime.Composable
-            import androidx.compose.ui.Modifier
-            import androidx.compose.ui.graphics.Color
-            import androidx.compose.ui.unit.dp
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.foundation.background
+        import androidx.compose.foundation.layout.Box
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.graphics.Color
+        import androidx.compose.ui.unit.dp
 
-            @Preview
-            @Composable
-            fun RedBoxPreview() {
-                Box(modifier = Modifier.size(100.dp).background(Color.Red))
-            }
-            """.trimIndent()
-        )
+        @Preview
+        @Composable
+        fun RedBoxPreview() {
+            Box(modifier = Modifier.size(100.dp).background(Color.Red))
+        }
+        """
+          .trimIndent()
+      )
 
-        return projectDir
-    }
+    return projectDir
+  }
 
-    @Test
-    fun `renderAllPreviews produces PNG files`() {
-        val projectDir = createTestProject()
+  @Test
+  fun `renderAllPreviews produces PNG files`() {
+    val projectDir = createTestProject()
 
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("renderAllPreviews", "--stacktrace")
-            .withPluginClasspath()
-            .build()
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("renderAllPreviews", "--stacktrace")
+        .withPluginClasspath()
+        .build()
 
-        assertThat(result.task(":renderPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(result.task(":renderPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
-        val rendersDir = File(projectDir, "build/compose-previews/renders")
-        assertThat(rendersDir.exists()).isTrue()
+    val rendersDir = File(projectDir, "build/compose-previews/renders")
+    assertThat(rendersDir.exists()).isTrue()
 
-        val pngFiles = rendersDir.listFiles { f -> f.extension == "png" } ?: emptyArray()
-        assertThat(pngFiles).isNotEmpty()
-    }
+    val pngFiles = rendersDir.listFiles { f -> f.extension == "png" } ?: emptyArray()
+    assertThat(pngFiles).isNotEmpty()
+  }
 
-    @Test
-    fun `rendered PNG has correct dimensions`() {
-        val projectDir = createTestProject()
+  @Test
+  fun `rendered PNG has correct dimensions`() {
+    val projectDir = createTestProject()
 
-        GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("renderAllPreviews")
-            .withPluginClasspath()
-            .build()
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("renderAllPreviews")
+      .withPluginClasspath()
+      .build()
 
-        val rendersDir = File(projectDir, "build/compose-previews/renders")
-        val pngFile = rendersDir.listFiles { f -> f.extension == "png" }?.firstOrNull()
-        assertThat(pngFile).isNotNull()
+    val rendersDir = File(projectDir, "build/compose-previews/renders")
+    val pngFile = rendersDir.listFiles { f -> f.extension == "png" }?.firstOrNull()
+    assertThat(pngFile).isNotNull()
 
-        val img: BufferedImage = ImageIO.read(pngFile!!)
-        // Synthetic functional-test projects don't have `:renderer-desktop` on
-        // their classpath, so the plugin falls back to the stub renderer
-        // (PreviewRenderWorkAction) — which writes a blank PNG of the
-        // task-computed sandbox size without running a real composition.
-        // Under AS-parity sizing, a bare `@Preview` gets the wrap-content
-        // sandbox (400×800 dp) at DEFAULT_DENSITY (2.625x) = 1050×2100 px.
-        // The real wrap-to-intrinsic crop is exercised end-to-end through the
-        // sample-cmp / sample-android render tasks, which pull in the actual
-        // renderer modules.
-        assertThat(img.width).isEqualTo(1050)
-        assertThat(img.height).isEqualTo(2100)
-    }
+    val img: BufferedImage = ImageIO.read(pngFile!!)
+    // Synthetic functional-test projects don't have `:renderer-desktop` on
+    // their classpath, so the plugin falls back to the stub renderer
+    // (PreviewRenderWorkAction) — which writes a blank PNG of the
+    // task-computed sandbox size without running a real composition.
+    // Under AS-parity sizing, a bare `@Preview` gets the wrap-content
+    // sandbox (400×800 dp) at DEFAULT_DENSITY (2.625x) = 1050×2100 px.
+    // The real wrap-to-intrinsic crop is exercised end-to-end through the
+    // sample-cmp / sample-android render tasks, which pull in the actual
+    // renderer modules.
+    assertThat(img.width).isEqualTo(1050)
+    assertThat(img.height).isEqualTo(2100)
+  }
 
-    @Test
-    fun `renderAllPreviews fails loudly when render produces no PNGs for a non-empty manifest`() {
-        val projectDir = createTestProject()
+  @Test
+  fun `renderAllPreviews fails loudly when render produces no PNGs for a non-empty manifest`() {
+    val projectDir = createTestProject()
 
-        // Discover first so `previews.json` exists with real entries; that's
-        // the precondition for the post-condition check. We run discovery
-        // directly rather than going through renderAllPreviews so no PNGs
-        // get produced as a side-effect.
-        GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("discoverPreviews")
-            .withPluginClasspath()
-            .build()
+    // Discover first so `previews.json` exists with real entries; that's
+    // the precondition for the post-condition check. We run discovery
+    // directly rather than going through renderAllPreviews so no PNGs
+    // get produced as a side-effect.
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("discoverPreviews")
+      .withPluginClasspath()
+      .build()
 
-        val manifest = File(projectDir, "build/compose-previews/previews.json")
-        assertThat(manifest.exists()).isTrue()
+    val manifest = File(projectDir, "build/compose-previews/previews.json")
+    assertThat(manifest.exists()).isTrue()
 
-        // Force the failure mode: invoke `renderAllPreviews` but exclude the
-        // render task. This mirrors the real-world regression where
-        // `renderPreviews` silently becomes NO-SOURCE — the aggregate task
-        // still fires but no PNGs land on disk.
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("renderAllPreviews", "-x", "renderPreviews", "--stacktrace")
-            .withPluginClasspath()
-            .buildAndFail()
+    // Force the failure mode: invoke `renderAllPreviews` but exclude the
+    // render task. This mirrors the real-world regression where
+    // `renderPreviews` silently becomes NO-SOURCE — the aggregate task
+    // still fires but no PNGs land on disk.
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("renderAllPreviews", "-x", "renderPreviews", "--stacktrace")
+        .withPluginClasspath()
+        .buildAndFail()
 
-        assertThat(result.output).contains("render produced no PNG")
-        assertThat(result.output).contains("NO-SOURCE")
-    }
+    assertThat(result.output).contains("render produced no PNG")
+    assertThat(result.output).contains("NO-SOURCE")
+  }
 
-    @Test
-    fun `renderPreviews is UP-TO-DATE on second run`() {
-        val projectDir = createTestProject()
+  @Test
+  fun `renderPreviews is UP-TO-DATE on second run`() {
+    val projectDir = createTestProject()
 
-        GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("renderAllPreviews")
-            .withPluginClasspath()
-            .build()
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("renderAllPreviews")
+      .withPluginClasspath()
+      .build()
 
-        val result = GradleRunner.create()
-            .withProjectDir(projectDir)
-            .withArguments("renderAllPreviews")
-            .withPluginClasspath()
-            .build()
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("renderAllPreviews")
+        .withPluginClasspath()
+        .build()
 
-        assertThat(result.task(":renderPreviews")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
-    }
+    assertThat(result.task(":renderPreviews")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -9,1092 +9,1135 @@ import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.testing.Test
 
 /**
- * All AGP-touching code lives here, segregated from [ComposePreviewPlugin] so
- * the plugin class stays loadable on classpaths without AGP (functional tests,
- * Compose-Multiplatform-only consumers). Gradle decorates the plugin class at
- * apply time — and decoration resolves referenced classes eagerly. Keeping
- * every `com.android.build.api.*` reference out of [ComposePreviewPlugin]'s
- * bytecode means AGP only gets loaded when this helper's static methods are
- * actually invoked, which happens inside
- * `pluginManager.withPlugin("com.android.application" / "com.android.library")`.
+ * All AGP-touching code lives here, segregated from [ComposePreviewPlugin] so the plugin class
+ * stays loadable on classpaths without AGP (functional tests, Compose-Multiplatform-only
+ * consumers). Gradle decorates the plugin class at apply time — and decoration resolves referenced
+ * classes eagerly. Keeping every `com.android.build.api.*` reference out of
+ * [ComposePreviewPlugin]'s bytecode means AGP only gets loaded when this helper's static methods
+ * are actually invoked, which happens inside `pluginManager.withPlugin("com.android.application" /
+ * "com.android.library")`.
  */
 internal object AndroidPreviewSupport {
-    /**
-     * Modules within `androidx.wear.tiles` whose presence in a consumer's
-     * declared deps signals "this project writes Tile previews." When any
-     * match, [configure] injects `wear.tiles:tiles-renderer` into the
-     * consumer's variant `implementation` so AGP generates R classes for
-     * protolayout-renderer — the class TilePreviewRenderer reflectively
-     * needs at render time. See the `afterEvaluate` block in
-     * [registerAndroidTasks] for the full rationale.
-     */
-    private val tilesSignalNames = setOf(
-        "tiles",
-        "tiles-renderer",
-        "tiles-tooling-preview",
-        "tiles-tooling",
+  /**
+   * Modules within `androidx.wear.tiles` whose presence in a consumer's declared deps signals "this
+   * project writes Tile previews." When any match, [configure] injects `wear.tiles:tiles-renderer`
+   * into the consumer's variant `implementation` so AGP generates R classes for
+   * protolayout-renderer — the class TilePreviewRenderer reflectively needs at render time. See the
+   * `afterEvaluate` block in [registerAndroidTasks] for the full rationale.
+   */
+  private val tilesSignalNames =
+    setOf("tiles", "tiles-renderer", "tiles-tooling-preview", "tiles-tooling")
+
+  /**
+   * `(group, name)` of every artifact whose presence in a module's declared deps marks it as a
+   * "valid preview module" — the plugin registers its tasks and runs discovery only when at least
+   * one matches. Convention-plugin-everywhere setups (e.g. applying `composePreview` to every
+   * Android module) stay silent no-ops on utility modules without any preview surface.
+   *
+   * Group+name match only (no version): cheap, IP-safe, doesn't trigger dependency resolution.
+   */
+  private val previewArtifactSignals =
+    setOf(
+      "androidx.compose.ui" to "ui-tooling-preview",
+      "androidx.compose.ui" to "ui-tooling-preview-android",
+      "androidx.wear.tiles" to "tiles-tooling-preview",
+      // CMP-only; AGP consumers never declare it but the helper is shared.
+      "org.jetbrains.compose.components" to "components-ui-tooling-preview",
     )
 
-    /**
-     * `(group, name)` of every artifact whose presence in a module's
-     * declared deps marks it as a "valid preview module" — the plugin
-     * registers its tasks and runs discovery only when at least one
-     * matches. Convention-plugin-everywhere setups (e.g. applying
-     * `composePreview` to every Android module) stay silent no-ops on
-     * utility modules without any preview surface.
-     *
-     * Group+name match only (no version): cheap, IP-safe, doesn't
-     * trigger dependency resolution.
-     */
-    private val previewArtifactSignals = setOf(
-        "androidx.compose.ui" to "ui-tooling-preview",
-        "androidx.compose.ui" to "ui-tooling-preview-android",
-        "androidx.wear.tiles" to "tiles-tooling-preview",
-        // CMP-only; AGP consumers never declare it but the helper is shared.
-        "org.jetbrains.compose.components" to "components-ui-tooling-preview",
-    )
+  fun configure(project: Project, extension: PreviewExtension) {
+    val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
 
-    fun configure(project: Project, extension: PreviewExtension) {
-        val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
-
-        androidComponents.finalizeDsl { android: Any ->
-            if (extension.enabled.get()) {
-                (android as CommonExtension).testOptions.unitTests.isIncludeAndroidResources = true
-            }
-        }
-
-        // Register render tasks once, for the variant the user picked. onVariants
-        // fires after AGP has created variant-specific configurations like
-        // `${variant}UnitTestRuntimeClasspath`, so everything we need is there.
-        // Fetching `sdkComponents.bootClasspath` eagerly (at apply time) forces
-        // AGP to read `compileOptions.targetCompatibility` before it's finalized
-        // and crashes — grab it inside onVariants instead.
-        var registered = false
-        androidComponents.onVariants(androidComponents.selector().all()) { variant ->
-            if (registered) return@onVariants
-            if (!extension.enabled.get()) return@onVariants
-            if (variant.name != extension.variant.get()) return@onVariants
-            if (!hasPreviewDependency(project)) {
-                project.logger.info(
-                    "compose-preview: no known @Preview dependency declared in module " +
-                        "'${project.path}'; skipping task registration. " +
-                        "Add one of ${previewArtifactSignals.joinToString { "${it.first}:${it.second}" }} " +
-                        "(or remove the plugin from this module) to opt in.",
-                )
-                return@onVariants
-            }
-            registered = true
-            registerAndroidTasks(project, extension, variant.name, androidComponents.sdkComponents.bootClasspath)
-        }
+    androidComponents.finalizeDsl { android: Any ->
+      if (extension.enabled.get()) {
+        (android as CommonExtension).testOptions.unitTests.isIncludeAndroidResources = true
+      }
     }
 
-    /**
-     * True when any declarative dep bucket (`implementation` / `api` /
-     * `runtimeOnly`, including their `<name>Implementation` variants)
-     * declares a coord in [previewArtifactSignals]. Read at onVariants
-     * time, after the consumer's `dependencies { }` block has populated
-     * configurations; avoids resolution and stays Isolated-Projects safe.
-     */
-    private fun hasPreviewDependency(project: Project): Boolean =
-        project.configurations.asSequence()
-            .filter { c ->
-                val n = c.name
-                n == "implementation" || n.endsWith("Implementation") ||
-                    n == "api" || n.endsWith("Api") ||
-                    n == "runtimeOnly" || n.endsWith("RuntimeOnly")
-            }
-            .any { c ->
-                c.allDependencies.any { dep ->
-                    val g = dep.group ?: return@any false
-                    previewArtifactSignals.any { (sg, sn) -> g == sg && dep.name == sn }
-                }
-            }
-
-    private fun registerAndroidTasks(
-        project: Project,
-        extension: PreviewExtension,
-        variantName: String,
-        bootClasspath: org.gradle.api.provider.Provider<List<org.gradle.api.file.RegularFile>>,
-    ) {
-        val capVariant = variantName.cap()
-        val previewOutputDir = project.layout.buildDirectory.dir("compose-previews")
-        val artifactType = Attribute.of("artifactType", String::class.java)
-
-        // `com.android.compose.screenshot` (Google's alpha Layoutlib-based
-        // screenshot testing plugin) adds its own `screenshotTest` source set
-        // alongside `main` / `test` / `androidTest`. We don't drive its
-        // validate/update tasks — we keep using our Robolectric renderer — but
-        // we DO want to discover and render any `@Preview` functions consumers
-        // put under `src/screenshotTest/`, so modules that already adopted the
-        // Google plugin (e.g. Confetti's `:androidApp`) surface those previews
-        // in the CLI / VS Code grid without duplicating them in `main`.
-        //
-        // Detection is by plugin id rather than the
-        // `android.experimental.enableScreenshotTest` gradle property, because
-        // the property is a global flag while the plugin is applied per-module
-        // — and only the latter actually causes AGP to register
-        // `compile${Cap}ScreenshotTestKotlin` and the
-        // `${variant}ScreenshotTestRuntimeClasspath` configuration we need.
-        val screenshotTestEnabled = project.pluginManager.hasPlugin("com.android.compose.screenshot")
-
-        val sourceClassDirs = project.files(
-            project.layout.buildDirectory.dir("tmp/kotlin-classes/$variantName"),
-            project.layout.buildDirectory.dir("intermediates/javac/$variantName/classes"),
-            project.layout.buildDirectory.dir("intermediates/built_in_kotlinc/$variantName/compile${capVariant}Kotlin/classes"),
-        )
-        if (screenshotTestEnabled) {
-            sourceClassDirs.from(
-                project.layout.buildDirectory.dir(
-                    "intermediates/built_in_kotlinc/${variantName}ScreenshotTest/compile${capVariant}ScreenshotTestKotlin/classes"
-                ),
-                project.layout.buildDirectory.dir(
-                    "intermediates/javac/${variantName}ScreenshotTest/classes"
-                ),
-            )
-        }
-
-        val dependencyConfigName = "${variantName}RuntimeClasspath"
-        val screenshotTestRuntimeConfig = if (screenshotTestEnabled) {
-            project.configurations.findByName("${variantName}ScreenshotTestRuntimeClasspath")
-        } else null
-
-        val discoverTask = ComposePreviewTasks.registerDiscoverTask(
-            project, sourceClassDirs, dependencyConfigName, previewOutputDir, extension,
-        ) {
-            dependsOn("compile${capVariant}Kotlin")
-            if (screenshotTestEnabled) {
-                dependsOn("compile${capVariant}ScreenshotTestKotlin")
-                screenshotTestRuntimeConfig?.let { stConfig ->
-                    dependencyJars.from(
-                        stConfig.incoming.artifactView {
-                            attributes.attribute(artifactType, "jar")
-                        }.files,
-                    )
-                    dependencyJars.from(
-                        stConfig.incoming.artifactView {
-                            attributes.attribute(artifactType, "android-classes")
-                        }.files,
-                    )
-                }
-            }
-        }
-
-        // Writes the plugin-side compat findings (CompatRules) to
-        // `build/compose-previews/doctor.json`. The CLI doesn't need this
-        // file (it reads the same data via the ComposePreviewModel Tooling
-        // API), but tools that invoke Gradle tasks rather than BuildActions
-        // — specifically the VS Code extension — do. Same JSON schema as
-        // `compose-preview doctor --json`'s per-module shape, so both
-        // surfaces converge on one contract.
-        // Resolve the runtime classpaths' root components at configuration
-        // time so the task action stays config-cache safe (no `task.project`
-        // access at execution). `findByName` may return null on variants that
-        // don't have a paired unit-test classpath; the task tolerates an
-        // unset Property as "no deps to inspect".
-        val mainRuntimeRoot = project.configurations.findByName("${variantName}RuntimeClasspath")
-            ?.incoming?.resolutionResult?.rootComponent
-        val testRuntimeRoot = project.configurations.findByName("${variantName}UnitTestRuntimeClasspath")
-            ?.incoming?.resolutionResult?.rootComponent
-
-        // Capture the running Gradle version at configuration time so the
-        // task action stays config-cache safe (GradleVersion.current() is a
-        // static call but keeping the read out of `@TaskAction` avoids
-        // surprises if Gradle ever namespaces it differently).
-        val currentGradleVersion = org.gradle.util.GradleVersion.current().version
-        // Accumulator for inject records. The unconditional and
-        // conditional blocks below each append; the doctor task reads the
-        // list lazily via `project.provider { ... }` so it's evaluated
-        // AFTER the `afterEvaluate` block populates the tiles entry.
-        val injectedDependencies = mutableListOf<ee.schimke.composeai.plugin.tooling.InjectedDependency>()
-        val injectedDependencyJson = kotlinx.serialization.json.Json { encodeDefaults = true }
-        project.tasks.register("composePreviewDoctor", ee.schimke.composeai.plugin.tooling.ComposePreviewDoctorTask::class.java) {
-            group = "compose preview"
-            description = "Write compose-preview doctor findings to build/compose-previews/doctor.json"
-            this.variant.set(variantName)
-            this.modulePath.set(project.path)
-            this.gradleVersion.set(currentGradleVersion)
-            this.outputFile.set(previewOutputDir.map { it.file("doctor.json") })
-            mainRuntimeRoot?.let { this.mainRuntimeRoot.set(it) }
-            testRuntimeRoot?.let { this.testRuntimeRoot.set(it) }
-            this.injectedDependenciesJson.set(project.provider {
-                injectedDependencyJson.encodeToString(
-                    kotlinx.serialization.builtins.ListSerializer(
-                        ee.schimke.composeai.plugin.tooling.InjectedDependency.serializer()
-                    ),
-                    injectedDependencies.toList(),
-                )
-            })
-        }
-
-        // Always inject `ui-test-manifest` + `ui-test-junit4` into the consumer's
-        // `testImplementation`:
-        //
-        //  * `ui-test-manifest` contributes the `<activity android:name=
-        //    "androidx.activity.ComponentActivity">` entry that has to land in
-        //    the consumer's merged unit-test AndroidManifest before
-        //    `createAndroidComposeRule<ComponentActivity>()` can launch its
-        //    ActivityScenario. Our plugin bypasses the normal AGP dep graph
-        //    (renderer classpath lives in our own resolvable config, not
-        //    `testImplementation`), so the manifest merger never sees it
-        //    otherwise.
-        //  * `ui-test-junit4` is where `createAndroidComposeRule` /
-        //    `ComposeTestRule` / `mainClock` live. The renderer test references
-        //    these unconditionally from its default `renderDefault` path (we
-        //    use `mainClock.autoAdvance = false` + explicit frame pumping to
-        //    make infinite animations terminate deterministically — see
-        //    RobolectricRenderTest.renderDefault), so the consumer's test
-        //    classpath needs these classes too, not just the resource/manifest
-        //    half of the story.
-        //
-        // `composePreview.manageDependencies = false` opts out of all
-        // plugin-side injection. Deps are recorded as SKIPPED_BY_CONFIG
-        // in `doctor.json` so consumers can see what they need to add,
-        // and the afterEvaluate block below validates the consumer did
-        // add them — the build fails during configuration with an
-        // explicit coordinate list instead of surfacing a
-        // ClassNotFoundException from Robolectric at render time.
-        val manageDependencies = extension.manageDependencies.get()
-
-        // No version: relies on the consumer's Compose BOM (or direct Compose
-        // dep) to resolve these artifacts. Projects using
-        // `implementation(platform(libs.compose.bom))` pick up the aligned
-        // version automatically; projects without a BOM need to add one (a
-        // reasonable ask — the plugin is for Compose apps).
-        if (manageDependencies) {
-            project.dependencies.add(
-                "testImplementation",
-                "androidx.compose.ui:ui-test-manifest",
-            )
-            project.dependencies.add(
-                "testImplementation",
-                "androidx.compose.ui:ui-test-junit4",
-            )
-            recordInjectedDependency(
-                project,
-                injectedDependencies,
-                coordinate = "androidx.compose.ui:ui-test-manifest",
-                configuration = "testImplementation",
-                outcome = "APPLIED",
-                reason = "merges ComponentActivity into the unit-test manifest for renderer",
-            )
-            recordInjectedDependency(
-                project,
-                injectedDependencies,
-                coordinate = "androidx.compose.ui:ui-test-junit4",
-                configuration = "testImplementation",
-                outcome = "APPLIED",
-                reason = "provides createAndroidComposeRule / mainClock used by renderer",
-            )
-        } else {
-            recordInjectedDependency(
-                project,
-                injectedDependencies,
-                coordinate = "androidx.compose.ui:ui-test-manifest",
-                configuration = "testImplementation",
-                outcome = "SKIPPED_BY_CONFIG",
-                reason = "manageDependencies=false; consumer must declare this in testImplementation",
-            )
-            recordInjectedDependency(
-                project,
-                injectedDependencies,
-                coordinate = "androidx.compose.ui:ui-test-junit4",
-                configuration = "testImplementation",
-                outcome = "SKIPPED_BY_CONFIG",
-                reason = "manageDependencies=false; consumer must declare this in testImplementation",
-            )
-        }
-
-        // Conditionally inject `androidx.wear.tiles:tiles-renderer` into the
-        // consumer's variant `implementation` when the consumer signals they
-        // want Tile previews. Detection is deferred to `afterEvaluate` so the
-        // consumer's declared deps are complete.
-        //
-        // Why we inject at all: TilePreviewRenderer.renderTileInto calls
-        // `TileRenderer(...)`, whose constructor builds `ProtoLayoutThemeImpl`
-        // which holds a Java reference to
-        // `androidx.wear.protolayout.renderer.R$style.ProtoLayoutBaseTheme`.
-        // That R class is only compiled into the consumer's merged R.jar when
-        // `wear.tiles:tiles-renderer` is on the MAIN compile classpath —
-        // `testImplementation` and `compileOnly` don't participate in AGP's R
-        // class generation. Consumer apps shouldn't have to restate a purely
-        // preview-rendering dep in their main `implementation`.
-        //
-        // Why the signal is "tiles-tooling-preview / tiles-renderer / tiles":
-        // these are the modules a consumer actually declares when they write
-        // `@Preview`-annotated tile functions. Horologist projects go through
-        // `horologist-tiles` so we include that too.
-        //
-        // No version — the consumer's wear.tiles atomic group constrains
-        // `tiles-renderer` to their wear.tiles version. When the detection
-        // misfires in a non-tiles project (shouldn't happen under the
-        // heuristic above), Gradle fails with a clear "no version for
-        // tiles-renderer" error.
-        project.afterEvaluate {
-            // Scan every configuration whose name ends in `Implementation` so
-            // the detection works for ANY buildType / flavor / variant combo
-            // (e.g. `uatImplementation`, `stagingImplementation`,
-            // `uatStagingImplementation`). The earlier hardcoded list of
-            // `debugImplementation` / `releaseImplementation` only fired on
-            // the default AGP buildTypes, missing custom flavored layouts
-            // like `uatDebug`. The group+name filter below is precise enough
-            // that casting a wider net is safe — false positives require a
-            // dep literally in the `androidx.wear.tiles` / horologist-tiles
-            // groups, which is the signal we're looking for.
-            // Scan every declarative dep-bucket name so the detection works
-            // regardless of which bucket (and which sourceSet / buildType /
-            // flavor / variant) the consumer used to declare their tile deps:
-            //   - `implementation` / `<sourceSet>Implementation` — the common case.
-            //   - `api` / `<sourceSet>Api` — Android library modules that
-            //     re-export tile APIs to their consumers.
-            //   - `runtimeOnly` / `<sourceSet>RuntimeOnly` — rare, but tile
-            //     deps declared runtime-only still need the R-class injection.
-            // Resolving the actual runtime classpath would be authoritative
-            // but triggers config-cache invalidation and is awkward under
-            // Isolated Projects, so we stay declarative. The group+name
-            // filter inside is precise enough (exact match on `androidx.wear.tiles` /
-            // horologist-tiles coords) that widening the config scan can't
-            // introduce false positives.
-            val matchedConfigs = mutableListOf<String>()
-            project.configurations.asSequence()
-                .filter { c ->
-                    val n = c.name
-                    n == "implementation" || n.endsWith("Implementation") ||
-                        n == "api" || n.endsWith("Api") ||
-                        n == "runtimeOnly" || n.endsWith("RuntimeOnly")
-                }
-                .forEach { c ->
-                    val hit = c.allDependencies.any { dep ->
-                        (dep.group == "androidx.wear.tiles" && dep.name in tilesSignalNames) ||
-                            (dep.group == "com.google.android.horologist" && dep.name == "horologist-tiles")
-                    }
-                    if (hit) matchedConfigs += c.name
-                }
-            if (matchedConfigs.isNotEmpty()) {
-                if (manageDependencies) {
-                    project.dependencies.add(
-                        "${variantName}Implementation",
-                        "androidx.wear.tiles:tiles-renderer",
-                    )
-                    recordInjectedDependency(
-                        project,
-                        injectedDependencies,
-                        coordinate = "androidx.wear.tiles:tiles-renderer",
-                        configuration = "${variantName}Implementation",
-                        outcome = "MATCHED",
-                        reason = "signal matched on [${matchedConfigs.joinToString(", ")}]",
-                    )
-                } else {
-                    recordInjectedDependency(
-                        project,
-                        injectedDependencies,
-                        coordinate = "androidx.wear.tiles:tiles-renderer",
-                        configuration = "${variantName}Implementation",
-                        outcome = "SKIPPED_BY_CONFIG",
-                        reason = "manageDependencies=false; tiles signal matched on [${matchedConfigs.joinToString(", ")}] but consumer must declare tiles-renderer in ${variantName}Implementation",
-                    )
-                }
-            } else {
-                recordInjectedDependency(
-                    project,
-                    injectedDependencies,
-                    coordinate = "androidx.wear.tiles:tiles-renderer",
-                    configuration = "",
-                    outcome = "SKIPPED",
-                    reason = "no androidx.wear.tiles / horologist-tiles dep on any *Implementation/*Api/*RuntimeOnly configuration",
-                )
-            }
-
-            // `manageDependencies=false`: verify the consumer actually
-            // declared the coords we would otherwise have injected. Fail
-            // during configuration (in afterEvaluate) with an explicit
-            // coordinate list rather than letting the render task die
-            // later with a ClassNotFoundException. Check by group/name
-            // across the relevant declarative buckets so the consumer
-            // can place them wherever their project conventions prefer.
-            if (!manageDependencies) {
-                validateExternallyManagedDependencies(
-                    project = project,
-                    variantName = variantName,
-                    tilesRendererRequired = matchedConfigs.isNotEmpty(),
-                )
-            }
-        }
-
-        val testConfig = project.configurations.findByName("${variantName}UnitTestRuntimeClasspath")
-
-        // The default path for external consumers: resolve
-        // `ee.schimke.composeai:renderer-android:<plugin-version>` from Maven.
-        // The plugin's own version is baked into the jar at build time so the
-        // matching renderer AAR is chosen automatically — see [PluginVersion].
-        //
-        // Dev-mode shortcut: when the plugin runs *inside* the compose-ai-tools
-        // build itself (in-repo samples), bypass Maven and depend on the sibling
-        // `:renderer-android` Gradle project directly. That way live renderer
-        // edits show up without a publish step. The signal is the presence of
-        // the sibling build script on disk; we deliberately avoid calling
-        // `rootProject.findProject(...)` here because reading the sibling's
-        // model under Isolated Projects is disallowed — a filesystem check is
-        // IP-safe, and only the in-repo layout matches it.
-        val rendererProjectDir = project.rootDir.resolve("renderer-android")
-        val useLocalRenderer = rendererProjectDir.resolve("build.gradle.kts").exists()
-                || rendererProjectDir.resolve("build.gradle").exists()
-
-        // Renderer's transitive runtime dependencies come through a dedicated
-        // resolvable configuration in *this* project. Attributes are copied
-        // from the sample's unit-test runtime classpath so Gradle picks the
-        // right Android variant without us declaring them by hand.
-        //
-        // `extendsFrom(testConfig)` is load-bearing: it tells Gradle to resolve
-        // renderer deps in the SAME graph as the consumer's test-runtime deps,
-        // so version conflicts pick a single coherent max version instead of
-        // two separate graphs that clash at class-load time. Without it, the
-        // renderer's transitive `androidx.core:1.8.0` and consumer's
-        // `androidx.core:1.16.0` both end up on the test classpath in different
-        // JARs — whichever is listed first wins for each class, and the loaded
-        // activity/lifecycle/compose-ui versions don't all agree. Symptoms:
-        //   - `NoSuchFieldError: androidx.lifecycle.ReportFragment.Companion`
-        //   - `NoSuchFieldError: … tag_compat_insets_dispatch`
-        val rendererConfig = project.configurations.maybeCreate("composePreviewAndroidRenderer$capVariant").apply {
-            isCanBeResolved = true
-            isCanBeConsumed = false
-            if (testConfig != null) {
-                copyAttributes(attributes, testConfig.attributes)
-                extendsFrom(testConfig)
-            }
-        }
-
-        if (useLocalRenderer) {
-            try {
-                project.dependencies.add(rendererConfig.name, project.dependencies.project(mapOf("path" to ":renderer-android")))
-            } catch (e: org.gradle.api.UnknownProjectException) {
-                project.logger.debug("compose-ai-tools: :renderer-android project not found, skipping", e)
-            }
-        } else {
-            project.dependencies.add(
-                rendererConfig.name,
-                "ee.schimke.composeai:renderer-android:${PluginVersion.value}",
-            )
-        }
-
-        // Classes used for Gradle's test-class scanning. Local mode: the
-        // renderer-android project's compiled output directories. External
-        // mode: the AAR's `classes.jar`, expanded via `zipTree` so Gradle's
-        // `Test.include("**/…Test.class")` filter can walk it — the include
-        // filter traverses file trees but does NOT descend into JAR entries,
-        // so feeding a raw JAR here silently produces `renderPreviews NO-SOURCE`
-        // and every preview ends up with no PNG. `android-classes` is AGP's
-        // `ArtifactType.CLASSES_JAR` (a JAR), not the extracted directory
-        // (that would be `android-classes-directory`).
-        val rendererClassDirs = if (useLocalRenderer) {
-            project.files(
-                rendererProjectDir.resolve("build/intermediates/built_in_kotlinc/$variantName/compile${capVariant}Kotlin/classes"),
-                rendererProjectDir.resolve("build/tmp/kotlin-classes/$variantName"),
-            )
-        } else {
-            val rendererJars = rendererConfig.incoming.artifactView {
-                attributes.attribute(artifactType, "android-classes")
-                componentFilter { id ->
-                    id is org.gradle.api.artifacts.component.ModuleComponentIdentifier
-                            && id.group == "ee.schimke.composeai"
-                            && id.module == "renderer-android"
-                }
-            }.files
-            // Callable defers `.files` resolution until the Test task queries
-            // this FileCollection, keeping the configuration lazy.
-            project.files(java.util.concurrent.Callable {
-                rendererJars.files.map { project.zipTree(it) }
-            })
-        }
-
-        // AGP's `generate${Variant}UnitTestConfig` task emits
-        // `com/android/tools/test_config.properties` under
-        // `intermediates/unit_test_config_directory/<variant>UnitTest/.../out/`.
-        // Robolectric loads it from the classpath and uses it to find the merged
-        // resource APK (`apk-for-local-test.ap_`) — the one that contains every
-        // AAR's merged resources (protolayout-renderer's `ProtoLayoutBaseTheme`
-        // etc.). Without this directory on the classpath, `getIdentifier` returns
-        // 0 for any library-provided style and TileRenderer's theme construction
-        // explodes on `Unknown resource value type 0`. Compose-only previews
-        // don't read AAR resources, which is why this only surfaced with tiles.
-        val unitTestConfigDir = project.layout.buildDirectory.dir(
-            "intermediates/unit_test_config_directory/${variantName}UnitTest/generate${capVariant}UnitTestConfig/out"
-        )
-
-        // Generates `ee/schimke/composeai/renderer/robolectric.properties`
-        // onto the render classpath so Robolectric overrides the consumer's
-        // `Application` with a stub by default — see
-        // [GenerateRobolectricPropertiesTask] for rationale and the opt-out.
-        val robolectricPropertiesDir = project.layout.buildDirectory
-            .dir("generated/composeai/robolectric/$variantName")
-        val generateRobolectricPropertiesTask = project.tasks.register(
-            "generateRobolectricProperties",
-            GenerateRobolectricPropertiesTask::class.java,
-        ) {
-            group = "compose preview"
-            description = "Generate package-level robolectric.properties for renderPreviews"
-            useConsumerApplication.set(extension.useConsumerApplication)
-            outputDir.set(robolectricPropertiesDir)
-        }
-
-        // Renderer classpath FIRST — renderer depends on kotlinx-serialization
-        // 1.11.x and Roborazzi 1.59+ while consumer apps may transitively drag
-        // in older versions (Compose BOM, etc). Gradle's FileCollection.from()
-        // doesn't do conflict resolution, so whichever JAR comes first wins at
-        // classload time. Putting the renderer's dependencies first ensures the
-        // test code gets the versions it was compiled against.
-        val resolvedClasspath = project.files().apply {
-            // Robolectric properties dir BEFORE consumer test resources so our
-            // Application override wins when classloader.getResource walks the
-            // classpath. Consumers with their own `robolectric.properties` at
-            // the same package path are unusual — they'd need it specifically
-            // for this renderer's test class.
-            from(generateRobolectricPropertiesTask.flatMap { it.outputDir })
-            from(rendererConfig.incoming.artifactView {
-                attributes.attribute(artifactType, "jar")
-            }.files)
-            from(rendererClassDirs)
-            if (testConfig != null) {
-                from(testConfig.incoming.artifactView {
-                    attributes.attribute(artifactType, "jar")
-                }.files)
-                from(testConfig.incoming.artifactView {
-                    attributes.attribute(artifactType, "android-classes")
-                }.files)
-            }
-            // screenshotTest source set has its own runtime config — any
-            // `screenshotTestImplementation(...)` dep the consumer declared is
-            // only visible here, not via `testConfig`. Include it so previews
-            // under `src/screenshotTest/` can reference those classes at
-            // render time. No-op when the screenshot plugin isn't applied.
-            screenshotTestRuntimeConfig?.let { stConfig ->
-                from(stConfig.incoming.artifactView {
-                    attributes.attribute(artifactType, "jar")
-                }.files)
-                from(stConfig.incoming.artifactView {
-                    attributes.attribute(artifactType, "android-classes")
-                }.files)
-            }
-            from(sourceClassDirs)
-            from(unitTestConfigDir)
-            // SDK stub android.jar on the OUTER classpath so JUnit can introspect
-            // the test class (RobolectricRenderTest.kt references android.graphics.Bitmap,
-            // android.view.PixelCopy, etc. in method signatures). Without it, JUnit fails
-            // with `NoClassDefFoundError: android/graphics/Bitmap` during test discovery,
-            // before Robolectric's sandbox classloader is even created.
-            //
-            // Inside the sandbox, `ParameterizedRobolectricTestRunner` loads the test class
-            // through Robolectric's InstrumentingClassLoader, which delegates `android.*`
-            // resolution to its own `android-all` artifact (real framework classes, with
-            // shadows applied). The outer stub does NOT shadow the sandboxed PixelCopy.
-            //
-            // Sourced from AGP's SdkComponents so we don't have to parse local.properties
-            // or read rootProject.file(...).
-            from(project.files(bootClasspath))
-        }
-
-        val manifestFile = previewOutputDir.map { it.file("previews.json").asFile.absolutePath }
-        val rendersDirectory = previewOutputDir.map { it.dir("renders") }
-        val rendersDir = rendersDirectory.map { it.asFile.absolutePath }
-
-        // Per-preview ATF findings land here. `verifyAccessibility` rolls them
-        // up into a single `accessibility.json` next to `previews.json`. Kept
-        // separate from renders/ so caching treats the two output trees
-        // independently.
-        val accessibilityPerPreviewDir = previewOutputDir.map { it.dir("accessibility-per-preview") }
-        val accessibilityReportFile = previewOutputDir.map { it.file("accessibility.json") }
-
-        val shardCount = resolveShardCount(project, extension, previewOutputDir.get().file("previews.json").asFile)
-        val shardsEnabled = shardCount > 1
-
-        // When sharded, generate N Java subclasses of RobolectricRenderTestBase, each with
-        // its own static @Parameters method that loads only that shard's slice of the manifest.
-        // Gradle distributes tests across forks at the class level, so a single parameterized
-        // class can't be split — we give it N classes. Each shard subclass resolves its
-        // Robolectric config via the generated package-level `robolectric.properties`
-        // (sdk/graphicsMode/application/shadows), so every JVM's sandbox key matches and
-        // each fork reuses its own cached sandbox across all previews in its slice.
-        val shardSourcesDir = project.layout.buildDirectory.dir("generated/composeai/render-shards/java")
-        val shardClassesDir = project.layout.buildDirectory.dir("generated/composeai/render-shards/classes")
-
-        val generateShardsTask = if (shardsEnabled) {
-            project.tasks.register("generateRenderShards", GenerateRenderShardsTask::class.java) {
-                group = "compose preview"
-                description = "Generate $shardCount RobolectricRenderTest_Shard subclasses"
-                shards.set(shardCount)
-                outputDir.set(shardSourcesDir)
-            }
-        } else null
-
-        val compileShardsTask = if (generateShardsTask != null) {
-            project.tasks.register("compileRenderShards", JavaCompile::class.java) {
-                group = "compose preview"
-                description = "Compile generated shard test subclasses"
-                source(generateShardsTask.map { it.outputDir.asFileTree })
-                classpath = resolvedClasspath
-                destinationDirectory.set(shardClassesDir)
-                options.release.set(21)
-                dependsOn(generateShardsTask)
-                if (useLocalRenderer) {
-                    dependsOn(":renderer-android:compile${capVariant}Kotlin")
-                }
-            }
-        } else null
-
-        val renderTask = project.tasks.register("renderPreviews", Test::class.java) {
-            group = "compose preview"
-            description = "Render Android previews via Robolectric"
-            val agpTestTask = project.tasks.findByName("test${capVariant}UnitTest") as? Test
-            testClassesDirs = if (compileShardsTask != null) {
-                rendererClassDirs + project.files(compileShardsTask.map { it.destinationDirectory }) + (agpTestTask?.testClassesDirs ?: project.files())
-            } else {
-                rendererClassDirs + (agpTestTask?.testClassesDirs ?: project.files())
-            }
-            // Append AGP's own `test${Cap}UnitTest` classpath at the END so we
-            // pick up files that only exist there: specifically, the unit-test
-            // merged R.jar for library modules (`com.android.library` variants
-            // publish their AAR-transitive R classes — e.g.
-            // `androidx.customview.poolingcontainer.R$id`, pulled in by
-            // `ViewCompositionStrategy` — via
-            // `compile_and_runtime_r_class_jar/${variant}UnitTest/process${Cap}UnitTestResources/R.jar`,
-            // which is added to `debugUnitTestRuntimeClasspath` as a raw file
-            // dep without the `artifactType=jar` attribute, so our
-            // attribute-filtered `artifactView` above silently drops it).
-            // Ordering is load-bearing — putting it last means our renderer's
-            // pinned versions still win classload lookups in the earlier
-            // classpath entries. No-op on applications, since
-            // `process${Cap}Resources` puts the merged R.jar on the main
-            // runtime classpath where our existing `artifactView` already
-            // picks it up. See issue #136.
-            val agpTestClasspath = agpTestTask?.classpath ?: project.files()
-            classpath = if (compileShardsTask != null) {
-                resolvedClasspath + project.files(compileShardsTask.map { it.destinationDirectory }) + (agpTestTask?.testClassesDirs ?: project.files()) + agpTestClasspath
-            } else {
-                resolvedClasspath + (agpTestTask?.testClassesDirs ?: project.files()) + agpTestClasspath
-            }
-            if (shardsEnabled) {
-                include("**/RobolectricRenderTest_Shard*.class")
-                maxParallelForks = shardCount
-            } else {
-                include("**/RobolectricRenderTest.class")
-            }
-            useJUnit()
-
-            // Copy JVM args from AGP's test task. Deferred to the configuration
-            // lambda (rather than called at registration time) so AGP has had
-            // a chance to register `test${capVariant}UnitTest` by the time this
-            // runs — onVariants fires before unit-test tasks are wired.
-            jvmArgs(agpTestTask?.jvmArgs ?: emptyList<String>())
-            jvmArgs(
-                "--add-opens=java.base/java.lang=ALL-UNNAMED",
-                "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
-                // Robolectric's `ShadowVMRuntime.getAddressOfDirectByteBuffer`
-                // reflectively invokes `DirectByteBuffer.address()`; under JDK 17+
-                // module rules this fails with IllegalAccessException without this
-                // opens. Reached via `PathIterator` — triggered here by Wear Compose's
-                // curved text renderer.
-                "--add-opens=java.base/java.nio=ALL-UNNAMED",
-            )
-
-            // Inherit AGP's unit-test javaLauncher so the forked test worker
-            // runs on the same JDK as `test${capVariant}UnitTest` — which
-            // AGP has already wired to the project's Java toolchain if the
-            // consumer configured one (`java { toolchain { … } }` /
-            // `kotlin { jvmToolchain(…) }`), or to the daemon JVM otherwise.
-            //
-            // Without this, a custom `Test` task's `javaLauncher` property
-            // defaults to the first `java` on PATH, which on CI and in local
-            // shells with `JAVA_HOME` overrides is NOT necessarily the same
-            // JVM the Gradle daemon is running. That mismatch produces
-            // `ClassNotFoundException: android.app.Application` during JUnit
-            // discovery on some JVM/classloader combinations. See #142.
-            agpTestTask?.javaLauncher?.orNull?.let { javaLauncher.set(it) }
-
-            // Belt-and-braces for the graphics/looper modes. Config now
-            // lives in `ee/schimke/composeai/renderer/robolectric.properties`
-            // (see `RobolectricRenderTestBase` KDoc for why we can't use
-            // `@GraphicsMode` directly). These system properties are a third
-            // independent Robolectric config channel and cost nothing to
-            // keep — survive both annotation and properties paths regressing.
-            systemProperty("robolectric.graphicsMode", "NATIVE")
-            systemProperty("robolectric.looperMode", "PAUSED")
-            // Conscrypt isn't needed for preview rendering (no TLS/HTTP paths
-            // execute) and its native library is flaky on some Linux sandboxes
-            // — e.g. missing/ABI-mismatched `libstdc++.so.6`. Telling Robolectric
-            // to skip the install avoids those failures without shipping our
-            // own Conscrypt stubs. See `ConscryptMode` /
-            // `ConscryptModeConfigurer` in Robolectric.
-            systemProperty("robolectric.conscryptMode", "OFF")
-            // Routes ShadowPixelCopy through HardwareRenderingScreenshot →
-            // ImageReader + HardwareRenderer.syncAndDraw, the only path that
-            // replays Compose's RenderNodes correctly.
-            systemProperty("robolectric.pixelCopyRenderMode", "hardware")
-            // Roborazzi defaults to "compare" mode (which doesn't write pixels
-            // unless the expected baseline exists). Force "record" so every run
-            // writes fresh PNGs.
-            systemProperty("roborazzi.test.record", "true")
-
-            systemProperty("composeai.render.manifest", manifestFile.get())
-            systemProperty("composeai.render.outputDir", rendersDir.get())
-
-            // GoogleFont interceptor cache — defaults to
-            // `<project>/.compose-preview-history/fonts/`, same root the
-            // history task uses, so committed TTFs sit beside committed PNGs.
-            // The renderer class no-ops when this property is absent, so the
-            // feature is fully additive for existing consumers.
-            val fontsCacheDir = extension.historyDir
-                .orElse(project.layout.projectDirectory.dir(".compose-preview-history"))
-                .map { it.dir("fonts").asFile.absolutePath }
-            systemProperty("composeai.fonts.cacheDir", fontsCacheDir.get())
-            // `-PcomposePreview.fontsOffline=true` (or the same Gradle property
-            // on a CI profile) skips network on cache miss so the render
-            // shows the fallback font rather than silently fetching from
-            // `fonts.googleapis.com`.
-            val fontsOffline = project.providers.gradleProperty("composePreview.fontsOffline")
-                .orElse("false")
-            systemProperty("composeai.fonts.offline", fontsOffline.get())
-
-            // ATF flags are routed through a CommandLineArgumentProvider
-            // rather than `systemProperty(...)` so toggling the `-P` override
-            // doesn't invalidate the Gradle configuration cache. `systemProperty`
-            // evaluates its value eagerly at configuration time — the provider
-            // we'd read there becomes part of the config-cache key, so flipping
-            // `-PcomposePreview.accessibilityChecks.enabled` forces a ~5-10s
-            // reconfigure. CommandLineArgumentProvider's `@Input` providers
-            // are only evaluated at task execution, which is exactly the
-            // lazy-input semantics we want for VSCode toggles.
-            //
-            // Renderer always inspects these sysprops at runtime; when
-            // enabled=false, the a11y code paths are no-ops (see
-            // [RobolectricRenderTest.renderWithA11y] / `renderDefault`).
-            jvmArgumentProviders.add(
-                AccessibilitySystemPropsProvider(
-                    enabled = resolveA11yEnabled(project, extension),
-                    annotate = resolveA11yAnnotate(project, extension),
-                    outputDir = accessibilityPerPreviewDir.map { it.asFile.absolutePath },
-                    debug = project.providers.gradleProperty("composeai.a11y.debug").orElse("false"),
-                ),
-            )
-            // Render-tier filter — fed via the same lazy `@Input` provider
-            // pattern so VS Code can flip `-PcomposePreview.tier=fast` on
-            // every save without paying a config-cache reconfigure. Renderer
-            // reads `composeai.render.tier` in [PreviewManifestLoader.loadShard]
-            // to drop HEAVY captures from each entry before sharding.
-            val tierProvider = resolveTier(project)
-            jvmArgumentProviders.add(TierSystemPropProvider(tier = tierProvider))
-            // Disable build-cache participation for `tier=fast` runs. A cache
-            // hit restores the cached `renders/` snapshot, which on a fast
-            // run only contains the cheap captures — heavy outputs from a
-            // previous full run would get wiped, breaking the "stale image"
-            // story VS Code shows on heavy cards. Up-to-date checks still
-            // apply, so a `tier=fast` re-run with no input changes is a
-            // no-op and the renders dir stays as-is. Full-tier runs cache
-            // normally.
-            outputs.cacheIf("renderPreviews caches tier=full runs only") {
-                tierProvider.get().equals("full", ignoreCase = true)
-            }
-            // Per-preview dir is always an output — the feature being off just
-            // means no files get written there. Declaring it unconditionally
-            // lets the config cache key stay stable across toggles.
-            outputs.dir(accessibilityPerPreviewDir).withPropertyName("a11yPerPreviewDir")
-
-            // The PNG files are written to `rendersDirectory` via the
-            // `composeai.render.outputDir` system property, not through any
-            // Gradle-managed output. Declare the directory as an additional
-            // output so the build cache round-trips the PNGs alongside the
-            // test reports; without this the task gets a cache hit on a fresh
-            // checkout but the renders are never restored, which is exactly
-            // how previous modules silently vanished from `preview_main`.
-            outputs.dir(rendersDirectory).withPropertyName("rendersDir")
-
-            dependsOn(discoverTask)
-            dependsOn(generateRobolectricPropertiesTask)
-            if (useLocalRenderer) {
-                dependsOn(":renderer-android:compile${capVariant}Kotlin")
-            }
-            if (screenshotTestEnabled) {
-                dependsOn("compile${capVariant}ScreenshotTestKotlin")
-            }
-            // `process${Cap}Resources` only exists on `com.android.application`
-            // variants — AGP 9.x libraries expose the resource pipeline through
-            // `merge${Cap}Resources` / `generate${Cap}RFile` / the unit-test-
-            // specific `process${Cap}UnitTestResources`. The unit-test resource
-            // APK we actually consume is already routed via
-            // `generate${Cap}UnitTestConfig` below, so the `processResources`
-            // dep is just belt-and-suspenders; skip it when absent so library
-            // modules configure cleanly. See issue #136.
-            listOf(
-                "process${capVariant}Resources",
-                "generate${capVariant}UnitTestConfig",
-            ).forEach { taskName ->
-                if (project.tasks.findByName(taskName) != null) {
-                    dependsOn(taskName)
-                }
-            }
-            if (compileShardsTask != null) {
-                dependsOn(compileShardsTask)
-            }
-        }
-
-        // `verifyAccessibility` is ALWAYS registered so toggling
-        // `-PcomposePreview.accessibilityChecks.enabled` doesn't change the
-        // task graph — config cache stays valid across VSCode / CLI toggles.
-        // An `onlyIf` gate backed by the lazy provider makes it a no-op when
-        // the feature is off: the task configures but never executes, so the
-        // JSON aggregation and failure thresholds only kick in when the user
-        // actually opted in.
-        val a11yEnabledProvider = resolveA11yEnabled(project, extension)
-        val verifyA11yTask = project.tasks.register(
-            "verifyAccessibility", VerifyAccessibilityTask::class.java,
-        ) {
-            group = "compose preview"
-            description = "Aggregate ATF findings from renderPreviews and fail per configured thresholds"
-            perPreviewDir.set(accessibilityPerPreviewDir)
-            reportFile.set(accessibilityReportFile)
-            moduleName.set(project.name)
-            failOnErrors.set(extension.accessibilityChecks.failOnErrors)
-            failOnWarnings.set(extension.accessibilityChecks.failOnWarnings)
-            dependsOn(renderTask)
-            onlyIf("composePreview.accessibilityChecks.enabled") { a11yEnabledProvider.get() }
-        }
-
-        ComposePreviewTasks.registerRenderAllPreviews(
-            project, extension, renderTask, previewOutputDir, verifyA11yTask,
-        )
-    }
-
-    /**
-     * Lazy holder for ATF-related system properties on the `renderPreviews`
-     * `Test` task. Using a CommandLineArgumentProvider — instead of
-     * `test.systemProperty(...)` — means the values are resolved at task
-     * execution time, so flipping the underlying Gradle property doesn't
-     * invalidate the configuration cache. Each `@Input` participates in the
-     * task's own up-to-date check, so toggling a11y correctly re-runs
-     * rendering.
-     */
-    internal class AccessibilitySystemPropsProvider(
-        @get:org.gradle.api.tasks.Input val enabled: org.gradle.api.provider.Provider<Boolean>,
-        @get:org.gradle.api.tasks.Input val annotate: org.gradle.api.provider.Provider<Boolean>,
-        @get:org.gradle.api.tasks.Input val outputDir: org.gradle.api.provider.Provider<String>,
-        @get:org.gradle.api.tasks.Input val debug: org.gradle.api.provider.Provider<String>,
-    ) : org.gradle.process.CommandLineArgumentProvider {
-        override fun asArguments(): Iterable<String> = listOf(
-            "-Dcomposeai.a11y.enabled=${enabled.get()}",
-            "-Dcomposeai.a11y.annotate=${annotate.get()}",
-            "-Dcomposeai.a11y.outputDir=${outputDir.get()}",
-            "-Dcomposeai.a11y.debug=${debug.get()}",
-        )
-    }
-
-    /**
-     * Returns a lazy `Provider<Boolean>` for the effective
-     * `accessibilityChecks.enabled` value. The
-     * `-PcomposePreview.accessibilityChecks.enabled=<true|false>` Gradle
-     * property WINS over the extension block — so VSCode (or a one-off CLI
-     * invocation) can flip the feature on for a single run without touching
-     * `build.gradle.kts`.
-     *
-     * **Deliberately returns a Provider, not a Boolean.** Reading `.get()` at
-     * configuration time keys the configuration cache on the current property
-     * value, which means every VSCode toggle would invalidate the cache and
-     * pay a ~5-10s reconfigure cost. Consumers should pass this provider to
-     * task `onlyIf`, `CommandLineArgumentProvider` inputs, etc. — those
-     * evaluate it at task-graph-resolution time without cache invalidation.
-     */
-    internal fun resolveA11yEnabled(
-        project: org.gradle.api.Project,
-        extension: PreviewExtension,
-    ): org.gradle.api.provider.Provider<Boolean> =
-        project.providers
-            .gradleProperty("composePreview.accessibilityChecks.enabled")
-            .map { it.toBooleanStrictOrNull() ?: false }
-            .orElse(extension.accessibilityChecks.enabled)
-
-    /** Same config-cache-friendly treatment for `annotateScreenshots`. See [resolveA11yEnabled]. */
-    internal fun resolveA11yAnnotate(
-        project: org.gradle.api.Project,
-        extension: PreviewExtension,
-    ): org.gradle.api.provider.Provider<Boolean> =
-        project.providers
-            .gradleProperty("composePreview.accessibilityChecks.annotateScreenshots")
-            .map { it.toBooleanStrictOrNull() ?: true }
-            .orElse(extension.accessibilityChecks.annotateScreenshots)
-
-    /**
-     * Resolve the active render tier from `-PcomposePreview.tier=<fast|full>`.
-     * `fast` tells the renderer to skip captures classified as
-     * [ee.schimke.composeai.plugin.CaptureCost.HEAVY] (`@AnimatedPreview` and
-     * non-TOP `@ScrollingPreview` modes); `full` (the default) renders
-     * everything as before.
-     *
-     * Returned as a `Provider<String>` for the same reason as
-     * [resolveA11yEnabled]: feeding `.get()` to a `CommandLineArgumentProvider`
-     * means the tier is resolved at task-execution time, so VS Code flipping
-     * the property between saves doesn't invalidate the configuration cache.
-     */
-    internal fun resolveTier(
-        project: org.gradle.api.Project,
-    ): org.gradle.api.provider.Provider<String> =
-        project.providers
-            .gradleProperty("composePreview.tier")
-            .map { v -> if (v.equals("fast", ignoreCase = true)) "fast" else "full" }
-            .orElse("full")
-
-    /**
-     * Lazy holder for the render-tier system property on the `renderPreviews`
-     * `Test` task. Same pattern as [AccessibilitySystemPropsProvider] — the
-     * Provider is `@Input`, so flipping `-PcomposePreview.tier` re-runs the
-     * task without invalidating the configuration cache.
-     */
-    internal class TierSystemPropProvider(
-        @get:org.gradle.api.tasks.Input val tier: org.gradle.api.provider.Provider<String>,
-    ) : org.gradle.process.CommandLineArgumentProvider {
-        override fun asArguments(): Iterable<String> =
-            listOf("-Dcomposeai.render.tier=${tier.get()}")
-    }
-
-    private fun copyAttributes(target: AttributeContainer, source: AttributeContainer) {
-        source.keySet().forEach { key ->
-            @Suppress("UNCHECKED_CAST")
-            val attr = key as Attribute<Any>
-            source.getAttribute(attr)?.let { target.attribute(attr, it) }
-        }
-    }
-
-    /**
-     * Resolves the effective shard count from [PreviewExtension.shards]:
-     *
-     *  - `≥1`: use the value as-is.
-     *  - `0` (auto): read [previewsJson] if it exists from a previous discover run and
-     *    hand the count to [ShardTuning.autoShards]. If the file is missing (very first
-     *    build), fall back to 1 — the next run will have better data and can
-     *    pick a higher count then.
-     */
-    private fun resolveShardCount(
-        project: Project,
-        extension: PreviewExtension,
-        previewsJson: java.io.File,
-    ): Int {
-        val requested = extension.shards.get()
-        if (requested > 0) return requested
-        if (!previewsJson.exists()) {
-            project.logger.info("compose-ai-tools: shards=auto but previews.json missing; defaulting to 1 for this run")
-            return 1
-        }
-        // Cheap regex parse — keeps kotlinx.serialization off the plugin
-        // classpath. Each Capture entry in `previews.json` carries its own
-        // `"renderOutput"` field (so counting those gives the capture
-        // count, not the preview count) and an optional `"cost"` (added
-        // post-0.8.0; older manifests omit it and the renderer treats
-        // missing as 1.0). We feed `(totalCost, maxIndividualCost,
-        // captureCount)` into [ShardTuning.autoShards] so a module with
-        // three GIF captures (cost = 40 each) gets sharded for the right
-        // reason rather than being judged by preview count alone.
-        val text = previewsJson.readText()
-        val captureCount = Regex("\"renderOutput\"\\s*:").findAll(text).count()
-        val costs = Regex("\"cost\"\\s*:\\s*([0-9.]+)")
-            .findAll(text)
-            .mapNotNull { it.groupValues[1].toDoubleOrNull() }
-            .toList()
-        val explicitCostSum = costs.sum()
-        val implicitCostSum = (captureCount - costs.size).coerceAtLeast(0).toDouble()
-        val totalCost = explicitCostSum + implicitCostSum
-        val maxIndividualCost = (costs.maxOrNull() ?: 1.0)
-            .coerceAtLeast(if (captureCount > costs.size) 1.0 else 0.0)
-        val resolved = ShardTuning.autoShards(totalCost, maxIndividualCost, captureCount)
-        project.logger.lifecycle(
-            "compose-ai-tools: shards=auto → $resolved " +
-                "(captures=$captureCount, totalCost=${"%.1f".format(totalCost)}, " +
-                "maxCost=${"%.1f".format(maxIndividualCost)}, " +
-                "cores=${Runtime.getRuntime().availableProcessors()})",
-        )
-        return resolved
-    }
-
-    private fun String.cap(): String =
-        replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
-
-    /**
-     * Append an [ee.schimke.composeai.plugin.tooling.InjectedDependency] record
-     * and emit a uniform `info`-level line. Central helper so every
-     * injection site — unconditional or conditional — contributes to
-     * the doctor.json accumulator and the grep-friendly log format with
-     * the same shape:
-     *
-     *     compose-ai-tools: inject[<coord>] <OUTCOME> → <config>  (<reason>)
-     */
-    private fun recordInjectedDependency(
-        project: Project,
-        sink: MutableList<ee.schimke.composeai.plugin.tooling.InjectedDependency>,
-        coordinate: String,
-        configuration: String,
-        outcome: String,
-        reason: String,
-    ) {
-        sink += ee.schimke.composeai.plugin.tooling.InjectedDependency(
-            coordinate = coordinate,
-            configuration = configuration,
-            outcome = outcome,
-            reason = reason,
-        )
-        val target = configuration.ifEmpty { "—" }
+    // Register render tasks once, for the variant the user picked. onVariants
+    // fires after AGP has created variant-specific configurations like
+    // `${variant}UnitTestRuntimeClasspath`, so everything we need is there.
+    // Fetching `sdkComponents.bootClasspath` eagerly (at apply time) forces
+    // AGP to read `compileOptions.targetCompatibility` before it's finalized
+    // and crashes — grab it inside onVariants instead.
+    var registered = false
+    androidComponents.onVariants(androidComponents.selector().all()) { variant ->
+      if (registered) return@onVariants
+      if (!extension.enabled.get()) return@onVariants
+      if (variant.name != extension.variant.get()) return@onVariants
+      if (!hasPreviewDependency(project)) {
         project.logger.info(
-            "compose-ai-tools: inject[$coordinate] $outcome → $target  ($reason)"
+          "compose-preview: no known @Preview dependency declared in module " +
+            "'${project.path}'; skipping task registration. " +
+            "Add one of ${previewArtifactSignals.joinToString { "${it.first}:${it.second}" }} " +
+            "(or remove the plugin from this module) to opt in."
         )
+        return@onVariants
+      }
+      registered = true
+      registerAndroidTasks(
+        project,
+        extension,
+        variant.name,
+        androidComponents.sdkComponents.bootClasspath,
+      )
+    }
+  }
+
+  /**
+   * True when any declarative dep bucket (`implementation` / `api` / `runtimeOnly`, including their
+   * `<name>Implementation` variants) declares a coord in [previewArtifactSignals]. Read at
+   * onVariants time, after the consumer's `dependencies { }` block has populated configurations;
+   * avoids resolution and stays Isolated-Projects safe.
+   */
+  private fun hasPreviewDependency(project: Project): Boolean =
+    project.configurations
+      .asSequence()
+      .filter { c ->
+        val n = c.name
+        n == "implementation" ||
+          n.endsWith("Implementation") ||
+          n == "api" ||
+          n.endsWith("Api") ||
+          n == "runtimeOnly" ||
+          n.endsWith("RuntimeOnly")
+      }
+      .any { c ->
+        c.allDependencies.any { dep ->
+          val g = dep.group ?: return@any false
+          previewArtifactSignals.any { (sg, sn) -> g == sg && dep.name == sn }
+        }
+      }
+
+  private fun registerAndroidTasks(
+    project: Project,
+    extension: PreviewExtension,
+    variantName: String,
+    bootClasspath: org.gradle.api.provider.Provider<List<org.gradle.api.file.RegularFile>>,
+  ) {
+    val capVariant = variantName.cap()
+    val previewOutputDir = project.layout.buildDirectory.dir("compose-previews")
+    val artifactType = Attribute.of("artifactType", String::class.java)
+
+    // `com.android.compose.screenshot` (Google's alpha Layoutlib-based
+    // screenshot testing plugin) adds its own `screenshotTest` source set
+    // alongside `main` / `test` / `androidTest`. We don't drive its
+    // validate/update tasks — we keep using our Robolectric renderer — but
+    // we DO want to discover and render any `@Preview` functions consumers
+    // put under `src/screenshotTest/`, so modules that already adopted the
+    // Google plugin (e.g. Confetti's `:androidApp`) surface those previews
+    // in the CLI / VS Code grid without duplicating them in `main`.
+    //
+    // Detection is by plugin id rather than the
+    // `android.experimental.enableScreenshotTest` gradle property, because
+    // the property is a global flag while the plugin is applied per-module
+    // — and only the latter actually causes AGP to register
+    // `compile${Cap}ScreenshotTestKotlin` and the
+    // `${variant}ScreenshotTestRuntimeClasspath` configuration we need.
+    val screenshotTestEnabled = project.pluginManager.hasPlugin("com.android.compose.screenshot")
+
+    val sourceClassDirs =
+      project.files(
+        project.layout.buildDirectory.dir("tmp/kotlin-classes/$variantName"),
+        project.layout.buildDirectory.dir("intermediates/javac/$variantName/classes"),
+        project.layout.buildDirectory.dir(
+          "intermediates/built_in_kotlinc/$variantName/compile${capVariant}Kotlin/classes"
+        ),
+      )
+    if (screenshotTestEnabled) {
+      sourceClassDirs.from(
+        project.layout.buildDirectory.dir(
+          "intermediates/built_in_kotlinc/${variantName}ScreenshotTest/compile${capVariant}ScreenshotTestKotlin/classes"
+        ),
+        project.layout.buildDirectory.dir(
+          "intermediates/javac/${variantName}ScreenshotTest/classes"
+        ),
+      )
     }
 
-    /**
-     * Validates that the consumer has declared every coordinate the plugin
-     * would otherwise have injected. Called from the `afterEvaluate` block
-     * in [registerAndroidTasks] when `composePreview.manageDependencies =
-     * false`. Fails during configuration (not at render time) so the
-     * error message carries the exact coordinate list to add, in the
-     * exact buckets the plugin would have used.
-     */
-    private fun validateExternallyManagedDependencies(
-        project: Project,
-        variantName: String,
-        tilesRendererRequired: Boolean,
-    ) {
-        // Declared-dependency scan, not resolved-classpath: we want to
-        // fail before Gradle resolves anything, and to accept the coord
-        // regardless of whether the consumer placed it in the explicit
-        // bucket below or any parent config that extends into it (Android
-        // library's `api` into variant `Implementation`, custom buckets,
-        // etc.). Group + name match only — versions are out of scope,
-        // matching how `manageDependencies=true` also passes no version.
-        fun declared(configName: String): Sequence<org.gradle.api.artifacts.Dependency> =
-            project.configurations.findByName(configName)
-                ?.allDependencies?.asSequence()
-                ?: emptySequence()
+    val dependencyConfigName = "${variantName}RuntimeClasspath"
+    val screenshotTestRuntimeConfig =
+      if (screenshotTestEnabled) {
+        project.configurations.findByName("${variantName}ScreenshotTestRuntimeClasspath")
+      } else null
 
-        fun hasCoord(configName: String, group: String, name: String): Boolean =
-            declared(configName).any { it.group == group && it.name == name }
-
-        val missing = mutableListOf<String>()
-        if (!hasCoord("testImplementation", "androidx.compose.ui", "ui-test-manifest")) {
-            missing += "testImplementation(\"androidx.compose.ui:ui-test-manifest\")"
-        }
-        if (!hasCoord("testImplementation", "androidx.compose.ui", "ui-test-junit4")) {
-            missing += "testImplementation(\"androidx.compose.ui:ui-test-junit4\")"
-        }
-        if (tilesRendererRequired &&
-            !hasCoord("${variantName}Implementation", "androidx.wear.tiles", "tiles-renderer")
-        ) {
-            missing += "${variantName}Implementation(\"androidx.wear.tiles:tiles-renderer\")"
-        }
-
-        if (missing.isNotEmpty()) {
-            val suffix = if (tilesRendererRequired) {
-                "\n  tiles-renderer required: wear.tiles signal was matched on this module."
-            } else ""
-            throw org.gradle.api.GradleException(
-                "composePreview.manageDependencies = false, but the following required " +
-                    "dependencies are not declared in module '${project.path}':\n" +
-                    missing.joinToString(separator = "\n") { "  - $it" } +
-                    suffix +
-                    "\n\nAdd them to your build file, or set composePreview.manageDependencies = true " +
-                    "to let the plugin add them automatically.",
+    val discoverTask =
+      ComposePreviewTasks.registerDiscoverTask(
+        project,
+        sourceClassDirs,
+        dependencyConfigName,
+        previewOutputDir,
+        extension,
+      ) {
+        dependsOn("compile${capVariant}Kotlin")
+        if (screenshotTestEnabled) {
+          dependsOn("compile${capVariant}ScreenshotTestKotlin")
+          screenshotTestRuntimeConfig?.let { stConfig ->
+            dependencyJars.from(
+              stConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files
             )
+            dependencyJars.from(
+              stConfig.incoming
+                .artifactView { attributes.attribute(artifactType, "android-classes") }
+                .files
+            )
+          }
         }
+      }
+
+    // Writes the plugin-side compat findings (CompatRules) to
+    // `build/compose-previews/doctor.json`. The CLI doesn't need this
+    // file (it reads the same data via the ComposePreviewModel Tooling
+    // API), but tools that invoke Gradle tasks rather than BuildActions
+    // — specifically the VS Code extension — do. Same JSON schema as
+    // `compose-preview doctor --json`'s per-module shape, so both
+    // surfaces converge on one contract.
+    // Resolve the runtime classpaths' root components at configuration
+    // time so the task action stays config-cache safe (no `task.project`
+    // access at execution). `findByName` may return null on variants that
+    // don't have a paired unit-test classpath; the task tolerates an
+    // unset Property as "no deps to inspect".
+    val mainRuntimeRoot =
+      project.configurations
+        .findByName("${variantName}RuntimeClasspath")
+        ?.incoming
+        ?.resolutionResult
+        ?.rootComponent
+    val testRuntimeRoot =
+      project.configurations
+        .findByName("${variantName}UnitTestRuntimeClasspath")
+        ?.incoming
+        ?.resolutionResult
+        ?.rootComponent
+
+    // Capture the running Gradle version at configuration time so the
+    // task action stays config-cache safe (GradleVersion.current() is a
+    // static call but keeping the read out of `@TaskAction` avoids
+    // surprises if Gradle ever namespaces it differently).
+    val currentGradleVersion = org.gradle.util.GradleVersion.current().version
+    // Accumulator for inject records. The unconditional and
+    // conditional blocks below each append; the doctor task reads the
+    // list lazily via `project.provider { ... }` so it's evaluated
+    // AFTER the `afterEvaluate` block populates the tiles entry.
+    val injectedDependencies =
+      mutableListOf<ee.schimke.composeai.plugin.tooling.InjectedDependency>()
+    val injectedDependencyJson = kotlinx.serialization.json.Json { encodeDefaults = true }
+    project.tasks.register(
+      "composePreviewDoctor",
+      ee.schimke.composeai.plugin.tooling.ComposePreviewDoctorTask::class.java,
+    ) {
+      group = "compose preview"
+      description = "Write compose-preview doctor findings to build/compose-previews/doctor.json"
+      this.variant.set(variantName)
+      this.modulePath.set(project.path)
+      this.gradleVersion.set(currentGradleVersion)
+      this.outputFile.set(previewOutputDir.map { it.file("doctor.json") })
+      mainRuntimeRoot?.let { this.mainRuntimeRoot.set(it) }
+      testRuntimeRoot?.let { this.testRuntimeRoot.set(it) }
+      this.injectedDependenciesJson.set(
+        project.provider {
+          injectedDependencyJson.encodeToString(
+            kotlinx.serialization.builtins.ListSerializer(
+              ee.schimke.composeai.plugin.tooling.InjectedDependency.serializer()
+            ),
+            injectedDependencies.toList(),
+          )
+        }
+      )
     }
+
+    // Always inject `ui-test-manifest` + `ui-test-junit4` into the consumer's
+    // `testImplementation`:
+    //
+    //  * `ui-test-manifest` contributes the `<activity android:name=
+    //    "androidx.activity.ComponentActivity">` entry that has to land in
+    //    the consumer's merged unit-test AndroidManifest before
+    //    `createAndroidComposeRule<ComponentActivity>()` can launch its
+    //    ActivityScenario. Our plugin bypasses the normal AGP dep graph
+    //    (renderer classpath lives in our own resolvable config, not
+    //    `testImplementation`), so the manifest merger never sees it
+    //    otherwise.
+    //  * `ui-test-junit4` is where `createAndroidComposeRule` /
+    //    `ComposeTestRule` / `mainClock` live. The renderer test references
+    //    these unconditionally from its default `renderDefault` path (we
+    //    use `mainClock.autoAdvance = false` + explicit frame pumping to
+    //    make infinite animations terminate deterministically — see
+    //    RobolectricRenderTest.renderDefault), so the consumer's test
+    //    classpath needs these classes too, not just the resource/manifest
+    //    half of the story.
+    //
+    // `composePreview.manageDependencies = false` opts out of all
+    // plugin-side injection. Deps are recorded as SKIPPED_BY_CONFIG
+    // in `doctor.json` so consumers can see what they need to add,
+    // and the afterEvaluate block below validates the consumer did
+    // add them — the build fails during configuration with an
+    // explicit coordinate list instead of surfacing a
+    // ClassNotFoundException from Robolectric at render time.
+    val manageDependencies = extension.manageDependencies.get()
+
+    // No version: relies on the consumer's Compose BOM (or direct Compose
+    // dep) to resolve these artifacts. Projects using
+    // `implementation(platform(libs.compose.bom))` pick up the aligned
+    // version automatically; projects without a BOM need to add one (a
+    // reasonable ask — the plugin is for Compose apps).
+    if (manageDependencies) {
+      project.dependencies.add("testImplementation", "androidx.compose.ui:ui-test-manifest")
+      project.dependencies.add("testImplementation", "androidx.compose.ui:ui-test-junit4")
+      recordInjectedDependency(
+        project,
+        injectedDependencies,
+        coordinate = "androidx.compose.ui:ui-test-manifest",
+        configuration = "testImplementation",
+        outcome = "APPLIED",
+        reason = "merges ComponentActivity into the unit-test manifest for renderer",
+      )
+      recordInjectedDependency(
+        project,
+        injectedDependencies,
+        coordinate = "androidx.compose.ui:ui-test-junit4",
+        configuration = "testImplementation",
+        outcome = "APPLIED",
+        reason = "provides createAndroidComposeRule / mainClock used by renderer",
+      )
+    } else {
+      recordInjectedDependency(
+        project,
+        injectedDependencies,
+        coordinate = "androidx.compose.ui:ui-test-manifest",
+        configuration = "testImplementation",
+        outcome = "SKIPPED_BY_CONFIG",
+        reason = "manageDependencies=false; consumer must declare this in testImplementation",
+      )
+      recordInjectedDependency(
+        project,
+        injectedDependencies,
+        coordinate = "androidx.compose.ui:ui-test-junit4",
+        configuration = "testImplementation",
+        outcome = "SKIPPED_BY_CONFIG",
+        reason = "manageDependencies=false; consumer must declare this in testImplementation",
+      )
+    }
+
+    // Conditionally inject `androidx.wear.tiles:tiles-renderer` into the
+    // consumer's variant `implementation` when the consumer signals they
+    // want Tile previews. Detection is deferred to `afterEvaluate` so the
+    // consumer's declared deps are complete.
+    //
+    // Why we inject at all: TilePreviewRenderer.renderTileInto calls
+    // `TileRenderer(...)`, whose constructor builds `ProtoLayoutThemeImpl`
+    // which holds a Java reference to
+    // `androidx.wear.protolayout.renderer.R$style.ProtoLayoutBaseTheme`.
+    // That R class is only compiled into the consumer's merged R.jar when
+    // `wear.tiles:tiles-renderer` is on the MAIN compile classpath —
+    // `testImplementation` and `compileOnly` don't participate in AGP's R
+    // class generation. Consumer apps shouldn't have to restate a purely
+    // preview-rendering dep in their main `implementation`.
+    //
+    // Why the signal is "tiles-tooling-preview / tiles-renderer / tiles":
+    // these are the modules a consumer actually declares when they write
+    // `@Preview`-annotated tile functions. Horologist projects go through
+    // `horologist-tiles` so we include that too.
+    //
+    // No version — the consumer's wear.tiles atomic group constrains
+    // `tiles-renderer` to their wear.tiles version. When the detection
+    // misfires in a non-tiles project (shouldn't happen under the
+    // heuristic above), Gradle fails with a clear "no version for
+    // tiles-renderer" error.
+    project.afterEvaluate {
+      // Scan every configuration whose name ends in `Implementation` so
+      // the detection works for ANY buildType / flavor / variant combo
+      // (e.g. `uatImplementation`, `stagingImplementation`,
+      // `uatStagingImplementation`). The earlier hardcoded list of
+      // `debugImplementation` / `releaseImplementation` only fired on
+      // the default AGP buildTypes, missing custom flavored layouts
+      // like `uatDebug`. The group+name filter below is precise enough
+      // that casting a wider net is safe — false positives require a
+      // dep literally in the `androidx.wear.tiles` / horologist-tiles
+      // groups, which is the signal we're looking for.
+      // Scan every declarative dep-bucket name so the detection works
+      // regardless of which bucket (and which sourceSet / buildType /
+      // flavor / variant) the consumer used to declare their tile deps:
+      //   - `implementation` / `<sourceSet>Implementation` — the common case.
+      //   - `api` / `<sourceSet>Api` — Android library modules that
+      //     re-export tile APIs to their consumers.
+      //   - `runtimeOnly` / `<sourceSet>RuntimeOnly` — rare, but tile
+      //     deps declared runtime-only still need the R-class injection.
+      // Resolving the actual runtime classpath would be authoritative
+      // but triggers config-cache invalidation and is awkward under
+      // Isolated Projects, so we stay declarative. The group+name
+      // filter inside is precise enough (exact match on `androidx.wear.tiles` /
+      // horologist-tiles coords) that widening the config scan can't
+      // introduce false positives.
+      val matchedConfigs = mutableListOf<String>()
+      project.configurations
+        .asSequence()
+        .filter { c ->
+          val n = c.name
+          n == "implementation" ||
+            n.endsWith("Implementation") ||
+            n == "api" ||
+            n.endsWith("Api") ||
+            n == "runtimeOnly" ||
+            n.endsWith("RuntimeOnly")
+        }
+        .forEach { c ->
+          val hit =
+            c.allDependencies.any { dep ->
+              (dep.group == "androidx.wear.tiles" && dep.name in tilesSignalNames) ||
+                (dep.group == "com.google.android.horologist" && dep.name == "horologist-tiles")
+            }
+          if (hit) matchedConfigs += c.name
+        }
+      if (matchedConfigs.isNotEmpty()) {
+        if (manageDependencies) {
+          project.dependencies.add(
+            "${variantName}Implementation",
+            "androidx.wear.tiles:tiles-renderer",
+          )
+          recordInjectedDependency(
+            project,
+            injectedDependencies,
+            coordinate = "androidx.wear.tiles:tiles-renderer",
+            configuration = "${variantName}Implementation",
+            outcome = "MATCHED",
+            reason = "signal matched on [${matchedConfigs.joinToString(", ")}]",
+          )
+        } else {
+          recordInjectedDependency(
+            project,
+            injectedDependencies,
+            coordinate = "androidx.wear.tiles:tiles-renderer",
+            configuration = "${variantName}Implementation",
+            outcome = "SKIPPED_BY_CONFIG",
+            reason =
+              "manageDependencies=false; tiles signal matched on [${matchedConfigs.joinToString(", ")}] but consumer must declare tiles-renderer in ${variantName}Implementation",
+          )
+        }
+      } else {
+        recordInjectedDependency(
+          project,
+          injectedDependencies,
+          coordinate = "androidx.wear.tiles:tiles-renderer",
+          configuration = "",
+          outcome = "SKIPPED",
+          reason =
+            "no androidx.wear.tiles / horologist-tiles dep on any *Implementation/*Api/*RuntimeOnly configuration",
+        )
+      }
+
+      // `manageDependencies=false`: verify the consumer actually
+      // declared the coords we would otherwise have injected. Fail
+      // during configuration (in afterEvaluate) with an explicit
+      // coordinate list rather than letting the render task die
+      // later with a ClassNotFoundException. Check by group/name
+      // across the relevant declarative buckets so the consumer
+      // can place them wherever their project conventions prefer.
+      if (!manageDependencies) {
+        validateExternallyManagedDependencies(
+          project = project,
+          variantName = variantName,
+          tilesRendererRequired = matchedConfigs.isNotEmpty(),
+        )
+      }
+    }
+
+    val testConfig = project.configurations.findByName("${variantName}UnitTestRuntimeClasspath")
+
+    // The default path for external consumers: resolve
+    // `ee.schimke.composeai:renderer-android:<plugin-version>` from Maven.
+    // The plugin's own version is baked into the jar at build time so the
+    // matching renderer AAR is chosen automatically — see [PluginVersion].
+    //
+    // Dev-mode shortcut: when the plugin runs *inside* the compose-ai-tools
+    // build itself (in-repo samples), bypass Maven and depend on the sibling
+    // `:renderer-android` Gradle project directly. That way live renderer
+    // edits show up without a publish step. The signal is the presence of
+    // the sibling build script on disk; we deliberately avoid calling
+    // `rootProject.findProject(...)` here because reading the sibling's
+    // model under Isolated Projects is disallowed — a filesystem check is
+    // IP-safe, and only the in-repo layout matches it.
+    val rendererProjectDir = project.rootDir.resolve("renderer-android")
+    val useLocalRenderer =
+      rendererProjectDir.resolve("build.gradle.kts").exists() ||
+        rendererProjectDir.resolve("build.gradle").exists()
+
+    // Renderer's transitive runtime dependencies come through a dedicated
+    // resolvable configuration in *this* project. Attributes are copied
+    // from the sample's unit-test runtime classpath so Gradle picks the
+    // right Android variant without us declaring them by hand.
+    //
+    // `extendsFrom(testConfig)` is load-bearing: it tells Gradle to resolve
+    // renderer deps in the SAME graph as the consumer's test-runtime deps,
+    // so version conflicts pick a single coherent max version instead of
+    // two separate graphs that clash at class-load time. Without it, the
+    // renderer's transitive `androidx.core:1.8.0` and consumer's
+    // `androidx.core:1.16.0` both end up on the test classpath in different
+    // JARs — whichever is listed first wins for each class, and the loaded
+    // activity/lifecycle/compose-ui versions don't all agree. Symptoms:
+    //   - `NoSuchFieldError: androidx.lifecycle.ReportFragment.Companion`
+    //   - `NoSuchFieldError: … tag_compat_insets_dispatch`
+    val rendererConfig =
+      project.configurations.maybeCreate("composePreviewAndroidRenderer$capVariant").apply {
+        isCanBeResolved = true
+        isCanBeConsumed = false
+        if (testConfig != null) {
+          copyAttributes(attributes, testConfig.attributes)
+          extendsFrom(testConfig)
+        }
+      }
+
+    if (useLocalRenderer) {
+      try {
+        project.dependencies.add(
+          rendererConfig.name,
+          project.dependencies.project(mapOf("path" to ":renderer-android")),
+        )
+      } catch (e: org.gradle.api.UnknownProjectException) {
+        project.logger.debug("compose-ai-tools: :renderer-android project not found, skipping", e)
+      }
+    } else {
+      project.dependencies.add(
+        rendererConfig.name,
+        "ee.schimke.composeai:renderer-android:${PluginVersion.value}",
+      )
+    }
+
+    // Classes used for Gradle's test-class scanning. Local mode: the
+    // renderer-android project's compiled output directories. External
+    // mode: the AAR's `classes.jar`, expanded via `zipTree` so Gradle's
+    // `Test.include("**/…Test.class")` filter can walk it — the include
+    // filter traverses file trees but does NOT descend into JAR entries,
+    // so feeding a raw JAR here silently produces `renderPreviews NO-SOURCE`
+    // and every preview ends up with no PNG. `android-classes` is AGP's
+    // `ArtifactType.CLASSES_JAR` (a JAR), not the extracted directory
+    // (that would be `android-classes-directory`).
+    val rendererClassDirs =
+      if (useLocalRenderer) {
+        project.files(
+          rendererProjectDir.resolve(
+            "build/intermediates/built_in_kotlinc/$variantName/compile${capVariant}Kotlin/classes"
+          ),
+          rendererProjectDir.resolve("build/tmp/kotlin-classes/$variantName"),
+        )
+      } else {
+        val rendererJars =
+          rendererConfig.incoming
+            .artifactView {
+              attributes.attribute(artifactType, "android-classes")
+              componentFilter { id ->
+                id is org.gradle.api.artifacts.component.ModuleComponentIdentifier &&
+                  id.group == "ee.schimke.composeai" &&
+                  id.module == "renderer-android"
+              }
+            }
+            .files
+        // Callable defers `.files` resolution until the Test task queries
+        // this FileCollection, keeping the configuration lazy.
+        project.files(
+          java.util.concurrent.Callable { rendererJars.files.map { project.zipTree(it) } }
+        )
+      }
+
+    // AGP's `generate${Variant}UnitTestConfig` task emits
+    // `com/android/tools/test_config.properties` under
+    // `intermediates/unit_test_config_directory/<variant>UnitTest/.../out/`.
+    // Robolectric loads it from the classpath and uses it to find the merged
+    // resource APK (`apk-for-local-test.ap_`) — the one that contains every
+    // AAR's merged resources (protolayout-renderer's `ProtoLayoutBaseTheme`
+    // etc.). Without this directory on the classpath, `getIdentifier` returns
+    // 0 for any library-provided style and TileRenderer's theme construction
+    // explodes on `Unknown resource value type 0`. Compose-only previews
+    // don't read AAR resources, which is why this only surfaced with tiles.
+    val unitTestConfigDir =
+      project.layout.buildDirectory.dir(
+        "intermediates/unit_test_config_directory/${variantName}UnitTest/generate${capVariant}UnitTestConfig/out"
+      )
+
+    // Generates `ee/schimke/composeai/renderer/robolectric.properties`
+    // onto the render classpath so Robolectric overrides the consumer's
+    // `Application` with a stub by default — see
+    // [GenerateRobolectricPropertiesTask] for rationale and the opt-out.
+    val robolectricPropertiesDir =
+      project.layout.buildDirectory.dir("generated/composeai/robolectric/$variantName")
+    val generateRobolectricPropertiesTask =
+      project.tasks.register(
+        "generateRobolectricProperties",
+        GenerateRobolectricPropertiesTask::class.java,
+      ) {
+        group = "compose preview"
+        description = "Generate package-level robolectric.properties for renderPreviews"
+        useConsumerApplication.set(extension.useConsumerApplication)
+        outputDir.set(robolectricPropertiesDir)
+      }
+
+    // Renderer classpath FIRST — renderer depends on kotlinx-serialization
+    // 1.11.x and Roborazzi 1.59+ while consumer apps may transitively drag
+    // in older versions (Compose BOM, etc). Gradle's FileCollection.from()
+    // doesn't do conflict resolution, so whichever JAR comes first wins at
+    // classload time. Putting the renderer's dependencies first ensures the
+    // test code gets the versions it was compiled against.
+    val resolvedClasspath =
+      project.files().apply {
+        // Robolectric properties dir BEFORE consumer test resources so our
+        // Application override wins when classloader.getResource walks the
+        // classpath. Consumers with their own `robolectric.properties` at
+        // the same package path are unusual — they'd need it specifically
+        // for this renderer's test class.
+        from(generateRobolectricPropertiesTask.flatMap { it.outputDir })
+        from(
+          rendererConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files
+        )
+        from(rendererClassDirs)
+        if (testConfig != null) {
+          from(testConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files)
+          from(
+            testConfig.incoming
+              .artifactView { attributes.attribute(artifactType, "android-classes") }
+              .files
+          )
+        }
+        // screenshotTest source set has its own runtime config — any
+        // `screenshotTestImplementation(...)` dep the consumer declared is
+        // only visible here, not via `testConfig`. Include it so previews
+        // under `src/screenshotTest/` can reference those classes at
+        // render time. No-op when the screenshot plugin isn't applied.
+        screenshotTestRuntimeConfig?.let { stConfig ->
+          from(stConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files)
+          from(
+            stConfig.incoming
+              .artifactView { attributes.attribute(artifactType, "android-classes") }
+              .files
+          )
+        }
+        from(sourceClassDirs)
+        from(unitTestConfigDir)
+        // SDK stub android.jar on the OUTER classpath so JUnit can introspect
+        // the test class (RobolectricRenderTest.kt references android.graphics.Bitmap,
+        // android.view.PixelCopy, etc. in method signatures). Without it, JUnit fails
+        // with `NoClassDefFoundError: android/graphics/Bitmap` during test discovery,
+        // before Robolectric's sandbox classloader is even created.
+        //
+        // Inside the sandbox, `ParameterizedRobolectricTestRunner` loads the test class
+        // through Robolectric's InstrumentingClassLoader, which delegates `android.*`
+        // resolution to its own `android-all` artifact (real framework classes, with
+        // shadows applied). The outer stub does NOT shadow the sandboxed PixelCopy.
+        //
+        // Sourced from AGP's SdkComponents so we don't have to parse local.properties
+        // or read rootProject.file(...).
+        from(project.files(bootClasspath))
+      }
+
+    val manifestFile = previewOutputDir.map { it.file("previews.json").asFile.absolutePath }
+    val rendersDirectory = previewOutputDir.map { it.dir("renders") }
+    val rendersDir = rendersDirectory.map { it.asFile.absolutePath }
+
+    // Per-preview ATF findings land here. `verifyAccessibility` rolls them
+    // up into a single `accessibility.json` next to `previews.json`. Kept
+    // separate from renders/ so caching treats the two output trees
+    // independently.
+    val accessibilityPerPreviewDir = previewOutputDir.map { it.dir("accessibility-per-preview") }
+    val accessibilityReportFile = previewOutputDir.map { it.file("accessibility.json") }
+
+    val shardCount =
+      resolveShardCount(project, extension, previewOutputDir.get().file("previews.json").asFile)
+    val shardsEnabled = shardCount > 1
+
+    // When sharded, generate N Java subclasses of RobolectricRenderTestBase, each with
+    // its own static @Parameters method that loads only that shard's slice of the manifest.
+    // Gradle distributes tests across forks at the class level, so a single parameterized
+    // class can't be split — we give it N classes. Each shard subclass resolves its
+    // Robolectric config via the generated package-level `robolectric.properties`
+    // (sdk/graphicsMode/application/shadows), so every JVM's sandbox key matches and
+    // each fork reuses its own cached sandbox across all previews in its slice.
+    val shardSourcesDir =
+      project.layout.buildDirectory.dir("generated/composeai/render-shards/java")
+    val shardClassesDir =
+      project.layout.buildDirectory.dir("generated/composeai/render-shards/classes")
+
+    val generateShardsTask =
+      if (shardsEnabled) {
+        project.tasks.register("generateRenderShards", GenerateRenderShardsTask::class.java) {
+          group = "compose preview"
+          description = "Generate $shardCount RobolectricRenderTest_Shard subclasses"
+          shards.set(shardCount)
+          outputDir.set(shardSourcesDir)
+        }
+      } else null
+
+    val compileShardsTask =
+      if (generateShardsTask != null) {
+        project.tasks.register("compileRenderShards", JavaCompile::class.java) {
+          group = "compose preview"
+          description = "Compile generated shard test subclasses"
+          source(generateShardsTask.map { it.outputDir.asFileTree })
+          classpath = resolvedClasspath
+          destinationDirectory.set(shardClassesDir)
+          options.release.set(21)
+          dependsOn(generateShardsTask)
+          if (useLocalRenderer) {
+            dependsOn(":renderer-android:compile${capVariant}Kotlin")
+          }
+        }
+      } else null
+
+    val renderTask =
+      project.tasks.register("renderPreviews", Test::class.java) {
+        group = "compose preview"
+        description = "Render Android previews via Robolectric"
+        val agpTestTask = project.tasks.findByName("test${capVariant}UnitTest") as? Test
+        testClassesDirs =
+          if (compileShardsTask != null) {
+            rendererClassDirs +
+              project.files(compileShardsTask.map { it.destinationDirectory }) +
+              (agpTestTask?.testClassesDirs ?: project.files())
+          } else {
+            rendererClassDirs + (agpTestTask?.testClassesDirs ?: project.files())
+          }
+        // Append AGP's own `test${Cap}UnitTest` classpath at the END so we
+        // pick up files that only exist there: specifically, the unit-test
+        // merged R.jar for library modules (`com.android.library` variants
+        // publish their AAR-transitive R classes — e.g.
+        // `androidx.customview.poolingcontainer.R$id`, pulled in by
+        // `ViewCompositionStrategy` — via
+        // `compile_and_runtime_r_class_jar/${variant}UnitTest/process${Cap}UnitTestResources/R.jar`,
+        // which is added to `debugUnitTestRuntimeClasspath` as a raw file
+        // dep without the `artifactType=jar` attribute, so our
+        // attribute-filtered `artifactView` above silently drops it).
+        // Ordering is load-bearing — putting it last means our renderer's
+        // pinned versions still win classload lookups in the earlier
+        // classpath entries. No-op on applications, since
+        // `process${Cap}Resources` puts the merged R.jar on the main
+        // runtime classpath where our existing `artifactView` already
+        // picks it up. See issue #136.
+        val agpTestClasspath = agpTestTask?.classpath ?: project.files()
+        classpath =
+          if (compileShardsTask != null) {
+            resolvedClasspath +
+              project.files(compileShardsTask.map { it.destinationDirectory }) +
+              (agpTestTask?.testClassesDirs ?: project.files()) +
+              agpTestClasspath
+          } else {
+            resolvedClasspath + (agpTestTask?.testClassesDirs ?: project.files()) + agpTestClasspath
+          }
+        if (shardsEnabled) {
+          include("**/RobolectricRenderTest_Shard*.class")
+          maxParallelForks = shardCount
+        } else {
+          include("**/RobolectricRenderTest.class")
+        }
+        useJUnit()
+
+        // Copy JVM args from AGP's test task. Deferred to the configuration
+        // lambda (rather than called at registration time) so AGP has had
+        // a chance to register `test${capVariant}UnitTest` by the time this
+        // runs — onVariants fires before unit-test tasks are wired.
+        jvmArgs(agpTestTask?.jvmArgs ?: emptyList<String>())
+        jvmArgs(
+          "--add-opens=java.base/java.lang=ALL-UNNAMED",
+          "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+          // Robolectric's `ShadowVMRuntime.getAddressOfDirectByteBuffer`
+          // reflectively invokes `DirectByteBuffer.address()`; under JDK 17+
+          // module rules this fails with IllegalAccessException without this
+          // opens. Reached via `PathIterator` — triggered here by Wear Compose's
+          // curved text renderer.
+          "--add-opens=java.base/java.nio=ALL-UNNAMED",
+        )
+
+        // Inherit AGP's unit-test javaLauncher so the forked test worker
+        // runs on the same JDK as `test${capVariant}UnitTest` — which
+        // AGP has already wired to the project's Java toolchain if the
+        // consumer configured one (`java { toolchain { … } }` /
+        // `kotlin { jvmToolchain(…) }`), or to the daemon JVM otherwise.
+        //
+        // Without this, a custom `Test` task's `javaLauncher` property
+        // defaults to the first `java` on PATH, which on CI and in local
+        // shells with `JAVA_HOME` overrides is NOT necessarily the same
+        // JVM the Gradle daemon is running. That mismatch produces
+        // `ClassNotFoundException: android.app.Application` during JUnit
+        // discovery on some JVM/classloader combinations. See #142.
+        agpTestTask?.javaLauncher?.orNull?.let { javaLauncher.set(it) }
+
+        // Belt-and-braces for the graphics/looper modes. Config now
+        // lives in `ee/schimke/composeai/renderer/robolectric.properties`
+        // (see `RobolectricRenderTestBase` KDoc for why we can't use
+        // `@GraphicsMode` directly). These system properties are a third
+        // independent Robolectric config channel and cost nothing to
+        // keep — survive both annotation and properties paths regressing.
+        systemProperty("robolectric.graphicsMode", "NATIVE")
+        systemProperty("robolectric.looperMode", "PAUSED")
+        // Conscrypt isn't needed for preview rendering (no TLS/HTTP paths
+        // execute) and its native library is flaky on some Linux sandboxes
+        // — e.g. missing/ABI-mismatched `libstdc++.so.6`. Telling Robolectric
+        // to skip the install avoids those failures without shipping our
+        // own Conscrypt stubs. See `ConscryptMode` /
+        // `ConscryptModeConfigurer` in Robolectric.
+        systemProperty("robolectric.conscryptMode", "OFF")
+        // Routes ShadowPixelCopy through HardwareRenderingScreenshot →
+        // ImageReader + HardwareRenderer.syncAndDraw, the only path that
+        // replays Compose's RenderNodes correctly.
+        systemProperty("robolectric.pixelCopyRenderMode", "hardware")
+        // Roborazzi defaults to "compare" mode (which doesn't write pixels
+        // unless the expected baseline exists). Force "record" so every run
+        // writes fresh PNGs.
+        systemProperty("roborazzi.test.record", "true")
+
+        systemProperty("composeai.render.manifest", manifestFile.get())
+        systemProperty("composeai.render.outputDir", rendersDir.get())
+
+        // GoogleFont interceptor cache — defaults to
+        // `<project>/.compose-preview-history/fonts/`, same root the
+        // history task uses, so committed TTFs sit beside committed PNGs.
+        // The renderer class no-ops when this property is absent, so the
+        // feature is fully additive for existing consumers.
+        val fontsCacheDir =
+          extension.historyDir
+            .orElse(project.layout.projectDirectory.dir(".compose-preview-history"))
+            .map { it.dir("fonts").asFile.absolutePath }
+        systemProperty("composeai.fonts.cacheDir", fontsCacheDir.get())
+        // `-PcomposePreview.fontsOffline=true` (or the same Gradle property
+        // on a CI profile) skips network on cache miss so the render
+        // shows the fallback font rather than silently fetching from
+        // `fonts.googleapis.com`.
+        val fontsOffline =
+          project.providers.gradleProperty("composePreview.fontsOffline").orElse("false")
+        systemProperty("composeai.fonts.offline", fontsOffline.get())
+
+        // ATF flags are routed through a CommandLineArgumentProvider
+        // rather than `systemProperty(...)` so toggling the `-P` override
+        // doesn't invalidate the Gradle configuration cache. `systemProperty`
+        // evaluates its value eagerly at configuration time — the provider
+        // we'd read there becomes part of the config-cache key, so flipping
+        // `-PcomposePreview.accessibilityChecks.enabled` forces a ~5-10s
+        // reconfigure. CommandLineArgumentProvider's `@Input` providers
+        // are only evaluated at task execution, which is exactly the
+        // lazy-input semantics we want for VSCode toggles.
+        //
+        // Renderer always inspects these sysprops at runtime; when
+        // enabled=false, the a11y code paths are no-ops (see
+        // [RobolectricRenderTest.renderWithA11y] / `renderDefault`).
+        jvmArgumentProviders.add(
+          AccessibilitySystemPropsProvider(
+            enabled = resolveA11yEnabled(project, extension),
+            annotate = resolveA11yAnnotate(project, extension),
+            outputDir = accessibilityPerPreviewDir.map { it.asFile.absolutePath },
+            debug = project.providers.gradleProperty("composeai.a11y.debug").orElse("false"),
+          )
+        )
+        // Render-tier filter — fed via the same lazy `@Input` provider
+        // pattern so VS Code can flip `-PcomposePreview.tier=fast` on
+        // every save without paying a config-cache reconfigure. Renderer
+        // reads `composeai.render.tier` in [PreviewManifestLoader.loadShard]
+        // to drop HEAVY captures from each entry before sharding.
+        val tierProvider = resolveTier(project)
+        jvmArgumentProviders.add(TierSystemPropProvider(tier = tierProvider))
+        // Disable build-cache participation for `tier=fast` runs. A cache
+        // hit restores the cached `renders/` snapshot, which on a fast
+        // run only contains the cheap captures — heavy outputs from a
+        // previous full run would get wiped, breaking the "stale image"
+        // story VS Code shows on heavy cards. Up-to-date checks still
+        // apply, so a `tier=fast` re-run with no input changes is a
+        // no-op and the renders dir stays as-is. Full-tier runs cache
+        // normally.
+        outputs.cacheIf("renderPreviews caches tier=full runs only") {
+          tierProvider.get().equals("full", ignoreCase = true)
+        }
+        // Per-preview dir is always an output — the feature being off just
+        // means no files get written there. Declaring it unconditionally
+        // lets the config cache key stay stable across toggles.
+        outputs.dir(accessibilityPerPreviewDir).withPropertyName("a11yPerPreviewDir")
+
+        // The PNG files are written to `rendersDirectory` via the
+        // `composeai.render.outputDir` system property, not through any
+        // Gradle-managed output. Declare the directory as an additional
+        // output so the build cache round-trips the PNGs alongside the
+        // test reports; without this the task gets a cache hit on a fresh
+        // checkout but the renders are never restored, which is exactly
+        // how previous modules silently vanished from `preview_main`.
+        outputs.dir(rendersDirectory).withPropertyName("rendersDir")
+
+        dependsOn(discoverTask)
+        dependsOn(generateRobolectricPropertiesTask)
+        if (useLocalRenderer) {
+          dependsOn(":renderer-android:compile${capVariant}Kotlin")
+        }
+        if (screenshotTestEnabled) {
+          dependsOn("compile${capVariant}ScreenshotTestKotlin")
+        }
+        // `process${Cap}Resources` only exists on `com.android.application`
+        // variants — AGP 9.x libraries expose the resource pipeline through
+        // `merge${Cap}Resources` / `generate${Cap}RFile` / the unit-test-
+        // specific `process${Cap}UnitTestResources`. The unit-test resource
+        // APK we actually consume is already routed via
+        // `generate${Cap}UnitTestConfig` below, so the `processResources`
+        // dep is just belt-and-suspenders; skip it when absent so library
+        // modules configure cleanly. See issue #136.
+        listOf("process${capVariant}Resources", "generate${capVariant}UnitTestConfig").forEach {
+          taskName ->
+          if (project.tasks.findByName(taskName) != null) {
+            dependsOn(taskName)
+          }
+        }
+        if (compileShardsTask != null) {
+          dependsOn(compileShardsTask)
+        }
+      }
+
+    // `verifyAccessibility` is ALWAYS registered so toggling
+    // `-PcomposePreview.accessibilityChecks.enabled` doesn't change the
+    // task graph — config cache stays valid across VSCode / CLI toggles.
+    // An `onlyIf` gate backed by the lazy provider makes it a no-op when
+    // the feature is off: the task configures but never executes, so the
+    // JSON aggregation and failure thresholds only kick in when the user
+    // actually opted in.
+    val a11yEnabledProvider = resolveA11yEnabled(project, extension)
+    val verifyA11yTask =
+      project.tasks.register("verifyAccessibility", VerifyAccessibilityTask::class.java) {
+        group = "compose preview"
+        description =
+          "Aggregate ATF findings from renderPreviews and fail per configured thresholds"
+        perPreviewDir.set(accessibilityPerPreviewDir)
+        reportFile.set(accessibilityReportFile)
+        moduleName.set(project.name)
+        failOnErrors.set(extension.accessibilityChecks.failOnErrors)
+        failOnWarnings.set(extension.accessibilityChecks.failOnWarnings)
+        dependsOn(renderTask)
+        onlyIf("composePreview.accessibilityChecks.enabled") { a11yEnabledProvider.get() }
+      }
+
+    ComposePreviewTasks.registerRenderAllPreviews(
+      project,
+      extension,
+      renderTask,
+      previewOutputDir,
+      verifyA11yTask,
+    )
+  }
+
+  /**
+   * Lazy holder for ATF-related system properties on the `renderPreviews` `Test` task. Using a
+   * CommandLineArgumentProvider — instead of `test.systemProperty(...)` — means the values are
+   * resolved at task execution time, so flipping the underlying Gradle property doesn't invalidate
+   * the configuration cache. Each `@Input` participates in the task's own up-to-date check, so
+   * toggling a11y correctly re-runs rendering.
+   */
+  internal class AccessibilitySystemPropsProvider(
+    @get:org.gradle.api.tasks.Input val enabled: org.gradle.api.provider.Provider<Boolean>,
+    @get:org.gradle.api.tasks.Input val annotate: org.gradle.api.provider.Provider<Boolean>,
+    @get:org.gradle.api.tasks.Input val outputDir: org.gradle.api.provider.Provider<String>,
+    @get:org.gradle.api.tasks.Input val debug: org.gradle.api.provider.Provider<String>,
+  ) : org.gradle.process.CommandLineArgumentProvider {
+    override fun asArguments(): Iterable<String> =
+      listOf(
+        "-Dcomposeai.a11y.enabled=${enabled.get()}",
+        "-Dcomposeai.a11y.annotate=${annotate.get()}",
+        "-Dcomposeai.a11y.outputDir=${outputDir.get()}",
+        "-Dcomposeai.a11y.debug=${debug.get()}",
+      )
+  }
+
+  /**
+   * Returns a lazy `Provider<Boolean>` for the effective `accessibilityChecks.enabled` value. The
+   * `-PcomposePreview.accessibilityChecks.enabled=<true|false>` Gradle property WINS over the
+   * extension block — so VSCode (or a one-off CLI invocation) can flip the feature on for a single
+   * run without touching `build.gradle.kts`.
+   *
+   * **Deliberately returns a Provider, not a Boolean.** Reading `.get()` at configuration time keys
+   * the configuration cache on the current property value, which means every VSCode toggle would
+   * invalidate the cache and pay a ~5-10s reconfigure cost. Consumers should pass this provider to
+   * task `onlyIf`, `CommandLineArgumentProvider` inputs, etc. — those evaluate it at
+   * task-graph-resolution time without cache invalidation.
+   */
+  internal fun resolveA11yEnabled(
+    project: org.gradle.api.Project,
+    extension: PreviewExtension,
+  ): org.gradle.api.provider.Provider<Boolean> =
+    project.providers
+      .gradleProperty("composePreview.accessibilityChecks.enabled")
+      .map { it.toBooleanStrictOrNull() ?: false }
+      .orElse(extension.accessibilityChecks.enabled)
+
+  /** Same config-cache-friendly treatment for `annotateScreenshots`. See [resolveA11yEnabled]. */
+  internal fun resolveA11yAnnotate(
+    project: org.gradle.api.Project,
+    extension: PreviewExtension,
+  ): org.gradle.api.provider.Provider<Boolean> =
+    project.providers
+      .gradleProperty("composePreview.accessibilityChecks.annotateScreenshots")
+      .map { it.toBooleanStrictOrNull() ?: true }
+      .orElse(extension.accessibilityChecks.annotateScreenshots)
+
+  /**
+   * Resolve the active render tier from `-PcomposePreview.tier=<fast|full>`. `fast` tells the
+   * renderer to skip captures classified as [ee.schimke.composeai.plugin.CaptureCost.HEAVY]
+   * (`@AnimatedPreview` and non-TOP `@ScrollingPreview` modes); `full` (the default) renders
+   * everything as before.
+   *
+   * Returned as a `Provider<String>` for the same reason as [resolveA11yEnabled]: feeding `.get()`
+   * to a `CommandLineArgumentProvider` means the tier is resolved at task-execution time, so VS
+   * Code flipping the property between saves doesn't invalidate the configuration cache.
+   */
+  internal fun resolveTier(
+    project: org.gradle.api.Project
+  ): org.gradle.api.provider.Provider<String> =
+    project.providers
+      .gradleProperty("composePreview.tier")
+      .map { v -> if (v.equals("fast", ignoreCase = true)) "fast" else "full" }
+      .orElse("full")
+
+  /**
+   * Lazy holder for the render-tier system property on the `renderPreviews` `Test` task. Same
+   * pattern as [AccessibilitySystemPropsProvider] — the Provider is `@Input`, so flipping
+   * `-PcomposePreview.tier` re-runs the task without invalidating the configuration cache.
+   */
+  internal class TierSystemPropProvider(
+    @get:org.gradle.api.tasks.Input val tier: org.gradle.api.provider.Provider<String>
+  ) : org.gradle.process.CommandLineArgumentProvider {
+    override fun asArguments(): Iterable<String> = listOf("-Dcomposeai.render.tier=${tier.get()}")
+  }
+
+  private fun copyAttributes(target: AttributeContainer, source: AttributeContainer) {
+    source.keySet().forEach { key ->
+      @Suppress("UNCHECKED_CAST") val attr = key as Attribute<Any>
+      source.getAttribute(attr)?.let { target.attribute(attr, it) }
+    }
+  }
+
+  /**
+   * Resolves the effective shard count from [PreviewExtension.shards]:
+   *
+   * - `≥1`: use the value as-is.
+   * - `0` (auto): read [previewsJson] if it exists from a previous discover run and hand the count
+   *   to [ShardTuning.autoShards]. If the file is missing (very first build), fall back to 1 — the
+   *   next run will have better data and can pick a higher count then.
+   */
+  private fun resolveShardCount(
+    project: Project,
+    extension: PreviewExtension,
+    previewsJson: java.io.File,
+  ): Int {
+    val requested = extension.shards.get()
+    if (requested > 0) return requested
+    if (!previewsJson.exists()) {
+      project.logger.info(
+        "compose-ai-tools: shards=auto but previews.json missing; defaulting to 1 for this run"
+      )
+      return 1
+    }
+    // Cheap regex parse — keeps kotlinx.serialization off the plugin
+    // classpath. Each Capture entry in `previews.json` carries its own
+    // `"renderOutput"` field (so counting those gives the capture
+    // count, not the preview count) and an optional `"cost"` (added
+    // post-0.8.0; older manifests omit it and the renderer treats
+    // missing as 1.0). We feed `(totalCost, maxIndividualCost,
+    // captureCount)` into [ShardTuning.autoShards] so a module with
+    // three GIF captures (cost = 40 each) gets sharded for the right
+    // reason rather than being judged by preview count alone.
+    val text = previewsJson.readText()
+    val captureCount = Regex("\"renderOutput\"\\s*:").findAll(text).count()
+    val costs =
+      Regex("\"cost\"\\s*:\\s*([0-9.]+)")
+        .findAll(text)
+        .mapNotNull { it.groupValues[1].toDoubleOrNull() }
+        .toList()
+    val explicitCostSum = costs.sum()
+    val implicitCostSum = (captureCount - costs.size).coerceAtLeast(0).toDouble()
+    val totalCost = explicitCostSum + implicitCostSum
+    val maxIndividualCost =
+      (costs.maxOrNull() ?: 1.0).coerceAtLeast(if (captureCount > costs.size) 1.0 else 0.0)
+    val resolved = ShardTuning.autoShards(totalCost, maxIndividualCost, captureCount)
+    project.logger.lifecycle(
+      "compose-ai-tools: shards=auto → $resolved " +
+        "(captures=$captureCount, totalCost=${"%.1f".format(totalCost)}, " +
+        "maxCost=${"%.1f".format(maxIndividualCost)}, " +
+        "cores=${Runtime.getRuntime().availableProcessors()})"
+    )
+    return resolved
+  }
+
+  private fun String.cap(): String = replaceFirstChar {
+    if (it.isLowerCase()) it.titlecase() else it.toString()
+  }
+
+  /**
+   * Append an [ee.schimke.composeai.plugin.tooling.InjectedDependency] record and emit a uniform
+   * `info`-level line. Central helper so every injection site — unconditional or conditional —
+   * contributes to the doctor.json accumulator and the grep-friendly log format with the same
+   * shape:
+   *
+   *     compose-ai-tools: inject[<coord>] <OUTCOME> → <config>  (<reason>)
+   */
+  private fun recordInjectedDependency(
+    project: Project,
+    sink: MutableList<ee.schimke.composeai.plugin.tooling.InjectedDependency>,
+    coordinate: String,
+    configuration: String,
+    outcome: String,
+    reason: String,
+  ) {
+    sink +=
+      ee.schimke.composeai.plugin.tooling.InjectedDependency(
+        coordinate = coordinate,
+        configuration = configuration,
+        outcome = outcome,
+        reason = reason,
+      )
+    val target = configuration.ifEmpty { "—" }
+    project.logger.info("compose-ai-tools: inject[$coordinate] $outcome → $target  ($reason)")
+  }
+
+  /**
+   * Validates that the consumer has declared every coordinate the plugin would otherwise have
+   * injected. Called from the `afterEvaluate` block in [registerAndroidTasks] when
+   * `composePreview.manageDependencies = false`. Fails during configuration (not at render time) so
+   * the error message carries the exact coordinate list to add, in the exact buckets the plugin
+   * would have used.
+   */
+  private fun validateExternallyManagedDependencies(
+    project: Project,
+    variantName: String,
+    tilesRendererRequired: Boolean,
+  ) {
+    // Declared-dependency scan, not resolved-classpath: we want to
+    // fail before Gradle resolves anything, and to accept the coord
+    // regardless of whether the consumer placed it in the explicit
+    // bucket below or any parent config that extends into it (Android
+    // library's `api` into variant `Implementation`, custom buckets,
+    // etc.). Group + name match only — versions are out of scope,
+    // matching how `manageDependencies=true` also passes no version.
+    fun declared(configName: String): Sequence<org.gradle.api.artifacts.Dependency> =
+      project.configurations.findByName(configName)?.allDependencies?.asSequence()
+        ?: emptySequence()
+
+    fun hasCoord(configName: String, group: String, name: String): Boolean =
+      declared(configName).any { it.group == group && it.name == name }
+
+    val missing = mutableListOf<String>()
+    if (!hasCoord("testImplementation", "androidx.compose.ui", "ui-test-manifest")) {
+      missing += "testImplementation(\"androidx.compose.ui:ui-test-manifest\")"
+    }
+    if (!hasCoord("testImplementation", "androidx.compose.ui", "ui-test-junit4")) {
+      missing += "testImplementation(\"androidx.compose.ui:ui-test-junit4\")"
+    }
+    if (
+      tilesRendererRequired &&
+        !hasCoord("${variantName}Implementation", "androidx.wear.tiles", "tiles-renderer")
+    ) {
+      missing += "${variantName}Implementation(\"androidx.wear.tiles:tiles-renderer\")"
+    }
+
+    if (missing.isNotEmpty()) {
+      val suffix =
+        if (tilesRendererRequired) {
+          "\n  tiles-renderer required: wear.tiles signal was matched on this module."
+        } else ""
+      throw org.gradle.api.GradleException(
+        "composePreview.manageDependencies = false, but the following required " +
+          "dependencies are not declared in module '${project.path}':\n" +
+          missing.joinToString(separator = "\n") { "  - $it" } +
+          suffix +
+          "\n\nAdd them to your build file, or set composePreview.manageDependencies = true " +
+          "to let the plugin add them automatically."
+      )
+    }
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
@@ -2,81 +2,85 @@ package ee.schimke.composeai.plugin
 
 import ee.schimke.composeai.plugin.tooling.ComposePreviewAppliedTask
 import ee.schimke.composeai.plugin.tooling.ComposePreviewModelBuilder
+import javax.inject.Inject
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
-import javax.inject.Inject
 
-abstract class ComposePreviewPlugin @Inject constructor(
-    // Gradle injects build-scoped services into plugin constructors. This is
-    // the documented way to get at `ToolingModelBuilderRegistry`; accessing
-    // `project.services` directly is internal API and not stable.
-    private val toolingRegistry: ToolingModelBuilderRegistry,
+abstract class ComposePreviewPlugin
+@Inject
+constructor(
+  // Gradle injects build-scoped services into plugin constructors. This is
+  // the documented way to get at `ToolingModelBuilderRegistry`; accessing
+  // `project.services` directly is internal API and not stable.
+  private val toolingRegistry: ToolingModelBuilderRegistry
 ) : Plugin<Project> {
-    override fun apply(project: Project) {
-        val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+  override fun apply(project: Project) {
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
 
-        // ToolingModelBuilderRegistry is a build-scoped service — registering
-        // from any applying project makes the model available on every
-        // Tooling-API connection for the build. `register` accepts multiple
-        // builders for the same model (Gradle iterates on `canBuild`), so
-        // registering once per applying subproject is safe even if
-        // `buildAll` only ever gets called on the first one that matches.
-        // Cross-project state (`rootProject.extras`) would trip Isolated
-        // Projects, so we just let every applying project register.
-        //
-        // Consumed by the CLI / VS Code extension via
-        // `connection.model(ComposePreviewModel::class.java)`.
-        toolingRegistry.register(ComposePreviewModelBuilder())
+    // ToolingModelBuilderRegistry is a build-scoped service — registering
+    // from any applying project makes the model available on every
+    // Tooling-API connection for the build. `register` accepts multiple
+    // builders for the same model (Gradle iterates on `canBuild`), so
+    // registering once per applying subproject is safe even if
+    // `buildAll` only ever gets called on the first one that matches.
+    // Cross-project state (`rootProject.extras`) would trip Isolated
+    // Projects, so we just let every applying project register.
+    //
+    // Consumed by the CLI / VS Code extension via
+    // `connection.model(ComposePreviewModel::class.java)`.
+    toolingRegistry.register(ComposePreviewModelBuilder())
 
-        // Sidecar-JSON applied-marker task. The VS Code extension goes through
-        // `vscjava.vscode-gradle`, which only exposes `runTask` — it can't reach
-        // the Tooling-API model above. Running `gradle composePreviewApplied`
-        // (no module prefix) fans out to every applying project and writes a
-        // tiny JSON at `<module>/build/compose-previews/applied.json`; the
-        // extension scans for those markers to discover applied modules
-        // authoritatively. Independent of `discoverPreviews` so it runs even
-        // in modules that never compile previews (e.g. library modules whose
-        // only preview usage is compile-time annotations).
-        project.tasks.register("composePreviewApplied", ComposePreviewAppliedTask::class.java) {
-            pluginVersion.set(PluginVersion.value)
-            modulePath.set(project.path)
-            moduleName.set(project.name)
-            outputFile.set(project.layout.buildDirectory.file("compose-previews/applied.json"))
-            group = "compose preview"
-            description = "Write a marker JSON advertising that this module applies the Compose Preview plugin."
-        }
-
-        // `pluginManager.withPlugin` replaces the old `project.afterEvaluate { ... }`
-        // block. `afterEvaluate` is discouraged under Gradle's Isolated Projects mode
-        // (and in general for plugin wiring); the plugin-manager hook fires as soon
-        // as the target plugin is applied, which is the right moment to wire up.
-        //
-        // The AGP-facing code (finalizeDsl / onVariants / cross-project dependency
-        // declaration) is isolated in [AndroidPreviewSupport]. Gradle decorates this
-        // plugin class at apply time and resolves all class references it sees in
-        // the plugin's bytecode — so keeping AGP types *out* of ComposePreviewPlugin
-        // is what lets the plugin load cleanly on non-Android projects (Compose
-        // Multiplatform consumers, functional tests, etc.). AGP classes only get
-        // loaded when `AndroidPreviewSupport.configure` actually runs.
-        var androidConfigured = false
-        val androidHandler: () -> Unit = {
-            if (!androidConfigured) {
-                androidConfigured = true
-                AndroidPreviewSupport.configure(project, extension)
-            }
-        }
-        project.pluginManager.withPlugin("com.android.application") { androidHandler() }
-        project.pluginManager.withPlugin("com.android.library") { androidHandler() }
-
-        project.pluginManager.withPlugin("org.jetbrains.compose") {
-            if (androidConfigured) return@withPlugin
-            if (project.plugins.hasPlugin("com.android.application")
-                || project.plugins.hasPlugin("com.android.library")
-            ) {
-                return@withPlugin
-            }
-            ComposePreviewTasks.registerDesktopTasks(project, extension)
-        }
+    // Sidecar-JSON applied-marker task. The VS Code extension goes through
+    // `vscjava.vscode-gradle`, which only exposes `runTask` — it can't reach
+    // the Tooling-API model above. Running `gradle composePreviewApplied`
+    // (no module prefix) fans out to every applying project and writes a
+    // tiny JSON at `<module>/build/compose-previews/applied.json`; the
+    // extension scans for those markers to discover applied modules
+    // authoritatively. Independent of `discoverPreviews` so it runs even
+    // in modules that never compile previews (e.g. library modules whose
+    // only preview usage is compile-time annotations).
+    project.tasks.register("composePreviewApplied", ComposePreviewAppliedTask::class.java) {
+      pluginVersion.set(PluginVersion.value)
+      modulePath.set(project.path)
+      moduleName.set(project.name)
+      outputFile.set(project.layout.buildDirectory.file("compose-previews/applied.json"))
+      group = "compose preview"
+      description =
+        "Write a marker JSON advertising that this module applies the Compose Preview plugin."
     }
+
+    // `pluginManager.withPlugin` replaces the old `project.afterEvaluate { ... }`
+    // block. `afterEvaluate` is discouraged under Gradle's Isolated Projects mode
+    // (and in general for plugin wiring); the plugin-manager hook fires as soon
+    // as the target plugin is applied, which is the right moment to wire up.
+    //
+    // The AGP-facing code (finalizeDsl / onVariants / cross-project dependency
+    // declaration) is isolated in [AndroidPreviewSupport]. Gradle decorates this
+    // plugin class at apply time and resolves all class references it sees in
+    // the plugin's bytecode — so keeping AGP types *out* of ComposePreviewPlugin
+    // is what lets the plugin load cleanly on non-Android projects (Compose
+    // Multiplatform consumers, functional tests, etc.). AGP classes only get
+    // loaded when `AndroidPreviewSupport.configure` actually runs.
+    var androidConfigured = false
+    val androidHandler: () -> Unit = {
+      if (!androidConfigured) {
+        androidConfigured = true
+        AndroidPreviewSupport.configure(project, extension)
+      }
+    }
+    project.pluginManager.withPlugin("com.android.application") { androidHandler() }
+    project.pluginManager.withPlugin("com.android.library") { androidHandler() }
+
+    project.pluginManager.withPlugin("org.jetbrains.compose") {
+      if (androidConfigured) return@withPlugin
+      if (
+        project.plugins.hasPlugin("com.android.application") ||
+          project.plugins.hasPlugin("com.android.library")
+      ) {
+        return@withPlugin
+      }
+      ComposePreviewTasks.registerDesktopTasks(project, extension)
+    }
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -13,399 +13,439 @@ import org.gradle.api.tasks.TaskProvider
 private val previewManifestJson = Json { ignoreUnknownKeys = true }
 
 /**
- * AGP-free task wiring shared between the Android and desktop code paths.
- * Keeping this out of [ComposePreviewPlugin] (or inside [AndroidPreviewSupport],
- * which does transitively reference AGP) means the desktop path can reuse these
- * helpers without dragging AGP onto the classpath.
+ * AGP-free task wiring shared between the Android and desktop code paths. Keeping this out of
+ * [ComposePreviewPlugin] (or inside [AndroidPreviewSupport], which does transitively reference AGP)
+ * means the desktop path can reuse these helpers without dragging AGP onto the classpath.
  */
 internal object ComposePreviewTasks {
-    fun registerDesktopTasks(project: Project, extension: PreviewExtension) {
-        val previewOutputDir = project.layout.buildDirectory.dir("compose-previews")
+  fun registerDesktopTasks(project: Project, extension: PreviewExtension) {
+    val previewOutputDir = project.layout.buildDirectory.dir("compose-previews")
 
-        val sourceClassDirs = project.files(
-            project.layout.buildDirectory.dir("classes/kotlin/main"),
-            project.layout.buildDirectory.dir("classes/kotlin/jvm/main"),
-            project.layout.buildDirectory.dir("classes/kotlin/desktop/main"),
+    val sourceClassDirs =
+      project.files(
+        project.layout.buildDirectory.dir("classes/kotlin/main"),
+        project.layout.buildDirectory.dir("classes/kotlin/jvm/main"),
+        project.layout.buildDirectory.dir("classes/kotlin/desktop/main"),
+      )
+
+    val dependencyConfigName =
+      listOf("jvmRuntimeClasspath", "desktopRuntimeClasspath", "runtimeClasspath").firstOrNull {
+        project.configurations.findByName(it) != null
+      } ?: "runtimeClasspath"
+
+    val discoverTask =
+      registerDiscoverTask(
+        project,
+        sourceClassDirs,
+        dependencyConfigName,
+        previewOutputDir,
+        extension,
+      ) {
+        onlyIf { extension.enabled.get() }
+        for (name in listOf("compileKotlinJvm", "compileKotlinDesktop", "compileKotlin")) {
+          if (project.tasks.findByName(name) != null) {
+            dependsOn(name)
+            break
+          }
+        }
+      }
+
+    val rendererConfigName = "composePreviewRenderer"
+    val rendererConfig = project.configurations.maybeCreate(rendererConfigName)
+    rendererConfig.isCanBeResolved = true
+    rendererConfig.isCanBeConsumed = false
+
+    val hasDesktopRenderer =
+      try {
+        project.dependencies.add(
+          rendererConfigName,
+          project.dependencies.project(mapOf("path" to ":renderer-desktop")),
         )
+        true
+      } catch (e: org.gradle.api.UnknownProjectException) {
+        project.logger.debug("compose-ai-tools: :renderer-desktop project not found, skipping", e)
+        false
+      }
 
-        val dependencyConfigName = listOf("jvmRuntimeClasspath", "desktopRuntimeClasspath", "runtimeClasspath")
-            .firstOrNull { project.configurations.findByName(it) != null }
-            ?: "runtimeClasspath"
-
-        val discoverTask = registerDiscoverTask(project, sourceClassDirs, dependencyConfigName, previewOutputDir, extension) {
-            onlyIf { extension.enabled.get() }
-            for (name in listOf("compileKotlinJvm", "compileKotlinDesktop", "compileKotlin")) {
-                if (project.tasks.findByName(name) != null) {
-                    dependsOn(name)
-                    break
-                }
-            }
+    if (hasDesktopRenderer) {
+      val renderTask =
+        project.tasks.register("renderPreviews", RenderPreviewsTask::class.java) {
+          onlyIf { extension.enabled.get() }
+          previewsJson.set(previewOutputDir.map { it.file("previews.json") })
+          outputDir.set(previewOutputDir.map { it.dir("renders") })
+          renderBackend.set("desktop")
+          useComposeRenderer.set(true)
+          tier.set(tierProperty(project))
+          renderClasspath.from(sourceClassDirs)
+          project.configurations.findByName(dependencyConfigName)?.let { renderClasspath.from(it) }
+          renderClasspath.from(rendererConfig)
+          group = "compose preview"
+          description = "Render all previews to PNG"
+          dependsOn(discoverTask)
         }
-
-        val rendererConfigName = "composePreviewRenderer"
-        val rendererConfig = project.configurations.maybeCreate(rendererConfigName)
-        rendererConfig.isCanBeResolved = true
-        rendererConfig.isCanBeConsumed = false
-
-        val hasDesktopRenderer = try {
-            project.dependencies.add(rendererConfigName, project.dependencies.project(mapOf("path" to ":renderer-desktop")))
-            true
-        } catch (e: org.gradle.api.UnknownProjectException) {
-            project.logger.debug("compose-ai-tools: :renderer-desktop project not found, skipping", e)
-            false
-        }
-
-        if (hasDesktopRenderer) {
-            val renderTask = project.tasks.register("renderPreviews", RenderPreviewsTask::class.java) {
-                onlyIf { extension.enabled.get() }
-                previewsJson.set(previewOutputDir.map { it.file("previews.json") })
-                outputDir.set(previewOutputDir.map { it.dir("renders") })
-                renderBackend.set("desktop")
-                useComposeRenderer.set(true)
-                tier.set(tierProperty(project))
-                renderClasspath.from(sourceClassDirs)
-                project.configurations.findByName(dependencyConfigName)?.let { renderClasspath.from(it) }
-                renderClasspath.from(rendererConfig)
-                group = "compose preview"
-                description = "Render all previews to PNG"
-                dependsOn(discoverTask)
-            }
-            registerRenderAllPreviews(project, extension, renderTask, previewOutputDir, verifyAccessibilityTask = null)
-        } else {
-            registerStubRenderTask(project, previewOutputDir, sourceClassDirs, dependencyConfigName, discoverTask, extension)
-        }
+      registerRenderAllPreviews(
+        project,
+        extension,
+        renderTask,
+        previewOutputDir,
+        verifyAccessibilityTask = null,
+      )
+    } else {
+      registerStubRenderTask(
+        project,
+        previewOutputDir,
+        sourceClassDirs,
+        dependencyConfigName,
+        discoverTask,
+        extension,
+      )
     }
+  }
 
-    /**
-     * Shared `Provider<String>` for the `composePreview.tier` Gradle property.
-     * `"fast"` (case-insensitive) tells the renderer to skip captures whose
-     * `cost` exceeds [HEAVY_COST_THRESHOLD]; anything else maps to `"full"`.
-     * Lazy + cacheable through `project.providers`, so reading `.get()` at
-     * task-execution time doesn't invalidate the configuration cache when
-     * the Gradle property flips between runs.
-     */
-    internal fun tierProperty(project: Project): Provider<String> =
+  /**
+   * Shared `Provider<String>` for the `composePreview.tier` Gradle property. `"fast"`
+   * (case-insensitive) tells the renderer to skip captures whose `cost` exceeds
+   * [HEAVY_COST_THRESHOLD]; anything else maps to `"full"`. Lazy + cacheable through
+   * `project.providers`, so reading `.get()` at task-execution time doesn't invalidate the
+   * configuration cache when the Gradle property flips between runs.
+   */
+  internal fun tierProperty(project: Project): Provider<String> =
+    project.providers
+      .gradleProperty("composePreview.tier")
+      .map { v -> if (v.equals("fast", ignoreCase = true)) "fast" else "full" }
+      .orElse("full")
+
+  fun registerDiscoverTask(
+    project: Project,
+    sourceClassDirs: FileCollection,
+    dependencyConfigName: String,
+    previewOutputDir: Provider<Directory>,
+    extension: PreviewExtension,
+    configureDeps: DiscoverPreviewsTask.() -> Unit,
+  ): TaskProvider<DiscoverPreviewsTask> {
+    val artifactType = Attribute.of("artifactType", String::class.java)
+
+    return project.tasks.register("discoverPreviews", DiscoverPreviewsTask::class.java) {
+      classDirs.from(sourceClassDirs)
+      project.configurations.findByName(dependencyConfigName)?.let { config ->
+        // For Android projects, dependencies resolve as AARs. Use artifact view
+        // filtering to request the extracted classes.jar (AGP registers the
+        // transform). Desktop/JVM projects already return JARs so this is a no-op.
+        dependencyJars.from(
+          config.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files
+        )
+        dependencyJars.from(
+          config.incoming
+            .artifactView { attributes.attribute(artifactType, "android-classes") }
+            .files
+        )
+      }
+      moduleName.set(project.name)
+      variantName.set(extension.variant)
+      // Gradle property override: `-PcomposePreview.accessibilityChecks.enabled=true`
+      // wins over the extension. Lets VSCode / CLI flip the feature on
+      // for a run without editing build.gradle.kts. Isolated-Projects-
+      // safe because `providers.gradleProperty` is.
+      accessibilityChecksEnabled.set(
         project.providers
-            .gradleProperty("composePreview.tier")
-            .map { v -> if (v.equals("fast", ignoreCase = true)) "fast" else "full" }
-            .orElse("full")
-
-    fun registerDiscoverTask(
-        project: Project,
-        sourceClassDirs: FileCollection,
-        dependencyConfigName: String,
-        previewOutputDir: Provider<Directory>,
-        extension: PreviewExtension,
-        configureDeps: DiscoverPreviewsTask.() -> Unit,
-    ): TaskProvider<DiscoverPreviewsTask> {
-        val artifactType = Attribute.of("artifactType", String::class.java)
-
-        return project.tasks.register("discoverPreviews", DiscoverPreviewsTask::class.java) {
-            classDirs.from(sourceClassDirs)
-            project.configurations.findByName(dependencyConfigName)?.let { config ->
-                // For Android projects, dependencies resolve as AARs. Use artifact view
-                // filtering to request the extracted classes.jar (AGP registers the
-                // transform). Desktop/JVM projects already return JARs so this is a no-op.
-                dependencyJars.from(config.incoming.artifactView {
-                    attributes.attribute(artifactType, "jar")
-                }.files)
-                dependencyJars.from(config.incoming.artifactView {
-                    attributes.attribute(artifactType, "android-classes")
-                }.files)
-            }
-            moduleName.set(project.name)
-            variantName.set(extension.variant)
-            // Gradle property override: `-PcomposePreview.accessibilityChecks.enabled=true`
-            // wins over the extension. Lets VSCode / CLI flip the feature on
-            // for a run without editing build.gradle.kts. Isolated-Projects-
-            // safe because `providers.gradleProperty` is.
-            accessibilityChecksEnabled.set(
-                project.providers.gradleProperty("composePreview.accessibilityChecks.enabled")
-                    .map { it.toBooleanStrictOrNull() ?: false }
-                    .orElse(extension.accessibilityChecks.enabled),
-            )
-            // `-PcomposePreview.failOnEmpty=true` wins over the extension, so
-            // CI profiles and one-off triage runs can flip the gate without
-            // touching build.gradle(.kts). Same pattern as
-            // `accessibilityChecks.enabled` above.
-            failOnEmpty.set(
-                project.providers.gradleProperty("composePreview.failOnEmpty")
-                    .map { it.toBooleanStrictOrNull() ?: false }
-                    .orElse(extension.failOnEmpty),
-            )
-            outputFile.set(previewOutputDir.map { it.file("previews.json") })
-            group = "compose preview"
-            description = "Discover @Preview annotations in compiled classes"
-            configureDeps()
-        }
+          .gradleProperty("composePreview.accessibilityChecks.enabled")
+          .map { it.toBooleanStrictOrNull() ?: false }
+          .orElse(extension.accessibilityChecks.enabled)
+      )
+      // `-PcomposePreview.failOnEmpty=true` wins over the extension, so
+      // CI profiles and one-off triage runs can flip the gate without
+      // touching build.gradle(.kts). Same pattern as
+      // `accessibilityChecks.enabled` above.
+      failOnEmpty.set(
+        project.providers
+          .gradleProperty("composePreview.failOnEmpty")
+          .map { it.toBooleanStrictOrNull() ?: false }
+          .orElse(extension.failOnEmpty)
+      )
+      outputFile.set(previewOutputDir.map { it.file("previews.json") })
+      group = "compose preview"
+      description = "Discover @Preview annotations in compiled classes"
+      configureDeps()
     }
+  }
 
-    fun registerStubRenderTask(
-        project: Project,
-        previewOutputDir: Provider<Directory>,
-        sourceClassDirs: FileCollection,
-        dependencyConfigName: String,
-        discoverTask: TaskProvider<DiscoverPreviewsTask>,
-        extension: PreviewExtension,
-    ) {
-        val renderTask = project.tasks.register("renderPreviews", RenderPreviewsTask::class.java) {
-            onlyIf { extension.enabled.get() }
-            previewsJson.set(previewOutputDir.map { it.file("previews.json") })
-            outputDir.set(previewOutputDir.map { it.dir("renders") })
-            renderBackend.set("stub")
-            useComposeRenderer.set(false)
-            tier.set(tierProperty(project))
-            renderClasspath.from(sourceClassDirs)
-            project.configurations.findByName(dependencyConfigName)?.let { renderClasspath.from(it) }
-            group = "compose preview"
-            description = "Render all previews to PNG (stub)"
-            dependsOn(discoverTask)
-        }
-        registerRenderAllPreviews(project, extension, renderTask, previewOutputDir, verifyAccessibilityTask = null)
-    }
+  fun registerStubRenderTask(
+    project: Project,
+    previewOutputDir: Provider<Directory>,
+    sourceClassDirs: FileCollection,
+    dependencyConfigName: String,
+    discoverTask: TaskProvider<DiscoverPreviewsTask>,
+    extension: PreviewExtension,
+  ) {
+    val renderTask =
+      project.tasks.register("renderPreviews", RenderPreviewsTask::class.java) {
+        onlyIf { extension.enabled.get() }
+        previewsJson.set(previewOutputDir.map { it.file("previews.json") })
+        outputDir.set(previewOutputDir.map { it.dir("renders") })
+        renderBackend.set("stub")
+        useComposeRenderer.set(false)
+        tier.set(tierProperty(project))
+        renderClasspath.from(sourceClassDirs)
+        project.configurations.findByName(dependencyConfigName)?.let { renderClasspath.from(it) }
+        group = "compose preview"
+        description = "Render all previews to PNG (stub)"
+        dependsOn(discoverTask)
+      }
+    registerRenderAllPreviews(
+      project,
+      extension,
+      renderTask,
+      previewOutputDir,
+      verifyAccessibilityTask = null,
+    )
+  }
 
-    /**
-     * Registers `renderAllPreviews` as the user-facing entry point. When
-     * `composePreview.historyEnabled = true`, inserts a `historizePreviews`
-     * task between the render task and the aggregate so every run archives
-     * changed PNGs into the configured history directory.
-     *
-     * `historizePreviews` is always registered (cheap — lazy TaskProvider) and
-     * `renderAllPreviews` picks which task to depend on via a Provider that
-     * Gradle resolves at task-graph-building time. That way we don't need to
-     * call `extension.historyEnabled.get()` at plugin-apply time, which would
-     * be premature — the user's `composePreview { ... }` block hasn't evaluated
-     * yet when `withPlugin` fires.
-     */
-    fun registerRenderAllPreviews(
-        project: Project,
-        extension: PreviewExtension,
-        renderTask: TaskProvider<*>,
-        previewOutputDir: Provider<Directory>,
-        verifyAccessibilityTask: TaskProvider<*>?,
-    ) {
-        // Default history dir: <project>/.compose-preview-history — outside `build/`
-        // so snapshots survive `./gradlew clean`. Users can override via extension.
-        val defaultHistoryDir = project.layout.projectDirectory.dir(".compose-preview-history")
-        val resolvedHistoryDir = extension.historyDir.orElse(defaultHistoryDir)
+  /**
+   * Registers `renderAllPreviews` as the user-facing entry point. When
+   * `composePreview.historyEnabled = true`, inserts a `historizePreviews` task between the render
+   * task and the aggregate so every run archives changed PNGs into the configured history
+   * directory.
+   *
+   * `historizePreviews` is always registered (cheap — lazy TaskProvider) and `renderAllPreviews`
+   * picks which task to depend on via a Provider that Gradle resolves at task-graph-building time.
+   * That way we don't need to call `extension.historyEnabled.get()` at plugin-apply time, which
+   * would be premature — the user's `composePreview { ... }` block hasn't evaluated yet when
+   * `withPlugin` fires.
+   */
+  fun registerRenderAllPreviews(
+    project: Project,
+    extension: PreviewExtension,
+    renderTask: TaskProvider<*>,
+    previewOutputDir: Provider<Directory>,
+    verifyAccessibilityTask: TaskProvider<*>?,
+  ) {
+    // Default history dir: <project>/.compose-preview-history — outside `build/`
+    // so snapshots survive `./gradlew clean`. Users can override via extension.
+    val defaultHistoryDir = project.layout.projectDirectory.dir(".compose-preview-history")
+    val resolvedHistoryDir = extension.historyDir.orElse(defaultHistoryDir)
 
-        val historizeTask = project.tasks.register("historizePreviews", HistorizePreviewsTask::class.java) {
-            previewsJson.set(previewOutputDir.map { it.file("previews.json") })
-            rendersDir.set(previewOutputDir.map { it.dir("renders") })
-            historyDir.set(resolvedHistoryDir)
-            group = "compose preview"
-            description = "Archive changed previews into the local history directory"
-            dependsOn(renderTask)
-        }
+    val historizeTask =
+      project.tasks.register("historizePreviews", HistorizePreviewsTask::class.java) {
+        previewsJson.set(previewOutputDir.map { it.file("previews.json") })
+        rendersDir.set(previewOutputDir.map { it.dir("renders") })
+        historyDir.set(resolvedHistoryDir)
+        group = "compose preview"
+        description = "Archive changed previews into the local history directory"
+        dependsOn(renderTask)
+      }
 
-        // Post-condition check: every entry in the manifest must have a PNG
-        // on disk after the render dependency ran. We ship the renderer
-        // (RobolectricRenderTest on Android, RenderPreviewsTask on desktop)
-        // so we KNOW the task should run for a non-empty manifest — a missing
-        // PNG is a wiring bug, never expected. The most common offender on
-        // Android is `renderPreviews` reporting NO-SOURCE because the AAR's
-        // classes.jar wasn't expanded via `zipTree` before being added to
-        // `testClassesDirs`, which silently skips rendering; without this
-        // check the failure surfaces only in downstream tools (CLI / VSCode).
-        val manifestFile = previewOutputDir.map { it.file("previews.json") }
-        val rendersDir = previewOutputDir.map { it.dir("renders") }
-        // Captured at config time so the `doLast` body doesn't reach for
-        // `project` at execution (config-cache safe). Resolves at execution
-        // to "fast" or "full"; "fast" tells the post-condition to tolerate
-        // heavy captures that legitimately weren't rendered this run.
-        val tierProvider = project.providers
-            .gradleProperty("composePreview.tier")
-            .map { v -> if (v.equals("fast", ignoreCase = true)) "fast" else "full" }
-            .orElse("full")
-        project.tasks.register("renderAllPreviews", DefaultTask::class.java) {
-            group = "compose preview"
-            dependsOn(extension.historyEnabled.map { enabled -> if (enabled) historizeTask else renderTask })
-            // `verifyAccessibility` runs AFTER rendering so PNGs always exist
-            // even when the check fails. `finalizedBy` (instead of `dependsOn`)
-            // lets the build still produce artefacts for CLI/VSCode to
-            // inspect when the a11y threshold trips the build.
-            verifyAccessibilityTask?.let { finalizedBy(it) }
-            doLast {
-                val isFastTier = tierProvider.get() == "fast"
-                val manifestOnDisk = manifestFile.get().asFile
-                if (!manifestOnDisk.exists()) return@doLast
-                val manifest = previewManifestJson
-                    .decodeFromString(PreviewManifest.serializer(), manifestOnDisk.readText())
-                if (manifest.previews.isEmpty()) return@doLast
+    // Post-condition check: every entry in the manifest must have a PNG
+    // on disk after the render dependency ran. We ship the renderer
+    // (RobolectricRenderTest on Android, RenderPreviewsTask on desktop)
+    // so we KNOW the task should run for a non-empty manifest — a missing
+    // PNG is a wiring bug, never expected. The most common offender on
+    // Android is `renderPreviews` reporting NO-SOURCE because the AAR's
+    // classes.jar wasn't expanded via `zipTree` before being added to
+    // `testClassesDirs`, which silently skips rendering; without this
+    // check the failure surfaces only in downstream tools (CLI / VSCode).
+    val manifestFile = previewOutputDir.map { it.file("previews.json") }
+    val rendersDir = previewOutputDir.map { it.dir("renders") }
+    // Captured at config time so the `doLast` body doesn't reach for
+    // `project` at execution (config-cache safe). Resolves at execution
+    // to "fast" or "full"; "fast" tells the post-condition to tolerate
+    // heavy captures that legitimately weren't rendered this run.
+    val tierProvider =
+      project.providers
+        .gradleProperty("composePreview.tier")
+        .map { v -> if (v.equals("fast", ignoreCase = true)) "fast" else "full" }
+        .orElse("full")
+    project.tasks.register("renderAllPreviews", DefaultTask::class.java) {
+      group = "compose preview"
+      dependsOn(
+        extension.historyEnabled.map { enabled -> if (enabled) historizeTask else renderTask }
+      )
+      // `verifyAccessibility` runs AFTER rendering so PNGs always exist
+      // even when the check fails. `finalizedBy` (instead of `dependsOn`)
+      // lets the build still produce artefacts for CLI/VSCode to
+      // inspect when the a11y threshold trips the build.
+      verifyAccessibilityTask?.let { finalizedBy(it) }
+      doLast {
+        val isFastTier = tierProvider.get() == "fast"
+        val manifestOnDisk = manifestFile.get().asFile
+        if (!manifestOnDisk.exists()) return@doLast
+        val manifest =
+          previewManifestJson.decodeFromString(
+            PreviewManifest.serializer(),
+            manifestOnDisk.readText(),
+          )
+        if (manifest.previews.isEmpty()) return@doLast
 
-                // `build/compose-previews/renders/` is a derived artefact —
-                // the renderer rewrites it every run, and downstream tools
-                // (VS Code, CLI, history) compare the CURRENT manifest
-                // against on-disk state. Files left over from deleted or
-                // renamed previews confuse that comparison, so we delete
-                // anything that isn't referenced by a current manifest
-                // entry.
-                //
-                // Parameterized (`@PreviewParameter`) previews are special:
-                // the Gradle side only knows the stem (e.g.
-                // `Foo_PARAM_template.png`), not which fan-out filenames
-                // the provider will produce. The renderer itself cleans up
-                // its own stale fan-out before writing (see
-                // `deleteStaleFanoutFiles` in the renderer modules), so
-                // here we keep every `<stem>_*<ext>` match rather than
-                // second-guessing the provider values.
-                cleanStaleRenders(previewOutputDir.get().asFile.resolve("renders"), manifest, logger)
-                // Each preview can produce multiple captures (`@RoboComposePreviewOptions`
-                // time fan-out, future scroll / dimension fan-outs). Verify each
-                // capture's renderOutput lands on disk — report back one missing
-                // entry per preview with at least one missing capture.
-                val outDir = previewOutputDir.get().asFile
-                // Files owned by non-parameterized siblings — exclude them
-                // from the `<stem>_*` glob so a `Foo_header.png` that
-                // belongs to a different preview never gets treated as
-                // part of `Foo`'s fan-out.
-                val siblingNames = manifest.previews
-                    .filter { it.params.previewParameterProviderClassName == null }
-                    .flatMap { it.captures.map { c -> c.renderOutput } }
-                    .filter { it.isNotEmpty() }
-                    .map { java.io.File(outDir, it).name }
-                    .toSet()
-                val missing = manifest.previews
-                    .filter { p ->
-                        p.captures.any { c ->
-                            // `tier=fast` legitimately skips heavy captures —
-                            // their PNG/GIF either still exists on disk from a
-                            // prior full run (and stays usable as the "stale"
-                            // image) or hasn't been produced yet. Either way,
-                            // it isn't a wiring bug worth failing the build
-                            // over, so exclude them from the must-exist check.
-                            if (isFastTier && isHeavyCost(c.cost)) return@any false
-                            val rel = c.renderOutput.ifEmpty { "renders/${p.id}.png" }
-                            // `@PreviewParameter` previews fan out at render
-                            // time: manifest carries a `<stem>.png` template,
-                            // but the actual files live at
-                            // `<stem>_<label>.png` (one per provider value,
-                            // or `_PARAM_<idx>` when the label can't be
-                            // derived). Check that at least ONE matching
-                            // fan-out file exists instead of demanding the
-                            // template itself.
-                            if (p.params.previewParameterProviderClassName != null) {
-                                val file = outDir.resolve(rel)
-                                val dir = file.parentFile ?: outDir
-                                val prefix = file.nameWithoutExtension + "_"
-                                val ext = ".${file.extension}"
-                                !(dir.listFiles()?.any { f ->
-                                    f.name.startsWith(prefix) &&
-                                        f.name.endsWith(ext) &&
-                                        f.name !in siblingNames
-                                } ?: false)
-                            } else {
-                                !outDir.resolve(rel).exists()
-                            }
-                        }
-                    }
-                    .map { it.id }
-                if (missing.isNotEmpty()) {
-                    val preview = missing.take(3).joinToString(", ")
-                    val andMore = if (missing.size > 3) " (+${missing.size - 3} more)" else ""
-                    throw GradleException(
-                        "renderAllPreviews: render produced no PNG for ${missing.size} of " +
-                            "${manifest.previews.size} preview(s): $preview$andMore. This means " +
-                            "`renderPreviews` was skipped or silently did nothing — on Android " +
-                            "that usually means it reported NO-SOURCE because " +
-                            "RobolectricRenderTest.class wasn't discoverable on its " +
-                            "testClassesDirs. Run with --info to see the task outcome.",
-                    )
-                }
-            }
-        }
-    }
-
-    /**
-     * Deletes files inside [rendersDir] that aren't referenced by [manifest].
-     *
-     * Keeps four kinds of files:
-     * 1. Exact `renderOutput` matches from non-parameterized previews.
-     * 2. `<stem>_*.<ext>` fan-out files where `<stem>` belongs to a
-     *    `@PreviewParameter` preview — the renderer itself cleans up its
-     *    own stale fan-outs (it knows the exact filenames), so the Gradle
-     *    side deliberately stays conservative and doesn't delete files it
-     *    can't be sure are stale.
-     * 3. `<stem>.a11y.png` siblings of registered renders. The renderer's
-     *    `AccessibilityOverlay` writes these next to the clean PNG when
-     *    a preview produces ATF findings; the manifest doesn't list them
-     *    (the pointer lives in `accessibility.json` instead), so without
-     *    this exemption they'd be deleted between writing and publishing.
-     * 4. Non-PNG/GIF files that aren't in the plugin's output domain.
-     *
-     * Anything else (PNGs or GIFs that were produced for a now-removed
-     * preview) gets removed so downstream tools compare the manifest
-     * against a clean directory.
-     */
-    private fun cleanStaleRenders(
-        rendersDir: java.io.File,
-        manifest: PreviewManifest,
-        logger: org.gradle.api.logging.Logger,
-    ) {
-        if (!rendersDir.isDirectory) return
-
-        val expectedRelPaths = manifest.previews
+        // `build/compose-previews/renders/` is a derived artefact —
+        // the renderer rewrites it every run, and downstream tools
+        // (VS Code, CLI, history) compare the CURRENT manifest
+        // against on-disk state. Files left over from deleted or
+        // renamed previews confuse that comparison, so we delete
+        // anything that isn't referenced by a current manifest
+        // entry.
+        //
+        // Parameterized (`@PreviewParameter`) previews are special:
+        // the Gradle side only knows the stem (e.g.
+        // `Foo_PARAM_template.png`), not which fan-out filenames
+        // the provider will produce. The renderer itself cleans up
+        // its own stale fan-out before writing (see
+        // `deleteStaleFanoutFiles` in the renderer modules), so
+        // here we keep every `<stem>_*<ext>` match rather than
+        // second-guessing the provider values.
+        cleanStaleRenders(previewOutputDir.get().asFile.resolve("renders"), manifest, logger)
+        // Each preview can produce multiple captures (`@RoboComposePreviewOptions`
+        // time fan-out, future scroll / dimension fan-outs). Verify each
+        // capture's renderOutput lands on disk — report back one missing
+        // entry per preview with at least one missing capture.
+        val outDir = previewOutputDir.get().asFile
+        // Files owned by non-parameterized siblings — exclude them
+        // from the `<stem>_*` glob so a `Foo_header.png` that
+        // belongs to a different preview never gets treated as
+        // part of `Foo`'s fan-out.
+        val siblingNames =
+          manifest.previews
             .filter { it.params.previewParameterProviderClassName == null }
-            .flatMap { it.captures.mapNotNull { c -> c.renderOutput.stripRendersPrefix() } }
+            .flatMap { it.captures.map { c -> c.renderOutput } }
+            .filter { it.isNotEmpty() }
+            .map { java.io.File(outDir, it).name }
             .toSet()
-
-        // `<stem>_` / `.<ext>` pairs we MUST leave alone — each one is the
-        // template filename of a `@PreviewParameter` preview. Any file in
-        // [rendersDir] whose leaf name starts with one of these prefixes
-        // and ends with the matching extension is treated as a fan-out
-        // sibling and preserved.
-        val paramStems = manifest.previews
-            .filter { it.params.previewParameterProviderClassName != null }
-            .flatMap { it.captures }
-            .mapNotNull { c ->
-                val rel = c.renderOutput.stripRendersPrefix() ?: return@mapNotNull null
-                val leaf = rel.substringAfterLast('/')
-                val dot = leaf.lastIndexOf('.')
-                if (dot <= 0) null
-                else FanoutKey(
-                    relDir = rel.substringBeforeLast('/', missingDelimiterValue = ""),
-                    prefix = leaf.substring(0, dot) + "_",
-                    ext = leaf.substring(dot),
-                )
-            }
-            .toSet()
-
-        rendersDir.walkBottomUp()
-            .filter { it.isFile && (it.extension == "png" || it.extension == "gif") }
-            .forEach { f ->
-                val rel = f.relativeTo(rendersDir).invariantSeparatorsPath
-                if (rel in expectedRelPaths) return@forEach
-                if (paramStems.any { it.matches(rel, f.name) }) return@forEach
-                if (isA11ySiblingOfExpected(rel, expectedRelPaths)) return@forEach
-                if (!f.delete()) {
-                    logger.warn("compose-preview: couldn't delete stale render $f")
+        val missing =
+          manifest.previews
+            .filter { p ->
+              p.captures.any { c ->
+                // `tier=fast` legitimately skips heavy captures —
+                // their PNG/GIF either still exists on disk from a
+                // prior full run (and stays usable as the "stale"
+                // image) or hasn't been produced yet. Either way,
+                // it isn't a wiring bug worth failing the build
+                // over, so exclude them from the must-exist check.
+                if (isFastTier && isHeavyCost(c.cost)) return@any false
+                val rel = c.renderOutput.ifEmpty { "renders/${p.id}.png" }
+                // `@PreviewParameter` previews fan out at render
+                // time: manifest carries a `<stem>.png` template,
+                // but the actual files live at
+                // `<stem>_<label>.png` (one per provider value,
+                // or `_PARAM_<idx>` when the label can't be
+                // derived). Check that at least ONE matching
+                // fan-out file exists instead of demanding the
+                // template itself.
+                if (p.params.previewParameterProviderClassName != null) {
+                  val file = outDir.resolve(rel)
+                  val dir = file.parentFile ?: outDir
+                  val prefix = file.nameWithoutExtension + "_"
+                  val ext = ".${file.extension}"
+                  !(dir.listFiles()?.any { f ->
+                    f.name.startsWith(prefix) && f.name.endsWith(ext) && f.name !in siblingNames
+                  } ?: false)
+                } else {
+                  !outDir.resolve(rel).exists()
                 }
+              }
             }
-    }
-
-    // `<stem>.a11y.png` lives next to the clean `<stem>.png` registered in
-    // the manifest. Match by mechanical suffix-strip rather than scanning
-    // accessibility.json: the cleanup runs whether a11y is enabled or not,
-    // and a stale `.a11y.png` whose clean sibling has been removed is still
-    // garbage we want gone.
-    internal fun isA11ySiblingOfExpected(
-        rel: String,
-        expectedRelPaths: Set<String>,
-    ): Boolean {
-        if (!rel.endsWith(".a11y.png")) return false
-        val cleanSibling = rel.removeSuffix(".a11y.png") + ".png"
-        return cleanSibling in expectedRelPaths
-    }
-
-    private fun String.stripRendersPrefix(): String? {
-        if (isEmpty()) return null
-        return substringAfter("renders/", missingDelimiterValue = this).takeIf { it.isNotEmpty() }
-    }
-
-    private data class FanoutKey(val relDir: String, val prefix: String, val ext: String) {
-        fun matches(rel: String, leaf: String): Boolean {
-            val dir = rel.substringBeforeLast('/', missingDelimiterValue = "")
-            return dir == relDir && leaf.startsWith(prefix) && leaf.endsWith(ext)
+            .map { it.id }
+        if (missing.isNotEmpty()) {
+          val preview = missing.take(3).joinToString(", ")
+          val andMore = if (missing.size > 3) " (+${missing.size - 3} more)" else ""
+          throw GradleException(
+            "renderAllPreviews: render produced no PNG for ${missing.size} of " +
+              "${manifest.previews.size} preview(s): $preview$andMore. This means " +
+              "`renderPreviews` was skipped or silently did nothing — on Android " +
+              "that usually means it reported NO-SOURCE because " +
+              "RobolectricRenderTest.class wasn't discoverable on its " +
+              "testClassesDirs. Run with --info to see the task outcome."
+          )
         }
+      }
     }
+  }
+
+  /**
+   * Deletes files inside [rendersDir] that aren't referenced by [manifest].
+   *
+   * Keeps four kinds of files:
+   * 1. Exact `renderOutput` matches from non-parameterized previews.
+   * 2. `<stem>_*.<ext>` fan-out files where `<stem>` belongs to a `@PreviewParameter` preview — the
+   *    renderer itself cleans up its own stale fan-outs (it knows the exact filenames), so the
+   *    Gradle side deliberately stays conservative and doesn't delete files it can't be sure are
+   *    stale.
+   * 3. `<stem>.a11y.png` siblings of registered renders. The renderer's `AccessibilityOverlay`
+   *    writes these next to the clean PNG when a preview produces ATF findings; the manifest
+   *    doesn't list them (the pointer lives in `accessibility.json` instead), so without this
+   *    exemption they'd be deleted between writing and publishing.
+   * 4. Non-PNG/GIF files that aren't in the plugin's output domain.
+   *
+   * Anything else (PNGs or GIFs that were produced for a now-removed preview) gets removed so
+   * downstream tools compare the manifest against a clean directory.
+   */
+  private fun cleanStaleRenders(
+    rendersDir: java.io.File,
+    manifest: PreviewManifest,
+    logger: org.gradle.api.logging.Logger,
+  ) {
+    if (!rendersDir.isDirectory) return
+
+    val expectedRelPaths =
+      manifest.previews
+        .filter { it.params.previewParameterProviderClassName == null }
+        .flatMap { it.captures.mapNotNull { c -> c.renderOutput.stripRendersPrefix() } }
+        .toSet()
+
+    // `<stem>_` / `.<ext>` pairs we MUST leave alone — each one is the
+    // template filename of a `@PreviewParameter` preview. Any file in
+    // [rendersDir] whose leaf name starts with one of these prefixes
+    // and ends with the matching extension is treated as a fan-out
+    // sibling and preserved.
+    val paramStems =
+      manifest.previews
+        .filter { it.params.previewParameterProviderClassName != null }
+        .flatMap { it.captures }
+        .mapNotNull { c ->
+          val rel = c.renderOutput.stripRendersPrefix() ?: return@mapNotNull null
+          val leaf = rel.substringAfterLast('/')
+          val dot = leaf.lastIndexOf('.')
+          if (dot <= 0) null
+          else
+            FanoutKey(
+              relDir = rel.substringBeforeLast('/', missingDelimiterValue = ""),
+              prefix = leaf.substring(0, dot) + "_",
+              ext = leaf.substring(dot),
+            )
+        }
+        .toSet()
+
+    rendersDir
+      .walkBottomUp()
+      .filter { it.isFile && (it.extension == "png" || it.extension == "gif") }
+      .forEach { f ->
+        val rel = f.relativeTo(rendersDir).invariantSeparatorsPath
+        if (rel in expectedRelPaths) return@forEach
+        if (paramStems.any { it.matches(rel, f.name) }) return@forEach
+        if (isA11ySiblingOfExpected(rel, expectedRelPaths)) return@forEach
+        if (!f.delete()) {
+          logger.warn("compose-preview: couldn't delete stale render $f")
+        }
+      }
+  }
+
+  // `<stem>.a11y.png` lives next to the clean `<stem>.png` registered in
+  // the manifest. Match by mechanical suffix-strip rather than scanning
+  // accessibility.json: the cleanup runs whether a11y is enabled or not,
+  // and a stale `.a11y.png` whose clean sibling has been removed is still
+  // garbage we want gone.
+  internal fun isA11ySiblingOfExpected(rel: String, expectedRelPaths: Set<String>): Boolean {
+    if (!rel.endsWith(".a11y.png")) return false
+    val cleanSibling = rel.removeSuffix(".a11y.png") + ".png"
+    return cleanSibling in expectedRelPaths
+  }
+
+  private fun String.stripRendersPrefix(): String? {
+    if (isEmpty()) return null
+    return substringAfter("renders/", missingDelimiterValue = this).takeIf { it.isNotEmpty() }
+  }
+
+  private data class FanoutKey(val relDir: String, val prefix: String, val ext: String) {
+    fun matches(rel: String, leaf: String): Boolean {
+      val dir = rel.substringBeforeLast('/', missingDelimiterValue = "")
+      return dir == relDir && leaf.startsWith(prefix) && leaf.endsWith(ext)
+    }
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceDimensions.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceDimensions.kt
@@ -1,217 +1,221 @@
 package ee.schimke.composeai.plugin
 
 object DeviceDimensions {
-    /**
-     * Per-device geometry resolved from a `@Preview(device = ...)` string.
-     *
-     * `density` is the Compose density factor (= densityDpi / 160). Renderers map
-     * this back to a Robolectric `<n>dpi` qualifier (and the desktop renderer
-     * passes it straight through to Compose's `Density(...)` constructor) so output
-     * PNGs match what Android Studio's preview renders for the same `@Preview`.
-     */
-    data class DeviceSpec(val widthDp: Int, val heightDp: Int, val density: Float = DEFAULT_DENSITY)
+  /**
+   * Per-device geometry resolved from a `@Preview(device = ...)` string.
+   *
+   * `density` is the Compose density factor (= densityDpi / 160). Renderers map this back to a
+   * Robolectric `<n>dpi` qualifier (and the desktop renderer passes it straight through to
+   * Compose's `Density(...)` constructor) so output PNGs match what Android Studio's preview
+   * renders for the same `@Preview`.
+   */
+  data class DeviceSpec(val widthDp: Int, val heightDp: Int, val density: Float = DEFAULT_DENSITY)
 
-    /**
-     * The density Android Studio uses when no device is specified — xxhdpi-ish
-     * (420dpi → 2.625x), matching its default phone-class preview. Picked over
-     * the previous 2.0x default to align with Studio; only affects previews
-     * that don't pin a `device` (or a `spec:...,dpi=...`).
-     */
-    const val DEFAULT_DENSITY: Float = 2.625f
+  /**
+   * The density Android Studio uses when no device is specified — xxhdpi-ish (420dpi → 2.625x),
+   * matching its default phone-class preview. Picked over the previous 2.0x default to align with
+   * Studio; only affects previews that don't pin a `device` (or a `spec:...,dpi=...`).
+   */
+  const val DEFAULT_DENSITY: Float = 2.625f
 
-    /**
-     * Per-axis sizing decision for a single preview, mirroring Android Studio's
-     * Compose preview pane: an axis is *fixed* when the user named a dp value or
-     * chose a device/`showSystemUi`, otherwise it *wraps* to the composable's
-     * intrinsic size. Wrapped axes still need a sandbox dimension so Robolectric
-     * Configuration qualifiers and the desktop `ImageComposeScene` have a finite
-     * canvas to render into — the renderer crops the PNG back down to the
-     * measured content bounds afterwards.
-     */
-    data class SizeSpec(
-        val widthDp: Int,
-        val heightDp: Int,
-        val wrapWidth: Boolean,
-        val wrapHeight: Boolean,
-        val density: Float = DEFAULT_DENSITY,
+  /**
+   * Per-axis sizing decision for a single preview, mirroring Android Studio's Compose preview pane:
+   * an axis is *fixed* when the user named a dp value or chose a device/`showSystemUi`, otherwise
+   * it *wraps* to the composable's intrinsic size. Wrapped axes still need a sandbox dimension so
+   * Robolectric Configuration qualifiers and the desktop `ImageComposeScene` have a finite canvas
+   * to render into — the renderer crops the PNG back down to the measured content bounds
+   * afterwards.
+   */
+  data class SizeSpec(
+    val widthDp: Int,
+    val heightDp: Int,
+    val wrapWidth: Boolean,
+    val wrapHeight: Boolean,
+    val density: Float = DEFAULT_DENSITY,
+  )
+
+  /**
+   * Sandbox dp used for wrapped axes — matches the historical default (400×800 dp) that stood in
+   * for "no device" before AS-parity sizing, so `fillMax*` composables measure into a phone-shaped
+   * viewport rather than a giant square. Wrapped small composables then crop well below this.
+   */
+  const val SANDBOX_WIDTH_DP = 400
+  const val SANDBOX_HEIGHT_DP = 800
+
+  /** Back-compat alias for callers/tests that want a single constant. */
+  const val SANDBOX_DP = SANDBOX_WIDTH_DP
+
+  // Source-of-truth for the dp values and densities below: sergio-sastre/ComposablePreviewScanner
+  // (Phone.kt / Tablet.kt / Wear.kt / GenericDevices.kt / Desktop.kt / Television.kt /
+  // Automotive.kt / XR.kt under android/.../device/types/), with dp = px / (densityDpi / 160)
+  // and density = densityDpi / 160. This is the same data the takahirom/roborazzi
+  // compose-preview-scanner-support pipeline uses.
+  private val KNOWN_DEVICES =
+    mapOf(
+      // --- Pixel phones ---
+      "id:pixel" to DeviceSpec(411, 731, 2.625f),
+      "id:pixel_xl" to DeviceSpec(411, 731, 3.5f),
+      "id:pixel_2" to DeviceSpec(411, 731, 2.625f),
+      "id:pixel_2_xl" to DeviceSpec(411, 823, 3.5f),
+      "id:pixel_3" to DeviceSpec(393, 786, 2.75f),
+      "id:pixel_3_xl" to DeviceSpec(411, 846, 3.5f),
+      "id:pixel_3a" to DeviceSpec(393, 808, 2.75f),
+      "id:pixel_3a_xl" to DeviceSpec(411, 823, 2.625f),
+      "id:pixel_4" to DeviceSpec(393, 829, 2.75f),
+      "id:pixel_4_xl" to DeviceSpec(411, 869, 3.5f),
+      "id:pixel_4a" to DeviceSpec(393, 851, 2.75f),
+      "id:pixel_5" to DeviceSpec(393, 851, 2.75f),
+      // Pixel 6 / 6a / 7 / 7a / 8 / 8a all share the same screen geometry
+      // (1080×2400 px @ 420dpi → 411×914 dp). Earlier revisions of this file
+      // accidentally used the Pixel 6 Pro value (891) for these — fixed.
+      "id:pixel_6" to DeviceSpec(411, 914, 2.625f),
+      "id:pixel_6a" to DeviceSpec(411, 914, 2.625f),
+      "id:pixel_6_pro" to DeviceSpec(411, 891, 3.5f),
+      "id:pixel_7" to DeviceSpec(411, 914, 2.625f),
+      "id:pixel_7a" to DeviceSpec(411, 914, 2.625f),
+      "id:pixel_7_pro" to DeviceSpec(411, 891, 3.5f),
+      "id:pixel_8" to DeviceSpec(411, 914, 2.625f),
+      "id:pixel_8a" to DeviceSpec(411, 914, 2.625f),
+      "id:pixel_8_pro" to DeviceSpec(448, 997, 3.0f),
+      "id:pixel_9" to DeviceSpec(411, 923, 2.625f),
+      "id:pixel_9a" to DeviceSpec(411, 923, 2.625f),
+      "id:pixel_9_pro" to DeviceSpec(426, 952, 3.0f),
+      "id:pixel_9_pro_xl" to DeviceSpec(438, 997, 3.0f),
+      // Foldables — natural orientation per upstream
+      "id:pixel_fold" to DeviceSpec(841, 701, 2.625f),
+      "id:pixel_9_pro_fold" to DeviceSpec(791, 819, 2.625f),
+
+      // --- Pixel tablets ---
+      "id:pixel_c" to DeviceSpec(1280, 900, 2.0f),
+      "id:pixel_tablet" to DeviceSpec(1280, 800, 2.0f),
+
+      // --- Generic Android Studio device IDs ---
+      // These appear as "Small Phone", "Medium Phone", "Medium Tablet", "Resizable
+      // (Experimental)" in the @Preview device picker.
+      "id:small_phone" to DeviceSpec(360, 640, 2.0f),
+      "id:medium_phone" to DeviceSpec(411, 914, 2.625f),
+      "id:medium_tablet" to DeviceSpec(1280, 800, 2.0f),
+      "id:resizable" to DeviceSpec(411, 914, 2.625f),
+
+      // --- Wear OS ---
+      // WearDevices constants from androidx.wear.tooling.preview.devices —
+      // used by @androidx.wear.tiles.tooling.preview.Preview. All wear devices
+      // run at 320dpi (xhdpi → 2.0x) per upstream. The xl_round entry isn't in
+      // sergio-sastre/ComposablePreviewScanner's table yet but ships in AOSP's
+      // sdklib/devices/wear.xml as a 480x480 px / xhdpi device.
+      "id:wearos_small_round" to DeviceSpec(192, 192, 2.0f),
+      "id:wearos_large_round" to DeviceSpec(227, 227, 2.0f),
+      "id:wearos_xl_round" to DeviceSpec(240, 240, 2.0f),
+      "id:wearos_square" to DeviceSpec(180, 180, 2.0f),
+      "id:wearos_rect" to DeviceSpec(201, 238, 2.0f),
+      // wearos_rectangular is the older Studio identifier for the same device as
+      // wearos_rect (kept around for projects that haven't migrated yet).
+      "id:wearos_rectangular" to DeviceSpec(201, 238, 2.0f),
+
+      // --- Desktop ---
+      // Studio's "Small/Medium/Large Desktop" entries; useful for Compose for Desktop
+      // previews routed through the Android renderer.
+      "id:desktop_small" to DeviceSpec(1366, 768, 1.0f),
+      "id:desktop_medium" to DeviceSpec(1920, 1080, 2.0f),
+      "id:desktop_large" to DeviceSpec(1920, 1080, 1.0f),
+
+      // --- Television (Android TV) ---
+      // 4K and 1080p resolve to the same dp surface; 4K just renders at 4× density.
+      "id:tv_720p" to DeviceSpec(931, 524, 1.375f),
+      "id:tv_1080p" to DeviceSpec(960, 540, 2.0f),
+      "id:tv_4k" to DeviceSpec(960, 540, 4.0f),
+
+      // --- Automotive (Android Auto / AAOS) ---
+      "id:automotive_1024p_landscape" to DeviceSpec(1024, 768, 1.0f),
+      "id:automotive_1080p_landscape" to DeviceSpec(1440, 800, 0.75f),
+      "id:automotive_1408p_landscape_with_google_apis" to DeviceSpec(1408, 792, 1.0f),
+      "id:automotive_1408p_landscape_with_play" to DeviceSpec(1408, 792, 1.0f),
+      "id:automotive_distant_display" to DeviceSpec(1440, 800, 0.75f),
+      "id:automotive_distant_display_with_play" to DeviceSpec(1440, 800, 0.75f),
+      "id:automotive_portrait" to DeviceSpec(1067, 1707, 0.75f),
+      "id:automotive_large_portrait" to DeviceSpec(1280, 1606, 1.0f),
+      "id:automotive_ultrawide" to DeviceSpec(2603, 880, 1.5f),
+
+      // --- XR ---
+      // xr_device is the deprecated identifier replaced by xr_headset_device in newer
+      // Android Studio versions; both refer to the same device.
+      "id:xr_headset_device" to DeviceSpec(1280, 1279, 2.0f),
+      "id:xr_device" to DeviceSpec(1280, 1279, 2.0f),
     )
 
-    /**
-     * Sandbox dp used for wrapped axes — matches the historical default
-     * (400×800 dp) that stood in for "no device" before AS-parity sizing, so
-     * `fillMax*` composables measure into a phone-shaped viewport rather than
-     * a giant square. Wrapped small composables then crop well below this.
-     */
-    const val SANDBOX_WIDTH_DP = 400
-    const val SANDBOX_HEIGHT_DP = 800
+  val DEFAULT = DeviceSpec(400, 800, DEFAULT_DENSITY)
+  val DEFAULT_WEAR = DeviceSpec(227, 227, 2.0f)
 
-    /** Back-compat alias for callers/tests that want a single constant. */
-    const val SANDBOX_DP = SANDBOX_WIDTH_DP
+  fun resolve(device: String?, widthDp: Int? = null, heightDp: Int? = null): DeviceSpec {
+    // Explicit widthDp/heightDp on the @Preview annotation — no device info,
+    // so fall back to the AS default density (xxhdpi-ish, matching Studio's
+    // default phone preview).
+    if (widthDp != null && widthDp > 0 && heightDp != null && heightDp > 0) {
+      return DeviceSpec(widthDp, heightDp, DEFAULT_DENSITY)
+    }
 
-    // Source-of-truth for the dp values and densities below: sergio-sastre/ComposablePreviewScanner
-    // (Phone.kt / Tablet.kt / Wear.kt / GenericDevices.kt / Desktop.kt / Television.kt /
-    // Automotive.kt / XR.kt under android/.../device/types/), with dp = px / (densityDpi / 160)
-    // and density = densityDpi / 160. This is the same data the takahirom/roborazzi
-    // compose-preview-scanner-support pipeline uses.
-    private val KNOWN_DEVICES = mapOf(
-        // --- Pixel phones ---
-        "id:pixel" to DeviceSpec(411, 731, 2.625f),
-        "id:pixel_xl" to DeviceSpec(411, 731, 3.5f),
-        "id:pixel_2" to DeviceSpec(411, 731, 2.625f),
-        "id:pixel_2_xl" to DeviceSpec(411, 823, 3.5f),
-        "id:pixel_3" to DeviceSpec(393, 786, 2.75f),
-        "id:pixel_3_xl" to DeviceSpec(411, 846, 3.5f),
-        "id:pixel_3a" to DeviceSpec(393, 808, 2.75f),
-        "id:pixel_3a_xl" to DeviceSpec(411, 823, 2.625f),
-        "id:pixel_4" to DeviceSpec(393, 829, 2.75f),
-        "id:pixel_4_xl" to DeviceSpec(411, 869, 3.5f),
-        "id:pixel_4a" to DeviceSpec(393, 851, 2.75f),
-        "id:pixel_5" to DeviceSpec(393, 851, 2.75f),
-        // Pixel 6 / 6a / 7 / 7a / 8 / 8a all share the same screen geometry
-        // (1080×2400 px @ 420dpi → 411×914 dp). Earlier revisions of this file
-        // accidentally used the Pixel 6 Pro value (891) for these — fixed.
-        "id:pixel_6" to DeviceSpec(411, 914, 2.625f),
-        "id:pixel_6a" to DeviceSpec(411, 914, 2.625f),
-        "id:pixel_6_pro" to DeviceSpec(411, 891, 3.5f),
-        "id:pixel_7" to DeviceSpec(411, 914, 2.625f),
-        "id:pixel_7a" to DeviceSpec(411, 914, 2.625f),
-        "id:pixel_7_pro" to DeviceSpec(411, 891, 3.5f),
-        "id:pixel_8" to DeviceSpec(411, 914, 2.625f),
-        "id:pixel_8a" to DeviceSpec(411, 914, 2.625f),
-        "id:pixel_8_pro" to DeviceSpec(448, 997, 3.0f),
-        "id:pixel_9" to DeviceSpec(411, 923, 2.625f),
-        "id:pixel_9a" to DeviceSpec(411, 923, 2.625f),
-        "id:pixel_9_pro" to DeviceSpec(426, 952, 3.0f),
-        "id:pixel_9_pro_xl" to DeviceSpec(438, 997, 3.0f),
-        // Foldables — natural orientation per upstream
-        "id:pixel_fold" to DeviceSpec(841, 701, 2.625f),
-        "id:pixel_9_pro_fold" to DeviceSpec(791, 819, 2.625f),
+    if (device != null) {
+      KNOWN_DEVICES[device]?.let {
+        return it
+      }
 
-        // --- Pixel tablets ---
-        "id:pixel_c" to DeviceSpec(1280, 900, 2.0f),
-        "id:pixel_tablet" to DeviceSpec(1280, 800, 2.0f),
-
-        // --- Generic Android Studio device IDs ---
-        // These appear as "Small Phone", "Medium Phone", "Medium Tablet", "Resizable
-        // (Experimental)" in the @Preview device picker.
-        "id:small_phone" to DeviceSpec(360, 640, 2.0f),
-        "id:medium_phone" to DeviceSpec(411, 914, 2.625f),
-        "id:medium_tablet" to DeviceSpec(1280, 800, 2.0f),
-        "id:resizable" to DeviceSpec(411, 914, 2.625f),
-
-        // --- Wear OS ---
-        // WearDevices constants from androidx.wear.tooling.preview.devices —
-        // used by @androidx.wear.tiles.tooling.preview.Preview. All wear devices
-        // run at 320dpi (xhdpi → 2.0x) per upstream. The xl_round entry isn't in
-        // sergio-sastre/ComposablePreviewScanner's table yet but ships in AOSP's
-        // sdklib/devices/wear.xml as a 480x480 px / xhdpi device.
-        "id:wearos_small_round" to DeviceSpec(192, 192, 2.0f),
-        "id:wearos_large_round" to DeviceSpec(227, 227, 2.0f),
-        "id:wearos_xl_round" to DeviceSpec(240, 240, 2.0f),
-        "id:wearos_square" to DeviceSpec(180, 180, 2.0f),
-        "id:wearos_rect" to DeviceSpec(201, 238, 2.0f),
-        // wearos_rectangular is the older Studio identifier for the same device as
-        // wearos_rect (kept around for projects that haven't migrated yet).
-        "id:wearos_rectangular" to DeviceSpec(201, 238, 2.0f),
-
-        // --- Desktop ---
-        // Studio's "Small/Medium/Large Desktop" entries; useful for Compose for Desktop
-        // previews routed through the Android renderer.
-        "id:desktop_small" to DeviceSpec(1366, 768, 1.0f),
-        "id:desktop_medium" to DeviceSpec(1920, 1080, 2.0f),
-        "id:desktop_large" to DeviceSpec(1920, 1080, 1.0f),
-
-        // --- Television (Android TV) ---
-        // 4K and 1080p resolve to the same dp surface; 4K just renders at 4× density.
-        "id:tv_720p" to DeviceSpec(931, 524, 1.375f),
-        "id:tv_1080p" to DeviceSpec(960, 540, 2.0f),
-        "id:tv_4k" to DeviceSpec(960, 540, 4.0f),
-
-        // --- Automotive (Android Auto / AAOS) ---
-        "id:automotive_1024p_landscape" to DeviceSpec(1024, 768, 1.0f),
-        "id:automotive_1080p_landscape" to DeviceSpec(1440, 800, 0.75f),
-        "id:automotive_1408p_landscape_with_google_apis" to DeviceSpec(1408, 792, 1.0f),
-        "id:automotive_1408p_landscape_with_play" to DeviceSpec(1408, 792, 1.0f),
-        "id:automotive_distant_display" to DeviceSpec(1440, 800, 0.75f),
-        "id:automotive_distant_display_with_play" to DeviceSpec(1440, 800, 0.75f),
-        "id:automotive_portrait" to DeviceSpec(1067, 1707, 0.75f),
-        "id:automotive_large_portrait" to DeviceSpec(1280, 1606, 1.0f),
-        "id:automotive_ultrawide" to DeviceSpec(2603, 880, 1.5f),
-
-        // --- XR ---
-        // xr_device is the deprecated identifier replaced by xr_headset_device in newer
-        // Android Studio versions; both refer to the same device.
-        "id:xr_headset_device" to DeviceSpec(1280, 1279, 2.0f),
-        "id:xr_device" to DeviceSpec(1280, 1279, 2.0f),
-    )
-
-    val DEFAULT = DeviceSpec(400, 800, DEFAULT_DENSITY)
-    val DEFAULT_WEAR = DeviceSpec(227, 227, 2.0f)
-
-    fun resolve(device: String?, widthDp: Int? = null, heightDp: Int? = null): DeviceSpec {
-        // Explicit widthDp/heightDp on the @Preview annotation — no device info,
-        // so fall back to the AS default density (xxhdpi-ish, matching Studio's
-        // default phone preview).
-        if (widthDp != null && widthDp > 0 && heightDp != null && heightDp > 0) {
-            return DeviceSpec(widthDp, heightDp, DEFAULT_DENSITY)
-        }
-
-        if (device != null) {
-            KNOWN_DEVICES[device]?.let { return it }
-
-            if (device.startsWith("spec:")) {
-                val params = device.removePrefix("spec:").split(",").mapNotNull {
-                    val parts = it.split("=", limit = 2)
-                    if (parts.size == 2) parts[0].trim() to parts[1].trim().removeSuffix("dp") else null
-                }.toMap()
-                val w = params["width"]?.toIntOrNull() ?: DEFAULT.widthDp
-                val h = params["height"]?.toIntOrNull() ?: DEFAULT.heightDp
-                // `dpi=` is part of Studio's spec: grammar (e.g. spec:width=411dp,height=914dp,dpi=420)
-                // — honour it if present, otherwise fall back to the AS default.
-                val density = params["dpi"]?.toIntOrNull()?.let { it / 160f } ?: DEFAULT_DENSITY
-                return DeviceSpec(w, h, density)
+      if (device.startsWith("spec:")) {
+        val params =
+          device
+            .removePrefix("spec:")
+            .split(",")
+            .mapNotNull {
+              val parts = it.split("=", limit = 2)
+              if (parts.size == 2) parts[0].trim() to parts[1].trim().removeSuffix("dp") else null
             }
+            .toMap()
+        val w = params["width"]?.toIntOrNull() ?: DEFAULT.widthDp
+        val h = params["height"]?.toIntOrNull() ?: DEFAULT.heightDp
+        // `dpi=` is part of Studio's spec: grammar (e.g. spec:width=411dp,height=914dp,dpi=420)
+        // — honour it if present, otherwise fall back to the AS default.
+        val density = params["dpi"]?.toIntOrNull()?.let { it / 160f } ?: DEFAULT_DENSITY
+        return DeviceSpec(w, h, density)
+      }
 
-            if (device.contains("wear", ignoreCase = true)) return DEFAULT_WEAR
-        }
-
-        return DEFAULT
+      if (device.contains("wear", ignoreCase = true)) return DEFAULT_WEAR
     }
 
-    /**
-     * AS-parity sizing: axes are fixed iff the user specified them (or chose
-     * a device frame / `showSystemUi`); otherwise the axis wraps to the
-     * composable's intrinsic size. The `widthDp` / `heightDp` fields of the
-     * returned [SizeSpec] are the *sandbox* dimensions the renderer should
-     * use — for wrapped axes that's [SANDBOX_DP]; for fixed axes it's the
-     * effective dp the frame was resolved to.
-     */
-    fun resolveForRender(
-        device: String?,
-        widthDp: Int?,
-        heightDp: Int?,
-        showSystemUi: Boolean,
-    ): SizeSpec {
-        val w = widthDp?.takeIf { it > 0 }
-        val h = heightDp?.takeIf { it > 0 }
-        // Device / showSystemUi → full device frame on both axes. Explicit
-        // widthDp/heightDp still override the resolved device spec (matches
-        // the existing `resolve()` precedence and AS).
-        if (device != null || showSystemUi) {
-            val spec = resolve(device, w, h)
-            return SizeSpec(
-                widthDp = spec.widthDp,
-                heightDp = spec.heightDp,
-                wrapWidth = false,
-                wrapHeight = false,
-                density = spec.density,
-            )
-        }
-        return SizeSpec(
-            widthDp = w ?: SANDBOX_WIDTH_DP,
-            heightDp = h ?: SANDBOX_HEIGHT_DP,
-            wrapWidth = w == null,
-            wrapHeight = h == null,
-        )
+    return DEFAULT
+  }
+
+  /**
+   * AS-parity sizing: axes are fixed iff the user specified them (or chose a device frame /
+   * `showSystemUi`); otherwise the axis wraps to the composable's intrinsic size. The `widthDp` /
+   * `heightDp` fields of the returned [SizeSpec] are the *sandbox* dimensions the renderer should
+   * use — for wrapped axes that's [SANDBOX_DP]; for fixed axes it's the effective dp the frame was
+   * resolved to.
+   */
+  fun resolveForRender(
+    device: String?,
+    widthDp: Int?,
+    heightDp: Int?,
+    showSystemUi: Boolean,
+  ): SizeSpec {
+    val w = widthDp?.takeIf { it > 0 }
+    val h = heightDp?.takeIf { it > 0 }
+    // Device / showSystemUi → full device frame on both axes. Explicit
+    // widthDp/heightDp still override the resolved device spec (matches
+    // the existing `resolve()` precedence and AS).
+    if (device != null || showSystemUi) {
+      val spec = resolve(device, w, h)
+      return SizeSpec(
+        widthDp = spec.widthDp,
+        heightDp = spec.heightDp,
+        wrapWidth = false,
+        wrapHeight = false,
+        density = spec.density,
+      )
     }
+    return SizeSpec(
+      widthDp = w ?: SANDBOX_WIDTH_DP,
+      heightDp = h ?: SANDBOX_HEIGHT_DP,
+      wrapWidth = w == null,
+      wrapHeight = h == null,
+    )
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -23,854 +23,890 @@ import org.gradle.api.tasks.TaskAction
 @CacheableTask
 abstract class DiscoverPreviewsTask : DefaultTask() {
 
-    @get:InputFiles
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val classDirs: ConfigurableFileCollection
+  @get:InputFiles
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val classDirs: ConfigurableFileCollection
 
-    @get:InputFiles
-    @get:PathSensitive(PathSensitivity.NONE)
-    abstract val dependencyJars: ConfigurableFileCollection
+  @get:InputFiles
+  @get:PathSensitive(PathSensitivity.NONE)
+  abstract val dependencyJars: ConfigurableFileCollection
 
-    @get:Input
-    abstract val moduleName: Property<String>
+  @get:Input abstract val moduleName: Property<String>
 
-    @get:Input
-    abstract val variantName: Property<String>
+  @get:Input abstract val variantName: Property<String>
 
-    /**
-     * When `true`, [outputFile] is written with a populated
-     * [PreviewManifest.accessibilityReport] pointer so downstream tools can
-     * locate the sidecar report. The file itself is produced later by the
-     * render task / verify task.
-     */
-    @get:Input
-    abstract val accessibilityChecksEnabled: Property<Boolean>
+  /**
+   * When `true`, [outputFile] is written with a populated [PreviewManifest.accessibilityReport]
+   * pointer so downstream tools can locate the sidecar report. The file itself is produced later by
+   * the render task / verify task.
+   */
+  @get:Input abstract val accessibilityChecksEnabled: Property<Boolean>
 
-    /**
-     * When `true` and discovery produces zero previews, emit a diagnostics
-     * block to the lifecycle log (classDirs contents, post-filter dep-JAR
-     * sample, ClassGraph scan summary, observed annotation FQNs) and fail
-     * the task. Wired from the `composePreview.failOnEmpty` extension /
-     * `-PcomposePreview.failOnEmpty=true` Gradle property.
-     */
-    @get:Input
-    abstract val failOnEmpty: Property<Boolean>
+  /**
+   * When `true` and discovery produces zero previews, emit a diagnostics block to the lifecycle log
+   * (classDirs contents, post-filter dep-JAR sample, ClassGraph scan summary, observed annotation
+   * FQNs) and fail the task. Wired from the `composePreview.failOnEmpty` extension /
+   * `-PcomposePreview.failOnEmpty=true` Gradle property.
+   */
+  @get:Input abstract val failOnEmpty: Property<Boolean>
 
-    @get:OutputFile
-    abstract val outputFile: RegularFileProperty
+  @get:OutputFile abstract val outputFile: RegularFileProperty
 
-    private val json = Json { prettyPrint = true; encodeDefaults = true }
+  private val json = Json {
+    prettyPrint = true
+    encodeDefaults = true
+  }
 
-    companion object {
-        private val PREVIEW_FQNS = setOf(
-            "androidx.compose.ui.tooling.preview.Preview",
-            "androidx.compose.desktop.ui.tooling.preview.Preview",
-            TILE_PREVIEW_FQN,
-        )
-        private val CONTAINER_FQNS = setOf(
-            "androidx.compose.ui.tooling.preview.Preview\$Container",
-            "androidx.compose.ui.tooling.preview.Preview.Container",
-            // Tiles @Preview is @Repeatable, so the compiler synthesises a
-            // `Preview.Container` too. Picking it up here lets us see every
-            // stacked tile preview (e.g. SMALL_ROUND + LARGE_ROUND on one fn).
-            "androidx.wear.tiles.tooling.preview.Preview\$Container",
-            "androidx.wear.tiles.tooling.preview.Preview.Container",
-        )
-        // androidx.compose.ui:ui-tooling-preview 1.11.0+ — wraps each preview in a custom
-        // PreviewWrapperProvider. Matched by FQN so older apps (no such class on classpath)
-        // simply never surface the annotation and discovery is a no-op.
-        private const val PREVIEW_WRAPPER_FQN = "androidx.compose.ui.tooling.preview.PreviewWrapper"
-        // Our own opt-in for scrolling-screenshot capture. Matched by FQN so projects
-        // that don't depend on `ee.schimke.composeai:preview-annotations` are unaffected.
-        private const val SCROLLING_PREVIEW_FQN = "ee.schimke.composeai.preview.ScrollingPreview"
-        // Animation-window capture — sibling annotation to @ScrollingPreview, same
-        // FQN-match policy. See `AnimatedPreview.kt`.
-        private const val ANIMATED_PREVIEW_FQN = "ee.schimke.composeai.preview.AnimatedPreview"
-        // The stable FQN is shared by both Android's ui-tooling-preview and CMP's
-        // `org.jetbrains.compose.components:components-ui-tooling-preview` — Kotlin
-        // `expect`/`actual` collapses onto the same `androidx...` class name on
-        // every target we care about.
-        private const val PREVIEW_PARAMETER_FQN = "androidx.compose.ui.tooling.preview.PreviewParameter"
+  companion object {
+    private val PREVIEW_FQNS =
+      setOf(
+        "androidx.compose.ui.tooling.preview.Preview",
+        "androidx.compose.desktop.ui.tooling.preview.Preview",
+        TILE_PREVIEW_FQN,
+      )
+    private val CONTAINER_FQNS =
+      setOf(
+        "androidx.compose.ui.tooling.preview.Preview\$Container",
+        "androidx.compose.ui.tooling.preview.Preview.Container",
+        // Tiles @Preview is @Repeatable, so the compiler synthesises a
+        // `Preview.Container` too. Picking it up here lets us see every
+        // stacked tile preview (e.g. SMALL_ROUND + LARGE_ROUND on one fn).
+        "androidx.wear.tiles.tooling.preview.Preview\$Container",
+        "androidx.wear.tiles.tooling.preview.Preview.Container",
+      )
+    // androidx.compose.ui:ui-tooling-preview 1.11.0+ — wraps each preview in a custom
+    // PreviewWrapperProvider. Matched by FQN so older apps (no such class on classpath)
+    // simply never surface the annotation and discovery is a no-op.
+    private const val PREVIEW_WRAPPER_FQN = "androidx.compose.ui.tooling.preview.PreviewWrapper"
+    // Our own opt-in for scrolling-screenshot capture. Matched by FQN so projects
+    // that don't depend on `ee.schimke.composeai:preview-annotations` are unaffected.
+    private const val SCROLLING_PREVIEW_FQN = "ee.schimke.composeai.preview.ScrollingPreview"
+    // Animation-window capture — sibling annotation to @ScrollingPreview, same
+    // FQN-match policy. See `AnimatedPreview.kt`.
+    private const val ANIMATED_PREVIEW_FQN = "ee.schimke.composeai.preview.AnimatedPreview"
+    // The stable FQN is shared by both Android's ui-tooling-preview and CMP's
+    // `org.jetbrains.compose.components:components-ui-tooling-preview` — Kotlin
+    // `expect`/`actual` collapses onto the same `androidx...` class name on
+    // every target we care about.
+    private const val PREVIEW_PARAMETER_FQN = "androidx.compose.ui.tooling.preview.PreviewParameter"
 
-        internal const val TILE_PREVIEW_FQN = "androidx.wear.tiles.tooling.preview.Preview"
+    internal const val TILE_PREVIEW_FQN = "androidx.wear.tiles.tooling.preview.Preview"
 
-        // failOnEmpty diagnostics: cap the JAR + annotation FQN sample sizes
-        // so the lifecycle log stays readable on projects with huge classpaths.
-        private const val DIAG_JAR_SAMPLE = 15
-        private const val DIAG_ANNOTATION_SAMPLE = 20
+    // failOnEmpty diagnostics: cap the JAR + annotation FQN sample sizes
+    // so the lifecycle log stays readable on projects with huge classpaths.
+    private const val DIAG_JAR_SAMPLE = 15
+    private const val DIAG_ANNOTATION_SAMPLE = 20
 
-        // Roborazzi's per-preview clock control. Opt-in: presence of the
-        // annotation on a @Preview method fans out one extra manifest entry
-        // per `ManualClockOptions.advanceTimeMillis` value, with filename
-        // suffix `_TIME_<ms>ms`. Absent → single entry with null timing
-        // (renderer falls back to its default CAPTURE_ADVANCE_MS).
-        //
-        // Shipped by `io.github.takahirom.roborazzi:roborazzi-annotations`.
-        // We never load the class — ClassGraph reads the annotation and its
-        // nested `ManualClockOptions` entries by descriptor, so the plugin
-        // itself doesn't need a compile-time dep.
-        private const val ROBO_COMPOSE_PREVIEW_OPTIONS_FQN =
-            "com.github.takahirom.roborazzi.annotations.RoboComposePreviewOptions"
-    }
-
-    @TaskAction
-    fun discover() {
-        val existingClassDirs = classDirs.files.filter { it.exists() && it.isDirectory }
-        // Match on the absolute path, not just the file name: AGP 9.x +
-        // KGP 2.3 resolve AAR dependencies to `<cache>/transforms/<hash>/
-        // transformed/<library>/jars/classes.jar` where the library name
-        // lives in the parent directory, not the filename. Filtering on
-        // `file.name` alone dropped every AAR-extracted jar — see #162.
-        val filteredDependencyJars = dependencyJars.files.filter { file ->
-            file.exists() && file.name.lowercase().endsWith(".jar") && run {
-                val path = file.absolutePath.lowercase()
-                path.contains("preview") || path.contains("tooling") ||
-                    path.contains("compose") || path.contains("annotation")
-            }
-        }
-        val classpath = existingClassDirs + filteredDependencyJars
-
-        val previews = mutableListOf<PreviewInfo>()
-        // Populated only on the diagnostics path (failOnEmpty + 0 previews)
-        // so we can tell users whether ClassGraph saw any classes at all,
-        // and which annotation FQNs it did see — which disambiguates
-        // "classpath is wrong" from "@Preview FQN doesn't match" in a
-        // single run.
-        var scanClassCount = 0
-        var scanMethodsWithAnnotations = 0
-        val annotationFqnCounts = LinkedHashMap<String, Int>()
-        // Which known @Preview annotation FQNs are reachable as ClassInfo
-        // on the scan classpath. Empty → discovery cannot resolve multi-
-        // preview annotations (they fan out via `scanResult.getClassInfo`),
-        // which is almost always a misconfigured dep-jar classpath.
-        var reachablePreviewFqns: List<String> = emptyList()
-
-        if (classpath.isNotEmpty()) {
-            ClassGraph()
-                .enableMethodInfo()
-                .enableAnnotationInfo()
-                // Kotlin `private fun` compiles to a JVM `private` method and
-                // ClassGraph's default visibility filter drops it; `internal
-                // fun` compiles to JVM `public` (with the `name$module` mangle)
-                // so it slips through. Without this flag, projects that follow
-                // the "private @Preview to keep them out of the namespace"
-                // convention silently surface zero previews.
-                .ignoreMethodVisibility()
-                .overrideClasspath(classpath.map { it.absolutePath })
-                .ignoreParentClassLoaders()
-                .scan().use { scanResult ->
-                    reachablePreviewFqns = PREVIEW_FQNS.filter { scanResult.getClassInfo(it) != null }
-                    for (classInfo in scanResult.allClasses) {
-                        scanClassCount++
-                        for (method in classInfo.methodInfo) {
-                            val annotations = method.annotationInfo ?: continue
-                            if (annotations.isNotEmpty()) scanMethodsWithAnnotations++
-                            for (ann in annotations) {
-                                annotationFqnCounts.merge(ann.name, 1, Int::plus)
-                            }
-                            discoverFromMethod(classInfo, method, annotations.toList(), scanResult, previews)
-                        }
-                    }
-                }
-        }
-
-        // id already encodes the name + (device, fontScale, uiMode) variant suffix, so
-        // dedup by id alone. Two identical preview variants on the same function collapse.
-        val deduped = previews.distinctBy { it.id }
-
-        // Rewrite each capture's renderOutput to a normalized, shell-safe
-        // filename: drop the package prefix shared by every preview in the
-        // module so `renders/ee.schimke.ha.previews.CardPreviewsKt.Foo.png`
-        // lands at `renders/CardPreviewsKt.Foo.png`; sanitize spaces, parens,
-        // and other awkward shell characters inherited from `@Preview(name =
-        // "tile light (light)")`. Keeps `PreviewInfo.id` untouched — consumers
-        // that key by id (history folders, CLI state, test names) are
-        // unaffected.
-        val normalized = normalizeRenderOutputs(deduped)
-
-        val manifest = PreviewManifest(
-            module = moduleName.get(),
-            variant = variantName.get(),
-            previews = normalized,
-            accessibilityReport = "accessibility.json".takeIf { accessibilityChecksEnabled.get() },
-        )
-
-        val outFile = outputFile.get().asFile
-        outFile.parentFile.mkdirs()
-        outFile.writeText(json.encodeToString(manifest))
-
-        logger.lifecycle("Discovered ${normalized.size} preview(s) in module '${moduleName.get()}':")
-        for (preview in normalized) {
-            logger.lifecycle("  ${preview.className}.${preview.functionName}${describeVariant(preview)}")
-        }
-
-        // Unconditional fail: the plugin scanned non-empty class dirs but
-        // none of the known @Preview annotation classes are on the scan
-        // classpath. Any multi-preview annotation (@LightDarkPreviews,
-        // @WearPreviewDevices, user wrappers) needs its class reachable via
-        // `scanResult.getClassInfo` to fan out, so this state silently
-        // hides the consumer's previews — see #162 for a real-world
-        // report. Preceded by the failOnEmpty diagnostics block so the
-        // error message points at the data that disambiguates the cause.
-        val previewAnnotationsMissing =
-            scanClassCount > 0 && reachablePreviewFqns.isEmpty()
-        if (normalized.isEmpty() && (failOnEmpty.get() || previewAnnotationsMissing)) {
-            logEmptyDiagnostics(
-                existingClassDirs = existingClassDirs,
-                allClassDirs = classDirs.files.toList(),
-                filteredJars = filteredDependencyJars,
-                allJarCount = dependencyJars.files.size,
-                scanClassCount = scanClassCount,
-                scanMethodsWithAnnotations = scanMethodsWithAnnotations,
-                annotationFqnCounts = annotationFqnCounts,
-                reachablePreviewFqns = reachablePreviewFqns,
-            )
-            val reason = if (previewAnnotationsMissing) {
-                "the @Preview annotation class is not on the ClassGraph classpath " +
-                    "(dependency-jar filter dropped every jar carrying it)"
-            } else {
-                "with failOnEmpty=true"
-            }
-            throw org.gradle.api.GradleException(
-                "composePreview: discovered 0 previews in module '${moduleName.get()}' — " +
-                    "$reason. See diagnostics above.",
-            )
-        }
-    }
-
-    private fun logEmptyDiagnostics(
-        existingClassDirs: List<java.io.File>,
-        allClassDirs: List<java.io.File>,
-        filteredJars: List<java.io.File>,
-        allJarCount: Int,
-        scanClassCount: Int,
-        scanMethodsWithAnnotations: Int,
-        annotationFqnCounts: Map<String, Int>,
-        reachablePreviewFqns: List<String>,
-    ) {
-        logger.lifecycle("composePreview: failOnEmpty diagnostics (0 previews discovered):")
-        logger.lifecycle("  classDirs (${allClassDirs.size} declared, ${existingClassDirs.size} existing):")
-        for (dir in allClassDirs) {
-            val exists = dir.exists()
-            val isDir = dir.isDirectory
-            val classCount = if (exists && isDir) {
-                dir.walkTopDown().count { it.extension == "class" }
-            } else 0
-            logger.lifecycle("    - $dir")
-            logger.lifecycle("      exists=$exists isDir=$isDir classFiles=$classCount")
-        }
-        logger.lifecycle("  dependencyJars: $allJarCount total, ${filteredJars.size} match " +
-            "(preview|tooling|compose|annotation)")
-        for (jar in filteredJars.take(DIAG_JAR_SAMPLE)) {
-            logger.lifecycle("    - ${jar.name}")
-        }
-        if (filteredJars.size > DIAG_JAR_SAMPLE) {
-            logger.lifecycle("    … and ${filteredJars.size - DIAG_JAR_SAMPLE} more")
-        }
-        logger.lifecycle("  ClassGraph scan: $scanClassCount classes, " +
-            "$scanMethodsWithAnnotations methods with any annotation")
-        if (scanClassCount > 0) {
-            if (reachablePreviewFqns.isEmpty()) {
-                // Most common #162-shaped failure: the consumer's preview
-                // annotations live in AAR-extracted `<library>/jars/classes.jar`
-                // files, whose `file.name` is just `classes.jar`. The
-                // dep-jar filter used to match on file name only and
-                // dropped every such jar, so no multi-preview annotation
-                // could be resolved.
-                logger.lifecycle("  known @Preview annotation classes NOT reachable on " +
-                    "ClassGraph classpath — multi-preview resolution is disabled.")
-                logger.lifecycle("    expected at least one of (by FQN):")
-                for (fqn in PREVIEW_FQNS) logger.lifecycle("      - $fqn")
-            } else {
-                logger.lifecycle("  reachable @Preview annotation classes on ClassGraph classpath:")
-                for (fqn in reachablePreviewFqns) logger.lifecycle("      - $fqn")
-            }
-        }
-        val previewAnnotationsSeen = PREVIEW_FQNS.filter { annotationFqnCounts.containsKey(it) }
-        if (previewAnnotationsSeen.isNotEmpty()) {
-            // If this path triggers we have a real bug: @Preview is on the
-            // classpath, it's on some method, but discovery still emitted
-            // nothing. Make it impossible to miss in the log.
-            logger.lifecycle("  known @Preview FQNs WERE seen on scanned methods " +
-                "(discovery dropped them — please report):")
-            for (fqn in previewAnnotationsSeen) {
-                logger.lifecycle("    - $fqn (${annotationFqnCounts[fqn]})")
-            }
-        } else if (scanClassCount > 0) {
-            logger.lifecycle("  no known @Preview FQN seen on any scanned method.")
-            logger.lifecycle("    expected one of:")
-            for (fqn in PREVIEW_FQNS) logger.lifecycle("      - $fqn")
-            val topAnnotations = annotationFqnCounts.entries
-                .sortedByDescending { it.value }
-                .take(DIAG_ANNOTATION_SAMPLE)
-            if (topAnnotations.isNotEmpty()) {
-                logger.lifecycle("    top annotation FQNs actually observed:")
-                for ((fqn, count) in topAnnotations) {
-                    logger.lifecycle("      - $fqn ($count)")
-                }
-            }
-        } else {
-            logger.lifecycle("  ClassGraph scanned 0 classes — check the classDirs listing above.")
-        }
-    }
-
-    /**
-     * Computes the common dotted prefix shared by every preview id (up to and
-     * including the last matched `.`) and strips it from each capture's
-     * `renderOutput` filename. Also runs every stem through [sanitizeFileStem]
-     * so spaces and shell-unfriendly characters inherited from `@Preview(name
-     * = "tile light (light)")` don't end up in the PNG filename.
-     *
-     * `preview.id` itself is deliberately left untouched — it's the stable
-     * identity consumers key by (history folders, CLI state, JUnit test
-     * names). The renderOutput is purely the on-disk filename, and that's
-     * what benefits from a shorter, quoted-free form.
-     *
-     * No-op on a single-preview module (empty prefix) or when sanitization
-     * would collapse two distinct ids to the same stem — in that case we
-     * keep the un-stripped, un-sanitized id for everyone so the pretty
-     * rename never introduces a filename collision.
-     */
-    private fun normalizeRenderOutputs(previews: List<PreviewInfo>): List<PreviewInfo> {
-        if (previews.isEmpty()) return previews
-        val commonPrefix = commonDottedPrefix(previews.map { it.id })
-        val stems = previews.map { sanitizeFileStem(it.id.removePrefix(commonPrefix)) }
-        val safe = stems.toSet().size == previews.size &&
-            stems.none { it.isEmpty() }
-        return previews.mapIndexed { i, preview ->
-            val newStem = if (safe) stems[i] else preview.id
-            val rewritten = preview.captures.map { c ->
-                c.copy(renderOutput = rewriteRenderStem(c.renderOutput, preview.id, newStem))
-            }
-            preview.copy(captures = rewritten)
-        }
-    }
-
-    /** `renders/<oldStem><tail>.<ext>` → `renders/<newStem><tail>.<ext>`. */
-    private fun rewriteRenderStem(renderOutput: String, oldStem: String, newStem: String): String {
-        if (renderOutput.isEmpty() || oldStem == newStem) return renderOutput
-        val dir = renderOutput.substringBeforeLast('/', missingDelimiterValue = "")
-        val leaf = renderOutput.substringAfterLast('/')
-        if (!leaf.startsWith(oldStem)) return renderOutput
-        val rewritten = newStem + leaf.removePrefix(oldStem)
-        return if (dir.isEmpty()) rewritten else "$dir/$rewritten"
-    }
-
-    private fun commonDottedPrefix(ids: List<String>): String {
-        if (ids.size < 2) return ""
-        var prefix = ids.first()
-        for (id in ids.drop(1)) {
-            var i = 0
-            val limit = minOf(prefix.length, id.length)
-            while (i < limit && prefix[i] == id[i]) i++
-            prefix = prefix.substring(0, i)
-            if (prefix.isEmpty()) return ""
-        }
-        val lastDot = prefix.lastIndexOf('.')
-        return if (lastDot < 0) "" else prefix.substring(0, lastDot + 1)
-    }
-
-    /**
-     * Sanitizes a filename stem to an ASCII-safe whitelist
-     * (`[A-Za-z0-9._-]`). Every other character collapses to `_`, runs of
-     * `_` collapse to a single `_`, and leading/trailing `_`, `.`, `-` are
-     * trimmed. A whitelist is deliberate: we can't enumerate every awkward
-     * character a preview name might contain (Unicode dashes, NBSP, RTL
-     * marks, emoji), and any one of them can break a downstream tool that
-     * expects a POSIX-plain filename. `.` is preserved so FQN-shaped stems
-     * (`CardPreviewsKt.Tile_Light_States`) survive intact when the package
-     * prefix strip can't flatten them further.
-     */
-    private fun sanitizeFileStem(s: String): String =
-        s.replace(Regex("""[^A-Za-z0-9._-]"""), "_")
-            .replace(Regex("""_+"""), "_")
-            .trim('_', '.', '-')
-
-    // Renders the distinguishing bits of a preview variant for the discovery log
-    // so sibling expansions (e.g. @WearPreviewFontScales × 6) aren't visually
-    // identical. Format mirrors the VSCode tooltip: `name` / `device` /
-    // `WxHdp` / `font Nx` / `uiMode=N` / `locale` / `group`.
-    private fun describeVariant(preview: PreviewInfo): String {
-        val p = preview.params
-        val parts = mutableListOf<String>()
-        p.name?.let(parts::add)
-        p.device?.let(parts::add)
-        val w = p.widthDp
-        val h = p.heightDp
-        if (w != null && h != null) parts.add("${w}x${h}dp")
-        if (p.fontScale != 1.0f) parts.add("font ${p.fontScale}x")
-        if (p.uiMode != 0) parts.add("uiMode=${p.uiMode}")
-        p.locale?.let(parts::add)
-        p.group?.let { parts.add("group=$it") }
-        // Summarise capture-level dimensions (time, scroll) on one line so
-        // the log remains a single bullet per preview even for fan-outs.
-        val timings = preview.captures.mapNotNull { it.advanceTimeMillis }
-        if (timings.isNotEmpty()) {
-            parts.add("${preview.captures.size} captures @ ${timings.joinToString(",") { "${it}ms" }}")
-        }
-        val scrollModes = preview.captures.mapNotNull { it.scroll?.mode }.distinct()
-        if (scrollModes.isNotEmpty()) {
-            parts.add("scroll=" + scrollModes.joinToString(",") { it.name.lowercase() })
-        }
-        val anim = preview.captures.firstNotNullOfOrNull { it.animation }
-        if (anim != null) {
-            val curveSuffix = if (anim.showCurves) "+curves" else ""
-            parts.add("animated=${anim.durationMs}ms@${anim.frameIntervalMs}ms$curveSuffix")
-        }
-        return if (parts.isEmpty()) "" else "  [" + parts.joinToString(" · ") + "]"
-    }
-
-    private fun discoverFromMethod(
-        classInfo: ClassInfo,
-        method: MethodInfo,
-        annotations: List<AnnotationInfo>,
-        scanResult: ScanResult,
-        previews: MutableList<PreviewInfo>,
-    ) {
-        // @PreviewWrapper and @ScrollingPreview are both non-repeatable and apply
-        // to every @Preview on the function (including expansions from
-        // multi-preview meta-annotations). `@ScrollingPreview.modes` fans out
-        // one capture per entry — see [buildCaptures]. `@AnimatedPreview` is
-        // single-shot (one GIF per function) so it doesn't fan out, but follows
-        // the same "one annotation per function, applies to every preview
-        // expansion" policy.
-        val wrapperFqn = extractWrapperFqn(annotations)
-        val scrollSpecs = extractScrollSpecs(annotations)
-        val animationSpec = extractAnimationSpec(annotations)
-        // @RoboComposePreviewOptions, similarly, applies to the function as a
-        // whole — each timing fans out into its own manifest entry, orthogonal
-        // to any multi-preview expansion.
-        val timings = extractRoboTimings(annotations)
-        // @PreviewParameter lives on a method PARAMETER, not the method itself,
-        // so it's sourced from `parameterInfo` rather than the method
-        // annotation list. Extracted once per function and applied to every
-        // multi-preview expansion — the provider is the same no matter which
-        // @Preview drove the fan-out.
-        val previewParameter = extractPreviewParameter(method)
-
-        val directPreviews = collectDirectPreviews(annotations)
-        if (directPreviews.isNotEmpty()) {
-            for (ann in directPreviews) {
-                previews.add(makePreview(classInfo, method, ann, wrapperFqn, scrollSpecs, animationSpec, timings, previewParameter))
-            }
-            return
-        }
-
-        for (ann in annotations) {
-            val resolved = resolveMultiPreview(ann, scanResult, mutableSetOf())
-            for (resolvedAnn in resolved) {
-                previews.add(makePreview(classInfo, method, resolvedAnn, wrapperFqn, scrollSpecs, animationSpec, timings, previewParameter))
-            }
-        }
-    }
-
-    /**
-     * Scans [method]'s parameters for `@PreviewParameter`. Returns the provider
-     * FQN + `limit` of the FIRST parameter that carries the annotation; `null`
-     * when none do. Supporting a single parameter mirrors the current upstream
-     * (Studio/Layoutlib) semantic — multi-param preview functions require
-     * explicit wiring in tooling code, which our renderer doesn't expose.
-     *
-     * ClassGraph surfaces parameter annotations on `MethodParameterInfo.annotationInfo`.
-     * The `value` field on `@PreviewParameter` carries the provider KClass, which
-     * comes back as an [AnnotationClassRef] — we pull its FQN without triggering
-     * classloading (matches how [extractWrapperFqn] handles `@PreviewWrapper`).
-     */
-    private fun extractPreviewParameter(method: MethodInfo): Pair<String, Int>? {
-        val params = method.parameterInfo ?: return null
-        for (param in params) {
-            val anns = param.annotationInfo ?: continue
-            val ann = anns.firstOrNull { it.name == PREVIEW_PARAMETER_FQN } ?: continue
-            val provider = when (val value = ann.parameterValues.getValue("provider")) {
-                is AnnotationClassRef -> value.name
-                is String -> value
-                else -> null
-            } ?: continue
-            val limit = (ann.parameterValues.getValue("limit") as? Int)
-                ?.coerceAtLeast(0)
-                ?: Int.MAX_VALUE
-            return provider to limit
-        }
-        return null
-    }
-
-    // Tile previews don't go through `mainClock` and can't scroll (the
-    // renderer inflates a View via `TileRenderer` and has no Compose
-    // animation clock / scrollable), so both dimensional annotations are
-    // no-ops for tiles.
-    private fun buildCaptures(
-        ann: AnnotationInfo,
-        previewId: String,
-        scrolls: List<ScrollCapture>,
-        animation: AnimationCapture?,
-        timings: List<Long>,
-    ): List<Capture> {
-        val isTile = ann.name == TILE_PREVIEW_FQN
-        val effectiveTimings = if (isTile) emptyList() else timings
-        val effectiveScrolls = if (isTile) emptyList() else scrolls
-        // Tile previews don't go through `mainClock` either — `TileRenderer`
-        // inflates a static View and there's no animation surface to drive.
-        val effectiveAnimation = if (isTile) null else animation
-
-        // @AnimatedPreview produces its own dedicated capture, alongside any
-        // scroll / time fan-out. The GIF gets a distinguishing `_anim` suffix
-        // when other captures share the function (the multi-mode scroll
-        // pattern), and the plain filename otherwise.
-        val animationCaptures: List<Capture> = if (effectiveAnimation == null) emptyList() else {
-            val sharesFn = effectiveScrolls.isNotEmpty() || effectiveTimings.isNotEmpty()
-            val suffix = if (sharesFn) "_anim" else ""
-            listOf(
-                Capture(
-                    animation = effectiveAnimation,
-                    renderOutput = "renders/${previewId}${suffix}.gif",
-                    cost = ANIMATION_COST,
-                ),
-            )
-        }
-
-        // Single-mode scroll keeps the plain filename so migrations from the
-        // old single-valued `mode = …` annotation land on identical paths.
-        // Multi-mode adds `_SCROLL_<mode>` to disambiguate siblings, same
-        // pattern as `_TIME_<ms>ms` for the time dimension.
-        val scrollRows: List<Pair<ScrollCapture?, String>> = when {
-            effectiveScrolls.isEmpty() -> listOf(null to "")
-            effectiveScrolls.size == 1 -> listOf(effectiveScrolls[0] to "")
-            else -> effectiveScrolls.map { it to "_SCROLL_${it.mode.name.lowercase()}" }
-        }
-        val timeRows: List<Pair<Long?, String>> =
-            if (effectiveTimings.isEmpty()) listOf(null to "")
-            else effectiveTimings.map { ms -> ms to "_TIME_${ms}ms" }
-
-        // When ONLY @AnimatedPreview is on the function, the scroll/time
-        // cross-product would still emit one (null, null) row — i.e. a static
-        // PNG capture. Suppress that to keep `@AnimatedPreview` a clean
-        // single-output annotation.
-        val emitStaticCross = effectiveScrolls.isNotEmpty() ||
-            effectiveTimings.isNotEmpty() ||
-            effectiveAnimation == null
-
-        val scrollTimeCaptures: List<Capture> = if (!emitStaticCross) emptyList() else {
-            scrollRows.flatMap { (scroll, scrollSuffix) ->
-                timeRows.map { (ms, timeSuffix) ->
-                    // GIF captures land on `.gif`; everything else is `.png`.
-                    // Branching the extension per-capture (rather than per-preview)
-                    // keeps multi-mode annotations like `modes = [TOP, GIF]`
-                    // producing one PNG + one GIF from the same function.
-                    val ext = if (scroll?.mode == ScrollMode.GIF) "gif" else "png"
-                    // Cost is normalised to a static @Preview = 1.0. The mode
-                    // ladder (TOP < END ≪ LONG < GIF) reflects how much extra
-                    // work each scroll variant adds on top of the baseline
-                    // compose pass. `advanceTimeMillis` alone is still one
-                    // pass at a specific virtual time, so it doesn't bump the
-                    // per-capture cost — the wall-time of a multi-timing
-                    // fan-out is in the *count*, which lives in the captures
-                    // list itself.
-                    val captureCost = when (scroll?.mode) {
-                        null -> STATIC_COST
-                        ScrollMode.TOP -> SCROLL_TOP_COST
-                        ScrollMode.END -> SCROLL_END_COST
-                        ScrollMode.LONG -> SCROLL_LONG_COST
-                        ScrollMode.GIF -> SCROLL_GIF_COST
-                    }
-                    Capture(
-                        advanceTimeMillis = ms,
-                        scroll = scroll,
-                        renderOutput = "renders/${previewId}${scrollSuffix}${timeSuffix}.${ext}",
-                        cost = captureCost,
-                    )
-                }
-            }
-        }
-
-        return scrollTimeCaptures + animationCaptures
-    }
-
-    // Reads `@RoboComposePreviewOptions(manualClockOptions = [...])` on the
-    // preview function and returns the `advanceTimeMillis` of each entry.
-    // Empty list if the annotation is absent OR present with no entries — the
-    // latter is equivalent to "default" per Roborazzi's own scanner-support
-    // behaviour. ClassGraph surfaces `manualClockOptions` as an
-    // Object[] of `AnnotationInfo` because the field type is `Array<ManualClockOptions>`.
-    private fun extractRoboTimings(annotations: List<AnnotationInfo>): List<Long> {
-        val ann = annotations.firstOrNull { it.name == ROBO_COMPOSE_PREVIEW_OPTIONS_FQN } ?: return emptyList()
-        val raw = ann.parameterValues.getValue("manualClockOptions") ?: return emptyList()
-        val items = when (raw) {
-            is Array<*> -> raw.filterIsInstance<AnnotationInfo>()
-            is AnnotationInfo -> listOf(raw)
-            else -> {
-                // Some ClassGraph versions hand back a typed primitive array or
-                // Kotlin wrapper — fall back to reflective iteration.
-                val len = runCatching { java.lang.reflect.Array.getLength(raw) }.getOrNull() ?: 0
-                (0 until len).mapNotNull { java.lang.reflect.Array.get(raw, it) as? AnnotationInfo }
-            }
-        }
-        return items.mapNotNull { it.parameterValues.getValue("advanceTimeMillis") as? Long }
-    }
-
-    private fun extractWrapperFqn(annotations: List<AnnotationInfo>): String? {
-        val wrapperAnn = annotations.firstOrNull { it.name == PREVIEW_WRAPPER_FQN } ?: return null
-        // The `wrapper: KClass<out PreviewWrapperProvider>` parameter surfaces as an
-        // AnnotationClassRef — pull the FQN without triggering classloading.
-        return when (val value = wrapperAnn.parameterValues.getValue("wrapper")) {
-            is AnnotationClassRef -> value.name
-            is String -> value
-            else -> null
-        }
-    }
-
-    /**
-     * Reads `@AnimatedPreview(durationMs, frameIntervalMs, showCurves)` off
-     * the function annotation list. Single-shot — at most one animation
-     * capture per function, so we return a nullable spec rather than a list.
-     * Negative / zero numeric fields fall back to the annotation defaults.
-     */
-    private fun extractAnimationSpec(annotations: List<AnnotationInfo>): AnimationCapture? {
-        val ann = annotations.firstOrNull { it.name == ANIMATED_PREVIEW_FQN } ?: return null
-        val pv = ann.parameterValues
-        // `durationMs = 0` is the auto-detect sentinel; let the renderer ask
-        // PreviewAnimationClock for the real duration. A positive value
-        // overrides; negatives clamp to the sentinel.
-        val durationMs = (pv.getValue("durationMs") as? Int)?.coerceAtLeast(0) ?: 0
-        val frameIntervalMs = (pv.getValue("frameIntervalMs") as? Int)?.takeIf { it > 0 } ?: 33
-        val showCurves = (pv.getValue("showCurves") as? Boolean) ?: true
-        return AnimationCapture(
-            durationMs = durationMs,
-            frameIntervalMs = frameIntervalMs,
-            showCurves = showCurves,
-        )
-    }
-
-    private fun extractScrollSpecs(annotations: List<AnnotationInfo>): List<ScrollCapture> {
-        val ann = annotations.firstOrNull { it.name == SCROLLING_PREVIEW_FQN } ?: return emptyList()
-        val pv = ann.parameterValues
-        // ClassGraph surfaces the `modes: Array<ScrollMode>` field as an
-        // Object[] of AnnotationEnumValue; same shape as `manualClockOptions`
-        // above. Enum constants are compared by `.valueName` so we never
-        // force-load the annotation's classes.
-        val rawModes = pv.getValue("modes")
-        val modes = readEnumArray(rawModes) { ScrollMode.valueOf(it) }
-        if (modes.isEmpty()) return emptyList()
-        val axis = (pv.getValue("axis") as? AnnotationEnumValue)?.valueName
-            ?.let { runCatching { ScrollAxis.valueOf(it) }.getOrNull() }
-            ?: ScrollAxis.VERTICAL
-        val maxScrollPx = (pv.getValue("maxScrollPx") as? Int)?.coerceAtLeast(0) ?: 0
-        val reduceMotion = (pv.getValue("reduceMotion") as? Boolean) ?: true
-        // `frameIntervalMs` only meaningful for GIF mode; we still read it
-        // unconditionally and carry it into every ScrollCapture so the
-        // manifest shape stays uniform. `0` (or negative, coerced) signals
-        // "use the renderer's default" — matching the annotation-side
-        // DEFAULT_GIF_FRAME_INTERVAL_MS without duplicating the literal here.
-        val frameIntervalMs = (pv.getValue("frameIntervalMs") as? Int)?.coerceAtLeast(0) ?: 0
-        // Result fields (atEnd, reachedPx) default to "not reported" — the
-        // renderer would fill them in post-capture; discovery knows only the
-        // intent. De-dup to guard against `modes = [END, END]` producing
-        // colliding paths. Sort by enum ordinal (TOP→END→LONG→GIF) so the
-        // renderer captures the initial frame before driving the scroller —
-        // otherwise `modes = [END, TOP]` would produce a "TOP" PNG at the
-        // scrolled-end position.
-        return modes.distinct().sortedBy { it.ordinal }.map { mode ->
-            ScrollCapture(
-                mode = mode,
-                axis = axis,
-                maxScrollPx = maxScrollPx,
-                reduceMotion = reduceMotion,
-                frameIntervalMs = frameIntervalMs,
-            )
-        }
-    }
-
-    // Reads an annotation's Array<EnumT> parameter and maps each entry by
-    // `.valueName` through [parse]. ClassGraph can hand this back as a plain
-    // array, a single AnnotationEnumValue (single-entry arrays), or a typed
-    // array we need to walk reflectively — same cases as
-    // [extractRoboTimings].
-    private fun <T> readEnumArray(raw: Any?, parse: (String) -> T): List<T> {
-        if (raw == null) return emptyList()
-        val items = when (raw) {
-            is Array<*> -> raw.filterIsInstance<AnnotationEnumValue>()
-            is AnnotationEnumValue -> listOf(raw)
-            else -> {
-                val len = runCatching { java.lang.reflect.Array.getLength(raw) }.getOrNull() ?: 0
-                (0 until len).mapNotNull { java.lang.reflect.Array.get(raw, it) as? AnnotationEnumValue }
-            }
-        }
-        return items.mapNotNull { runCatching { parse(it.valueName) }.getOrNull() }
-    }
-
-    private fun isDirectPreview(ann: AnnotationInfo): Boolean =
-        ann.name in PREVIEW_FQNS
-
-    private fun isPreviewContainer(ann: AnnotationInfo): Boolean =
-        ann.name in CONTAINER_FQNS
-
-    private fun collectDirectPreviews(annotations: List<AnnotationInfo>): List<AnnotationInfo> {
-        val result = mutableListOf<AnnotationInfo>()
-        for (ann in annotations) {
-            when {
-                isDirectPreview(ann) -> result.add(ann)
-                isPreviewContainer(ann) -> {
-                    val value = ann.parameterValues.getValue("value")
-                    when (value) {
-                        is Array<*> -> value.filterIsInstance<AnnotationInfo>().forEach { result.add(it) }
-                        is AnnotationInfo -> result.add(value)
-                        else -> {
-                            val len = java.lang.reflect.Array.getLength(value)
-                            for (i in 0 until len) {
-                                val elem = java.lang.reflect.Array.get(value, i)
-                                if (elem is AnnotationInfo) result.add(elem)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        return result
-    }
-
-    private fun resolveMultiPreview(
-        ann: AnnotationInfo,
-        scanResult: ScanResult,
-        visited: MutableSet<String>,
-    ): List<AnnotationInfo> {
-        if (ann.name in visited) return emptyList()
-        if (isDirectPreview(ann) || isPreviewContainer(ann)) return emptyList()
-        visited.add(ann.name)
-
-        val annClassInfo = scanResult.getClassInfo(ann.name) ?: return emptyList()
-        val directPreviews = collectDirectPreviews(annClassInfo.annotationInfo.toList())
-        if (directPreviews.isNotEmpty()) return directPreviews
-
-        val result = mutableListOf<AnnotationInfo>()
-        for (metaAnn in annClassInfo.annotationInfo) {
-            result.addAll(resolveMultiPreview(metaAnn, scanResult, visited))
-        }
-        return result
-    }
-
-    private fun makePreview(
-        classInfo: ClassInfo,
-        method: MethodInfo,
-        ann: AnnotationInfo,
-        wrapperClassName: String?,
-        scrolls: List<ScrollCapture>,
-        animation: AnimationCapture?,
-        timings: List<Long>,
-        previewParameter: Pair<String, Int>?,
-    ): PreviewInfo {
-        val params = extractPreviewParams(ann, wrapperClassName, previewParameter)
-        val fqn = "${classInfo.name}.${method.name}"
-        val suffix = buildVariantSuffix(params)
-        val id = fqn + suffix
-        return PreviewInfo(
-            id = id,
-            functionName = method.name,
-            className = classInfo.name,
-            sourceFile = packageQualifiedSourcePath(classInfo),
-            params = params,
-            captures = buildCaptures(ann, id, scrolls, animation, timings),
-        )
-    }
-
-    // Package-qualified source path, e.g. "com/example/samplewear/Previews.kt".
-    // The bytecode SourceFile attribute is just the basename, which collides
-    // when two files with the same name live in different packages within one
-    // module. Prefixing with the package path makes the value unique and lets
-    // the VSCode extension / CLI resolve a preview back to the exact file.
-    private fun packageQualifiedSourcePath(classInfo: ClassInfo): String? {
-        val simpleName = classInfo.sourceFile ?: return null
-        val pkg = classInfo.packageName.orEmpty()
-        return if (pkg.isEmpty()) simpleName else "${pkg.replace('.', '/')}/$simpleName"
-    }
-
-    // Disambiguates multi-preview expansions (e.g. @WearPreviewDevices → large_round
-    // + small_round) when the inner @Preview has no explicit `name`. Without this
-    // every variant collides on the same id / PNG path.
+    // Roborazzi's per-preview clock control. Opt-in: presence of the
+    // annotation on a @Preview method fans out one extra manifest entry
+    // per `ManualClockOptions.advanceTimeMillis` value, with filename
+    // suffix `_TIME_<ms>ms`. Absent → single entry with null timing
+    // (renderer falls back to its default CAPTURE_ADVANCE_MS).
     //
-    // Prefer `group` — Horologist's @WearPreview* annotations set a distinct, human
-    // readable group per variant (e.g. "Fonts - Large"), so it captures exactly what
-    // varies. Fall back to device + fontScale + uiMode only if neither name nor
-    // group is present.
-    private fun buildVariantSuffix(params: PreviewParams): String {
-        if (!params.name.isNullOrBlank()) return "_${params.name}"
-        if (!params.group.isNullOrBlank()) return "_${sanitizeForPath(params.group)}"
-        val parts = mutableListOf<String>()
-        params.device?.substringAfterLast(":")?.takeIf { it.isNotBlank() }?.let(parts::add)
-        if (params.fontScale != 1.0f) parts.add("fs${params.fontScale}")
-        if (params.uiMode != 0) parts.add("ui${params.uiMode}")
-        return if (parts.isEmpty()) "" else "_" + parts.joinToString("_")
-    }
+    // Shipped by `io.github.takahirom.roborazzi:roborazzi-annotations`.
+    // We never load the class — ClassGraph reads the annotation and its
+    // nested `ManualClockOptions` entries by descriptor, so the plugin
+    // itself doesn't need a compile-time dep.
+    private const val ROBO_COMPOSE_PREVIEW_OPTIONS_FQN =
+      "com.github.takahirom.roborazzi.annotations.RoboComposePreviewOptions"
+  }
 
-    // Strip characters that would break file paths or IDs. Spaces are left alone
-    // (they already appear in existing `_Red Box.png`-style outputs).
-    private fun sanitizeForPath(s: String): String =
-        s.replace(Regex("""[/\\:*?"<>|]"""), "_")
+  @TaskAction
+  fun discover() {
+    val existingClassDirs = classDirs.files.filter { it.exists() && it.isDirectory }
+    // Match on the absolute path, not just the file name: AGP 9.x +
+    // KGP 2.3 resolve AAR dependencies to `<cache>/transforms/<hash>/
+    // transformed/<library>/jars/classes.jar` where the library name
+    // lives in the parent directory, not the filename. Filtering on
+    // `file.name` alone dropped every AAR-extracted jar — see #162.
+    val filteredDependencyJars =
+      dependencyJars.files.filter { file ->
+        file.exists() &&
+          file.name.lowercase().endsWith(".jar") &&
+          run {
+            val path = file.absolutePath.lowercase()
+            path.contains("preview") ||
+              path.contains("tooling") ||
+              path.contains("compose") ||
+              path.contains("annotation")
+          }
+      }
+    val classpath = existingClassDirs + filteredDependencyJars
 
-    private fun extractPreviewParams(
-        ann: AnnotationInfo,
-        wrapperClassName: String?,
-        previewParameter: Pair<String, Int>?,
-    ): PreviewParams {
-        val pv = ann.parameterValues
-        val kind = if (ann.name == TILE_PREVIEW_FQN) PreviewKind.TILE else PreviewKind.COMPOSE
-        val device = (pv.getValue("device") as? String)?.ifBlank { null }
-        val rawWidth = (pv.getValue("widthDp") as? Int)?.takeIf { it > 0 }
-        val rawHeight = (pv.getValue("heightDp") as? Int)?.takeIf { it > 0 }
-        val showSystemUi = (pv.getValue("showSystemUi") as? Boolean) ?: false
-        // AS-parity sizing: when the user picked a device or asked for the
-        // system UI frame, resolve up-front so downstream consumers (renderers,
-        // VS Code extension, CLI) see the effective widthDp/heightDp and the
-        // device's density. When no frame was requested, keep the raw user
-        // values — nulls on either axis signal "wrap to intrinsic" to the
-        // renderers, matching how Android Studio's preview pane sizes
-        // component previews.
-        val effectiveWidth: Int?
-        val effectiveHeight: Int?
-        val effectiveDensity: Float?
-        if (device != null || showSystemUi) {
-            val dims = DeviceDimensions.resolve(device, rawWidth, rawHeight)
-            effectiveWidth = dims.widthDp
-            effectiveHeight = dims.heightDp
-            effectiveDensity = dims.density
-        } else {
-            effectiveWidth = rawWidth
-            effectiveHeight = rawHeight
-            // Pin Android Studio's default preview density (xxhdpi-ish, 420dpi
-            // → 2.625x). Without this the Robolectric renderer defaults to
-            // mdpi (1.0x), which is fine at the PNG level but fuzzy in the VS
-            // Code tile grid: tiles have a `max-width: 180px`, so a 100-dp
-            // composable that produced a 100-px PNG under mdpi gets upscaled
-            // and looks blurry next to device-based previews rendered at
-            // their native densities. Pinning here keeps wrap-content
-            // previews at the same pixel density as both the Desktop
-            // renderer and Studio's own preview pane.
-            effectiveDensity = DeviceDimensions.DEFAULT_DENSITY
+    val previews = mutableListOf<PreviewInfo>()
+    // Populated only on the diagnostics path (failOnEmpty + 0 previews)
+    // so we can tell users whether ClassGraph saw any classes at all,
+    // and which annotation FQNs it did see — which disambiguates
+    // "classpath is wrong" from "@Preview FQN doesn't match" in a
+    // single run.
+    var scanClassCount = 0
+    var scanMethodsWithAnnotations = 0
+    val annotationFqnCounts = LinkedHashMap<String, Int>()
+    // Which known @Preview annotation FQNs are reachable as ClassInfo
+    // on the scan classpath. Empty → discovery cannot resolve multi-
+    // preview annotations (they fan out via `scanResult.getClassInfo`),
+    // which is almost always a misconfigured dep-jar classpath.
+    var reachablePreviewFqns: List<String> = emptyList()
+
+    if (classpath.isNotEmpty()) {
+      ClassGraph()
+        .enableMethodInfo()
+        .enableAnnotationInfo()
+        // Kotlin `private fun` compiles to a JVM `private` method and
+        // ClassGraph's default visibility filter drops it; `internal
+        // fun` compiles to JVM `public` (with the `name$module` mangle)
+        // so it slips through. Without this flag, projects that follow
+        // the "private @Preview to keep them out of the namespace"
+        // convention silently surface zero previews.
+        .ignoreMethodVisibility()
+        .overrideClasspath(classpath.map { it.absolutePath })
+        .ignoreParentClassLoaders()
+        .scan()
+        .use { scanResult ->
+          reachablePreviewFqns = PREVIEW_FQNS.filter { scanResult.getClassInfo(it) != null }
+          for (classInfo in scanResult.allClasses) {
+            scanClassCount++
+            for (method in classInfo.methodInfo) {
+              val annotations = method.annotationInfo ?: continue
+              if (annotations.isNotEmpty()) scanMethodsWithAnnotations++
+              for (ann in annotations) {
+                annotationFqnCounts.merge(ann.name, 1, Int::plus)
+              }
+              discoverFromMethod(classInfo, method, annotations.toList(), scanResult, previews)
+            }
+          }
         }
-        return PreviewParams(
-            name = (pv.getValue("name") as? String)?.ifBlank { null },
-            device = device,
-            widthDp = effectiveWidth,
-            heightDp = effectiveHeight,
-            density = effectiveDensity,
-            fontScale = (pv.getValue("fontScale") as? Float)?.takeIf { it > 0 } ?: 1.0f,
-            showSystemUi = showSystemUi,
-            showBackground = (pv.getValue("showBackground") as? Boolean) ?: false,
-            backgroundColor = (pv.getValue("backgroundColor") as? Long) ?: 0L,
-            uiMode = (pv.getValue("uiMode") as? Int)?.takeIf { it > 0 } ?: 0,
-            locale = (pv.getValue("locale") as? String)?.ifBlank { null },
-            group = (pv.getValue("group") as? String)?.ifBlank { null },
-            // @PreviewWrapper targets composables. Tile previews aren't composable,
-            // so even if the annotation happened to be present on the function,
-            // the wrapper's `Wrap(content)` would never wrap the tile View.
-            wrapperClassName = if (kind == PreviewKind.TILE) null else wrapperClassName,
-            // @PreviewParameter targets composables too. Tile preview functions
-            // return `TilePreviewData`; the renderer reflects them directly and
-            // has no code path for injecting a provider value.
-            previewParameterProviderClassName =
-                if (kind == PreviewKind.TILE) null else previewParameter?.first,
-            previewParameterLimit = previewParameter?.second ?: Int.MAX_VALUE,
-            kind = kind,
-            // @ScrollingPreview is applied by `makePreview` via `.copy(scroll = …)` so
-            // the timings fan-out and scroll spec live side-by-side in one place.
-        )
     }
+
+    // id already encodes the name + (device, fontScale, uiMode) variant suffix, so
+    // dedup by id alone. Two identical preview variants on the same function collapse.
+    val deduped = previews.distinctBy { it.id }
+
+    // Rewrite each capture's renderOutput to a normalized, shell-safe
+    // filename: drop the package prefix shared by every preview in the
+    // module so `renders/ee.schimke.ha.previews.CardPreviewsKt.Foo.png`
+    // lands at `renders/CardPreviewsKt.Foo.png`; sanitize spaces, parens,
+    // and other awkward shell characters inherited from `@Preview(name =
+    // "tile light (light)")`. Keeps `PreviewInfo.id` untouched — consumers
+    // that key by id (history folders, CLI state, test names) are
+    // unaffected.
+    val normalized = normalizeRenderOutputs(deduped)
+
+    val manifest =
+      PreviewManifest(
+        module = moduleName.get(),
+        variant = variantName.get(),
+        previews = normalized,
+        accessibilityReport = "accessibility.json".takeIf { accessibilityChecksEnabled.get() },
+      )
+
+    val outFile = outputFile.get().asFile
+    outFile.parentFile.mkdirs()
+    outFile.writeText(json.encodeToString(manifest))
+
+    logger.lifecycle("Discovered ${normalized.size} preview(s) in module '${moduleName.get()}':")
+    for (preview in normalized) {
+      logger.lifecycle("  ${preview.className}.${preview.functionName}${describeVariant(preview)}")
+    }
+
+    // Unconditional fail: the plugin scanned non-empty class dirs but
+    // none of the known @Preview annotation classes are on the scan
+    // classpath. Any multi-preview annotation (@LightDarkPreviews,
+    // @WearPreviewDevices, user wrappers) needs its class reachable via
+    // `scanResult.getClassInfo` to fan out, so this state silently
+    // hides the consumer's previews — see #162 for a real-world
+    // report. Preceded by the failOnEmpty diagnostics block so the
+    // error message points at the data that disambiguates the cause.
+    val previewAnnotationsMissing = scanClassCount > 0 && reachablePreviewFqns.isEmpty()
+    if (normalized.isEmpty() && (failOnEmpty.get() || previewAnnotationsMissing)) {
+      logEmptyDiagnostics(
+        existingClassDirs = existingClassDirs,
+        allClassDirs = classDirs.files.toList(),
+        filteredJars = filteredDependencyJars,
+        allJarCount = dependencyJars.files.size,
+        scanClassCount = scanClassCount,
+        scanMethodsWithAnnotations = scanMethodsWithAnnotations,
+        annotationFqnCounts = annotationFqnCounts,
+        reachablePreviewFqns = reachablePreviewFqns,
+      )
+      val reason =
+        if (previewAnnotationsMissing) {
+          "the @Preview annotation class is not on the ClassGraph classpath " +
+            "(dependency-jar filter dropped every jar carrying it)"
+        } else {
+          "with failOnEmpty=true"
+        }
+      throw org.gradle.api.GradleException(
+        "composePreview: discovered 0 previews in module '${moduleName.get()}' — " +
+          "$reason. See diagnostics above."
+      )
+    }
+  }
+
+  private fun logEmptyDiagnostics(
+    existingClassDirs: List<java.io.File>,
+    allClassDirs: List<java.io.File>,
+    filteredJars: List<java.io.File>,
+    allJarCount: Int,
+    scanClassCount: Int,
+    scanMethodsWithAnnotations: Int,
+    annotationFqnCounts: Map<String, Int>,
+    reachablePreviewFqns: List<String>,
+  ) {
+    logger.lifecycle("composePreview: failOnEmpty diagnostics (0 previews discovered):")
+    logger.lifecycle(
+      "  classDirs (${allClassDirs.size} declared, ${existingClassDirs.size} existing):"
+    )
+    for (dir in allClassDirs) {
+      val exists = dir.exists()
+      val isDir = dir.isDirectory
+      val classCount =
+        if (exists && isDir) {
+          dir.walkTopDown().count { it.extension == "class" }
+        } else 0
+      logger.lifecycle("    - $dir")
+      logger.lifecycle("      exists=$exists isDir=$isDir classFiles=$classCount")
+    }
+    logger.lifecycle(
+      "  dependencyJars: $allJarCount total, ${filteredJars.size} match " +
+        "(preview|tooling|compose|annotation)"
+    )
+    for (jar in filteredJars.take(DIAG_JAR_SAMPLE)) {
+      logger.lifecycle("    - ${jar.name}")
+    }
+    if (filteredJars.size > DIAG_JAR_SAMPLE) {
+      logger.lifecycle("    … and ${filteredJars.size - DIAG_JAR_SAMPLE} more")
+    }
+    logger.lifecycle(
+      "  ClassGraph scan: $scanClassCount classes, " +
+        "$scanMethodsWithAnnotations methods with any annotation"
+    )
+    if (scanClassCount > 0) {
+      if (reachablePreviewFqns.isEmpty()) {
+        // Most common #162-shaped failure: the consumer's preview
+        // annotations live in AAR-extracted `<library>/jars/classes.jar`
+        // files, whose `file.name` is just `classes.jar`. The
+        // dep-jar filter used to match on file name only and
+        // dropped every such jar, so no multi-preview annotation
+        // could be resolved.
+        logger.lifecycle(
+          "  known @Preview annotation classes NOT reachable on " +
+            "ClassGraph classpath — multi-preview resolution is disabled."
+        )
+        logger.lifecycle("    expected at least one of (by FQN):")
+        for (fqn in PREVIEW_FQNS) logger.lifecycle("      - $fqn")
+      } else {
+        logger.lifecycle("  reachable @Preview annotation classes on ClassGraph classpath:")
+        for (fqn in reachablePreviewFqns) logger.lifecycle("      - $fqn")
+      }
+    }
+    val previewAnnotationsSeen = PREVIEW_FQNS.filter { annotationFqnCounts.containsKey(it) }
+    if (previewAnnotationsSeen.isNotEmpty()) {
+      // If this path triggers we have a real bug: @Preview is on the
+      // classpath, it's on some method, but discovery still emitted
+      // nothing. Make it impossible to miss in the log.
+      logger.lifecycle(
+        "  known @Preview FQNs WERE seen on scanned methods " +
+          "(discovery dropped them — please report):"
+      )
+      for (fqn in previewAnnotationsSeen) {
+        logger.lifecycle("    - $fqn (${annotationFqnCounts[fqn]})")
+      }
+    } else if (scanClassCount > 0) {
+      logger.lifecycle("  no known @Preview FQN seen on any scanned method.")
+      logger.lifecycle("    expected one of:")
+      for (fqn in PREVIEW_FQNS) logger.lifecycle("      - $fqn")
+      val topAnnotations =
+        annotationFqnCounts.entries.sortedByDescending { it.value }.take(DIAG_ANNOTATION_SAMPLE)
+      if (topAnnotations.isNotEmpty()) {
+        logger.lifecycle("    top annotation FQNs actually observed:")
+        for ((fqn, count) in topAnnotations) {
+          logger.lifecycle("      - $fqn ($count)")
+        }
+      }
+    } else {
+      logger.lifecycle("  ClassGraph scanned 0 classes — check the classDirs listing above.")
+    }
+  }
+
+  /**
+   * Computes the common dotted prefix shared by every preview id (up to and including the last
+   * matched `.`) and strips it from each capture's `renderOutput` filename. Also runs every stem
+   * through [sanitizeFileStem] so spaces and shell-unfriendly characters inherited from
+   * `@Preview(name = "tile light (light)")` don't end up in the PNG filename.
+   *
+   * `preview.id` itself is deliberately left untouched — it's the stable identity consumers key by
+   * (history folders, CLI state, JUnit test names). The renderOutput is purely the on-disk
+   * filename, and that's what benefits from a shorter, quoted-free form.
+   *
+   * No-op on a single-preview module (empty prefix) or when sanitization would collapse two
+   * distinct ids to the same stem — in that case we keep the un-stripped, un-sanitized id for
+   * everyone so the pretty rename never introduces a filename collision.
+   */
+  private fun normalizeRenderOutputs(previews: List<PreviewInfo>): List<PreviewInfo> {
+    if (previews.isEmpty()) return previews
+    val commonPrefix = commonDottedPrefix(previews.map { it.id })
+    val stems = previews.map { sanitizeFileStem(it.id.removePrefix(commonPrefix)) }
+    val safe = stems.toSet().size == previews.size && stems.none { it.isEmpty() }
+    return previews.mapIndexed { i, preview ->
+      val newStem = if (safe) stems[i] else preview.id
+      val rewritten =
+        preview.captures.map { c ->
+          c.copy(renderOutput = rewriteRenderStem(c.renderOutput, preview.id, newStem))
+        }
+      preview.copy(captures = rewritten)
+    }
+  }
+
+  /** `renders/<oldStem><tail>.<ext>` → `renders/<newStem><tail>.<ext>`. */
+  private fun rewriteRenderStem(renderOutput: String, oldStem: String, newStem: String): String {
+    if (renderOutput.isEmpty() || oldStem == newStem) return renderOutput
+    val dir = renderOutput.substringBeforeLast('/', missingDelimiterValue = "")
+    val leaf = renderOutput.substringAfterLast('/')
+    if (!leaf.startsWith(oldStem)) return renderOutput
+    val rewritten = newStem + leaf.removePrefix(oldStem)
+    return if (dir.isEmpty()) rewritten else "$dir/$rewritten"
+  }
+
+  private fun commonDottedPrefix(ids: List<String>): String {
+    if (ids.size < 2) return ""
+    var prefix = ids.first()
+    for (id in ids.drop(1)) {
+      var i = 0
+      val limit = minOf(prefix.length, id.length)
+      while (i < limit && prefix[i] == id[i]) i++
+      prefix = prefix.substring(0, i)
+      if (prefix.isEmpty()) return ""
+    }
+    val lastDot = prefix.lastIndexOf('.')
+    return if (lastDot < 0) "" else prefix.substring(0, lastDot + 1)
+  }
+
+  /**
+   * Sanitizes a filename stem to an ASCII-safe whitelist (`[A-Za-z0-9._-]`). Every other character
+   * collapses to `_`, runs of `_` collapse to a single `_`, and leading/trailing `_`, `.`, `-` are
+   * trimmed. A whitelist is deliberate: we can't enumerate every awkward character a preview name
+   * might contain (Unicode dashes, NBSP, RTL marks, emoji), and any one of them can break a
+   * downstream tool that expects a POSIX-plain filename. `.` is preserved so FQN-shaped stems
+   * (`CardPreviewsKt.Tile_Light_States`) survive intact when the package prefix strip can't flatten
+   * them further.
+   */
+  private fun sanitizeFileStem(s: String): String =
+    s.replace(Regex("""[^A-Za-z0-9._-]"""), "_").replace(Regex("""_+"""), "_").trim('_', '.', '-')
+
+  // Renders the distinguishing bits of a preview variant for the discovery log
+  // so sibling expansions (e.g. @WearPreviewFontScales × 6) aren't visually
+  // identical. Format mirrors the VSCode tooltip: `name` / `device` /
+  // `WxHdp` / `font Nx` / `uiMode=N` / `locale` / `group`.
+  private fun describeVariant(preview: PreviewInfo): String {
+    val p = preview.params
+    val parts = mutableListOf<String>()
+    p.name?.let(parts::add)
+    p.device?.let(parts::add)
+    val w = p.widthDp
+    val h = p.heightDp
+    if (w != null && h != null) parts.add("${w}x${h}dp")
+    if (p.fontScale != 1.0f) parts.add("font ${p.fontScale}x")
+    if (p.uiMode != 0) parts.add("uiMode=${p.uiMode}")
+    p.locale?.let(parts::add)
+    p.group?.let { parts.add("group=$it") }
+    // Summarise capture-level dimensions (time, scroll) on one line so
+    // the log remains a single bullet per preview even for fan-outs.
+    val timings = preview.captures.mapNotNull { it.advanceTimeMillis }
+    if (timings.isNotEmpty()) {
+      parts.add("${preview.captures.size} captures @ ${timings.joinToString(",") { "${it}ms" }}")
+    }
+    val scrollModes = preview.captures.mapNotNull { it.scroll?.mode }.distinct()
+    if (scrollModes.isNotEmpty()) {
+      parts.add("scroll=" + scrollModes.joinToString(",") { it.name.lowercase() })
+    }
+    val anim = preview.captures.firstNotNullOfOrNull { it.animation }
+    if (anim != null) {
+      val curveSuffix = if (anim.showCurves) "+curves" else ""
+      parts.add("animated=${anim.durationMs}ms@${anim.frameIntervalMs}ms$curveSuffix")
+    }
+    return if (parts.isEmpty()) "" else "  [" + parts.joinToString(" · ") + "]"
+  }
+
+  private fun discoverFromMethod(
+    classInfo: ClassInfo,
+    method: MethodInfo,
+    annotations: List<AnnotationInfo>,
+    scanResult: ScanResult,
+    previews: MutableList<PreviewInfo>,
+  ) {
+    // @PreviewWrapper and @ScrollingPreview are both non-repeatable and apply
+    // to every @Preview on the function (including expansions from
+    // multi-preview meta-annotations). `@ScrollingPreview.modes` fans out
+    // one capture per entry — see [buildCaptures]. `@AnimatedPreview` is
+    // single-shot (one GIF per function) so it doesn't fan out, but follows
+    // the same "one annotation per function, applies to every preview
+    // expansion" policy.
+    val wrapperFqn = extractWrapperFqn(annotations)
+    val scrollSpecs = extractScrollSpecs(annotations)
+    val animationSpec = extractAnimationSpec(annotations)
+    // @RoboComposePreviewOptions, similarly, applies to the function as a
+    // whole — each timing fans out into its own manifest entry, orthogonal
+    // to any multi-preview expansion.
+    val timings = extractRoboTimings(annotations)
+    // @PreviewParameter lives on a method PARAMETER, not the method itself,
+    // so it's sourced from `parameterInfo` rather than the method
+    // annotation list. Extracted once per function and applied to every
+    // multi-preview expansion — the provider is the same no matter which
+    // @Preview drove the fan-out.
+    val previewParameter = extractPreviewParameter(method)
+
+    val directPreviews = collectDirectPreviews(annotations)
+    if (directPreviews.isNotEmpty()) {
+      for (ann in directPreviews) {
+        previews.add(
+          makePreview(
+            classInfo,
+            method,
+            ann,
+            wrapperFqn,
+            scrollSpecs,
+            animationSpec,
+            timings,
+            previewParameter,
+          )
+        )
+      }
+      return
+    }
+
+    for (ann in annotations) {
+      val resolved = resolveMultiPreview(ann, scanResult, mutableSetOf())
+      for (resolvedAnn in resolved) {
+        previews.add(
+          makePreview(
+            classInfo,
+            method,
+            resolvedAnn,
+            wrapperFqn,
+            scrollSpecs,
+            animationSpec,
+            timings,
+            previewParameter,
+          )
+        )
+      }
+    }
+  }
+
+  /**
+   * Scans [method]'s parameters for `@PreviewParameter`. Returns the provider FQN + `limit` of the
+   * FIRST parameter that carries the annotation; `null` when none do. Supporting a single parameter
+   * mirrors the current upstream (Studio/Layoutlib) semantic — multi-param preview functions
+   * require explicit wiring in tooling code, which our renderer doesn't expose.
+   *
+   * ClassGraph surfaces parameter annotations on `MethodParameterInfo.annotationInfo`. The `value`
+   * field on `@PreviewParameter` carries the provider KClass, which comes back as an
+   * [AnnotationClassRef] — we pull its FQN without triggering classloading (matches how
+   * [extractWrapperFqn] handles `@PreviewWrapper`).
+   */
+  private fun extractPreviewParameter(method: MethodInfo): Pair<String, Int>? {
+    val params = method.parameterInfo ?: return null
+    for (param in params) {
+      val anns = param.annotationInfo ?: continue
+      val ann = anns.firstOrNull { it.name == PREVIEW_PARAMETER_FQN } ?: continue
+      val provider =
+        when (val value = ann.parameterValues.getValue("provider")) {
+          is AnnotationClassRef -> value.name
+          is String -> value
+          else -> null
+        } ?: continue
+      val limit = (ann.parameterValues.getValue("limit") as? Int)?.coerceAtLeast(0) ?: Int.MAX_VALUE
+      return provider to limit
+    }
+    return null
+  }
+
+  // Tile previews don't go through `mainClock` and can't scroll (the
+  // renderer inflates a View via `TileRenderer` and has no Compose
+  // animation clock / scrollable), so both dimensional annotations are
+  // no-ops for tiles.
+  private fun buildCaptures(
+    ann: AnnotationInfo,
+    previewId: String,
+    scrolls: List<ScrollCapture>,
+    animation: AnimationCapture?,
+    timings: List<Long>,
+  ): List<Capture> {
+    val isTile = ann.name == TILE_PREVIEW_FQN
+    val effectiveTimings = if (isTile) emptyList() else timings
+    val effectiveScrolls = if (isTile) emptyList() else scrolls
+    // Tile previews don't go through `mainClock` either — `TileRenderer`
+    // inflates a static View and there's no animation surface to drive.
+    val effectiveAnimation = if (isTile) null else animation
+
+    // @AnimatedPreview produces its own dedicated capture, alongside any
+    // scroll / time fan-out. The GIF gets a distinguishing `_anim` suffix
+    // when other captures share the function (the multi-mode scroll
+    // pattern), and the plain filename otherwise.
+    val animationCaptures: List<Capture> =
+      if (effectiveAnimation == null) emptyList()
+      else {
+        val sharesFn = effectiveScrolls.isNotEmpty() || effectiveTimings.isNotEmpty()
+        val suffix = if (sharesFn) "_anim" else ""
+        listOf(
+          Capture(
+            animation = effectiveAnimation,
+            renderOutput = "renders/${previewId}${suffix}.gif",
+            cost = ANIMATION_COST,
+          )
+        )
+      }
+
+    // Single-mode scroll keeps the plain filename so migrations from the
+    // old single-valued `mode = …` annotation land on identical paths.
+    // Multi-mode adds `_SCROLL_<mode>` to disambiguate siblings, same
+    // pattern as `_TIME_<ms>ms` for the time dimension.
+    val scrollRows: List<Pair<ScrollCapture?, String>> =
+      when {
+        effectiveScrolls.isEmpty() -> listOf(null to "")
+        effectiveScrolls.size == 1 -> listOf(effectiveScrolls[0] to "")
+        else -> effectiveScrolls.map { it to "_SCROLL_${it.mode.name.lowercase()}" }
+      }
+    val timeRows: List<Pair<Long?, String>> =
+      if (effectiveTimings.isEmpty()) listOf(null to "")
+      else effectiveTimings.map { ms -> ms to "_TIME_${ms}ms" }
+
+    // When ONLY @AnimatedPreview is on the function, the scroll/time
+    // cross-product would still emit one (null, null) row — i.e. a static
+    // PNG capture. Suppress that to keep `@AnimatedPreview` a clean
+    // single-output annotation.
+    val emitStaticCross =
+      effectiveScrolls.isNotEmpty() || effectiveTimings.isNotEmpty() || effectiveAnimation == null
+
+    val scrollTimeCaptures: List<Capture> =
+      if (!emitStaticCross) emptyList()
+      else {
+        scrollRows.flatMap { (scroll, scrollSuffix) ->
+          timeRows.map { (ms, timeSuffix) ->
+            // GIF captures land on `.gif`; everything else is `.png`.
+            // Branching the extension per-capture (rather than per-preview)
+            // keeps multi-mode annotations like `modes = [TOP, GIF]`
+            // producing one PNG + one GIF from the same function.
+            val ext = if (scroll?.mode == ScrollMode.GIF) "gif" else "png"
+            // Cost is normalised to a static @Preview = 1.0. The mode
+            // ladder (TOP < END ≪ LONG < GIF) reflects how much extra
+            // work each scroll variant adds on top of the baseline
+            // compose pass. `advanceTimeMillis` alone is still one
+            // pass at a specific virtual time, so it doesn't bump the
+            // per-capture cost — the wall-time of a multi-timing
+            // fan-out is in the *count*, which lives in the captures
+            // list itself.
+            val captureCost =
+              when (scroll?.mode) {
+                null -> STATIC_COST
+                ScrollMode.TOP -> SCROLL_TOP_COST
+                ScrollMode.END -> SCROLL_END_COST
+                ScrollMode.LONG -> SCROLL_LONG_COST
+                ScrollMode.GIF -> SCROLL_GIF_COST
+              }
+            Capture(
+              advanceTimeMillis = ms,
+              scroll = scroll,
+              renderOutput = "renders/${previewId}${scrollSuffix}${timeSuffix}.${ext}",
+              cost = captureCost,
+            )
+          }
+        }
+      }
+
+    return scrollTimeCaptures + animationCaptures
+  }
+
+  // Reads `@RoboComposePreviewOptions(manualClockOptions = [...])` on the
+  // preview function and returns the `advanceTimeMillis` of each entry.
+  // Empty list if the annotation is absent OR present with no entries — the
+  // latter is equivalent to "default" per Roborazzi's own scanner-support
+  // behaviour. ClassGraph surfaces `manualClockOptions` as an
+  // Object[] of `AnnotationInfo` because the field type is `Array<ManualClockOptions>`.
+  private fun extractRoboTimings(annotations: List<AnnotationInfo>): List<Long> {
+    val ann =
+      annotations.firstOrNull { it.name == ROBO_COMPOSE_PREVIEW_OPTIONS_FQN } ?: return emptyList()
+    val raw = ann.parameterValues.getValue("manualClockOptions") ?: return emptyList()
+    val items =
+      when (raw) {
+        is Array<*> -> raw.filterIsInstance<AnnotationInfo>()
+        is AnnotationInfo -> listOf(raw)
+        else -> {
+          // Some ClassGraph versions hand back a typed primitive array or
+          // Kotlin wrapper — fall back to reflective iteration.
+          val len = runCatching { java.lang.reflect.Array.getLength(raw) }.getOrNull() ?: 0
+          (0 until len).mapNotNull { java.lang.reflect.Array.get(raw, it) as? AnnotationInfo }
+        }
+      }
+    return items.mapNotNull { it.parameterValues.getValue("advanceTimeMillis") as? Long }
+  }
+
+  private fun extractWrapperFqn(annotations: List<AnnotationInfo>): String? {
+    val wrapperAnn = annotations.firstOrNull { it.name == PREVIEW_WRAPPER_FQN } ?: return null
+    // The `wrapper: KClass<out PreviewWrapperProvider>` parameter surfaces as an
+    // AnnotationClassRef — pull the FQN without triggering classloading.
+    return when (val value = wrapperAnn.parameterValues.getValue("wrapper")) {
+      is AnnotationClassRef -> value.name
+      is String -> value
+      else -> null
+    }
+  }
+
+  /**
+   * Reads `@AnimatedPreview(durationMs, frameIntervalMs, showCurves)` off the function annotation
+   * list. Single-shot — at most one animation capture per function, so we return a nullable spec
+   * rather than a list. Negative / zero numeric fields fall back to the annotation defaults.
+   */
+  private fun extractAnimationSpec(annotations: List<AnnotationInfo>): AnimationCapture? {
+    val ann = annotations.firstOrNull { it.name == ANIMATED_PREVIEW_FQN } ?: return null
+    val pv = ann.parameterValues
+    // `durationMs = 0` is the auto-detect sentinel; let the renderer ask
+    // PreviewAnimationClock for the real duration. A positive value
+    // overrides; negatives clamp to the sentinel.
+    val durationMs = (pv.getValue("durationMs") as? Int)?.coerceAtLeast(0) ?: 0
+    val frameIntervalMs = (pv.getValue("frameIntervalMs") as? Int)?.takeIf { it > 0 } ?: 33
+    val showCurves = (pv.getValue("showCurves") as? Boolean) ?: true
+    return AnimationCapture(
+      durationMs = durationMs,
+      frameIntervalMs = frameIntervalMs,
+      showCurves = showCurves,
+    )
+  }
+
+  private fun extractScrollSpecs(annotations: List<AnnotationInfo>): List<ScrollCapture> {
+    val ann = annotations.firstOrNull { it.name == SCROLLING_PREVIEW_FQN } ?: return emptyList()
+    val pv = ann.parameterValues
+    // ClassGraph surfaces the `modes: Array<ScrollMode>` field as an
+    // Object[] of AnnotationEnumValue; same shape as `manualClockOptions`
+    // above. Enum constants are compared by `.valueName` so we never
+    // force-load the annotation's classes.
+    val rawModes = pv.getValue("modes")
+    val modes = readEnumArray(rawModes) { ScrollMode.valueOf(it) }
+    if (modes.isEmpty()) return emptyList()
+    val axis =
+      (pv.getValue("axis") as? AnnotationEnumValue)?.valueName?.let {
+        runCatching { ScrollAxis.valueOf(it) }.getOrNull()
+      } ?: ScrollAxis.VERTICAL
+    val maxScrollPx = (pv.getValue("maxScrollPx") as? Int)?.coerceAtLeast(0) ?: 0
+    val reduceMotion = (pv.getValue("reduceMotion") as? Boolean) ?: true
+    // `frameIntervalMs` only meaningful for GIF mode; we still read it
+    // unconditionally and carry it into every ScrollCapture so the
+    // manifest shape stays uniform. `0` (or negative, coerced) signals
+    // "use the renderer's default" — matching the annotation-side
+    // DEFAULT_GIF_FRAME_INTERVAL_MS without duplicating the literal here.
+    val frameIntervalMs = (pv.getValue("frameIntervalMs") as? Int)?.coerceAtLeast(0) ?: 0
+    // Result fields (atEnd, reachedPx) default to "not reported" — the
+    // renderer would fill them in post-capture; discovery knows only the
+    // intent. De-dup to guard against `modes = [END, END]` producing
+    // colliding paths. Sort by enum ordinal (TOP→END→LONG→GIF) so the
+    // renderer captures the initial frame before driving the scroller —
+    // otherwise `modes = [END, TOP]` would produce a "TOP" PNG at the
+    // scrolled-end position.
+    return modes
+      .distinct()
+      .sortedBy { it.ordinal }
+      .map { mode ->
+        ScrollCapture(
+          mode = mode,
+          axis = axis,
+          maxScrollPx = maxScrollPx,
+          reduceMotion = reduceMotion,
+          frameIntervalMs = frameIntervalMs,
+        )
+      }
+  }
+
+  // Reads an annotation's Array<EnumT> parameter and maps each entry by
+  // `.valueName` through [parse]. ClassGraph can hand this back as a plain
+  // array, a single AnnotationEnumValue (single-entry arrays), or a typed
+  // array we need to walk reflectively — same cases as
+  // [extractRoboTimings].
+  private fun <T> readEnumArray(raw: Any?, parse: (String) -> T): List<T> {
+    if (raw == null) return emptyList()
+    val items =
+      when (raw) {
+        is Array<*> -> raw.filterIsInstance<AnnotationEnumValue>()
+        is AnnotationEnumValue -> listOf(raw)
+        else -> {
+          val len = runCatching { java.lang.reflect.Array.getLength(raw) }.getOrNull() ?: 0
+          (0 until len).mapNotNull { java.lang.reflect.Array.get(raw, it) as? AnnotationEnumValue }
+        }
+      }
+    return items.mapNotNull { runCatching { parse(it.valueName) }.getOrNull() }
+  }
+
+  private fun isDirectPreview(ann: AnnotationInfo): Boolean = ann.name in PREVIEW_FQNS
+
+  private fun isPreviewContainer(ann: AnnotationInfo): Boolean = ann.name in CONTAINER_FQNS
+
+  private fun collectDirectPreviews(annotations: List<AnnotationInfo>): List<AnnotationInfo> {
+    val result = mutableListOf<AnnotationInfo>()
+    for (ann in annotations) {
+      when {
+        isDirectPreview(ann) -> result.add(ann)
+        isPreviewContainer(ann) -> {
+          val value = ann.parameterValues.getValue("value")
+          when (value) {
+            is Array<*> -> value.filterIsInstance<AnnotationInfo>().forEach { result.add(it) }
+            is AnnotationInfo -> result.add(value)
+            else -> {
+              val len = java.lang.reflect.Array.getLength(value)
+              for (i in 0 until len) {
+                val elem = java.lang.reflect.Array.get(value, i)
+                if (elem is AnnotationInfo) result.add(elem)
+              }
+            }
+          }
+        }
+      }
+    }
+    return result
+  }
+
+  private fun resolveMultiPreview(
+    ann: AnnotationInfo,
+    scanResult: ScanResult,
+    visited: MutableSet<String>,
+  ): List<AnnotationInfo> {
+    if (ann.name in visited) return emptyList()
+    if (isDirectPreview(ann) || isPreviewContainer(ann)) return emptyList()
+    visited.add(ann.name)
+
+    val annClassInfo = scanResult.getClassInfo(ann.name) ?: return emptyList()
+    val directPreviews = collectDirectPreviews(annClassInfo.annotationInfo.toList())
+    if (directPreviews.isNotEmpty()) return directPreviews
+
+    val result = mutableListOf<AnnotationInfo>()
+    for (metaAnn in annClassInfo.annotationInfo) {
+      result.addAll(resolveMultiPreview(metaAnn, scanResult, visited))
+    }
+    return result
+  }
+
+  private fun makePreview(
+    classInfo: ClassInfo,
+    method: MethodInfo,
+    ann: AnnotationInfo,
+    wrapperClassName: String?,
+    scrolls: List<ScrollCapture>,
+    animation: AnimationCapture?,
+    timings: List<Long>,
+    previewParameter: Pair<String, Int>?,
+  ): PreviewInfo {
+    val params = extractPreviewParams(ann, wrapperClassName, previewParameter)
+    val fqn = "${classInfo.name}.${method.name}"
+    val suffix = buildVariantSuffix(params)
+    val id = fqn + suffix
+    return PreviewInfo(
+      id = id,
+      functionName = method.name,
+      className = classInfo.name,
+      sourceFile = packageQualifiedSourcePath(classInfo),
+      params = params,
+      captures = buildCaptures(ann, id, scrolls, animation, timings),
+    )
+  }
+
+  // Package-qualified source path, e.g. "com/example/samplewear/Previews.kt".
+  // The bytecode SourceFile attribute is just the basename, which collides
+  // when two files with the same name live in different packages within one
+  // module. Prefixing with the package path makes the value unique and lets
+  // the VSCode extension / CLI resolve a preview back to the exact file.
+  private fun packageQualifiedSourcePath(classInfo: ClassInfo): String? {
+    val simpleName = classInfo.sourceFile ?: return null
+    val pkg = classInfo.packageName.orEmpty()
+    return if (pkg.isEmpty()) simpleName else "${pkg.replace('.', '/')}/$simpleName"
+  }
+
+  // Disambiguates multi-preview expansions (e.g. @WearPreviewDevices → large_round
+  // + small_round) when the inner @Preview has no explicit `name`. Without this
+  // every variant collides on the same id / PNG path.
+  //
+  // Prefer `group` — Horologist's @WearPreview* annotations set a distinct, human
+  // readable group per variant (e.g. "Fonts - Large"), so it captures exactly what
+  // varies. Fall back to device + fontScale + uiMode only if neither name nor
+  // group is present.
+  private fun buildVariantSuffix(params: PreviewParams): String {
+    if (!params.name.isNullOrBlank()) return "_${params.name}"
+    if (!params.group.isNullOrBlank()) return "_${sanitizeForPath(params.group)}"
+    val parts = mutableListOf<String>()
+    params.device?.substringAfterLast(":")?.takeIf { it.isNotBlank() }?.let(parts::add)
+    if (params.fontScale != 1.0f) parts.add("fs${params.fontScale}")
+    if (params.uiMode != 0) parts.add("ui${params.uiMode}")
+    return if (parts.isEmpty()) "" else "_" + parts.joinToString("_")
+  }
+
+  // Strip characters that would break file paths or IDs. Spaces are left alone
+  // (they already appear in existing `_Red Box.png`-style outputs).
+  private fun sanitizeForPath(s: String): String = s.replace(Regex("""[/\\:*?"<>|]"""), "_")
+
+  private fun extractPreviewParams(
+    ann: AnnotationInfo,
+    wrapperClassName: String?,
+    previewParameter: Pair<String, Int>?,
+  ): PreviewParams {
+    val pv = ann.parameterValues
+    val kind = if (ann.name == TILE_PREVIEW_FQN) PreviewKind.TILE else PreviewKind.COMPOSE
+    val device = (pv.getValue("device") as? String)?.ifBlank { null }
+    val rawWidth = (pv.getValue("widthDp") as? Int)?.takeIf { it > 0 }
+    val rawHeight = (pv.getValue("heightDp") as? Int)?.takeIf { it > 0 }
+    val showSystemUi = (pv.getValue("showSystemUi") as? Boolean) ?: false
+    // AS-parity sizing: when the user picked a device or asked for the
+    // system UI frame, resolve up-front so downstream consumers (renderers,
+    // VS Code extension, CLI) see the effective widthDp/heightDp and the
+    // device's density. When no frame was requested, keep the raw user
+    // values — nulls on either axis signal "wrap to intrinsic" to the
+    // renderers, matching how Android Studio's preview pane sizes
+    // component previews.
+    val effectiveWidth: Int?
+    val effectiveHeight: Int?
+    val effectiveDensity: Float?
+    if (device != null || showSystemUi) {
+      val dims = DeviceDimensions.resolve(device, rawWidth, rawHeight)
+      effectiveWidth = dims.widthDp
+      effectiveHeight = dims.heightDp
+      effectiveDensity = dims.density
+    } else {
+      effectiveWidth = rawWidth
+      effectiveHeight = rawHeight
+      // Pin Android Studio's default preview density (xxhdpi-ish, 420dpi
+      // → 2.625x). Without this the Robolectric renderer defaults to
+      // mdpi (1.0x), which is fine at the PNG level but fuzzy in the VS
+      // Code tile grid: tiles have a `max-width: 180px`, so a 100-dp
+      // composable that produced a 100-px PNG under mdpi gets upscaled
+      // and looks blurry next to device-based previews rendered at
+      // their native densities. Pinning here keeps wrap-content
+      // previews at the same pixel density as both the Desktop
+      // renderer and Studio's own preview pane.
+      effectiveDensity = DeviceDimensions.DEFAULT_DENSITY
+    }
+    return PreviewParams(
+      name = (pv.getValue("name") as? String)?.ifBlank { null },
+      device = device,
+      widthDp = effectiveWidth,
+      heightDp = effectiveHeight,
+      density = effectiveDensity,
+      fontScale = (pv.getValue("fontScale") as? Float)?.takeIf { it > 0 } ?: 1.0f,
+      showSystemUi = showSystemUi,
+      showBackground = (pv.getValue("showBackground") as? Boolean) ?: false,
+      backgroundColor = (pv.getValue("backgroundColor") as? Long) ?: 0L,
+      uiMode = (pv.getValue("uiMode") as? Int)?.takeIf { it > 0 } ?: 0,
+      locale = (pv.getValue("locale") as? String)?.ifBlank { null },
+      group = (pv.getValue("group") as? String)?.ifBlank { null },
+      // @PreviewWrapper targets composables. Tile previews aren't composable,
+      // so even if the annotation happened to be present on the function,
+      // the wrapper's `Wrap(content)` would never wrap the tile View.
+      wrapperClassName = if (kind == PreviewKind.TILE) null else wrapperClassName,
+      // @PreviewParameter targets composables too. Tile preview functions
+      // return `TilePreviewData`; the renderer reflects them directly and
+      // has no code path for injecting a provider value.
+      previewParameterProviderClassName =
+        if (kind == PreviewKind.TILE) null else previewParameter?.first,
+      previewParameterLimit = previewParameter?.second ?: Int.MAX_VALUE,
+      kind = kind,
+      // @ScrollingPreview is applied by `makePreview` via `.copy(scroll = …)` so
+      // the timings fan-out and scroll spec live side-by-side in one place.
+    )
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GenerateRenderShardsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GenerateRenderShardsTask.kt
@@ -9,34 +9,33 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
 /**
- * Generates `RobolectricRenderTest_ShardN` subclasses (one per shard) in Java. Each
- * subclass declares its own static `@Parameters` method that calls
- * `PreviewManifestLoader.loadShard(N, shardCount)`, so the `ParameterizedRobolectricTestRunner`
- * sees a distinct parameter set per class. Gradle's test fork distribution happens at the
- * class level, so N classes → N parallel JVMs when `maxParallelForks = N`.
+ * Generates `RobolectricRenderTest_ShardN` subclasses (one per shard) in Java. Each subclass
+ * declares its own static `@Parameters` method that calls `PreviewManifestLoader.loadShard(N,
+ * shardCount)`, so the `ParameterizedRobolectricTestRunner` sees a distinct parameter set per
+ * class. Gradle's test fork distribution happens at the class level, so N classes → N parallel JVMs
+ * when `maxParallelForks = N`.
  *
  * Java (not Kotlin) deliberately: avoids pulling a Kotlin compiler into the plugin's
- * generated-source path. `javac --release 21` is enough since the base class is a plain
- * JVM class from the plugin's perspective.
+ * generated-source path. `javac --release 21` is enough since the base class is a plain JVM class
+ * from the plugin's perspective.
  */
 @CacheableTask
 abstract class GenerateRenderShardsTask : DefaultTask() {
-    @get:Input
-    abstract val shards: Property<Int>
+  @get:Input abstract val shards: Property<Int>
 
-    @get:OutputDirectory
-    abstract val outputDir: DirectoryProperty
+  @get:OutputDirectory abstract val outputDir: DirectoryProperty
 
-    @TaskAction
-    fun generate() {
-        val count = shards.get()
-        val dir = outputDir.get().asFile.resolve("ee/schimke/composeai/renderer")
-        dir.deleteRecursively()
-        dir.mkdirs()
+  @TaskAction
+  fun generate() {
+    val count = shards.get()
+    val dir = outputDir.get().asFile.resolve("ee/schimke/composeai/renderer")
+    dir.deleteRecursively()
+    dir.mkdirs()
 
-        for (i in 0 until count) {
-            val className = "RobolectricRenderTest_Shard$i"
-            val source = """
+    for (i in 0 until count) {
+      val className = "RobolectricRenderTest_Shard$i"
+      val source =
+        """
                 |package ee.schimke.composeai.renderer;
                 |
                 |import java.util.List;
@@ -62,9 +61,10 @@ abstract class GenerateRenderShardsTask : DefaultTask() {
                 |        return PreviewManifestLoader.loadShard($i, $count);
                 |    }
                 |}
-                |""".trimMargin()
-            dir.resolve("$className.java").writeText(source)
-        }
-        logger.lifecycle("Generated $count shard test subclasses in $dir")
+                |"""
+          .trimMargin()
+      dir.resolve("$className.java").writeText(source)
     }
+    logger.lifecycle("Generated $count shard test subclasses in $dir")
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GenerateRobolectricPropertiesTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GenerateRobolectricPropertiesTask.kt
@@ -9,73 +9,68 @@ import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
 /**
- * Writes `ee/schimke/composeai/renderer/robolectric.properties` into a
- * generated resources directory added to the `renderPreviews` test classpath.
+ * Writes `ee/schimke/composeai/renderer/robolectric.properties` into a generated resources
+ * directory added to the `renderPreviews` test classpath.
  *
- * Robolectric reads package-level `robolectric.properties` from the classpath
- * and merges its fields into each test's effective config.
- * `RobolectricRenderTestBase` deliberately carries NO `@Config` or
- * `@GraphicsMode` annotation so this file is the sole source of truth for
- * those settings — see that class's KDoc for the #142 motivation.
+ * Robolectric reads package-level `robolectric.properties` from the classpath and merges its fields
+ * into each test's effective config. `RobolectricRenderTestBase` deliberately carries NO `@Config`
+ * or `@GraphicsMode` annotation so this file is the sole source of truth for those settings — see
+ * that class's KDoc for the #142 motivation.
  *
  * Fields written unconditionally:
- *   - `sdk=$TARGET_SDK` — the Android SDK level Robolectric targets.
- *     Matches the renderer's compilation target.
- *   - `graphicsMode=NATIVE` — routes Compose capture through
- *     HardwareRenderer, the only path that replays RenderNodes correctly
- *     for `roborazzi`'s `captureRoboImage`.
- *   - `shadows=…ShadowFontsContractCompat` — globally registers the
- *     GoogleFont shadow so `Font(GoogleFont(...), provider)` renders
- *     without the consumer having to add `@Config(shadows = [...])`.
+ * - `sdk=$TARGET_SDK` — the Android SDK level Robolectric targets. Matches the renderer's
+ *   compilation target.
+ * - `graphicsMode=NATIVE` — routes Compose capture through HardwareRenderer, the only path that
+ *   replays RenderNodes correctly for `roborazzi`'s `captureRoboImage`.
+ * - `shadows=…ShadowFontsContractCompat` — globally registers the GoogleFont shadow so
+ *   `Font(GoogleFont(...), provider)` renders without the consumer having to add `@Config(shadows =
+ *   [...])`.
  *
  * Fields that depend on [useConsumerApplication]:
- *   - Default ([useConsumerApplication] = false): the file pins
- *     `application=android.app.Application`, so Robolectric creates a plain
- *     Application and SKIPS the consumer's `onCreate()`. Consumer-side init
- *     that depends on platform features Robolectric doesn't emulate
- *     (BridgingManager on non-Wear sandboxes, Firebase, WorkManager, Play
- *     Services) no longer runs during preview rendering.
- *   - Opt-out ([useConsumerApplication] = true): the file is written
- *     without `application=`, so Robolectric falls back to the manifest-
- *     declared Application class. Intended for preview setups that
- *     genuinely require their custom Application (e.g. Hilt's generated
- *     testing application).
+ * - Default ([useConsumerApplication] = false): the file pins
+ *   `application=android.app.Application`, so Robolectric creates a plain Application and SKIPS the
+ *   consumer's `onCreate()`. Consumer-side init that depends on platform features Robolectric
+ *   doesn't emulate (BridgingManager on non-Wear sandboxes, Firebase, WorkManager, Play Services)
+ *   no longer runs during preview rendering.
+ * - Opt-out ([useConsumerApplication] = true): the file is written without `application=`, so
+ *   Robolectric falls back to the manifest- declared Application class. Intended for preview setups
+ *   that genuinely require their custom Application (e.g. Hilt's generated testing application).
  */
 @CacheableTask
 abstract class GenerateRobolectricPropertiesTask : DefaultTask() {
-    @get:Input
-    abstract val useConsumerApplication: Property<Boolean>
+  @get:Input abstract val useConsumerApplication: Property<Boolean>
 
-    @get:OutputDirectory
-    abstract val outputDir: DirectoryProperty
+  @get:OutputDirectory abstract val outputDir: DirectoryProperty
 
-    @TaskAction
-    fun generate() {
-        val dir = outputDir.get().asFile.resolve("ee/schimke/composeai/renderer")
-        dir.deleteRecursively()
-        dir.mkdirs()
-        val file = dir.resolve("robolectric.properties")
-        // `shadows=` registers our GoogleFont shadow globally for every test
-        // in this package. See [ShadowFontsContractCompat].
-        val shadowsLine = "shadows=ee.schimke.composeai.renderer.ShadowFontsContractCompat"
-        // `sdk=` and `graphicsMode=` live here (not on `@Config`/`@GraphicsMode`
-        // on `RobolectricRenderTestBase`) to avoid JUnit's `AnnotationParser`
-        // resolving `@Config.application()`'s `android.app.Application` default
-        // during test-class discovery — that resolution fails under some
-        // JVM/classloader combinations and produces `ClassNotFoundException:
-        // android.app.Application`. See issue #142.
-        val sdkLine = "sdk=$TARGET_SDK"
-        val graphicsLine = "graphicsMode=NATIVE"
-        val body = if (useConsumerApplication.get()) {
-            """
+  @TaskAction
+  fun generate() {
+    val dir = outputDir.get().asFile.resolve("ee/schimke/composeai/renderer")
+    dir.deleteRecursively()
+    dir.mkdirs()
+    val file = dir.resolve("robolectric.properties")
+    // `shadows=` registers our GoogleFont shadow globally for every test
+    // in this package. See [ShadowFontsContractCompat].
+    val shadowsLine = "shadows=ee.schimke.composeai.renderer.ShadowFontsContractCompat"
+    // `sdk=` and `graphicsMode=` live here (not on `@Config`/`@GraphicsMode`
+    // on `RobolectricRenderTestBase`) to avoid JUnit's `AnnotationParser`
+    // resolving `@Config.application()`'s `android.app.Application` default
+    // during test-class discovery — that resolution fails under some
+    // JVM/classloader combinations and produces `ClassNotFoundException:
+    // android.app.Application`. See issue #142.
+    val sdkLine = "sdk=$TARGET_SDK"
+    val graphicsLine = "graphicsMode=NATIVE"
+    val body =
+      if (useConsumerApplication.get()) {
+        """
             |# Generated by compose-ai-tools.
             |# useConsumerApplication=true — Robolectric falls back to the manifest-declared Application.
             |$sdkLine
             |$graphicsLine
             |$shadowsLine
-            |""".trimMargin()
-        } else {
-            """
+            |"""
+          .trimMargin()
+      } else {
+        """
             |# Generated by compose-ai-tools.
             |# Override the consumer's Application to a Robolectric-safe stub so
             |# preview rendering skips app-lifecycle side effects (DI, BridgingManager,
@@ -85,19 +80,18 @@ abstract class GenerateRobolectricPropertiesTask : DefaultTask() {
             |$sdkLine
             |$graphicsLine
             |$shadowsLine
-            |""".trimMargin()
-        }
-        file.writeText(body)
-    }
+            |"""
+          .trimMargin()
+      }
+    file.writeText(body)
+  }
 
-    companion object {
-        /**
-         * Android SDK level the renderer targets. Must match
-         * `renderer-android`'s `targetSdk` — Robolectric synthesizes a
-         * framework of this level, so a mismatch between this value and
-         * what the renderer compiles against surfaces as `NoSuchMethodError`
-         * on framework classes.
-         */
-        internal const val TARGET_SDK = 35
-    }
+  companion object {
+    /**
+     * Android SDK level the renderer targets. Must match `renderer-android`'s `targetSdk` —
+     * Robolectric synthesizes a framework of this level, so a mismatch between this value and what
+     * the renderer compiles against surfaces as `NoSuchMethodError` on framework classes.
+     */
+    internal const val TARGET_SDK = 35
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/HistorizePreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/HistorizePreviewsTask.kt
@@ -1,112 +1,116 @@
 package ee.schimke.composeai.plugin
 
-import kotlinx.serialization.json.Json
-import org.gradle.api.DefaultTask
-import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
-import org.gradle.api.tasks.TaskAction
-import org.gradle.work.DisableCachingByDefault
 import java.io.File
 import java.security.MessageDigest
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import kotlinx.serialization.json.Json
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
 
 /**
- * Archives a snapshot of each rendered preview into a per-preview history
- * folder (keyed by preview id), only when the PNG's SHA-256 differs from the
- * most recent archived entry. Timestamp-prefixed filenames sort
- * lexicographically, so "latest" = lexicographically max file.
+ * Archives a snapshot of each rendered preview into a per-preview history folder (keyed by preview
+ * id), only when the PNG's SHA-256 differs from the most recent archived entry. Timestamp-prefixed
+ * filenames sort lexicographically, so "latest" = lexicographically max file.
  *
- * The history directory is intentionally **not** declared as a task output:
- * it lives outside `build/` and must survive `./gradlew clean`. This makes
- * the task ineligible for build-cache restoration — we mark it disabled and
- * rely on its input bytes (renders + manifest) for up-to-date checks.
+ * The history directory is intentionally **not** declared as a task output: it lives outside
+ * `build/` and must survive `./gradlew clean`. This makes the task ineligible for build-cache
+ * restoration — we mark it disabled and rely on its input bytes (renders + manifest) for up-to-date
+ * checks.
  */
 @DisableCachingByDefault(because = "maintains persistent cross-build history outside build/")
 abstract class HistorizePreviewsTask : DefaultTask() {
 
-    @get:InputFile
-    @get:PathSensitive(PathSensitivity.NONE)
-    abstract val previewsJson: RegularFileProperty
+  @get:InputFile
+  @get:PathSensitive(PathSensitivity.NONE)
+  abstract val previewsJson: RegularFileProperty
 
-    @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val rendersDir: DirectoryProperty
+  @get:InputDirectory
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val rendersDir: DirectoryProperty
 
-    /** Intentionally @Internal — persistent across builds; not a Gradle-managed output. */
-    @get:Internal
-    abstract val historyDir: DirectoryProperty
+  /** Intentionally @Internal — persistent across builds; not a Gradle-managed output. */
+  @get:Internal abstract val historyDir: DirectoryProperty
 
-    @TaskAction
-    fun historize() {
-        val json = Json { ignoreUnknownKeys = true }
-        val manifest = json.decodeFromString<PreviewManifest>(previewsJson.get().asFile.readText())
+  @TaskAction
+  fun historize() {
+    val json = Json { ignoreUnknownKeys = true }
+    val manifest = json.decodeFromString<PreviewManifest>(previewsJson.get().asFile.readText())
 
-        val historyRoot = historyDir.get().asFile
-        val rendersRoot = rendersDir.get().asFile
-        val timestamp = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")
-            .withZone(ZoneOffset.UTC)
-            .format(ZonedDateTime.now(ZoneOffset.UTC))
+    val historyRoot = historyDir.get().asFile
+    val rendersRoot = rendersDir.get().asFile
+    val timestamp =
+      DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")
+        .withZone(ZoneOffset.UTC)
+        .format(ZonedDateTime.now(ZoneOffset.UTC))
 
-        var archived = 0
-        for (preview in manifest.previews) {
-            // Use the capture's renderOutput (module-relative, e.g.
-            // `renders/Foo.png`) rather than inferring from `preview.id`.
-            // Since discovery normalizes stems (strips package prefix,
-            // sanitizes shell-unsafe characters), the on-disk filename no
-            // longer matches `${id}.png`.
-            val relRender = preview.captures.firstOrNull()?.renderOutput
-                ?.substringAfter("renders/", missingDelimiterValue = "")
-                ?.takeIf { it.isNotEmpty() }
-                ?: continue
-            val currentRender = rendersRoot.resolve(relRender)
-            if (!currentRender.exists()) continue
+    var archived = 0
+    for (preview in manifest.previews) {
+      // Use the capture's renderOutput (module-relative, e.g.
+      // `renders/Foo.png`) rather than inferring from `preview.id`.
+      // Since discovery normalizes stems (strips package prefix,
+      // sanitizes shell-unsafe characters), the on-disk filename no
+      // longer matches `${id}.png`.
+      val relRender =
+        preview.captures
+          .firstOrNull()
+          ?.renderOutput
+          ?.substringAfter("renders/", missingDelimiterValue = "")
+          ?.takeIf { it.isNotEmpty() } ?: continue
+      val currentRender = rendersRoot.resolve(relRender)
+      if (!currentRender.exists()) continue
 
-            val previewFolder = historyRoot.resolve(sanitize(preview.id)).apply { mkdirs() }
-            val currentHash = sha256(currentRender.readBytes())
-            val latestHash = latestHashIn(previewFolder)
+      val previewFolder = historyRoot.resolve(sanitize(preview.id)).apply { mkdirs() }
+      val currentHash = sha256(currentRender.readBytes())
+      val latestHash = latestHashIn(previewFolder)
 
-            if (latestHash == currentHash) continue
+      if (latestHash == currentHash) continue
 
-            val dest = uniqueDest(previewFolder, timestamp)
-            currentRender.copyTo(dest)
-            archived++
-            logger.info("compose-preview history: archived ${preview.id} -> ${dest.name}")
-        }
-
-        logger.lifecycle("compose-preview history: archived $archived new snapshot(s) under $historyRoot")
+      val dest = uniqueDest(previewFolder, timestamp)
+      currentRender.copyTo(dest)
+      archived++
+      logger.info("compose-preview history: archived ${preview.id} -> ${dest.name}")
     }
 
-    private fun latestHashIn(dir: File): String? {
-        val latest = dir.listFiles { f -> f.isFile && f.extension == "png" }
-            ?.maxByOrNull { it.name }
-            ?: return null
-        return sha256(latest.readBytes())
-    }
+    logger.lifecycle(
+      "compose-preview history: archived $archived new snapshot(s) under $historyRoot"
+    )
+  }
 
-    /** If multiple renders happen inside the same second, append `-N` so filenames stay unique. */
-    private fun uniqueDest(dir: File, timestamp: String): File {
-        val primary = dir.resolve("$timestamp.png")
-        if (!primary.exists()) return primary
-        for (n in 1..999) {
-            val alt = dir.resolve("$timestamp-$n.png")
-            if (!alt.exists()) return alt
-        }
-        error("Too many history snapshots for timestamp $timestamp in ${dir.path}")
-    }
+  private fun latestHashIn(dir: File): String? {
+    val latest =
+      dir.listFiles { f -> f.isFile && f.extension == "png" }?.maxByOrNull { it.name }
+        ?: return null
+    return sha256(latest.readBytes())
+  }
 
-    private fun sha256(bytes: ByteArray): String {
-        val md = MessageDigest.getInstance("SHA-256")
-        return md.digest(bytes).joinToString("") { "%02x".format(it) }
+  /** If multiple renders happen inside the same second, append `-N` so filenames stay unique. */
+  private fun uniqueDest(dir: File, timestamp: String): File {
+    val primary = dir.resolve("$timestamp.png")
+    if (!primary.exists()) return primary
+    for (n in 1..999) {
+      val alt = dir.resolve("$timestamp-$n.png")
+      if (!alt.exists()) return alt
     }
+    error("Too many history snapshots for timestamp $timestamp in ${dir.path}")
+  }
 
-    private fun sanitize(id: String): String = buildString(id.length) {
-        for (c in id) append(if (c.isLetterOrDigit() || c == '.' || c == '_' || c == '-') c else '_')
+  private fun sha256(bytes: ByteArray): String {
+    val md = MessageDigest.getInstance("SHA-256")
+    return md.digest(bytes).joinToString("") { "%02x".format(it) }
+  }
+
+  private fun sanitize(id: String): String =
+    buildString(id.length) {
+      for (c in id) append(if (c.isLetterOrDigit() || c == '.' || c == '_' || c == '-') c else '_')
     }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PluginVersion.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PluginVersion.kt
@@ -4,18 +4,20 @@ import java.util.Properties
 
 /**
  * Plugin version baked into the jar by `generatePluginVersionResource` in
- * [gradle-plugin/build.gradle.kts]. Used to pick the matching published
- * `renderer-android` AAR version when a consumer applies the plugin via
- * Maven coordinates (rather than an includeBuild of this repo).
+ * [gradle-plugin/build.gradle.kts]. Used to pick the matching published `renderer-android` AAR
+ * version when a consumer applies the plugin via Maven coordinates (rather than an includeBuild of
+ * this repo).
  */
 internal object PluginVersion {
-    val value: String by lazy {
-        val props = Properties()
-        val stream = PluginVersion::class.java.classLoader
-            .getResourceAsStream("ee/schimke/composeai/plugin/plugin-version.properties")
-            ?: error("plugin-version.properties missing from plugin jar")
-        stream.use { props.load(it) }
-        props.getProperty("version")
-            ?: error("version property missing from plugin-version.properties")
-    }
+  val value: String by lazy {
+    val props = Properties()
+    val stream =
+      PluginVersion::class
+        .java
+        .classLoader
+        .getResourceAsStream("ee/schimke/composeai/plugin/plugin-version.properties")
+        ?: error("plugin-version.properties missing from plugin jar")
+    stream.use { props.load(it) }
+    props.getProperty("version") ?: error("version property missing from plugin-version.properties")
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -3,109 +3,101 @@ package ee.schimke.composeai.plugin
 import kotlinx.serialization.Serializable
 
 /**
- * Which @Preview flavour the entry came from. Drives renderer selection —
- * [COMPOSE] previews are `@Composable` functions invoked through the normal
- * Compose machinery; [TILE] previews are plain functions returning
- * `androidx.wear.tiles.tooling.preview.TilePreviewData` that need to be
+ * Which @Preview flavour the entry came from. Drives renderer selection — [COMPOSE] previews are
+ * `@Composable` functions invoked through the normal Compose machinery; [TILE] previews are plain
+ * functions returning `androidx.wear.tiles.tooling.preview.TilePreviewData` that need to be
  * inflated via `androidx.wear.tiles.renderer.TileRenderer`.
  */
 enum class PreviewKind {
-    COMPOSE,
-    TILE,
+  COMPOSE,
+  TILE,
 }
 
 /**
- * Mirrors `ee.schimke.composeai.preview.ScrollMode` from the `preview-annotations`
- * artifact. Duplicated here so the Gradle plugin can serialize the value into
- * `previews.json` without pulling the annotation artifact onto the plugin's
- * compile classpath — same split we use for [PreviewKind] across plugin /
- * renderer modules.
+ * Mirrors `ee.schimke.composeai.preview.ScrollMode` from the `preview-annotations` artifact.
+ * Duplicated here so the Gradle plugin can serialize the value into `previews.json` without pulling
+ * the annotation artifact onto the plugin's compile classpath — same split we use for [PreviewKind]
+ * across plugin / renderer modules.
  */
 enum class ScrollMode {
-    TOP,
-    END,
-    LONG,
-    GIF,
+  TOP,
+  END,
+  LONG,
+  GIF,
 }
 
 /** Mirrors `ee.schimke.composeai.preview.ScrollAxis`. */
 enum class ScrollAxis {
-    VERTICAL,
-    HORIZONTAL,
+  VERTICAL,
+  HORIZONTAL,
 }
 
 /**
- * Scroll state of a capture. Combines the intent sourced from
- * `@ScrollingPreview` ([mode], [axis], [maxScrollPx], [reduceMotion]) with the
- * outcome recorded by the renderer ([atEnd], [reachedPx]). `null` on
- * [Capture.scroll] means the capture didn't drive any scrollable.
+ * Scroll state of a capture. Combines the intent sourced from `@ScrollingPreview` ([mode], [axis],
+ * [maxScrollPx], [reduceMotion]) with the outcome recorded by the renderer ([atEnd], [reachedPx]).
+ * `null` on [Capture.scroll] means the capture didn't drive any scrollable.
  *
- * Result fields default to "not populated" so the plugin-side initial build
- * can emit this type before the renderer has run; the renderer overwrites
- * them post-capture (today it doesn't, pending a manifest-rewrite step —
- * they're here so the JSON shape is stable in advance).
+ * Result fields default to "not populated" so the plugin-side initial build can emit this type
+ * before the renderer has run; the renderer overwrites them post-capture (today it doesn't, pending
+ * a manifest-rewrite step — they're here so the JSON shape is stable in advance).
  */
 @Serializable
 data class ScrollCapture(
-    // Intent
-    val mode: ScrollMode,
-    val axis: ScrollAxis = ScrollAxis.VERTICAL,
-    val maxScrollPx: Int = 0,
-    val reduceMotion: Boolean = true,
-    /**
-     * Per-frame delay for [ScrollMode.GIF] output, in milliseconds. Ignored
-     * by other modes. `0` means "use the renderer's built-in default"
-     * (matches the annotation default).
-     */
-    val frameIntervalMs: Int = 0,
-    // Outcome
-    /**
-     * `true` when the scrollable reported it was already at the end of its
-     * content before the renderer stopped. Distinct from `reachedPx ==
-     * maxScrollPx`, which signals the user-set cap was hit without
-     * necessarily exhausting the content.
-     */
-    val atEnd: Boolean = false,
-    /** Pixels actually scrolled. `null` when not yet reported. */
-    val reachedPx: Int? = null,
+  // Intent
+  val mode: ScrollMode,
+  val axis: ScrollAxis = ScrollAxis.VERTICAL,
+  val maxScrollPx: Int = 0,
+  val reduceMotion: Boolean = true,
+  /**
+   * Per-frame delay for [ScrollMode.GIF] output, in milliseconds. Ignored by other modes. `0` means
+   * "use the renderer's built-in default" (matches the annotation default).
+   */
+  val frameIntervalMs: Int = 0,
+  // Outcome
+  /**
+   * `true` when the scrollable reported it was already at the end of its content before the
+   * renderer stopped. Distinct from `reachedPx == maxScrollPx`, which signals the user-set cap was
+   * hit without necessarily exhausting the content.
+   */
+  val atEnd: Boolean = false,
+  /** Pixels actually scrolled. `null` when not yet reported. */
+  val reachedPx: Int? = null,
 )
 
 /**
- * Animation capture state sourced from `@AnimatedPreview`. Carried as its
- * own field on [Capture] (orthogonal to [Capture.scroll] / [Capture.advanceTimeMillis])
- * so the renderer can switch on its presence without overloading the scroll
- * machinery. Output is always a single `.gif` plus an optional `<stem>_curves.png`
- * sidecar when [showCurves] is true.
+ * Animation capture state sourced from `@AnimatedPreview`. Carried as its own field on [Capture]
+ * (orthogonal to [Capture.scroll] / [Capture.advanceTimeMillis]) so the renderer can switch on its
+ * presence without overloading the scroll machinery. Output is always a single `.gif` plus an
+ * optional `<stem>_curves.png` sidecar when [showCurves] is true.
  */
 @Serializable
 data class AnimationCapture(
-    val durationMs: Int,
-    val frameIntervalMs: Int,
-    val showCurves: Boolean = false,
+  val durationMs: Int,
+  val frameIntervalMs: Int,
+  val showCurves: Boolean = false,
 )
 
 /**
- * Cost catalogue, normalised so a static `@Preview` (single compose pass +
- * one screenshot) is `1.0`. The discovery task stamps the right value onto
- * each [Capture]; tooling reads them back to throttle interactive renders.
+ * Cost catalogue, normalised so a static `@Preview` (single compose pass + one screenshot) is
+ * `1.0`. The discovery task stamps the right value onto each [Capture]; tooling reads them back to
+ * throttle interactive renders.
  *
  * Values are wall-time approximations (relative, not absolute):
  *
- *  - [STATIC_COST] / [SCROLL_TOP_COST] = 1 — one compose pass, one PNG.
- *  - [SCROLL_END_COST] ≈ 3 — single capture plus a scroll-drive prelude.
- *  - [SCROLL_LONG_COST] ≈ 20 — multi-slice stitched into a tall PNG.
- *  - [SCROLL_GIF_COST] ≈ 40 — many frames + GIF encode.
- *  - [ANIMATION_COST] ≈ 50 — `@AnimatedPreview` window: frame loop +
- *    optional curve strip + GIF encode. Frame counts vary slightly with
- *    the auto-detected duration, but the wall-time is dominated by the
- *    GIF encode, so a flat figure approximates well enough for tiering.
- *  - [ACCESSIBILITY_COST_PER_CAPTURE] = 4 — flat per-capture overhead
- *    when ATF runs (not stored on the manifest because it's a global
- *    runtime toggle; tooling adds it in when computing effective cost).
+ * - [STATIC_COST] / [SCROLL_TOP_COST] = 1 — one compose pass, one PNG.
+ * - [SCROLL_END_COST] ≈ 3 — single capture plus a scroll-drive prelude.
+ * - [SCROLL_LONG_COST] ≈ 20 — multi-slice stitched into a tall PNG.
+ * - [SCROLL_GIF_COST] ≈ 40 — many frames + GIF encode.
+ * - [ANIMATION_COST] ≈ 50 — `@AnimatedPreview` window: frame loop + optional curve strip + GIF
+ *   encode. Frame counts vary slightly with the auto-detected duration, but the wall-time is
+ *   dominated by the GIF encode, so a flat figure approximates well enough for tiering.
+ * - [ACCESSIBILITY_COST_PER_CAPTURE] = 4 — flat per-capture overhead when ATF runs (not stored on
+ *   the manifest because it's a global runtime toggle; tooling adds it in when computing effective
+ *   cost).
  *
- * [HEAVY_COST_THRESHOLD] sits above END (3) and below LONG (20), so the
- * cheap-enough-for-every-save bucket includes static + TOP + END, and
- * LONG / GIF / animated captures fall into the on-demand "heavy" bucket.
+ * [HEAVY_COST_THRESHOLD] sits above END (3) and below LONG (20), so the cheap-enough-for-every-save
+ * bucket includes static + TOP + END, and LONG / GIF / animated captures fall into the on-demand
+ * "heavy" bucket.
  */
 const val STATIC_COST: Float = 1.0f
 const val SCROLL_TOP_COST: Float = 1.0f
@@ -117,121 +109,115 @@ const val ACCESSIBILITY_COST_PER_CAPTURE: Float = 4.0f
 const val HEAVY_COST_THRESHOLD: Float = 5.0f
 
 /**
- * Returns `true` when [cost] exceeds [HEAVY_COST_THRESHOLD]. Single seam so
- * the plugin, renderer, and VS Code extension all agree on which captures
- * the interactive save loop should skip — there's no separate enum field
- * on the manifest, just the numeric cost.
+ * Returns `true` when [cost] exceeds [HEAVY_COST_THRESHOLD]. Single seam so the plugin, renderer,
+ * and VS Code extension all agree on which captures the interactive save loop should skip — there's
+ * no separate enum field on the manifest, just the numeric cost.
  */
 fun isHeavyCost(cost: Float): Boolean = cost > HEAVY_COST_THRESHOLD
 
 @Serializable
 data class PreviewParams(
-    val name: String? = null,
-    val device: String? = null,
-    val widthDp: Int? = null,
-    val heightDp: Int? = null,
-    /**
-     * Compose density factor (= densityDpi / 160), resolved from the `@Preview`
-     * device or `spec:...,dpi=...` at discovery time. `null` means the renderer
-     * should fall back to its built-in default.
-     *
-     * Renderers map this to a Robolectric `<n>dpi` qualifier so output bitmap
-     * dimensions match what Android Studio renders for the same `@Preview` —
-     * the `xxhdpi`-class phones it pictures by default come out at ~2.625x, not
-     * the 2.0x `xhdpi` Robolectric otherwise picks.
-     */
-    val density: Float? = null,
-    val fontScale: Float = 1.0f,
-    val showSystemUi: Boolean = false,
-    val showBackground: Boolean = false,
-    val backgroundColor: Long = 0,
-    val uiMode: Int = 0,
-    val locale: String? = null,
-    val group: String? = null,
-    /** FQN of the `PreviewWrapperProvider` from `@PreviewWrapper`, if any. */
-    val wrapperClassName: String? = null,
-    /**
-     * FQN of a `PreviewParameterProvider` from `@PreviewParameter` on one of the
-     * preview function's parameters, if any. Discovery only records the spec —
-     * the renderer instantiates the provider, enumerates its `values` (capped
-     * by [previewParameterLimit]), and fans out one rendered file per value
-     * with a `_PARAM_<idx>` suffix inserted before the extension.
-     *
-     * We intentionally do not expand at discovery time: the plugin's own
-     * classpath doesn't have the consumer's Compose dependencies, so loading
-     * the provider would require rebuilding the consumer's classloader from
-     * scratch. Leaving fan-out to the renderer keeps discovery classpath-cheap.
-     */
-    val previewParameterProviderClassName: String? = null,
-    /**
-     * Mirrors `@PreviewParameter.limit`. `Int.MAX_VALUE` is the annotation
-     * default — the renderer takes every value the provider yields. Applied
-     * via `values.take(limit)` so providers backed by infinite sequences stay
-     * bounded.
-     */
-    val previewParameterLimit: Int = Int.MAX_VALUE,
-    val kind: PreviewKind = PreviewKind.COMPOSE,
+  val name: String? = null,
+  val device: String? = null,
+  val widthDp: Int? = null,
+  val heightDp: Int? = null,
+  /**
+   * Compose density factor (= densityDpi / 160), resolved from the `@Preview` device or
+   * `spec:...,dpi=...` at discovery time. `null` means the renderer should fall back to its
+   * built-in default.
+   *
+   * Renderers map this to a Robolectric `<n>dpi` qualifier so output bitmap dimensions match what
+   * Android Studio renders for the same `@Preview` — the `xxhdpi`-class phones it pictures by
+   * default come out at ~2.625x, not the 2.0x `xhdpi` Robolectric otherwise picks.
+   */
+  val density: Float? = null,
+  val fontScale: Float = 1.0f,
+  val showSystemUi: Boolean = false,
+  val showBackground: Boolean = false,
+  val backgroundColor: Long = 0,
+  val uiMode: Int = 0,
+  val locale: String? = null,
+  val group: String? = null,
+  /** FQN of the `PreviewWrapperProvider` from `@PreviewWrapper`, if any. */
+  val wrapperClassName: String? = null,
+  /**
+   * FQN of a `PreviewParameterProvider` from `@PreviewParameter` on one of the preview function's
+   * parameters, if any. Discovery only records the spec — the renderer instantiates the provider,
+   * enumerates its `values` (capped by [previewParameterLimit]), and fans out one rendered file per
+   * value with a `_PARAM_<idx>` suffix inserted before the extension.
+   *
+   * We intentionally do not expand at discovery time: the plugin's own classpath doesn't have the
+   * consumer's Compose dependencies, so loading the provider would require rebuilding the
+   * consumer's classloader from scratch. Leaving fan-out to the renderer keeps discovery
+   * classpath-cheap.
+   */
+  val previewParameterProviderClassName: String? = null,
+  /**
+   * Mirrors `@PreviewParameter.limit`. `Int.MAX_VALUE` is the annotation default — the renderer
+   * takes every value the provider yields. Applied via `values.take(limit)` so providers backed by
+   * infinite sequences stay bounded.
+   */
+  val previewParameterLimit: Int = Int.MAX_VALUE,
+  val kind: PreviewKind = PreviewKind.COMPOSE,
 )
 
 /**
- * One rendered snapshot of a preview at a specific point in some dimensional
- * space. The non-null fields on a [Capture] *are* its dimensions: a static
- * preview has a single capture with everything null; a
- * `@RoboComposePreviewOptions`-annotated preview produces N captures differing
- * only in [advanceTimeMillis]; a `@ScrollingPreview` produces a capture with
- * [scroll] set; a preview annotated with both produces the cross-product.
+ * One rendered snapshot of a preview at a specific point in some dimensional space. The non-null
+ * fields on a [Capture] *are* its dimensions: a static preview has a single capture with everything
+ * null; a `@RoboComposePreviewOptions`-annotated preview produces N captures differing only in
+ * [advanceTimeMillis]; a `@ScrollingPreview` produces a capture with [scroll] set; a preview
+ * annotated with both produces the cross-product.
  *
- * The JSON carries each dimension as a typed field rather than a generic
- * `dimensions: map` so agent consumers of `previews.json` can read specific
- * knobs without traversing an untyped structure.
+ * The JSON carries each dimension as a typed field rather than a generic `dimensions: map` so agent
+ * consumers of `previews.json` can read specific knobs without traversing an untyped structure.
  */
 @Serializable
 data class Capture(
-    /** `null` → no explicit `mainClock.advanceTimeBy` before capture (renderer applies its default step). */
-    val advanceTimeMillis: Long? = null,
-    /** `null` → no scroll drive. */
-    val scroll: ScrollCapture? = null,
-    /** `null` → not an animation capture. Mutually exclusive with [scroll] in practice. */
-    val animation: AnimationCapture? = null,
-    /** Module-relative PNG path, e.g. `renders/<preview id>_TIME_500ms.png`. */
-    val renderOutput: String = "",
-    /**
-     * Estimated render cost, normalised so a static `@Preview` is `1.0`.
-     * See the cost catalogue at the top of this file ([STATIC_COST],
-     * [SCROLL_LONG_COST], [ANIMATION_COST], …) for the figures the
-     * discovery task stamps in. Defaults to `1.0` so older manifests
-     * (pre-cost field) parse as cheap-everywhere and older tooling keeps
-     * its historical "render everything on every save" behaviour.
-     */
-    val cost: Float = STATIC_COST,
+  /**
+   * `null` → no explicit `mainClock.advanceTimeBy` before capture (renderer applies its default
+   * step).
+   */
+  val advanceTimeMillis: Long? = null,
+  /** `null` → no scroll drive. */
+  val scroll: ScrollCapture? = null,
+  /** `null` → not an animation capture. Mutually exclusive with [scroll] in practice. */
+  val animation: AnimationCapture? = null,
+  /** Module-relative PNG path, e.g. `renders/<preview id>_TIME_500ms.png`. */
+  val renderOutput: String = "",
+  /**
+   * Estimated render cost, normalised so a static `@Preview` is `1.0`. See the cost catalogue at
+   * the top of this file ([STATIC_COST], [SCROLL_LONG_COST], [ANIMATION_COST], …) for the figures
+   * the discovery task stamps in. Defaults to `1.0` so older manifests (pre-cost field) parse as
+   * cheap-everywhere and older tooling keeps its historical "render everything on every save"
+   * behaviour.
+   */
+  val cost: Float = STATIC_COST,
 )
 
 @Serializable
 data class PreviewInfo(
-    val id: String,
-    val functionName: String,
-    val className: String,
-    val sourceFile: String? = null,
-    val params: PreviewParams = PreviewParams(),
-    /**
-     * All snapshots this preview produces. Always at least one element:
-     * a static preview has a single capture with null dimensions; an
-     * animated / scrolled preview can have many.
-     */
-    val captures: List<Capture> = listOf(Capture()),
+  val id: String,
+  val functionName: String,
+  val className: String,
+  val sourceFile: String? = null,
+  val params: PreviewParams = PreviewParams(),
+  /**
+   * All snapshots this preview produces. Always at least one element: a static preview has a single
+   * capture with null dimensions; an animated / scrolled preview can have many.
+   */
+  val captures: List<Capture> = listOf(Capture()),
 )
 
 @Serializable
 data class PreviewManifest(
-    val module: String,
-    val variant: String,
-    val previews: List<PreviewInfo>,
-    /**
-     * Relative path (from this manifest's parent directory) to a sidecar
-     * accessibility report JSON, when `composePreview.accessibilityChecks.enabled`
-     * is `true`. `null` signals the feature is off — downstream tools should
-     * treat the absence of this pointer as "no a11y data" rather than probing
-     * for the file on disk.
-     */
-    val accessibilityReport: String? = null,
+  val module: String,
+  val variant: String,
+  val previews: List<PreviewInfo>,
+  /**
+   * Relative path (from this manifest's parent directory) to a sidecar accessibility report JSON,
+   * when `composePreview.accessibilityChecks.enabled` is `true`. `null` signals the feature is off
+   * — downstream tools should treat the absence of this pointer as "no a11y data" rather than
+   * probing for the file on disk.
+   */
+  val accessibilityReport: String? = null,
 )

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -1,152 +1,139 @@
 package ee.schimke.composeai.plugin
 
+import javax.inject.Inject
 import org.gradle.api.Action
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
-import javax.inject.Inject
 
 abstract class PreviewExtension @Inject constructor(private val objects: ObjectFactory) {
-    val variant: Property<String> = objects.property(String::class.java).convention("debug")
-    val sdkVersion: Property<Int> = objects.property(Int::class.java).convention(35)
-    val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
+  val variant: Property<String> = objects.property(String::class.java).convention("debug")
+  val sdkVersion: Property<Int> = objects.property(Int::class.java).convention(35)
+  val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 
-    /**
-     * When true, each `renderAllPreviews` run archives every rendered PNG whose
-     * content differs from the most recent entry into [historyDir]. Default: false.
-     */
-    val historyEnabled: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+  /**
+   * When true, each `renderAllPreviews` run archives every rendered PNG whose content differs from
+   * the most recent entry into [historyDir]. Default: false.
+   */
+  val historyEnabled: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-    /**
-     * Root directory for preview history snapshots. Each preview gets a
-     * subfolder named after its id; inside, filenames are timestamps.
-     * Lives outside `build/` by default so `./gradlew clean` doesn't wipe it.
-     */
-    val historyDir: DirectoryProperty = objects.directoryProperty()
+  /**
+   * Root directory for preview history snapshots. Each preview gets a subfolder named after its id;
+   * inside, filenames are timestamps. Lives outside `build/` by default so `./gradlew clean`
+   * doesn't wipe it.
+   */
+  val historyDir: DirectoryProperty = objects.directoryProperty()
 
-    /**
-     * Number of parallel JVM forks used to render previews. Default 1 (no sharding).
-     *
-     * Special values:
-     *  - `1` (default): no sharding; a single JVM renders every preview.
-     *  - `0`: auto — the plugin picks a shard count based on the discovered
-     *    preview count and available CPU cores, using [ShardTuning]'s cost
-     *    model. Falls back to 1 if previews.json hasn't been generated yet.
-     *  - `≥2`: explicit shard count.
-     *
-     * Each shard runs a generated `RobolectricRenderTest_ShardN` subclass with its
-     * own slice of the manifest (round-robin partition). Within a shard, the
-     * Robolectric sandbox is reused across that shard's previews; across shards
-     * each JVM pays its own ~3–4s cold-start cost, so sharding is a net win only
-     * when the module has enough previews to amortise that overhead.
-     */
-    val shards: Property<Int> = objects.property(Int::class.java).convention(1)
+  /**
+   * Number of parallel JVM forks used to render previews. Default 1 (no sharding).
+   *
+   * Special values:
+   * - `1` (default): no sharding; a single JVM renders every preview.
+   * - `0`: auto — the plugin picks a shard count based on the discovered preview count and
+   *   available CPU cores, using [ShardTuning]'s cost model. Falls back to 1 if previews.json
+   *   hasn't been generated yet.
+   * - `≥2`: explicit shard count.
+   *
+   * Each shard runs a generated `RobolectricRenderTest_ShardN` subclass with its own slice of the
+   * manifest (round-robin partition). Within a shard, the Robolectric sandbox is reused across that
+   * shard's previews; across shards each JVM pays its own ~3–4s cold-start cost, so sharding is a
+   * net win only when the module has enough previews to amortise that overhead.
+   */
+  val shards: Property<Int> = objects.property(Int::class.java).convention(1)
 
-    /**
-     * When `true`, Robolectric instantiates the consumer's manifest-declared
-     * `Application` class (e.g. `MyApp : Application()`) before rendering each
-     * preview. Default: `false` — the renderer installs a plain
-     * `android.app.Application` via a generated package-level
-     * `robolectric.properties`, so consumer-side init (DI containers,
-     * `BridgingManager.setConfig`, Firebase bootstrap, WorkManager scheduling,
-     * …) does NOT run during preview rendering.
-     *
-     * Stub by default because Application-level init routinely fails in
-     * Robolectric — it depends on platform features the sandbox doesn't
-     * emulate (Play Services, Firebase, Wear `FEATURE_WATCH`). Previews
-     * should be self-contained composables anyway, not coupled to
-     * app-lifecycle state.
-     *
-     * Flip to `true` only if your previews genuinely depend on your
-     * custom Application being constructed (rare) — and expect to supply
-     * a Robolectric-safe subclass guarded against unsupported APIs.
-     */
-    val useConsumerApplication: Property<Boolean> =
-        objects.property(Boolean::class.java).convention(false)
+  /**
+   * When `true`, Robolectric instantiates the consumer's manifest-declared `Application` class
+   * (e.g. `MyApp : Application()`) before rendering each preview. Default: `false` — the renderer
+   * installs a plain `android.app.Application` via a generated package-level
+   * `robolectric.properties`, so consumer-side init (DI containers, `BridgingManager.setConfig`,
+   * Firebase bootstrap, WorkManager scheduling, …) does NOT run during preview rendering.
+   *
+   * Stub by default because Application-level init routinely fails in Robolectric — it depends on
+   * platform features the sandbox doesn't emulate (Play Services, Firebase, Wear `FEATURE_WATCH`).
+   * Previews should be self-contained composables anyway, not coupled to app-lifecycle state.
+   *
+   * Flip to `true` only if your previews genuinely depend on your custom Application being
+   * constructed (rare) — and expect to supply a Robolectric-safe subclass guarded against
+   * unsupported APIs.
+   */
+  val useConsumerApplication: Property<Boolean> =
+    objects.property(Boolean::class.java).convention(false)
 
-    /**
-     * When `true`, `discoverPreviews` fails the build if it finds zero
-     * `@Preview`-annotated functions and emits a diagnostics block to the
-     * lifecycle log (classDirs entries with class-file counts, a sample of
-     * post-filter dependency JARs, the ClassGraph scan summary, and — if
-     * classes WERE scanned but no previews matched — the annotation FQNs
-     * observed so users can see whether a different-FQN `@Preview` is in
-     * use). Default: `false`, so existing empty modules stay silent.
-     *
-     * Intended mainly for CI (catch a silent regression where a wiring
-     * change drops every preview) and for triaging "0 previews discovered"
-     * reports — hence the double duty: the flag that fails the build also
-     * turns on the logging you need to know why it failed.
-     *
-     * Override at the command line with
-     * `-PcomposePreview.failOnEmpty=true` to flip for a single run without
-     * editing `build.gradle.kts`.
-     */
-    val failOnEmpty: Property<Boolean> =
-        objects.property(Boolean::class.java).convention(false)
+  /**
+   * When `true`, `discoverPreviews` fails the build if it finds zero `@Preview`-annotated functions
+   * and emits a diagnostics block to the lifecycle log (classDirs entries with class-file counts, a
+   * sample of post-filter dependency JARs, the ClassGraph scan summary, and — if classes WERE
+   * scanned but no previews matched — the annotation FQNs observed so users can see whether a
+   * different-FQN `@Preview` is in use). Default: `false`, so existing empty modules stay silent.
+   *
+   * Intended mainly for CI (catch a silent regression where a wiring change drops every preview)
+   * and for triaging "0 previews discovered" reports — hence the double duty: the flag that fails
+   * the build also turns on the logging you need to know why it failed.
+   *
+   * Override at the command line with `-PcomposePreview.failOnEmpty=true` to flip for a single run
+   * without editing `build.gradle.kts`.
+   */
+  val failOnEmpty: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-    /**
-     * When `true` (default), the plugin auto-adds the test/runtime
-     * dependencies it needs (`androidx.compose.ui:ui-test-manifest`,
-     * `:ui-test-junit4`, and conditionally `androidx.wear.tiles:tiles-renderer`)
-     * to the consumer's classpath. When `false`, the plugin injects
-     * nothing and instead requires the consumer to declare every
-     * required coordinate themselves — `composePreviewDoctor` lists
-     * anything missing, and `discoverPreviews` / the render task fail
-     * fast with the exact coordinates to add.
-     *
-     * Flip to `false` in projects that enforce strict, explicit dependency
-     * management (version-catalog-only, custom BOMs, or consumers that
-     * require review before any plugin mutates their graph). Backwards-
-     * compatible default keeps existing builds working unchanged.
-     */
-    val manageDependencies: Property<Boolean> =
-        objects.property(Boolean::class.java).convention(true)
+  /**
+   * When `true` (default), the plugin auto-adds the test/runtime dependencies it needs
+   * (`androidx.compose.ui:ui-test-manifest`, `:ui-test-junit4`, and conditionally
+   * `androidx.wear.tiles:tiles-renderer`) to the consumer's classpath. When `false`, the plugin
+   * injects nothing and instead requires the consumer to declare every required coordinate
+   * themselves — `composePreviewDoctor` lists anything missing, and `discoverPreviews` / the render
+   * task fail fast with the exact coordinates to add.
+   *
+   * Flip to `false` in projects that enforce strict, explicit dependency management
+   * (version-catalog-only, custom BOMs, or consumers that require review before any plugin mutates
+   * their graph). Backwards- compatible default keeps existing builds working unchanged.
+   */
+  val manageDependencies: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 
-    /**
-     * ATF (Accessibility Test Framework) checks, run against each rendered
-     * preview. Off by default — turning it on surfaces findings in the CLI,
-     * VSCode diagnostics, and `accessibility.json`, but does NOT break the
-     * build. Set `failOnErrors = true` / `failOnWarnings = true` to gate
-     * builds on findings.
-     *
-     *     composePreview {
-     *         accessibilityChecks {
-     *             enabled = true
-     *             failOnErrors = true  // opt in to build gating
-     *         }
-     *     }
-     */
-    val accessibilityChecks: AccessibilityChecksExtension =
-        objects.newInstance(AccessibilityChecksExtension::class.java)
+  /**
+   * ATF (Accessibility Test Framework) checks, run against each rendered preview. Off by default —
+   * turning it on surfaces findings in the CLI, VSCode diagnostics, and `accessibility.json`, but
+   * does NOT break the build. Set `failOnErrors = true` / `failOnWarnings = true` to gate builds on
+   * findings.
+   *
+   *     composePreview {
+   *         accessibilityChecks {
+   *             enabled = true
+   *             failOnErrors = true  // opt in to build gating
+   *         }
+   *     }
+   */
+  val accessibilityChecks: AccessibilityChecksExtension =
+    objects.newInstance(AccessibilityChecksExtension::class.java)
 
-    fun accessibilityChecks(action: Action<AccessibilityChecksExtension>) {
-        action.execute(accessibilityChecks)
-    }
+  fun accessibilityChecks(action: Action<AccessibilityChecksExtension>) {
+    action.execute(accessibilityChecks)
+  }
 }
 
 abstract class AccessibilityChecksExtension @Inject constructor(objects: ObjectFactory) {
-    /** Default: `false`. Enabling turns on ATF checks and the `verifyAccessibility` task. */
-    val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+  /** Default: `false`. Enabling turns on ATF checks and the `verifyAccessibility` task. */
+  val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-    /**
-     * Fail the build if any ERROR-level ATF finding is reported. Default:
-     * `false` — findings are reported (logged, written to the JSON report,
-     * surfaced as CLI/VSCode diagnostics) but do not fail the build unless
-     * the consumer explicitly opts in. That way turning on `enabled` is a
-     * safe, purely additive change.
-     */
-    val failOnErrors: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+  /**
+   * Fail the build if any ERROR-level ATF finding is reported. Default: `false` — findings are
+   * reported (logged, written to the JSON report, surfaced as CLI/VSCode diagnostics) but do not
+   * fail the build unless the consumer explicitly opts in. That way turning on `enabled` is a safe,
+   * purely additive change.
+   */
+  val failOnErrors: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-    /** Fail the build if any WARNING-level ATF finding is reported. Default: `false` (same rationale as [failOnErrors]). */
-    val failOnWarnings: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+  /**
+   * Fail the build if any WARNING-level ATF finding is reported. Default: `false` (same rationale
+   * as [failOnErrors]).
+   */
+  val failOnWarnings: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
 
-    /**
-     * Generate an annotated screenshot per preview showing each finding as a
-     * numbered badge + legend panel. Costs ~10ms/preview when there are
-     * findings, zero when there aren't. Default: `true` — if you asked for
-     * checks, you probably want to see what they found. Set to `false` for
-     * CI jobs that only care about the JSON / fail-on-errors gate.
-     */
-    val annotateScreenshots: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
+  /**
+   * Generate an annotated screenshot per preview showing each finding as a numbered badge + legend
+   * panel. Costs ~10ms/preview when there are findings, zero when there aren't. Default: `true` —
+   * if you asked for checks, you probably want to see what they found. Set to `false` for CI jobs
+   * that only care about the JSON / fail-on-errors gate.
+   */
+  val annotateScreenshots: Property<Boolean> =
+    objects.property(Boolean::class.java).convention(true)
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewWorker.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewWorker.kt
@@ -1,52 +1,52 @@
 package ee.schimke.composeai.plugin
 
+import java.awt.Color
+import java.awt.image.BufferedImage
+import javax.imageio.ImageIO
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
-import java.awt.Color
-import java.awt.image.BufferedImage
-import javax.imageio.ImageIO
 
 interface PreviewRenderParams : WorkParameters {
-    val className: Property<String>
-    val functionName: Property<String>
-    val widthDp: Property<Int>
-    val heightDp: Property<Int>
-    /**
-     * Compose density factor (= densityDpi / 160). Sized via DeviceDimensions
-     * from the `@Preview` device, so stub PNGs scale the same way the real
-     * Android renderer would (and Android Studio does).
-     */
-    val density: Property<Float>
-    val fontScale: Property<Float>
-    val showBackground: Property<Boolean>
-    val backgroundColor: Property<Long>
-    val outputFile: RegularFileProperty
-    val backend: Property<String>
+  val className: Property<String>
+  val functionName: Property<String>
+  val widthDp: Property<Int>
+  val heightDp: Property<Int>
+  /**
+   * Compose density factor (= densityDpi / 160). Sized via DeviceDimensions from the `@Preview`
+   * device, so stub PNGs scale the same way the real Android renderer would (and Android Studio
+   * does).
+   */
+  val density: Property<Float>
+  val fontScale: Property<Float>
+  val showBackground: Property<Boolean>
+  val backgroundColor: Property<Long>
+  val outputFile: RegularFileProperty
+  val backend: Property<String>
 }
 
 abstract class PreviewRenderWorkAction : WorkAction<PreviewRenderParams> {
-    override fun execute() {
-        val p = parameters
-        val density = p.density.getOrElse(DeviceDimensions.DEFAULT_DENSITY)
-        val width = (p.widthDp.get() * density).toInt().coerceAtLeast(1)
-        val height = (p.heightDp.get() * density).toInt().coerceAtLeast(1)
-        val outFile = p.outputFile.get().asFile
-        outFile.parentFile?.mkdirs()
+  override fun execute() {
+    val p = parameters
+    val density = p.density.getOrElse(DeviceDimensions.DEFAULT_DENSITY)
+    val width = (p.widthDp.get() * density).toInt().coerceAtLeast(1)
+    val height = (p.heightDp.get() * density).toInt().coerceAtLeast(1)
+    val outFile = p.outputFile.get().asFile
+    outFile.parentFile?.mkdirs()
 
-        val img = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
-        val g = img.createGraphics()
-        try {
-            val bgLong = p.backgroundColor.get()
-            if (p.showBackground.get() || bgLong != 0L) {
-                val argb = if (bgLong != 0L) bgLong.toInt() else 0xFFFFFFFF.toInt()
-                g.color = Color(argb, true)
-                g.fillRect(0, 0, width, height)
-            }
-        } finally {
-            g.dispose()
-        }
-        ImageIO.write(img, "PNG", outFile)
+    val img = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+    val g = img.createGraphics()
+    try {
+      val bgLong = p.backgroundColor.get()
+      if (p.showBackground.get() || bgLong != 0L) {
+        val argb = if (bgLong != 0L) bgLong.toInt() else 0xFFFFFFFF.toInt()
+        g.color = Color(argb, true)
+        g.fillRect(0, 0, width, height)
+      }
+    } finally {
+      g.dispose()
     }
+    ImageIO.write(img, "PNG", outFile)
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/RenderPreviewsTask.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin
 
+import javax.inject.Inject
 import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
@@ -16,186 +17,187 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
 import org.gradle.workers.WorkerExecutor
-import javax.inject.Inject
 
 @CacheableTask
 abstract class RenderPreviewsTask : DefaultTask() {
 
-    @get:InputFile
-    @get:PathSensitive(PathSensitivity.NONE)
-    abstract val previewsJson: RegularFileProperty
+  @get:InputFile
+  @get:PathSensitive(PathSensitivity.NONE)
+  abstract val previewsJson: RegularFileProperty
 
-    @get:Input
-    abstract val renderBackend: Property<String>
+  @get:Input abstract val renderBackend: Property<String>
 
-    @get:Input
-    abstract val useComposeRenderer: Property<Boolean>
+  @get:Input abstract val useComposeRenderer: Property<Boolean>
 
-    /**
-     * Render-tier filter. When `"fast"` the desktop / stub path skips any
-     * preview whose representative capture is heavier than
-     * [HEAVY_COST_THRESHOLD] (TOP / static stay in; LONG / GIF / animated
-     * fall out). Default `"full"` keeps the historical behaviour (every
-     * preview rendered).
-     */
-    @get:Input
-    abstract val tier: Property<String>
+  /**
+   * Render-tier filter. When `"fast"` the desktop / stub path skips any preview whose
+   * representative capture is heavier than [HEAVY_COST_THRESHOLD] (TOP / static stay in; LONG / GIF
+   * / animated fall out). Default `"full"` keeps the historical behaviour (every preview rendered).
+   */
+  @get:Input abstract val tier: Property<String>
 
-    @get:Classpath
-    abstract val renderClasspath: ConfigurableFileCollection
+  @get:Classpath abstract val renderClasspath: ConfigurableFileCollection
 
-    @get:OutputDirectory
-    abstract val outputDir: DirectoryProperty
+  @get:OutputDirectory abstract val outputDir: DirectoryProperty
 
-    @get:Inject
-    abstract val execOperations: ExecOperations
+  @get:Inject abstract val execOperations: ExecOperations
 
-    @get:Inject
-    abstract val workerExecutor: WorkerExecutor
+  @get:Inject abstract val workerExecutor: WorkerExecutor
 
-    init {
-        // Caching is intentionally gated on `tier=full`: a `tier=fast` run
-        // only writes a subset of captures (fast ones), so a build-cache
-        // restore from a fast snapshot would *wipe* the previous full run's
-        // heavy outputs from `outputDir` — exactly the stale images the
-        // interactive UI relies on. Up-to-date checks still apply, so a
-        // re-run with no input changes is a no-op and the renders directory
-        // stays as-is regardless of tier.
-        outputs.cacheIf("renderPreviews caches tier=full runs only") {
-            tier.get().equals("full", ignoreCase = true)
+  init {
+    // Caching is intentionally gated on `tier=full`: a `tier=fast` run
+    // only writes a subset of captures (fast ones), so a build-cache
+    // restore from a fast snapshot would *wipe* the previous full run's
+    // heavy outputs from `outputDir` — exactly the stale images the
+    // interactive UI relies on. Up-to-date checks still apply, so a
+    // re-run with no input changes is a no-op and the renders directory
+    // stays as-is regardless of tier.
+    outputs.cacheIf("renderPreviews caches tier=full runs only") {
+      tier.get().equals("full", ignoreCase = true)
+    }
+  }
+
+  @TaskAction
+  fun render() {
+    val json = Json { ignoreUnknownKeys = true }
+    val rawManifest = json.decodeFromString<PreviewManifest>(previewsJson.get().asFile.readText())
+
+    // Tier filter — drop previews whose representative capture is heavy
+    // when running in `fast` mode. The desktop / stub path renders just
+    // the first capture per preview, so the decision is per-preview
+    // rather than per-capture (unlike the Robolectric path which can
+    // pick and choose among an entry's captures). Skipped previews keep
+    // their previous PNG on disk (referenced by the manifest, untouched
+    // by `cleanStaleRenders`) so VS Code can still display the stale
+    // image with its badge.
+    val isFastTier = tier.get().equals("fast", ignoreCase = true)
+    val previews =
+      if (!isFastTier) rawManifest.previews
+      else
+        rawManifest.previews.filter {
+          val firstCost = it.captures.firstOrNull()?.cost ?: STATIC_COST
+          !isHeavyCost(firstCost)
         }
+    val manifest = if (isFastTier) rawManifest.copy(previews = previews) else rawManifest
+
+    if (manifest.previews.isEmpty()) {
+      logger.lifecycle("No previews to render.")
+      return
     }
 
-    @TaskAction
-    fun render() {
-        val json = Json { ignoreUnknownKeys = true }
-        val rawManifest = json.decodeFromString<PreviewManifest>(previewsJson.get().asFile.readText())
+    val outDir = outputDir.get().asFile
+    outDir.mkdirs()
 
-        // Tier filter — drop previews whose representative capture is heavy
-        // when running in `fast` mode. The desktop / stub path renders just
-        // the first capture per preview, so the decision is per-preview
-        // rather than per-capture (unlike the Robolectric path which can
-        // pick and choose among an entry's captures). Skipped previews keep
-        // their previous PNG on disk (referenced by the manifest, untouched
-        // by `cleanStaleRenders`) so VS Code can still display the stale
-        // image with its badge.
-        val isFastTier = tier.get().equals("fast", ignoreCase = true)
-        val previews = if (!isFastTier) rawManifest.previews else rawManifest.previews.filter {
-            val firstCost = it.captures.firstOrNull()?.cost ?: STATIC_COST
-            !isHeavyCost(firstCost)
-        }
-        val manifest = if (isFastTier) rawManifest.copy(previews = previews) else rawManifest
-
-        if (manifest.previews.isEmpty()) {
-            logger.lifecycle("No previews to render.")
-            return
-        }
-
-        val outDir = outputDir.get().asFile
-        outDir.mkdirs()
-
-        if (useComposeRenderer.get()) {
-            renderWithCompose(manifest, outDir)
-        } else {
-            renderWithStub(manifest, outDir)
-        }
-
-        val tierTag = if (isFastTier) " (fast tier; ${rawManifest.previews.size - manifest.previews.size} heavy skipped)" else ""
-        logger.lifecycle("Rendered ${manifest.previews.size} preview(s)$tierTag")
+    if (useComposeRenderer.get()) {
+      renderWithCompose(manifest, outDir)
+    } else {
+      renderWithStub(manifest, outDir)
     }
 
-    private fun renderWithCompose(manifest: PreviewManifest, outDir: java.io.File) {
-        // This path is only used for desktop rendering.
-        // Android rendering uses a separate Test-type task (see ComposePreviewPlugin).
-        val mainClass = "ee.schimke.composeai.renderer.DesktopRendererMainKt"
+    val tierTag =
+      if (isFastTier)
+        " (fast tier; ${rawManifest.previews.size - manifest.previews.size} heavy skipped)"
+      else ""
+    logger.lifecycle("Rendered ${manifest.previews.size} preview(s)$tierTag")
+  }
 
-        for (preview in manifest.previews) {
-            val spec = DeviceDimensions.resolveForRender(
-                device = preview.params.device,
-                widthDp = preview.params.widthDp,
-                heightDp = preview.params.heightDp,
-                showSystemUi = preview.params.showSystemUi,
-            )
-            // Per-device density (= densityDpi / 160), so output bitmaps match
-            // what Android Studio renders for the same `@Preview`. Source: the
-            // same data sergio-sastre/ComposablePreviewScanner /
-            // takahirom/roborazzi consume. Discovery pins `params.density` when
-            // a device/showSystemUi frame applies; the wrap-content path leaves
-            // it null and we fall back to `spec.density` (= DEFAULT_DENSITY).
-            val density = preview.params.density ?: spec.density
-            val widthPx = (spec.widthDp * density).toInt().coerceAtLeast(1)
-            val heightPx = (spec.heightDp * density).toInt().coerceAtLeast(1)
-            // The discovery task writes a normalized `renderOutput` (package
-            // prefix stripped, unsafe chars sanitized) into each capture;
-            // honour it rather than rebuilding the path from `preview.id`
-            // so the file actually lands where the manifest claims it will.
-            val relRender = preview.captures.firstOrNull()
-                ?.renderOutput
-                ?.substringAfter("renders/", missingDelimiterValue = "")
-                ?.takeIf { it.isNotEmpty() }
-                ?: "${preview.id}.png"
-            val outputFile = outDir.resolve(relRender)
+  private fun renderWithCompose(manifest: PreviewManifest, outDir: java.io.File) {
+    // This path is only used for desktop rendering.
+    // Android rendering uses a separate Test-type task (see ComposePreviewPlugin).
+    val mainClass = "ee.schimke.composeai.renderer.DesktopRendererMainKt"
 
-            execOperations.javaexec {
-                classpath = renderClasspath
-                this.mainClass.set(mainClass)
-                args = listOf(
-                    preview.className,
-                    preview.functionName,
-                    widthPx.toString(),
-                    heightPx.toString(),
-                    density.toString(),
-                    preview.params.showBackground.toString(),
-                    preview.params.backgroundColor.toString(),
-                    outputFile.absolutePath,
-                    // 9th arg — empty string signals "no wrapper" (keeps arg positions stable).
-                    preview.params.wrapperClassName.orEmpty(),
-                    // 10th/11th — AS-parity wrap flags. When set, the renderer
-                    // wraps the composable, measures it, and crops the PNG to
-                    // the intrinsic bounds on that axis.
-                    spec.wrapWidth.toString(),
-                    spec.wrapHeight.toString(),
-                    // 12th/13th — @PreviewParameter spec. Empty string signals
-                    // "no provider"; otherwise the renderer enumerates the
-                    // provider's values.take(limit) in-process and writes one
-                    // `<id>_PARAM_<idx>.png` per value. Plugin-side can't know
-                    // the count (consumer's classpath isn't loaded here), so
-                    // fan-out is delegated to the renderer process that already
-                    // has everything on its classpath.
-                    preview.params.previewParameterProviderClassName.orEmpty(),
-                    preview.params.previewParameterLimit.toString(),
-                )
-            }
-        }
+    for (preview in manifest.previews) {
+      val spec =
+        DeviceDimensions.resolveForRender(
+          device = preview.params.device,
+          widthDp = preview.params.widthDp,
+          heightDp = preview.params.heightDp,
+          showSystemUi = preview.params.showSystemUi,
+        )
+      // Per-device density (= densityDpi / 160), so output bitmaps match
+      // what Android Studio renders for the same `@Preview`. Source: the
+      // same data sergio-sastre/ComposablePreviewScanner /
+      // takahirom/roborazzi consume. Discovery pins `params.density` when
+      // a device/showSystemUi frame applies; the wrap-content path leaves
+      // it null and we fall back to `spec.density` (= DEFAULT_DENSITY).
+      val density = preview.params.density ?: spec.density
+      val widthPx = (spec.widthDp * density).toInt().coerceAtLeast(1)
+      val heightPx = (spec.heightDp * density).toInt().coerceAtLeast(1)
+      // The discovery task writes a normalized `renderOutput` (package
+      // prefix stripped, unsafe chars sanitized) into each capture;
+      // honour it rather than rebuilding the path from `preview.id`
+      // so the file actually lands where the manifest claims it will.
+      val relRender =
+        preview.captures
+          .firstOrNull()
+          ?.renderOutput
+          ?.substringAfter("renders/", missingDelimiterValue = "")
+          ?.takeIf { it.isNotEmpty() } ?: "${preview.id}.png"
+      val outputFile = outDir.resolve(relRender)
+
+      execOperations.javaexec {
+        classpath = renderClasspath
+        this.mainClass.set(mainClass)
+        args =
+          listOf(
+            preview.className,
+            preview.functionName,
+            widthPx.toString(),
+            heightPx.toString(),
+            density.toString(),
+            preview.params.showBackground.toString(),
+            preview.params.backgroundColor.toString(),
+            outputFile.absolutePath,
+            // 9th arg — empty string signals "no wrapper" (keeps arg positions stable).
+            preview.params.wrapperClassName.orEmpty(),
+            // 10th/11th — AS-parity wrap flags. When set, the renderer
+            // wraps the composable, measures it, and crops the PNG to
+            // the intrinsic bounds on that axis.
+            spec.wrapWidth.toString(),
+            spec.wrapHeight.toString(),
+            // 12th/13th — @PreviewParameter spec. Empty string signals
+            // "no provider"; otherwise the renderer enumerates the
+            // provider's values.take(limit) in-process and writes one
+            // `<id>_PARAM_<idx>.png` per value. Plugin-side can't know
+            // the count (consumer's classpath isn't loaded here), so
+            // fan-out is delegated to the renderer process that already
+            // has everything on its classpath.
+            preview.params.previewParameterProviderClassName.orEmpty(),
+            preview.params.previewParameterLimit.toString(),
+          )
+      }
     }
+  }
 
-    private fun renderWithStub(manifest: PreviewManifest, outDir: java.io.File) {
-        val workQueue = workerExecutor.noIsolation()
+  private fun renderWithStub(manifest: PreviewManifest, outDir: java.io.File) {
+    val workQueue = workerExecutor.noIsolation()
 
-        for (preview in manifest.previews) {
-            val spec = DeviceDimensions.resolveForRender(
-                device = preview.params.device,
-                widthDp = preview.params.widthDp,
-                heightDp = preview.params.heightDp,
-                showSystemUi = preview.params.showSystemUi,
-            )
-            val relRender = preview.captures.firstOrNull()
-                ?.renderOutput
-                ?.substringAfter("renders/", missingDelimiterValue = "")
-                ?.takeIf { it.isNotEmpty() }
-                ?: "${preview.id}.png"
-            workQueue.submit(PreviewRenderWorkAction::class.java) {
-                className.set(preview.className)
-                functionName.set(preview.functionName)
-                widthDp.set(spec.widthDp)
-                heightDp.set(spec.heightDp)
-                density.set(preview.params.density ?: spec.density)
-                fontScale.set(preview.params.fontScale)
-                showBackground.set(preview.params.showBackground)
-                backgroundColor.set(preview.params.backgroundColor)
-                outputFile.set(outDir.resolve(relRender))
-                backend.set(renderBackend.get())
-            }
-        }
+    for (preview in manifest.previews) {
+      val spec =
+        DeviceDimensions.resolveForRender(
+          device = preview.params.device,
+          widthDp = preview.params.widthDp,
+          heightDp = preview.params.heightDp,
+          showSystemUi = preview.params.showSystemUi,
+        )
+      val relRender =
+        preview.captures
+          .firstOrNull()
+          ?.renderOutput
+          ?.substringAfter("renders/", missingDelimiterValue = "")
+          ?.takeIf { it.isNotEmpty() } ?: "${preview.id}.png"
+      workQueue.submit(PreviewRenderWorkAction::class.java) {
+        className.set(preview.className)
+        functionName.set(preview.functionName)
+        widthDp.set(spec.widthDp)
+        heightDp.set(spec.heightDp)
+        density.set(preview.params.density ?: spec.density)
+        fontScale.set(preview.params.fontScale)
+        showBackground.set(preview.params.showBackground)
+        backgroundColor.set(preview.params.backgroundColor)
+        outputFile.set(outDir.resolve(relRender))
+        backend.set(renderBackend.get())
+      }
     }
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ShardTuning.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ShardTuning.kt
@@ -1,120 +1,116 @@
 package ee.schimke.composeai.plugin
 
-import kotlin.math.ceil
 import kotlin.math.max
 
 /**
- * Measured costs for Robolectric-driven Compose preview rendering, used to pick a
- * shard count in auto mode. Update these when the cost profile changes (faster
- * hardware, a slimmer sandbox, a new Robolectric release).
+ * Measured costs for Robolectric-driven Compose preview rendering, used to pick a shard count in
+ * auto mode. Update these when the cost profile changes (faster hardware, a slimmer sandbox, a new
+ * Robolectric release).
  *
- * Benchmarked on 2026-04-14 against the `sample-android` module (5 previews,
- * Robolectric `sdk=34`, `graphicsMode=NATIVE`). Numbers come from the per-testcase
- * times in `build/test-results/renderPreviews/` (one XML per task run):
- *  - First preview in a JVM: 4.03s (sandbox + classloader + first Compose setContent).
- *  - Previews 2–5 in the same JVM: 0.11–0.22s each (warm sandbox, cached classes).
+ * Benchmarked on 2026-04-14 against the `sample-android` module (5 previews, Robolectric `sdk=34`,
+ * `graphicsMode=NATIVE`). Numbers come from the per-testcase times in
+ * `build/test-results/renderPreviews/` (one XML per task run):
+ * - First preview in a JVM: 4.03s (sandbox + classloader + first Compose setContent).
+ * - Previews 2–5 in the same JVM: 0.11–0.22s each (warm sandbox, cached classes).
  *
- * **Cost-aware model.** Earlier versions modelled every preview as a flat
- * [SECONDS_PER_COST_UNIT]; the per-capture `cost` field landed in the manifest
- * (catalogue: static / TOP = 1, END = 3, LONG = 20, GIF = 40, animated = 50)
- * lets us scale that estimate by the actual work the renderer is going to do
- * for each preview. A module with three GIF captures dwarfs a module with
- * thirty static ones, even though the preview count says otherwise.
+ * **Cost-aware model.** Earlier versions modelled every preview as a flat [SECONDS_PER_COST_UNIT];
+ * the per-capture `cost` field landed in the manifest (catalogue: static / TOP = 1, END = 3, LONG =
+ * 20, GIF = 40, animated = 50) lets us scale that estimate by the actual work the renderer is going
+ * to do for each preview. A module with three GIF captures dwarfs a module with thirty static ones,
+ * even though the preview count says otherwise.
  *
- * Fork-startup overhead is an estimate — Gradle's worker-forking and JVM spin-up
- * cost above and beyond the shared sandbox warmup. Measure again if fork counts
- * ever seem wildly off.
+ * Fork-startup overhead is an estimate — Gradle's worker-forking and JVM spin-up cost above and
+ * beyond the shared sandbox warmup. Measure again if fork counts ever seem wildly off.
  */
 internal object ShardTuning {
-    /**
-     * Per-fork sandbox + classloader setup, **before any Compose work**. The
-     * historical 4.0s "warmup" included the first capture's render; we split
-     * it out so the same constant works for both fast (1-cost static) and
-     * heavy (50-cost animation) first captures. Subsequent compose work is
-     * priced at [SECONDS_PER_COST_UNIT] × the capture's cost.
-     */
-    const val PER_FORK_SETUP_SECONDS = 3.85
+  /**
+   * Per-fork sandbox + classloader setup, **before any Compose work**. The historical 4.0s "warmup"
+   * included the first capture's render; we split it out so the same constant works for both fast
+   * (1-cost static) and heavy (50-cost animation) first captures. Subsequent compose work is priced
+   * at [SECONDS_PER_COST_UNIT] × the capture's cost.
+   */
+  const val PER_FORK_SETUP_SECONDS = 3.85
 
-    /**
-     * Wall-time per cost unit. A static `@Preview` is `cost = 1.0`, which
-     * historically rendered in ~0.15s once the sandbox was warm. Every
-     * other catalogue entry — END = 3, LONG = 20, GIF = 40, animated = 50
-     * — is a multiple of that baseline.
-     */
-    const val SECONDS_PER_COST_UNIT = 0.15
+  /**
+   * Wall-time per cost unit. A static `@Preview` is `cost = 1.0`, which historically rendered in
+   * ~0.15s once the sandbox was warm. Every other catalogue entry — END = 3, LONG = 20, GIF = 40,
+   * animated = 50 — is a multiple of that baseline.
+   */
+  const val SECONDS_PER_COST_UNIT = 0.15
 
-    /**
-     * Extra seconds per additional fork, on top of warmup — Gradle worker
-     * startup, test-report aggregation, scheduler overhead. Warmups themselves
-     * run in parallel across forks, so only the excess cost is counted.
-     */
-    const val FORK_OVERHEAD_SECONDS = 1.0
+  /**
+   * Extra seconds per additional fork, on top of warmup — Gradle worker startup, test-report
+   * aggregation, scheduler overhead. Warmups themselves run in parallel across forks, so only the
+   * excess cost is counted.
+   */
+  const val FORK_OVERHEAD_SECONDS = 1.0
 
-    /** Hard upper bound on shards, regardless of preview count or CPU. */
-    const val MAX_SHARDS = 8
+  /** Hard upper bound on shards, regardless of preview count or CPU. */
+  const val MAX_SHARDS = 8
 
-    /**
-     * Auto mode only turns sharding on when both thresholds are met versus the
-     * single-fork baseline. Rationale: forking is an externally visible cost
-     * (more JVMs, more memory, more log noise) — we should only pay it when
-     * the gain is unambiguous. A 2s→1s speedup is not worth the complexity.
-     */
-    const val MIN_SAVING_SECONDS = 3.0
-    const val MIN_SAVING_FRACTION = 0.30
+  /**
+   * Auto mode only turns sharding on when both thresholds are met versus the single-fork baseline.
+   * Rationale: forking is an externally visible cost (more JVMs, more memory, more log noise) — we
+   * should only pay it when the gain is unambiguous. A 2s→1s speedup is not worth the complexity.
+   */
+  const val MIN_SAVING_SECONDS = 3.0
+  const val MIN_SAVING_FRACTION = 0.30
 
-    /**
-     * Predicted wall time for K shards under the cost-aware model:
-     *
-     *   makespanCost = max(totalCost / K, maxIndividualCost)
-     *   T(K) = PER_FORK_SETUP + makespanCost × SECONDS_PER_COST_UNIT + (K − 1) × FORK_OVERHEAD
-     *
-     * `makespanCost` is the lower bound on what an LPT-balanced K-way split
-     * can achieve: the average load per shard, floored by the largest
-     * individual capture (no shard can finish before its biggest preview
-     * completes). The setup is paid concurrently across forks, so only the
-     * `(K − 1)` extra fork-startup cost is summed. Returned in seconds.
-     */
-    fun predictedSeconds(totalCost: Double, maxIndividualCost: Double, shards: Int): Double {
-        if (totalCost <= 0.0 || shards <= 0) return 0.0
-        val avgPerShard = totalCost / shards
-        val makespanCost = max(avgPerShard, maxIndividualCost)
-        return PER_FORK_SETUP_SECONDS +
-            makespanCost * SECONDS_PER_COST_UNIT +
-            (shards - 1).coerceAtLeast(0) * FORK_OVERHEAD_SECONDS
+  /**
+   * Predicted wall time for K shards under the cost-aware model:
+   *
+   * makespanCost = max(totalCost / K, maxIndividualCost) T(K) = PER_FORK_SETUP + makespanCost ×
+   * SECONDS_PER_COST_UNIT + (K − 1) × FORK_OVERHEAD
+   *
+   * `makespanCost` is the lower bound on what an LPT-balanced K-way split can achieve: the average
+   * load per shard, floored by the largest individual capture (no shard can finish before its
+   * biggest preview completes). The setup is paid concurrently across forks, so only the `(K − 1)`
+   * extra fork-startup cost is summed. Returned in seconds.
+   */
+  fun predictedSeconds(totalCost: Double, maxIndividualCost: Double, shards: Int): Double {
+    if (totalCost <= 0.0 || shards <= 0) return 0.0
+    val avgPerShard = totalCost / shards
+    val makespanCost = max(avgPerShard, maxIndividualCost)
+    return PER_FORK_SETUP_SECONDS +
+      makespanCost * SECONDS_PER_COST_UNIT +
+      (shards - 1).coerceAtLeast(0) * FORK_OVERHEAD_SECONDS
+  }
+
+  /**
+   * Picks the K ≥ 2 that minimises [predictedSeconds] over the allowed range, and returns it only
+   * if the improvement over K = 1 clears BOTH the absolute ([MIN_SAVING_SECONDS]) and relative
+   * ([MIN_SAVING_FRACTION]) thresholds. Otherwise returns 1.
+   *
+   * Upper bound is `min(MAX_SHARDS, cores / 2, captureCount)` — leave CPU headroom for Gradle
+   * workers; never shard below one capture per fork.
+   *
+   * @param totalCost sum of `Capture.cost` across every capture in the manifest
+   * @param maxIndividualCost largest single `Capture.cost` value (sets the makespan floor)
+   * @param captureCount total number of captures (caps shard count so each fork gets ≥ 1)
+   */
+  fun autoShards(
+    totalCost: Double,
+    maxIndividualCost: Double,
+    captureCount: Int,
+    cores: Int = Runtime.getRuntime().availableProcessors(),
+  ): Int {
+    if (captureCount < 2 || totalCost <= 0.0) return 1
+    val maxK = minOf(MAX_SHARDS, (cores / 2).coerceAtLeast(1), captureCount)
+    if (maxK < 2) return 1
+
+    val baseline = predictedSeconds(totalCost, maxIndividualCost, 1)
+    var bestK = 1
+    var bestT = baseline
+    for (k in 2..maxK) {
+      val t = predictedSeconds(totalCost, maxIndividualCost, k)
+      if (t < bestT) {
+        bestK = k
+        bestT = t
+      }
     }
-
-    /**
-     * Picks the K ≥ 2 that minimises [predictedSeconds] over the allowed range,
-     * and returns it only if the improvement over K = 1 clears BOTH the
-     * absolute ([MIN_SAVING_SECONDS]) and relative ([MIN_SAVING_FRACTION])
-     * thresholds. Otherwise returns 1.
-     *
-     * Upper bound is `min(MAX_SHARDS, cores / 2, captureCount)` — leave CPU
-     * headroom for Gradle workers; never shard below one capture per fork.
-     *
-     * @param totalCost          sum of `Capture.cost` across every capture in the manifest
-     * @param maxIndividualCost  largest single `Capture.cost` value (sets the makespan floor)
-     * @param captureCount       total number of captures (caps shard count so each fork gets ≥ 1)
-     */
-    fun autoShards(
-        totalCost: Double,
-        maxIndividualCost: Double,
-        captureCount: Int,
-        cores: Int = Runtime.getRuntime().availableProcessors(),
-    ): Int {
-        if (captureCount < 2 || totalCost <= 0.0) return 1
-        val maxK = minOf(MAX_SHARDS, (cores / 2).coerceAtLeast(1), captureCount)
-        if (maxK < 2) return 1
-
-        val baseline = predictedSeconds(totalCost, maxIndividualCost, 1)
-        var bestK = 1
-        var bestT = baseline
-        for (k in 2..maxK) {
-            val t = predictedSeconds(totalCost, maxIndividualCost, k)
-            if (t < bestT) { bestK = k; bestT = t }
-        }
-        val saved = baseline - bestT
-        val fraction = if (baseline > 0) saved / baseline else 0.0
-        return if (bestK >= 2 && saved >= MIN_SAVING_SECONDS && fraction >= MIN_SAVING_FRACTION) bestK else 1
-    }
+    val saved = baseline - bestT
+    val fraction = if (baseline > 0) saved / baseline else 0.0
+    return if (bestK >= 2 && saved >= MIN_SAVING_SECONDS && fraction >= MIN_SAVING_FRACTION) bestK
+    else 1
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/VerifyAccessibilityTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/VerifyAccessibilityTask.kt
@@ -16,10 +16,9 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 /**
- * Aggregates the per-preview ATF reports emitted by [RobolectricRenderTestBase]
- * into a single `accessibility.json` keyed by previewId, and fails the build
- * when findings exceed the thresholds configured on
- * [AccessibilityChecksExtension].
+ * Aggregates the per-preview ATF reports emitted by [RobolectricRenderTestBase] into a single
+ * `accessibility.json` keyed by previewId, and fails the build when findings exceed the thresholds
+ * configured on [AccessibilityChecksExtension].
  *
  * Runs once per Android module after `renderPreviews`. Only registered when
  * `composePreview.accessibilityChecks.enabled = true`.
@@ -27,104 +26,107 @@ import org.gradle.api.tasks.TaskAction
 @CacheableTask
 abstract class VerifyAccessibilityTask : DefaultTask() {
 
-    @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.NONE)
-    abstract val perPreviewDir: DirectoryProperty
+  @get:InputDirectory
+  @get:PathSensitive(PathSensitivity.NONE)
+  abstract val perPreviewDir: DirectoryProperty
 
-    @get:Input
-    abstract val moduleName: Property<String>
+  @get:Input abstract val moduleName: Property<String>
 
-    @get:Input
-    abstract val failOnErrors: Property<Boolean>
+  @get:Input abstract val failOnErrors: Property<Boolean>
 
-    @get:Input
-    abstract val failOnWarnings: Property<Boolean>
+  @get:Input abstract val failOnWarnings: Property<Boolean>
 
-    @get:OutputFile
-    abstract val reportFile: RegularFileProperty
+  @get:OutputFile abstract val reportFile: RegularFileProperty
 
-    // Serializers duplicated here rather than shared with renderer-android —
-    // the plugin runs on the Gradle JVM and cannot depend on an Android
-    // artifact. Stay in sync with [RenderManifest.kt] in renderer-android.
-    @Serializable
-    private data class A11yFinding(
-        val level: String,
-        val type: String,
-        val message: String,
-        val viewDescription: String? = null,
-        val boundsInScreen: String? = null,
-    )
+  // Serializers duplicated here rather than shared with renderer-android —
+  // the plugin runs on the Gradle JVM and cannot depend on an Android
+  // artifact. Stay in sync with [RenderManifest.kt] in renderer-android.
+  @Serializable
+  private data class A11yFinding(
+    val level: String,
+    val type: String,
+    val message: String,
+    val viewDescription: String? = null,
+    val boundsInScreen: String? = null,
+  )
 
-    @Serializable
-    private data class A11yNode(
-        val label: String,
-        val role: String? = null,
-        val states: List<String> = emptyList(),
-        val boundsInScreen: String,
-    )
+  @Serializable
+  private data class A11yNode(
+    val label: String,
+    val role: String? = null,
+    val states: List<String> = emptyList(),
+    val boundsInScreen: String,
+  )
 
-    @Serializable
-    private data class A11yEntry(
-        val previewId: String,
-        val findings: List<A11yFinding>,
-        // Mirror of [renderer-android/RenderManifest.AccessibilityNode] —
-        // round-trips through the aggregate JSON so downstream tools (CLI,
-        // VS Code, the python report lib) can read the ANI overlay data
-        // without going through the renderer's classpath.
-        val nodes: List<A11yNode> = emptyList(),
-        val annotatedPath: String? = null,
-    )
+  @Serializable
+  private data class A11yEntry(
+    val previewId: String,
+    val findings: List<A11yFinding>,
+    // Mirror of [renderer-android/RenderManifest.AccessibilityNode] —
+    // round-trips through the aggregate JSON so downstream tools (CLI,
+    // VS Code, the python report lib) can read the ANI overlay data
+    // without going through the renderer's classpath.
+    val nodes: List<A11yNode> = emptyList(),
+    val annotatedPath: String? = null,
+  )
 
-    @Serializable
-    private data class A11yReport(val module: String, val entries: List<A11yEntry>)
+  @Serializable private data class A11yReport(val module: String, val entries: List<A11yEntry>)
 
-    @TaskAction
-    fun verify() {
-        val json = Json { prettyPrint = true; encodeDefaults = true; ignoreUnknownKeys = true }
-
-        val dir = perPreviewDir.get().asFile
-        val entries = if (dir.exists()) {
-            dir.listFiles { f -> f.isFile && f.name.endsWith(".json") }
-                .orEmpty()
-                .sortedBy { it.name }
-                .map { json.decodeFromString(A11yEntry.serializer(), it.readText()) }
-        } else {
-            emptyList()
-        }
-
-        val report = A11yReport(module = moduleName.get(), entries = entries)
-        val out = reportFile.get().asFile
-        out.parentFile?.mkdirs()
-        out.writeText(json.encodeToString(A11yReport.serializer(), report))
-
-        val errorCount = entries.sumOf { it.findings.count { f -> f.level == "ERROR" } }
-        val warningCount = entries.sumOf { it.findings.count { f -> f.level == "WARNING" } }
-
-        logger.lifecycle(
-            "Accessibility: ${entries.size} preview(s), " +
-                "$errorCount error(s), $warningCount warning(s)",
-        )
-        for (entry in entries) {
-            for (finding in entry.findings) {
-                if (finding.level == "INFO") continue
-                logger.lifecycle("  [${finding.level}] ${entry.previewId} · ${finding.type}: ${finding.message}")
-            }
-        }
-
-        val failures = mutableListOf<String>()
-        if (failOnErrors.get() && errorCount > 0) {
-            failures += "$errorCount error(s)"
-        }
-        if (failOnWarnings.get() && warningCount > 0) {
-            failures += "$warningCount warning(s)"
-        }
-        if (failures.isNotEmpty()) {
-            throw GradleException(
-                "Accessibility check failed: ${failures.joinToString(", ")}. " +
-                    "See ${out.absolutePath} for the full report, or disable the " +
-                    "relevant `failOn*` flag in `composePreview.accessibilityChecks` " +
-                    "to downgrade to a warning.",
-            )
-        }
+  @TaskAction
+  fun verify() {
+    val json = Json {
+      prettyPrint = true
+      encodeDefaults = true
+      ignoreUnknownKeys = true
     }
+
+    val dir = perPreviewDir.get().asFile
+    val entries =
+      if (dir.exists()) {
+        dir
+          .listFiles { f -> f.isFile && f.name.endsWith(".json") }
+          .orEmpty()
+          .sortedBy { it.name }
+          .map { json.decodeFromString(A11yEntry.serializer(), it.readText()) }
+      } else {
+        emptyList()
+      }
+
+    val report = A11yReport(module = moduleName.get(), entries = entries)
+    val out = reportFile.get().asFile
+    out.parentFile?.mkdirs()
+    out.writeText(json.encodeToString(A11yReport.serializer(), report))
+
+    val errorCount = entries.sumOf { it.findings.count { f -> f.level == "ERROR" } }
+    val warningCount = entries.sumOf { it.findings.count { f -> f.level == "WARNING" } }
+
+    logger.lifecycle(
+      "Accessibility: ${entries.size} preview(s), " +
+        "$errorCount error(s), $warningCount warning(s)"
+    )
+    for (entry in entries) {
+      for (finding in entry.findings) {
+        if (finding.level == "INFO") continue
+        logger.lifecycle(
+          "  [${finding.level}] ${entry.previewId} · ${finding.type}: ${finding.message}"
+        )
+      }
+    }
+
+    val failures = mutableListOf<String>()
+    if (failOnErrors.get() && errorCount > 0) {
+      failures += "$errorCount error(s)"
+    }
+    if (failOnWarnings.get() && warningCount > 0) {
+      failures += "$warningCount warning(s)"
+    }
+    if (failures.isNotEmpty()) {
+      throw GradleException(
+        "Accessibility check failed: ${failures.joinToString(", ")}. " +
+          "See ${out.absolutePath} for the full report, or disable the " +
+          "relevant `failOn*` flag in `composePreview.accessibilityChecks` " +
+          "to downgrade to a warning."
+      )
+    }
+  }
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
@@ -3,306 +3,311 @@ package ee.schimke.composeai.plugin.tooling
 import java.time.YearMonth
 
 /**
- * Plugin-side compat-check rules. Single source of truth used by both
- * [ComposePreviewModelBuilder] (Tooling API path, consumed by the CLI) and
- * [ComposePreviewDoctorTask] (Gradle-task path, consumed by the VS Code
- * extension and anything else that drives Gradle tasks but can't run
+ * Plugin-side compat-check rules. Single source of truth used by both [ComposePreviewModelBuilder]
+ * (Tooling API path, consumed by the CLI) and [ComposePreviewDoctorTask] (Gradle-task path,
+ * consumed by the VS Code extension and anything else that drives Gradle tasks but can't run
  * `BuildAction`s).
  *
- * Bump the thresholds here — and only here — when a new AndroidX AAR adds
- * an R.id field that older transitives don't have. Keep the catalogue in
- * `docs/RENDERER_COMPATIBILITY.md` in sync.
+ * Bump the thresholds here — and only here — when a new AndroidX AAR adds an R.id field that older
+ * transitives don't have. Keep the catalogue in `docs/RENDERER_COMPATIBILITY.md` in sync.
  */
 internal object CompatRules {
 
-    /**
-     * Effective minimum Gradle version for consumers applying the plugin.
-     *
-     * The binding constraint is **AGP's own floor**, not any API we use:
-     * AGP 9.1.x requires Gradle 9.3.1+ (per the AGP release notes), and
-     * AGP itself rejects older Gradle at its own version check — long
-     * before our `apply()` runs. The plugin's own code only reaches
-     * Gradle APIs that have been stable since the 8.x line, so there's
-     * no floor we set independently of AGP.
-     *
-     * Keep this in lockstep with AGP's documented minimum when bumping
-     * `libs.versions.toml`:
-     *   AGP 9.0.x → Gradle 9.1.0
-     *   AGP 9.1.x → Gradle 9.3.1
-     *
-     * The repo wrapper (currently 9.4.1) is the dev/test toolchain — not
-     * a floor we impose on consumers. Don't conflate the two.
-     */
-    internal val GRADLE_MIN = Semver(9, 3, 1)
+  /**
+   * Effective minimum Gradle version for consumers applying the plugin.
+   *
+   * The binding constraint is **AGP's own floor**, not any API we use: AGP 9.1.x requires Gradle
+   * 9.3.1+ (per the AGP release notes), and AGP itself rejects older Gradle at its own version
+   * check — long before our `apply()` runs. The plugin's own code only reaches Gradle APIs that
+   * have been stable since the 8.x line, so there's no floor we set independently of AGP.
+   *
+   * Keep this in lockstep with AGP's documented minimum when bumping `libs.versions.toml`: AGP
+   * 9.0.x → Gradle 9.1.0 AGP 9.1.x → Gradle 9.3.1
+   *
+   * The repo wrapper (currently 9.4.1) is the dev/test toolchain — not a floor we impose on
+   * consumers. Don't conflate the two.
+   */
+  internal val GRADLE_MIN = Semver(9, 3, 1)
 
-    /**
-     * activity 1.11+ transitively brought `androidx.navigationevent:1.0.0`.
-     * Consumers whose main variant has older activity end up with the
-     * `ComponentActivity` classes expecting `R.id.view_tree_…` resources
-     * that aren't in the merged APK — crashes Robolectric with
-     * `NoClassDefFoundError: androidx/navigationevent/R$id`.
-     */
-    private val NAVIGATIONEVENT_REQUIRES_ACTIVITY = Semver(1, 11, 0)
+  /**
+   * activity 1.11+ transitively brought `androidx.navigationevent:1.0.0`. Consumers whose main
+   * variant has older activity end up with the `ComponentActivity` classes expecting
+   * `R.id.view_tree_…` resources that aren't in the merged APK — crashes Robolectric with
+   * `NoClassDefFoundError: androidx/navigationevent/R$id`.
+   */
+  private val NAVIGATIONEVENT_REQUIRES_ACTIVITY = Semver(1, 11, 0)
 
-    /**
-     * compose-ui 1.10.0 added a call site that references
-     * `androidx.core.R.id.tag_compat_insets_dispatch`, added in
-     * `androidx.core:core:1.16.0`.
-     */
-    private val COMPOSE_UI_NEEDS_CORE_1_16 = Semver(1, 10, 0)
-    private val CORE_1_16 = Semver(1, 16, 0)
+  /**
+   * compose-ui 1.10.0 added a call site that references
+   * `androidx.core.R.id.tag_compat_insets_dispatch`, added in `androidx.core:core:1.16.0`.
+   */
+  private val COMPOSE_UI_NEEDS_CORE_1_16 = Semver(1, 10, 0)
+  private val CORE_1_16 = Semver(1, 16, 0)
 
-    /**
-     * Generic "you're well behind head" minimums for libraries whose
-     * version commonly shapes renderer behaviour. Threshold policy:
-     * roughly the second-to-last known stable at time of writing —
-     * recent enough to flag genuinely stale stacks, lenient enough that
-     * a consumer one release behind head doesn't get nagged. Bump when
-     * the paired upstream line ships a new stable minor.
-     *
-     * The specific compat rules above (navigationevent, core-vs-compose)
-     * still fire on their own when they apply — this list is the
-     * catch-all for "nothing's actively broken, but you're old".
-     */
-    private val OLD_DEP_MINIMUMS: List<Pair<String, Semver>> = listOf(
-        "androidx.compose.ui:ui" to Semver(1, 9, 0),
-        "androidx.activity:activity" to Semver(1, 10, 0),
-        "androidx.core:core" to Semver(1, 15, 0),
-        "androidx.lifecycle:lifecycle-runtime" to Semver(2, 8, 0),
+  /**
+   * Generic "you're well behind head" minimums for libraries whose version commonly shapes renderer
+   * behaviour. Threshold policy: roughly the second-to-last known stable at time of writing —
+   * recent enough to flag genuinely stale stacks, lenient enough that a consumer one release behind
+   * head doesn't get nagged. Bump when the paired upstream line ships a new stable minor.
+   *
+   * The specific compat rules above (navigationevent, core-vs-compose) still fire on their own when
+   * they apply — this list is the catch-all for "nothing's actively broken, but you're old".
+   */
+  private val OLD_DEP_MINIMUMS: List<Pair<String, Semver>> =
+    listOf(
+      "androidx.compose.ui:ui" to Semver(1, 9, 0),
+      "androidx.activity:activity" to Semver(1, 10, 0),
+      "androidx.core:core" to Semver(1, 15, 0),
+      "androidx.lifecycle:lifecycle-runtime" to Semver(2, 8, 0),
     )
 
-    /**
-     * Runs every rule against the given dep snapshot and returns findings
-     * ordered by severity. Pure — safe to call from tests and from the
-     * serialisation path.
-     */
-    fun evaluate(
-        main: Map<String, String>,
-        test: Map<String, String>,
-        gradleVersion: String? = null,
-    ): List<ModuleFindingData> {
-        val findings = mutableListOf<ModuleFindingData>()
-        val mainV = parseVersions(main)
-        val testV = parseVersions(test)
-        checkGradleVersion(gradleVersion)?.let(findings::add)
-        checkUiTestManifest(testV)?.let(findings::add)
-        checkNavigationEvent(mainV, testV, main)?.let(findings::add)
-        checkComposeUiVsCore(mainV, testV, main)?.let(findings::add)
-        checkComposeBom(main)?.let(findings::add)
-        findings += checkOldDeps(mainV, testV, main, test)
-        return findings
-    }
+  /**
+   * Runs every rule against the given dep snapshot and returns findings ordered by severity. Pure —
+   * safe to call from tests and from the serialisation path.
+   */
+  fun evaluate(
+    main: Map<String, String>,
+    test: Map<String, String>,
+    gradleVersion: String? = null,
+  ): List<ModuleFindingData> {
+    val findings = mutableListOf<ModuleFindingData>()
+    val mainV = parseVersions(main)
+    val testV = parseVersions(test)
+    checkGradleVersion(gradleVersion)?.let(findings::add)
+    checkUiTestManifest(testV)?.let(findings::add)
+    checkNavigationEvent(mainV, testV, main)?.let(findings::add)
+    checkComposeUiVsCore(mainV, testV, main)?.let(findings::add)
+    checkComposeBom(main)?.let(findings::add)
+    findings += checkOldDeps(mainV, testV, main, test)
+    return findings
+  }
 
-    /**
-     * Flags Gradle versions below [GRADLE_MIN]. Parameter is the raw version
-     * string from `GradleVersion.current().version` (e.g. `"9.3.1"`,
-     * `"9.4.1"`, `"9.5.0-rc-1"`). `null` means the caller didn't plumb the
-     * version through — keeps the pre-existing call sites and tests working
-     * without forcing every path to know about Gradle's runtime.
-     *
-     * On paper this is unreachable in an AGP build — AGP's own compat check
-     * fails the build before `apply()` runs. In practice the rule is still
-     * worth keeping for two reasons: CMP Desktop builds don't have AGP
-     * guarding the gate, and a clear "gradle-too-old" finding beats the
-     * Tooling API's opaque `Could not execute build using connection to
-     * Gradle distribution …` wrapper when something does slip through.
-     */
-    private fun checkGradleVersion(gradleVersion: String?): ModuleFindingData? {
-        val raw = gradleVersion ?: return null
-        val parsed = Semver.parseOrNull(raw) ?: return null
-        if (parsed >= GRADLE_MIN) return null
-        return ModuleFindingData(
-            id = "gradle-too-old",
-            severity = "error",
-            message = "Gradle $raw is below AGP 9.1.x's minimum ($GRADLE_MIN)",
-            detail = "AGP 9.1.x requires Gradle >= $GRADLE_MIN. The plugin itself only uses APIs " +
-                "stable since Gradle 8.x, so the floor comes from AGP — on an Android build AGP's " +
-                "own compat check fails before this rule even fires. The finding is still emitted " +
-                "for CMP Desktop projects (no AGP gate) and to give a clear remediation when the " +
-                "Tooling API wraps the real cause in a generic `Could not execute build using " +
-                "connection to Gradle distribution …` message.",
-            remediationSummary = "Upgrade the project's Gradle wrapper to >= $GRADLE_MIN.",
-            remediationCommands = listOf("./gradlew wrapper --gradle-version $GRADLE_MIN"),
-            docsUrl = null,
+  /**
+   * Flags Gradle versions below [GRADLE_MIN]. Parameter is the raw version string from
+   * `GradleVersion.current().version` (e.g. `"9.3.1"`, `"9.4.1"`, `"9.5.0-rc-1"`). `null` means the
+   * caller didn't plumb the version through — keeps the pre-existing call sites and tests working
+   * without forcing every path to know about Gradle's runtime.
+   *
+   * On paper this is unreachable in an AGP build — AGP's own compat check fails the build before
+   * `apply()` runs. In practice the rule is still worth keeping for two reasons: CMP Desktop builds
+   * don't have AGP guarding the gate, and a clear "gradle-too-old" finding beats the Tooling API's
+   * opaque `Could not execute build using connection to Gradle distribution …` wrapper when
+   * something does slip through.
+   */
+  private fun checkGradleVersion(gradleVersion: String?): ModuleFindingData? {
+    val raw = gradleVersion ?: return null
+    val parsed = Semver.parseOrNull(raw) ?: return null
+    if (parsed >= GRADLE_MIN) return null
+    return ModuleFindingData(
+      id = "gradle-too-old",
+      severity = "error",
+      message = "Gradle $raw is below AGP 9.1.x's minimum ($GRADLE_MIN)",
+      detail =
+        "AGP 9.1.x requires Gradle >= $GRADLE_MIN. The plugin itself only uses APIs " +
+          "stable since Gradle 8.x, so the floor comes from AGP — on an Android build AGP's " +
+          "own compat check fails before this rule even fires. The finding is still emitted " +
+          "for CMP Desktop projects (no AGP gate) and to give a clear remediation when the " +
+          "Tooling API wraps the real cause in a generic `Could not execute build using " +
+          "connection to Gradle distribution …` message.",
+      remediationSummary = "Upgrade the project's Gradle wrapper to >= $GRADLE_MIN.",
+      remediationCommands = listOf("./gradlew wrapper --gradle-version $GRADLE_MIN"),
+      docsUrl = null,
+    )
+  }
+
+  private fun checkUiTestManifest(test: Map<String, Semver>): ModuleFindingData? {
+    if (test.containsKey("androidx.compose.ui:ui-test-manifest")) return null
+    return ModuleFindingData(
+      id = "ui-test-manifest-missing",
+      severity = "error",
+      message = "androidx.compose.ui:ui-test-manifest missing from test classpath",
+      detail =
+        "ComposeTestRule-backed paths (a11y checks, future renderer features) need the <activity> entry merged into the test AndroidManifest. Without it, Robolectric can't launch the host Activity at render time.",
+      remediationSummary = "Apply the plugin so it injects ui-test-manifest, or add it manually.",
+      remediationCommands = listOf("testImplementation(\"androidx.compose.ui:ui-test-manifest\")"),
+      docsUrl = DOCS_UI_TEST_MANIFEST,
+    )
+  }
+
+  private fun checkNavigationEvent(
+    main: Map<String, Semver>,
+    test: Map<String, Semver>,
+    rawMain: Map<String, String>,
+  ): ModuleFindingData? {
+    val navEvent = test["androidx.navigationevent:navigationevent"] ?: return null
+    val mainActivity = main["androidx.activity:activity"]
+    if (mainActivity != null && mainActivity >= NAVIGATIONEVENT_REQUIRES_ACTIVITY) return null
+    return ModuleFindingData(
+      id = "activity-vs-navigationevent",
+      severity = "error",
+      message = "navigationevent on test classpath but main variant activity is too old",
+      detail =
+        "Test classpath has androidx.navigationevent:$navEvent pulled in via a newer activity. " +
+          "AGP builds the merged test resource APK from the main variant " +
+          "(activity:${rawMain["androidx.activity:activity"] ?: "(absent)"}), so " +
+          "`androidx.navigationevent.R.id.*` resources aren't merged. Expect " +
+          "`NoClassDefFoundError: androidx/navigationevent/R\$id` at render time.",
+      remediationSummary =
+        "Upgrade main-variant activity-compose to >= $NAVIGATIONEVENT_REQUIRES_ACTIVITY, or avoid transitively pulling navigationevent into tests.",
+      remediationCommands =
+        listOf(
+          "implementation(\"androidx.activity:activity-compose:$NAVIGATIONEVENT_REQUIRES_ACTIVITY\")"
+        ),
+      docsUrl = DOCS_NAVIGATIONEVENT,
+    )
+  }
+
+  private fun checkComposeUiVsCore(
+    main: Map<String, Semver>,
+    test: Map<String, Semver>,
+    rawMain: Map<String, String>,
+  ): ModuleFindingData? {
+    val composeUi = test["androidx.compose.ui:ui"] ?: return null
+    if (composeUi < COMPOSE_UI_NEEDS_CORE_1_16) return null
+    val mainCore = main["androidx.core:core"]
+    if (mainCore != null && mainCore >= CORE_1_16) return null
+    return ModuleFindingData(
+      id = "compose-ui-vs-core",
+      severity = "error",
+      message = "compose-ui $composeUi expects androidx.core >= $CORE_1_16",
+      detail =
+        "Test classpath has compose-ui:$composeUi which calls `ViewCompat.setOnApplyWindowInsetsListener`, reading `R.id.tag_compat_insets_dispatch` (added in androidx.core:1.16.0). Main variant has core:${rawMain["androidx.core:core"] ?: "(absent)"}, so that resource isn't in the merged APK. Expect `NoSuchFieldError: … tag_compat_insets_dispatch`.",
+      remediationSummary =
+        "Bump Compose BOM (or androidx.core directly) on the main variant so it resolves to >= $CORE_1_16.",
+      remediationCommands = emptyList(),
+      docsUrl = DOCS_COMPOSE_UI_VS_CORE,
+    )
+  }
+
+  /**
+   * Emits one warning per [OLD_DEP_MINIMUMS] entry whose highest resolved version (main or test
+   * classpath) is below the minimum. Libraries absent from both classpaths are silently skipped —
+   * the consumer isn't using them, so there's nothing to warn about.
+   */
+  private fun checkOldDeps(
+    main: Map<String, Semver>,
+    test: Map<String, Semver>,
+    rawMain: Map<String, String>,
+    rawTest: Map<String, String>,
+  ): List<ModuleFindingData> {
+    val out = mutableListOf<ModuleFindingData>()
+    for ((artifact, minVersion) in OLD_DEP_MINIMUMS) {
+      val resolved = listOfNotNull(main[artifact], test[artifact]).maxOrNull() ?: continue
+      if (resolved >= minVersion) continue
+      val rawVersion = rawMain[artifact] ?: rawTest[artifact] ?: resolved.toString()
+      out +=
+        ModuleFindingData(
+          id = "old-dep-$artifact",
+          severity = "warning",
+          message = "$artifact is on $rawVersion; recommended >= $minVersion",
+          detail =
+            "Resolved $artifact:$rawVersion is several releases behind. Renderer compat issues tend to cluster around older Compose / Activity / Core / Lifecycle versions; upgrading clears a class of bugs before they hit.",
+          remediationSummary = "Upgrade $artifact to at least $minVersion.",
+          remediationCommands = listOf("implementation(\"$artifact:$minVersion\")"),
+          docsUrl = null,
         )
     }
+    return out
+  }
 
-    private fun checkUiTestManifest(test: Map<String, Semver>): ModuleFindingData? {
-        if (test.containsKey("androidx.compose.ui:ui-test-manifest")) return null
-        return ModuleFindingData(
-            id = "ui-test-manifest-missing",
-            severity = "error",
-            message = "androidx.compose.ui:ui-test-manifest missing from test classpath",
-            detail = "ComposeTestRule-backed paths (a11y checks, future renderer features) need the <activity> entry merged into the test AndroidManifest. Without it, Robolectric can't launch the host Activity at render time.",
-            remediationSummary = "Apply the plugin so it injects ui-test-manifest, or add it manually.",
-            remediationCommands = listOf("testImplementation(\"androidx.compose.ui:ui-test-manifest\")"),
-            docsUrl = DOCS_UI_TEST_MANIFEST,
-        )
+  private fun checkComposeBom(rawMain: Map<String, String>): ModuleFindingData? {
+    if (rawMain.containsKey("androidx.compose:compose-bom")) return null
+    return ModuleFindingData(
+      id = "compose-bom-missing",
+      severity = "warning",
+      message = "no Compose BOM declared",
+      detail =
+        "Without a BOM, compose-ui / compose-runtime / compose-foundation can end up on non-lockstep versions. Most consumer failure reports we see start here.",
+      remediationSummary = "Declare a Compose BOM to align all compose-* artifact versions.",
+      remediationCommands =
+        listOf(
+          "implementation(platform(\"androidx.compose:compose-bom:${suggestedComposeBom()}\"))"
+        ),
+      docsUrl = null,
+    )
+  }
+
+  /**
+   * Suggest the previous calendar month's BOM (`YYYY.MM.00`). Compose BOM publishes monthly with
+   * the `.00` as the initial release, so "last month's BOM" is both a real version and a safe,
+   * conservative choice — it always exists, and we're never recommending a literal that will age
+   * out the moment this file is committed.
+   */
+  internal fun suggestedComposeBom(today: YearMonth = YearMonth.now()): String {
+    val ym = today.minusMonths(1)
+    return "%04d.%02d.00".format(ym.year, ym.monthValue)
+  }
+
+  private fun parseVersions(raw: Map<String, String>): Map<String, Semver> {
+    val out = LinkedHashMap<String, Semver>(raw.size)
+    for ((key, version) in raw) {
+      Semver.parseOrNull(version)?.let { out[key] = it }
     }
+    return out
+  }
 
-    private fun checkNavigationEvent(
-        main: Map<String, Semver>,
-        test: Map<String, Semver>,
-        rawMain: Map<String, String>,
-    ): ModuleFindingData? {
-        val navEvent = test["androidx.navigationevent:navigationevent"] ?: return null
-        val mainActivity = main["androidx.activity:activity"]
-        if (mainActivity != null && mainActivity >= NAVIGATIONEVENT_REQUIRES_ACTIVITY) return null
-        return ModuleFindingData(
-            id = "activity-vs-navigationevent",
-            severity = "error",
-            message = "navigationevent on test classpath but main variant activity is too old",
-            detail = "Test classpath has androidx.navigationevent:$navEvent pulled in via a newer activity. " +
-                "AGP builds the merged test resource APK from the main variant " +
-                "(activity:${rawMain["androidx.activity:activity"] ?: "(absent)"}), so " +
-                "`androidx.navigationevent.R.id.*` resources aren't merged. Expect " +
-                "`NoClassDefFoundError: androidx/navigationevent/R\$id` at render time.",
-            remediationSummary = "Upgrade main-variant activity-compose to >= $NAVIGATIONEVENT_REQUIRES_ACTIVITY, or avoid transitively pulling navigationevent into tests.",
-            remediationCommands = listOf("implementation(\"androidx.activity:activity-compose:$NAVIGATIONEVENT_REQUIRES_ACTIVITY\")"),
-            docsUrl = DOCS_NAVIGATIONEVENT,
-        )
-    }
-
-    private fun checkComposeUiVsCore(
-        main: Map<String, Semver>,
-        test: Map<String, Semver>,
-        rawMain: Map<String, String>,
-    ): ModuleFindingData? {
-        val composeUi = test["androidx.compose.ui:ui"] ?: return null
-        if (composeUi < COMPOSE_UI_NEEDS_CORE_1_16) return null
-        val mainCore = main["androidx.core:core"]
-        if (mainCore != null && mainCore >= CORE_1_16) return null
-        return ModuleFindingData(
-            id = "compose-ui-vs-core",
-            severity = "error",
-            message = "compose-ui $composeUi expects androidx.core >= $CORE_1_16",
-            detail = "Test classpath has compose-ui:$composeUi which calls `ViewCompat.setOnApplyWindowInsetsListener`, reading `R.id.tag_compat_insets_dispatch` (added in androidx.core:1.16.0). Main variant has core:${rawMain["androidx.core:core"] ?: "(absent)"}, so that resource isn't in the merged APK. Expect `NoSuchFieldError: … tag_compat_insets_dispatch`.",
-            remediationSummary = "Bump Compose BOM (or androidx.core directly) on the main variant so it resolves to >= $CORE_1_16.",
-            remediationCommands = emptyList(),
-            docsUrl = DOCS_COMPOSE_UI_VS_CORE,
-        )
-    }
-
-    /**
-     * Emits one warning per [OLD_DEP_MINIMUMS] entry whose highest resolved
-     * version (main or test classpath) is below the minimum. Libraries
-     * absent from both classpaths are silently skipped — the consumer
-     * isn't using them, so there's nothing to warn about.
-     */
-    private fun checkOldDeps(
-        main: Map<String, Semver>,
-        test: Map<String, Semver>,
-        rawMain: Map<String, String>,
-        rawTest: Map<String, String>,
-    ): List<ModuleFindingData> {
-        val out = mutableListOf<ModuleFindingData>()
-        for ((artifact, minVersion) in OLD_DEP_MINIMUMS) {
-            val resolved = listOfNotNull(main[artifact], test[artifact]).maxOrNull() ?: continue
-            if (resolved >= minVersion) continue
-            val rawVersion = rawMain[artifact] ?: rawTest[artifact] ?: resolved.toString()
-            out += ModuleFindingData(
-                id = "old-dep-$artifact",
-                severity = "warning",
-                message = "$artifact is on $rawVersion; recommended >= $minVersion",
-                detail = "Resolved $artifact:$rawVersion is several releases behind. Renderer compat issues tend to cluster around older Compose / Activity / Core / Lifecycle versions; upgrading clears a class of bugs before they hit.",
-                remediationSummary = "Upgrade $artifact to at least $minVersion.",
-                remediationCommands = listOf("implementation(\"$artifact:$minVersion\")"),
-                docsUrl = null,
-            )
-        }
-        return out
-    }
-
-    private fun checkComposeBom(rawMain: Map<String, String>): ModuleFindingData? {
-        if (rawMain.containsKey("androidx.compose:compose-bom")) return null
-        return ModuleFindingData(
-            id = "compose-bom-missing",
-            severity = "warning",
-            message = "no Compose BOM declared",
-            detail = "Without a BOM, compose-ui / compose-runtime / compose-foundation can end up on non-lockstep versions. Most consumer failure reports we see start here.",
-            remediationSummary = "Declare a Compose BOM to align all compose-* artifact versions.",
-            remediationCommands = listOf("implementation(platform(\"androidx.compose:compose-bom:${suggestedComposeBom()}\"))"),
-            docsUrl = null,
-        )
-    }
-
-    /**
-     * Suggest the previous calendar month's BOM (`YYYY.MM.00`). Compose BOM
-     * publishes monthly with the `.00` as the initial release, so "last
-     * month's BOM" is both a real version and a safe, conservative choice —
-     * it always exists, and we're never recommending a literal that will
-     * age out the moment this file is committed.
-     */
-    internal fun suggestedComposeBom(today: YearMonth = YearMonth.now()): String {
-        val ym = today.minusMonths(1)
-        return "%04d.%02d.00".format(ym.year, ym.monthValue)
-    }
-
-    private fun parseVersions(raw: Map<String, String>): Map<String, Semver> {
-        val out = LinkedHashMap<String, Semver>(raw.size)
-        for ((key, version) in raw) {
-            Semver.parseOrNull(version)?.let { out[key] = it }
-        }
-        return out
-    }
-
-    private const val DOCS_ROOT = "https://github.com/yschimke/compose-ai-tools/blob/main/docs/RENDERER_COMPATIBILITY.md"
-    private const val DOCS_UI_TEST_MANIFEST = "$DOCS_ROOT#consumer-scope-ui-test-manifest-injection"
-    private const val DOCS_NAVIGATIONEVENT = "$DOCS_ROOT#activity-compose-111-on-a-consumer-with-an-older-activity"
-    private const val DOCS_COMPOSE_UI_VS_CORE = "$DOCS_ROOT#compose-ui-110-on-a-consumer-with-older-androidxcore"
+  private const val DOCS_ROOT =
+    "https://github.com/yschimke/compose-ai-tools/blob/main/docs/RENDERER_COMPATIBILITY.md"
+  private const val DOCS_UI_TEST_MANIFEST = "$DOCS_ROOT#consumer-scope-ui-test-manifest-injection"
+  private const val DOCS_NAVIGATIONEVENT =
+    "$DOCS_ROOT#activity-compose-111-on-a-consumer-with-an-older-activity"
+  private const val DOCS_COMPOSE_UI_VS_CORE =
+    "$DOCS_ROOT#compose-ui-110-on-a-consumer-with-older-androidxcore"
 }
 
 /**
- * Minimal semver used by compat rules. Lives plugin-side so the rules can
- * work against the resolved-version strings Gradle produces, without a
- * dependency on any external semver library.
+ * Minimal semver used by compat rules. Lives plugin-side so the rules can work against the
+ * resolved-version strings Gradle produces, without a dependency on any external semver library.
  */
-internal data class Semver(
-    val major: Int,
-    val minor: Int,
-    val patch: Int,
-    val extra: String = "",
-) : Comparable<Semver> {
-    override fun compareTo(other: Semver): Int {
-        val base = compareValuesBy(this, other, { it.major }, { it.minor }, { it.patch })
-        if (base != 0) return base
-        return when {
-            extra == other.extra -> 0
-            extra.isEmpty() -> 1   // release beats pre-release
-            other.extra.isEmpty() -> -1
-            else -> extra.compareTo(other.extra)
-        }
+internal data class Semver(val major: Int, val minor: Int, val patch: Int, val extra: String = "") :
+  Comparable<Semver> {
+  override fun compareTo(other: Semver): Int {
+    val base = compareValuesBy(this, other, { it.major }, { it.minor }, { it.patch })
+    if (base != 0) return base
+    return when {
+      extra == other.extra -> 0
+      extra.isEmpty() -> 1 // release beats pre-release
+      other.extra.isEmpty() -> -1
+      else -> extra.compareTo(other.extra)
     }
+  }
 
-    override fun toString(): String = buildString {
-        append(major); append('.'); append(minor); append('.'); append(patch)
-        if (extra.isNotEmpty()) { append('-'); append(extra) }
+  override fun toString(): String = buildString {
+    append(major)
+    append('.')
+    append(minor)
+    append('.')
+    append(patch)
+    if (extra.isNotEmpty()) {
+      append('-')
+      append(extra)
     }
+  }
 
-    companion object {
-        fun parseOrNull(s: String): Semver? {
-            val parts = s.split('-', limit = 2)
-            val core = parts[0].split('.')
-            if (core.size < 2) return null
-            val major = core[0].toIntOrNull() ?: return null
-            val minor = core[1].toIntOrNull() ?: return null
-            val patch = core.getOrNull(2)?.toIntOrNull() ?: 0
-            val extra = parts.getOrNull(1).orEmpty()
-            return Semver(major, minor, patch, extra)
-        }
+  companion object {
+    fun parseOrNull(s: String): Semver? {
+      val parts = s.split('-', limit = 2)
+      val core = parts[0].split('.')
+      if (core.size < 2) return null
+      val major = core[0].toIntOrNull() ?: return null
+      val minor = core[1].toIntOrNull() ?: return null
+      val patch = core.getOrNull(2)?.toIntOrNull() ?: 0
+      val extra = parts.getOrNull(1).orEmpty()
+      return Semver(major, minor, patch, extra)
     }
+  }
 }
 
 /**
- * [ModuleFinding] impl used by both the model builder and the task. Named
- * `Data` not `Impl` to match the existing ModuleInfoData / ComposePreviewModelData.
+ * [ModuleFinding] impl used by both the model builder and the task. Named `Data` not `Impl` to
+ * match the existing ModuleInfoData / ComposePreviewModelData.
  */
 internal data class ModuleFindingData(
-    override val id: String,
-    override val severity: String,
-    override val message: String,
-    override val detail: String?,
-    override val remediationSummary: String?,
-    override val remediationCommands: List<String>,
-    override val docsUrl: String?,
+  override val id: String,
+  override val severity: String,
+  override val message: String,
+  override val detail: String?,
+  override val remediationSummary: String?,
+  override val remediationCommands: List<String>,
+  override val docsUrl: String?,
 ) : ModuleFinding, java.io.Serializable

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewAppliedTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewAppliedTask.kt
@@ -14,16 +14,15 @@ import org.gradle.api.tasks.TaskAction
 /**
  * Writes a tiny applied-marker JSON to `<module>/build/compose-previews/applied.json`.
  *
- * Exists so IDE-side tooling (the VS Code extension) can reliably discover
- * which modules apply the plugin *without* parsing build scripts or the
- * Gradle version catalog. `gradle composePreviewApplied` (no module prefix)
- * fans out to every applying subproject, producing one marker per module.
+ * Exists so IDE-side tooling (the VS Code extension) can reliably discover which modules apply the
+ * plugin *without* parsing build scripts or the Gradle version catalog. `gradle
+ * composePreviewApplied` (no module prefix) fans out to every applying subproject, producing one
+ * marker per module.
  *
- * Parallels the sidecar-JSON approach used by [ComposePreviewDoctorTask]:
- * the VS Code extension uses the vscode-gradle API, which only exposes
- * `runTask` — it cannot call the [ComposePreviewModel] Tooling API directly
- * the way the CLI does. A task that writes a small JSON is the cheapest
- * authoritative bridge.
+ * Parallels the sidecar-JSON approach used by [ComposePreviewDoctorTask]: the VS Code extension
+ * uses the vscode-gradle API, which only exposes `runTask` — it cannot call the
+ * [ComposePreviewModel] Tooling API directly the way the CLI does. A task that writes a small JSON
+ * is the cheapest authoritative bridge.
  *
  * JSON shape (schema `compose-preview-applied/v1`):
  *
@@ -34,48 +33,48 @@ import org.gradle.api.tasks.TaskAction
  *       "moduleName": "wearApp"
  *     }
  *
- * Kept deliberately minimal — downstream tools only need "does the plugin
- * apply here?". If more per-module metadata is needed later, extend the
- * Tooling-API [ComposePreviewModel] rather than widening the marker.
+ * Kept deliberately minimal — downstream tools only need "does the plugin apply here?". If more
+ * per-module metadata is needed later, extend the Tooling-API [ComposePreviewModel] rather than
+ * widening the marker.
  */
 @CacheableTask
 abstract class ComposePreviewAppliedTask : DefaultTask() {
 
-    @get:Input
-    abstract val pluginVersion: Property<String>
+  @get:Input abstract val pluginVersion: Property<String>
 
-    @get:Input
-    abstract val modulePath: Property<String>
+  @get:Input abstract val modulePath: Property<String>
 
-    @get:Input
-    abstract val moduleName: Property<String>
+  @get:Input abstract val moduleName: Property<String>
 
-    @get:OutputFile
-    abstract val outputFile: RegularFileProperty
+  @get:OutputFile abstract val outputFile: RegularFileProperty
 
-    @TaskAction
-    fun write() {
-        val out = outputFile.get().asFile
-        out.parentFile.mkdirs()
-        val marker = AppliedMarker(
-            schema = SCHEMA,
-            pluginVersion = pluginVersion.get(),
-            modulePath = modulePath.get(),
-            moduleName = moduleName.get(),
-        )
-        out.writeText(JSON.encodeToString(marker))
+  @TaskAction
+  fun write() {
+    val out = outputFile.get().asFile
+    out.parentFile.mkdirs()
+    val marker =
+      AppliedMarker(
+        schema = SCHEMA,
+        pluginVersion = pluginVersion.get(),
+        modulePath = modulePath.get(),
+        moduleName = moduleName.get(),
+      )
+    out.writeText(JSON.encodeToString(marker))
+  }
+
+  companion object {
+    internal const val SCHEMA = "compose-preview-applied/v1"
+    private val JSON = Json {
+      prettyPrint = true
+      encodeDefaults = true
     }
-
-    companion object {
-        internal const val SCHEMA = "compose-preview-applied/v1"
-        private val JSON = Json { prettyPrint = true; encodeDefaults = true }
-    }
+  }
 }
 
 @Serializable
 internal data class AppliedMarker(
-    val schema: String,
-    val pluginVersion: String,
-    val modulePath: String,
-    val moduleName: String,
+  val schema: String,
+  val pluginVersion: String,
+  val modulePath: String,
+  val moduleName: String,
 )

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewDoctorTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewDoctorTask.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin.tooling
 
+import java.io.File
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -15,203 +16,197 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.work.DisableCachingByDefault
-import java.io.File
 
 /**
- * Writes [CompatRules] findings for the current module to a sidecar JSON.
- * Parallels the `ComposePreviewModel` path used by the CLI — this task
- * exists so drivers that can't run Gradle `BuildAction`s (notably the
- * VS Code extension, which uses the vscode-gradle task API) still get the
- * same output shape via a plain task invocation.
+ * Writes [CompatRules] findings for the current module to a sidecar JSON. Parallels the
+ * `ComposePreviewModel` path used by the CLI — this task exists so drivers that can't run Gradle
+ * `BuildAction`s (notably the VS Code extension, which uses the vscode-gradle task API) still get
+ * the same output shape via a plain task invocation.
  *
  * Output shape matches [DoctorReport] in
- * `cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt` at the
- * per-module level — the CLI and the extension converge on the same JSON
- * schema (`compose-preview-doctor/v1`).
+ * `cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt` at the per-module level — the CLI
+ * and the extension converge on the same JSON schema (`compose-preview-doctor/v1`).
  *
- * Cheap to run: resolves the two configurations' `resolutionResult` (no
- * artifact downloads), applies rules, writes a small JSON file.
+ * Cheap to run: resolves the two configurations' `resolutionResult` (no artifact downloads),
+ * applies rules, writes a small JSON file.
  *
- * Configuration-cache safe: the runtime classpath `ResolutionResult`s are
- * wired in as `Provider<ResolvedComponentResult>` at registration time so
- * the action never reaches back to `task.project`.
+ * Configuration-cache safe: the runtime classpath `ResolutionResult`s are wired in as
+ * `Provider<ResolvedComponentResult>` at registration time so the action never reaches back to
+ * `task.project`.
  */
-@DisableCachingByDefault(because = "Doctor findings depend on the live configuration resolution, not on a declared input set — caching across a version bump would silently stale-surface fixed issues.")
+@DisableCachingByDefault(
+  because =
+    "Doctor findings depend on the live configuration resolution, not on a declared input set — caching across a version bump would silently stale-surface fixed issues."
+)
 abstract class ComposePreviewDoctorTask : DefaultTask() {
 
-    @get:Input
-    abstract val variant: Property<String>
+  @get:Input abstract val variant: Property<String>
 
-    @get:Input
-    abstract val modulePath: Property<String>
+  @get:Input abstract val modulePath: Property<String>
 
-    /**
-     * Gradle runtime version, e.g. `"9.4.1"`. Wired at task-registration
-     * time from `GradleVersion.current().version` so [CompatRules] can
-     * flag consumers on older wrappers than the plugin supports. Kept as
-     * a plain [Property<String>] rather than a non-serialisable Gradle
-     * object so the configuration-cache image round-trips cleanly.
-     */
-    @get:Input
-    abstract val gradleVersion: Property<String>
+  /**
+   * Gradle runtime version, e.g. `"9.4.1"`. Wired at task-registration time from
+   * `GradleVersion.current().version` so [CompatRules] can flag consumers on older wrappers than
+   * the plugin supports. Kept as a plain [Property<String>] rather than a non-serialisable Gradle
+   * object so the configuration-cache image round-trips cleanly.
+   */
+  @get:Input abstract val gradleVersion: Property<String>
 
-    @get:Internal
-    abstract val mainRuntimeRoot: Property<ResolvedComponentResult>
+  @get:Internal abstract val mainRuntimeRoot: Property<ResolvedComponentResult>
 
-    @get:Internal
-    abstract val testRuntimeRoot: Property<ResolvedComponentResult>
+  @get:Internal abstract val testRuntimeRoot: Property<ResolvedComponentResult>
 
-    /**
-     * JSON-encoded `List<InjectedDependency>` captured at plugin-apply time
-     * (populated inside `AndroidPreviewSupport.registerAndroidTasks`).
-     * Defaults to `"[]"` so the task produces a clean empty list when
-     * no injections are relevant. JSON-as-Input keeps the config-cache
-     * image simple — a single string round-trips without needing a
-     * registered serializer for the nested data class.
-     */
-    @get:Input
-    abstract val injectedDependenciesJson: Property<String>
+  /**
+   * JSON-encoded `List<InjectedDependency>` captured at plugin-apply time (populated inside
+   * `AndroidPreviewSupport.registerAndroidTasks`). Defaults to `"[]"` so the task produces a clean
+   * empty list when no injections are relevant. JSON-as-Input keeps the config-cache image simple —
+   * a single string round-trips without needing a registered serializer for the nested data class.
+   */
+  @get:Input abstract val injectedDependenciesJson: Property<String>
 
-    @get:OutputFile
-    abstract val outputFile: RegularFileProperty
+  @get:OutputFile abstract val outputFile: RegularFileProperty
 
-    @TaskAction
-    fun run() {
-        val variantName = variant.get()
-        val main = collectModuleVersions(mainRuntimeRoot.orNull)
-        val test = collectModuleVersions(testRuntimeRoot.orNull)
-        val findings = CompatRules.evaluate(main, test, gradleVersion.orNull)
-        val injections = decodeInjectedDependencys(injectedDependenciesJson.getOrElse("[]"))
-        val report = DoctorModuleReport(
-            schema = SCHEMA,
-            module = modulePath.get(),
-            variant = variantName,
-            findings = findings.map { f ->
-                DoctorFinding(
-                    id = f.id,
-                    severity = f.severity,
-                    message = f.message,
-                    detail = f.detail,
-                    remediationSummary = f.remediationSummary,
-                    remediationCommands = f.remediationCommands,
-                    docsUrl = f.docsUrl,
-                )
-            },
-            injectedDependencies = injections,
-        )
-        val out = outputFile.get().asFile
-        out.parentFile.mkdirs()
-        out.writeText(JSON.encodeToString(report))
-        printSummary(report, out)
+  @TaskAction
+  fun run() {
+    val variantName = variant.get()
+    val main = collectModuleVersions(mainRuntimeRoot.orNull)
+    val test = collectModuleVersions(testRuntimeRoot.orNull)
+    val findings = CompatRules.evaluate(main, test, gradleVersion.orNull)
+    val injections = decodeInjectedDependencys(injectedDependenciesJson.getOrElse("[]"))
+    val report =
+      DoctorModuleReport(
+        schema = SCHEMA,
+        module = modulePath.get(),
+        variant = variantName,
+        findings =
+          findings.map { f ->
+            DoctorFinding(
+              id = f.id,
+              severity = f.severity,
+              message = f.message,
+              detail = f.detail,
+              remediationSummary = f.remediationSummary,
+              remediationCommands = f.remediationCommands,
+              docsUrl = f.docsUrl,
+            )
+          },
+        injectedDependencies = injections,
+      )
+    val out = outputFile.get().asFile
+    out.parentFile.mkdirs()
+    out.writeText(JSON.encodeToString(report))
+    printSummary(report, out)
+  }
+
+  private fun decodeInjectedDependencys(raw: String): List<InjectedDependency> =
+    runCatching { JSON.decodeFromString<List<InjectedDependency>>(raw) }.getOrElse { emptyList() }
+
+  /**
+   * Mirror the CLI's `emitText` shape at module scope: header, one marker line per finding,
+   * optional remediation. The JSON file is authoritative for tooling; this is purely for the human
+   * watching the Gradle output.
+   */
+  private fun printSummary(report: DoctorModuleReport, out: File) {
+    logger.lifecycle("compose-preview doctor — ${report.module} (variant: ${report.variant})")
+    if (report.findings.isEmpty()) {
+      logger.lifecycle("  ✓ no compatibility issues found")
+    } else {
+      for (f in report.findings) {
+        val marker =
+          when (f.severity) {
+            "error" -> "✗"
+            "warning" -> "!"
+            "info" -> "∙"
+            else -> "?"
+          }
+        logger.lifecycle("  $marker [${f.severity}] ${f.message}")
+        f.remediationSummary?.let { logger.lifecycle("      → $it") }
+        for (cmd in f.remediationCommands) logger.lifecycle("        \$ $cmd")
+        f.docsUrl?.let { logger.lifecycle("        docs: $it") }
+      }
+      val errors = report.findings.count { it.severity == "error" }
+      val warnings = report.findings.count { it.severity == "warning" }
+      logger.lifecycle(
+        "  ${report.findings.size} finding(s): $errors error(s), $warnings warning(s)"
+      )
     }
-
-    private fun decodeInjectedDependencys(raw: String): List<InjectedDependency> =
-        runCatching { JSON.decodeFromString<List<InjectedDependency>>(raw) }
-            .getOrElse { emptyList() }
-
-    /**
-     * Mirror the CLI's `emitText` shape at module scope: header, one marker
-     * line per finding, optional remediation. The JSON file is authoritative
-     * for tooling; this is purely for the human watching the Gradle output.
-     */
-    private fun printSummary(report: DoctorModuleReport, out: File) {
-        logger.lifecycle("compose-preview doctor — ${report.module} (variant: ${report.variant})")
-        if (report.findings.isEmpty()) {
-            logger.lifecycle("  ✓ no compatibility issues found")
-        } else {
-            for (f in report.findings) {
-                val marker = when (f.severity) {
-                    "error" -> "✗"
-                    "warning" -> "!"
-                    "info" -> "∙"
-                    else -> "?"
-                }
-                logger.lifecycle("  $marker [${f.severity}] ${f.message}")
-                f.remediationSummary?.let { logger.lifecycle("      → $it") }
-                for (cmd in f.remediationCommands) logger.lifecycle("        \$ $cmd")
-                f.docsUrl?.let { logger.lifecycle("        docs: $it") }
-            }
-            val errors = report.findings.count { it.severity == "error" }
-            val warnings = report.findings.count { it.severity == "warning" }
-            logger.lifecycle("  ${report.findings.size} finding(s): $errors error(s), $warnings warning(s)")
-        }
-        if (report.injectedDependencies.isNotEmpty()) {
-            logger.lifecycle("  injected dependencies:")
-            for (inj in report.injectedDependencies) {
-                val config = inj.configuration.ifEmpty { "—" }
-                logger.lifecycle("    ${inj.outcome} [${inj.coordinate}] → $config  (${inj.reason})")
-            }
-        }
-        logger.lifecycle("  report: ${out.path}")
+    if (report.injectedDependencies.isNotEmpty()) {
+      logger.lifecycle("  injected dependencies:")
+      for (inj in report.injectedDependencies) {
+        val config = inj.configuration.ifEmpty { "—" }
+        logger.lifecycle("    ${inj.outcome} [${inj.coordinate}] → $config  (${inj.reason})")
+      }
     }
+    logger.lifecycle("  report: ${out.path}")
+  }
 
-    private fun collectModuleVersions(root: ResolvedComponentResult?): Map<String, String> {
-        if (root == null) return emptyMap()
-        val out = LinkedHashMap<String, String>()
-        val seen = HashSet<ResolvedComponentResult>()
-        val stack = ArrayDeque<ResolvedComponentResult>()
-        stack.addLast(root)
-        while (stack.isNotEmpty()) {
-            val node = stack.removeLast()
-            if (!seen.add(node)) continue
-            val id = node.id
-            if (id is ModuleComponentIdentifier) {
-                out.putIfAbsent("${id.group}:${id.module}", id.version)
-            }
-            for (dep in node.dependencies) {
-                val resolved = dep as? ResolvedDependencyResult ?: continue
-                stack.addLast(resolved.selected)
-            }
-        }
-        return out
+  private fun collectModuleVersions(root: ResolvedComponentResult?): Map<String, String> {
+    if (root == null) return emptyMap()
+    val out = LinkedHashMap<String, String>()
+    val seen = HashSet<ResolvedComponentResult>()
+    val stack = ArrayDeque<ResolvedComponentResult>()
+    stack.addLast(root)
+    while (stack.isNotEmpty()) {
+      val node = stack.removeLast()
+      if (!seen.add(node)) continue
+      val id = node.id
+      if (id is ModuleComponentIdentifier) {
+        out.putIfAbsent("${id.group}:${id.module}", id.version)
+      }
+      for (dep in node.dependencies) {
+        val resolved = dep as? ResolvedDependencyResult ?: continue
+        stack.addLast(resolved.selected)
+      }
     }
+    return out
+  }
 
-    companion object {
-        internal const val SCHEMA = "compose-preview-doctor/v1"
-        private val JSON = Json { prettyPrint = true; encodeDefaults = true }
+  companion object {
+    internal const val SCHEMA = "compose-preview-doctor/v1"
+    private val JSON = Json {
+      prettyPrint = true
+      encodeDefaults = true
     }
+  }
 }
 
 @Serializable
 internal data class DoctorModuleReport(
-    val schema: String,
-    val module: String,
-    val variant: String,
-    val findings: List<DoctorFinding>,
-    val injectedDependencies: List<InjectedDependency> = emptyList(),
+  val schema: String,
+  val module: String,
+  val variant: String,
+  val findings: List<DoctorFinding>,
+  val injectedDependencies: List<InjectedDependency> = emptyList(),
 )
 
 @Serializable
 internal data class DoctorFinding(
-    val id: String,
-    val severity: String,
-    val message: String,
-    val detail: String? = null,
-    val remediationSummary: String? = null,
-    val remediationCommands: List<String> = emptyList(),
-    val docsUrl: String? = null,
+  val id: String,
+  val severity: String,
+  val message: String,
+  val detail: String? = null,
+  val remediationSummary: String? = null,
+  val remediationCommands: List<String> = emptyList(),
+  val docsUrl: String? = null,
 )
 
 /**
- * Record of one injected-dependency decision made by the plugin at apply time.
- * Populated for both unconditional injections (e.g. `ui-test-manifest`,
- * `ui-test-junit4`) and conditional ones (e.g. the wear-tiles signal
- * scan). Surfaced via the plugin's sidecar `doctor.json` so drivers that
- * can't run Gradle `BuildAction`s — notably the VS Code extension — can
- * show the same injected-dependency state the CLI / `--info` log already
- * exposes.
+ * Record of one injected-dependency decision made by the plugin at apply time. Populated for both
+ * unconditional injections (e.g. `ui-test-manifest`, `ui-test-junit4`) and conditional ones (e.g.
+ * the wear-tiles signal scan). Surfaced via the plugin's sidecar `doctor.json` so drivers that
+ * can't run Gradle `BuildAction`s — notably the VS Code extension — can show the same
+ * injected-dependency state the CLI / `--info` log already exposes.
  *
  * `outcome` takes one of:
- *   - `APPLIED`  — unconditional injection fired.
- *   - `MATCHED`  — conditional injection fired because the signal was found.
- *   - `SKIPPED`  — conditional injection DID NOT fire because the signal
- *                  was not found; `configuration` is empty in this case
- *                  because nothing was actually added.
+ * - `APPLIED` — unconditional injection fired.
+ * - `MATCHED` — conditional injection fired because the signal was found.
+ * - `SKIPPED` — conditional injection DID NOT fire because the signal was not found;
+ *   `configuration` is empty in this case because nothing was actually added.
  */
 @Serializable
 internal data class InjectedDependency(
-    val coordinate: String,
-    val configuration: String,
-    val outcome: String,
-    val reason: String,
+  val coordinate: String,
+  val configuration: String,
+  val outcome: String,
+  val reason: String,
 )

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt
@@ -1,170 +1,156 @@
 package ee.schimke.composeai.plugin.tooling
 
 /**
- * Tooling API model exposing plugin-side state to external drivers — CLI
- * (`compose-preview doctor`, future commands), VS Code extension, agents.
+ * Tooling API model exposing plugin-side state to external drivers — CLI (`compose-preview doctor`,
+ * future commands), VS Code extension, agents.
  *
- * The goal is ONE model that grows alongside the plugin, rather than a new
- * model per feature. Keep return types to [Map] / [List] / [String] /
- * [Boolean] (what Gradle's Tooling API can marshal across the daemon
- * boundary), and keep interfaces in lockstep with the CLI-side copy at the
- * same FQN (`ee.schimke.composeai.plugin.tooling.ComposePreviewModel`).
- * Tooling API bridges them with reflective proxies — method signatures
- * drifting between sides silently produces `null`s.
+ * The goal is ONE model that grows alongside the plugin, rather than a new model per feature. Keep
+ * return types to [Map] / [List] / [String] / [Boolean] (what Gradle's Tooling API can marshal
+ * across the daemon boundary), and keep interfaces in lockstep with the CLI-side copy at the same
+ * FQN (`ee.schimke.composeai.plugin.tooling.ComposePreviewModel`). Tooling API bridges them with
+ * reflective proxies — method signatures drifting between sides silently produces `null`s.
  *
- * Registered once per build by
- * [ee.schimke.composeai.plugin.ComposePreviewPlugin.apply]. Retrieved from
- * the CLI with `connection.model(ComposePreviewModel::class.java).get()` —
- * works against any project in the build (the builder always returns the
- * build-wide snapshot).
+ * Registered once per build by [ee.schimke.composeai.plugin.ComposePreviewPlugin.apply]. Retrieved
+ * from the CLI with `connection.model(ComposePreviewModel::class.java).get()` — works against any
+ * project in the build (the builder always returns the build-wide snapshot).
  */
 interface ComposePreviewModel {
-    /**
-     * Plugin version recorded at build time. Useful when the CLI needs to
-     * report the plugin version without parsing the consumer's build files.
-     */
-    val pluginVersion: String
+  /**
+   * Plugin version recorded at build time. Useful when the CLI needs to report the plugin version
+   * without parsing the consumer's build files.
+   */
+  val pluginVersion: String
 
-    /**
-     * Every project where the compose-preview plugin was applied. Key is the
-     * Gradle project path (starts with `:`, e.g. `:app`, `:sample-wear`).
-     * Empty if no project applied the plugin — the CLI treats that case
-     * specially (it surfaces an actionable "apply the plugin" remediation).
-     */
-    val modules: Map<String, ModuleInfo>
+  /**
+   * Every project where the compose-preview plugin was applied. Key is the Gradle project path
+   * (starts with `:`, e.g. `:app`, `:sample-wear`). Empty if no project applied the plugin — the
+   * CLI treats that case specially (it surfaces an actionable "apply the plugin" remediation).
+   */
+  val modules: Map<String, ModuleInfo>
 }
 
 /**
- * Per-module state. Starts narrow — just dependency versions for doctor's
- * compat checks — but this interface is the extension point: add getters
- * here (e.g. discovered-preview counts, source roots, enabled features) as
- * the CLI grows. Any addition needs the CLI-side copy updated in lockstep.
+ * Per-module state. Starts narrow — just dependency versions for doctor's compat checks — but this
+ * interface is the extension point: add getters here (e.g. discovered-preview counts, source roots,
+ * enabled features) as the CLI grows. Any addition needs the CLI-side copy updated in lockstep.
  */
 interface ModuleInfo {
-    /**
-     * The plugin's configured variant — typically `"debug"`. The CLI uses
-     * this to phrase remediation hints and to pick the right configuration
-     * names when resolving deps.
-     */
-    val variant: String
+  /**
+   * The plugin's configured variant — typically `"debug"`. The CLI uses this to phrase remediation
+   * hints and to pick the right configuration names when resolving deps.
+   */
+  val variant: String
 
-    /**
-     * Resolved dependencies for the module's `${variant}RuntimeClasspath`
-     * configuration (main app runtime — drives AGP's merged resource APK).
-     * Map key is `group:name`; value is Gradle's resolved version string.
-     *
-     * Empty if the configuration didn't exist or didn't resolve — doctor
-     * treats that as "not checkable" rather than erroring.
-     */
-    val mainRuntimeDependencies: Map<String, String>
+  /**
+   * Resolved dependencies for the module's `${variant}RuntimeClasspath` configuration (main app
+   * runtime — drives AGP's merged resource APK). Map key is `group:name`; value is Gradle's
+   * resolved version string.
+   *
+   * Empty if the configuration didn't exist or didn't resolve — doctor treats that as "not
+   * checkable" rather than erroring.
+   */
+  val mainRuntimeDependencies: Map<String, String>
 
-    /**
-     * Resolved dependencies for `${variant}UnitTestRuntimeClasspath` — what
-     * the preview renderer actually runs against. Same shape as
-     * [mainRuntimeDependencies].
-     */
-    val testRuntimeDependencies: Map<String, String>
+  /**
+   * Resolved dependencies for `${variant}UnitTestRuntimeClasspath` — what the preview renderer
+   * actually runs against. Same shape as [mainRuntimeDependencies].
+   */
+  val testRuntimeDependencies: Map<String, String>
 
-    /**
-     * Compat-check findings produced by the plugin's rules against the
-     * dependency maps above. Each entry matches one of the known AAR/R.id
-     * mismatches from `docs/RENDERER_COMPATIBILITY.md`. Rules live plugin-
-     * side so the CLI (`compose-preview doctor`) and the VS Code extension
-     * both consume the same list — no per-tool drift.
-     */
-    val findings: List<ModuleFinding>
+  /**
+   * Compat-check findings produced by the plugin's rules against the dependency maps above. Each
+   * entry matches one of the known AAR/R.id mismatches from `docs/RENDERER_COMPATIBILITY.md`. Rules
+   * live plugin- side so the CLI (`compose-preview doctor`) and the VS Code extension both consume
+   * the same list — no per-tool drift.
+   */
+  val findings: List<ModuleFinding>
 
-    /**
-     * Android Gradle Plugin version applied to the module, or `null` if we
-     * couldn't read it (no AGP plugin applied, or AGP internals moved).
-     * Exposed for bug-report triage: issues like #142 depend on the AGP
-     * version the consumer is on.
-     */
-    val agpVersion: String?
+  /**
+   * Android Gradle Plugin version applied to the module, or `null` if we couldn't read it (no AGP
+   * plugin applied, or AGP internals moved). Exposed for bug-report triage: issues like #142 depend
+   * on the AGP version the consumer is on.
+   */
+  val agpVersion: String?
 
-    /**
-     * Kotlin Gradle Plugin version applied to the module, or `null` if we
-     * couldn't read it. Same motivation as [agpVersion].
-     */
-    val kotlinVersion: String?
+  /**
+   * Kotlin Gradle Plugin version applied to the module, or `null` if we couldn't read it. Same
+   * motivation as [agpVersion].
+   */
+  val kotlinVersion: String?
 
-    /**
-     * Diagnostic snapshot of the `renderPreviews` Test task — the Java
-     * launcher it will fork the test worker with, its classpath/bootstrap-
-     * classpath shape, and any JVM args copied from AGP. `null` when the
-     * task wasn't registered (plugin disabled for this module). Introduced
-     * to make bug reports like #142 self-contained: the silent "test worker
-     * falls back to system default JDK" footgun is visible directly here.
-     */
-    val renderPreviewsTask: RenderPreviewsTaskInfo?
+  /**
+   * Diagnostic snapshot of the `renderPreviews` Test task — the Java launcher it will fork the test
+   * worker with, its classpath/bootstrap- classpath shape, and any JVM args copied from AGP. `null`
+   * when the task wasn't registered (plugin disabled for this module). Introduced to make bug
+   * reports like #142 self-contained: the silent "test worker falls back to system default JDK"
+   * footgun is visible directly here.
+   */
+  val renderPreviewsTask: RenderPreviewsTaskInfo?
 }
 
 /**
- * Snapshot of the `renderPreviews` Test task's JVM configuration. Taken at
- * Tooling-model build time, not at task execution — values reflect what
- * Gradle would use if the task ran now.
+ * Snapshot of the `renderPreviews` Test task's JVM configuration. Taken at Tooling-model build
+ * time, not at task execution — values reflect what Gradle would use if the task ran now.
  */
 interface RenderPreviewsTaskInfo {
-    /**
-     * `true` when the task has an explicit toolchain launcher wired (either
-     * by the plugin itself in future, or inherited from AGP's test task).
-     * `false` when Gradle will fall back to the daemon's own JVM — or, worse
-     * on some Linux setups, to the system default `java` on PATH if the
-     * daemon was launched with a different JAVA_HOME override. See #142.
-     */
-    val javaLauncherPinned: Boolean
+  /**
+   * `true` when the task has an explicit toolchain launcher wired (either by the plugin itself in
+   * future, or inherited from AGP's test task). `false` when Gradle will fall back to the daemon's
+   * own JVM — or, worse on some Linux setups, to the system default `java` on PATH if the daemon
+   * was launched with a different JAVA_HOME override. See #142.
+   */
+  val javaLauncherPinned: Boolean
 
-    /** Effective Java major version the test worker will fork with. */
-    val javaLauncherVersion: String?
+  /** Effective Java major version the test worker will fork with. */
+  val javaLauncherVersion: String?
 
-    /** Effective JVM vendor (e.g. "Temurin", "Google Inc.") — useful for triage. */
-    val javaLauncherVendor: String?
+  /** Effective JVM vendor (e.g. "Temurin", "Google Inc.") — useful for triage. */
+  val javaLauncherVendor: String?
 
-    /** Effective `java.home` the forked worker will use. */
-    val javaLauncherPath: String?
+  /** Effective `java.home` the forked worker will use. */
+  val javaLauncherPath: String?
 
-    /** Number of entries on the task's `classpath`. */
-    val classpathSize: Int
+  /** Number of entries on the task's `classpath`. */
+  val classpathSize: Int
 
-    /**
-     * Number of entries on the task's `bootstrapClasspath`. Non-zero on an
-     * AGP-wired unit-test task (AGP injects `mockable-android.jar`), zero on
-     * `renderPreviews` today. Exposed so doctor can call out the asymmetry.
-     */
-    val bootstrapClasspathSize: Int
+  /**
+   * Number of entries on the task's `bootstrapClasspath`. Non-zero on an AGP-wired unit-test task
+   * (AGP injects `mockable-android.jar`), zero on `renderPreviews` today. Exposed so doctor can
+   * call out the asymmetry.
+   */
+  val bootstrapClasspathSize: Int
 
-    /** JVM args applied to the forked worker (post-`jvmArgs(...)` copies). */
-    val jvmArgs: List<String>
+  /** JVM args applied to the forked worker (post-`jvmArgs(...)` copies). */
+  val jvmArgs: List<String>
 }
 
 /**
- * One compat-check result. Matches the shape the CLI prints under
- * `compose-preview doctor` and the shape the VS Code extension consumes for
- * the Problems view.
+ * One compat-check result. Matches the shape the CLI prints under `compose-preview doctor` and the
+ * shape the VS Code extension consumes for the Problems view.
  *
- * Getters only return Tooling-API-marshalable types; the CLI-side duplicate
- * at `cli/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt`
- * must track these method-for-method.
+ * Getters only return Tooling-API-marshalable types; the CLI-side duplicate at
+ * `cli/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModel.kt` must track these
+ * method-for-method.
  */
 interface ModuleFinding {
-    /** Stable dotted id, e.g. `ui-test-manifest-missing`. */
-    val id: String
+  /** Stable dotted id, e.g. `ui-test-manifest-missing`. */
+  val id: String
 
-    /** `"error"` | `"warning"` | `"info"`. */
-    val severity: String
+  /** `"error"` | `"warning"` | `"info"`. */
+  val severity: String
 
-    /** Single-line human-readable summary. */
-    val message: String
+  /** Single-line human-readable summary. */
+  val message: String
 
-    /** Longer rationale (optional). */
-    val detail: String?
+  /** Longer rationale (optional). */
+  val detail: String?
 
-    /** One-line action the user can take (optional). */
-    val remediationSummary: String?
+  /** One-line action the user can take (optional). */
+  val remediationSummary: String?
 
-    /** Concrete commands / snippets that implement the action. */
-    val remediationCommands: List<String>
+  /** Concrete commands / snippets that implement the action. */
+  val remediationCommands: List<String>
 
-    /** Deep-link to project documentation (optional). */
-    val docsUrl: String?
+  /** Deep-link to project documentation (optional). */
+  val docsUrl: String?
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/ComposePreviewModelBuilder.kt
@@ -2,157 +2,166 @@ package ee.schimke.composeai.plugin.tooling
 
 import ee.schimke.composeai.plugin.PluginVersion
 import ee.schimke.composeai.plugin.PreviewExtension
+import java.io.Serializable
 import org.gradle.api.Project
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.tasks.testing.Test
 import org.gradle.tooling.provider.model.ToolingModelBuilder
-import java.io.Serializable
 
 /**
- * Builds a build-wide [ComposePreviewModel] snapshot — resolves
- * `${variant}RuntimeClasspath` and `${variant}UnitTestRuntimeClasspath` on
- * every project where the compose-preview plugin applied, and packs the
- * result into interfaces the CLI consumes over the Tooling API.
+ * Builds a build-wide [ComposePreviewModel] snapshot — resolves `${variant}RuntimeClasspath` and
+ * `${variant}UnitTestRuntimeClasspath` on every project where the compose-preview plugin applied,
+ * and packs the result into interfaces the CLI consumes over the Tooling API.
  *
- * Registered once per build from
- * [ee.schimke.composeai.plugin.ComposePreviewPlugin.apply]. [canBuild]
- * accepts the build-root path regardless of which project the caller hit —
- * we always return the build-wide snapshot so the CLI doesn't have to iterate.
+ * Registered once per build from [ee.schimke.composeai.plugin.ComposePreviewPlugin.apply].
+ * [canBuild] accepts the build-root path regardless of which project the caller hit — we always
+ * return the build-wide snapshot so the CLI doesn't have to iterate.
  */
 internal class ComposePreviewModelBuilder : ToolingModelBuilder {
 
-    override fun canBuild(modelName: String): Boolean =
-        modelName == ComposePreviewModel::class.java.name
+  override fun canBuild(modelName: String): Boolean =
+    modelName == ComposePreviewModel::class.java.name
 
-    override fun buildAll(modelName: String, project: Project): Any {
-        // Builder runs per-project under Isolated Projects — we can only
-        // inspect the project we were invoked on. The CLI walks the project
-        // tree with `GradleProject` and asks for this model on each leaf;
-        // projects where the plugin wasn't applied return an empty
-        // `modules` map, which the CLI filters out.
-        val hasPlugin = project.tasks.findByName("discoverPreviews") != null
-        if (!hasPlugin) {
-            return ComposePreviewModelData(PluginVersion.value, emptyMap())
+  override fun buildAll(modelName: String, project: Project): Any {
+    // Builder runs per-project under Isolated Projects — we can only
+    // inspect the project we were invoked on. The CLI walks the project
+    // tree with `GradleProject` and asks for this model on each leaf;
+    // projects where the plugin wasn't applied return an empty
+    // `modules` map, which the CLI filters out.
+    val hasPlugin = project.tasks.findByName("discoverPreviews") != null
+    if (!hasPlugin) {
+      return ComposePreviewModelData(PluginVersion.value, emptyMap())
+    }
+    val variant = resolveVariant(project)
+    val main = resolveConfiguration(project, "${variant}RuntimeClasspath")
+    val test = resolveConfiguration(project, "${variant}UnitTestRuntimeClasspath")
+    val gradleVersion = org.gradle.util.GradleVersion.current().version
+    val findings: List<ModuleFinding> = CompatRules.evaluate(main, test, gradleVersion)
+    val info: ModuleInfo =
+      ModuleInfoData(
+        variant = variant,
+        mainRuntimeDependencies = main,
+        testRuntimeDependencies = test,
+        findings = findings,
+        agpVersion = resolveAgpVersion(),
+        kotlinVersion = resolveKotlinVersion(project),
+        renderPreviewsTask = resolveRenderPreviewsTask(project),
+      )
+    return ComposePreviewModelData(PluginVersion.value, mapOf(project.path to info))
+  }
+
+  /**
+   * Reads AGP's embedded version constant via reflection so the plugin doesn't take a hard
+   * compile-time dependency on AGP internals. Returns `null` on any failure — doctor treats that as
+   * "unknown" rather than an error.
+   */
+  private fun resolveAgpVersion(): String? {
+    return try {
+      Class.forName("com.android.Version").getField("ANDROID_GRADLE_PLUGIN_VERSION").get(null)
+        as? String
+    } catch (_: Throwable) {
+      null
+    }
+  }
+
+  /**
+   * Reads the Kotlin Gradle Plugin version via its documented helper
+   * (`KotlinPluginWrapperKt.getKotlinPluginVersion(Project)`). Reflective call to avoid a hard KGP
+   * compile dep on this plugin. Returns `null` if KGP isn't applied or its API moved.
+   */
+  private fun resolveKotlinVersion(project: Project): String? {
+    return try {
+      Class.forName("org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapperKt")
+        .getMethod("getKotlinPluginVersion", Project::class.java)
+        .invoke(null, project) as? String
+    } catch (_: Throwable) {
+      null
+    }
+  }
+
+  /**
+   * Snapshots the `renderPreviews` Test task's forked-JVM configuration so doctor can flag
+   * the #142-class footgun (test worker silently forking on a different JDK than the Gradle
+   * daemon).
+   *
+   * `javaLauncher.isPresent` is always `true` at resolution time — Gradle fills in a convention
+   * value from the project toolchain or the daemon JVM. We can't observe "user never touched this"
+   * via the API, so we report the effective launcher and leave the mismatch check to the doctor
+   * side, which compares against the daemon JVM.
+   */
+  private fun resolveRenderPreviewsTask(project: Project): RenderPreviewsTaskInfo? {
+    val task = project.tasks.findByName("renderPreviews") as? Test ?: return null
+    val launcher =
+      try {
+        task.javaLauncher.orNull
+      } catch (_: Throwable) {
+        null
+      }
+    val metadata = launcher?.metadata
+    val classpathSize =
+      try {
+        task.classpath.files.size
+      } catch (_: Throwable) {
+        -1
+      }
+    val bootstrapSize =
+      try {
+        task.bootstrapClasspath.files.size
+      } catch (_: Throwable) {
+        -1
+      }
+    val args =
+      try {
+        task.jvmArgs?.toList() ?: emptyList()
+      } catch (_: Throwable) {
+        emptyList()
+      }
+    return RenderPreviewsTaskInfoData(
+      javaLauncherPinned = launcher != null,
+      javaLauncherVersion = metadata?.languageVersion?.asInt()?.toString(),
+      javaLauncherVendor = metadata?.vendor,
+      javaLauncherPath = metadata?.installationPath?.asFile?.absolutePath,
+      classpathSize = classpathSize,
+      bootstrapClasspathSize = bootstrapSize,
+      jvmArgs = args,
+    )
+  }
+
+  /**
+   * Reads the `composePreview { variant = … }` setting, falling back to `"debug"` if the extension
+   * isn't present (plugin not applied on this project). The `Property` itself carries a `"debug"`
+   * convention, so `.getOrElse` is belt-and-braces for the unconfigured case.
+   */
+  private fun resolveVariant(project: Project): String {
+    val ext = project.extensions.findByType(PreviewExtension::class.java) ?: return "debug"
+    return ext.variant.getOrElse("debug")
+  }
+
+  /**
+   * Resolves `config` on [project] and returns `group:name → version`. Swallows failures — doctor
+   * treats empty as "not checkable" rather than erroring. Uses the resolution-result API instead of
+   * `resolvedConfiguration.resolvedArtifacts` because we only need version metadata, not the
+   * downloaded artifacts.
+   */
+  private fun resolveConfiguration(project: Project, name: String): Map<String, String> {
+    val config = project.configurations.findByName(name) ?: return emptyMap()
+    if (!config.isCanBeResolved) return emptyMap()
+    return try {
+      val out = linkedMapOf<String, String>()
+      for (dep in config.incoming.resolutionResult.allDependencies) {
+        val resolved = dep as? org.gradle.api.artifacts.result.ResolvedDependencyResult ?: continue
+        val id = resolved.selected.id
+        if (id is ModuleComponentIdentifier) {
+          // First occurrence wins — resolutionResult already
+          // deduplicates to Gradle's conflict-resolved version.
+          out.putIfAbsent("${id.group}:${id.module}", id.version)
         }
-        val variant = resolveVariant(project)
-        val main = resolveConfiguration(project, "${variant}RuntimeClasspath")
-        val test = resolveConfiguration(project, "${variant}UnitTestRuntimeClasspath")
-        val gradleVersion = org.gradle.util.GradleVersion.current().version
-        val findings: List<ModuleFinding> = CompatRules.evaluate(main, test, gradleVersion)
-        val info: ModuleInfo = ModuleInfoData(
-            variant = variant,
-            mainRuntimeDependencies = main,
-            testRuntimeDependencies = test,
-            findings = findings,
-            agpVersion = resolveAgpVersion(),
-            kotlinVersion = resolveKotlinVersion(project),
-            renderPreviewsTask = resolveRenderPreviewsTask(project),
-        )
-        return ComposePreviewModelData(PluginVersion.value, mapOf(project.path to info))
+      }
+      out
+    } catch (_: Throwable) {
+      emptyMap()
     }
-
-    /**
-     * Reads AGP's embedded version constant via reflection so the plugin
-     * doesn't take a hard compile-time dependency on AGP internals. Returns
-     * `null` on any failure — doctor treats that as "unknown" rather than
-     * an error.
-     */
-    private fun resolveAgpVersion(): String? {
-        return try {
-            Class.forName("com.android.Version")
-                .getField("ANDROID_GRADLE_PLUGIN_VERSION")
-                .get(null) as? String
-        } catch (_: Throwable) {
-            null
-        }
-    }
-
-    /**
-     * Reads the Kotlin Gradle Plugin version via its documented helper
-     * (`KotlinPluginWrapperKt.getKotlinPluginVersion(Project)`). Reflective
-     * call to avoid a hard KGP compile dep on this plugin. Returns `null`
-     * if KGP isn't applied or its API moved.
-     */
-    private fun resolveKotlinVersion(project: Project): String? {
-        return try {
-            Class.forName("org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapperKt")
-                .getMethod("getKotlinPluginVersion", Project::class.java)
-                .invoke(null, project) as? String
-        } catch (_: Throwable) {
-            null
-        }
-    }
-
-    /**
-     * Snapshots the `renderPreviews` Test task's forked-JVM configuration
-     * so doctor can flag the #142-class footgun (test worker silently
-     * forking on a different JDK than the Gradle daemon).
-     *
-     * `javaLauncher.isPresent` is always `true` at resolution time — Gradle
-     * fills in a convention value from the project toolchain or the daemon
-     * JVM. We can't observe "user never touched this" via the API, so we
-     * report the effective launcher and leave the mismatch check to the
-     * doctor side, which compares against the daemon JVM.
-     */
-    private fun resolveRenderPreviewsTask(project: Project): RenderPreviewsTaskInfo? {
-        val task = project.tasks.findByName("renderPreviews") as? Test ?: return null
-        val launcher = try {
-            task.javaLauncher.orNull
-        } catch (_: Throwable) {
-            null
-        }
-        val metadata = launcher?.metadata
-        val classpathSize = try { task.classpath.files.size } catch (_: Throwable) { -1 }
-        val bootstrapSize = try { task.bootstrapClasspath.files.size } catch (_: Throwable) { -1 }
-        val args = try { task.jvmArgs?.toList() ?: emptyList() } catch (_: Throwable) { emptyList() }
-        return RenderPreviewsTaskInfoData(
-            javaLauncherPinned = launcher != null,
-            javaLauncherVersion = metadata?.languageVersion?.asInt()?.toString(),
-            javaLauncherVendor = metadata?.vendor,
-            javaLauncherPath = metadata?.installationPath?.asFile?.absolutePath,
-            classpathSize = classpathSize,
-            bootstrapClasspathSize = bootstrapSize,
-            jvmArgs = args,
-        )
-    }
-
-    /**
-     * Reads the `composePreview { variant = … }` setting, falling back to
-     * `"debug"` if the extension isn't present (plugin not applied on this
-     * project). The `Property` itself carries a `"debug"` convention, so
-     * `.getOrElse` is belt-and-braces for the unconfigured case.
-     */
-    private fun resolveVariant(project: Project): String {
-        val ext = project.extensions.findByType(PreviewExtension::class.java) ?: return "debug"
-        return ext.variant.getOrElse("debug")
-    }
-
-    /**
-     * Resolves `config` on [project] and returns `group:name → version`.
-     * Swallows failures — doctor treats empty as "not checkable" rather than
-     * erroring. Uses the resolution-result API instead of
-     * `resolvedConfiguration.resolvedArtifacts` because we only need version
-     * metadata, not the downloaded artifacts.
-     */
-    private fun resolveConfiguration(project: Project, name: String): Map<String, String> {
-        val config = project.configurations.findByName(name) ?: return emptyMap()
-        if (!config.isCanBeResolved) return emptyMap()
-        return try {
-            val out = linkedMapOf<String, String>()
-            for (dep in config.incoming.resolutionResult.allDependencies) {
-                val resolved = dep as? org.gradle.api.artifacts.result.ResolvedDependencyResult ?: continue
-                val id = resolved.selected.id
-                if (id is ModuleComponentIdentifier) {
-                    // First occurrence wins — resolutionResult already
-                    // deduplicates to Gradle's conflict-resolved version.
-                    out.putIfAbsent("${id.group}:${id.module}", id.version)
-                }
-            }
-            out
-        } catch (_: Throwable) {
-            emptyMap()
-        }
-    }
+  }
 }
 
 // --- Wire impls ------------------------------------------------------------
@@ -162,26 +171,26 @@ internal class ComposePreviewModelBuilder : ToolingModelBuilder {
 // depends on that.
 
 private data class ComposePreviewModelData(
-    override val pluginVersion: String,
-    override val modules: Map<String, ModuleInfo>,
+  override val pluginVersion: String,
+  override val modules: Map<String, ModuleInfo>,
 ) : ComposePreviewModel, Serializable
 
 private data class ModuleInfoData(
-    override val variant: String,
-    override val mainRuntimeDependencies: Map<String, String>,
-    override val testRuntimeDependencies: Map<String, String>,
-    override val findings: List<ModuleFinding>,
-    override val agpVersion: String?,
-    override val kotlinVersion: String?,
-    override val renderPreviewsTask: RenderPreviewsTaskInfo?,
+  override val variant: String,
+  override val mainRuntimeDependencies: Map<String, String>,
+  override val testRuntimeDependencies: Map<String, String>,
+  override val findings: List<ModuleFinding>,
+  override val agpVersion: String?,
+  override val kotlinVersion: String?,
+  override val renderPreviewsTask: RenderPreviewsTaskInfo?,
 ) : ModuleInfo, Serializable
 
 private data class RenderPreviewsTaskInfoData(
-    override val javaLauncherPinned: Boolean,
-    override val javaLauncherVersion: String?,
-    override val javaLauncherVendor: String?,
-    override val javaLauncherPath: String?,
-    override val classpathSize: Int,
-    override val bootstrapClasspathSize: Int,
-    override val jvmArgs: List<String>,
+  override val javaLauncherPinned: Boolean,
+  override val javaLauncherVersion: String?,
+  override val javaLauncherVendor: String?,
+  override val javaLauncherPath: String?,
+  override val classpathSize: Int,
+  override val bootstrapClasspathSize: Int,
+  override val jvmArgs: List<String>,
 ) : RenderPreviewsTaskInfo, Serializable

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
@@ -5,40 +5,33 @@ import org.junit.Test
 
 class CleanStaleRendersTest {
 
-    private val expected = setOf(
-        "Foo.png",
-        "sub/Bar.png",
-        "Baz_TIME_500ms.png",
-    )
+  private val expected = setOf("Foo.png", "sub/Bar.png", "Baz_TIME_500ms.png")
 
-    @Test
-    fun `keeps a11y sibling of registered render`() {
-        assertThat(ComposePreviewTasks.isA11ySiblingOfExpected("Foo.a11y.png", expected)).isTrue()
-        assertThat(ComposePreviewTasks.isA11ySiblingOfExpected("sub/Bar.a11y.png", expected)).isTrue()
-    }
+  @Test
+  fun `keeps a11y sibling of registered render`() {
+    assertThat(ComposePreviewTasks.isA11ySiblingOfExpected("Foo.a11y.png", expected)).isTrue()
+    assertThat(ComposePreviewTasks.isA11ySiblingOfExpected("sub/Bar.a11y.png", expected)).isTrue()
+  }
 
-    @Test
-    fun `keeps a11y sibling of fan-out capture`() {
-        // Multi-capture previews encode dimensions in the basename
-        // (`_TIME_500ms`); the a11y overlay sits next to the same basename.
-        assertThat(
-            ComposePreviewTasks.isA11ySiblingOfExpected("Baz_TIME_500ms.a11y.png", expected),
-        ).isTrue()
-    }
+  @Test
+  fun `keeps a11y sibling of fan-out capture`() {
+    // Multi-capture previews encode dimensions in the basename
+    // (`_TIME_500ms`); the a11y overlay sits next to the same basename.
+    assertThat(ComposePreviewTasks.isA11ySiblingOfExpected("Baz_TIME_500ms.a11y.png", expected))
+      .isTrue()
+  }
 
-    @Test
-    fun `drops a11y png with no clean sibling`() {
-        assertThat(
-            ComposePreviewTasks.isA11ySiblingOfExpected("Removed.a11y.png", expected),
-        ).isFalse()
-    }
+  @Test
+  fun `drops a11y png with no clean sibling`() {
+    assertThat(ComposePreviewTasks.isA11ySiblingOfExpected("Removed.a11y.png", expected)).isFalse()
+  }
 
-    @Test
-    fun `ignores non-a11y png entirely`() {
-        // Plain renders are handled by the exact-match branch in
-        // cleanStaleRenders; this helper should pass them through (false)
-        // so the caller decides.
-        assertThat(ComposePreviewTasks.isA11ySiblingOfExpected("Foo.png", expected)).isFalse()
-        assertThat(ComposePreviewTasks.isA11ySiblingOfExpected("Foo.gif", expected)).isFalse()
-    }
+  @Test
+  fun `ignores non-a11y png entirely`() {
+    // Plain renders are handled by the exact-match branch in
+    // cleanStaleRenders; this helper should pass them through (false)
+    // so the caller decides.
+    assertThat(ComposePreviewTasks.isA11ySiblingOfExpected("Foo.png", expected)).isFalse()
+    assertThat(ComposePreviewTasks.isA11ySiblingOfExpected("Foo.gif", expected)).isFalse()
+  }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DeviceDimensionsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DeviceDimensionsTest.kt
@@ -5,290 +5,294 @@ import org.junit.Test
 
 class DeviceDimensionsTest {
 
-    @Test
-    fun `explicit dimensions override device spec`() {
-        val spec = DeviceDimensions.resolve("id:pixel_6", widthDp = 200, heightDp = 300)
-        assertThat(spec.widthDp).isEqualTo(200)
-        assertThat(spec.heightDp).isEqualTo(300)
-    }
+  @Test
+  fun `explicit dimensions override device spec`() {
+    val spec = DeviceDimensions.resolve("id:pixel_6", widthDp = 200, heightDp = 300)
+    assertThat(spec.widthDp).isEqualTo(200)
+    assertThat(spec.heightDp).isEqualTo(300)
+  }
 
-    @Test
-    fun `known device ID resolves correctly`() {
-        // Pixel 6 = 1080x2400 px @ 420dpi → 411x914 dp
-        // (sergio-sastre/ComposablePreviewScanner Phone.PIXEL_6, exposed via the
-        // takahirom/roborazzi compose-preview-scanner-support pipeline.)
-        val spec = DeviceDimensions.resolve("id:pixel_6")
-        assertThat(spec.widthDp).isEqualTo(411)
-        assertThat(spec.heightDp).isEqualTo(914)
-    }
+  @Test
+  fun `known device ID resolves correctly`() {
+    // Pixel 6 = 1080x2400 px @ 420dpi → 411x914 dp
+    // (sergio-sastre/ComposablePreviewScanner Phone.PIXEL_6, exposed via the
+    // takahirom/roborazzi compose-preview-scanner-support pipeline.)
+    val spec = DeviceDimensions.resolve("id:pixel_6")
+    assertThat(spec.widthDp).isEqualTo(411)
+    assertThat(spec.heightDp).isEqualTo(914)
+  }
 
-    @Test
-    fun `pixel 6 pro has different dimensions from pixel 6`() {
-        // Regression guard against the historical copy-paste that gave pixel_6 the
-        // pixel_6_pro values. Pro is 1440x3120 @ 560dpi → 411x891 dp.
-        val pro = DeviceDimensions.resolve("id:pixel_6_pro")
-        assertThat(pro.widthDp).isEqualTo(411)
-        assertThat(pro.heightDp).isEqualTo(891)
-        assertThat(pro).isNotEqualTo(DeviceDimensions.resolve("id:pixel_6"))
-    }
+  @Test
+  fun `pixel 6 pro has different dimensions from pixel 6`() {
+    // Regression guard against the historical copy-paste that gave pixel_6 the
+    // pixel_6_pro values. Pro is 1440x3120 @ 560dpi → 411x891 dp.
+    val pro = DeviceDimensions.resolve("id:pixel_6_pro")
+    assertThat(pro.widthDp).isEqualTo(411)
+    assertThat(pro.heightDp).isEqualTo(891)
+    assertThat(pro).isNotEqualTo(DeviceDimensions.resolve("id:pixel_6"))
+  }
 
-    @Test
-    fun `pixel 9 has updated geometry from pixel 6 family`() {
-        // Pixel 9/9a = 1080x2424 px @ 420dpi → 411x923 dp (one extra row vs Pixel 6/7/8).
-        val spec = DeviceDimensions.resolve("id:pixel_9")
-        assertThat(spec.widthDp).isEqualTo(411)
-        assertThat(spec.heightDp).isEqualTo(923)
-    }
+  @Test
+  fun `pixel 9 has updated geometry from pixel 6 family`() {
+    // Pixel 9/9a = 1080x2424 px @ 420dpi → 411x923 dp (one extra row vs Pixel 6/7/8).
+    val spec = DeviceDimensions.resolve("id:pixel_9")
+    assertThat(spec.widthDp).isEqualTo(411)
+    assertThat(spec.heightDp).isEqualTo(923)
+  }
 
-    @Test
-    fun `generic device IDs resolve`() {
-        // The "Medium Phone" / "Small Phone" / "Medium Tablet" entries in the @Preview
-        // device picker (Identifier.MEDIUM_PHONE etc. in ComposablePreviewScanner).
-        assertThat(DeviceDimensions.resolve("id:medium_phone").widthDp).isEqualTo(411)
-        assertThat(DeviceDimensions.resolve("id:medium_phone").heightDp).isEqualTo(914)
-        assertThat(DeviceDimensions.resolve("id:small_phone").widthDp).isEqualTo(360)
-        assertThat(DeviceDimensions.resolve("id:small_phone").heightDp).isEqualTo(640)
-        assertThat(DeviceDimensions.resolve("id:medium_tablet").widthDp).isEqualTo(1280)
-        assertThat(DeviceDimensions.resolve("id:medium_tablet").heightDp).isEqualTo(800)
-    }
+  @Test
+  fun `generic device IDs resolve`() {
+    // The "Medium Phone" / "Small Phone" / "Medium Tablet" entries in the @Preview
+    // device picker (Identifier.MEDIUM_PHONE etc. in ComposablePreviewScanner).
+    assertThat(DeviceDimensions.resolve("id:medium_phone").widthDp).isEqualTo(411)
+    assertThat(DeviceDimensions.resolve("id:medium_phone").heightDp).isEqualTo(914)
+    assertThat(DeviceDimensions.resolve("id:small_phone").widthDp).isEqualTo(360)
+    assertThat(DeviceDimensions.resolve("id:small_phone").heightDp).isEqualTo(640)
+    assertThat(DeviceDimensions.resolve("id:medium_tablet").widthDp).isEqualTo(1280)
+    assertThat(DeviceDimensions.resolve("id:medium_tablet").heightDp).isEqualTo(800)
+  }
 
-    @Test
-    fun `pixel fold is landscape-natural`() {
-        val spec = DeviceDimensions.resolve("id:pixel_fold")
-        assertThat(spec.widthDp).isGreaterThan(spec.heightDp)
-    }
+  @Test
+  fun `pixel fold is landscape-natural`() {
+    val spec = DeviceDimensions.resolve("id:pixel_fold")
+    assertThat(spec.widthDp).isGreaterThan(spec.heightDp)
+  }
 
-    @Test
-    fun `spec string is parsed`() {
-        val spec = DeviceDimensions.resolve("spec:width=320dp,height=480dp")
-        assertThat(spec.widthDp).isEqualTo(320)
-        assertThat(spec.heightDp).isEqualTo(480)
-    }
+  @Test
+  fun `spec string is parsed`() {
+    val spec = DeviceDimensions.resolve("spec:width=320dp,height=480dp")
+    assertThat(spec.widthDp).isEqualTo(320)
+    assertThat(spec.heightDp).isEqualTo(480)
+  }
 
-    @Test
-    fun `wear device returns wear defaults`() {
-        val spec = DeviceDimensions.resolve("id:wearos_large_round")
-        assertThat(spec.widthDp).isEqualTo(227)
-        assertThat(spec.heightDp).isEqualTo(227)
-    }
+  @Test
+  fun `wear device returns wear defaults`() {
+    val spec = DeviceDimensions.resolve("id:wearos_large_round")
+    assertThat(spec.widthDp).isEqualTo(227)
+    assertThat(spec.heightDp).isEqualTo(227)
+  }
 
-    @Test
-    fun `desktop tier IDs resolve`() {
-        // Identifier.SMALL_DESKTOP / MEDIUM_DESKTOP / LARGE_DESKTOP in
-        // ComposablePreviewScanner.
-        assertThat(DeviceDimensions.resolve("id:desktop_small").widthDp).isEqualTo(1366)
-        assertThat(DeviceDimensions.resolve("id:desktop_medium").widthDp).isEqualTo(1920)
-        assertThat(DeviceDimensions.resolve("id:desktop_large").widthDp).isEqualTo(1920)
-    }
+  @Test
+  fun `desktop tier IDs resolve`() {
+    // Identifier.SMALL_DESKTOP / MEDIUM_DESKTOP / LARGE_DESKTOP in
+    // ComposablePreviewScanner.
+    assertThat(DeviceDimensions.resolve("id:desktop_small").widthDp).isEqualTo(1366)
+    assertThat(DeviceDimensions.resolve("id:desktop_medium").widthDp).isEqualTo(1920)
+    assertThat(DeviceDimensions.resolve("id:desktop_large").widthDp).isEqualTo(1920)
+  }
 
-    @Test
-    fun `television tier IDs resolve`() {
-        // 4K renders at the same dp as 1080p (4×4K density vs 2×1080p density),
-        // matching Identifier.TV_4K / TV_1080p in ComposablePreviewScanner.
-        assertThat(DeviceDimensions.resolve("id:tv_720p").widthDp).isEqualTo(931)
-        assertThat(DeviceDimensions.resolve("id:tv_1080p").widthDp).isEqualTo(960)
-        assertThat(DeviceDimensions.resolve("id:tv_4k").widthDp).isEqualTo(960)
-    }
+  @Test
+  fun `television tier IDs resolve`() {
+    // 4K renders at the same dp as 1080p (4×4K density vs 2×1080p density),
+    // matching Identifier.TV_4K / TV_1080p in ComposablePreviewScanner.
+    assertThat(DeviceDimensions.resolve("id:tv_720p").widthDp).isEqualTo(931)
+    assertThat(DeviceDimensions.resolve("id:tv_1080p").widthDp).isEqualTo(960)
+    assertThat(DeviceDimensions.resolve("id:tv_4k").widthDp).isEqualTo(960)
+  }
 
-    @Test
-    fun `automotive landscape IDs resolve and are wider than tall`() {
-        val landscape = DeviceDimensions.resolve("id:automotive_1408p_landscape_with_google_apis")
-        assertThat(landscape.widthDp).isEqualTo(1408)
-        assertThat(landscape.heightDp).isEqualTo(792)
-        assertThat(landscape.widthDp).isGreaterThan(landscape.heightDp)
-    }
+  @Test
+  fun `automotive landscape IDs resolve and are wider than tall`() {
+    val landscape = DeviceDimensions.resolve("id:automotive_1408p_landscape_with_google_apis")
+    assertThat(landscape.widthDp).isEqualTo(1408)
+    assertThat(landscape.heightDp).isEqualTo(792)
+    assertThat(landscape.widthDp).isGreaterThan(landscape.heightDp)
+  }
 
-    @Test
-    fun `automotive portrait orientation is preserved`() {
-        // Portrait variants invert the usual landscape geometry.
-        val portrait = DeviceDimensions.resolve("id:automotive_portrait")
-        assertThat(portrait.heightDp).isGreaterThan(portrait.widthDp)
-    }
+  @Test
+  fun `automotive portrait orientation is preserved`() {
+    // Portrait variants invert the usual landscape geometry.
+    val portrait = DeviceDimensions.resolve("id:automotive_portrait")
+    assertThat(portrait.heightDp).isGreaterThan(portrait.widthDp)
+  }
 
-    @Test
-    fun `xr_device alias matches xr_headset_device`() {
-        // xr_device is the deprecated identifier replaced by xr_headset_device in
-        // newer Android Studio versions; both refer to the same device.
-        assertThat(DeviceDimensions.resolve("id:xr_device"))
-            .isEqualTo(DeviceDimensions.resolve("id:xr_headset_device"))
-    }
+  @Test
+  fun `xr_device alias matches xr_headset_device`() {
+    // xr_device is the deprecated identifier replaced by xr_headset_device in
+    // newer Android Studio versions; both refer to the same device.
+    assertThat(DeviceDimensions.resolve("id:xr_device"))
+      .isEqualTo(DeviceDimensions.resolve("id:xr_headset_device"))
+  }
 
-    @Test
-    fun `wearos_rectangular alias matches wearos_rect`() {
-        // wearos_rectangular is the deprecated identifier replaced by wearos_rect in
-        // newer Android Studio versions; both refer to the same device.
-        assertThat(DeviceDimensions.resolve("id:wearos_rectangular"))
-            .isEqualTo(DeviceDimensions.resolve("id:wearos_rect"))
-    }
+  @Test
+  fun `wearos_rectangular alias matches wearos_rect`() {
+    // wearos_rectangular is the deprecated identifier replaced by wearos_rect in
+    // newer Android Studio versions; both refer to the same device.
+    assertThat(DeviceDimensions.resolve("id:wearos_rectangular"))
+      .isEqualTo(DeviceDimensions.resolve("id:wearos_rect"))
+  }
 
-    @Test
-    fun `unknown wear device returns wear defaults`() {
-        val spec = DeviceDimensions.resolve("id:some_wear_device")
-        assertThat(spec.widthDp).isEqualTo(227)
-        assertThat(spec.heightDp).isEqualTo(227)
-    }
+  @Test
+  fun `unknown wear device returns wear defaults`() {
+    val spec = DeviceDimensions.resolve("id:some_wear_device")
+    assertThat(spec.widthDp).isEqualTo(227)
+    assertThat(spec.heightDp).isEqualTo(227)
+  }
 
-    @Test
-    fun `null device returns phone defaults`() {
-        val spec = DeviceDimensions.resolve(null)
-        assertThat(spec.widthDp).isEqualTo(400)
-        assertThat(spec.heightDp).isEqualTo(800)
-    }
+  @Test
+  fun `null device returns phone defaults`() {
+    val spec = DeviceDimensions.resolve(null)
+    assertThat(spec.widthDp).isEqualTo(400)
+    assertThat(spec.heightDp).isEqualTo(800)
+  }
 
-    // -- Density coverage --
-    //
-    // density = densityDpi / 160. We carry this through PreviewParams so renderers
-    // can size bitmaps the same way Android Studio's `@Preview` does (Studio's
-    // default phone-class preview is 420dpi → 2.625x, not Robolectric's mdpi 1.0x
-    // / xhdpi 2.0x default).
+  // -- Density coverage --
+  //
+  // density = densityDpi / 160. We carry this through PreviewParams so renderers
+  // can size bitmaps the same way Android Studio's `@Preview` does (Studio's
+  // default phone-class preview is 420dpi → 2.625x, not Robolectric's mdpi 1.0x
+  // / xhdpi 2.0x default).
 
-    @Test
-    fun `pixel 6 density matches its 420dpi panel`() {
-        // 1080x2400 px @ 420dpi → density 2.625 (xxhdpi-ish).
-        assertThat(DeviceDimensions.resolve("id:pixel_6").density).isEqualTo(2.625f)
-    }
+  @Test
+  fun `pixel 6 density matches its 420dpi panel`() {
+    // 1080x2400 px @ 420dpi → density 2.625 (xxhdpi-ish).
+    assertThat(DeviceDimensions.resolve("id:pixel_6").density).isEqualTo(2.625f)
+  }
 
-    @Test
-    fun `pixel 6 pro is denser than pixel 6`() {
-        // 560dpi vs 420dpi.
-        assertThat(DeviceDimensions.resolve("id:pixel_6_pro").density).isEqualTo(3.5f)
-        assertThat(DeviceDimensions.resolve("id:pixel_6_pro").density)
-            .isGreaterThan(DeviceDimensions.resolve("id:pixel_6").density)
-    }
+  @Test
+  fun `pixel 6 pro is denser than pixel 6`() {
+    // 560dpi vs 420dpi.
+    assertThat(DeviceDimensions.resolve("id:pixel_6_pro").density).isEqualTo(3.5f)
+    assertThat(DeviceDimensions.resolve("id:pixel_6_pro").density)
+      .isGreaterThan(DeviceDimensions.resolve("id:pixel_6").density)
+  }
 
-    @Test
-    fun `tv 4k renders at 4x density`() {
-        // Same dp surface as 1080p but rendered at 640dpi vs 320dpi — the dp/density
-        // pair is what makes "4K" 4K.
-        assertThat(DeviceDimensions.resolve("id:tv_4k").density).isEqualTo(4.0f)
-        assertThat(DeviceDimensions.resolve("id:tv_1080p").density).isEqualTo(2.0f)
-    }
+  @Test
+  fun `tv 4k renders at 4x density`() {
+    // Same dp surface as 1080p but rendered at 640dpi vs 320dpi — the dp/density
+    // pair is what makes "4K" 4K.
+    assertThat(DeviceDimensions.resolve("id:tv_4k").density).isEqualTo(4.0f)
+    assertThat(DeviceDimensions.resolve("id:tv_1080p").density).isEqualTo(2.0f)
+  }
 
-    @Test
-    fun `automotive sub-mdpi densities are preserved`() {
-        // Several automotive panels run below mdpi — 120dpi is 0.75x density. Don't
-        // round these up to 1.0.
-        assertThat(DeviceDimensions.resolve("id:automotive_portrait").density).isEqualTo(0.75f)
-    }
+  @Test
+  fun `automotive sub-mdpi densities are preserved`() {
+    // Several automotive panels run below mdpi — 120dpi is 0.75x density. Don't
+    // round these up to 1.0.
+    assertThat(DeviceDimensions.resolve("id:automotive_portrait").density).isEqualTo(0.75f)
+  }
 
-    @Test
-    fun `unknown device falls back to AS default density`() {
-        // 2.625x matches Android Studio's default phone preview rather than the
-        // historical 2.0x (Robolectric xhdpi).
-        assertThat(DeviceDimensions.resolve(null).density)
-            .isEqualTo(DeviceDimensions.DEFAULT_DENSITY)
-        assertThat(DeviceDimensions.resolve("id:something_unknown").density)
-            .isEqualTo(DeviceDimensions.DEFAULT_DENSITY)
-    }
+  @Test
+  fun `unknown device falls back to AS default density`() {
+    // 2.625x matches Android Studio's default phone preview rather than the
+    // historical 2.0x (Robolectric xhdpi).
+    assertThat(DeviceDimensions.resolve(null).density).isEqualTo(DeviceDimensions.DEFAULT_DENSITY)
+    assertThat(DeviceDimensions.resolve("id:something_unknown").density)
+      .isEqualTo(DeviceDimensions.DEFAULT_DENSITY)
+  }
 
-    @Test
-    fun `spec string honors dpi parameter`() {
-        // Studio's spec: grammar accepts a `dpi=` clause; we honour it so consumers
-        // can pin a specific density without using a known device id.
-        val spec = DeviceDimensions.resolve("spec:width=411dp,height=914dp,dpi=560")
-        assertThat(spec.widthDp).isEqualTo(411)
-        assertThat(spec.heightDp).isEqualTo(914)
-        assertThat(spec.density).isEqualTo(3.5f)
-    }
+  @Test
+  fun `spec string honors dpi parameter`() {
+    // Studio's spec: grammar accepts a `dpi=` clause; we honour it so consumers
+    // can pin a specific density without using a known device id.
+    val spec = DeviceDimensions.resolve("spec:width=411dp,height=914dp,dpi=560")
+    assertThat(spec.widthDp).isEqualTo(411)
+    assertThat(spec.heightDp).isEqualTo(914)
+    assertThat(spec.density).isEqualTo(3.5f)
+  }
 
-    @Test
-    fun `spec string without dpi falls back to AS default`() {
-        val spec = DeviceDimensions.resolve("spec:width=300dp,height=500dp")
-        assertThat(spec.density).isEqualTo(DeviceDimensions.DEFAULT_DENSITY)
-    }
+  @Test
+  fun `spec string without dpi falls back to AS default`() {
+    val spec = DeviceDimensions.resolve("spec:width=300dp,height=500dp")
+    assertThat(spec.density).isEqualTo(DeviceDimensions.DEFAULT_DENSITY)
+  }
 
-    @Test
-    fun `wear devices share xhdpi density`() {
-        // All wear devices upstream are 320dpi → 2.0x.
-        assertThat(DeviceDimensions.resolve("id:wearos_large_round").density).isEqualTo(2.0f)
-        assertThat(DeviceDimensions.resolve("id:wearos_square").density).isEqualTo(2.0f)
-        assertThat(DeviceDimensions.resolve("id:wearos_xl_round").density).isEqualTo(2.0f)
-    }
+  @Test
+  fun `wear devices share xhdpi density`() {
+    // All wear devices upstream are 320dpi → 2.0x.
+    assertThat(DeviceDimensions.resolve("id:wearos_large_round").density).isEqualTo(2.0f)
+    assertThat(DeviceDimensions.resolve("id:wearos_square").density).isEqualTo(2.0f)
+    assertThat(DeviceDimensions.resolve("id:wearos_xl_round").density).isEqualTo(2.0f)
+  }
 
-    @Test
-    fun `wearos_xl_round resolves`() {
-        // 480x480 px @ xhdpi → 240x240 dp. Source: AOSP sdklib/devices/wear.xml.
-        // Larger than wearos_large_round (227dp) — sits at the top of the
-        // 192–240 dp wear range Material 2.5 calls out.
-        val spec = DeviceDimensions.resolve("id:wearos_xl_round")
-        assertThat(spec.widthDp).isEqualTo(240)
-        assertThat(spec.heightDp).isEqualTo(240)
-        assertThat(spec.widthDp)
-            .isGreaterThan(DeviceDimensions.resolve("id:wearos_large_round").widthDp)
-    }
+  @Test
+  fun `wearos_xl_round resolves`() {
+    // 480x480 px @ xhdpi → 240x240 dp. Source: AOSP sdklib/devices/wear.xml.
+    // Larger than wearos_large_round (227dp) — sits at the top of the
+    // 192–240 dp wear range Material 2.5 calls out.
+    val spec = DeviceDimensions.resolve("id:wearos_xl_round")
+    assertThat(spec.widthDp).isEqualTo(240)
+    assertThat(spec.heightDp).isEqualTo(240)
+    assertThat(spec.widthDp)
+      .isGreaterThan(DeviceDimensions.resolve("id:wearos_large_round").widthDp)
+  }
 
-    // -- resolveForRender (AS-parity sizing) --
+  // -- resolveForRender (AS-parity sizing) --
 
-    @Test
-    fun `resolveForRender wraps both axes when no hints are given`() {
-        val spec = DeviceDimensions.resolveForRender(
-            device = null,
-            widthDp = null,
-            heightDp = null,
-            showSystemUi = false,
-        )
-        assertThat(spec.wrapWidth).isTrue()
-        assertThat(spec.wrapHeight).isTrue()
-        // Wrap-axes get the phone-shaped 400×800 dp sandbox so fillMaxSize
-        // composables render into a reasonable viewport before the PNG crop.
-        assertThat(spec.widthDp).isEqualTo(DeviceDimensions.SANDBOX_WIDTH_DP)
-        assertThat(spec.heightDp).isEqualTo(DeviceDimensions.SANDBOX_HEIGHT_DP)
-    }
+  @Test
+  fun `resolveForRender wraps both axes when no hints are given`() {
+    val spec =
+      DeviceDimensions.resolveForRender(
+        device = null,
+        widthDp = null,
+        heightDp = null,
+        showSystemUi = false,
+      )
+    assertThat(spec.wrapWidth).isTrue()
+    assertThat(spec.wrapHeight).isTrue()
+    // Wrap-axes get the phone-shaped 400×800 dp sandbox so fillMaxSize
+    // composables render into a reasonable viewport before the PNG crop.
+    assertThat(spec.widthDp).isEqualTo(DeviceDimensions.SANDBOX_WIDTH_DP)
+    assertThat(spec.heightDp).isEqualTo(DeviceDimensions.SANDBOX_HEIGHT_DP)
+  }
 
-    @Test
-    fun `resolveForRender keeps device frame when device is set`() {
-        val spec = DeviceDimensions.resolveForRender(
-            device = "id:pixel_6",
-            widthDp = null,
-            heightDp = null,
-            showSystemUi = false,
-        )
-        assertThat(spec.wrapWidth).isFalse()
-        assertThat(spec.wrapHeight).isFalse()
-        // Pixel 6 = 411×914 dp after the upstream per-device density refresh.
-        assertThat(spec.widthDp).isEqualTo(411)
-        assertThat(spec.heightDp).isEqualTo(914)
-    }
+  @Test
+  fun `resolveForRender keeps device frame when device is set`() {
+    val spec =
+      DeviceDimensions.resolveForRender(
+        device = "id:pixel_6",
+        widthDp = null,
+        heightDp = null,
+        showSystemUi = false,
+      )
+    assertThat(spec.wrapWidth).isFalse()
+    assertThat(spec.wrapHeight).isFalse()
+    // Pixel 6 = 411×914 dp after the upstream per-device density refresh.
+    assertThat(spec.widthDp).isEqualTo(411)
+    assertThat(spec.heightDp).isEqualTo(914)
+  }
 
-    @Test
-    fun `resolveForRender keeps full frame when showSystemUi is true`() {
-        val spec = DeviceDimensions.resolveForRender(
-            device = null,
-            widthDp = null,
-            heightDp = null,
-            showSystemUi = true,
-        )
-        assertThat(spec.wrapWidth).isFalse()
-        assertThat(spec.wrapHeight).isFalse()
-        assertThat(spec.widthDp).isEqualTo(400)
-        assertThat(spec.heightDp).isEqualTo(800)
-    }
+  @Test
+  fun `resolveForRender keeps full frame when showSystemUi is true`() {
+    val spec =
+      DeviceDimensions.resolveForRender(
+        device = null,
+        widthDp = null,
+        heightDp = null,
+        showSystemUi = true,
+      )
+    assertThat(spec.wrapWidth).isFalse()
+    assertThat(spec.wrapHeight).isFalse()
+    assertThat(spec.widthDp).isEqualTo(400)
+    assertThat(spec.heightDp).isEqualTo(800)
+  }
 
-    @Test
-    fun `resolveForRender wraps only the axis the user left unset`() {
-        val spec = DeviceDimensions.resolveForRender(
-            device = null,
-            widthDp = 240,
-            heightDp = null,
-            showSystemUi = false,
-        )
-        assertThat(spec.wrapWidth).isFalse()
-        assertThat(spec.wrapHeight).isTrue()
-        assertThat(spec.widthDp).isEqualTo(240)
-        assertThat(spec.heightDp).isEqualTo(DeviceDimensions.SANDBOX_HEIGHT_DP)
-    }
+  @Test
+  fun `resolveForRender wraps only the axis the user left unset`() {
+    val spec =
+      DeviceDimensions.resolveForRender(
+        device = null,
+        widthDp = 240,
+        heightDp = null,
+        showSystemUi = false,
+      )
+    assertThat(spec.wrapWidth).isFalse()
+    assertThat(spec.wrapHeight).isTrue()
+    assertThat(spec.widthDp).isEqualTo(240)
+    assertThat(spec.heightDp).isEqualTo(DeviceDimensions.SANDBOX_HEIGHT_DP)
+  }
 
-    @Test
-    fun `resolveForRender explicit dims override device frame`() {
-        val spec = DeviceDimensions.resolveForRender(
-            device = "id:pixel_6",
-            widthDp = 200,
-            heightDp = 300,
-            showSystemUi = false,
-        )
-        assertThat(spec.wrapWidth).isFalse()
-        assertThat(spec.wrapHeight).isFalse()
-        assertThat(spec.widthDp).isEqualTo(200)
-        assertThat(spec.heightDp).isEqualTo(300)
-    }
+  @Test
+  fun `resolveForRender explicit dims override device frame`() {
+    val spec =
+      DeviceDimensions.resolveForRender(
+        device = "id:pixel_6",
+        widthDp = 200,
+        heightDp = 300,
+        showSystemUi = false,
+      )
+    assertThat(spec.wrapWidth).isFalse()
+    assertThat(spec.wrapHeight).isFalse()
+    assertThat(spec.widthDp).isEqualTo(200)
+    assertThat(spec.heightDp).isEqualTo(300)
+  }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/GenerateRobolectricPropertiesTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/GenerateRobolectricPropertiesTaskTest.kt
@@ -7,46 +7,45 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
 /**
- * Pins the contract of the generated `robolectric.properties`:
- * `sdk`, `graphicsMode`, `shadows`, and the `application` toggle driven by
- * `composePreview.useConsumerApplication`. The `sdk` + `graphicsMode` keys
- * live here rather than on `@Config` / `@GraphicsMode` to avoid JUnit's
- * `AnnotationParser` resolving `android.app.Application` during test-class
- * discovery — see issue #142 and `GenerateRobolectricPropertiesTask` KDoc.
+ * Pins the contract of the generated `robolectric.properties`: `sdk`, `graphicsMode`, `shadows`,
+ * and the `application` toggle driven by `composePreview.useConsumerApplication`. The `sdk` +
+ * `graphicsMode` keys live here rather than on `@Config` / `@GraphicsMode` to avoid JUnit's
+ * `AnnotationParser` resolving `android.app.Application` during test-class discovery — see
+ * issue #142 and `GenerateRobolectricPropertiesTask` KDoc.
  */
 class GenerateRobolectricPropertiesTaskTest {
 
-    @get:Rule val tmp = TemporaryFolder()
+  @get:Rule val tmp = TemporaryFolder()
 
-    @Test
-    fun `default emits sdk graphicsMode application shadows`() {
-        val body = generate(useConsumerApplication = false)
-        assertThat(body).contains("sdk=${GenerateRobolectricPropertiesTask.TARGET_SDK}")
-        assertThat(body).contains("graphicsMode=NATIVE")
-        assertThat(body).contains("application=android.app.Application")
-        assertThat(body).contains("shadows=ee.schimke.composeai.renderer.ShadowFontsContractCompat")
-    }
+  @Test
+  fun `default emits sdk graphicsMode application shadows`() {
+    val body = generate(useConsumerApplication = false)
+    assertThat(body).contains("sdk=${GenerateRobolectricPropertiesTask.TARGET_SDK}")
+    assertThat(body).contains("graphicsMode=NATIVE")
+    assertThat(body).contains("application=android.app.Application")
+    assertThat(body).contains("shadows=ee.schimke.composeai.renderer.ShadowFontsContractCompat")
+  }
 
-    @Test
-    fun `useConsumerApplication drops application line but keeps sdk graphicsMode shadows`() {
-        val body = generate(useConsumerApplication = true)
-        assertThat(body).contains("sdk=${GenerateRobolectricPropertiesTask.TARGET_SDK}")
-        assertThat(body).contains("graphicsMode=NATIVE")
-        assertThat(body).doesNotContain("application=")
-        assertThat(body).contains("shadows=ee.schimke.composeai.renderer.ShadowFontsContractCompat")
-    }
+  @Test
+  fun `useConsumerApplication drops application line but keeps sdk graphicsMode shadows`() {
+    val body = generate(useConsumerApplication = true)
+    assertThat(body).contains("sdk=${GenerateRobolectricPropertiesTask.TARGET_SDK}")
+    assertThat(body).contains("graphicsMode=NATIVE")
+    assertThat(body).doesNotContain("application=")
+    assertThat(body).contains("shadows=ee.schimke.composeai.renderer.ShadowFontsContractCompat")
+  }
 
-    private fun generate(useConsumerApplication: Boolean): String {
-        val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
-        val task = project.tasks.register(
-            "generateRobolectricProperties",
-            GenerateRobolectricPropertiesTask::class.java,
-        ).get()
-        task.useConsumerApplication.set(useConsumerApplication)
-        task.outputDir.set(tmp.newFolder("out"))
-        task.generate()
-        val file = task.outputDir.get().asFile
-            .resolve("ee/schimke/composeai/renderer/robolectric.properties")
-        return file.readText()
-    }
+  private fun generate(useConsumerApplication: Boolean): String {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    val task =
+      project.tasks
+        .register("generateRobolectricProperties", GenerateRobolectricPropertiesTask::class.java)
+        .get()
+    task.useConsumerApplication.set(useConsumerApplication)
+    task.outputDir.set(tmp.newFolder("out"))
+    task.generate()
+    val file =
+      task.outputDir.get().asFile.resolve("ee/schimke/composeai/renderer/robolectric.properties")
+    return file.readText()
+  }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewDataTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewDataTest.kt
@@ -7,48 +7,53 @@ import org.junit.Test
 
 class PreviewDataTest {
 
-    private val json = Json { prettyPrint = true; encodeDefaults = true }
+  private val json = Json {
+    prettyPrint = true
+    encodeDefaults = true
+  }
 
-    @Test
-    fun `manifest serialization round-trips`() {
-        val manifest = PreviewManifest(
-            module = "app",
-            variant = "debug",
-            previews = listOf(
-                PreviewInfo(
-                    id = "com.example.PreviewsKt.RedBoxPreview_Red Box",
-                    functionName = "RedBoxPreview",
-                    className = "com.example.PreviewsKt",
-                    sourceFile = "Previews.kt",
-                    params = PreviewParams(
-                        name = "Red Box",
-                        showBackground = true,
-                        backgroundColor = 0xFFFF0000,
-                    ),
-                    captures = listOf(
-                        Capture(
-                            renderOutput = "renders/com.example.PreviewsKt.RedBoxPreview_Red Box.png",
-                        ),
-                    ),
+  @Test
+  fun `manifest serialization round-trips`() {
+    val manifest =
+      PreviewManifest(
+        module = "app",
+        variant = "debug",
+        previews =
+          listOf(
+            PreviewInfo(
+              id = "com.example.PreviewsKt.RedBoxPreview_Red Box",
+              functionName = "RedBoxPreview",
+              className = "com.example.PreviewsKt",
+              sourceFile = "Previews.kt",
+              params =
+                PreviewParams(
+                  name = "Red Box",
+                  showBackground = true,
+                  backgroundColor = 0xFFFF0000,
                 ),
-            ),
-        )
+              captures =
+                listOf(
+                  Capture(renderOutput = "renders/com.example.PreviewsKt.RedBoxPreview_Red Box.png")
+                ),
+            )
+          ),
+      )
 
-        val serialized = json.encodeToString(manifest)
-        val deserialized = json.decodeFromString<PreviewManifest>(serialized)
+    val serialized = json.encodeToString(manifest)
+    val deserialized = json.decodeFromString<PreviewManifest>(serialized)
 
-        assertThat(deserialized).isEqualTo(manifest)
-        assertThat(deserialized.previews).hasSize(1)
-        assertThat(deserialized.previews[0].params.backgroundColor).isEqualTo(0xFFFF0000)
-    }
+    assertThat(deserialized).isEqualTo(manifest)
+    assertThat(deserialized.previews).hasSize(1)
+    assertThat(deserialized.previews[0].params.backgroundColor).isEqualTo(0xFFFF0000)
+  }
 
-    @Test
-    fun `default params have sensible values`() {
-        val params = PreviewParams()
-        assertThat(params.widthDp).isNull()
-        assertThat(params.heightDp).isNull()
-        assertThat(params.fontScale).isEqualTo(1.0f)
-        assertThat(params.showBackground).isFalse()
-        assertThat(params.backgroundColor).isEqualTo(0L)
-    }
+  @Test
+  fun `default params have sensible values`() {
+    val params = PreviewParams()
+    assertThat(params.widthDp).isNull()
+    assertThat(params.heightDp).isNull()
+    assertThat(params.fontScale).isEqualTo(1.0f)
+    assertThat(params.showBackground).isFalse()
+    assertThat(params.backgroundColor).isEqualTo(0L)
+  }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ShardTuningTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ShardTuningTest.kt
@@ -6,126 +6,116 @@ import org.junit.Test
 /**
  * Behavioural tests for the cost-aware sharding heuristic.
  *
- * Each test pins a *decision*, not a model coefficient — the constants in
- * [ShardTuning] (PER_FORK_SETUP_SECONDS, SECONDS_PER_COST_UNIT,
- * FORK_OVERHEAD_SECONDS) get re-tuned over time as hardware and the
- * Robolectric stack evolve. What we want to lock in is "two GIFs at 40
- * cost each justify two shards" rather than "K=2 takes exactly 7.85s".
+ * Each test pins a *decision*, not a model coefficient — the constants in [ShardTuning]
+ * (PER_FORK_SETUP_SECONDS, SECONDS_PER_COST_UNIT, FORK_OVERHEAD_SECONDS) get re-tuned over time as
+ * hardware and the Robolectric stack evolve. What we want to lock in is "two GIFs at 40 cost each
+ * justify two shards" rather than "K=2 takes exactly 7.85s".
  */
 class ShardTuningTest {
 
-    @Test
-    fun `single static preview never shards`() {
-        val k = ShardTuning.autoShards(
-            totalCost = 1.0,
-            maxIndividualCost = 1.0,
-            captureCount = 1,
-            cores = 16,
-        )
-        assertThat(k).isEqualTo(1)
-    }
+  @Test
+  fun `single static preview never shards`() {
+    val k =
+      ShardTuning.autoShards(totalCost = 1.0, maxIndividualCost = 1.0, captureCount = 1, cores = 16)
+    assertThat(k).isEqualTo(1)
+  }
 
-    @Test
-    fun `dozens of static previews still don't justify sharding`() {
-        // 40 static previews × 1.0 cost = 40 total. Single shard:
-        // 3.85 + 40×0.15 ≈ 9.85s. K=2 saves only ~3s, and the relative
-        // gain (~30%) is right at the threshold; with FORK_OVERHEAD it
-        // dips just under, so we stay single-shard. The point is the
-        // decision is governed by total work, not preview count.
-        val k = ShardTuning.autoShards(
-            totalCost = 40.0,
-            maxIndividualCost = 1.0,
-            captureCount = 40,
-            cores = 16,
-        )
-        assertThat(k).isAtMost(2) // model-stable assertion: would be 1 today, 2 if constants ever shift
-    }
+  @Test
+  fun `dozens of static previews still don't justify sharding`() {
+    // 40 static previews × 1.0 cost = 40 total. Single shard:
+    // 3.85 + 40×0.15 ≈ 9.85s. K=2 saves only ~3s, and the relative
+    // gain (~30%) is right at the threshold; with FORK_OVERHEAD it
+    // dips just under, so we stay single-shard. The point is the
+    // decision is governed by total work, not preview count.
+    val k =
+      ShardTuning.autoShards(
+        totalCost = 40.0,
+        maxIndividualCost = 1.0,
+        captureCount = 40,
+        cores = 16,
+      )
+    assertThat(k).isAtMost(2) // model-stable assertion: would be 1 today, 2 if constants ever shift
+  }
 
-    @Test
-    fun `a few heavy GIF captures DO justify sharding`() {
-        // 8 captures, three of them GIFs (cost 40). totalCost = 5*1 + 3*40 = 125.
-        // Under the OLD uniform-cost model this looked like 8 previews at
-        // 0.15s each — well below the saving threshold, so sharding was
-        // (incorrectly) skipped. Under the new model, 125×0.15 ≈ 18.75s of
-        // compose work, and a 2-way split nearly halves the make-span.
-        val k = ShardTuning.autoShards(
-            totalCost = 125.0,
-            maxIndividualCost = 40.0,
-            captureCount = 8,
-            cores = 16,
-        )
-        assertThat(k).isAtLeast(2)
-    }
+  @Test
+  fun `a few heavy GIF captures DO justify sharding`() {
+    // 8 captures, three of them GIFs (cost 40). totalCost = 5*1 + 3*40 = 125.
+    // Under the OLD uniform-cost model this looked like 8 previews at
+    // 0.15s each — well below the saving threshold, so sharding was
+    // (incorrectly) skipped. Under the new model, 125×0.15 ≈ 18.75s of
+    // compose work, and a 2-way split nearly halves the make-span.
+    val k =
+      ShardTuning.autoShards(
+        totalCost = 125.0,
+        maxIndividualCost = 40.0,
+        captureCount = 8,
+        cores = 16,
+      )
+    assertThat(k).isAtLeast(2)
+  }
 
-    @Test
-    fun `make-span floor caps useful sharding when one capture dominates`() {
-        // One animated preview at cost 50 + 4 cheap ones at cost 1.
-        // totalCost=54, maxIndividualCost=50. The animated capture sets a
-        // floor of 50×0.15=7.5s — adding more shards past 2 doesn't help
-        // because the largest preview lives entirely on one fork. The
-        // model is supposed to recognise this and not over-shard.
-        val k = ShardTuning.autoShards(
-            totalCost = 54.0,
-            maxIndividualCost = 50.0,
-            captureCount = 5,
-            cores = 16,
-        )
-        assertThat(k).isAtMost(2)
-    }
+  @Test
+  fun `make-span floor caps useful sharding when one capture dominates`() {
+    // One animated preview at cost 50 + 4 cheap ones at cost 1.
+    // totalCost=54, maxIndividualCost=50. The animated capture sets a
+    // floor of 50×0.15=7.5s — adding more shards past 2 doesn't help
+    // because the largest preview lives entirely on one fork. The
+    // model is supposed to recognise this and not over-shard.
+    val k =
+      ShardTuning.autoShards(
+        totalCost = 54.0,
+        maxIndividualCost = 50.0,
+        captureCount = 5,
+        cores = 16,
+      )
+    assertThat(k).isAtMost(2)
+  }
 
-    @Test
-    fun `predictedSeconds respects the make-span floor`() {
-        // 1 capture at cost 50 split into 4 shards: average per shard =
-        // 12.5, but the largest single capture is 50 so the make-span
-        // can't drop below 50 cost units. Model returns the floor.
-        val secondsAt4 = ShardTuning.predictedSeconds(
-            totalCost = 50.0,
-            maxIndividualCost = 50.0,
-            shards = 4,
-        )
-        val secondsAt1 = ShardTuning.predictedSeconds(
-            totalCost = 50.0,
-            maxIndividualCost = 50.0,
-            shards = 1,
-        )
-        // 4-shard run pays the (K−1)×fork-overhead but still has the same
-        // 50-cost floor as a 1-shard run, so it's strictly slower.
-        assertThat(secondsAt4).isGreaterThan(secondsAt1)
-    }
+  @Test
+  fun `predictedSeconds respects the make-span floor`() {
+    // 1 capture at cost 50 split into 4 shards: average per shard =
+    // 12.5, but the largest single capture is 50 so the make-span
+    // can't drop below 50 cost units. Model returns the floor.
+    val secondsAt4 =
+      ShardTuning.predictedSeconds(totalCost = 50.0, maxIndividualCost = 50.0, shards = 4)
+    val secondsAt1 =
+      ShardTuning.predictedSeconds(totalCost = 50.0, maxIndividualCost = 50.0, shards = 1)
+    // 4-shard run pays the (K−1)×fork-overhead but still has the same
+    // 50-cost floor as a 1-shard run, so it's strictly slower.
+    assertThat(secondsAt4).isGreaterThan(secondsAt1)
+  }
 
-    @Test
-    fun `shard count is bounded by half the available cores`() {
-        // Lots of cheap captures, but only 4 cores → cap at K = 2.
-        val k = ShardTuning.autoShards(
-            totalCost = 1000.0,
-            maxIndividualCost = 1.0,
-            captureCount = 1000,
-            cores = 4,
-        )
-        assertThat(k).isAtMost(2)
-    }
+  @Test
+  fun `shard count is bounded by half the available cores`() {
+    // Lots of cheap captures, but only 4 cores → cap at K = 2.
+    val k =
+      ShardTuning.autoShards(
+        totalCost = 1000.0,
+        maxIndividualCost = 1.0,
+        captureCount = 1000,
+        cores = 4,
+      )
+    assertThat(k).isAtMost(2)
+  }
 
-    @Test
-    fun `shard count never exceeds capture count`() {
-        // 3 captures, 16 cores: even if 8 shards would minimise wall-time,
-        // we never assign fewer than 1 capture per fork.
-        val k = ShardTuning.autoShards(
-            totalCost = 90.0,
-            maxIndividualCost = 30.0,
-            captureCount = 3,
-            cores = 16,
-        )
-        assertThat(k).isAtMost(3)
-    }
+  @Test
+  fun `shard count never exceeds capture count`() {
+    // 3 captures, 16 cores: even if 8 shards would minimise wall-time,
+    // we never assign fewer than 1 capture per fork.
+    val k =
+      ShardTuning.autoShards(
+        totalCost = 90.0,
+        maxIndividualCost = 30.0,
+        captureCount = 3,
+        cores = 16,
+      )
+    assertThat(k).isAtMost(3)
+  }
 
-    @Test
-    fun `module with no captures returns single shard`() {
-        val k = ShardTuning.autoShards(
-            totalCost = 0.0,
-            maxIndividualCost = 0.0,
-            captureCount = 0,
-            cores = 16,
-        )
-        assertThat(k).isEqualTo(1)
-    }
+  @Test
+  fun `module with no captures returns single shard`() {
+    val k =
+      ShardTuning.autoShards(totalCost = 0.0, maxIndividualCost = 0.0, captureCount = 0, cores = 16)
+    assertThat(k).isEqualTo(1)
+  }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
@@ -7,184 +7,223 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Every rule gets two test cases — one that triggers it, one that doesn't.
- * Rules are pure so no mocking or Project fixture required; we hand-roll
- * the dependency maps.
+ * Every rule gets two test cases — one that triggers it, one that doesn't. Rules are pure so no
+ * mocking or Project fixture required; we hand-roll the dependency maps.
  */
 class CompatRulesTest {
 
-    @Test fun `ui-test-manifest missing fires error`() {
-        val findings = CompatRules.evaluate(mainWithBom(), testWithoutUiTestManifest())
-        val f = findings.single { it.id == "ui-test-manifest-missing" }
-        assertEquals("error", f.severity)
-        assertTrue(f.remediationCommands.any { "ui-test-manifest" in it })
+  @Test
+  fun `ui-test-manifest missing fires error`() {
+    val findings = CompatRules.evaluate(mainWithBom(), testWithoutUiTestManifest())
+    val f = findings.single { it.id == "ui-test-manifest-missing" }
+    assertEquals("error", f.severity)
+    assertTrue(f.remediationCommands.any { "ui-test-manifest" in it })
+  }
+
+  @Test
+  fun `ui-test-manifest present is quiet`() {
+    val test = testWithoutUiTestManifest() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
+    val findings = CompatRules.evaluate(mainWithBom(), test)
+    assertNull(findings.firstOrNull { it.id == "ui-test-manifest-missing" })
+  }
+
+  @Test
+  fun `navigationevent with old main activity fires error`() {
+    val main = mainWithBom() + ("androidx.activity:activity" to "1.8.0")
+    val test =
+      testWithoutUiTestManifest() +
+        ("androidx.navigationevent:navigationevent" to "1.0.0") +
+        ("androidx.activity:activity" to "1.13.0")
+    val findings = CompatRules.evaluate(main, test)
+    val f = findings.single { it.id == "activity-vs-navigationevent" }
+    assertEquals("error", f.severity)
+    assertTrue("1.8.0" in (f.detail ?: ""))
+  }
+
+  @Test
+  fun `navigationevent with matching main activity is quiet`() {
+    val main = mainWithBom() + ("androidx.activity:activity" to "1.13.0")
+    val test =
+      main +
+        ("androidx.navigationevent:navigationevent" to "1.0.0") +
+        ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
+    val findings = CompatRules.evaluate(main, test)
+    assertNull(findings.firstOrNull { it.id == "activity-vs-navigationevent" })
+  }
+
+  @Test
+  fun `compose-ui 1_10 with old core fires error`() {
+    val main = mainWithBom() + ("androidx.core:core" to "1.15.0")
+    val test =
+      main +
+        ("androidx.compose.ui:ui" to "1.10.6") +
+        ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
+    val findings = CompatRules.evaluate(main, test)
+    val f = findings.single { it.id == "compose-ui-vs-core" }
+    assertEquals("error", f.severity)
+  }
+
+  @Test
+  fun `compose-ui 1_9 is below threshold (no finding even with old core)`() {
+    val main = mainWithBom() + ("androidx.core:core" to "1.15.0")
+    val test =
+      main +
+        ("androidx.compose.ui:ui" to "1.9.4") +
+        ("androidx.compose.ui:ui-test-manifest" to "1.9.4")
+    val findings = CompatRules.evaluate(main, test)
+    assertNull(findings.firstOrNull { it.id == "compose-ui-vs-core" })
+  }
+
+  @Test
+  fun `no compose BOM yields warning`() {
+    val main = mapOf("androidx.core:core" to "1.16.0")
+    val test = main + ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
+    val findings = CompatRules.evaluate(main, test)
+    val f = findings.single { it.id == "compose-bom-missing" }
+    assertEquals("warning", f.severity)
+  }
+
+  @Test
+  fun `with compose BOM, bom finding is absent`() {
+    val findings =
+      CompatRules.evaluate(
+        mainWithBom(),
+        mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
+      )
+    assertNull(findings.firstOrNull { it.id == "compose-bom-missing" })
+  }
+
+  @Test
+  fun `all findings populated have non-empty docs or commands`() {
+    // Stacked scenario: everything wrong — exercises every rule at once.
+    val main = mapOf("androidx.activity:activity" to "1.8.0", "androidx.core:core" to "1.15.0")
+    val test =
+      mapOf(
+        "androidx.navigationevent:navigationevent" to "1.0.0",
+        "androidx.compose.ui:ui" to "1.10.6",
+      )
+    val findings = CompatRules.evaluate(main, test)
+    assertTrue(findings.size >= 3)
+    // Every finding should carry at least one actionable hint.
+    for (f in findings) {
+      val actionable = f.remediationCommands.isNotEmpty() || f.docsUrl != null
+      assertTrue(
+        "finding ${f.id} has no actionable remediation",
+        actionable || f.remediationSummary != null,
+      )
     }
+  }
 
-    @Test fun `ui-test-manifest present is quiet`() {
-        val test = testWithoutUiTestManifest() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
-        val findings = CompatRules.evaluate(mainWithBom(), test)
-        assertNull(findings.firstOrNull { it.id == "ui-test-manifest-missing" })
-    }
+  @Test
+  fun `old activity fires old-dep warning`() {
+    val main = mainWithBom() + ("androidx.activity:activity" to "1.8.0")
+    val test = main + ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
+    val findings = CompatRules.evaluate(main, test)
+    val f = findings.single { it.id == "old-dep-androidx.activity:activity" }
+    assertEquals("warning", f.severity)
+    assertTrue("1.8.0" in f.message)
+    assertTrue(f.remediationCommands.any { "androidx.activity:activity" in it })
+  }
 
-    @Test fun `navigationevent with old main activity fires error`() {
-        val main = mainWithBom() + ("androidx.activity:activity" to "1.8.0")
-        val test = testWithoutUiTestManifest() +
-            ("androidx.navigationevent:navigationevent" to "1.0.0") +
-            ("androidx.activity:activity" to "1.13.0")
-        val findings = CompatRules.evaluate(main, test)
-        val f = findings.single { it.id == "activity-vs-navigationevent" }
-        assertEquals("error", f.severity)
-        assertTrue("1.8.0" in (f.detail ?: ""))
-    }
+  @Test
+  fun `current activity is quiet`() {
+    val main = mainWithBom() + ("androidx.activity:activity" to "1.13.0")
+    val test = main + ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
+    val findings = CompatRules.evaluate(main, test)
+    assertNull(findings.firstOrNull { it.id.startsWith("old-dep-androidx.activity") })
+  }
 
-    @Test fun `navigationevent with matching main activity is quiet`() {
-        val main = mainWithBom() + ("androidx.activity:activity" to "1.13.0")
-        val test = main + ("androidx.navigationevent:navigationevent" to "1.0.0") +
-            ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
-        val findings = CompatRules.evaluate(main, test)
-        assertNull(findings.firstOrNull { it.id == "activity-vs-navigationevent" })
-    }
+  @Test
+  fun `absent library emits no old-dep finding`() {
+    // lifecycle-runtime isn't on the classpath at all — silently skipped.
+    val findings =
+      CompatRules.evaluate(
+        mainWithBom(),
+        mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
+      )
+    assertNull(findings.firstOrNull { it.id.startsWith("old-dep-androidx.lifecycle") })
+  }
 
-    @Test fun `compose-ui 1_10 with old core fires error`() {
-        val main = mainWithBom() + ("androidx.core:core" to "1.15.0")
-        val test = main + ("androidx.compose.ui:ui" to "1.10.6") +
-            ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
-        val findings = CompatRules.evaluate(main, test)
-        val f = findings.single { it.id == "compose-ui-vs-core" }
-        assertEquals("error", f.severity)
-    }
+  @Test
+  fun `test-classpath higher than main is taken as resolved`() {
+    // Main has old activity, test classpath has newer — we take the max.
+    val main = mainWithBom() + ("androidx.activity:activity" to "1.8.0")
+    val test =
+      main +
+        ("androidx.activity:activity" to "1.13.0") +
+        ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
+    val findings = CompatRules.evaluate(main, test)
+    assertNull(findings.firstOrNull { it.id.startsWith("old-dep-androidx.activity") })
+  }
 
-    @Test fun `compose-ui 1_9 is below threshold (no finding even with old core)`() {
-        val main = mainWithBom() + ("androidx.core:core" to "1.15.0")
-        val test = main + ("androidx.compose.ui:ui" to "1.9.4") +
-            ("androidx.compose.ui:ui-test-manifest" to "1.9.4")
-        val findings = CompatRules.evaluate(main, test)
-        assertNull(findings.firstOrNull { it.id == "compose-ui-vs-core" })
-    }
+  @Test
+  fun `old gradle fires error`() {
+    val findings =
+      CompatRules.evaluate(
+        mainWithBom(),
+        mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
+        gradleVersion = "9.2.1",
+      )
+    val f = findings.single { it.id == "gradle-too-old" }
+    assertEquals("error", f.severity)
+    assertTrue("9.2.1" in f.message)
+    assertTrue(f.remediationCommands.any { "gradle-version" in it })
+  }
 
-    @Test fun `no compose BOM yields warning`() {
-        val main = mapOf("androidx.core:core" to "1.16.0")
-        val test = main + ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
-        val findings = CompatRules.evaluate(main, test)
-        val f = findings.single { it.id == "compose-bom-missing" }
-        assertEquals("warning", f.severity)
-    }
+  @Test
+  fun `minimum gradle is quiet`() {
+    val findings =
+      CompatRules.evaluate(
+        mainWithBom(),
+        mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
+        gradleVersion = CompatRules.GRADLE_MIN.toString(),
+      )
+    assertNull(findings.firstOrNull { it.id == "gradle-too-old" })
+  }
 
-    @Test fun `with compose BOM, bom finding is absent`() {
-        val findings = CompatRules.evaluate(mainWithBom(), mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"))
-        assertNull(findings.firstOrNull { it.id == "compose-bom-missing" })
-    }
+  @Test
+  fun `newer gradle is quiet`() {
+    val findings =
+      CompatRules.evaluate(
+        mainWithBom(),
+        mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
+        gradleVersion = "9.9.0",
+      )
+    assertNull(findings.firstOrNull { it.id == "gradle-too-old" })
+  }
 
-    @Test fun `all findings populated have non-empty docs or commands`() {
-        // Stacked scenario: everything wrong — exercises every rule at once.
-        val main = mapOf(
-            "androidx.activity:activity" to "1.8.0",
-            "androidx.core:core" to "1.15.0",
-        )
-        val test = mapOf(
-            "androidx.navigationevent:navigationevent" to "1.0.0",
-            "androidx.compose.ui:ui" to "1.10.6",
-        )
-        val findings = CompatRules.evaluate(main, test)
-        assertTrue(findings.size >= 3)
-        // Every finding should carry at least one actionable hint.
-        for (f in findings) {
-            val actionable = f.remediationCommands.isNotEmpty() || f.docsUrl != null
-            assertTrue("finding ${f.id} has no actionable remediation", actionable || f.remediationSummary != null)
-        }
-    }
+  @Test
+  fun `absent gradle version emits no finding`() {
+    // Back-compat: callers that don't plumb the running Gradle version
+    // still get the dependency checks without a bogus "unknown version"
+    // finding.
+    val findings =
+      CompatRules.evaluate(
+        mainWithBom(),
+        mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
+      )
+    assertNull(findings.firstOrNull { it.id == "gradle-too-old" })
+  }
 
-    @Test fun `old activity fires old-dep warning`() {
-        val main = mainWithBom() + ("androidx.activity:activity" to "1.8.0")
-        val test = main + ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
-        val findings = CompatRules.evaluate(main, test)
-        val f = findings.single { it.id == "old-dep-androidx.activity:activity" }
-        assertEquals("warning", f.severity)
-        assertTrue("1.8.0" in f.message)
-        assertTrue(f.remediationCommands.any { "androidx.activity:activity" in it })
-    }
+  @Test
+  fun `semver parses and compares`() {
+    assertEquals(Semver(1, 16, 0), Semver.parseOrNull("1.16.0"))
+    assertEquals(Semver(1, 16, 0), Semver.parseOrNull("1.16"))
+    assertNull(Semver.parseOrNull("foo"))
+    assertTrue(Semver(1, 16, 0) > Semver(1, 15, 0))
+    assertTrue(Semver(1, 13, 0) > Semver(1, 13, 0, "alpha01"))
+    assertNotNull(Semver.parseOrNull("1.13.0-alpha01"))
+  }
 
-    @Test fun `current activity is quiet`() {
-        val main = mainWithBom() + ("androidx.activity:activity" to "1.13.0")
-        val test = main + ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
-        val findings = CompatRules.evaluate(main, test)
-        assertNull(findings.firstOrNull { it.id.startsWith("old-dep-androidx.activity") })
-    }
+  // --- Fixtures ----------------------------------------------------------
 
-    @Test fun `absent library emits no old-dep finding`() {
-        // lifecycle-runtime isn't on the classpath at all — silently skipped.
-        val findings = CompatRules.evaluate(mainWithBom(), mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"))
-        assertNull(findings.firstOrNull { it.id.startsWith("old-dep-androidx.lifecycle") })
-    }
-
-    @Test fun `test-classpath higher than main is taken as resolved`() {
-        // Main has old activity, test classpath has newer — we take the max.
-        val main = mainWithBom() + ("androidx.activity:activity" to "1.8.0")
-        val test = main + ("androidx.activity:activity" to "1.13.0") +
-            ("androidx.compose.ui:ui-test-manifest" to "1.10.6")
-        val findings = CompatRules.evaluate(main, test)
-        assertNull(findings.firstOrNull { it.id.startsWith("old-dep-androidx.activity") })
-    }
-
-    @Test fun `old gradle fires error`() {
-        val findings = CompatRules.evaluate(
-            mainWithBom(),
-            mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
-            gradleVersion = "9.2.1",
-        )
-        val f = findings.single { it.id == "gradle-too-old" }
-        assertEquals("error", f.severity)
-        assertTrue("9.2.1" in f.message)
-        assertTrue(f.remediationCommands.any { "gradle-version" in it })
-    }
-
-    @Test fun `minimum gradle is quiet`() {
-        val findings = CompatRules.evaluate(
-            mainWithBom(),
-            mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
-            gradleVersion = CompatRules.GRADLE_MIN.toString(),
-        )
-        assertNull(findings.firstOrNull { it.id == "gradle-too-old" })
-    }
-
-    @Test fun `newer gradle is quiet`() {
-        val findings = CompatRules.evaluate(
-            mainWithBom(),
-            mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
-            gradleVersion = "9.9.0",
-        )
-        assertNull(findings.firstOrNull { it.id == "gradle-too-old" })
-    }
-
-    @Test fun `absent gradle version emits no finding`() {
-        // Back-compat: callers that don't plumb the running Gradle version
-        // still get the dependency checks without a bogus "unknown version"
-        // finding.
-        val findings = CompatRules.evaluate(
-            mainWithBom(),
-            mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
-        )
-        assertNull(findings.firstOrNull { it.id == "gradle-too-old" })
-    }
-
-    @Test fun `semver parses and compares`() {
-        assertEquals(Semver(1, 16, 0), Semver.parseOrNull("1.16.0"))
-        assertEquals(Semver(1, 16, 0), Semver.parseOrNull("1.16"))
-        assertNull(Semver.parseOrNull("foo"))
-        assertTrue(Semver(1, 16, 0) > Semver(1, 15, 0))
-        assertTrue(Semver(1, 13, 0) > Semver(1, 13, 0, "alpha01"))
-        assertNotNull(Semver.parseOrNull("1.13.0-alpha01"))
-    }
-
-    // --- Fixtures ----------------------------------------------------------
-
-    private fun mainWithBom(): Map<String, String> = mapOf(
-        "androidx.compose:compose-bom" to "2025.03.00",
-        "androidx.activity:activity" to "1.13.0",
-        "androidx.core:core" to "1.18.0",
+  private fun mainWithBom(): Map<String, String> =
+    mapOf(
+      "androidx.compose:compose-bom" to "2025.03.00",
+      "androidx.activity:activity" to "1.13.0",
+      "androidx.core:core" to "1.18.0",
     )
 
-    private fun testWithoutUiTestManifest(): Map<String, String> = mapOf(
-        "androidx.activity:activity" to "1.13.0",
-    )
+  private fun testWithoutUiTestManifest(): Map<String, String> =
+    mapOf("androidx.activity:activity" to "1.13.0")
 }

--- a/preview-annotations/build.gradle.kts
+++ b/preview-annotations/build.gradle.kts
@@ -1,78 +1,81 @@
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-    `maven-publish`
-    alias(libs.plugins.maven.publish)
+  alias(libs.plugins.kotlin.jvm)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
+
 // See gradle-plugin/build.gradle.kts for how CI sets PLUGIN_VERSION. Local
 // builds derive the SNAPSHOT version from `.release-please-manifest.json`.
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: run {
-    val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-    val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-    val (major, minor, patch) = current.split(".").map { it.toInt() }
-    "$major.$minor.${patch + 1}-SNAPSHOT"
-}
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
 
-java {
-    toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
-}
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 // Annotation-only artifact — deliberately no runtime deps so adding it to a
 // Compose app classpath never drags anything else in.
 
 publishing {
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri(
-                providers.environmentVariable("GITHUB_REPOSITORY")
-                    .map { "https://maven.pkg.github.com/$it" }
-                    .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools"),
-            )
-            credentials {
-                username = providers.environmentVariable("GITHUB_ACTOR").orNull
-                password = providers.environmentVariable("GITHUB_TOKEN").orNull
-            }
-        }
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
     }
+  }
 }
 
 mavenPublishing {
-    publishToMavenCentral(automaticRelease = true)
-    if (!version.toString().endsWith("SNAPSHOT")) {
-        signAllPublications()
-    }
+  publishToMavenCentral(automaticRelease = true)
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
 
-    coordinates("ee.schimke.composeai", "preview-annotations", version.toString())
+  coordinates("ee.schimke.composeai", "preview-annotations", version.toString())
 
-    pom {
-        name.set("Compose Preview — Annotations")
-        description.set(
-            "Annotations consumed by the compose-preview Gradle plugin — e.g. " +
-                "@ScrollingPreview for opting @Preview composables into scrolling " +
-                "screenshot capture.",
-        )
-        url.set("https://github.com/yschimke/compose-ai-tools")
-        inceptionYear.set("2025")
-        licenses {
-            license {
-                name.set("The Apache License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-                distribution.set("repo")
-            }
-        }
-        developers {
-            developer {
-                id.set("yschimke")
-                name.set("Yuri Schimke")
-                url.set("https://github.com/yschimke")
-            }
-        }
-        scm {
-            url.set("https://github.com/yschimke/compose-ai-tools")
-            connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-            developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-        }
+  pom {
+    name.set("Compose Preview — Annotations")
+    description.set(
+      "Annotations consumed by the compose-preview Gradle plugin — e.g. " +
+        "@ScrollingPreview for opting @Preview composables into scrolling " +
+        "screenshot capture."
+    )
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2025")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
     }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
 }

--- a/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/AnimatedPreview.kt
+++ b/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/AnimatedPreview.kt
@@ -3,75 +3,64 @@ package ee.schimke.composeai.preview
 /**
  * Opts a `@Preview` composable into animation capture.
  *
- * Discovery picks this up by FQN, mirroring the [ScrollingPreview] split:
- * consumers that want to use the annotation in their own code depend on
- * `ee.schimke.composeai:preview-annotations`.
+ * Discovery picks this up by FQN, mirroring the [ScrollingPreview] split: consumers that want to
+ * use the annotation in their own code depend on `ee.schimke.composeai:preview-annotations`.
  *
- * The renderer drives a paused `mainClock.advanceTimeBy([frameIntervalMs])`
- * across the captured window, capturing each frame and encoding the
- * sequence as an animated GIF at `renders/<id>.gif`.
+ * The renderer drives a paused `mainClock.advanceTimeBy([frameIntervalMs])` across the captured
+ * window, capturing each frame and encoding the sequence as an animated GIF at `renders/<id>.gif`.
  *
- * When [showCurves] is true (the default) the GIF is composed of two
- * stacked panels per frame — the preview composable on top, a curve
- * strip plotting each tracked animation's value vs. time below, with a
- * dot marking the current frame's position on each curve. This path
- * requires Compose UI Tooling 1.10.6+ on the test classpath; earlier
- * versions fail at render time with a clear message naming the missing
- * class. Set [showCurves] = `false` to emit a screenshot-only GIF.
+ * When [showCurves] is true (the default) the GIF is composed of two stacked panels per frame — the
+ * preview composable on top, a curve strip plotting each tracked animation's value vs. time below,
+ * with a dot marking the current frame's position on each curve. This path requires Compose UI
+ * Tooling 1.10.6+ on the test classpath; earlier versions fail at render time with a clear message
+ * naming the missing class. Set [showCurves] = `false` to emit a screenshot-only GIF.
  *
- * When [durationMs] is `0` (the default), the renderer asks
- * `PreviewAnimationClock` how long the discovered animations actually
- * run and uses that as the GIF duration — a 600ms tween renders a
- * 600ms GIF rather than 900ms of "settled at target" padding. Set a
- * positive value to override (`InfiniteTransition` has no inherent
- * duration; sometimes a longer dwell is wanted for review).
+ * When [durationMs] is `0` (the default), the renderer asks `PreviewAnimationClock` how long the
+ * discovered animations actually run and uses that as the GIF duration — a 600ms tween renders a
+ * 600ms GIF rather than 900ms of "settled at target" padding. Set a positive value to override
+ * (`InfiniteTransition` has no inherent duration; sometimes a longer dwell is wanted for review).
  */
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.FUNCTION)
 @MustBeDocumented
 annotation class AnimatedPreview(
-    /**
-     * Total animation window to capture, in milliseconds.
-     *
-     * `0` (the default) asks the renderer to auto-detect the duration
-     * via `PreviewAnimationClock.getMaxDuration()`. Falls back to
-     * [DEFAULT_ANIMATION_DURATION_MS] when no Compose animations are
-     * discovered (e.g. a static `@Preview` accidentally annotated, or
-     * a hand-rolled `withFrameNanos` loop the inspector can't see).
-     *
-     * A positive value overrides the auto-detected duration.
-     * Capped at 5000ms regardless to keep GIF size bounded.
-     */
-    val durationMs: Int = AUTO_DETECT_DURATION_MS,
-    /**
-     * Per-frame delay, in milliseconds. Drives both the virtual-time
-     * stepping and the GIF's per-frame `delayTime`. Snaps to GIF's 10ms
-     * timing resolution at encode time. Default 33ms ≈ 30fps.
-     */
-    val frameIntervalMs: Int = DEFAULT_ANIMATION_FRAME_INTERVAL_MS,
-    /**
-     * When `true` (the default), the captured GIF is composed of two
-     * stacked panels per frame: the preview on top, and a curve strip
-     * below plotting each discovered animated property's value over
-     * time with a moving dot marking the current frame's position.
-     *
-     * Set `false` to emit a screenshot-only GIF — useful for visual
-     * diff workflows that compare against earlier non-instrumented
-     * renders.
-     */
-    val showCurves: Boolean = true,
+  /**
+   * Total animation window to capture, in milliseconds.
+   *
+   * `0` (the default) asks the renderer to auto-detect the duration via
+   * `PreviewAnimationClock.getMaxDuration()`. Falls back to [DEFAULT_ANIMATION_DURATION_MS] when no
+   * Compose animations are discovered (e.g. a static `@Preview` accidentally annotated, or a
+   * hand-rolled `withFrameNanos` loop the inspector can't see).
+   *
+   * A positive value overrides the auto-detected duration. Capped at 5000ms regardless to keep GIF
+   * size bounded.
+   */
+  val durationMs: Int = AUTO_DETECT_DURATION_MS,
+  /**
+   * Per-frame delay, in milliseconds. Drives both the virtual-time stepping and the GIF's per-frame
+   * `delayTime`. Snaps to GIF's 10ms timing resolution at encode time. Default 33ms ≈ 30fps.
+   */
+  val frameIntervalMs: Int = DEFAULT_ANIMATION_FRAME_INTERVAL_MS,
+  /**
+   * When `true` (the default), the captured GIF is composed of two stacked panels per frame: the
+   * preview on top, and a curve strip below plotting each discovered animated property's value over
+   * time with a moving dot marking the current frame's position.
+   *
+   * Set `false` to emit a screenshot-only GIF — useful for visual diff workflows that compare
+   * against earlier non-instrumented renders.
+   */
+  val showCurves: Boolean = true,
 )
 
 /**
- * Sentinel `durationMs` value asking the renderer to auto-detect the
- * animation duration via `PreviewAnimationClock`. See
- * [AnimatedPreview.durationMs].
+ * Sentinel `durationMs` value asking the renderer to auto-detect the animation duration via
+ * `PreviewAnimationClock`. See [AnimatedPreview.durationMs].
  */
 const val AUTO_DETECT_DURATION_MS: Int = 0
 
 /**
- * Fallback total animation window for `@AnimatedPreview` when auto-
- * detection is requested but no Compose animations were discovered.
+ * Fallback total animation window for `@AnimatedPreview` when auto- detection is requested but no
+ * Compose animations were discovered.
  */
 const val DEFAULT_ANIMATION_DURATION_MS: Int = 1500
 

--- a/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/ScrollingPreview.kt
+++ b/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/ScrollingPreview.kt
@@ -3,92 +3,79 @@ package ee.schimke.composeai.preview
 /**
  * Opts a `@Preview` composable into scrolling-screenshot capture.
  *
- * The compose-preview Gradle plugin's discovery task picks this up by FQN,
- * independently of whether the annotation artifact is on the consumer's
- * compile classpath at plugin-apply time. Consumers that want to use the
- * annotation in their own code depend on
+ * The compose-preview Gradle plugin's discovery task picks this up by FQN, independently of whether
+ * the annotation artifact is on the consumer's compile classpath at plugin-apply time. Consumers
+ * that want to use the annotation in their own code depend on
  * `ee.schimke.composeai:preview-annotations`.
  *
- * Each entry in [modes] fans out into its own capture. TOP / END / LONG
- * produce a single PNG per capture; GIF produces an animated `.gif`.
- * Shared knobs — [axis], [maxScrollPx], [reduceMotion] — apply to every
- * capture produced by a single annotation instance. A single-mode
- * annotation (e.g. `modes = [ScrollMode.END]`) keeps the plain
- * `renders/<id>.<ext>` filename; multi-mode annotations disambiguate
- * siblings with a `_SCROLL_<mode>` suffix
- * (`renders/<id>_SCROLL_top.png`, `renders/<id>_SCROLL_end.png`,
- * `renders/<id>_SCROLL_gif.gif`, …).
+ * Each entry in [modes] fans out into its own capture. TOP / END / LONG produce a single PNG per
+ * capture; GIF produces an animated `.gif`. Shared knobs — [axis], [maxScrollPx], [reduceMotion] —
+ * apply to every capture produced by a single annotation instance. A single-mode annotation (e.g.
+ * `modes = [ScrollMode.END]`) keeps the plain `renders/<id>.<ext>` filename; multi-mode annotations
+ * disambiguate siblings with a `_SCROLL_<mode>` suffix (`renders/<id>_SCROLL_top.png`,
+ * `renders/<id>_SCROLL_end.png`, `renders/<id>_SCROLL_gif.gif`, …).
  */
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.FUNCTION)
 @MustBeDocumented
 annotation class ScrollingPreview(
-    /**
-     * Capture strategies for the scrollable content. Each mode produces one
-     * PNG. Defaults to `[END]` so migrating from the pre-0.7 single-mode
-     * shape (`mode = ScrollMode.END`) is a one-line edit.
-     */
-    val modes: Array<ScrollMode> = [ScrollMode.END],
-    /**
-     * Upper bound on how far we'll scroll, in pixels. `0` means unbounded —
-     * drive to the content's natural end. Use a positive value on infinite
-     * or very tall scrollers to cap capture size. Applies to [ScrollMode.END],
-     * [ScrollMode.LONG], and [ScrollMode.GIF]; ignored for [ScrollMode.TOP].
-     */
-    val maxScrollPx: Int = 0,
-    /**
-     * If true, scrolling captures wrap the preview body in a
-     * `LocalReduceMotion provides ReduceMotion(true)` to flatten Wear
-     * `TransformingLazyColumn` item transforms so slices / end-state
-     * captures look consistent.
-     */
-    val reduceMotion: Boolean = true,
-    /** Which axis to drive. Only [ScrollAxis.VERTICAL] is rendered today. */
-    val axis: ScrollAxis = ScrollAxis.VERTICAL,
-    /**
-     * Per-frame delay for [ScrollMode.GIF] output, in milliseconds. Snaps to
-     * GIF's 10ms timing resolution at encode time. Default 80ms ≈ 12.5fps —
-     * smooth enough for a UI scroll, small enough to keep file size
-     * reasonable. Ignored by all other modes.
-     */
-    val frameIntervalMs: Int = DEFAULT_GIF_FRAME_INTERVAL_MS,
+  /**
+   * Capture strategies for the scrollable content. Each mode produces one PNG. Defaults to `[END]`
+   * so migrating from the pre-0.7 single-mode shape (`mode = ScrollMode.END`) is a one-line edit.
+   */
+  val modes: Array<ScrollMode> = [ScrollMode.END],
+  /**
+   * Upper bound on how far we'll scroll, in pixels. `0` means unbounded — drive to the content's
+   * natural end. Use a positive value on infinite or very tall scrollers to cap capture size.
+   * Applies to [ScrollMode.END], [ScrollMode.LONG], and [ScrollMode.GIF]; ignored for
+   * [ScrollMode.TOP].
+   */
+  val maxScrollPx: Int = 0,
+  /**
+   * If true, scrolling captures wrap the preview body in a `LocalReduceMotion provides
+   * ReduceMotion(true)` to flatten Wear `TransformingLazyColumn` item transforms so slices /
+   * end-state captures look consistent.
+   */
+  val reduceMotion: Boolean = true,
+  /** Which axis to drive. Only [ScrollAxis.VERTICAL] is rendered today. */
+  val axis: ScrollAxis = ScrollAxis.VERTICAL,
+  /**
+   * Per-frame delay for [ScrollMode.GIF] output, in milliseconds. Snaps to GIF's 10ms timing
+   * resolution at encode time. Default 80ms ≈ 12.5fps — smooth enough for a UI scroll, small enough
+   * to keep file size reasonable. Ignored by all other modes.
+   */
+  val frameIntervalMs: Int = DEFAULT_GIF_FRAME_INTERVAL_MS,
 )
 
 /**
  * Default per-frame delay, in milliseconds, for `@ScrollingPreview(modes = [ScrollMode.GIF])`.
- * Exposed as a top-level const because Kotlin annotation classes can't carry a
- * companion object. Referenced as the default for
- * [ScrollingPreview.frameIntervalMs].
+ * Exposed as a top-level const because Kotlin annotation classes can't carry a companion object.
+ * Referenced as the default for [ScrollingPreview.frameIntervalMs].
  */
 const val DEFAULT_GIF_FRAME_INTERVAL_MS: Int = 80
 
 enum class ScrollMode {
-    /**
-     * Capture the initial (unscrolled) frame. Equivalent to a plain
-     * `@Preview` but lets you emit a top-state capture alongside END/LONG
-     * from one function.
-     */
-    TOP,
+  /**
+   * Capture the initial (unscrolled) frame. Equivalent to a plain `@Preview` but lets you emit a
+   * top-state capture alongside END/LONG from one function.
+   */
+  TOP,
 
-    /** Scroll to the end of the content, then capture a single frame. */
-    END,
+  /** Scroll to the end of the content, then capture a single frame. */
+  END,
 
-    /**
-     * Capture the full scrollable content, stitching multiple frames into
-     * one tall (or wide) PNG.
-     */
-    LONG,
+  /** Capture the full scrollable content, stitching multiple frames into one tall (or wide) PNG. */
+  LONG,
 
-    /**
-     * Capture the full scrollable content as an animated GIF showing the
-     * scroll from top to bottom. Output lands at `renders/<id>.gif` (or
-     * `renders/<id>_SCROLL_gif.gif` for a multi-mode annotation). Frame
-     * cadence is controlled by [ScrollingPreview.frameIntervalMs].
-     */
-    GIF,
+  /**
+   * Capture the full scrollable content as an animated GIF showing the scroll from top to bottom.
+   * Output lands at `renders/<id>.gif` (or `renders/<id>_SCROLL_gif.gif` for a multi-mode
+   * annotation). Frame cadence is controlled by [ScrollingPreview.frameIntervalMs].
+   */
+  GIF,
 }
 
 enum class ScrollAxis {
-    VERTICAL,
-    HORIZONTAL,
+  VERTICAL,
+  HORIZONTAL,
 }

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -1,206 +1,210 @@
-@file:Suppress("DEPRECATION") // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
+@file:Suppress(
+  "DEPRECATION"
+) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
+
 // types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
 
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.kotlin.serialization)
-    `maven-publish`
-    alias(libs.plugins.maven.publish)
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.kotlin.serialization)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
+
 // See gradle-plugin/build.gradle.kts for how CI sets PLUGIN_VERSION. Local
 // builds derive the SNAPSHOT version from `.release-please-manifest.json`.
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: run {
-    val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-    val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-    val (major, minor, patch) = current.split(".").map { it.toInt() }
-    "$major.$minor.${patch + 1}-SNAPSHOT"
-}
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
 
 android {
-    namespace = "ee.schimke.composeai.renderer"
-    compileSdk = 36
+  namespace = "ee.schimke.composeai.renderer"
+  compileSdk = 36
 
-    defaultConfig {
-        minSdk = 24
-    }
+  defaultConfig { minSdk = 24 }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
 
-    testOptions {
-        unitTests {
-            isIncludeAndroidResources = true
-        }
-    }
-    // `AndroidSingleVariantLibrary` in `mavenPublishing {}` below wires the
-    // `singleVariant("release")` publication for us — don't declare it twice.
+  testOptions { unitTests { isIncludeAndroidResources = true } }
+  // `AndroidSingleVariantLibrary` in `mavenPublishing {}` below wires the
+  // `singleVariant("release")` publication for us — don't declare it twice.
 }
 
 dependencies {
-    implementation(libs.robolectric)
-    implementation(libs.junit)
-    implementation(libs.kotlinx.serialization.json)
+  implementation(libs.robolectric)
+  implementation(libs.junit)
+  implementation(libs.kotlinx.serialization.json)
 
-    // Compose / Activity / Compose-UI-test libs are `compileOnly` on purpose:
-    // they must match what the CONSUMER module declares, because AGP's
-    // `process<Variant>Resources` builds the unit-test merged resource APK
-    // (`apk-for-local-test.ap_`) from the consumer's dependency graph — NOT
-    // from our custom `composePreviewAndroidRenderer` configuration. If these
-    // are `implementation`, Gradle drags our newer activity-compose 1.13 onto
-    // the test JVM classpath — which transitively brings `androidx.navigationevent`
-    // — while the consumer's merged resource APK stays on their older
-    // activity. The test JVM then loads the 1.13 Activity bootstrap and crashes
-    // on `NoClassDefFoundError: androidx/navigationevent/R$id` because the
-    // navigationevent resources were never merged. Same class of failure for
-    // `androidx.core.R.tag_compat_insets_dispatch` (compose-ui 1.10 →
-    // androidx.core 1.16 resources missing on older consumers).
-    //
-    // `testImplementation` mirrors `compileOnly` for our own unit tests, which
-    // need actual runtime classes. The plugin separately injects ui-test-manifest
-    // into the consumer's `testImplementation` in AndroidPreviewSupport so its
-    // `ComponentActivity` entry lands in the consumer's merged test manifest.
-    //
-    // We compile against the OLDER `compose-bom-compat` rather than the
-    // top-level `compose-bom`. Rationale: AndroidX honours binary-backward-
-    // compatibility within a major version, so bytecode emitted against a
-    // 1.9.x API surface runs unchanged on consumer apps at 1.10.x / 1.11.x
-    // (where we've confirmed all referenced methods still exist). The
-    // reverse — compiling against 1.10.x — emits calls like
-    // `Updater.init-impl(Composer, Object, Function2)` that didn't exist
-    // before 1.10.2, so consumers pinned to older Compose BOMs fail with
-    // NoSuchMethodError at render time. Our own unit tests use the same
-    // compat BOM (not the latest) so accidentally reaching for a 1.10-only
-    // API fails at our compile step, not at a downstream consumer's.
-    //
-    // `LocalScrollCaptureInProgress` (compose-ui ≥ 1.7) is looked up
-    // reflectively via [ScrollCaptureInProgressLocal] — a null return
-    // degrades scroll-capture to a no-op for consumers on even older Compose.
-    compileOnly(platform(libs.compose.bom.compat))
-    compileOnly(libs.compose.ui)
-    compileOnly(libs.compose.foundation)
-    compileOnly(libs.compose.material3)
-    compileOnly(libs.compose.runtime)
-    compileOnly(libs.compose.ui.tooling.preview)
-    compileOnly(libs.activity.compose)
-    compileOnly("androidx.compose.ui:ui-test-junit4")
-    compileOnly("androidx.compose.ui:ui-test-manifest")
-    // `@AnimatedPreview(showCurves = true)` snapshots the active
-    // composition's slot table via `currentComposer.compositionData`
-    // (`@InternalComposeApi` from compose-runtime) and walks it via
-    // `androidx.compose.ui.tooling.data.asTree` (compose-ui-tooling-data).
-    // Renderer compile-classpath deps stop there — `PreviewAnimationClock`,
-    // `AnimationSearch`, and `ComposeAnimation` / `ComposeAnimatedProperty`
-    // are reached via reflection at runtime so consumers without curve
-    // support never need ui-tooling on their classpath.
-    compileOnly("androidx.compose.ui:ui-tooling-data")
+  // Compose / Activity / Compose-UI-test libs are `compileOnly` on purpose:
+  // they must match what the CONSUMER module declares, because AGP's
+  // `process<Variant>Resources` builds the unit-test merged resource APK
+  // (`apk-for-local-test.ap_`) from the consumer's dependency graph — NOT
+  // from our custom `composePreviewAndroidRenderer` configuration. If these
+  // are `implementation`, Gradle drags our newer activity-compose 1.13 onto
+  // the test JVM classpath — which transitively brings `androidx.navigationevent`
+  // — while the consumer's merged resource APK stays on their older
+  // activity. The test JVM then loads the 1.13 Activity bootstrap and crashes
+  // on `NoClassDefFoundError: androidx/navigationevent/R$id` because the
+  // navigationevent resources were never merged. Same class of failure for
+  // `androidx.core.R.tag_compat_insets_dispatch` (compose-ui 1.10 →
+  // androidx.core 1.16 resources missing on older consumers).
+  //
+  // `testImplementation` mirrors `compileOnly` for our own unit tests, which
+  // need actual runtime classes. The plugin separately injects ui-test-manifest
+  // into the consumer's `testImplementation` in AndroidPreviewSupport so its
+  // `ComponentActivity` entry lands in the consumer's merged test manifest.
+  //
+  // We compile against the OLDER `compose-bom-compat` rather than the
+  // top-level `compose-bom`. Rationale: AndroidX honours binary-backward-
+  // compatibility within a major version, so bytecode emitted against a
+  // 1.9.x API surface runs unchanged on consumer apps at 1.10.x / 1.11.x
+  // (where we've confirmed all referenced methods still exist). The
+  // reverse — compiling against 1.10.x — emits calls like
+  // `Updater.init-impl(Composer, Object, Function2)` that didn't exist
+  // before 1.10.2, so consumers pinned to older Compose BOMs fail with
+  // NoSuchMethodError at render time. Our own unit tests use the same
+  // compat BOM (not the latest) so accidentally reaching for a 1.10-only
+  // API fails at our compile step, not at a downstream consumer's.
+  //
+  // `LocalScrollCaptureInProgress` (compose-ui ≥ 1.7) is looked up
+  // reflectively via [ScrollCaptureInProgressLocal] — a null return
+  // degrades scroll-capture to a no-op for consumers on even older Compose.
+  compileOnly(platform(libs.compose.bom.compat))
+  compileOnly(libs.compose.ui)
+  compileOnly(libs.compose.foundation)
+  compileOnly(libs.compose.material3)
+  compileOnly(libs.compose.runtime)
+  compileOnly(libs.compose.ui.tooling.preview)
+  compileOnly(libs.activity.compose)
+  compileOnly("androidx.compose.ui:ui-test-junit4")
+  compileOnly("androidx.compose.ui:ui-test-manifest")
+  // `@AnimatedPreview(showCurves = true)` snapshots the active
+  // composition's slot table via `currentComposer.compositionData`
+  // (`@InternalComposeApi` from compose-runtime) and walks it via
+  // `androidx.compose.ui.tooling.data.asTree` (compose-ui-tooling-data).
+  // Renderer compile-classpath deps stop there — `PreviewAnimationClock`,
+  // `AnimationSearch`, and `ComposeAnimation` / `ComposeAnimatedProperty`
+  // are reached via reflection at runtime so consumers without curve
+  // support never need ui-tooling on their classpath.
+  compileOnly("androidx.compose.ui:ui-tooling-data")
 
-    testImplementation(platform(libs.compose.bom.compat))
-    testImplementation(libs.compose.ui)
-    testImplementation(libs.compose.foundation)
-    testImplementation(libs.compose.material3)
-    testImplementation(libs.compose.runtime)
-    testImplementation(libs.compose.ui.tooling.preview)
-    testImplementation(libs.activity.compose)
-    testImplementation("androidx.compose.ui:ui-test-junit4")
-    testImplementation("androidx.compose.ui:ui-test-manifest")
-    testImplementation("androidx.compose.ui:ui-tooling-data")
-    // GoogleFont detector's unit test constructs a real
-    // `Font(GoogleFont("Roboto"), provider)` so the reflective FQCN check
-    // runs against an actual `GoogleFontImpl` instance. Test-only — the
-    // main source deliberately stays off this artifact so consumers without
-    // downloadable fonts don't get it transitively from our AAR.
-    testImplementation("androidx.compose.ui:ui-text-google-fonts")
+  testImplementation(platform(libs.compose.bom.compat))
+  testImplementation(libs.compose.ui)
+  testImplementation(libs.compose.foundation)
+  testImplementation(libs.compose.material3)
+  testImplementation(libs.compose.runtime)
+  testImplementation(libs.compose.ui.tooling.preview)
+  testImplementation(libs.activity.compose)
+  testImplementation("androidx.compose.ui:ui-test-junit4")
+  testImplementation("androidx.compose.ui:ui-test-manifest")
+  testImplementation("androidx.compose.ui:ui-tooling-data")
+  // GoogleFont detector's unit test constructs a real
+  // `Font(GoogleFont("Roboto"), provider)` so the reflective FQCN check
+  // runs against an actual `GoogleFontImpl` instance. Test-only — the
+  // main source deliberately stays off this artifact so consumers without
+  // downloadable fonts don't get it transitively from our AAR.
+  testImplementation("androidx.compose.ui:ui-text-google-fonts")
 
-    implementation(libs.roborazzi)
-    implementation(libs.roborazzi.compose)
-    // ATF accessibility checks. Exercised only when consumers opt in via
-    // `composePreview { accessibilityChecks { enabled = true } }`, but always
-    // on the classpath because the renderer test references these types
-    // unconditionally.
-    //
-    // The a11y-enabled path uses `createAndroidComposeRule<ComponentActivity>()`
-    // + `onRoot().captureRoboImage(...)` + ATF against the `ViewRootForTest`
-    // backing the SemanticsNode. That's the same plumbing roborazzi-
-    // accessibility-check's `checkRoboAccessibility` extension uses — it's the
-    // only combination where Robolectric populates the accessibility
-    // hierarchy richly enough for ATF to surface findings. The composable-
-    // form `captureRoboImage { @Composable }` closes its ActivityScenario
-    // eagerly, which detaches the view before ATF gets to run.
-    implementation(libs.roborazzi.accessibility.check)
+  implementation(libs.roborazzi)
+  implementation(libs.roborazzi.compose)
+  // ATF accessibility checks. Exercised only when consumers opt in via
+  // `composePreview { accessibilityChecks { enabled = true } }`, but always
+  // on the classpath because the renderer test references these types
+  // unconditionally.
+  //
+  // The a11y-enabled path uses `createAndroidComposeRule<ComponentActivity>()`
+  // + `onRoot().captureRoboImage(...)` + ATF against the `ViewRootForTest`
+  // backing the SemanticsNode. That's the same plumbing roborazzi-
+  // accessibility-check's `checkRoboAccessibility` extension uses — it's the
+  // only combination where Robolectric populates the accessibility
+  // hierarchy richly enough for ATF to surface findings. The composable-
+  // form `captureRoboImage { @Composable }` closes its ActivityScenario
+  // eagerly, which detaches the view before ATF gets to run.
+  implementation(libs.roborazzi.accessibility.check)
 
-    // Tiles rendering is reflection-driven at runtime (the consumer module
-    // supplies the actual classes on the JUnit classpath), so we only need
-    // these to compile TilePreviewRenderer — a consumer without tile deps
-    // will never hit the TILE branch in RobolectricRenderTestBase.
-    compileOnly(libs.wear.tiles)
-    compileOnly(libs.wear.tiles.renderer)
-    compileOnly(libs.wear.tiles.tooling.preview)
-    compileOnly(libs.wear.protolayout)
-    compileOnly(libs.wear.protolayout.expression)
+  // Tiles rendering is reflection-driven at runtime (the consumer module
+  // supplies the actual classes on the JUnit classpath), so we only need
+  // these to compile TilePreviewRenderer — a consumer without tile deps
+  // will never hit the TILE branch in RobolectricRenderTestBase.
+  compileOnly(libs.wear.tiles)
+  compileOnly(libs.wear.tiles.renderer)
+  compileOnly(libs.wear.tiles.tooling.preview)
+  compileOnly(libs.wear.protolayout)
+  compileOnly(libs.wear.protolayout.expression)
 }
 
 // GitHub Packages repo kept alongside Maven Central for internal/CI convenience.
 // Vanniktech's `AndroidSingleVariantLibrary` creates the release publication
 // (with sources + javadoc jar) — do not create one manually; it clashes.
 publishing {
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri(
-                providers.environmentVariable("GITHUB_REPOSITORY")
-                    .map { "https://maven.pkg.github.com/$it" }
-                    .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools"),
-            )
-            credentials {
-                username = providers.environmentVariable("GITHUB_ACTOR").orNull
-                password = providers.environmentVariable("GITHUB_TOKEN").orNull
-            }
-        }
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
     }
+  }
 }
 
 mavenPublishing {
-    publishToMavenCentral(automaticRelease = true)
-    configure(AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true))
-    if (!version.toString().endsWith("SNAPSHOT")) {
-        signAllPublications()
-    }
+  publishToMavenCentral(automaticRelease = true)
+  configure(
+    AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true)
+  )
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
 
-    coordinates("ee.schimke.composeai", "renderer-android", version.toString())
+  coordinates("ee.schimke.composeai", "renderer-android", version.toString())
 
-    pom {
-        name.set("Compose Preview — Android Renderer")
-        description.set(
-            "Robolectric-based renderer for Jetpack Compose @Preview functions, " +
-                "used by the compose-preview Gradle plugin to produce PNGs off-device.",
-        )
-        url.set("https://github.com/yschimke/compose-ai-tools")
-        inceptionYear.set("2025")
-        licenses {
-            license {
-                name.set("The Apache License, Version 2.0")
-                url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-                distribution.set("repo")
-            }
-        }
-        developers {
-            developer {
-                id.set("yschimke")
-                name.set("Yuri Schimke")
-                url.set("https://github.com/yschimke")
-            }
-        }
-        scm {
-            url.set("https://github.com/yschimke/compose-ai-tools")
-            connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-            developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-        }
+  pom {
+    name.set("Compose Preview — Android Renderer")
+    description.set(
+      "Robolectric-based renderer for Jetpack Compose @Preview functions, " +
+        "used by the compose-preview Gradle plugin to produce PNGs off-device."
+    )
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2025")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
     }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
 }

--- a/renderer-desktop/build.gradle.kts
+++ b/renderer-desktop/build.gradle.kts
@@ -1,20 +1,18 @@
 @file:Suppress("DEPRECATION")
 
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.compose.multiplatform)
-    alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.compose.multiplatform)
+  alias(libs.plugins.compose.compiler)
 }
 
 dependencies {
-    implementation(compose.desktop.currentOs)
-    implementation(compose.ui)
-    implementation(compose.foundation)
-    implementation(compose.material3)
-    implementation(compose.runtime)
-    implementation(compose.components.uiToolingPreview)
+  implementation(compose.desktop.currentOs)
+  implementation(compose.ui)
+  implementation(compose.foundation)
+  implementation(compose.material3)
+  implementation(compose.runtime)
+  implementation(compose.components.uiToolingPreview)
 }
 
-java {
-    toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
-}
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }

--- a/renderer-desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
+++ b/renderer-desktop/src/main/kotlin/ee/schimke/composeai/renderer/DesktopRendererMain.kt
@@ -17,109 +17,128 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
-import org.jetbrains.skia.EncodedImageFormat
 import java.io.ByteArrayInputStream
 import java.io.File
 import javax.imageio.ImageIO
 import kotlin.system.exitProcess
+import org.jetbrains.skia.EncodedImageFormat
 
 /**
  * Standalone entry point for rendering Compose Desktop previews to PNG.
  *
- * Args: className functionName widthPx heightPx density showBackground backgroundColor outputFile [wrapperClassName] [wrapWidth] [wrapHeight] [previewParameterProviderFqn] [previewParameterLimit]
+ * Args: className functionName widthPx heightPx density showBackground backgroundColor outputFile
+ * [wrapperClassName] [wrapWidth] [wrapHeight] [previewParameterProviderFqn] [previewParameterLimit]
  *
- * The optional 9th argument is the FQN of a `PreviewWrapperProvider` (Compose 1.11+);
- * pass an empty string or omit to skip wrapping.
+ * The optional 9th argument is the FQN of a `PreviewWrapperProvider` (Compose 1.11+); pass an empty
+ * string or omit to skip wrapping.
  *
- * Args 10 and 11 are AS-parity wrap flags. When an axis wraps, widthPx/heightPx
- * are treated as a sandbox dimension — the renderer wraps the composable,
- * measures its intrinsic size, and crops the final PNG to that size on the
- * wrapped axis. Defaults to `false` when omitted so older callers keep the
- * full-frame behaviour.
+ * Args 10 and 11 are AS-parity wrap flags. When an axis wraps, widthPx/heightPx are treated as a
+ * sandbox dimension — the renderer wraps the composable, measures its intrinsic size, and crops the
+ * final PNG to that size on the wrapped axis. Defaults to `false` when omitted so older callers
+ * keep the full-frame behaviour.
  *
- * Args 12 and 13 are the `@PreviewParameter` provider FQN + limit. When
- * arg 12 is non-empty the renderer instantiates the provider, iterates its
- * `values.take(limit)`, and writes one file per value using `outputFile` as
- * a template (`_PARAM_<idx>` inserted before the extension). Looping inside
- * a single JVM — instead of spawning one subprocess per value — avoids N×
- * Compose cold-start cost; the same `ImageComposeScene` is reused across
- * values.
+ * Args 12 and 13 are the `@PreviewParameter` provider FQN + limit. When arg 12 is non-empty the
+ * renderer instantiates the provider, iterates its `values.take(limit)`, and writes one file per
+ * value using `outputFile` as a template (`_PARAM_<idx>` inserted before the extension). Looping
+ * inside a single JVM — instead of spawning one subprocess per value — avoids N× Compose cold-start
+ * cost; the same `ImageComposeScene` is reused across values.
  */
 fun main(args: Array<String>) {
-    if (args.size < 8) {
-        System.err.println("Usage: DesktopRendererMain <className> <functionName> <widthPx> <heightPx> <density> <showBackground> <backgroundColor> <outputFile> [wrapperClassName] [wrapWidth] [wrapHeight] [previewParameterProviderFqn] [previewParameterLimit]")
-        exitProcess(1)
-    }
+  if (args.size < 8) {
+    System.err.println(
+      "Usage: DesktopRendererMain <className> <functionName> <widthPx> <heightPx> <density> <showBackground> <backgroundColor> <outputFile> [wrapperClassName] [wrapWidth] [wrapHeight] [previewParameterProviderFqn] [previewParameterLimit]"
+    )
+    exitProcess(1)
+  }
 
-    val className = args[0]
-    val functionName = args[1]
-    val widthPx = args[2].toIntOrNull() ?: run {
+  val className = args[0]
+  val functionName = args[1]
+  val widthPx =
+    args[2].toIntOrNull()
+      ?: run {
         System.err.println("Invalid widthPx: '${args[2]}' (expected integer)")
         exitProcess(1)
-    }
-    val heightPx = args[3].toIntOrNull() ?: run {
+      }
+  val heightPx =
+    args[3].toIntOrNull()
+      ?: run {
         System.err.println("Invalid heightPx: '${args[3]}' (expected integer)")
         exitProcess(1)
-    }
-    val density = args[4].toFloatOrNull() ?: run {
+      }
+  val density =
+    args[4].toFloatOrNull()
+      ?: run {
         System.err.println("Invalid density: '${args[4]}' (expected float)")
         exitProcess(1)
-    }
-    val showBackground = args[5].toBoolean()
-    val backgroundColor = args[6].toLongOrNull() ?: run {
+      }
+  val showBackground = args[5].toBoolean()
+  val backgroundColor =
+    args[6].toLongOrNull()
+      ?: run {
         System.err.println("Invalid backgroundColor: '${args[6]}' (expected long)")
         exitProcess(1)
-    }
-    val outputFile = File(args[7])
-    val wrapperClassName = args.getOrNull(8)?.takeIf { it.isNotBlank() }
-    val wrapWidth = args.getOrNull(9)?.toBoolean() ?: false
-    val wrapHeight = args.getOrNull(10)?.toBoolean() ?: false
-    val previewParameterProviderFqn = args.getOrNull(11)?.takeIf { it.isNotBlank() }
-    val previewParameterLimit = args.getOrNull(12)?.toIntOrNull()?.coerceAtLeast(0) ?: Int.MAX_VALUE
+      }
+  val outputFile = File(args[7])
+  val wrapperClassName = args.getOrNull(8)?.takeIf { it.isNotBlank() }
+  val wrapWidth = args.getOrNull(9)?.toBoolean() ?: false
+  val wrapHeight = args.getOrNull(10)?.toBoolean() ?: false
+  val previewParameterProviderFqn = args.getOrNull(11)?.takeIf { it.isNotBlank() }
+  val previewParameterLimit = args.getOrNull(12)?.toIntOrNull()?.coerceAtLeast(0) ?: Int.MAX_VALUE
 
-    try {
-        val values: List<Any?> = if (previewParameterProviderFqn != null && previewParameterLimit > 0) {
-            loadProviderValues(previewParameterProviderFqn, previewParameterLimit).also { vs ->
-                if (vs.isEmpty()) {
-                    System.err.println(
-                        "@PreviewParameter(provider = $previewParameterProviderFqn) on $functionName produced no values — skipping.",
-                    )
-                }
-            }
-        } else {
-            listOf(NO_PARAM)
-        }
-
-        val suffixes: List<String> = if (values.size == 1 && values[0] === NO_PARAM) {
-            listOf("")
-        } else {
-            PreviewParameterLabels.suffixesFor(values)
-        }
-        val targetFiles = values.mapIndexed { idx, value ->
-            if (value === NO_PARAM) outputFile
-            else File(insertBeforeExtension(outputFile.path, suffixes[idx]))
-        }
-        // Renderer is authoritative about the fan-out — delete any
-        // `<stem>_*<ext>` files from prior runs that aren't in this run's
-        // expected output. Guards against provider renames and the
-        // `_PARAM_<idx>` → `_<label>` migration leaving stale PNGs behind.
-        if (values.any { it !== NO_PARAM }) {
-            deleteStaleFanoutFiles(outputFile, targetFiles.map { it.name }.toSet())
-        }
-        for ((idx, value) in values.withIndex()) {
-            val targetFile = targetFiles[idx]
-            val previewArgs = if (value === NO_PARAM) emptyList() else listOf(value)
-            renderPreview(
-                className, functionName, widthPx, heightPx, density,
-                showBackground, backgroundColor, targetFile, wrapperClassName,
-                wrapWidth, wrapHeight, previewArgs,
+  try {
+    val values: List<Any?> =
+      if (previewParameterProviderFqn != null && previewParameterLimit > 0) {
+        loadProviderValues(previewParameterProviderFqn, previewParameterLimit).also { vs ->
+          if (vs.isEmpty()) {
+            System.err.println(
+              "@PreviewParameter(provider = $previewParameterProviderFqn) on $functionName produced no values — skipping."
             )
+          }
         }
-    } catch (e: Exception) {
-        System.err.println("Render failed for $className.$functionName: ${e.message}")
-        e.printStackTrace()
-        exitProcess(2)
+      } else {
+        listOf(NO_PARAM)
+      }
+
+    val suffixes: List<String> =
+      if (values.size == 1 && values[0] === NO_PARAM) {
+        listOf("")
+      } else {
+        PreviewParameterLabels.suffixesFor(values)
+      }
+    val targetFiles = values.mapIndexed { idx, value ->
+      if (value === NO_PARAM) outputFile
+      else File(insertBeforeExtension(outputFile.path, suffixes[idx]))
     }
+    // Renderer is authoritative about the fan-out — delete any
+    // `<stem>_*<ext>` files from prior runs that aren't in this run's
+    // expected output. Guards against provider renames and the
+    // `_PARAM_<idx>` → `_<label>` migration leaving stale PNGs behind.
+    if (values.any { it !== NO_PARAM }) {
+      deleteStaleFanoutFiles(outputFile, targetFiles.map { it.name }.toSet())
+    }
+    for ((idx, value) in values.withIndex()) {
+      val targetFile = targetFiles[idx]
+      val previewArgs = if (value === NO_PARAM) emptyList() else listOf(value)
+      renderPreview(
+        className,
+        functionName,
+        widthPx,
+        heightPx,
+        density,
+        showBackground,
+        backgroundColor,
+        targetFile,
+        wrapperClassName,
+        wrapWidth,
+        wrapHeight,
+        previewArgs,
+      )
+    }
+  } catch (e: Exception) {
+    System.err.println("Render failed for $className.$functionName: ${e.message}")
+    e.printStackTrace()
+    exitProcess(2)
+  }
 }
 
 // Sentinel: distinguishes "no @PreviewParameter fan-out" from "provider yielded null".
@@ -128,265 +147,270 @@ fun main(args: Array<String>) {
 private val NO_PARAM = Any()
 
 private fun deleteStaleFanoutFiles(template: File, expectedNames: Set<String>) {
-    val dir = template.parentFile ?: return
-    if (!dir.isDirectory) return
-    val stem = template.nameWithoutExtension
-    val ext = ".${template.extension}"
-    val prefix = stem + "_"
-    dir.listFiles()
-        ?.filter { it.name.startsWith(prefix) && it.name.endsWith(ext) && it.name !in expectedNames }
-        ?.forEach { f ->
-            if (!f.delete()) {
-                System.err.println("Failed to delete stale fan-out file: ${f.absolutePath}")
-            }
-        }
+  val dir = template.parentFile ?: return
+  if (!dir.isDirectory) return
+  val stem = template.nameWithoutExtension
+  val ext = ".${template.extension}"
+  val prefix = stem + "_"
+  dir
+    .listFiles()
+    ?.filter { it.name.startsWith(prefix) && it.name.endsWith(ext) && it.name !in expectedNames }
+    ?.forEach { f ->
+      if (!f.delete()) {
+        System.err.println("Failed to delete stale fan-out file: ${f.absolutePath}")
+      }
+    }
 }
 
 private fun insertBeforeExtension(path: String, suffix: String): String {
-    if (path.isEmpty()) return path
-    val dot = path.lastIndexOf('.')
-    val slash = path.lastIndexOf(File.separatorChar).coerceAtLeast(path.lastIndexOf('/'))
-    return if (dot > slash) path.substring(0, dot) + suffix + path.substring(dot)
-    else path + suffix
+  if (path.isEmpty()) return path
+  val dot = path.lastIndexOf('.')
+  val slash = path.lastIndexOf(File.separatorChar).coerceAtLeast(path.lastIndexOf('/'))
+  return if (dot > slash) path.substring(0, dot) + suffix + path.substring(dot) else path + suffix
 }
 
 /**
- * Loads and enumerates a `PreviewParameterProvider` reflectively — same
- * strategy the Android renderer uses in `PreviewManifestLoader.loadProviderValues`.
- * Keeping this renderer-local avoids a shared module dependency and the
- * lookup stays limited to the method shapes the interface guarantees
- * (`getValues(): Sequence`).
+ * Loads and enumerates a `PreviewParameterProvider` reflectively — same strategy the Android
+ * renderer uses in `PreviewManifestLoader.loadProviderValues`. Keeping this renderer-local avoids a
+ * shared module dependency and the lookup stays limited to the method shapes the interface
+ * guarantees (`getValues(): Sequence`).
  */
 private fun loadProviderValues(providerFqn: String, limit: Int): List<Any?> {
-    val clazz = try {
-        Class.forName(providerFqn)
+  val clazz =
+    try {
+      Class.forName(providerFqn)
     } catch (e: ClassNotFoundException) {
-        System.err.println("@PreviewParameter: provider class $providerFqn not found — skipping.")
-        return emptyList()
+      System.err.println("@PreviewParameter: provider class $providerFqn not found — skipping.")
+      return emptyList()
     }
-    val instance = runCatching {
+  val instance =
+    runCatching {
         val ctor = clazz.getDeclaredConstructor()
         ctor.isAccessible = true
         ctor.newInstance()
-    }.getOrElse { e ->
-        System.err.println("@PreviewParameter: couldn't instantiate $providerFqn via nullary ctor: ${e.message}")
+      }
+      .getOrElse { e ->
+        System.err.println(
+          "@PreviewParameter: couldn't instantiate $providerFqn via nullary ctor: ${e.message}"
+        )
         return emptyList()
-    }
-    val getValues = runCatching { clazz.getMethod("getValues") }.getOrElse {
-        System.err.println("@PreviewParameter: $providerFqn has no getValues() — not a PreviewParameterProvider?")
+      }
+  val getValues =
+    runCatching { clazz.getMethod("getValues") }
+      .getOrElse {
+        System.err.println(
+          "@PreviewParameter: $providerFqn has no getValues() — not a PreviewParameterProvider?"
+        )
         return emptyList()
-    }
-    @Suppress("UNCHECKED_CAST")
-    val sequence = getValues.invoke(instance) as? Sequence<Any?> ?: return emptyList()
-    // `Sequence.take(Int)` is lazy and `.toList()` drives it — bounds the
-    // enumeration for infinite providers without requiring an explicit
-    // counter. Calling through the typed Kotlin API avoids reflective
-    // access into `kotlin.jvm.internal.ArrayIterator`, whose visibility is
-    // package-private and throws `IllegalAccessException` from outside the
-    // stdlib's own module.
-    return sequence.take(limit).toList()
+      }
+  @Suppress("UNCHECKED_CAST")
+  val sequence = getValues.invoke(instance) as? Sequence<Any?> ?: return emptyList()
+  // `Sequence.take(Int)` is lazy and `.toList()` drives it — bounds the
+  // enumeration for infinite providers without requiring an explicit
+  // counter. Calling through the typed Kotlin API avoids reflective
+  // access into `kotlin.jvm.internal.ArrayIterator`, whose visibility is
+  // package-private and throws `IllegalAccessException` from outside the
+  // stdlib's own module.
+  return sequence.take(limit).toList()
 }
 
 private fun renderPreview(
-    className: String,
-    functionName: String,
-    widthPx: Int,
-    heightPx: Int,
-    density: Float,
-    showBackground: Boolean,
-    backgroundColor: Long,
-    outputFile: File,
-    wrapperClassName: String?,
-    wrapWidth: Boolean,
-    wrapHeight: Boolean,
-    previewArgs: List<Any?>,
+  className: String,
+  functionName: String,
+  widthPx: Int,
+  heightPx: Int,
+  density: Float,
+  showBackground: Boolean,
+  backgroundColor: Long,
+  outputFile: File,
+  wrapperClassName: String?,
+  wrapWidth: Boolean,
+  wrapHeight: Boolean,
+  previewArgs: List<Any?>,
 ) {
-    val clazz = Class.forName(className)
-    val composableMethod = if (previewArgs.isEmpty()) {
-        clazz.getDeclaredComposableMethod(functionName)
+  val clazz = Class.forName(className)
+  val composableMethod =
+    if (previewArgs.isEmpty()) {
+      clazz.getDeclaredComposableMethod(functionName)
     } else {
-        findComposableMethodWithArgs(clazz, functionName, previewArgs)
+      findComposableMethodWithArgs(clazz, functionName, previewArgs)
     }
 
-    val scene = ImageComposeScene(
-        width = widthPx,
-        height = heightPx,
-        density = Density(density),
-    )
+  val scene = ImageComposeScene(width = widthPx, height = heightPx, density = Density(density))
 
-    // Measured content size in pixels, captured from the wrapping Box via
-    // onGloballyPositioned. Only read when at least one axis wraps.
-    var measured: IntSize? = null
+  // Measured content size in pixels, captured from the wrapping Box via
+  // onGloballyPositioned. Only read when at least one axis wraps.
+  var measured: IntSize? = null
 
-    scene.setContent {
-        CompositionLocalProvider(LocalInspectionMode provides true) {
-            val bgColor = when {
-                backgroundColor != 0L -> Color(backgroundColor.toInt())
-                showBackground -> Color.White
-                else -> Color.Transparent
-            }
-            val body: @Composable () -> Unit = {
-                if (wrapWidth || wrapHeight) {
-                    // AS-parity wrap: measure the composable with unbounded
-                    // constraints on wrapped axes (keep the sandbox constraint
-                    // on fixed axes), capture the child's pixel size, then
-                    // size the outer Box to exactly that. The .layout modifier
-                    // lets us both observe and bound the child's size in a
-                    // single measurement pass — more reliable under
-                    // ImageComposeScene than onGloballyPositioned, which is
-                    // tied to a post-layout effect pass the scene doesn't
-                    // always flush.
-                    // Bounded sandbox constraints (not Infinity) — matches
-                    // Android Studio's preview pane. `fillMaxWidth` / LazyColumn
-                    // / etc. require bounded constraints; they'd throw from
-                    // `InlineClassHelper` under an Infinity max. Small
-                    // composables (`Modifier.size(100.dp)`) still measure at
-                    // their intrinsic size and get cropped to that below;
-                    // `fillMax*` composables measure at the sandbox size and
-                    // no crop happens on that axis.
-                    Box(
-                        modifier = Modifier
-                            .layout { measurable, constraints ->
-                                // Relax the min constraint on wrapped axes so
-                                // small composables can shrink below the
-                                // sandbox; keep the max bounded (the parent's
-                                // maxWidth/maxHeight) so `fillMax*` / LazyColumn
-                                // still have a finite viewport.
-                                val wrappedConstraints = Constraints(
-                                    minWidth = if (wrapWidth) 0 else constraints.minWidth,
-                                    maxWidth = constraints.maxWidth,
-                                    minHeight = if (wrapHeight) 0 else constraints.minHeight,
-                                    maxHeight = constraints.maxHeight,
-                                )
-                                val placeable = measurable.measure(wrappedConstraints)
-                                measured = IntSize(placeable.width, placeable.height)
-                                layout(placeable.width, placeable.height) {
-                                    placeable.place(0, 0)
-                                }
-                            }
-                            .background(bgColor),
-                    ) {
-                        InvokeComposable(composableMethod, null, previewArgs)
-                    }
-                } else {
-                    Box(modifier = Modifier.fillMaxSize().background(bgColor)) {
-                        InvokeComposable(composableMethod, null, previewArgs)
-                    }
+  scene.setContent {
+    CompositionLocalProvider(LocalInspectionMode provides true) {
+      val bgColor =
+        when {
+          backgroundColor != 0L -> Color(backgroundColor.toInt())
+          showBackground -> Color.White
+          else -> Color.Transparent
+        }
+      val body: @Composable () -> Unit = {
+        if (wrapWidth || wrapHeight) {
+          // AS-parity wrap: measure the composable with unbounded
+          // constraints on wrapped axes (keep the sandbox constraint
+          // on fixed axes), capture the child's pixel size, then
+          // size the outer Box to exactly that. The .layout modifier
+          // lets us both observe and bound the child's size in a
+          // single measurement pass — more reliable under
+          // ImageComposeScene than onGloballyPositioned, which is
+          // tied to a post-layout effect pass the scene doesn't
+          // always flush.
+          // Bounded sandbox constraints (not Infinity) — matches
+          // Android Studio's preview pane. `fillMaxWidth` / LazyColumn
+          // / etc. require bounded constraints; they'd throw from
+          // `InlineClassHelper` under an Infinity max. Small
+          // composables (`Modifier.size(100.dp)`) still measure at
+          // their intrinsic size and get cropped to that below;
+          // `fillMax*` composables measure at the sandbox size and
+          // no crop happens on that axis.
+          Box(
+            modifier =
+              Modifier.layout { measurable, constraints ->
+                  // Relax the min constraint on wrapped axes so
+                  // small composables can shrink below the
+                  // sandbox; keep the max bounded (the parent's
+                  // maxWidth/maxHeight) so `fillMax*` / LazyColumn
+                  // still have a finite viewport.
+                  val wrappedConstraints =
+                    Constraints(
+                      minWidth = if (wrapWidth) 0 else constraints.minWidth,
+                      maxWidth = constraints.maxWidth,
+                      minHeight = if (wrapHeight) 0 else constraints.minHeight,
+                      maxHeight = constraints.maxHeight,
+                    )
+                  val placeable = measurable.measure(wrappedConstraints)
+                  measured = IntSize(placeable.width, placeable.height)
+                  layout(placeable.width, placeable.height) { placeable.place(0, 0) }
                 }
-            }
-            // `@PreviewWrapper(Provider::class)` — instantiate the provider reflectively
-            // so the renderer stays compatible with apps on stable Compose (no
-            // `PreviewWrapperProvider` on classpath).
-            if (wrapperClassName != null) {
-                InvokeWrappedComposable(wrapperClassName, body)
-            } else {
-                body()
-            }
-        }
-    }
-
-    // Render two frames for animations/effects to settle
-    scene.render()
-    val image = scene.render()
-
-    val pngData = image.encodeToData(EncodedImageFormat.PNG)
-        ?: throw IllegalStateException("Failed to encode image to PNG")
-
-    outputFile.parentFile?.mkdirs()
-
-    // Crop to the measured content bounds on wrapped axes. `measured` is
-    // populated during the Modifier.layout measure pass in the wrap branch
-    // above — if it somehow wasn't set (shouldn't happen, but defensive),
-    // fall back to the sandbox dimensions and write the uncropped PNG.
-    if ((wrapWidth || wrapHeight) && measured != null) {
-        val m = measured!!
-        val cropW = (if (wrapWidth) m.width else widthPx).coerceIn(1, widthPx)
-        val cropH = (if (wrapHeight) m.height else heightPx).coerceIn(1, heightPx)
-        val decoded = ByteArrayInputStream(pngData.bytes).use { ImageIO.read(it) }
-        if (decoded != null && (cropW < decoded.width || cropH < decoded.height)) {
-            val sub = decoded.getSubimage(
-                0,
-                0,
-                cropW.coerceAtMost(decoded.width),
-                cropH.coerceAtMost(decoded.height),
-            )
-            ImageIO.write(sub, "PNG", outputFile)
+                .background(bgColor)
+          ) {
+            InvokeComposable(composableMethod, null, previewArgs)
+          }
         } else {
-            outputFile.writeBytes(pngData.bytes)
+          Box(modifier = Modifier.fillMaxSize().background(bgColor)) {
+            InvokeComposable(composableMethod, null, previewArgs)
+          }
         }
-    } else {
-        outputFile.writeBytes(pngData.bytes)
+      }
+      // `@PreviewWrapper(Provider::class)` — instantiate the provider reflectively
+      // so the renderer stays compatible with apps on stable Compose (no
+      // `PreviewWrapperProvider` on classpath).
+      if (wrapperClassName != null) {
+        InvokeWrappedComposable(wrapperClassName, body)
+      } else {
+        body()
+      }
     }
+  }
 
-    scene.close()
+  // Render two frames for animations/effects to settle
+  scene.render()
+  val image = scene.render()
+
+  val pngData =
+    image.encodeToData(EncodedImageFormat.PNG)
+      ?: throw IllegalStateException("Failed to encode image to PNG")
+
+  outputFile.parentFile?.mkdirs()
+
+  // Crop to the measured content bounds on wrapped axes. `measured` is
+  // populated during the Modifier.layout measure pass in the wrap branch
+  // above — if it somehow wasn't set (shouldn't happen, but defensive),
+  // fall back to the sandbox dimensions and write the uncropped PNG.
+  if ((wrapWidth || wrapHeight) && measured != null) {
+    val m = measured!!
+    val cropW = (if (wrapWidth) m.width else widthPx).coerceIn(1, widthPx)
+    val cropH = (if (wrapHeight) m.height else heightPx).coerceIn(1, heightPx)
+    val decoded = ByteArrayInputStream(pngData.bytes).use { ImageIO.read(it) }
+    if (decoded != null && (cropW < decoded.width || cropH < decoded.height)) {
+      val sub =
+        decoded.getSubimage(
+          0,
+          0,
+          cropW.coerceAtMost(decoded.width),
+          cropH.coerceAtMost(decoded.height),
+        )
+      ImageIO.write(sub, "PNG", outputFile)
+    } else {
+      outputFile.writeBytes(pngData.bytes)
+    }
+  } else {
+    outputFile.writeBytes(pngData.bytes)
+  }
+
+  scene.close()
 }
 
 @Composable
 private fun InvokeComposable(
-    composableMethod: ComposableMethod,
-    instance: Any?,
-    previewArgs: List<Any?>,
+  composableMethod: ComposableMethod,
+  instance: Any?,
+  previewArgs: List<Any?>,
 ) {
-    composableMethod.invoke(currentComposer, instance, *previewArgs.toTypedArray())
+  composableMethod.invoke(currentComposer, instance, *previewArgs.toTypedArray())
 }
 
 /**
- * Desktop mirror of the Android renderer's lookup for `@PreviewParameter`
- * functions — see [ee.schimke.composeai.renderer.findComposableMethodWithArgs]
- * for the full commentary. Kept local (not shared via a common module) so the
- * two renderer artefacts stay independently buildable.
+ * Desktop mirror of the Android renderer's lookup for `@PreviewParameter` functions — see
+ * [ee.schimke.composeai.renderer.findComposableMethodWithArgs] for the full commentary. Kept local
+ * (not shared via a common module) so the two renderer artefacts stay independently buildable.
  */
 private fun findComposableMethodWithArgs(
-    clazz: Class<*>,
-    name: String,
-    previewArgs: List<Any?>,
+  clazz: Class<*>,
+  name: String,
+  previewArgs: List<Any?>,
 ): ComposableMethod {
-    val argCount = previewArgs.size
-    val candidate = clazz.declaredMethods.firstOrNull { m ->
-        m.name == name && m.parameterCount >= argCount + 2 && argsMatch(m, previewArgs)
-    } ?: throw NoSuchMethodException(
+  val argCount = previewArgs.size
+  val candidate =
+    clazz.declaredMethods.firstOrNull { m ->
+      m.name == name && m.parameterCount >= argCount + 2 && argsMatch(m, previewArgs)
+    }
+      ?: throw NoSuchMethodException(
         "Couldn't find composable method $name on ${clazz.name} taking $argCount parameter(s); " +
-            "check that the @PreviewParameter provider's value type matches the preview's parameter type.",
-    )
-    val declaredTypes = candidate.parameterTypes.take(argCount).toTypedArray()
-    return clazz.getDeclaredComposableMethod(name, *declaredTypes)
+          "check that the @PreviewParameter provider's value type matches the preview's parameter type."
+      )
+  val declaredTypes = candidate.parameterTypes.take(argCount).toTypedArray()
+  return clazz.getDeclaredComposableMethod(name, *declaredTypes)
 }
 
 private fun argsMatch(method: java.lang.reflect.Method, previewArgs: List<Any?>): Boolean {
-    for ((i, arg) in previewArgs.withIndex()) {
-        val expected = method.parameterTypes[i]
-        if (arg == null) {
-            if (expected.isPrimitive) return false
-            continue
-        }
-        val actual = arg.javaClass
-        if (expected.isAssignableFrom(actual)) continue
-        if (expected.kotlin.javaObjectType.isAssignableFrom(actual)) continue
-        return false
+  for ((i, arg) in previewArgs.withIndex()) {
+    val expected = method.parameterTypes[i]
+    if (arg == null) {
+      if (expected.isPrimitive) return false
+      continue
     }
-    return true
+    val actual = arg.javaClass
+    if (expected.isAssignableFrom(actual)) continue
+    if (expected.kotlin.javaObjectType.isAssignableFrom(actual)) continue
+    return false
+  }
+  return true
 }
 
 /**
- * Reflectively instantiates the `PreviewWrapperProvider` identified by [wrapperFqn]
- * and invokes its `Wrap(content)` composable around [body].
+ * Reflectively instantiates the `PreviewWrapperProvider` identified by [wrapperFqn] and invokes its
+ * `Wrap(content)` composable around [body].
  *
  * See [RobolectricRenderTest.resolveWrapper] — same lookup strategy, same caveats.
  */
 @Composable
-private fun InvokeWrappedComposable(
-    wrapperFqn: String,
-    body: @Composable () -> Unit,
-) {
-    val resolved = remember(wrapperFqn) { resolveWrapper(wrapperFqn) }
-    resolved.first.invoke(currentComposer, resolved.second, body)
+private fun InvokeWrappedComposable(wrapperFqn: String, body: @Composable () -> Unit) {
+  val resolved = remember(wrapperFqn) { resolveWrapper(wrapperFqn) }
+  resolved.first.invoke(currentComposer, resolved.second, body)
 }
 
 private fun resolveWrapper(wrapperFqn: String): Pair<ComposableMethod, Any> {
-    val cls = Class.forName(wrapperFqn)
-    val instance = cls.getDeclaredConstructor().apply { isAccessible = true }.newInstance()
-    // PreviewWrapperProvider.Wrap(content: @Composable () -> Unit) compiles to
-    // Wrap(Function2, Composer, int) at the bytecode level.
-    val method = cls.getDeclaredComposableMethod("Wrap", Function2::class.java)
-    return method to instance
+  val cls = Class.forName(wrapperFqn)
+  val instance = cls.getDeclaredConstructor().apply { isAccessible = true }.newInstance()
+  // PreviewWrapperProvider.Wrap(content: @Composable () -> Unit) compiles to
+  // Wrap(Function2, Composer, int) at the bytecode level.
+  val method = cls.getDeclaredComposableMethod("Wrap", Function2::class.java)
+  return method to instance
 }

--- a/renderer-desktop/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterLabels.kt
+++ b/renderer-desktop/src/main/kotlin/ee/schimke/composeai/renderer/PreviewParameterLabels.kt
@@ -1,64 +1,63 @@
 package ee.schimke.composeai.renderer
 
 /**
- * Desktop mirror of the Android renderer's [PreviewParameterLabels] — see
- * that file for the full commentary on label derivation and fallback rules.
- * Duplicated here (not shared via a common module) so the two renderer
- * artefacts stay independently buildable.
+ * Desktop mirror of the Android renderer's [PreviewParameterLabels] — see that file for the full
+ * commentary on label derivation and fallback rules. Duplicated here (not shared via a common
+ * module) so the two renderer artefacts stay independently buildable.
  */
 internal object PreviewParameterLabels {
 
-    fun suffixesFor(values: List<Any?>): List<String> {
-        val labels = values.map { rawLabel(it)?.let(::sanitize)?.takeIf { s -> s.isNotEmpty() } }
-        val nonNull = labels.filterNotNull()
-        val hasCollision = nonNull.size != nonNull.toSet().size
-        return labels.mapIndexed { idx, label ->
-            when {
-                label == null || hasCollision -> "_PARAM_$idx"
-                else -> "_$label"
+  fun suffixesFor(values: List<Any?>): List<String> {
+    val labels = values.map { rawLabel(it)?.let(::sanitize)?.takeIf { s -> s.isNotEmpty() } }
+    val nonNull = labels.filterNotNull()
+    val hasCollision = nonNull.size != nonNull.toSet().size
+    return labels.mapIndexed { idx, label ->
+      when {
+        label == null || hasCollision -> "_PARAM_$idx"
+        else -> "_$label"
+      }
+    }
+  }
+
+  private fun rawLabel(value: Any?): String? {
+    if (value == null) return null
+    if (value is Pair<*, *>) {
+      val first = value.first ?: return null
+      return (first as? String) ?: first.toString()
+    }
+    val fromProperty = propertyLabel(value)
+    if (fromProperty != null) return fromProperty
+    val str = runCatching { value.toString() }.getOrNull() ?: return null
+    val defaultPrefix = value.javaClass.name + "@"
+    return if (str.startsWith(defaultPrefix)) null else str
+  }
+
+  private fun propertyLabel(value: Any?): String? {
+    val v = value ?: return null
+    for (candidate in listOf("name", "label", "id")) {
+      val getter = "get" + candidate.replaceFirstChar { it.uppercase() }
+      val method =
+        runCatching {
+            v.javaClass.methods.firstOrNull {
+              it.name == getter && it.parameterCount == 0 && it.returnType == String::class.java
             }
-        }
+          }
+          .getOrNull() ?: continue
+      val result = runCatching { method.invoke(v) as? String }.getOrNull()
+      if (!result.isNullOrBlank()) return result
     }
+    return null
+  }
 
-    private fun rawLabel(value: Any?): String? {
-        if (value == null) return null
-        if (value is Pair<*, *>) {
-            val first = value.first ?: return null
-            return (first as? String) ?: first.toString()
-        }
-        val fromProperty = propertyLabel(value)
-        if (fromProperty != null) return fromProperty
-        val str = runCatching { value.toString() }.getOrNull() ?: return null
-        val defaultPrefix = value.javaClass.name + "@"
-        return if (str.startsWith(defaultPrefix)) null else str
+  private fun sanitize(label: String): String {
+    val replaced = label.trim().replace(Regex("""[^A-Za-z0-9._-]"""), "_")
+    val collapsed = replaced.replace(Regex("""_+"""), "_").trim('_', '.', '-')
+    return if (collapsed.length > MAX_LABEL_LEN) {
+      collapsed.substring(0, MAX_LABEL_LEN).trim('_', '.', '-')
+    } else {
+      collapsed
     }
+  }
 
-    private fun propertyLabel(value: Any?): String? {
-        val v = value ?: return null
-        for (candidate in listOf("name", "label", "id")) {
-            val getter = "get" + candidate.replaceFirstChar { it.uppercase() }
-            val method = runCatching {
-                v.javaClass.methods.firstOrNull {
-                    it.name == getter &&
-                        it.parameterCount == 0 &&
-                        it.returnType == String::class.java
-                }
-            }.getOrNull() ?: continue
-            val result = runCatching { method.invoke(v) as? String }.getOrNull()
-            if (!result.isNullOrBlank()) return result
-        }
-        return null
-    }
-
-    private fun sanitize(label: String): String {
-        val replaced = label.trim().replace(Regex("""[^A-Za-z0-9._-]"""), "_")
-        val collapsed = replaced.replace(Regex("""_+"""), "_").trim('_', '.', '-')
-        return if (collapsed.length > MAX_LABEL_LEN) {
-            collapsed.substring(0, MAX_LABEL_LEN).trim('_', '.', '-')
-        } else {
-            collapsed
-        }
-    }
-
-    private const val MAX_LABEL_LEN = 32
+  private const val MAX_LABEL_LEN = 32
 }

--- a/sample-android-library/build.gradle.kts
+++ b/sample-android-library/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.compose.compiler)
-    id("ee.schimke.composeai.preview")
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.compose.compiler)
+  id("ee.schimke.composeai.preview")
 }
 
 // Regression coverage for issue #136: applying `composePreview` to a
@@ -11,34 +11,26 @@ plugins {
 // stays configured + executes end-to-end.
 
 android {
-    namespace = "com.example.samplelibrary"
-    compileSdk = 36
+  namespace = "com.example.samplelibrary"
+  compileSdk = 36
 
-    defaultConfig {
-        minSdk = 24
-    }
+  defaultConfig { minSdk = 24 }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
 
-    buildFeatures {
-        compose = true
-    }
+  buildFeatures { compose = true }
 
-    testOptions {
-        unitTests.all {
-            it.jvmArgs("-Xmx2048m")
-        }
-    }
+  testOptions { unitTests.all { it.jvmArgs("-Xmx2048m") } }
 }
 
 dependencies {
-    implementation(platform(libs.compose.bom))
-    implementation(libs.compose.ui)
-    implementation(libs.compose.material3)
-    implementation(libs.compose.ui.tooling.preview)
-    implementation(libs.compose.foundation)
-    debugImplementation("androidx.compose.ui:ui-tooling")
+  implementation(platform(libs.compose.bom))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.material3)
+  implementation(libs.compose.ui.tooling.preview)
+  implementation(libs.compose.foundation)
+  debugImplementation("androidx.compose.ui:ui-tooling")
 }

--- a/sample-android-screenshot-test/build.gradle.kts
+++ b/sample-android-screenshot-test/build.gradle.kts
@@ -11,56 +11,54 @@
 @file:Suppress("UnstableApiUsage")
 
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.compose.compiler)
-    alias(libs.plugins.android.compose.screenshot)
-    id("ee.schimke.composeai.preview")
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.compose.compiler)
+  alias(libs.plugins.android.compose.screenshot)
+  id("ee.schimke.composeai.preview")
 }
 
 android {
-    namespace = "com.example.sampleandroidscreenshot"
-    compileSdk = 36
+  namespace = "com.example.sampleandroidscreenshot"
+  compileSdk = 36
 
-    defaultConfig {
-        applicationId = "com.example.sampleandroidscreenshot"
-        minSdk = 24
-        targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
-    }
+  defaultConfig {
+    applicationId = "com.example.sampleandroidscreenshot"
+    minSdk = 24
+    targetSdk = 36
+    versionCode = 1
+    versionName = "1.0"
+  }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
 
-    buildFeatures {
-        compose = true
-    }
+  buildFeatures { compose = true }
 
-    // Required opt-in for `com.android.compose.screenshot`. Without this the
-    // plugin registers no tasks and the `screenshotTest` source set never
-    // appears on disk — at which point we'd only discover `main` previews
-    // and this sample would degenerate into a carbon copy of
-    // `:sample-android`.
-    experimentalProperties["android.experimental.enableScreenshotTest"] = true
+  // Required opt-in for `com.android.compose.screenshot`. Without this the
+  // plugin registers no tasks and the `screenshotTest` source set never
+  // appears on disk — at which point we'd only discover `main` previews
+  // and this sample would degenerate into a carbon copy of
+  // `:sample-android`.
+  experimentalProperties["android.experimental.enableScreenshotTest"] = true
 }
 
 dependencies {
-    implementation(platform(libs.compose.bom))
-    implementation(libs.compose.ui)
-    implementation(libs.compose.material3)
-    implementation(libs.compose.ui.tooling.preview)
-    implementation(libs.compose.foundation)
-    implementation(libs.activity.compose)
-    debugImplementation("androidx.compose.ui:ui-tooling")
+  implementation(platform(libs.compose.bom))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.material3)
+  implementation(libs.compose.ui.tooling.preview)
+  implementation(libs.compose.foundation)
+  implementation(libs.activity.compose)
+  debugImplementation("androidx.compose.ui:ui-tooling")
 
-    // Google's plugin requires `ui-tooling` on the screenshotTest classpath
-    // to instantiate PreviewParameter providers and run the `@Preview`
-    // functions under Layoutlib. Our renderer doesn't use this configuration
-    // — it drives composables via its own ClassGraph-discovered methods —
-    // but compiling the screenshotTest source set still needs it.
-    "screenshotTestImplementation"(platform(libs.compose.bom))
-    "screenshotTestImplementation"(libs.compose.ui.tooling.preview)
-    "screenshotTestImplementation"("androidx.compose.ui:ui-tooling")
+  // Google's plugin requires `ui-tooling` on the screenshotTest classpath
+  // to instantiate PreviewParameter providers and run the `@Preview`
+  // functions under Layoutlib. Our renderer doesn't use this configuration
+  // — it drives composables via its own ClassGraph-discovered methods —
+  // but compiling the screenshotTest source set still needs it.
+  "screenshotTestImplementation"(platform(libs.compose.bom))
+  "screenshotTestImplementation"(libs.compose.ui.tooling.preview)
+  "screenshotTestImplementation"("androidx.compose.ui:ui-tooling")
 }

--- a/sample-android/build.gradle.kts
+++ b/sample-android/build.gradle.kts
@@ -1,46 +1,40 @@
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.compose.compiler)
-    id("ee.schimke.composeai.preview")
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.compose.compiler)
+  id("ee.schimke.composeai.preview")
 }
 
 composePreview {
-    accessibilityChecks {
-        // Sample includes deliberately-broken previews (BadButton,
-        // TinyTapTarget, TinyNativeButton) used as demo data for the CLI /
-        // VSCode surfacing of a11y findings. Flip to `true` to exercise the
-        // opt-in path; defaults off to keep the sample's render build
-        // byte-identical to the non-a11y baseline.
-        enabled = false
-    }
+  accessibilityChecks {
+    // Sample includes deliberately-broken previews (BadButton,
+    // TinyTapTarget, TinyNativeButton) used as demo data for the CLI /
+    // VSCode surfacing of a11y findings. Flip to `true` to exercise the
+    // opt-in path; defaults off to keep the sample's render build
+    // byte-identical to the non-a11y baseline.
+    enabled = false
+  }
 }
 
 android {
-    namespace = "com.example.sampleandroid"
-    compileSdk = 36
+  namespace = "com.example.sampleandroid"
+  compileSdk = 36
 
-    defaultConfig {
-        applicationId = "com.example.sampleandroid"
-        minSdk = 24
-        targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
-    }
+  defaultConfig {
+    applicationId = "com.example.sampleandroid"
+    minSdk = 24
+    targetSdk = 36
+    versionCode = 1
+    versionName = "1.0"
+  }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
 
-    buildFeatures {
-        compose = true
-    }
+  buildFeatures { compose = true }
 
-    testOptions {
-        unitTests.all {
-            it.jvmArgs("-Xmx2048m")
-        }
-    }
+  testOptions { unitTests.all { it.jvmArgs("-Xmx2048m") } }
 }
 
 // `ScrollPreviewPixelTest` reads PNGs under `build/compose-previews/renders/`
@@ -56,45 +50,46 @@ android {
 // replaces the discouraged `afterEvaluate { tasks.findByName(...) }` block,
 // which forced eager configuration and isn't IP-friendly.
 val pixelTestUnitTestTasks = setOf("testDebugUnitTest", "testReleaseUnitTest")
-tasks.matching { it.name in pixelTestUnitTestTasks }.configureEach {
-    dependsOn("renderAllPreviews")
+
+tasks
+  .matching { it.name in pixelTestUnitTestTasks }
+  .configureEach { dependsOn("renderAllPreviews") }
+
+dependencies {
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
 }
 
 dependencies {
-    testImplementation(libs.junit)
-    testImplementation(libs.truth)
-}
-
-dependencies {
-    implementation(platform(libs.compose.bom))
-    implementation(libs.compose.ui)
-    implementation(libs.compose.material3)
-    implementation(libs.compose.ui.tooling.preview)
-    implementation(libs.compose.foundation)
-    implementation(libs.activity.compose)
-    // Exercises the `Font(GoogleFont(...), provider)` path under Robolectric —
-    // the shadow in `renderer-android` swaps the GMS provider lookup for a
-    // local cache under `.compose-preview-history/fonts/`.
-    implementation("androidx.compose.ui:ui-text-google-fonts")
-    // Roborazzi's per-preview clock control annotation. Source-retained
-    // metadata read by `DiscoverPreviewsTask` — the annotation itself has no
-    // runtime behaviour in production builds.
-    implementation(libs.roborazzi.annotations)
-    // Our `@ScrollingPreview` lives here — same role as above, read by FQN
-    // at discovery time; no runtime behaviour.
-    implementation(project(":preview-annotations"))
-    debugImplementation("androidx.compose.ui:ui-tooling")
-    // `@AnimatedPreview(showCurves = true)` reflectively probes
-    // `androidx.compose.ui.tooling.animation.PreviewAnimationClock` /
-    // `AnimationSearch` on the unit-test classpath. ui-tooling is only on
-    // the debug variant by default, so add it to the unit-test scope so
-    // the renderer can attach the animation inspector during render runs.
-    testImplementation("androidx.compose.ui:ui-tooling")
-    // `getAnimatedProperties(...)` returns
-    // `List<androidx.compose.animation.tooling.ComposeAnimatedProperty>` —
-    // those tooling types live in the `animation-tooling-internal`
-    // artifact, NOT in `animation-core`. The compose-bom pins it to the
-    // matching version; without this dep the curves path errors at attach
-    // time with "Missing class: ComposeAnimatedProperty".
-    testImplementation("androidx.compose.animation:animation-tooling-internal")
+  implementation(platform(libs.compose.bom))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.material3)
+  implementation(libs.compose.ui.tooling.preview)
+  implementation(libs.compose.foundation)
+  implementation(libs.activity.compose)
+  // Exercises the `Font(GoogleFont(...), provider)` path under Robolectric —
+  // the shadow in `renderer-android` swaps the GMS provider lookup for a
+  // local cache under `.compose-preview-history/fonts/`.
+  implementation("androidx.compose.ui:ui-text-google-fonts")
+  // Roborazzi's per-preview clock control annotation. Source-retained
+  // metadata read by `DiscoverPreviewsTask` — the annotation itself has no
+  // runtime behaviour in production builds.
+  implementation(libs.roborazzi.annotations)
+  // Our `@ScrollingPreview` lives here — same role as above, read by FQN
+  // at discovery time; no runtime behaviour.
+  implementation(project(":preview-annotations"))
+  debugImplementation("androidx.compose.ui:ui-tooling")
+  // `@AnimatedPreview(showCurves = true)` reflectively probes
+  // `androidx.compose.ui.tooling.animation.PreviewAnimationClock` /
+  // `AnimationSearch` on the unit-test classpath. ui-tooling is only on
+  // the debug variant by default, so add it to the unit-test scope so
+  // the renderer can attach the animation inspector during render runs.
+  testImplementation("androidx.compose.ui:ui-tooling")
+  // `getAnimatedProperties(...)` returns
+  // `List<androidx.compose.animation.tooling.ComposeAnimatedProperty>` —
+  // those tooling types live in the `animation-tooling-internal`
+  // artifact, NOT in `animation-core`. The compose-bom pins it to the
+  // matching version; without this dep the curves path errors at attach
+  // time with "Missing class: ComposeAnimatedProperty".
+  testImplementation("androidx.compose.animation:animation-tooling-internal")
 }

--- a/sample-cmp/build.gradle.kts
+++ b/sample-cmp/build.gradle.kts
@@ -1,21 +1,19 @@
 @file:Suppress("DEPRECATION")
 
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.compose.multiplatform)
-    alias(libs.plugins.compose.compiler)
-    id("ee.schimke.composeai.preview")
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.compose.multiplatform)
+  alias(libs.plugins.compose.compiler)
+  id("ee.schimke.composeai.preview")
 }
 
 dependencies {
-    implementation(compose.desktop.currentOs)
-    implementation(compose.material3)
-    implementation(compose.foundation)
-    implementation(compose.ui)
-    implementation(compose.uiTooling)
-    implementation(compose.components.uiToolingPreview)
+  implementation(compose.desktop.currentOs)
+  implementation(compose.material3)
+  implementation(compose.foundation)
+  implementation(compose.ui)
+  implementation(compose.uiTooling)
+  implementation(compose.components.uiToolingPreview)
 }
 
-java {
-    toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
-}
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }

--- a/sample-cmp/src/main/kotlin/com/example/samplecmp/App.kt
+++ b/sample-cmp/src/main/kotlin/com/example/samplecmp/App.kt
@@ -1,24 +1,21 @@
 package com.example.samplecmp
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
 
 @Composable
 fun App() {
-    MaterialTheme {
-        Column(
-            modifier = Modifier.fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
-            Text("Compose Multiplatform Sample")
-        }
+  MaterialTheme {
+    Column(
+      modifier = Modifier.fillMaxSize(),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.Center,
+    ) {
+      Text("Compose Multiplatform Sample")
     }
+  }
 }

--- a/sample-cmp/src/main/kotlin/com/example/samplecmp/Main.kt
+++ b/sample-cmp/src/main/kotlin/com/example/samplecmp/Main.kt
@@ -4,7 +4,5 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 
 fun main() = application {
-    Window(onCloseRequest = ::exitApplication, title = "Sample CMP") {
-        App()
-    }
+  Window(onCloseRequest = ::exitApplication, title = "Sample CMP") { App() }
 }

--- a/sample-cmp/src/main/kotlin/com/example/samplecmp/PreviewParameterPreviews.kt
+++ b/sample-cmp/src/main/kotlin/com/example/samplecmp/PreviewParameterPreviews.kt
@@ -19,51 +19,43 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 
 /**
- * Demo data for the CMP Desktop `@PreviewParameter` sample. Each value has a
- * distinct label + colour, so the fan-out lands on visually different PNGs —
- * and since [SwatchData] exposes a [label] property, the renderer derives
- * filename suffixes from it (`<id>_Crimson.png`, `<id>_Teal.png`, …) instead
- * of opaque `_PARAM_<idx>` indices.
+ * Demo data for the CMP Desktop `@PreviewParameter` sample. Each value has a distinct label +
+ * colour, so the fan-out lands on visually different PNGs — and since [SwatchData] exposes a
+ * [label] property, the renderer derives filename suffixes from it (`<id>_Crimson.png`,
+ * `<id>_Teal.png`, …) instead of opaque `_PARAM_<idx>` indices.
  */
 data class SwatchData(val label: String, val color: Long)
 
 class SwatchProvider : PreviewParameterProvider<SwatchData> {
-    override val values: Sequence<SwatchData> = sequenceOf(
-        SwatchData("Crimson", 0xFFDC143C),
-        SwatchData("Teal", 0xFF008B8B),
-        SwatchData("Amber", 0xFFFFBF00),
-        SwatchData("Violet", 0xFF7F00FF),
+  override val values: Sequence<SwatchData> =
+    sequenceOf(
+      SwatchData("Crimson", 0xFFDC143C),
+      SwatchData("Teal", 0xFF008B8B),
+      SwatchData("Amber", 0xFFFFBF00),
+      SwatchData("Violet", 0xFF7F00FF),
     )
 }
 
 /**
- * Desktop (CMP) `@PreviewParameter` smoke test. The JVM renderer consumes
- * the provider FQN + limit passed on the command line, loops over
- * `values.take(limit)` inside a single process, and emits one PNG per
- * value — keyed by the value's derived label (from a `name`/`label`/`id`
- * property or a `Pair`'s `first`) and falling back to `_PARAM_<idx>` when
- * no label can be derived.
+ * Desktop (CMP) `@PreviewParameter` smoke test. The JVM renderer consumes the provider FQN + limit
+ * passed on the command line, loops over `values.take(limit)` inside a single process, and emits
+ * one PNG per value — keyed by the value's derived label (from a `name`/`label`/`id` property or a
+ * `Pair`'s `first`) and falling back to `_PARAM_<idx>` when no label can be derived.
  */
 @Preview(name = "Color Swatch", backgroundColor = 0xFFFFFFFF, showBackground = true)
 @Composable
-fun SwatchPreview(
-    @PreviewParameter(SwatchProvider::class) swatch: SwatchData,
-) {
-    MaterialTheme {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Box(
-                modifier = Modifier
-                    .size(160.dp, 80.dp)
-                    .clip(RoundedCornerShape(12.dp))
-                    .background(Color(swatch.color.toInt())),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = swatch.label,
-                    color = Color.White,
-                    style = MaterialTheme.typography.titleMedium,
-                )
-            }
-        }
+fun SwatchPreview(@PreviewParameter(SwatchProvider::class) swatch: SwatchData) {
+  MaterialTheme {
+    Column(modifier = Modifier.padding(16.dp)) {
+      Box(
+        modifier =
+          Modifier.size(160.dp, 80.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color(swatch.color.toInt())),
+        contentAlignment = Alignment.Center,
+      ) {
+        Text(text = swatch.label, color = Color.White, style = MaterialTheme.typography.titleMedium)
+      }
     }
+  }
 }

--- a/sample-cmp/src/main/kotlin/com/example/samplecmp/Previews.kt
+++ b/sample-cmp/src/main/kotlin/com/example/samplecmp/Previews.kt
@@ -14,27 +14,24 @@ import androidx.compose.ui.unit.dp
 @Preview(name = "Red Box", backgroundColor = 0xFFFF0000, showBackground = true)
 @Composable
 fun RedBoxPreview() {
-    Box(
-        modifier = Modifier.size(100.dp).background(Color.Red),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text("Red", color = Color.White)
-    }
+  Box(modifier = Modifier.size(100.dp).background(Color.Red), contentAlignment = Alignment.Center) {
+    Text("Red", color = Color.White)
+  }
 }
 
 @Preview(name = "Blue Box", backgroundColor = 0xFF0000FF, showBackground = true)
 @Composable
 fun BlueBoxPreview() {
-    Box(
-        modifier = Modifier.size(100.dp).background(Color.Blue),
-        contentAlignment = Alignment.Center,
-    ) {
-        Text("Blue", color = Color.White)
-    }
+  Box(
+    modifier = Modifier.size(100.dp).background(Color.Blue),
+    contentAlignment = Alignment.Center,
+  ) {
+    Text("Blue", color = Color.White)
+  }
 }
 
 @Preview
 @Composable
 fun AppPreview() {
-    App()
+  App()
 }

--- a/sample-remotecompose/build.gradle.kts
+++ b/sample-remotecompose/build.gradle.kts
@@ -1,61 +1,53 @@
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.compose.compiler)
-    id("ee.schimke.composeai.preview")
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.compose.compiler)
+  id("ee.schimke.composeai.preview")
 }
 
-composePreview {
-    accessibilityChecks {
-        enabled = false
-    }
-}
+composePreview { accessibilityChecks { enabled = false } }
 
 android {
-    namespace = "com.example.sampleremotecompose"
-    compileSdk = 36
+  namespace = "com.example.sampleremotecompose"
+  compileSdk = 36
 
-    defaultConfig {
-        applicationId = "com.example.sampleremotecompose"
-        // Remote Compose alpha artifacts require API 29+.
-        minSdk = 29
-        targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
-    }
+  defaultConfig {
+    applicationId = "com.example.sampleremotecompose"
+    // Remote Compose alpha artifacts require API 29+.
+    minSdk = 29
+    targetSdk = 36
+    versionCode = 1
+    versionName = "1.0"
+  }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
 
-    buildFeatures {
-        compose = true
-    }
+  buildFeatures { compose = true }
 
-    // Remote Compose APIs are `@RestrictTo(LIBRARY_GROUP)` — source-level
-    // `@file:Suppress("RestrictedApiAndroidX")` quiets the IDE inspection
-    // but AGP's lint runs `RestrictedApi` separately. Mirror what
-    // AndroidX's own samples do and disable the check for this module.
-    lint {
-        disable += "RestrictedApi"
-    }
+  // Remote Compose APIs are `@RestrictTo(LIBRARY_GROUP)` — source-level
+  // `@file:Suppress("RestrictedApiAndroidX")` quiets the IDE inspection
+  // but AGP's lint runs `RestrictedApi` separately. Mirror what
+  // AndroidX's own samples do and disable the check for this module.
+  lint { disable += "RestrictedApi" }
 }
 
 dependencies {
-    // This module does NOT use the Compose BOM — wear-compose-remote-material3
-    // alpha01's POM pulls in Compose 1.11.0-beta01 runtime for foundation /
-    // runtime / ui, and `PreviewWrapper` only exists in ui-tooling-preview
-    // 1.11.0-beta+. Pinning explicit versions keeps resolution aligned with
-    // the 1.11 line and avoids fighting the 1.10.x BOM used elsewhere.
-    implementation(libs.compose.ui.tooling.preview.wrapper)
-    implementation(libs.compose.remote.tooling.preview)
-    // `remote-tooling-preview`'s POM declares its creation/compose deps with
-    // `runtime` scope, so the compile classpath doesn't see `RemoteButton`'s
-    // parameter types (`RemoteModifier`, `RemoteString`, `HostAction`, etc.)
-    // unless we pull them in explicitly.
-    implementation(libs.compose.remote.creation)
-    implementation(libs.compose.remote.creation.compose)
-    implementation(libs.wear.compose.remote.material3)
-    implementation(libs.activity.compose)
-    debugImplementation("androidx.compose.ui:ui-tooling:1.11.0-rc01")
+  // This module does NOT use the Compose BOM — wear-compose-remote-material3
+  // alpha01's POM pulls in Compose 1.11.0-beta01 runtime for foundation /
+  // runtime / ui, and `PreviewWrapper` only exists in ui-tooling-preview
+  // 1.11.0-beta+. Pinning explicit versions keeps resolution aligned with
+  // the 1.11 line and avoids fighting the 1.10.x BOM used elsewhere.
+  implementation(libs.compose.ui.tooling.preview.wrapper)
+  implementation(libs.compose.remote.tooling.preview)
+  // `remote-tooling-preview`'s POM declares its creation/compose deps with
+  // `runtime` scope, so the compile classpath doesn't see `RemoteButton`'s
+  // parameter types (`RemoteModifier`, `RemoteString`, `HostAction`, etc.)
+  // unless we pull them in explicitly.
+  implementation(libs.compose.remote.creation)
+  implementation(libs.compose.remote.creation.compose)
+  implementation(libs.wear.compose.remote.material3)
+  implementation(libs.activity.compose)
+  debugImplementation("androidx.compose.ui:ui-tooling:1.11.0-rc01")
 }

--- a/sample-wear/build.gradle.kts
+++ b/sample-wear/build.gradle.kts
@@ -1,68 +1,66 @@
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.compose.compiler)
-    id("ee.schimke.composeai.preview")
+  alias(libs.plugins.android.application)
+  alias(libs.plugins.compose.compiler)
+  id("ee.schimke.composeai.preview")
 }
 
 composePreview {
-    accessibilityChecks {
-        // Sample wires a deliberately-broken `BadWearButtonPreview` so the
-        // `.a11y.png` for Wear exercises the stacked (legend-below) layout.
-        // Flip to `true` and re-run to see the annotation; defaults off so
-        // `./gradlew check` stays clean.
-        enabled = false
-    }
+  accessibilityChecks {
+    // Sample wires a deliberately-broken `BadWearButtonPreview` so the
+    // `.a11y.png` for Wear exercises the stacked (legend-below) layout.
+    // Flip to `true` and re-run to see the annotation; defaults off so
+    // `./gradlew check` stays clean.
+    enabled = false
+  }
 }
 
 android {
-    namespace = "com.example.samplewear"
-    compileSdk = 36
+  namespace = "com.example.samplewear"
+  compileSdk = 36
 
-    defaultConfig {
-        applicationId = "com.example.samplewear"
-        minSdk = 30
-        targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
-    }
+  defaultConfig {
+    applicationId = "com.example.samplewear"
+    minSdk = 30
+    targetSdk = 36
+    versionCode = 1
+    versionName = "1.0"
+  }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
 
-    buildFeatures {
-        compose = true
-    }
+  buildFeatures { compose = true }
 }
 
 dependencies {
-    implementation(platform(libs.compose.bom))
-    implementation(libs.compose.ui)
-    implementation(libs.compose.foundation)
-    implementation(libs.activity.compose)
-    implementation(libs.wear.compose.material3)
-    implementation(libs.wear.compose.foundation)
-    implementation(libs.wear.compose.ui.tooling)
-    implementation(libs.compose.ui.tooling.preview)
-    debugImplementation("androidx.compose.ui:ui-tooling")
+  implementation(platform(libs.compose.bom))
+  implementation(libs.compose.ui)
+  implementation(libs.compose.foundation)
+  implementation(libs.activity.compose)
+  implementation(libs.wear.compose.material3)
+  implementation(libs.wear.compose.foundation)
+  implementation(libs.wear.compose.ui.tooling)
+  implementation(libs.compose.ui.tooling.preview)
+  debugImplementation("androidx.compose.ui:ui-tooling")
 
-    // Wear Tiles — for the `@androidx.wear.tiles.tooling.preview.Preview` sample
-    // rendered via TilePreviewRenderer in renderer-android. `wear.tiles.renderer`
-    // is deliberately NOT declared here — the plugin injects it when the
-    // consumer's variant runtime classpath already includes `androidx.wear.tiles:tiles`,
-    // so consumer apps don't need to restate this preview-only dependency.
-    implementation(libs.wear.tiles)
-    implementation(libs.wear.tiles.tooling.preview)
-    implementation(libs.wear.protolayout)
-    implementation(libs.wear.protolayout.expression)
-    implementation(libs.wear.protolayout.material3)
-    implementation(libs.wear.tooling.preview)
-    // `@ScrollingPreview` — read by FQN at discovery time; no runtime cost.
-    implementation(project(":preview-annotations"))
+  // Wear Tiles — for the `@androidx.wear.tiles.tooling.preview.Preview` sample
+  // rendered via TilePreviewRenderer in renderer-android. `wear.tiles.renderer`
+  // is deliberately NOT declared here — the plugin injects it when the
+  // consumer's variant runtime classpath already includes `androidx.wear.tiles:tiles`,
+  // so consumer apps don't need to restate this preview-only dependency.
+  implementation(libs.wear.tiles)
+  implementation(libs.wear.tiles.tooling.preview)
+  implementation(libs.wear.protolayout)
+  implementation(libs.wear.protolayout.expression)
+  implementation(libs.wear.protolayout.material3)
+  implementation(libs.wear.tooling.preview)
+  // `@ScrollingPreview` — read by FQN at discovery time; no runtime cost.
+  implementation(project(":preview-annotations"))
 
-    testImplementation(libs.junit)
-    testImplementation(libs.truth)
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
 }
 
 // `LongScrollPreviewPixelTest` reads PNGs produced by `renderAllPreviews`.
@@ -75,6 +73,7 @@ dependencies {
 // don't need the discouraged `afterEvaluate` block to wait for AGP to wire
 // the unit-test tasks.
 val pixelTestUnitTestTasks = setOf("testDebugUnitTest", "testReleaseUnitTest")
-tasks.matching { it.name in pixelTestUnitTestTasks }.configureEach {
-    dependsOn("renderAllPreviews")
-}
+
+tasks
+  .matching { it.name in pixelTestUnitTestTasks }
+  .configureEach { dependsOn("renderAllPreviews") }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,30 +1,40 @@
 pluginManagement {
-    repositories {
-        gradlePluginPortal()
-        google()
-        mavenCentral()
-    }
+  repositories {
+    gradlePluginPortal()
+    google()
+    mavenCentral()
+  }
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        google()
-        mavenCentral()
-        maven("https://repo.gradle.org/gradle/libs-releases")
-    }
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    google()
+    mavenCentral()
+    maven("https://repo.gradle.org/gradle/libs-releases")
+  }
 }
 
 rootProject.name = "compose-ai-tools"
 
 includeBuild("gradle-plugin")
+
 include(":cli")
+
 include(":preview-annotations")
+
 include(":sample-android")
+
 include(":sample-android-library")
+
 include(":sample-android-screenshot-test")
+
 include(":sample-wear")
+
 include(":sample-cmp")
+
 include(":sample-remotecompose")
+
 include(":renderer-desktop")
+
 include(":renderer-android")


### PR DESCRIPTION
## Summary

- Mechanical reformat — pure output of `./gradlew ktfmtFormatAll` against the existing tree.
- Stacked on #210 (the ktfmt setup); rebase onto `main` once that lands.
- No behavioural changes. The diff is large (~10k +/-) but every change is whitespace, line-wrap, or trailing-comma normalisation.

## Test plan

- [x] `./gradlew ktfmtCheckAll` passes locally on this branch.
- [ ] Format CI workflow (added by #210) passes.
- [ ] Existing `:gradle-plugin:test` and `:gradle-plugin:functionalTest` still green (CI).