### PR TITLE
docs(skill): expand permissions list with read-only gh CI inspection

### DIFF
--- a/skills/compose-preview/SKILL.md
+++ b/skills/compose-preview/SKILL.md
@@ -95,21 +95,26 @@ keep anything that publishes or mutates shared state on the prompt path.
 - `./gradlew` / `gradle` — already trusted in most JVM projects.
 - Reading `**/build/**` — rendered PNGs and staged copies live here.
 - `mkdir -p`, `cp`, `rm -f` — for staging copies (see below).
-- `git worktree add|remove|list`, `git ls-remote`, `git fetch`, `git show` —
-  used by the PR-review workflow to render a base branch without touching
-  the working copy.
-- `gh pr view`, `gh pr diff`, and `GET` on `gh api repos/…/comments`.
+- Read-only git: `git worktree add|remove|list`, `git ls-remote`, `git fetch`,
+  `git show`, `git diff`, `git log`. Used by the PR-review workflow to render
+  a base branch without touching the working copy.
+- Read-only `gh`: `gh pr view`, `gh pr diff`, `gh run list|view [--log[-failed]]|watch`,
+  `gh workflow list|view`, `gh release list|view`, `gh auth status`, plus GET
+  on `gh api repos/<owner>/<repo>/{comments,actions,contents,…}`. The
+  `gh run` calls come up constantly when a render fails on the runner.
 
 **Require explicit consent** (publish or mutate shared state — keep on the
 prompt path):
 
 - `gh gist create` — public by default; even `--secret` URLs are shareable.
-- `gh pr comment`, `gh pr review`, `POST`/`PATCH`/`DELETE` via `gh api`.
+- `gh pr edit`, `gh pr comment`, `gh pr review`, `gh pr merge|close|reopen|ready`.
+- `POST`/`PATCH`/`DELETE` via `gh api`.
 - `git push`, `git commit`, `git branch -D`, `git reset --hard`.
 - Uploads to external hosts (image hosts, paste services).
 
-If the user approves a gist or PR comment once, don't persist it as a
-general allowlist entry — the next PR may not want it.
+If the user approves a gist, PR edit, or push once, don't persist it as a
+general allowlist entry — the next iteration may not want the same level of
+publicity.
 
 ### Staging PNGs outside the render output
 


### PR DESCRIPTION
## Summary

Partial response to #252 — apply the parts of the permissions-list proposal
that are honestly skill-scoped and harness-encodable today, and split the
rest out as separate work.

In this PR:

- **Pre-approve** gains the read-only `gh` CI bucket (`gh run list|view
  [--log[-failed]]|watch`, `gh workflow list|view`, `gh release list|view`,
  `gh auth status`, plus GET on `gh api repos/.../{comments,actions,contents,…}`).
  Agents reach for these every time a render fails on the runner.
- **Pre-approve** read-only git is broadened to include `git diff` and
  `git log` alongside the existing `worktree`/`ls-remote`/`fetch`/`show`.
- **Require explicit consent** lists `gh pr edit` and the rest of the `gh
  pr` mutation verbs (`merge|close|reopen|ready`) explicitly rather than
  rolling them into the `gh api` PATCH catch-all.
- One-off-approval note expands to cover PR edits and pushes, not just
  gists and comments.

Deliberately not in this PR (split out so each lands as its own change):

- #263 — relocate `.compose-preview-history/` under `build/` and expand
  `doctor --verbose` to surface plugin internals. Kills the
  `unzip`/`javap`-the-jar diagnostic detour.
- #264 — wrap the `preview_pr`/`preview_main` push flow and the
  markdown-with-images gist flow in `compose-preview` subcommands. Once
  those exist, the multi-step "git push to staging branch from a /tmp dir
  with a carved-out `git config` identity" and "seed gist, clone, drop
  PNGs, push" patterns collapse into single CLI calls a harness can
  pre-approve as one entry — no cwd/branch-name conditionals required.

The proposed standalone deny-list from #252 is not added: most of those
entries (`gh auth login|refresh|setup-git`, `gh ssh-key|gpg-key add`, `gh
repo create|delete|fork`, `git filter-branch|filter-repo|replace`) are
sandbox/harness policy rather than compose-preview workflow concerns. The
remaining skill-relevant denies (push outside `preview_*`, raw `--force`)
are already implied by the consent bucket.

Leave #252 open until #263 and #264 land.

## Test plan

- [ ] SKILL.md renders cleanly on GitHub — bullet lists and code spans format
      as intended.
- [ ] Diff against the previous version: no pre-existing entry dropped
      without intent.


---
_Generated by [Claude Code](https://claude.ai/code/session_0172DjRAFRAyyWMMnifBYrmT)_