### PR TITLE
fix(plugin): align Hamcrest on renderer classpath; doctor flags 2.x/1.3 skew

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -27,6 +27,9 @@ import kotlinx.serialization.json.Json
  *     - `deps.<module>.activity-vs-navigationevent` — navigationevent on test, older activity on
  *       main
  *     - `deps.<module>.compose-ui-vs-core` — compose-ui 1.10+ on test, older androidx.core on main
+ *     - `deps.<module>.hamcrest-skew` — `org.hamcrest:hamcrest:2.x` and the legacy split
+ *       `:hamcrest-library` / `:hamcrest-core` 1.3 jars both on the test classpath; mixed `AllOf` /
+ *       `Matchers` classes break Espresso's `<clinit>` with `NoSuchMethodError`
  *     - `deps.<module>.compose-bom` (warning) — no Compose BOM declared
  *
  * Output modes:

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -603,6 +603,32 @@ internal object AndroidPreviewSupport {
           copyAttributes(attributes, testConfig.attributes)
           extendsFrom(testConfig)
         }
+        // Espresso (transitively pulled by `androidx.compose.ui:ui-test-junit4`) was
+        // compiled against Hamcrest 1.3, whose `Matchers.java:33` invokes
+        // `org.hamcrest.core.AllOf.allOf(Matcher, Matcher)` — an explicit 2-arg
+        // overload that 2.x removed in favour of varargs. When a consumer adds
+        // `org.hamcrest:hamcrest:2.x` (e.g. via `junit-jupiter:5.x`), the merged
+        // 2.x jar coexists with the legacy split `hamcrest-core` / `hamcrest-library`
+        // 1.3 jars (different module coordinates → no Gradle dedup). Whichever
+        // class wins for `AllOf` vs `Matchers` is classpath-order-dependent; in
+        // the failing case `Matchers` comes from 1.3 and calls into 2.x's
+        // `AllOf` — `NoSuchMethodError` at `Espresso.<clinit>` triggered the
+        // first time `runUntilIdle` walks through `EspressoLink`.
+        //
+        // Substituting the merged artifact back to `hamcrest-core:1.3` on
+        // *this* configuration is enough: `resolvedClasspath` puts rendererConfig's
+        // files ahead of the AGP test classpath in the renderPreviews JVM
+        // classpath (see comment above `resolvedClasspath` below), so Hamcrest
+        // 1.3 wins class lookup even if the consumer's `${variant}UnitTestRuntimeClasspath`
+        // still resolves 2.x for their own tests.
+        resolutionStrategy.eachDependency {
+          if (requested.group == "org.hamcrest" && requested.name == "hamcrest") {
+            useTarget("org.hamcrest:hamcrest-core:1.3")
+            because(
+              "Espresso bytecode needs Hamcrest 1.3's AllOf.allOf(Matcher,Matcher); 2.x removed it"
+            )
+          }
+        }
       }
 
     if (useLocalRenderer) {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
@@ -77,8 +77,67 @@ internal object CompatRules {
     checkNavigationEvent(mainV, testV, main)?.let(findings::add)
     checkComposeUiVsCore(mainV, testV, main)?.let(findings::add)
     checkComposeBom(main)?.let(findings::add)
+    checkHamcrestSkew(test)?.let(findings::add)
     findings += checkOldDeps(mainV, testV, main, test)
     return findings
+  }
+
+  /**
+   * Hamcrest 2.x's merged `org.hamcrest:hamcrest` artifact removed the explicit
+   * `AllOf.allOf(Matcher, Matcher)` overload (varargs replaced it). Espresso 3.5/3.6 compiled
+   * against Hamcrest 1.3 calls into that 2-arg method via `Matchers.java:33`, so when a consumer's
+   * classpath has both:
+   *
+   * - `org.hamcrest:hamcrest:2.x` (often pulled by `junit-jupiter:5.x` or direct test asserts), and
+   * - `org.hamcrest:hamcrest-library:1.3` (transitive of `androidx.test.espresso:espresso-core`),
+   *
+   * the JVM classloader picks `Matchers` from one jar and `AllOf` from the other — boom,
+   * `NoSuchMethodError` at `Espresso.<clinit>` the first time
+   * `RobolectricIdlingStrategy.runUntilIdle` walks through `EspressoLink`.
+   *
+   * The plugin already substitutes `hamcrest:*` → `hamcrest-core:1.3` on its own
+   * `composePreviewAndroidRenderer<Variant>` configuration so the renderPreviews task's classpath
+   * stays clean. This finding still surfaces the latent skew so consumers know to align their own
+   * AGP unit-test runs (which use the unfiltered `${variant}UnitTestRuntimeClasspath`).
+   */
+  private fun checkHamcrestSkew(test: Map<String, String>): ModuleFindingData? {
+    val merged = test["org.hamcrest:hamcrest"] ?: return null
+    val library13 = test["org.hamcrest:hamcrest-library"]
+    val core13 = test["org.hamcrest:hamcrest-core"]
+    if (library13 == null && core13 == null) return null
+    val mergedSemver = Semver.parseOrNull(merged) ?: return null
+    if (mergedSemver < Semver(2, 0, 0)) return null
+    val legacy =
+      listOfNotNull(library13?.let { "hamcrest-library:$it" }, core13?.let { "hamcrest-core:$it" })
+        .joinToString(", ")
+    return ModuleFindingData(
+      id = "hamcrest-skew",
+      severity = "error",
+      message = "mixed Hamcrest versions on the unit-test classpath (hamcrest:$merged + $legacy)",
+      detail =
+        "Espresso (transitively via androidx.compose.ui:ui-test-junit4) was compiled against " +
+          "Hamcrest 1.3 and calls `org.hamcrest.core.AllOf.allOf(Matcher, Matcher)` — a 2-arg " +
+          "overload removed in Hamcrest 2.x. With both `org.hamcrest:hamcrest:$merged` and the " +
+          "legacy split `org.hamcrest:hamcrest-library` / `:hamcrest-core` jars on the classpath, " +
+          "class lookup is order-dependent: when `Matchers` resolves to 1.3 but `AllOf` resolves " +
+          "to 2.x, `Espresso.<clinit>` fails with `NoSuchMethodError` the first time " +
+          "`RobolectricIdlingStrategy.runUntilIdle` walks through `EspressoLink`. The renderer's " +
+          "own classpath has the merged jar substituted out, but AGP-driven test tasks still see " +
+          "the skew.",
+      remediationSummary =
+        "Force-align hamcrest on the unit-test runtime classpath, or exclude `org.hamcrest:hamcrest` from whichever transitive pulls 2.x.",
+      remediationCommands =
+        listOf(
+          "configurations.matching { it.name.endsWith(\"UnitTestRuntimeClasspath\") }.configureEach {",
+          "  resolutionStrategy.eachDependency {",
+          "    if (requested.group == \"org.hamcrest\" && requested.name == \"hamcrest\") {",
+          "      useTarget(\"org.hamcrest:hamcrest-core:1.3\")",
+          "    }",
+          "  }",
+          "}",
+        ),
+      docsUrl = DOCS_HAMCREST_SKEW,
+    )
   }
 
   /**
@@ -253,6 +312,7 @@ internal object CompatRules {
     "$DOCS_ROOT#activity-compose-111-on-a-consumer-with-an-older-activity"
   private const val DOCS_COMPOSE_UI_VS_CORE =
     "$DOCS_ROOT#compose-ui-110-on-a-consumer-with-older-androidxcore"
+  private const val DOCS_HAMCREST_SKEW = "$DOCS_ROOT#hamcrest-2x-on-the-unit-test-classpath"
 }
 
 /**

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
@@ -206,6 +206,43 @@ class CompatRulesTest {
   }
 
   @Test
+  fun `hamcrest 2x with legacy 1_3 fires error`() {
+    val test =
+      mainWithBom() +
+        ("androidx.compose.ui:ui-test-manifest" to "1.10.6") +
+        ("org.hamcrest:hamcrest" to "2.2") +
+        ("org.hamcrest:hamcrest-library" to "1.3") +
+        ("org.hamcrest:hamcrest-core" to "1.3")
+    val findings = CompatRules.evaluate(mainWithBom(), test)
+    val f = findings.single { it.id == "hamcrest-skew" }
+    assertEquals("error", f.severity)
+    assertTrue("hamcrest:2.2" in f.message)
+    assertTrue("hamcrest-library:1.3" in f.message)
+    assertTrue(f.remediationCommands.any { "useTarget" in it })
+  }
+
+  @Test
+  fun `hamcrest 2x alone is quiet`() {
+    val test =
+      mainWithBom() +
+        ("androidx.compose.ui:ui-test-manifest" to "1.10.6") +
+        ("org.hamcrest:hamcrest" to "2.2")
+    val findings = CompatRules.evaluate(mainWithBom(), test)
+    assertNull(findings.firstOrNull { it.id == "hamcrest-skew" })
+  }
+
+  @Test
+  fun `hamcrest 1_3 alone is quiet`() {
+    val test =
+      mainWithBom() +
+        ("androidx.compose.ui:ui-test-manifest" to "1.10.6") +
+        ("org.hamcrest:hamcrest-library" to "1.3") +
+        ("org.hamcrest:hamcrest-core" to "1.3")
+    val findings = CompatRules.evaluate(mainWithBom(), test)
+    assertNull(findings.firstOrNull { it.id == "hamcrest-skew" })
+  }
+
+  @Test
   fun `semver parses and compares`() {
     assertEquals(Semver(1, 16, 0), Semver.parseOrNull("1.16.0"))
     assertEquals(Semver(1, 16, 0), Semver.parseOrNull("1.16"))


### PR DESCRIPTION
## Summary

- Substitute `org.hamcrest:hamcrest:*` → `org.hamcrest:hamcrest-core:1.3` on the renderer's `composePreviewAndroidRenderer<Variant>` configuration so the renderPreviews JVM never sees the merged Hamcrest 2.x jar alongside the legacy `hamcrest-library` / `hamcrest-core` 1.3 jars Espresso transitively requires.
- Add a `hamcrest-skew` rule to `CompatRules` so the doctor task surfaces the latent conflict for AGP-driven test runs (`test<Variant>UnitTest`) that don't go through the renderer's filtered classpath.

## Root cause

`androidx.compose.ui:ui-test-junit4`'s `RobolectricIdlingStrategy.runUntilIdle` routes through `EspressoLink`, which forces `androidx.test.espresso.Espresso.<clinit>` the first time a Robolectric test waits for idle — including `setContent` from `createAndroidComposeRule`.

Espresso was compiled against Hamcrest 1.3, whose `Matchers.java:33` invokes `org.hamcrest.core.AllOf.allOf(Matcher, Matcher)` — an explicit 2-arg overload that Hamcrest 2.x removed in favour of varargs. When a consumer pulls the merged `org.hamcrest:hamcrest:2.x` (e.g. via `junit-jupiter:5.x`), Gradle does not deduplicate it against the split-1.3 modules (different coordinates), and both jars end up on the test classpath. The JVM picks `Matchers` from one and `AllOf` from the other; in the failing classpath order:

```
java.lang.NoSuchMethodError: 'org.hamcrest.Matcher org.hamcrest.core.AllOf.allOf(org.hamcrest.Matcher, org.hamcrest.Matcher)'
    at org.hamcrest.Matchers.allOf(Matchers.java:33)
    at androidx.test.espresso.Espresso.<clinit>(Espresso.java:5)
    at androidx.compose.ui.test.EspressoLink_androidKt.runEspressoOnIdle(EspressoLink.android.kt:88)
    at androidx.compose.ui.test.RobolectricIdlingStrategy.runUntilIdle$lambda$0(...)
```

Reproduced locally with a minimal Java program (`Matchers` from `hamcrest-library:1.3` + `AllOf` from `hamcrest:2.2`) producing the same exception.

## Why scope the substitution to `rendererConfig`

`resolvedClasspath` (which feeds `renderPreviews.classpath`) puts `composePreviewAndroidRenderer<Variant>` files **before** the appended AGP `${variant}UnitTestRuntimeClasspath`, so once Hamcrest 1.3 lives in rendererConfig's slice, the JVM resolves both `Matchers` and `AllOf` from 1.3 — the 2.x jar in the consumer's slice loses class lookup. This avoids silently rewriting the consumer's own test deps; their AGP unit-test tasks still get whatever they declared (and the doctor finding tells them what to do about it).

## Test plan

- [x] `./gradlew :gradle-plugin:test --tests "ee.schimke.composeai.plugin.tooling.CompatRulesTest"` — three new cases (skew triggers, 2.x alone quiet, 1.3 alone quiet)
- [x] `./gradlew ktfmtFormatAll` clean
- [x] `./gradlew :samples:android:renderPreviews` after temporarily adding `testImplementation("org.hamcrest:hamcrest:2.2")` to the sample — passes; `composePreviewAndroidRendererDebug` resolves only `hamcrest-library-1.3.jar` / `hamcrest-core-1.3.jar` / `hamcrest-integration-1.3.jar`, no `hamcrest-2.2.jar`
- [x] `./gradlew :samples:android:composePreviewDoctor` with the same probe dep — emits the new error finding with concrete `useTarget` remediation; clean sample shows zero findings


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q57BGQC7QR7u9WRYrwfdmG)_