### PR TITLE
feat(vscode): resources view in the Compose preview panel

### DIFF
--- a/vscode-extension/src/androidManifestCodeLensProvider.ts
+++ b/vscode-extension/src/androidManifestCodeLensProvider.ts
@@ -1,0 +1,79 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { GradleService } from './gradleService';
+import { findManifestIconReferences } from './manifestIconReferences';
+import { ResourceManifest, ResourcePreview } from './types';
+
+/**
+ * Surfaces a "$(file-media) Preview <id>" CodeLens above every `android:icon` / `roundIcon` /
+ * `logo` / `banner` attribute in `AndroidManifest.xml` whose target resource resolves into the
+ * module's `resources.json`. Click → opens the rendered PNG via the standard VS Code image
+ * editor.
+ *
+ * The lens lookup uses `resources.json` directly rather than the `manifestReferences` index in
+ * that file. Reasons:
+ *   - The manifest reference's `source` field points at the *merged* manifest under `build/`,
+ *     not the source manifest the user has open. Surfacing the lens on the open document means
+ *     parsing it client-side anyway.
+ *   - The lookup we want is "is there a rendered preview for this resource id?" — a direct
+ *     `resources[]` scan answers that without a join through `manifestReferences`.
+ */
+export class AndroidManifestCodeLensProvider implements vscode.CodeLensProvider {
+    private readonly emitter = new vscode.EventEmitter<void>();
+    readonly onDidChangeCodeLenses = this.emitter.event;
+
+    constructor(private readonly gradleService: GradleService) {}
+
+    /** Fired after a render or discovery run so existing lenses pick up new resources. */
+    refresh(): void {
+        this.emitter.fire();
+    }
+
+    provideCodeLenses(doc: vscode.TextDocument): vscode.CodeLens[] {
+        if (!doc.fileName.endsWith('AndroidManifest.xml')) { return []; }
+        const module = this.gradleService.resolveModule(doc.uri.fsPath);
+        if (!module) { return []; }
+        const manifest = this.gradleService.readResourceManifest(module);
+        if (!manifest) { return []; }
+
+        const byId = indexResources(manifest);
+        const matches = findManifestIconReferences(doc.getText());
+        const lenses: vscode.CodeLens[] = [];
+        for (const m of matches) {
+            const resourceId = `${m.resourceType}/${m.resourceName}`;
+            const resource = byId.get(resourceId);
+            if (!resource) { continue; }
+            const firstCapture = resource.captures.find((c) => c.renderOutput);
+            if (!firstCapture) { continue; }
+            const pngPath = path.join(
+                this.gradleService.workspaceRoot,
+                module,
+                'build',
+                'compose-previews',
+                firstCapture.renderOutput,
+            );
+            const pos = doc.positionAt(m.offset);
+            const range = new vscode.Range(pos.line, 0, pos.line, 0);
+            lenses.push(
+                new vscode.CodeLens(range, {
+                    title: `$(file-media) Preview ${resourceId}`,
+                    command: 'composePreview.previewResource',
+                    arguments: [pngPath, resourceId],
+                }),
+            );
+        }
+        return lenses;
+    }
+
+    dispose(): void {
+        this.emitter.dispose();
+    }
+}
+
+function indexResources(manifest: ResourceManifest): Map<string, ResourcePreview> {
+    const out = new Map<string, ResourcePreview>();
+    for (const r of manifest.resources) {
+        out.set(r.id, r);
+    }
+    return out;
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -308,6 +308,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
 
     context.subscriptions.push(
         vscode.window.onDidChangeActiveTextEditor(editor => {
+            // AndroidManifest.xml swaps the panel into resources mode —
+            // the icon attributes the user is editing become a section of
+            // cards above the rest of the resources catalogue. Match by
+            // basename (not language id) since xml extensions vary by
+            // user setup.
+            if (editor && path.basename(editor.document.uri.fsPath) === 'AndroidManifest.xml') {
+                const filePath = editor.document.uri.fsPath;
+                if (filePath === currentScopeFile) { return; }
+                currentScopeFile = filePath;
+                void refreshForManifest(filePath);
+                return;
+            }
             if (editor?.document.languageId === 'kotlin') {
                 const filePath = editor.document.uri.fsPath;
                 // Focus toggling (editor ↔ webview/terminal ↔ back) fires this
@@ -576,6 +588,100 @@ const fastTierModules = new Set<string>();
  *                     overrides to `'fast'` (see {@link runRefreshExclusive}).
  *                     Ignored when `forceRender` is false (discover-only).
  */
+/**
+ * Loads `<module>/build/compose-previews/resources.json` for the module that owns the open
+ * `AndroidManifest.xml` and posts a [setResources] payload to the webview. Falls back to a
+ * sensible empty-state message when the manifest belongs to an older-plugin module that hasn't
+ * written `resources.json` (CodeLens provider's same defensive shape — see the comment in
+ * `androidManifestCodeLensProvider.ts`).
+ *
+ * Image loading mirrors the composable refresh path: post `setResources` first so the webview
+ * can paint card skeletons, then stream `updateImage` per capture so each card paints as soon
+ * as its bytes arrive.
+ */
+async function refreshForManifest(filePath: string): Promise<void> {
+    if (!gradleService || !panel) { return; }
+    pendingRefresh?.abort();
+    const abort = new AbortController();
+    pendingRefresh = abort;
+
+    const module = gradleService.resolveModule(filePath);
+    if (!module) {
+        logLine(`manifest no module — file=${filePath}`);
+        panel.postMessage({ command: 'clearAll' });
+        panel.postMessage({
+            command: 'showMessage',
+            text: `Couldn't resolve a Compose module for ${path.basename(filePath)}.`,
+        });
+        return;
+    }
+    const manifest = gradleService.readResourceManifest(module);
+    if (!manifest) {
+        logLine(`manifest no resources.json — module=${module}`);
+        panel.postMessage({ command: 'clearAll' });
+        panel.postMessage({
+            command: 'showMessage',
+            text:
+                `No resources.json for ${module}. Run \`:${module}:renderAndroidResources\` ` +
+                `or upgrade the plugin to a version that emits the manifest.`,
+        });
+        return;
+    }
+
+    // The reference index records the merged manifest path under `build/`.
+    // Filter to references whose resourceType+resourceName actually has a
+    // matching ResourcePreview — the source field comparison would miss
+    // PRs where the merged-manifest path differs from the open file.
+    const knownIds = new Set(manifest.resources.map(r => r.id));
+    const references = manifest.manifestReferences.filter(ref =>
+        knownIds.has(`${ref.resourceType}/${ref.resourceName}`),
+    );
+
+    panel.postMessage({
+        command: 'setResources',
+        resources: manifest.resources,
+        references,
+        module,
+    });
+    logLine(
+        `rendered ${manifest.resources.length} resource preview(s) for ${path.basename(filePath)} ` +
+            `(${references.length} manifest reference(s))`,
+    );
+
+    // Stream PNG/GIF bytes per capture, same shape as the composable refresh.
+    const imageJobs: Promise<void>[] = [];
+    for (const resource of manifest.resources) {
+        for (let captureIndex = 0; captureIndex < resource.captures.length; captureIndex++) {
+            const capture = resource.captures[captureIndex];
+            if (!capture.renderOutput) { continue; }
+            const idx = captureIndex;
+            imageJobs.push((async () => {
+                if (abort.signal.aborted) { return; }
+                const imageData = await gradleService!.readPreviewImage(module, capture.renderOutput);
+                if (abort.signal.aborted || !panel) { return; }
+                if (imageData) {
+                    panel.postMessage({
+                        command: 'updateImage',
+                        previewId: resource.id,
+                        captureIndex: idx,
+                        imageData,
+                    });
+                } else {
+                    panel.postMessage({
+                        command: 'setImageError',
+                        previewId: resource.id,
+                        captureIndex: idx,
+                        message:
+                            `Render not on disk: ${capture.renderOutput}. ` +
+                            `Run \`:${module}:renderAndroidResources\`.`,
+                    });
+                }
+            })());
+        }
+    }
+    await Promise.allSettled(imageJobs);
+}
+
 async function refresh(
     forceRender: boolean,
     forFilePath?: string,
@@ -824,6 +930,21 @@ function handleWebviewMessage(msg: WebviewToExtensionMessage) {
                 openPreviewSource(msg.className, msg.functionName);
             }
             break;
+        case 'openResourceSource':
+            // Resource card title click — open the source XML in a sibling
+            // editor. `sourceFile` is module-relative (e.g.
+            // `src/main/res/drawable/foo.xml`); resolve against the
+            // workspace root + module path, same shape the CodeLens uses
+            // for the rendered PNG.
+            if (msg.module && msg.sourceFile && gradleService) {
+                const absPath = path.join(
+                    gradleService.workspaceRoot,
+                    msg.module,
+                    msg.sourceFile,
+                );
+                void vscode.commands.executeCommand('vscode.open', vscode.Uri.file(absPath));
+            }
+            break;
         case 'selectModule':
             selectedModule = msg.value || null;
             sendModuleList();
@@ -862,6 +983,10 @@ interface WebviewToExtensionMessage {
     value?: string;
     previewId?: string;
     filename?: string;
+    /** From the resource card title click — see `openResourceSource` in types.ts. */
+    module?: string;
+    /** Module-relative path of a resource source XML, e.g. `src/main/res/drawable/foo.xml`. */
+    sourceFile?: string;
 }
 
 function sendHistoryList(previewId: string) {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -9,6 +9,7 @@ import { PreviewRegistry } from './previewRegistry';
 import { PreviewGutterDecorations } from './previewGutterDecorations';
 import { PreviewHoverProvider } from './previewHoverProvider';
 import { PreviewCodeLensProvider } from './previewCodeLensProvider';
+import { AndroidManifestCodeLensProvider } from './androidManifestCodeLensProvider';
 import { PreviewA11yDiagnostics } from './previewA11yDiagnostics';
 import { PreviewDoctorDiagnostics } from './previewDoctorDiagnostics';
 import { packageQualifiedSourcePath } from './sourcePath';
@@ -236,14 +237,42 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         (msg) => outputChannel.appendLine(`[doctor] ${msg}`),
     );
     const kotlinFiles: vscode.DocumentSelector = { language: 'kotlin', scheme: 'file' };
+    // AndroidManifest.xml lives at module-root, not under res/, so the existing
+    // `**/res/**/*.xml` watcher misses it. Match files by name rather than
+    // language id — the language id depends on the user's xml extension setup
+    // and isn't a load-bearing signal.
+    const androidManifestFiles: vscode.DocumentSelector = {
+        scheme: 'file',
+        pattern: '**/AndroidManifest.xml',
+    };
+    const androidManifestCodeLensProvider = new AndroidManifestCodeLensProvider(gradleService);
     context.subscriptions.push(
         vscode.languages.registerHoverProvider(kotlinFiles, hoverProvider),
         vscode.languages.registerCodeLensProvider(kotlinFiles, codeLensProvider),
+        vscode.languages.registerCodeLensProvider(
+            androidManifestFiles,
+            androidManifestCodeLensProvider,
+        ),
         codeLensProvider,
+        androidManifestCodeLensProvider,
         gutterDecorations,
         a11yDiagnostics,
         doctorDiagnostics,
         { dispose: () => registry.dispose() },
+    );
+
+    // Open the rendered PNG / GIF in VS Code's default editor. `vscode.open`
+    // routes PNGs to the built-in image viewer and GIFs to the same viewer
+    // (animated playback included). Non-existent paths surface as a standard
+    // "Unable to open file" error — useful signal that the consumer hasn't
+    // run `:<module>:renderAndroidResources` yet.
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            'composePreview.previewResource',
+            (pngPath: string, _resourceId: string) => {
+                void vscode.commands.executeCommand('vscode.open', vscode.Uri.file(pngPath));
+            },
+        ),
     );
 
     // Refresh doctor diagnostics on first load, on-demand from the command,

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -99,7 +99,10 @@ export interface GradleApi {
 }
 
 export class GradleService {
-    private workspaceRoot: string;
+    /** Absolute path to the workspace root. Read-only — exposed for callers that need to resolve
+     *  module-relative artifact paths (e.g. the Android manifest CodeLens, which jumps to a
+     *  rendered PNG given a `<module>/build/compose-previews/...` relative path). */
+    public readonly workspaceRoot: string;
     private logger: Logger;
     private gradleApi: GradleApi;
     private argsProvider: () => string[];

--- a/vscode-extension/src/manifestIconReferences.ts
+++ b/vscode-extension/src/manifestIconReferences.ts
@@ -1,0 +1,41 @@
+/**
+ * One icon-bearing attribute on a manifest line. Public so the
+ * [AndroidManifestCodeLensProvider] consumer and its unit tests share a single shape, and so
+ * future surfaces (hover, doctor diagnostic) can reuse the parser without round-tripping through
+ * VS Code APIs.
+ */
+export interface ManifestIconMatch {
+    /** Byte offset of the matched attribute within the document text. */
+    offset: number;
+    /** Local attribute name without the `android:` prefix — `icon` / `roundIcon` / `logo` / `banner`. */
+    attribute: 'icon' | 'roundIcon' | 'logo' | 'banner';
+    /** `drawable` or `mipmap`. */
+    resourceType: 'drawable' | 'mipmap';
+    /** Resource name without the `@type/` prefix. */
+    resourceName: string;
+}
+
+/**
+ * Walks [text] and emits one [ManifestIconMatch] per icon-bearing manifest attribute that points
+ * at a `@drawable/` or `@mipmap/` resource. Plain regex rather than full XML parsing — manifests
+ * are simple enough that the regex correctly handles the common forms (single-line attribute,
+ * attributes split across lines, both quote styles), and the Kotlin-side
+ * `ManifestReferenceExtractor` is the canonical extractor for tooling that needs full fidelity.
+ *
+ * Lives outside the CodeLens provider so unit tests don't pull in the VS Code module — the
+ * extension test environment has it; plain Mocha doesn't.
+ */
+export function findManifestIconReferences(text: string): ManifestIconMatch[] {
+    const out: ManifestIconMatch[] = [];
+    const re = /android:(icon|roundIcon|logo|banner)\s*=\s*["'](@(?:\+)?(drawable|mipmap)\/([A-Za-z0-9_]+))["']/g;
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(text)) !== null) {
+        out.push({
+            offset: match.index,
+            attribute: match[1] as ManifestIconMatch['attribute'],
+            resourceType: match[3] as ManifestIconMatch['resourceType'],
+            resourceName: match[4],
+        });
+    }
+    return out;
+}

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -429,6 +429,183 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             return card;
         }
 
+        // Variant label for one ResourceCapture: 'xhdpi · CIRCLE', 'night-xhdpi',
+        // or '' when both qualifiers and shape are absent. Built client-side so
+        // ResourceCapture's wire shape stays untouched (composables lean on a
+        // pre-baked .label, but the resource path isn't worth threading the
+        // same metadata through extension.ts for what amounts to a string
+        // concat).
+        function resourceCaptureLabel(capture) {
+            const v = capture.variant || {};
+            const parts = [];
+            if (v.qualifiers) parts.push(v.qualifiers);
+            if (v.shape) parts.push(v.shape);
+            return parts.join(' · ');
+        }
+
+        // Build one card for a ResourcePreview. Mirrors createCard's shape so
+        // the carousel / skeleton / frame-controls plumbing stays shared, but
+        // diverges on:
+        //   - title click → opens the resource's source XML, not a Kotlin file.
+        //   - subtitle (variant-badge slot) → resource type + optional
+        //     'used by …' summary derived from manifest references.
+        //   - no a11y findings, no group filter, no history drawer (resources
+        //     don't carry those today).
+        function createResourceCard(r, refsByResource, module) {
+            const captures = (r.captures && r.captures.length > 0)
+                ? r.captures
+                : [{ variant: null, renderOutput: '' }];
+            const animated = captures.length > 1;
+
+            const card = document.createElement('div');
+            card.className = 'preview-card resource-card' + (animated ? ' animated-card' : '');
+            card.id = 'resource-' + sanitizeId(r.id);
+            card.setAttribute('role', 'listitem');
+            card.dataset.previewId = r.id;
+            card.dataset.resourceType = r.type || '';
+            card.dataset.currentIndex = '0';
+
+            cardCaptures.set(r.id, captures.map(c => ({
+                label: resourceCaptureLabel(c),
+                renderOutput: c.renderOutput || '',
+                imageData: null,
+                errorMessage: null,
+            })));
+
+            const header = document.createElement('div');
+            header.className = 'card-header';
+
+            const titleRow = document.createElement('div');
+            titleRow.className = 'card-title-row';
+
+            const title = document.createElement('button');
+            title.className = 'card-title';
+            title.textContent = r.id;
+            // Pick the default-qualifier source file (key '') if present;
+            // otherwise the first qualified entry. anydpi-v26 adaptive icons
+            // typically only have an 'anydpi-v26' key, so this falls back to
+            // it without special-casing the type.
+            const sources = r.sourceFiles || {};
+            const defaultSource = sources[''];
+            const firstSource = defaultSource || Object.values(sources)[0] || null;
+            if (firstSource) {
+                title.title = 'Open ' + firstSource;
+                title.addEventListener('click', () => {
+                    vscode.postMessage({
+                        command: 'openResourceSource',
+                        module,
+                        sourceFile: firstSource,
+                    });
+                });
+            } else {
+                title.disabled = true;
+                title.title = 'No source file for this resource';
+            }
+            titleRow.appendChild(title);
+
+            if (animated) {
+                const icon = document.createElement('i');
+                icon.className = 'codicon codicon-play-circle animation-icon';
+                icon.title = captures.length + ' captures';
+                icon.setAttribute('aria-label',
+                    'Resource with ' + captures.length + ' captures');
+                titleRow.appendChild(icon);
+            }
+            header.appendChild(titleRow);
+            card.appendChild(header);
+
+            const imgContainer = document.createElement('div');
+            imgContainer.className = 'image-container';
+            const skeleton = document.createElement('div');
+            skeleton.className = 'skeleton';
+            skeleton.setAttribute('aria-label', 'Loading resource preview');
+            imgContainer.appendChild(skeleton);
+            card.appendChild(imgContainer);
+
+            const subtitleParts = [r.type];
+            const refs = refsByResource.get(r.id) || [];
+            if (refs.length > 0) {
+                // Compact summary — e.g. 'used by application@icon, MainActivity@icon'.
+                const refSummary = refs.map(ref => {
+                    const owner = ref.componentName
+                        ? ref.componentName.substring(ref.componentName.lastIndexOf('.') + 1)
+                        : ref.componentKind;
+                    const attr = (ref.attributeName || '').replace(/^android:/, '');
+                    return owner + '@' + attr;
+                }).join(', ');
+                subtitleParts.push('used by ' + refSummary);
+            }
+            const badge = document.createElement('div');
+            badge.className = 'variant-badge';
+            badge.textContent = subtitleParts.join(' · ');
+            card.appendChild(badge);
+
+            if (animated) {
+                card.appendChild(buildFrameControls(card));
+            }
+            return card;
+        }
+
+        // Two stacked sections in the grid:
+        //   1. 'Declared in AndroidManifest.xml' — resources with at least one
+        //      manifestReferences row pointing at them.
+        //   2. 'Other resources' — everything else.
+        // When section 1 is empty (manifest references nothing the renderer
+        // produced — possible if the consumer's manifest references a raster
+        // mipmap we don't render), the section header is omitted and only
+        // section 2 shows.
+        function renderResources(resources, references) {
+            grid.innerHTML = '';
+            grid.classList.add('resources-mode');
+
+            // Index references by "<resourceType>/<resourceName>" so the card
+            // builder can attach a 'used by …' summary in O(1).
+            const refsByResource = new Map();
+            for (const ref of references) {
+                const id = (ref.resourceType || '') + '/' + (ref.resourceName || '');
+                if (!refsByResource.has(id)) refsByResource.set(id, []);
+                refsByResource.get(id).push(ref);
+            }
+
+            const declared = [];
+            const other = [];
+            for (const r of resources) {
+                if (refsByResource.has(r.id)) declared.push(r);
+                else other.push(r);
+            }
+            // Within each section, sort by id so the order is stable across
+            // discovery-task runs (which use a LinkedHashMap but the order
+            // shifts when a new resource is added mid-list).
+            declared.sort((a, b) => a.id.localeCompare(b.id));
+            other.sort((a, b) => a.id.localeCompare(b.id));
+
+            if (declared.length > 0) {
+                const heading = document.createElement('h3');
+                heading.className = 'resources-section-heading';
+                heading.textContent = 'Declared in AndroidManifest.xml';
+                grid.appendChild(heading);
+                for (const r of declared) {
+                    grid.appendChild(createResourceCard(r, refsByResource, currentResourceModule));
+                }
+            }
+            if (other.length > 0) {
+                if (declared.length > 0) {
+                    const heading = document.createElement('h3');
+                    heading.className = 'resources-section-heading';
+                    heading.textContent = 'Other resources';
+                    grid.appendChild(heading);
+                }
+                for (const r of other) {
+                    grid.appendChild(createResourceCard(r, refsByResource, currentResourceModule));
+                }
+            }
+        }
+        // Module name supplied alongside the resources payload — used by card
+        // titles to resolve their click target. Held in a webview-scope 'let'
+        // (rather than threaded through every render call) so updateImage and
+        // similar follow-up messages don't need to know about it.
+        let currentResourceModule = '';
+
         function buildFrameControls(card) {
             const bar = document.createElement('div');
             bar.className = 'frame-controls';
@@ -1109,7 +1286,26 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         window.addEventListener('message', event => {
             const msg = event.data;
             switch (msg.command) {
+                case 'setResources': {
+                    // Resources mode is fully orthogonal to the composable
+                    // preview state — clear the latter so a previous
+                    // setPreviews payload doesn't leak into the resources
+                    // view's filter dropdowns or relative-sizing pass.
+                    allPreviews = [];
+                    currentResourceModule = msg.module;
+                    moduleDir = msg.module;
+                    renderResources(msg.resources, msg.references);
+                    // Function / group filters are composable concepts;
+                    // hide the toolbar entries by populating them empty so
+                    // the dropdowns don't dangle stale options.
+                    populateFilter(filterFunction, [], 'functions');
+                    populateFilter(filterGroup, [], 'groups');
+                    setMessage('', 'extension');
+                    break;
+                }
+
                 case 'setPreviews': {
+                    grid.classList.remove('resources-mode');
                     allPreviews = msg.previews;
                     moduleDir = msg.moduleDir;
                     renderPreviews(msg.previews);

--- a/vscode-extension/src/test/androidManifestCodeLensProvider.test.ts
+++ b/vscode-extension/src/test/androidManifestCodeLensProvider.test.ts
@@ -1,0 +1,93 @@
+import * as assert from 'assert';
+import { findManifestIconReferences } from '../manifestIconReferences';
+
+describe('findManifestIconReferences', () => {
+    it('extracts icon and roundIcon from <application>', () => {
+        const xml = `
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                <application
+                    android:icon="@mipmap/ic_launcher"
+                    android:roundIcon="@mipmap/ic_launcher_round" />
+            </manifest>
+        `;
+        const matches = findManifestIconReferences(xml);
+        assert.strictEqual(matches.length, 2);
+        assert.deepStrictEqual(matches.map((m) => m.attribute), ['icon', 'roundIcon']);
+        assert.deepStrictEqual(matches.map((m) => m.resourceType), ['mipmap', 'mipmap']);
+        assert.deepStrictEqual(matches.map((m) => m.resourceName), ['ic_launcher', 'ic_launcher_round']);
+    });
+
+    it('extracts an activity-level icon override', () => {
+        const xml = `
+            <activity android:name=".MainActivity" android:icon="@drawable/ic_settings"/>
+        `;
+        const matches = findManifestIconReferences(xml);
+        assert.strictEqual(matches.length, 1);
+        assert.deepStrictEqual(matches[0], {
+            offset: matches[0].offset,
+            attribute: 'icon',
+            resourceType: 'drawable',
+            resourceName: 'ic_settings',
+        });
+    });
+
+    it('handles attributes split across lines with single quotes', () => {
+        const xml = `
+            <activity
+                android:name='.Foo'
+                android:icon = '@drawable/foo_icon' />
+        `;
+        const matches = findManifestIconReferences(xml);
+        assert.strictEqual(matches.length, 1);
+        assert.strictEqual(matches[0].resourceName, 'foo_icon');
+    });
+
+    it('skips framework drawable references (@android:drawable/...)', () => {
+        const xml = `<application android:icon="@android:drawable/sym_def_app_icon" />`;
+        assert.deepStrictEqual(findManifestIconReferences(xml), []);
+    });
+
+    it('skips theme attribute references (?attr/...)', () => {
+        const xml = `<activity android:icon="?attr/iconResource" />`;
+        assert.deepStrictEqual(findManifestIconReferences(xml), []);
+    });
+
+    it('skips non-icon attributes carrying drawable refs', () => {
+        const xml = `
+            <application android:theme="@style/AppTheme">
+                <activity android:label="@string/title" />
+            </application>
+        `;
+        assert.deepStrictEqual(findManifestIconReferences(xml), []);
+    });
+
+    it('records the offset of each match for CodeLens range positioning', () => {
+        const xml = 'before <activity android:icon="@drawable/foo" /> after';
+        const matches = findManifestIconReferences(xml);
+        assert.strictEqual(matches.length, 1);
+        // Offset should land on the `android:` prefix, not the start of the document.
+        assert.strictEqual(xml.slice(matches[0].offset, matches[0].offset + 'android:icon'.length), 'android:icon');
+    });
+
+    it('handles logo and banner attributes', () => {
+        const xml = `
+            <application android:logo="@drawable/app_logo">
+                <activity android:banner="@drawable/tv_banner" />
+            </application>
+        `;
+        const matches = findManifestIconReferences(xml);
+        assert.deepStrictEqual(matches.map((m) => m.attribute).sort(), ['banner', 'logo']);
+    });
+
+    it('returns empty for a manifest with no icon attributes', () => {
+        const xml = `<manifest xmlns:android="http://schemas.android.com/apk/res/android"><application /></manifest>`;
+        assert.deepStrictEqual(findManifestIconReferences(xml), []);
+    });
+
+    it('accepts the @+drawable/ resource-id form', () => {
+        const xml = `<application android:icon="@+drawable/new_icon" />`;
+        const matches = findManifestIconReferences(xml);
+        assert.strictEqual(matches.length, 1);
+        assert.strictEqual(matches[0].resourceName, 'new_icon');
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -248,6 +248,19 @@ export type ExtensionToWebview =
            */
           heavyStaleIds?: string[];
       }
+    /**
+     * Resources view, posted when the active editor is `AndroidManifest.xml`.
+     * Renders [ResourcePreview] cards in two stacked sections — the ones
+     * referenced from the open manifest first, the rest below.
+     */
+    | {
+          command: 'setResources';
+          resources: ResourcePreview[];
+          /** Manifest references whose `source` matches the open manifest file (module-relative). */
+          references: ManifestReference[];
+          /** Module name used to resolve source-file open clicks back to absolute paths. */
+          module: string;
+      }
     /** `captureIndex` addresses which capture within an animated preview the
      *  image belongs to. Static previews have a single capture at index 0. */
     | { command: 'updateImage'; previewId: string; captureIndex: number; imageData: string }
@@ -274,4 +287,11 @@ export type WebviewToExtension =
      * re-rendered. (A future per-preview filter would scope this to the
      * single previewId; today it falls back to a full-module render.)
      */
-    | { command: 'refreshHeavy'; previewId: string };
+    | { command: 'refreshHeavy'; previewId: string }
+    /**
+     * User clicked a resource card's title in the resources view. Opens the
+     * resource's source XML file in a sibling editor — `module` is the
+     * Gradle module the resource belongs to, `sourceFile` is the
+     * module-relative path the manifest carries (`src/main/res/drawable/foo.xml`).
+     */
+    | { command: 'openResourceSource'; module: string; sourceFile: string };


### PR DESCRIPTION
## Summary

Stacks on #272. When the active editor is `AndroidManifest.xml`, the existing Compose preview panel switches into a **resources view** — same panel, same toolbar, same image-load plumbing, different cards. Triggered from `onDidChangeActiveTextEditor` so there's no new command, no new button, and Kotlin files keep their existing behaviour.

## Layout

Two stacked sections in the panel:

1. **Declared in AndroidManifest.xml** — one card per `ManifestReference` row whose `(resourceType, resourceName)` resolves to a `ResourcePreview` in the module's `resources.json`. Subtitle reads `used by application@icon, MainActivity@icon` so the user can see at a glance which manifest line each card maps to.
2. **Other resources** — every other resource in the module (rendered XML drawables not referenced from the manifest) in the existing card grid layout.

Adaptive icons render with their existing 4-shape carousel (`xhdpi · CIRCLE` / `ROUNDED_SQUARE` / `SQUARE` / `LEGACY`); the existing animated preview plumbing (skeleton, image-container, frame-controls, cardCaptures) is reused without modification.

## How it diverges from composable cards

Resource cards share most of the existing card markup but diverge on:

- **Title click** → posts `openResourceSource` (opens the source XML in a sibling editor) rather than `openFile` (which jumps to a Kotlin function).
- **Subtitle slot** shows the resource type + manifest reference summary, not the `@Preview` params.
- **No a11y findings, no group filter, no history drawer** — those don't apply to the resource pipeline today.

## Defensive shape (older plugin versions)

Same three-guard pattern as the AndroidManifest CodeLens (#272):

| Scenario | Behaviour |
|---|---|
| Plugin predates resource pipeline; no `resources.json` | `setResources` not posted; panel shows `No resources.json for <module>. Run \`:<module>:renderAndroidResources\` …` |
| `resources.json` present but PNGs not rendered | Cards appear with skeletons, then each missing capture posts `setImageError` pointing at the render task |
| Module path can't resolve from `AndroidManifest.xml` location | Panel shows `Couldn't resolve a Compose module for AndroidManifest.xml.` |

No exceptions, no spurious cards, no blank panel.

## Test plan

- [x] `cd vscode-extension && npm test` — 79 tests still pass (no regressions).
- [ ] Open `samples/android/src/main/AndroidManifest.xml` in a VS Code window with the extension running. Verify the panel shows three cards under "Declared in AndroidManifest.xml" (`mipmap/ic_launcher`, `mipmap/ic_launcher_round`, `drawable/ic_settings`) and the rest of the resources under "Other resources".
- [ ] Click a card title; verify the source XML opens in a sibling editor.
- [ ] Switch back to a `.kt` file; verify the panel reverts to composable previews.
- [ ] Open a manifest in a module without resource previews configured; verify the empty-state message appears rather than a blank panel.

## Out of scope

- Per-capture-label customisation for adaptive icons (`xhdpi · CIRCLE` could be `Circle` if we wanted a less technical label).
- Triggering `:<module>:renderAndroidResources` from the panel when PNGs are missing — currently shows `setImageError` pointing at the task; auto-running it on demand could be a follow-up similar to the existing `refreshHeavy` path.
- Webview-side unit tests — the resource-card render code is in a webview-runtime template literal not currently exercised by the Mocha test runner. End-to-end gate is manual verification under the extension runtime.

---
_Generated by [Claude Code](https://claude.ai/code/session_01APmYnc8AMQmZivBivcGiNY)_