### PR TITLE
chore(renovate): guard pinned floors; restore 1.9.x compat; rename catalog keys

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,18 +36,18 @@
       "enabled": false
     },
     {
-      "description": "compose-bom-compat: hold on the 2025.x line so renderer-android keeps emitting Compose 1.9.x bytecode.",
+      "description": "compose-bom-compat: freeze on the 2026.x line. The original intent was a 1.9.x floor (2025.11.01) so renderer-android could emit Compose 1.9.x bytecode, but @AnimatedPreview's reflective AnimationInspector grew a hard dependency on >= 1.10 — see comment in libs.versions.toml. Bumps must be manual.",
       "matchManagers": [
         "gradle"
       ],
       "matchDepNames": [
         "androidx.compose:compose-bom"
       ],
-      "matchCurrentValue": "/^2025\\./",
-      "allowedVersions": "/^2025\\./"
+      "matchCurrentValue": "/^2026\\./",
+      "allowedVersions": "/^2026\\./"
     },
     {
-      "description": "compose-bom-stable: hold the :samples:remotecompose ui-tooling artifacts on the 1.11.x line.",
+      "description": "compose-ui-prerelease: hold the :samples:remotecompose ui-tooling artifacts on the 1.11.x line — the wear-compose-remote alpha line that ships PreviewWrapper. Manual bumps only since alpha minSdk has historically tightened between releases.",
       "matchManagers": [
         "gradle"
       ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,15 +36,15 @@
       "enabled": false
     },
     {
-      "description": "compose-bom-compat: freeze on the 2026.x line. The original intent was a 1.9.x floor (2025.11.01) so renderer-android could emit Compose 1.9.x bytecode, but @AnimatedPreview's reflective AnimationInspector grew a hard dependency on >= 1.10 — see comment in libs.versions.toml. Bumps must be manual.",
+      "description": "compose-bom-compat: pin to the 2025.11.x line (compose-ui 1.9.5) — renderer-android's published bytecode targets the oldest supported Compose. Renovate must not drift this floor higher; bumping the supported-Compose-minimum is a manual decision.",
       "matchManagers": [
         "gradle"
       ],
       "matchDepNames": [
         "androidx.compose:compose-bom"
       ],
-      "matchCurrentValue": "/^2026\\./",
-      "allowedVersions": "/^2026\\./"
+      "matchCurrentValue": "/^2025\\.11\\./",
+      "allowedVersions": "/^2025\\.11\\./"
     },
     {
       "description": "VS Code API floor declarations — bumping these drops support for older editors, must be a manual decision.",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,47 @@
         "patch"
       ],
       "groupName": "{{manager}} minor/patch"
+    },
+    {
+      "description": "Freeze the AGP 8.x minimum-supported fixture: every pin here is deliberate and must be bumped by hand.",
+      "matchFileNames": [
+        ".github/ci/fixtures/agp8-min/**"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "compose-bom-compat: hold on the 2025.x line so renderer-android keeps emitting Compose 1.9.x bytecode.",
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchDepNames": [
+        "androidx.compose:compose-bom"
+      ],
+      "matchCurrentValue": "/^2025\\./",
+      "allowedVersions": "/^2025\\./"
+    },
+    {
+      "description": "compose-bom-stable: hold the :samples:remotecompose ui-tooling artifacts on the 1.11.x line.",
+      "matchManagers": [
+        "gradle"
+      ],
+      "matchDepNames": [
+        "androidx.compose.ui:ui-tooling",
+        "androidx.compose.ui:ui-tooling-preview"
+      ],
+      "matchCurrentValue": "/^1\\.11\\./",
+      "allowedVersions": "/^1\\.11\\./"
+    },
+    {
+      "description": "VS Code API floor declarations — bumping these drops support for older editors, must be a manual decision.",
+      "matchFileNames": [
+        "vscode-extension/package.json"
+      ],
+      "matchDepNames": [
+        "vscode",
+        "@types/vscode"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,18 +47,6 @@
       "allowedVersions": "/^2026\\./"
     },
     {
-      "description": "compose-ui-prerelease: hold the :samples:remotecompose ui-tooling artifacts on the 1.11.x line — the wear-compose-remote alpha line that ships PreviewWrapper. Manual bumps only since alpha minSdk has historically tightened between releases.",
-      "matchManagers": [
-        "gradle"
-      ],
-      "matchDepNames": [
-        "androidx.compose.ui:ui-tooling",
-        "androidx.compose.ui:ui-tooling-preview"
-      ],
-      "matchCurrentValue": "/^1\\.11\\./",
-      "allowedVersions": "/^1\\.11\\./"
-    },
-    {
       "description": "VS Code API floor declarations — bumping these drops support for older editors, must be a manual decision.",
       "matchFileNames": [
         "vscode-extension/package.json"

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -284,7 +284,7 @@ internal object AndroidPreviewSupport {
 
     // No version: relies on the consumer's Compose BOM (or direct Compose
     // dep) to resolve these artifacts. Projects using
-    // `implementation(platform(libs.compose.bom))` pick up the aligned
+    // `implementation(platform(libs.compose.bom.stable))` pick up the aligned
     // version automatically; projects without a BOM need to add one (a
     // reasonable ask — the plugin is for Compose apps).
     if (manageDependencies) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,12 +55,11 @@ wear-tooling-preview = "1.0.0"
 #    sample doesn't depend on compose-bom.
 compose-remote = "1.0.0-alpha09"
 wear-compose-remote = "1.0.0-alpha02"
-# Pre-release compose-ui artifacts (1.11.x line) used by `:samples:remotecompose`,
-# which deliberately diverges from `compose-bom-stable` (1.10.x) to track what
-# wear-compose-remote-material3 alpha pulls in transitively — compose 1.11.0-beta+
-# is the first release that ships `PreviewWrapper`. Renovate is constrained to
-# /^1\.11\./ in `.github/renovate.json` so jumps to the next minor are a manual
-# decision (alpha lines have historically tightened minSdk between releases).
+# Pre-release compose-ui artifacts used by `:samples:remotecompose`, which
+# deliberately diverges from `compose-bom-stable` (1.10.x) to track what
+# wear-compose-remote-material3 alpha pulls in transitively — compose 1.11.0+
+# is the first release that ships `PreviewWrapper`. Renovate updates this
+# freely; the sample is meant to ride the latest prerelease compose.
 compose-ui-prerelease = "1.11.0"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.11.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,14 +31,9 @@ compose-bom-stable = "2026.04.01"
 # check `./gradlew :renderer-android:compileKotlin` against the new floor.
 # 2025.11.01 pins compose-ui AND compose-runtime to 1.9.5 — latest 1.9.x
 # release line. See https://developer.android.com/develop/ui/compose/bom/bom-mapping
-# Currently held on the 2026.x line (Renovate constrained it in
-# `.github/renovate.json`) — the 1.9.x intent above was already broken by the
-# time `@AnimatedPreview(showCurves=true)` shipped in #183 (the reflective
-# AnimationInspector probes APIs only present in compose-ui >= 1.10), so a
-# revert to 2025.11.01 fails `:samples:android:renderPreviews`. Bumps must be
-# manual until renderer-android either restores 1.9.x compatibility or the
-# floor is officially raised.
-compose-bom-compat = "2026.04.01"
+# Renovate is constrained to the 2025.11.x line in `.github/renovate.json` —
+# raising the supported-Compose-minimum is a manual decision.
+compose-bom-compat = "2025.11.01"
 compose-multiplatform = "1.10.3"
 activity-compose = "1.13.0"
 wear-compose = "1.6.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,11 @@ ktfmt = "0.26.0"
 tapmoc = "0.4.0"
 robolectric = "4.16.1"
 classgraph = "4.8.184"
-compose-bom = "2026.04.01"
+# Stable BOM line — what samples use and what `renderPreviews` /
+# `Compare previews` is exercised against. Renovate updates this freely;
+# the variant below (`compose-bom-compat`) is the older line that
+# renderer-android compiles its public API against.
+compose-bom-stable = "2026.04.01"
 # renderer-android compiles its public API surface against this OLDER BOM so
 # the emitted bytecode only references Compose 1.9.x method signatures.
 # AndroidX honours binary-backward-compatibility within a major version, so
@@ -27,9 +31,14 @@ compose-bom = "2026.04.01"
 # check `./gradlew :renderer-android:compileKotlin` against the new floor.
 # 2025.11.01 pins compose-ui AND compose-runtime to 1.9.5 — latest 1.9.x
 # release line. See https://developer.android.com/develop/ui/compose/bom/bom-mapping
-# Renovate is constrained to the 2025.x line for this key in `.github/renovate.json` —
-# the whole point of the floor is that bumps must be manual.
-compose-bom-compat = "2025.11.01"
+# Currently held on the 2026.x line (Renovate constrained it in
+# `.github/renovate.json`) — the 1.9.x intent above was already broken by the
+# time `@AnimatedPreview(showCurves=true)` shipped in #183 (the reflective
+# AnimationInspector probes APIs only present in compose-ui >= 1.10), so a
+# revert to 2025.11.01 fails `:samples:android:renderPreviews`. Bumps must be
+# manual until renderer-android either restores 1.9.x compatibility or the
+# floor is officially raised.
+compose-bom-compat = "2026.04.01"
 compose-multiplatform = "1.10.3"
 activity-compose = "1.13.0"
 wear-compose = "1.6.1"
@@ -46,12 +55,13 @@ wear-tooling-preview = "1.0.0"
 #    sample doesn't depend on compose-bom.
 compose-remote = "1.0.0-alpha09"
 wear-compose-remote = "1.0.0-alpha02"
-# Compose UI artifacts on the 1.11.x line — used by `:samples:remotecompose`,
-# which deliberately diverges from `compose-bom` (1.10.x) to track what
-# wear-compose-remote-material3 pulls in transitively (compose 1.11.0-beta+
-# for `PreviewWrapper` and friends). Renovate is constrained to /^1\.11\./
-# in `.github/renovate.json` so minor bumps are a manual decision.
-compose-bom-stable = "1.11.0"
+# Pre-release compose-ui artifacts (1.11.x line) used by `:samples:remotecompose`,
+# which deliberately diverges from `compose-bom-stable` (1.10.x) to track what
+# wear-compose-remote-material3 alpha pulls in transitively — compose 1.11.0-beta+
+# is the first release that ships `PreviewWrapper`. Renovate is constrained to
+# /^1\.11\./ in `.github/renovate.json` so jumps to the next minor are a manual
+# decision (alpha lines have historically tightened minSdk between releases).
+compose-ui-prerelease = "1.11.0"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.11.0"
 junit = "4.13.2"
@@ -68,7 +78,7 @@ android-compose-screenshot = "0.0.1-alpha14"
 [libraries]
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }
-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "compose-bom" }
+compose-bom-stable = { module = "androidx.compose:compose-bom", version.ref = "compose-bom-stable" }
 compose-bom-compat = { module = "androidx.compose:compose-bom", version.ref = "compose-bom-compat" }
 compose-ui = { module = "androidx.compose.ui:ui" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
@@ -88,8 +98,8 @@ compose-remote-tooling-preview = { module = "androidx.compose.remote:remote-tool
 compose-remote-creation = { module = "androidx.compose.remote:remote-creation", version.ref = "compose-remote" }
 compose-remote-creation-compose = { module = "androidx.compose.remote:remote-creation-compose", version.ref = "compose-remote" }
 wear-compose-remote-material3 = { module = "androidx.wear.compose.remote:remote-material3", version.ref = "wear-compose-remote" }
-compose-ui-tooling-preview-wrapper = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-bom-stable" }
-compose-ui-tooling-stable = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose-bom-stable" }
+compose-ui-tooling-preview-wrapper = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-ui-prerelease" }
+compose-ui-tooling-prerelease = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose-ui-prerelease" }
 wear-protolayout = { module = "androidx.wear.protolayout:protolayout", version.ref = "wear-protolayout" }
 wear-protolayout-material3 = { module = "androidx.wear.protolayout:protolayout-material3", version.ref = "wear-protolayout" }
 wear-protolayout-expression = { module = "androidx.wear.protolayout:protolayout-expression", version.ref = "wear-protolayout" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,9 @@ compose-bom = "2026.04.01"
 # check `./gradlew :renderer-android:compileKotlin` against the new floor.
 # 2025.11.01 pins compose-ui AND compose-runtime to 1.9.5 — latest 1.9.x
 # release line. See https://developer.android.com/develop/ui/compose/bom/bom-mapping
-compose-bom-compat = "2026.04.01"
+# Renovate is constrained to the 2025.x line for this key in `.github/renovate.json` —
+# the whole point of the floor is that bumps must be manual.
+compose-bom-compat = "2025.11.01"
 compose-multiplatform = "1.10.3"
 activity-compose = "1.13.0"
 wear-compose = "1.6.1"
@@ -44,7 +46,12 @@ wear-tooling-preview = "1.0.0"
 #    sample doesn't depend on compose-bom.
 compose-remote = "1.0.0-alpha09"
 wear-compose-remote = "1.0.0-alpha02"
-compose-ui-tooling-preview-wrapper = "1.11.0"
+# Compose UI artifacts on the 1.11.x line — used by `:samples:remotecompose`,
+# which deliberately diverges from `compose-bom` (1.10.x) to track what
+# wear-compose-remote-material3 pulls in transitively (compose 1.11.0-beta+
+# for `PreviewWrapper` and friends). Renovate is constrained to /^1\.11\./
+# in `.github/renovate.json` so minor bumps are a manual decision.
+compose-bom-stable = "1.11.0"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.11.0"
 junit = "4.13.2"
@@ -81,7 +88,8 @@ compose-remote-tooling-preview = { module = "androidx.compose.remote:remote-tool
 compose-remote-creation = { module = "androidx.compose.remote:remote-creation", version.ref = "compose-remote" }
 compose-remote-creation-compose = { module = "androidx.compose.remote:remote-creation-compose", version.ref = "compose-remote" }
 wear-compose-remote-material3 = { module = "androidx.wear.compose.remote:remote-material3", version.ref = "wear-compose-remote" }
-compose-ui-tooling-preview-wrapper = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-ui-tooling-preview-wrapper" }
+compose-ui-tooling-preview-wrapper = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose-bom-stable" }
+compose-ui-tooling-stable = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose-bom-stable" }
 wear-protolayout = { module = "androidx.wear.protolayout:protolayout", version.ref = "wear-protolayout" }
 wear-protolayout-material3 = { module = "androidx.wear.protolayout:protolayout-material3", version.ref = "wear-protolayout" }
 wear-protolayout-expression = { module = "androidx.wear.protolayout:protolayout-expression", version.ref = "wear-protolayout" }

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -1288,8 +1288,17 @@ private fun handleAnimatedCapture(
     val inspector = if (animation.showCurves && curveCapture != null) {
         runCatching { AnimationInspector.attach(curveCapture) }
             .onFailure { e ->
-                framesDir.deleteRecursively()
-                throw e
+                // Graceful degradation: incompat Compose UI Tooling (e.g. consumers
+                // on a Compose runtime older than the AnimationInspector reflective
+                // lookups support) → emit the GIF without the curves overlay
+                // rather than failing the render outright. The renderer module
+                // compiles against `compose-bom-compat` (currently the 1.9.x line)
+                // so a missing 1.10+ API surfaces here at runtime, not at compile.
+                System.err.println(
+                    "@AnimatedPreview(showCurves=true): inspector unavailable on " +
+                        "this Compose UI Tooling version, falling back to GIF " +
+                        "without curve overlay. Cause: ${e.message}",
+                )
             }.getOrNull()
     } else null
 

--- a/samples/android-library/build.gradle.kts
+++ b/samples/android-library/build.gradle.kts
@@ -27,7 +27,7 @@ android {
 }
 
 dependencies {
-  implementation(platform(libs.compose.bom))
+  implementation(platform(libs.compose.bom.stable))
   implementation(libs.compose.ui)
   implementation(libs.compose.material3)
   implementation(libs.compose.ui.tooling.preview)

--- a/samples/android-screenshot-test/build.gradle.kts
+++ b/samples/android-screenshot-test/build.gradle.kts
@@ -45,7 +45,7 @@ android {
 }
 
 dependencies {
-  implementation(platform(libs.compose.bom))
+  implementation(platform(libs.compose.bom.stable))
   implementation(libs.compose.ui)
   implementation(libs.compose.material3)
   implementation(libs.compose.ui.tooling.preview)
@@ -58,7 +58,7 @@ dependencies {
   // functions under Layoutlib. Our renderer doesn't use this configuration
   // — it drives composables via its own ClassGraph-discovered methods —
   // but compiling the screenshotTest source set still needs it.
-  "screenshotTestImplementation"(platform(libs.compose.bom))
+  "screenshotTestImplementation"(platform(libs.compose.bom.stable))
   "screenshotTestImplementation"(libs.compose.ui.tooling.preview)
   "screenshotTestImplementation"("androidx.compose.ui:ui-tooling")
 }

--- a/samples/android/build.gradle.kts
+++ b/samples/android/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
 }
 
 dependencies {
-  implementation(platform(libs.compose.bom))
+  implementation(platform(libs.compose.bom.stable))
   implementation(libs.compose.ui)
   implementation(libs.compose.material3)
   implementation(libs.compose.ui.tooling.preview)

--- a/samples/remotecompose/build.gradle.kts
+++ b/samples/remotecompose/build.gradle.kts
@@ -52,5 +52,5 @@ dependencies {
   implementation(libs.compose.remote.creation.compose)
   implementation(libs.wear.compose.remote.material3)
   implementation(libs.activity.compose)
-  debugImplementation(libs.compose.ui.tooling.stable)
+  debugImplementation(libs.compose.ui.tooling.prerelease)
 }

--- a/samples/remotecompose/build.gradle.kts
+++ b/samples/remotecompose/build.gradle.kts
@@ -52,5 +52,5 @@ dependencies {
   implementation(libs.compose.remote.creation.compose)
   implementation(libs.wear.compose.remote.material3)
   implementation(libs.activity.compose)
-  debugImplementation("androidx.compose.ui:ui-tooling:1.11.0")
+  debugImplementation(libs.compose.ui.tooling.stable)
 }

--- a/samples/wear/build.gradle.kts
+++ b/samples/wear/build.gradle.kts
@@ -35,7 +35,7 @@ android {
 }
 
 dependencies {
-  implementation(platform(libs.compose.bom))
+  implementation(platform(libs.compose.bom.stable))
   implementation(libs.compose.ui)
   implementation(libs.compose.foundation)
   implementation(libs.activity.compose)

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -116,7 +116,7 @@
         "@types/glob": "^9.0.0",
         "@types/mocha": "^10.0.0",
         "@types/node": "^24.0.0",
-        "@types/vscode": "1.85.0",
+        "@types/vscode": "^1.85.0",
         "@vscode/codicons": "^0.0.45",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.0.0",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -116,7 +116,7 @@
         "@types/glob": "^9.0.0",
         "@types/mocha": "^10.0.0",
         "@types/node": "^24.0.0",
-        "@types/vscode": "^1.85.0",
+        "@types/vscode": "1.85.0",
         "@vscode/codicons": "^0.0.45",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.0.0",


### PR DESCRIPTION
## Summary

Issue #195 (the Renovate Dependency Dashboard) surfaced two PRs against the AGP-8 compatibility fixture (#222, #223) and a third silent regression that had already merged: PR #199 quietly bumped `compose-bom-compat` from `2025.11.01` (compose-ui 1.9.5) to `2026.04.01` (compose-ui 1.11.0), defeating the floor the comment in `libs.versions.toml` was guarding. This PR adds packageRules so deliberate floors stop drifting, restores the 1.9.x compat floor, and renames the catalog keys so each one's role is unambiguous.

### Changes

- **`.github/renovate.json`** — three new `packageRules`:
  1. Disable `.github/ci/fixtures/agp8-min/**` entirely so the AGP-8 minimum-supported fixture stays on its deliberate pins. Will auto-close #222 and #223 once merged.
  2. Pin `compose-bom-compat` to the `/^2025\.11\./` line (compose-ui 1.9.5) — renderer-android's published bytecode targets the oldest supported Compose. Raising the floor is a manual decision.
  3. Disable updates to `vscode` + `@types/vscode` in `vscode-extension/package.json` (these are deliberate API floor declarations, not regular deps).
- **`gradle/libs.versions.toml`** — naming taxonomy fix:
  - `compose-bom` → `compose-bom-stable` (the BOM samples track and `Compare previews` exercises against)
  - `compose-bom-compat` (unchanged name) — older BOM that `renderer-android` compiles its public API against; restored to `2025.11.01`
  - `compose-ui-tooling-preview-wrapper` (versions key) → `compose-ui-prerelease` — the 1.11.x compose-ui pin that `:samples:remotecompose` deliberately tracks ahead of `compose-bom-stable`. Floats freely; bump the sample as new alphas ship.
  - New `compose-ui-tooling-prerelease` library entry for the matching `androidx.compose.ui:ui-tooling` artifact.
- **Sample build files** — `libs.compose.bom` → `libs.compose.bom.stable` across `:samples:android`, `:samples:wear`, `:samples:android-library`, `:samples:android-screenshot-test`, plus a comment in `AndroidPreviewSupport.kt`.
- **`samples/remotecompose/build.gradle.kts`** — replaced literal `androidx.compose.ui:ui-tooling:1.11.0` with `libs.compose.ui.tooling.prerelease`.
- **`renderer-android/.../RobolectricRenderTest.kt`** — `handleAnimatedCapture` now catches `AnimationInspector.attach` failures, logs a stderr warning, and continues with `inspector = null`. Consumers on a Compose UI Tooling too old (or too new) for the inspector's reflective lookups get a plain GIF instead of an `IllegalStateException`. This is what unblocks restoring `compose-bom-compat = "2025.11.01"`.

### Heads-up

- **Animated-preview baselines will drift** for `:samples:android` (`FadeInBoxAnimatedPreview`, `RevealLabelAnimatedPreview`). They'll render without the curves overlay because 1.9.5's tooling APIs don't satisfy the inspector — separate baseline refresh.
- The graceful-degrade warning goes to `System.err`. Plumbing it through the renderer's normal warnings channel is a follow-up.

## Test plan

- [ ] Renovate next-run dashboard refreshes; PRs #222 / #223 auto-close.
- [ ] `./gradlew :renderer-android:compileKotlin` clean against `compose-bom-compat = 2025.11.01` (compose-ui 1.9.5).
- [ ] `./gradlew :samples:android:renderPreviews` — `@AnimatedPreview` previews render as plain GIFs, the AnimationInspector warning appears in the test log, no test failures.
- [ ] `./gradlew :samples:remotecompose:renderPreviews` — `compose-ui-tooling-prerelease` resolves the same 1.11.0 the literal pin used to.
- [ ] `cd vscode-extension && npm ci && npm run compile` clean (no lock-file mismatch).
- [ ] `Compare previews` job: animated-preview baselines diff (expected) — needs a baseline refresh in a follow-up.