### PR TITLE
style: apply ktfmt across daemon modules and gradle-plugin

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/IncrementalDiscovery.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/IncrementalDiscovery.kt
@@ -20,20 +20,20 @@ import java.nio.file.Path
  *
  * **Pipeline** (see [DESIGN.md § 8 Tier 2](../../../../../../../docs/daemon/DESIGN.md)).
  *
- * 1. **Cheap pre-filter** — [cheapPrefilter] regex-greps the saved `.kt` file's text for
- *    `@Preview` (or any registered multi-preview meta-annotation FQN already in the index). If no
- *    match AND the file isn't currently in the preview-bearing set, the file definitely doesn't
- *    contribute previews and we can skip the scan entirely. ~1ms per save. Fail-safe: returns
- *    `true` on any I/O exception so a transient read error doesn't drop a real edit.
+ * 1. **Cheap pre-filter** — [cheapPrefilter] regex-greps the saved `.kt` file's text for `@Preview`
+ *    (or any registered multi-preview meta-annotation FQN already in the index). If no match AND
+ *    the file isn't currently in the preview-bearing set, the file definitely doesn't contribute
+ *    previews and we can skip the scan entirely. ~1ms per save. Fail-safe: returns `true` on any
+ *    I/O exception so a transient read error doesn't drop a real edit.
  * 2. **Scoped scan** — [scanForFile] runs ClassGraph filtered to the smallest classpath element
  *    containing the changed file's compiled `.class` output. Returns the previews this file
  *    currently contributes. Fail-safe: returns `emptySet` on scan failure (logged via stderr —
  *    free-form per [PROTOCOL.md § 1](../../../../../../../docs/daemon/PROTOCOL.md)).
  *
- * **Limitations.** v1 uses a path-substring heuristic for source `.kt` → classpath dir mapping
- * (see [classpathElementForFile]). When the heuristic misses, the scan falls back to the full
- * daemon classpath — correct, just slower. v2 (a follow-up; not in this commit) would source the
- * mapping from the launch descriptor.
+ * **Limitations.** v1 uses a path-substring heuristic for source `.kt` → classpath dir mapping (see
+ * [classpathElementForFile]). When the heuristic misses, the scan falls back to the full daemon
+ * classpath — correct, just slower. v2 (a follow-up; not in this commit) would source the mapping
+ * from the launch descriptor.
  *
  * **Multi-preview meta-annotations.** Users can define `@LightDarkPreviews` etc. that fan out to
  * multiple `@Preview`s. The plugin discovers these via `scanResult.getClassInfo(annName)` and
@@ -76,20 +76,20 @@ class IncrementalDiscovery(
    * known to contribute previews to [currentIndex]. Returning `true` means callers should escalate
    * to [scanForFile]; returning `false` means the save can be skipped entirely.
    *
-   * Fail-safe on I/O errors — returns `true` so a transient read failure can't silently drop a
-   * real edit.
+   * Fail-safe on I/O errors — returns `true` so a transient read failure can't silently drop a real
+   * edit.
    */
   fun cheapPrefilter(file: Path, currentIndex: PreviewIndex): Boolean {
     // Quick path: file currently contributes previews. The basename match guards against the
     // worst-case "absolute path" → "relative path" mismatch by also accepting suffix matches.
     val pathString = file.toString()
     val basename = file.fileName?.toString().orEmpty()
-    val indexedSourceFiles = currentIndex.snapshot().values.mapNotNullTo(HashSet()) { it.sourceFile }
-    val indexHit =
-      indexedSourceFiles.any { sourceFile ->
-        sourceFile == pathString ||
-          (basename.isNotEmpty() && (sourceFile == basename || sourceFile.endsWith("/$basename")))
-      }
+    val indexedSourceFiles =
+      currentIndex.snapshot().values.mapNotNullTo(HashSet()) { it.sourceFile }
+    val indexHit = indexedSourceFiles.any { sourceFile ->
+      sourceFile == pathString ||
+        (basename.isNotEmpty() && (sourceFile == basename || sourceFile.endsWith("/$basename")))
+    }
     if (indexHit) return true
 
     return try {
@@ -110,9 +110,9 @@ class IncrementalDiscovery(
    * The returned set's id field uses the same `<className>.<methodName>` form the gradle plugin
    * emits when no variant suffix is present, plus any `_<name>` / `_<group>` suffix needed to
    * disambiguate multi-preview expansions. We deliberately do NOT recompute the plugin's full
-   * variant suffix (device/fontScale/uiMode); the diff path only uses tracked fields, and adding
-   * a fresh preview variant via the daemon path is rare enough that picking up the new id on the
-   * next plugin-side full discovery is acceptable v1 behaviour.
+   * variant suffix (device/fontScale/uiMode); the diff path only uses tracked fields, and adding a
+   * fresh preview variant via the daemon path is rare enough that picking up the new id on the next
+   * plugin-side full discovery is acceptable v1 behaviour.
    *
    * Fail-safe: returns `emptySet` on any scan failure (and writes a stderr diagnostic).
    */
@@ -237,10 +237,10 @@ class IncrementalDiscovery(
   }
 
   /**
-   * Resolves the saved source `.kt` file to the smallest classpath element that holds its
-   * compiled `.class` output. Heuristic: walk classpath dirs (skipping JARs), pick the one whose
-   * absolute path overlaps with the source file's path components after a recognised source-set
-   * prefix (`src/main/kotlin/`, `src/<variant>/kotlin/`). Returns `null` when no dir overlaps.
+   * Resolves the saved source `.kt` file to the smallest classpath element that holds its compiled
+   * `.class` output. Heuristic: walk classpath dirs (skipping JARs), pick the one whose absolute
+   * path overlaps with the source file's path components after a recognised source-set prefix
+   * (`src/main/kotlin/`, `src/<variant>/kotlin/`). Returns `null` when no dir overlaps.
    *
    * v2 follow-up: the gradle plugin's `composePreviewDaemonStart` could emit a source-set →
    * classpath-dir mapping in its launch descriptor, removing the heuristic. Until then this is
@@ -251,13 +251,15 @@ class IncrementalDiscovery(
     val pathString = file.toString().replace('\\', '/')
     // Pull off the "src/<sourceSet>/kotlin/<rel>" tail; the `<rel>` is the package path the
     // compiler outputs into.
-    val idx = SOURCE_SET_PREFIXES.firstNotNullOfOrNull { prefix ->
-      val match = Regex("""/$prefix/(?<rel>.+\.kt)$""").find(pathString)
-      match?.groups?.get("rel")?.value
-    } ?: return null
+    val idx =
+      SOURCE_SET_PREFIXES.firstNotNullOfOrNull { prefix ->
+        val match = Regex("""/$prefix/(?<rel>.+\.kt)$""").find(pathString)
+        match?.groups?.get("rel")?.value
+      } ?: return null
 
     val withoutKt = idx.removeSuffix(".kt")
-    // `<package>/<filename>` — match against any classpath dir holding `<package>/<filename>Kt.class`
+    // `<package>/<filename>` — match against any classpath dir holding
+    // `<package>/<filename>Kt.class`
     // OR `<package>/<file's class without Kt>.class`.
     val packagePath = withoutKt.substringBeforeLast('/', missingDelimiterValue = "")
     return classpath

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -103,17 +103,17 @@ class JsonRpcServer(
    * source-compatible — the empty index reports `path = ""` and `previewCount = 0`, matching the
    * pre-B2.2 stub.
    *
-   * B2.2 phase 2 — the index is now mutable. `fileChanged({kind: source})` runs the
-   * cheap-prefilter → scoped-scan → diff → applyDiff cascade against [incrementalDiscovery] and
-   * emits `discoveryUpdated` when the diff is non-empty.
+   * B2.2 phase 2 — the index is now mutable. `fileChanged({kind: source})` runs the cheap-prefilter
+   * → scoped-scan → diff → applyDiff cascade against [incrementalDiscovery] and emits
+   * `discoveryUpdated` when the diff is non-empty.
    */
   private val previewIndex: PreviewIndex = PreviewIndex.empty(),
   /**
    * B2.2 phase 2 — when non-null, [handleFileChanged] for `kind: "source"` runs the cheap pre-
    * filter + scoped ClassGraph scan against this discovery instance, diffs against [previewIndex],
-   * applies the diff in-place, and emits `discoveryUpdated`. When null (the in-process
-   * integration tests, the pre-phase-2 default) the source path stays a classloader-swap-only
-   * no-op — same behaviour as before phase 2 landed.
+   * applies the diff in-place, and emits `discoveryUpdated`. When null (the in-process integration
+   * tests, the pre-phase-2 default) the source path stays a classloader-swap-only no-op — same
+   * behaviour as before phase 2 landed.
    */
   private val incrementalDiscovery: IncrementalDiscovery? = null,
   private val onExit: (Int) -> Unit = { code -> System.exit(code) },
@@ -339,7 +339,8 @@ class JsonRpcServer(
         manifest =
           Manifest(
             // B2.2 phase 1 — the daemon owns its preview index now. Path is the absolute path of
-            // the `previews.json` we loaded at startup ("" when no `composeai.daemon.previewsJsonPath`
+            // the `previews.json` we loaded at startup ("" when no
+            // `composeai.daemon.previewsJsonPath`
             // sysprop was supplied — fake-mode / in-process tests). B2.2 phase 2 keeps the count
             // live by mutating the index in-place from `discoveryUpdated` emissions; the path is
             // immutable for the daemon's lifetime.
@@ -522,13 +523,13 @@ class JsonRpcServer(
    * hosts that don't time their bodies pass `0L`.
    *
    * **B2.3 — structured [RenderMetrics].** When the host populates the four B2.3 keys
-   * (`heapAfterGcMb`, `nativeHeapMb`, `sandboxAgeRenders`, `sandboxAgeMs`) on
-   * `result.metrics`, [RenderMetrics.fromFlatMap] translates them into a structured
-   * [RenderMetrics] for the wire. A partial map (some but not all four keys) emits a warn-level
-   * `log` notification so drift is observable, and we still emit `metrics: null` — half-populated
-   * objects are misleading because callers cannot tell "field was zero" from "field was missing".
-   * Hosts that return `null` metrics (the B1.5-era stub hosts that don't measure anything) keep
-   * the pre-B2.3 `metrics: null` behaviour.
+   * (`heapAfterGcMb`, `nativeHeapMb`, `sandboxAgeRenders`, `sandboxAgeMs`) on `result.metrics`,
+   * [RenderMetrics.fromFlatMap] translates them into a structured [RenderMetrics] for the wire. A
+   * partial map (some but not all four keys) emits a warn-level `log` notification so drift is
+   * observable, and we still emit `metrics: null` — half-populated objects are misleading because
+   * callers cannot tell "field was zero" from "field was missing". Hosts that return `null` metrics
+   * (the B1.5-era stub hosts that don't measure anything) keep the pre-B2.3 `metrics: null`
+   * behaviour.
    */
   private fun renderFinishedFromResult(
     previewId: String,
@@ -590,22 +591,20 @@ class JsonRpcServer(
    * Routes a `fileChanged` notification.
    *
    * - **`kind: "source"`** (B2.0 + B2.2 phase 2):
-   *   1. Drops the strong reference to the host's current child classloader so the next render
-   *      lazily allocates a fresh [java.net.URLClassLoader] reading the recompiled bytecode off
-   *      disk (B2.0 — see
-   *      [CLASSLOADER.md](../../../../../../docs/daemon/CLASSLOADER.md)).
-   *   2. When [incrementalDiscovery] is wired, runs the cheap-prefilter → scoped-scan → diff →
-   *      applyDiff cascade on a worker thread and emits `discoveryUpdated` if the diff is
-   *      non-empty (B2.2 phase 2 —
-   *      [DESIGN § 8 Tier 2](../../../../../../docs/daemon/DESIGN.md)).
+   *     1. Drops the strong reference to the host's current child classloader so the next render
+   *        lazily allocates a fresh [java.net.URLClassLoader] reading the recompiled bytecode off
+   *        disk (B2.0 — see [CLASSLOADER.md](../../../../../../docs/daemon/CLASSLOADER.md)).
+   *     2. When [incrementalDiscovery] is wired, runs the cheap-prefilter → scoped-scan → diff →
+   *        applyDiff cascade on a worker thread and emits `discoveryUpdated` if the diff is
+   *        non-empty (B2.2 phase 2 — [DESIGN § 8 Tier 2](../../../../../../docs/daemon/DESIGN.md)).
    *
-   *   Honours the no-mid-render-cancellation invariant: both steps are queue-time events, not
-   *   preemption, so any in-flight render keeps using its already-resolved `Class<?>` and the
-   *   already-snapshotted `PreviewIndex`.
+   *    Honours the no-mid-render-cancellation invariant: both steps are queue-time events, not
+   *    preemption, so any in-flight render keeps using its already-resolved `Class<?>` and the
+   *    already-snapshotted `PreviewIndex`.
    * - **`kind: "classpath"`** → Tier-1 fingerprint cascade ([handleClasspathFileChanged]).
    * - **`kind: "resource"`** → conservative v1: would mark all previews stale, but the daemon does
-   *   not yet own its own preview index for resources, so this is a no-op for now. B2.0c lands
-   *   the smart variant (per-preview resource-read tracking).
+   *   not yet own its own preview index for resources, so this is a no-op for now. B2.0c lands the
+   *   smart variant (per-preview resource-read tracking).
    *
    * Hosts that don't participate in the parent/child split (the harness's `FakeHost`, the B1.3
    * stub) return `null` from [RenderHost.userClassloaderHolder]; the swap is then skipped.
@@ -633,14 +632,14 @@ class JsonRpcServer(
    * source-file `fileChanged` notification, applies the resulting diff in-place to [previewIndex],
    * and emits `discoveryUpdated` if non-empty.
    *
-   * Runs the heavy work on a fresh daemon thread so the JSON-RPC read loop never blocks on a
-   * scan. Mirrors the fire-and-forget pattern [submitRenderAsync] uses for renders. We
-   * deliberately pick a fresh thread (rather than reusing an executor) for symmetry with the
-   * render path; saved-file events arrive O(seconds) apart in a typical save loop, so the cost of
-   * one short-lived `Thread` per save is negligible compared to a ClassGraph scan.
+   * Runs the heavy work on a fresh daemon thread so the JSON-RPC read loop never blocks on a scan.
+   * Mirrors the fire-and-forget pattern [submitRenderAsync] uses for renders. We deliberately pick
+   * a fresh thread (rather than reusing an executor) for symmetry with the render path; saved-file
+   * events arrive O(seconds) apart in a typical save loop, so the cost of one short-lived `Thread`
+   * per save is negligible compared to a ClassGraph scan.
    *
-   * No-op when [incrementalDiscovery] is null — preserves the pre-phase-2 contract for
-   * in-process integration tests.
+   * No-op when [incrementalDiscovery] is null — preserves the pre-phase-2 contract for in-process
+   * integration tests.
    */
   private fun runIncrementalDiscovery(path: String) {
     val discovery = incrementalDiscovery ?: return

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
@@ -16,9 +16,9 @@ import kotlinx.serialization.json.Json
  * `:daemon:core` from depending on `:gradle-plugin`. The plugin owns the authoritative
  * [PreviewInfo] type (`gradle-plugin/.../PreviewData.kt`) and writes it to disk via
  * kotlinx-serialization; the daemon parses the same JSON shape with this minimal mirror, capturing
- * only the fields the daemon actually needs. Extra fields the plugin emits (params block,
- * captures list, accessibility report pointer, …) are ignored at parse time via
- * `ignoreUnknownKeys`, so adding new plugin-side fields does NOT break the daemon's parser.
+ * only the fields the daemon actually needs. Extra fields the plugin emits (params block, captures
+ * list, accessibility report pointer, …) are ignored at parse time via `ignoreUnknownKeys`, so
+ * adding new plugin-side fields does NOT break the daemon's parser.
  *
  * **Why duplicate instead of share.** Sharing the type would either pull `:gradle-plugin` onto the
  * daemon's classpath (heavy, and a layering inversion) or carve a third "shared protocol" module
@@ -67,8 +67,8 @@ private data class PreviewManifestDto(val previews: List<PreviewInfoDto> = empty
 
 /**
  * Diff produced by [PreviewIndex.diff] — what changed between the cached index and a fresh scan
- * scoped to one source file. Mirrors the wire shape of `discoveryUpdated`
- * ([PROTOCOL.md § 6](../../../../../../../docs/daemon/PROTOCOL.md)).
+ * scoped to one source file. Mirrors the wire shape of `discoveryUpdated` ([PROTOCOL.md §
+ * 6](../../../../../../../docs/daemon/PROTOCOL.md)).
  */
 data class DiscoveryDiff(
   /** Previews present in the new scan but not in the cached index. */
@@ -91,8 +91,8 @@ fun discoveryDiffEmpty(diff: DiscoveryDiff): Boolean =
 /**
  * In-memory preview index owned by the daemon.
  *
- * **B2.2 phase 1.** The daemon parses `previews.json` once at startup and exposes the resulting
- * map for `initialize.manifest.{path, previewCount}`.
+ * **B2.2 phase 1.** The daemon parses `previews.json` once at startup and exposes the resulting map
+ * for `initialize.manifest.{path, previewCount}`.
  *
  * **B2.2 phase 2.** The index is now mutable — [diff] computes the delta against a freshly-scanned
  * `Set<PreviewInfoDto>` for one source file, and [applyDiff] merges that delta in-place. Reads use
@@ -127,15 +127,17 @@ internal constructor(
   /** All known preview ids. Phase 2 will diff a fresh scan against this set. */
   fun ids(): Set<String> = lock.read { byId.keys.toSet() }
 
-  /** Snapshot of the current `id → PreviewInfoDto` map. Not live; safe to iterate without locking. */
+  /**
+   * Snapshot of the current `id → PreviewInfoDto` map. Not live; safe to iterate without locking.
+   */
   fun snapshot(): Map<String, PreviewInfoDto> = lock.read { LinkedHashMap(byId) }
 
   /**
    * Computes a [DiscoveryDiff] for one source file.
    *
    * - `added` = previews in [newScanForFile] whose id is NOT currently in the index.
-   * - `removed` = ids in the current index whose `sourceFile == sourceFile.toString()` AND that
-   *   are absent from [newScanForFile].
+   * - `removed` = ids in the current index whose `sourceFile == sourceFile.toString()` AND that are
+   *   absent from [newScanForFile].
    * - `changed` = ids present in both, but whose [PreviewInfoDto] differs by `==`.
    * - `totalPreviews` = the index's size AFTER applying the diff (so callers can emit it on the
    *   wire without a second lookup).
@@ -158,12 +160,7 @@ internal constructor(
       // Compute the post-update size: start with current, drop removed, add additions.
       // Changed entries don't move the count.
       val newTotal = byId.size - removed.size + added.size
-      DiscoveryDiff(
-        added = added,
-        removed = removed,
-        changed = changed,
-        totalPreviews = newTotal,
-      )
+      DiscoveryDiff(added = added, removed = removed, changed = changed, totalPreviews = newTotal)
     }
   }
 
@@ -185,8 +182,8 @@ internal constructor(
   companion object {
     /**
      * The empty placeholder. Used when no `composeai.daemon.previewsJsonPath` was supplied — e.g.
-     * fake-mode harness scenarios, the in-process integration tests, the pre-B2.2 default.
-     * `path = null`, `size = 0`.
+     * fake-mode harness scenarios, the in-process integration tests, the pre-B2.2 default. `path =
+     * null`, `size = 0`.
      */
     fun empty(): PreviewIndex = PreviewIndex(path = null, initial = emptyMap())
 
@@ -200,8 +197,8 @@ internal constructor(
 
     /**
      * Parses [path] as a plugin-emitted `previews.json` and returns an index over its `previews`
-     * array. Returns [empty] (and prints a warn-level diagnostic to stderr) if the file is
-     * missing, unreadable, or malformed; never throws.
+     * array. Returns [empty] (and prints a warn-level diagnostic to stderr) if the file is missing,
+     * unreadable, or malformed; never throws.
      */
     fun loadFromFile(path: Path): PreviewIndex {
       val absolute = path.toAbsolutePath()
@@ -242,8 +239,8 @@ internal constructor(
     /**
      * System property the per-target [DaemonMain] reads to locate `previews.json`. The gradle
      * plugin emits this as part of `composePreviewDaemonStart`'s descriptor (see
-     * [DaemonClasspathDescriptor.systemProperties]); when unset, the daemon comes up with
-     * [empty] — preserves pre-B2.2 in-process / fake-mode behaviour.
+     * [DaemonClasspathDescriptor.systemProperties]); when unset, the daemon comes up with [empty] —
+     * preserves pre-B2.2 in-process / fake-mode behaviour.
      */
     const val PREVIEWS_JSON_PATH_PROP: String = "composeai.daemon.previewsJsonPath"
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -8,9 +8,8 @@ import java.util.concurrent.atomic.AtomicLong
  *
  * One implementation per backend:
  *
- * - `RobolectricHost` (in `:daemon:android`) holds a Robolectric sandbox open via the
- *   dummy-`@Test` runner trick (DESIGN.md § 9) and bridges work across the sandbox classloader
- *   boundary.
+ * - `RobolectricHost` (in `:daemon:android`) holds a Robolectric sandbox open via the dummy-`@Test`
+ *   runner trick (DESIGN.md § 9) and bridges work across the sandbox classloader boundary.
  * - `DesktopHost` (planned, in `:daemon:desktop`, Stream B-desktop) holds a long-lived
  *   `Recomposer` + Skiko `Surface` warm.
  *
@@ -102,13 +101,13 @@ sealed interface RenderRequest {
  * load-bearing daemon invariant).
  *
  * `pngPath` and `metrics` are populated by hosts that actually render bytes (`FakeHost` in
- * `:daemon:harness`, `DesktopHost`/`RobolectricHost` once their B1.4 render-engine bodies
- * land). They map directly onto the
- * [`renderFinished`](../../docs/daemon/PROTOCOL.md#renderfinished) wire shape: `pngPath` becomes
- * `renderFinished.pngPath`; `metrics` becomes a flat `renderFinished.metrics` (numeric counters;
- * the structured `RenderMetrics` shape is filled in by B2.3 once the daemon tracks heap /
- * sandbox-age etc.). Both default to `null` so the B1.5-era stub paths in
- * `JsonRpcServer.renderFinishedFromResult` keep emitting the placeholder `daemon-stub-${id}.png`.
+ * `:daemon:harness`, `DesktopHost`/`RobolectricHost` once their B1.4 render-engine bodies land).
+ * They map directly onto the [`renderFinished`](../../docs/daemon/PROTOCOL.md#renderfinished) wire
+ * shape: `pngPath` becomes `renderFinished.pngPath`; `metrics` becomes a flat
+ * `renderFinished.metrics` (numeric counters; the structured `RenderMetrics` shape is filled in by
+ * B2.3 once the daemon tracks heap / sandbox-age etc.). Both default to `null` so the B1.5-era stub
+ * paths in `JsonRpcServer.renderFinishedFromResult` keep emitting the placeholder
+ * `daemon-stub-${id}.png`.
  */
 data class RenderResult(
   val id: Long,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/SandboxLifecycle.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/SandboxLifecycle.kt
@@ -38,8 +38,8 @@ class SandboxLifecycleStats(
   fun bumpRenderCount(): Long = renderCount.incrementAndGet()
 
   /**
-   * Resets both counters — wired from B2.5's recycle path once that lands. For B2.3 v1 nobody
-   * calls this in production; only unit tests use it.
+   * Resets both counters — wired from B2.5's recycle path once that lands. For B2.3 v1 nobody calls
+   * this in production; only unit tests use it.
    */
   fun reset() {
     startNs = System.nanoTime()
@@ -48,24 +48,24 @@ class SandboxLifecycleStats(
 }
 
 /**
- * Per-render measurement helper — collects the four B2.3 metrics into a flat
- * `Map<String, Long>` carrier so the renderer-agnostic [RenderResult.metrics] stays a free-form
- * `Map<String, Long>?` (per the B2.3 brief: "translate flat map → structured `RenderMetrics` in
- * `JsonRpcServer`"). The engine calls [collect] once per render-completion.
+ * Per-render measurement helper — collects the four B2.3 metrics into a flat `Map<String, Long>`
+ * carrier so the renderer-agnostic [RenderResult.metrics] stays a free-form `Map<String, Long>?`
+ * (per the B2.3 brief: "translate flat map → structured `RenderMetrics` in `JsonRpcServer`"). The
+ * engine calls [collect] once per render-completion.
  *
  * Measurement cost target: < 10ms per render (B2.3 DoD). Composed of:
- * - One `System.gc()` hint (HotSpot mostly honours this for instrumentation; not load-bearing,
- *   we just want post-render heap to reflect short-lived allocation).
+ * - One `System.gc()` hint (HotSpot mostly honours this for instrumentation; not load-bearing, we
+ *   just want post-render heap to reflect short-lived allocation).
  * - Three `MemoryMXBean` / `Runtime` accessor calls (each O(1)).
  * - One [SandboxLifecycleStats] read + bump.
  *
- * **`nativeHeapMb` is an approximation** — we report the JVM's committed virtual memory size
- * (via [com.sun.management.OperatingSystemMXBean.getCommittedVirtualMemorySize]), divided by 1MB.
- * That is *not* strictly the "native heap" — it covers JVM heap + native libs + mapped files —
- * but it's the closest portable proxy on HotSpot. The daemon's heaviest native-side state is Skia
- * (desktop) and Robolectric's native libs (Android), both of which show up under committed
- * virtual memory. On non-HotSpot JVMs where the cast fails we fall back to 0 with a one-time
- * warn-log; clients see `nativeHeapMb = 0` and that's clearer than a hand-waved heuristic.
+ * **`nativeHeapMb` is an approximation** — we report the JVM's committed virtual memory size (via
+ * [com.sun.management.OperatingSystemMXBean.getCommittedVirtualMemorySize]), divided by 1MB. That
+ * is *not* strictly the "native heap" — it covers JVM heap + native libs + mapped files — but it's
+ * the closest portable proxy on HotSpot. The daemon's heaviest native-side state is Skia (desktop)
+ * and Robolectric's native libs (Android), both of which show up under committed virtual memory. On
+ * non-HotSpot JVMs where the cast fails we fall back to 0 with a one-time warn-log; clients see
+ * `nativeHeapMb = 0` and that's clearer than a hand-waved heuristic.
  */
 object SandboxMeasurement {
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt
@@ -19,10 +19,10 @@ import java.net.URLClassLoader
  * cached `Class<?>`.
  *
  * Per [Decision 2](../../../../../../docs/daemon/CLASSLOADER.md#decisions-made) this lives in
- * `:daemon:core`. It's renderer-agnostic: a `URLClassLoader` lifecycle holder doesn't
- * touch Compose, Robolectric, or any backend specifics. Both [RenderHost] implementations
- * (`DesktopHost` and `RobolectricHost`) construct one against the user-class-dirs sysprop wired by
- * the gradle plugin's launch descriptor.
+ * `:daemon:core`. It's renderer-agnostic: a `URLClassLoader` lifecycle holder doesn't touch
+ * Compose, Robolectric, or any backend specifics. Both [RenderHost] implementations (`DesktopHost`
+ * and `RobolectricHost`) construct one against the user-class-dirs sysprop wired by the gradle
+ * plugin's launch descriptor.
  *
  * **Thread-safety.** The holder is read by the render thread and mutated by the JSON-RPC read
  * thread (when `handleFileChanged` arrives). All access goes through `synchronized(this)` — the

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/forensics/ClassloaderForensics.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/forensics/ClassloaderForensics.kt
@@ -21,11 +21,11 @@ import kotlinx.serialization.json.put
  * package versions, and a SHA-256 of the class's bytecode (`moduleHash`) reachable via the class's
  * own classloader. Plus a runtime-config snapshot for the active Robolectric configuration.
  *
- * **Renderer-agnostic.** Lives in `:daemon:core` because both `:renderer-android` (the
- * working standalone path, Configuration A) and `:daemon:android` (the broken daemon path,
- * Configuration B) need to call `capture(...)` against the *same* survey set — and the library
- * itself touches only `Class<?>` / `ClassLoader` / `getProtectionDomain` reflection, so it has no
- * Compose / Robolectric / AndroidX dependency at the type level.
+ * **Renderer-agnostic.** Lives in `:daemon:core` because both `:renderer-android` (the working
+ * standalone path, Configuration A) and `:daemon:android` (the broken daemon path, Configuration B)
+ * need to call `capture(...)` against the *same* survey set — and the library itself touches only
+ * `Class<?>` / `ClassLoader` / `getProtectionDomain` reflection, so it has no Compose / Robolectric
+ * / AndroidX dependency at the type level.
  *
  * **Two entrypoints:**
  *

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -214,16 +214,16 @@ data class RenderMetrics(
 
     /**
      * Translates the flat `Map<String, Long>` carrier on `RenderResult.metrics` into a structured
-     * [RenderMetrics] for the wire. Returns `null` when any of the four B2.3 keys is missing —
-     * we deliberately do not emit a half-populated metrics object since callers can't tell the
+     * [RenderMetrics] for the wire. Returns `null` when any of the four B2.3 keys is missing — we
+     * deliberately do not emit a half-populated metrics object since callers can't tell the
      * difference between "field truly was zero" and "field was missing", and the wire-level
-     * presence of `metrics: null` already encodes "measurement unavailable" cleanly. Extra
-     * unknown keys (e.g. the renderer's pre-existing `tookMs`) are ignored — they continue to
-     * flow through `RenderFinishedParams.tookMs` at the top level.
+     * presence of `metrics: null` already encodes "measurement unavailable" cleanly. Extra unknown
+     * keys (e.g. the renderer's pre-existing `tookMs`) are ignored — they continue to flow through
+     * `RenderFinishedParams.tookMs` at the top level.
      *
-     * Returns a `Result` so the caller (`JsonRpcServer.renderFinishedFromResult`) can warn-log
-     * the partial-map case and observe drift — a common shape early in a host backend's
-     * measurement plumbing.
+     * Returns a `Result` so the caller (`JsonRpcServer.renderFinishedFromResult`) can warn-log the
+     * partial-map case and observe drift — a common shape early in a host backend's measurement
+     * plumbing.
      */
     fun fromFlatMap(map: Map<String, Long>?): FromFlatMapResult {
       if (map == null) return FromFlatMapResult.AbsentSource

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/IncrementalDiscoveryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/IncrementalDiscoveryTest.kt
@@ -12,10 +12,11 @@ import org.junit.Test
 /**
  * B2.2 phase 2 — pins the daemon-side incremental rescan path.
  *
- * **Scan fixture.** [`TestPreviewFixtures`][ee.schimke.composeai.daemon.fixtures.TestPreviewFixtures]
- * carries two `@TestPreview`-annotated methods on the test classpath. The `@TestPreview`
- * annotation is the daemon-test-only stand-in for `androidx.compose.ui.tooling.preview.Preview` —
- * we can't depend on the real Compose tooling artefact here without inverting
+ * **Scan fixture.**
+ * [`TestPreviewFixtures`][ee.schimke.composeai.daemon.fixtures.TestPreviewFixtures] carries two
+ * `@TestPreview`-annotated methods on the test classpath. The `@TestPreview` annotation is the
+ * daemon-test-only stand-in for `androidx.compose.ui.tooling.preview.Preview` — we can't depend on
+ * the real Compose tooling artefact here without inverting
  * [LAYERING.md](../../../../../../docs/daemon/LAYERING.md). The tests construct
  * [IncrementalDiscovery] with `knownPreviewAnnotationFqns = setOf("...TestPreview")` so the scan
  * recognises it.
@@ -159,10 +160,7 @@ class IncrementalDiscoveryTest {
       ids.any { it.endsWith(".secondPreview_alpha") },
     )
     val first = results.first { it.id.endsWith(".firstPreview_first") }
-    assertEquals(
-      "ee.schimke.composeai.daemon.fixtures.TestPreviewFixtures",
-      first.className,
-    )
+    assertEquals("ee.schimke.composeai.daemon.fixtures.TestPreviewFixtures", first.className)
     assertEquals("firstPreview", first.methodName)
     assertEquals("first", first.displayName)
   }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
@@ -32,8 +32,8 @@ import org.junit.Test
  *
  * Uses a [FakeRenderHost] that bypasses any backend (no Robolectric sandbox, no desktop Compose
  * runtime) so the test is deterministic and fast (sub-second). The real-host smoke test for the
- * Robolectric backend lives in `:daemon:android`'s `DaemonHostTest`, which is separately
- * gated because Robolectric cold-boot is non-deterministic and incompatible with Gradle's default
+ * Robolectric backend lives in `:daemon:android`'s `DaemonHostTest`, which is separately gated
+ * because Robolectric cold-boot is non-deterministic and incompatible with Gradle's default
  * same-JVM test ordering (multiple `JUnitCore.runClasses` invocations in one JVM intermittently
  * hang on the second sandbox bootstrap).
  *
@@ -42,8 +42,8 @@ import org.junit.Test
  *
  * 1. The descriptor produced by Stream A's `composePreviewDaemonStart` task lives in
  *    `samples/android/build/...` and isn't available to a unit test classpath without a Gradle
- *    dependency on the consumer module — that would be a circular dep (`:daemon:android`
- *    consumes `:samples:android`).
+ *    dependency on the consumer module — that would be a circular dep (`:daemon:android` consumes
+ *    `:samples:android`).
  * 2. The real value the DoD wanted to prove — request → response → notification round-trip with a
  *    working host — is fully exercised here, including the no-mid-render-cancellation invariant (we
  *    drain the in-flight queue before resolving `shutdown`). A subprocess wrapper would only add
@@ -206,10 +206,10 @@ class JsonRpcServerIntegrationTest {
   }
 
   /**
-   * B2.2 phase 1 — when the daemon is constructed with a non-empty [PreviewIndex], the
-   * `initialize` response's `manifest` block reports the absolute path of the loaded
-   * `previews.json` and the count of previews known to the daemon. Mirrors the
-   * `initialize.classpathFingerprint` pin in the B2.1 test below.
+   * B2.2 phase 1 — when the daemon is constructed with a non-empty [PreviewIndex], the `initialize`
+   * response's `manifest` block reports the absolute path of the loaded `previews.json` and the
+   * count of previews known to the daemon. Mirrors the `initialize.classpathFingerprint` pin in the
+   * B2.1 test below.
    */
   @Test(timeout = 30_000)
   fun initialize_manifest_reports_preview_index_path_and_count() {
@@ -310,9 +310,9 @@ class JsonRpcServerIntegrationTest {
 
   /**
    * B2.2 phase 1 back-compat — when the daemon is constructed without a [PreviewIndex] (the
-   * default), `initialize.manifest` reports `path = ""` and `previewCount = 0`. Pins the
-   * pre-B2.2 stub shape so existing in-process callers that don't yet wire the index keep
-   * receiving the empty placeholder.
+   * default), `initialize.manifest` reports `path = ""` and `previewCount = 0`. Pins the pre-B2.2
+   * stub shape so existing in-process callers that don't yet wire the index keep receiving the
+   * empty placeholder.
    */
   @Test(timeout = 30_000)
   fun initialize_manifest_defaults_to_empty_index() {
@@ -603,11 +603,11 @@ class JsonRpcServerIntegrationTest {
 
   /**
    * B2.2 phase 2 — `fileChanged({kind: source, path: <.kt>})` against a daemon configured with a
-   * non-empty [PreviewIndex] AND a wired [IncrementalDiscovery] must emit `discoveryUpdated`
-   * within a couple of seconds with the diff against the cached index.
+   * non-empty [PreviewIndex] AND a wired [IncrementalDiscovery] must emit `discoveryUpdated` within
+   * a couple of seconds with the diff against the cached index.
    *
-   * The synthetic classpath has no `@Preview`-bearing classes, so the scoped scan returns empty
-   * and the diff carries `removed = [the index's preview]`.
+   * The synthetic classpath has no `@Preview`-bearing classes, so the scoped scan returns empty and
+   * the diff carries `removed = [the index's preview]`.
    */
   @Test(timeout = 30_000)
   fun fileChanged_source_emits_discoveryUpdated() {
@@ -695,15 +695,13 @@ class JsonRpcServerIntegrationTest {
       )
 
       val discoveryNotif =
-        pollUntil(received) {
-          it["method"]?.jsonPrimitive?.contentOrNull == "discoveryUpdated"
-        }
+        pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "discoveryUpdated" }
       assertNotNull("discoveryUpdated notification must arrive", discoveryNotif)
       val params = discoveryNotif!!["params"]!!.jsonObject
       val removed =
-        params["removed"]
-          ?.let { (it as kotlinx.serialization.json.JsonArray).map { e -> e.jsonPrimitive.content } }
-          ?: emptyList()
+        params["removed"]?.let {
+          (it as kotlinx.serialization.json.JsonArray).map { e -> e.jsonPrimitive.content }
+        } ?: emptyList()
       assertEquals(listOf("Foo"), removed)
       assertEquals(0, params["totalPreviews"]?.jsonPrimitive?.intOrNull)
       // Verify the index was updated in-place.
@@ -728,8 +726,8 @@ class JsonRpcServerIntegrationTest {
 
   /**
    * B2.3 — when the host returns a `RenderResult.metrics` map carrying the four B2.3 keys,
-   * `JsonRpcServer.renderFinishedFromResult` translates them into a structured [RenderMetrics]
-   * on the wire.
+   * `JsonRpcServer.renderFinishedFromResult` translates them into a structured [RenderMetrics] on
+   * the wire.
    */
   @Test(timeout = 30_000)
   fun renderFinished_metrics_populated_when_host_supplies_all_four_b23_keys() {
@@ -752,22 +750,10 @@ class JsonRpcServerIntegrationTest {
           metricsField,
         )
         val metricsObj = metricsField!!.jsonObject
-        assertEquals(
-          100L,
-          metricsObj[RenderMetrics.KEY_HEAP_AFTER_GC_MB]?.jsonPrimitive?.long,
-        )
-        assertEquals(
-          200L,
-          metricsObj[RenderMetrics.KEY_NATIVE_HEAP_MB]?.jsonPrimitive?.long,
-        )
-        assertEquals(
-          5L,
-          metricsObj[RenderMetrics.KEY_SANDBOX_AGE_RENDERS]?.jsonPrimitive?.long,
-        )
-        assertEquals(
-          4321L,
-          metricsObj[RenderMetrics.KEY_SANDBOX_AGE_MS]?.jsonPrimitive?.long,
-        )
+        assertEquals(100L, metricsObj[RenderMetrics.KEY_HEAP_AFTER_GC_MB]?.jsonPrimitive?.long)
+        assertEquals(200L, metricsObj[RenderMetrics.KEY_NATIVE_HEAP_MB]?.jsonPrimitive?.long)
+        assertEquals(5L, metricsObj[RenderMetrics.KEY_SANDBOX_AGE_RENDERS]?.jsonPrimitive?.long)
+        assertEquals(4321L, metricsObj[RenderMetrics.KEY_SANDBOX_AGE_MS]?.jsonPrimitive?.long)
         // tookMs at the top level too — already wired pre-B2.3.
         assertEquals(7L, params["tookMs"]?.jsonPrimitive?.longOrNull)
       },
@@ -797,8 +783,8 @@ class JsonRpcServerIntegrationTest {
   /**
    * B2.3 partial-map path — when the host populates *some* B2.3 keys but not all four, the wire
    * still emits `metrics: null` (no half-populated objects) and the daemon warn-logs the gap.
-   * Pinned here to lock the JsonRpcServer behaviour; the partial-map outcome itself is unit-
-   * tested in [RenderMetricsFromFlatMapTest].
+   * Pinned here to lock the JsonRpcServer behaviour; the partial-map outcome itself is unit- tested
+   * in [RenderMetricsFromFlatMapTest].
    */
   @Test(timeout = 30_000)
   fun renderFinished_metrics_null_when_host_supplies_partial_map() {
@@ -822,9 +808,9 @@ class JsonRpcServerIntegrationTest {
   }
 
   /**
-   * Drives the initialize → renderNow → renderFinished round-trip against a custom
-   * [FakeRenderHost] and lets the caller assert on the `renderFinished.params` JSON. Factored out
-   * of the three B2.3 tests above so they can each focus on the metrics shape.
+   * Drives the initialize → renderNow → renderFinished round-trip against a custom [FakeRenderHost]
+   * and lets the caller assert on the `renderFinished.params` JSON. Factored out of the three B2.3
+   * tests above so they can each focus on the metrics shape.
    */
   private fun runRenderAndPollFinished(
     host: FakeRenderHost,
@@ -930,8 +916,8 @@ class JsonRpcServerIntegrationTest {
 /**
  * In-test [RenderHost] implementation that mimics a real backend's submit/shutdown contract without
  * bootstrapping anything heavy (Robolectric sandbox, Compose desktop runtime, …). Renderer-agnostic
- * by design: it lives alongside [JsonRpcServer] in `:daemon:core`, away from any specific
- * render backend.
+ * by design: it lives alongside [JsonRpcServer] in `:daemon:core`, away from any specific render
+ * backend.
  *
  * Renders complete instantly on a single dedicated worker thread, mirroring the real backends'
  * "single render thread" guarantee. The [interruptCount] counter spies on `Thread.interrupt()`
@@ -939,9 +925,9 @@ class JsonRpcServerIntegrationTest {
  */
 private class FakeRenderHost(
   /**
-   * If non-null, every successful render returns this map verbatim as `RenderResult.metrics`.
-   * Used by the B2.3 integration tests to drive `JsonRpcServer.renderFinishedFromResult` through
-   * its happy / partial / null branches.
+   * If non-null, every successful render returns this map verbatim as `RenderResult.metrics`. Used
+   * by the B2.3 integration tests to drive `JsonRpcServer.renderFinishedFromResult` through its
+   * happy / partial / null branches.
    */
   private val metricsToReturn: Map<String, Long>? = null
 ) : RenderHost {

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewIndexDiffTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewIndexDiffTest.kt
@@ -9,8 +9,7 @@ import org.junit.Test
 /**
  * B2.2 phase 2 — pins the diff path against the cached [PreviewIndex]. The diff is the producer of
  * the `discoveryUpdated` wire payload, so these cases lock its arithmetic verbatim against the
- * scenarios documented in
- * [DESIGN § 8 Tier 2](../../../../../../docs/daemon/DESIGN.md).
+ * scenarios documented in [DESIGN § 8 Tier 2](../../../../../../docs/daemon/DESIGN.md).
  */
 class PreviewIndexDiffTest {
 
@@ -109,7 +108,13 @@ class PreviewIndexDiffTest {
 
   @Test
   fun `discoveryDiffEmpty true when all three lists empty`() {
-    val empty = DiscoveryDiff(added = emptyList(), removed = emptyList(), changed = emptyList(), totalPreviews = 7)
+    val empty =
+      DiscoveryDiff(
+        added = emptyList(),
+        removed = emptyList(),
+        changed = emptyList(),
+        totalPreviews = 7,
+      )
     assertTrue(discoveryDiffEmpty(empty))
   }
 }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/fixtures/TestPreview.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/fixtures/TestPreview.kt
@@ -5,9 +5,9 @@ package ee.schimke.composeai.daemon.fixtures
  * ClassGraph scan path without pulling Compose UI tooling onto the `:daemon:core` test classpath
  * (which would be a layering inversion — the daemon core deliberately doesn't depend on Compose).
  *
- * `RUNTIME` retention so ClassGraph's annotation reader sees it; `name` / `group` parameters
- * mirror the real `@Preview`'s `name = "..."` / `group = "..."` so the diff-tracked field
- * extraction in `IncrementalDiscovery.toDto` has something to read.
+ * `RUNTIME` retention so ClassGraph's annotation reader sees it; `name` / `group` parameters mirror
+ * the real `@Preview`'s `name = "..."` / `group = "..."` so the diff-tracked field extraction in
+ * `IncrementalDiscovery.toDto` has something to read.
  */
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/forensics/ClassloaderForensicsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/forensics/ClassloaderForensicsTest.kt
@@ -12,8 +12,8 @@ import org.junit.Test
  * Unit-test surface for the renderer-agnostic [ClassloaderForensics] library. Exercises capture +
  * diff against the host JVM's classloader graph (no Robolectric) — the Android-specific behaviour
  * is covered by `:renderer-android`'s `ClassloaderForensicsTest` (Configuration A) and
- * `:daemon:android`'s `ClassloaderForensicsDaemonTest` (Configuration B). This test only
- * pins the library's invariants:
+ * `:daemon:android`'s `ClassloaderForensicsDaemonTest` (Configuration B). This test only pins the
+ * library's invariants:
  *
  * * Capturing twice in the same JVM produces the same per-class data (sanity check 1 from
  *   CLASSLOADER-FORENSICS.md § Sanity checks — modulo timestamps/contextHint differences).

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/protocol/RenderMetricsFromFlatMapTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/protocol/RenderMetricsFromFlatMapTest.kt
@@ -5,16 +5,16 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Unit tests for [RenderMetrics.fromFlatMap] — the flat `Map<String, Long>` →
- * structured [RenderMetrics] translator B2.3 lands.
+ * Unit tests for [RenderMetrics.fromFlatMap] — the flat `Map<String, Long>` → structured
+ * [RenderMetrics] translator B2.3 lands.
  *
  * Three cases the JSON-RPC server depends on:
  * - Happy path: all four B2.3 keys present → struct populated 1:1 with the map values.
  * - Partial map: at least one key missing → result is [RenderMetrics.FromFlatMapResult.PartialMap]
  *   with the missing-keys list. The wire layer logs a warn-level notification on this and emits
  *   `metrics: null` (no half-populated objects).
- * - Extras: unknown keys (e.g. `tookMs`, future host-private counters) are ignored — the four
- *   known keys still translate cleanly.
+ * - Extras: unknown keys (e.g. `tookMs`, future host-private counters) are ignored — the four known
+ *   keys still translate cleanly.
  */
 class RenderMetricsFromFlatMapTest {
 
@@ -121,13 +121,15 @@ class RenderMetricsFromFlatMapTest {
     )
     val partial = result as RenderMetrics.FromFlatMapResult.PartialMap
     assertEquals(4, partial.missingKeys.size)
-    assertTrue(partial.missingKeys.containsAll(
-      listOf(
-        RenderMetrics.KEY_HEAP_AFTER_GC_MB,
-        RenderMetrics.KEY_NATIVE_HEAP_MB,
-        RenderMetrics.KEY_SANDBOX_AGE_RENDERS,
-        RenderMetrics.KEY_SANDBOX_AGE_MS,
+    assertTrue(
+      partial.missingKeys.containsAll(
+        listOf(
+          RenderMetrics.KEY_HEAP_AFTER_GC_MB,
+          RenderMetrics.KEY_NATIVE_HEAP_MB,
+          RenderMetrics.KEY_SANDBOX_AGE_RENDERS,
+          RenderMetrics.KEY_SANDBOX_AGE_MS,
+        )
       )
-    ))
+    )
   }
 }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -173,9 +173,9 @@ fun main(args: Array<String>) {
  *    `InputStream.read(...)`; closing the stream surfaces an `IOException` / EOF and the loop
  *    breaks. This is option (a) from the B-desktop.1.6 task brief — "close `System.in` from the
  *    shutdown hook so the loop sees EOF" — chosen over adding a `requestStop()` API to
- *    `:daemon:core` because it doesn't widen the core surface. The trade-off is the read
- *    loop still walks through its own EOF→idle-timeout path before reaching `cleanShutdown`; the
- *    drain we care about (host render thread) is handled by step 2 below, independently.
+ *    `:daemon:core` because it doesn't widen the core surface. The trade-off is the read loop still
+ *    walks through its own EOF→idle-timeout path before reaching `cleanShutdown`; the drain we care
+ *    about (host render thread) is handled by step 2 below, independently.
  * 2. Calls [RenderHost.shutdown] with the timeout from `composeai.daemon.idleTimeoutMs` (capped at
  *    the JVM's default 30s shutdown-hook grace window — JVMs kill non-daemon hooks that exceed
  *    this). [DesktopHost.shutdown] enqueues a poison pill on the render queue and joins the worker
@@ -195,12 +195,12 @@ fun main(args: Array<String>) {
  * doesn't span renders. There is nothing we can do about this in user code; the only mitigation is
  * the gradle plugin / VS Code client preferring SIGTERM over SIGKILL for routine daemon disposal.
  *
- * **Manual smoke test.** Run `./gradlew :daemon:desktop:runDaemonMain` in one terminal,
- * note the PID printed in the hello banner, and `kill -TERM <pid>` from another terminal. The
- * hook's "draining…" line lands on stderr, [DesktopHost.shutdown] returns once the worker is gone,
- * and the JVM exits within ~1s for an idle daemon (the time taken by `host.shutdown()` plus the
- * read loop's EOF→idleTimeout-sleep walk; the latter is bounded by the
- * `composeai.daemon.idleTimeoutMs` system property, default 5s).
+ * **Manual smoke test.** Run `./gradlew :daemon:desktop:runDaemonMain` in one terminal, note the
+ * PID printed in the hello banner, and `kill -TERM <pid>` from another terminal. The hook's
+ * "draining…" line lands on stderr, [DesktopHost.shutdown] returns once the worker is gone, and the
+ * JVM exits within ~1s for an idle daemon (the time taken by `host.shutdown()` plus the read loop's
+ * EOF→idleTimeout-sleep walk; the latter is bounded by the `composeai.daemon.idleTimeoutMs` system
+ * property, default 5s).
  */
 private fun installSigtermShutdownHook(host: RenderHost, originalStdin: java.io.InputStream) {
   // Same property the JsonRpcServer reads, so a single sysprop tunes both timeouts coherently.

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -82,11 +82,11 @@ open class DesktopHost(
   private val results: ConcurrentHashMap<Long, LinkedBlockingQueue<Any>> = ConcurrentHashMap()
 
   /**
-   * B2.3 — per-host sandbox-lifecycle counters. Captured at host construction so
-   * `sandboxAgeMs` is wall-clock since the desktop host was instantiated; bumped per render-
-   * completion by [SandboxMeasurement.collect] (called from [RenderEngine.render]). Sandbox
-   * recycle (B2.5) will reset these once it lands; for B2.3 v1 the counter just keeps growing
-   * over the host's lifetime — documented behaviour.
+   * B2.3 — per-host sandbox-lifecycle counters. Captured at host construction so `sandboxAgeMs` is
+   * wall-clock since the desktop host was instantiated; bumped per render- completion by
+   * [SandboxMeasurement.collect] (called from [RenderEngine.render]). Sandbox recycle (B2.5) will
+   * reset these once it lands; for B2.3 v1 the counter just keeps growing over the host's lifetime
+   * — documented behaviour.
    */
   private val sandboxStats: SandboxLifecycleStats = SandboxLifecycleStats()
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -11,10 +11,10 @@ import kotlinx.serialization.json.Json
  *
  * Mirrors the test-only `SpecRoutingHost` from
  * [JsonRpcDesktopIntegrationTest][ee.schimke.composeai.daemon.JsonRpcDesktopIntegrationTest], but
- * lives in the main source set so [DaemonMain] can mount it when spawned by
- * `:daemon:harness`'s `RealDesktopHarnessLauncher`. Without this routing the real daemon
- * (driven by `JsonRpcServer.handleRenderNow`, which only forwards `previewId=<id>` in the payload —
- * see `JsonRpcServer.kt` line ~352) would fall through to [DesktopHost.dispatchRender]'s
+ * lives in the main source set so [DaemonMain] can mount it when spawned by `:daemon:harness`'s
+ * `RealDesktopHarnessLauncher`. Without this routing the real daemon (driven by
+ * `JsonRpcServer.handleRenderNow`, which only forwards `previewId=<id>` in the payload — see
+ * `JsonRpcServer.kt` line ~352) would fall through to [DesktopHost.dispatchRender]'s
  * `renderStubFallback` path, producing no PNG.
  *
  * **Activated only when** `-Dcomposeai.harness.previewsManifest=<path>` is set on the JVM —

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -82,10 +82,10 @@ class RenderEngine(
       RenderEngine::class.java.classLoader ?: ClassLoader.getSystemClassLoader(),
     /**
      * B2.3 — per-host measurement context. The host owns its own [SandboxLifecycleStats] (start
-     * time + render counter); the engine simply reads from it at metrics-population time and
-     * bumps the counter once per render. Defaults to a fresh per-call instance for unit tests
-     * that drive the engine directly without a host wrapper — the resulting metrics are still
-     * populated, just with a sandbox-age that resets on every test render.
+     * time + render counter); the engine simply reads from it at metrics-population time and bumps
+     * the counter once per render. Defaults to a fresh per-call instance for unit tests that drive
+     * the engine directly without a host wrapper — the resulting metrics are still populated, just
+     * with a sandbox-age that resets on every test render.
      */
     sandboxStats: SandboxLifecycleStats = SandboxLifecycleStats(),
   ): RenderResult {

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/CancellationInvariantTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/CancellationInvariantTest.kt
@@ -44,9 +44,8 @@ import org.junit.rules.TemporaryFolder
  * about: an `interrupt()` while the worker is in `take()` or `Thread.sleep()` would surface as an
  * `InterruptedException` (covered by [DesktopHost.renderThreadInterrupted]); an `interrupt()` set
  * outside a blocking call would leave the flag visible if any subsequent blocking call was made,
- * also covered. The contributing-doc rule (see `daemon/desktop/CONTRIBUTING.md`) catches
- * the static case — any `Thread.interrupt()` call introduced under
- * `:daemon:desktop/src/main/`.
+ * also covered. The contributing-doc rule (see `daemon/desktop/CONTRIBUTING.md`) catches the static
+ * case — any `Thread.interrupt()` call introduced under `:daemon:desktop/src/main/`.
  */
 class CancellationInvariantTest {
 

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcDesktopIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcDesktopIntegrationTest.kt
@@ -39,8 +39,8 @@ import org.junit.rules.TemporaryFolder
  * JVM. We deferred — same reasoning as B1.5's `JsonRpcServerIntegrationTest`:
  *
  * 1. Subprocess plumbing (ProcessBuilder + descriptor wiring) duplicates work that
- *    `:daemon:harness`'s `HarnessClient` already implements; D-harness.v1.5 will hit this
- *    code path against a real spawned daemon as part of its `-Pharness.host=real` flip.
+ *    `:daemon:harness`'s `HarnessClient` already implements; D-harness.v1.5 will hit this code path
+ *    against a real spawned daemon as part of its `-Pharness.host=real` flip.
  * 2. The wire-layer round-trip + real-render assertion the DoD wants to prove are fully exercised
  *    in-process. A subprocess would only add `ProcessBuilder` plumbing on top.
  *

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -24,10 +24,10 @@ import org.junit.rules.TemporaryFolder
  *   subsequent renders should be faster). The test only fails if a render itself fails — the timing
  *   data is for the agent to report back, not a CI assertion.
  *
- * Pixel-diff helper is inlined here rather than imported from `:daemon:harness`'s `PixelDiff`
- * to avoid a circular dep (`:daemon:desktop` ← `:daemon:harness` would invert the
- * dependency graph the harness was built around). v2 reconciles by hoisting `PixelDiff` into a
- * shared utilities module if a third call-site needs it.
+ * Pixel-diff helper is inlined here rather than imported from `:daemon:harness`'s `PixelDiff` to
+ * avoid a circular dep (`:daemon:desktop` ← `:daemon:harness` would invert the dependency graph the
+ * harness was built around). v2 reconciles by hoisting `PixelDiff` into a shared utilities module
+ * if a third call-site needs it.
  */
 class RenderEngineTest {
 

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
@@ -25,13 +25,12 @@ import java.nio.file.Path
  * *production-shaped*, not piped streams in the same JVM (that's [`JsonRpcServerIntegrationTest`]'s
  * job in core).
  *
- * **B2.2 phase 2.** The fake daemon also seeds the daemon-side [PreviewIndex] from the same
- * fixture manifest [FakeHost] reads, then wires an [IncrementalDiscovery] so
- * `fileChanged({kind: source})` actually exercises the discovery cascade end-to-end (cheap
- * pre-filter → scoped scan → diff → emit `discoveryUpdated`). The harness's classpath has no
- * compiled `@Preview` classes, so `scanForFile` returns empty and the diff carries `removed` for
- * any preview whose `sourceFile` matches the saved path — that's exactly what the S3 scenario
- * test asserts.
+ * **B2.2 phase 2.** The fake daemon also seeds the daemon-side [PreviewIndex] from the same fixture
+ * manifest [FakeHost] reads, then wires an [IncrementalDiscovery] so `fileChanged({kind: source})`
+ * actually exercises the discovery cascade end-to-end (cheap pre-filter → scoped scan → diff → emit
+ * `discoveryUpdated`). The harness's classpath has no compiled `@Preview` classes, so `scanForFile`
+ * returns empty and the diff carries `removed` for any preview whose `sourceFile` matches the saved
+ * path — that's exactly what the S3 scenario test asserts.
  */
 fun main(args: Array<String>) {
   val fixtureProp =

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeHost.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeHost.kt
@@ -61,12 +61,12 @@ class FakeHost(private val fixtureDir: File, private val manifest: Map<String, F
   private val sidecarCache = ConcurrentHashMap<String, ResolvedSidecars>()
 
   /**
-   * B2.3 — per-host sandbox-lifecycle counters. Captured at host construction so `sandboxAgeMs`
-   * is wall-clock since the FakeHost was instantiated; `sandboxAgeRenders` increments on every
-   * `submit()`. Synthetic but real values (the harness wire-format contract is "metrics are
-   * present and parse"; their numeric meaning under fake-mode is nominal). The S8 + B2.3 soak
-   * tests assert presence + monotonic increment of `sandboxAgeRenders`, not absolute heap
-   * numbers — those live behind real-mode soak tests.
+   * B2.3 — per-host sandbox-lifecycle counters. Captured at host construction so `sandboxAgeMs` is
+   * wall-clock since the FakeHost was instantiated; `sandboxAgeRenders` increments on every
+   * `submit()`. Synthetic but real values (the harness wire-format contract is "metrics are present
+   * and parse"; their numeric meaning under fake-mode is nominal). The S8 + B2.3 soak tests assert
+   * presence + monotonic increment of `sandboxAgeRenders`, not absolute heap numbers — those live
+   * behind real-mode soak tests.
    */
   private val sandboxStartNs: Long = System.nanoTime()
   private val renderCount: AtomicLong = AtomicLong(0)
@@ -226,8 +226,8 @@ class FakeHost(private val fixtureDir: File, private val manifest: Map<String, F
  * notification (v1+); they have no semantic effect on the v0 S1 flow. Only `id` is load-bearing.
  *
  * **B2.2 phase 2** added [sourceFile], [displayName], and [group] so the harness can stage a
- * fake-mode `discoveryUpdated` end-to-end. When the test writes a `.kt` file under the fixture
- * dir, sets `sourceFile` to that absolute path, and sends `fileChanged({kind: source, path: <.kt>})`,
+ * fake-mode `discoveryUpdated` end-to-end. When the test writes a `.kt` file under the fixture dir,
+ * sets `sourceFile` to that absolute path, and sends `fileChanged({kind: source, path: <.kt>})`,
  * the daemon's diff path observes "preview removed from this file" (because ClassGraph has no
  * compiled bytecode under the fixture dir to find) and emits `discoveryUpdated`. Optional —
  * fixtures predating phase 2 omit the field and the diff path collapses to a no-op for them.

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
@@ -67,16 +67,16 @@ class FakeHarnessLauncher(
 }
 
 /**
- * Spawns the real desktop daemon — `ee.schimke.composeai.daemon.DaemonMain` from
- * `:daemon:desktop` — for D-harness.v1.5a's `-Pharness.host=real` mode.
+ * Spawns the real desktop daemon — `ee.schimke.composeai.daemon.DaemonMain` from `:daemon:desktop`
+ * — for D-harness.v1.5a's `-Pharness.host=real` mode.
  *
  * **Classpath resolution (Option A from the v1.5a task brief).** The harness module deliberately
- * does not depend on `:daemon:desktop` in production code — that would tie the
- * renderer-agnostic harness production classpath to a specific renderer. We add the dep as
- * `testImplementation` only, so the harness's *test* `java.class.path` includes the desktop
- * daemon's main classes (`DaemonMain`, `DesktopHost`, `RenderEngine`, `RenderSpec`) and Compose
- * Desktop / Skiko's `compose.desktop.currentOs` native bundle. The production classpath is
- * unaffected — the renderer-agnostic invariant from
+ * does not depend on `:daemon:desktop` in production code — that would tie the renderer-agnostic
+ * harness production classpath to a specific renderer. We add the dep as `testImplementation` only,
+ * so the harness's *test* `java.class.path` includes the desktop daemon's main classes
+ * (`DaemonMain`, `DesktopHost`, `RenderEngine`, `RenderSpec`) and Compose Desktop / Skiko's
+ * `compose.desktop.currentOs` native bundle. The production classpath is unaffected — the
+ * renderer-agnostic invariant from
  * [DESIGN § 4](../../../../docs/daemon/DESIGN.md#renderer-agnostic-surface) holds where it matters.
  *
  * **System properties on the spawned JVM:**
@@ -140,8 +140,8 @@ class RealDesktopHarnessLauncher(
 }
 
 /**
- * Spawns the real Android daemon — `ee.schimke.composeai.daemon.DaemonMain` from
- * `:daemon:android` — for D-harness.v2's `-Ptarget=android` mode.
+ * Spawns the real Android daemon — `ee.schimke.composeai.daemon.DaemonMain` from `:daemon:android`
+ * — for D-harness.v2's `-Ptarget=android` mode.
  *
  * **The JVM entry point is identical to the desktop launcher.** The package is
  * `ee.schimke.composeai.daemon` in both modules, just different runtime classpaths. The Android
@@ -200,12 +200,12 @@ class RealAndroidHarnessLauncher(
     /**
      * Returns the spawned-daemon classpath the harness build wired up via
      * `composeai.harness.androidDaemonClasspath` (a file listing one absolute JAR path per line).
-     * D-harness.v2's harness build resolves `:daemon:android`'s runtime classpath +
-     * testFixtures into that file at task execution time so the harness's plain JVM test runtime
-     * (which can't natively consume Android library variants) doesn't have to handle AGP variant
-     * resolution. Returns null if the property is unset — tests that need the Android daemon gate
-     * themselves with `Assume.assumeTrue(target == "android")` and the harness build only sets the
-     * property when `-Ptarget=android`-compatible test runs are configured.
+     * D-harness.v2's harness build resolves `:daemon:android`'s runtime classpath + testFixtures
+     * into that file at task execution time so the harness's plain JVM test runtime (which can't
+     * natively consume Android library variants) doesn't have to handle AGP variant resolution.
+     * Returns null if the property is unset — tests that need the Android daemon gate themselves
+     * with `Assume.assumeTrue(target == "android")` and the harness build only sets the property
+     * when `-Ptarget=android`-compatible test runs are configured.
      */
     fun classpathFromProperty(): List<File>? {
       val path = System.getProperty("composeai.harness.androidDaemonClasspath") ?: return null

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessTestSupport.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessTestSupport.kt
@@ -102,12 +102,12 @@ object HarnessTestSupport {
     System.getProperty("composeai.harness.regenerate")?.equals("true", ignoreCase = true) == true
 
   /**
-   * Resolves a real-mode baseline PNG path under
-   * `daemon/harness/baselines/<target>/<scenario>` relative to the harness module's working
-   * directory. The path is materialised lazily by [diffOrCaptureBaseline] — callers don't need to
-   * mkdir. Defaults to the current `-Ptarget=` (desktop unless overridden); D-harness.v2 added the
-   * per-target split so Robolectric's bitmap output and Skiko's bitmap output (which won't be
-   * byte-identical for "the same composable") have separate baselines per target.
+   * Resolves a real-mode baseline PNG path under `daemon/harness/baselines/<target>/<scenario>`
+   * relative to the harness module's working directory. The path is materialised lazily by
+   * [diffOrCaptureBaseline] — callers don't need to mkdir. Defaults to the current `-Ptarget=`
+   * (desktop unless overridden); D-harness.v2 added the per-target split so Robolectric's bitmap
+   * output and Skiko's bitmap output (which won't be byte-identical for "the same composable") have
+   * separate baselines per target.
    */
   fun baselineFile(scenario: String, name: String, target: String = harnessTarget()): File {
     val rel = File("baselines/$target/$scenario/$name")
@@ -339,8 +339,8 @@ fun writePreviewsManifest(fixtureDir: File, previewIds: List<String>) {
 
 /**
  * **B2.2 phase 2 overload** — emits one preview row per `(id, sourceFile)` pair. When `sourceFile`
- * is non-null it's serialised into the row so the daemon-side [PreviewIndex] anchors the preview
- * to that file path; the fake-mode S3 scenario uses this so a `fileChanged` against the same path
+ * is non-null it's serialised into the row so the daemon-side [PreviewIndex] anchors the preview to
+ * that file path; the fake-mode S3 scenario uses this so a `fileChanged` against the same path
  * produces a `discoveryUpdated` with `removed = [id]`.
  */
 @JvmName("writePreviewsManifestWithSources")

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/B23SoakAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/B23SoakAndroidRealModeTest.kt
@@ -10,8 +10,8 @@ import org.junit.Test
  *
  * Intent when enabled: 50 sequential `RobolectricHost` renders, comparing tookMs distributions
  * with/without measurement to verify the < 10ms-per-render overhead threshold from the B2.3 DoD.
- * Robolectric sandbox cold-boot dominates the first render (~5–15s); the test must take that out
- * of the average.
+ * Robolectric sandbox cold-boot dominates the first render (~5–15s); the test must take that out of
+ * the average.
  */
 @Ignore("B2.3 real-mode soak — enable with the measurement-disable toggle (B2.4 follow-up).")
 class B23SoakAndroidRealModeTest {

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/B23SoakDesktopRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/B23SoakDesktopRealModeTest.kt
@@ -4,22 +4,22 @@ import org.junit.Ignore
 import org.junit.Test
 
 /**
- * B2.3 desktop real-mode soak placeholder. Disabled — pulling this in is a follow-up; the B2.3
- * task brief says "Do NOT run real-mode tests in verification."
+ * B2.3 desktop real-mode soak placeholder. Disabled — pulling this in is a follow-up; the B2.3 task
+ * brief says "Do NOT run real-mode tests in verification."
  *
  * Intent when enabled:
  * - Spawn a real `DesktopHost` daemon via the `realModeScenario` helper.
  * - Run 50 sequential renders against a small fixture composable.
  * - Capture two `tookMs` series:
- *   1. With measurement enabled (the production path).
- *   2. With measurement disabled (a hypothetical `composeai.daemon.skipMeasurement=true` toggle
- *      on the engine — to be added when this test is enabled).
- * - Assert `mean(withMeasurement) - mean(withoutMeasurement) < 10ms` per render. This is the
- *   B2.3 DoD's "measurement adds < 10ms to render time" threshold, averaged over 50 renders to
- *   absorb single-render jitter.
+ *     1. With measurement enabled (the production path).
+ *     2. With measurement disabled (a hypothetical `composeai.daemon.skipMeasurement=true` toggle
+ *        on the engine — to be added when this test is enabled).
+ * - Assert `mean(withMeasurement) - mean(withoutMeasurement) < 10ms` per render. This is the B2.3
+ *   DoD's "measurement adds < 10ms to render time" threshold, averaged over 50 renders to absorb
+ *   single-render jitter.
  *
- * The "skip measurement" toggle does not exist yet — adding it is part of enabling this test.
- * Until then, the unit + fake-mode harness covers B2.3's wire-format contract end-to-end.
+ * The "skip measurement" toggle does not exist yet — adding it is part of enabling this test. Until
+ * then, the unit + fake-mode harness covers B2.3's wire-format contract end-to-end.
  */
 @Ignore("B2.3 real-mode soak — enable with the measurement-disable toggle (B2.4 follow-up).")
 class B23SoakDesktopRealModeTest {

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/B23SoakTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/B23SoakTest.kt
@@ -20,17 +20,16 @@ import org.junit.Test
  *
  * **What the soak test pins:**
  * - All 100 renders return `renderFinished.metrics` populated (not `null` / `JsonNull`).
- * - `sandboxAgeRenders` increments monotonically across renders (1, 2, …, 100). FakeHost holds
- *   one host instance for the whole test, so this counter starts at 1 and grows by 1 per render.
+ * - `sandboxAgeRenders` increments monotonically across renders (1, 2, …, 100). FakeHost holds one
+ *   host instance for the whole test, so this counter starts at 1 and grows by 1 per render.
  * - `sandboxAgeMs` is non-decreasing across renders (wall-clock).
  * - `heapAfterGcMb > 0` and `nativeHeapMb > 0` — synthetic FakeHost defaults are 1, so this
  *   exercises the wire-level "metrics arrived populated" contract end-to-end.
  *
- * Real measurement-overhead assertion (the < 10ms-per-render DoD threshold) lives behind real-
- * mode soak tests on the desktop daemon — see [B23SoakDesktopRealModeTest] (`@Disabled` for now;
- * pulling in real-mode soak runs is a B2.4-era follow-up). FakeHost doesn't actually measure
- * anything (it just stamps synthetic values), so the overhead check is meaningless under fake
- * mode.
+ * Real measurement-overhead assertion (the < 10ms-per-render DoD threshold) lives behind real- mode
+ * soak tests on the desktop daemon — see [B23SoakDesktopRealModeTest] (`@Disabled` for now; pulling
+ * in real-mode soak runs is a B2.4-era follow-up). FakeHost doesn't actually measure anything (it
+ * just stamps synthetic values), so the overhead check is meaningless under fake mode.
  */
 class B23SoakTest {
 
@@ -55,7 +54,11 @@ class B23SoakTest {
 
       for (i in 1..renderCount) {
         val rn = client.renderNow(previews = listOf(previewId), tier = RenderTier.FAST)
-        assertEquals("renderNow($i) must queue exactly the one preview", listOf(previewId), rn.queued)
+        assertEquals(
+          "renderNow($i) must queue exactly the one preview",
+          listOf(previewId),
+          rn.queued,
+        )
         val finished = client.pollRenderFinishedFor(previewId, timeout = 10.seconds)
         val params =
           finished["params"]?.jsonObject ?: error("renderFinished($i) missing params: $finished")
@@ -63,11 +66,7 @@ class B23SoakTest {
         // Every renderFinished must carry populated metrics — no JsonNull, no missing field.
         val wireMetrics = params["metrics"]
         assertNotNull("renderFinished($i).metrics must be populated", wireMetrics)
-        assertNotEquals(
-          "renderFinished($i).metrics must not be JsonNull",
-          JsonNull,
-          wireMetrics,
-        )
+        assertNotEquals("renderFinished($i).metrics must not be JsonNull", JsonNull, wireMetrics)
         val metricsObj = wireMetrics!!.jsonObject
 
         val heapAfterGcMb =
@@ -76,20 +75,14 @@ class B23SoakTest {
             ?.contentOrNull
             ?.toLongOrNull()
         val nativeHeapMb =
-          metricsObj[RenderMetrics.KEY_NATIVE_HEAP_MB]
-            ?.jsonPrimitive
-            ?.contentOrNull
-            ?.toLongOrNull()
+          metricsObj[RenderMetrics.KEY_NATIVE_HEAP_MB]?.jsonPrimitive?.contentOrNull?.toLongOrNull()
         val sandboxAgeRenders =
           metricsObj[RenderMetrics.KEY_SANDBOX_AGE_RENDERS]
             ?.jsonPrimitive
             ?.contentOrNull
             ?.toLongOrNull()
         val sandboxAgeMs =
-          metricsObj[RenderMetrics.KEY_SANDBOX_AGE_MS]
-            ?.jsonPrimitive
-            ?.contentOrNull
-            ?.toLongOrNull()
+          metricsObj[RenderMetrics.KEY_SANDBOX_AGE_MS]?.jsonPrimitive?.contentOrNull?.toLongOrNull()
 
         assertNotNull("render($i).heapAfterGcMb must parse as Long", heapAfterGcMb)
         assertNotNull("render($i).nativeHeapMb must parse as Long", nativeHeapMb)

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S1LifecycleAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S1LifecycleAndroidRealModeTest.kt
@@ -18,10 +18,10 @@ import org.junit.Test
 /**
  * D-harness.v2 Android counterpart of [S1LifecycleRealModeTest] — drives the same lifecycle
  * (`initialize → initialized → renderNow → renderStarted → renderFinished → shutdown → exit`), but
- * spawns the real `:daemon:android` `DaemonMain` via [RealAndroidHarnessLauncher] rather
- * than [RealDesktopHarnessLauncher]. The first time DESIGN § 4's renderer-agnostic claim is
- * enforced end-to-end at the harness level: same scenario shape, same composable, only the launcher
- * and baseline directory differ.
+ * spawns the real `:daemon:android` `DaemonMain` via [RealAndroidHarnessLauncher] rather than
+ * [RealDesktopHarnessLauncher]. The first time DESIGN § 4's renderer-agnostic claim is enforced
+ * end-to-end at the harness level: same scenario shape, same composable, only the launcher and
+ * baseline directory differ.
  *
  * **Skipped under fake mode and under `-Ptarget=desktop`.**
  *
@@ -32,8 +32,8 @@ import org.junit.Test
  *
  * **Per-target baselines.** Robolectric's bitmap output (HardwareRenderer/ImageReader) won't be
  * byte-identical to Skiko's — different renderers produce different AA / sub-pixel positioning. The
- * android baseline at `daemon/harness/baselines/android/s1/red-square.png` is captured
- * separately on first run; subsequent runs pixel-diff against it within the standard tolerance.
+ * android baseline at `daemon/harness/baselines/android/s1/red-square.png` is captured separately
+ * on first run; subsequent runs pixel-diff against it within the standard tolerance.
  */
 class S1LifecycleAndroidRealModeTest {
 

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S1LifecycleRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S1LifecycleRealModeTest.kt
@@ -18,16 +18,15 @@ import org.junit.Test
 /**
  * Real-mode counterpart to [S1LifecycleTest] — drives the same `initialize → initialized →
  * renderNow → renderStarted → renderFinished → shutdown → exit` lifecycle, but spawns the actual
- * `:daemon:desktop` `DaemonMain` via [RealDesktopHarnessLauncher] rather than
- * [FakeDaemonMain].
+ * `:daemon:desktop` `DaemonMain` via [RealDesktopHarnessLauncher] rather than [FakeDaemonMain].
  *
  * **Skipped under fake mode.** `JUnit Assume.assumeTrue(harnessHost == "real")` short-circuits the
  * test under the default `-Pharness.host=fake`. Run with `./gradlew :daemon:harness:test
  * -Pharness.host=real --tests "*S1LifecycleRealModeTest"`.
  *
  * **Auto-capture-on-first-run baseline.** A baseline PNG lives at
- * `daemon/harness/baselines/desktop/s1/red-square.png`. On the first run the test captures
- * the rendered PNG to that path and asserts only the basic "PNG exists, mostly red" properties. On
+ * `daemon/harness/baselines/desktop/s1/red-square.png`. On the first run the test captures the
+ * rendered PNG to that path and asserts only the basic "PNG exists, mostly red" properties. On
  * subsequent runs it pixel-diffs against the baseline. A `regenerateBaselines` task is the v1.5b
  * story; this auto-capture is the v1.5a flow — re-capturing means deleting the baseline file by
  * hand.

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3RenderAfterEditRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3RenderAfterEditRealModeTest.kt
@@ -27,8 +27,8 @@ import org.junit.Test
  * real-mode flow doesn't yet send a `fileChanged` notification because the render bypasses any
  * file-watching path entirely (no real source `.kt` is being edited mid-test) — adding that
  * assertion would require a recompile-on-the-fly fixture similar to
- * `S3_5RecompileSaveLoopRealModeTest`. Out of scope for v1; this test stays the
- * "different previewId → different bytes" round-trip check.
+ * `S3_5RecompileSaveLoopRealModeTest`. Out of scope for v1; this test stays the "different
+ * previewId → different bytes" round-trip check.
  *
  * Captured baselines: reuses `red-square.png` from v1.5a's S1 (no duplication) and adds
  * `blue-square.png`. Both live under `daemon/harness/baselines/desktop/s3/`.

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S4VisibilityFilterRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S4VisibilityFilterRealModeTest.kt
@@ -22,8 +22,8 @@ import org.junit.Test
  * and the latency CSV.
  *
  * Three preview composables — `RedSquare`, `BlueSquare`, `GreenSquare` — and three baselines under
- * `daemon/harness/baselines/desktop/s4/`. The diff catches a wire-level mix-up (e.g. the
- * daemon dispatching the wrong composable for a previewId).
+ * `daemon/harness/baselines/desktop/s4/`. The diff catches a wire-level mix-up (e.g. the daemon
+ * dispatching the wrong composable for a previewId).
  */
 class S4VisibilityFilterRealModeTest {
 

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S7LatencyRecordOnlyTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S7LatencyRecordOnlyTest.kt
@@ -24,8 +24,8 @@ import org.junit.Test
  *    the same preview — gives a "cold then warm" picture).
  * 2. Verify the CSV file is correctly created at the expected path with a header row and at least
  *    one data row after the suite runs. (Per the task brief: "Latency CSV exists at
- *    `daemon/harness/build/reports/daemon-harness/latency.csv` after a test run, populated
- *    for every scenario × preview pair.")
+ *    `daemon/harness/build/reports/daemon-harness/latency.csv` after a test run, populated for
+ *    every scenario × preview pair.")
  *
  * For fake mode the actual will be ~50ms (FakeHost just reads from disk + replies); the baselineMs
  * in the CSV is the desktop real-render median (~1100ms from

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S8CostModelMetricsAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S8CostModelMetricsAndroidRealModeTest.kt
@@ -15,15 +15,15 @@ import org.junit.Assume
 import org.junit.Test
 
 /**
- * D-harness.v2 Android counterpart of [S8CostModelMetricsRealModeTest] — verifies that the
- * Android daemon's wire-level `renderFinished.tookMs` carries the timing the engine measured, and
- * that the four post-B2.3 cost-model fields populate `renderFinished.metrics`.
+ * D-harness.v2 Android counterpart of [S8CostModelMetricsRealModeTest] — verifies that the Android
+ * daemon's wire-level `renderFinished.tookMs` carries the timing the engine measured, and that the
+ * four post-B2.3 cost-model fields populate `renderFinished.metrics`.
  *
  * **Same wire shape as desktop.** Both backends populate `RenderResult.metrics` from
  * `SandboxMeasurement.collect`; `JsonRpcServer.renderFinishedFromResult` (in `:daemon:core`)
  * translates the flat map into the structured [RenderMetrics] for the wire. On Android the
- * `SandboxLifecycleStats` lives inside the Robolectric sandbox (per-sandbox lifetime), so the
- * first render's `sandboxAgeRenders` is 1.
+ * `SandboxLifecycleStats` lives inside the Robolectric sandbox (per-sandbox lifetime), so the first
+ * render's `sandboxAgeRenders` is 1.
  *
  * **No baseline PNG.** Test asserts on the wire shape only.
  */
@@ -104,10 +104,7 @@ class S8CostModelMetricsAndroidRealModeTest {
           ?.contentOrNull
           ?.toLongOrNull()
       val sandboxAgeMs =
-        metricsObj[RenderMetrics.KEY_SANDBOX_AGE_MS]
-          ?.jsonPrimitive
-          ?.contentOrNull
-          ?.toLongOrNull()
+        metricsObj[RenderMetrics.KEY_SANDBOX_AGE_MS]?.jsonPrimitive?.contentOrNull?.toLongOrNull()
       assertNotNull("metrics.heapAfterGcMb must be a Long", heapAfterGcMb)
       assertNotNull("metrics.nativeHeapMb must be a Long", nativeHeapMb)
       assertNotNull("metrics.sandboxAgeRenders must be a Long", sandboxAgeRenders)
@@ -120,11 +117,7 @@ class S8CostModelMetricsAndroidRealModeTest {
         "metrics.nativeHeapMb >= 0 (0 if non-HotSpot fallback): got $nativeHeapMb",
         nativeHeapMb!! >= 0L,
       )
-      assertEquals(
-        "first render's sandboxAgeRenders must be 1",
-        1L,
-        sandboxAgeRenders,
-      )
+      assertEquals("first render's sandboxAgeRenders must be 1", 1L, sandboxAgeRenders)
       assertTrue(
         "metrics.sandboxAgeMs must be non-negative: got $sandboxAgeMs",
         sandboxAgeMs!! >= 0L,

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S8CostModelMetricsRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S8CostModelMetricsRealModeTest.kt
@@ -21,11 +21,11 @@ import org.junit.Test
  *
  * **What's present post-B2.3:**
  * - `renderFinished.tookMs` reflects the wall-clock the engine spent in `RenderEngine.render`.
- * - `renderFinished.metrics` (typed as `RenderMetrics?`) carries the four B2.3 cost-model
- *   fields — `heapAfterGcMb` (post-`System.gc()` Runtime delta), `nativeHeapMb` (committed
- *   virtual memory size on HotSpot), `sandboxAgeRenders` (per-sandbox counter), `sandboxAgeMs`
- *   (wall-clock since `DesktopHost`'s construction). The desktop host owns its own
- *   `SandboxLifecycleStats`, so the first render's `sandboxAgeRenders` is exactly 1.
+ * - `renderFinished.metrics` (typed as `RenderMetrics?`) carries the four B2.3 cost-model fields —
+ *   `heapAfterGcMb` (post-`System.gc()` Runtime delta), `nativeHeapMb` (committed virtual memory
+ *   size on HotSpot), `sandboxAgeRenders` (per-sandbox counter), `sandboxAgeMs` (wall-clock since
+ *   `DesktopHost`'s construction). The desktop host owns its own `SandboxLifecycleStats`, so the
+ *   first render's `sandboxAgeRenders` is exactly 1.
  *
  * **No baseline PNG.** Test asserts on the wire shape only.
  */
@@ -106,10 +106,7 @@ class S8CostModelMetricsRealModeTest {
           ?.contentOrNull
           ?.toLongOrNull()
       val sandboxAgeMs =
-        metricsObj[RenderMetrics.KEY_SANDBOX_AGE_MS]
-          ?.jsonPrimitive
-          ?.contentOrNull
-          ?.toLongOrNull()
+        metricsObj[RenderMetrics.KEY_SANDBOX_AGE_MS]?.jsonPrimitive?.contentOrNull?.toLongOrNull()
       assertNotNull("metrics.heapAfterGcMb must be a Long", heapAfterGcMb)
       assertNotNull("metrics.nativeHeapMb must be a Long", nativeHeapMb)
       assertNotNull("metrics.sandboxAgeRenders must be a Long", sandboxAgeRenders)
@@ -122,11 +119,7 @@ class S8CostModelMetricsRealModeTest {
         "metrics.nativeHeapMb >= 0 (0 if non-HotSpot fallback): got $nativeHeapMb",
         nativeHeapMb!! >= 0L,
       )
-      assertEquals(
-        "first render's sandboxAgeRenders must be 1",
-        1L,
-        sandboxAgeRenders,
-      )
+      assertEquals("first render's sandboxAgeRenders must be 1", 1L, sandboxAgeRenders)
       assertTrue(
         "metrics.sandboxAgeMs must be non-negative: got $sandboxAgeMs",
         sandboxAgeMs!! >= 0L,

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S8CostModelMetricsTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S8CostModelMetricsTest.kt
@@ -24,21 +24,21 @@ import org.junit.Test
  * Long>` that `FakeHost` populates `RenderResult.metrics` with; the harness asserts the
  * round-tripped JSON matches.
  *
- * **Post-B2.3 wire shape.** `JsonRpcServer.renderFinishedFromResult` now translates the host's
- * flat `Map<String, Long>` carrier into a structured [RenderMetrics] on the wire (see
+ * **Post-B2.3 wire shape.** `JsonRpcServer.renderFinishedFromResult` now translates the host's flat
+ * `Map<String, Long>` carrier into a structured [RenderMetrics] on the wire (see
  * [RenderMetrics.fromFlatMap]). [FakeHost] populates the four B2.3 keys on every render —
  * `heapAfterGcMb` / `nativeHeapMb` / `sandboxAgeRenders` / `sandboxAgeMs` — with synthetic but
- * non-zero values. Sidecar-supplied metrics from `<previewId>.metrics.json` still take
- * precedence on key collision so legacy fixtures (this test's `heapAfterGcMb=42`,
- * `nativeHeapMb=17`, `sandboxAgeRenders=3` example) keep their explicit values.
+ * non-zero values. Sidecar-supplied metrics from `<previewId>.metrics.json` still take precedence
+ * on key collision so legacy fixtures (this test's `heapAfterGcMb=42`, `nativeHeapMb=17`,
+ * `sandboxAgeRenders=3` example) keep their explicit values.
  *
  * **What this test asserts after B2.3:**
  *
  * 1. `FakeHost` round-trips the fixture's metrics map verbatim (sidecar loader sanity check).
- * 2. The wire-level `renderFinished.metrics` is now a populated [RenderMetrics] object (not
- *    null) and carries the four B2.3 fields — sidecar values for `heapAfterGcMb`,
- *    `nativeHeapMb`, `sandboxAgeRenders`, plus the FakeHost-provided default for `sandboxAgeMs`
- *    (which the sidecar doesn't override, so we just check it's a non-negative `Long`).
+ * 2. The wire-level `renderFinished.metrics` is now a populated [RenderMetrics] object (not null)
+ *    and carries the four B2.3 fields — sidecar values for `heapAfterGcMb`, `nativeHeapMb`,
+ *    `sandboxAgeRenders`, plus the FakeHost-provided default for `sandboxAgeMs` (which the sidecar
+ *    doesn't override, so we just check it's a non-negative `Long`).
  *
  * Real cost-model parity (TEST-HARNESS § 3's "measured ratios within ±50% of cost-catalogue
  * ratios") is impossible against `FakeHost` — the metrics are whatever we configure. That parity
@@ -107,18 +107,12 @@ class S8CostModelMetricsTest {
           ?.contentOrNull
           ?.toLongOrNull()
       val sandboxAgeMs =
-        metricsObj[RenderMetrics.KEY_SANDBOX_AGE_MS]
-          ?.jsonPrimitive
-          ?.contentOrNull
-          ?.toLongOrNull()
+        metricsObj[RenderMetrics.KEY_SANDBOX_AGE_MS]?.jsonPrimitive?.contentOrNull?.toLongOrNull()
       assertEquals("heapAfterGcMb sourced from sidecar", 42L, heapAfterGcMb)
       assertEquals("nativeHeapMb sourced from sidecar", 17L, nativeHeapMb)
       assertEquals("sandboxAgeRenders sourced from sidecar", 3L, sandboxAgeRenders)
       assertNotNull("sandboxAgeMs supplied by FakeHost B2.3 default", sandboxAgeMs)
-      assertTrue(
-        "sandboxAgeMs must be a non-negative wall-clock measurement",
-        sandboxAgeMs!! >= 0L,
-      )
+      assertTrue("sandboxAgeMs must be a non-negative wall-clock measurement", sandboxAgeMs!! >= 0L)
 
       paths.latency.record(
         scenario = paths.name,

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -741,10 +741,7 @@ internal object AndroidPreviewSupport {
           project.dependencies.project(mapOf("path" to ":daemon:android")),
         )
       } catch (e: org.gradle.api.UnknownProjectException) {
-        project.logger.debug(
-          "compose-ai-tools: :daemon:android project not found, skipping",
-          e,
-        )
+        project.logger.debug("compose-ai-tools: :daemon:android project not found, skipping", e)
       }
     } else {
       // External mode is intentionally a no-op while the daemon is

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonBootstrapTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonBootstrapTask.kt
@@ -32,12 +32,12 @@ import org.gradle.api.tasks.TaskAction
  * `renderPreviews` task uses. That guarantees the daemon JVM is byte-for-byte equivalent to a
  * `renderPreviews` JVM, modulo the daemon-specific entries documented below.
  *
- * **Pending Stream B integration.** The daemon's own renderer JAR (`daemon/android`, Phase
- * 1 task B1.1) is NOT yet on disk in this worktree. When it lands, `registerAndroidTasks` should
- * prepend that configuration's resolved files to [classpath] so
- * [DaemonClasspathDescriptor.mainClass] (`ee.schimke.composeai.daemon.DaemonMain`) is loadable by
- * the launched JVM. Until then, the descriptor's [DaemonClasspathDescriptor.enabled] field defaults
- * to `false` and the VS Code extension MUST refuse to launch.
+ * **Pending Stream B integration.** The daemon's own renderer JAR (`daemon/android`, Phase 1 task
+ * B1.1) is NOT yet on disk in this worktree. When it lands, `registerAndroidTasks` should prepend
+ * that configuration's resolved files to [classpath] so [DaemonClasspathDescriptor.mainClass]
+ * (`ee.schimke.composeai.daemon.DaemonMain`) is loadable by the launched JVM. Until then, the
+ * descriptor's [DaemonClasspathDescriptor.enabled] field defaults to `false` and the VS Code
+ * extension MUST refuse to launch.
  *
  * **Caching.** `@CacheableTask` because the only output is a small JSON derivable from declared
  * inputs — the entire body is deterministic. The classpath is `@Classpath` (not `@InputFiles`) so a

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonClasspathDescriptor.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonClasspathDescriptor.kt
@@ -45,8 +45,8 @@ internal data class DaemonClasspathDescriptor(
   val enabled: Boolean,
   /**
    * Fully-qualified main class, e.g. `ee.schimke.composeai.daemon.DaemonMain`. Stream B
-   * (`daemon/android`) provides this entry point; until that module exists, the descriptor
-   * still encodes the conventional name so the descriptor schema is stable.
+   * (`daemon/android`) provides this entry point; until that module exists, the descriptor still
+   * encodes the conventional name so the descriptor schema is stable.
    */
   val mainClass: String,
   /**


### PR DESCRIPTION
## Summary

- Ran `./gradlew ktfmtFormatAll` to apply the configured Google-style ktfmt across the codebase.
- 39 Kotlin files reformatted (no behavioural changes), spanning `daemon/core`, `daemon/desktop`, `daemon/harness`, and parts of `gradle-plugin`.

## Test plan

- [x] `./gradlew ktfmtCheckAll` passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01MjkVA79RB4zsk8dw8TGCbK)_