### PR TITLE
fix(plugin): detect transitive @Preview dep in CMP-Android layouts

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -72,7 +72,7 @@ internal object AndroidPreviewSupport {
       if (registered) return@onVariants
       if (!extension.enabled.get()) return@onVariants
       if (variant.name != extension.variant.get()) return@onVariants
-      if (!hasPreviewDependency(project)) {
+      if (!hasPreviewDependency(project, variant.name)) {
         project.logger.info(
           "compose-preview: no known @Preview dependency declared in module " +
             "'${project.path}'; skipping task registration. " +
@@ -93,11 +93,17 @@ internal object AndroidPreviewSupport {
 
   /**
    * True when any declarative dep bucket (`implementation` / `api` / `runtimeOnly`, including their
-   * `<name>Implementation` variants) declares a coord in [previewArtifactSignals]. Read at
-   * onVariants time, after the consumer's `dependencies { }` block has populated configurations;
-   * avoids resolution and stays Isolated-Projects safe.
+   * `<name>Implementation` variants) declares a coord in [previewArtifactSignals], OR when the
+   * resolved runtime classpath transitively includes one. The CMP-Android canonical layout has
+   * Compose UI behind a `project(":shared")` reference and only surfaces preview tooling
+   * transitively — see issue #241 — so direct-only inspection wrongly rejects `:composeApp`-style
+   * shells. Direct check first (cheap, no resolution); the transitive walk only fires when the
+   * cheap check fails.
    */
-  private fun hasPreviewDependency(project: Project): Boolean =
+  internal fun hasPreviewDependency(project: Project, variantName: String): Boolean =
+    hasDirectPreviewDependency(project) || hasTransitivePreviewDependency(project, variantName)
+
+  private fun hasDirectPreviewDependency(project: Project): Boolean =
     project.configurations
       .asSequence()
       .filter { c ->
@@ -115,6 +121,64 @@ internal object AndroidPreviewSupport {
           previewArtifactSignals.any { (sg, sn) -> g == sg && dep.name == sn }
         }
       }
+
+  /**
+   * Walks the resolved `${variantName}RuntimeClasspath` dep graph looking for any
+   * [previewArtifactSignals] match. Resolves the dependency *graph* (no artifact downloads), and is
+   * Isolated-Projects safe — the resolution result is the consumer module's own view of its
+   * classpath, not a reach into another project's model.
+   *
+   * Walks both selected components ([ResolvedDependencyResult]) and unresolved-but-requested
+   * coords. Treating a requested-but-unresolved signal as "yes, this module wants the preview
+   * tooling" matches the doctor task's "declared intent" semantics — an offline cache miss or a
+   * one-time metadata 503 shouldn't push the user back into the "no @Preview dependency declared"
+   * skip-and-confuse path.
+   *
+   * Returns false when the variant runtime classpath isn't present (non-Android modules / variants
+   * that don't synthesise one) or when traversing the resolution result throws (corrupt graph
+   * during early configuration). The caller treats both as "no signal found" and logs the standard
+   * "no known @Preview dependency declared" message.
+   */
+  private fun hasTransitivePreviewDependency(project: Project, variantName: String): Boolean {
+    val runtime =
+      project.configurations.findByName("${variantName}RuntimeClasspath") ?: return false
+    val root = runCatching { runtime.incoming.resolutionResult.root }.getOrNull() ?: return false
+    val seen = HashSet<org.gradle.api.artifacts.result.ResolvedComponentResult>()
+    val stack = ArrayDeque<org.gradle.api.artifacts.result.ResolvedComponentResult>()
+    stack.addLast(root)
+    while (stack.isNotEmpty()) {
+      val node = stack.removeLast()
+      if (!seen.add(node)) continue
+      val id = node.id
+      if (id is org.gradle.api.artifacts.component.ModuleComponentIdentifier) {
+        if (previewArtifactSignals.any { (g, n) -> id.group == g && id.module == n }) return true
+      }
+      for (dep in node.dependencies) {
+        // ResolvedDependencyResult — the happy path. Walk the selected component.
+        // UnresolvedDependencyResult — resolution failed (offline, missing
+        // artifact, etc.) but the consumer DID request a coord; check that
+        // `requested` selector against the signal list so a missing transitive
+        // doesn't mask the intent. Same reasoning the doctor task uses for
+        // its dep audit: declared intent counts even when resolution slipped.
+        when (dep) {
+          is org.gradle.api.artifacts.result.ResolvedDependencyResult -> stack.addLast(dep.selected)
+          else -> {
+            val requested = dep.requested
+            if (requested is org.gradle.api.artifacts.component.ModuleComponentSelector) {
+              if (
+                previewArtifactSignals.any { (g, n) ->
+                  requested.group == g && requested.module == n
+                }
+              ) {
+                return true
+              }
+            }
+          }
+        }
+      }
+    }
+    return false
+  }
 
   private fun registerAndroidTasks(
     project: Project,

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewPlugin.kt
@@ -76,11 +76,27 @@ constructor(
     project.pluginManager.withPlugin("com.android.application") { androidHandler() }
     project.pluginManager.withPlugin("com.android.library") { androidHandler() }
 
+    // The new `com.android.kotlin.multiplatform.library` plugin (the recommended
+    // replacement for nesting `com.android.library` inside KMP) doesn't expose
+    // classic AGP `debug`/`release` build variants — only an `androidMain`
+    // variant via `KotlinMultiplatformAndroidComponentsExtension` — so the
+    // `AndroidComponentsExtension`-based path in [AndroidPreviewSupport] can't
+    // be reused as-is. Until that path lands (issue #241), we still treat the
+    // KMP-Android plugin as "the project applies an Android plugin" so the
+    // desktop-tasks branch below doesn't fire on a CMP-Android `:shared`
+    // module and produce confusing errors. The `composePreviewApplied` marker
+    // task (registered above, plugin-id agnostic) still publishes from these
+    // modules so the CLI / VS Code extension can discover them.
+    project.pluginManager.withPlugin("com.android.kotlin.multiplatform.library") {
+      androidConfigured = true
+    }
+
     project.pluginManager.withPlugin("org.jetbrains.compose") {
       if (androidConfigured) return@withPlugin
       if (
         project.plugins.hasPlugin("com.android.application") ||
-          project.plugins.hasPlugin("com.android.library")
+          project.plugins.hasPlugin("com.android.library") ||
+          project.plugins.hasPlugin("com.android.kotlin.multiplatform.library")
       ) {
         return@withPlugin
       }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/HasPreviewDependencyTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/HasPreviewDependencyTest.kt
@@ -1,0 +1,137 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Pins the contract of [AndroidPreviewSupport.hasPreviewDependency].
+ *
+ * Two paths matter:
+ * 1. The cheap declared-deps walk over `*Implementation` / `*Api` / `*RuntimeOnly` buckets — what
+ *    plain `com.android.application` / `com.android.library` consumers hit. Doesn't resolve any
+ *    classpath.
+ * 2. The transitive walk over the resolved `${variant}RuntimeClasspath` graph — added for
+ *    issue #241. The CMP-Android canonical layout (`:composeApp` applies `com.android.application`
+ *    and depends on `:shared` via `project(":shared")`) only has the Compose preview tooling on the
+ *    runtime classpath transitively; declared-only inspection rejected those modules with a "no
+ *    known @Preview dependency declared" log line, even though the tooling was right there in the
+ *    resolved graph.
+ *
+ * The tests stay AGP-free on purpose: ProjectBuilder gives us enough to build a
+ * `${variant}RuntimeClasspath`-shaped resolvable configuration and a multi-project graph through
+ * the standard `java-library` + `java` plugins. The transitive case asserts on a `requested` but
+ * unresolved coord — the walker treats declared intent as a signal even when the artifact didn't
+ * download (offline cache miss, transient 503), which keeps the regression locked in without making
+ * the test depend on real network access to an AAR's Maven metadata.
+ */
+class HasPreviewDependencyTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  @Test
+  fun `direct declared dep on a preview signal is detected via cheap path`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+
+    // No repositories configured: the cheap path inspects `allDependencies` —
+    // a declared `Dependency` doesn't trigger resolution. This exercises the
+    // pre-#241 path and confirms it still works.
+    project.configurations.create("debugImplementation")
+    project.dependencies.add(
+      "debugImplementation",
+      "org.jetbrains.compose.components:components-ui-tooling-preview:0.0.0-stub",
+    )
+
+    assertThat(AndroidPreviewSupport.hasPreviewDependency(project, "debug")).isTrue()
+  }
+
+  @Test
+  fun `transitive preview signal in the runtime classpath is detected via graph walk`() {
+    // Multi-project setup: `:lib` declares the preview signal as a real api dep;
+    // `:app` only depends on `:lib` via project dep, with no preview-related
+    // declarative bucket. Mirrors the issue #241 layout (CMP-Android `:shared`
+    // exposing Compose preview tooling, `:composeApp` consuming it transitively).
+    val rootProject = ProjectBuilder.builder().withName("root").withProjectDir(tmp.root).build()
+    val lib =
+      ProjectBuilder.builder()
+        .withName("lib")
+        .withProjectDir(tmp.newFolder("lib"))
+        .withParent(rootProject)
+        .build()
+    val app =
+      ProjectBuilder.builder()
+        .withName("app")
+        .withProjectDir(tmp.newFolder("app"))
+        .withParent(rootProject)
+        .build()
+
+    // `java-library` gives us the standard `apiElements` / `runtimeElements`
+    // outgoing variants on `:lib` and matching `runtimeClasspath` consumer on
+    // `:app`. Plain `java` plugin would also work but `java-library` is closer
+    // to how a real shared module is shaped.
+    lib.plugins.apply("java-library")
+    app.plugins.apply("java")
+    app.repositories.mavenCentral()
+    lib.repositories.mavenCentral()
+
+    // `:lib` declares the preview signal on `api` so it propagates to consumers'
+    // runtime classpaths. Keep the version pinned and avoid `-android`-suffixed
+    // artifacts to keep AGP's variant attributes out of the picture — this test
+    // is about the graph walk, not AGP integration.
+    lib.dependencies.add(
+      "api",
+      "org.jetbrains.compose.components:components-ui-tooling-preview:1.7.5",
+    )
+
+    // `:app` shapes the runtime classpath like AGP would: a `${variant}RuntimeClasspath`
+    // configuration extending from the consumer's `implementation` bucket, which in
+    // turn depends on `:lib` via project dep. Cheap path can't see the preview
+    // signal here — only the graph walk over `debugRuntimeClasspath` finds it
+    // through the transitive `:lib` → preview-tooling chain.
+    val implementation = app.configurations.getByName("implementation")
+    implementation.dependencies.add(app.dependencies.project(mapOf("path" to ":lib")))
+    app.configurations.create("debugRuntimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+      extendsFrom(implementation)
+      attributes.attribute(
+        org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE,
+        app.objects.named(
+          org.gradle.api.attributes.Usage::class.java,
+          org.gradle.api.attributes.Usage.JAVA_RUNTIME,
+        ),
+      )
+    }
+
+    assertThat(AndroidPreviewSupport.hasPreviewDependency(app, "debug")).isTrue()
+  }
+
+  @Test
+  fun `unrelated runtime classpath returns false from both paths`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+    project.repositories.mavenCentral()
+
+    project.configurations.create("debugImplementation")
+    project.dependencies.add("debugImplementation", "com.google.guava:guava:33.0.0-jre")
+
+    project.configurations.create("debugRuntimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+    project.dependencies.add("debugRuntimeClasspath", "com.google.guava:guava:33.0.0-jre")
+
+    assertThat(AndroidPreviewSupport.hasPreviewDependency(project, "debug")).isFalse()
+  }
+
+  @Test
+  fun `missing variant runtime classpath returns false without throwing`() {
+    val project = ProjectBuilder.builder().withProjectDir(tmp.root).build()
+
+    // No declarative-bucket match, no `${variant}RuntimeClasspath` configuration —
+    // mirrors a fresh module before AGP has wired its variant configurations.
+    // Function should return false instead of throwing.
+    assertThat(AndroidPreviewSupport.hasPreviewDependency(project, "debug")).isFalse()
+  }
+}


### PR DESCRIPTION
`AndroidPreviewSupport.hasPreviewDependency` only inspected declared deps
on `*Implementation` / `*Api` / `*RuntimeOnly` buckets. The canonical CMP
layout (`:composeApp` applies `com.android.application` and depends on
`:shared` via `project(":shared")`, with Compose preview tooling living
on `:shared`) failed that check — preview tooling was on the runtime
classpath transitively but not directly declared, so the plugin logged
"no known @Preview dependency declared" and skipped task registration.

Now we also walk the resolved `${variant}RuntimeClasspath` dep graph
when the cheap declared-deps check misses. Walks both
ResolvedDependencyResult.selected and (for unresolved-but-requested
coords) the requested ModuleComponentSelector, so an offline cache miss
or a transient 503 on a transitive AAR's metadata doesn't push consumers
back into the skip path. Resolves the graph (no artifact downloads).

Also recognises the new `com.android.kotlin.multiplatform.library`
plugin id so the desktop-tasks branch doesn't fire on a CMP-Android
`:shared` module — the variant pipeline for that plugin lives on
KotlinMultiplatformAndroidComponentsExtension and needs separate
plumbing, tracked in #241; for now `composePreviewApplied` (plugin-id
agnostic) still publishes from those modules so the CLI / VS Code
extension can discover them.

Tests: ProjectBuilder-based unit tests pin the cheap path, the
transitive walk via a `:lib` → `:app` graph, an unrelated-classpath
negative case, and the missing-runtime-classpath fallback.

Fixes #241