### PR TITLE
docs(daemon): design and work breakdown for persistent preview server

### DIFF
--- a/docs/daemon/DESIGN.md
+++ b/docs/daemon/DESIGN.md
@@ -1,0 +1,411 @@
+# Persistent preview server — design
+
+> **Status:** experimental design proposal. v1 ships behind `composePreview.experimental.daemon=true`. The Gradle `renderPreviews` task remains the always-available fallback and the CI-canonical render path.
+
+## 1. Goals & non-goals
+
+**Goals**
+
+- Sub-second preview refresh for a single focused preview after a no-classpath-change file save in VS Code.
+- Eliminate Gradle configuration, JVM fork startup, and Robolectric sandbox bootstrap from the per-save hot path.
+- Keep the existing `renderPreviews` Gradle task path untouched and always available.
+
+**Non-goals (v1)**
+
+- Per-project (cross-module) sandbox sharing — each consumer module gets its own daemon JVM.
+- CLI / MCP daemon mode — the `compose-preview` binary keeps using the Gradle task.
+- Replacing `renderPreviews` — daemon fronts it for the editor loop only.
+- Hot kotlinc / compile-daemon integration — out of scope; we still let Gradle drive Kotlin compilation.
+- Tier-3 dependency-graph reachability index — v1 uses a conservative "module-changed = all previews stale, filtered by visibility" rule.
+
+## 2. Verdict on feasibility
+
+The current pipeline is ~80% ready. The Robolectric/Compose render code is **not structurally tied to JUnit's lifecycle** — it leans on `ParameterizedRobolectricTestRunner` for sandbox bootstrap and on `createAndroidComposeRule<ComponentActivity>()` for activity setup, but neither is load-bearing. The `mainClock.autoAdvance=false` + `advanceTimeBy(...)` pattern, the per-preview `RuntimeEnvironment.setQualifiers()`, and the `setContent { ... }` capture loop are all composition-scoped, not test-scoped.
+
+The two actual blockers are:
+
+1. **Classpath immutability.** Robolectric's `InstrumentingClassLoader` is created once per sandbox config and caches shadow installations and native libs. Any classpath mutation (a new dependency, a Compose version bump, an AAR change) requires tearing down the sandbox. The daemon must detect this and recycle cleanly.
+2. **Discovery is currently a full ClassGraph re-scan.** `DiscoverPreviewsTask` has no per-file mapping — `PreviewInfo` carries `className` but not the source `.kt` path. The daemon needs that mapping (cheap to add) plus a scoped scan path.
+
+`System.exit`, JVM-wide hooks, and global statics that would prevent reuse are not present. `PixelSystemFontAliases.seedSystemFontMap()` is idempotent and process-cached. `ShadowPackageManager` registrations persist across previews but are additive.
+
+## 3. Why not Robolectric Simulator
+
+`org.robolectric.simulator.Simulator` (Robolectric 4.15+) is explicitly "highly experimental, proof-of-concept stage" and exposes only `start()` — it launches an interactive preview window of your app's main `Activity`. It's meant for human debugging of a single Activity, not headless batch rendering of `@Composable` functions to PNG. There's no documented way to drive it from `main()`, no API to swap compositions or capture frames programmatically.
+
+We do **not** want Simulator. What we want is a long-lived process that bootstraps a Robolectric sandbox once, exposes a render entry point that reuses that sandbox, and talks to VS Code over IPC. The Roborazzi capture path (`captureRoboImage` → `HardwareRenderingScreenshot`) stays — that's the part that actually works correctly under Robolectric.
+
+## 4. Architecture
+
+```
+VS Code extension
+   │
+   │  JSON-RPC over stdio
+   ▼
+preview-daemon (one JVM per consumer module)
+   │
+   ├── ManifestWatcher       — debounced file events from VS Code
+   ├── IncrementalDiscovery  — re-scans only changed source class dirs
+   ├── FocusTracker          — current visible-preview set from VS Code
+   ├── RenderQueue           — coalesces, prioritises focused previews first
+   └── RobolectricHost       — single hot sandbox + warm spare
+            │
+            └── ComponentActivity + ComposeTestRule, recycled per preview
+```
+
+**Per-module, not per-project.** Robolectric sandbox config is a function of the consumer module's classpath + AndroidX versions + `compileSdk`. Two modules in the same project can legitimately have incompatible Compose versions (renderer-vs-consumer alignment is documented in [docs/RENDERER_COMPATIBILITY.md](../RENDERER_COMPATIBILITY.md)). One sandbox per module sidesteps this. A future per-project mode is possible if we share the renderer JAR plus isolate per-module classloaders under a parent — out of scope for v1.
+
+The daemon is **launched by VS Code** (replacing the `GradleApi.runTask("renderPreviews")` call in `gradleService.ts`) but **bootstrapped by Gradle** — we still need Gradle once at startup to compute the test classpath, JVM args, and `robolectric.properties` exactly the way `AndroidPreviewSupport.kt` does today. New Gradle task `composePreviewDaemonStart` emits a JSON descriptor (classpath, JVM args, system props, java launcher path); VS Code execs `java` with those args.
+
+A manual `./gradlew composePreviewDaemonStart --foreground` mode is also available, for debugging the daemon without VS Code in the loop.
+
+## 5. IPC contract (sketch)
+
+JSON-RPC over stdio.
+
+**VS Code → daemon (notifications):**
+
+- `setVisible({ ids })` — currently visible preview cards in the panel; updates on scroll/resize.
+- `setFocus({ ids })` — active preview (click, file scope change). Subset of visible. Rendered first.
+- `fileChanged({ path, kind: "source" | "resource" | "classpath" })` — saved file event.
+- `renderNow({ previews, tier: "fast" | "full" })` — explicit user action.
+- `shutdown()`.
+
+**Daemon → VS Code (notifications):**
+
+- `discoveryUpdated({ added, removed, changed })`
+- `renderStarted({ id })`, `renderFinished({ id, pngPath, tookMs, metrics })`, `renderFailed({ id, error })`
+- `classpathDirty({ reason })` — daemon will exit; VS Code re-bootstraps.
+- `sandboxRecycle({ reason, ageMs, renderCount })` — informational; expected periodically.
+- `daemonWarming({ etaMs })` — recycle in progress, no spare ready.
+
+The protocol must be locked in Phase 0 of the implementation work — see [TODO.md](TODO.md). Both daemon and VS Code client teams depend on the protocol shape being stable.
+
+## 6. Module layout
+
+```
+renderer-android/                    UNCHANGED — RobolectricRenderTest.kt etc.
+renderer-android-daemon/             NEW — depends on renderer-android
+  src/main/kotlin/.../daemon/
+    DaemonMain.kt                    JSON-RPC server, lifecycle, signal handling
+    DaemonHost.kt                    Holds Robolectric sandbox open
+    RenderEngine.kt                  Per-preview render body (initially duplicated)
+    IncrementalDiscovery.kt          Tier-2 scoped ClassGraph
+    DependencyIndex.kt               Tier-3 ASM walk + reverse index (v2)
+    ClasspathFingerprint.kt          Tier-1 dirty detection
+    SandboxScope.kt                  Per-classloader storage helper
+    ProcessCache.kt                  Process-level pure-data cache helper
+    SandboxLifecycle.kt              Measurement + recycle policy + warm spare
+    protocol/
+      Messages.kt                    @Serializable request/response types
+
+gradle-plugin/                       ADDITIVE ONLY (one helper extraction)
+  src/main/kotlin/.../plugin/daemon/
+    DaemonBootstrapTask.kt           Emits launch-descriptor JSON
+    DaemonExtension.kt               composePreview.experimental.daemon { … }
+    DaemonClasspathDescriptor.kt     Serialises the JVM launch spec
+
+vscode-extension/                    ADDITIVE ONLY (one router shim)
+  src/daemon/
+    daemonClient.ts                  JSON-RPC over stdio
+    daemonProcess.ts                 Spawn/respawn/health
+    daemonProtocol.ts                Types mirroring Messages.kt
+    daemonGate.ts                    Feature-flag check + fallback to gradleService
+
+samples/
+  android-daemon-bench/              NEW — latency harness, diff against existing PNGs
+```
+
+## 7. Sharing strategy — what crosses the boundary
+
+**`renderer-android-daemon` depends on `renderer-android`** for already-extracted helpers that have no test-runner coupling: `AccessibilityChecker`, `GoogleFontInterceptor`, `AnimationInspector`, `ScrollDriver`, `PixelSystemFontAliases`, `RenderManifest`, `PreviewRenderStrategy`. These are already separate files and safe to import.
+
+**`RobolectricRenderTest.kt` itself is NOT a dependency.** The per-preview render body (qualifiers + `setContent` + `advanceTimeBy` + `captureRoboImage`) is **duplicated** into `RenderEngine.kt` for v1, because:
+
+- The daemon path is experimental; if it diverges, the JUnit path is untouched.
+- Extracting the render body from a 1500-line test class into a shared helper is a real refactor that risks the working path. Not worth it before the daemon proves itself.
+- Reconciliation is a v2 task: once the daemon is stable for a release or two, extract the shared body into `renderer-android` and have the test class call into it. CI gate: byte-identical PNGs from both paths against `samples/android`.
+
+**Drift detection:** `samples/android-daemon-bench` renders the full `samples/android` set via the daemon and pixel-diffs against the PNGs from `samples:android:renderAllPreviews`. Runs on every PR. First diff = either a real bug or a missed port.
+
+**One shared-helper extraction in `gradle-plugin`.** The daemon needs the same classpath, JVM args, and system properties that `AndroidPreviewSupport` builds today. Hoist `buildTestClasspath(variant)` and `buildJvmArgs(variant)` into a package-private `AndroidPreviewClasspath.kt`; existing `registerAndroidTasks` calls the helpers instead of inlining. Behaviour byte-identical, callers unchanged otherwise. Existing functional tests catch any regression.
+
+## 8. Staleness cascade — when do we actually re-render?
+
+A four-tier cascade. Each tier is cheaper than the next; stop at the cheapest "no work" answer.
+
+### Tier 1 — project fundamentally changed
+
+**Trigger:** classpath JAR list, Compose/AndroidX versions, `compileSdk`, Robolectric config, or `robolectric.properties` content changed.
+
+**Cheap signal:** SHA-256 over a small fixed set: `libs.versions.toml`, all `build.gradle.kts`, `settings.gradle.kts`, `gradle.properties`, `local.properties`. Recompute only on file save in those paths.
+
+**Authoritative signal:** SHA over the resolved test runtime classpath JAR list (paths + mtimes), computed at daemon start and re-checked on cheap-signal hit.
+
+**Action:** emit `classpathDirty`, exit cleanly. VS Code re-runs `composePreviewDaemonStart` and the new daemon comes up with the new classpath. Do **not** swap classloaders in-place — that's where leaks and version-skew bugs live.
+
+### Tier 2 — preview list possibly changed
+
+**Trigger:** edit to a `.kt` file that either currently contributes previews or might newly contribute one.
+
+**"Currently contributes" set is free** once we add `sourceFile: String?` to `PreviewInfo` (kotlinc writes the `SourceFile` bytecode attribute; ClassGraph exposes it). Save to a file in this set → re-run discovery scoped to just that file's compiled classes.
+
+**"Might newly contribute" via cheap pre-filter:** regex-grep the saved file's text for `@Preview` (or any registered multi-preview annotation name we already know). Match → escalate to discovery. No match → Tier 2 clean. ~1ms per save, no false negatives unless the user defines a brand-new multi-preview meta-annotation in the same save (rare; recovered by the next save touching anything).
+
+**Incremental discovery scope:** ClassGraph filtered to a single classpath element / package. After kotlinc rebuilds, re-scan only `build/.../classes/` paths whose mtime moved. Diff against cached `previews.json`, emit `discoveryUpdated`.
+
+### Tier 3 — a preview's render output may have changed
+
+This is the hard tier. `FooPreview()` calls `BarComposable()` defined in another file; `BarKt` changed; `FooPreview` is now stale even though `FooKt` wasn't touched.
+
+**v1 conservative:** any `.kt` change inside the module's source set marks **every preview in the module** as stale. Combined with Tier 4 (focus filter), the waste is bounded — we only re-render what the user is looking at.
+
+**v2 precise (deferred):** per-preview reachable-class set built via ASM walk at discovery time. Reverse index `class → previews that transitively reference it`. Map class → sourceFile via the `SourceFile` attribute. Stale set = union of reverse-index lookups for changed classes. Cost: one ASM walk per preview at discovery, ~ms per class.
+
+**Resources:** treat any `res/**` change as "all previews in module stale" for v1. Resource edits are infrequent enough that brute-force + visibility filter is fine.
+
+### Tier 4 — is the user looking at this?
+
+**State from VS Code:**
+
+- `setVisible({ ids })` — preview cards currently visible in the panel webview (not just the file scope; the actual visible cards).
+- `setFocus({ ids })` — active selection (click, hover, file scope change). Rendered first.
+
+**Render policy:**
+
+- Stale ∩ visible → render now, in priority order (focus first).
+- Stale ∩ not-visible → mark stale, render lazily on scroll-into-view, or background after the visible queue drains.
+- Not stale → no-op.
+
+**Coalescing:** rapid saves produce overlapping stale sets. The render queue dedupes by preview ID. If a render is in-flight when its preview is re-marked stale, mark "needs another pass after this one finishes" rather than cancelling — Robolectric mid-render cancellation is a leak source.
+
+### Cost shape
+
+| Tier | Per-save cost when clean | Per-save cost when dirty |
+|------|--------------------------|--------------------------|
+| 1    | 4 file SHAs              | daemon restart (~5s)     |
+| 2    | regex grep of one file   | scoped ClassGraph + diff (~50–200ms) |
+| 3    | reverse-index lookup (μs) | N × per-preview render (visible only) |
+| 4    | set intersection          | render                   |
+
+Clean save (file in module, no previews depend on it, user not looking) → ~5ms total. That's the floor.
+
+## 9. Sandbox lifecycle
+
+### Bootstrap
+
+The daemon runs a single dummy `@Test` whose body blocks on a `LinkedBlockingQueue<RenderRequest>` until shutdown. This holds a Robolectric sandbox open without re-implementing sandbox setup — we inherit all the `robolectric.properties` plumbing for free. The "test" never returns; the JVM exits when the daemon stops.
+
+### Per-preview render loop
+
+Prologue:
+
+1. Drain ShadowPackageManager records added by the previous preview (see § 11).
+2. Reset `RuntimeEnvironment.setQualifiers/setFontScale` for the new preview.
+3. Re-create `ComponentActivity` (cheaper than risking unknown reuse leaks).
+
+Render body: same as `RobolectricRenderTest` — `setContent { ... }`, `mainClock.autoAdvance = false`, `advanceTimeBy(CAPTURE_ADVANCE_MS)`, `captureRoboImage(...)`.
+
+Epilogue:
+
+1. `setContent { }` (empty) to give Compose a frame to dispose `LaunchedEffect` / `DisposableEffect`.
+2. Encode bitmap, then `bitmap.recycle()`.
+3. Close any `HardwareRenderer` / `ImageReader` opened by the capture path.
+
+### Recycle policy
+
+Trigger on any:
+
+- **Heap (post-GC) >** `daemon.maxHeapMb` (default 1024). Hard ceiling.
+- **Heap drift > 30% over rolling window of 50 renders.** Catches slow leaks before the ceiling.
+- **Render time drift > 50% over rolling window.** Catches GC-pressure leaks.
+- **Class histogram delta > Y for any tracked class over rolling window.** Catches known leak shapes early.
+- **Render count >** `daemon.maxRendersPerSandbox` (default 1000). Belt-and-braces.
+- **`leakSuspected` event from active detection (§ 10).** Immediate.
+
+Each trigger emits `sandboxRecycle({ reason, ageMs, renderCount })`.
+
+### Warm spare
+
+The naive recycle is "drop sandbox, GC, build new one" — a 3–6s user-visible pause. Avoid that:
+
+- Daemon keeps two sandbox slots: `active` and `spare`.
+- Background thread builds a new `spare` after every recycle and at startup.
+- Recycle = atomically swap `spare → active`, schedule old `active` for teardown, kick off building a new `spare`. User-visible cost on recycle: zero, assuming spare is ready.
+- Spare not ready → block the next render, surface `daemonWarming` to VS Code so the panel shows a spinner. If this happens twice in a row, bump recycle thresholds.
+
+Spare cost: doubles daemon idle memory. Configurable via `daemon.warmSpare=false` for memory-constrained dev machines.
+
+### Sandbox teardown verification
+
+Drop the strong sandbox reference, force GC, then check the WeakReference to the sandbox classloader. If it doesn't clear within 2 GCs → log `sandboxLeaked`. After 3 `sandboxLeaked` events, exit cleanly; VS Code re-bootstraps. This is the ultimate safety valve — the JVM permanently leaks per leaked sandbox, so we cap accumulation.
+
+## 10. Memory leak defense in depth
+
+Three layers, plus warm-spare to hide cost, plus proactive fixes for known leak shapes.
+
+### Layer 1 — measure on every render (always on)
+
+Cheap (<5ms), in-band, emitted on `renderFinished`:
+
+- Heap after GC: `MemoryMXBean.getHeapMemoryUsage().used` post-GC.
+- Native/off-heap: `BufferPoolMXBean` for direct buffers; `Debug.getNativeHeapAllocatedSize()` inside the sandbox for HardwareRenderer + Bitmaps.
+- Class instance counts: programmatic `jcmd GC.class_histogram` via `DiagnosticCommandMBean.invoke("gcClassHistogram")`. Track `Composition`, `Recomposer`, `ComposeView`, `ComponentActivity`, `Bitmap`, `HardwareRenderer`, `ImageReader`.
+- Render time (already measured).
+- Sandbox age: render count + wall-clock since sandbox start.
+
+Bench harness consumes this as CSV; CI soak test asserts bounded growth.
+
+### Layer 2 — active leak detection (periodic, opt-in)
+
+Every Nth render (default 50) or via `--detect-leaks` daemon flag:
+
+- **Weak-reference probe.** Hold `WeakReference` to activity, composition, root `View`. After the next preview's `setContent` swap, force GC twice with 50ms sleep; check if previous refs cleared. Anything reachable → emit `leakSuspected` with class name and last-render context.
+- **LeakCanary JVM (`leakcanary-jvm-test`).** On-demand via `--detect-leaks=heavy`. Heavy (seconds), runs Shark on a heap dump for reference chains. Worth wiring up because reference-chain output is exactly what we'd ask for in a bug report.
+- **JFR.** Always enabled with a 5MB in-memory ring buffer. On `leakSuspected` or recycle, dump JFR to `.compose-preview-history/leaks/`. Negligible cost.
+
+### Layer 3 — recycle (see § 9)
+
+### Layer 4 — known leak shapes, fix proactively
+
+Render loop's per-preview prologue/epilogue handles these without waiting for detection:
+
+- **Compose disposal.** Empty `setContent { }` flush before teardown, so `LaunchedEffect`/`DisposableEffect` cleanup runs.
+- **Activity recreate per preview** (v1 default; reuse only if bench shows it's necessary).
+- **Bitmap recycle** after encoding.
+- **HardwareRenderer/ImageReader** closed in `finally`.
+- **ShadowPackageManager adds** tracked and reversed (see § 11).
+
+## 11. Scope discipline — `SandboxScope` and `ProcessCache`
+
+The invariant: **sandbox death wipes everything written by our helpers.** Helpers needing cross-render state declare a scope; recycle path doesn't need bespoke per-helper cleanup.
+
+### Two storage tiers
+
+**`ProcessCache`** — JVM-process-level, survives sandbox recycle. **Only pure data**: bytes, strings, primitives, paths. Anything that could hold a transitive reference to a class loaded by the Robolectric classloader is banned.
+
+Examples that fit: downloaded GoogleFont bytes (`Map<String, ByteArray>`), the disk cache directory, parsed manifest config.
+
+**`SandboxScope`** — keyed off the current sandbox's classloader via `WeakHashMap<ClassLoader, MutableMap<String, Any>>`. Holds anything referencing sandbox-loaded classes: `Typeface` registrations, the GoogleFont interceptor instance with its Compose hook, `ShadowPackageManager` add-records, cached `Class<?>`, `Recomposer` instances, mid-render `Bitmap` refs.
+
+When the sandbox is dropped and the classloader becomes unreachable, the WeakHashMap entry collects automatically. The "recycle" mechanic is just "drop active sandbox reference and GC."
+
+### Helper
+
+```kotlin
+object SandboxScope {
+  private val store = WeakHashMap<ClassLoader, MutableMap<String, Any>>()
+
+  @Suppress("UNCHECKED_CAST")
+  fun <T : Any> get(key: String, init: () -> T): T {
+    val cl = Thread.currentThread().contextClassLoader  // Robolectric sets this
+    val map = synchronized(store) { store.getOrPut(cl) { mutableMapOf() } }
+    return synchronized(map) { map.getOrPut(key) { init() } } as T
+  }
+
+  fun activeSandboxCount(): Int = synchronized(store) {
+    System.gc(); store.size  // diagnostic; not hot path
+  }
+}
+```
+
+`activeSandboxCount()` is the leak canary — after a recycle and 2 GCs it should drop by one. If it doesn't, something on the process-level path is pinning a sandbox classloader.
+
+### Helper audit
+
+| Helper | Today | Daemon-safe? | Action |
+|--------|-------|--------------|--------|
+| `GoogleFontInterceptor` (disk cache) | Disk files keyed by URL hash | yes (ProcessCache shape) | leave |
+| `GoogleFontInterceptor` (Compose hook + `Typeface` cache) | Hook into sandbox-loaded Compose runtime, holds `Typeface` refs | currently a singleton | wrap behind `SandboxScope.get("googleFontInterceptor") { … }` in daemon path; JUnit path unchanged |
+| `PixelSystemFontAliases.seedSystemFontMap()` | `Map<String, String>` of name → path | yes (pure strings) | verify; if it secretly holds a `Typeface`, move to SandboxScope |
+| `ShadowFontsContractCompat` | Robolectric `@Implements` shadow | yes (sandbox-bound by definition) | leave |
+| `ShadowPackageManager` adds | No record of what *we* added | no — leaks across previews within a sandbox (correctness, not memory) | `SandboxScope.get("pmAdds") { … }`; reverse adds in per-preview epilogue |
+| `AccessibilityChecker` | Per-render ATF state | yes | leave |
+| `AnimationInspector` | Hooks into Compose recomposer | sandbox-loaded refs | SandboxScope it |
+| `RuntimeEnvironment.setQualifiers/setFontScale` | Robolectric internal static | yes (lives inside sandbox classloader) | leave |
+| Manifest / config parsing | Pure data | yes | leave |
+
+The two real fixes are GoogleFont interceptor wrapping and ShadowPackageManager add-tracking.
+
+### JUnit path unchanged
+
+The original `RobolectricRenderTest` runs one sandbox per Gradle test fork JVM, then exits. Process-level statics in helpers don't cause leaks there because the JVM dies. So the `SandboxScope` discipline is **daemon-module-only** — existing helpers in `renderer-android` keep working unchanged.
+
+### Lint to keep the discipline
+
+A small static check in the daemon module's build: scan for `companion object` / `object` declarations holding any field whose declared type comes from Compose, AndroidX, or Android framework packages. If found → fail with "use SandboxScope." Cheap, catches the regression class that's easiest to introduce by accident.
+
+## 12. VS Code extension routing
+
+One shim, one place. In `extension.ts` where `gradleService.renderPreviews(...)` is called today:
+
+```ts
+const renderer = daemonGate.isEnabled(config)
+  ? daemonClient
+  : gradleService;
+await renderer.renderPreviews(module, tier);
+```
+
+`daemonGate` checks `composePreview.experimental.daemon` and verifies daemon health. On daemon failure, falls back to `gradleService` automatically and surfaces a notification. Existing `gradleService.ts`, file watcher, and debouncer in `extension.ts` are untouched — the daemon client receives the same calls, plus visibility/focus signals from the webview.
+
+## 13. Latency budget
+
+Estimated; first task in implementation is to capture a real baseline with the bench harness.
+
+| Phase | Cold | Warm (Gradle daemon hot, no code change) | Daemon warm |
+|-------|------|------------------------------------------|-------------|
+| Gradle config + up-to-date checks | 3–8s | 1–3s | 0 |
+| `compileKotlin` (single file) | — | 1–4s | 1–4s |
+| `discoverPreviews` ClassGraph scan | 1–3s | 1–3s | 10–100ms (incremental) |
+| Test JVM fork + Robolectric sandbox init | 3–6s | 3–6s | 0 |
+| Render N previews | 0.3–1s each | 0.3–1s each | 0.3–1s each |
+
+Daemon-warm floor for a single focused preview: **kotlinc (1–2s) + 1 render (0.3–1s) ≈ 1.5–3s**. Sub-second is achievable when the user pre-saves a class-only file with a non-source change, or with a v2 kotlinc-daemon path. v1 target: **< 1s for a single focused preview when no kotlinc work is needed; < 3s with kotlinc.**
+
+## 14. Validation strategy
+
+Three checkpoints, each a buildable artifact:
+
+1. **Bench harness** (week 1, before any rewrite). `:samples:android-daemon-bench:benchPreviewLatency` times: cold render, warm render with no edit, warm render after a 1-line edit. Captures baseline. Re-run after each phase.
+2. **Headless prototype** (week 1). One-off `main()` that uses the dummy-`@Test`-holds-sandbox pattern, renders 10 previews from `samples/android` in a loop, reading manifest entries from stdin. If sandbox reuse + composition replacement works for 10 iterations without leaks or visual drift vs. baseline PNGs → architecture validated. If not, we know early.
+3. **End-to-end with VS Code** (week 2). Daemon + extension behind the flag. Compare render-after-save latency against bench numbers. Acceptance: ≥5× speedup on warm path for a single focused preview, no visual regressions in `samples/android` PNG diffs.
+
+## 15. CI gates before un-flagging
+
+1. `samples:android-daemon-bench:renderAll` produces PNGs that pixel-diff identical to `samples:android:renderAllPreviews`.
+2. 1000-render soak test in a single sandbox completes without OOM, with bounded heap growth (< 50MB drift over the run).
+3. Tier-1 dirty detection correctly recycles the daemon on a `libs.versions.toml` bump in a synthetic functional test.
+4. End-to-end save→render latency < 1s for a single focused preview on `samples/android`, on the reference dev machine. Baseline captured before any of this work starts.
+5. Zero `sandboxLeaked` events and ≤ 2 `sandboxRecycle` events over the 1000-render soak.
+
+## 16. Risks
+
+- **Robolectric sandbox memory leak over many renders.** Mitigated by the multi-layer detection in § 10 and the soak gate in § 15.
+- **Hidden global state in renderer.** `ShadowPackageManager` adds, GoogleFont interceptor caches, font alias seeding. Mitigated by the helper audit in § 11 and the `SandboxScope` discipline.
+- **Classpath drift undetected.** Daemon misses a `libs.versions.toml` bump and silently renders against stale code. Mitigated by Tier-1 fingerprint over both file SHAs and the resolved classpath JAR list.
+- **AGP/Robolectric version churn.** Pipeline is already pinned to Robolectric SDK 35 with known-fragile combinations. Daemon doesn't change that surface but extends "things that can break." Mitigated by pinned versions + samples in CI on bumps.
+- **VS Code lifecycle.** Daemon must shut down on extension deactivate / window close, not leak JVMs. Mitigated by parent-PID watchdog + idle timeout.
+- **Concurrency.** Two saves arriving 100ms apart racing. Mitigated by single-threaded render queue + dedup-by-preview-ID + "needs another pass" flag.
+- **Drift between duplicated render body in `RenderEngine.kt` vs `RobolectricRenderTest.kt`.** Mitigated by per-PR pixel-diff gate. Reconciled in v2 by extracting shared body.
+
+## 17. Decisions log
+
+Resolved during design discussion:
+
+- **Per-module vs per-project sandbox:** per-module. Robolectric sandbox semantics + renderer-vs-consumer version alignment risk make per-project not worth it for v1.
+- **Daemon process lifecycle:** spawn-on-demand from VS Code by default; manual `gradle composePreviewDaemonStart --foreground` mode also available for debugging.
+- **CLI daemon mode:** no, v1 is VS Code-only. CLI keeps using the Gradle task. CLI's primary use case (CI, agent rendering) doesn't benefit from a hot sandbox.
+- **Keep Gradle `renderPreviews` task indefinitely:** yes, for now. It's the always-available fallback and the CI-canonical path. Daemon never replaces it.
+- **Render body sharing:** duplicated into daemon module for v1; reconciled in v2 once daemon stable. Drift caught by pixel-diff CI gate.
+- **Plugin helper extraction:** `buildTestClasspath` and `buildJvmArgs` hoisted into package-private helpers so daemon and existing test task share the same logic. Behaviour byte-identical, callers unchanged.
+- **Tier-3 dependency index:** deferred to v2. v1 uses conservative module-stale + visibility filter.
+- **kotlinc / compile-daemon integration:** out of scope. We let Gradle drive Kotlin compilation as today.
+
+## 18. Future work (v2+)
+
+- Extract shared render body from daemon back into `renderer-android`; `RobolectricRenderTest` becomes a thin wrapper.
+- Per-preview ASM-walk reachability index for precise Tier-3 invalidation.
+- Per-project sandbox sharing (parent classloader + per-module child loaders).
+- CLI / MCP daemon mode for batch rendering without Gradle.
+- Direct kotlinc-daemon integration to skip the Gradle compile step.
+- Resource-edit precision: parse changed XML, cross-reference Compose's resolved-resource cache.

--- a/docs/daemon/README.md
+++ b/docs/daemon/README.md
@@ -1,0 +1,32 @@
+# Preview daemon — design docs
+
+Design and planning for an experimental persistent preview server that replaces the per-save Gradle invocation with a long-lived JVM holding a hot Robolectric sandbox.
+
+> **Status:** design only. No code shipped yet. v1 will land behind `composePreview.experimental.daemon=true` with a "may eat your laundry" warning.
+
+## What this is
+
+Today, every preview refresh in the VS Code extension runs the Gradle `renderPreviews` task: Gradle config + classpath up-to-date checks + JVM fork + Robolectric sandbox init + render. Cold this is 10–20s; warm with a no-code-change save it's still 5–10s, dominated by Gradle config and Robolectric bootstrap.
+
+The daemon keeps the Robolectric sandbox alive between saves so the per-save hot path collapses to just kotlinc + N renders. Target: **sub-second refresh for a single focused preview after a no-classpath-change save.**
+
+## Files
+
+- **[DESIGN.md](DESIGN.md)** — the full architecture: scope, module layout, staleness cascade, lifecycle, leak defense, validation strategy, decisions log.
+- **[TODO.md](TODO.md)** — work breakdown with parallelisation guidance: which streams can run in parallel, which agents own what, definition-of-done per chunk.
+
+## Non-goals (v1)
+
+- Per-project (multi-module) sandbox sharing — deferred. Each module gets its own daemon.
+- CLI / MCP daemon mode — CLI keeps using the Gradle task.
+- Replacing the Gradle `renderPreviews` task — kept as fallback and CI-canonical path indefinitely.
+- Hot kotlinc / compile daemon integration — v2.
+- Tier-3 dependency-graph reachability index — v1 ships with conservative "module-changed = all previews stale, filtered by visibility."
+
+## How to use these docs
+
+If you're reviewing the proposal: read [DESIGN.md](DESIGN.md) end to end (~30 min).
+
+If you're implementing or about to assign work to agents: read [DESIGN.md](DESIGN.md) for context, then drive the work from [TODO.md](TODO.md) which has the dependency graph and parallel work streams.
+
+If you're triaging a daemon bug: future `docs/daemon/TROUBLESHOOTING.md` once the thing exists.

--- a/docs/daemon/TODO.md
+++ b/docs/daemon/TODO.md
@@ -1,0 +1,329 @@
+# Preview daemon — work breakdown & parallelisation
+
+> Read [DESIGN.md](DESIGN.md) first. This file enumerates concrete work items, their dependencies, and how to split them across parallel agents.
+
+## How to use this file
+
+- **Phases** are chronological gates — Phase N must complete before Phase N+1 starts.
+- **Streams** within a phase run in parallel. Each stream is sized to fit one focused agent.
+- **Each task** has explicit `Depends on` IDs and a **DoD** (definition of done) — when an agent completes a task, the DoD is what the reviewer checks.
+- Tasks marked **[shared seam]** modify code visible to other streams. Schedule those serially and notify other agents when merged.
+
+## Branching strategy for parallel agents
+
+- One worktree per agent: `agent/preview-daemon-streamA`, `agent/preview-daemon-streamB`, etc.
+- All branch from `agent/preview-daemon-design` (the docs branch — these design docs are the contract).
+- Each stream opens its own PR against `main`. Sequential merges in dependency order.
+- Phase 0 changes go to a single integration branch first; everyone rebases on it before Phase 1.
+
+---
+
+## Phase 0 — foundations (sequential, blocks everything)
+
+These must land first because every other stream consumes them. Single agent or pair-coordinated; small but load-bearing.
+
+### P0.1 — Capture latency baseline [Stream D]
+
+Build `:samples:android-daemon-bench` (skeleton sample module) with a `benchPreviewLatency` task that times the existing Gradle `renderPreviews` path: cold, warm-no-edit, warm-after-1-line-edit. Output CSV with phase breakdown (config, compile, discovery, fork, render).
+
+- **Depends on:** none
+- **DoD:** CSV checked into `docs/daemon/baseline-latency.csv` for the reference dev machine. Numbers referenced from `DESIGN.md` § 13 are validated or corrected.
+
+### P0.2 — Add `sourceFile` to `PreviewInfo` [Stream A] [shared seam]
+
+Extend `PreviewInfo` (in `gradle-plugin/.../PreviewData.kt`) with `sourceFile: String?` populated from `ClassInfo.sourceFile` (ClassGraph exposes the bytecode `SourceFile` attribute). Wire through `DiscoverPreviewsTask`. Update `previews.json` schema.
+
+- **Depends on:** none
+- **DoD:** existing `:samples:android:renderAllPreviews` still passes. New field present in generated `previews.json` and surfaced in `PreviewInfo` consumers. Functional test asserts non-null for at least one preview in `samples/android`.
+
+### P0.3 — Hoist classpath/JVM-args helpers [Stream A] [shared seam]
+
+Extract `buildTestClasspath(variant)` and `buildJvmArgs(variant)` from `AndroidPreviewSupport.kt` into a package-private `AndroidPreviewClasspath.kt`. Existing `registerAndroidTasks` calls the helpers instead of inlining. Behaviour must be byte-identical.
+
+- **Depends on:** none
+- **DoD:** `:gradle-plugin:functionalTest` passes unchanged. `:samples:android:renderAllPreviews` produces identical PNGs to `main` (manual diff check in PR description).
+
+### P0.4 — Lock IPC protocol [Streams B + C, joint] [shared seam]
+
+Define the JSON-RPC protocol in `docs/daemon/PROTOCOL.md` (new file). Lock message shapes for `setVisible`, `setFocus`, `fileChanged`, `renderNow`, `shutdown`, `discoveryUpdated`, `renderStarted/Finished/Failed`, `classpathDirty`, `sandboxRecycle`, `daemonWarming`. Include JSON examples and field semantics.
+
+- **Depends on:** none
+- **DoD:** doc merged. Both Kotlin (`Messages.kt`) and TypeScript (`daemonProtocol.ts`) types in later phases reference it as the source of truth.
+
+---
+
+## Phase 1 — first end-to-end render (parallel)
+
+Goal: a daemon JVM that can be spawned by VS Code and render a single preview to PNG behind the feature flag. No optimisations, no recycle, no incremental anything.
+
+### Stream A — Gradle bootstrap
+
+#### A1.1 — `composePreviewDaemonStart` task
+
+New `DaemonBootstrapTask` that, given a variant, emits `build/compose-previews/daemon-launch.json` containing: classpath JARs, JVM args, system properties, java launcher path. Uses helpers from P0.3.
+
+- **Depends on:** P0.3
+- **DoD:** running `./gradlew :samples:android:composePreviewDaemonStart` writes a valid descriptor that, when manually exec'd as `java @args`, starts a JVM that loads `RobolectricHost.main()`.
+
+#### A1.2 — `DaemonExtension` DSL
+
+Add `composePreview.experimental.daemon { … }` extension with `enabled`, `maxHeapMb`, `maxRendersPerSandbox`, `warmSpare` fields. No-op when disabled. Documented in `docs/daemon/CONFIG.md` (new).
+
+- **Depends on:** A1.1
+- **DoD:** unit test on the extension's defaults. README of daemon docs links to config doc.
+
+### Stream B — daemon core
+
+#### B1.1 — Module skeleton
+
+Create `renderer-android-daemon/` module. `build.gradle.kts` depends on `renderer-android` + Robolectric + kotlinx-serialization. Empty `DaemonMain.kt` that prints "hello" and exits.
+
+- **Depends on:** none
+- **DoD:** `./gradlew :renderer-android-daemon:assemble` succeeds. Manual `java -cp ... DaemonMainKt` prints "hello".
+
+#### B1.2 — `Messages.kt` protocol types
+
+`@Serializable` Kotlin data classes mirroring P0.4. One file under `daemon/protocol/`.
+
+- **Depends on:** P0.4, B1.1
+- **DoD:** unit test round-trips one of each message via `Json.encodeToString` / `decodeFromString`.
+
+#### B1.3 — `DaemonHost` (sandbox holder)
+
+A class that runs a single dummy `@Test` whose body blocks on `LinkedBlockingQueue<RenderRequest>`. Submitting a request triggers a render in the sandbox thread; result returned via callback.
+
+- **Depends on:** B1.1
+- **DoD:** unit test: submit 10 dummy renders to a single host instance; all complete; sandbox classloader is reused (assert via reflection on `Thread.currentThread().contextClassLoader.hashCode()`).
+
+#### B1.4 — `RenderEngine` (per-preview body)
+
+Duplicate the relevant parts of `RobolectricRenderTest`'s render body into `RenderEngine.kt`. Inputs: `PreviewInfo`, output dir. Output: `RenderResult { pngPath, tookMs }`. **Comment in the file noting the duplication and the reconciliation v2 plan.**
+
+- **Depends on:** B1.3
+- **DoD:** rendered PNG of one `samples/android` preview via `RenderEngine` is byte-identical (or pixel-identical with no AA drift) to the same preview rendered via `RobolectricRenderTest`.
+
+#### B1.5 — `JsonRpcServer` over stdio
+
+Read line-delimited JSON from stdin, dispatch to handlers, write replies/notifications to stdout. Single-threaded dispatch onto the host's render queue.
+
+- **Depends on:** B1.2, B1.3
+- **DoD:** integration test: spawn the daemon JVM as a subprocess, send `renderNow` for one preview, assert the PNG appears and a `renderFinished` notification is read back.
+
+#### B1.6 — `SandboxScope` + `ProcessCache` helpers
+
+Implement the helpers from `DESIGN.md` § 11. Add the lint check (script under `gradle-plugin/build-logic/`) that fails the daemon module's build if `companion object` / `object` declarations hold Compose/AndroidX/Android-typed fields.
+
+- **Depends on:** B1.1
+- **DoD:** unit test: `SandboxScope.activeSandboxCount()` decreases by one after dropping a sandbox + 2 GCs. Lint check: introduce a deliberate violation; build fails with helpful message.
+
+#### B1.7 — Wrap `GoogleFontInterceptor` and `ShadowPackageManager` adds
+
+In the daemon module, add wrappers that delegate to the existing `renderer-android` helpers but route mutable state through `SandboxScope`. Per-preview prologue/epilogue in `RenderEngine` reverses ShadowPackageManager adds.
+
+- **Depends on:** B1.4, B1.6
+- **DoD:** integration test: render preview A (which adds activity X to the package manager), then preview B. Assert preview B's `PackageManager` does **not** contain activity X.
+
+### Stream C — VS Code client
+
+#### C1.1 — `daemonProtocol.ts` types
+
+TypeScript types mirroring P0.4. Match field names exactly.
+
+- **Depends on:** P0.4
+- **DoD:** lint passes. Unit test serialises one of each message and validates against the JSON-shape definitions in P0.4.
+
+#### C1.2 — `daemonProcess.ts` lifecycle
+
+Spawn the daemon JVM (using the descriptor from A1.1), monitor process health, watchdog on parent-PID exit, restart on `classpathDirty`, idle timeout shutdown.
+
+- **Depends on:** A1.1, C1.1
+- **DoD:** unit test (mocked child process): spawn, send shutdown, child exits cleanly. Restart on simulated `classpathDirty` notification.
+
+#### C1.3 — `daemonClient.ts` JSON-RPC client
+
+Stdio JSON-RPC over the spawned process. Methods mirror those used by `gradleService.ts` (specifically `renderPreviews`, `discoverPreviews`).
+
+- **Depends on:** B1.5, C1.2
+- **DoD:** integration test against the real daemon JAR: spawn, render one preview from `samples/android`, PNG appears, returned manifest matches expected shape.
+
+#### C1.4 — `daemonGate.ts` router shim
+
+Read `composePreview.experimental.daemon` setting. If enabled and daemon healthy → use `daemonClient`; else fall back to `gradleService`. One call site in `extension.ts`. On daemon failure, log + notification + auto-fallback for the remainder of the session.
+
+- **Depends on:** C1.3
+- **DoD:** manual smoke test in VS Code: enable flag, observe daemon spawn on first preview action, render works. Disable flag, observe normal Gradle path.
+
+---
+
+## Phase 2 — productionise (parallel)
+
+Goal: the daemon is fast enough and stable enough to be the recommended path for daily editor use, even if still flagged.
+
+### Stream B — daemon hardening
+
+#### B2.1 — `ClasspathFingerprint` (Tier 1)
+
+SHA over `libs.versions.toml`, all `build.gradle.kts`, `settings.gradle.kts`, `gradle.properties`, `local.properties`. Re-check on file change in those paths. Authoritative SHA over resolved classpath JAR list at startup. On hit: emit `classpathDirty`, exit cleanly.
+
+- **Depends on:** B1.5
+- **DoD:** integration test: bump a version in `libs.versions.toml` while daemon running; daemon emits `classpathDirty` and exits within 2s.
+
+#### B2.2 — `IncrementalDiscovery` (Tier 2)
+
+Scoped ClassGraph scan of a single classpath element. Regex pre-filter for `@Preview` on saved files outside the existing preview-bearing set. Diff against cached `previews.json`. Emit `discoveryUpdated`.
+
+- **Depends on:** P0.2, B1.5
+- **DoD:** unit test: synthetic project with 100 preview-bearing classes; edit one; discovery completes in < 100ms; diff is exactly that one class's previews.
+
+#### B2.3 — `SandboxLifecycle` measurement (Layer 1)
+
+Per-render: heap post-GC, native heap, class histogram for tracked classes, render time, sandbox age. Emitted on `renderFinished.metrics`.
+
+- **Depends on:** B1.5
+- **DoD:** soak test runs 100 renders; CSV shows all metrics populated; no measurement adds > 10ms to render time.
+
+#### B2.4 — Active leak detection (Layer 2)
+
+Weak-reference probe every Nth render. `--detect-leaks=heavy` flag wires LeakCanary JVM-test. JFR ring buffer always on; dumped on `leakSuspected` or `sandboxRecycle`.
+
+- **Depends on:** B2.3
+- **DoD:** synthetic leak (deliberately retain Activity ref) detected within 50 renders. JFR dump appears in `.compose-preview-history/leaks/`.
+
+#### B2.5 — Recycle policy + warm spare (Layer 3)
+
+Triggers from `DESIGN.md` § 9. `active`/`spare` slots; background spare builder. Recycle = atomic swap + teardown old + start new spare. `daemonWarming` notification when spare not ready.
+
+- **Depends on:** B1.3, B2.3
+- **DoD:** integration test: force recycle (via `maxRendersPerSandbox=10`), assert no user-visible pause (next render starts within 50ms of swap). Spare always ready except in deliberate spare-blocked test.
+
+#### B2.6 — Sandbox teardown verification
+
+WeakReference to sandbox classloader; force GC after recycle; emit `sandboxLeaked` if classloader not collected within 2 GCs. After 3 events, exit cleanly.
+
+- **Depends on:** B2.5
+- **DoD:** synthetic leak (deliberately pin classloader from process-level cache); first recycle emits `sandboxLeaked`; daemon exits after 3 events.
+
+### Stream C — VS Code refinements
+
+#### C2.1 — Visibility tracking from webview
+
+Webview reports preview cards entering/leaving viewport (IntersectionObserver). Extension translates into `setVisible({ ids })` to daemon.
+
+- **Depends on:** C1.4
+- **DoD:** manual: scroll panel; daemon log shows `setVisible` updates with correct IDs.
+
+#### C2.2 — Focus signal
+
+On hover / click / file scope change, send `setFocus({ ids })` (subset of visible).
+
+- **Depends on:** C2.1
+- **DoD:** manual: click a preview card; daemon renders that one first when multiple are stale.
+
+#### C2.3 — Daemon-warming UX
+
+Render `daemonWarming` and `sandboxRecycle` notifications as a non-blocking status indicator in the panel.
+
+- **Depends on:** B2.5, C1.4
+- **DoD:** visual review of status indicator during a forced recycle.
+
+### Stream D — bench & CI
+
+#### D2.1 — Daemon-mode bench
+
+Extend P0.1 bench to include daemon-mode timings: spawn cost, first-render cost, warm-render cost, edit-then-render cost. Same CSV format.
+
+- **Depends on:** B1.5, P0.1
+- **DoD:** `docs/daemon/baseline-latency.csv` updated with daemon columns. PR description includes ratio analysis.
+
+#### D2.2 — Pixel-diff CI gate
+
+CI job that runs `samples:android-daemon-bench:renderAll` (daemon path) and pixel-diffs against `samples:android:renderAllPreviews` (Gradle path). Must be 100% identical.
+
+- **Depends on:** B1.7, D2.1
+- **DoD:** GitHub Actions workflow added; job green on this branch; deliberately introduce a render bug → job fails with diff image artifact.
+
+#### D2.3 — Soak test in CI
+
+Runs nightly. 1000 renders in a single sandbox on `samples/android`. Asserts: no OOM, heap drift < 50MB, zero `sandboxLeaked`, ≤ 2 `sandboxRecycle`.
+
+- **Depends on:** B2.5, B2.6
+- **DoD:** workflow green; metrics summary posted as workflow output.
+
+---
+
+## Phase 3 — un-flag decision (sequential)
+
+### P3.1 — Documentation
+
+`docs/daemon/USER_GUIDE.md` covering: how to enable, what to expect, how to disable, what to do when something goes wrong (classpath dirty loops, persistent leaks, fallback to Gradle). Update VS Code extension README with the experimental flag.
+
+- **Depends on:** all of Phase 2
+- **DoD:** doc reviewed; one external developer uses it to enable the daemon end-to-end without further questions.
+
+### P3.2 — Acceptance review
+
+All CI gates from `DESIGN.md` § 15 green. Bench numbers meet the < 1s focused-preview target. Soak stable for one week of nightly runs.
+
+- **Depends on:** D2.2, D2.3
+- **DoD:** PR opened to flip the default of `composePreview.experimental.daemon` from `false` → still `false` but with "stable preview" label; or hold at experimental for another release cycle.
+
+---
+
+## Suggested agent assignment
+
+Four parallel agents after Phase 0 lands:
+
+| Agent | Streams | Focus | Worktree |
+|-------|---------|-------|----------|
+| **Agent A — Plugin** | A1.1, A1.2 | Gradle plugin Kotlin; JVM bootstrap descriptor | `agent/preview-daemon-streamA` |
+| **Agent B — Daemon core** | B1.1–B1.7, then B2.1–B2.6 | Robolectric/Compose internals; sandbox lifecycle; leak detection | `agent/preview-daemon-streamB` |
+| **Agent C — VS Code** | C1.1–C1.4, then C2.1–C2.3 | TypeScript; extension UX; webview wiring | `agent/preview-daemon-streamC` |
+| **Agent D — Bench/CI** | P0.1, D2.1–D2.3 | Benchmarking; CI workflows; pixel-diff infra | `agent/preview-daemon-streamD` |
+
+Agent B is the largest — could split internally as B1 (core renderer + protocol + scope discipline) and B2 (lifecycle + leak detection + tier classifications) into two sub-agents once Phase 1 lands. They coordinate via the `RobolectricHost` + `RenderEngine` interfaces, which are stable after B1.5.
+
+### Coordination rules
+
+- **Phase 0 first.** No parallel work until P0.1–P0.4 are merged. They define the contracts other streams depend on.
+- **Protocol changes go through P0.4's doc.** Any change to message shapes during Phase 1+ requires an explicit PR to `PROTOCOL.md` first; both Stream B and Stream C rebase before continuing.
+- **No edits to existing `renderer-android` code in Phase 1.** Stream B duplicates the render body. Refactoring the original is a v2 task tracked separately.
+- **Shared-seam tasks merge serially.** P0.2 and P0.3 cannot land in the same PR; Agent A handles them one at a time.
+- **Daily sync via PR descriptions.** Each stream's PR description includes "interfaces I depend on" and "interfaces I expose" — review on those terms.
+
+### Sequencing diagram
+
+```
+Phase 0: P0.1 P0.2 P0.3 P0.4   ──── all merged ────┐
+                                                   │
+Phase 1:  ┌── A1.1 ── A1.2                         │
+          │                                        │
+          ├── B1.1 ── B1.2 ── B1.3 ── B1.4 ── B1.7
+          │                    │                    
+          │                    └── B1.5 ── B1.6    
+          │                          │              
+          └── C1.1 ── C1.2 ── C1.3 ── C1.4         
+                                                   
+Phase 2:  ┌── B2.1 ── B2.2                          
+          │                                         
+          ├── B2.3 ── B2.4 ── B2.5 ── B2.6         
+          │                                         
+          ├── C2.1 ── C2.2 ── C2.3                  
+          │                                         
+          └── D2.1 ── D2.2 ── D2.3                  
+                                                   
+Phase 3:  P3.1 ── P3.2                              
+```
+
+A1.1 unblocks C1.2; B1.5 unblocks C1.3; B2.5 unblocks C2.3. Otherwise streams are mostly independent within a phase.
+
+---
+
+## Risks to track per task
+
+If an agent hits one of these mid-task, raise immediately rather than working around it:
+
+- **B1.3 sandbox-reuse failure.** If the dummy-`@Test` blocking pattern doesn't actually keep the sandbox classloader alive across `LinkedBlockingQueue` waits, escalate. We may need to invoke Robolectric's lower-level `Sandbox` API directly.
+- **B1.4 render-body extraction reveals coupling.** If the duplicated render body needs more than mechanical copy-paste to work outside `@Test`, document the divergence and plan reconciliation earlier.
+- **B1.7 ShadowPackageManager add-reversal incomplete.** If we can't enumerate what we added, a sandbox reset between previews is the fallback (slower; defeats v1 perf target). Escalate.
+- **B2.5 warm-spare cost too high.** If two sandboxes use > 2GB combined, default `warmSpare=false` and accept the recycle pause. Document.
+- **D2.2 daemon and Gradle paths produce different PNGs.** Block until reconciled. This is the canary for divergence; never paper over.


### PR DESCRIPTION
## Summary

Adds `docs/daemon/` with a design proposal for an experimental persistent preview server that replaces the per-save Gradle invocation with a long-lived JVM holding a hot Robolectric sandbox.

Goal: sub-second preview refresh after a file save in VS Code. Today's path runs the full Gradle `renderPreviews` task on every save (config + JVM fork + Robolectric init + render = 5–20s); the daemon collapses that to kotlinc + render.

This PR is **docs only**. No code, no behaviour change. v1 will land behind `composePreview.experimental.daemon=true` with the existing Gradle path kept indefinitely as the always-available fallback and CI-canonical render path.

### What's in the docs

- `README.md` — index, non-goals, how to use the docs
- `DESIGN.md` — architecture, 4-tier staleness cascade, sandbox lifecycle and recycle policy with warm spare, memory leak defense in depth, `SandboxScope` / `ProcessCache` discipline, validation strategy, CI gates, decisions log
- `TODO.md` — phased work breakdown with parallel streams (4 agents), explicit dependencies, definition-of-done per task, sequencing diagram, risks to escalate per task

### Scope decisions locked in DESIGN.md § 17

- Per-module sandbox (not per-project)
- Daemon spawned by VS Code; manual `--foreground` mode for triage
- VS Code-only client (CLI keeps using Gradle task)
- Gradle `renderPreviews` task kept indefinitely
- Render body duplicated into daemon module for v1 (drift caught by pixel-diff CI gate); reconciliation in v2
- Tier-3 dependency reachability index deferred to v2

## Test plan

- [ ] Reviewer reads `README.md` to orient
- [ ] Reviewer reads `DESIGN.md` end to end (~30 min)
- [ ] Reviewer sanity-checks `TODO.md` task split — does each stream make sense as one focused agent's PR?
- [ ] Confirm scope decisions in § 17 match intent before any implementation work starts
- [ ] No build/test impact (docs only) — CI green is sufficient