### PR TITLE
feat(vscode): auto-render resources + AndroidManifest hover provider

### DIFF
--- a/vscode-extension/src/androidManifestHoverProvider.ts
+++ b/vscode-extension/src/androidManifestHoverProvider.ts
@@ -1,0 +1,80 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { GradleService } from './gradleService';
+import { findManifestIconReferences } from './manifestIconReferences';
+
+/**
+ * Hover sibling to [AndroidManifestCodeLensProvider]. When the cursor is over an
+ * icon-bearing attribute in `AndroidManifest.xml` (`android:icon`, `roundIcon`, `logo`,
+ * `banner`) whose target resolves into the module's `resources.json`, surfaces a markdown
+ * tooltip with the rendered PNG inline plus a one-line summary of the resource type and
+ * captures.
+ *
+ * Two reasons to keep this alongside the CodeLens rather than collapsing into one surface:
+ *
+ *  - **Different ergonomics.** Hover is "I'm reading the manifest, what does this icon look
+ *    like?" — passive, on-demand, no commit to leaving the manifest. CodeLens is "open the
+ *    PNG full-size in a sibling tab" — requires a click but gives you the actual viewer.
+ *    Both are useful, neither subsumes the other.
+ *  - **No vscode dependency in the parser.** `findManifestIconReferences` lives in a
+ *    no-vscode module so the test runs under plain Mocha; layering both providers on top of
+ *    that single parser is the natural shape.
+ */
+export class AndroidManifestHoverProvider implements vscode.HoverProvider {
+    constructor(private readonly gradleService: GradleService) {}
+
+    provideHover(
+        doc: vscode.TextDocument,
+        position: vscode.Position,
+    ): vscode.Hover | undefined {
+        if (!doc.fileName.endsWith('AndroidManifest.xml')) { return undefined; }
+        const module = this.gradleService.resolveModule(doc.uri.fsPath);
+        if (!module) { return undefined; }
+
+        // Find the icon-attribute match, if any, that contains the cursor.
+        const text = doc.getText();
+        const offset = doc.offsetAt(position);
+        const matches = findManifestIconReferences(text);
+        const match = matches.find((m) => {
+            // The full attribute span (start through closing quote of the
+            // value) is roughly `android:NAME="@TYPE/NAME"`. The parser
+            // returns the offset of `android:`, and the match length is
+            // bounded by a generous estimate — but doc.offsetAt(position) is
+            // a line+col offset, so we just check whether the cursor sits
+            // anywhere on the line that owns this match.
+            const matchLine = doc.positionAt(m.offset).line;
+            return matchLine === position.line;
+        });
+        if (!match) { return undefined; }
+
+        const manifest = this.gradleService.readResourceManifest(module);
+        if (!manifest) { return undefined; }
+
+        const resourceId = `${match.resourceType}/${match.resourceName}`;
+        const resource = manifest.resources.find((r) => r.id === resourceId);
+        if (!resource) { return undefined; }
+        const firstCapture = resource.captures.find((c) => c.renderOutput);
+        if (!firstCapture) { return undefined; }
+
+        const pngPath = path.join(
+            this.gradleService.workspaceRoot,
+            module,
+            'build',
+            'compose-previews',
+            firstCapture.renderOutput,
+        );
+
+        // Markdown image syntax + a one-line summary. Use a `vscode.MarkdownString`
+        // with `isTrusted = false` (default) — the image src is a `file:` URL but
+        // contains no executable content, so trust isn't required.
+        const md = new vscode.MarkdownString();
+        md.supportHtml = true;
+        md.appendMarkdown(`![${resourceId}](${vscode.Uri.file(pngPath).toString()})\n\n`);
+        const captureCount = resource.captures.length;
+        const captureSummary = captureCount === 1
+            ? '1 capture'
+            : `${captureCount} captures`;
+        md.appendMarkdown(`**\`${resourceId}\`** — ${resource.type}, ${captureSummary}`);
+        return new vscode.Hover(md);
+    }
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -10,10 +10,11 @@ import { PreviewGutterDecorations } from './previewGutterDecorations';
 import { PreviewHoverProvider } from './previewHoverProvider';
 import { PreviewCodeLensProvider } from './previewCodeLensProvider';
 import { AndroidManifestCodeLensProvider } from './androidManifestCodeLensProvider';
+import { AndroidManifestHoverProvider } from './androidManifestHoverProvider';
 import { PreviewA11yDiagnostics } from './previewA11yDiagnostics';
 import { PreviewDoctorDiagnostics } from './previewDoctorDiagnostics';
 import { packageQualifiedSourcePath } from './sourcePath';
-import { HEAVY_COST_THRESHOLD, PreviewInfo } from './types';
+import { HEAVY_COST_THRESHOLD, PreviewInfo, ResourceManifest } from './types';
 import { captureLabel } from './captureLabels';
 
 const DEBOUNCE_MS = 1500;
@@ -246,12 +247,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         pattern: '**/AndroidManifest.xml',
     };
     const androidManifestCodeLensProvider = new AndroidManifestCodeLensProvider(gradleService);
+    const androidManifestHoverProvider = new AndroidManifestHoverProvider(gradleService);
     context.subscriptions.push(
         vscode.languages.registerHoverProvider(kotlinFiles, hoverProvider),
         vscode.languages.registerCodeLensProvider(kotlinFiles, codeLensProvider),
         vscode.languages.registerCodeLensProvider(
             androidManifestFiles,
             androidManifestCodeLensProvider,
+        ),
+        vscode.languages.registerHoverProvider(
+            androidManifestFiles,
+            androidManifestHoverProvider,
         ),
         codeLensProvider,
         androidManifestCodeLensProvider,
@@ -590,14 +596,19 @@ const fastTierModules = new Set<string>();
  */
 /**
  * Loads `<module>/build/compose-previews/resources.json` for the module that owns the open
- * `AndroidManifest.xml` and posts a [setResources] payload to the webview. Falls back to a
- * sensible empty-state message when the manifest belongs to an older-plugin module that hasn't
- * written `resources.json` (CodeLens provider's same defensive shape — see the comment in
- * `androidManifestCodeLensProvider.ts`).
+ * `AndroidManifest.xml` and posts a [setResources] payload to the webview.
  *
- * Image loading mirrors the composable refresh path: post `setResources` first so the webview
- * can paint card skeletons, then stream `updateImage` per capture so each card paints as soon
- * as its bytes arrive.
+ * Two-phase to keep the panel snappy:
+ *   1. Read the existing `resources.json` (if any) and post it immediately — the user sees
+ *      cards within ~ms of opening the manifest, even on a cold gradle daemon.
+ *   2. In the background, run `:<module>:renderAndroidResources` to refresh stale captures.
+ *      Re-post the updated manifest when it returns. Gradle's up-to-date check makes this a
+ *      sub-second no-op when nothing changed since the last render.
+ *
+ * Falls back to a clear empty-state message when the consumer is on an older plugin that
+ * doesn't emit `resources.json` and the render-task invocation failed (likely "task not
+ * found" — same defensive shape as the AndroidManifest CodeLens, see the comment in
+ * `androidManifestCodeLensProvider.ts`).
  */
 async function refreshForManifest(filePath: string): Promise<void> {
     if (!gradleService || !panel) { return; }
@@ -615,19 +626,61 @@ async function refreshForManifest(filePath: string): Promise<void> {
         });
         return;
     }
-    const manifest = gradleService.readResourceManifest(module);
-    if (!manifest) {
-        logLine(`manifest no resources.json — module=${module}`);
+
+    // Phase 1 — paint whatever's on disk right now. May be stale (or null
+    // on first-ever open), but at worst the user sees nothing for a few ms
+    // longer than they would have. Empty/null is silent here; the
+    // background render below will own the empty-state message if needed.
+    const cached = gradleService.readResourceManifest(module);
+    if (cached) {
+        await postResources(cached, module, abort);
+    } else {
+        // No resources.json on disk yet — show a "rendering…" message so
+        // the panel isn't blank during the gradle cold start.
         panel.postMessage({ command: 'clearAll' });
         panel.postMessage({
             command: 'showMessage',
-            text:
-                `No resources.json for ${module}. Run \`:${module}:renderAndroidResources\` ` +
-                `or upgrade the plugin to a version that emits the manifest.`,
+            text: `Rendering ${module} resource previews…`,
         });
+    }
+
+    // Phase 2 — refresh in the background. `renderAndroidResources` is
+    // catalogue-driven (Gradle up-to-date), so this is a sub-second no-op
+    // when nothing changed. First-ever invocation pays the Robolectric
+    // cold-start cost (~3–5s) but the cards from phase 1 mask that wait.
+    const fresh = await gradleService.renderAndroidResources(module);
+    if (abort.signal.aborted || !panel) { return; }
+    if (!fresh) {
+        if (!cached) {
+            // Couldn't render AND nothing was on disk — older plugin or a
+            // genuine task failure. Surface the empty state so the user
+            // knows what to do.
+            panel.postMessage({ command: 'clearAll' });
+            panel.postMessage({
+                command: 'showMessage',
+                text:
+                    `Couldn't render ${module} resource previews. Check the gradle output, ` +
+                    `or upgrade the plugin to a version that emits resources.json.`,
+            });
+        }
+        // Cached payload already painted; leave it. The user can re-trigger
+        // a render from the command palette if they need to.
         return;
     }
 
+    // Re-post even if the manifest didn't change shape — the captures' on-
+    // disk PNGs may have been refreshed even though the manifest entries
+    // are identical, and the webview's image cache won't notice without
+    // a fresh round of updateImage messages.
+    await postResources(fresh, module, abort);
+}
+
+async function postResources(
+    manifest: ResourceManifest,
+    module: string,
+    abort: AbortController,
+): Promise<void> {
+    if (!gradleService || !panel) { return; }
     // The reference index records the merged manifest path under `build/`.
     // Filter to references whose resourceType+resourceName actually has a
     // matching ResourcePreview — the source field comparison would miss
@@ -636,7 +689,6 @@ async function refreshForManifest(filePath: string): Promise<void> {
     const references = manifest.manifestReferences.filter(ref =>
         knownIds.has(`${ref.resourceType}/${ref.resourceName}`),
     );
-
     panel.postMessage({
         command: 'setResources',
         resources: manifest.resources,
@@ -644,11 +696,9 @@ async function refreshForManifest(filePath: string): Promise<void> {
         module,
     });
     logLine(
-        `rendered ${manifest.resources.length} resource preview(s) for ${path.basename(filePath)} ` +
+        `rendered ${manifest.resources.length} resource preview(s) for ${module} ` +
             `(${references.length} manifest reference(s))`,
     );
-
-    // Stream PNG/GIF bytes per capture, same shape as the composable refresh.
     const imageJobs: Promise<void>[] = [];
     for (const resource of manifest.resources) {
         for (let captureIndex = 0; captureIndex < resource.captures.length; captureIndex++) {

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -169,6 +169,33 @@ export class GradleService {
     }
 
     /**
+     * Runs `:<module>:renderAndroidResources` and returns the parsed
+     * `resources.json`. Gradle's up-to-date check makes this cheap on warm
+     * runs (sub-second when no source XML or AndroidManifest changed); the
+     * first invocation pays the Robolectric sandbox cold-start cost
+     * (~3–5s).
+     *
+     * Returns `null` when the consumer is on an older plugin that hasn't
+     * registered the task yet, when the gradle invocation itself fails,
+     * or when the manifest is malformed. Callers should treat null as
+     * "skip the resources view for this module" rather than an error
+     * state.
+     */
+    async renderAndroidResources(module: string): Promise<ResourceManifest | null> {
+        try {
+            await this.runTask(`:${module}:renderAndroidResources`);
+        } catch (e) {
+            this.logger.appendLine(
+                `:${module}:renderAndroidResources failed: ${
+                    e instanceof Error ? e.message : String(e)
+                }`,
+            );
+            return null;
+        }
+        return this.readResourceManifest(module);
+    }
+
+    /**
      * Runs `:<module>:composePreviewDoctor` and returns the parsed sidecar
      * report. Same JSON schema as `compose-preview doctor --json`'s per-
      * module shape — see `ComposePreviewDoctorTask.kt` in `gradle-plugin`.


### PR DESCRIPTION
## Summary

Two related polish improvements on the resources view (#275). Stacks on that PR; once #275 lands GitHub auto-updates the base to `main`.

### 1. Auto-render on missing PNGs

#275 surfaced per-capture `setImageError` messages when PNGs were missing — the user had to spot the error text and run `:<module>:renderAndroidResources` themselves. Now the panel runs the task automatically, with a two-phase paint to keep it snappy:

- **Phase 1** — paint the cached `resources.json` instantly so the panel isn't blank during the gradle cold start (~3–5s on first invocation).
- **Phase 2** — invoke `:<module>:renderAndroidResources` in the background. Gradle's up-to-date check makes this a sub-second no-op when nothing changed since the last render. Re-post the updated manifest when it returns.

Surfaces a clear empty-state message (`Couldn't render <module> resource previews. Check the gradle output, or upgrade the plugin to a version that emits resources.json.`) when the render task invocation fails AND there's no cached payload — same defensive shape as the AndroidManifest CodeLens (#272) for older plugin versions that don't register the task.

New `gradleService.renderAndroidResources(module)` method runs the task and reads back `resources.json`, returning `null` on failure. No caching there yet — `refreshForManifest` already handles the snappy paint via the existing `readResourceManifest` path.

### 2. AndroidManifest hover provider

Sibling to the CodeLens (#272). Hover over an icon-bearing attribute (`android:icon`, `roundIcon`, `logo`, `banner`) whose target resolves into `resources.json` and the hover surfaces a markdown tooltip with the rendered PNG inline plus a one-line summary (`drawable/ic_settings — VECTOR, 1 capture`).

Different ergonomics from the CodeLens:
- **Hover** = "I'm reading the manifest, what does this icon look like?" — passive, on-demand, no commit to leaving the manifest.
- **CodeLens** = "open the PNG full-size in a sibling tab" — requires a click but gives you the actual viewer.

Both layer on top of the same `findManifestIconReferences` parser in `manifestIconReferences.ts` (no vscode dependency, so the parser stays unit-testable under plain Mocha — same 10 tests cover both surfaces).

## Test plan

- [x] `cd vscode-extension && npm test` — 79 passing (no regressions).
- [ ] Open `samples/android/src/main/AndroidManifest.xml` with stale or missing renders. Verify the panel paints cards immediately, then refreshes after the gradle task completes.
- [ ] Open the same manifest after `gradlew clean`. Verify the panel shows "Rendering …" while gradle runs, then paints the resource cards.
- [ ] Hover over `android:icon="@mipmap/ic_launcher"`. Verify the tooltip shows the rendered PNG inline plus the resource summary.
- [ ] Hover over a manifest line that doesn't reference a renderable resource. Verify no hover appears.
- [ ] Open a manifest in a module without resource previews configured. Verify the empty-state message appears, no hover, no CodeLens.

## Out of scope

- Per-capture hover (currently shows the first capture only). Could iterate through captures with a small carousel or a `## Variants` markdown section if the single-capture preview turns out to be too narrow.
- Trigger button on the panel toolbar to manually re-render. The auto-render covers most of the use cases, and a manual trigger is one more surface to maintain.

---
_Generated by [Claude Code](https://claude.ai/code/session_01APmYnc8AMQmZivBivcGiNY)_