### PR TITLE
fix(cli): surface failing renderPreviews tests on build failure

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -295,6 +295,17 @@ abstract class Command(protected val args: List<String>) {
     return gradle.runTasks(*tasks, timeoutSeconds = timeoutSeconds)
   }
 
+  /**
+   * Reads each module's JUnit XML report under `build/test-results/renderPreviews/` and prints any
+   * `<failure>`/`<error>` entries to stderr. Called on Gradle build failure so users see the actual
+   * test exception in the CLI log instead of just Gradle's "There were failing tests. See the
+   * report at file:///…/index.html" pointer (which is unreachable from CI runner logs).
+   */
+  protected fun reportRenderFailures(modules: List<PreviewModule>) {
+    val failures = collectRenderTestFailures(modules)
+    printRenderTestFailures(failures)
+  }
+
   protected fun readManifest(module: PreviewModule): PreviewManifest? {
     val manifestFile = module.projectDir.resolve("build/compose-previews/previews.json")
     if (!manifestFile.exists()) return null
@@ -622,6 +633,7 @@ class ShowCommand(args: List<String>) : Command(args) {
       val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
 
       if (!runGradle(gradle, *tasks)) {
+        reportRenderFailures(modules)
         System.err.println("Render failed")
         exitProcess(2)
       }
@@ -743,7 +755,10 @@ class RenderCommand(args: List<String>) : Command(args) {
       val modules = resolveModules(gradle)
       val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
 
-      if (!runGradle(gradle, *tasks)) exitProcess(2)
+      if (!runGradle(gradle, *tasks)) {
+        reportRenderFailures(modules)
+        exitProcess(2)
+      }
 
       val manifests = readAllManifests(modules)
       val all = buildResults(manifests)
@@ -807,6 +822,7 @@ class A11yCommand(args: List<String>) : Command(args) {
       val modules = resolveModules(gradle)
       val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
       val buildOk = runGradle(gradle, *tasks)
+      if (!buildOk) reportRenderFailures(modules)
 
       val manifests = readAllManifests(modules)
       val enabledModules = manifests.filter { it.second.accessibilityReport != null }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/RenderFailures.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/RenderFailures.kt
@@ -1,0 +1,115 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.io.PrintStream
+import javax.xml.parsers.DocumentBuilderFactory
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+
+data class RenderTestFailure(
+  val module: String,
+  val className: String,
+  val testName: String,
+  val kind: String,
+  val message: String?,
+  val stackTrace: String?,
+)
+
+/**
+ * Walks `<module>/build/test-results/<taskName>/TEST-*.xml` for each module and parses any
+ * `<failure>`/`<error>` elements out of the JUnit XML reports Gradle's `Test` task always writes.
+ *
+ * The HTML report Gradle's "What went wrong" message points at is unreachable from CI logs (the
+ * runner's filesystem is gone by the time a human reads the log), so the CLI surfaces the same
+ * information by reading the sidecar XML — it's been the targeted source of truth since JUnit 4.
+ */
+internal fun collectRenderTestFailures(
+  modules: List<PreviewModule>,
+  taskName: String = "renderPreviews",
+): List<RenderTestFailure> {
+  val failures = mutableListOf<RenderTestFailure>()
+  for (module in modules) {
+    val resultsDir = module.projectDir.resolve("build/test-results/$taskName")
+    if (!resultsDir.isDirectory) continue
+    val xmls =
+      resultsDir.listFiles { f -> f.name.startsWith("TEST-") && f.name.endsWith(".xml") }
+        ?: continue
+    for (xml in xmls.sortedBy { it.name }) {
+      failures += parseJUnitXml(xml, module.gradlePath)
+    }
+  }
+  return failures
+}
+
+internal fun printRenderTestFailures(
+  failures: List<RenderTestFailure>,
+  err: PrintStream = System.err,
+  stackLines: Int = 6,
+) {
+  if (failures.isEmpty()) return
+  // Group by module so the agent reading the log can map each block back
+  // to the Gradle subproject without scanning every line for context.
+  val byModule = failures.groupBy { it.module }
+  for ((module, entries) in byModule) {
+    err.println()
+    err.println("Failing tests in :$module:renderPreviews (${entries.size}):")
+    for (failure in entries) {
+      err.println("  ${failure.kind} ${failure.className}.${failure.testName}")
+      val msg = failure.message?.lines()?.firstOrNull { it.isNotBlank() }?.trim()
+      if (!msg.isNullOrEmpty()) err.println("    ${msg}")
+      // Trim the stack trace to keep the failure block short — agents
+      // can rerun with --verbose for the full thing.
+      val trimmed =
+        failure.stackTrace?.lines()?.map { it.trim() }?.filter { it.isNotEmpty() }?.take(stackLines)
+          ?: emptyList()
+      for (line in trimmed) err.println("    $line")
+    }
+  }
+}
+
+private fun parseJUnitXml(file: File, module: String): List<RenderTestFailure> {
+  return try {
+    val factory =
+      DocumentBuilderFactory.newInstance().apply {
+        // The XML files are produced by Gradle's own Test task on the
+        // local filesystem so XXE isn't a real threat — but harden the
+        // parser anyway so we don't regret it later if the input source
+        // ever broadens.
+        setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+        setFeature("http://xml.org/sax/features/external-general-entities", false)
+        setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+        isXIncludeAware = false
+        isExpandEntityReferences = false
+      }
+    val doc = factory.newDocumentBuilder().parse(file)
+    val cases = doc.getElementsByTagName("testcase")
+    val out = mutableListOf<RenderTestFailure>()
+    for (i in 0 until cases.length) {
+      val tc = cases.item(i) as? Element ?: continue
+      val cls = tc.getAttribute("classname").orEmpty()
+      val name = tc.getAttribute("name").orEmpty()
+      val children = tc.childNodes
+      for (j in 0 until children.length) {
+        val child = children.item(j)
+        if (child.nodeType != Node.ELEMENT_NODE) continue
+        val el = child as Element
+        if (el.nodeName != "failure" && el.nodeName != "error") continue
+        out +=
+          RenderTestFailure(
+            module = module,
+            className = cls,
+            testName = name,
+            kind = el.nodeName,
+            message = el.getAttribute("message").takeIf { it.isNotEmpty() },
+            stackTrace = el.textContent?.takeIf { it.isNotBlank() },
+          )
+      }
+    }
+    out
+  } catch (e: Exception) {
+    // A malformed XML report shouldn't itself become an error — fall
+    // back to the existing Gradle exception chain. Surfacing the parse
+    // error would just muddy the failure log.
+    emptyList()
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/RenderFailuresTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/RenderFailuresTest.kt
@@ -1,0 +1,141 @@
+package ee.schimke.composeai.cli
+
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.PrintStream
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RenderFailuresTest {
+  private val tempDir = createTempDirectory("render-failures-test").toFile()
+
+  @AfterTest
+  fun cleanup() {
+    tempDir.deleteRecursively()
+  }
+
+  private fun moduleWithReport(name: String, vararg xmls: Pair<String, String>): PreviewModule {
+    val dir = File(tempDir, name).apply { mkdirs() }
+    val resultsDir = File(dir, "build/test-results/renderPreviews").apply { mkdirs() }
+    for ((fileName, contents) in xmls) {
+      File(resultsDir, fileName).writeText(contents)
+    }
+    return PreviewModule(gradlePath = name, projectDir = dir)
+  }
+
+  @Test
+  fun `parses failure and error elements with messages and stack traces`() {
+    val module =
+      moduleWithReport(
+        "app",
+        "TEST-RobolectricRenderTest.xml" to
+          """
+          <?xml version="1.0" encoding="UTF-8"?>
+          <testsuite name="RobolectricRenderTest" tests="2" failures="1" errors="1">
+            <testcase name="render_PreviewA" classname="RobolectricRenderTest">
+              <failure message="expected: &lt;1&gt; but was: &lt;2&gt;" type="org.junit.ComparisonFailure">
+          org.junit.ComparisonFailure: expected: &lt;1&gt; but was: &lt;2&gt;
+            at RobolectricRenderTest.render_PreviewA(RobolectricRenderTest.kt:42)
+            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+              </failure>
+            </testcase>
+            <testcase name="render_PreviewB" classname="RobolectricRenderTest">
+              <error message="boom" type="java.lang.RuntimeException">
+          java.lang.RuntimeException: boom
+            at RobolectricRenderTest.render_PreviewB(RobolectricRenderTest.kt:99)
+              </error>
+            </testcase>
+          </testsuite>
+          """
+            .trimIndent(),
+      )
+
+    val failures = collectRenderTestFailures(listOf(module))
+
+    assertEquals(2, failures.size)
+    val byTest = failures.associateBy { it.testName }
+    val a = byTest.getValue("render_PreviewA")
+    assertEquals("failure", a.kind)
+    assertEquals("expected: <1> but was: <2>", a.message)
+    assertTrue(a.stackTrace!!.contains("RobolectricRenderTest.render_PreviewA"))
+    val b = byTest.getValue("render_PreviewB")
+    assertEquals("error", b.kind)
+    assertEquals("boom", b.message)
+  }
+
+  @Test
+  fun `skips passing testcases and modules without reports`() {
+    val module =
+      moduleWithReport(
+        "app",
+        "TEST-RobolectricRenderTest.xml" to
+          """
+          <?xml version="1.0" encoding="UTF-8"?>
+          <testsuite name="RobolectricRenderTest" tests="1" failures="0" errors="0">
+            <testcase name="render_Ok" classname="RobolectricRenderTest"/>
+          </testsuite>
+          """
+            .trimIndent(),
+      )
+    val emptyModule =
+      PreviewModule(
+        gradlePath = "previews",
+        projectDir = File(tempDir, "previews").apply { mkdirs() },
+      )
+
+    val failures = collectRenderTestFailures(listOf(module, emptyModule))
+
+    assertEquals(0, failures.size)
+  }
+
+  @Test
+  fun `prints grouped failures with module path and trimmed stack`() {
+    val failures =
+      listOf(
+        RenderTestFailure(
+          module = "app",
+          className = "RobolectricRenderTest",
+          testName = "render_PreviewA",
+          kind = "failure",
+          message = "expected: <1> but was: <2>",
+          stackTrace =
+            """
+            org.junit.ComparisonFailure: expected: <1> but was: <2>
+              at RobolectricRenderTest.render_PreviewA(RobolectricRenderTest.kt:42)
+              at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+              at line.4
+              at line.5
+              at line.6
+              at line.7
+              at line.8
+            """
+              .trimIndent(),
+        )
+      )
+    val buf = ByteArrayOutputStream()
+
+    printRenderTestFailures(failures, PrintStream(buf), stackLines = 4)
+
+    val out = buf.toString()
+    assertTrue(out.contains("Failing tests in :app:renderPreviews (1):"), out)
+    assertTrue(out.contains("failure RobolectricRenderTest.render_PreviewA"), out)
+    assertTrue(out.contains("expected: <1> but was: <2>"), out)
+    assertTrue(
+      out.contains("RobolectricRenderTest.render_PreviewA(RobolectricRenderTest.kt:42)"),
+      out,
+    )
+    assertTrue(!out.contains("line.5"), "stack trace should be capped at 4 lines: $out")
+  }
+
+  @Test
+  fun `malformed XML is swallowed`() {
+    val module = moduleWithReport("app", "TEST-Broken.xml" to "not actually xml <<")
+
+    val failures = collectRenderTestFailures(listOf(module))
+
+    assertEquals(0, failures.size)
+  }
+}


### PR DESCRIPTION
## Summary

Today when `compose-preview show|render|a11y` hits a `renderPreviews` test failure, the CLI prints Gradle's stock `> There were failing tests. See the report at: file:///…/index.html` and exits 2. That `file://` link is unreachable from CI logs (the runner's filesystem is gone by the time anyone reads it), so users have to rerun with `--verbose` to find out which test actually failed — see e.g. https://github.com/yschimke/homeassistant-remotecompose/actions/runs/24955627572/job/73073264985.

This change makes the CLI parse each module's `build/test-results/renderPreviews/TEST-*.xml` (Gradle's `Test` task always writes these JUnit XML reports) on failure and prints, per failing testcase:

- the kind (`failure`/`error`), classname, and test name
- the failure message (first non-blank line)
- a trimmed stack trace (default 6 lines, agents can still pass `--verbose` for the full Gradle log)

Output is grouped per module and goes to stderr, so it doesn't pollute `--json` stdout.

Wired into `ShowCommand`, `RenderCommand`, and `A11yCommand` — every code path that runs `renderAllPreviews` and exits non-zero on failure.

## Test plan

- [x] `./gradlew :cli:test :cli:ktfmtCheck`
- [ ] Trigger a real `renderPreviews` test failure in a downstream consumer (e.g. homeassistant-remotecompose) and confirm the failure is visible in the GitHub Actions log without `--verbose`

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFkjBUvP8sYVn9ed87D7Qm)_