### PR TITLE
fix(cli): publish-images branch-name allowlist + refname validation

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PublishImagesCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PublishImagesCommand.kt
@@ -27,12 +27,30 @@ class PublishImagesCommand(args: List<String>) {
   private val remote: String = args.flagValue("--remote") ?: "origin"
   private val prNumber: String? = args.flagValue("--pr-number")
   private val customMessage: String? = args.flagValue("--message")
+  /**
+   * Opt-in escape hatch for branch names outside the `preview_*` allowlist. Hard-blocked names
+   * ([HARD_BLOCKED_BRANCHES]) stay rejected even with this flag — pushing rendered PNGs onto
+   * `main`/`master`/etc. is never the intended use of this command.
+   */
+  private val allowNonPreviewBranch = "--allow-non-preview-branch" in args
   private val positional: List<String> = parsePositional(args)
 
   fun run() {
     if (positional.size != 1) {
       System.err.println(USAGE)
       exitProcess(64) // EX_USAGE
+    }
+
+    validateBranch(branch, allowNonPreviewBranch)?.let { message ->
+      System.err.println(message)
+      exitProcess(64)
+    }
+
+    if (remote.startsWith("-")) {
+      // `git push -<flag>` would be interpreted as a flag, not a remote. Defensive even though
+      // git remote names with leading dashes are unusual in practice.
+      System.err.println("invalid --remote: $remote (must not start with '-')")
+      exitProcess(64)
     }
 
     val source = File(positional[0])
@@ -285,7 +303,7 @@ class PublishImagesCommand(args: List<String>) {
 
   companion object {
     private const val USAGE =
-      "usage: compose-preview publish-images DIR [--branch BRANCH] [--remote REMOTE] [--pr-number N] [--message MSG] [--json]"
+      "usage: compose-preview publish-images DIR [--branch BRANCH] [--remote REMOTE] [--pr-number N] [--message MSG] [--allow-non-preview-branch] [--json]"
 
     private const val MAX_PUSH_ATTEMPTS = 5
 
@@ -295,7 +313,23 @@ class PublishImagesCommand(args: List<String>) {
     }
 
     private val FLAGS_TAKING_VALUE = setOf("--branch", "--remote", "--pr-number", "--message")
-    private val FLAGS_NO_VALUE = setOf("--json")
+    private val FLAGS_NO_VALUE = setOf("--json", "--allow-non-preview-branch")
+
+    /**
+     * Branches `publish-images` will never push to, regardless of `--allow-non-preview-branch`.
+     * This is policy on top of the allowlist: pushing rendered PNGs onto a project's mainline or
+     * release branches is never the intended use of this command, so we hard-block even with the
+     * escape hatch. Anything else outside the `preview_*` allowlist requires the flag.
+     */
+    private val HARD_BLOCKED_BRANCHES = setOf("main", "master", "develop", "trunk", "HEAD")
+    private val HARD_BLOCKED_PREFIXES = listOf("release/", "releases/")
+
+    /**
+     * Conservative subset of `git check-ref-format`. Real refnames allow more, but for this
+     * command's scope (push to a named branch the user controls) we want a tight surface that
+     * rejects path-injection (`../`), refspec syntax (`:`), and flag-injection (`-`).
+     */
+    private val SAFE_REFNAME = Regex("""^[A-Za-z0-9][A-Za-z0-9._/-]*$""")
 
     internal fun parsePositional(args: List<String>): List<String> {
       val out = mutableListOf<String>()
@@ -313,6 +347,36 @@ class PublishImagesCommand(args: List<String>) {
         }
       }
       return out
+    }
+
+    /**
+     * Branch-name safety check, layered. Returns null when the branch is acceptable; otherwise the
+     * error message a caller should print.
+     *
+     * 1. Refname must match [SAFE_REFNAME] — catches `--branch ../foo`, `:bar`, `-flag`, etc.
+     *    before they reach `git push`.
+     * 2. Refname must not be in [HARD_BLOCKED_BRANCHES] or under [HARD_BLOCKED_PREFIXES] — pushing
+     *    rendered PNGs onto mainline / release branches is never the intended use, even with the
+     *    escape hatch.
+     * 3. Refname must match the `preview_` prefix, OR `--allow-non-preview-branch` must be set.
+     *
+     * The first failing rule wins so error messages stay focused.
+     */
+    internal fun validateBranch(branch: String, allowNonPreview: Boolean): String? {
+      if (!SAFE_REFNAME.matches(branch) || ".." in branch || "@{" in branch) {
+        return "invalid --branch '$branch': must start with a letter or digit and use only " +
+          "[A-Za-z0-9._/-]; refspec/path-injection patterns rejected."
+      }
+      if (branch in HARD_BLOCKED_BRANCHES || HARD_BLOCKED_PREFIXES.any { branch.startsWith(it) }) {
+        return "refusing to push to '$branch': mainline / release branches are never a valid " +
+          "destination for publish-images, even with --allow-non-preview-branch."
+      }
+      if (!branch.startsWith("preview_") && !allowNonPreview) {
+        return "branch '$branch' is outside the preview_* allowlist. Pass " +
+          "--allow-non-preview-branch to push to a custom branch (mainline branches stay " +
+          "blocked regardless)."
+      }
+      return null
     }
 
     /** Default commit message format mirrors the GHA's: `Preview renders for PR #N (sha::8)`. */

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PublishImagesCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PublishImagesCommandTest.kt
@@ -2,7 +2,9 @@ package ee.schimke.composeai.cli
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class PublishImagesArgParsingTest {
   @Test
@@ -59,6 +61,80 @@ class PublishImagesMessageTest {
   @Test
   fun `message with neither falls back to bare`() {
     assertEquals("Preview renders", PublishImagesCommand.defaultMessage(null, null))
+  }
+}
+
+class PublishImagesBranchValidationTest {
+  @Test
+  fun `preview_pr passes by default`() {
+    assertNull(PublishImagesCommand.validateBranch("preview_pr", allowNonPreview = false))
+  }
+
+  @Test
+  fun `preview_main passes by default`() {
+    assertNull(PublishImagesCommand.validateBranch("preview_main", allowNonPreview = false))
+  }
+
+  @Test
+  fun `non-preview branch rejected without escape hatch`() {
+    val message = PublishImagesCommand.validateBranch("screenshots", allowNonPreview = false)
+    assertTrue(
+      message != null && "preview_*" in message && "--allow-non-preview-branch" in message,
+      "expected reject mentioning the allowlist and escape flag, got $message",
+    )
+  }
+
+  @Test
+  fun `non-preview branch passes with escape hatch`() {
+    assertNull(PublishImagesCommand.validateBranch("screenshots", allowNonPreview = true))
+  }
+
+  @Test
+  fun `main is hard-blocked even with escape hatch`() {
+    val message = PublishImagesCommand.validateBranch("main", allowNonPreview = true)
+    assertTrue(
+      message != null && "mainline" in message,
+      "expected hard-block on main, got $message",
+    )
+  }
+
+  @Test
+  fun `master develop trunk HEAD all hard-blocked`() {
+    for (b in listOf("master", "develop", "trunk", "HEAD")) {
+      val message = PublishImagesCommand.validateBranch(b, allowNonPreview = true)
+      assertTrue(message != null, "expected hard-block on '$b', got null")
+    }
+  }
+
+  @Test
+  fun `release prefix hard-blocked even with escape hatch`() {
+    assertNotNull(PublishImagesCommand.validateBranch("release/v1.0", allowNonPreview = true))
+  }
+
+  @Test
+  fun `path traversal rejected`() {
+    val message = PublishImagesCommand.validateBranch("../etc", allowNonPreview = true)
+    assertTrue(
+      message != null && "path-injection" in message,
+      "expected refname rejection, got $message",
+    )
+  }
+
+  @Test
+  fun `refspec colon rejected`() {
+    assertNotNull(PublishImagesCommand.validateBranch("preview_pr:main", allowNonPreview = false))
+  }
+
+  @Test
+  fun `leading dash rejected to prevent flag injection`() {
+    assertNotNull(PublishImagesCommand.validateBranch("-force", allowNonPreview = true))
+  }
+
+  @Test
+  fun `at-brace rejected`() {
+    // `branch@{1}` is a reflog selector; pushing to it is meaningless and we don't want exotic
+    // git syntax leaking through.
+    assertNotNull(PublishImagesCommand.validateBranch("preview_pr@{1}", allowNonPreview = false))
   }
 }
 

--- a/skills/compose-preview/design/AGENT_PR.md
+++ b/skills/compose-preview/design/AGENT_PR.md
@@ -135,7 +135,10 @@ destination before acting:
   `compose-preview-publish-images/v1` envelope. Prefer this over the
   gist when you want clean GitHub-hosted URLs and the user's confirmed
   they want a branch created — the CLI does NOT auto-detect prior
-  consent; it just runs the push.
+  consent; it just runs the push. Branch names must match `preview_*`
+  by default; `--allow-non-preview-branch` opts into a custom name.
+  Mainline / release branches (`main`, `master`, `develop`, `trunk`,
+  `HEAD`, `release/*`) are hard-blocked regardless of the flag.
 - **Issue/PR attachment upload** — not reliably available via `gh`; skip.
 
 Never use inline base64 or data URIs — GitHub strips them. Never push images


### PR DESCRIPTION
## Summary

Closes the safety gap in #274 (publish-images). As shipped, the command
had no guards on `--branch` — a user passing `--branch main` against a
repo where `main` is empty or missing would have orphan-committed a
tree of PNGs as the only commit on `main`. Refname interpolation also
went straight into `git push` without sanity checks, so `--branch ../foo`
or `--branch -force` could reach git.

Adds a layered `validateBranch()` called before any process work:

1. **Refname format** — conservative subset of `git check-ref-format`:
   `[A-Za-z0-9][A-Za-z0-9._/-]*` with no `..` or `@{` substrings.
   Rejects path-injection, refspec syntax (`:`), leading-dash flag
   injection, and reflog selectors before they reach git.
2. **Hard denylist** — `main`, `master`, `develop`, `trunk`, `HEAD`,
   `release/`, `releases/` are never a valid destination for
   `publish-images`, even with the escape hatch. The command exists
   for ephemeral PNG branches; pushing it to mainline is always wrong.
3. **Allowlist** — `preview_` prefix by default. Anything else
   requires the new `--allow-non-preview-branch` flag, with the hard
   denylist still trumping.

Also rejects a leading-dash `--remote` value as defence against the
same flag-injection vector on the remote arg.

`design/AGENT_PR.md` updated to document the allowlist + escape hatch
+ hard denylist on the dedicated-branch bullet.

## Why `String?` not a sealed class

Kept `validateBranch` returning `String?` (null = ok, non-null = error
message) rather than a sealed-class result. The function stays
trivially unit-testable without driving `exitProcess`, the call site
is one `?.let { … exitProcess }`, and there's no semantic ambiguity
about the intermediate states.

## Test plan

- [x] `./gradlew :cli:test` passes — adds 11 cases under
      `PublishImagesBranchValidationTest` covering each rule
      independently (preview-allowlist, escape hatch, hard denylist,
      refname rejection for `..`/`-`/`:`/`@{`).
- [x] `./gradlew :cli:ktfmtCheckMain :cli:ktfmtCheckTest` passes.
- [ ] Manual: `compose-preview publish-images <dir> --branch main`
      now exits with the hard-block message (no git network calls).
      Skipped — would need a real repo to fully reproduce.
