### PR TITLE
docs(ci-previews): document the local .compose-preview-history/ directory

### DIFF
--- a/skills/compose-preview/design/CI_PREVIEWS.md
+++ b/skills/compose-preview/design/CI_PREVIEWS.md
@@ -147,3 +147,33 @@ Both `preview_main` and `preview_pr` are append-only:
   to commit SHAs on `preview_main` and `preview_pr`, not branch
   names — so images keep resolving after the PR merges and after
   later PRs advance either branch.
+
+## Local persistent state: `.compose-preview-history/`
+
+CI keeps long-lived state on the `preview_main` and `preview_pr`
+branches. There's also a per-module local equivalent —
+`<module>/.compose-preview-history/`, deliberately outside `build/` so
+it survives `./gradlew clean`. Two distinct things land there:
+
+- **Snapshots**, when `composePreview.historyEnabled = true` is set in
+  the module's `build.gradle.kts`. Every rendered PNG that differs from
+  the previous snapshot gets archived under `<id>/<timestamp>.png`,
+  giving you cross-`./gradlew clean` history without going via CI.
+- **Downloadable-font cache** (`fonts/`), populated automatically the
+  first time a preview pulls a Google Font — no opt-in needed. Cached
+  here so repeated renders after `clean` don't re-download, and so
+  `-PcomposePreview.fontsOffline=true` can serve cache misses without
+  hitting the network.
+
+Both subtrees are designed to be **committed to git** when
+reproducibility matters (network-free renders, byte-stable baselines).
+The samples in this repo commit their cached `fonts/` so CI doesn't
+depend on `fonts.gstatic.com` being reachable. Override the location
+via `composePreview.historyDir = layout.projectDirectory.dir("…")`.
+
+If your project doesn't want this, `.gitignore` the directory — the
+choice is between local reproducibility and a smaller working tree.
+Agents and humans should expect to encounter the directory at the
+module root rather than under `build/`; it's the one deliberate
+exception to the otherwise-true "writes go under gitignored `build/`"
+framing the SKILL uses.


### PR DESCRIPTION
## Summary

First half of #263 — document `.compose-preview-history/` properly so
agents stop reading it as a bug.

The dir lives at the module root (outside `build/`) on purpose: both
the opt-in `historyEnabled` snapshots and the always-on
downloadable-font cache (`fonts/`) need to survive `./gradlew clean`.
The samples in this repo commit their cached fonts so CI doesn't
depend on `fonts.gstatic.com` being reachable.

Adds the section to `design/CI_PREVIEWS.md` rather than `SKILL.md` —
both `preview_main`/`preview_pr` and `.compose-preview-history/` are
about persistent state for reproducible renders, just at different
scopes (CI vs local). Keeps the `SKILL.md` surface small.

The other half of #263 (surface applied plugin version per module in
`doctor`) is in #268.

Note: the original framing in #263 ("relocate the dir under `build/`")
was wrong — that would break the deliberate cross-clean property. The
issue is updated with the corrected analysis.

## Test plan

- [ ] CI_PREVIEWS.md renders cleanly on GitHub — the new section sits
      after "Branch durability".
