### PR TITLE
fix(plugin): accept org.jetbrains.compose.ui:ui-tooling-preview as @Preview signal

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -43,6 +43,13 @@ internal object AndroidPreviewSupport {
       "androidx.wear.tiles" to "tiles-tooling-preview",
       // CMP-only; AGP consumers never declare it but the helper is shared.
       "org.jetbrains.compose.components" to "components-ui-tooling-preview",
+      // CMP relocates `androidx.compose.ui:ui-tooling-preview` under its own
+      // group when `compose.ui` is consumed via the JetBrains BOM. Same FQN
+      // for `@Preview` at runtime — see DiscoverPreviewsTask comments — so
+      // accept it as a valid signal too. Without this, CMP-on-Android
+      // consumers hit the "no known @Preview dependency" gate and the
+      // plugin silently skips task registration.
+      "org.jetbrains.compose.ui" to "ui-tooling-preview",
     )
 
   fun configure(project: Project, extension: PreviewExtension) {


### PR DESCRIPTION
## Summary

CMP-on-Android consumers that pull `ui-tooling-preview` via the JetBrains-relocated coordinate (`org.jetbrains.compose.ui:ui-tooling-preview`) were silently losing every `composePreview*` task except the sidecar `composePreviewApplied` marker.

The `hasPreviewDependency` gate added in 0.7.11 (#178) only allowed:
- `androidx.compose.ui:ui-tooling-preview` / `-android`
- `androidx.wear.tiles:tiles-tooling-preview`
- `org.jetbrains.compose.components:components-ui-tooling-preview`

Adding `org.jetbrains.compose.ui:ui-tooling-preview` to the allowlist restores task registration for those consumers. Same `@Preview` FQN at runtime — `DiscoverPreviewsTask` already documents this — so it's a no-risk widen, not a behavioural change.

Caught against `meshcore-mobile`, which declares the JB coord in `libs.versions.toml`. Without this fix, `discoverPreviews` / `renderPreviews` / `composePreviewDoctor` / `verifyAccessibility` never get registered and the CLI sees an empty graph.

## Test plan

- [ ] Verify against meshcore-mobile: tasks register, `renderPreviews` runs, CLI sees the consumer.
- [ ] Existing functional tests still pass.