### PR TITLE
feat(cli): add publish-images subcommand for preview_pr-style branch pushes

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -20,8 +20,13 @@ fun main(args: Array<String>) {
       "--plugin-version",
       "--fail-on",
       "--desc",
+      "--branch",
+      "--remote",
+      "--pr-number",
+      "--message",
     )
-  val commands = setOf("show", "list", "render", "a11y", "doctor", "share-gist", "help")
+  val commands =
+    setOf("show", "list", "render", "a11y", "doctor", "share-gist", "publish-images", "help")
 
   var commandIndex = -1
   var i = 0
@@ -59,6 +64,7 @@ fun main(args: Array<String>) {
     "a11y" -> A11yCommand(allArgs).run()
     "doctor" -> DoctorCommand(allArgs).run()
     "share-gist" -> ShareGistCommand(allArgs).run()
+    "publish-images" -> PublishImagesCommand(allArgs).run()
     "help" -> printUsage()
     else -> {
       System.err.println("Unknown command: $command")
@@ -76,13 +82,14 @@ private fun printUsage() {
     Usage: compose-preview [options] <command> [options]
 
     Commands:
-      show         Discover and render previews; print id, path, sha256, changed flag
-      list         List discovered previews
-      render       Render previews; with --output copies a single match to disk
-      a11y         Render previews and print ATF accessibility findings
-      doctor       Verify Java 17 + Compose/AGP environment before editing Gradle files
-      share-gist   Create a gist from a markdown file plus image attachments
-      help         Show this help message
+      show             Discover and render previews; print id, path, sha256, changed flag
+      list             List discovered previews
+      render           Render previews; with --output copies a single match to disk
+      a11y             Render previews and print ATF accessibility findings
+      doctor           Verify Java 17 + Compose/AGP environment before editing Gradle files
+      share-gist       Create a gist from a markdown file plus image attachments
+      publish-images   Push a directory of rendered PNGs to a shared branch (default preview_pr)
+      help             Show this help message
 
     Options:
       --module <name>      Target module (default: auto-detect all)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PublishImagesCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PublishImagesCommand.kt
@@ -1,0 +1,374 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import kotlin.system.exitProcess
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * `compose-preview publish-images DIR [--branch preview_pr] [--remote origin] [--pr-number N]
+ * [--message MSG] [--json]`
+ *
+ * Pushes the contents of a staging directory as a single commit on a shared rendered-PNG branch
+ * (default `preview_pr`), mirroring what the `preview-comment` GitHub Action does in CI. Lets an
+ * agent that already has a populated `_pr_renders/`-shape directory get stable raw URLs without
+ * scripting the `git init` / `commit-tree` / race-loop dance by hand.
+ *
+ * Deliberately small: this is the push primitive, not the whole `preview-comment` workflow. The
+ * agent decides what to put in the staging directory (typically the changed/new PNGs from a
+ * `compose-preview show --json` diff) and writes the PR comment markdown itself; this command just
+ * gets the bytes onto a branch and prints the resulting commit SHA + raw URL pattern.
+ */
+class PublishImagesCommand(args: List<String>) {
+  private val jsonOut = "--json" in args
+  private val branch: String = args.flagValue("--branch") ?: "preview_pr"
+  private val remote: String = args.flagValue("--remote") ?: "origin"
+  private val prNumber: String? = args.flagValue("--pr-number")
+  private val customMessage: String? = args.flagValue("--message")
+  private val positional: List<String> = parsePositional(args)
+
+  fun run() {
+    if (positional.size != 1) {
+      System.err.println(USAGE)
+      exitProcess(64) // EX_USAGE
+    }
+
+    val source = File(positional[0])
+    if (!source.isDirectory) {
+      System.err.println("not a directory: ${source.path}")
+      exitProcess(1)
+    }
+    if (File(source, ".git").exists()) {
+      System.err.println(
+        "${source.path} contains a `.git` directory — refusing to publish a nested repo. " +
+          "Pass a plain directory of PNGs."
+      )
+      exitProcess(1)
+    }
+
+    val files = source.walkTopDown().filter { it.isFile }.toList()
+    if (files.isEmpty()) {
+      // Mirrors the GHA's noop-on-empty behaviour: it's a successful no-op, not an error.
+      if (jsonOut) {
+        println(
+          JSON.encodeToString(
+            PublishImagesResponse.serializer(),
+            PublishImagesResponse(
+              commit = null,
+              branch = branch,
+              remote = remote,
+              remoteUrl = "",
+              rawUrlPattern = null,
+              pushedFiles = emptyList(),
+            ),
+          )
+        )
+      } else {
+        println("Nothing to publish — ${source.path} contains no files.")
+      }
+      return
+    }
+
+    requireOnPath("git", "Install git.")
+    val (committerName, committerEmail) = readGitIdentity()
+    val remoteUrl = readRemoteUrl(remote)
+    val rawUrlBase = githubRawUrlBase(remoteUrl)
+    val headSha = readHeadSha()
+    val message = customMessage ?: defaultMessage(prNumber, headSha)
+
+    val tmp = Files.createTempDirectory("compose-preview-publish-")
+    try {
+      val staging = tmp.resolve("staging").toFile().apply { mkdirs() }
+      // Copy SOURCE's contents (not SOURCE itself) into staging so the commit tree mirrors
+      // SOURCE's layout exactly — `renders/<module>/<id>.png` stays at the same relative path.
+      source.copyRecursively(staging, overwrite = true)
+
+      runOrFail(listOf("git", "-C", staging.path, "init", "--quiet"), "git init failed")
+      runOrFail(
+        listOf("git", "-C", staging.path, "remote", "add", remote, remoteUrl),
+        "git remote add failed",
+      )
+      runOrFail(listOf("git", "-C", staging.path, "add", "-A"), "git add failed")
+
+      val tree =
+        execOrFail(listOf("git", "-C", staging.path, "write-tree"), "git write-tree failed")
+          .stdout
+          .trim()
+
+      val commitSha = pushWithRetry(staging, committerName, committerEmail, tree, message)
+
+      val pushedRelative =
+        files.map { it.relativeTo(source).path.replace(File.separatorChar, '/') }.sorted()
+      emit(commitSha, remoteUrl, rawUrlBase, pushedRelative)
+    } finally {
+      tmp.toFile().deleteRecursively()
+    }
+  }
+
+  /**
+   * Up to [MAX_PUSH_ATTEMPTS] attempts at the fetch-parent → commit-tree → push cycle. Mirrors the
+   * GHA's retry shape: the shared branch can have parallel pushes from sibling PRs in flight,
+   * second-to-push hits non-fast-forward, re-parent on the new tip and retry. Returns the commit
+   * SHA on success.
+   */
+  private fun pushWithRetry(
+    staging: File,
+    committerName: String,
+    committerEmail: String,
+    tree: String,
+    message: String,
+  ): String {
+    var attempt = 1
+    while (true) {
+      val parent = fetchParent(staging)
+      val commitArgs = mutableListOf("git", "-C", staging.path)
+      // Identity goes on the commit-tree call rather than `git config --local` so we don't
+      // mutate any persistent state — the temp staging dir gets deleted, but defending against
+      // a stray copy of staged config is cheap and explicit.
+      commitArgs += listOf("-c", "user.name=$committerName", "-c", "user.email=$committerEmail")
+      commitArgs += listOf("commit-tree", tree)
+      if (parent != null) commitArgs += listOf("-p", parent)
+      commitArgs += listOf("-m", message)
+      val commit = execOrFail(commitArgs, "git commit-tree failed").stdout.trim()
+
+      val push =
+        exec(listOf("git", "-C", staging.path, "push", remote, "$commit:refs/heads/$branch"))
+      if (push.exitCode == 0) return commit
+
+      if (attempt >= MAX_PUSH_ATTEMPTS) {
+        System.err.println("push to $remote/$branch failed after $attempt attempt(s). Last error:")
+        if (push.stderr.isNotBlank()) System.err.println(push.stderr.trim())
+        exitProcess(1)
+      }
+      val isRace =
+        push.stderr.contains("non-fast-forward", ignoreCase = true) ||
+          push.stderr.contains("fetch first", ignoreCase = true) ||
+          push.stderr.contains("rejected", ignoreCase = true)
+      if (!isRace) {
+        // Some other failure (auth, network, missing remote). Retry won't help.
+        System.err.println("push to $remote/$branch failed:")
+        if (push.stderr.isNotBlank()) System.err.println(push.stderr.trim())
+        exitProcess(1)
+      }
+      val delaySeconds = attempt * 2 + (0..2).random()
+      System.err.println(
+        "push to $remote/$branch lost the race; retry $attempt/$MAX_PUSH_ATTEMPTS in ${delaySeconds}s…"
+      )
+      Thread.sleep(delaySeconds * 1000L)
+      attempt++
+    }
+  }
+
+  /**
+   * Tip of the remote branch as a SHA, or null on first-ever push (the branch doesn't exist yet —
+   * the GHA falls back to an orphan commit in that case, and so do we via the null-parent path in
+   * [pushWithRetry]).
+   */
+  private fun fetchParent(staging: File): String? {
+    val fetch =
+      exec(listOf("git", "-C", staging.path, "fetch", "--depth=1", "--quiet", remote, branch))
+    if (fetch.exitCode != 0) return null
+    val rev = exec(listOf("git", "-C", staging.path, "rev-parse", "FETCH_HEAD"))
+    return if (rev.exitCode == 0) rev.stdout.trim().takeIf { it.isNotEmpty() } else null
+  }
+
+  private fun emit(commitSha: String, remoteUrl: String, rawUrlBase: String?, files: List<String>) {
+    if (jsonOut) {
+      println(
+        JSON.encodeToString(
+          PublishImagesResponse.serializer(),
+          PublishImagesResponse(
+            commit = commitSha,
+            branch = branch,
+            remote = remote,
+            remoteUrl = remoteUrl,
+            rawUrlPattern = rawUrlBase?.let { "$it/$commitSha/{path}" },
+            pushedFiles = files,
+          ),
+        )
+      )
+    } else {
+      println("Pushed ${files.size} file(s) to $remote/$branch")
+      println("  commit: $commitSha")
+      if (rawUrlBase != null) {
+        println("  raw URL pattern: $rawUrlBase/$commitSha/{path}")
+      } else {
+        println("  remote: $remoteUrl (no GitHub raw URL pattern available — non-GitHub remote)")
+      }
+    }
+  }
+
+  // --- helpers ------------------------------------------------------------
+
+  private fun readGitIdentity(): Pair<String, String> {
+    val name = exec(listOf("git", "config", "--get", "user.name")).stdout.trim()
+    val email = exec(listOf("git", "config", "--get", "user.email")).stdout.trim()
+    if (name.isBlank() || email.isBlank()) {
+      System.err.println(
+        "git user.name / user.email not set. Run:\n" +
+          "  git config --global user.name 'Your Name'\n" +
+          "  git config --global user.email 'you@example.com'\n" +
+          "(Used only as the commit identity in the temporary staging repo.)"
+      )
+      exitProcess(1)
+    }
+    return name to email
+  }
+
+  /**
+   * `git remote get-url <remote>` from the cwd. `<remote>` must exist on the project repo — the
+   * staging clone re-adds it pointing at the same URL so credentials resolve the same way.
+   */
+  private fun readRemoteUrl(remote: String): String {
+    val result = exec(listOf("git", "remote", "get-url", remote))
+    if (result.exitCode != 0 || result.stdout.isBlank()) {
+      System.err.println(
+        "git remote '$remote' not found in this repo. " +
+          "Pass --remote NAME, or run from a checkout that has the remote configured."
+      )
+      exitProcess(1)
+    }
+    return result.stdout.trim()
+  }
+
+  private fun readHeadSha(): String? {
+    val result = exec(listOf("git", "rev-parse", "HEAD"))
+    return if (result.exitCode == 0) result.stdout.trim().takeIf { it.isNotEmpty() } else null
+  }
+
+  private fun requireOnPath(binary: String, hint: String) {
+    val probe = exec(listOf("sh", "-c", "command -v $binary"))
+    if (probe.exitCode != 0 || probe.stdout.isBlank()) {
+      System.err.println("$binary not found on PATH. $hint")
+      exitProcess(1)
+    }
+  }
+
+  private fun runOrFail(cmd: List<String>, contextMessage: String) {
+    val result = exec(cmd)
+    if (result.exitCode != 0) {
+      System.err.println(contextMessage)
+      if (result.stderr.isNotBlank()) System.err.println(result.stderr.trim())
+      exitProcess(result.exitCode.takeIf { it != 0 } ?: 1)
+    }
+  }
+
+  private fun execOrFail(cmd: List<String>, contextMessage: String): ExecResult {
+    val result = exec(cmd)
+    if (result.exitCode != 0) {
+      System.err.println(contextMessage)
+      if (result.stderr.isNotBlank()) System.err.println(result.stderr.trim())
+      exitProcess(result.exitCode.takeIf { it != 0 } ?: 1)
+    }
+    return result
+  }
+
+  private fun exec(cmd: List<String>): ExecResult {
+    return try {
+      val p = ProcessBuilder(cmd).redirectErrorStream(false).start()
+      val stdout = p.inputStream.bufferedReader().use { it.readText() }
+      val stderr = p.errorStream.bufferedReader().use { it.readText() }
+      if (!p.waitFor(120, TimeUnit.SECONDS)) {
+        p.destroyForcibly()
+        ExecResult(124, stdout, stderr + "\n[command timed out]")
+      } else {
+        ExecResult(p.exitValue(), stdout, stderr)
+      }
+    } catch (e: Exception) {
+      ExecResult(1, "", e.message ?: e.javaClass.simpleName)
+    }
+  }
+
+  private data class ExecResult(val exitCode: Int, val stdout: String, val stderr: String)
+
+  companion object {
+    private const val USAGE =
+      "usage: compose-preview publish-images DIR [--branch BRANCH] [--remote REMOTE] [--pr-number N] [--message MSG] [--json]"
+
+    private const val MAX_PUSH_ATTEMPTS = 5
+
+    private val JSON = Json {
+      prettyPrint = true
+      encodeDefaults = true
+    }
+
+    private val FLAGS_TAKING_VALUE = setOf("--branch", "--remote", "--pr-number", "--message")
+    private val FLAGS_NO_VALUE = setOf("--json")
+
+    internal fun parsePositional(args: List<String>): List<String> {
+      val out = mutableListOf<String>()
+      var i = 0
+      while (i < args.size) {
+        val a = args[i]
+        when {
+          a in FLAGS_TAKING_VALUE -> i += 2
+          a in FLAGS_NO_VALUE -> i += 1
+          a.startsWith("--") -> i += 1
+          else -> {
+            out += a
+            i += 1
+          }
+        }
+      }
+      return out
+    }
+
+    /** Default commit message format mirrors the GHA's: `Preview renders for PR #N (sha::8)`. */
+    internal fun defaultMessage(prNumber: String?, headSha: String?): String {
+      val shortSha = headSha?.take(8)
+      return when {
+        prNumber != null && shortSha != null -> "Preview renders for PR #$prNumber ($shortSha)"
+        prNumber != null -> "Preview renders for PR #$prNumber"
+        shortSha != null -> "Preview renders ($shortSha)"
+        else -> "Preview renders"
+      }
+    }
+
+    /**
+     * Maps a GitHub remote URL (HTTPS or SSH) to its raw.githubusercontent.com prefix, minus the
+     * commit and path components. Returns null for non-GitHub remotes — those callers get the
+     * commit SHA but not a guess at where the bytes live.
+     *
+     * Examples:
+     * - `https://github.com/owner/repo.git` → `https://raw.githubusercontent.com/owner/repo`
+     * - `git@github.com:owner/repo.git` → `https://raw.githubusercontent.com/owner/repo`
+     * - `git@gitlab.com:owner/repo.git` → null
+     */
+    internal fun githubRawUrlBase(remoteUrl: String): String? {
+      val ownerRepo =
+        when {
+            remoteUrl.startsWith("https://github.com/") ->
+              remoteUrl.removePrefix("https://github.com/")
+            remoteUrl.startsWith("http://github.com/") ->
+              remoteUrl.removePrefix("http://github.com/")
+            remoteUrl.startsWith("git@github.com:") -> remoteUrl.removePrefix("git@github.com:")
+            remoteUrl.startsWith("ssh://git@github.com/") ->
+              remoteUrl.removePrefix("ssh://git@github.com/")
+            else -> return null
+          }
+          .removeSuffix(".git")
+          .trimEnd('/')
+      // Sanity: we expect exactly `owner/repo`. Anything weirder, bail.
+      if (ownerRepo.count { it == '/' } != 1 || ownerRepo.isBlank()) return null
+      return "https://raw.githubusercontent.com/$ownerRepo"
+    }
+  }
+}
+
+@Serializable
+internal data class PublishImagesResponse(
+  val schema: String = "compose-preview-publish-images/v1",
+  /** Null when [pushedFiles] was empty (noop). */
+  val commit: String?,
+  val branch: String,
+  val remote: String,
+  val remoteUrl: String,
+  /**
+   * Template URL with `{path}` placeholder; substitute the per-image relative path. Null for
+   * non-GitHub remotes or when nothing was pushed.
+   */
+  val rawUrlPattern: String?,
+  val pushedFiles: List<String>,
+)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PublishImagesCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PublishImagesCommandTest.kt
@@ -1,0 +1,102 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class PublishImagesArgParsingTest {
+  @Test
+  fun `single positional past flags`() {
+    val args =
+      listOf(
+        "_pr_renders",
+        "--branch",
+        "preview_pr",
+        "--remote",
+        "origin",
+        "--pr-number",
+        "42",
+        "--json",
+      )
+    assertEquals(listOf("_pr_renders"), PublishImagesCommand.parsePositional(args))
+  }
+
+  @Test
+  fun `message flag with spaces in value`() {
+    val args = listOf("--message", "Preview renders for issue #99", "/tmp/staging")
+    assertEquals(listOf("/tmp/staging"), PublishImagesCommand.parsePositional(args))
+  }
+
+  @Test
+  fun `unknown flag is dropped without consuming next positional`() {
+    val args = listOf("--something", "/tmp/staging")
+    assertEquals(listOf("/tmp/staging"), PublishImagesCommand.parsePositional(args))
+  }
+}
+
+class PublishImagesMessageTest {
+  @Test
+  fun `message with both pr number and head sha matches GHA shape`() {
+    assertEquals(
+      "Preview renders for PR #42 (a1b2c3d4)",
+      PublishImagesCommand.defaultMessage("42", "a1b2c3d4e5f6789"),
+    )
+  }
+
+  @Test
+  fun `message with only pr number`() {
+    assertEquals("Preview renders for PR #42", PublishImagesCommand.defaultMessage("42", null))
+  }
+
+  @Test
+  fun `message with only head sha`() {
+    assertEquals(
+      "Preview renders (a1b2c3d4)",
+      PublishImagesCommand.defaultMessage(null, "a1b2c3d4e5f6789"),
+    )
+  }
+
+  @Test
+  fun `message with neither falls back to bare`() {
+    assertEquals("Preview renders", PublishImagesCommand.defaultMessage(null, null))
+  }
+}
+
+class PublishImagesRawUrlBaseTest {
+  @Test
+  fun `https github remote maps to raw url base`() {
+    assertEquals(
+      "https://raw.githubusercontent.com/yschimke/compose-ai-tools",
+      PublishImagesCommand.githubRawUrlBase("https://github.com/yschimke/compose-ai-tools.git"),
+    )
+  }
+
+  @Test
+  fun `ssh github remote maps to raw url base`() {
+    assertEquals(
+      "https://raw.githubusercontent.com/yschimke/compose-ai-tools",
+      PublishImagesCommand.githubRawUrlBase("git@github.com:yschimke/compose-ai-tools.git"),
+    )
+  }
+
+  @Test
+  fun `https remote without git suffix still maps`() {
+    assertEquals(
+      "https://raw.githubusercontent.com/owner/repo",
+      PublishImagesCommand.githubRawUrlBase("https://github.com/owner/repo"),
+    )
+  }
+
+  @Test
+  fun `non-github remote returns null`() {
+    assertNull(PublishImagesCommand.githubRawUrlBase("git@gitlab.com:owner/repo.git"))
+    assertNull(PublishImagesCommand.githubRawUrlBase("https://example.com/owner/repo.git"))
+  }
+
+  @Test
+  fun `malformed remote returns null`() {
+    // Missing the `owner/` segment — defensive against weird remote URLs.
+    assertNull(PublishImagesCommand.githubRawUrlBase("https://github.com/repo.git"))
+    assertNull(PublishImagesCommand.githubRawUrlBase("git@github.com:repo.git"))
+  }
+}

--- a/skills/compose-preview/design/AGENT_PR.md
+++ b/skills/compose-preview/design/AGENT_PR.md
@@ -124,9 +124,18 @@ destination before acting:
   `gh` and `git` on PATH and a `git config user.name|user.email` set
   somewhere in the global/local chain (used only as the commit
   identity in the throwaway clone).
-- **Dedicated branch in the repo** (the CI integration appends to a
-  shared `preview_pr` branch, pinning URLs to commit SHAs) — clean raw
-  URLs but creates a branch the user may not want; get confirmation.
+- **Dedicated branch in the repo** (`compose-preview publish-images
+  DIR [--branch preview_pr] [--remote origin] [--pr-number N] [--json]`).
+  Pushes the staging directory's contents as a single commit on the
+  shared `preview_pr` branch, mirroring what the `preview-comment` CI
+  integration does — same retry-on-race loop for parallel pushes from
+  sibling PRs. Output is the resulting commit SHA and a raw URL pattern
+  (`https://raw.githubusercontent.com/<owner>/<repo>/<sha>/{path}`)
+  that pins images to the SHA so they survive merges. `--json` emits a
+  `compose-preview-publish-images/v1` envelope. Prefer this over the
+  gist when you want clean GitHub-hosted URLs and the user's confirmed
+  they want a branch created — the CLI does NOT auto-detect prior
+  consent; it just runs the push.
 - **Issue/PR attachment upload** — not reliably available via `gh`; skip.
 
 Never use inline base64 or data URIs — GitHub strips them. Never push images


### PR DESCRIPTION
## Summary

Closes the second half of #264. Wraps the `git init` / `commit-tree` /
race-loop push primitive that `preview-comment` does server-side, so an
agent that already has a populated staging directory can get stable raw
URLs without scripting it by hand.

```
compose-preview publish-images DIR [--branch BRANCH]
                               [--remote REMOTE] [--pr-number N]
                               [--message MSG] [--json]
```

Defaults match `preview-comment`: `--branch preview_pr`,
`--remote origin`. `DIR`'s contents become the commit tree as-is —
typical input is the `renders/MODULE/ID.png` shape that the GHA's
`compare-previews.py copy-changed` produces.

Mirrors the GHA's behaviour where it makes sense:

- **Retry loop on non-fast-forward.** Up to 5 attempts with jittered
  backoff. Two PRs racing on the shared branch don't deadlock the
  second one — re-fetch tip, re-parent, re-push. Non-race failures
  (auth, network) bail immediately rather than retrying pointlessly.
- **Orphan commit on first-ever push.** When the branch doesn't exist
  yet, `fetchParent` returns null and `commit-tree` is called without
  `-p` — same fallback the GHA uses.
- **Empty staging directory is a noop**, not an error (matches the
  GHA exiting cleanly when there are no changed renders to push).

Diverges from the GHA where the local-CLI vs CI-runner context differs:

- **Identity** comes from the project repo's `git config
  user.name|user.email` rather than a `github-actions[bot]` identity.
  Pushed on the user's behalf, under their credentials.
- **Auth** is the user's existing `git remote` credentials (HTTPS PAT
  or SSH agent). No `GITHUB_TOKEN` substitution.
- **Identity is set per-invocation via `-c user.name=… -c user.email=…`
  on `commit-tree`** — never via `git config --local` on the temp
  staging dir, so even if the temp dir somehow leaked nothing
  persists.

Output:

- Text mode: `Pushed N file(s) to origin/preview_pr` + commit SHA +
  raw URL pattern.
- `--json`: `compose-preview-publish-images/v1` envelope with the
  commit SHA, branch, remote URL, raw URL pattern (`{path}` template
  for substitution), and the list of pushed file paths.

Non-GitHub remotes get the commit SHA but not a raw URL pattern (we
don't know where their bytes live).

Deliberately **not** in scope:

- **Diff against `preview_main`.** The agent already has the diff via
  `compose-preview show --json` before/after; we don't re-implement
  `compare-previews.py copy-changed`.
- **Comment generation.** Markdown is the agent's job — see
  `design/AGENT_PR.md` section 4.
- **Posting the PR comment.** `gh pr comment` on consent is the right
  path; the CLI shouldn't fan out notifications.

`design/AGENT_PR.md` section 3's "Dedicated branch in the repo" bullet
is updated to reference this command instead of describing the CI
integration abstractly.

## Test plan

- [x] `./gradlew :cli:test` passes — adds tests for arg parsing,
      default commit message format (matches the GHA's
      `Preview renders for PR #N (sha::8)` shape), and the GitHub
      remote-URL → raw-URL-base mapping (https/ssh/no-suffix variants
      plus negative cases for non-GitHub and malformed remotes).
- [x] `./gradlew :cli:ktfmtCheckMain :cli:ktfmtCheckTest` passes.
- [ ] Manual end-to-end against a real GitHub-authenticated
      environment (skipped — would post a real commit).
