### PR TITLE
feat(resource-preview): themed monochrome + squircle adaptive-icon captures

### DIFF
--- a/docs/ANDROID_RESOURCE_PREVIEWS.md
+++ b/docs/ANDROID_RESOURCE_PREVIEWS.md
@@ -14,7 +14,7 @@ Plan for treating Android XML resources as first-class previewables alongside `@
 |---|---|---|---|
 | Vector drawable | `<vector>` | `ContextCompat.getDrawable(ctx, R.drawable.foo)` → bitmap-backed canvas | resource qualifiers (see below) |
 | Animated vector | `<animated-vector>` | `start()`, drive `mainClock.advanceTimeBy` per frame, GIF-encode via `ScrollGifEncoder` | resource qualifiers (one GIF per qualifier set); duration auto-detected from animator XML |
-| Adaptive icon | `<adaptive-icon>` (mipmap-anydpi-v26) | composite foreground + background into 108dp canvas, apply shape clip path | resource qualifiers × shape (`CIRCLE`, `ROUNDED_SQUARE`, `SQUARE`) + `LEGACY` |
+| Adaptive icon | `<adaptive-icon>` (mipmap-anydpi-v26) | composite foreground + background into 108dp canvas, apply shape clip path; `THEMED_*` styles tint the `<monochrome>` layer with a 2-tone Material 3 baseline palette before masking | resource qualifiers × shape (`CIRCLE`, `SQUIRCLE`, `ROUNDED_SQUARE`, `SQUARE`) × style (`FULL_COLOR`, `THEMED_LIGHT`, `THEMED_DARK`) + `LEGACY` (single capture per qualifier, mask-independent) |
 
 Out of scope for this iteration: `<animation-list>`, `<shape>`, `<selector>`, `<layer-list>`, `<level-list>`, `<ripple>`, `<bitmap>`. The discovery and JSON-schema work below leaves room for them — adding a new `ResourceType` value plus a renderer branch is the only thing needed to extend the catalogue later.
 
@@ -35,7 +35,8 @@ New types in `gradle-plugin/.../PreviewData.kt`, mirrored TypeScript-side in `vs
 
 ```kotlin
 @Serializable enum class ResourceType { VECTOR, ANIMATED_VECTOR, ADAPTIVE_ICON }
-@Serializable enum class AdaptiveShape { CIRCLE, ROUNDED_SQUARE, SQUARE, LEGACY }
+@Serializable enum class AdaptiveShape { CIRCLE, SQUIRCLE, ROUNDED_SQUARE, SQUARE }
+@Serializable enum class AdaptiveStyle { FULL_COLOR, THEMED_LIGHT, THEMED_DARK, LEGACY }
 
 @Serializable
 data class ResourceVariant(
@@ -55,9 +56,18 @@ data class ResourceVariant(
   /**
    * Adaptive-icon shape mask applied at render time. Not an Android
    * qualifier — adaptive icons are masked at composition time, not at
-   * resource-resolution time. `null` for non-adaptive resources.
+   * resource-resolution time. `null` for non-adaptive resources, and `null`
+   * for `LEGACY` style captures (the mask doesn't apply).
    */
   val shape: AdaptiveShape? = null,
+  /**
+   * Adaptive-icon style. `FULL_COLOR` is the App Search appearance
+   * (composited foreground+background); `THEMED_LIGHT` / `THEMED_DARK` are
+   * the home-screen "Themed icons" appearance (monochrome layer tinted
+   * with a Material 3 baseline 2-tone palette); `LEGACY` is the pre-O
+   * fallback. `null` for non-adaptive resources.
+   */
+  val style: AdaptiveStyle? = null,
 )
 
 @Serializable
@@ -155,8 +165,11 @@ Following the whitelist + normalization rules in [RENDER_FILENAMES.md](RENDER_FI
 - `renders/resources/drawable/ic_compose_logo_night-xhdpi.png` — `drawable-night/` source × xhdpi
 - `renders/resources/drawable/ic_compose_logo_ldrtl-xhdpi.png` — `drawable-ldrtl/` source × xhdpi
 - `renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_circle.png`
+- `renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_squircle.png`
 - `renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_rounded_square.png`
 - `renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_square.png`
+- `renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_squircle_themed-light.png`
+- `renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_squircle_themed-dark.png`
 - `renders/resources/mipmap/ic_launcher_xhdpi_LEGACY.png`
 - `renders/resources/drawable/avd_pulse_xhdpi.gif`
 
@@ -172,7 +185,7 @@ Mirror of `RobolectricRenderTest`, in a new `ResourcePreviewRenderer` class unde
 - For each `ResourceCapture`, the renderer first sets `RuntimeEnvironment.setQualifiers(variant.qualifiers)` so AAPT picks the correct source file, then per-type:
   - **Vector**: resolve drawable, set bounds from intrinsic size × density factor (parsed from the qualifier string), draw to a bitmap canvas, write PNG.
   - **Animated vector**: resolve drawable, reflect to the AVD's internal `AnimatorSet` (search the drawable's class hierarchy for `mAnimatorSetFromXml` / inside `mAnimatorSet` / inside `mAnimatedVectorState`), drive it directly via `setCurrentPlayTime(t)` per frame, GIF-encode via the existing `ScrollGifEncoder`. Bypasses Choreographer / Looper entirely — under Robolectric's `looperMode=PAUSED` (which we pin for Compose's render path), the AVD's `ObjectAnimator` doesn't receive frame callbacks, but `AnimatorSet.setCurrentPlayTime` synchronously updates each child animator's fraction and notifies its property listeners (which poke the underlying `VectorDrawable`'s group/path values), and the next `draw()` reflects the new state. Window length capped at 1.5s × 50ms/frame = 30 frames to bound looping animators (`repeatCount=-1`, e.g. the sample's pulse). Falls back to a single-frame GIF when reflection misses an unfamiliar AVD layout.
-  - **Adaptive icon**: render foreground + background each into a 108dp×108dp canvas, composite, then apply each `AdaptiveShape`'s clip path. `LEGACY` falls back to the `android:icon` attribute on the `<adaptive-icon>` parent (when present) or to the foreground rendered against a transparent background. Mask paths come from the same set Studio uses (circle, rounded-rect r=8dp, square).
+  - **Adaptive icon**: per-(shape × style) capture. For `FULL_COLOR`, render foreground + background each into a 108dp×108dp canvas and composite, then apply the shape clip. For `THEMED_LIGHT` / `THEMED_DARK`, render the `<monochrome>` layer (`AdaptiveIconDrawable.getMonochrome()`, API 33+) tinted with a fixed Material 3 baseline 2-tone palette against a flat surface-container background, then apply the shape clip. For `LEGACY`, draw the foreground against transparent (no mask). Mask radii: circle / square / rounded-square at 25% / squircle approximated as a rounded-rect at 40%.
 - `ResourcePreviewRenderer` runs as a separate Robolectric test class. The render-task wiring decides which renderer(s) to launch based on which manifests exist post-discovery.
 - The renderer never reads `manifestReferences` — references are pure metadata.
 
@@ -187,7 +200,7 @@ When a resource referenced from the manifest does *not* appear in `resources` (e
 
 ## VS Code surfacing
 
-- `vscode-extension/src/types.ts` mirrors of `ResourceManifest`, `ResourcePreview`, `ResourceCapture`, `ResourceVariant`, `AdaptiveShape`, `ManifestReference`.
+- `vscode-extension/src/types.ts` mirrors of `ResourceManifest`, `ResourcePreview`, `ResourceCapture`, `ResourceVariant`, `AdaptiveShape`, `AdaptiveStyle`, `ManifestReference`.
 - `ResourceManifestService` watches `resources.json` alongside the existing `previews.json` watcher.
 - `AndroidManifestCodeLensProvider` registered against `AndroidManifest.xml`. Returns one CodeLens per `ManifestReference` whose `source` matches the open file. Lens command opens the resource preview tab focused on the referenced resource.
 - Webview: extend the existing Compose preview view with a tabbed "Resources" section (decision deferred to implementation — depends on how busy the existing UI ends up).
@@ -201,14 +214,20 @@ composePreview {
     densities = listOf("mdpi", "xhdpi")     // implicit density fan-out
     shapes = listOf(                        // restrict adaptive-icon shapes
       AdaptiveShape.CIRCLE,
+      AdaptiveShape.SQUIRCLE,
       AdaptiveShape.ROUNDED_SQUARE,
       AdaptiveShape.SQUARE,
-      AdaptiveShape.LEGACY,
+    )
+    styles = listOf(
+      AdaptiveStyle.FULL_COLOR,
+      AdaptiveStyle.THEMED_LIGHT,
+      AdaptiveStyle.THEMED_DARK,
+      AdaptiveStyle.LEGACY,
     )
     // Explicit qualifier dimensions are picked up automatically from the
     // consumer's res/<base>-<quals>/ directories — no DSL needed. Only
-    // implicit dimensions (density fan-out, adaptive-icon shapes) are
-    // configured here.
+    // implicit dimensions (density fan-out, adaptive-icon shapes / styles)
+    // are configured here.
   }
 }
 ```
@@ -237,8 +256,8 @@ Files added under `samples/android/src/main/res/`:
 - `drawable/ic_launcher_background.xml` — vector (background for the adaptive icon).
 - `drawable/ic_launcher_legacy.xml` — vector (pre-O fallback baked into the adaptive icon's legacy slot).
 - `drawable/ic_settings.xml` — vector used as an `android:icon` override on `MainActivity`.
-- `mipmap-anydpi-v26/ic_launcher.xml` — adaptive icon referencing fg+bg.
-- `mipmap-anydpi-v26/ic_launcher_round.xml` — round adaptive variant.
+- `mipmap-anydpi-v26/ic_launcher.xml` — adaptive icon with `<background>` + `<foreground>` + `<monochrome>` (the monochrome layer drives `THEMED_*` rendering) and `android:icon="@drawable/ic_launcher_legacy"` on the root for the pre-O slot.
+- `mipmap-anydpi-v26/ic_launcher_round.xml` — round adaptive variant, same layers.
 
 `samples/android/src/main/AndroidManifest.xml` gains:
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -123,6 +123,7 @@ internal object AndroidPreviewSupport {
       variantName.set(variant.name)
       densities.set(extension.resourcePreviews.densities)
       shapes.set(extension.resourcePreviews.shapes)
+      styles.set(extension.resourcePreviews.styles)
       projectDirectory.set(projectRoot)
       outputFile.set(previewOutputDir.map { it.file("resources.json") })
     }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverAndroidResourcesTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverAndroidResourcesTask.kt
@@ -51,6 +51,8 @@ abstract class DiscoverAndroidResourcesTask : DefaultTask() {
 
   @get:Input abstract val shapes: ListProperty<AdaptiveShape>
 
+  @get:Input abstract val styles: ListProperty<AdaptiveStyle>
+
   /**
    * Project root path used to render module-relative paths in the manifest. Captured at
    * configuration time (via `project.layout.projectDirectory.asFile.absolutePath`) so the task
@@ -70,6 +72,7 @@ abstract class DiscoverAndroidResourcesTask : DefaultTask() {
           resSourceRoots = sourceRoots,
           densities = densities.get(),
           shapes = shapes.get(),
+          styles = styles.get(),
           sourceRootRelativePath = { root -> root.toRelativeStringSafe(projectRoot) },
         )
       )

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -243,14 +243,41 @@ enum class ResourceType {
 
 /**
  * Adaptive-icon shape mask. Applied at render time as a canvas clip path — not a resource
- * qualifier. `LEGACY` falls back to the `<adaptive-icon android:icon=…>` slot when present, or to
- * the foreground rendered against a transparent background otherwise.
+ * qualifier. The mask only describes *what shape* the launcher would clip the icon to; the
+ * *contents* inside the mask (full-color foreground+background, or 2-tone themed monochrome) are a
+ * separate axis — see [AdaptiveStyle].
  */
 @Serializable
 enum class AdaptiveShape {
   CIRCLE,
+  /**
+   * Pixel / Material You default mask. Approximated with a superellipse-ish path (rounded rectangle
+   * with corner radius ≈ 50% of the half-width); good enough at preview densities without requiring
+   * a `Path` per-render.
+   */
+  SQUIRCLE,
   ROUNDED_SQUARE,
   SQUARE,
+}
+
+/**
+ * What goes inside the [AdaptiveShape] mask. Mirrors the two surfaces a launcher renders an
+ * adaptive icon at:
+ * - [FULL_COLOR] — composited foreground + background, the colour appearance you see in App Search
+ *   / app drawer.
+ * - [THEMED_LIGHT] / [THEMED_DARK] — the `<monochrome>` layer (Android 13+) tinted with a
+ *   wallpaper-derived 2-tone palette, the appearance launchers use on the home screen when "Themed
+ *   icons" is enabled. Tints come from the Material 3 baseline neutral scheme so the preview is
+ *   reproducible without a live wallpaper.
+ * - [LEGACY] — the pre-O fallback. Renders the `<adaptive-icon android:icon=…>` slot when the
+ *   consumer supplied one; otherwise the foreground against a transparent background. Single
+ *   capture per qualifier — [LEGACY] doesn't fan out across [AdaptiveShape].
+ */
+@Serializable
+enum class AdaptiveStyle {
+  FULL_COLOR,
+  THEMED_LIGHT,
+  THEMED_DARK,
   LEGACY,
 }
 
@@ -259,9 +286,17 @@ enum class AdaptiveShape {
  * was rendered under (see [ResourceQualifierParser]) — *not* the qualifier of any particular source
  * file: when a resource has both a default-qualifier file and qualified variants, AAPT picks
  * whichever matches the active configuration, and we record what we asked for.
+ *
+ * [shape] and [style] are independent axes for adaptive-icon captures. [style] =
+ * [AdaptiveStyle.LEGACY] always pairs with `shape = null` (legacy fallback ignores the mask); other
+ * styles always carry a shape. Both fields are `null` for non-adaptive resources.
  */
 @Serializable
-data class ResourceVariant(val qualifiers: String? = null, val shape: AdaptiveShape? = null)
+data class ResourceVariant(
+  val qualifiers: String? = null,
+  val shape: AdaptiveShape? = null,
+  val style: AdaptiveStyle? = null,
+)
 
 @Serializable
 data class ResourceCapture(

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -178,12 +178,35 @@ abstract class ResourcePreviewsExtension @Inject constructor(objects: ObjectFact
 
   /**
    * Adaptive-icon shape masks to render. Each shape is applied as a canvas clip on top of the
-   * composed foreground+background. `LEGACY` falls back to the `<adaptive-icon android:icon=…>`
-   * slot or to the foreground rendered against a transparent background.
+   * style-specific contents (full-colour composite, or tinted monochrome).
    *
-   * Default: every shape — `CIRCLE`, `ROUNDED_SQUARE`, `SQUARE`, `LEGACY`. Restrict the list to
-   * trim down rendering cost on modules with many adaptive icons.
+   * Default: every mask — `CIRCLE`, `SQUIRCLE`, `ROUNDED_SQUARE`, `SQUARE`. Restrict to trim
+   * rendering cost on modules with many adaptive icons. The [styles] axis multiplies onto this
+   * list; one capture is emitted per `(shape × style)` combination, plus one bare `LEGACY` capture
+   * per qualifier when [styles] contains [AdaptiveStyle.LEGACY].
    */
   val shapes: ListProperty<AdaptiveShape> =
-    objects.listProperty(AdaptiveShape::class.java).convention(AdaptiveShape.entries.toList())
+    objects
+      .listProperty(AdaptiveShape::class.java)
+      .convention(
+        listOf(
+          AdaptiveShape.CIRCLE,
+          AdaptiveShape.SQUIRCLE,
+          AdaptiveShape.ROUNDED_SQUARE,
+          AdaptiveShape.SQUARE,
+        )
+      )
+
+  /**
+   * Adaptive-icon style variants to render. [AdaptiveStyle.FULL_COLOR] is the App Search appearance
+   * (colour composite); [AdaptiveStyle.THEMED_LIGHT] / [AdaptiveStyle.THEMED_DARK] are the
+   * home-screen "Themed icons" appearance (monochrome layer tinted with a 2-tone Material 3
+   * baseline palette); [AdaptiveStyle.LEGACY] is the pre-O fallback.
+   *
+   * Default: every style. Drop [AdaptiveStyle.THEMED_LIGHT] / [AdaptiveStyle.THEMED_DARK] from the
+   * list when your icons don't ship a `<monochrome>` layer — captures for those styles are skipped
+   * at render time with a warning, but listing them still costs a manifest row each.
+   */
+  val styles: ListProperty<AdaptiveStyle> =
+    objects.listProperty(AdaptiveStyle::class.java).convention(AdaptiveStyle.entries.toList())
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ResourceDiscovery.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ResourceDiscovery.kt
@@ -20,6 +20,7 @@ object ResourceDiscovery {
     val resSourceRoots: List<File>,
     val densities: List<String>,
     val shapes: List<AdaptiveShape>,
+    val styles: List<AdaptiveStyle> = AdaptiveStyle.entries.toList(),
     /** Module-relative path to use as the [ManifestReference.source] root, e.g. `src/main`. */
     val sourceRootRelativePath: (File) -> String = { it.path },
   )
@@ -75,6 +76,7 @@ object ResourceDiscovery {
     densities: List<String>,
     shapes: List<AdaptiveShape>,
     resourceId: String,
+    styles: List<AdaptiveStyle> = AdaptiveStyle.entries.toList(),
   ): List<ResourceCapture> {
     val out = linkedSetOf<ResourceCapture>()
     val baseQualifierSets =
@@ -87,15 +89,41 @@ object ResourceDiscovery {
         val combined = combineQualifiers(cleaned, density)
         when (type) {
           ResourceType.ADAPTIVE_ICON -> {
+            // Two-axis fan-out: every (shape × non-LEGACY style) plus one bare LEGACY capture
+            // (mask-independent — pre-O fallback ignores the system mask).
+            val maskedStyles = styles.filter { it != AdaptiveStyle.LEGACY }
             for (shape in shapes) {
+              for (style in maskedStyles) {
+                out +=
+                  ResourceCapture(
+                    variant = ResourceVariant(qualifiers = combined, shape = shape, style = style),
+                    renderOutput =
+                      renderOutputPath(
+                        resourceId = resourceId,
+                        qualifier = combined,
+                        shape = shape,
+                        style = style,
+                        extension = "png",
+                      ),
+                    cost = RESOURCE_ADAPTIVE_COST,
+                  )
+              }
+            }
+            if (AdaptiveStyle.LEGACY in styles) {
               out +=
                 ResourceCapture(
-                  variant = ResourceVariant(qualifiers = combined, shape = shape),
+                  variant =
+                    ResourceVariant(
+                      qualifiers = combined,
+                      shape = null,
+                      style = AdaptiveStyle.LEGACY,
+                    ),
                   renderOutput =
                     renderOutputPath(
                       resourceId = resourceId,
                       qualifier = combined,
-                      shape = shape,
+                      shape = null,
+                      style = AdaptiveStyle.LEGACY,
                       extension = "png",
                     ),
                   cost = RESOURCE_ADAPTIVE_COST,
@@ -111,6 +139,7 @@ object ResourceDiscovery {
                     resourceId = resourceId,
                     qualifier = combined,
                     shape = null,
+                    style = null,
                     extension = "gif",
                   ),
                 cost = RESOURCE_ANIMATED_COST,
@@ -125,6 +154,7 @@ object ResourceDiscovery {
                     resourceId = resourceId,
                     qualifier = combined,
                     shape = null,
+                    style = null,
                     extension = "png",
                   ),
                 cost = RESOURCE_STATIC_COST,
@@ -166,6 +196,7 @@ object ResourceDiscovery {
     resourceId: String,
     qualifier: String?,
     shape: AdaptiveShape?,
+    style: AdaptiveStyle?,
     extension: String,
   ): String {
     val (base, name) = resourceId.split('/', limit = 2).let { it[0] to it[1] }
@@ -174,8 +205,13 @@ object ResourceDiscovery {
     val parts = buildList {
       add(safeName)
       if (!safeQualifier.isNullOrEmpty()) add(safeQualifier)
-      if (shape != null) {
-        if (shape == AdaptiveShape.LEGACY) add("LEGACY") else add("SHAPE_${shape.name.lowercase()}")
+      if (shape != null) add("SHAPE_${shape.name.lowercase()}")
+      when (style) {
+        null,
+        AdaptiveStyle.FULL_COLOR -> Unit
+        AdaptiveStyle.THEMED_LIGHT -> add("themed-light")
+        AdaptiveStyle.THEMED_DARK -> add("themed-dark")
+        AdaptiveStyle.LEGACY -> add("LEGACY")
       }
     }
     return "renders/resources/$base/${parts.joinToString("_")}.$extension"
@@ -204,6 +240,7 @@ object ResourceDiscovery {
           densities = config.densities,
           shapes = config.shapes,
           resourceId = id,
+          styles = config.styles,
         )
       return ResourcePreview(
         id = id,

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewDataTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewDataTest.kt
@@ -92,10 +92,36 @@ class PreviewDataTest {
               captures =
                 listOf(
                   ResourceCapture(
-                    variant = ResourceVariant(qualifiers = "xhdpi", shape = AdaptiveShape.CIRCLE),
+                    variant =
+                      ResourceVariant(
+                        qualifiers = "xhdpi",
+                        shape = AdaptiveShape.CIRCLE,
+                        style = AdaptiveStyle.FULL_COLOR,
+                      ),
                     renderOutput = "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_circle.png",
                     cost = RESOURCE_ADAPTIVE_COST,
-                  )
+                  ),
+                  ResourceCapture(
+                    variant =
+                      ResourceVariant(
+                        qualifiers = "xhdpi",
+                        shape = AdaptiveShape.SQUIRCLE,
+                        style = AdaptiveStyle.THEMED_LIGHT,
+                      ),
+                    renderOutput =
+                      "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_squircle_themed-light.png",
+                    cost = RESOURCE_ADAPTIVE_COST,
+                  ),
+                  ResourceCapture(
+                    variant =
+                      ResourceVariant(
+                        qualifiers = "xhdpi",
+                        shape = null,
+                        style = AdaptiveStyle.LEGACY,
+                      ),
+                    renderOutput = "renders/resources/mipmap/ic_launcher_xhdpi_LEGACY.png",
+                    cost = RESOURCE_ADAPTIVE_COST,
+                  ),
                 ),
             ),
           ),

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ResourceDiscoveryTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ResourceDiscoveryTest.kt
@@ -22,12 +22,14 @@ class ResourceDiscoveryTest {
   private fun discover(
     densities: List<String> = listOf("xhdpi"),
     shapes: List<AdaptiveShape> = listOf(AdaptiveShape.CIRCLE, AdaptiveShape.SQUARE),
+    styles: List<AdaptiveStyle> = listOf(AdaptiveStyle.FULL_COLOR),
   ): List<ResourcePreview> =
     ResourceDiscovery.discover(
       ResourceDiscovery.Config(
         resSourceRoots = listOf(File(temp.root, "res")),
         densities = densities,
         shapes = shapes,
+        styles = styles,
         sourceRootRelativePath = { "res" },
       )
     )
@@ -62,19 +64,59 @@ class ResourceDiscoveryTest {
   }
 
   @Test
-  fun `adaptive icon fans out across shapes for each density`() {
+  fun `adaptive icon fans out shape x style and emits a single LEGACY capture`() {
     writeXml("mipmap-anydpi-v26", "ic_launcher.xml", "<adaptive-icon />")
-    val preview = discover(shapes = listOf(AdaptiveShape.CIRCLE, AdaptiveShape.LEGACY)).single()
+    val preview =
+      discover(
+          shapes = listOf(AdaptiveShape.CIRCLE),
+          styles =
+            listOf(AdaptiveStyle.FULL_COLOR, AdaptiveStyle.THEMED_LIGHT, AdaptiveStyle.LEGACY),
+        )
+        .single()
     assertThat(preview.id).isEqualTo("mipmap/ic_launcher")
     assertThat(preview.type).isEqualTo(ResourceType.ADAPTIVE_ICON)
     assertThat(preview.captures.map { it.renderOutput })
       .containsExactly(
         "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_circle.png",
+        "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_circle_themed-light.png",
         "renders/resources/mipmap/ic_launcher_xhdpi_LEGACY.png",
       )
       .inOrder()
+    assertThat(preview.captures.last().variant?.shape).isNull()
+    assertThat(preview.captures.last().variant?.style).isEqualTo(AdaptiveStyle.LEGACY)
     assertThat(preview.captures.map { it.cost })
-      .containsExactly(RESOURCE_ADAPTIVE_COST, RESOURCE_ADAPTIVE_COST)
+      .containsExactly(RESOURCE_ADAPTIVE_COST, RESOURCE_ADAPTIVE_COST, RESOURCE_ADAPTIVE_COST)
+  }
+
+  @Test
+  fun `adaptive icon LEGACY appears once per qualifier regardless of shape count`() {
+    writeXml("mipmap-anydpi-v26", "ic_launcher.xml", "<adaptive-icon />")
+    val preview =
+      discover(
+          shapes =
+            listOf(AdaptiveShape.CIRCLE, AdaptiveShape.SQUIRCLE, AdaptiveShape.ROUNDED_SQUARE),
+          styles = listOf(AdaptiveStyle.FULL_COLOR, AdaptiveStyle.LEGACY),
+        )
+        .single()
+    val legacyCaptures = preview.captures.filter { it.variant?.style == AdaptiveStyle.LEGACY }
+    assertThat(legacyCaptures).hasSize(1)
+  }
+
+  @Test
+  fun `themed styles produce themed-light and themed-dark filename suffixes`() {
+    writeXml("mipmap-anydpi-v26", "ic_launcher.xml", "<adaptive-icon />")
+    val preview =
+      discover(
+          shapes = listOf(AdaptiveShape.SQUIRCLE),
+          styles = listOf(AdaptiveStyle.THEMED_LIGHT, AdaptiveStyle.THEMED_DARK),
+        )
+        .single()
+    assertThat(preview.captures.map { it.renderOutput })
+      .containsExactly(
+        "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_squircle_themed-light.png",
+        "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_squircle_themed-dark.png",
+      )
+      .inOrder()
   }
 
   @Test
@@ -119,6 +161,7 @@ class ResourceDiscoveryTest {
         resourceId = "drawable/foo bar",
         qualifier = "night-xhdpi",
         shape = null,
+        style = null,
         extension = "png",
       )
     assertThat(path).isEqualTo("renders/resources/drawable/foo_bar_night-xhdpi.png")

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderResourceManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderResourceManifest.kt
@@ -21,8 +21,16 @@ enum class RenderResourceType {
 @Serializable
 enum class RenderAdaptiveShape {
   CIRCLE,
+  SQUIRCLE,
   ROUNDED_SQUARE,
   SQUARE,
+}
+
+@Serializable
+enum class RenderAdaptiveStyle {
+  FULL_COLOR,
+  THEMED_LIGHT,
+  THEMED_DARK,
   LEGACY,
 }
 
@@ -30,6 +38,7 @@ enum class RenderAdaptiveShape {
 data class RenderResourceVariant(
   val qualifiers: String? = null,
   val shape: RenderAdaptiveShape? = null,
+  val style: RenderAdaptiveStyle? = null,
 )
 
 @Serializable

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTest.kt
@@ -97,9 +97,11 @@ class ResourcePreviewRenderTest {
           }
           RenderResourceType.ADAPTIVE_ICON -> {
             val shape = capture.variant?.shape
-            if (shape == null) {
+            val style = capture.variant?.style ?: RenderAdaptiveStyle.FULL_COLOR
+            if (style != RenderAdaptiveStyle.LEGACY && shape == null) {
               System.err.println(
-                "compose-preview: adaptive icon ${preview.id} capture has no shape; skipping"
+                "compose-preview: adaptive icon ${preview.id} ${style.name} capture has no " +
+                  "shape; skipping"
               )
               missing++
               continue
@@ -108,12 +110,16 @@ class ResourcePreviewRenderTest {
             if (adaptive == null) {
               System.err.println(
                 "compose-preview: ${preview.id} resolved as ${drawable.javaClass.simpleName}, " +
-                  "not AdaptiveIconDrawable; skipping ${shape.name} capture"
+                  "not AdaptiveIconDrawable; skipping ${shape?.name ?: style.name} capture"
               )
               missing++
               continue
             }
-            val bitmap = renderAdaptiveIcon(adaptive, shape)
+            val bitmap = renderAdaptiveIcon(adaptive, shape, style, preview.id)
+            if (bitmap == null) {
+              missing++
+              continue
+            }
             try {
               outFile.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
             } finally {
@@ -152,24 +158,36 @@ class ResourcePreviewRenderTest {
   }
 
   /**
-   * Composites foreground + background into a 108dp canvas, then masks to [shape]. The mask path
-   * uses [PorterDuff.Mode.SRC_IN] so anti-aliased edges come through cleanly — `Canvas.clipPath` is
-   * documented as not anti-aliased, which produces visible jaggies on circular masks at the
-   * densities we render at.
+   * Renders one adaptive-icon capture. Two surfaces, picked by [style]:
+   * - [RenderAdaptiveStyle.FULL_COLOR] composites the consumer's `<background>` + `<foreground>`
+   *   into an offscreen bitmap, then masks with [shape]. This is the appearance launchers show
+   *   in app drawers / search.
+   * - [RenderAdaptiveStyle.THEMED_LIGHT] / [RenderAdaptiveStyle.THEMED_DARK] take the
+   *   `<monochrome>` layer (Android 13+ only — `getMonochrome()` returns null when absent),
+   *   tint it with a Material 3 baseline 2-tone pair against a flat surface-container
+   *   background, then mask with [shape]. This is the home-screen "Themed icons" appearance.
+   *   Returns null with a warning when there's no `<monochrome>` layer to render — caller
+   *   skips the capture.
+   * - [RenderAdaptiveStyle.LEGACY] ignores the mask and draws the foreground against
+   *   transparent. Approximates the pre-O fallback; real legacy raster mipmaps
+   *   (`mipmap-mdpi/ic_launcher.png` etc.) aren't surfaced through
+   *   `AdaptiveIconDrawable.foreground`, and parsing the consumer's mipmap directory ourselves
+   *   is out of scope.
    *
-   * `LEGACY` skips the mask and renders just the foreground against transparent, approximating the
-   * pre-API-26 fallback. Real legacy mipmap files (`mipmap-mdpi/ic_launcher.png` etc.) aren't
-   * surfaced through `AdaptiveIconDrawable.foreground`, so this is the closest approximation
-   * without parsing the consumer's mipmap directory ourselves.
+   * The mask path uses [PorterDuff.Mode.SRC_IN] so anti-aliased edges come through cleanly —
+   * `Canvas.clipPath` is documented as not anti-aliased, which produces visible jaggies on
+   * circular masks at the densities we render at.
    */
   private fun renderAdaptiveIcon(
     drawable: AdaptiveIconDrawable,
-    shape: RenderAdaptiveShape,
-  ): Bitmap {
+    shape: RenderAdaptiveShape?,
+    style: RenderAdaptiveStyle,
+    resourceId: String,
+  ): Bitmap? {
     val width = drawable.intrinsicWidth.coerceAtLeast(1)
     val height = drawable.intrinsicHeight.coerceAtLeast(1)
 
-    if (shape == RenderAdaptiveShape.LEGACY) {
+    if (style == RenderAdaptiveStyle.LEGACY) {
       val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
       val canvas = Canvas(bitmap)
       drawable.foreground?.also {
@@ -179,18 +197,48 @@ class ResourcePreviewRenderTest {
       return bitmap
     }
 
-    // 1. Compose fg+bg into an offscreen bitmap so the SRC_IN compositor below has a single
-    //    layer to mask.
+    requireNotNull(shape) { "non-LEGACY style $style requires a shape" }
+
+    // 1. Compose the style's contents into an offscreen bitmap so the SRC_IN compositor below
+    //    has a single layer to mask.
     val composed = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
-    try {
+    return try {
       val composedCanvas = Canvas(composed)
-      drawable.background?.also {
-        it.setBounds(0, 0, width, height)
-        it.draw(composedCanvas)
-      }
-      drawable.foreground?.also {
-        it.setBounds(0, 0, width, height)
-        it.draw(composedCanvas)
+      when (style) {
+        RenderAdaptiveStyle.FULL_COLOR -> {
+          drawable.background?.also {
+            it.setBounds(0, 0, width, height)
+            it.draw(composedCanvas)
+          }
+          drawable.foreground?.also {
+            it.setBounds(0, 0, width, height)
+            it.draw(composedCanvas)
+          }
+        }
+        RenderAdaptiveStyle.THEMED_LIGHT,
+        RenderAdaptiveStyle.THEMED_DARK -> {
+          val monochrome = drawable.monochrome
+          if (monochrome == null) {
+            System.err.println(
+              "compose-preview: $resourceId has no <monochrome> layer; skipping " +
+                "${style.name} capture"
+            )
+            composed.recycle()
+            return null
+          }
+          val (bgColor, fgColor) = themedColors(style)
+          composedCanvas.drawColor(bgColor)
+          // mutate(): decouple from any shared constant state before mutating the tint —
+          // cached drawables are reused by the platform across resolutions, and we don't want
+          // a tint applied here to leak into a later FULL_COLOR / LEGACY capture of a sibling
+          // resource that happens to share state.
+          val tintable = monochrome.mutate()
+          tintable.setBounds(0, 0, width, height)
+          tintable.setTintMode(PorterDuff.Mode.SRC_IN)
+          tintable.setTint(fgColor)
+          tintable.draw(composedCanvas)
+        }
+        RenderAdaptiveStyle.LEGACY -> error("unreachable") // handled above
       }
 
       // 2. Draw the mask shape into the output bitmap, then composite the icon with SRC_IN so
@@ -202,20 +250,40 @@ class ResourcePreviewRenderTest {
       when (shape) {
         RenderAdaptiveShape.CIRCLE ->
           outputCanvas.drawCircle(width / 2f, height / 2f, width / 2f, paint)
+        RenderAdaptiveShape.SQUIRCLE -> {
+          // Pixel-ish squircle approximation. A real superellipse needs Path + cubic Béziers;
+          // a rounded rect with r ≈ 40% of the side is visually close at preview densities.
+          val r = width * 0.40f
+          outputCanvas.drawRoundRect(rect, r, r, paint)
+        }
         RenderAdaptiveShape.ROUNDED_SQUARE -> {
-          val r = width * 0.22f
+          // Aligned with AndroidX IconShape's rounded-square (~25% corner radius).
+          val r = width * 0.25f
           outputCanvas.drawRoundRect(rect, r, r, paint)
         }
         RenderAdaptiveShape.SQUARE -> outputCanvas.drawRect(rect, paint)
-        RenderAdaptiveShape.LEGACY -> error("unreachable") // handled above
       }
       paint.xfermode = PorterDuffXfermode(PorterDuff.Mode.SRC_IN)
       outputCanvas.drawBitmap(composed, 0f, 0f, paint)
-      return output
+      output
     } finally {
-      composed.recycle()
+      if (!composed.isRecycled) composed.recycle()
     }
   }
+
+  /**
+   * Material 3 baseline neutrals used to fake "Themed icons" without a live wallpaper-derived
+   * palette. Pair = (surface-container background, on-surface foreground tint). Reproducible
+   * across runs since they don't depend on the wallpaper / system theme.
+   */
+  private fun themedColors(style: RenderAdaptiveStyle): Pair<Int, Int> =
+    when (style) {
+      // light: surfaceContainerHigh, onSurfaceVariant
+      RenderAdaptiveStyle.THEMED_LIGHT -> 0xFFECE6F0.toInt() to 0xFF49454F.toInt()
+      // dark: surfaceContainerHigh, onSurfaceVariant
+      RenderAdaptiveStyle.THEMED_DARK -> 0xFF2B2930.toInt() to 0xFFCAC4D0.toInt()
+      else -> error("themed colours requested for non-themed style $style")
+    }
 
   /**
    * Renders [drawable] (an `AnimatedVectorDrawable` / `AnimatedVectorDrawableCompat`) into a

--- a/samples/android/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/samples/android/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android"
+    android:icon="@drawable/ic_launcher_legacy">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/samples/android/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/samples/android/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android"
+    android:icon="@drawable/ic_launcher_legacy">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
 </adaptive-icon>

--- a/skills/compose-preview/design/RESOURCE_PREVIEWS.md
+++ b/skills/compose-preview/design/RESOURCE_PREVIEWS.md
@@ -19,7 +19,7 @@ Modules with no matching XML resources self-no-op (a single empty
 | Resource kind | Output | Variant axes |
 |---|---|---|
 | `<vector>` | PNG at intrinsic size × density | `densities`; explicit qualifier dirs (`drawable-night/`, `drawable-ldrtl/`, …) automatically picked up |
-| `<adaptive-icon>` (mipmap-anydpi-v26) | PNG per shape mask, composited fg+bg | `densities` × `shapes` (`CIRCLE`, `ROUNDED_SQUARE`, `SQUARE`, `LEGACY`) |
+| `<adaptive-icon>` (mipmap-anydpi-v26) | PNG per (shape × style), demonstrating both App Search (full colour) and Home (shape-clipped, optionally 2-tone themed) launcher surfaces | `densities` × `shapes` (`CIRCLE`, `SQUIRCLE`, `ROUNDED_SQUARE`, `SQUARE`) × `styles` (`FULL_COLOR`, `THEMED_LIGHT`, `THEMED_DARK`, `LEGACY`) |
 | `<animated-vector>` | GIF | `densities` |
 
 Out of scope today: `<animation-list>`, `<shape>`, `<selector>`,
@@ -36,13 +36,24 @@ composePreview {
         densities = listOf("xhdpi")                 // implicit density fan-out
         shapes = listOf(                            // adaptive-icon mask set
             AdaptiveShape.CIRCLE,
+            AdaptiveShape.SQUIRCLE,                 // Pixel / Material You default
             AdaptiveShape.ROUNDED_SQUARE,
             AdaptiveShape.SQUARE,
-            AdaptiveShape.LEGACY,
+        )
+        styles = listOf(                            // adaptive-icon style set
+            AdaptiveStyle.FULL_COLOR,               // App Search appearance
+            AdaptiveStyle.THEMED_LIGHT,             // Home, "Themed icons" on, light theme
+            AdaptiveStyle.THEMED_DARK,              // Home, "Themed icons" on, dark theme
+            AdaptiveStyle.LEGACY,                   // pre-O fallback
         )
     }
 }
 ```
+
+`THEMED_LIGHT` / `THEMED_DARK` need a `<monochrome>` element on the
+`<adaptive-icon>` (Android 13+). Captures for icons missing the monochrome
+layer are skipped at render time with a warning rather than failing the
+build.
 
 ## AndroidManifest.xml link-don't-re-render
 

--- a/vscode-extension/src/test/fixtures/resources.json
+++ b/vscode-extension/src/test/fixtures/resources.json
@@ -11,12 +11,12 @@
             },
             "captures": [
                 {
-                    "variant": { "qualifiers": "xhdpi", "shape": null },
+                    "variant": { "qualifiers": "xhdpi", "shape": null, "style": null },
                     "renderOutput": "renders/resources/drawable/ic_compose_logo_xhdpi.png",
                     "cost": 1.0
                 },
                 {
-                    "variant": { "qualifiers": "night-xhdpi", "shape": null },
+                    "variant": { "qualifiers": "night-xhdpi", "shape": null, "style": null },
                     "renderOutput": "renders/resources/drawable/ic_compose_logo_night-xhdpi.png",
                     "cost": 1.0
                 }
@@ -30,12 +30,22 @@
             },
             "captures": [
                 {
-                    "variant": { "qualifiers": "xhdpi", "shape": "CIRCLE" },
+                    "variant": { "qualifiers": "xhdpi", "shape": "CIRCLE", "style": "FULL_COLOR" },
                     "renderOutput": "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_circle.png",
                     "cost": 4.0
                 },
                 {
-                    "variant": { "qualifiers": "xhdpi", "shape": "LEGACY" },
+                    "variant": { "qualifiers": "xhdpi", "shape": "SQUIRCLE", "style": "THEMED_LIGHT" },
+                    "renderOutput": "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_squircle_themed-light.png",
+                    "cost": 4.0
+                },
+                {
+                    "variant": { "qualifiers": "xhdpi", "shape": "SQUIRCLE", "style": "THEMED_DARK" },
+                    "renderOutput": "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_squircle_themed-dark.png",
+                    "cost": 4.0
+                },
+                {
+                    "variant": { "qualifiers": "xhdpi", "shape": null, "style": "LEGACY" },
                     "renderOutput": "renders/resources/mipmap/ic_launcher_xhdpi_LEGACY.png",
                     "cost": 4.0
                 }
@@ -49,7 +59,7 @@
             },
             "captures": [
                 {
-                    "variant": { "qualifiers": "xhdpi", "shape": null },
+                    "variant": { "qualifiers": "xhdpi", "shape": null, "style": null },
                     "renderOutput": "renders/resources/drawable/avd_pulse_xhdpi.gif",
                     "cost": 35.0
                 }

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -114,9 +114,15 @@ describe('GradleService', () => {
             const compose = manifest!.resources.find((r) => r.id === 'drawable/ic_compose_logo')!;
             assert.deepStrictEqual(Object.keys(compose.sourceFiles).sort(), ['', 'night']);
 
-            // Adaptive-icon captures should carry their shape; vector captures should not.
+            // Adaptive-icon captures should carry their shape and style; vector captures
+            // should carry neither. LEGACY captures carry style but no shape.
             const launcher = manifest!.resources.find((r) => r.id === 'mipmap/ic_launcher')!;
             assert.strictEqual(launcher.captures[0].variant?.shape, 'CIRCLE');
+            assert.strictEqual(launcher.captures[0].variant?.style, 'FULL_COLOR');
+            const themedLight = launcher.captures.find((c) => c.variant?.style === 'THEMED_LIGHT')!;
+            assert.strictEqual(themedLight.variant?.shape, 'SQUIRCLE');
+            const legacy = launcher.captures.find((c) => c.variant?.style === 'LEGACY')!;
+            assert.strictEqual(legacy.variant?.shape, null);
             assert.strictEqual(compose.captures[0].variant?.shape, null);
 
             // Manifest references resolve activity short-form names against the package.

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -130,7 +130,9 @@ export interface AccessibilityReport {
 
 export type ResourceType = 'VECTOR' | 'ANIMATED_VECTOR' | 'ADAPTIVE_ICON' | string;
 
-export type AdaptiveShape = 'CIRCLE' | 'ROUNDED_SQUARE' | 'SQUARE' | 'LEGACY' | string;
+export type AdaptiveShape = 'CIRCLE' | 'SQUIRCLE' | 'ROUNDED_SQUARE' | 'SQUARE' | string;
+
+export type AdaptiveStyle = 'FULL_COLOR' | 'THEMED_LIGHT' | 'THEMED_DARK' | 'LEGACY' | string;
 
 export interface ResourceVariant {
     /**
@@ -140,8 +142,19 @@ export interface ResourceVariant {
      * qualifier of any particular source file (AAPT picks whichever matches at render time).
      */
     qualifiers: string | null;
-    /** Adaptive-icon shape mask. `null` for non-adaptive resources. */
+    /**
+     * Adaptive-icon shape mask. `null` for non-adaptive resources, and `null` for `LEGACY`
+     * captures (the legacy fallback ignores the system mask).
+     */
     shape: AdaptiveShape | null;
+    /**
+     * Adaptive-icon style. `'FULL_COLOR'` is the foreground+background composite (App Search
+     * appearance); `'THEMED_LIGHT'` / `'THEMED_DARK'` tint the `<monochrome>` layer with a
+     * 2-tone Material 3 palette (home-screen "Themed icons" appearance); `'LEGACY'` is the
+     * pre-O fallback. `null` on resources where the field wasn't populated by an older
+     * plugin version — treat as `'FULL_COLOR'`.
+     */
+    style?: AdaptiveStyle | null;
 }
 
 export interface ResourceCapture {


### PR DESCRIPTION
Adaptive-icon previews now demonstrate both surfaces a launcher renders
icons at: full-colour foreground+background (App Search appearance) and
shape-clipped 2-tone monochrome (home-screen "Themed icons" appearance).

- Split adaptive-icon variant into two axes: AdaptiveShape (mask) is now
  CIRCLE / SQUIRCLE / ROUNDED_SQUARE / SQUARE; AdaptiveStyle (contents)
  is FULL_COLOR / THEMED_LIGHT / THEMED_DARK / LEGACY. Captures fan out
  shape x style for masked styles, plus one bare LEGACY capture per
  qualifier (mask-independent).
- THEMED_* tints AdaptiveIconDrawable.getMonochrome() (API 33+) with a
  Material 3 baseline 2-tone palette (surfaceContainerHigh +
  onSurfaceVariant for light/dark) so previews are reproducible without
  a wallpaper-derived dynamic palette. Icons missing a <monochrome>
  layer skip the themed captures with a warning rather than failing.
- SQUIRCLE approximated as a rounded-rect at 40% radius; ROUNDED_SQUARE
  bumped from 22% to 25% to align with AndroidX IconShape.
- Sample ic_launcher{,_round}.xml gain <monochrome> layers and an
  android:icon legacy slot reference for the new captures to exercise.

Closes #291.