### PR TITLE
feat(renderer): mark unmerged a11y nodes and surface more semantic state

### DIFF
--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityChecker.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityChecker.kt
@@ -6,6 +6,7 @@ import com.google.android.apps.common.testing.accessibility.framework.Accessibil
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityCheckResult.AccessibilityCheckResultType
 import com.google.android.apps.common.testing.accessibility.framework.AccessibilityHierarchyCheckResult
 import com.google.android.apps.common.testing.accessibility.framework.uielement.AccessibilityHierarchyAndroid
+import com.google.android.apps.common.testing.accessibility.framework.uielement.ViewHierarchyElement
 import java.io.File
 import java.util.Locale
 import kotlinx.serialization.json.Json
@@ -87,18 +88,25 @@ internal object AccessibilityChecker {
             val label = (v.contentDescription?.toString()?.trim().orEmpty())
                 .ifEmpty { v.text?.toString()?.trim().orEmpty() }
             val role = simplifyRole(v.accessibilityClassName?.toString() ?: v.className?.toString())
-            val states = buildList {
-                if (v.isCheckable == true) {
-                    add(if (v.isChecked == true) "checked" else "unchecked")
-                }
-            }
+            val states = buildStates(
+                isCheckable = v.isCheckable == true,
+                isChecked = v.isChecked == true,
+                isClickable = v.isClickable,
+                isLongClickable = v.isLongClickable,
+                isScrollable = v.isScrollable == true,
+                isEditable = v.isEditable == true,
+                isEnabled = v.isEnabled,
+                stateDescription = v.stateDescription?.toString()?.trim().orEmpty(),
+                hintText = v.hintText?.toString()?.trim().orEmpty(),
+            )
+            val merged = isMergedSemanticsRoot(v)
             // Drop nodes that wouldn't carry weight in the legend: a label,
             // a role beyond plain View, an actionable state, or clickability
             // is enough to keep them. Clickable-but-empty containers (a card
             // with text inside it that's already its own node) drop out.
             val keep = label.isNotEmpty() ||
                 states.isNotEmpty() ||
-                (role != null && v.isClickable)
+                (role != null && (v.isClickable || v.isLongClickable))
             if (!keep) continue
             // The label is what reviewers scan for first; an unlabelled
             // clickable element with a known role still surfaces, but with
@@ -108,10 +116,73 @@ internal object AccessibilityChecker {
                 label = label,
                 role = role,
                 states = states,
+                merged = merged,
                 boundsInScreen = "${bounds.left},${bounds.top},${bounds.right},${bounds.bottom}",
             )
         }
         return out
+    }
+
+    /**
+     * Pure projection from the booleans / strings ATF exposes on a single
+     * [com.google.android.apps.common.testing.accessibility.framework.uielement.ViewHierarchyElement]
+     * to the legend chips the overlay renders. Factored out of [extractNodes]
+     * so the chip selection rules can be unit-tested without standing up an
+     * ATF hierarchy (which needs a real `View` graph).
+     *
+     * Order of chips is intentional and stable: structural state first
+     * (`checked` / `unchecked`), then behaviour (`clickable`,
+     * `long-clickable`, `scrollable`, `editable`), then disability /
+     * descriptive overrides (`disabled`, the verbatim
+     * `stateDescription`, the `hint: …` line). Reviewers scan top-to-bottom
+     * for what they care about.
+     *
+     * Heading / selected aren't here: ATF's `ViewHierarchyElement` doesn't
+     * expose Compose-side `Modifier.semantics { heading() }` /
+     * `selected = true` cleanly enough to gate a chip on.
+     */
+    internal fun buildStates(
+        isCheckable: Boolean,
+        isChecked: Boolean,
+        isClickable: Boolean,
+        isLongClickable: Boolean,
+        isScrollable: Boolean,
+        isEditable: Boolean,
+        isEnabled: Boolean,
+        stateDescription: String,
+        hintText: String,
+    ): List<String> = buildList {
+        if (isCheckable) add(if (isChecked) "checked" else "unchecked")
+        if (isClickable) add("clickable")
+        if (isLongClickable) add("long-clickable")
+        if (isScrollable) add("scrollable")
+        if (isEditable) add("editable")
+        if (!isEnabled) add("disabled")
+        if (stateDescription.isNotEmpty()) add(stateDescription)
+        if (hintText.isNotEmpty()) add("hint: $hintText")
+    }
+
+    /**
+     * `true` when [v] is its own TalkBack focus stop — either ATF marks it
+     * `isScreenReaderFocusable()` or it has no screen-reader-focusable
+     * ancestor (so it's a standalone node, not a child of a merged
+     * container). `false` for the inner `Text` of a `Button` whose
+     * semantics are merged into the button: TalkBack would announce the
+     * button as one stop, so the inner text is "part of" something
+     * already shown.
+     *
+     * The overlay renders unmerged descendants with a dashed border + `↳ `
+     * legend prefix so reviewers can see structure without mistaking the
+     * extra rows for additional TalkBack stops.
+     */
+    internal fun isMergedSemanticsRoot(v: ViewHierarchyElement): Boolean {
+        if (v.isScreenReaderFocusable) return true
+        var p = v.parentView
+        while (p != null) {
+            if (p.isScreenReaderFocusable) return false
+            p = p.parentView
+        }
+        return true
     }
 
     /**

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityOverlay.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityOverlay.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.DashPathEffect
 import android.graphics.Paint
 import android.graphics.Rect
 import android.graphics.RectF
@@ -59,6 +60,17 @@ internal object AccessibilityOverlay {
      * full-strength outline + badge on top.
      */
     private const val NODE_FILL_ALPHA = 80
+
+    /**
+     * Fill alpha for unmerged descendants (the inner `Text` of a `Button`
+     * whose semantics merge into the button). Roughly half [NODE_FILL_ALPHA]
+     * so reviewers eyeball "this is structure underneath a real focus
+     * stop, not its own TalkBack stop".
+     */
+    private const val UNMERGED_NODE_FILL_ALPHA = 40
+
+    /** Dash on/off pattern (px) for unmerged-node borders. */
+    private val UNMERGED_DASH_INTERVAL = floatArrayOf(6f, 4f)
 
     /** Aspect at which we switch from stacked-legend to side-by-side. */
     private const val TALL_ASPECT = 1.3f
@@ -289,7 +301,7 @@ internal object AccessibilityOverlay {
         nodes.forEachIndexed { i, node ->
             val r = parseBounds(node.boundsInScreen) ?: return@forEachIndexed
             paint.color = nodeColors[i]
-            paint.alpha = NODE_FILL_ALPHA
+            paint.alpha = if (node.merged) NODE_FILL_ALPHA else UNMERGED_NODE_FILL_ALPHA
             canvas.drawRect(
                 offsetX + r.left, offsetY + r.top, offsetX + r.right, offsetY + r.bottom,
                 paint,
@@ -304,15 +316,22 @@ internal object AccessibilityOverlay {
         offsetX: Float,
         offsetY: Float,
     ) {
-        val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        // Two paint instances so the cached `pathEffect` doesn't leak across
+        // merged borders (Paint mutates its effect ref on assignment).
+        val solid = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             style = Paint.Style.STROKE
             strokeWidth = 1.5f
-            alpha = 200
+        }
+        val dashed = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.STROKE
+            strokeWidth = 1f
+            pathEffect = DashPathEffect(UNMERGED_DASH_INTERVAL, 0f)
         }
         nodes.forEachIndexed { i, node ->
             val r = parseBounds(node.boundsInScreen) ?: return@forEachIndexed
+            val paint = if (node.merged) solid else dashed
             paint.color = nodeColors[i]
-            paint.alpha = 200
+            paint.alpha = if (node.merged) 200 else 140
             canvas.drawRect(
                 offsetX + r.left + 0.5f, offsetY + r.top + 0.5f,
                 offsetX + r.right - 0.5f, offsetY + r.bottom - 0.5f,
@@ -547,7 +566,13 @@ internal object AccessibilityOverlay {
         }
         val rightMargin = LEGEND_MARGIN
         val textWidth = (panelWidth - (textX - originX) - rightMargin).toInt()
-        val labelText = node.label.ifEmpty { node.role ?: "(unlabelled)" }
+        val baseLabel = node.label.ifEmpty { node.role ?: "(unlabelled)" }
+        // ↳ marks rows whose semantics merge into a screen-reader-focusable
+        // ancestor, so reviewers can tell "extra structure underneath a
+        // focus stop" from "a separate TalkBack stop". Kept on the same
+        // line as the label rather than as a state chip — the prefix is
+        // structural, not a state.
+        val labelText = if (node.merged) baseLabel else "↳ $baseLabel"
         val labelLines = wrap(labelText, labelPaint, textWidth)
         var y = top + 22f
         for (line in labelLines) {
@@ -604,7 +629,8 @@ internal object AccessibilityOverlay {
         val textWidth = panelWidth - LEGEND_MARGIN * 2 - (SWATCH_SIDE + 14f).toInt()
         var total = 0
         for (n in nodes) {
-            val labelText = n.label.ifEmpty { n.role ?: "(unlabelled)" }
+            val baseLabel = n.label.ifEmpty { n.role ?: "(unlabelled)" }
+            val labelText = if (n.merged) baseLabel else "↳ $baseLabel"
             val lines = wrap(labelText, labelPaint, textWidth).size.coerceAtLeast(1)
             val hasSubtitle = n.role != null || n.states.isNotEmpty()
             total += 22 + 24 * lines + (if (hasSubtitle) 20 else 0) + ROW_PADDING

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -125,11 +125,28 @@ data class AccessibilityNode(
      */
     val role: String? = null,
     /**
-     * Extra semantic state (`selected`, `checked`, `unchecked`). Empty for
-     * stateless nodes. Heading isn't here — ATF's hierarchy doesn't expose
-     * it cleanly enough to detect Compose-side `Modifier.semantics { heading() }`.
+     * Non-default behavioural / state flags surfaced to the legend
+     * subtitle. Currently emitted (when their underlying value differs
+     * from the View default): `clickable`, `long-clickable`, `scrollable`,
+     * `editable`, `disabled`, `checked` / `unchecked`, plus the verbatim
+     * `getStateDescription()` string and a `hint: <text>` line for
+     * `getHintText()`. Heading isn't here — ATF's hierarchy doesn't
+     * expose it cleanly enough to detect Compose-side
+     * `Modifier.semantics { heading() }`.
      */
     val states: List<String> = emptyList(),
+    /**
+     * `true` when this node is its own TalkBack focus target
+     * (ATF: `isScreenReaderFocusable()`, or no screen-reader-focusable
+     * ancestor exists). `false` when it sits underneath a focusable
+     * ancestor — e.g. the inner `Text` of a `Button` whose semantics
+     * are merged into the button. The overlay uses this to draw
+     * unmerged descendants with a dashed border + `↳ ` legend prefix
+     * so reviewers can see structure without confusing it for "two
+     * separate TalkBack stops". Default `true` keeps older
+     * `accessibility.json` files parsing as merged.
+     */
+    val merged: Boolean = true,
     /** `left,top,right,bottom` in source-bitmap pixels — same shape as [AccessibilityFinding.boundsInScreen]. */
     val boundsInScreen: String,
 )

--- a/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityCheckerStatesTest.kt
+++ b/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityCheckerStatesTest.kt
@@ -1,0 +1,161 @@
+package ee.schimke.composeai.renderer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-JVM coverage of [AccessibilityChecker.buildStates] — the projection
+ * from ATF's per-element booleans / strings to the legend chip list. ATF
+ * itself can't be exercised here without a real `View` graph, so we test
+ * the chip selection rules (and their order) directly.
+ */
+class AccessibilityCheckerStatesTest {
+
+    @Test
+    fun `default node emits no chips`() {
+        assertEquals(
+            emptyList<String>(),
+            AccessibilityChecker.buildStates(
+                isCheckable = false,
+                isChecked = false,
+                isClickable = false,
+                isLongClickable = false,
+                isScrollable = false,
+                isEditable = false,
+                isEnabled = true,
+                stateDescription = "",
+                hintText = "",
+            ),
+        )
+    }
+
+    @Test
+    fun `checkable surfaces checked or unchecked depending on state`() {
+        val checked = AccessibilityChecker.buildStates(
+            isCheckable = true,
+            isChecked = true,
+            isClickable = false,
+            isLongClickable = false,
+            isScrollable = false,
+            isEditable = false,
+            isEnabled = true,
+            stateDescription = "",
+            hintText = "",
+        )
+        val unchecked = AccessibilityChecker.buildStates(
+            isCheckable = true,
+            isChecked = false,
+            isClickable = false,
+            isLongClickable = false,
+            isScrollable = false,
+            isEditable = false,
+            isEnabled = true,
+            stateDescription = "",
+            hintText = "",
+        )
+        assertEquals(listOf("checked"), checked)
+        assertEquals(listOf("unchecked"), unchecked)
+    }
+
+    @Test
+    fun `non-checkable suppresses checked chip even if isChecked is true`() {
+        // ATF returns non-null isChecked even when the View isn't a
+        // checkable widget; gate strictly on isCheckable so a stray Boolean
+        // doesn't surface a meaningless "unchecked" on every label.
+        assertEquals(
+            emptyList<String>(),
+            AccessibilityChecker.buildStates(
+                isCheckable = false,
+                isChecked = true,
+                isClickable = false,
+                isLongClickable = false,
+                isScrollable = false,
+                isEditable = false,
+                isEnabled = true,
+                stateDescription = "",
+                hintText = "",
+            ),
+        )
+    }
+
+    @Test
+    fun `clickable button surfaces clickable chip`() {
+        assertEquals(
+            listOf("clickable"),
+            AccessibilityChecker.buildStates(
+                isCheckable = false,
+                isChecked = false,
+                isClickable = true,
+                isLongClickable = false,
+                isScrollable = false,
+                isEditable = false,
+                isEnabled = true,
+                stateDescription = "",
+                hintText = "",
+            ),
+        )
+    }
+
+    @Test
+    fun `long-clickable scrollable editable disabled all surface independently`() {
+        assertEquals(
+            listOf("long-clickable", "scrollable", "editable", "disabled"),
+            AccessibilityChecker.buildStates(
+                isCheckable = false,
+                isChecked = false,
+                isClickable = false,
+                isLongClickable = true,
+                isScrollable = true,
+                isEditable = true,
+                isEnabled = false,
+                stateDescription = "",
+                hintText = "",
+            ),
+        )
+    }
+
+    @Test
+    fun `stateDescription and hintText round-trip into the chip list`() {
+        assertEquals(
+            listOf("expanded", "hint: Search"),
+            AccessibilityChecker.buildStates(
+                isCheckable = false,
+                isChecked = false,
+                isClickable = false,
+                isLongClickable = false,
+                isScrollable = false,
+                isEditable = false,
+                isEnabled = true,
+                stateDescription = "expanded",
+                hintText = "Search",
+            ),
+        )
+    }
+
+    @Test
+    fun `chip order is stable - structural state, behaviour, disability, descriptive`() {
+        assertEquals(
+            listOf(
+                "checked",
+                "clickable",
+                "long-clickable",
+                "scrollable",
+                "editable",
+                "disabled",
+                "selected",
+                "hint: Tap",
+            ),
+            AccessibilityChecker.buildStates(
+                isCheckable = true,
+                isChecked = true,
+                isClickable = true,
+                isLongClickable = true,
+                isScrollable = true,
+                isEditable = true,
+                isEnabled = false,
+                stateDescription = "selected",
+                hintText = "Tap",
+            ),
+        )
+    }
+}

--- a/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityOverlayMergedTest.kt
+++ b/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityOverlayMergedTest.kt
@@ -1,0 +1,200 @@
+package ee.schimke.composeai.renderer
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * End-to-end coverage for the merged-vs-unmerged visual treatment in
+ * [AccessibilityOverlay]. Uses the same Robolectric + native graphics
+ * setup as [CircularClipTest] so `Canvas.drawRect` with a
+ * `DashPathEffect` actually rasterises (the JVM-only path skips effects).
+ *
+ * Strategy: render two overlays against a **black** source bitmap. With a
+ * black background the translucent fill + border treatment maps to easy-
+ * to-distinguish pixel intensities — the alpha-200 solid border stroke
+ * for merged nodes blends to a clearly bright pastel, while the alpha-40
+ * fill-only zones in a dashed-border gap stay dark. Counting "bright"
+ * pixels along the bounds rectangle's top edge then separates solid from
+ * dashed cleanly.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class AccessibilityOverlayMergedTest {
+
+    @get:Rule
+    val tempDir = TemporaryFolder()
+
+    @Test
+    fun `unmerged border is dashed - fewer bright stroke pixels than merged solid`() {
+        val sourceFile = blackSourcePng(width = 400, height = 200)
+        val bounds = "100,40,300,140"
+
+        val mergedBitmap = renderOverlay(sourceFile, bounds, merged = true)
+        val unmergedBitmap = renderOverlay(sourceFile, bounds, merged = false)
+
+        val mergedHits = countBrightStrokePixelsAtTopEdge(mergedBitmap, bounds)
+        val unmergedHits = countBrightStrokePixelsAtTopEdge(unmergedBitmap, bounds)
+
+        assertTrue(
+            "merged border should paint many bright stroke pixels along its top edge: " +
+                "hits=$mergedHits",
+            mergedHits >= 100,
+        )
+        assertTrue(
+            "unmerged border should still paint *some* bright stroke pixels (dashes, " +
+                "not absence): hits=$unmergedHits",
+            unmergedHits >= 20,
+        )
+        assertTrue(
+            "unmerged border should paint visibly fewer bright stroke pixels than merged " +
+                "(dashed pattern leaves gaps): merged=$mergedHits, unmerged=$unmergedHits",
+            unmergedHits < mergedHits - 30,
+        )
+    }
+
+    @Test
+    fun `merged and unmerged overlays differ pixel-wise`() {
+        // Belt-and-braces sanity: merged vs unmerged must produce
+        // distinguishable PNGs even before we measure stroke counts. If
+        // this regresses, something has decoupled `merged` from the
+        // overlay code path entirely.
+        val sourceFile = blackSourcePng(width = 400, height = 200)
+        val bounds = "100,40,300,140"
+
+        val mergedBitmap = renderOverlay(sourceFile, bounds, merged = true)
+        val unmergedBitmap = renderOverlay(sourceFile, bounds, merged = false)
+
+        var differing = 0
+        for (y in 0 until mergedBitmap.height) {
+            for (x in 0 until mergedBitmap.width) {
+                if (mergedBitmap.getPixel(x, y) != unmergedBitmap.getPixel(x, y)) differing++
+            }
+        }
+        assertNotEquals(
+            "merged vs unmerged overlays must differ pixel-wise: differing=$differing",
+            0,
+            differing,
+        )
+    }
+
+    @Test
+    fun `older accessibility json without merged field deserializes as merged`() {
+        // Backward-compat guard for accessibility.json files written before
+        // the merged flag was added: missing field must round-trip as
+        // merged=true so historical reports keep rendering with solid
+        // borders + no `↳` prefix.
+        val legacy = """
+            {
+              "label": "Hello",
+              "role": "TextView",
+              "boundsInScreen": "0,0,10,10"
+            }
+        """.trimIndent()
+        val node = kotlinx.serialization.json.Json.decodeFromString(
+            AccessibilityNode.serializer(),
+            legacy,
+        )
+        assertEquals(true, node.merged)
+    }
+
+    private fun blackSourcePng(width: Int, height: Int): File {
+        val src = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888).apply {
+            eraseColor(Color.BLACK)
+        }
+        val out = tempDir.newFile()
+        out.outputStream().use { src.compress(Bitmap.CompressFormat.PNG, 100, it) }
+        return out
+    }
+
+    private fun renderOverlay(sourceFile: File, bounds: String, merged: Boolean): Bitmap {
+        val node = AccessibilityNode(
+            label = "Save",
+            role = "Button",
+            states = listOf("clickable"),
+            merged = merged,
+            boundsInScreen = bounds,
+        )
+        val written = AccessibilityOverlay.generate(sourceFile, emptyList(), listOf(node))
+        assertNotNull("overlay should be written", written)
+        val bm = BitmapFactory.decodeFile(written!!.absolutePath)
+        assertNotNull("overlay PNG should decode", bm)
+        return bm
+    }
+
+    /**
+     * Counts pixels along the node's top-border row that look like a
+     * stroke pixel — bright pastel against black, distinguishable from
+     * the alpha-40/80 fill underneath. Locates the screenshot offset by
+     * finding the topmost row containing a black pixel run wide enough
+     * to be the screenshot bitmap (legend / header rows are white or
+     * pale grey, never solid black).
+     */
+    private fun countBrightStrokePixelsAtTopEdge(composite: Bitmap, bounds: String): Int {
+        val parts = bounds.split(",").map { it.toInt() }
+        val left = parts[0]
+        val top = parts[1]
+        val right = parts[2]
+
+        // Find the screenshot offset by locating the topmost row with a
+        // long run of pure black — that's the source bitmap, which only
+        // appears inside the screenshot band.
+        var imageY = -1
+        var imageX = -1
+        outer@ for (y in 0 until composite.height) {
+            var runStart = -1
+            for (x in 0 until composite.width) {
+                if (composite.getPixel(x, y) == Color.BLACK) {
+                    if (runStart == -1) runStart = x
+                    if (x - runStart >= 50) {
+                        imageY = y
+                        imageX = runStart
+                        break@outer
+                    }
+                } else {
+                    runStart = -1
+                }
+            }
+        }
+        check(imageY >= 0 && imageX >= 0) {
+            "could not locate screenshot band in composite ${composite.width}x${composite.height}"
+        }
+
+        // Border stroke top edge is at y = imageY + top (the drawRect
+        // call insets by 0.5px so AA spreads across two rows; this row
+        // catches the densest run).
+        val edgeRow = imageY + top
+        val span = (imageX + left)..(imageX + right - 1)
+
+        var hits = 0
+        for (x in span) {
+            if (x !in 0 until composite.width) continue
+            if (isBrightStrokePixel(composite.getPixel(x, edgeRow))) hits++
+        }
+        return hits
+    }
+
+    /**
+     * `true` when the pixel reads as a stroke (alpha-200 pastel border on
+     * black) rather than a fill-only zone (alpha-40/80 pastel on black).
+     * Empirical threshold from manual sampling — the bright stroke channel
+     * peaks at ~195 (`0xF8 * 200/255`) while alpha-80 fill caps at ~78
+     * (`0xF8 * 80/255`). Any single channel above 120 is firmly in stroke
+     * territory and well clear of even the alpha-80 fill ceiling.
+     */
+    private fun isBrightStrokePixel(px: Int): Boolean =
+        Color.red(px) > 120 || Color.green(px) > 120 || Color.blue(px) > 120
+}


### PR DESCRIPTION
## Summary
- Mark a11y nodes whose semantics merge into a screen-reader-focusable
  ancestor: `AccessibilityNode.merged = false` triggers a dashed border
  (DashPathEffect), softer fill alpha, and a `↳ ` legend prefix, so
  reviewers no longer mistake a `Button { Text("OK") }` for two TalkBack
  stops.
- Surface the per-element semantic state we'd been dropping: `clickable`,
  `long-clickable`, `scrollable`, `editable`, `disabled`, the verbatim
  `getStateDescription()`, and `hint: <text>` from `getHintText()`.
  Stable order (structural → behaviour → disability → descriptive).
- Factor the chip-selection rules into a pure
  `AccessibilityChecker.buildStates(...)` so they're unit-testable
  without standing up an ATF hierarchy.

`merged` defaults to `true` on the data class so older
`accessibility.json` entries keep deserialising as solid-bordered nodes.

Closes #226.

## Test plan
- [x] `./gradlew :renderer-android:testDebugUnitTest --tests "ee.schimke.composeai.renderer.AccessibilityCheckerStatesTest"` — 7 cases covering each chip in isolation, the structural-state gating, and the stable order under all-true input.
- [x] `./gradlew :renderer-android:testDebugUnitTest --tests "ee.schimke.composeai.renderer.AccessibilityOverlayMergedTest"` — Robolectric + native graphics; renders an overlay against a black source and asserts the dashed-unmerged border paints strictly fewer bright stroke pixels than the solid-merged one (≥30-pixel gap), plus a backward-compat round-trip of legacy `accessibility.json` (no `merged` field) → `merged = true`.
- [x] Full `./gradlew :renderer-android:testDebugUnitTest` — only pre-existing `LongScrollGhostOverlayTest` failure (unrelated, reproduces on `main` without these changes).
- [ ] End-to-end render against `samples/android` and visual inspection of an `*.a11y.png` containing a Button to confirm the dashed treatment + new chips render as intended (didn't run locally — sandbox lacks the network access for AGP / Android-platform fetches).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8LkBHH8aVnJoFK7fE4RQe)_