### PR TITLE
feat(plugin): fail-fast on too-old Gradle at apply time

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
@@ -3,9 +3,11 @@ package ee.schimke.composeai.plugin
 import ee.schimke.composeai.plugin.tooling.ComposePreviewAppliedTask
 import ee.schimke.composeai.plugin.tooling.ComposePreviewModelBuilder
 import javax.inject.Inject
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
+import org.gradle.util.GradleVersion
 
 abstract class ComposePreviewPlugin
 @Inject
@@ -16,6 +18,8 @@ constructor(
   private val toolingRegistry: ToolingModelBuilderRegistry
 ) : Plugin<Project> {
   override fun apply(project: Project) {
+    GradleVersionCheck.problem(GradleVersion.current())?.let { throw GradleException(it) }
+
     val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
 
     // ToolingModelBuilderRegistry is a build-scoped service — registering

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GradleVersionCheck.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GradleVersionCheck.kt
@@ -1,0 +1,31 @@
+package ee.schimke.composeai.plugin
+
+import org.gradle.util.GradleVersion
+
+/**
+ * Fail-fast guard so `compose-preview` produces a clear error on too-old Gradle instead of letting
+ * the build limp on and surface an opaque `NoSuchMethodError` from a Gradle API we depend on.
+ *
+ * Floor matches `CompatRules.GRADLE_MIN` — the binding constraint is AGP's own minimum (9.1.x →
+ * Gradle 9.3.1), so on Android builds AGP rejects older Gradle before our `apply()` runs anyway.
+ * The check still earns its keep on **CMP Desktop** consumers (no AGP gate) and as documentation
+ * any time something slips past AGP's check.
+ *
+ * Pure on purpose so the unit test can drive every branch without spinning up a `Project`.
+ */
+internal object GradleVersionCheck {
+  internal val MIN: GradleVersion = GradleVersion.version("9.3.1")
+
+  /**
+   * @return `null` when [current] satisfies the floor, otherwise a remediation message suitable
+   *   for [org.gradle.api.GradleException].
+   */
+  internal fun problem(current: GradleVersion): String? {
+    if (current.baseVersion >= MIN) return null
+    return buildString {
+      append("compose-preview requires Gradle ${MIN.version} or newer; this build is on ")
+      append(current.version)
+      append(". Upgrade via `./gradlew wrapper --gradle-version ${MIN.version}`.")
+    }
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GradleVersionCheck.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/GradleVersionCheck.kt
@@ -6,19 +6,20 @@ import org.gradle.util.GradleVersion
  * Fail-fast guard so `compose-preview` produces a clear error on too-old Gradle instead of letting
  * the build limp on and surface an opaque `NoSuchMethodError` from a Gradle API we depend on.
  *
- * Floor matches `CompatRules.GRADLE_MIN` — the binding constraint is AGP's own minimum (9.1.x →
- * Gradle 9.3.1), so on Android builds AGP rejects older Gradle before our `apply()` runs anyway.
- * The check still earns its keep on **CMP Desktop** consumers (no AGP gate) and as documentation
- * any time something slips past AGP's check.
+ * Floor is the lowest Gradle line our integration matrix routinely exercises (Gradle 9.0.x). Most
+ * Android consumers are gated more strictly by AGP's own minimum — AGP 9.0.x needs Gradle 9.1.0+,
+ * AGP 9.1.x needs 9.3.1+ — so on Android builds AGP rejects older Gradle before our `apply()` runs
+ * anyway. The check still earns its keep on **CMP Desktop** consumers (no AGP gate) and as
+ * documentation any time something slips past AGP's check.
  *
  * Pure on purpose so the unit test can drive every branch without spinning up a `Project`.
  */
 internal object GradleVersionCheck {
-  internal val MIN: GradleVersion = GradleVersion.version("9.3.1")
+  internal val MIN: GradleVersion = GradleVersion.version("9.0.0")
 
   /**
-   * @return `null` when [current] satisfies the floor, otherwise a remediation message suitable
-   *   for [org.gradle.api.GradleException].
+   * @return `null` when [current] satisfies the floor, otherwise a remediation message suitable for
+   *   [org.gradle.api.GradleException].
    */
   internal fun problem(current: GradleVersion): String? {
     if (current.baseVersion >= MIN) return null

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
@@ -16,18 +16,16 @@ internal object CompatRules {
   /**
    * Effective minimum Gradle version for consumers applying the plugin.
    *
-   * The binding constraint is **AGP's own floor**, not any API we use: AGP 9.1.x requires Gradle
-   * 9.3.1+ (per the AGP release notes), and AGP itself rejects older Gradle at its own version
-   * check — long before our `apply()` runs. The plugin's own code only reaches Gradle APIs that
-   * have been stable since the 8.x line, so there's no floor we set independently of AGP.
-   *
-   * Keep this in lockstep with AGP's documented minimum when bumping `libs.versions.toml`: AGP
-   * 9.0.x → Gradle 9.1.0 AGP 9.1.x → Gradle 9.3.1
+   * Set to the lowest Gradle line our integration matrix routinely exercises (9.0.x). The plugin's
+   * own code only reaches Gradle APIs that have been stable since the 8.x line, so this floor is a
+   * coverage statement, not a hard API requirement. Most Android consumers are gated more strictly
+   * by AGP's own floor anyway — AGP 9.0.x needs Gradle 9.1.0+, AGP 9.1.x needs 9.3.1+ — and AGP
+   * rejects older Gradle at its own version check long before our `apply()` runs.
    *
    * The repo wrapper (currently 9.4.1) is the dev/test toolchain — not a floor we impose on
    * consumers. Don't conflate the two.
    */
-  internal val GRADLE_MIN = Semver(9, 3, 1)
+  internal val GRADLE_MIN = Semver(9, 0, 0)
 
   /**
    * activity 1.11+ transitively brought `androidx.navigationevent:1.0.0`. Consumers whose main
@@ -101,14 +99,15 @@ internal object CompatRules {
     return ModuleFindingData(
       id = "gradle-too-old",
       severity = "error",
-      message = "Gradle $raw is below AGP 9.1.x's minimum ($GRADLE_MIN)",
+      message = "Gradle $raw is below the supported floor ($GRADLE_MIN)",
       detail =
-        "AGP 9.1.x requires Gradle >= $GRADLE_MIN. The plugin itself only uses APIs " +
-          "stable since Gradle 8.x, so the floor comes from AGP — on an Android build AGP's " +
-          "own compat check fails before this rule even fires. The finding is still emitted " +
-          "for CMP Desktop projects (no AGP gate) and to give a clear remediation when the " +
-          "Tooling API wraps the real cause in a generic `Could not execute build using " +
-          "connection to Gradle distribution …` message.",
+        "compose-preview is integration-tested against Gradle $GRADLE_MIN and newer. The plugin " +
+          "itself only uses APIs stable since the 8.x line, so older Gradle may happen to work, " +
+          "but isn't covered by CI. On Android builds AGP's own check usually rejects too-old " +
+          "Gradle before our `apply()` runs (AGP 9.0.x needs 9.1.0+, AGP 9.1.x needs 9.3.1+); " +
+          "this finding is still emitted for CMP Desktop projects (no AGP gate) and to give a " +
+          "clear remediation when the Tooling API wraps the real cause in a generic `Could not " +
+          "execute build using connection to Gradle distribution …` message.",
       remediationSummary = "Upgrade the project's Gradle wrapper to >= $GRADLE_MIN.",
       remediationCommands = listOf("./gradlew wrapper --gradle-version $GRADLE_MIN"),
       docsUrl = null,

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/GradleVersionCheckTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/GradleVersionCheckTest.kt
@@ -11,7 +11,7 @@ class GradleVersionCheckTest {
 
   @Test
   fun `current floor passes`() {
-    assertNull(GradleVersionCheck.problem(GradleVersion.version("9.3.1")))
+    assertNull(GradleVersionCheck.problem(GradleVersion.version("9.0.0")))
   }
 
   @Test
@@ -20,23 +20,29 @@ class GradleVersionCheckTest {
   }
 
   @Test
+  fun `androidify-style 9_3 passes`() {
+    // Spot-check: real-world consumer (android/androidify) at the time of writing.
+    assertNull(GradleVersionCheck.problem(GradleVersion.version("9.3.0")))
+  }
+
+  @Test
   fun `release candidate of floor passes`() {
-    // GradleVersion.baseVersion strips the `-rc-N` suffix, so 9.3.1-rc-1 still satisfies 9.3.1.
-    assertNull(GradleVersionCheck.problem(GradleVersion.version("9.3.1-rc-1")))
+    // GradleVersion.baseVersion strips the `-rc-N` suffix, so 9.0.0-rc-1 still satisfies 9.0.0.
+    assertNull(GradleVersionCheck.problem(GradleVersion.version("9.0.0-rc-1")))
   }
 
   @Test
   fun `older than floor fails with remediation`() {
-    val msg = GradleVersionCheck.problem(GradleVersion.version("9.3.0"))
+    val msg = GradleVersionCheck.problem(GradleVersion.version("8.13"))
     assertNotNull(msg)
-    assertTrue(msg!!.contains("9.3.0"))
-    assertTrue(msg.contains("9.3.1"))
-    assertTrue(msg.contains("./gradlew wrapper --gradle-version 9.3.1"))
+    assertTrue(msg!!.contains("8.13"))
+    assertTrue(msg.contains("9.0.0"))
+    assertTrue(msg.contains("./gradlew wrapper --gradle-version 9.0.0"))
   }
 
   @Test
   fun `floor constant matches CompatRules`() {
-    // Drift guard — both floors are driven by AGP's documented minimum and should move together.
-    assertEquals("9.3.1", GradleVersionCheck.MIN.version)
+    // Drift guard — both floors should move together when we widen / narrow consumer support.
+    assertEquals("9.0.0", GradleVersionCheck.MIN.version)
   }
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/GradleVersionCheckTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/GradleVersionCheckTest.kt
@@ -1,0 +1,42 @@
+package ee.schimke.composeai.plugin
+
+import org.gradle.util.GradleVersion
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GradleVersionCheckTest {
+
+  @Test
+  fun `current floor passes`() {
+    assertNull(GradleVersionCheck.problem(GradleVersion.version("9.3.1")))
+  }
+
+  @Test
+  fun `newer than floor passes`() {
+    assertNull(GradleVersionCheck.problem(GradleVersion.version("9.4.1")))
+  }
+
+  @Test
+  fun `release candidate of floor passes`() {
+    // GradleVersion.baseVersion strips the `-rc-N` suffix, so 9.3.1-rc-1 still satisfies 9.3.1.
+    assertNull(GradleVersionCheck.problem(GradleVersion.version("9.3.1-rc-1")))
+  }
+
+  @Test
+  fun `older than floor fails with remediation`() {
+    val msg = GradleVersionCheck.problem(GradleVersion.version("9.3.0"))
+    assertNotNull(msg)
+    assertTrue(msg!!.contains("9.3.0"))
+    assertTrue(msg.contains("9.3.1"))
+    assertTrue(msg.contains("./gradlew wrapper --gradle-version 9.3.1"))
+  }
+
+  @Test
+  fun `floor constant matches CompatRules`() {
+    // Drift guard — both floors are driven by AGP's documented minimum and should move together.
+    assertEquals("9.3.1", GradleVersionCheck.MIN.version)
+  }
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
@@ -162,11 +162,11 @@ class CompatRulesTest {
       CompatRules.evaluate(
         mainWithBom(),
         mainWithBom() + ("androidx.compose.ui:ui-test-manifest" to "1.10.6"),
-        gradleVersion = "9.2.1",
+        gradleVersion = "8.13",
       )
     val f = findings.single { it.id == "gradle-too-old" }
     assertEquals("error", f.severity)
-    assertTrue("9.2.1" in f.message)
+    assertTrue("8.13" in f.message)
     assertTrue(f.remediationCommands.any { "gradle-version" in it })
   }
 


### PR DESCRIPTION
## Summary

Surface a clear "Gradle too old" error at plugin-apply time instead of letting the build limp on and hit an opaque `NoSuchMethodError` from a Gradle internal API.

The 9.3.1 floor is the same one `CompatRules.GRADLE_MIN` already uses for the doctor command — driven by AGP 9.1.x's documented minimum, not by anything in our own code. On Android builds AGP rejects older Gradle before our `apply()` runs anyway; the value-add is on **CMP Desktop** consumers (no AGP gate) and as a friendlier first error any time something slips past AGP's check.

The check is a small pure object (`GradleVersionCheck`) so the unit test can drive every branch — floor, above floor, `-rc-N` of floor, below floor, plus a drift guard asserting `MIN.version == "9.3.1"` to catch us forgetting to update one place when AGP's minimum moves.

Follow-up not in this PR: a TestKit matrix that actually applies the plugin under the floor Gradle (9.3.1) so we'd catch the inverse — *us* drifting into a newer-only Gradle API. Worth doing but a bigger CI lift; flagging separately.

## Test plan

- [x] `./gradlew :gradle-plugin:test --tests "ee.schimke.composeai.plugin.GradleVersionCheckTest"` — 5/5 pass
- [x] `./gradlew :gradle-plugin:test` — full unit suite passes
- [x] `./gradlew ktfmtFormat` — no formatting changes required
- [ ] CI green on all configurations (incl. existing functional/preview tests, since they apply the plugin under the repo wrapper Gradle 9.4.1, which is above the floor)

---
_Generated by [Claude Code](https://claude.ai/code/session_013SS5ps9ABoRf8vG7Uy8ANV)_