### PR TITLE
build: lower Kotlin compatibility floor 2.1.21 → 2.0.21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,15 @@ kotlin = "2.3.21"
 # so consumers on an older Kotlin can still link against our artifacts —
 # tapmoc enforces this and fails the build if a transitive API dep raises
 # the floor. Bump only when the published surface needs a newer feature.
-kotlinCoreLibraries = "2.1.21"
+# 2.0.21 captures consumers on Kotlin 2.0.x (e.g. apps still on Gradle 8.x,
+# whose embedded Kotlin runtime tops out around 2.0.21); we use no 2.1+
+# language features in any published module so dropping to 2.0.21 has zero
+# cost on our source today.
+# Caveat: the 2.3.x compiler emits `Language version 2.0 is deprecated and
+# its support will be removed in a future version of Kotlin`. When that
+# removal lands (likely 2.4.x), bump this to `2.1.x` and accept that
+# Kotlin 2.0.x consumers will need to upgrade.
+kotlinCoreLibraries = "2.0.21"
 agp = "9.2.0"
 ktfmt = "0.26.0"
 tapmoc = "0.4.0"


### PR DESCRIPTION
## Summary

Quick win against [#213](https://github.com/yschimke/compose-ai-tools/pull/213). Captures consumers on Kotlin 2.0.x — most notably anyone on the Gradle 8.x line, whose embedded Kotlin runtime tops out around 2.0.21. From the OSS survey done earlier: Tivi, Signal-Android, and any AGP 8.x consumer running Gradle 8.x falls into this bucket.

We use no 2.1+ language features in any published module (`grep -rn 'context('` came back empty), so dropping the floor has zero cost on our source today. tapmoc's three check tasks (`tapmocCheckClassFileVersions`, `tapmocCheckKotlinMetadataVersions`, `tapmocCheckKotlinStdlibVersions`) all pass on `preview-annotations`, `renderer-android`, and `gradle-plugin` under the new floor.

### Documented caveat

The 2.3.x compiler already emits

```
w: Language version 2.0 is deprecated and its support will be removed in a future version of Kotlin. Update the version to 2.1.
```

When that removal actually lands (likely 2.4.x), the floor will need to bump back to 2.1.x and Kotlin 2.0.x consumers will need to upgrade. Recorded inline in `libs.versions.toml` so future-us doesn't get surprised.

## Test plan

- [x] `./gradlew :preview-annotations:tapmocCheck{ClassFileVersions,KotlinMetadataVersions,KotlinStdlibVersions} --rerun-tasks` — all pass
- [x] `./gradlew :renderer-android:tapmocCheck* --rerun-tasks` — all pass
- [x] `./gradlew :gradle-plugin:tapmocCheck* --rerun-tasks` — all pass
- [x] `./gradlew :preview-annotations:compileKotlin :gradle-plugin:compileKotlin --rerun-tasks` — clean compile under 2.0.21 floor (modulo the documented language-version-deprecated warning)
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_013SS5ps9ABoRf8vG7Uy8ANV)_