### PR TITLE
feat(render): stage Android resource renders into preview_main

### DIFF
--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -433,6 +433,155 @@ def cmd_copy_changed(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# generate-resources mode
+#
+# Sibling of `generate`. Walks every `<module>/build/compose-previews/resources.json`
+# under `--workspace-root` and copies the rendered PNGs / GIFs into
+# `<output_dir>/renders/<module>/resources/<...>` so they land in `preview_main`
+# alongside the existing composable baselines. Writes `resource-baselines.json`
+# next to `baselines.json` and appends a section to the README.
+#
+# Independent walk (rather than reusing the `compose-preview show --json`
+# output) — the CLI doesn't know about resources today, and keeping the
+# resources path orthogonal to the composable path means modules with no
+# `resources.json` (consumers who applied the plugin but never enabled
+# `composePreview.resourcePreviews`) don't perturb the existing baselines tree.
+# ---------------------------------------------------------------------------
+
+def _resource_render_dest(render_output: str) -> str:
+    """`renders/resources/drawable/foo.png` → `resources/drawable/foo.png`.
+
+    The leading `renders/` segment is stripped so the destination tree is
+    `<output>/renders/<module>/resources/...`, consistent with how the
+    composable path lays out `<output>/renders/<module>/<basename>`.
+    """
+    if render_output.startswith("renders/"):
+        return render_output[len("renders/"):]
+    return render_output
+
+
+def load_resource_manifests(workspace_root: Path) -> dict[str, dict]:
+    """Globs `<module>/build/compose-previews/resources.json` and returns a
+    flat key→entry map. Key shape: `<module>::<resourceId>::<renderOutput>` —
+    stable enough to detect changes across runs without colliding when a single
+    resource has multiple captures (e.g. adaptive-icon shape masks).
+
+    Returns an empty dict when no `resources.json` exists anywhere — that's
+    the dominant case for projects that don't write XML drawables, and an
+    empty result is a no-op for `cmd_generate_resources`.
+    """
+    out: dict[str, dict] = {}
+    for manifest_path in sorted(workspace_root.glob("*/build/compose-previews/resources.json")):
+        module_dir = manifest_path.parent.parent.parent
+        module = str(module_dir.relative_to(workspace_root)).replace("\\", "/")
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        for resource in manifest.get("resources", []) or []:
+            resource_id = resource.get("id")
+            resource_type = resource.get("type", "")
+            if not resource_id:
+                continue
+            for capture in resource.get("captures", []) or []:
+                render_output = capture.get("renderOutput") or ""
+                if not render_output:
+                    continue
+                src = module_dir / "build" / "compose-previews" / render_output
+                key = f"{module}::{resource_id}::{render_output}"
+                out[key] = {
+                    "module": module,
+                    "moduleDir": module_dir,
+                    "resourceId": resource_id,
+                    "resourceType": resource_type,
+                    "renderOutput": render_output,
+                    "destRelative": _resource_render_dest(render_output),
+                    "pngPath": src,
+                    "sha256": sha256(src) if src.exists() else None,
+                    "qualifiers": (capture.get("variant") or {}).get("qualifiers"),
+                    "shape": (capture.get("variant") or {}).get("shape"),
+                }
+    return out
+
+
+def cmd_generate_resources(args: argparse.Namespace) -> int:
+    workspace_root = Path(args.workspace_root).resolve()
+    out_dir = Path(args.output_dir)
+
+    entries = load_resource_manifests(workspace_root)
+    if not entries:
+        # Not an error — modules without resources.json are common.
+        print("No Android resource manifests found; skipping resource baselines.",
+              file=sys.stderr)
+        return 0
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    resource_baselines: dict[str, dict] = {}
+    by_module: dict[str, list[tuple[str, dict]]] = {}
+    for key, info in entries.items():
+        if not info["sha256"]:
+            continue
+        dest = out_dir / "renders" / info["module"] / info["destRelative"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(info["pngPath"], dest)
+        resource_baselines[key] = {
+            "sha256": info["sha256"],
+            "module": info["module"],
+            "resourceId": info["resourceId"],
+            "resourceType": info["resourceType"],
+            "renderBasename": info["destRelative"],
+            "qualifiers": info["qualifiers"],
+            "shape": info["shape"],
+        }
+        by_module.setdefault(info["module"], []).append((key, info))
+
+    if not resource_baselines:
+        print("Resource manifests existed but no rendered PNGs were on disk; "
+              "skipping resource baselines.",
+              file=sys.stderr)
+        return 0
+
+    (out_dir / "resource-baselines.json").write_text(
+        json.dumps(resource_baselines, indent=2, sort_keys=True) + "\n")
+
+    # Append the resource gallery to the README. The composable `cmd_generate`
+    # has already written the file; we add a sibling section. When run on its
+    # own (no prior README), seed the file so the section header has a parent.
+    readme = out_dir / "README.md"
+    existing = readme.read_text() if readme.exists() else "# Preview Baselines\n"
+    body_lines: list[str] = []
+    if not existing.rstrip().endswith(""):
+        body_lines.append("")
+    body_lines += [
+        "",
+        "## Android XML Resource Previews",
+        "",
+        "Rendered from `:<module>:renderAndroidResources`. One row per "
+        "(resource × qualifier × shape) capture. See "
+        "[`design/RESOURCE_PREVIEWS.md`](https://github.com/yschimke/compose-ai-tools/blob/main/skills/compose-preview/design/RESOURCE_PREVIEWS.md) "
+        "for the rendering catalogue.",
+        "",
+    ]
+    for module in sorted(by_module):
+        module_entries = sorted(by_module[module], key=lambda kv: kv[0])
+        body_lines.append(f"### {module}")
+        body_lines.append("")
+        body_lines.append("| Resource | Type | Qualifiers | Shape | Image |")
+        body_lines.append("|---|---|---|---|---|")
+        for _, info in module_entries:
+            qualifiers = info["qualifiers"] or "—"
+            shape = info["shape"] or "—"
+            img_path = f"renders/{info['module']}/{info['destRelative']}"
+            body_lines.append(
+                f"| `{info['resourceId']}` | {info['resourceType']} | "
+                f"`{qualifiers}` | {shape} | <img src=\"{img_path}\" height=\"96\" /> |"
+            )
+        body_lines.append("")
+    readme.write_text(existing.rstrip() + "\n" + "\n".join(body_lines).lstrip("\n") + "\n")
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -466,11 +615,22 @@ def main() -> int:
     cp.add_argument("--baselines", required=True)
     cp.add_argument("--output-dir", required=True)
 
+    gen_res = sub.add_parser(
+        "generate-resources",
+        help="Walk every <module>/build/compose-previews/resources.json and stage the "
+             "rendered PNGs / GIFs into the baselines tree. No-ops on workspaces "
+             "without any resources.json.",
+    )
+    gen_res.add_argument("--output-dir", required=True)
+    gen_res.add_argument("--workspace-root", default=".",
+                         help="Root to glob for <module>/build/compose-previews/resources.json")
+
     args = ap.parse_args()
     handlers = {
         "generate": cmd_generate,
         "compare": cmd_compare,
         "copy-changed": cmd_copy_changed,
+        "generate-resources": cmd_generate_resources,
     }
     return handlers[args.command](args)
 

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -545,5 +545,168 @@ class MultiCaptureCompareTest(unittest.TestCase):
         self.assertIn("S_SCROLL_end.png", out)
 
 
+class GenerateResourcesTests(unittest.TestCase):
+    """`cmd_generate_resources` walks `<module>/build/compose-previews/resources.json`
+    and stages the rendered PNGs / GIFs into `<output>/renders/<module>/resources/...`."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp()
+        self.workspace = Path(self.tmp) / "ws"
+        self.workspace.mkdir()
+        self.output = Path(self.tmp) / "out"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp)
+
+    def _write_module(self, module: str, manifest: dict, png_files: dict[str, bytes]) -> None:
+        module_dir = self.workspace / module / "build" / "compose-previews"
+        module_dir.mkdir(parents=True, exist_ok=True)
+        (module_dir / "resources.json").write_text(json.dumps(manifest))
+        for relative, content in png_files.items():
+            target = module_dir / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(content)
+
+    def _run(self) -> int:
+        from types import SimpleNamespace
+        return cp.cmd_generate_resources(SimpleNamespace(
+            output_dir=str(self.output),
+            workspace_root=str(self.workspace),
+        ))
+
+    def test_no_manifests_is_a_clean_noop(self) -> None:
+        self.assertEqual(self._run(), 0)
+        # Output dir shouldn't be created when there's nothing to do — keeps
+        # the baselines tree byte-identical for projects that don't write XML
+        # resources.
+        self.assertFalse(self.output.exists())
+
+    def test_copies_pngs_and_writes_resource_baselines_json(self) -> None:
+        self._write_module(
+            "app",
+            manifest={
+                "module": "app", "variant": "debug",
+                "resources": [
+                    {
+                        "id": "drawable/ic_logo",
+                        "type": "VECTOR",
+                        "sourceFiles": {"": "src/main/res/drawable/ic_logo.xml"},
+                        "captures": [{
+                            "variant": {"qualifiers": "xhdpi", "shape": None},
+                            "renderOutput": "renders/resources/drawable/ic_logo_xhdpi.png",
+                            "cost": 1.0,
+                        }],
+                    },
+                ],
+                "manifestReferences": [],
+            },
+            png_files={"renders/resources/drawable/ic_logo_xhdpi.png": b"png-bytes"},
+        )
+
+        self.assertEqual(self._run(), 0)
+
+        # PNG copied to the canonical baselines layout — the leading
+        # `renders/` of the manifest's `renderOutput` is absorbed into the
+        # destination root so it doesn't double-up.
+        dest = self.output / "renders" / "app" / "resources" / "drawable" / "ic_logo_xhdpi.png"
+        self.assertTrue(dest.exists())
+        self.assertEqual(dest.read_bytes(), b"png-bytes")
+
+        baselines = json.loads((self.output / "resource-baselines.json").read_text())
+        self.assertEqual(len(baselines), 1)
+        key = next(iter(baselines))
+        self.assertIn("app::drawable/ic_logo::renders/resources/drawable/ic_logo_xhdpi.png", key)
+        entry = baselines[key]
+        self.assertEqual(entry["resourceId"], "drawable/ic_logo")
+        self.assertEqual(entry["resourceType"], "VECTOR")
+        self.assertEqual(entry["qualifiers"], "xhdpi")
+        self.assertIsNone(entry["shape"])
+        self.assertEqual(entry["renderBasename"], "resources/drawable/ic_logo_xhdpi.png")
+
+    def test_skips_captures_whose_pngs_dont_exist(self) -> None:
+        self._write_module(
+            "app",
+            manifest={
+                "module": "app", "variant": "debug",
+                "resources": [{
+                    "id": "drawable/ghost",
+                    "type": "VECTOR",
+                    "sourceFiles": {"": "src/main/res/drawable/ghost.xml"},
+                    "captures": [{
+                        "variant": {"qualifiers": "xhdpi", "shape": None},
+                        "renderOutput": "renders/resources/drawable/ghost_xhdpi.png",
+                    }],
+                }],
+                "manifestReferences": [],
+            },
+            png_files={},  # discovery saw the resource but renderer hasn't run
+        )
+        self.assertEqual(self._run(), 0)
+        # No baselines file should be written, since no PNG exists to record.
+        self.assertFalse((self.output / "resource-baselines.json").exists())
+
+    def test_records_adaptive_icon_shape_per_capture(self) -> None:
+        self._write_module(
+            "app",
+            manifest={
+                "module": "app", "variant": "debug",
+                "resources": [{
+                    "id": "mipmap/ic_launcher",
+                    "type": "ADAPTIVE_ICON",
+                    "sourceFiles": {"anydpi-v26": "src/main/res/mipmap-anydpi-v26/ic_launcher.xml"},
+                    "captures": [
+                        {
+                            "variant": {"qualifiers": "xhdpi", "shape": "CIRCLE"},
+                            "renderOutput": "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_circle.png",
+                        },
+                        {
+                            "variant": {"qualifiers": "xhdpi", "shape": "LEGACY"},
+                            "renderOutput": "renders/resources/mipmap/ic_launcher_xhdpi_LEGACY.png",
+                        },
+                    ],
+                }],
+                "manifestReferences": [],
+            },
+            png_files={
+                "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_circle.png": b"circle",
+                "renders/resources/mipmap/ic_launcher_xhdpi_LEGACY.png": b"legacy",
+            },
+        )
+        self.assertEqual(self._run(), 0)
+        baselines = json.loads((self.output / "resource-baselines.json").read_text())
+        shapes = sorted(entry["shape"] for entry in baselines.values())
+        self.assertEqual(shapes, ["CIRCLE", "LEGACY"])
+
+    def test_appends_resource_section_to_existing_readme(self) -> None:
+        # Simulate `cmd_generate` having already written a composable README.
+        self.output.mkdir()
+        (self.output / "README.md").write_text("# Preview Baselines\n\n## sample-android\n\n…\n")
+        self._write_module(
+            "app",
+            manifest={
+                "module": "app", "variant": "debug",
+                "resources": [{
+                    "id": "drawable/ic_logo",
+                    "type": "VECTOR",
+                    "sourceFiles": {"": "src/main/res/drawable/ic_logo.xml"},
+                    "captures": [{
+                        "variant": {"qualifiers": "xhdpi", "shape": None},
+                        "renderOutput": "renders/resources/drawable/ic_logo_xhdpi.png",
+                    }],
+                }],
+                "manifestReferences": [],
+            },
+            png_files={"renders/resources/drawable/ic_logo_xhdpi.png": b"png"},
+        )
+        self.assertEqual(self._run(), 0)
+        readme = (self.output / "README.md").read_text()
+        # Original composable section preserved.
+        self.assertIn("## sample-android", readme)
+        # Resource section appended.
+        self.assertIn("## Android XML Resource Previews", readme)
+        self.assertIn("`drawable/ic_logo`", readme)
+        self.assertIn("VECTOR", readme)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.github/actions/preview-baselines/action.yml
+++ b/.github/actions/preview-baselines/action.yml
@@ -88,6 +88,21 @@ runs:
           --repo "$REPO" \
           --branch "$BASELINE_BRANCH"
 
+    # Stage Android XML resource previews (vector / animated-vector /
+    # adaptive-icon) into the same _baselines/ tree so the preview_main
+    # branch covers them alongside composable @Preview renders. No-ops on
+    # consumers without any resources.json — the helper exits 0 with a
+    # status line. The CLI doesn't surface resource captures yet, so the
+    # helper globs the workspace directly.
+    - name: Stage resource baselines
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        python3 "$ACTION_PATH/../lib/compare-previews.py" generate-resources \
+          --output-dir _baselines \
+          --workspace-root .
+
     - name: Push to baselines branch
       shell: bash
       # All templated values go through env first so a malicious input


### PR DESCRIPTION
## Summary

Builds on #259 (now merged). Extends the `preview-baselines` composite action so the rendered Android XML resource previews (vector / animated-vector / adaptive-icon) land on the `preview_main` branch alongside `@Preview` composables — same place CI publishes the composable gallery, browsable inline on GitHub.

- **`compare-previews.py`** grows a new `generate-resources` subcommand that globs `<module>/build/compose-previews/resources.json`, walks each `ResourcePreview`'s captures, and copies the rendered PNGs / GIFs into `<output>/renders/<module>/resources/<...>`. Destination layout parallels the existing composable path so the `preview_main` tree stays predictable. Writes a sibling `resource-baselines.json` (independent of the composable `baselines.json` — different lookup shape, different consumers) and appends an "Android XML Resource Previews" section to the README so the baseline branch's gallery shows them inline.
- **`preview-baselines/action.yml`** runs the new subcommand after the existing `generate` step, before the push. No-ops on workspaces without any `resources.json` (the dominant case for projects that don't write XML drawables), so the existing baselines tree stays byte-identical when the feature isn't in use.

The CLI doesn't surface resource captures today, so the helper globs the workspace directly rather than threading through `compose-preview show --json`. That's the smallest insertion point that gets resource PNGs into `preview_main`; a CLI integration can come later if the python glob shape becomes a maintenance issue.

## Follow-up (next commit on this branch)

`preview-comment.yml` integration. PR auto-comments still don't show before/after for resource changes — the comment path needs a parallel `compare-resources` mode and updates to the markdown generator.

## Test plan

- [ ] `python3 -m unittest .github/actions/lib.test_compare_previews -v` — all 29 tests pass (5 new in `GenerateResourcesTests` + 24 existing).
- [ ] On a real `preview_main` push (next merge to `main`): the `Stage resource baselines` step runs the new subcommand, the published `_baselines/` tree contains `renders/<module>/resources/<...>` with the rendered set, and the README has an "Android XML Resource Previews" section.
- [ ] Verify on a project with no `resources.json`: `Stage resource baselines` runs and exits 0 with `No Android resource manifests found; skipping resource baselines.` — no perturbation to the existing baselines tree.