### PR TITLE
fix(format): reformat Commands.kt + auto-install git hooks on session start

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# SessionStart hook: point this clone's git hooks at .githooks/ so the
+# ktfmt pre-commit guard runs on every commit. Idempotent.
+
+set -euo pipefail
+
+cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
+
+if [ -x scripts/install-git-hooks.sh ]; then
+  scripts/install-git-hooks.sh >&2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,14 @@ replay_pid*
 Thumbs.db
 
 # AI
-.claude/
+# Ignore local .claude/ scratch (sessions, projects, shell-snapshots, etc.)
+# but track the shared SessionStart hook + settings so every clone gets the
+# same agent setup wiring.
+.claude/*
+!.claude/hooks/
+!.claude/settings.json
+.claude/hooks/*
+!.claude/hooks/*.sh
 .gemini/
 
 # Local properties

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -908,8 +908,8 @@ private fun sha256(bytes: ByteArray): String {
  * progressive item materialisation produces a slightly different frame sequence on every run — and
  * therefore a different encoded GIF — even when the source composable hasn't changed (issue #209).
  * The bookend frames are the hold-start dwell at scroll position 0 and the settled hold-end at
- * content end, both of which are stable for fixed source content. Mid-scroll frames are ignored,
- * so changes that only manifest while scrolling won't show as Changed.
+ * content end, both of which are stable for fixed source content. Mid-scroll frames are ignored, so
+ * changes that only manifest while scrolling won't show as Changed.
  */
 internal fun previewSha256(file: File): String =
   if (file.extension.equals("gif", ignoreCase = true)) {


### PR DESCRIPTION
## Summary

- Reflow the `previewSha256` KDoc in `cli/.../Commands.kt` so ktfmt's 100-column wrap is happy. The Format Check (ktfmt Google style) workflow was failing on push because the paragraph break landed one word too early; running `./gradlew ktfmtFormatAll` fixes it.
- Add a SessionStart hook (`.claude/hooks/session-start.sh` + matching `.claude/settings.json`) that calls `scripts/install-git-hooks.sh` on every agent session start, so `core.hooksPath` is wired to `.githooks/` and the existing pre-commit ktfmt guard catches the same drift locally before it reaches CI.
- Narrow `.gitignore` so the shared SessionStart hook + settings are tracked while local `.claude/` scratch (sessions, projects, shell-snapshots) stays ignored.

## Test plan

- [x] `./gradlew ktfmtCheckAll` passes locally on the new tree.
- [x] `CLAUDE_PROJECT_DIR=$PWD ./.claude/hooks/session-start.sh` succeeds and sets `git config core.hooksPath` → `.githooks` (idempotent).
- [x] Pre-commit hook ran on this very commit (Commands.kt was staged) and passed.
- [ ] CI: Format Check workflow goes green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tzw1nMZxxgcUtS6ZvSCMcg)_