### PR TITLE
Fix nested module layouts for preview-baselines resource glob

### DIFF
--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -572,12 +572,28 @@ def load_resource_manifests(workspace_root: Path) -> dict[str, dict]:
     stable enough to detect changes across runs without colliding when a single
     resource has multiple captures (e.g. adaptive-icon shape masks).
 
+    Walks recursively because consumer module layouts vary — flat
+    `app/build/...` works under a non-recursive glob, but nested layouts like
+    `samples/android/build/...` (used by this repo's own samples) need `**`.
+    The composable side dodges this via the CLI's Tooling-API module
+    enumeration (the resulting absolute paths are written into the JSON the
+    helper consumes); the resource side does its own filesystem walk and used
+    to silently miss every nested module on `preview_main` runs.
+
     Returns an empty dict when no `resources.json` exists anywhere — that's
     the dominant case for projects that don't write XML drawables, and an
     empty result is a no-op for `cmd_generate_resources`.
     """
     out: dict[str, dict] = {}
-    for manifest_path in sorted(workspace_root.glob("*/build/compose-previews/resources.json")):
+    # Skip the obvious noise dirs that can't contain a Gradle module's
+    # build/ output. Keeps the recursive walk fast on large monorepos.
+    skip_dirs = {".git", ".gradle", "node_modules", ".idea", "_baselines",
+                 "_resource_baselines", "_pr_renders"}
+    candidates = [
+        p for p in workspace_root.rglob("build/compose-previews/resources.json")
+        if not any(part in skip_dirs for part in p.relative_to(workspace_root).parts)
+    ]
+    for manifest_path in sorted(candidates):
         module_dir = manifest_path.parent.parent.parent
         module = str(module_dir.relative_to(workspace_root)).replace("\\", "/")
         try:

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -777,6 +777,56 @@ class GenerateResourcesTests(unittest.TestCase):
         # resources.
         self.assertFalse(self.output.exists())
 
+    def test_finds_resources_json_in_nested_module_layouts(self) -> None:
+        """Regression for the `preview_resources_main`-not-created bug: this
+        repo's modules live at `samples/android/build/...` (two segments
+        deep), but the helper used to walk only one segment deep with
+        `workspace_root.glob('*/build/...')`. Nested layouts silently
+        produced empty entries, so the staging step skipped the push."""
+        manifest = {
+            "module": "samples:android",
+            "variant": "debug",
+            "resources": [
+                {
+                    "id": "drawable/ic_logo",
+                    "type": "VECTOR",
+                    "sourceFiles": {"": "src/main/res/drawable/ic_logo.xml"},
+                    "captures": [
+                        {
+                            "variant": {"qualifiers": "xhdpi", "shape": None},
+                            "renderOutput": "renders/resources/drawable/ic_logo_xhdpi.png",
+                        }
+                    ],
+                }
+            ],
+            "manifestReferences": [],
+        }
+        self._write_module(
+            "samples/android",
+            manifest,
+            {"renders/resources/drawable/ic_logo_xhdpi.png": b"vector-bytes"},
+        )
+        self.assertEqual(self._run(), 0)
+        # The generate step writes resource-baselines.json into the output dir
+        # ONLY when it found at least one resources.json on disk. Pre-fix,
+        # the recursive glob missed `samples/android/...` and the file was
+        # never written → preview-baselines/action.yml's push step
+        # short-circuited with "No resource baselines staged".
+        baselines_file = self.output / "resource-baselines.json"
+        self.assertTrue(
+            baselines_file.exists(),
+            f"resource-baselines.json should exist after generate; got {list(self.output.iterdir()) if self.output.exists() else 'no output dir'}",
+        )
+        baselines = json.loads(baselines_file.read_text())
+        self.assertEqual(len(baselines), 1)
+        # Module name comes from the filesystem path, with `/` left as-is so
+        # gradle:path-style identifiers map cleanly to the same string.
+        first_key = next(iter(baselines))
+        self.assertTrue(
+            first_key.startswith("samples/android::"),
+            f"expected 'samples/android::' prefix, got {first_key!r}",
+        )
+
     def test_copies_pngs_and_writes_resource_baselines_json(self) -> None:
         self._write_module(
             "app",


### PR DESCRIPTION
## Summary

`load_resource_manifests` used `workspace_root.glob("*/build/compose-previews/resources.json")` — single `*` matches one path segment, so it found `<root>/foo/build/...` but **missed nested layouts** like `<root>/samples/android/build/...`. This repo's modules sit at `samples/android/`, `samples/wear/`, etc., so the helper silently produced empty entries on every preview-baselines run on main. Result: the workflow's `Push to resource baselines branch` step short-circuited with `No resource baselines staged; skipping push to preview_resources_main.` and the branch was never created.

## Workflow log confirming

From the most recent `Preview Baselines` run on main:

```
Run compose-preview show-resources --json --timeout "$RENDER_TIMEOUT" > _resources.json
Found preview modules: samples:android, samples:android-library, samples:android-screenshot-test, ...
Run python3 ".../compare-previews.py" generate-resources ...
No Android resource manifests found; skipping resource baselines.
Run set -euo pipefail
No resource baselines staged; skipping push to preview_resources_main.
```

The CLI ran fine, the gradle render produced `samples/android/build/compose-previews/resources.json`, but the helper's glob never reached it.

## Fix

Switches to recursive `rglob("build/compose-previews/resources.json")` with a small skip list (`.git`, `.gradle`, `node_modules`, `.idea`, the action's own staging dirs `_baselines` / `_resource_baselines` / `_pr_renders`) so the walk stays fast on large monorepos and doesn't pick up its own intermediate output.

The composable side dodges this entirely because `cmd_generate` reads absolute paths from the CLI's `_previews.json` envelope rather than walking the workspace. Only the resource side does its own filesystem walk (added in #267 before `compose-preview show-resources` existed) and needed the depth fix.

## Does this apply to composable previews?

**No** — the composable `cmd_generate` reads absolute `pngPath` values from `_previews.json` (the CLI output), so it doesn't glob the workspace at all. The composable side has been working correctly with nested module layouts since inception. Same shape is the long-term fix for the resource side too — make `cmd_generate_resources` consume `_resources.json` (which already contains absolute paths from `compose-preview show-resources`'s envelope) — but this PR is the smaller "fix the bug now" diff.

## Test plan

- [x] `python3 -m unittest .github/actions/lib.test_compare_previews -v` — 51 tests pass (1 new in `GenerateResourcesTests` covering the nested-module case).
- [ ] Next push to main: verify `preview_resources_main` gets created for the first time with 8 vector PNGs + 8 adaptive icon shape masks + 1 multi-frame AVD GIF from `samples:android`.
- [ ] Verify the previously-broken behaviour stays broken if reverted: existing flat-module test (`test_copies_pngs_and_writes_resource_baselines_json`) still uses `module="app"` (single segment), would still pass under the old non-recursive glob — the new test specifically covers `module="samples/android"` (two segments).

## Out of scope

- Switching `cmd_generate_resources` to consume `_resources.json` directly. Cleaner long-term shape (eliminates the duplicate workspace walk), but bigger diff and not required to unblock `preview_resources_main`. Worth following up on as a refactor.
- Same recursive-glob pattern for any other helper that walks the workspace. `cmd_generate` (composable) reads CLI JSON so doesn't need it; `cmd_compare_resources` and `cmd_copy_changed_resources` both call `load_resource_manifests` so are fixed by the same patch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01APmYnc8AMQmZivBivcGiNY)_