### PR TITLE
refactor(cli): capture failing tests via Tooling API instead of XML walk

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -296,14 +296,13 @@ abstract class Command(protected val args: List<String>) {
   }
 
   /**
-   * Reads each module's JUnit XML report under `build/test-results/renderPreviews/` and prints any
-   * `<failure>`/`<error>` entries to stderr. Called on Gradle build failure so users see the actual
-   * test exception in the CLI log instead of just Gradle's "There were failing tests. See the
-   * report at file:///…/index.html" pointer (which is unreachable from CI runner logs).
+   * Prints failing tests captured live during the build by [GradleConnection]'s Tooling API
+   * listener. Called on Gradle build failure so users see the actual test exception in the CLI log
+   * instead of just Gradle's "There were failing tests. See the report at file:///…/index.html"
+   * pointer (which is unreachable from CI runner logs).
    */
-  protected fun reportRenderFailures(modules: List<PreviewModule>) {
-    val failures = collectRenderTestFailures(modules)
-    printRenderTestFailures(failures)
+  protected fun reportRenderFailures(gradle: GradleConnection) {
+    printCapturedTestFailures(gradle.lastTestFailures())
   }
 
   protected fun readManifest(module: PreviewModule): PreviewManifest? {
@@ -633,7 +632,7 @@ class ShowCommand(args: List<String>) : Command(args) {
       val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
 
       if (!runGradle(gradle, *tasks)) {
-        reportRenderFailures(modules)
+        reportRenderFailures(gradle)
         System.err.println("Render failed")
         exitProcess(2)
       }
@@ -756,7 +755,7 @@ class RenderCommand(args: List<String>) : Command(args) {
       val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
 
       if (!runGradle(gradle, *tasks)) {
-        reportRenderFailures(modules)
+        reportRenderFailures(gradle)
         exitProcess(2)
       }
 
@@ -822,7 +821,7 @@ class A11yCommand(args: List<String>) : Command(args) {
       val modules = resolveModules(gradle)
       val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
       val buildOk = runGradle(gradle, *tasks)
-      if (!buildOk) reportRenderFailures(modules)
+      if (!buildOk) reportRenderFailures(gradle)
 
       val manifests = readAllManifests(modules)
       val enabledModules = manifests.filter { it.second.accessibilityReport != null }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -6,10 +6,15 @@ import java.io.OutputStream
 import java.util.Collections
 import org.gradle.tooling.CancellationTokenSource
 import org.gradle.tooling.GradleConnector
+import org.gradle.tooling.events.FailureResult
 import org.gradle.tooling.events.FinishEvent
+import org.gradle.tooling.events.OperationDescriptor
 import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.events.ProgressEvent
 import org.gradle.tooling.events.StartEvent
+import org.gradle.tooling.events.task.TaskOperationDescriptor
+import org.gradle.tooling.events.test.JvmTestOperationDescriptor
+import org.gradle.tooling.events.test.TestOperationDescriptor
 
 /**
  * Handle for a subproject that applies `ee.schimke.composeai.preview`.
@@ -31,10 +36,22 @@ class GradleConnection(
   private val connector = GradleConnector.newConnector().forProjectDirectory(projectDir)
   private val connection = connector.connect()
 
+  private val capturedTestFailures =
+    Collections.synchronizedList(mutableListOf<CapturedTestFailure>())
+
+  /**
+   * Test failures captured during the most recent [runTasks] call. Populated live from the Tooling
+   * API's progress events — no need to walk JUnit XML reports after the build. Empty until the
+   * first failing test finishes; cleared at the start of each [runTasks].
+   */
+  fun lastTestFailures(): List<CapturedTestFailure> =
+    synchronized(capturedTestFailures) { capturedTestFailures.toList() }
+
   fun runTasks(vararg tasks: String, timeoutSeconds: Long = 300): Boolean {
     val tokenSource: CancellationTokenSource = GradleConnector.newCancellationTokenSource()
     val startTime = System.currentTimeMillis()
     val runningTasks = Collections.synchronizedSet(linkedSetOf<String>())
+    capturedTestFailures.clear()
 
     // Ctrl+C otherwise kills the CLI without going through the cancellation
     // token — leaving the Gradle daemon still executing and any forked Test
@@ -101,39 +118,48 @@ class GradleConnection(
         launcher.setStandardError(errorCapture)
       }
 
-      val listenerTypes =
-        if (verbose) {
-          setOf(OperationType.TASK, OperationType.TEST)
-        } else {
-          setOf(OperationType.TASK)
-        }
+      // TEST events are always on so we can capture failing-test details
+      // for `printBuildFailure`. Discriminate by descriptor type in the
+      // listener so test events don't pollute the task-progress counters
+      // or the heartbeat's "running:" list (a single render run can fire
+      // hundreds of test events).
+      val listenerTypes = setOf(OperationType.TASK, OperationType.TEST)
 
       launcher.addProgressListener(
         { event: ProgressEvent ->
-          val desc = event.descriptor.name
-          when (event) {
-            is StartEvent -> {
-              taskCount++
-              runningTasks.add(desc)
-            }
-            is FinishEvent -> {
-              runningTasks.remove(desc)
-              tasksFinished++
-              if (taskCount > 0) {
-                TerminalProgress.show((tasksFinished * 100) / taskCount)
+          val descriptor = event.descriptor
+          when {
+            descriptor is TaskOperationDescriptor -> {
+              val desc = descriptor.name
+              when (event) {
+                is StartEvent -> {
+                  taskCount++
+                  runningTasks.add(desc)
+                }
+                is FinishEvent -> {
+                  runningTasks.remove(desc)
+                  tasksFinished++
+                  if (taskCount > 0) {
+                    TerminalProgress.show((tasksFinished * 100) / taskCount)
+                  }
+                  if (
+                    progress &&
+                      !verbose &&
+                      (desc.contains("discoverPreviews") ||
+                        desc.contains("renderPreviews") ||
+                        desc.contains("renderAllPreviews"))
+                  ) {
+                    val elapsed = (System.currentTimeMillis() - startTime) / 1000
+                    System.err.println("  [${elapsed}s] $desc")
+                  }
+                }
+                else -> {}
               }
-              if (
-                progress &&
-                  !verbose &&
-                  (desc.contains("discoverPreviews") ||
-                    desc.contains("renderPreviews") ||
-                    desc.contains("renderAllPreviews"))
-              ) {
-                val elapsed = (System.currentTimeMillis() - startTime) / 1000
-                System.err.println("  [${elapsed}s] $desc")
-              }
             }
-            else -> {}
+            descriptor is TestOperationDescriptor && event is FinishEvent -> {
+              val result = event.result
+              if (result is FailureResult) collectTestFailures(descriptor, result.failures)
+            }
           }
         },
         listenerTypes,
@@ -209,6 +235,39 @@ class GradleConnection(
 
     System.err.println()
     System.err.println("Run with --verbose for full build output.")
+  }
+
+  private fun collectTestFailures(
+    descriptor: TestOperationDescriptor,
+    failures: List<org.gradle.tooling.Failure>,
+  ) {
+    val taskPath = findTaskPath(descriptor) ?: "(unknown task)"
+    val (className, methodName) =
+      when (descriptor) {
+        is JvmTestOperationDescriptor -> descriptor.className to descriptor.methodName
+        else -> null to null
+      }
+    val displayName = descriptor.displayName
+    for (failure in failures) {
+      capturedTestFailures +=
+        CapturedTestFailure(
+          taskPath = taskPath,
+          className = className,
+          methodName = methodName,
+          displayName = displayName,
+          message = failure.message,
+          description = failure.description,
+        )
+    }
+  }
+
+  private fun findTaskPath(descriptor: OperationDescriptor): String? {
+    var d: OperationDescriptor? = descriptor
+    while (d != null) {
+      if (d is TaskOperationDescriptor) return d.taskPath
+      d = d.parent
+    }
+    return null
   }
 
   /**

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/RenderFailures.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/RenderFailures.kt
@@ -1,115 +1,65 @@
 package ee.schimke.composeai.cli
 
-import java.io.File
 import java.io.PrintStream
-import javax.xml.parsers.DocumentBuilderFactory
-import org.w3c.dom.Element
-import org.w3c.dom.Node
 
-data class RenderTestFailure(
-  val module: String,
-  val className: String,
-  val testName: String,
-  val kind: String,
+/**
+ * One test failure captured live by [GradleConnection]'s Tooling API listener. Carries everything
+ * we'd otherwise have to extract from a per-task JUnit XML report.
+ * - [taskPath] — Gradle path of the owning `Test` task (e.g. `:app:renderPreviews`), so output can
+ *   be grouped per task and the agent reading the log knows which subproject to look at.
+ * - [className]/[methodName] — populated for JVM tests (`JvmTestOperationDescriptor`); both null
+ *   for non-JVM frameworks, in which case [displayName] is the fallback identifier.
+ * - [message]/[description] — straight from `org.gradle.tooling.Failure`. `description` is the
+ *   stack trace.
+ */
+data class CapturedTestFailure(
+  val taskPath: String,
+  val className: String?,
+  val methodName: String?,
+  val displayName: String,
   val message: String?,
-  val stackTrace: String?,
+  val description: String?,
 )
 
 /**
- * Walks `<module>/build/test-results/<taskName>/TEST-*.xml` for each module and parses any
- * `<failure>`/`<error>` elements out of the JUnit XML reports Gradle's `Test` task always writes.
+ * Prints captured test failures to stderr, grouped by Gradle task path. Replaces the post-build
+ * walk over JUnit XML reports — the same data is now captured live during the build via
+ * [GradleConnection.lastTestFailures].
  *
- * The HTML report Gradle's "What went wrong" message points at is unreachable from CI logs (the
- * runner's filesystem is gone by the time a human reads the log), so the CLI surfaces the same
- * information by reading the sidecar XML — it's been the targeted source of truth since JUnit 4.
+ * Default [stackLines] keeps the per-failure block short; agents can still rerun with `--verbose`
+ * for the full Gradle output.
  */
-internal fun collectRenderTestFailures(
-  modules: List<PreviewModule>,
-  taskName: String = "renderPreviews",
-): List<RenderTestFailure> {
-  val failures = mutableListOf<RenderTestFailure>()
-  for (module in modules) {
-    val resultsDir = module.projectDir.resolve("build/test-results/$taskName")
-    if (!resultsDir.isDirectory) continue
-    val xmls =
-      resultsDir.listFiles { f -> f.name.startsWith("TEST-") && f.name.endsWith(".xml") }
-        ?: continue
-    for (xml in xmls.sortedBy { it.name }) {
-      failures += parseJUnitXml(xml, module.gradlePath)
-    }
-  }
-  return failures
-}
-
-internal fun printRenderTestFailures(
-  failures: List<RenderTestFailure>,
+internal fun printCapturedTestFailures(
+  failures: List<CapturedTestFailure>,
   err: PrintStream = System.err,
   stackLines: Int = 6,
 ) {
   if (failures.isEmpty()) return
-  // Group by module so the agent reading the log can map each block back
-  // to the Gradle subproject without scanning every line for context.
-  val byModule = failures.groupBy { it.module }
-  for ((module, entries) in byModule) {
+  val byTask = failures.groupBy { it.taskPath }
+  for ((taskPath, entries) in byTask) {
     err.println()
-    err.println("Failing tests in :$module:renderPreviews (${entries.size}):")
+    err.println("Failing tests in $taskPath (${entries.size}):")
     for (failure in entries) {
-      err.println("  ${failure.kind} ${failure.className}.${failure.testName}")
+      err.println("  ${formatTestId(failure)}")
       val msg = failure.message?.lines()?.firstOrNull { it.isNotBlank() }?.trim()
-      if (!msg.isNullOrEmpty()) err.println("    ${msg}")
-      // Trim the stack trace to keep the failure block short — agents
-      // can rerun with --verbose for the full thing.
+      if (!msg.isNullOrEmpty()) err.println("    $msg")
       val trimmed =
-        failure.stackTrace?.lines()?.map { it.trim() }?.filter { it.isNotEmpty() }?.take(stackLines)
-          ?: emptyList()
+        failure.description
+          ?.lines()
+          ?.map { it.trim() }
+          ?.filter { it.isNotEmpty() }
+          ?.take(stackLines) ?: emptyList()
       for (line in trimmed) err.println("    $line")
     }
   }
 }
 
-private fun parseJUnitXml(file: File, module: String): List<RenderTestFailure> {
-  return try {
-    val factory =
-      DocumentBuilderFactory.newInstance().apply {
-        // The XML files are produced by Gradle's own Test task on the
-        // local filesystem so XXE isn't a real threat — but harden the
-        // parser anyway so we don't regret it later if the input source
-        // ever broadens.
-        setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
-        setFeature("http://xml.org/sax/features/external-general-entities", false)
-        setFeature("http://xml.org/sax/features/external-parameter-entities", false)
-        isXIncludeAware = false
-        isExpandEntityReferences = false
-      }
-    val doc = factory.newDocumentBuilder().parse(file)
-    val cases = doc.getElementsByTagName("testcase")
-    val out = mutableListOf<RenderTestFailure>()
-    for (i in 0 until cases.length) {
-      val tc = cases.item(i) as? Element ?: continue
-      val cls = tc.getAttribute("classname").orEmpty()
-      val name = tc.getAttribute("name").orEmpty()
-      val children = tc.childNodes
-      for (j in 0 until children.length) {
-        val child = children.item(j)
-        if (child.nodeType != Node.ELEMENT_NODE) continue
-        val el = child as Element
-        if (el.nodeName != "failure" && el.nodeName != "error") continue
-        out +=
-          RenderTestFailure(
-            module = module,
-            className = cls,
-            testName = name,
-            kind = el.nodeName,
-            message = el.getAttribute("message").takeIf { it.isNotEmpty() },
-            stackTrace = el.textContent?.takeIf { it.isNotBlank() },
-          )
-      }
-    }
-    out
-  } catch (e: Exception) {
-    // A malformed XML report shouldn't itself become an error — fall
-    // back to the existing Gradle exception chain. Surfacing the parse
-    // error would just muddy the failure log.
-    emptyList()
+private fun formatTestId(failure: CapturedTestFailure): String {
+  val cls = failure.className
+  val method = failure.methodName
+  return when {
+    cls != null && method != null -> "$cls.$method"
+    cls != null -> cls
+    else -> failure.displayName
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/RenderFailuresTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/RenderFailuresTest.kt
@@ -1,107 +1,24 @@
 package ee.schimke.composeai.cli
 
 import java.io.ByteArrayOutputStream
-import java.io.File
 import java.io.PrintStream
-import kotlin.io.path.createTempDirectory
-import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class RenderFailuresTest {
-  private val tempDir = createTempDirectory("render-failures-test").toFile()
-
-  @AfterTest
-  fun cleanup() {
-    tempDir.deleteRecursively()
-  }
-
-  private fun moduleWithReport(name: String, vararg xmls: Pair<String, String>): PreviewModule {
-    val dir = File(tempDir, name).apply { mkdirs() }
-    val resultsDir = File(dir, "build/test-results/renderPreviews").apply { mkdirs() }
-    for ((fileName, contents) in xmls) {
-      File(resultsDir, fileName).writeText(contents)
-    }
-    return PreviewModule(gradlePath = name, projectDir = dir)
-  }
-
   @Test
-  fun `parses failure and error elements with messages and stack traces`() {
-    val module =
-      moduleWithReport(
-        "app",
-        "TEST-RobolectricRenderTest.xml" to
-          """
-          <?xml version="1.0" encoding="UTF-8"?>
-          <testsuite name="RobolectricRenderTest" tests="2" failures="1" errors="1">
-            <testcase name="render_PreviewA" classname="RobolectricRenderTest">
-              <failure message="expected: &lt;1&gt; but was: &lt;2&gt;" type="org.junit.ComparisonFailure">
-          org.junit.ComparisonFailure: expected: &lt;1&gt; but was: &lt;2&gt;
-            at RobolectricRenderTest.render_PreviewA(RobolectricRenderTest.kt:42)
-            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
-              </failure>
-            </testcase>
-            <testcase name="render_PreviewB" classname="RobolectricRenderTest">
-              <error message="boom" type="java.lang.RuntimeException">
-          java.lang.RuntimeException: boom
-            at RobolectricRenderTest.render_PreviewB(RobolectricRenderTest.kt:99)
-              </error>
-            </testcase>
-          </testsuite>
-          """
-            .trimIndent(),
-      )
-
-    val failures = collectRenderTestFailures(listOf(module))
-
-    assertEquals(2, failures.size)
-    val byTest = failures.associateBy { it.testName }
-    val a = byTest.getValue("render_PreviewA")
-    assertEquals("failure", a.kind)
-    assertEquals("expected: <1> but was: <2>", a.message)
-    assertTrue(a.stackTrace!!.contains("RobolectricRenderTest.render_PreviewA"))
-    val b = byTest.getValue("render_PreviewB")
-    assertEquals("error", b.kind)
-    assertEquals("boom", b.message)
-  }
-
-  @Test
-  fun `skips passing testcases and modules without reports`() {
-    val module =
-      moduleWithReport(
-        "app",
-        "TEST-RobolectricRenderTest.xml" to
-          """
-          <?xml version="1.0" encoding="UTF-8"?>
-          <testsuite name="RobolectricRenderTest" tests="1" failures="0" errors="0">
-            <testcase name="render_Ok" classname="RobolectricRenderTest"/>
-          </testsuite>
-          """
-            .trimIndent(),
-      )
-    val emptyModule =
-      PreviewModule(
-        gradlePath = "previews",
-        projectDir = File(tempDir, "previews").apply { mkdirs() },
-      )
-
-    val failures = collectRenderTestFailures(listOf(module, emptyModule))
-
-    assertEquals(0, failures.size)
-  }
-
-  @Test
-  fun `prints grouped failures with module path and trimmed stack`() {
+  fun `prints failures grouped by task path with class+method id`() {
     val failures =
       listOf(
-        RenderTestFailure(
-          module = "app",
+        CapturedTestFailure(
+          taskPath = ":app:renderPreviews",
           className = "RobolectricRenderTest",
-          testName = "render_PreviewA",
-          kind = "failure",
+          methodName = "render_PreviewA",
+          displayName = "render_PreviewA(RobolectricRenderTest)",
           message = "expected: <1> but was: <2>",
-          stackTrace =
+          description =
             """
             org.junit.ComparisonFailure: expected: <1> but was: <2>
               at RobolectricRenderTest.render_PreviewA(RobolectricRenderTest.kt:42)
@@ -113,29 +30,57 @@ class RenderFailuresTest {
               at line.8
             """
               .trimIndent(),
+        ),
+        CapturedTestFailure(
+          taskPath = ":previews:renderPreviews",
+          className = "DesktopRenderTest",
+          methodName = "renders_PreviewC",
+          displayName = "renders_PreviewC(DesktopRenderTest)",
+          message = "boom",
+          description = "java.lang.RuntimeException: boom",
+        ),
+      )
+    val buf = ByteArrayOutputStream()
+
+    printCapturedTestFailures(failures, PrintStream(buf), stackLines = 4)
+
+    val out = buf.toString()
+    assertTrue(out.contains("Failing tests in :app:renderPreviews (1):"), out)
+    assertTrue(out.contains("RobolectricRenderTest.render_PreviewA"), out)
+    assertTrue(out.contains("expected: <1> but was: <2>"), out)
+    assertTrue(out.contains("Failing tests in :previews:renderPreviews (1):"), out)
+    assertTrue(out.contains("DesktopRenderTest.renders_PreviewC"), out)
+    assertFalse(out.contains("line.5"), "stack trace should be capped at 4 lines: $out")
+  }
+
+  @Test
+  fun `falls back to displayName when class+method are absent`() {
+    val failures =
+      listOf(
+        CapturedTestFailure(
+          taskPath = ":app:renderPreviews",
+          className = null,
+          methodName = null,
+          displayName = "Robolectric setup",
+          message = "no testRuntimeOnly libraries available",
+          description = null,
         )
       )
     val buf = ByteArrayOutputStream()
 
-    printRenderTestFailures(failures, PrintStream(buf), stackLines = 4)
+    printCapturedTestFailures(failures, PrintStream(buf))
 
     val out = buf.toString()
-    assertTrue(out.contains("Failing tests in :app:renderPreviews (1):"), out)
-    assertTrue(out.contains("failure RobolectricRenderTest.render_PreviewA"), out)
-    assertTrue(out.contains("expected: <1> but was: <2>"), out)
-    assertTrue(
-      out.contains("RobolectricRenderTest.render_PreviewA(RobolectricRenderTest.kt:42)"),
-      out,
-    )
-    assertTrue(!out.contains("line.5"), "stack trace should be capped at 4 lines: $out")
+    assertTrue(out.contains("Robolectric setup"), out)
+    assertTrue(out.contains("no testRuntimeOnly libraries available"), out)
   }
 
   @Test
-  fun `malformed XML is swallowed`() {
-    val module = moduleWithReport("app", "TEST-Broken.xml" to "not actually xml <<")
+  fun `empty list is a no-op`() {
+    val buf = ByteArrayOutputStream()
 
-    val failures = collectRenderTestFailures(listOf(module))
+    printCapturedTestFailures(emptyList(), PrintStream(buf))
 
-    assertEquals(0, failures.size)
+    assertEquals("", buf.toString())
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #224. That PR walked each module's `build/test-results/renderPreviews/TEST-*.xml` after the build to surface failing tests; this swaps the walk for the Tooling API's own progress events, which is what Gradle wants you to use.

- `GradleConnection` now always listens on `OperationType.TEST` and captures any `TestFinishEvent` whose result is a `TestFailureResult`. Failures are stashed live and exposed via `lastTestFailures()`.
- Listener discriminates by descriptor type (`TaskOperationDescriptor` vs `TestOperationDescriptor`) so test events don't pollute the existing task-progress counters or the `--progress` heartbeat's `running:` list (a single render run can fire hundreds of test events).
- Per-failure shape uses Gradle's own `taskPath`, `className`/`methodName` (when the descriptor is `JvmTestOperationDescriptor`), and the `Failure`'s `message`/`description` (= stack trace).
- Drops the XML parser, file glob, and XXE-hardening boilerplate. Output format unchanged for typical render failures.

## Test plan

- [x] `./gradlew :cli:test :cli:ktfmtCheck`
- [x] `./gradlew :cli:installDist`
- [ ] Trigger a real `renderPreviews` test failure in a downstream consumer and confirm the failing test is visible without `--verbose` (same UX as #224, validated end-to-end against the live listener)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFkjBUvP8sYVn9ed87D7Qm)_