### PR TITLE
docs: add meshcore-mobile#36 to agent PR hall of fame

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ verify their changes.
 
 <!-- Add interesting agent PRs here as they happen — link, agent, one-liner. -->
 
-*Currently empty — open a PR or [an issue](https://github.com/yschimke/compose-ai-tools/issues/new)
-if you have one to add.*
+- [`yschimke/meshcore-mobile#36`](https://github.com/yschimke/meshcore-mobile/pull/36) — renders Play Store listing screenshots (phone + 7"/10" tablet) directly from `Play Store — …` `@Preview` composables, replacing hand-crafted PNGs.
+
+Have one to add? Open a PR or [an issue](https://github.com/yschimke/compose-ai-tools/issues/new).
 
 ## More
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ branch.
 Real-world PRs opened by AI coding agents that used `compose-preview` to
 verify their changes.
 
-<!-- Add interesting agent PRs here as they happen — link, agent, one-liner. -->
+<!-- Add interesting agent PRs here as they happen — link + one-liner. -->
 
 - [`yschimke/meshcore-mobile#36`](https://github.com/yschimke/meshcore-mobile/pull/36) — renders Play Store listing screenshots (phone + 7"/10" tablet) directly from `Play Store — …` `@Preview` composables, replacing hand-crafted PNGs.
 


### PR DESCRIPTION
## Summary

- Adds `yschimke/meshcore-mobile#36` as the first entry in the Agent PR hall of fame — Play Store listing screenshots rendered from `@Preview` composables.
- Replaces the *currently empty* placeholder with a "Have one to add?" footer.
- Trims the format hint comment to `link + one-liner` (no agent column).

## Test plan

- [ ] `README.md` renders on GitHub with the new bullet and the link resolves.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TXUfqm4fDEyRnAKnWsDXN3)_