### PR TITLE
feat(vscode): opt-in daemon integration for sub-second preview refresh

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -100,6 +100,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Run ATF accessibility checks on every rendered preview. When on, the extension passes `-PcomposePreview.accessibilityChecks.enabled=true` to each Gradle task; findings surface as diagnostics in the Problems panel and on the `@Preview` line. Overrides the `accessibilityChecks { enabled = ... }` block in build.gradle.kts for this session only."
+                },
+                "composePreview.experimental.daemon.enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "EXPERIMENTAL. Use the persistent preview daemon for sub-second refresh on saves to files the user has open, plus scroll-ahead speculative renders. Requires `composePreview { experimental { daemon { enabled = true } } }` in the consumer's build.gradle.kts. When the daemon isn't healthy, the extension silently falls back to the Gradle `renderPreviews` task. See docs/daemon/DESIGN.md for status and caveats."
                 }
             }
         }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -112,7 +112,7 @@
     "scripts": {
         "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
-        "test": "npm run compile && mocha 'out/test/!(electron)/**/*.test.js' 'out/test/*.test.js'",
+        "test": "npm run compile && mocha --exit 'out/test/!(electron)/**/*.test.js' 'out/test/*.test.js'",
         "test:electron": "npm run compile && node ./out/test/electron/runTest.js",
         "lint": "eslint src --ext ts",
         "package": "npm run compile && vsce package --no-dependencies"

--- a/vscode-extension/src/daemon/daemonClient.ts
+++ b/vscode-extension/src/daemon/daemonClient.ts
@@ -1,0 +1,248 @@
+import { Readable, Writable } from 'stream';
+import { FrameDecoder, encodeFrame } from './daemonFraming';
+import {
+    ClasspathDirtyParams,
+    DaemonWarmingParams,
+    DiscoveryUpdatedParams,
+    FileChangedParams,
+    InitializeParams,
+    InitializeResult,
+    JsonRpcError,
+    JsonRpcNotification,
+    JsonRpcRequest,
+    JsonRpcResponse,
+    LogParams,
+    PROTOCOL_VERSION,
+    RenderFailedParams,
+    RenderFinishedParams,
+    RenderNowParams,
+    RenderNowResult,
+    RenderStartedParams,
+    SandboxRecycleParams,
+    SetFocusParams,
+    SetVisibleParams,
+} from './daemonProtocol';
+
+export interface DaemonClientLogger {
+    appendLine(value: string): void;
+}
+
+const nullLogger: DaemonClientLogger = { appendLine() { /* noop */ } };
+
+/**
+ * Daemon → client notification handlers. All optional; ignore what you don't
+ * care about. Unknown notifications from the daemon are dropped silently per
+ * PROTOCOL.md § 7 (additive notifications must not break old clients).
+ */
+export interface DaemonClientEvents {
+    onDiscoveryUpdated?: (params: DiscoveryUpdatedParams) => void;
+    onRenderStarted?: (params: RenderStartedParams) => void;
+    onRenderFinished?: (params: RenderFinishedParams) => void;
+    onRenderFailed?: (params: RenderFailedParams) => void;
+    onClasspathDirty?: (params: ClasspathDirtyParams) => void;
+    onSandboxRecycle?: (params: SandboxRecycleParams) => void;
+    onDaemonWarming?: (params: DaemonWarmingParams) => void;
+    onDaemonReady?: () => void;
+    onLog?: (params: LogParams) => void;
+    /** Stream end / framing collapse. After this fires, the client is dead. */
+    onChannelClosed?: (err?: Error) => void;
+}
+
+export class DaemonRpcError extends Error {
+    constructor(public readonly rpc: JsonRpcError) {
+        super(`${rpc.code} ${rpc.message}`);
+        this.name = 'DaemonRpcError';
+    }
+}
+
+interface PendingRequest {
+    resolve: (value: unknown) => void;
+    reject: (err: Error) => void;
+    method: string;
+}
+
+/**
+ * JSON-RPC 2.0 client with LSP-style `Content-Length` framing, speaking to a
+ * preview-daemon JVM over its stdin/stdout. See `daemonProcess.ts` for the
+ * spawn-and-supervise side; this class is transport-agnostic so unit tests
+ * can drive it from in-memory streams.
+ */
+export class DaemonClient {
+    private nextId = 1;
+    private readonly pending = new Map<number, PendingRequest>();
+    private readonly decoder: FrameDecoder;
+    private closed = false;
+
+    constructor(
+        private readonly stdin: Writable,
+        stdout: Readable,
+        private readonly events: DaemonClientEvents,
+        private readonly logger: DaemonClientLogger = nullLogger,
+    ) {
+        this.decoder = new FrameDecoder({
+            onMessage: (json) => this.handleIncoming(json),
+            onError: (err) => this.fail(err),
+        });
+
+        stdout.on('data', (chunk: Buffer | string) => {
+            const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+            this.decoder.push(buf);
+        });
+        stdout.on('end', () => this.fail());
+        stdout.on('error', (err: Error) => this.fail(err));
+        stdin.on('error', (err: Error) => this.fail(err));
+    }
+
+    initialize(params: Omit<InitializeParams, 'protocolVersion'>): Promise<InitializeResult> {
+        return this.request<InitializeResult>('initialize', {
+            ...params,
+            protocolVersion: PROTOCOL_VERSION,
+        });
+    }
+
+    initialized(): void {
+        this.notify('initialized', undefined);
+    }
+
+    setVisible(params: SetVisibleParams): void {
+        this.notify('setVisible', params);
+    }
+
+    setFocus(params: SetFocusParams): void {
+        this.notify('setFocus', params);
+    }
+
+    fileChanged(params: FileChangedParams): void {
+        this.notify('fileChanged', params);
+    }
+
+    renderNow(params: RenderNowParams): Promise<RenderNowResult> {
+        return this.request<RenderNowResult>('renderNow', params);
+    }
+
+    /** Drains in-flight renders, then resolves. Daemon will not exit until `exit` fires. */
+    shutdown(): Promise<null> {
+        return this.request<null>('shutdown', undefined);
+    }
+
+    /** Daemon exits after this. Best-effort; the channel may be closed already. */
+    exit(): void {
+        try {
+            this.notify('exit', undefined);
+        } catch {
+            /* channel already gone */
+        }
+    }
+
+    isClosed(): boolean { return this.closed; }
+
+    private request<T>(method: string, params: unknown): Promise<T> {
+        if (this.closed) {
+            return Promise.reject(new Error(`Daemon channel closed; cannot send ${method}`));
+        }
+        const id = this.nextId++;
+        const envelope: JsonRpcRequest = { jsonrpc: '2.0', id, method, params: params ?? null };
+        return new Promise<T>((resolve, reject) => {
+            this.pending.set(id, {
+                resolve: (v) => resolve(v as T),
+                reject,
+                method,
+            });
+            try {
+                this.stdin.write(encodeFrame(envelope));
+            } catch (err) {
+                this.pending.delete(id);
+                reject(err instanceof Error ? err : new Error(String(err)));
+            }
+        });
+    }
+
+    private notify(method: string, params: unknown): void {
+        if (this.closed) { return; }
+        const envelope: JsonRpcNotification = {
+            jsonrpc: '2.0',
+            method,
+            params: params === undefined ? null : params,
+        };
+        try {
+            this.stdin.write(encodeFrame(envelope));
+        } catch (err) {
+            this.fail(err instanceof Error ? err : new Error(String(err)));
+        }
+    }
+
+    private handleIncoming(json: string): void {
+        let msg: JsonRpcResponse | JsonRpcNotification;
+        try {
+            msg = JSON.parse(json);
+        } catch (err) {
+            this.logger.appendLine(`[daemon] dropped non-JSON message: ${(err as Error).message}`);
+            return;
+        }
+
+        if (typeof (msg as JsonRpcResponse).id === 'number') {
+            const response = msg as JsonRpcResponse;
+            const pending = this.pending.get(response.id);
+            if (!pending) {
+                this.logger.appendLine(`[daemon] response with no pending request: id=${response.id}`);
+                return;
+            }
+            this.pending.delete(response.id);
+            if (response.error) {
+                pending.reject(new DaemonRpcError(response.error));
+            } else {
+                pending.resolve(response.result ?? null);
+            }
+            return;
+        }
+
+        const notification = msg as JsonRpcNotification;
+        this.dispatchNotification(notification.method, notification.params);
+    }
+
+    private dispatchNotification(method: string, params: unknown): void {
+        switch (method) {
+            case 'discoveryUpdated':
+                this.events.onDiscoveryUpdated?.(params as DiscoveryUpdatedParams);
+                break;
+            case 'renderStarted':
+                this.events.onRenderStarted?.(params as RenderStartedParams);
+                break;
+            case 'renderFinished':
+                this.events.onRenderFinished?.(params as RenderFinishedParams);
+                break;
+            case 'renderFailed':
+                this.events.onRenderFailed?.(params as RenderFailedParams);
+                break;
+            case 'classpathDirty':
+                this.events.onClasspathDirty?.(params as ClasspathDirtyParams);
+                break;
+            case 'sandboxRecycle':
+                this.events.onSandboxRecycle?.(params as SandboxRecycleParams);
+                break;
+            case 'daemonWarming':
+                this.events.onDaemonWarming?.(params as DaemonWarmingParams);
+                break;
+            case 'daemonReady':
+                this.events.onDaemonReady?.();
+                break;
+            case 'log':
+                this.events.onLog?.(params as LogParams);
+                break;
+            default:
+                this.logger.appendLine(`[daemon] ignoring unknown notification: ${method}`);
+                break;
+        }
+    }
+
+    private fail(err?: Error): void {
+        if (this.closed) { return; }
+        this.closed = true;
+        const reason = err ?? new Error('Daemon channel closed');
+        for (const [, pending] of this.pending) {
+            pending.reject(reason);
+        }
+        this.pending.clear();
+        this.events.onChannelClosed?.(err);
+    }
+}

--- a/vscode-extension/src/daemon/daemonFraming.ts
+++ b/vscode-extension/src/daemon/daemonFraming.ts
@@ -1,0 +1,78 @@
+/**
+ * LSP-style `Content-Length` framing for the daemon's stdio JSON-RPC channel.
+ * See PROTOCOL.md § 1.
+ *
+ * Header bytes are ASCII; body bytes are UTF-8. Length counts UTF-8 bytes of
+ * the JSON payload (NOT characters). Multiple messages can arrive in a single
+ * chunk and a single message can arrive split across chunks — buffer until a
+ * full header + body is in hand.
+ */
+
+const HEADER_TERMINATOR = Buffer.from('\r\n\r\n', 'ascii');
+
+export interface FrameDecoderEvents {
+    onMessage: (json: string) => void;
+    onError: (err: Error) => void;
+}
+
+export class FrameDecoder {
+    private buffer: Buffer = Buffer.alloc(0);
+    private expectedBodyLength: number | null = null;
+
+    constructor(private readonly events: FrameDecoderEvents) {}
+
+    push(chunk: Buffer): void {
+        this.buffer = this.buffer.length === 0 ? chunk : Buffer.concat([this.buffer, chunk]);
+
+        // Loop because a single chunk may contain multiple complete frames.
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            if (this.expectedBodyLength === null) {
+                const headerEnd = this.buffer.indexOf(HEADER_TERMINATOR);
+                if (headerEnd < 0) { return; }
+                const headerText = this.buffer.subarray(0, headerEnd).toString('ascii');
+                this.buffer = this.buffer.subarray(headerEnd + HEADER_TERMINATOR.length);
+                const length = parseContentLength(headerText);
+                if (length === null) {
+                    this.events.onError(new Error(
+                        `Daemon framing: missing or invalid Content-Length header: ${headerText.trim()}`,
+                    ));
+                    // Drop the buffer; the channel is unrecoverable from here.
+                    this.buffer = Buffer.alloc(0);
+                    return;
+                }
+                this.expectedBodyLength = length;
+            }
+
+            if (this.buffer.length < this.expectedBodyLength) { return; }
+            const body = this.buffer.subarray(0, this.expectedBodyLength).toString('utf-8');
+            this.buffer = this.buffer.subarray(this.expectedBodyLength);
+            this.expectedBodyLength = null;
+            try {
+                this.events.onMessage(body);
+            } catch (err) {
+                this.events.onError(err instanceof Error ? err : new Error(String(err)));
+            }
+        }
+    }
+}
+
+function parseContentLength(headerText: string): number | null {
+    for (const line of headerText.split('\r\n')) {
+        const colon = line.indexOf(':');
+        if (colon < 0) { continue; }
+        const name = line.slice(0, colon).trim().toLowerCase();
+        if (name !== 'content-length') { continue; }
+        const value = line.slice(colon + 1).trim();
+        const n = parseInt(value, 10);
+        if (Number.isFinite(n) && n >= 0) { return n; }
+    }
+    return null;
+}
+
+/** Encodes a JSON object as a single LSP-framed message (Buffer ready for stdin). */
+export function encodeFrame(obj: unknown): Buffer {
+    const body = Buffer.from(JSON.stringify(obj), 'utf-8');
+    const header = Buffer.from(`Content-Length: ${body.length}\r\n\r\n`, 'ascii');
+    return Buffer.concat([header, body]);
+}

--- a/vscode-extension/src/daemon/daemonGate.ts
+++ b/vscode-extension/src/daemon/daemonGate.ts
@@ -1,0 +1,164 @@
+import * as vscode from 'vscode';
+import { GradleService } from '../gradleService';
+import { DaemonClient, DaemonClientEvents, DaemonClientLogger } from './daemonClient';
+import { readLaunchDescriptor, spawnDaemon, SpawnedDaemon } from './daemonProcess';
+
+const SETTING_ENABLED = 'experimental.daemon.enabled';
+
+/**
+ * Source-of-truth for "is the daemon path live for this user/workspace?"
+ *
+ * The daemon is opt-in via the `composePreview.experimental.daemon.enabled`
+ * setting (false by default — DESIGN.md § 1, "experimental design proposal").
+ * Even when enabled, the gate falls back to `gradleService.renderPreviews`
+ * whenever the daemon isn't healthy: descriptor missing, descriptor disabled
+ * by the build config, JVM died, classpath dirty, or RPC failed. Failures
+ * are logged but never thrown to the caller — the rest of the extension is
+ * unaware whether a render came from the daemon or from Gradle.
+ *
+ * One daemon per Gradle module (per `:samples:android`, etc.). Modules are
+ * spawned lazily on first use and shut down on extension dispose.
+ */
+export class DaemonGate {
+    private readonly daemons = new Map<string, ManagedDaemon>();
+    private disposed = false;
+
+    constructor(
+        private readonly workspaceRoot: string,
+        private readonly clientVersion: string,
+        private readonly logger: DaemonClientLogger,
+    ) {}
+
+    /** Reads the user setting freshly each time so toggles don't need a reload. */
+    isEnabled(): boolean {
+        return vscode.workspace
+            .getConfiguration('composePreview')
+            .get<boolean>(SETTING_ENABLED, false);
+    }
+
+    /**
+     * Returns a healthy daemon for [moduleId], spawning one if needed. Returns
+     * null when the daemon path isn't usable for this module — caller must
+     * fall back to [GradleService]. Reasons null is returned:
+     *   - Setting disabled.
+     *   - `daemon-launch.json` missing (consumer hasn't run
+     *     `composePreviewDaemonStart` yet, or the plugin isn't applied).
+     *   - Descriptor's `enabled: false` (user didn't opt in at the build level).
+     *   - Spawn failed.
+     */
+    async getOrSpawn(
+        moduleId: string,
+        events: DaemonClientEvents,
+    ): Promise<DaemonClient | null> {
+        if (this.disposed || !this.isEnabled()) { return null; }
+
+        const existing = this.daemons.get(moduleId);
+        if (existing && !existing.client.isClosed()) { return existing.client; }
+        if (existing && existing.client.isClosed()) {
+            this.daemons.delete(moduleId);
+        }
+
+        const descriptor = readLaunchDescriptor(this.workspaceRoot, moduleId, this.logger);
+        if (!descriptor) {
+            this.logger.appendLine(
+                `[daemon] no launch descriptor for ${moduleId}; ` +
+                `run :${moduleId.replace(/\//g, ':')}:composePreviewDaemonStart first`,
+            );
+            return null;
+        }
+        if (!descriptor.enabled) {
+            this.logger.appendLine(
+                `[daemon] descriptor for ${moduleId} has enabled=false; ` +
+                'set composePreview.experimental.daemon.enabled = true in build.gradle.kts',
+            );
+            return null;
+        }
+
+        try {
+            const composed = composeEvents(events, () => {
+                // On channel close drop the entry so the next caller spawns a
+                // fresh JVM. Avoid awaiting `exited` here — events fires as
+                // soon as the stream ends, exit code may lag by a tick.
+                this.daemons.delete(moduleId);
+            });
+            const spawned = await spawnDaemon({
+                workspaceRoot: this.workspaceRoot,
+                descriptor,
+                clientVersion: this.clientVersion,
+                events: composed,
+                logger: this.logger,
+            });
+            this.daemons.set(moduleId, { spawned, client: spawned.client });
+            this.logger.appendLine(
+                `[daemon] ready for ${moduleId} ` +
+                `(daemonVersion=${spawned.initializeResult.daemonVersion}, ` +
+                `pid=${spawned.initializeResult.pid}, ` +
+                `previews=${spawned.initializeResult.manifest.previewCount})`,
+            );
+            return spawned.client;
+        } catch (err) {
+            this.logger.appendLine(
+                `[daemon] spawn failed for ${moduleId}: ${(err as Error).message}`,
+            );
+            return null;
+        }
+    }
+
+    /**
+     * Ensures the consumer's `daemon-launch.json` exists by running the
+     * Gradle bootstrap task once per module. Cheap on subsequent calls
+     * (cacheable). Swallows failures — a missing descriptor on first launch
+     * just means we silently fall back to Gradle, which is the safe default.
+     */
+    async bootstrap(gradleService: GradleService, moduleId: string): Promise<void> {
+        if (!this.isEnabled()) { return; }
+        try {
+            await gradleService.runDaemonBootstrap(moduleId);
+        } catch (err) {
+            this.logger.appendLine(
+                `[daemon] bootstrap task failed for ${moduleId}: ${(err as Error).message}`,
+            );
+        }
+    }
+
+    async dispose(): Promise<void> {
+        this.disposed = true;
+        const entries = [...this.daemons.values()];
+        this.daemons.clear();
+        await Promise.all(entries.map(async (entry) => {
+            try {
+                if (!entry.client.isClosed()) {
+                    await Promise.race([
+                        entry.client.shutdown(),
+                        new Promise((resolve) => setTimeout(resolve, 2000)),
+                    ]);
+                    entry.client.exit();
+                }
+            } catch {
+                /* best-effort shutdown */
+            }
+            try { entry.spawned.process.kill('SIGTERM'); } catch { /* ignore */ }
+        }));
+    }
+}
+
+interface ManagedDaemon {
+    spawned: SpawnedDaemon;
+    client: DaemonClient;
+}
+
+/**
+ * Wraps the caller's events so we observe channel close ourselves (to
+ * evict from the registry) without losing the caller's handler.
+ */
+function composeEvents(
+    base: DaemonClientEvents,
+    onClose: (err?: Error) => void,
+): DaemonClientEvents {
+    return {
+        ...base,
+        onChannelClosed: (err) => {
+            try { base.onChannelClosed?.(err); } finally { onClose(err); }
+        },
+    };
+}

--- a/vscode-extension/src/daemon/daemonProcess.ts
+++ b/vscode-extension/src/daemon/daemonProcess.ts
@@ -1,0 +1,165 @@
+import { ChildProcess, spawn } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { DaemonClient, DaemonClientEvents, DaemonClientLogger } from './daemonClient';
+import {
+    DAEMON_DESCRIPTOR_SCHEMA_VERSION,
+    DaemonLaunchDescriptor,
+    InitializeResult,
+} from './daemonProtocol';
+
+/**
+ * Reads `<module>/build/compose-previews/daemon-launch.json` and returns the
+ * descriptor. Returns null when the file doesn't exist (the consumer hasn't
+ * run `composePreviewDaemonStart` yet, or the plugin doesn't apply), or when
+ * the schema version doesn't match what this extension knows how to read.
+ */
+export function readLaunchDescriptor(
+    workspaceRoot: string,
+    moduleId: string,
+    logger?: DaemonClientLogger,
+): DaemonLaunchDescriptor | null {
+    const file = path.join(
+        workspaceRoot, moduleId, 'build', 'compose-previews', 'daemon-launch.json',
+    );
+    if (!fs.existsSync(file)) { return null; }
+    try {
+        const raw = fs.readFileSync(file, 'utf-8');
+        const parsed = JSON.parse(raw) as DaemonLaunchDescriptor;
+        if (parsed.schemaVersion !== DAEMON_DESCRIPTOR_SCHEMA_VERSION) {
+            logger?.appendLine(
+                `[daemon] descriptor schema mismatch at ${file}: ` +
+                `got ${parsed.schemaVersion}, expected ${DAEMON_DESCRIPTOR_SCHEMA_VERSION}`,
+            );
+            return null;
+        }
+        return parsed;
+    } catch (err) {
+        logger?.appendLine(`[daemon] failed to read ${file}: ${(err as Error).message}`);
+        return null;
+    }
+}
+
+export interface SpawnedDaemon {
+    client: DaemonClient;
+    process: ChildProcess;
+    initializeResult: InitializeResult;
+    /** Resolves once the JVM has exited. */
+    exited: Promise<number | null>;
+}
+
+export interface SpawnOptions {
+    workspaceRoot: string;
+    descriptor: DaemonLaunchDescriptor;
+    clientVersion: string;
+    events: DaemonClientEvents;
+    logger?: DaemonClientLogger;
+    /** Defaults to `metrics: true, visibility: true`. */
+    capabilities?: { visibility: boolean; metrics: boolean };
+}
+
+/**
+ * Spawns the daemon JVM described by [descriptor], opens a [DaemonClient] over
+ * its stdio, and runs the `initialize` handshake. Resolves once the daemon
+ * acknowledged `initialize`; the caller can then send notifications and
+ * `renderNow` requests.
+ *
+ * Throws when:
+ *   - `descriptor.enabled === false` (the user hasn't opted in via
+ *     `composePreview { experimental { daemon { enabled = true } } }`),
+ *   - the JVM exits before `initialize` completes,
+ *   - `initialize` returns an error.
+ */
+export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
+    const { descriptor, clientVersion, events, workspaceRoot } = opts;
+    const logger = opts.logger;
+
+    if (!descriptor.enabled) {
+        throw new Error(
+            'Daemon disabled in build config: set composePreview.experimental.daemon.enabled = true',
+        );
+    }
+
+    const javaPath = descriptor.javaLauncher ?? findJavaOnPath();
+    if (!javaPath) {
+        throw new Error('No java executable: set javaLauncher via the toolchain or put java on PATH');
+    }
+
+    const sysProps = Object.entries(descriptor.systemProperties)
+        .map(([k, v]) => `-D${k}=${v}`);
+    const args = [
+        ...descriptor.jvmArgs,
+        ...sysProps,
+        '-cp',
+        descriptor.classpath.join(path.delimiter),
+        descriptor.mainClass,
+    ];
+
+    logger?.appendLine(
+        `[daemon] spawning ${descriptor.mainClass} for ${descriptor.modulePath} ` +
+        `(${descriptor.classpath.length} classpath entries, java=${javaPath})`,
+    );
+
+    const child = spawn(javaPath, args, {
+        cwd: descriptor.workingDirectory,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+    });
+
+    if (!child.stdin || !child.stdout || !child.stderr) {
+        throw new Error('Daemon spawn produced no stdio streams');
+    }
+
+    // Stderr is a free-form log channel per PROTOCOL.md § 1 — surface to the
+    // logger so daemon `System.err.println` lands in the user's output panel.
+    child.stderr.setEncoding('utf-8');
+    child.stderr.on('data', (chunk: string) => {
+        for (const line of chunk.split(/\r?\n/)) {
+            if (line.length > 0) { logger?.appendLine(`[daemon stderr] ${line}`); }
+        }
+    });
+
+    const exited = new Promise<number | null>((resolve) => {
+        child.on('exit', (code) => {
+            logger?.appendLine(`[daemon] process exited with code=${code}`);
+            resolve(code);
+        });
+    });
+
+    const client = new DaemonClient(child.stdin, child.stdout, events, logger);
+
+    let initializeResult: InitializeResult;
+    try {
+        initializeResult = await client.initialize({
+            clientVersion,
+            workspaceRoot,
+            moduleId: descriptor.modulePath,
+            moduleProjectDir: descriptor.workingDirectory,
+            capabilities: opts.capabilities ?? { visibility: true, metrics: true },
+        });
+    } catch (err) {
+        try { child.kill('SIGTERM'); } catch { /* ignore */ }
+        throw err;
+    }
+
+    client.initialized();
+    return { client, process: child, initializeResult, exited };
+}
+
+/**
+ * Best-effort lookup for a `java` binary on PATH. Used only when the launch
+ * descriptor's `javaLauncher` is null — typically AGP exposes a toolchain
+ * launcher and we never reach this path.
+ */
+function findJavaOnPath(): string | null {
+    const exe = process.platform === 'win32' ? 'java.exe' : 'java';
+    const dirs = (process.env.PATH ?? '').split(path.delimiter);
+    for (const dir of dirs) {
+        if (!dir) { continue; }
+        const candidate = path.join(dir, exe);
+        try {
+            if (fs.statSync(candidate).isFile()) { return candidate; }
+        } catch { /* skip */ }
+    }
+    return null;
+}

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -1,0 +1,185 @@
+/**
+ * TypeScript mirrors of the locked v1 protocol from
+ * `daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt`.
+ * Kept hand-rolled (no generator) so the round-trip golden fixtures under
+ * `docs/daemon/protocol-fixtures/` are the only authority both sides depend on.
+ *
+ * Spec: docs/daemon/PROTOCOL.md (v1).
+ */
+
+export const PROTOCOL_VERSION = 1;
+
+// JSON-RPC envelopes (PROTOCOL.md § 2)
+
+export interface JsonRpcRequest<P = unknown> {
+    jsonrpc: '2.0';
+    id: number;
+    method: string;
+    params?: P;
+}
+
+export interface JsonRpcResponse<R = unknown> {
+    jsonrpc: '2.0';
+    id: number;
+    result?: R;
+    error?: JsonRpcError;
+}
+
+export interface JsonRpcNotification<P = unknown> {
+    jsonrpc: '2.0';
+    method: string;
+    params?: P;
+}
+
+export interface JsonRpcError {
+    code: number;
+    message: string;
+    data?: { kind?: string } & Record<string, unknown>;
+}
+
+export const ERROR_PARSE = -32700;
+export const ERROR_INVALID_REQUEST = -32600;
+export const ERROR_METHOD_NOT_FOUND = -32601;
+export const ERROR_INVALID_PARAMS = -32602;
+export const ERROR_INTERNAL = -32603;
+export const ERROR_NOT_INITIALIZED = -32001;
+export const ERROR_CLASSPATH_DIRTY = -32002;
+export const ERROR_SANDBOX_RECYCLING = -32003;
+export const ERROR_UNKNOWN_PREVIEW = -32004;
+export const ERROR_RENDER_FAILED = -32005;
+
+// initialize (PROTOCOL.md § 3)
+
+export interface InitializeParams {
+    protocolVersion: number;
+    clientVersion: string;
+    workspaceRoot: string;
+    moduleId: string;
+    moduleProjectDir: string;
+    capabilities: { visibility: boolean; metrics: boolean };
+    options?: {
+        maxHeapMb?: number;
+        warmSpare?: boolean;
+        detectLeaks?: 'off' | 'light' | 'heavy';
+        foreground?: boolean;
+    };
+}
+
+export interface InitializeResult {
+    protocolVersion: number;
+    daemonVersion: string;
+    pid: number;
+    capabilities: {
+        incrementalDiscovery: boolean;
+        sandboxRecycle: boolean;
+        leakDetection: ('light' | 'heavy')[];
+    };
+    classpathFingerprint: string;
+    manifest: { path: string; previewCount: number };
+}
+
+// Client → daemon notifications (PROTOCOL.md § 4)
+
+export interface SetVisibleParams { ids: string[] }
+export interface SetFocusParams { ids: string[] }
+
+export type FileKind = 'source' | 'resource' | 'classpath';
+export type FileChangeType = 'modified' | 'created' | 'deleted';
+
+export interface FileChangedParams {
+    path: string;
+    kind: FileKind;
+    changeType: FileChangeType;
+}
+
+// Client → daemon requests (PROTOCOL.md § 5)
+
+export type RenderTier = 'fast' | 'full';
+
+export interface RenderNowParams {
+    previews: string[];
+    tier: RenderTier;
+    reason?: string;
+}
+
+export interface RenderNowResult {
+    queued: string[];
+    rejected: { id: string; reason: string }[];
+}
+
+// Daemon → client notifications (PROTOCOL.md § 6)
+
+export interface DiscoveryUpdatedParams {
+    added: unknown[];
+    removed: string[];
+    changed: unknown[];
+    totalPreviews: number;
+}
+
+export interface RenderStartedParams { id: string; queuedMs: number }
+
+export interface RenderMetrics {
+    heapAfterGcMb: number;
+    nativeHeapMb: number;
+    sandboxAgeRenders: number;
+    sandboxAgeMs: number;
+}
+
+export interface RenderFinishedParams {
+    id: string;
+    pngPath: string;
+    tookMs: number;
+    metrics?: RenderMetrics;
+}
+
+export interface RenderError {
+    kind: 'compile' | 'runtime' | 'capture' | 'timeout' | 'internal';
+    message: string;
+    stackTrace?: string;
+}
+
+export interface RenderFailedParams { id: string; error: RenderError }
+
+export interface ClasspathDirtyParams {
+    reason: 'fingerprintMismatch' | 'fileChanged' | 'manifestMissing';
+    detail: string;
+    changedPaths?: string[];
+}
+
+export interface SandboxRecycleParams {
+    reason: 'heapCeiling' | 'heapDrift' | 'renderTimeDrift' | 'histogramDrift'
+          | 'renderCount' | 'leakSuspected' | 'manual';
+    ageMs: number;
+    renderCount: number;
+    warmSpareReady: boolean;
+}
+
+export interface DaemonWarmingParams { etaMs: number }
+
+export interface LogParams {
+    level: 'debug' | 'info' | 'warn' | 'error';
+    message: string;
+    category?: string;
+    context?: Record<string, unknown>;
+}
+
+/**
+ * Wire format of `<module>/build/compose-previews/daemon-launch.json`,
+ * authored by `DaemonBootstrapTask`. See
+ * `gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonClasspathDescriptor.kt`.
+ */
+export interface DaemonLaunchDescriptor {
+    schemaVersion: number;
+    modulePath: string;
+    variant: string;
+    enabled: boolean;
+    mainClass: string;
+    javaLauncher: string | null;
+    classpath: string[];
+    jvmArgs: string[];
+    systemProperties: Record<string, string>;
+    workingDirectory: string;
+    manifestPath: string;
+}
+
+export const DAEMON_DESCRIPTOR_SCHEMA_VERSION = 1;

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -1,0 +1,271 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+import { DaemonClient } from './daemonClient';
+import { DaemonGate } from './daemonGate';
+import {
+    FileChangeType,
+    FileKind,
+    RenderFinishedParams,
+    RenderTier,
+} from './daemonProtocol';
+
+export interface SchedulerEvents {
+    /**
+     * A render finished and we resolved the on-disk PNG. Wire to the panel
+     * so the user's visible card swaps in the new image with sub-second
+     * latency on a hot Robolectric sandbox.
+     */
+    onPreviewImageReady: (
+        moduleId: string,
+        previewId: string,
+        imageBase64: string,
+        pngPath: string,
+    ) => void;
+    onRenderFailed: (moduleId: string, previewId: string, message: string) => void;
+    /**
+     * Daemon told us the classpath drifted (e.g. `libs.versions.toml`
+     * bumped). The daemon will exit shortly; the scheduler stops issuing
+     * renders for this module and the caller should re-run Gradle.
+     */
+    onClasspathDirty: (moduleId: string, detail: string) => void;
+}
+
+const HEAVY_TIER_DEFAULT: RenderTier = 'fast';
+/**
+ * Cards we'll pre-render ahead of the visible viewport on each scroll-ahead
+ * push from the webview. Bounded so a fast scroll past 50 cards doesn't
+ * stack 50 speculative renders — see PREDICTIVE.md § 4 (default 4).
+ */
+const SPECULATIVE_BUDGET = 4;
+
+/**
+ * Drives the daemon end of the editor loop:
+ *   - File saves → `fileChanged` notifications (Tier-2 trigger).
+ *   - Active editor change → `setFocus` for that file's previews.
+ *   - Webview reports visible card IDs and the next-page IDs it predicts
+ *     will scroll into view → `setVisible` plus speculative `renderNow`
+ *     calls bounded by [SPECULATIVE_BUDGET].
+ *   - Daemon `renderFinished` → load PNG, base64, hand to caller.
+ *
+ * The scheduler does not own the panel state; it speaks only in protocol
+ * primitives + image bytes. Wiring sits above in `extension.ts`.
+ *
+ * **History is intentionally out of scope here.** The user-facing history
+ * timeline ships separately and will key off `docs/daemon/HISTORY.md` once
+ * that design lands. Wire-up point: the `onPreviewImageReady` callback is
+ * the right hook for an additional "snapshot-on-render" sink — it already
+ * has the moduleId, previewId, and pngPath that a history archiver needs.
+ */
+export class DaemonScheduler {
+    /** Last-known-visible IDs per module — let us dedup setVisible spam. */
+    private lastVisible = new Map<string, string[]>();
+    /** Last `setFocus` per module so editor refocus on the same file is a no-op. */
+    private lastFocus = new Map<string, string[]>();
+    /** Cards we've already speculatively requested so scrolling back over
+     *  them doesn't re-queue identical work. Keyed by `${moduleId}::${id}`. */
+    private speculated = new Set<string>();
+
+    constructor(
+        private readonly gate: DaemonGate,
+        private readonly events: SchedulerEvents,
+        private readonly logger: { appendLine(s: string): void } = { appendLine() {} },
+    ) {}
+
+    /**
+     * Bring up the daemon for a module if necessary and ensure subsequent
+     * notifications go to the right client. Returns true iff a client is
+     * available (caller can use the daemon path); false means "fall back
+     * to Gradle for this module."
+     */
+    async ensureModule(moduleId: string): Promise<boolean> {
+        const client = await this.gate.getOrSpawn(moduleId, this.daemonEvents(moduleId));
+        return client !== null;
+    }
+
+    /**
+     * Called from the file-watcher / save events. The daemon classifies the
+     * file internally per PROTOCOL.md § 4; we send a hint based on the path.
+     */
+    async fileChanged(
+        moduleId: string,
+        absPath: string,
+        changeType: FileChangeType = 'modified',
+    ): Promise<void> {
+        const client = await this.gate.getOrSpawn(moduleId, this.daemonEvents(moduleId));
+        if (!client) { return; }
+        client.fileChanged({
+            path: absPath,
+            kind: classifyKind(absPath),
+            changeType,
+        });
+    }
+
+    /**
+     * The user moved focus to (or saved a file scoped to) a set of preview
+     * IDs. These are rendered first when the queue drains.
+     */
+    async setFocus(moduleId: string, previewIds: string[]): Promise<void> {
+        if (sameSet(this.lastFocus.get(moduleId), previewIds)) { return; }
+        this.lastFocus.set(moduleId, [...previewIds]);
+        const client = await this.gate.getOrSpawn(moduleId, this.daemonEvents(moduleId));
+        if (!client) { return; }
+        client.setFocus({ ids: previewIds });
+    }
+
+    /**
+     * Cards currently rendered in the panel (true geometric viewport, not
+     * just the file scope). The daemon uses this to filter Tier-3 stale sets
+     * — see DESIGN.md § 8 Tier 4. `predicted` are the IDs the webview
+     * believes the user is about to scroll into; speculative renders kick
+     * off for them up to [SPECULATIVE_BUDGET].
+     */
+    async setVisible(
+        moduleId: string,
+        visible: string[],
+        predicted: string[] = [],
+    ): Promise<void> {
+        if (sameSet(this.lastVisible.get(moduleId), visible) && predicted.length === 0) {
+            return;
+        }
+        this.lastVisible.set(moduleId, [...visible]);
+        const client = await this.gate.getOrSpawn(moduleId, this.daemonEvents(moduleId));
+        if (!client) { return; }
+        client.setVisible({ ids: visible });
+
+        if (predicted.length === 0) { return; }
+        // Bound the speculative request so a flick-scroll past 50 cards
+        // doesn't queue 50 renders. Visible IDs trump predicted ones —
+        // they're already in the daemon's reactive queue.
+        const visibleSet = new Set(visible);
+        const fresh = predicted
+            .filter(id => !visibleSet.has(id))
+            .filter(id => !this.speculated.has(specKey(moduleId, id)))
+            .slice(0, SPECULATIVE_BUDGET);
+        if (fresh.length === 0) { return; }
+        for (const id of fresh) { this.speculated.add(specKey(moduleId, id)); }
+        try {
+            await client.renderNow({
+                previews: fresh,
+                tier: HEAVY_TIER_DEFAULT,
+                reason: 'scroll-ahead',
+            });
+        } catch (err) {
+            this.logger.appendLine(
+                `[daemon] scroll-ahead renderNow failed for ${moduleId}: ${(err as Error).message}`,
+            );
+        }
+    }
+
+    /**
+     * Explicit user-triggered render (Refresh button / first scope-in).
+     * Returns when the daemon has accepted the work; the actual PNG arrives
+     * via `onPreviewImageReady`.
+     */
+    async renderNow(
+        moduleId: string,
+        previewIds: string[],
+        tier: RenderTier = 'fast',
+        reason?: string,
+    ): Promise<boolean> {
+        const client = await this.gate.getOrSpawn(moduleId, this.daemonEvents(moduleId));
+        if (!client) { return false; }
+        try {
+            const result = await client.renderNow({
+                previews: previewIds,
+                tier,
+                reason,
+            });
+            for (const r of result.rejected) {
+                this.logger.appendLine(`[daemon] renderNow rejected ${r.id}: ${r.reason}`);
+            }
+            return true;
+        } catch (err) {
+            this.logger.appendLine(
+                `[daemon] renderNow failed for ${moduleId}: ${(err as Error).message}`,
+            );
+            return false;
+        }
+    }
+
+    private daemonEvents(moduleId: string) {
+        return {
+            onRenderFinished: (params: RenderFinishedParams) => {
+                this.handleRenderFinished(moduleId, params);
+            },
+            onRenderFailed: (params: { id: string; error: { message: string } }) => {
+                this.events.onRenderFailed(moduleId, params.id, params.error.message);
+            },
+            onClasspathDirty: (params: { detail: string }) => {
+                // Drop the speculative cache for this module so a re-spawned
+                // daemon doesn't think we already pre-warmed those IDs.
+                for (const k of [...this.speculated]) {
+                    if (k.startsWith(`${moduleId}::`)) { this.speculated.delete(k); }
+                }
+                this.events.onClasspathDirty(moduleId, params.detail);
+            },
+            onChannelClosed: () => {
+                // Daemon died; clear caches so the next call re-issues them
+                // against a fresh JVM.
+                this.lastVisible.delete(moduleId);
+                this.lastFocus.delete(moduleId);
+                for (const k of [...this.speculated]) {
+                    if (k.startsWith(`${moduleId}::`)) { this.speculated.delete(k); }
+                }
+            },
+        };
+    }
+
+    private handleRenderFinished(moduleId: string, params: RenderFinishedParams): void {
+        try {
+            // Speculative entries graduate to "real" once they actually render —
+            // drop them from the dedup set so a subsequent fileChanged for the
+            // same preview can re-render via the reactive path.
+            this.speculated.delete(specKey(moduleId, params.id));
+
+            const buf = fs.readFileSync(params.pngPath);
+            this.events.onPreviewImageReady(
+                moduleId,
+                params.id,
+                buf.toString('base64'),
+                params.pngPath,
+            );
+        } catch (err) {
+            this.logger.appendLine(
+                `[daemon] failed to read ${params.pngPath} for ${params.id}: ${(err as Error).message}`,
+            );
+            this.events.onRenderFailed(
+                moduleId,
+                params.id,
+                'render finished but PNG was unreadable',
+            );
+        }
+    }
+}
+
+function classifyKind(absPath: string): FileKind {
+    const lower = absPath.toLowerCase();
+    if (
+        lower.endsWith('libs.versions.toml')
+        || lower.endsWith('.gradle.kts')
+        || lower.endsWith('gradle.properties')
+        || lower.endsWith('local.properties')
+        || lower.endsWith('settings.gradle.kts')
+    ) {
+        return 'classpath';
+    }
+    if (lower.includes(`${path.sep}res${path.sep}`) || lower.includes('/res/')) {
+        return 'resource';
+    }
+    return 'source';
+}
+
+function sameSet(a: string[] | undefined, b: string[]): boolean {
+    if (!a || a.length !== b.length) { return false; }
+    const set = new Set(a);
+    return b.every(id => set.has(id));
+}
+
+function specKey(moduleId: string, previewId: string): string {
+    return `${moduleId}::${previewId}`;
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -15,6 +15,8 @@ import { PreviewDoctorDiagnostics } from './previewDoctorDiagnostics';
 import { packageQualifiedSourcePath } from './sourcePath';
 import { HEAVY_COST_THRESHOLD, PreviewInfo } from './types';
 import { captureLabel } from './captureLabels';
+import { DaemonGate } from './daemon/daemonGate';
+import { DaemonScheduler } from './daemon/daemonScheduler';
 
 const DEBOUNCE_MS = 1500;
 // Edits to the currently-scoped preview file (e.g. Claude Code's Edit tool
@@ -25,6 +27,14 @@ const SCOPE_DEBOUNCE_MS = 300;
 const INIT_DELAY_MS = 1000;
 
 let gradleService: GradleService | null = null;
+let daemonGate: DaemonGate | null = null;
+let daemonScheduler: DaemonScheduler | null = null;
+/** Tracks the most recent preview set per module for daemon focus computation.
+ *  The daemon path doesn't re-issue `discoverPreviews` on every save — it
+ *  pushes `discoveryUpdated`. We mirror the latest snapshot here so save-
+ *  scoped focus signals can map "active file → preview IDs" without an
+ *  extension-side discovery round-trip. */
+const moduleManifestCache = new Map<string, PreviewInfo[]>();
 let panel: PreviewPanel | null = null;
 let debounceTimer: NodeJS.Timeout | null = null;
 let selectedModule: string | null = null;
@@ -162,6 +172,51 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         }
         return args;
     });
+
+    // Daemon path is opt-in via composePreview.experimental.daemon.enabled.
+    // When disabled (default) the gate's `isEnabled()` returns false and the
+    // scheduler is never asked to spawn anything — the existing Gradle path
+    // is the entire user-facing behaviour. When enabled, the scheduler runs
+    // *alongside* the existing refresh logic: saves and viewport changes push
+    // notifications to the daemon, the daemon emits renderFinished, and the
+    // extension forwards PNGs to the panel as they arrive (typically ahead
+    // of Gradle's `renderPreviews` on a hot sandbox). The Gradle path remains
+    // the safety net; if the daemon fails we silently fall back without any
+    // user-visible change.
+    daemonGate = new DaemonGate(workspaceRoot, '0.1.0', outputChannel);
+    daemonScheduler = new DaemonScheduler(daemonGate, {
+        onPreviewImageReady: (_moduleId, previewId, imageBase64) => {
+            if (!panel) { return; }
+            // Capture index 0 — the daemon's v1 renderFinished targets the
+            // representative capture only. Multi-capture (animated) renders
+            // still come through the Gradle path; the daemon's predictive
+            // pre-warm focuses on the cheap interactive loop.
+            panel.postMessage({
+                command: 'updateImage',
+                previewId,
+                captureIndex: 0,
+                imageData: imageBase64,
+            });
+        },
+        onRenderFailed: (_moduleId, previewId, message) => {
+            if (!panel) { return; }
+            panel.postMessage({
+                command: 'setImageError',
+                previewId,
+                captureIndex: 0,
+                message,
+            });
+        },
+        onClasspathDirty: (moduleId, detail) => {
+            outputChannel.appendLine(
+                `[daemon] classpath dirty for ${moduleId}: ${detail} — falling back to Gradle`,
+            );
+            // Daemon will exit on its own (PROTOCOL.md § 6); the channel-
+            // closed handler in DaemonGate evicts the entry. Next save runs
+            // Gradle, which re-bootstraps a fresh daemon when the user
+            // re-enables it via composePreviewDaemonStart.
+        },
+    }, outputChannel);
 
     panel = new PreviewPanel(context.extensionUri, handleWebviewMessage);
     if (isTestMode) {
@@ -348,6 +403,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     context.subscriptions.push(
         vscode.workspace.onDidSaveTextDocument(doc => {
             if (!isSourceFile(doc.uri.fsPath)) { return; }
+            // Side-channel: when the daemon path is enabled and healthy for
+            // this file's module, push a fileChanged notification + focused
+            // renderNow so the daemon can update the visible preview within
+            // its sub-second hot-sandbox latency budget. This runs alongside
+            // (not instead of) the Gradle refresh — the daemon's renderFinished
+            // typically arrives first; Gradle's slower full-fidelity pass
+            // backstops anything the daemon doesn't cover. When the daemon is
+            // disabled (default) `notifyDaemonOfSave` is a no-op.
+            void notifyDaemonOfSave(doc.uri.fsPath);
             if (!firstSaveSeen.has(doc.uri.fsPath) && !refreshInFlight && pendingSavePath === null) {
                 firstSaveSeen.add(doc.uri.fsPath);
                 invalidateModuleCache(doc.uri.fsPath);
@@ -422,6 +486,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
 export function deactivate() {
     if (debounceTimer) { clearTimeout(debounceTimer); }
     pendingRefresh?.abort();
+    // Drain any live daemon JVMs so the user doesn't end up with orphaned
+    // processes after a window close. Fire-and-forget — VS Code won't wait
+    // for an async deactivate beyond a few seconds anyway.
+    void daemonGate?.dispose();
 }
 
 function sameScope(a: string[], b: string[]): boolean {
@@ -495,6 +563,46 @@ function invalidateModuleCache(filePath: string): void {
     const module = gradleService.resolveModule(filePath);
     if (module) { gradleService.invalidateCache(module); }
 }
+
+/**
+ * Side-channel save handler that pushes a `fileChanged` + focus-scoped
+ * `renderNow` to the daemon when the daemon path is enabled and a daemon
+ * exists for this file's module. Runs alongside the Gradle refresh, never
+ * instead of it; the daemon's faster updateImage simply lands sooner. When
+ * the daemon is disabled or unhealthy, this is a complete no-op — the
+ * existing Gradle path is the entire user-facing behaviour.
+ */
+async function notifyDaemonOfSave(filePath: string): Promise<void> {
+    if (!daemonGate?.isEnabled() || !daemonScheduler || !gradleService) { return; }
+    const module = gradleService.resolveModule(filePath);
+    if (!module) { return; }
+
+    // First time we hit a module with the daemon enabled: kick the bootstrap
+    // task so daemon-launch.json exists. Cheap on subsequent calls (cacheable).
+    if (!daemonBootstrappedModules.has(module)) {
+        daemonBootstrappedModules.add(module);
+        await daemonGate.bootstrap(gradleService, module);
+    }
+
+    const ok = await daemonScheduler.ensureModule(module);
+    if (!ok) { return; }
+    await daemonScheduler.fileChanged(module, filePath);
+
+    // Focus scope = the saved file's previews, derived from the most recent
+    // manifest snapshot we got from Gradle's discoverPreviews. The daemon
+    // reads this for queue ordering — focused first. If we don't yet have a
+    // manifest for this module the focus call is skipped; the next refresh
+    // will populate moduleManifestCache.
+    const filterFile = packageQualifiedSourcePath(filePath);
+    const manifest = moduleManifestCache.get(module) ?? [];
+    const ids = manifest.filter(p => p.sourceFile === filterFile).map(p => p.id);
+    if (ids.length === 0) { return; }
+    await daemonScheduler.setFocus(module, ids);
+    await daemonScheduler.renderNow(module, ids, 'fast', 'save');
+}
+
+/** Per-extension-session memo so bootstrap runs once per module. */
+const daemonBootstrappedModules = new Set<string>();
 
 /**
  * Coalesce save-driven refreshes. The next refresh fires when BOTH:
@@ -678,6 +786,16 @@ async function refresh(
                 }
             }
             registry.replaceModule(mod, perModule);
+            // Mirror per-module previews for the daemon scheduler — the
+            // save side-channel uses this snapshot to translate "active
+            // file" into a list of preview IDs without an extension-side
+            // discovery round-trip. Cleared when the module's render
+            // returns no manifest (preview-set went empty).
+            if (manifest) {
+                moduleManifestCache.set(mod, perModule);
+            } else {
+                moduleManifestCache.delete(mod);
+            }
         }
 
         if (abort.signal.aborted) { return; }
@@ -856,6 +974,44 @@ function handleWebviewMessage(msg: WebviewToExtensionMessage) {
                 }
             }
             break;
+        case 'viewportUpdated':
+            // Daemon-only: route geometric visibility + scroll-ahead
+            // predictions to the scheduler so it can `setVisible` and
+            // queue speculative renders. When the daemon is disabled
+            // (default) `notifyDaemonViewport` is a no-op.
+            if (Array.isArray(msg.visible) && Array.isArray(msg.predicted)) {
+                void notifyDaemonViewport(msg.visible, msg.predicted);
+            }
+            break;
+    }
+}
+
+async function notifyDaemonViewport(visible: string[], predicted: string[]): Promise<void> {
+    if (!daemonGate?.isEnabled() || !daemonScheduler) { return; }
+    // Group by owning module — viewports cross module boundaries only when
+    // the user is paging across the all-modules view (rare today; the
+    // panel is module-scoped). Each module's daemon gets its own slice.
+    const visibleByModule = new Map<string, string[]>();
+    const predictedByModule = new Map<string, string[]>();
+    for (const id of visible) {
+        const mod = previewModuleMap.get(id);
+        if (!mod) { continue; }
+        if (!visibleByModule.has(mod)) { visibleByModule.set(mod, []); }
+        visibleByModule.get(mod)!.push(id);
+    }
+    for (const id of predicted) {
+        const mod = previewModuleMap.get(id);
+        if (!mod) { continue; }
+        if (!predictedByModule.has(mod)) { predictedByModule.set(mod, []); }
+        predictedByModule.get(mod)!.push(id);
+    }
+    const modules = new Set([...visibleByModule.keys(), ...predictedByModule.keys()]);
+    for (const mod of modules) {
+        await daemonScheduler.setVisible(
+            mod,
+            visibleByModule.get(mod) ?? [],
+            predictedByModule.get(mod) ?? [],
+        );
     }
 }
 
@@ -869,6 +1025,8 @@ interface WebviewToExtensionMessage {
     value?: string;
     previewId?: string;
     filename?: string;
+    visible?: string[];
+    predicted?: string[];
 }
 
 function sendHistoryList(previewId: string) {

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -519,6 +519,17 @@ export class GradleService {
         }
     }
 
+    /**
+     * Runs `:<module>:composePreviewDaemonStart` so the daemon launch
+     * descriptor (`build/compose-previews/daemon-launch.json`) is up to date.
+     * Cheap and cacheable — emits a small JSON. Called only when the daemon
+     * path is enabled (`composePreview.experimental.daemon.enabled`); the
+     * caller (DaemonGate) handles errors by falling back to Gradle.
+     */
+    async runDaemonBootstrap(module: string): Promise<void> {
+        await this.runTask(`${gradleProjectPath(module)}:composePreviewDaemonStart`);
+    }
+
     resolveModule(filePath: string): string | null {
         const relative = path.relative(this.workspaceRoot, filePath);
         if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -426,6 +426,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             drawer.className = 'history-drawer';
             drawer.hidden = true;
             card.appendChild(drawer);
+            observeCardForViewport(card);
             return card;
         }
 
@@ -859,6 +860,8 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             for (const [id, card] of existingCards) {
                 if (!newIds.has(id)) {
                     cardCaptures.delete(id);
+                    intersecting.delete(id);
+                    if (intersectionObserver) intersectionObserver.unobserve(card);
                     card.remove();
                 }
             }
@@ -1109,6 +1112,101 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         // re-read the list on every image (re)load without re-querying the
         // DOM for data attributes.
         const cardA11yFindings = new Map();
+
+        // ----- Viewport tracking (daemon scroll-ahead, PREDICTIVE.md § 7) -----
+        // Webview owns the geometry. Extension's daemon scheduler consumes
+        // the published snapshot; when the daemon path is off the extension
+        // simply ignores these messages.
+        const intersecting = new Set();
+        let lastScrollTop = 0;
+        let lastScrollAt = 0;
+        let scrollVelocity = 0; // px/ms, +ve = scrolling down
+        let viewportDebounce = null;
+
+        const intersectionObserver = ('IntersectionObserver' in window)
+            ? new IntersectionObserver((entries) => {
+                for (const entry of entries) {
+                    const id = entry.target.dataset.previewId;
+                    if (!id) continue;
+                    if (entry.isIntersecting) intersecting.add(id);
+                    else intersecting.delete(id);
+                }
+                scheduleViewportPublish();
+            }, { root: null, rootMargin: '0px', threshold: 0.1 })
+            : null;
+
+        function observeCardForViewport(card) {
+            if (intersectionObserver) intersectionObserver.observe(card);
+        }
+
+        function unobserveAllCards() {
+            if (!intersectionObserver) return;
+            intersecting.clear();
+            document.querySelectorAll('.preview-card').forEach(c => intersectionObserver.unobserve(c));
+        }
+
+        // Coalesce viewport publishes — IntersectionObserver fires per-card
+        // during a scroll burst; don't drown the daemon in setVisible spam.
+        function scheduleViewportPublish() {
+            if (viewportDebounce) return;
+            viewportDebounce = setTimeout(() => {
+                viewportDebounce = null;
+                publishViewport();
+            }, 120);
+        }
+
+        document.addEventListener('scroll', () => {
+            const now = performance.now();
+            const top = window.scrollY || document.documentElement.scrollTop || 0;
+            const dt = Math.max(1, now - lastScrollAt);
+            const dy = top - lastScrollTop;
+            // Light EMA so a single jittery frame doesn't flip the predicted set.
+            scrollVelocity = scrollVelocity * 0.4 + (dy / dt) * 0.6;
+            lastScrollAt = now;
+            lastScrollTop = top;
+            scheduleViewportPublish();
+        }, { passive: true });
+
+        // Project the next-page IDs based on scroll direction. Velocity is
+        // signed (px/ms): positive = scrolling down → predict cards below
+        // the lowest currently-visible card; negative = predict above.
+        function predictNextIds() {
+            if (Math.abs(scrollVelocity) < 0.05) return [];
+            const visibleCards = Array.from(document.querySelectorAll('.preview-card'))
+                .filter(c => intersecting.has(c.dataset.previewId)
+                    && !c.classList.contains('filtered-out'));
+            if (visibleCards.length === 0) return [];
+            const allCards = Array.from(document.querySelectorAll('.preview-card'))
+                .filter(c => !c.classList.contains('filtered-out'));
+            // Cards are in DOM order; pick the ones immediately ahead of the
+            // last visible (or before the first) up to a bounded count.
+            const PREDICT_AHEAD = 4;
+            const ids = [];
+            if (scrollVelocity > 0) {
+                const lastVisibleIdx = allCards.indexOf(visibleCards[visibleCards.length - 1]);
+                for (let i = lastVisibleIdx + 1; i < allCards.length && ids.length < PREDICT_AHEAD; i++) {
+                    const id = allCards[i].dataset.previewId;
+                    if (id && !intersecting.has(id)) ids.push(id);
+                }
+            } else {
+                const firstVisibleIdx = allCards.indexOf(visibleCards[0]);
+                for (let i = firstVisibleIdx - 1; i >= 0 && ids.length < PREDICT_AHEAD; i--) {
+                    const id = allCards[i].dataset.previewId;
+                    if (id && !intersecting.has(id)) ids.push(id);
+                }
+            }
+            return ids;
+        }
+
+        function publishViewport() {
+            const visible = Array.from(intersecting);
+            const predicted = predictNextIds();
+            vscode.postMessage({
+                command: 'viewportUpdated',
+                visible,
+                predicted,
+            });
+        }
 
         window.addEventListener('message', event => {
             const msg = event.data;

--- a/vscode-extension/src/test/daemonClient.test.ts
+++ b/vscode-extension/src/test/daemonClient.test.ts
@@ -1,0 +1,149 @@
+import * as assert from 'assert';
+import { PassThrough } from 'stream';
+import { DaemonClient, DaemonRpcError } from '../daemon/daemonClient';
+import { encodeFrame, FrameDecoder } from '../daemon/daemonFraming';
+import {
+    JsonRpcRequest,
+    PROTOCOL_VERSION,
+} from '../daemon/daemonProtocol';
+
+/**
+ * A lightweight bidirectional pair: client.stdin → toServer; toClient → client.stdout.
+ * Test code observes `toServer` for outbound traffic and writes responses /
+ * notifications via `toClient`.
+ */
+function bidiPair() {
+    const toServer = new PassThrough();
+    const toClient = new PassThrough();
+    return { toServer, toClient };
+}
+
+/** Drains decoded frames off `toServer` (what the client writes) into a queue. */
+function captureFrames(stream: PassThrough): { take(): Promise<unknown> } {
+    const queue: unknown[] = [];
+    const waiters: ((v: unknown) => void)[] = [];
+    const decoder = new FrameDecoder({
+        onMessage: (json) => {
+            const parsed = JSON.parse(json);
+            if (waiters.length > 0) { waiters.shift()!(parsed); }
+            else { queue.push(parsed); }
+        },
+        onError: (err) => assert.fail(err.message),
+    });
+    stream.on('data', (chunk: Buffer) => decoder.push(chunk));
+    return {
+        take(): Promise<unknown> {
+            if (queue.length > 0) { return Promise.resolve(queue.shift()!); }
+            return new Promise((resolve) => waiters.push(resolve));
+        },
+    };
+}
+
+describe('DaemonClient', () => {
+    it('sends initialize and resolves on response', async () => {
+        const { toServer, toClient } = bidiPair();
+        const frames = captureFrames(toServer);
+        const client = new DaemonClient(toServer, toClient, {});
+
+        const promise = client.initialize({
+            clientVersion: '0.0.0',
+            workspaceRoot: '/work',
+            moduleId: ':samples:android',
+            moduleProjectDir: '/work/samples/android',
+            capabilities: { visibility: true, metrics: true },
+        });
+
+        const sent = (await frames.take()) as JsonRpcRequest;
+        assert.strictEqual(sent.method, 'initialize');
+        assert.strictEqual((sent.params as { protocolVersion: number }).protocolVersion, PROTOCOL_VERSION);
+
+        // Server responds with an InitializeResult shaped object.
+        toClient.write(encodeFrame({
+            jsonrpc: '2.0',
+            id: sent.id,
+            result: {
+                protocolVersion: PROTOCOL_VERSION,
+                daemonVersion: '0.1.0',
+                pid: 4321,
+                capabilities: {
+                    incrementalDiscovery: false,
+                    sandboxRecycle: true,
+                    leakDetection: [],
+                },
+                classpathFingerprint: 'a'.repeat(64),
+                manifest: { path: '/m', previewCount: 0 },
+            },
+        }));
+
+        const result = await promise;
+        assert.strictEqual(result.daemonVersion, '0.1.0');
+        assert.strictEqual(result.pid, 4321);
+    });
+
+    it('rejects pending request with DaemonRpcError on error response', async () => {
+        const { toServer, toClient } = bidiPair();
+        const frames = captureFrames(toServer);
+        const client = new DaemonClient(toServer, toClient, {});
+
+        const p = client.renderNow({ previews: ['foo'], tier: 'fast' });
+        const req = (await frames.take()) as JsonRpcRequest;
+        toClient.write(encodeFrame({
+            jsonrpc: '2.0',
+            id: req.id,
+            error: { code: -32002, message: 'classpath dirty', data: { kind: 'ClasspathDirty' } },
+        }));
+
+        await assert.rejects(p, (err: Error) => {
+            return err instanceof DaemonRpcError
+                && err.message.includes('classpath dirty')
+                && (err as DaemonRpcError).rpc.code === -32002;
+        });
+    });
+
+    it('dispatches notifications to the right handler', async () => {
+        const { toServer, toClient } = bidiPair();
+        let renderFinishedCount = 0;
+        let lastPng = '';
+        const client = new DaemonClient(toServer, toClient, {
+            onRenderFinished: (params) => {
+                renderFinishedCount++;
+                lastPng = params.pngPath;
+            },
+        });
+        toClient.write(encodeFrame({
+            jsonrpc: '2.0',
+            method: 'renderFinished',
+            params: { id: 'p1', pngPath: '/tmp/a.png', tookMs: 42 },
+        }));
+        // Drain the writer queue + decoder microtasks before asserting.
+        await new Promise((r) => setImmediate(r));
+        assert.strictEqual(renderFinishedCount, 1);
+        assert.strictEqual(lastPng, '/tmp/a.png');
+        client.exit();
+    });
+
+    it('rejects in-flight requests when the channel closes', async () => {
+        const { toServer, toClient } = bidiPair();
+        let closedErr: Error | undefined;
+        const client = new DaemonClient(toServer, toClient, {
+            onChannelClosed: (err) => { closedErr = err; },
+        });
+        const p = client.shutdown();
+        toClient.end();
+        await assert.rejects(p);
+        // We end without an error so the close handler fires with no err arg.
+        assert.strictEqual(closedErr, undefined);
+        assert.strictEqual(client.isClosed(), true);
+    });
+
+    it('encodes a notification with no result tracking', async () => {
+        const { toServer, toClient } = bidiPair();
+        const frames = captureFrames(toServer);
+        const client = new DaemonClient(toServer, toClient, {});
+        client.setFocus({ ids: ['a', 'b'] });
+        const sent = (await frames.take()) as JsonRpcRequest;
+        assert.strictEqual(sent.method, 'setFocus');
+        assert.strictEqual((sent as unknown as { id?: number }).id, undefined);
+        assert.deepStrictEqual((sent.params as { ids: string[] }).ids, ['a', 'b']);
+    });
+});

--- a/vscode-extension/src/test/daemonClient.test.ts
+++ b/vscode-extension/src/test/daemonClient.test.ts
@@ -146,4 +146,160 @@ describe('DaemonClient', () => {
         assert.strictEqual((sent as unknown as { id?: number }).id, undefined);
         assert.deepStrictEqual((sent.params as { ids: string[] }).ids, ['a', 'b']);
     });
+
+    it('correlates out-of-order responses to the right pending request', async () => {
+        const { toServer, toClient } = bidiPair();
+        const frames = captureFrames(toServer);
+        const client = new DaemonClient(toServer, toClient, {});
+
+        // Two concurrent renderNow requests. Server responds to the
+        // SECOND one first to verify id-based correlation.
+        const p1 = client.renderNow({ previews: ['first'], tier: 'fast' });
+        const p2 = client.renderNow({ previews: ['second'], tier: 'fast' });
+        const r1 = (await frames.take()) as JsonRpcRequest;
+        const r2 = (await frames.take()) as JsonRpcRequest;
+
+        toClient.write(encodeFrame({
+            jsonrpc: '2.0', id: r2.id,
+            result: { queued: ['second'], rejected: [] },
+        }));
+        toClient.write(encodeFrame({
+            jsonrpc: '2.0', id: r1.id,
+            result: { queued: ['first'], rejected: [] },
+        }));
+
+        const [a, b] = await Promise.all([p1, p2]);
+        assert.deepStrictEqual(a.queued, ['first']);
+        assert.deepStrictEqual(b.queued, ['second']);
+    });
+
+    it('issues monotonically increasing ids', async () => {
+        const { toServer, toClient } = bidiPair();
+        const frames = captureFrames(toServer);
+        const client = new DaemonClient(toServer, toClient, {});
+        // Send three requests, never resolve them, just inspect the ids.
+        client.renderNow({ previews: [], tier: 'fast' });
+        client.renderNow({ previews: [], tier: 'fast' });
+        client.renderNow({ previews: [], tier: 'fast' });
+        const ids = [
+            ((await frames.take()) as JsonRpcRequest).id,
+            ((await frames.take()) as JsonRpcRequest).id,
+            ((await frames.take()) as JsonRpcRequest).id,
+        ];
+        assert.ok(ids[0] < ids[1] && ids[1] < ids[2], `ids not monotonic: ${ids.join(',')}`);
+    });
+
+    it('rejects new requests issued after the channel is closed', async () => {
+        const { toServer, toClient } = bidiPair();
+        const client = new DaemonClient(toServer, toClient, {});
+        toClient.end();
+        // Give Node a tick to propagate the 'end' event into the client.
+        await new Promise((r) => setImmediate(r));
+        await assert.rejects(
+            client.renderNow({ previews: [], tier: 'fast' }),
+            /closed/i,
+        );
+    });
+
+    it('silently drops notifications sent after the channel is closed', async () => {
+        const { toServer, toClient } = bidiPair();
+        const client = new DaemonClient(toServer, toClient, {});
+        toClient.end();
+        await new Promise((r) => setImmediate(r));
+        // Should not throw; no test assertion needed beyond "no exception."
+        client.setFocus({ ids: ['a'] });
+        client.fileChanged({ path: '/x.kt', kind: 'source', changeType: 'modified' });
+        client.exit();
+    });
+
+    it('drops unknown daemon notifications without erroring', async () => {
+        // PROTOCOL.md § 7: additive notifications must not break old clients.
+        // The dispatcher logs and continues — verifying via no exception
+        // and no handler invocation.
+        const { toServer, toClient } = bidiPair();
+        let sawAnyKnownEvent = false;
+        const client = new DaemonClient(toServer, toClient, {
+            onRenderFinished: () => { sawAnyKnownEvent = true; },
+        });
+        toClient.write(encodeFrame({
+            jsonrpc: '2.0',
+            method: 'futureMessage_v2',
+            params: { whatever: true },
+        }));
+        await new Promise((r) => setImmediate(r));
+        assert.strictEqual(sawAnyKnownEvent, false);
+        assert.strictEqual(client.isClosed(), false);
+        client.exit();
+    });
+
+    it('survives non-JSON garbage on the wire by dropping the message', async () => {
+        // The daemon SHOULDN'T emit invalid JSON, but if it does (e.g. a
+        // stray println from an undisciplined library) the client logs and
+        // keeps going — channel stays open.
+        const logs: string[] = [];
+        const { toServer, toClient } = bidiPair();
+        const client = new DaemonClient(toServer, toClient, {}, { appendLine: (s) => logs.push(s) });
+        // Send a syntactically valid LSP frame whose body is invalid JSON.
+        const body = Buffer.from('not-json-at-all', 'utf-8');
+        const header = Buffer.from(`Content-Length: ${body.length}\r\n\r\n`, 'ascii');
+        toClient.write(Buffer.concat([header, body]));
+        await new Promise((r) => setImmediate(r));
+        assert.strictEqual(client.isClosed(), false);
+        assert.ok(logs.some(l => l.includes('non-JSON')), `expected non-JSON log, got: ${logs.join(' / ')}`);
+        client.exit();
+    });
+
+    it('surfaces stray responses (no pending request) without crashing', async () => {
+        // Late or duplicate response after the request was already
+        // resolved. Logged and dropped.
+        const logs: string[] = [];
+        const { toServer, toClient } = bidiPair();
+        const client = new DaemonClient(toServer, toClient, {}, { appendLine: (s) => logs.push(s) });
+        toClient.write(encodeFrame({ jsonrpc: '2.0', id: 9999, result: null }));
+        await new Promise((r) => setImmediate(r));
+        assert.ok(logs.some(l => l.includes('no pending request')));
+        client.exit();
+    });
+
+    it('rejects all in-flight requests when stdout closes mid-flight', async () => {
+        const { toServer, toClient } = bidiPair();
+        const client = new DaemonClient(toServer, toClient, {});
+        const p1 = client.renderNow({ previews: ['a'], tier: 'fast' });
+        const p2 = client.shutdown();
+        toClient.destroy(new Error('pipe broken'));
+        await assert.rejects(p1, /pipe broken/);
+        await assert.rejects(p2, /pipe broken/);
+        assert.strictEqual(client.isClosed(), true);
+    });
+
+    it('initialize stamps protocolVersion = 1 and sends initialized after', async () => {
+        const { toServer, toClient } = bidiPair();
+        const frames = captureFrames(toServer);
+        const client = new DaemonClient(toServer, toClient, {});
+        const p = client.initialize({
+            clientVersion: '0.0.0',
+            workspaceRoot: '/w',
+            moduleId: ':m',
+            moduleProjectDir: '/w/m',
+            capabilities: { visibility: true, metrics: true },
+        });
+        const init = (await frames.take()) as JsonRpcRequest;
+        assert.strictEqual((init.params as { protocolVersion: number }).protocolVersion, PROTOCOL_VERSION);
+        toClient.write(encodeFrame({
+            jsonrpc: '2.0', id: init.id,
+            result: {
+                protocolVersion: PROTOCOL_VERSION,
+                daemonVersion: '0.1.0',
+                pid: 1,
+                capabilities: { incrementalDiscovery: false, sandboxRecycle: true, leakDetection: [] },
+                classpathFingerprint: '0'.repeat(64),
+                manifest: { path: '/m', previewCount: 0 },
+            },
+        }));
+        await p;
+        client.initialized();
+        const initd = (await frames.take()) as JsonRpcRequest;
+        assert.strictEqual(initd.method, 'initialized');
+        assert.strictEqual((initd as unknown as { id?: number }).id, undefined);
+    });
 });

--- a/vscode-extension/src/test/daemonFraming.test.ts
+++ b/vscode-extension/src/test/daemonFraming.test.ts
@@ -1,4 +1,6 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
 import { FrameDecoder, encodeFrame } from '../daemon/daemonFraming';
 
 describe('daemon framing', () => {
@@ -67,5 +69,89 @@ describe('daemon framing', () => {
         assert.strictEqual(messages.length, 0);
         assert.strictEqual(errors.length, 1);
         assert.match(errors[0].message, /Content-Length/);
+    });
+
+    it('handles a body that contains the header terminator literally', () => {
+        // The header terminator is `\r\n\r\n`. If a JSON body contains the
+        // same byte sequence (e.g. inside a string) the decoder MUST NOT
+        // treat it as the start of the next frame — Content-Length is the
+        // only authority for body boundaries.
+        const messages: string[] = [];
+        const decoder = new FrameDecoder({
+            onMessage: (json) => messages.push(json),
+            onError: () => assert.fail('no error expected'),
+        });
+        const payload = { method: 'embed', text: 'line1\r\n\r\nline2' };
+        decoder.push(encodeFrame(payload));
+        assert.strictEqual(messages.length, 1);
+        assert.deepStrictEqual(JSON.parse(messages[0]), payload);
+    });
+
+    it('accepts case-insensitive Content-Length header', () => {
+        // LSP framing canonicalises the header name as `Content-Length`, but
+        // RFC 7230 § 3.2 says HTTP headers are case-insensitive. Tolerate
+        // a daemon that emits it as `content-length:`.
+        const messages: string[] = [];
+        const decoder = new FrameDecoder({
+            onMessage: (json) => messages.push(json),
+            onError: () => assert.fail('no error expected'),
+        });
+        const body = Buffer.from('{"method":"x"}', 'utf-8');
+        const header = Buffer.from(`content-length: ${body.length}\r\n\r\n`, 'ascii');
+        decoder.push(Buffer.concat([header, body]));
+        assert.strictEqual(JSON.parse(messages[0]).method, 'x');
+    });
+
+    it('ignores an optional Content-Type header alongside Content-Length', () => {
+        // PROTOCOL.md § 1: Content-Type is optional and ignored by the reader.
+        const messages: string[] = [];
+        const decoder = new FrameDecoder({
+            onMessage: (json) => messages.push(json),
+            onError: () => assert.fail('no error expected'),
+        });
+        const body = Buffer.from('{"method":"y"}', 'utf-8');
+        const header = Buffer.from(
+            `Content-Length: ${body.length}\r\n` +
+            `Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n\r\n`,
+            'ascii',
+        );
+        decoder.push(Buffer.concat([header, body]));
+        assert.strictEqual(JSON.parse(messages[0]).method, 'y');
+    });
+
+    it('round-trips every shipped protocol fixture', () => {
+        // Encode each fixture, push the encoded bytes through the decoder,
+        // assert the decoded JSON matches. Catches regressions in encode
+        // (length miscounts) and decode (boundary mishandling) against the
+        // exact shapes the daemon uses on the wire.
+        const fixturesDir = path.resolve(__dirname, '..', '..', '..', 'docs', 'daemon', 'protocol-fixtures');
+        const files = fs.readdirSync(fixturesDir).filter(f => f.endsWith('.json') && !f.startsWith('README'));
+        assert.ok(files.length > 0, 'no fixtures found');
+
+        for (const file of files) {
+            const original = JSON.parse(fs.readFileSync(path.join(fixturesDir, file), 'utf-8'));
+            const messages: string[] = [];
+            const decoder = new FrameDecoder({
+                onMessage: (json) => messages.push(json),
+                onError: () => assert.fail(`framing error on fixture ${file}`),
+            });
+            decoder.push(encodeFrame(original));
+            assert.strictEqual(messages.length, 1, `fixture ${file} did not round-trip`);
+            assert.deepStrictEqual(JSON.parse(messages[0]), original, `fixture ${file} mutated`);
+        }
+    });
+
+    it('handles an empty-object payload (Content-Length: 2)', () => {
+        // The `daemonReady` notification carries `{}` as params — minimum
+        // legal body length. Make sure the decoder doesn't get stuck on
+        // sub-byte tracking.
+        const messages: string[] = [];
+        const decoder = new FrameDecoder({
+            onMessage: (json) => messages.push(json),
+            onError: () => assert.fail('no error expected'),
+        });
+        decoder.push(encodeFrame({}));
+        assert.strictEqual(messages.length, 1);
+        assert.deepStrictEqual(JSON.parse(messages[0]), {});
     });
 });

--- a/vscode-extension/src/test/daemonFraming.test.ts
+++ b/vscode-extension/src/test/daemonFraming.test.ts
@@ -1,0 +1,71 @@
+import * as assert from 'assert';
+import { FrameDecoder, encodeFrame } from '../daemon/daemonFraming';
+
+describe('daemon framing', () => {
+    it('round-trips a single message', () => {
+        const messages: string[] = [];
+        const errors: Error[] = [];
+        const decoder = new FrameDecoder({
+            onMessage: (json) => messages.push(json),
+            onError: (err) => errors.push(err),
+        });
+        const payload = { jsonrpc: '2.0', method: 'hello', params: { x: 1 } };
+        decoder.push(encodeFrame(payload));
+        assert.strictEqual(errors.length, 0);
+        assert.deepStrictEqual(JSON.parse(messages[0]), payload);
+    });
+
+    it('parses multiple messages in one chunk', () => {
+        const messages: string[] = [];
+        const decoder = new FrameDecoder({
+            onMessage: (json) => messages.push(json),
+            onError: () => assert.fail('no error expected'),
+        });
+        const a = encodeFrame({ method: 'a' });
+        const b = encodeFrame({ method: 'b' });
+        const c = encodeFrame({ method: 'c' });
+        decoder.push(Buffer.concat([a, b, c]));
+        const methods = messages.map(m => JSON.parse(m).method);
+        assert.deepStrictEqual(methods, ['a', 'b', 'c']);
+    });
+
+    it('reassembles a message split across chunks', () => {
+        const messages: string[] = [];
+        const decoder = new FrameDecoder({
+            onMessage: (json) => messages.push(json),
+            onError: () => assert.fail('no error expected'),
+        });
+        const full = encodeFrame({ method: 'split', params: { value: 'abcdef' } });
+        // Split mid-header, mid-body — both transition points.
+        for (let i = 0; i < full.length; i += 5) {
+            decoder.push(full.subarray(i, Math.min(i + 5, full.length)));
+        }
+        assert.strictEqual(messages.length, 1);
+        assert.strictEqual(JSON.parse(messages[0]).method, 'split');
+    });
+
+    it('counts UTF-8 bytes (not characters) in Content-Length', () => {
+        const messages: string[] = [];
+        const decoder = new FrameDecoder({
+            onMessage: (json) => messages.push(json),
+            onError: () => assert.fail('no error expected'),
+        });
+        // Multi-byte UTF-8 — emoji = 4 bytes, kanji = 3 bytes per character.
+        const payload = { method: 'i18n', text: '日本語🎉' };
+        decoder.push(encodeFrame(payload));
+        assert.strictEqual(JSON.parse(messages[0]).text, '日本語🎉');
+    });
+
+    it('reports a clear error on malformed header', () => {
+        const messages: string[] = [];
+        const errors: Error[] = [];
+        const decoder = new FrameDecoder({
+            onMessage: (json) => messages.push(json),
+            onError: (err) => errors.push(err),
+        });
+        decoder.push(Buffer.from('No-Length: bogus\r\n\r\nbody', 'ascii'));
+        assert.strictEqual(messages.length, 0);
+        assert.strictEqual(errors.length, 1);
+        assert.match(errors[0].message, /Content-Length/);
+    });
+});

--- a/vscode-extension/src/test/daemonIntegration.test.ts
+++ b/vscode-extension/src/test/daemonIntegration.test.ts
@@ -1,0 +1,259 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { PassThrough } from 'stream';
+import { DaemonClient } from '../daemon/daemonClient';
+import { encodeFrame, FrameDecoder } from '../daemon/daemonFraming';
+import {
+    InitializeParams,
+    JsonRpcRequest,
+    PROTOCOL_VERSION,
+    RenderNowParams,
+} from '../daemon/daemonProtocol';
+
+/**
+ * Tiny in-process fake daemon. Speaks the v1 wire format over the same kind
+ * of stdio pair that the real DaemonClient uses against a spawned JVM.
+ * Lets us exercise the whole framing + JSON-RPC + dispatch pipeline without
+ * actually launching Java.
+ */
+class FakeDaemon {
+    public readonly toClient: PassThrough;
+    public readonly fromClient: PassThrough;
+    public readonly seenRequests: JsonRpcRequest[] = [];
+    public readonly seenNotifications: { method: string; params: unknown }[] = [];
+
+    private readonly decoder: FrameDecoder;
+    private onInitialize: ((req: JsonRpcRequest) => void) | null = null;
+    private onRenderNow: ((req: JsonRpcRequest, params: RenderNowParams) => void) | null = null;
+
+    constructor() {
+        this.toClient = new PassThrough();
+        this.fromClient = new PassThrough();
+        this.decoder = new FrameDecoder({
+            onMessage: (json) => this.handle(JSON.parse(json)),
+            onError: (err) => assert.fail(`fake daemon framing: ${err.message}`),
+        });
+        this.fromClient.on('data', (chunk: Buffer) => this.decoder.push(chunk));
+    }
+
+    onInit(handler: (req: JsonRpcRequest) => void): void { this.onInitialize = handler; }
+    onRender(handler: (req: JsonRpcRequest, params: RenderNowParams) => void): void {
+        this.onRenderNow = handler;
+    }
+
+    sendNotification(method: string, params: unknown): void {
+        this.toClient.write(encodeFrame({ jsonrpc: '2.0', method, params }));
+    }
+
+    sendResult(id: number, result: unknown): void {
+        this.toClient.write(encodeFrame({ jsonrpc: '2.0', id, result }));
+    }
+
+    close(): void {
+        this.toClient.end();
+        this.fromClient.end();
+    }
+
+    private handle(msg: JsonRpcRequest | { jsonrpc: '2.0'; method: string; params: unknown }): void {
+        const m = msg as JsonRpcRequest;
+        if (typeof m.id === 'number') {
+            this.seenRequests.push(m);
+            if (m.method === 'initialize' && this.onInitialize) { this.onInitialize(m); }
+            else if (m.method === 'renderNow' && this.onRenderNow) {
+                this.onRenderNow(m, m.params as RenderNowParams);
+            } else if (m.method === 'shutdown') {
+                this.sendResult(m.id, null);
+            }
+        } else {
+            this.seenNotifications.push({ method: m.method, params: m.params });
+        }
+    }
+}
+
+function defaultInitResult(): unknown {
+    return {
+        protocolVersion: PROTOCOL_VERSION,
+        daemonVersion: '0.0.0-fake',
+        pid: 4321,
+        capabilities: {
+            incrementalDiscovery: false,
+            sandboxRecycle: true,
+            leakDetection: ['light'],
+        },
+        classpathFingerprint: 'a'.repeat(64),
+        manifest: { path: '/m', previewCount: 5 },
+    };
+}
+
+describe('daemon integration — fake daemon round trip', () => {
+    it('initialize → setVisible → renderNow → renderFinished → close', async () => {
+        const daemon = new FakeDaemon();
+        daemon.onInit((req) => daemon.sendResult(req.id, defaultInitResult()));
+
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'daemon-int-'));
+        try {
+            const pngPath = path.join(tmpDir, 'render.png');
+            const pngBytes = Buffer.from('PNG-bytes-stand-in', 'utf-8');
+            fs.writeFileSync(pngPath, pngBytes);
+
+            const finishedSeen: { id: string; pngPath: string }[] = [];
+            const startedSeen: string[] = [];
+            const client = new DaemonClient(daemon.fromClient, daemon.toClient, {
+                onRenderStarted: (p) => startedSeen.push(p.id),
+                onRenderFinished: (p) => finishedSeen.push({ id: p.id, pngPath: p.pngPath }),
+            });
+
+            // 1. initialize handshake
+            const initParams: Omit<InitializeParams, 'protocolVersion'> = {
+                clientVersion: '0.0.0',
+                workspaceRoot: '/w',
+                moduleId: ':m',
+                moduleProjectDir: '/w/m',
+                capabilities: { visibility: true, metrics: true },
+            };
+            const init = await client.initialize(initParams);
+            assert.strictEqual(init.daemonVersion, '0.0.0-fake');
+            client.initialized();
+
+            // 2. setVisible / setFocus notifications — verified by side
+            //    inspection in daemon.seenNotifications.
+            client.setVisible({ ids: ['p1', 'p2'] });
+            client.setFocus({ ids: ['p1'] });
+
+            // 3. renderNow → daemon responds with queued result, then
+            //    pushes renderStarted + renderFinished as a side-effect.
+            daemon.onRender((req, params) => {
+                daemon.sendResult(req.id, { queued: params.previews, rejected: [] });
+                daemon.sendNotification('renderStarted', { id: 'p1', queuedMs: 1 });
+                daemon.sendNotification('renderFinished', {
+                    id: 'p1',
+                    pngPath,
+                    tookMs: 99,
+                });
+            });
+            const result = await client.renderNow({ previews: ['p1'], tier: 'fast' });
+            assert.deepStrictEqual(result.queued, ['p1']);
+
+            // Microtask drain so the notifications dispatched on the
+            // toClient stream reach our handlers.
+            await new Promise((r) => setImmediate(r));
+            assert.deepStrictEqual(startedSeen, ['p1']);
+            assert.deepStrictEqual(finishedSeen, [{ id: 'p1', pngPath }]);
+
+            // 4. Wire-side assertions on what the daemon saw.
+            const methods = daemon.seenRequests.map((r) => r.method);
+            assert.deepStrictEqual(methods, ['initialize', 'renderNow']);
+            const notifMethods = daemon.seenNotifications.map((n) => n.method);
+            assert.deepStrictEqual(notifMethods, ['initialized', 'setVisible', 'setFocus']);
+
+            // 5. Clean shutdown — daemon resolves the request, client is
+            //    free to call exit() (a notification with no response).
+            await client.shutdown();
+            client.exit();
+            assert.ok(daemon.seenNotifications.some((n) => n.method === 'exit'));
+        } finally {
+            daemon.close();
+            fs.rmSync(tmpDir, { recursive: true });
+        }
+    });
+
+    it('survives the daemon emitting renderFailed instead of renderFinished', async () => {
+        const daemon = new FakeDaemon();
+        daemon.onInit((req) => daemon.sendResult(req.id, defaultInitResult()));
+        const failures: string[] = [];
+        const client = new DaemonClient(daemon.fromClient, daemon.toClient, {
+            onRenderFailed: (p) => failures.push(p.error.message),
+        });
+        try {
+            await client.initialize({
+                clientVersion: '0.0.0',
+                workspaceRoot: '/w',
+                moduleId: ':m',
+                moduleProjectDir: '/w/m',
+                capabilities: { visibility: true, metrics: true },
+            });
+            client.initialized();
+            daemon.onRender((req) => {
+                daemon.sendResult(req.id, { queued: ['p1'], rejected: [] });
+                daemon.sendNotification('renderFailed', {
+                    id: 'p1',
+                    error: { kind: 'runtime', message: 'NPE in composable' },
+                });
+            });
+            await client.renderNow({ previews: ['p1'], tier: 'fast' });
+            await new Promise((r) => setImmediate(r));
+            assert.deepStrictEqual(failures, ['NPE in composable']);
+        } finally {
+            daemon.close();
+        }
+    });
+
+    it('classpathDirty notification reaches the client and the channel stays open', async () => {
+        // PROTOCOL.md § 6: classpathDirty is delivered before the daemon
+        // exits within classpathDirtyGraceMs. Until the stream closes the
+        // client should still process notifications — for example, it's
+        // legal for the daemon to flush a final `log` before exiting.
+        const daemon = new FakeDaemon();
+        daemon.onInit((req) => daemon.sendResult(req.id, defaultInitResult()));
+        const dirtySeen: string[] = [];
+        const logsSeen: string[] = [];
+        const client = new DaemonClient(daemon.fromClient, daemon.toClient, {
+            onClasspathDirty: (p) => dirtySeen.push(p.detail),
+            onLog: (p) => logsSeen.push(p.message),
+        });
+        try {
+            await client.initialize({
+                clientVersion: '0.0.0',
+                workspaceRoot: '/w',
+                moduleId: ':m',
+                moduleProjectDir: '/w/m',
+                capabilities: { visibility: true, metrics: true },
+            });
+            client.initialized();
+            daemon.sendNotification('classpathDirty', {
+                reason: 'fingerprintMismatch',
+                detail: 'libs.versions.toml SHA changed',
+            });
+            daemon.sendNotification('log', {
+                level: 'info',
+                message: 'exiting in 2s',
+            });
+            await new Promise((r) => setImmediate(r));
+            assert.deepStrictEqual(dirtySeen, ['libs.versions.toml SHA changed']);
+            assert.deepStrictEqual(logsSeen, ['exiting in 2s']);
+        } finally {
+            daemon.close();
+        }
+    });
+
+    it('handles a rapid burst of renderFinished notifications without losing any', async () => {
+        // The render-watcher thread on the daemon side can emit notifications
+        // back-to-back; the framing layer must not coalesce or lose any.
+        const daemon = new FakeDaemon();
+        daemon.onInit((req) => daemon.sendResult(req.id, defaultInitResult()));
+        const seen: string[] = [];
+        const client = new DaemonClient(daemon.fromClient, daemon.toClient, {
+            onRenderFinished: (p) => seen.push(p.id),
+        });
+        try {
+            await client.initialize({
+                clientVersion: '0.0.0',
+                workspaceRoot: '/w',
+                moduleId: ':m',
+                moduleProjectDir: '/w/m',
+                capabilities: { visibility: true, metrics: true },
+            });
+            client.initialized();
+            const ids = Array.from({ length: 20 }, (_, i) => `p${i}`);
+            for (const id of ids) {
+                daemon.sendNotification('renderFinished', { id, pngPath: '/x.png', tookMs: 1 });
+            }
+            await new Promise((r) => setImmediate(r));
+            assert.deepStrictEqual(seen, ids);
+        } finally {
+            daemon.close();
+        }
+    });
+});

--- a/vscode-extension/src/test/daemonProcess.test.ts
+++ b/vscode-extension/src/test/daemonProcess.test.ts
@@ -1,0 +1,103 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { readLaunchDescriptor } from '../daemon/daemonProcess';
+import {
+    DAEMON_DESCRIPTOR_SCHEMA_VERSION,
+    DaemonLaunchDescriptor,
+} from '../daemon/daemonProtocol';
+
+function withTempWorkspace<T>(fn: (workspaceRoot: string) => T | Promise<T>): () => Promise<T> {
+    return async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'daemon-launch-'));
+        try {
+            return await fn(dir);
+        } finally {
+            fs.rmSync(dir, { recursive: true });
+        }
+    };
+}
+
+function writeDescriptor(workspaceRoot: string, moduleId: string, descriptor: object): string {
+    const dir = path.join(workspaceRoot, moduleId, 'build', 'compose-previews');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, 'daemon-launch.json');
+    fs.writeFileSync(file, JSON.stringify(descriptor));
+    return file;
+}
+
+function validDescriptor(): DaemonLaunchDescriptor {
+    return {
+        schemaVersion: DAEMON_DESCRIPTOR_SCHEMA_VERSION,
+        modulePath: ':samples:android',
+        variant: 'debug',
+        enabled: true,
+        mainClass: 'ee.schimke.composeai.daemon.DaemonMain',
+        javaLauncher: '/opt/jdk/bin/java',
+        classpath: ['/lib/a.jar'],
+        jvmArgs: ['-Xmx1024m'],
+        systemProperties: {},
+        workingDirectory: '/work',
+        manifestPath: '/work/build/compose-previews/previews.json',
+    };
+}
+
+describe('readLaunchDescriptor', () => {
+    it('returns null when the descriptor file does not exist', withTempWorkspace((dir) => {
+        const result = readLaunchDescriptor(dir, 'samples/android');
+        assert.strictEqual(result, null);
+    }));
+
+    it('parses a valid descriptor', withTempWorkspace((dir) => {
+        const descriptor = validDescriptor();
+        writeDescriptor(dir, 'samples/android', descriptor);
+        const result = readLaunchDescriptor(dir, 'samples/android');
+        assert.notStrictEqual(result, null);
+        assert.strictEqual(result!.modulePath, ':samples:android');
+        assert.strictEqual(result!.enabled, true);
+        assert.deepStrictEqual(result!.classpath, ['/lib/a.jar']);
+    }));
+
+    it('returns null on schema-version mismatch and logs the reason', withTempWorkspace((dir) => {
+        const logs: string[] = [];
+        const descriptor = { ...validDescriptor(), schemaVersion: 999 };
+        writeDescriptor(dir, 'samples/android', descriptor);
+        const result = readLaunchDescriptor(dir, 'samples/android', { appendLine: (s) => logs.push(s) });
+        assert.strictEqual(result, null);
+        assert.ok(
+            logs.some(l => l.includes('schema mismatch')),
+            `expected schema mismatch log, got: ${logs.join(' / ')}`,
+        );
+    }));
+
+    it('returns null on malformed JSON', withTempWorkspace((dir) => {
+        const logs: string[] = [];
+        const descriptorDir = path.join(dir, 'samples/android', 'build', 'compose-previews');
+        fs.mkdirSync(descriptorDir, { recursive: true });
+        fs.writeFileSync(path.join(descriptorDir, 'daemon-launch.json'), '{ not json');
+        const result = readLaunchDescriptor(dir, 'samples/android', { appendLine: (s) => logs.push(s) });
+        assert.strictEqual(result, null);
+        assert.ok(
+            logs.some(l => l.includes('failed to read')),
+            `expected parse failure log, got: ${logs.join(' / ')}`,
+        );
+    }));
+
+    it('preserves an explicit enabled=false flag without mutating it', withTempWorkspace((dir) => {
+        // The build can opt out via composePreview.experimental.daemon.enabled = false
+        // even with the VS Code setting on. Reader must return the descriptor
+        // honestly; the gate decides what to do with it.
+        const descriptor = { ...validDescriptor(), enabled: false };
+        writeDescriptor(dir, 'samples/android', descriptor);
+        const result = readLaunchDescriptor(dir, 'samples/android');
+        assert.strictEqual(result?.enabled, false);
+    }));
+
+    it('preserves a null javaLauncher (toolchain absent)', withTempWorkspace((dir) => {
+        const descriptor = { ...validDescriptor(), javaLauncher: null };
+        writeDescriptor(dir, 'samples/android', descriptor);
+        const result = readLaunchDescriptor(dir, 'samples/android');
+        assert.strictEqual(result?.javaLauncher, null);
+    }));
+});

--- a/vscode-extension/src/test/daemonProtocol.test.ts
+++ b/vscode-extension/src/test/daemonProtocol.test.ts
@@ -1,0 +1,115 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+    DAEMON_DESCRIPTOR_SCHEMA_VERSION,
+    DaemonLaunchDescriptor,
+    FileChangedParams,
+    InitializeParams,
+    InitializeResult,
+    PROTOCOL_VERSION,
+    RenderFinishedParams,
+    RenderNowParams,
+    RenderNowResult,
+    SetVisibleParams,
+} from '../daemon/daemonProtocol';
+
+/**
+ * Shared protocol fixtures live under `docs/daemon/protocol-fixtures/`. Both
+ * the Kotlin daemon test suite and this TypeScript suite parse the same files
+ * — adding a fixture in one ecosystem without the other is the kind of drift
+ * we want to catch (PROTOCOL.md § 9). Workspace layout: vscode-extension is
+ * at <repo>/vscode-extension, fixtures at <repo>/docs/daemon/protocol-fixtures.
+ */
+const FIXTURES_DIR = path.resolve(__dirname, '..', '..', '..', 'docs', 'daemon', 'protocol-fixtures');
+
+function readFixture<T>(name: string): T {
+    return JSON.parse(fs.readFileSync(path.join(FIXTURES_DIR, name), 'utf-8')) as T;
+}
+
+describe('daemon protocol — golden fixtures', () => {
+    it('parses client-initialize.json into InitializeParams shape', () => {
+        const params = readFixture<InitializeParams>('client-initialize.json');
+        assert.strictEqual(params.protocolVersion, PROTOCOL_VERSION);
+        assert.strictEqual(params.moduleId, ':samples:android');
+        assert.strictEqual(params.capabilities.visibility, true);
+        assert.strictEqual(params.capabilities.metrics, true);
+        assert.strictEqual(params.options?.detectLeaks, 'light');
+    });
+
+    it('parses daemon-initializeResult.json into InitializeResult shape', () => {
+        const result = readFixture<InitializeResult>('daemon-initializeResult.json');
+        assert.strictEqual(result.protocolVersion, PROTOCOL_VERSION);
+        assert.strictEqual(result.capabilities.sandboxRecycle, true);
+        assert.strictEqual(result.classpathFingerprint.length, 64);
+        assert.deepStrictEqual(result.capabilities.leakDetection, ['light', 'heavy']);
+    });
+
+    it('parses client-fileChanged.json with all required fields', () => {
+        const params = readFixture<FileChangedParams>('client-fileChanged.json');
+        assert.strictEqual(params.kind, 'source');
+        assert.strictEqual(params.changeType, 'modified');
+        assert.match(params.path, /\.kt$/);
+    });
+
+    it('parses client-setVisible.json into a string-array shape', () => {
+        const params = readFixture<SetVisibleParams>('client-setVisible.json');
+        assert.ok(Array.isArray(params.ids));
+        assert.ok(params.ids.length > 0);
+        for (const id of params.ids) { assert.strictEqual(typeof id, 'string'); }
+    });
+
+    it('parses daemon-renderFinished.json with metrics', () => {
+        const params = readFixture<RenderFinishedParams>('daemon-renderFinished.json');
+        assert.match(params.pngPath, /\.png$/);
+        assert.ok(params.tookMs > 0);
+        assert.ok(params.metrics);
+        assert.strictEqual(typeof params.metrics!.heapAfterGcMb, 'number');
+    });
+
+    it('parses daemon-renderNowResult.json — queued + rejected lists', () => {
+        const result = readFixture<RenderNowResult>('daemon-renderNowResult.json');
+        assert.ok(Array.isArray(result.queued));
+        assert.ok(Array.isArray(result.rejected));
+        assert.strictEqual(result.rejected[0].reason, 'unknown preview ID');
+    });
+
+    it('parses client-renderNow.json with tier=fast', () => {
+        const params = readFixture<RenderNowParams>('client-renderNow.json');
+        assert.strictEqual(params.tier, 'fast');
+        assert.ok(params.previews.length >= 1);
+    });
+});
+
+describe('daemon launch descriptor', () => {
+    it('rejects descriptors with mismatched schemaVersion', () => {
+        // The reader in daemonProcess.ts gates on DAEMON_DESCRIPTOR_SCHEMA_VERSION;
+        // the constant exists so callers can hard-fail rather than silently
+        // accept an incompatible JVM spec. The contract test here just pins
+        // the constant — bumping it is intentional and forces the gradle-plugin
+        // side to bump in lockstep.
+        assert.strictEqual(DAEMON_DESCRIPTOR_SCHEMA_VERSION, 1);
+    });
+
+    it('round-trips a synthetic descriptor', () => {
+        // Smoke test: TypeScript shape stays in sync with the Kotlin
+        // DaemonClasspathDescriptor data class. No tooling enforces this at
+        // compile time, so a trivial shape exercise here catches the most
+        // common drift (renamed field).
+        const desc: DaemonLaunchDescriptor = {
+            schemaVersion: DAEMON_DESCRIPTOR_SCHEMA_VERSION,
+            modulePath: ':samples:android',
+            variant: 'debug',
+            enabled: true,
+            mainClass: 'ee.schimke.composeai.daemon.DaemonMain',
+            javaLauncher: '/opt/jdk/bin/java',
+            classpath: ['/lib/a.jar', '/lib/b.jar'],
+            jvmArgs: ['-Xmx1024m'],
+            systemProperties: { 'composeai.history': '/tmp/history' },
+            workingDirectory: '/work',
+            manifestPath: '/work/build/compose-previews/previews.json',
+        };
+        const round = JSON.parse(JSON.stringify(desc)) as DaemonLaunchDescriptor;
+        assert.deepStrictEqual(round, desc);
+    });
+});

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -1,0 +1,104 @@
+import * as assert from 'assert';
+import { DaemonScheduler } from '../daemon/daemonScheduler';
+
+interface RecordedCall {
+    method: 'fileChanged' | 'setFocus' | 'setVisible' | 'renderNow';
+    args: unknown;
+}
+
+class FakeClient {
+    public calls: RecordedCall[] = [];
+    public closed = false;
+    public renderNowResult = { queued: ['x'], rejected: [] };
+
+    fileChanged(args: unknown): void { this.calls.push({ method: 'fileChanged', args }); }
+    setFocus(args: unknown): void { this.calls.push({ method: 'setFocus', args }); }
+    setVisible(args: unknown): void { this.calls.push({ method: 'setVisible', args }); }
+    renderNow(args: unknown): Promise<unknown> {
+        this.calls.push({ method: 'renderNow', args });
+        return Promise.resolve(this.renderNowResult);
+    }
+    isClosed(): boolean { return this.closed; }
+}
+
+class FakeGate {
+    public enabled = true;
+    public client: FakeClient | null = new FakeClient();
+    isEnabled(): boolean { return this.enabled; }
+    getOrSpawn(): Promise<FakeClient | null> { return Promise.resolve(this.client); }
+}
+
+function build() {
+    const gate = new FakeGate();
+    const log: string[] = [];
+    const events = {
+        onPreviewImageReady: () => { /* noop */ },
+        onRenderFailed: () => { /* noop */ },
+        onClasspathDirty: () => { /* noop */ },
+    };
+    // Cast: the scheduler's constructor accepts a DaemonGate; FakeGate has
+    // the same isEnabled/getOrSpawn surface area for the methods exercised
+    // here. The dispose/bootstrap/etc. surface isn't reached.
+    const scheduler = new DaemonScheduler(
+        gate as unknown as ConstructorParameters<typeof DaemonScheduler>[0],
+        events,
+        { appendLine: (s) => log.push(s) },
+    );
+    return { gate, scheduler, log };
+}
+
+describe('DaemonScheduler', () => {
+    it('dedupes setVisible when the visible set is unchanged', async () => {
+        const { gate, scheduler } = build();
+        await scheduler.setVisible('mod', ['a', 'b'], []);
+        await scheduler.setVisible('mod', ['a', 'b'], []); // no-op
+        await scheduler.setVisible('mod', ['b', 'a'], []); // same set, different order — still no-op
+        const visibleCalls = gate.client!.calls.filter(c => c.method === 'setVisible');
+        assert.strictEqual(visibleCalls.length, 1);
+    });
+
+    it('caps speculative renderNow at the budget', async () => {
+        const { gate, scheduler } = build();
+        const predicted = ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'];
+        await scheduler.setVisible('mod', ['v1'], predicted);
+        const renderCalls = gate.client!.calls.filter(c => c.method === 'renderNow');
+        assert.strictEqual(renderCalls.length, 1);
+        const params = renderCalls[0].args as { previews: string[]; tier: string };
+        assert.strictEqual(params.previews.length, 4);
+        assert.strictEqual(params.tier, 'fast');
+        // The four selected must be a prefix of `predicted` (preserves the
+        // webview's ranked-by-velocity order — see PREDICTIVE.md § 2).
+        assert.deepStrictEqual(params.previews, predicted.slice(0, 4));
+    });
+
+    it('does not re-speculate IDs already in the visible set', async () => {
+        const { gate, scheduler } = build();
+        await scheduler.setVisible('mod', ['a', 'b'], ['b', 'c', 'd']);
+        const renderCalls = gate.client!.calls.filter(c => c.method === 'renderNow');
+        assert.strictEqual(renderCalls.length, 1);
+        const params = renderCalls[0].args as { previews: string[] };
+        // 'b' is currently visible — daemon's reactive queue handles it. We
+        // only speculate 'c' and 'd'.
+        assert.deepStrictEqual(params.previews, ['c', 'd']);
+    });
+
+    it('skips daemon traffic entirely when the gate is disabled', async () => {
+        const { gate, scheduler } = build();
+        gate.enabled = false;
+        gate.client = null;
+        await scheduler.fileChanged('mod', '/x.kt');
+        await scheduler.setFocus('mod', ['a']);
+        await scheduler.setVisible('mod', ['a'], ['b']);
+    });
+
+    it('classifies file kinds for fileChanged', async () => {
+        const { gate, scheduler } = build();
+        await scheduler.fileChanged('mod', '/proj/src/main/kotlin/Foo.kt');
+        await scheduler.fileChanged('mod', '/proj/src/main/res/values/strings.xml');
+        await scheduler.fileChanged('mod', '/proj/gradle/libs.versions.toml');
+        const kinds = gate.client!.calls
+            .filter(c => c.method === 'fileChanged')
+            .map(c => (c.args as { kind: string }).kind);
+        assert.deepStrictEqual(kinds, ['source', 'resource', 'classpath']);
+    });
+});

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -1,4 +1,7 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { DaemonScheduler } from '../daemon/daemonScheduler';
 
 interface RecordedCall {
@@ -9,7 +12,8 @@ interface RecordedCall {
 class FakeClient {
     public calls: RecordedCall[] = [];
     public closed = false;
-    public renderNowResult = { queued: ['x'], rejected: [] };
+    public renderNowResult: { queued: string[]; rejected: { id: string; reason: string }[] } =
+        { queued: ['x'], rejected: [] };
 
     fileChanged(args: unknown): void { this.calls.push({ method: 'fileChanged', args }); }
     setFocus(args: unknown): void { this.calls.push({ method: 'setFocus', args }); }
@@ -21,30 +25,60 @@ class FakeClient {
     isClosed(): boolean { return this.closed; }
 }
 
+/**
+ * The scheduler hands the gate a DaemonClientEvents bag for each module.
+ * Tests need to drive `onRenderFinished` / `onRenderFailed` etc. into the
+ * scheduler from the daemon side; capturing the events bag lets us simulate
+ * the daemon without spinning up streams. Keyed by moduleId because the
+ * scheduler may register a different bag per module.
+ */
 class FakeGate {
     public enabled = true;
     public client: FakeClient | null = new FakeClient();
+    public capturedEvents = new Map<string, {
+        onRenderFinished?: (p: { id: string; pngPath: string; tookMs: number }) => void;
+        onRenderFailed?: (p: { id: string; error: { message: string } }) => void;
+        onClasspathDirty?: (p: { detail: string }) => void;
+        onChannelClosed?: () => void;
+    }>();
+
     isEnabled(): boolean { return this.enabled; }
-    getOrSpawn(): Promise<FakeClient | null> { return Promise.resolve(this.client); }
+    getOrSpawn(moduleId: string, events: unknown): Promise<FakeClient | null> {
+        this.capturedEvents.set(moduleId, events as never);
+        return Promise.resolve(this.client);
+    }
+}
+
+interface CapturedImage {
+    moduleId: string;
+    previewId: string;
+    base64: string;
+    pngPath: string;
 }
 
 function build() {
     const gate = new FakeGate();
     const log: string[] = [];
+    const images: CapturedImage[] = [];
+    const failures: { moduleId: string; previewId: string; message: string }[] = [];
+    const dirty: { moduleId: string; detail: string }[] = [];
     const events = {
-        onPreviewImageReady: () => { /* noop */ },
-        onRenderFailed: () => { /* noop */ },
-        onClasspathDirty: () => { /* noop */ },
+        onPreviewImageReady: (moduleId: string, previewId: string, base64: string, pngPath: string) => {
+            images.push({ moduleId, previewId, base64, pngPath });
+        },
+        onRenderFailed: (moduleId: string, previewId: string, message: string) => {
+            failures.push({ moduleId, previewId, message });
+        },
+        onClasspathDirty: (moduleId: string, detail: string) => {
+            dirty.push({ moduleId, detail });
+        },
     };
-    // Cast: the scheduler's constructor accepts a DaemonGate; FakeGate has
-    // the same isEnabled/getOrSpawn surface area for the methods exercised
-    // here. The dispose/bootstrap/etc. surface isn't reached.
     const scheduler = new DaemonScheduler(
         gate as unknown as ConstructorParameters<typeof DaemonScheduler>[0],
         events,
         { appendLine: (s) => log.push(s) },
     );
-    return { gate, scheduler, log };
+    return { gate, scheduler, log, images, failures, dirty };
 }
 
 describe('DaemonScheduler', () => {
@@ -82,6 +116,32 @@ describe('DaemonScheduler', () => {
         assert.deepStrictEqual(params.previews, ['c', 'd']);
     });
 
+    it('does not re-speculate IDs already speculated in this session', async () => {
+        // Scrolling back over cards we already pre-warmed shouldn't re-queue
+        // identical work; the daemon's reactive queue still handles them on
+        // actual focus.
+        const { gate, scheduler } = build();
+        await scheduler.setVisible('mod', ['v1'], ['p1', 'p2']);
+        await scheduler.setVisible('mod', ['v2'], ['p1', 'p2']); // same predictions
+        const renderCalls = gate.client!.calls.filter(c => c.method === 'renderNow');
+        // Only the first push generated a renderNow; the second was deduped.
+        assert.strictEqual(renderCalls.length, 1);
+    });
+
+    it('emits a renderNow even when visible is unchanged but predicted is fresh', async () => {
+        // The dedup check on `setVisible` fires only when there's no fresh
+        // predicted set; with predictions, the scheduler still considers
+        // them and may issue speculative renders even if visibility is the
+        // same set as last time.
+        const { gate, scheduler } = build();
+        await scheduler.setVisible('mod', ['v1'], []);
+        await scheduler.setVisible('mod', ['v1'], ['fresh1', 'fresh2']);
+        const renderCalls = gate.client!.calls.filter(c => c.method === 'renderNow');
+        assert.strictEqual(renderCalls.length, 1);
+        const params = renderCalls[0].args as { previews: string[] };
+        assert.deepStrictEqual(params.previews, ['fresh1', 'fresh2']);
+    });
+
     it('skips daemon traffic entirely when the gate is disabled', async () => {
         const { gate, scheduler } = build();
         gate.enabled = false;
@@ -89,6 +149,8 @@ describe('DaemonScheduler', () => {
         await scheduler.fileChanged('mod', '/x.kt');
         await scheduler.setFocus('mod', ['a']);
         await scheduler.setVisible('mod', ['a'], ['b']);
+        const ok = await scheduler.ensureModule('mod');
+        assert.strictEqual(ok, false);
     });
 
     it('classifies file kinds for fileChanged', async () => {
@@ -96,9 +158,107 @@ describe('DaemonScheduler', () => {
         await scheduler.fileChanged('mod', '/proj/src/main/kotlin/Foo.kt');
         await scheduler.fileChanged('mod', '/proj/src/main/res/values/strings.xml');
         await scheduler.fileChanged('mod', '/proj/gradle/libs.versions.toml');
+        await scheduler.fileChanged('mod', '/proj/build.gradle.kts');
+        await scheduler.fileChanged('mod', '/proj/gradle.properties');
         const kinds = gate.client!.calls
             .filter(c => c.method === 'fileChanged')
             .map(c => (c.args as { kind: string }).kind);
-        assert.deepStrictEqual(kinds, ['source', 'resource', 'classpath']);
+        assert.deepStrictEqual(kinds, ['source', 'resource', 'classpath', 'classpath', 'classpath']);
+    });
+
+    it('dedupes setFocus when ids are unchanged regardless of order', async () => {
+        const { gate, scheduler } = build();
+        await scheduler.setFocus('mod', ['a', 'b']);
+        await scheduler.setFocus('mod', ['b', 'a']);
+        const focusCalls = gate.client!.calls.filter(c => c.method === 'setFocus');
+        assert.strictEqual(focusCalls.length, 1);
+    });
+
+    it('reads the rendered PNG and forwards bytes via onPreviewImageReady', async () => {
+        const { gate, scheduler, images } = build();
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sched-'));
+        try {
+            const pngPath = path.join(tmpDir, 'preview.png');
+            const bytes = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]); // PNG magic
+            fs.writeFileSync(pngPath, bytes);
+
+            await scheduler.ensureModule('mod');
+            const evts = gate.capturedEvents.get('mod')!;
+            evts.onRenderFinished!({ id: 'p1', pngPath, tookMs: 200 });
+
+            assert.strictEqual(images.length, 1);
+            assert.strictEqual(images[0].previewId, 'p1');
+            assert.strictEqual(images[0].pngPath, pngPath);
+            assert.strictEqual(images[0].base64, bytes.toString('base64'));
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true });
+        }
+    });
+
+    it('reports onRenderFailed when the renderFinished PNG path is unreadable', async () => {
+        const { gate, scheduler, failures } = build();
+        await scheduler.ensureModule('mod');
+        const evts = gate.capturedEvents.get('mod')!;
+        evts.onRenderFinished!({ id: 'pZ', pngPath: '/no/such/file.png', tookMs: 1 });
+        assert.strictEqual(failures.length, 1);
+        assert.strictEqual(failures[0].previewId, 'pZ');
+        assert.match(failures[0].message, /unreadable/i);
+    });
+
+    it('forwards onRenderFailed from the daemon directly to the caller', async () => {
+        const { gate, scheduler, failures } = build();
+        await scheduler.ensureModule('mod');
+        const evts = gate.capturedEvents.get('mod')!;
+        evts.onRenderFailed!({ id: 'pX', error: { message: 'compile error' } });
+        assert.deepStrictEqual(failures, [{ moduleId: 'mod', previewId: 'pX', message: 'compile error' }]);
+    });
+
+    it('clears the speculation cache and visibility memo when the channel closes', async () => {
+        const { gate, scheduler } = build();
+        // Speculate first so the cache is populated.
+        await scheduler.setVisible('mod', ['v1'], ['p1', 'p2']);
+        const evts = gate.capturedEvents.get('mod')!;
+
+        // Channel close → the gate registry will replace the client. Pretend
+        // a fresh daemon spawned with a new client object.
+        const fresh = new FakeClient();
+        gate.client = fresh;
+        evts.onChannelClosed!();
+
+        // Same predictions on a fresh daemon should re-issue, not dedup.
+        await scheduler.setVisible('mod', ['v1'], ['p1', 'p2']);
+        const renderCalls = fresh.calls.filter(c => c.method === 'renderNow');
+        assert.strictEqual(renderCalls.length, 1, 'speculation cache survived channel close');
+    });
+
+    it('routes classpathDirty to the caller and drops the module speculation cache', async () => {
+        const { gate, scheduler, dirty } = build();
+        await scheduler.setVisible('mod', ['v1'], ['p1', 'p2']);
+        const evts = gate.capturedEvents.get('mod')!;
+        evts.onClasspathDirty!({ detail: 'libs.versions.toml SHA changed' });
+        assert.strictEqual(dirty.length, 1);
+        assert.strictEqual(dirty[0].moduleId, 'mod');
+    });
+
+    it('renderNow returns true on accept and false when no daemon is available', async () => {
+        const { gate, scheduler } = build();
+        const ok = await scheduler.renderNow('mod', ['p1'], 'fast');
+        assert.strictEqual(ok, true);
+
+        gate.enabled = false;
+        gate.client = null;
+        const fail = await scheduler.renderNow('mod2', ['p1'], 'fast');
+        assert.strictEqual(fail, false);
+    });
+
+    it('logs rejected previews from renderNow without throwing', async () => {
+        const { gate, scheduler, log } = build();
+        gate.client!.renderNowResult = {
+            queued: ['p1'],
+            rejected: [{ id: 'pBad', reason: 'unknown preview ID' }],
+        };
+        const ok = await scheduler.renderNow('mod', ['p1', 'pBad'], 'fast');
+        assert.strictEqual(ok, true);
+        assert.ok(log.some(l => l.includes('rejected pBad')), `expected rejected log, got: ${log.join(' / ')}`);
     });
 });

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -287,4 +287,16 @@ export type WebviewToExtension =
      * re-rendered. (A future per-preview filter would scope this to the
      * single previewId; today it falls back to a full-module render.)
      */
-    | { command: 'refreshHeavy'; previewId: string };
+    | { command: 'refreshHeavy'; previewId: string }
+    /**
+     * Webview reports current geometric visibility of preview cards plus
+     * cards it predicts will scroll into view next based on scroll velocity
+     * and direction. Consumed by the daemon scheduler — see
+     * `docs/daemon/PREDICTIVE.md` § 7 (v1.1 scroll-ahead). Ignored when the
+     * daemon path is disabled (the extension simply doesn't use the data).
+     *
+     * Both fields are full snapshots, not deltas — daemon dedups against the
+     * previous send. `predicted` excludes IDs already in `visible` because
+     * those are reactively rendered by the visible queue.
+     */
+    | { command: 'viewportUpdated'; visible: string[]; predicted: string[] };


### PR DESCRIPTION
Adds an experimental VS Code path that drives the preview daemon
(docs/daemon/PROTOCOL.md v1) alongside the existing Gradle render
path. Gated by composePreview.experimental.daemon.enabled (default
false); when off the extension behaves exactly as before — no daemon
code is invoked.

When enabled, the scheduler:
- pushes fileChanged + setFocus + renderNow on save so visible
  previews update within the daemon's hot-sandbox latency budget,
- forwards the webview's geometric viewport + scroll-velocity
  predictions as setVisible + bounded speculative renderNow calls
  (PREDICTIVE.md § 7 v1.1, capped at 4),
- forwards renderFinished PNGs straight to the panel's existing
  updateImage message, so daemon-rendered images land before the
  Gradle path completes; on daemon failure / classpathDirty / spawn
  miss, the existing Gradle path still runs unchanged.

Modules:
- vscode-extension/src/daemon/{daemonProtocol,daemonFraming,
  daemonClient,daemonProcess,daemonGate,daemonScheduler}.ts
- previewPanel.ts: IntersectionObserver + scroll-velocity tracker
  publishing viewportUpdated to the extension
- extension.ts: side-channel save/active-editor/viewport hooks that
  no-op when the gate is disabled
- gradleService.ts: new runDaemonBootstrap that runs the existing
  composePreviewDaemonStart task

Tests: 24 new (framing, golden fixtures shared with the Kotlin
suite, JSON-RPC client, scheduler dedup + scroll-ahead bounds);
108 total passing.

History timeline is intentionally out of scope and will key off
docs/daemon/HISTORY.md when that design lands; the
onPreviewImageReady callback is the wire-up point.