### PR TITLE
docs(WEAR_UI): clarify scrolling vs fixed screens for round-face clipping

### DIFF
--- a/skills/compose-preview/design/WEAR_UI.md
+++ b/skills/compose-preview/design/WEAR_UI.md
@@ -216,8 +216,15 @@ Implications when designing previews:
 
 - Don't waste effort styling the corners of a round preview — they'll be
   clipped away.
-- Place primary content within the inscribed circle. The corners of the
-  preview canvas are *not* a usable design area.
+- On **fixed (non-scrolling) screens**, place primary content within the
+  inscribed circle. The corners of the preview canvas are *not* a usable
+  design area, so content must stay inside the inner safe rectangle.
+- On **scrolling screens** (`TransformingLazyColumn` / `ScalingLazyColumn`),
+  content is *expected* to be cropped at the top and bottom of the visible
+  area by the round face — the column's `contentPadding` plus user scrolling
+  handles edge access. Don't try to inset every item to fully avoid the
+  round face on these screens; only fixed screens need to keep all content
+  within the inner safe rectangle.
 - Stitched `@ScrollingPreview(modes = [LONG])` round captures use a capsule
   mask (top half-circle + rectangle + bottom half-circle), not per-slice
   circles, so vertical content in the middle remains visible.


### PR DESCRIPTION
## Summary

- Splits the §6 "Round-face clipping" bullet into separate guidance for fixed vs. scrolling screens.
- Fixed screens still must keep content inside the inner safe rectangle.
- Scrolling screens (`TransformingLazyColumn` / `ScalingLazyColumn`) are *expected* to have content cropped at the round face's top/bottom — `contentPadding` + user scrolling handles edge access, so don't inset every item.

Closes #191

## Test plan

- [ ] Skim the rendered `skills/compose-preview/design/WEAR_UI.md` §6 on GitHub to confirm the new bullets read cleanly and the distinction is unambiguous.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HxdEHXVyh4LtnzXUwnJgde)_