### PR TITLE
fix(vscode): find nested modules + silence cancel-as-failure noise

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,9 +7,12 @@ set -euo pipefail
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
-mapfile -d '' staged < <(
-  git diff --cached --name-only --diff-filter=ACMR -z -- '*.kt' '*.kts'
-)
+# Portable replacement for `mapfile -d ''` — bash 3.2 (macOS system bash)
+# doesn't have mapfile.
+staged=()
+while IFS= read -r -d '' file; do
+  staged+=("$file")
+done < <(git diff --cached --name-only --diff-filter=ACMR -z -- '*.kt' '*.kts')
 
 if [ ${#staged[@]} -eq 0 ]; then
   exit 0

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import { GradleService, GradleApi } from './gradleService';
+import { GradleService, GradleApi, TaskCancelledError } from './gradleService';
 import { JdkImageError } from './jdkImageErrorDetector';
 import { findPluginAppliedAncestor } from './pluginDetection';
 import { PreviewPanel } from './previewPanel';
@@ -797,6 +797,13 @@ async function refresh(
         // "populate then go blank" regression.
     } catch (err: unknown) {
         if (abort.signal.aborted) { return; }
+        // Cancellation = a follow-up refresh superseded this one. The new
+        // refresh owns the panel state from here; surfacing a "FAILED" toast
+        // would be misleading and noisy.
+        if (err instanceof TaskCancelledError) {
+            logLine(`cancelled — superseded by a newer refresh`);
+            return;
+        }
         if (err instanceof JdkImageError) {
             logLine(`FAILED (jlink missing): ${err.finding.jlinkPath}`);
             panel.postMessage({

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -67,6 +67,39 @@ function expandParamCaptures(
 const TASK_TIMEOUT_MS = 5 * 60 * 1000;
 const MANIFEST_CACHE_TTL_MS = 30_000;
 
+/**
+ * Distinguishes cancellation (a normal lifecycle event when a new refresh
+ * supersedes an in-flight one) from real build failures, so callers can
+ * silently drop cancellation without surfacing a misleading "FAILED" toast.
+ *
+ * vscode-gradle's gRPC layer rejects with a `Status.CANCELLED` error whose
+ * `.message` looks like `"1 CANCELLED: Call cancelled"` — match on that,
+ * not on a less stable substring.
+ */
+export class TaskCancelledError extends Error {
+    constructor(public readonly task: string) {
+        super(`Gradle task ${task} was cancelled.`);
+        this.name = 'TaskCancelledError';
+    }
+}
+
+const CANCELLED_RE = /\bCANCELLED\b/i;
+
+// Module identifiers are stored as forward-slash relative paths from the
+// workspace root (e.g. `samples/wear`) so the same string serves both as a
+// Gradle project segment and a filesystem path through `path.join`. Gradle
+// task names take the colon-separated form (`:samples:wear:foo`) — convert
+// at task-name construction sites only.
+function gradleProjectPath(module: string): string {
+    return ':' + module.split('/').join(':');
+}
+
+const SCAN_SKIP_DIRS = new Set([
+    'node_modules', 'build', 'gradle', 'src', 'out', 'dist',
+    '.compose-preview-history',
+]);
+const SCAN_MAX_DEPTH = 4;
+
 export interface Logger {
     appendLine(value: string): void;
     append(value: string): void;
@@ -127,7 +160,7 @@ export class GradleService {
         if (cached && Date.now() - cached.timestamp < MANIFEST_CACHE_TTL_MS) {
             return cached.manifest;
         }
-        await this.runTask(`:${module}:discoverPreviews`);
+        await this.runTask(`${gradleProjectPath(module)}:discoverPreviews`);
         const manifest = this.readManifest(module);
         if (manifest) {
             this.manifestCache.set(module, { manifest, timestamp: Date.now() });
@@ -158,7 +191,7 @@ export class GradleService {
     ): Promise<PreviewManifest | null> {
         this.manifestCache.delete(module);
         await this.runTask(
-            `:${module}:renderAllPreviews`,
+            `${gradleProjectPath(module)}:renderAllPreviews`,
             [`-PcomposePreview.tier=${tier}`],
         );
         const manifest = this.readManifest(module);
@@ -179,10 +212,11 @@ export class GradleService {
      * diagnostics for this module", not as an empty finding set.
      */
     async runDoctor(module: string): Promise<DoctorModuleReport | null> {
+        const task = `${gradleProjectPath(module)}:composePreviewDoctor`;
         try {
-            await this.runTask(`:${module}:composePreviewDoctor`);
+            await this.runTask(task);
         } catch (e) {
-            this.logger.appendLine(`[doctor] :${module}:composePreviewDoctor failed: ${(e as Error).message}`);
+            this.logger.appendLine(`[doctor] ${task} failed: ${(e as Error).message}`);
             return null;
         }
         const reportPath = path.join(this.workspaceRoot, module, 'build', 'compose-previews', 'doctor.json');
@@ -402,8 +436,13 @@ export class GradleService {
     }
 
     /**
-     * Returns the names of direct-child subdirectories whose module applies
-     * the Compose Preview plugin. Merges two signals:
+     * Returns module identifiers — forward-slash relative paths from the
+     * workspace root, e.g. `samples/wear` — for every Gradle subproject that
+     * applies the Compose Preview plugin. Walks the directory tree up to
+     * [SCAN_MAX_DEPTH] so nested modules (`:samples:wear`) are reachable, not
+     * just direct children.
+     *
+     * Two signals are merged at every level:
      *
      *   1. `<module>/build/compose-previews/applied.json` — authoritative
      *      marker written by the `composePreviewApplied` Gradle task. Covers
@@ -417,28 +456,43 @@ export class GradleService {
      * others (applied but not yet built) to disappear from the list.
      * Projects that only apply via a catalog alias show up as empty until
      * the bootstrap marker run completes — see [bootstrapAppliedMarkers].
+     *
+     * Recursion continues past a matched directory because Gradle allows
+     * modules to nest (`:foo:bar` inside `:foo`). [SCAN_SKIP_DIRS] prunes
+     * source / output trees that can't contain a module root.
      */
     findPreviewModules(): string[] {
         const found = new Set<string>();
-        let entries: fs.Dirent[];
-        try {
-            entries = fs.readdirSync(this.workspaceRoot, { withFileTypes: true });
-        } catch {
-            return [];
-        }
-        for (const entry of entries) {
-            if (!entry.isDirectory()) { continue; }
-            const dir = entry.name;
-            const marker = path.join(
-                this.workspaceRoot, dir, 'build', 'compose-previews', 'applied.json',
-            );
-            if (fs.existsSync(marker)) { found.add(dir); continue; }
-            const buildFile = path.join(this.workspaceRoot, dir, 'build.gradle.kts');
+        const walk = (relDir: string, depth: number): void => {
+            if (depth > SCAN_MAX_DEPTH) { return; }
+            const absDir = relDir ? path.join(this.workspaceRoot, relDir) : this.workspaceRoot;
+            let entries: fs.Dirent[];
             try {
-                const content = fs.readFileSync(buildFile, 'utf-8');
-                if (appliesPlugin(content)) { found.add(dir); }
-            } catch { /* skip */ }
-        }
+                entries = fs.readdirSync(absDir, { withFileTypes: true });
+            } catch {
+                return;
+            }
+            for (const entry of entries) {
+                if (!entry.isDirectory()) { continue; }
+                if (entry.name.startsWith('.')) { continue; }
+                if (SCAN_SKIP_DIRS.has(entry.name)) { continue; }
+                const childRel = relDir ? `${relDir}/${entry.name}` : entry.name;
+                const marker = path.join(
+                    this.workspaceRoot, childRel, 'build', 'compose-previews', 'applied.json',
+                );
+                if (fs.existsSync(marker)) {
+                    found.add(childRel);
+                } else {
+                    const buildFile = path.join(this.workspaceRoot, childRel, 'build.gradle.kts');
+                    try {
+                        const content = fs.readFileSync(buildFile, 'utf-8');
+                        if (appliesPlugin(content)) { found.add(childRel); }
+                    } catch { /* skip */ }
+                }
+                walk(childRel, depth + 1);
+            }
+        };
+        walk('', 0);
         return [...found].sort();
     }
 
@@ -467,9 +521,19 @@ export class GradleService {
 
     resolveModule(filePath: string): string | null {
         const relative = path.relative(this.workspaceRoot, filePath);
-        const topDir = relative.split(path.sep)[0];
-        if (topDir && this.findPreviewModules().includes(topDir)) {
-            return topDir;
+        if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+            return null;
+        }
+        // Split on either separator so the same path works on Windows and POSIX.
+        const segments = relative.split(/[\\/]+/).filter((s: string) => s.length > 0);
+        if (segments.length < 2) { return null; }
+        const modules = new Set(this.findPreviewModules());
+        // Longest-prefix match: walk from deepest possible module path to
+        // shallowest. With nested modules (e.g. `:foo:bar` inside `:foo`)
+        // we prefer the more specific match.
+        for (let n = segments.length - 1; n >= 1; n--) {
+            const candidate = segments.slice(0, n).join('/');
+            if (modules.has(candidate)) { return candidate; }
         }
         return null;
     }
@@ -512,7 +576,16 @@ export class GradleService {
         }).then(
             () => { this.logger.appendLine(`> ${task} completed`); },
             (err) => {
-                this.logger.appendLine(`> ${task} FAILED: ${err?.message ?? err}`);
+                const message = err?.message ?? String(err);
+                // vscode-gradle reports a superseded task as a gRPC CANCELLED
+                // error — that's the normal "new refresh replaced this one"
+                // path, not a build failure. Log it differently and throw a
+                // typed error so callers can drop it silently.
+                if (CANCELLED_RE.test(message)) {
+                    this.logger.appendLine(`> ${task} cancelled`);
+                    throw new TaskCancelledError(task);
+                }
+                this.logger.appendLine(`> ${task} FAILED: ${message}`);
                 detector.end();
                 const finding = detector.getFinding();
                 if (finding) {

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -848,16 +848,6 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 setMessage('No @Preview functions found', 'empty');
                 return;
             }
-            // Clear transient owner messages now that we have cards. The
-            // 'loading' Building… banner gets clobbered here so cards aren't
-            // hidden under it while images stream in. 'extension'-owned
-            // messages (build errors, empty-state notices) are left alone —
-            // those are terminal states the extension is asserting and the
-            // caller wouldn't be sending setPreviews alongside them anyway.
-            if (message.dataset.owner && message.dataset.owner !== 'extension') {
-                setMessage('', message.dataset.owner);
-            }
-
             const newIds = new Set(previews.map(p => p.id));
             const existingCards = new Map();
             grid.querySelectorAll('.preview-card').forEach(card => {
@@ -907,6 +897,20 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     }
                     lastInsertedCard = card;
                 }
+            }
+
+            // Clear transient owner messages now that cards are in the DOM.
+            // The 'loading' Building… banner and the 'fallback' "Preparing
+            // previews…" placeholder both get cleared here. 'extension'-owned
+            // messages (build errors, empty-state notices) are left alone —
+            // those are terminal states the extension is asserting and the
+            // caller wouldn't be sending setPreviews alongside them anyway.
+            //
+            // Must run *after* cards are inserted: setMessage('', …) calls
+            // ensureNotBlank, which would re-set "Preparing previews…" if
+            // the grid still looked empty when the message was cleared.
+            if (message.dataset.owner && message.dataset.owner !== 'extension') {
+                setMessage('', message.dataset.owner);
             }
         }
 

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
-import { GradleService, GradleApi } from '../gradleService';
+import { GradleService, GradleApi, TaskCancelledError } from '../gradleService';
 import { JdkImageError } from '../jdkImageErrorDetector';
 
 /** Stub GradleApi that records invocations and allows test control. */
@@ -258,6 +258,26 @@ describe('GradleService', () => {
             const service = new GradleService(dir, api);
             assert.deepStrictEqual(service.findPreviewModules(), ['app', 'lib']);
         }));
+
+        it('finds nested modules (e.g. samples/wear)', withTempDir((dir, api) => {
+            // Multi-project layouts where modules live under an organising
+            // parent directory (`samples/wear`, `features/login`) — the
+            // parent itself has no build file.
+            fs.mkdirSync(path.join(dir, 'samples', 'wear'), { recursive: true });
+            fs.writeFileSync(path.join(dir, 'samples', 'wear', 'build.gradle.kts'),
+                'plugins { id("ee.schimke.composeai.preview") }');
+            fs.mkdirSync(path.join(dir, 'samples', 'cmp'));
+            const markerDir = path.join(dir, 'samples', 'cmp', 'build', 'compose-previews');
+            fs.mkdirSync(markerDir, { recursive: true });
+            fs.writeFileSync(path.join(markerDir, 'applied.json'),
+                '{"schema":"compose-preview-applied/v1","modulePath":":samples:cmp","moduleName":"cmp","pluginVersion":"0.8.0"}');
+
+            const service = new GradleService(dir, api);
+            assert.deepStrictEqual(
+                service.findPreviewModules(),
+                ['samples/cmp', 'samples/wear'],
+            );
+        }));
     });
 
     describe('resolveModule', () => {
@@ -276,6 +296,41 @@ describe('GradleService', () => {
         it('returns null for file outside any module', withTempDir((dir, api) => {
             const service = new GradleService(dir, api);
             assert.strictEqual(service.resolveModule(path.join(dir, 'unknown', 'Foo.kt')), null);
+        }));
+
+        it('resolves nested module paths', withTempDir((dir, api) => {
+            fs.mkdirSync(path.join(dir, 'samples', 'wear'), { recursive: true });
+            fs.writeFileSync(path.join(dir, 'samples', 'wear', 'build.gradle.kts'),
+                'plugins { id("ee.schimke.composeai.preview") }');
+
+            const service = new GradleService(dir, api);
+            assert.strictEqual(
+                service.resolveModule(path.join(
+                    dir, 'samples', 'wear',
+                    'src', 'main', 'kotlin', 'com', 'example', 'Foo.kt',
+                )),
+                'samples/wear',
+            );
+        }));
+
+        it('prefers the deepest matching module (longest-prefix match)', withTempDir((dir, api) => {
+            // Gradle allows `:foo:bar` to nest inside `:foo`. A file under
+            // `foo/bar/...` belongs to `foo/bar`, not `foo`.
+            fs.mkdirSync(path.join(dir, 'foo', 'bar'), { recursive: true });
+            fs.writeFileSync(path.join(dir, 'foo', 'build.gradle.kts'),
+                'plugins { id("ee.schimke.composeai.preview") }');
+            fs.writeFileSync(path.join(dir, 'foo', 'bar', 'build.gradle.kts'),
+                'plugins { id("ee.schimke.composeai.preview") }');
+
+            const service = new GradleService(dir, api);
+            assert.strictEqual(
+                service.resolveModule(path.join(dir, 'foo', 'bar', 'src', 'Foo.kt')),
+                'foo/bar',
+            );
+            assert.strictEqual(
+                service.resolveModule(path.join(dir, 'foo', 'src', 'Foo.kt')),
+                'foo',
+            );
         }));
     });
 
@@ -298,6 +353,30 @@ describe('GradleService', () => {
             assert.strictEqual(api.runCalls.length, 1);
             assert.strictEqual(api.runCalls[0].taskName, ':mod:discoverPreviews');
         }));
+
+        it('translates nested module path to colon-separated Gradle task name',
+            withTempDir(async (dir, api) => {
+                fs.mkdirSync(path.join(dir, 'samples', 'wear'), { recursive: true });
+                fs.writeFileSync(path.join(dir, 'samples', 'wear', 'build.gradle.kts'),
+                    'plugins { id("ee.schimke.composeai.preview") }');
+                const manifestDir = path.join(
+                    dir, 'samples', 'wear', 'build', 'compose-previews',
+                );
+                fs.mkdirSync(manifestDir, { recursive: true });
+                fs.copyFileSync(
+                    path.join(__dirname, '..', '..', 'src', 'test', 'fixtures', 'previews.json'),
+                    path.join(manifestDir, 'previews.json'),
+                );
+
+                const service = new GradleService(dir, api);
+                await service.discoverPreviews('samples/wear');
+
+                assert.strictEqual(api.runCalls.length, 1);
+                assert.strictEqual(
+                    api.runCalls[0].taskName,
+                    ':samples:wear:discoverPreviews',
+                );
+            }));
 
         it('uses cache for repeated calls within TTL', withTempDir(async (dir, api) => {
             fs.mkdirSync(path.join(dir, 'mod'));
@@ -342,6 +421,24 @@ describe('GradleService', () => {
                 /Gradle task .* failed/,
             );
         }));
+
+        it('throws TaskCancelledError (not generic failure) when vscode-gradle reports a cancelled task',
+            withTempDir(async (dir, api) => {
+                // vscode-gradle's gRPC layer rejects superseded tasks with
+                // a Status.CANCELLED error. That's a normal lifecycle event
+                // (a follow-up refresh replaced this one), not a build
+                // failure — callers need to be able to drop it silently.
+                api.nextRunResult = new Error('1 CANCELLED: Call cancelled');
+
+                const service = new GradleService(dir, api);
+                await assert.rejects(
+                    service.discoverPreviews('mod'),
+                    (err: unknown) => {
+                        assert.ok(err instanceof TaskCancelledError, 'expected TaskCancelledError');
+                        return true;
+                    },
+                );
+            }));
 
         it('throws JdkImageError when the failure output contains the jlink signature',
             withTempDir(async (dir, api) => {


### PR DESCRIPTION
## Summary

Three closely related panel issues that all surfaced when running the extension against this repo's `samples/wear/` etc. modules:

- **Nested modules invisible.** `findPreviewModules` only scanned direct children of the workspace root, so `samples/wear` (the actual Gradle module path) was never found — `resolveModule` returned null and the panel showed the empty state. Now walks up to depth 4, returns `samples/wear`-style identifiers, and `resolveModule` does longest-prefix match (so `:foo:bar` wins over `:foo`). New `gradleProjectPath` helper translates slash-form to colon-form at task-name construction sites only — FS reads keep the slash form unchanged.
- **Superseded refreshes reported as "FAILED".** When a save-driven refresh superseded an in-flight one, vscode-gradle's gRPC layer rejected with `1 CANCELLED: Call cancelled` — surfaced verbatim as a build-failure message in the panel. Now thrown as `TaskCancelledError` and silently dropped by `refresh()`.
- **"Preparing previews…" stuck alongside cards.** `renderPreviews` cleared the loading banner via `setMessage('', …)` *before* inserting cards; the chained `ensureNotBlank` saw an empty grid and backfilled with the safety-net "Preparing previews…" placeholder, which was never cleared once cards arrived. Move the clear to after card insertion.

Also fixes the pre-commit hook so it works on macOS system bash 3.2 (no `mapfile`).

## Test plan

- [x] `npm run compile` clean.
- [x] `npm test` — 84 passing, 0 failing. Added 5 new tests:
  - `finds nested modules (e.g. samples/wear)`
  - `resolves nested module paths`
  - `prefers the deepest matching module (longest-prefix match)`
  - `translates nested module path to colon-separated Gradle task name`
  - `throws TaskCancelledError (not generic failure) when vscode-gradle reports a cancelled task`
- [ ] Reload extension host with this branch installed; open `samples/wear/.../Previews.kt` and confirm previews render (`module=samples/wear` in the log, no "no module" line).
- [ ] Save the file rapidly to trigger a superseded refresh; confirm Output shows `cancelled — superseded by a newer refresh` rather than a `FAILED` message in the panel.
- [ ] Confirm the panel doesn't display "Preparing previews…" alongside cards after a refresh cycle.