### PR TITLE
build: enforce Kotlin 2.1.21 compatibility floor on published modules

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,3 +1,6 @@
+import tapmoc.TapmocExtension
+import tapmoc.configureKotlinCompatibility
+
 plugins {
   `java-gradle-plugin`
   `kotlin-dsl`
@@ -5,9 +8,18 @@ plugins {
   alias(libs.plugins.kotlin.serialization)
   alias(libs.plugins.maven.publish)
   alias(libs.plugins.ktfmt)
+  alias(libs.plugins.tapmoc)
 }
 
 ktfmt { googleStyle() }
+
+// `kotlin-dsl` already pins the language/api version to Gradle's embedded
+// Kotlin (currently 2.x); tapmoc is wired here primarily for
+// `checkDependencies()`, which surfaces if any KGP/AGP transitive raises the
+// Kotlin floor we'd push onto plugin consumers' buildscript classpaths.
+configureKotlinCompatibility(version = libs.versions.kotlinCoreLibraries.get())
+
+extensions.configure<TapmocExtension> { checkDependencies() }
 
 group = "ee.schimke.composeai"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,13 @@
 [versions]
 kotlin = "2.3.21"
+# Kotlin language/api floor for published modules. Set lower than `kotlin`
+# so consumers on an older Kotlin can still link against our artifacts —
+# tapmoc enforces this and fails the build if a transitive API dep raises
+# the floor. Bump only when the published surface needs a newer feature.
+kotlinCoreLibraries = "2.1.21"
 agp = "9.2.0"
 ktfmt = "0.26.0"
+tapmoc = "0.4.0"
 robolectric = "4.16.1"
 classgraph = "4.8.184"
 compose-bom = "2026.04.01"
@@ -94,3 +100,4 @@ compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-m
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
 android-compose-screenshot = { id = "com.android.compose.screenshot", version.ref = "android-compose-screenshot" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
+tapmoc = { id = "com.gradleup.tapmoc", version.ref = "tapmoc" }

--- a/preview-annotations/build.gradle.kts
+++ b/preview-annotations/build.gradle.kts
@@ -1,8 +1,20 @@
+import tapmoc.TapmocExtension
+import tapmoc.configureKotlinCompatibility
+
 plugins {
   alias(libs.plugins.kotlin.jvm)
   `maven-publish`
   alias(libs.plugins.maven.publish)
+  alias(libs.plugins.tapmoc)
 }
+
+// Pin the Kotlin language/api surface to `kotlinCoreLibraries` (lower than
+// the compiler `kotlin` version) so consumers on older Kotlin can still link
+// against this artifact. `checkDependencies()` fails the build if a
+// transitive API dep raises the floor.
+configureKotlinCompatibility(version = libs.versions.kotlinCoreLibraries.get())
+
+extensions.configure<TapmocExtension> { checkDependencies() }
 
 group = "ee.schimke.composeai"
 

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -5,6 +5,8 @@
 // types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
 
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import tapmoc.TapmocExtension
+import tapmoc.configureKotlinCompatibility
 
 plugins {
   alias(libs.plugins.android.library)
@@ -12,7 +14,13 @@ plugins {
   alias(libs.plugins.kotlin.serialization)
   `maven-publish`
   alias(libs.plugins.maven.publish)
+  alias(libs.plugins.tapmoc)
 }
+
+// See preview-annotations/build.gradle.kts for the rationale.
+configureKotlinCompatibility(version = libs.versions.kotlinCoreLibraries.get())
+
+extensions.configure<TapmocExtension> { checkDependencies() }
 
 group = "ee.schimke.composeai"
 


### PR DESCRIPTION
## Summary

Wire the [GradleUp tapmoc](https://github.com/GradleUp/tapmoc) plugin into the three published modules (`preview-annotations`, `renderer-android`, `gradle-plugin`) so the compiler `kotlin = 2.3.21` doesn't silently raise the floor we push onto consumers:

- `configureKotlinCompatibility(version = "2.1.21")` pins `languageVersion` / `apiVersion` to a stable floor lower than the compiler version. Consumers on Kotlin 2.1.x can keep linking against our artifacts without metadata-version warnings.
- `checkDependencies()` adds three verification tasks (`tapmocCheckClassFileVersions`, `tapmocCheckKotlinMetadataVersions`, `tapmocCheckKotlinStdlibVersions`) that fail the build if a transitive API dep raises the Kotlin metadata, stdlib, or JVM bytecode floor. Catches accidental drift on future Renovate bumps before it reaches consumers.

The new `kotlinCoreLibraries` version in `libs.versions.toml` is the single knob to bump when the published surface deliberately needs a newer feature.

Why 2.1 (and not 2.0): grepped both published and internal modules — no `context(...)` parameters or other Kotlin 2.2+ language features in use, so 2.1 fits without source changes.

Why include `gradle-plugin`: `kotlin-dsl` already pins the language/api version to Gradle's embedded Kotlin, so `configureKotlinCompatibility` is mostly a no-op there. But `checkDependencies()` still surfaces if any KGP/AGP transitive raises the Kotlin floor we'd push onto plugin consumers' buildscript classpaths — that's the value-add for this module.

## Test plan

- [x] `./gradlew :preview-annotations:tapmocCheck{ClassFileVersions,KotlinMetadataVersions,KotlinStdlibVersions}` — all pass
- [x] `./gradlew :renderer-android:tapmocCheck*` — all pass (Stdlib check is `SKIPPED`, no runtime stdlib dep declared)
- [x] `./gradlew :gradle-plugin:tapmocCheck*` — all pass
- [x] `./gradlew :preview-annotations:compileKotlin` (forced rerun) — clean under the new floor
- [x] `./gradlew :gradle-plugin:compileKotlin` (forced rerun) — clean under the new floor
- [x] `./gradlew ktfmtFormat` — no formatting changes required
- [ ] CI green on all configurations

---
_Generated by [Claude Code](https://claude.ai/code/session_013SS5ps9ABoRf8vG7Uy8ANV)_