### PR TITLE
feat(cli): add share-gist subcommand for markdown + image attachments

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -11,8 +11,17 @@ fun main(args: Array<String>) {
   // Find the command — first non-flag argument that isn't a flag's value.
   // Flags that take values: --module, --filter, --id, --output, --timeout, --plugin-version
   val valuedFlags =
-    setOf("--module", "--filter", "--id", "--output", "--timeout", "--plugin-version", "--fail-on")
-  val commands = setOf("show", "list", "render", "a11y", "doctor", "help")
+    setOf(
+      "--module",
+      "--filter",
+      "--id",
+      "--output",
+      "--timeout",
+      "--plugin-version",
+      "--fail-on",
+      "--desc",
+    )
+  val commands = setOf("show", "list", "render", "a11y", "doctor", "share-gist", "help")
 
   var commandIndex = -1
   var i = 0
@@ -49,6 +58,7 @@ fun main(args: Array<String>) {
     "render" -> RenderCommand(allArgs).run()
     "a11y" -> A11yCommand(allArgs).run()
     "doctor" -> DoctorCommand(allArgs).run()
+    "share-gist" -> ShareGistCommand(allArgs).run()
     "help" -> printUsage()
     else -> {
       System.err.println("Unknown command: $command")
@@ -66,12 +76,13 @@ private fun printUsage() {
     Usage: compose-preview [options] <command> [options]
 
     Commands:
-      show    Discover and render previews; print id, path, sha256, changed flag
-      list    List discovered previews
-      render  Render previews; with --output copies a single match to disk
-      a11y    Render previews and print ATF accessibility findings
-      doctor  Verify Java 17 + Compose/AGP environment before editing Gradle files
-      help    Show this help message
+      show         Discover and render previews; print id, path, sha256, changed flag
+      list         List discovered previews
+      render       Render previews; with --output copies a single match to disk
+      a11y         Render previews and print ATF accessibility findings
+      doctor       Verify Java 17 + Compose/AGP environment before editing Gradle files
+      share-gist   Create a gist from a markdown file plus image attachments
+      help         Show this help message
 
     Options:
       --module <name>      Target module (default: auto-detect all)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ShareGistCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ShareGistCommand.kt
@@ -1,0 +1,298 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.copyTo
+import kotlin.system.exitProcess
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * `compose-preview share-gist <markdown> [--public|--secret] [--desc TEXT] [--json] <image>...`
+ *
+ * Creates a GitHub gist containing a markdown file plus image attachments. `gh gist create` rejects
+ * binary inputs, so this seeds the gist with the markdown text-only, then pushes the images into
+ * the gist's git repo (gists are git repos).
+ *
+ * Default visibility is `--secret`. `--public` is opt-in.
+ *
+ * Image references inside the markdown should use basenames (e.g. `![](before.png)`). This command
+ * does NOT rewrite paths.
+ */
+class ShareGistCommand(args: List<String>) {
+  private val jsonOut = "--json" in args
+  private val visibility: GistVisibility =
+    when {
+      "--public" in args -> GistVisibility.PUBLIC
+      else -> GistVisibility.SECRET
+    }
+  private val description: String? = args.flagValue("--desc")
+  private val positional: List<String> = parsePositional(args)
+
+  fun run() {
+    if (positional.size < 2) {
+      System.err.println(USAGE)
+      exitProcess(64) // EX_USAGE
+    }
+
+    val markdown = File(positional[0])
+    val images = positional.drop(1).map(::File)
+
+    if (!markdown.isFile) {
+      System.err.println("not a file: ${markdown.path}")
+      exitProcess(1)
+    }
+    val missingImages = images.filterNot { it.isFile }
+    if (missingImages.isNotEmpty()) {
+      System.err.println("not a file: ${missingImages.joinToString(", ") { it.path }}")
+      exitProcess(1)
+    }
+
+    // Image basename collisions would silently overwrite each other in the gist's flat git tree.
+    // Catch before doing any network work.
+    val byName = images.groupBy { it.name }
+    val collisions = byName.filterValues { it.size > 1 }
+    if (collisions.isNotEmpty()) {
+      System.err.println(
+        "image basename collisions: ${collisions.keys.joinToString(", ")}. " +
+          "Rename so each image has a unique filename."
+      )
+      exitProcess(1)
+    }
+
+    requireOnPath("gh", "Install GitHub CLI: https://cli.github.com")
+    requireOnPath("git", "Install git.")
+
+    val (committerName, committerEmail) = readGitIdentity()
+
+    val gistUrl = createGist(markdown)
+    val gistId = parseGistId(gistUrl)
+    val rawBase = parseRawBase(gistUrl)
+
+    val tmp = Files.createTempDirectory("compose-preview-gist-")
+    try {
+      val clone = tmp.resolve("g").toFile()
+      runOrFail(
+        listOf("git", "clone", "--quiet", "https://gist.github.com/$gistId.git", clone.path),
+        "git clone of the new gist failed (gist exists at $gistUrl)",
+      )
+
+      for (img in images) {
+        img.toPath().copyTo(clone.toPath().resolve(img.name), overwrite = true)
+      }
+
+      runOrFail(
+        listOf("git", "-C", clone.path, "add", "--") + images.map { it.name },
+        "git add failed (gist exists at $gistUrl)",
+      )
+      runOrFail(
+        listOf(
+          "git",
+          "-C",
+          clone.path,
+          "-c",
+          "user.name=$committerName",
+          "-c",
+          "user.email=$committerEmail",
+          "commit",
+          "--quiet",
+          "-m",
+          "add images",
+        ),
+        "git commit failed (gist exists at $gistUrl)",
+      )
+      runOrFail(
+        listOf("git", "-C", clone.path, "push", "--quiet", "origin", "HEAD"),
+        "git push to gist failed (gist exists at $gistUrl)",
+      )
+    } finally {
+      tmp.toFile().deleteRecursively()
+    }
+
+    emit(gistUrl, rawBase, images)
+  }
+
+  private fun emit(gistUrl: String, rawBase: String, images: List<File>) {
+    if (jsonOut) {
+      val response =
+        ShareGistResponse(
+          url = gistUrl,
+          rawBaseUrl = rawBase,
+          images =
+            images.map { ShareGistImage(path = it.absolutePath, rawUrl = "$rawBase/${it.name}") },
+        )
+      println(JSON.encodeToString(ShareGistResponse.serializer(), response))
+    } else {
+      val label = if (visibility == GistVisibility.PUBLIC) "public" else "secret"
+      println("Created $label gist: $gistUrl")
+      for (img in images) println("  $rawBase/${img.name}")
+    }
+  }
+
+  private fun createGist(markdown: File): String {
+    val cmd = buildList {
+      add("gh")
+      add("gist")
+      add("create")
+      when (visibility) {
+        GistVisibility.PUBLIC -> add("--public")
+        GistVisibility.SECRET -> {} // gh's default
+      }
+      description?.let {
+        add("--desc")
+        add(it)
+      }
+      add("--")
+      add(markdown.path)
+    }
+    val result = exec(cmd)
+    if (result.exitCode != 0) {
+      System.err.println("gh gist create failed (exit ${result.exitCode}):")
+      if (result.stderr.isNotBlank()) System.err.println(result.stderr.trim())
+      exitProcess(result.exitCode.takeIf { it != 0 } ?: 1)
+    }
+    val url = extractGistUrl(result.stdout)
+    if (url == null) {
+      System.err.println("gh gist create did not print a gist URL. stdout was: ${result.stdout}")
+      exitProcess(1)
+    }
+    return url
+  }
+
+  private fun readGitIdentity(): Pair<String, String> {
+    val name = exec(listOf("git", "config", "--get", "user.name")).stdout.trim()
+    val email = exec(listOf("git", "config", "--get", "user.email")).stdout.trim()
+    if (name.isBlank() || email.isBlank()) {
+      System.err.println(
+        "git user.name / user.email not set. Run:\n" +
+          "  git config --global user.name 'Your Name'\n" +
+          "  git config --global user.email 'you@example.com'\n" +
+          "(Used only as the commit identity inside the throwaway gist clone.)"
+      )
+      exitProcess(1)
+    }
+    return name to email
+  }
+
+  private fun requireOnPath(binary: String, hint: String) {
+    val probe = exec(listOf("sh", "-c", "command -v $binary"))
+    if (probe.exitCode != 0 || probe.stdout.isBlank()) {
+      System.err.println("$binary not found on PATH. $hint")
+      exitProcess(1)
+    }
+  }
+
+  private fun runOrFail(cmd: List<String>, contextMessage: String) {
+    val result = exec(cmd)
+    if (result.exitCode != 0) {
+      System.err.println(contextMessage)
+      if (result.stderr.isNotBlank()) System.err.println(result.stderr.trim())
+      exitProcess(result.exitCode.takeIf { it != 0 } ?: 1)
+    }
+  }
+
+  private fun exec(cmd: List<String>): ExecResult {
+    return try {
+      val p = ProcessBuilder(cmd).redirectErrorStream(false).start()
+      val stdout = p.inputStream.bufferedReader().use { it.readText() }
+      val stderr = p.errorStream.bufferedReader().use { it.readText() }
+      if (!p.waitFor(60, TimeUnit.SECONDS)) {
+        p.destroyForcibly()
+        ExecResult(124, stdout, stderr + "\n[command timed out]")
+      } else {
+        ExecResult(p.exitValue(), stdout, stderr)
+      }
+    } catch (e: Exception) {
+      ExecResult(1, "", e.message ?: e.javaClass.simpleName)
+    }
+  }
+
+  private data class ExecResult(val exitCode: Int, val stdout: String, val stderr: String)
+
+  enum class GistVisibility {
+    PUBLIC,
+    SECRET,
+  }
+
+  companion object {
+    private const val USAGE =
+      "usage: compose-preview share-gist <markdown> [--public|--secret] [--desc TEXT] [--json] <image>..."
+
+    private val JSON = Json {
+      prettyPrint = true
+      encodeDefaults = true
+    }
+
+    private val FLAGS_TAKING_VALUE = setOf("--desc")
+    private val FLAGS_NO_VALUE = setOf("--public", "--secret", "--json")
+
+    /**
+     * Picks positional arguments (markdown + images) out of the argv, skipping flags and their
+     * values. Mirrors the dispatch logic in [Main] but locally — the CLI's shared [flagValue]
+     * helper only does single-flag lookup, not full positional extraction.
+     */
+    internal fun parsePositional(args: List<String>): List<String> {
+      val out = mutableListOf<String>()
+      var i = 0
+      while (i < args.size) {
+        val a = args[i]
+        when {
+          a in FLAGS_TAKING_VALUE -> i += 2
+          a in FLAGS_NO_VALUE -> i += 1
+          a.startsWith("--") -> i += 1 // unknown flag — skip just the flag, not a following value
+          else -> {
+            out += a
+            i += 1
+          }
+        }
+      }
+      return out
+    }
+
+    /**
+     * `gh gist create` prints log lines on stderr ("Creating gist…") and the resulting URL on
+     * stdout. The URL is the first `https://gist.github.com/...` token. Returns null when no URL is
+     * present.
+     */
+    internal fun extractGistUrl(stdout: String): String? {
+      val pattern = Regex("""https://gist\.github\.com/[A-Za-z0-9_./-]+""")
+      return pattern.find(stdout)?.value?.trimEnd('/')
+    }
+
+    /**
+     * Gist URLs have either `https://gist.github.com/<id>` (anonymous) or
+     * `https://gist.github.com/<user>/<id>` (authenticated, the common case via `gh`). The git
+     * remote is keyed by `<id>` only.
+     */
+    internal fun parseGistId(url: String): String {
+      val tail = url.substringAfter("https://gist.github.com/").trimEnd('/')
+      // Last path segment is always the gist id (32-char hex), regardless of whether the username
+      // segment is present.
+      return tail.substringAfterLast('/')
+    }
+
+    /**
+     * Raw asset URLs for a gist live on `gist.githubusercontent.com` and require both the username
+     * and the gist id. We compute it from the create-time URL rather than the git remote so the
+     * username is preserved; anonymous gists fall back to the no-username form.
+     */
+    internal fun parseRawBase(url: String): String {
+      val tail = url.substringAfter("https://gist.github.com/").trimEnd('/')
+      val rawTail =
+        if ('/' in tail) tail // <user>/<id>
+        else tail // <id> only (anonymous)
+      return "https://gist.githubusercontent.com/$rawTail/raw"
+    }
+  }
+}
+
+@Serializable
+internal data class ShareGistResponse(
+  val schema: String = "compose-preview-share-gist/v1",
+  val url: String,
+  val rawBaseUrl: String,
+  val images: List<ShareGistImage>,
+)
+
+@Serializable internal data class ShareGistImage(val path: String, val rawUrl: String)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ShareGistCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ShareGistCommandTest.kt
@@ -1,0 +1,85 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ShareGistArgParsingTest {
+  @Test
+  fun `positional args are extracted past flags and their values`() {
+    val args =
+      listOf("report.md", "--secret", "--desc", "before/after for #123", "before.png", "after.png")
+    assertEquals(
+      listOf("report.md", "before.png", "after.png"),
+      ShareGistCommand.parsePositional(args),
+    )
+  }
+
+  @Test
+  fun `unknown flags are skipped without consuming a following positional`() {
+    // `--something` is treated as a value-less flag; the next token (`note.md`) stays positional.
+    val args = listOf("--something", "note.md", "img.png")
+    assertEquals(listOf("note.md", "img.png"), ShareGistCommand.parsePositional(args))
+  }
+
+  @Test
+  fun `desc consumes the value after it even when the value contains spaces`() {
+    val args = listOf("--desc", "PR #42 before/after", "doc.md", "a.png")
+    assertEquals(listOf("doc.md", "a.png"), ShareGistCommand.parsePositional(args))
+  }
+
+  @Test
+  fun `json and public secret flags drop out of positionals`() {
+    val args = listOf("--json", "doc.md", "--public", "a.png", "b.png")
+    assertEquals(listOf("doc.md", "a.png", "b.png"), ShareGistCommand.parsePositional(args))
+  }
+}
+
+class ShareGistUrlParsingTest {
+  @Test
+  fun `extracts gist URL from gh stdout with surrounding whitespace`() {
+    val out = "\nhttps://gist.github.com/octocat/abc123def456\n"
+    assertEquals(
+      "https://gist.github.com/octocat/abc123def456",
+      ShareGistCommand.extractGistUrl(out),
+    )
+  }
+
+  @Test
+  fun `returns null when stdout has no gist URL`() {
+    assertNull(ShareGistCommand.extractGistUrl("nothing useful here"))
+  }
+
+  @Test
+  fun `gist id is the last path segment for authenticated URL`() {
+    assertEquals(
+      "abc123def456",
+      ShareGistCommand.parseGistId("https://gist.github.com/octocat/abc123def456"),
+    )
+  }
+
+  @Test
+  fun `gist id is the only path segment for anonymous URL`() {
+    assertEquals(
+      "abc123def456",
+      ShareGistCommand.parseGistId("https://gist.github.com/abc123def456"),
+    )
+  }
+
+  @Test
+  fun `raw base preserves username when present`() {
+    // Authenticated gists serve raw assets under user/id, matching what GitHub's UI links to.
+    assertEquals(
+      "https://gist.githubusercontent.com/octocat/abc123def456/raw",
+      ShareGistCommand.parseRawBase("https://gist.github.com/octocat/abc123def456"),
+    )
+  }
+
+  @Test
+  fun `raw base falls back to id-only for anonymous URL`() {
+    assertEquals(
+      "https://gist.githubusercontent.com/abc123def456/raw",
+      ShareGistCommand.parseRawBase("https://gist.github.com/abc123def456"),
+    )
+  }
+}

--- a/skills/compose-preview/design/AGENT_PR.md
+++ b/skills/compose-preview/design/AGENT_PR.md
@@ -110,8 +110,20 @@ Without pre-existing image hosting, the simplest flow is:
 If the human asks for images in the comment, pick **one** and confirm the
 destination before acting:
 
-- **Gist** (`gh gist create <png> --public`) — quick, one image per file,
-  public by default. Ask before posting anything public.
+- **Gist with markdown + images** (`compose-preview share-gist <md>
+  [--public|--secret] [--desc TEXT] [--json] <png>...`). Default is
+  `--secret` — even secret gist URLs are shareable, so still ask before
+  posting one in a public PR comment, and only use `--public` on
+  explicit request. Wraps the gist-as-git-repo dance: `gh gist create`
+  rejects binary files, so the CLI seeds a text-only gist with the
+  markdown then pushes the images into the gist's git repo. Output is
+  the gist URL plus stable raw URLs you can drop into the PR comment;
+  `--json` emits a `compose-preview-share-gist/v1` envelope. The
+  markdown should reference images by basename
+  (`![](before.png)`) — the command does not rewrite paths. Requires
+  `gh` and `git` on PATH and a `git config user.name|user.email` set
+  somewhere in the global/local chain (used only as the commit
+  identity in the throwaway clone).
 - **Dedicated branch in the repo** (the CI integration appends to a
   shared `preview_pr` branch, pinning URLs to commit SHAs) — clean raw
   URLs but creates a branch the user may not want; get confirmation.


### PR DESCRIPTION
## Summary

First half of #264 — wraps the markdown-with-images gist flow into a
single CLI subcommand so harnesses can pre-approve `compose-preview *`
once and stop asking for consent on each step of the assembled shell
flow.

```
compose-preview share-gist MARKDOWN [--public|--secret]
                           [--desc TEXT] [--json] IMAGE...
```

`gh gist create` rejects binary inputs, so the command seeds a
text-only gist with the markdown, clones the resulting gist (gists are
git repos), copies the images into the clone, and pushes. Output is
the gist URL plus stable raw URLs ready to drop into a PR comment.

Defaults:

- `--secret` — even secret gist URLs are shareable, so `--public` is
  opt-in.
- The markdown should reference images by basename
  (`![](before.png)`). The command does not rewrite paths — that's a
  judgement call best left to the human authoring the comment.

`--json` emits a `compose-preview-share-gist/v1` envelope (gist URL,
raw base URL, per-image `path`/`rawUrl`) — designed for agents that
want to programmatically substitute paths in markdown before posting.

Preconditions caught up-front so we don't half-create a gist:

- `gh` and `git` on `PATH` (clear errors with install hints when not).
- `git config user.name|user.email` set somewhere in the chain (used
  only as the commit identity inside the throwaway clone — never on
  the project repo).
- No basename collisions in the image list (would silently overwrite
  in the gist's flat tree).

If the gist creation succeeds but the image push fails (network),
errors include the gist URL so the user can recover manually.

`design/AGENT_PR.md` updated to point at this command instead of the
bare `gh gist create PNG --public` line that was there before, which
doesn't actually work with binaries.

The other half of #264 (`compose-preview publish-images` for the
`preview_pr` push flow) is queued separately — it's a meaningfully
larger lift since it overlaps the `preview-comment` GitHub Action's
tree shape and baseline-diff conventions. Will follow.

## Test plan

- [x] `./gradlew :cli:test` passes — adds `ShareGistArgParsingTest` and
      `ShareGistUrlParsingTest` covering positional extraction and
      gist URL parsing (the parts that don't need network or `gh`).
- [x] `./gradlew :cli:ktfmtCheckMain :cli:ktfmtCheckTest` passes.
- [ ] Manual end-to-end against a real `gh`-authenticated environment
      (skipped in this PR — requires actual GitHub auth and would post
      a real gist).
