### PR TITLE
fix(ci): stop install smoke test racing release uploads

### DIFF
--- a/.github/workflows/install-action-test.yml
+++ b/.github/workflows/install-action-test.yml
@@ -11,14 +11,26 @@ on:
   push:
     branches: [main]
     paths:
-      - '.github/actions/install/**'
+      - '.github/actions/install/action.yml'
+      - '.github/actions/install/resolve-version.py'
       - '.github/workflows/install-action-test.yml'
   pull_request:
     paths:
-      - '.github/actions/install/**'
+      - '.github/actions/install/action.yml'
+      - '.github/actions/install/resolve-version.py'
       - '.github/workflows/install-action-test.yml'
   # Manual dispatch for ad-hoc verification (e.g. after a release that
   # changes the asset naming).
+  #
+  # Path filter intentionally lists action.yml + resolve-version.py rather
+  # than the directory glob: release-please version-bumps the install
+  # README on every release (it's listed in release-please-config.json's
+  # extra-files), and a directory glob would co-trigger this workflow on
+  # the release-please merge commit. The `latest` matrix entry would then
+  # race the release.yml upload step — the empty Release exists once the
+  # tag lands but assets aren't uploaded until release.yml's `release`
+  # job finishes — and 404 trying to download the not-yet-uploaded
+  # tarball.
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- `install-action-test.yml`'s path glob `.github/actions/install/**` co-triggered on release-please merge commits because release-please version-bumps `.github/actions/install/README.md` on every release (listed in `release-please-config.json`'s `extra-files`).
- That race caused the `latest` matrix entry to resolve to the just-tagged version and curl 404 the tarball before `release.yml`'s upload step had finished — observed on run [24964068944](https://github.com/yschimke/compose-ai-tools/actions/runs/24964068944) for v0.8.7.
- Narrow the trigger paths to the action source files (`action.yml`, `resolve-version.py`) so README-only bumps no longer fire the smoke test. PR coverage on real install-action changes is preserved.

## Test plan

- [ ] Next release-please merge commit does NOT trigger `Install Action Smoke Test`.
- [ ] A PR that touches `.github/actions/install/action.yml` or `resolve-version.py` still triggers the smoke matrix.
- [ ] Manual `workflow_dispatch` of `Install Action Smoke Test` continues to work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PpeVtygAB5uczHqzMY16SV)_