### PR TITLE
feat(actions): add consumer-facing install composite action

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -34,8 +34,8 @@ inputs:
   github-token:
     description: >
       Token used to authenticate the releases API call (avoids the
-      unauthenticated rate limit on shared GHA runners). Defaults to
-      ${{ github.token }} via the runs.steps env block below.
+      unauthenticated rate limit on shared GHA runners). Empty falls
+      back to the workflow token (github.token) inside the steps below.
     default: ''
 
 outputs:

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -1,0 +1,137 @@
+name: 'Install compose-preview CLI'
+description: >
+  Download a release of the compose-preview CLI and add its bin/ to
+  $GITHUB_PATH. The version is a literal string (e.g. "0.8.1"), the
+  word "latest" (resolved via the GitHub releases API), or the word
+  "catalog" (read from a Gradle version catalog).
+
+  This is the consumer-facing install action. The sibling install-cli
+  action — which builds the CLI from source — is internal to this
+  repo's CI (see preview-baselines / preview-comment) and exists so
+  PRs that change the CLI/plugin schema don't break against a stale
+  released CLI. External consumers should use this action.
+
+  Scope cuts vs. scripts/install.sh: no skill bundle, no JDK install,
+  no Android SDK. CI consumers compose actions/setup-java and
+  android-actions/setup-android themselves.
+
+inputs:
+  version:
+    description: >
+      Literal version (e.g. "0.8.1"), "latest", or "catalog". A leading
+      "v" is stripped.
+    default: 'latest'
+  catalog-path:
+    description: >
+      Path to the Gradle version catalog, used when version=catalog.
+    default: 'gradle/libs.versions.toml'
+  catalog-key:
+    description: >
+      [versions] key to read, used when version=catalog. Consumers
+      pick their own key — the default matches the convention in the
+      README's Renovate snippet.
+    default: 'composePreviewCli'
+  github-token:
+    description: >
+      Token used to authenticate the releases API call (avoids the
+      unauthenticated rate limit on shared GHA runners). Defaults to
+      ${{ github.token }} via the runs.steps env block below.
+    default: ''
+
+outputs:
+  version:
+    description: 'Resolved version, no leading "v" (e.g. "0.8.1").'
+    value: ${{ steps.resolve.outputs.version }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve version
+      id: resolve
+      shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+        CATALOG_PATH: ${{ inputs.catalog-path }}
+        CATALOG_KEY: ${{ inputs.catalog-key }}
+        # github-token override falls back to the workflow token so the
+        # default path is "authenticated" without consumer ceremony.
+        GITHUB_TOKEN: ${{ inputs.github-token != '' && inputs.github-token || github.token }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+        ver=$(python3 "$ACTION_PATH/resolve-version.py")
+        printf 'version=%s\n' "$ver" >> "$GITHUB_OUTPUT"
+        printf '::notice::Resolved compose-preview version: %s\n' "$ver"
+
+    - name: Download CLI
+      shell: bash
+      env:
+        VER: ${{ steps.resolve.outputs.version }}
+        GITHUB_TOKEN: ${{ inputs.github-token != '' && inputs.github-token || github.token }}
+      run: |
+        set -euo pipefail
+        # Repo is hardcoded — the action ships from this repo and
+        # downloads its own releases. Don't expose it as an input
+        # (would invite use against forks with no integrity story).
+        repo='yschimke/compose-ai-tools'
+        asset="compose-preview-${VER}.tar.gz"
+        url="https://github.com/${repo}/releases/download/v${VER}/${asset}"
+
+        tmp=$(mktemp -d)
+        trap 'rm -rf "$tmp"' EXIT
+
+        printf 'Downloading %s\n' "$url"
+        curl -fL --retry 3 --retry-connrefused -o "$tmp/$asset" "$url"
+
+        # Best-effort sha256 verification via the releases API. The
+        # asset's `digest` field is "sha256:<hex>". On failure (network,
+        # rate limit, missing digest) we warn and continue — same
+        # posture as scripts/install.sh, since the curl above already
+        # rode HTTPS to github.com.
+        api="https://api.github.com/repos/${repo}/releases/tags/v${VER}"
+        if meta=$(curl -fsSL \
+            -H 'Accept: application/vnd.github+json' \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "$api" 2>/dev/null); then
+          # awk-parse to mirror scripts/install.sh:357-366 (no jq on
+          # macos-latest by default; avoids inline-Python heredoc
+          # gymnastics inside command substitution).
+          want=$(printf '%s' "$meta" | awk -v asset="$asset" '
+            /"name":/ { in_asset = ($0 ~ asset) }
+            in_asset && /"digest":/ {
+              sub(/.*"digest":[[:space:]]*"sha256:/, "")
+              sub(/".*/, "")
+              print
+              exit
+            }
+          ')
+          if [ -n "${want:-}" ]; then
+            if command -v sha256sum >/dev/null 2>&1; then
+              got=$(sha256sum "$tmp/$asset" | awk '{print $1}')
+            else
+              got=$(shasum -a 256 "$tmp/$asset" | awk '{print $1}')
+            fi
+            if [ "$got" != "$want" ]; then
+              printf '::error::sha256 mismatch for %s: expected %s, got %s\n' "$asset" "$want" "$got"
+              exit 1
+            fi
+            printf 'Verified sha256: %s\n' "$got"
+          else
+            printf '::warning::No sha256 digest in release metadata for %s; skipping verification\n' "$asset"
+          fi
+        else
+          printf '::warning::Could not fetch release metadata for v%s; skipping sha256 verification\n' "$VER"
+        fi
+
+        # Hardcoded install dir keeps the $GITHUB_PATH literal in the
+        # next step a fixed string — zizmor's `github-env` rule rejects
+        # expansion-backed values written to $GITHUB_PATH because any
+        # attacker-influence over the expansion becomes attacker
+        # influence over every later step's $PATH.
+        sudo mkdir -p /opt/compose-preview
+        sudo tar -xzf "$tmp/$asset" -C /opt/compose-preview --strip-components=1
+
+    - name: Add CLI to PATH
+      shell: bash
+      run: echo '/opt/compose-preview/bin' >> "$GITHUB_PATH"

--- a/.github/actions/install/resolve-version.py
+++ b/.github/actions/install/resolve-version.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Resolve a compose-preview CLI version from action inputs.
+
+Reads INPUT_VERSION from the environment ("latest" | "catalog" |
+literal) and prints the bare version string (no leading "v") on stdout.
+CATALOG_PATH and CATALOG_KEY are honoured when INPUT_VERSION="catalog".
+GITHUB_TOKEN, when set, authenticates the releases API call.
+
+Kept as a separate script (rather than inline Python in action.yml)
+so the catalog parser is testable in isolation and the YAML stays
+free of heredoc-in-command-substitution syntax that's easy to break
+on edit.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tomllib
+import urllib.error
+import urllib.request
+
+REPO = "yschimke/compose-ai-tools"
+
+
+def fail(msg: str) -> "NoReturn":  # type: ignore[name-defined]
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def latest_version() -> str:
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{REPO}/releases/latest",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.load(resp)
+    except urllib.error.URLError as exc:
+        fail(f"could not reach api.github.com: {exc}")
+    tag = data.get("tag_name")
+    if not tag:
+        fail("releases/latest payload missing tag_name")
+    return tag.lstrip("v")
+
+
+def catalog_version() -> str:
+    path = os.environ.get("CATALOG_PATH") or "gradle/libs.versions.toml"
+    key = os.environ.get("CATALOG_KEY") or "composePreviewCli"
+    try:
+        with open(path, "rb") as fh:
+            cat = tomllib.load(fh)
+    except FileNotFoundError:
+        fail(f"version catalog not found: {path}")
+    except OSError as exc:
+        fail(f"could not read {path}: {exc}")
+    except tomllib.TOMLDecodeError as exc:
+        fail(f"could not parse {path}: {exc}")
+    versions = cat.get("versions") or {}
+    value = versions.get(key)
+    if value is None:
+        fail(f"version key {key!r} not found in {path} [versions]")
+    if not isinstance(value, str):
+        fail(f"version key {key!r} in {path} is not a string: {value!r}")
+    return value.lstrip("v")
+
+
+def main() -> None:
+    inp = (os.environ.get("INPUT_VERSION") or "latest").strip()
+    if inp == "latest":
+        print(latest_version())
+    elif inp == "catalog":
+        print(catalog_version())
+    else:
+        print(inp.lstrip("v"))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/actions/preview-baselines/action.yml
+++ b/.github/actions/preview-baselines/action.yml
@@ -7,17 +7,44 @@ description: >
   so PR comments pinned to a past baseline keep resolving forever.
 
 inputs:
+  cli-version:
+    description: >
+      compose-preview CLI version. Literal (e.g. "0.8.1"), "latest"
+      (resolved via the GitHub releases API), or "catalog" (read from
+      a Gradle version catalog — see catalog-path / catalog-key).
+    default: 'latest'
+  catalog-path:
+    description: 'Path to the Gradle version catalog (when cli-version=catalog).'
+    default: 'gradle/libs.versions.toml'
+  catalog-key:
+    description: '[versions] key to read (when cli-version=catalog).'
+    default: 'composePreviewCli'
   timeout:
-    description: 'CLI render timeout in seconds'
+    description: 'CLI render timeout in seconds.'
     default: '600'
   branch:
-    description: 'Branch name for baselines'
+    description: 'Branch name for baselines.'
     default: 'preview_main'
 
 runs:
   using: 'composite'
   steps:
-    - uses: ./.github/actions/install-cli
+    # Source-build path is internal to this repo's CI: when a PR changes
+    # the CLI/plugin schema, the released CLI is one tag behind HEAD and
+    # would 'version-skew' against the new previews.json shape. External
+    # consumers never need this; their CLI/plugin pair always matches a
+    # released tag.
+    - name: Install CLI from source
+      if: inputs.cli-version == 'source'
+      uses: ./.github/actions/install-cli
+
+    - name: Install CLI from release
+      if: inputs.cli-version != 'source'
+      uses: ./.github/actions/install
+      with:
+        version: ${{ inputs.cli-version }}
+        catalog-path: ${{ inputs.catalog-path }}
+        catalog-key: ${{ inputs.catalog-key }}
 
     - name: Render previews
       id: render

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -6,23 +6,46 @@ description: >
   URLs to commit SHAs so the images keep resolving after merge.
 
 inputs:
+  cli-version:
+    description: >
+      compose-preview CLI version. Literal (e.g. "0.8.1"), "latest"
+      (resolved via the GitHub releases API), or "catalog" (read from
+      a Gradle version catalog — see catalog-path / catalog-key).
+    default: 'latest'
+  catalog-path:
+    description: 'Path to the Gradle version catalog (when cli-version=catalog).'
+    default: 'gradle/libs.versions.toml'
+  catalog-key:
+    description: '[versions] key to read (when cli-version=catalog).'
+    default: 'composePreviewCli'
   timeout:
-    description: 'CLI render timeout in seconds'
+    description: 'CLI render timeout in seconds.'
     default: '600'
   base-branch:
-    description: 'Branch name for baselines'
+    description: 'Branch name for baselines.'
     default: 'preview_main'
   head-branch:
-    description: 'Shared branch that accumulates per-PR render commits'
+    description: 'Shared branch that accumulates per-PR render commits.'
     default: 'preview_pr'
   pr-number:
-    description: 'Pull request number (auto-detected from context if omitted)'
+    description: 'Pull request number (auto-detected from context if omitted).'
     default: ''
 
 runs:
   using: 'composite'
   steps:
-    - uses: ./.github/actions/install-cli
+    # See preview-baselines/action.yml for the source-vs-release rationale.
+    - name: Install CLI from source
+      if: inputs.cli-version == 'source'
+      uses: ./.github/actions/install-cli
+
+    - name: Install CLI from release
+      if: inputs.cli-version != 'source'
+      uses: ./.github/actions/install
+      with:
+        version: ${{ inputs.cli-version }}
+        catalog-path: ${{ inputs.catalog-path }}
+        catalog-key: ${{ inputs.catalog-key }}
 
     - name: Render previews
       shell: bash

--- a/.github/workflows/install-action-test.yml
+++ b/.github/workflows/install-action-test.yml
@@ -1,0 +1,109 @@
+name: Install Action Smoke Test
+
+# Exercises the consumer-facing install composite. The action's contract
+# is "give me a release tarball name and a $GITHUB_PATH entry that
+# resolves to a runnable launcher" — so the test is a matrix that
+# covers each version-resolution mode against ubuntu-latest and
+# macos-latest, plus a catalog-fixture job that asserts the
+# tomllib-based parser pulls the right key.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/actions/install/**'
+      - '.github/workflows/install-action-test.yml'
+  pull_request:
+    paths:
+      - '.github/actions/install/**'
+      - '.github/workflows/install-action-test.yml'
+  # Manual dispatch for ad-hoc verification (e.g. after a release that
+  # changes the asset naming).
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  install:
+    name: install ${{ matrix.version }} on ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        version: ['latest', '0.8.1']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      # The CLI launcher needs Java 17+ on PATH at run time. Ubuntu and
+      # macOS images both ship a JDK by default, but the version varies
+      # — pin Temurin 17 so --help is a real smoke test, not a
+      # JAVA_HOME-resolution assertion.
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: ./.github/actions/install
+        id: install
+        with:
+          version: ${{ matrix.version }}
+      - name: Verify launcher on PATH
+        shell: bash
+        env:
+          RESOLVED: ${{ steps.install.outputs.version }}
+        run: |
+          set -euo pipefail
+          which compose-preview
+          compose-preview --help >/dev/null
+          # Resolved output should look like a semver-ish string with no
+          # leading "v". Belt-and-braces — the action strips it, but a
+          # regression here would be silent otherwise.
+          case "$RESOLVED" in
+            v*|'') echo "::error::resolved version looks wrong: $RESOLVED"; exit 1 ;;
+          esac
+
+  install-from-catalog:
+    name: install via catalog fixture
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: temurin
+          java-version: 17
+      # Synthesize a minimal version catalog. The repo's own
+      # gradle/libs.versions.toml deliberately doesn't define
+      # composePreviewCli (we don't dogfood the install action against
+      # ourselves at HEAD — see install-cli/ for the source-build path).
+      - name: Write catalog fixture
+        shell: bash
+        run: |
+          mkdir -p tmp/gradle
+          cat > tmp/gradle/libs.versions.toml <<'EOF'
+          [versions]
+          composePreviewCli = "0.8.1"
+          EOF
+      - uses: ./.github/actions/install
+        id: install
+        with:
+          version: catalog
+          catalog-path: tmp/gradle/libs.versions.toml
+      - name: Assert resolved version
+        shell: bash
+        env:
+          RESOLVED: ${{ steps.install.outputs.version }}
+        run: |
+          set -euo pipefail
+          [ "$RESOLVED" = "0.8.1" ] || {
+            echo "::error::expected 0.8.1, got '$RESOLVED'"
+            exit 1
+          }
+          compose-preview --help >/dev/null

--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -25,3 +25,9 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/preview-baselines
+        with:
+          # In-repo CI uses the CLI built from the current checkout so
+          # PRs that change the previews.json schema don't render
+          # against a stale released CLI. External consumers omit this
+          # input — the default (latest release) is what they want.
+          cli-version: source

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -29,3 +29,6 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/preview-comment
+        with:
+          # See preview-baselines.yml for the source-vs-release rationale.
+          cli-version: source

--- a/README.md
+++ b/README.md
@@ -206,12 +206,12 @@ The snapshot version is the next patch ahead of the latest release
 
 <!-- x-release-please-start-version -->
 Download `compose-preview-0.8.2.tar.gz` (or `.zip`) from the
-[v0.8.2 release](https://github.com/yschimke/compose-ai-tools/releases/tag/v0.4.0)
+[v0.8.2 release](https://github.com/yschimke/compose-ai-tools/releases/tag/v0.8.2)
 and put the `bin/` directory on your `PATH`:
 
 ```sh
 curl -L -o compose-preview.tar.gz \
-  https://github.com/yschimke/compose-ai-tools/releases/download/v0.8.2/compose-preview-0.4.0.tar.gz
+  https://github.com/yschimke/compose-ai-tools/releases/download/v0.8.2/compose-preview-0.8.2.tar.gz
 tar -xzf compose-preview.tar.gz
 export PATH="$PWD/compose-preview-0.8.2/bin:$PATH"
 
@@ -221,6 +221,65 @@ compose-preview --help
 
 Requires Java 17 or newer on `PATH` (or `JAVA_HOME`). JDK 21 / 25 are
 fine — the CLI and renderer are compiled to JDK 17 bytecode.
+
+### On GitHub Actions
+
+Use the install composite action instead of curl-piping the install
+script — it pins to a tagged version of this repo, so consumer CI
+isn't exposed to changes on `main`:
+
+<!-- x-release-please-start-version -->
+```yaml
+- uses: actions/setup-java@v5
+  with:
+    distribution: temurin
+    java-version: 17
+- uses: yschimke/compose-ai-tools/.github/actions/install@v0.8.2
+  with:
+    # Literal "0.8.2", "latest", or "catalog" (read from a Gradle
+    # version catalog — see catalog-path / catalog-key inputs).
+    version: latest
+```
+<!-- x-release-please-end -->
+
+After this step the `compose-preview` binary is on `$PATH` for the
+remainder of the job.
+
+To keep the CLI version in lockstep with the rest of the project's
+toolchain, declare it in `gradle/libs.versions.toml` and let
+[Renovate](https://docs.renovatebot.com/) bump it on releases:
+
+<!-- x-release-please-start-version -->
+```toml
+# gradle/libs.versions.toml
+[versions]
+composePreviewCli = "0.8.2"
+```
+
+```yaml
+- uses: yschimke/compose-ai-tools/.github/actions/install@v0.8.2
+  with:
+    version: catalog   # reads composePreviewCli from libs.versions.toml
+```
+<!-- x-release-please-end -->
+
+```json
+// .github/renovate.json
+{
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)gradle/libs\\.versions\\.toml$"],
+      "matchStrings": [
+        "composePreviewCli\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "yschimke/compose-ai-tools",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    }
+  ]
+}
+```
 
 ## Install the VS Code extension
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,7 @@
         "README.md",
         "vscode-extension/README.md",
         "skills/compose-preview/SKILL.md",
+        "skills/compose-preview/design/CI_PREVIEWS.md",
         "docs/RELEASING.md",
         {
           "type": "generic",

--- a/skills/compose-preview/design/CI_PREVIEWS.md
+++ b/skills/compose-preview/design/CI_PREVIEWS.md
@@ -1,89 +1,149 @@
 # CI preview baselines (`preview_main` branch)
 
-Projects that use the Gradle plugin can set up CI workflows to maintain a
-`preview_main` branch with rendered PNGs and a `baselines.json` file (preview
-ID → SHA-256). This serves two purposes:
+Projects that use the Gradle plugin can wire up two GitHub Actions
+workflows to maintain a `preview_main` branch with rendered PNGs and a
+`baselines.json` file (preview ID → SHA-256). This serves two purposes:
 
 1. **Browsable gallery** — the branch has a `README.md` with inline images,
    viewable directly on GitHub.
 2. **PR diff comments** — a companion workflow renders previews on each PR,
    compares against the baselines, and posts a before/after comment.
 
-## Checking if baselines are available
+Both workflows ship from this repo as composite actions. Add two
+workflow files to your project; you're done.
 
-```bash
-git ls-remote --exit-code origin preview_main
-```
-
-## Fetching current main previews
-
-```bash
-# Get the baselines manifest
-git fetch origin preview_main
-git show origin/preview_main:baselines.json
-
-# Get a specific rendered PNG
-git show origin/preview_main:renders/<module>/<preview-id>.png > preview.png
-```
-
-Or via raw URL:
-```
-https://raw.githubusercontent.com/<owner>/<repo>/preview_main/renders/<module>/<preview-id>.png
-```
-
-## Installing the CLI in your workflow
-
-Use the [`install` composite action](https://github.com/yschimke/compose-ai-tools/tree/main/.github/actions/install)
-to put the `compose-preview` CLI on `$PATH`. Pin to a tagged version of
-this repo so consumer CI isn't exposed to changes on `main`:
+## Workflow 1 — update baselines on push to `main`
 
 <!-- x-release-please-start-version -->
 ```yaml
-- uses: actions/setup-java@v5
-  with:
-    distribution: temurin
-    java-version: 17
-- uses: yschimke/compose-ai-tools/.github/actions/install@v0.8.1
-  with:
-    version: catalog   # or "latest", or a literal "0.8.1"
+# .github/workflows/preview-baselines.yml
+name: Preview Baselines
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: write
+concurrency:
+  group: preview-baselines
+  cancel-in-progress: true
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@v6
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@v0.8.2
+        with:
+          cli-version: catalog   # or "latest", or a literal "0.8.2"
 ```
 <!-- x-release-please-end -->
 
-`version: catalog` reads the `composePreviewCli` key from
-`gradle/libs.versions.toml`; pair it with the Renovate `customManager`
-snippet in the [README](../../../README.md#on-github-actions) to keep
-the CLI version in lockstep with the rest of the project's toolchain.
+## Workflow 2 — post before/after comments on PRs
 
-After this step the `compose-preview` binary is on `$PATH` for the
-remainder of the job. Render previews with:
+<!-- x-release-please-start-version -->
+```yaml
+# .github/workflows/preview-comment.yml
+name: Preview Comment
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+permissions:
+  contents: read
+concurrency:
+  group: preview-comment-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+jobs:
+  compare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write          # appends to preview_pr branch
+      pull-requests: write     # upserts the PR comment
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: gradle/actions/setup-gradle@v6
+      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@v0.8.2
+        with:
+          cli-version: catalog
+```
+<!-- x-release-please-end -->
+
+## Pinning the CLI version
+
+`cli-version` accepts:
+
+- A literal string (e.g. `"0.8.2"`) — pinned, deterministic.
+- `latest` — resolved via the GitHub releases API on each run.
+- `catalog` — read the `composePreviewCli` key from
+  `gradle/libs.versions.toml`. Pair with the Renovate `customManager`
+  snippet in the [README](../../../README.md#on-github-actions) to keep
+  the version bumped on releases.
+
+`catalog-path` and `catalog-key` override the catalog location and key
+when needed.
+
+## Inputs at a glance
+
+`preview-baselines`:
+
+| Input | Default | Purpose |
+| --- | --- | --- |
+| `cli-version` | `latest` | CLI version (literal / `latest` / `catalog`). |
+| `catalog-path` | `gradle/libs.versions.toml` | Catalog file when `cli-version=catalog`. |
+| `catalog-key` | `composePreviewCli` | `[versions]` key when `cli-version=catalog`. |
+| `timeout` | `600` | CLI render timeout in seconds. |
+| `branch` | `preview_main` | Branch the baselines push to. |
+
+`preview-comment`:
+
+| Input | Default | Purpose |
+| --- | --- | --- |
+| `cli-version` | `latest` | CLI version (literal / `latest` / `catalog`). |
+| `catalog-path` | `gradle/libs.versions.toml` | Catalog file when `cli-version=catalog`. |
+| `catalog-key` | `composePreviewCli` | `[versions]` key when `cli-version=catalog`. |
+| `timeout` | `600` | CLI render timeout in seconds. |
+| `base-branch` | `preview_main` | Branch the baselines were pushed to. |
+| `head-branch` | `preview_pr` | Shared branch for per-PR render commits. |
+| `pr-number` | (event) | PR number, auto-detected from the `pull_request` event. |
+
+## Querying baselines outside CI
 
 ```bash
-compose-preview show --json --timeout 600 > _previews.json
+git ls-remote --exit-code origin preview_main          # check existence
+git fetch origin preview_main
+git show origin/preview_main:baselines.json            # read manifest
+git show origin/preview_main:renders/<module>/<id>.png # read PNG
 ```
 
-## Wiring up the full pipeline
+Or via raw URL:
 
-Two workflows do the work — render and push baselines on `main`,
-render and post a comment on PRs. The reference implementations live
-in this repo's own `.github/workflows/preview-baselines.yml` and
-`.github/workflows/preview-comment.yml`; the post-render bookkeeping
-(baselines layout, PR-comment generation, fast-forward push to
-`preview_main` / `preview_pr`) currently lives as Python in
-[`.github/actions/lib/compare-previews.py`](https://github.com/yschimke/compose-ai-tools/blob/main/.github/actions/lib/compare-previews.py).
-
-Until that bookkeeping ships as a consumer-callable composite or as
-`compose-preview baselines …` CLI subcommands (sketched in the
-"Follow-up" section of
-[#227](https://github.com/yschimke/compose-ai-tools/issues/227)),
-copy those reference workflows into your project as the starting
-point and adapt to taste.
+```
+https://raw.githubusercontent.com/<owner>/<repo>/preview_main/renders/<module>/<id>.png
+```
 
 ## Branch durability
 
-The `preview-comment` workflow appends a commit to a shared
-`preview_pr` branch (one commit per PR push, tree = that PR's changed
-PNGs). The PR comment pins Before/After `<img>` URLs to commit SHAs
-on `preview_main` and `preview_pr`, not branch names — so images keep
-resolving after the PR merges and after later PRs advance either
-branch. Neither branch is ever force-pushed; old commits stay
-reachable via branch history.
+Both `preview_main` and `preview_pr` are append-only:
+
+- `preview-baselines` adds one commit per push to `main` (parented on
+  the previous tip; skipped when the rendered tree is unchanged). A
+  fast-forward push on a serialised concurrency group means no
+  rewrites.
+- `preview-comment` appends one commit per PR push to `preview_pr`
+  (tree = that PR's changed PNGs). The PR comment pins `<img>` URLs
+  to commit SHAs on `preview_main` and `preview_pr`, not branch
+  names — so images keep resolving after the PR merges and after
+  later PRs advance either branch.

--- a/skills/compose-preview/design/CI_PREVIEWS.md
+++ b/skills/compose-preview/design/CI_PREVIEWS.md
@@ -31,68 +31,59 @@ Or via raw URL:
 https://raw.githubusercontent.com/<owner>/<repo>/preview_main/renders/<module>/<preview-id>.png
 ```
 
-## Adding preview CI to your project
+## Installing the CLI in your workflow
 
-The actions are published as composite GitHub Actions. Add two workflow files
-to your project:
+Use the [`install` composite action](https://github.com/yschimke/compose-ai-tools/tree/main/.github/actions/install)
+to put the `compose-preview` CLI on `$PATH`. Pin to a tagged version of
+this repo so consumer CI isn't exposed to changes on `main`:
 
-**`.github/workflows/preview-baselines.yml`** — updates `preview_main` on push
-to main:
-
+<!-- x-release-please-start-version -->
 ```yaml
-name: Preview Baselines
-on:
-  push:
-    branches: [main]
-permissions:
-  contents: write
-jobs:
-  update:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-      - uses: gradle/actions/setup-gradle@v4
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-baselines@main
+- uses: actions/setup-java@v5
+  with:
+    distribution: temurin
+    java-version: 17
+- uses: yschimke/compose-ai-tools/.github/actions/install@v0.8.1
+  with:
+    version: catalog   # or "latest", or a literal "0.8.1"
+```
+<!-- x-release-please-end -->
+
+`version: catalog` reads the `composePreviewCli` key from
+`gradle/libs.versions.toml`; pair it with the Renovate `customManager`
+snippet in the [README](../../../README.md#on-github-actions) to keep
+the CLI version in lockstep with the rest of the project's toolchain.
+
+After this step the `compose-preview` binary is on `$PATH` for the
+remainder of the job. Render previews with:
+
+```bash
+compose-preview show --json --timeout 600 > _previews.json
 ```
 
-**`.github/workflows/preview-comment.yml`** — posts before/after comments on
-PRs:
+## Wiring up the full pipeline
 
-```yaml
-name: Preview Comment
-on:
-  pull_request:
-    types: [opened, synchronize]
-permissions:
-  contents: write
-  pull-requests: write
-jobs:
-  compare:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-      - uses: gradle/actions/setup-gradle@v4
-      - uses: yschimke/compose-ai-tools/.github/actions/preview-comment@main
-```
+Two workflows do the work — render and push baselines on `main`,
+render and post a comment on PRs. The reference implementations live
+in this repo's own `.github/workflows/preview-baselines.yml` and
+`.github/workflows/preview-comment.yml`; the post-render bookkeeping
+(baselines layout, PR-comment generation, fast-forward push to
+`preview_main` / `preview_pr`) currently lives as Python in
+[`.github/actions/lib/compare-previews.py`](https://github.com/yschimke/compose-ai-tools/blob/main/.github/actions/lib/compare-previews.py).
 
-The actions download the `compose-preview` CLI from the latest release,
-auto-discover all modules that apply the plugin, and handle the baselines
-branch and PR comment lifecycle. Gradle build caching via `setup-gradle`
-keeps subsequent renders fast.
+Until that bookkeeping ships as a consumer-callable composite or as
+`compose-preview baselines …` CLI subcommands (sketched in the
+"Follow-up" section of
+[#227](https://github.com/yschimke/compose-ai-tools/issues/227)),
+copy those reference workflows into your project as the starting
+point and adapt to taste.
 
 ## Branch durability
 
-The `preview-comment` action appends a commit to a shared `preview_pr`
-branch (one commit per PR push, tree = that PR's changed PNGs). The PR
-comment pins Before/After `<img>` URLs to commit SHAs on `preview_main`
-and `preview_pr`, not branch names — so images keep resolving after the
-PR merges and after later PRs advance either branch. Neither branch is
-ever force-pushed; old commits stay reachable via branch history.
+The `preview-comment` workflow appends a commit to a shared
+`preview_pr` branch (one commit per PR push, tree = that PR's changed
+PNGs). The PR comment pins Before/After `<img>` URLs to commit SHAs
+on `preview_main` and `preview_pr`, not branch names — so images keep
+resolving after the PR merges and after later PRs advance either
+branch. Neither branch is ever force-pushed; old commits stay
+reachable via branch history.


### PR DESCRIPTION
Closes #227.

## Summary

Ships `.github/actions/install/` as the canonical way for downstream projects (cadence, homeassistant-remotecompose) to install the `compose-preview` CLI on GitHub Actions. Replaces the supply-chain-fragile pattern of piping `scripts/install.sh` from `main`, and the ~50 lines of YAML each consumer currently maintains in their own `.github/actions/install-cli/`.

Three version-resolution modes via the `version` input:
- `latest` — resolved via the GitHub releases API (authenticated with `$GITHUB_TOKEN` to avoid the unauthenticated rate-limit on shared GHA runners).
- `catalog` — read a key from a Gradle version catalog (`gradle/libs.versions.toml` + `composePreviewCli` by default; both overridable). Pair with the Renovate `customManager` snippet in the README to keep the version bumped on releases.
- a literal version string (e.g. `"0.8.1"`) — pinned download.

```yaml
- uses: yschimke/compose-ai-tools/.github/actions/install@v0.8.1
  with:
    version: catalog
```

## Implementation notes

- `resolve-version.py` is split out so the parser is testable in isolation and the YAML stays free of inline-Python heredoc syntax that's easy to break on edit.
- sha256 verification mirrors `scripts/install.sh`: best-effort via the releases API, warns and continues if rate-limited / digest missing (the underlying `curl` already rode HTTPS to `github.com`).
- `$GITHUB_PATH` write is a literal string, not an expansion — zizmor's `github-env` rule rejects expansion-backed values.
- Coexists with the existing internal `.github/actions/install-cli/` (which builds the CLI from source so this repo's own CI stays in lockstep with the plugin/renderer schema on the current commit). Action descriptions cross-link the two so the audience split is explicit.

## Doc fix-up

`skills/compose-preview/design/CI_PREVIEWS.md` previously pointed external consumers at `preview-baselines@main` / `preview-comment@main`, but those composites only work inside this repo's own checkout (they `./gradlew :cli:installDist` in `$GITHUB_WORKSPACE`, which is the consumer's repo with no `:cli` module). Doc now points at the install action as the working primitive and points to this repo's own workflows as the reference implementation for the full `preview_main` pipeline. Higher-level composite-shipment work flagged as a follow-up to #227.

Also fixed stale `0.4.0` strings in the existing release-please block in `README.md`.

## Test plan

- [ ] `install-action-test.yml` workflow passes on this PR (matrix: ubuntu-latest × macos-latest × `latest` + literal `0.8.1`, plus a catalog-fixture job that asserts the resolved version is `0.8.1`).
- [ ] Local sanity-check on `resolve-version.py` covers `latest`, literal (with and without leading `v`), `catalog` happy path, missing-key error, missing-file error.
- [ ] `compose-preview --help` succeeds on `$PATH` after the action runs (the smoke test asserts this in CI).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNkTc64zHxH85fvg59dj7z)_