### PR TITLE
refactor(plugin): hoist renderPreviews classpath/JVM-args helpers (P0.3 + P0.2 wrap-up)

### DIFF
--- a/docs/daemon/TODO.md
+++ b/docs/daemon/TODO.md
@@ -29,14 +29,16 @@ Build `:samples:android-daemon-bench` (skeleton sample module) with a `benchPrev
 - **Depends on:** none
 - **DoD:** CSV checked into `docs/daemon/baseline-latency.csv` for the reference dev machine. Numbers referenced from `DESIGN.md` § 13 are validated or corrected.
 
-### P0.2 — Add `sourceFile` to `PreviewInfo` [Stream A] [shared seam]
+### P0.2 — Add `sourceFile` to `PreviewInfo` [Stream A] [shared seam] ✅
 
 Extend `PreviewInfo` (in `gradle-plugin/.../PreviewData.kt`) with `sourceFile: String?` populated from `ClassInfo.sourceFile` (ClassGraph exposes the bytecode `SourceFile` attribute). Wire through `DiscoverPreviewsTask`. Update `previews.json` schema.
+
+The field was already shipped before this breakdown was written — see [`PreviewData.kt:202`](../../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt#L202) and [`DiscoverPreviewsTask.kt:805`](../../gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt#L805) (populated with the package-qualified path). The remaining outstanding work was a functional-test guard asserting non-null, which is now inlined into `DiscoveryFunctionalTest.discoverPreviews finds annotated composables`.
 
 - **Depends on:** none
 - **DoD:** existing `:samples:android:renderAllPreviews` still passes. New field present in generated `previews.json` and surfaced in `PreviewInfo` consumers. Functional test asserts non-null for at least one preview in `samples/android`.
 
-### P0.3 — Hoist classpath/JVM-args helpers [Stream A] [shared seam]
+### P0.3 — Hoist classpath/JVM-args helpers [Stream A] [shared seam] ✅
 
 Extract `buildTestClasspath(variant)` and `buildJvmArgs(variant)` from `AndroidPreviewSupport.kt` into a package-private `AndroidPreviewClasspath.kt`. Existing `registerAndroidTasks` calls the helpers instead of inlining. Behaviour must be byte-identical.
 

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -139,6 +139,13 @@ class DiscoveryFunctionalTest {
       assertThat(it.params.device).isNull()
       assertThat(it.params.showSystemUi).isFalse()
     }
+
+    // P0.2 daemon prep: at least one preview must surface its `sourceFile`
+    // so the daemon's incremental-discovery path (B2.2) has a path to
+    // file-event correlation. Field is populated from ClassGraph's
+    // bytecode `SourceFile` attribute and rewritten to a package-qualified
+    // path in DiscoverPreviewsTask — see PreviewData.sourceFile.
+    assertThat(manifest.previews.any { !it.sourceFile.isNullOrBlank() }).isTrue()
   }
 
   @Test

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt
@@ -1,0 +1,181 @@
+package ee.schimke.composeai.plugin
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.file.Directory
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+
+/**
+ * Pure-data builders for the renderer test JVM's classpath, JVM args, and system properties.
+ *
+ * Extracted out of [AndroidPreviewSupport.registerAndroidTasks] so the upcoming "preview daemon"
+ * (see `docs/daemon/DESIGN.md`) can reuse the exact same construction logic to launch its own JVM
+ * — instead of duplicating the inline Test-task DSL block. Each helper returns a value
+ * (FileCollection / List / Map). None of them touches the Test task DSL directly. The Test task
+ * lambda still composes the final classpath (it appends the AGP unit-test classes / classpath,
+ * which can only be resolved late via `project.tasks.findByName("test${Cap}UnitTest")`) and still
+ * registers the dynamic argument providers (a11y / tier) which need lazy `Provider<>` evaluation
+ * at execution time.
+ *
+ * Ordering invariants (load-bearing — see callers' comments and `AndroidPreviewSupport.kt`):
+ *  - Robolectric properties dir BEFORE consumer test resources, so the renderer's
+ *    `robolectric.properties` wins classloader lookup.
+ *  - Renderer artifacts BEFORE consumer test runtime, so the renderer's pinned
+ *    kotlinx-serialization / Roborazzi versions win on classload conflicts.
+ *  - SDK boot classpath LAST in the outer FileCollection, since it's only there to satisfy
+ *    JUnit's introspection of the test class signatures (the sandbox supplies its own
+ *    `android-all` framework jars).
+ *
+ * Behaviour must match the inline construction byte-for-byte; this file is a refactor with no
+ * semantic change.
+ */
+internal object AndroidPreviewClasspath {
+
+  private val artifactType: Attribute<String> = Attribute.of("artifactType", String::class.java)
+
+  /**
+   * Builds the renderer test classpath as the existing inline block does today, EXCLUDING the
+   * trailing AGP test classes / AGP test classpath additions which are still resolved inside the
+   * Test task lambda (they need `project.tasks.findByName("test${Cap}UnitTest")` which only
+   * resolves late).
+   *
+   * Inputs are everything the existing inline block reads. Output is a single FileCollection
+   * equivalent to the existing `resolvedClasspath` local.
+   */
+  fun buildTestClasspath(
+    project: Project,
+    bootClasspath: Provider<List<RegularFile>>,
+    rendererConfig: Configuration,
+    rendererClassDirs: FileCollection,
+    sourceClassDirs: FileCollection,
+    testConfig: Configuration?,
+    screenshotTestRuntimeConfig: Configuration?,
+    unitTestConfigDir: Provider<Directory>,
+    robolectricPropertiesDir: Provider<Directory>,
+  ): FileCollection =
+    project.files().apply {
+      // Robolectric properties dir BEFORE consumer test resources so our
+      // Application override wins when classloader.getResource walks the
+      // classpath. Consumers with their own `robolectric.properties` at
+      // the same package path are unusual — they'd need it specifically
+      // for this renderer's test class.
+      from(robolectricPropertiesDir)
+      from(rendererConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files)
+      from(rendererClassDirs)
+      if (testConfig != null) {
+        from(testConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files)
+        from(
+          testConfig.incoming
+            .artifactView { attributes.attribute(artifactType, "android-classes") }
+            .files
+        )
+      }
+      // screenshotTest source set has its own runtime config — any
+      // `screenshotTestImplementation(...)` dep the consumer declared is
+      // only visible here, not via `testConfig`. Include it so previews
+      // under `src/screenshotTest/` can reference those classes at
+      // render time. No-op when the screenshot plugin isn't applied.
+      screenshotTestRuntimeConfig?.let { stConfig ->
+        from(stConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files)
+        from(
+          stConfig.incoming
+            .artifactView { attributes.attribute(artifactType, "android-classes") }
+            .files
+        )
+      }
+      from(sourceClassDirs)
+      from(unitTestConfigDir)
+      // SDK stub android.jar on the OUTER classpath so JUnit can introspect
+      // the test class (RobolectricRenderTest.kt references android.graphics.Bitmap,
+      // android.view.PixelCopy, etc. in method signatures). Without it, JUnit fails
+      // with `NoClassDefFoundError: android/graphics/Bitmap` during test discovery,
+      // before Robolectric's sandbox classloader is even created.
+      //
+      // Inside the sandbox, `ParameterizedRobolectricTestRunner` loads the test class
+      // through Robolectric's InstrumentingClassLoader, which delegates `android.*`
+      // resolution to its own `android-all` artifact (real framework classes, with
+      // shadows applied). The outer stub does NOT shadow the sandboxed PixelCopy.
+      //
+      // Sourced from AGP's SdkComponents so we don't have to parse local.properties
+      // or read rootProject.file(...).
+      from(project.files(bootClasspath))
+    }
+
+  /**
+   * Static JVM open flags that the renderPreviews test JVM needs. Pure data — no Gradle DSL
+   * coupling.
+   */
+  fun buildJvmArgs(): List<String> =
+    listOf(
+      "--add-opens=java.base/java.lang=ALL-UNNAMED",
+      "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+      // Robolectric's `ShadowVMRuntime.getAddressOfDirectByteBuffer`
+      // reflectively invokes `DirectByteBuffer.address()`; under JDK 17+
+      // module rules this fails with IllegalAccessException without this
+      // opens. Reached via `PathIterator` — triggered here by Wear Compose's
+      // curved text renderer.
+      "--add-opens=java.base/java.nio=ALL-UNNAMED",
+    )
+
+  /**
+   * Static system properties (graphicsMode, looperMode, conscryptMode, pixelCopyRenderMode,
+   * roborazzi.test.record, composeai.render.manifest, composeai.render.outputDir,
+   * composeai.fonts.cacheDir, composeai.fonts.offline). Caller passes the resolved values for the
+   * path-bearing ones; the helper returns the full map.
+   *
+   * Note: the dynamic per-task ArgumentProviders (a11y, tier) stay inline because they need lazy
+   * `Provider<>` evaluation at task execution time.
+   *
+   * The returned map preserves insertion order — callers iterate it to call `systemProperty(...)`
+   * on the Test task and the order is irrelevant to the JVM (system properties are an unordered
+   * map on the receiving side), but keeping it stable simplifies golden-output comparisons in
+   * future tests.
+   */
+  fun buildSystemProperties(
+    manifestPath: String,
+    rendersDir: String,
+    fontsCacheDir: String,
+    fontsOffline: String,
+  ): Map<String, String> =
+    linkedMapOf(
+      // Belt-and-braces for the graphics/looper modes. Config now
+      // lives in `ee/schimke/composeai/renderer/robolectric.properties`
+      // (see `RobolectricRenderTestBase` KDoc for why we can't use
+      // `@GraphicsMode` directly). These system properties are a third
+      // independent Robolectric config channel and cost nothing to
+      // keep — survive both annotation and properties paths regressing.
+      "robolectric.graphicsMode" to "NATIVE",
+      "robolectric.looperMode" to "PAUSED",
+      // Conscrypt isn't needed for preview rendering (no TLS/HTTP paths
+      // execute) and its native library is flaky on some Linux sandboxes
+      // — e.g. missing/ABI-mismatched `libstdc++.so.6`. Telling Robolectric
+      // to skip the install avoids those failures without shipping our
+      // own Conscrypt stubs. See `ConscryptMode` /
+      // `ConscryptModeConfigurer` in Robolectric.
+      "robolectric.conscryptMode" to "OFF",
+      // Routes ShadowPixelCopy through HardwareRenderingScreenshot →
+      // ImageReader + HardwareRenderer.syncAndDraw, the only path that
+      // replays Compose's RenderNodes correctly.
+      "robolectric.pixelCopyRenderMode" to "hardware",
+      // Roborazzi defaults to "compare" mode (which doesn't write pixels
+      // unless the expected baseline exists). Force "record" so every run
+      // writes fresh PNGs.
+      "roborazzi.test.record" to "true",
+      "composeai.render.manifest" to manifestPath,
+      "composeai.render.outputDir" to rendersDir,
+      // GoogleFont interceptor cache — defaults to
+      // `<project>/.compose-preview-history/fonts/`, same root the
+      // history task uses, so committed TTFs sit beside committed PNGs.
+      // The renderer class no-ops when this property is absent, so the
+      // feature is fully additive for existing consumers.
+      "composeai.fonts.cacheDir" to fontsCacheDir,
+      // `-PcomposePreview.fontsOffline=true` (or the same Gradle property
+      // on a CI profile) skips network on cache miss so the render
+      // shows the fallback font rather than silently fetching from
+      // `fonts.googleapis.com`.
+      "composeai.fonts.offline" to fontsOffline,
+    )
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -658,56 +658,25 @@ internal object AndroidPreviewSupport {
     // doesn't do conflict resolution, so whichever JAR comes first wins at
     // classload time. Putting the renderer's dependencies first ensures the
     // test code gets the versions it was compiled against.
+    //
+    // Construction is delegated to [AndroidPreviewClasspath.buildTestClasspath] so
+    // the upcoming preview daemon (see docs/daemon/DESIGN.md) can build the same
+    // classpath without re-implementing the inline DSL. The trailing AGP test
+    // classes / classpath additions are still composed in the Test lambda below
+    // (they need `findByName("test${capVariant}UnitTest")` which only resolves
+    // late).
     val resolvedClasspath =
-      project.files().apply {
-        // Robolectric properties dir BEFORE consumer test resources so our
-        // Application override wins when classloader.getResource walks the
-        // classpath. Consumers with their own `robolectric.properties` at
-        // the same package path are unusual — they'd need it specifically
-        // for this renderer's test class.
-        from(generateRobolectricPropertiesTask.flatMap { it.outputDir })
-        from(
-          rendererConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files
-        )
-        from(rendererClassDirs)
-        if (testConfig != null) {
-          from(testConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files)
-          from(
-            testConfig.incoming
-              .artifactView { attributes.attribute(artifactType, "android-classes") }
-              .files
-          )
-        }
-        // screenshotTest source set has its own runtime config — any
-        // `screenshotTestImplementation(...)` dep the consumer declared is
-        // only visible here, not via `testConfig`. Include it so previews
-        // under `src/screenshotTest/` can reference those classes at
-        // render time. No-op when the screenshot plugin isn't applied.
-        screenshotTestRuntimeConfig?.let { stConfig ->
-          from(stConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files)
-          from(
-            stConfig.incoming
-              .artifactView { attributes.attribute(artifactType, "android-classes") }
-              .files
-          )
-        }
-        from(sourceClassDirs)
-        from(unitTestConfigDir)
-        // SDK stub android.jar on the OUTER classpath so JUnit can introspect
-        // the test class (RobolectricRenderTest.kt references android.graphics.Bitmap,
-        // android.view.PixelCopy, etc. in method signatures). Without it, JUnit fails
-        // with `NoClassDefFoundError: android/graphics/Bitmap` during test discovery,
-        // before Robolectric's sandbox classloader is even created.
-        //
-        // Inside the sandbox, `ParameterizedRobolectricTestRunner` loads the test class
-        // through Robolectric's InstrumentingClassLoader, which delegates `android.*`
-        // resolution to its own `android-all` artifact (real framework classes, with
-        // shadows applied). The outer stub does NOT shadow the sandboxed PixelCopy.
-        //
-        // Sourced from AGP's SdkComponents so we don't have to parse local.properties
-        // or read rootProject.file(...).
-        from(project.files(bootClasspath))
-      }
+      AndroidPreviewClasspath.buildTestClasspath(
+        project = project,
+        bootClasspath = bootClasspath,
+        rendererConfig = rendererConfig,
+        rendererClassDirs = rendererClassDirs,
+        sourceClassDirs = sourceClassDirs,
+        testConfig = testConfig,
+        screenshotTestRuntimeConfig = screenshotTestRuntimeConfig,
+        unitTestConfigDir = unitTestConfigDir,
+        robolectricPropertiesDir = generateRobolectricPropertiesTask.flatMap { it.outputDir },
+      )
 
     val manifestFile = previewOutputDir.map { it.file("previews.json").asFile.absolutePath }
     val rendersDirectory = previewOutputDir.map { it.dir("renders") }
@@ -814,16 +783,9 @@ internal object AndroidPreviewSupport {
         // a chance to register `test${capVariant}UnitTest` by the time this
         // runs — onVariants fires before unit-test tasks are wired.
         jvmArgs(agpTestTask?.jvmArgs ?: emptyList<String>())
-        jvmArgs(
-          "--add-opens=java.base/java.lang=ALL-UNNAMED",
-          "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
-          // Robolectric's `ShadowVMRuntime.getAddressOfDirectByteBuffer`
-          // reflectively invokes `DirectByteBuffer.address()`; under JDK 17+
-          // module rules this fails with IllegalAccessException without this
-          // opens. Reached via `PathIterator` — triggered here by Wear Compose's
-          // curved text renderer.
-          "--add-opens=java.base/java.nio=ALL-UNNAMED",
-        )
+        // Static JVM open flags live in [AndroidPreviewClasspath.buildJvmArgs] so the
+        // preview daemon can reuse the same set when launching its own JVM.
+        jvmArgs(AndroidPreviewClasspath.buildJvmArgs())
 
         // Inherit AGP's unit-test javaLauncher so the forked test worker
         // runs on the same JDK as `test${capVariant}UnitTest` — which
@@ -839,33 +801,6 @@ internal object AndroidPreviewSupport {
         // discovery on some JVM/classloader combinations. See #142.
         agpTestTask?.javaLauncher?.orNull?.let { javaLauncher.set(it) }
 
-        // Belt-and-braces for the graphics/looper modes. Config now
-        // lives in `ee/schimke/composeai/renderer/robolectric.properties`
-        // (see `RobolectricRenderTestBase` KDoc for why we can't use
-        // `@GraphicsMode` directly). These system properties are a third
-        // independent Robolectric config channel and cost nothing to
-        // keep — survive both annotation and properties paths regressing.
-        systemProperty("robolectric.graphicsMode", "NATIVE")
-        systemProperty("robolectric.looperMode", "PAUSED")
-        // Conscrypt isn't needed for preview rendering (no TLS/HTTP paths
-        // execute) and its native library is flaky on some Linux sandboxes
-        // — e.g. missing/ABI-mismatched `libstdc++.so.6`. Telling Robolectric
-        // to skip the install avoids those failures without shipping our
-        // own Conscrypt stubs. See `ConscryptMode` /
-        // `ConscryptModeConfigurer` in Robolectric.
-        systemProperty("robolectric.conscryptMode", "OFF")
-        // Routes ShadowPixelCopy through HardwareRenderingScreenshot →
-        // ImageReader + HardwareRenderer.syncAndDraw, the only path that
-        // replays Compose's RenderNodes correctly.
-        systemProperty("robolectric.pixelCopyRenderMode", "hardware")
-        // Roborazzi defaults to "compare" mode (which doesn't write pixels
-        // unless the expected baseline exists). Force "record" so every run
-        // writes fresh PNGs.
-        systemProperty("roborazzi.test.record", "true")
-
-        systemProperty("composeai.render.manifest", manifestFile.get())
-        systemProperty("composeai.render.outputDir", rendersDir.get())
-
         // GoogleFont interceptor cache — defaults to
         // `<project>/.compose-preview-history/fonts/`, same root the
         // history task uses, so committed TTFs sit beside committed PNGs.
@@ -875,14 +810,24 @@ internal object AndroidPreviewSupport {
           extension.historyDir
             .orElse(project.layout.projectDirectory.dir(".compose-preview-history"))
             .map { it.dir("fonts").asFile.absolutePath }
-        systemProperty("composeai.fonts.cacheDir", fontsCacheDir.get())
         // `-PcomposePreview.fontsOffline=true` (or the same Gradle property
         // on a CI profile) skips network on cache miss so the render
         // shows the fallback font rather than silently fetching from
         // `fonts.googleapis.com`.
         val fontsOffline =
           project.providers.gradleProperty("composePreview.fontsOffline").orElse("false")
-        systemProperty("composeai.fonts.offline", fontsOffline.get())
+        // Static system properties (Robolectric modes + the path-bearing composeai.*
+        // values) live in [AndroidPreviewClasspath.buildSystemProperties] so the
+        // preview daemon can replay the same set when launching its own JVM. The
+        // dynamic per-task ArgumentProviders (a11y, tier) stay below — they need
+        // lazy `Provider<>` evaluation at task-execution time.
+        AndroidPreviewClasspath.buildSystemProperties(
+            manifestPath = manifestFile.get(),
+            rendersDir = rendersDir.get(),
+            fontsCacheDir = fontsCacheDir.get(),
+            fontsOffline = fontsOffline.get(),
+          )
+          .forEach { (k, v) -> systemProperty(k, v) }
 
         // ATF flags are routed through a CommandLineArgumentProvider
         // rather than `systemProperty(...)` so toggling the `-P` override


### PR DESCRIPTION
> Stacked on top of #249 (P0.4). Review-and-merge order is #249 → this PR.

## Summary

- Extracts the renderPreviews test classpath, static JVM open flags, and static system-property set out of the inline \`project.tasks.register(\"renderPreviews\", Test::class.java) { ... }\` block in [AndroidPreviewSupport.kt](gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt) into a new package-private helper [AndroidPreviewClasspath.kt](gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewClasspath.kt). Each helper returns data; nothing calls Test DSL methods.
- Wraps up **P0.2** while in the area: \`PreviewInfo.sourceFile\` was already shipped before the daemon work breakdown was written, so this PR adds the missing functional-test guard (\`DiscoveryFunctionalTest\` asserts non-blank for at least one preview) and marks P0.2 done in [TODO.md](docs/daemon/TODO.md).

## Why

The upcoming preview daemon (see [docs/daemon/DESIGN.md](docs/daemon/DESIGN.md)) needs to construct the same classpath / JVM args / sysprops to launch its own JVM. Sharing the construction logic now means we don't duplicate the inline DSL block when wiring \`DaemonBootstrapTask\` (Phase 1 / Stream A / A1.1).

## What stays inline

The Test task lambda still:

- Composes the final classpath (appends AGP unit-test classes / classpath; only resolvable late via \`findByName(\"test\${Cap}UnitTest\")\`).
- Inherits AGP's \`javaLauncher\`.
- Registers the dynamic \`ArgumentProvider\`s (a11y, tier) which need lazy \`Provider<>\` evaluation at task-execution time to avoid config-cache invalidation on \`-P\` toggles.
- Copies AGP's test-task JVM args.

## Verification

- \`./gradlew :samples:android:renderAllPreviews\` — **pass**, no PNG diffs vs. main (\`git status\` clean across \`samples/android/\`).
- \`./gradlew :gradle-plugin:test\` — **pass**.
- \`./gradlew :gradle-plugin:functionalTest\` — **pass**, including the new \`sourceFile\` non-null assertion.

File ordering inside the classpath \`FileCollection\`, JVM-arg order, and the system-property set match the previous inline construction byte-for-byte.

## Test plan

- [ ] CI green on this branch.
- [ ] Render a preview locally and confirm output matches main (only needed if a reviewer doubts the byte-identical claim — \`renderAllPreviews\` already covers it).