### PR TITLE
fix(diff): tolerate empty / missing baselines.json in preview-comment action

### DIFF
--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -37,6 +37,40 @@ def sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def _load_baselines(path: Path) -> dict:
+    """Read a baselines JSON file, treating missing / empty / malformed input as `{}`.
+
+    The fetch step in `preview-comment/action.yml` runs
+    `git show "$REF:baselines.json" > path 2>/dev/null || true`. Bash's `>`
+    truncates `path` to zero bytes BEFORE the command runs — so when the
+    target file doesn't exist on the base branch (the typical case for the
+    first run after a new baseline file is added, e.g. `resource-baselines.json`
+    landing on `preview_main`), the action ends up with an existing-but-empty
+    file. `json.loads("")` then raises `JSONDecodeError`, breaking the
+    diff-on-PR comment for everyone — including the composable side, which
+    has historically dodged this only because the composable `baselines.json`
+    has been on `preview_main` for so long that nobody re-runs the
+    bootstrap path.
+
+    Treat any of (missing path, empty file, unparseable JSON, non-dict
+    payload) as "no baselines to compare against" — strictly more permissive
+    than the previous behaviour, never less.
+    """
+    if not path.exists():
+        return {}
+    try:
+        text = path.read_text()
+    except OSError:
+        return {}
+    if not text.strip():
+        return {}
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
 # Pixel count above pixelmatch's per-pixel threshold that we still treat as
 # perceptually unchanged. The Compose stitched-LONG renderer (issue #190) can
 # emit a handful of sub-pixel-AA-different rounded-corner pixels between runs
@@ -346,7 +380,7 @@ def cmd_compare(args: argparse.Namespace) -> int:
     )
 
     current = load_cli_output(cli_json)
-    baselines = json.loads(baselines_path.read_text()) if baselines_path.exists() else {}
+    baselines = _load_baselines(baselines_path)
 
     new: list[tuple[str, dict]] = []
     changed: list[tuple[str, dict, dict]] = []
@@ -479,7 +513,7 @@ def cmd_copy_changed(args: argparse.Namespace) -> int:
     )
 
     current = load_cli_output(cli_json)
-    baselines = json.loads(baselines_path.read_text()) if baselines_path.exists() else {}
+    baselines = _load_baselines(baselines_path)
 
     copied = 0
     for key, info in current.items():
@@ -675,7 +709,7 @@ def cmd_copy_changed_resources(args: argparse.Namespace) -> int:
     entries = load_resource_manifests(workspace_root)
     if not entries:
         return 0
-    baselines = json.loads(baselines_path.read_text()) if baselines_path.exists() else {}
+    baselines = _load_baselines(baselines_path)
 
     copied = 0
     for key, info in entries.items():
@@ -737,7 +771,7 @@ def cmd_compare_resources(args: argparse.Namespace) -> int:
     head_ref = args.head_ref
 
     current = load_resource_manifests(workspace_root)
-    baselines = json.loads(baselines_path.read_text()) if baselines_path.exists() else {}
+    baselines = _load_baselines(baselines_path)
 
     new: list[tuple[str, dict]] = []
     changed: list[tuple[str, dict, dict]] = []

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -1134,5 +1134,102 @@ class CompareResourcesTests(unittest.TestCase):
                          "Comment should append nothing when no diff was detected.")
 
 
+class LoadBaselinesTest(unittest.TestCase):
+    """Pins `_load_baselines`'s permissive shape against everything the
+    `git show … > file 2>/dev/null || true` redirect in
+    `preview-comment/action.yml` can produce."""
+
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def test_missing_file_is_empty_dict(self):
+        self.assertEqual(cp._load_baselines(self.tmp / "nope.json"), {})
+
+    def test_empty_file_is_empty_dict(self):
+        # The original failure mode: bash `> file 2>/dev/null || true`
+        # truncates `file` to 0 bytes before git show runs; the file is
+        # then `exists() == True` but contents = "".
+        p = self.tmp / "empty.json"
+        p.write_text("")
+        self.assertEqual(cp._load_baselines(p), {})
+
+    def test_whitespace_only_file_is_empty_dict(self):
+        # Defensive — strip-then-test rather than literal "" check, in case
+        # a future redirect path leaves a stray newline.
+        p = self.tmp / "ws.json"
+        p.write_text("   \n\t  \n")
+        self.assertEqual(cp._load_baselines(p), {})
+
+    def test_malformed_json_is_empty_dict(self):
+        p = self.tmp / "bad.json"
+        p.write_text('{"oops')
+        self.assertEqual(cp._load_baselines(p), {})
+
+    def test_non_dict_payload_is_empty_dict(self):
+        # baselines.json is supposed to be an object; treat anything else
+        # as no baselines rather than letting downstream `key in baselines`
+        # blow up on a list/string/null.
+        for payload in ('[]', '"oops"', '42', 'null'):
+            p = self.tmp / "shape.json"
+            p.write_text(payload)
+            self.assertEqual(cp._load_baselines(p), {}, f"{payload} should normalise to {{}}")
+
+    def test_valid_dict_payload_returns_parsed(self):
+        p = self.tmp / "ok.json"
+        p.write_text(json.dumps({"app/Foo": {"sha256": "abc"}}))
+        self.assertEqual(cp._load_baselines(p), {"app/Foo": {"sha256": "abc"}})
+
+
+class CompareResourcesAgainstEmptyBaselineTest(unittest.TestCase):
+    """End-to-end regression for the failure mode that broke PR comments
+    after #269 landed: `git show … > resource-baselines.json` truncated the
+    file to zero bytes when `preview_main` didn't yet have a
+    `resource-baselines.json`, and `cmd_compare_resources` blew up with
+    `JSONDecodeError`."""
+
+    def test_empty_baselines_file_treats_every_resource_as_new(self):
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp)
+        workspace = tmp / "ws"
+        workspace.mkdir()
+        # Empty baseline file — the exact shape the action's truncating
+        # redirect produces on first run.
+        baselines = tmp / "resource-baselines.json"
+        baselines.write_text("")
+
+        manifest_dir = workspace / "app" / "build" / "compose-previews"
+        manifest_dir.mkdir(parents=True)
+        (manifest_dir / "resources.json").write_text(json.dumps({
+            "module": "app", "variant": "debug",
+            "resources": [{"id": "drawable/foo", "type": "VECTOR",
+                           "sourceFiles": {"": "src/main/res/drawable/foo.xml"},
+                           "captures": [{"variant": {"qualifiers": "xhdpi", "shape": None},
+                                         "renderOutput": "renders/resources/drawable/foo_xhdpi.png"}]}],
+            "manifestReferences": [],
+        }))
+        png = manifest_dir / "renders/resources/drawable/foo_xhdpi.png"
+        png.parent.mkdir(parents=True)
+        png.write_bytes(b"contents")
+
+        # Capture stdout; the run must succeed (no JSONDecodeError) AND emit
+        # markdown listing the resource as new.
+        import io, contextlib
+        from types import SimpleNamespace
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = cp.cmd_compare_resources(SimpleNamespace(
+                workspace_root=str(workspace),
+                baselines=str(baselines),
+                repo="owner/repo",
+                base_ref="deadbeef",
+                head_ref="cafef00d",
+            ))
+        self.assertEqual(rc, 0)
+        self.assertIn("## Resource Changes", buf.getvalue())
+        self.assertIn("### New", buf.getvalue())
+        self.assertIn("`drawable/foo`", buf.getvalue())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Hotfix for the failure observed on a downstream PR after #269 landed:

```
File ".../compare-previews.py", line 668, in cmd_compare_resources
  baselines = json.loads(baselines_path.read_text()) if baselines_path.exists() else {}
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

## Root cause

`preview-comment/action.yml` fetches the baseline JSON with:

```bash
git show "origin/${BASE_BRANCH}:resource-baselines.json" \
  > _baselines/resource-baselines.json 2>/dev/null || true
```

Bash's `>` truncates the redirect target to zero bytes **before** `git show` runs. When the file doesn't exist on `preview_main` (the typical case for the first run after a new baseline file is added — `resource-baselines.json` landing on `preview_main` is exactly this case), `git show` exits non-zero, `|| true` swallows the code, but the on-disk file is already 0 bytes.

`json.loads(baselines_path.read_text())` then raises `JSONDecodeError("Expecting value")` and the action exits 1.

The composable side (`baselines.json`) has always carried this same vulnerability — the `git show > … 2>/dev/null || true` pattern is in `preview-comment/action.yml` since inception. It only escaped the bug in practice because `preview_main` has carried a non-empty `baselines.json` for so long that no consumer hits the bootstrap path. The resource side (landed in #269) hits empty-file on first run for every consumer that hadn't yet pushed a `preview_main` with `resource-baselines.json`.

## Fix

Python-side defence at all four read sites — same fix, narrower blast radius than reworking the action.yml redirect. Adds a `_load_baselines(path)` helper that returns `{}` for any of:
- Missing path
- Empty / whitespace-only file (the production failure mode)
- Unparseable JSON
- Non-dict payload (`[]`, `42`, `null`, …)

Strictly more permissive than the previous behaviour — never less. Replaces all four call sites (`cmd_compare`, `cmd_copy_changed`, `cmd_compare_resources`, `cmd_copy_changed_resources`).

## Test plan

- [x] `python3 -m unittest .github/actions/lib.test_compare_previews -v` — 50 tests pass (7 new in `LoadBaselinesTest` + `CompareResourcesAgainstEmptyBaselineTest`, 43 existing).
- [ ] On a PR after this lands: the comment action no longer fails on first run with an empty `resource-baselines.json`. The empty file is treated as "no baselines" → every resource shows under "New".

## Out of scope

The shell redirect itself is still vulnerable. A follow-up could swap it for the `git show > tmp; mv tmp file || rm tmp` pattern, but defensive coding at the read site is the smaller, broader fix — protects against any future redirect-style truncation, including `cmd_copy_changed`'s baseline path which has the same shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_01APmYnc8AMQmZivBivcGiNY)_