### PR TITLE
ci(preview-baselines): upload renderPreviews reports on failure

### DIFF
--- a/.github/actions/preview-baselines/action.yml
+++ b/.github/actions/preview-baselines/action.yml
@@ -20,10 +20,26 @@ runs:
     - uses: ./.github/actions/install-cli
 
     - name: Render previews
+      id: render
       shell: bash
       env:
         RENDER_TIMEOUT: ${{ inputs.timeout }}
       run: compose-preview show --json --timeout "$RENDER_TIMEOUT" > _previews.json
+
+    # When `renderPreviews` fails the actual stack traces only live in
+    # samples/*/build/reports/tests/renderPreviews/ and test-results/.
+    # Upload them so the failure is debuggable from the run page.
+    - name: Upload renderPreviews reports
+      if: failure() && steps.render.outcome == 'failure'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: renderPreviews-reports
+        path: |
+          **/build/reports/tests/renderPreviews/
+          **/build/test-results/renderPreviews/
+          _previews.json
+        if-no-files-found: ignore
+        retention-days: 14
 
     - name: Generate baselines
       shell: bash


### PR DESCRIPTION
## Summary

- Every recent `Preview Baselines` run on `main` has been failing in `compose-preview show`, but the surfaced log only contains `> There were failing tests. See the report at: file://.../build/reports/tests/renderPreviews/index.html` — the HTML/XML reports were never uploaded, so failures are undebuggable from the run page (e.g. [run 24956297211](https://github.com/yschimke/compose-ai-tools/actions/runs/24956297211/job/73075028729) on `cd8d1a8`).
- Adds an `actions/upload-artifact` step in `.github/actions/preview-baselines/action.yml`, gated on `failure() && steps.render.outcome == 'failure'`, that publishes:
  - `**/build/reports/tests/renderPreviews/` (HTML)
  - `**/build/test-results/renderPreviews/` (XML)
  - `_previews.json` (partial output, when present)
- Pinned to the same `actions/upload-artifact` SHA (`v7.0.1`) used elsewhere in the repo. Successful runs still upload nothing.

## Test plan

- [ ] Next failing `Preview Baselines` run produces a `renderPreviews-reports` artifact downloadable via `gh run download`.
- [ ] A successful run produces no extra artifact (the upload step is skipped because `failure()` is false).