### PR TITLE
chore(gitignore): restore blanket .claude/ ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,14 +26,7 @@ replay_pid*
 Thumbs.db
 
 # AI
-# Ignore local .claude/ scratch (sessions, projects, shell-snapshots, etc.)
-# but track the shared SessionStart hook + settings so every clone gets the
-# same agent setup wiring.
-.claude/*
-!.claude/hooks/
-!.claude/settings.json
-.claude/hooks/*
-!.claude/hooks/*.sh
+.claude/
 .gemini/
 
 # Local properties


### PR DESCRIPTION
## Summary

Follow-up to #237. Restore the blanket `.claude/` ignore — the two committed files (`.claude/hooks/session-start.sh`, `.claude/settings.json`) stay tracked because git keeps tracking already-committed paths even when later gitignore'd, so the per-path `!`-exceptions aren't needed. Drops 7 lines of gitignore noise.

## Test plan

- [x] `git ls-files .claude/` still lists both tracked files after the change.
- [x] A fresh local `.claude/sessions/foo` is correctly ignored under the blanket rule.