### PR TITLE
feat(renderer): paint synthetic system bars when showSystemUi = true

### DIFF
--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -95,7 +95,16 @@ dependencies {
   compileOnly(libs.compose.foundation)
   compileOnly(libs.compose.material3)
   compileOnly(libs.compose.runtime)
-  compileOnly(libs.compose.ui.tooling.preview)
+  // `compose.ui.tooling.preview` from `compose-bom-compat` (1.9.x) doesn't
+  // ship `PreviewWrapper` / `PreviewWrapperProvider` — those landed in
+  // ui-tooling-preview 1.11.0. We pin the 1.11+ variant here so
+  // [SystemBarsPreviewWrapper] can extend `PreviewWrapperProvider` at compile
+  // time. Consumers on Compose 1.11+ get the symbol from their own runtime;
+  // consumers on 1.10 and below can still use the rest of the renderer
+  // (loading [SystemBarsPreviewWrapper] is the only path that requires the
+  // 1.11 symbol, and that only fires when a consumer explicitly references
+  // it via `@PreviewWrapper(SystemBarsPreviewWrapper::class)`).
+  compileOnly(libs.compose.ui.tooling.preview.wrapper)
   compileOnly(libs.activity.compose)
   compileOnly("androidx.compose.ui:ui-test-junit4")
   compileOnly("androidx.compose.ui:ui-test-manifest")

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -543,19 +543,39 @@ abstract class RobolectricRenderTestBase(
                         add(reduceMotionLocal provides true)
                     }
                 }.toTypedArray()
+                // `showSystemUi = true` on a phone-shape preview wraps the
+                // composition in [SystemBarsFrame] so the captured PNG carries
+                // synthetic status + gesture-pill nav bars. Robolectric has no
+                // SystemUI process to draw real bars; without the wrapper the
+                // canvas comes back at the right device size but with no chrome
+                // (issue #256). Conceptually the same as `@PreviewWrapper`,
+                // applied automatically here for the system-UI case. Skipped
+                // for round Wear devices (circular clip already brands the
+                // capture) and for tile previews (tiles fill the whole watch
+                // face — bars don't apply).
+                val applySystemBars = params.showSystemUi &&
+                    params.kind != PreviewKind.TILE &&
+                    !isRoundDevice(params.device)
                 rule.setContent {
                     CompositionLocalProvider(values = providedValues) {
                         val previewBody: @Composable () -> Unit = {
-                            if (wrapWidth || wrapHeight) {
-                                MeasuredWrapBox(
-                                    wrapWidth = wrapWidth,
-                                    wrapHeight = wrapHeight,
-                                    onMeasured = { measured = it },
-                                ) {
+                            val core: @Composable () -> Unit = {
+                                if (wrapWidth || wrapHeight) {
+                                    MeasuredWrapBox(
+                                        wrapWidth = wrapWidth,
+                                        wrapHeight = wrapHeight,
+                                        onMeasured = { measured = it },
+                                    ) {
+                                        strategyFor(params.kind).Render(preview, widthDp, heightDp, previewArgs)
+                                    }
+                                } else {
                                     strategyFor(params.kind).Render(preview, widthDp, heightDp, previewArgs)
                                 }
+                            }
+                            if (applySystemBars) {
+                                SystemBarsFrame(uiMode = params.uiMode) { core() }
                             } else {
-                                strategyFor(params.kind).Render(preview, widthDp, heightDp, previewArgs)
+                                core()
                             }
                         }
                         if (animationCurveCapture != null) {

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/SystemBarsFrame.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/SystemBarsFrame.kt
@@ -1,0 +1,211 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Synthetic Android phone system UI: status bar at the top, gesture-pill
+ * navigation bar at the bottom. Wraps a composable so it renders inside
+ * something that *looks* like a phone screenshot rather than a naked
+ * rectangle.
+ *
+ * Why this exists: Robolectric runs the test without the SystemUI process
+ * that paints real bars on-device, so a `@Preview(device = "id:pixel_8",
+ * showSystemUi = true)` capture comes back at the right canvas size but with
+ * no chrome (issue #256). Android Studio's preview pane closes the same gap
+ * via LayoutLib's frame overlay; we draw the equivalent in Compose code
+ * inside the same composition the preview itself runs in — no Java2D
+ * post-processing — so the bars participate in capture naturally.
+ *
+ * Three usage shapes, in order of how invasive they are:
+ *   1. **Implicit (default)** — set `showSystemUi = true` on a phone-shape
+ *      `@Preview`. The renderer wraps the composition in this frame
+ *      automatically. Skipped for round Wear devices and tile previews —
+ *      the circular clip / tile renderers already brand those captures.
+ *   2. **Annotation-driven** — apply `@PreviewWrapper(SystemBarsPreviewWrapper::class)`
+ *      to a preview function. Useful when you want phone-shape chrome
+ *      around a component preview that doesn't pin a device, or when
+ *      composing multiple wrappers. Requires Compose 1.11+ on the consumer
+ *      classpath (where `@PreviewWrapper` lives).
+ *   3. **Explicit** — call `SystemBarsFrame { … }` directly from a
+ *      composable. No annotations needed; works on any Compose version that
+ *      has the basic `Box` / `Row` / `Canvas` primitives this composable
+ *      uses (1.0+). Useful when you want bar chrome inside an app screen
+ *      shot or other in-app context.
+ *
+ * Style choices:
+ *  - Bars are translucent overlays on top of the content (`Box` overlay,
+ *    not a `Column` that resizes the body), matching modern edge-to-edge
+ *    Android behaviour. No content is reserved out from under the bars.
+ *  - 24dp status bar with a "9:30" clock on the left and a small battery
+ *    glyph on the right.
+ *  - 24dp navigation bar with a centred gesture pill (~108×4dp).
+ *  - Light/dark tint chosen from the [uiMode] mask so a `night` capture
+ *    gets dark chrome with light icons rather than always-light overlays
+ *    on top of a dark surface.
+ *
+ * @param uiMode Configuration UI-mode bits. Only the `UI_MODE_NIGHT_*` bits
+ *     are inspected — pass `Configuration.UI_MODE_NIGHT_YES` (or `0` for
+ *     light) when calling from app code; the renderer threads through
+ *     `params.uiMode` from the discovered `@Preview` annotation.
+ */
+@Composable
+fun SystemBarsFrame(
+    uiMode: Int,
+    content: @Composable () -> Unit,
+) {
+    val night = (uiMode and UI_MODE_NIGHT_MASK) == UI_MODE_NIGHT_YES
+    val barTint = if (night) Color(0x70000000) else Color(0x70FFFFFF)
+    val foreground = if (night) Color(0xFFEBEBEB) else Color(0xFF141414)
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        content()
+        StatusBar(
+            modifier = Modifier.align(Alignment.TopCenter),
+            tint = barTint,
+            foreground = foreground,
+        )
+        NavigationPillBar(
+            modifier = Modifier.align(Alignment.BottomCenter),
+            tint = barTint,
+            foreground = foreground,
+        )
+    }
+}
+
+@Composable
+private fun StatusBar(
+    modifier: Modifier,
+    tint: Color,
+    foreground: Color,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(STATUS_BAR_HEIGHT_DP.dp)
+            .background(tint)
+            .padding(horizontal = SIDE_INSET_DP.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        BasicText(
+            text = "9:30",
+            style = TextStyle(
+                color = foreground,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Bold,
+            ),
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        BatteryGlyph(color = foreground)
+    }
+}
+
+/**
+ * Compact battery icon — outlined body with a terminal nub and a ~75% fill.
+ * Drawn with `Canvas` rather than nested `Box`es so the stroke + fill can
+ * share one drawing pass.
+ */
+@Composable
+private fun BatteryGlyph(color: Color) {
+    Canvas(
+        modifier = Modifier
+            .width(BATTERY_WIDTH_DP.dp)
+            .height(BATTERY_HEIGHT_DP.dp),
+    ) {
+        val nubW = 1.5.dp.toPx()
+        val nubH = size.height * 0.5f
+        val cornerR = 1.5.dp.toPx()
+        val strokeW = 1.dp.toPx()
+        val bodyW = size.width - nubW
+        val bodyH = size.height
+        // Outline — drawn as stroke, leaves the centre transparent so the
+        // background tint shows through.
+        drawRoundRect(
+            color = color,
+            topLeft = androidx.compose.ui.geometry.Offset(0f, 0f),
+            size = androidx.compose.ui.geometry.Size(bodyW, bodyH),
+            cornerRadius = androidx.compose.ui.geometry.CornerRadius(cornerR),
+            style = androidx.compose.ui.graphics.drawscope.Stroke(width = strokeW),
+        )
+        // Terminal nub.
+        drawRoundRect(
+            color = color,
+            topLeft = androidx.compose.ui.geometry.Offset(bodyW, (bodyH - nubH) / 2f),
+            size = androidx.compose.ui.geometry.Size(nubW, nubH),
+            cornerRadius = androidx.compose.ui.geometry.CornerRadius(cornerR / 2f),
+        )
+        // ~75% charge fill so the glyph reads as a battery rather than an
+        // empty rectangle.
+        val pad = strokeW + 0.5f
+        val fillW = ((bodyW - pad * 2f) * 0.75f).coerceAtLeast(1f)
+        drawRoundRect(
+            color = color,
+            topLeft = androidx.compose.ui.geometry.Offset(pad, pad),
+            size = androidx.compose.ui.geometry.Size(fillW, bodyH - pad * 2f),
+            cornerRadius = androidx.compose.ui.geometry.CornerRadius(cornerR / 2f),
+        )
+    }
+}
+
+@Composable
+private fun NavigationPillBar(
+    modifier: Modifier,
+    tint: Color,
+    foreground: Color,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(NAV_BAR_HEIGHT_DP.dp)
+            .background(tint),
+        contentAlignment = Alignment.Center,
+    ) {
+        // Gesture handle: rounded pill centred horizontally; sits visually a
+        // hair lower than the bar's centre to match Android's placement.
+        Box(
+            modifier = Modifier
+                .padding(top = (NAV_BAR_HEIGHT_DP / 6).dp)
+                .size(width = PILL_WIDTH_DP.dp, height = PILL_HEIGHT_DP.dp)
+                .clip(RoundedCornerShape(PILL_HEIGHT_DP.dp / 2))
+                .background(foreground)
+                .fillMaxHeight(),
+        )
+    }
+}
+
+private const val STATUS_BAR_HEIGHT_DP = 24
+private const val NAV_BAR_HEIGHT_DP = 24
+private const val SIDE_INSET_DP = 16
+private const val BATTERY_WIDTH_DP = 16
+private const val BATTERY_HEIGHT_DP = 8
+private const val PILL_WIDTH_DP = 108
+private const val PILL_HEIGHT_DP = 4
+
+/**
+ * `(uiMode and UI_MODE_NIGHT_MASK) == UI_MODE_NIGHT_YES` — kept as raw
+ * constants so the call site stays free of an `android.content.res` import,
+ * matching how the rest of this file consumes the `uiMode` int.
+ */
+private const val UI_MODE_NIGHT_MASK = 0x30
+private const val UI_MODE_NIGHT_YES = 0x20

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/SystemBarsPreviewWrapper.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/SystemBarsPreviewWrapper.kt
@@ -1,0 +1,38 @@
+package ee.schimke.composeai.renderer
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.PreviewWrapperProvider
+
+/**
+ * `@PreviewWrapper`-driven entry point for [SystemBarsFrame]. Apply with
+ *
+ * ```kotlin
+ * @PreviewWrapper(SystemBarsPreviewWrapper::class)
+ * @Preview(device = "id:pixel_8")
+ * @Composable
+ * fun MyScreenPreview() { ... }
+ * ```
+ *
+ * Equivalent to wrapping the preview body manually in
+ * `SystemBarsFrame(uiMode = 0) { ... }` — useful when a preview doesn't pin
+ * `showSystemUi = true` (so the renderer's automatic wrap doesn't fire) but
+ * still wants phone-shape chrome around the captured surface, or when the
+ * caller wants to compose this wrapper with other `PreviewWrapperProvider`s.
+ *
+ * Defaults to light-mode chrome: `PreviewWrapperProvider.Wrap` doesn't expose
+ * the `@Preview(uiMode = …)` value to the wrapper, so dark-mode behaviour
+ * still flows through the renderer's automatic path (where `params.uiMode`
+ * is threaded directly into [SystemBarsFrame]).
+ *
+ * Requires `androidx.compose.ui.tooling.preview` 1.11+ on the consumer
+ * classpath — that's the version that introduced `PreviewWrapperProvider`.
+ * On older Compose, this class will fail to load if referenced; the
+ * implicit `showSystemUi = true` path stays available regardless.
+ */
+@Suppress("RestrictedApiAndroidX")
+class SystemBarsPreviewWrapper : PreviewWrapperProvider {
+    @Composable
+    override fun Wrap(content: @Composable () -> Unit) {
+        SystemBarsFrame(uiMode = 0, content = content)
+    }
+}

--- a/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/SystemBarsFrameTest.kt
+++ b/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/SystemBarsFrameTest.kt
@@ -1,0 +1,184 @@
+package ee.schimke.composeai.renderer
+
+import android.content.res.Configuration
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color as AndroidColor
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalInspectionMode
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import org.robolectric.shadows.ShadowLooper
+
+/**
+ * Verifies [SystemBarsFrame] paints a status bar at the top and a navigation
+ * pill bar at the bottom. The wrapped content fills the canvas with a single
+ * solid colour; we then sample pixel rows at known y-offsets and assert that
+ * the bar bands are tinted away from the body colour while the centre row is
+ * untouched.
+ *
+ * Stays close to [PreviewWrapperTest]'s setup: Robolectric activity, manual
+ * measure/layout pump, then `decor.draw(Canvas(bitmap))` to grab pixels. No
+ * Roborazzi / no `captureRoboImage` — keeps the test independent of the
+ * full preview pipeline so a rendering regression in [SystemBarsFrame]
+ * can't be masked by an unrelated capture-path failure.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class SystemBarsFrameTest {
+
+    @Test
+    fun `light mode paints translucent bars over the top and bottom of the content`() {
+        val width = 200
+        val height = 600
+        val bitmap = renderToBitmap(width, height, uiMode = 0) {
+            Box(modifier = Modifier.fillMaxSize().background(Color.Red))
+        }
+
+        val centrePixel = bitmap.getPixel(width / 2, height / 2)
+        // Centre is body content — the red fill is preserved untouched.
+        assertEquals(
+            "centre pixel should remain a strong red, got rgb=" +
+                "(${AndroidColor.red(centrePixel)},${AndroidColor.green(centrePixel)}," +
+                "${AndroidColor.blue(centrePixel)})",
+            true,
+            AndroidColor.red(centrePixel) > 200 &&
+                AndroidColor.green(centrePixel) < 50 &&
+                AndroidColor.blue(centrePixel) < 50,
+        )
+
+        // Status bar lifts the red toward pink via its translucent white tint.
+        // We sample a column position that's clear of the clock text and the
+        // battery glyph (left edge gets the clock; right edge gets the battery
+        // — middle is the bar background).
+        val statusPixel = bitmap.getPixel(width / 2, 4)
+        assertTrue(
+            "status bar pixel should have a green/blue lift from the white tint, " +
+                "got rgb=(${AndroidColor.red(statusPixel)}," +
+                "${AndroidColor.green(statusPixel)},${AndroidColor.blue(statusPixel)})",
+            AndroidColor.green(statusPixel) > 40 && AndroidColor.blue(statusPixel) > 40,
+        )
+    }
+
+    @Test
+    fun `dark mode darkens the top strip rather than lightening it`() {
+        val width = 200
+        val height = 600
+        val bitmap = renderToBitmap(
+            width = width,
+            height = height,
+            uiMode = Configuration.UI_MODE_NIGHT_YES,
+        ) {
+            Box(modifier = Modifier.fillMaxSize().background(Color.Red))
+        }
+
+        val statusPixel = bitmap.getPixel(width / 2, 4)
+        // Translucent black tint pulls the red channel below the original 255
+        // fill — same shape `cropPngTopLeft` uses to validate post-process
+        // behaviour without committing to an exact alpha-blend formula.
+        assertTrue(
+            "dark-mode status bar pixel should be darkened by the night tint, " +
+                "got red=${AndroidColor.red(statusPixel)}",
+            AndroidColor.red(statusPixel) < 230,
+        )
+    }
+
+    @Test
+    fun `nav bar paints a band along the bottom of the content`() {
+        val width = 200
+        val height = 600
+        val bitmap = renderToBitmap(width, height, uiMode = 0) {
+            Box(modifier = Modifier.fillMaxSize().background(Color.Red))
+        }
+
+        val navPixel = bitmap.getPixel(width / 2, height - 4)
+        // Nav bar uses the same translucent white tint as the status bar in
+        // light mode — assert the same lift signature so a regression that
+        // forgets to draw the bottom band fails this test.
+        assertTrue(
+            "nav bar pixel should have a green/blue lift from the white tint, " +
+                "got rgb=(${AndroidColor.red(navPixel)}," +
+                "${AndroidColor.green(navPixel)},${AndroidColor.blue(navPixel)})",
+            AndroidColor.green(navPixel) > 40 && AndroidColor.blue(navPixel) > 40,
+        )
+    }
+
+    // --- helpers ----------------------------------------------------------
+
+    private fun renderToBitmap(
+        width: Int,
+        height: Int,
+        uiMode: Int,
+        body: @Composable () -> Unit,
+    ): Bitmap {
+        val controller = Robolectric.buildActivity(ComponentActivity::class.java)
+        val activity = controller.get()
+        activity.setTheme(android.R.style.Theme_Material_Light_NoActionBar)
+        val hwAccel = WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED
+        activity.window.setFlags(hwAccel, hwAccel)
+        controller.create().start().resume().visible()
+
+        @Suppress("DEPRECATION")
+        val shadowDisplay = Shadows.shadowOf(activity.windowManager.defaultDisplay)
+        shadowDisplay.setWidth(width)
+        shadowDisplay.setHeight(height)
+
+        activity.setContent {
+            CompositionLocalProvider(LocalInspectionMode provides true) {
+                SystemBarsFrame(uiMode = uiMode, content = body)
+            }
+        }
+
+        val decor = activity.window.decorView
+        findComposeView(decor)?.apply {
+            layoutParams = layoutParams.apply {
+                this.width = ViewGroup.LayoutParams.MATCH_PARENT
+                this.height = ViewGroup.LayoutParams.MATCH_PARENT
+            }
+        }
+
+        val wSpec = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY)
+        val hSpec = View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY)
+        repeat(5) {
+            ShadowLooper.idleMainLooper(16L, TimeUnit.MILLISECONDS)
+            decor.measure(wSpec, hSpec)
+            decor.layout(0, 0, width, height)
+            decor.invalidate()
+            ShadowLooper.idleMainLooper(16L, TimeUnit.MILLISECONDS)
+        }
+
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        decor.draw(Canvas(bitmap))
+        return bitmap
+    }
+
+    private fun findComposeView(view: View): View? {
+        if (view.javaClass.simpleName == "ComposeView") return view
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) {
+                findComposeView(view.getChildAt(i))?.let { return it }
+            }
+        }
+        return null
+    }
+}

--- a/samples/android/src/main/kotlin/com/example/sampleandroid/Previews.kt
+++ b/samples/android/src/main/kotlin/com/example/sampleandroid/Previews.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
@@ -142,6 +143,49 @@ fun PhoneGreetingPreview() {
         Surface {
             Column(modifier = Modifier.padding(16.dp)) {
                 Greeting("Phone")
+            }
+        }
+    }
+}
+
+/**
+ * Issue #256: rendering a known phone (Pixel 8) with `showSystemUi = true`
+ * should produce a PNG that *looks* like a phone screenshot — full device
+ * canvas plus the system bars (status bar at the top, gesture-pill nav at the
+ * bottom). Robolectric has no SystemUI process to draw real bars, so the
+ * renderer paints a synthetic overlay onto the captured PNG to bridge the gap
+ * (see [ee.schimke.composeai.renderer.SystemBarsOverlay] in renderer-android).
+ *
+ * Two variants — light and dark — exercise the `uiMode`-aware tint branches
+ * of the overlay so reviewers can confirm the bars adapt to the theme rather
+ * than always rendering as light chrome on a dark surface.
+ */
+@Preview(name = "Pixel 8", device = "id:pixel_8", showSystemUi = true)
+@Preview(
+    name = "Pixel 8 - Night",
+    device = "id:pixel_8",
+    showSystemUi = true,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+)
+@Composable
+fun Pixel8SystemUiPreview() {
+    val scheme = if (isSystemInDarkTheme()) darkColorScheme() else lightColorScheme()
+    MaterialTheme(colorScheme = scheme) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background,
+        ) {
+            Column(modifier = Modifier.padding(24.dp)) {
+                Text(
+                    text = "Pixel 8",
+                    color = MaterialTheme.colorScheme.onBackground,
+                    fontSize = 28.sp,
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+                Text(
+                    text = "showSystemUi = true",
+                    color = MaterialTheme.colorScheme.onBackground,
+                )
             }
         }
     }


### PR DESCRIPTION
Closes #256.

## Summary

Robolectric runs the test without a SystemUI process, so a `@Preview(device = "id:pixel_8", showSystemUi = true)` capture comes back at the right canvas size but with no chrome. This mirrors what Android Studio's preview pane does via LayoutLib's frame overlay — paints synthetic bars in Compose so they participate in capture naturally (no Java2D post-processing).

Wraps the preview composition in a new `SystemBarsFrame` composable that paints:
- **Status bar** (24dp, top): clock on the left, battery glyph on the right.
- **Navigation bar** (24dp, bottom): centred gesture pill.

Bars are translucent overlays tinted from the `@Preview(uiMode = ...)` value so dark-mode captures get dark chrome with light icons rather than always-light overlays on a dark surface — matching modern edge-to-edge Android behaviour.

### Usage paths

1. **Implicit** — set `showSystemUi = true` on a phone-shape `@Preview`. The renderer wraps automatically.
2. **Annotation-driven** — `@PreviewWrapper(SystemBarsPreviewWrapper::class)` for previews that don't pin a device.
3. **Explicit** — call `SystemBarsFrame(uiMode = ...) { ... }` directly from app code.

Skipped for round Wear devices and tile previews — circular-clip / tile renderers already brand those captures.

### Compose 1.11 floor

Bumps `renderer-android`'s `ui-tooling-preview` `compileOnly` to the 1.11 variant (`PreviewWrapperProvider` lives there). The bytecode-floor compatibility for the rest of the renderer is preserved: only `SystemBarsPreviewWrapper` references the 1.11 symbol, and that class only loads when a consumer explicitly wires it via `@PreviewWrapper`.

### Sample renders

`@Preview(name = "Pixel 8", device = "id:pixel_8", showSystemUi = true)` and a `Configuration.UI_MODE_NIGHT_YES` variant — confirms the bars adapt to the theme.

## Test plan

- [x] `./gradlew :renderer-android:compileDebugKotlin` — clean
- [x] `./gradlew :renderer-android:testDebugUnitTest --tests "*SystemBarsFrameTest"` — 3/3 pass
- [x] `./gradlew :renderer-android:testDebugUnitTest` — only pre-existing `LongScrollGhostOverlayTest` failure (verified to fail on the baseline too, unrelated)
- [x] `./gradlew :gradle-plugin:test` — pass
- [x] `./gradlew :samples:android:renderAllPreviews` — pass; new Pixel 8 light + night PNGs render with the expected chrome
- [x] `./gradlew :renderer-android:ktfmtCheck :samples:android:ktfmtCheck` — pass
- [x] `./gradlew :renderer-android:lintDebug` — pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01V11PL2VRYEBt6buzsk6nh9)_