### PR TITLE
fix(actions): pin nested uses: refs so external consumers resolve

### DIFF
--- a/.github/actions/preview-baselines/action.yml
+++ b/.github/actions/preview-baselines/action.yml
@@ -34,13 +34,21 @@ runs:
     # would 'version-skew' against the new previews.json shape. External
     # consumers never need this; their CLI/plugin pair always matches a
     # released tag.
+    #
+    # Both nested `uses:` references resolve as full `org/repo/path@ref`
+    # forms rather than `./.github/actions/...`. Inside a composite action,
+    # relative `./` paths resolve against the *consumer's* $GITHUB_WORKSPACE
+    # (not this action's own checkout), so external consumers of
+    # preview-baselines@vX.Y.Z would otherwise hit "Can't find action.yml
+    # under .github/actions/install". The pinned tag is bumped on every
+    # release by release-please (see release-please-config.json).
     - name: Install CLI from source
       if: inputs.cli-version == 'source'
-      uses: ./.github/actions/install-cli
+      uses: yschimke/compose-ai-tools/.github/actions/install-cli@v0.8.3 # x-release-please-version
 
     - name: Install CLI from release
       if: inputs.cli-version != 'source'
-      uses: ./.github/actions/install
+      uses: yschimke/compose-ai-tools/.github/actions/install@v0.8.3 # x-release-please-version
       with:
         version: ${{ inputs.cli-version }}
         catalog-path: ${{ inputs.catalog-path }}

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -34,14 +34,18 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    # See preview-baselines/action.yml for the source-vs-release rationale.
+    # See preview-baselines/action.yml for the source-vs-release rationale
+    # and for why these are full `org/repo/path@ref` references rather than
+    # `./.github/actions/...` (relative `./` from inside a composite action
+    # resolves against the consumer's $GITHUB_WORKSPACE, breaking external
+    # use). The pinned tag is bumped per release by release-please.
     - name: Install CLI from source
       if: inputs.cli-version == 'source'
-      uses: ./.github/actions/install-cli
+      uses: yschimke/compose-ai-tools/.github/actions/install-cli@v0.8.3 # x-release-please-version
 
     - name: Install CLI from release
       if: inputs.cli-version != 'source'
-      uses: ./.github/actions/install
+      uses: yschimke/compose-ai-tools/.github/actions/install@v0.8.3 # x-release-please-version
       with:
         version: ${{ inputs.cli-version }}
         catalog-path: ${{ inputs.catalog-path }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,6 +19,14 @@
         {
           "type": "generic",
           "path": "cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt"
+        },
+        {
+          "type": "generic",
+          "path": ".github/actions/preview-baselines/action.yml"
+        },
+        {
+          "type": "generic",
+          "path": ".github/actions/preview-comment/action.yml"
         }
       ]
     }


### PR DESCRIPTION
`yschimke/compose-ai-tools/.github/actions/preview-baselines@vX.Y.Z`
(and preview-comment) failed with "Can't find action.yml under
.github/actions/install" when consumed from another repo. From inside
a composite action, `uses: ./.github/actions/install` resolves against
the consumer's $GITHUB_WORKSPACE — not against the action repo's own
checkout — so the relative path can never reach the install action
that ships alongside.

Replace both `./.github/actions/install` and
`./.github/actions/install-cli` references with full `org/repo/path@ref`
forms pinned to the current release. Wire the two action.yml files into
release-please-config.json's extra-files so the pinned tag bumps each
release.

In-repo CI (which checks out this repo and runs the composite via `./`)
continues to work because it now references the previous tag's install
action, which exists at the pinned ref on github.com.