### PR TITLE
fix(cli): hash GIF previews by first+last frame (#209)

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -1,7 +1,10 @@
 package ee.schimke.composeai.cli
 
+import java.awt.image.BufferedImage
 import java.io.File
+import java.nio.ByteBuffer
 import java.security.MessageDigest
+import javax.imageio.ImageIO
 import kotlin.system.exitProcess
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -412,7 +415,7 @@ abstract class Command(protected val args: List<String>) {
               .takeIf { it.isNotEmpty() }
               ?.let { module.projectDir.resolve("build/compose-previews/$it").canonicalFile }
               ?.takeIf { it.exists() }
-          val sha = pngFile?.let { sha256(it.readBytes()) }
+          val sha = pngFile?.let { previewSha256(it) }
           val stateKey = if (index == 0) p.id else "${p.id}#$index"
           if (sha != null) updated[stateKey] = sha
           val priorSha = prior[stateKey]
@@ -893,4 +896,58 @@ class A11yCommand(args: List<String>) : Command(args) {
 private fun sha256(bytes: ByteArray): String {
   val md = MessageDigest.getInstance("SHA-256")
   return md.digest(bytes).joinToString("") { "%02x".format(it) }
+}
+
+/**
+ * Hash used for change detection of a rendered preview file.
+ *
+ * For PNGs (the common case) this is just sha256 of the file bytes — the renderer is deterministic
+ * so the encoded bytes are stable across runs.
+ *
+ * For GIFs (`@ScrollingPreview(modes = [GIF])` output) we instead hash the first and last frames'
+ * pixels. The scripted scroll walk reads `liveRemaining` from a `LazyColumn` mid-walk, so
+ * progressive item materialisation produces a slightly different frame sequence on every run — and
+ * therefore a different encoded GIF — even when the source composable hasn't changed (issue #209).
+ * The bookend frames are the hold-start dwell at scroll position 0 and the settled hold-end at
+ * content end, both of which are stable for fixed source content. Mid-scroll frames are ignored,
+ * so changes that only manifest while scrolling won't show as Changed.
+ */
+internal fun previewSha256(file: File): String =
+  if (file.extension.equals("gif", ignoreCase = true)) {
+    gifBookendFrameSha256(file) ?: sha256(file.readBytes())
+  } else {
+    sha256(file.readBytes())
+  }
+
+/** Hash a GIF's first + last frames as `(w:int)(h:int)(pixels:int[w*h])` ARGB bytes per frame. */
+private fun gifBookendFrameSha256(file: File): String? {
+  val reader = ImageIO.getImageReadersByFormatName("gif").asSequence().firstOrNull() ?: return null
+  return try {
+    ImageIO.createImageInputStream(file).use { stream ->
+      reader.input = stream
+      val numFrames = reader.getNumImages(true)
+      if (numFrames <= 0) return null
+      val first = reader.read(0) ?: return null
+      val last = if (numFrames == 1) first else reader.read(numFrames - 1) ?: return null
+      sha256(framesToBytes(listOf(first, last)))
+    }
+  } catch (_: Exception) {
+    null
+  } finally {
+    reader.dispose()
+  }
+}
+
+private fun framesToBytes(frames: List<BufferedImage>): ByteArray {
+  val totalPixels = frames.sumOf { it.width * it.height }
+  val buffer = ByteBuffer.allocate(frames.size * 8 + totalPixels * 4)
+  for (img in frames) {
+    val w = img.width
+    val h = img.height
+    val pixels = img.getRGB(0, 0, w, h, null, 0, w)
+    buffer.putInt(w)
+    buffer.putInt(h)
+    for (p in pixels) buffer.putInt(p)
+  }
+  return buffer.array()
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewSha256Test.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewSha256Test.kt
@@ -1,0 +1,107 @@
+package ee.schimke.composeai.cli
+
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.IIOImage
+import javax.imageio.ImageIO
+import javax.imageio.stream.FileImageOutputStream
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Guards the issue-#209 contract: GIFs are hashed by their first + last frames only, so a
+ * non-deterministic scrolling preview (whose mid-walk frames vary run-to-run with `LazyColumn`
+ * materialisation) doesn't show up as "Changed" in the PR diff bot just because of encoder noise
+ * between the bookend frames.
+ */
+class PreviewSha256Test {
+  private val tempDir = createTempDirectory("preview-sha-test").toFile()
+
+  @AfterTest
+  fun cleanup() {
+    tempDir.deleteRecursively()
+  }
+
+  @Test
+  fun `gif hash ignores middle frames`() {
+    val a = writeGif("a.gif", listOf(Color.RED, Color.BLUE, Color.GREEN, Color.YELLOW))
+    val b = writeGif("b.gif", listOf(Color.RED, Color.MAGENTA, Color.CYAN, Color.YELLOW))
+
+    assertEquals(previewSha256(a), previewSha256(b))
+  }
+
+  @Test
+  fun `gif hash changes when first frame changes`() {
+    val redFirst = writeGif("red-first.gif", listOf(Color.RED, Color.GRAY, Color.BLUE))
+    val greenFirst = writeGif("green-first.gif", listOf(Color.GREEN, Color.GRAY, Color.BLUE))
+
+    assertNotEquals(previewSha256(redFirst), previewSha256(greenFirst))
+  }
+
+  @Test
+  fun `gif hash changes when last frame changes`() {
+    val blueLast = writeGif("blue-last.gif", listOf(Color.RED, Color.GRAY, Color.BLUE))
+    val yellowLast = writeGif("yellow-last.gif", listOf(Color.RED, Color.GRAY, Color.YELLOW))
+
+    assertNotEquals(previewSha256(blueLast), previewSha256(yellowLast))
+  }
+
+  @Test
+  fun `single-frame gif hashes without crashing`() {
+    val one = writeGif("one.gif", listOf(Color.RED))
+    val same = writeGif("same.gif", listOf(Color.RED))
+    val other = writeGif("other.gif", listOf(Color.BLUE))
+
+    assertEquals(previewSha256(one), previewSha256(same))
+    assertNotEquals(previewSha256(one), previewSha256(other))
+  }
+
+  @Test
+  fun `png hash uses the full file bytes`() {
+    val a = writePng("a.png", Color.RED)
+    val b = writePng("b.png", Color.RED)
+    val c = writePng("c.png", Color.BLUE)
+
+    assertEquals(previewSha256(a), previewSha256(b))
+    assertNotEquals(previewSha256(a), previewSha256(c))
+  }
+
+  private fun writePng(name: String, color: Color): File {
+    val img = solidImage(color)
+    val file = File(tempDir, name)
+    ImageIO.write(img, "png", file)
+    return file
+  }
+
+  private fun writeGif(name: String, colors: List<Color>): File {
+    val file = File(tempDir, name)
+    val writer = ImageIO.getImageWritersByFormatName("gif").next()
+    FileImageOutputStream(file).use { out ->
+      writer.output = out
+      val param = writer.defaultWriteParam
+      writer.prepareWriteSequence(null)
+      for (c in colors) {
+        writer.writeToSequence(IIOImage(solidImage(c), null, null), param)
+      }
+      writer.endWriteSequence()
+    }
+    writer.dispose()
+    return file
+  }
+
+  private fun solidImage(color: Color): BufferedImage {
+    val img = BufferedImage(8, 8, BufferedImage.TYPE_INT_RGB)
+    val g = img.createGraphics()
+    try {
+      g.color = color
+      g.fillRect(0, 0, img.width, img.height)
+    } finally {
+      g.dispose()
+    }
+    return img
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #209. GIF outputs from `@ScrollingPreview(modes = [GIF])` were always landing in the diff bot's "Changed" bucket — see the noise on #207's preview comment for `ActivityListGifPreview`.

The scripted scroll walk in `RobolectricRenderTest.handleGifCapture` reads `liveRemaining = remainingScrollPx(...)` mid-walk and feeds it back into `emitTailFlings(...)`. With a `LazyColumn`/`TransformingLazyColumn` that materializes items progressively, tiny differences in measured remaining-extent shift the per-step scroll deltas just enough to produce a slightly different frame sequence on every run — and therefore a byte-different encoded GIF — even when the source composable is unchanged. Sample previews that materialize the whole list upfront (e.g. `RedToBlueScrollGifPreview`, `count = 16`) stay deterministic, which matches what PR #207's diff bot showed.

Now: when the rendered file is `.gif`, the change-detection sha256 is computed over the first + last frames' ARGB pixels rather than the full container. The bookends are the hold-start dwell at scroll 0 and the settled hold-end at content end — both stable for fixed source content. PNGs are unchanged (still full-file sha256, that path is already deterministic).

Tradeoff: changes that only manifest mid-scroll won't surface as a diff. That's acceptable for the fan-out we render today; sampling additional fixed-position frames is a localised follow-up if it bites.

## Test plan

- [x] `./gradlew :cli:test` — new `PreviewSha256Test` covers (a) GIFs with the same bookends but different middles hash equal, (b) different first frame → different hash, (c) different last frame → different hash, (d) single-frame GIFs work, (e) PNG hashing is unchanged
- [ ] Diff bot run on a sample-wear PR confirms `ActivityListGifPreview` no longer shows in the Changed section


---
_Generated by [Claude Code](https://claude.ai/code/session_0125AyZmuoH8AcBDPDgW2QMh)_