### PR TITLE
Split resource baselines onto preview_resources_main

### DIFF
--- a/.github/actions/preview-baselines/action.yml
+++ b/.github/actions/preview-baselines/action.yml
@@ -23,8 +23,16 @@ inputs:
     description: 'CLI render timeout in seconds.'
     default: '600'
   branch:
-    description: 'Branch name for baselines.'
+    description: 'Branch name for composable @Preview baselines.'
     default: 'preview_main'
+  resource-branch:
+    description: >
+      Branch name for Android XML resource baselines (vector / animated-vector /
+      adaptive-icon). Kept separate from `branch` because resource and composable
+      previews are disjoint workflows — independent push cadence, independent
+      bisect history, independent diff comments. Set to '' to skip the resource
+      push entirely.
+    default: 'preview_resources_main'
 
 runs:
   using: 'composite'
@@ -88,21 +96,6 @@ runs:
           --repo "$REPO" \
           --branch "$BASELINE_BRANCH"
 
-    # Stage Android XML resource previews (vector / animated-vector /
-    # adaptive-icon) into the same _baselines/ tree so the preview_main
-    # branch covers them alongside composable @Preview renders. No-ops on
-    # consumers without any resources.json — the helper exits 0 with a
-    # status line. The CLI doesn't surface resource captures yet, so the
-    # helper globs the workspace directly.
-    - name: Stage resource baselines
-      shell: bash
-      env:
-        ACTION_PATH: ${{ github.action_path }}
-      run: |
-        python3 "$ACTION_PATH/../lib/compare-previews.py" generate-resources \
-          --output-dir _baselines \
-          --workspace-root .
-
     - name: Push to baselines branch
       shell: bash
       # All templated values go through env first so a malicious input
@@ -152,3 +145,90 @@ runs:
         # its concurrency group so no race is expected; a non-FF rejection
         # here means something external moved the ref and warrants an alert.
         git push --quiet origin "${COMMIT}:refs/heads/${BASELINE_BRANCH}"
+
+    # ─── Android XML resource previews ────────────────────────────────────
+    # Sibling pipeline pushing to its own branch (default `preview_resources_main`).
+    # Workflows are disjoint from composable @Preview, so we keep the histories
+    # separate — independent bisect, independent diff comments, independent
+    # push cadence. See the `resource-branch` input docstring above.
+
+    - name: Render resource previews
+      if: inputs.resource-branch != ''
+      id: render-resources
+      shell: bash
+      env:
+        RENDER_TIMEOUT: ${{ inputs.timeout }}
+      # `compose-preview show-resources` self-no-ops on workspaces without
+      # any `resources.json` (exit 0 with "No Android resource previews
+      # found.") — the subsequent generate / push steps then short-circuit.
+      run: compose-preview show-resources --json --timeout "$RENDER_TIMEOUT" > _resources.json
+
+    - name: Upload renderAndroidResources reports
+      if: failure() && steps.render-resources.outcome == 'failure'
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: renderAndroidResources-reports
+        path: |
+          **/build/reports/tests/renderAndroidResources/
+          **/build/test-results/renderAndroidResources/
+          _resources.json
+        if-no-files-found: ignore
+        retention-days: 14
+
+    - name: Generate resource baselines
+      if: inputs.resource-branch != ''
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+      # `generate-resources` globs `<module>/build/compose-previews/resources.json`
+      # — the show-resources call above guarantees those exist + their PNGs
+      # are fresh on disk. Output dir is the staging tree the next step pushes.
+      run: |
+        python3 "$ACTION_PATH/../lib/compare-previews.py" generate-resources \
+          --output-dir _resource_baselines \
+          --workspace-root .
+
+    - name: Push to resource baselines branch
+      if: inputs.resource-branch != ''
+      shell: bash
+      env:
+        RESOURCE_BRANCH: ${{ inputs.resource-branch }}
+        REPO: ${{ github.repository }}
+        GITHUB_TOKEN_INLINE: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        # Workspace had no resource manifests / no rendered PNGs — generate
+        # didn't create the staging dir. Skip the push silently rather than
+        # creating an empty branch.
+        if [ ! -d _resource_baselines ] || [ ! -f _resource_baselines/resource-baselines.json ]; then
+          echo "No resource baselines staged; skipping push to ${RESOURCE_BRANCH}."
+          exit 0
+        fi
+
+        cd _resource_baselines
+        git init -q
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git remote add origin \
+          "https://x-access-token:${GITHUB_TOKEN_INLINE}@github.com/${REPO}.git"
+
+        git add -A
+        TREE=$(git write-tree)
+
+        PARENT=""
+        if git fetch --depth=1 --quiet origin "$RESOURCE_BRANCH" 2>/dev/null; then
+          PARENT=$(git rev-parse FETCH_HEAD)
+          PARENT_TREE=$(git rev-parse "${PARENT}^{tree}")
+          if [ "$TREE" = "$PARENT_TREE" ]; then
+            echo "Resource baselines unchanged vs ${RESOURCE_BRANCH}; skipping push."
+            exit 0
+          fi
+        fi
+
+        MSG="Update resource baselines from ${GITHUB_SHA::8}"
+        if [ -n "$PARENT" ]; then
+          COMMIT=$(git commit-tree "$TREE" -p "$PARENT" -m "$MSG")
+        else
+          COMMIT=$(git commit-tree "$TREE" -m "$MSG")
+        fi
+        git push --quiet origin "${COMMIT}:refs/heads/${RESOURCE_BRANCH}"

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -22,8 +22,15 @@ inputs:
     description: 'CLI render timeout in seconds.'
     default: '600'
   base-branch:
-    description: 'Branch name for baselines.'
+    description: 'Branch name for composable @Preview baselines.'
     default: 'preview_main'
+  resource-base-branch:
+    description: >
+      Branch name for Android XML resource baselines. Kept separate from
+      `base-branch` because resource and composable previews are disjoint
+      workflows (sibling sticky comments, sibling baseline branches). Set
+      to '' to skip the resource compare entirely.
+    default: 'preview_resources_main'
   head-branch:
     description: 'Shared branch that accumulates per-PR render commits.'
     default: 'preview_pr'
@@ -82,19 +89,13 @@ runs:
       shell: bash
       env:
         BASE_BRANCH: ${{ inputs.base-branch }}
+        RESOURCE_BASE_BRANCH: ${{ inputs.resource-base-branch }}
       run: |
         mkdir -p _baselines
         if git ls-remote --exit-code origin "$BASE_BRANCH" >/dev/null 2>&1; then
           git fetch origin "$BASE_BRANCH"
           git show "origin/${BASE_BRANCH}:baselines.json" \
             > _baselines/baselines.json 2>/dev/null || true
-          # Resource baselines are a sibling file written by the
-          # `Stage resource baselines` step in preview-baselines/action.yml.
-          # First-ever resource render on a project doesn't have it yet —
-          # `git show` returns non-zero, the file stays absent, and the
-          # compare-resources call below treats every resource as new.
-          git show "origin/${BASE_BRANCH}:resource-baselines.json" \
-            > _baselines/resource-baselines.json 2>/dev/null || true
           # Extract the baseline renders/ tree alongside baselines.json so
           # the pixelmatch-based perceptual filter in compare-previews.py
           # has both PNGs to diff. `git archive` writes to stdout so the
@@ -104,6 +105,17 @@ runs:
             | tar -x -C _baselines/ 2>/dev/null || true
         else
           echo "No $BASE_BRANCH branch yet — treating all previews as new."
+        fi
+        # Resource baselines live on their own branch (default
+        # `preview_resources_main`) — disjoint workflow from the composable
+        # `preview_main`. First-ever resource render on a project hasn't
+        # populated it yet; absent branch falls back to "treat every
+        # resource as new".
+        if [ -n "$RESOURCE_BASE_BRANCH" ] && \
+           git ls-remote --exit-code origin "$RESOURCE_BASE_BRANCH" >/dev/null 2>&1; then
+          git fetch origin "$RESOURCE_BASE_BRANCH"
+          git show "origin/${RESOURCE_BASE_BRANCH}:resource-baselines.json" \
+            > _baselines/resource-baselines.json 2>/dev/null || true
         fi
 
     - name: Install perceptual-diff dependencies
@@ -120,6 +132,7 @@ runs:
       shell: bash
       env:
         BASE_BRANCH: ${{ inputs.base-branch }}
+        RESOURCE_BASE_BRANCH: ${{ inputs.resource-base-branch }}
         REPO: ${{ github.repository }}
         GITHUB_TOKEN_INLINE: ${{ github.token }}
       run: |
@@ -137,6 +150,21 @@ runs:
           BASE_SHA="$BASE_BRANCH"
         fi
         echo "$BASE_SHA" > _base_sha
+        # Sibling Before SHA for the resources comment — pins to its own
+        # branch (default `preview_resources_main`). When the input is
+        # blank the resources comment is skipped further down anyway, so
+        # we also blank `_resource_base_sha` to be defensive.
+        if [ -n "$RESOURCE_BASE_BRANCH" ]; then
+          RESOURCE_BASE_SHA=$(git ls-remote \
+            "https://x-access-token:${GITHUB_TOKEN_INLINE}@github.com/${REPO}.git" \
+            "refs/heads/${RESOURCE_BASE_BRANCH}" | awk '{print $1}')
+          if [ -z "$RESOURCE_BASE_SHA" ]; then
+            RESOURCE_BASE_SHA="$RESOURCE_BASE_BRANCH"
+          fi
+        else
+          RESOURCE_BASE_SHA=""
+        fi
+        echo "$RESOURCE_BASE_SHA" > _resource_base_sha
 
     - name: Copy changed PNGs
       shell: bash
@@ -255,10 +283,17 @@ runs:
         # and Android XML resource changes are different concerns and should
         # be edited / scrolled past independently. Empty stdout when nothing
         # diffed; the post step below skips emitting an empty comment.
+        # Before URL pins to the resource base branch (default
+        # `preview_resources_main`), distinct from the composable BASE_REF
+        # so the markdown image links resolve to the right tree.
+        RESOURCE_BASE_REF=$(cat _resource_base_sha 2>/dev/null || true)
+        if [ -z "$RESOURCE_BASE_REF" ]; then
+          RESOURCE_BASE_REF="$BASE_REF"
+        fi
         python3 "$ACTION_PATH/../lib/compare-previews.py" compare-resources \
           --baselines _baselines/resource-baselines.json \
           --repo "$REPO" \
-          --base-ref "$BASE_REF" \
+          --base-ref "$RESOURCE_BASE_REF" \
           --head-ref "$HEAD_REF" \
           --workspace-root . \
           > _comment_body_resources.md


### PR DESCRIPTION
## Summary

Android XML resource baselines land on a sibling branch (`preview_resources_main` by default) instead of being mixed into `preview_main`. Reflects the disjoint-workflow split that already exists at every other layer:

| | Composable | Resource |
|---|---|---|
| CLI command | `compose-preview show` | `compose-preview show-resources` (#279) |
| JSON envelope | `compose-preview-show/v1` | `compose-preview-show-resources/v1` |
| PR comment | `<!-- preview-diff -->` | `<!-- preview-diff-resources -->` (#269) |
| State file | `.cli-state.json` | `.cli-state-resources.json` |
| **Baseline branch** | `preview_main` | **`preview_resources_main`** (this) |

Independent histories let each kind of regression bisect separately, each push cadence drift independently, and each branch's auto-generated README describe one feature instead of two interleaved sections.

## Changes

**`preview-baselines/action.yml`**:
- New `resource-branch` input (default `preview_resources_main`); set to `''` to skip the resource pipeline entirely.
- Drops the `Stage resource baselines` step that was lumping resources into the composable `_baselines/` tree.
- Adds a sibling pipeline after the composable push:
  1. `Render resource previews` — `compose-preview show-resources --json` (drives the gradle render through #279's CLI command, same up-to-date semantics as composables).
  2. `Generate resource baselines` — `compare-previews.py generate-resources` into `_resource_baselines/`.
  3. `Push to resource baselines branch` — fast-forward push to `$RESOURCE_BRANCH`. Short-circuits silently when no `resources.json` exists in the workspace (rather than creating an empty branch).
- `Upload renderAndroidResources reports` artifact for the resource render path, mirroring the existing `renderPreviews-reports` artifact.

**`preview-comment/action.yml`**:
- New `resource-base-branch` input (default `preview_resources_main`).
- `Fetch baselines` step now fetches `resource-baselines.json` from the new branch (was `preview_main`).
- New `_resource_base_sha` pinned to the resource branch tip, so the resources sticky comment's Before image URLs resolve to the right tree.
- `compare-resources` is invoked with `--base-ref $RESOURCE_BASE_REF` rather than the composable `BASE_REF`.

## Transition

Next push to main after this lands:
- `preview_main` is rewritten without the `resource-baselines.json` + `renders/<module>/resources/` subtree (composable-only).
- `preview_resources_main` is created from scratch with just the resource baselines.
- PR comments transparently fetch from the new branch.

No consumer-facing CLI changes — `show-resources` already exists from #279.

## Test plan

- [x] `python3 -m unittest .github/actions/lib.test_compare_previews -v` — 50 tests still pass (script unchanged, only the action wires it differently).
- [x] YAML syntax validates for both action files.
- [ ] Next push to main: verify `preview_resources_main` is created with `resource-baselines.json` + `renders/samples:android/resources/` (8 resources × 14 captures + 1 GIF).
- [ ] Verify `preview_main` no longer carries the resource subtree after the next push.
- [ ] Open a PR that touches `samples/android/src/main/res/drawable/ic_compose_logo.xml` after both branches exist; verify the resources sticky comment renders Before/After image tags pinned to `preview_resources_main` tip.
- [ ] Open a PR that doesn't touch resources; verify no resource sticky comment is posted (composable diff still works).

## Out of scope

- **`preview_pr` split into `preview_resources_pr`** for the After URLs. Today the resource-changed PNGs ride along in the same `preview_pr` tree under `renders/<module>/resources/`. Could split for full consistency, but lower-value than the baseline branch split (PR-renders branches are short-lived per PR; baseline branches are forever).

---
_Generated by [Claude Code](https://claude.ai/code/session_01APmYnc8AMQmZivBivcGiNY)_