### PR TITLE
fix(deps): hold compose-remote at alpha08 to match remote-material3 alpha02

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,14 @@ wear-tooling-preview = "1.0.0"
 #    contains `PreviewWrapper` / `PreviewWrapperProvider` — 1.10.x (the
 #    current BOM) doesn't have them. Declared explicitly because the
 #    sample doesn't depend on compose-bom.
-compose-remote = "1.0.0-alpha09"
+#  * compose-remote is held at alpha08 because alpha09 dropped
+#    `androidx.compose.remote.creation.compose.modifier.ClickActionModifierKt`,
+#    which `wear-compose-remote:remote-material3:alpha02` was built against
+#    and still calls into. Bumping the pair together (e.g. once a newer
+#    `wear-compose-remote` rebuilt against alpha09+ ships) is fine — bumping
+#    only `compose-remote` reintroduces a runtime `NoClassDefFoundError`
+#    inside `RemoteButtonImpl` at preview render time.
+compose-remote = "1.0.0-alpha08"
 wear-compose-remote = "1.0.0-alpha02"
 compose-ui-tooling-preview-wrapper = "1.11.0"
 kotlinx-coroutines = "1.10.2"


### PR DESCRIPTION
## Summary

`samples:remotecompose:renderPreviews` has been failing on every CI run with:

```
NoClassDefFoundError: androidx/compose/remote/creation/compose/modifier/ClickActionModifierKt
  at androidx.wear.compose.remote.material3.RemoteButtonKt.RemoteButtonImpl(RemoteButton.kt:466)
Caused by: ClassNotFoundException
```

`wear-compose-remote:remote-material3:1.0.0-alpha02` was published against `compose-remote:1.0.0-alpha08`. Its `RemoteButtonImpl` calls into `androidx.compose.remote.creation.compose.modifier.ClickActionModifierKt`, which exists in alpha08 and was dropped in alpha09 — so against alpha09 every `RemoteButton` preview crashes at render time.

Verified by `unzip -l` against the cached AARs:

```
remote-creation-compose 1.0.0-alpha08 · ClickAction lookup
     4981  ClickActionModifier.class
     5358  ClickActionModifierKt.class
remote-creation-compose 1.0.0-alpha09 · ClickAction lookup
(none — class removed)
```

Drops `compose-remote` back to alpha08; leaves `wear-compose-remote` at alpha02 (no rebuilt artifact ships yet for alpha09's surface). Added an inline note in `libs.versions.toml` so the next bump treats the two as a coordinated pair.

## Test plan

- [x] `./gradlew :samples:remotecompose:compileDebugKotlin` — clean.
- [x] `./gradlew :samples:remotecompose:renderPreviews` — passes locally. All three capture targets render (`RemoteButtonEnabledPreview`, `RemoteButtonWithShapePreview`, `RemoteButtonWithBorderPreview`).
- [ ] CI `Preview Baselines` run on this branch shows `samples:remotecompose` passing. Combined with #228, the workflow should go green end-to-end.