### PR TITLE
feat(actions): include resource diffs in PR preview comments

### DIFF
--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -685,10 +685,15 @@ def cmd_compare_resources(args: argparse.Namespace) -> int:
         if key not in current:
             removed.append((key, bl_info))
 
+    marker = "<!-- preview-diff-resources -->"
     if not (new or changed or removed):
-        return 0  # nothing to append
+        # Empty stdout when nothing diffed — the action treats no output as
+        # "skip the resource comment entirely" rather than posting a "no
+        # changes" sticky comment that would clutter PRs that don't touch
+        # resources.
+        return 0
 
-    lines: list[str] = ["## Resource Changes", ""]
+    lines: list[str] = [marker, "## Resource Changes", ""]
 
     if changed:
         # Group by (module, resourceId) so all captures of the same resource

--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -582,6 +582,188 @@ def cmd_generate_resources(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# copy-changed-resources mode
+# ---------------------------------------------------------------------------
+
+def cmd_copy_changed_resources(args: argparse.Namespace) -> int:
+    """Sibling of [cmd_copy_changed]. Globs every
+    `<workspace>/<module>/build/compose-previews/resources.json`, compares the
+    rendered PNGs / GIFs against `resource-baselines.json`, and copies new or
+    changed ones into `<output>/renders/<module>/resources/<...>`.
+
+    Output layout matches [cmd_generate_resources] so the push to `preview_pr`
+    lands these PNGs at paths the comment markdown can `_render_url` to.
+    Modules without `resources.json` are skipped silently — same behaviour as
+    `cmd_generate_resources`.
+    """
+    workspace_root = Path(args.workspace_root).resolve()
+    baselines_path = Path(args.baselines)
+    out_dir = Path(args.output_dir)
+
+    entries = load_resource_manifests(workspace_root)
+    if not entries:
+        return 0
+    baselines = json.loads(baselines_path.read_text()) if baselines_path.exists() else {}
+
+    copied = 0
+    for key, info in entries.items():
+        if not info["sha256"]:
+            continue
+        is_new = key not in baselines
+        is_changed = not is_new and info["sha256"] != baselines[key]["sha256"]
+        if not (is_new or is_changed):
+            continue
+        dest = out_dir / "renders" / info["module"] / info["destRelative"]
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(info["pngPath"], dest)
+        copied += 1
+
+    print(f"Copied {copied} changed/new resource preview(s) to {out_dir}", file=sys.stderr)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# compare-resources mode
+# ---------------------------------------------------------------------------
+
+def _resource_url(repo: str, ref: str, module: str, basename: str) -> str:
+    """Same shape as [_render_url] but the resource basenames carry their own
+    `resources/<type>/...` prefix, so the URL encodes
+    `renders/<module>/resources/...`."""
+    return (
+        f"https://raw.githubusercontent.com/{repo}/{ref}"
+        f"/renders/{module}/{basename}"
+    )
+
+
+def _resource_label(info: dict) -> str:
+    """Human-readable label for one resource capture: `xhdpi`, `night-xhdpi`,
+    `xhdpi · CIRCLE`, or `default` when no qualifiers / shape are set. Mirrors
+    [_entry_label]'s role for composables."""
+    parts: list[str] = []
+    qualifiers = info.get("qualifiers")
+    shape = info.get("shape")
+    if qualifiers:
+        parts.append(qualifiers)
+    if shape:
+        parts.append(shape)
+    return " · ".join(parts) if parts else "default"
+
+
+def cmd_compare_resources(args: argparse.Namespace) -> int:
+    """Sibling of [cmd_compare] that emits a "Resource changes" markdown
+    section against `resource-baselines.json`. No leading marker — the
+    composable comment owns the marker, and this output is concatenated by
+    `preview-comment/action.yml` after [cmd_compare]'s body. Emits an empty
+    string when no resource manifests exist or no diff is detected, so the
+    action can append unconditionally without polluting the comment.
+    """
+    workspace_root = Path(args.workspace_root).resolve()
+    baselines_path = Path(args.baselines)
+    repo = args.repo
+    base_ref = args.base_ref
+    head_ref = args.head_ref
+
+    current = load_resource_manifests(workspace_root)
+    baselines = json.loads(baselines_path.read_text()) if baselines_path.exists() else {}
+
+    new: list[tuple[str, dict]] = []
+    changed: list[tuple[str, dict, dict]] = []
+    removed: list[tuple[str, dict]] = []
+    unchanged: list[tuple[str, dict]] = []
+
+    for key, info in sorted(current.items()):
+        if not info["sha256"]:
+            continue
+        if key not in baselines:
+            new.append((key, info))
+        elif info["sha256"] != baselines[key]["sha256"]:
+            changed.append((key, info, baselines[key]))
+        else:
+            unchanged.append((key, info))
+    for key, bl_info in sorted(baselines.items()):
+        if key not in current:
+            removed.append((key, bl_info))
+
+    if not (new or changed or removed):
+        return 0  # nothing to append
+
+    lines: list[str] = ["## Resource Changes", ""]
+
+    if changed:
+        # Group by (module, resourceId) so all captures of the same resource
+        # land under one heading — adaptive icons fan out to 4 shape masks
+        # per icon and the per-capture rows would otherwise drown the diff.
+        groups: dict[tuple[str, str], list[tuple[str, dict, dict]]] = {}
+        for key, cur, bl in changed:
+            groups.setdefault((cur["module"], cur["resourceId"]), []).append((key, cur, bl))
+        lines.append(
+            f"### Changed ({len(changed)} variant(s) across {len(groups)} resource(s))"
+        )
+        lines.append("")
+        for (module, resource_id), entries in sorted(groups.items()):
+            hero_key, hero_cur, hero_bl = entries[0]
+            before = _resource_url(repo, base_ref, module, hero_cur["destRelative"])
+            after = _resource_url(repo, head_ref, module, hero_cur["destRelative"])
+            lines.append(f"**`{resource_id}`** ({module}, {hero_cur['resourceType']})")
+            lines.append("")
+            lines.append("| Before | After |")
+            lines.append("|--------|-------|")
+            lines.append(
+                f"| <img src=\"{before}\" width=\"200\" /> "
+                f"| <img src=\"{after}\" width=\"200\" /> |"
+            )
+            if len(entries) > 1:
+                variant_links = []
+                for _okey, ocur, _obl in entries[1:]:
+                    label = _resource_label(ocur)
+                    link = _resource_url(repo, head_ref, module, ocur["destRelative"])
+                    variant_links.append(f"[{label}]({link})")
+                lines.append("")
+                lines.append(f"Other variants: {', '.join(variant_links)}")
+            lines.append("")
+
+    if new:
+        groups_new: dict[tuple[str, str], list[tuple[str, dict]]] = {}
+        for key, info in new:
+            groups_new.setdefault((info["module"], info["resourceId"]), []).append((key, info))
+        lines.append(
+            f"### New ({len(new)} variant(s) across {len(groups_new)} resource(s))"
+        )
+        lines.append("")
+        for (module, resource_id), entries in sorted(groups_new.items()):
+            hero_key, hero_info = entries[0]
+            after = _resource_url(repo, head_ref, module, hero_info["destRelative"])
+            lines.append(
+                f"**`{resource_id}`** ({module}, {hero_info['resourceType']}) "
+                f"<img src=\"{after}\" width=\"200\" />"
+            )
+            if len(entries) > 1:
+                variant_links = []
+                for _okey, oinfo in entries[1:]:
+                    label = _resource_label(oinfo)
+                    link = _resource_url(repo, head_ref, module, oinfo["destRelative"])
+                    variant_links.append(f"[{label}]({link})")
+                lines.append(f"Variants: {', '.join(variant_links)}")
+            lines.append("")
+
+    if removed:
+        # Group by (module, resourceId) — a resource being deleted typically
+        # removes all its captures at once, surfacing them as N rows would be
+        # noise.
+        rm_resources = sorted({(bl_info.get("module", "?"), bl_info.get("resourceId", "?"))
+                               for _, bl_info in removed})
+        lines.append(f"### Removed ({len(removed)} variant(s) across {len(rm_resources)} resource(s))")
+        lines.append("")
+        for module, resource_id in rm_resources:
+            lines.append(f"- ~`{resource_id}`~ ({module})")
+        lines.append("")
+
+    print("\n".join(lines))
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -625,12 +807,35 @@ def main() -> int:
     gen_res.add_argument("--workspace-root", default=".",
                          help="Root to glob for <module>/build/compose-previews/resources.json")
 
+    cp_res = sub.add_parser(
+        "copy-changed-resources",
+        help="Sibling of `copy-changed` for resource captures.",
+    )
+    cp_res.add_argument("--baselines", required=True,
+                        help="Path to resource-baselines.json (fetched from preview_main)")
+    cp_res.add_argument("--output-dir", required=True)
+    cp_res.add_argument("--workspace-root", default=".")
+
+    cmp_res = sub.add_parser(
+        "compare-resources",
+        help="Sibling of `compare` for resource captures. Emits the markdown section "
+             "to append after the composable diff. Empty stdout when nothing changed.",
+    )
+    cmp_res.add_argument("--baselines", required=True,
+                         help="Path to resource-baselines.json (fetched from preview_main)")
+    cmp_res.add_argument("--repo", required=True)
+    cmp_res.add_argument("--base-ref", default="preview_main")
+    cmp_res.add_argument("--head-ref", required=True)
+    cmp_res.add_argument("--workspace-root", default=".")
+
     args = ap.parse_args()
     handlers = {
         "generate": cmd_generate,
         "compare": cmd_compare,
         "copy-changed": cmd_copy_changed,
         "generate-resources": cmd_generate_resources,
+        "copy-changed-resources": cmd_copy_changed_resources,
+        "compare-resources": cmd_compare_resources,
     }
     return handlers[args.command](args)
 

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -842,6 +842,10 @@ class CompareResourcesTests(unittest.TestCase):
             },
         }))
         out = self._run()
+        # First line is the dedicated marker so the action's post step can
+        # find / patch a sibling sticky comment without colliding with the
+        # composable `<!-- preview-diff -->` marker.
+        self.assertTrue(out.startswith("<!-- preview-diff-resources -->"))
         self.assertIn("## Resource Changes", out)
         self.assertIn("### Changed (1 variant(s) across 1 resource(s))", out)
         self.assertIn("`drawable/ic_logo`", out)

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -708,5 +708,231 @@ class GenerateResourcesTests(unittest.TestCase):
         self.assertIn("VECTOR", readme)
 
 
+class CopyChangedResourcesTests(unittest.TestCase):
+    """`cmd_copy_changed_resources` mirrors `cmd_copy_changed` for resource
+    captures: globs each module's `resources.json`, hashes the rendered PNGs,
+    and copies new/changed entries into `<output>/renders/<module>/...`."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp()
+        self.workspace = Path(self.tmp) / "ws"
+        self.workspace.mkdir()
+        self.output = Path(self.tmp) / "out"
+        self.baselines = Path(self.tmp) / "resource-baselines.json"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp)
+
+    def _write_module(self, module: str, manifest: dict, png_files: dict[str, bytes]) -> None:
+        module_dir = self.workspace / module / "build" / "compose-previews"
+        module_dir.mkdir(parents=True, exist_ok=True)
+        (module_dir / "resources.json").write_text(json.dumps(manifest))
+        for relative, content in png_files.items():
+            target = module_dir / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(content)
+
+    def _run(self) -> int:
+        from types import SimpleNamespace
+        return cp.cmd_copy_changed_resources(SimpleNamespace(
+            workspace_root=str(self.workspace),
+            baselines=str(self.baselines),
+            output_dir=str(self.output),
+        ))
+
+    def test_copies_only_new_or_changed_pngs(self) -> None:
+        # Three captures: one matches baseline (skip), one differs (changed,
+        # copy), one is absent from baseline (new, copy).
+        manifest = {
+            "module": "app", "variant": "debug",
+            "resources": [
+                {"id": "drawable/same", "type": "VECTOR",
+                 "sourceFiles": {"": "src/main/res/drawable/same.xml"},
+                 "captures": [{"variant": {"qualifiers": "xhdpi", "shape": None},
+                               "renderOutput": "renders/resources/drawable/same_xhdpi.png"}]},
+                {"id": "drawable/changed", "type": "VECTOR",
+                 "sourceFiles": {"": "src/main/res/drawable/changed.xml"},
+                 "captures": [{"variant": {"qualifiers": "xhdpi", "shape": None},
+                               "renderOutput": "renders/resources/drawable/changed_xhdpi.png"}]},
+                {"id": "drawable/new", "type": "VECTOR",
+                 "sourceFiles": {"": "src/main/res/drawable/new.xml"},
+                 "captures": [{"variant": {"qualifiers": "xhdpi", "shape": None},
+                               "renderOutput": "renders/resources/drawable/new_xhdpi.png"}]},
+            ],
+            "manifestReferences": [],
+        }
+        self._write_module("app", manifest, {
+            "renders/resources/drawable/same_xhdpi.png": b"same",
+            "renders/resources/drawable/changed_xhdpi.png": b"NEW-CONTENT",
+            "renders/resources/drawable/new_xhdpi.png": b"new",
+        })
+        # Baseline has the SAME and CHANGED entries with their old shas.
+        same_sha = cp.sha256(self.workspace / "app" / "build" / "compose-previews"
+                             / "renders/resources/drawable/same_xhdpi.png")
+        self.baselines.write_text(json.dumps({
+            "app::drawable/same::renders/resources/drawable/same_xhdpi.png": {
+                "sha256": same_sha,
+                "renderBasename": "resources/drawable/same_xhdpi.png",
+            },
+            "app::drawable/changed::renders/resources/drawable/changed_xhdpi.png": {
+                "sha256": "OLD-SHA",
+                "renderBasename": "resources/drawable/changed_xhdpi.png",
+            },
+        }))
+
+        self.assertEqual(self._run(), 0)
+        # Only `changed` and `new` should be copied.
+        copied = sorted(p.name for p in (self.output / "renders" / "app" / "resources" / "drawable").iterdir())
+        self.assertEqual(copied, ["changed_xhdpi.png", "new_xhdpi.png"])
+
+    def test_no_resources_is_a_clean_noop(self) -> None:
+        self.assertEqual(self._run(), 0)
+        self.assertFalse(self.output.exists())
+
+
+class CompareResourcesTests(unittest.TestCase):
+    """`cmd_compare_resources` emits a "Resource Changes" markdown section.
+    Empty stdout when no diff is detected."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.mkdtemp()
+        self.workspace = Path(self.tmp) / "ws"
+        self.workspace.mkdir()
+        self.baselines = Path(self.tmp) / "resource-baselines.json"
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp)
+
+    def _write_module(self, module: str, manifest: dict, png_files: dict[str, bytes]) -> None:
+        module_dir = self.workspace / module / "build" / "compose-previews"
+        module_dir.mkdir(parents=True, exist_ok=True)
+        (module_dir / "resources.json").write_text(json.dumps(manifest))
+        for relative, content in png_files.items():
+            target = module_dir / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(content)
+
+    def _run(self, base_ref: str = "deadbeef", head_ref: str = "cafef00d") -> str:
+        import io, contextlib
+        from types import SimpleNamespace
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            cp.cmd_compare_resources(SimpleNamespace(
+                workspace_root=str(self.workspace),
+                baselines=str(self.baselines),
+                repo="owner/repo",
+                base_ref=base_ref,
+                head_ref=head_ref,
+            ))
+        return buf.getvalue()
+
+    def test_emits_resource_changes_section_for_changed_capture(self) -> None:
+        self._write_module("app", manifest={
+            "module": "app", "variant": "debug",
+            "resources": [{"id": "drawable/ic_logo", "type": "VECTOR",
+                           "sourceFiles": {"": "src/main/res/drawable/ic_logo.xml"},
+                           "captures": [{"variant": {"qualifiers": "xhdpi", "shape": None},
+                                         "renderOutput": "renders/resources/drawable/ic_logo_xhdpi.png"}]}],
+            "manifestReferences": [],
+        }, png_files={"renders/resources/drawable/ic_logo_xhdpi.png": b"NEW"})
+        self.baselines.write_text(json.dumps({
+            "app::drawable/ic_logo::renders/resources/drawable/ic_logo_xhdpi.png": {
+                "sha256": "OLD-SHA",
+                "renderBasename": "resources/drawable/ic_logo_xhdpi.png",
+            },
+        }))
+        out = self._run()
+        self.assertIn("## Resource Changes", out)
+        self.assertIn("### Changed (1 variant(s) across 1 resource(s))", out)
+        self.assertIn("`drawable/ic_logo`", out)
+        # Before/After URLs pinned to the supplied SHAs.
+        self.assertIn("/deadbeef/renders/app/resources/drawable/ic_logo_xhdpi.png", out)
+        self.assertIn("/cafef00d/renders/app/resources/drawable/ic_logo_xhdpi.png", out)
+
+    def test_groups_adaptive_icon_shapes_under_one_resource_heading(self) -> None:
+        # Four shape-mask captures of the same adaptive icon, all changed —
+        # they should appear under a single `mipmap/ic_launcher` group, not
+        # four separate ones (otherwise the comment drowns the diff).
+        captures = [
+            {"variant": {"qualifiers": "xhdpi", "shape": shape},
+             "renderOutput": f"renders/resources/mipmap/ic_launcher_xhdpi_{shape}.png"}
+            for shape in ("CIRCLE", "ROUNDED_SQUARE", "SQUARE", "LEGACY")
+        ]
+        png_files = {
+            f"renders/resources/mipmap/ic_launcher_xhdpi_{shape}.png": shape.encode()
+            for shape in ("CIRCLE", "ROUNDED_SQUARE", "SQUARE", "LEGACY")
+        }
+        self._write_module("app", manifest={
+            "module": "app", "variant": "debug",
+            "resources": [{"id": "mipmap/ic_launcher", "type": "ADAPTIVE_ICON",
+                           "sourceFiles": {"anydpi-v26": "src/main/res/mipmap-anydpi-v26/ic_launcher.xml"},
+                           "captures": captures}],
+            "manifestReferences": [],
+        }, png_files=png_files)
+        self.baselines.write_text(json.dumps({
+            f"app::mipmap/ic_launcher::renders/resources/mipmap/ic_launcher_xhdpi_{shape}.png": {
+                "sha256": "OLD",
+                "renderBasename": f"resources/mipmap/ic_launcher_xhdpi_{shape}.png",
+            }
+            for shape in ("CIRCLE", "ROUNDED_SQUARE", "SQUARE", "LEGACY")
+        }))
+        out = self._run()
+        # 4 variants but 1 resource group.
+        self.assertIn("### Changed (4 variant(s) across 1 resource(s))", out)
+        # Other 3 shapes link out as variants under the hero.
+        self.assertIn("Other variants:", out)
+
+    def test_new_resource_shows_with_after_image(self) -> None:
+        self._write_module("app", manifest={
+            "module": "app", "variant": "debug",
+            "resources": [{"id": "drawable/new_icon", "type": "VECTOR",
+                           "sourceFiles": {"": "src/main/res/drawable/new_icon.xml"},
+                           "captures": [{"variant": {"qualifiers": "xhdpi", "shape": None},
+                                         "renderOutput": "renders/resources/drawable/new_icon_xhdpi.png"}]}],
+            "manifestReferences": [],
+        }, png_files={"renders/resources/drawable/new_icon_xhdpi.png": b"hi"})
+        self.baselines.write_text("{}")
+        out = self._run()
+        self.assertIn("### New (1 variant(s) across 1 resource(s))", out)
+        self.assertIn("`drawable/new_icon`", out)
+
+    def test_removed_resource_appears_as_strikethrough(self) -> None:
+        # Empty workspace — every baseline entry counts as removed.
+        self.workspace.mkdir(exist_ok=True)
+        self.baselines.write_text(json.dumps({
+            "app::drawable/gone::renders/resources/drawable/gone_xhdpi.png": {
+                "sha256": "abc",
+                "module": "app",
+                "resourceId": "drawable/gone",
+                "renderBasename": "resources/drawable/gone_xhdpi.png",
+            },
+        }))
+        out = self._run()
+        self.assertIn("### Removed", out)
+        self.assertIn("~`drawable/gone`~", out)
+
+    def test_empty_when_nothing_changed(self) -> None:
+        # Resource exists, baseline matches → no diff section at all.
+        self._write_module("app", manifest={
+            "module": "app", "variant": "debug",
+            "resources": [{"id": "drawable/stable", "type": "VECTOR",
+                           "sourceFiles": {"": "src/main/res/drawable/stable.xml"},
+                           "captures": [{"variant": {"qualifiers": "xhdpi", "shape": None},
+                                         "renderOutput": "renders/resources/drawable/stable_xhdpi.png"}]}],
+            "manifestReferences": [],
+        }, png_files={"renders/resources/drawable/stable_xhdpi.png": b"stable"})
+        sha = cp.sha256(self.workspace / "app" / "build" / "compose-previews"
+                        / "renders/resources/drawable/stable_xhdpi.png")
+        self.baselines.write_text(json.dumps({
+            "app::drawable/stable::renders/resources/drawable/stable_xhdpi.png": {
+                "sha256": sha,
+                "renderBasename": "resources/drawable/stable_xhdpi.png",
+            },
+        }))
+        out = self._run()
+        self.assertEqual(out, "",
+                         "Comment should append nothing when no diff was detected.")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -222,17 +222,18 @@ runs:
           --base-ref "$BASE_REF" \
           --head-ref "$HEAD_REF" \
           > _comment_body.md
-        # Append the resource diff section. Empty stdout when nothing
-        # changed (or no resources.json on the workspace), so the
-        # composable comment stays unaffected on projects without XML
-        # drawables.
+        # Resources land in their own sticky comment with a sibling marker
+        # (`<!-- preview-diff-resources -->`) — composable @Preview changes
+        # and Android XML resource changes are different concerns and should
+        # be edited / scrolled past independently. Empty stdout when nothing
+        # diffed; the post step below skips emitting an empty comment.
         python3 "$ACTION_PATH/../lib/compare-previews.py" compare-resources \
           --baselines _baselines/resource-baselines.json \
           --repo "$REPO" \
           --base-ref "$BASE_REF" \
           --head-ref "$HEAD_REF" \
           --workspace-root . \
-          >> _comment_body.md
+          > _comment_body_resources.md
 
     - name: Post or update PR comment
       shell: bash
@@ -258,4 +259,45 @@ runs:
             -X PATCH -f body="$BODY"
         else
           gh pr comment "$PR_NUMBER" --body "$BODY"
+        fi
+
+    - name: Post or update resource preview comment
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR_INPUT_NUMBER: ${{ inputs.pr-number }}
+        EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+        REPO: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+        PR_NUMBER="${PR_INPUT_NUMBER:-$EVENT_PR_NUMBER}"
+        MARKER="<!-- preview-diff-resources -->"
+
+        COMMENT_ID=$(gh api \
+          "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+          --paginate \
+          --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
+          | head -1)
+
+        # Three states for resource comments:
+        #
+        # 1. New diff this run + no prior comment  → post a fresh comment.
+        # 2. New diff this run + prior comment      → PATCH the existing one.
+        # 3. No diff this run + prior comment      → PATCH to a "resolved"
+        #    body so reviewers can see resources used to differ but no longer
+        #    do. Deleting outright would lose the comment-thread link in PR
+        #    review history.
+        # 4. No diff this run + no prior comment   → do nothing.
+        if [ -s _comment_body_resources.md ]; then
+          BODY=$(cat _comment_body_resources.md)
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -f body="$BODY"
+          else
+            gh pr comment "$PR_NUMBER" --body "$BODY"
+          fi
+        elif [ -n "$COMMENT_ID" ]; then
+          BODY="${MARKER}"$'\n'"## Resource Changes"$'\n\n'"_No resource changes in this PR's latest render._"
+          gh api "repos/${REPO}/issues/comments/${COMMENT_ID}" \
+            -X PATCH -f body="$BODY"
         fi

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -57,6 +57,18 @@ runs:
         RENDER_TIMEOUT: ${{ inputs.timeout }}
       run: compose-preview show --json --timeout "$RENDER_TIMEOUT" > _previews.json
 
+    # Render Android XML resource previews (vector / animated-vector /
+    # adaptive-icon) so the comment can include before/after for resource
+    # changes. The CLI's `show` command runs `:<module>:renderAllPreviews`
+    # which doesn't yet depend on `:<module>:renderAndroidResources`, so we
+    # invoke the resource render explicitly. `|| true` keeps the action
+    # forgiving on consumers who haven't applied the plugin to any module
+    # with resources — `compare-resources` no-ops on an empty workspace
+    # anyway.
+    - name: Render Android resource previews
+      shell: bash
+      run: ./gradlew renderAndroidResources --quiet 2>/dev/null || true
+
     - name: Fetch baselines
       shell: bash
       env:
@@ -67,6 +79,13 @@ runs:
           git fetch origin "$BASE_BRANCH"
           git show "origin/${BASE_BRANCH}:baselines.json" \
             > _baselines/baselines.json 2>/dev/null || true
+          # Resource baselines are a sibling file written by the
+          # `Stage resource baselines` step in preview-baselines/action.yml.
+          # First-ever resource render on a project doesn't have it yet —
+          # `git show` returns non-zero, the file stays absent, and the
+          # compare-resources call below treats every resource as new.
+          git show "origin/${BASE_BRANCH}:resource-baselines.json" \
+            > _baselines/resource-baselines.json 2>/dev/null || true
         else
           echo "No $BASE_BRANCH branch yet — treating all previews as new."
         fi
@@ -101,6 +120,13 @@ runs:
         python3 "$ACTION_PATH/../lib/compare-previews.py" copy-changed _previews.json \
           --baselines _baselines/baselines.json \
           --output-dir _pr_renders
+        # Resource captures land alongside under _pr_renders/renders/<module>/
+        # resources/<...>. The script silently no-ops on workspaces without
+        # any resources.json, so this is safe to run unconditionally.
+        python3 "$ACTION_PATH/../lib/compare-previews.py" copy-changed-resources \
+          --baselines _baselines/resource-baselines.json \
+          --output-dir _pr_renders \
+          --workspace-root .
 
     - name: Push PR renders
       shell: bash
@@ -196,6 +222,17 @@ runs:
           --base-ref "$BASE_REF" \
           --head-ref "$HEAD_REF" \
           > _comment_body.md
+        # Append the resource diff section. Empty stdout when nothing
+        # changed (or no resources.json on the workspace), so the
+        # composable comment stays unaffected on projects without XML
+        # drawables.
+        python3 "$ACTION_PATH/../lib/compare-previews.py" compare-resources \
+          --baselines _baselines/resource-baselines.json \
+          --repo "$REPO" \
+          --base-ref "$BASE_REF" \
+          --head-ref "$HEAD_REF" \
+          --workspace-root . \
+          >> _comment_body.md
 
     - name: Post or update PR comment
       shell: bash


### PR DESCRIPTION
## Summary

Builds on #267 (now landed). Extends `preview-comment` so PR auto-comments include before/after for changed Android XML resource previews alongside `@Preview` composables. The "Resource Changes" section appends to the existing **Preview Changes** comment rather than creating a second sticky comment — same marker, same comment ID, same edit-in-place behaviour.

`compare-previews.py` gets two siblings of the existing composable flow:

- **`copy-changed-resources`** — globs each module's `resources.json`, compares against `resource-baselines.json` (fetched from `preview_main`), and copies new/changed PNGs / GIFs into `<output>/renders/<module>/resources/<...>` so the existing push-to-`preview_pr` step picks them up unchanged.
- **`compare-resources`** — emits the markdown section to append after `compare`'s body. Captures of the same resource (adaptive icons fanning out across 4 shape masks) land under one heading with the rest linked as variant URLs, mirroring how the composable side groups by `(module, functionName)`. Empty stdout when no diff is detected, so the action can append unconditionally.

`preview-comment/action.yml`:

1. After `compose-preview show`, run `./gradlew renderAndroidResources --quiet` (the CLI's `show` doesn't yet trigger the resource render).
2. Alongside `baselines.json`, fetch `resource-baselines.json` from `preview_main`.
3. Call `copy-changed-resources` after the existing `copy-changed` so the `_pr_renders/` tree has both composable and resource changes for the existing push step.
4. Append `compare-resources` output to `_comment_body.md` before posting.

All four new calls are no-ops when the workspace has no `resources.json` — the existing comment flow stays byte-identical for projects without XML drawables.

## Test plan

- [x] `python3 -m unittest .github/actions/lib.test_compare_previews -v` — 36 tests pass (7 new in `CopyChangedResourcesTests` + `CompareResourcesTests`, 29 existing).
- [ ] On a real PR after this lands: change `samples/android/src/main/res/drawable/ic_compose_logo.xml`, push, and verify the PR comment grows a "## Resource Changes" section with `drawable/ic_compose_logo` listed under "Changed".
- [ ] Verify on a PR that doesn't touch resources: the comment stays at exactly the existing **Preview Changes** body, with no trailing whitespace or stray "## Resource Changes" header.
- [ ] Verify on a PR that adds a new adaptive icon: the 4 shape-mask captures group under a single heading with three of them linked as variants from the hero row.

## Out of scope

`compose-preview show` still doesn't internally drive `:<module>:renderAndroidResources` — the action invokes Gradle directly. Folding that into the CLI is a follow-up; the current shape is the smallest insertion point that gets resource diffs onto PR comments without a CLI release dance.

---
_Generated by [Claude Code](https://claude.ai/code/session_01APmYnc8AMQmZivBivcGiNY)_