### PR TITLE
fix(diff-bot): perceptual filter for resource captures

### DIFF
--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -721,10 +721,22 @@ def cmd_copy_changed_resources(args: argparse.Namespace) -> int:
     `preview_resources_pr` lands these PNGs at paths the comment markdown
     can `_resource_url` to. Empty CLI envelope (no Android modules) is a
     silent no-op — same behaviour as `cmd_generate_resources`.
+
+    When ``--baseline-renders`` points at the extracted
+    `preview_resources_main/renders/` tree, sha-mismatched pairs run through
+    the same pixelmatch-based perceptual filter as the composable side
+    (issue #190 / PR #270). Adaptive icons are particularly susceptible to
+    sub-pixel jitter from the AA mask + ``PorterDuff.SRC_IN`` composite, so
+    skipping the filter for resources made every adaptive-icon capture a
+    likely false positive. Falls back to strict-bytes when the flag isn't
+    passed (e.g. first-ever PR before `preview_resources_main` exists).
     """
     cli_json = Path(args.cli_json)
     baselines_path = Path(args.baselines)
     out_dir = Path(args.output_dir)
+    baseline_renders = (
+        Path(args.baseline_renders) if getattr(args, "baseline_renders", None) else None
+    )
 
     entries = load_resource_results(cli_json)
     if not entries:
@@ -736,7 +748,7 @@ def cmd_copy_changed_resources(args: argparse.Namespace) -> int:
         if not info["sha256"]:
             continue
         is_new = key not in baselines
-        is_changed = not is_new and info["sha256"] != baselines[key]["sha256"]
+        is_changed = not is_new and _is_changed(info, baselines[key], baseline_renders)
         if not (is_new or is_changed):
             continue
         dest = out_dir / "renders" / info["module"] / info["destRelative"]
@@ -783,12 +795,22 @@ def cmd_compare_resources(args: argparse.Namespace) -> int:
     `preview-comment/action.yml` after [cmd_compare]'s body. Emits an empty
     string when no resource manifests exist or no diff is detected, so the
     action can append unconditionally without polluting the comment.
+
+    Uses the same `_is_changed` perceptual filter as the composable side
+    when `--baseline-renders` is provided — adaptive icons composite
+    foreground+background through an AA mask with `PorterDuff.SRC_IN`,
+    which produces sha-different-but-perceptually-identical PNGs across
+    Robolectric runs, so a strict-bytes compare flagged every adaptive icon
+    on every PR (issue #190 redux for resources).
     """
     cli_json = Path(args.cli_json)
     baselines_path = Path(args.baselines)
     repo = args.repo
     base_ref = args.base_ref
     head_ref = args.head_ref
+    baseline_renders = (
+        Path(args.baseline_renders) if getattr(args, "baseline_renders", None) else None
+    )
 
     current = load_resource_results(cli_json)
     baselines = _load_baselines(baselines_path)
@@ -803,7 +825,7 @@ def cmd_compare_resources(args: argparse.Namespace) -> int:
             continue
         if key not in baselines:
             new.append((key, info))
-        elif info["sha256"] != baselines[key]["sha256"]:
+        elif _is_changed(info, baselines[key], baseline_renders):
             changed.append((key, info, baselines[key]))
         else:
             unchanged.append((key, info))
@@ -954,6 +976,13 @@ def main() -> int:
     cp_res.add_argument("--baselines", required=True,
                         help="Path to resource-baselines.json (fetched from preview_resources_main)")
     cp_res.add_argument("--output-dir", required=True)
+    # Same perceptual-filter knob as `copy-changed` — when provided,
+    # sha-mismatched pairs run through pixelmatch before being copied as
+    # changed. Filters AA jitter that adaptive-icon mask compositing
+    # produces between Robolectric runs (issue #190).
+    cp_res.add_argument("--baseline-renders",
+                        help="Directory containing baseline resource PNGs "
+                             "(renders/<module>/resources/...)")
 
     cmp_res = sub.add_parser(
         "compare-resources",
@@ -967,6 +996,9 @@ def main() -> int:
     cmp_res.add_argument("--repo", required=True)
     cmp_res.add_argument("--base-ref", default="preview_resources_main")
     cmp_res.add_argument("--head-ref", required=True)
+    cmp_res.add_argument("--baseline-renders",
+                         help="Directory containing baseline resource PNGs "
+                              "(renders/<module>/resources/...)")
 
     args = ap.parse_args()
     handlers = {

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -1212,6 +1212,129 @@ class LoadBaselinesTest(unittest.TestCase):
         self.assertEqual(cp._load_baselines(p), {"app/Foo": {"sha256": "abc"}})
 
 
+class ResourcePerceptualFilterTest(unittest.TestCase):
+    """Mirrors `PerceptualFilterTest` for the resource path: sha-different
+    but pixelmatch-clean resource captures (typical of `AdaptiveIconDrawable`
+    composite renders, where the AA mask + `PorterDuff.SRC_IN` step produces
+    sub-pixel jitter between Robolectric runs) must read as ``unchanged`` in
+    both `cmd_compare_resources` and `cmd_copy_changed_resources`.
+
+    The strict-bytes fallback path (no `--baseline-renders`) is exercised by
+    the existing `CompareResourcesTests` / `CopyChangedResourcesTests`."""
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp)
+        # Filename convention: PNGs whose name contains "noise" model the
+        # adaptive-icon AA flake (sha-different, pixelmatch-clean), anything
+        # else is a genuine pixel diff.
+        self._real = cp._perceptually_changed
+        cp._perceptually_changed = lambda prior, current: "noise" not in current.name
+        self.addCleanup(setattr, cp, "_perceptually_changed", self._real)
+
+        # Resource baseline tree mimics what the action's
+        # `git archive preview_resources_main renders | tar -x` produces.
+        baseline_root = self.tmp / "_resource_baselines" / "renders" / "app" / "resources" / "mipmap"
+        baseline_root.mkdir(parents=True)
+        (baseline_root / "ic_launcher_xhdpi_SHAPE_circle_noise.png").write_bytes(b"baseline-noise")
+        (baseline_root / "ic_launcher_xhdpi_SHAPE_square.png").write_bytes(b"baseline-real")
+        self.baseline_renders = self.tmp / "_resource_baselines" / "renders"
+
+        # Current renders the CLI just produced — same filenames, "new" bytes.
+        self.noise_png = self.tmp / "ic_launcher_xhdpi_SHAPE_circle_noise.png"
+        self.noise_png.write_bytes(b"current-noise")
+        self.real_png = self.tmp / "ic_launcher_xhdpi_SHAPE_square.png"
+        self.real_png.write_bytes(b"current-real")
+
+        self.cli_json = self.tmp / "_resources.json"
+        self.cli_json.write_text(json.dumps(_resource_envelope(_resource_entry(
+            id="mipmap/ic_launcher", module="app", type="ADAPTIVE_ICON",
+            captures=[
+                _resource_capture(
+                    render_output="renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_circle_noise.png",
+                    png_path=str(self.noise_png), sha256="new-noise",
+                    qualifiers="xhdpi", shape="CIRCLE",
+                ),
+                _resource_capture(
+                    render_output="renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_square.png",
+                    png_path=str(self.real_png), sha256="new-real",
+                    qualifiers="xhdpi", shape="SQUARE",
+                ),
+            ],
+        ))))
+        self.baselines = self.tmp / "resource-baselines.json"
+        self.baselines.write_text(json.dumps({
+            "app::mipmap/ic_launcher::renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_circle_noise.png": {
+                "sha256": "old-noise",
+                "renderBasename": "resources/mipmap/ic_launcher_xhdpi_SHAPE_circle_noise.png",
+            },
+            "app::mipmap/ic_launcher::renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_square.png": {
+                "sha256": "old-real",
+                "renderBasename": "resources/mipmap/ic_launcher_xhdpi_SHAPE_square.png",
+            },
+        }))
+
+    def test_compare_resources_filters_perceptual_noise(self) -> None:
+        from types import SimpleNamespace
+        import io
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = cp.cmd_compare_resources(SimpleNamespace(
+                cli_json=str(self.cli_json),
+                baselines=str(self.baselines),
+                repo="owner/repo",
+                base_ref="bef0",
+                head_ref="aft0",
+                baseline_renders=str(self.baseline_renders),
+            ))
+        self.assertEqual(rc, 0)
+        out = buf.getvalue()
+        # Real change still surfaces; the noise capture is filtered out so
+        # the Changed section reports 1 variant, not 2.
+        self.assertIn("### Changed (1 variant(s)", out)
+        self.assertIn("`mipmap/ic_launcher`", out)
+        # The noise capture was the CIRCLE shape — it must NOT appear as a
+        # variant link in the comment body.
+        self.assertNotIn("ic_launcher_xhdpi_SHAPE_circle_noise.png", out)
+
+    def test_copy_changed_resources_filters_perceptual_noise(self) -> None:
+        from types import SimpleNamespace
+        out_dir = self.tmp / "out"
+        rc = cp.cmd_copy_changed_resources(SimpleNamespace(
+            cli_json=str(self.cli_json),
+            baselines=str(self.baselines),
+            output_dir=str(out_dir),
+            baseline_renders=str(self.baseline_renders),
+        ))
+        self.assertEqual(rc, 0)
+        # Only the real-diff PNG should be copied; the AA-noise capture is
+        # filtered before it gets staged for the preview_resources_pr push.
+        copied = sorted(p.name for p in
+                        (out_dir / "renders" / "app" / "resources" / "mipmap").iterdir())
+        self.assertEqual(copied, ["ic_launcher_xhdpi_SHAPE_square.png"])
+
+    def test_strict_bytes_fallback_when_baseline_renders_omitted(self) -> None:
+        # No `baseline_renders` argument → falls back to strict-sha behaviour
+        # (the first-ever-PR shape, when preview_resources_main has no
+        # renders/ tree to extract). Both captures are sha-different so both
+        # should surface as Changed.
+        from types import SimpleNamespace
+        import io
+        import contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            cp.cmd_compare_resources(SimpleNamespace(
+                cli_json=str(self.cli_json),
+                baselines=str(self.baselines),
+                repo="owner/repo",
+                base_ref="bef0",
+                head_ref="aft0",
+                # No baseline_renders → getattr returns None → strict path.
+            ))
+        self.assertIn("### Changed (2 variant(s)", buf.getvalue())
+
+
 class CompareResourcesAgainstEmptyBaselineTest(unittest.TestCase):
     """End-to-end regression for the failure mode that broke PR comments
     after #269 landed: `git show … > resource-baselines.json` truncated the

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -137,12 +137,28 @@ runs:
         # `preview_resources_main`) — disjoint workflow from the composable
         # `preview_main`. First-ever resource render on a project hasn't
         # populated it yet; absent branch falls back to "treat every
-        # resource as new".
+        # resource as new". Resource renders extract to a sibling directory
+        # so the two trees can't shadow each other (preview_main and
+        # preview_resources_main both lay PNGs out as `renders/<module>/...`,
+        # and even though resource paths carry a `resources/` segment after
+        # the module, keeping the staging dirs separate avoids any chance
+        # of cross-branch tar extraction stomping on a composable render).
+        mkdir -p _resource_baselines
         if [ -n "$RESOURCE_BASE_BRANCH" ] && \
            git ls-remote --exit-code origin "$RESOURCE_BASE_BRANCH" >/dev/null 2>&1; then
           git fetch origin "$RESOURCE_BASE_BRANCH"
           git show "origin/${RESOURCE_BASE_BRANCH}:resource-baselines.json" \
             > _baselines/resource-baselines.json 2>/dev/null || true
+          # Extract the baseline renders/ tree so the perceptual filter has
+          # prior PNGs to diff. Adaptive-icon composite renders are sha-noisy
+          # between Robolectric runs (the AA mask + PorterDuff.SRC_IN composite
+          # produces sub-pixel jitter), so without this every adaptive icon
+          # surfaces as a false diff — same failure mode as composable
+          # issue #190 / PR #270 fixed for the @Preview side. Failures
+          # (first run, no renders/ tree yet) fall back to the strict-bytes
+          # path inside compare-previews.
+          git archive "origin/${RESOURCE_BASE_BRANCH}" renders 2>/dev/null \
+            | tar -x -C _resource_baselines/ 2>/dev/null || true
         fi
 
     - name: Install perceptual-diff dependencies
@@ -212,6 +228,7 @@ runs:
         python3 "$ACTION_PATH/../lib/compare-previews.py" copy-changed-resources \
           _resources.json \
           --baselines _baselines/resource-baselines.json \
+          --baseline-renders _resource_baselines/renders \
           --output-dir _pr_resource_renders
 
     - name: Push PR renders
@@ -399,6 +416,7 @@ runs:
         python3 "$ACTION_PATH/../lib/compare-previews.py" compare-resources \
           _resources.json \
           --baselines _baselines/resource-baselines.json \
+          --baseline-renders _resource_baselines/renders \
           --repo "$REPO" \
           --base-ref "$RESOURCE_BASE_REF" \
           --head-ref "$RESOURCE_HEAD_REF" \


### PR DESCRIPTION
## Summary

Resource captures (vector / animated-vector / adaptive-icon) were being compared strict-bytes against `resource-baselines.json`, with no perceptual filter. Adaptive icons in particular composite foreground+background through an AA mask + `PorterDuff.SRC_IN` in `ResourcePreviewRenderTest.renderAdaptiveIcon`, which produces sha-different-but-pixelmatch-clean PNGs between Robolectric runs — same failure mode as composable issue #190 / PR #270, just on the resource side that #269 / #286 left unwired.

Concretely: `mipmap/ic_launcher` and `mipmap/ic_launcher_round` in `samples/android` (both `ADAPTIVE_ICON`, both referencing `@drawable/ic_launcher_background` + `@drawable/ic_launcher_foreground`) were surfacing all 4 shape variants (`CIRCLE` / `ROUNDED_SQUARE` / `SQUARE` / `LEGACY`) as Changed on every PR.

Wire `_is_changed` / `_perceptually_changed` (the existing pixelmatch path, 16-pixel tolerance) into the resource subcommands:

- `compare-resources` and `copy-changed-resources` accept `--baseline-renders`. Sha-mismatched pairs run through `_is_changed`; strict-bytes is preserved as the no-flag fallback for first-ever runs.
- `preview-comment/action.yml` extracts the baseline `renders/` tree from `preview_resources_main` (sibling of the existing extract from `preview_main`) into `_resource_baselines/` and passes it to both subcommands. Separate staging dir keeps the two branch archives from shadowing each other on tar extraction.
- `preview-baselines/action.yml` is unchanged — it only generates baselines, never compares.

## Test plan

- [x] `python3 -m unittest test_compare_previews` — 55 tests pass (3 new in `ResourcePerceptualFilterTest`, 52 existing, 1 skipped: pixelmatch lib not installed locally).
- [x] New tests pin: noise filtered out of the Changed section in `cmd_compare_resources`, noise not staged for push by `cmd_copy_changed_resources`, and the strict-bytes fallback fires when `--baseline-renders` is omitted.
- [ ] CI on this PR exercises the full path against `preview_resources_main`'s actual renders tree — the adaptive icons in `samples/android` should land in Unchanged this run, where they were Changed on prior PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_019S3wHmHhpgyt5M4JGpEjZf)_