### PR TITLE
fix(plugin): walk a copyRecursive() so transitive detection doesn't lock parent configs

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -134,6 +134,16 @@ internal object AndroidPreviewSupport {
    * one-time metadata 503 shouldn't push the user back into the "no @Preview dependency declared"
    * skip-and-confuse path.
    *
+   * Resolves a `copyRecursive()` rather than the original configuration. Resolving the original
+   * `${variantName}RuntimeClasspath` marks its `extendsFrom` parents —
+   * `${variantName}Implementation`, `implementation`, `runtimeOnly`, etc. — as observed, which then
+   * forbids the `dependencies.add( "testImplementation", …)` / `${variantName}Implementation` calls
+   * below in [registerAndroidTasks] (and its `afterEvaluate` block) when another plugin like
+   * tapmoc's `checkDependencies` has already pulled the test runtime classpath into resolution
+   * earlier in the lifecycle. The recursive copy flattens the parent chain into a detached
+   * configuration, so resolving it exercises the same dep graph without observing any of the
+   * consumer's declarable buckets — see issue #244 (cadence) for the original repro.
+   *
    * Returns false when the variant runtime classpath isn't present (non-Android modules / variants
    * that don't synthesise one) or when traversing the resolution result throws (corrupt graph
    * during early configuration). The caller treats both as "no signal found" and logs the standard
@@ -142,7 +152,8 @@ internal object AndroidPreviewSupport {
   private fun hasTransitivePreviewDependency(project: Project, variantName: String): Boolean {
     val runtime =
       project.configurations.findByName("${variantName}RuntimeClasspath") ?: return false
-    val root = runCatching { runtime.incoming.resolutionResult.root }.getOrNull() ?: return false
+    val probe = runCatching { runtime.copyRecursive() }.getOrNull() ?: return false
+    val root = runCatching { probe.incoming.resolutionResult.root }.getOrNull() ?: return false
     val seen = HashSet<org.gradle.api.artifacts.result.ResolvedComponentResult>()
     val stack = ArrayDeque<org.gradle.api.artifacts.result.ResolvedComponentResult>()
     stack.addLast(root)

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/HasPreviewDependencyTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/HasPreviewDependencyTest.kt
@@ -134,4 +134,69 @@ class HasPreviewDependencyTest {
     // Function should return false instead of throwing.
     assertThat(AndroidPreviewSupport.hasPreviewDependency(project, "debug")).isFalse()
   }
+
+  @Test
+  fun `transitive walk does not lock parent configurations against later modification`() {
+    // Issue #244 (cadence): the transitive walk has to inspect the resolved runtime
+    // dep graph but mustn't observe `${variant}Implementation` / `implementation`
+    // in the process — `registerAndroidTasks` adds testImplementation / variant-
+    // implementation deps after this method returns true (and an `afterEvaluate`
+    // block adds `tiles-renderer` to `${variant}Implementation` later). Resolving
+    // `${variant}RuntimeClasspath` directly marks its parent chain as observed,
+    // which in projects where another plugin (tapmoc's checkDependencies in cadence's
+    // case) has already pulled the unit-test classpath into resolution lifts that
+    // observation up to `testImplementation` itself. Walking a `copyRecursive()`
+    // sidesteps the issue — pin that here so the fix doesn't regress.
+    val rootProject = ProjectBuilder.builder().withName("root").withProjectDir(tmp.root).build()
+    val lib =
+      ProjectBuilder.builder()
+        .withName("lib")
+        .withProjectDir(tmp.newFolder("lib"))
+        .withParent(rootProject)
+        .build()
+    val app =
+      ProjectBuilder.builder()
+        .withName("app")
+        .withProjectDir(tmp.newFolder("app"))
+        .withParent(rootProject)
+        .build()
+
+    lib.plugins.apply("java-library")
+    app.plugins.apply("java")
+    app.repositories.mavenCentral()
+    lib.repositories.mavenCentral()
+    lib.dependencies.add(
+      "api",
+      "org.jetbrains.compose.components:components-ui-tooling-preview:1.7.5",
+    )
+
+    val implementation = app.configurations.getByName("implementation")
+    implementation.dependencies.add(app.dependencies.project(mapOf("path" to ":lib")))
+
+    // Mirror AGP's `${variant}Implementation` / `${variant}RuntimeClasspath`
+    // shape so the locking semantics match a real consumer.
+    val debugImplementation =
+      app.configurations.create("debugImplementation") { extendsFrom(implementation) }
+    app.configurations.create("debugRuntimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+      extendsFrom(debugImplementation)
+      attributes.attribute(
+        org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE,
+        app.objects.named(
+          org.gradle.api.attributes.Usage::class.java,
+          org.gradle.api.attributes.Usage.JAVA_RUNTIME,
+        ),
+      )
+    }
+
+    assertThat(AndroidPreviewSupport.hasPreviewDependency(app, "debug")).isTrue()
+
+    // The fix matters: without `copyRecursive()`, both of these would throw
+    // `InvalidUserCodeException: Cannot mutate the dependencies of configuration
+    // ':app:implementation' / ':app:debugImplementation' after the configuration's
+    // child configuration ':app:debugRuntimeClasspath' was resolved.`
+    app.dependencies.add("debugImplementation", "androidx.wear.tiles:tiles-renderer:1.0.0")
+    app.dependencies.add("implementation", "androidx.appcompat:appcompat:1.6.1")
+  }
 }


### PR DESCRIPTION
## Summary

`hasTransitivePreviewDependency` (added in #242) resolves `${variant}RuntimeClasspath` to spot transitively-pulled preview tooling — the `:composeApp` → `:shared` → `compose.uiToolingPreview` chain. Resolving the configuration directly marks its `extendsFrom` parents (`${variant}Implementation`, `implementation`, `runtimeOnly`) as observed, which then forbids the `dependencies.add("testImplementation", …)` and `${variant}Implementation` calls that `registerAndroidTasks` (and its `afterEvaluate` block) make right after. In cadence's CMP-Android layout, tapmoc's `checkDependencies` pulls a sibling classpath into resolution before our `onVariants` fires, which lifts that lock up to `testImplementation` itself and the build dies with `Cannot mutate the dependencies of configuration ':composeApp:testImplementation' after the configuration's child configuration ':composeApp:debugRuntimeClasspath' was resolved`.

Walk `runtime.copyRecursive()` instead. `copyRecursive()` flattens the parent chain into a detached configuration with the same attributes, so resolving it exercises the same dep graph without observing any of the consumer's declarable buckets, and the dependency adds afterwards keep working.

## Test plan

- [x] New `HasPreviewDependencyTest` case mirrors the cadence shape (`:lib` declares the preview signal as `api`; `:app` consumes via `project(":lib")` only) and asserts that `dependencies.add("debugImplementation", …)` / `dependencies.add("implementation", …)` succeed after the transitive walk. Without the fix this case throws `InvalidUserCodeException`; with the fix it passes.
- [x] Existing `HasPreviewDependencyTest` cases still pass (direct check, transitive detection, unrelated runtime classpath, missing variant).
- [x] `./gradlew test ktfmtCheck` clean.
- [ ] Verify against cadence (`yschimke/cadence`) by pointing it at a snapshot of this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdCbeNSSiYh3pjQVBgPeCJ)_