### PR TITLE
feat(mcp): top-level :mcp module — Model Context Protocol server over the preview daemon

### DIFF
--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -1,0 +1,49 @@
+// Top-level MCP server module — exposes the preview daemon as a Model Context Protocol server.
+// See docs/daemon/MCP.md (high-level design) and docs/daemon/MCP-KOTLIN.md (implementation
+// specifics) — except the module path: this is `:mcp`, top-level, not nested under `:daemon`.
+//
+// The MCP shim is renderer-agnostic: it depends only on `:daemon:core` for protocol message
+// types and spawns daemon JVMs via launch descriptors emitted by `composePreviewDaemonStart`.
+// It never depends on `:daemon:android` or `:daemon:desktop`.
+//
+// One server process can multiplex per-(workspace, module) daemons across multiple distinct
+// projects or worktrees — see `DaemonSupervisor` for the workspace-id derivation.
+
+plugins {
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
+}
+
+group = "ee.schimke.composeai"
+
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
+
+dependencies {
+  implementation(libs.kotlinx.coroutines.core)
+  implementation(libs.kotlinx.serialization.json)
+  // For DaemonClasspathDescriptor (read at supervisor spawn time) and the protocol message types
+  // exchanged with daemon JVMs.
+  implementation(project(":daemon:core"))
+
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+  testImplementation(libs.kotlinx.coroutines.core)
+}
+
+// We deliberately do NOT depend on `io.modelcontextprotocol:kotlin-sdk` in v0:
+// - The SDK auto-registers internal handlers for `resources/list` / `resources/read` / `subscribe`,
+//   making the dynamic catalog + push subscription model we need awkward to bolt on.
+// - Rolling our own keeps the wire layer self-contained, mirrors the proven
+//   `:daemon:core` `JsonRpcServer` framing, and removes a 0.x-version-pin risk.
+// - The SDK can be reintroduced as a non-breaking internal refactor once the surface stabilises.
+
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
+
+tasks.withType<Test>().configureEach { useJUnit() }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
@@ -1,0 +1,251 @@
+package ee.schimke.composeai.mcp
+
+import ee.schimke.composeai.daemon.protocol.ClientCapabilities
+import ee.schimke.composeai.daemon.protocol.InitializeParams
+import ee.schimke.composeai.daemon.protocol.InitializeResult
+import ee.schimke.composeai.daemon.protocol.JsonRpcNotification
+import ee.schimke.composeai.daemon.protocol.JsonRpcRequest
+import ee.schimke.composeai.daemon.protocol.RenderNowParams
+import ee.schimke.composeai.daemon.protocol.RenderNowResult
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.daemon.protocol.SetFocusParams
+import ee.schimke.composeai.daemon.protocol.SetVisibleParams
+import java.io.ByteArrayOutputStream
+import java.io.Closeable
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+
+/**
+ * A JSON-RPC client over `Content-Length`-framed stdio against a single daemon JVM, paired with a
+ * callback-driven notification stream. The structure mirrors
+ * [`HarnessClient`][ee.schimke.composeai.daemon.harness.HarnessClient] from `:daemon:harness`, with
+ * two changes:
+ *
+ * 1. The transport is taken as `(InputStream, OutputStream)` rather than wrapping a [Process], so
+ *    tests can drive the client over an in-memory pipe without a subprocess.
+ * 2. Notifications are dispatched via [onNotification] rather than queued for caller polling — the
+ *    MCP supervisor consumes every notification (`renderFinished` → push update; `discoveryUpdated`
+ *    → list_changed; `classpathDirty` → respawn) so we don't need the predicate-poll API the
+ *    harness uses for assertions.
+ */
+class DaemonClient(
+  private val input: InputStream,
+  private val output: OutputStream,
+  /** Notification sink. Called from the reader thread; handlers must not block. */
+  private val onNotification: (method: String, params: JsonObject?) -> Unit,
+  /** Optional: invoked when the read thread observes EOF. Supervisor uses this for respawn. */
+  private val onClose: () -> Unit = {},
+  threadName: String = "mcp-daemon-client-reader",
+) : Closeable {
+
+  private val json = Json { ignoreUnknownKeys = true }
+  private val nextId = AtomicLong(1)
+  private val responseSlots = ConcurrentHashMap<Long, LinkedBlockingQueue<JsonObject>>()
+  private val closed = java.util.concurrent.atomic.AtomicBoolean(false)
+  private val readerThread =
+    Thread({ runReader() }, threadName).apply {
+      isDaemon = true
+      start()
+    }
+
+  /** Drives `initialize` + `initialized`. Returns the daemon's [InitializeResult]. */
+  fun initialize(
+    workspaceRoot: String,
+    moduleId: String,
+    moduleProjectDir: String,
+    capabilities: ClientCapabilities = ClientCapabilities(visibility = true, metrics = true),
+    timeout: Duration = 30.seconds,
+  ): InitializeResult {
+    val id = nextId.getAndIncrement()
+    val params =
+      InitializeParams(
+        protocolVersion = 1,
+        clientVersion = "compose-preview-mcp/v0",
+        workspaceRoot = workspaceRoot,
+        moduleId = moduleId,
+        moduleProjectDir = moduleProjectDir,
+        capabilities = capabilities,
+      )
+    val request =
+      JsonRpcRequest(
+        id = id,
+        method = "initialize",
+        params = json.encodeToJsonElement(InitializeParams.serializer(), params),
+      )
+    val response = sendAndAwait(id, request, timeout)
+    val resultElem =
+      response["result"]
+        ?: error("initialize: no result — error=${response["error"]}, full=$response")
+    val result = json.decodeFromJsonElement(InitializeResult.serializer(), resultElem)
+    sendNotification("initialized", JsonObject(emptyMap()))
+    return result
+  }
+
+  fun setVisible(ids: List<String>) =
+    sendNotification(
+      "setVisible",
+      json.encodeToJsonElement(SetVisibleParams.serializer(), SetVisibleParams(ids = ids)),
+    )
+
+  fun setFocus(ids: List<String>) =
+    sendNotification(
+      "setFocus",
+      json.encodeToJsonElement(SetFocusParams.serializer(), SetFocusParams(ids = ids)),
+    )
+
+  /** Drives `renderNow` for the given preview ids at the given [tier]. */
+  fun renderNow(
+    previews: List<String>,
+    tier: RenderTier = RenderTier.FULL,
+    reason: String? = null,
+    timeout: Duration = 30.seconds,
+  ): RenderNowResult {
+    val id = nextId.getAndIncrement()
+    val params = RenderNowParams(previews = previews, tier = tier, reason = reason)
+    val request =
+      JsonRpcRequest(
+        id = id,
+        method = "renderNow",
+        params = json.encodeToJsonElement(RenderNowParams.serializer(), params),
+      )
+    val response = sendAndAwait(id, request, timeout)
+    val resultElem =
+      response["result"]
+        ?: error("renderNow: no result — error=${response["error"]}, full=$response")
+    return json.decodeFromJsonElement(RenderNowResult.serializer(), resultElem)
+  }
+
+  /**
+   * Sends `shutdown` (drains in-flight renders) then `exit`. Does not wait for process exit — the
+   * [DaemonSpawn] owner does that.
+   */
+  fun shutdownAndExit(timeout: Duration = 15.seconds) {
+    if (closed.get()) return
+    runCatching {
+      val id = nextId.getAndIncrement()
+      val request = JsonRpcRequest(id = id, method = "shutdown", params = JsonNull)
+      sendAndAwait(id, request, timeout)
+    }
+    runCatching { sendNotification("exit", JsonNull) }
+  }
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    runCatching { input.close() }
+    runCatching { output.close() }
+    readerThread.join(2_000)
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals — framing + reader
+  // -------------------------------------------------------------------------
+
+  private fun sendAndAwait(id: Long, request: JsonRpcRequest, timeout: Duration): JsonObject {
+    val slot = responseSlots.computeIfAbsent(id) { LinkedBlockingQueue() }
+    sendFrame(json.encodeToString(JsonRpcRequest.serializer(), request))
+    val response = slot.poll(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+    responseSlots.remove(id)
+    return response
+      ?: error(
+        "DaemonClient: response for id=$id (method=${request.method}) timed out after $timeout"
+      )
+  }
+
+  private fun sendNotification(method: String, params: kotlinx.serialization.json.JsonElement) {
+    val n = JsonRpcNotification(method = method, params = params)
+    sendFrame(json.encodeToString(JsonRpcNotification.serializer(), n))
+  }
+
+  private fun sendFrame(jsonText: String) {
+    val payload = jsonText.toByteArray(Charsets.UTF_8)
+    val header = "Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII)
+    synchronized(output) {
+      output.write(header)
+      output.write(payload)
+      output.flush()
+    }
+  }
+
+  private fun runReader() {
+    try {
+      while (!closed.get()) {
+        val frame = readFrame(input) ?: break
+        val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+        val responseId = obj["id"]?.jsonPrimitive?.long
+        if (responseId != null) {
+          responseSlots.computeIfAbsent(responseId) { LinkedBlockingQueue() }.put(obj)
+        } else {
+          val method = obj["method"]?.jsonPrimitive?.contentOrNull
+          if (method != null) {
+            val params = obj["params"]?.jsonObject
+            runCatching { onNotification(method, params) }
+          }
+        }
+      }
+    } catch (_: IOException) {
+      // EOF — fall through to onClose.
+    } catch (e: Throwable) {
+      System.err.println("DaemonClient reader: ${e.message}")
+      e.printStackTrace(System.err)
+    } finally {
+      runCatching { onClose() }
+    }
+  }
+
+  private fun readFrame(input: InputStream): ByteArray? {
+    var contentLength = -1
+    val headerBuf = ByteArrayOutputStream(64)
+    var sawAny = false
+    while (true) {
+      val line = readHeaderLine(input, headerBuf) ?: return if (sawAny) null else null
+      sawAny = true
+      if (line.isEmpty()) break
+      val colon = line.indexOf(':')
+      if (colon <= 0) error("malformed daemon header line: '$line'")
+      val name = line.substring(0, colon).trim()
+      val value = line.substring(colon + 1).trim()
+      if (name.equals("Content-Length", ignoreCase = true)) {
+        contentLength = value.toIntOrNull() ?: error("non-integer Content-Length: '$value'")
+      }
+    }
+    if (contentLength < 0) error("missing Content-Length header")
+    val payload = ByteArray(contentLength)
+    var off = 0
+    while (off < contentLength) {
+      val n = input.read(payload, off, contentLength - off)
+      if (n < 0) return null
+      off += n
+    }
+    return payload
+  }
+
+  private fun readHeaderLine(input: InputStream, buf: ByteArrayOutputStream): String? {
+    buf.reset()
+    while (true) {
+      val b = input.read()
+      if (b < 0) return if (buf.size() == 0) null else buf.toString(Charsets.US_ASCII.name())
+      if (b == '\n'.code) {
+        val bytes = buf.toByteArray()
+        val end =
+          if (bytes.isNotEmpty() && bytes.last() == '\r'.code.toByte()) bytes.size - 1
+          else bytes.size
+        return String(bytes, 0, end, Charsets.US_ASCII)
+      }
+      buf.write(b)
+    }
+  }
+}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -1,0 +1,160 @@
+package ee.schimke.composeai.mcp
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Entry point for the standalone MCP server. Stdio transport in v0; remote / HTTP transports are a
+ * follow-up (see docs/daemon/MCP-KOTLIN.md § "Transports").
+ *
+ * **CLI:**
+ *
+ * ```
+ * compose-preview-mcp [--project <path>[:<rootProjectName>]]...
+ * ```
+ *
+ * Each `--project` flag pre-registers a workspace with the supervisor at startup so connecting
+ * clients see the project in `list_projects` immediately. Projects can also be added at runtime via
+ * the `register_project` MCP tool.
+ *
+ * On stdin EOF the server tears down every supervised daemon (sending `shutdown` + `exit` per
+ * PROTOCOL.md § 3) and exits cleanly.
+ */
+object DaemonMcpMain {
+
+  @JvmStatic
+  fun main(args: Array<String>) {
+    val supervisor =
+      DaemonSupervisor(
+        descriptorProvider = DescriptorProvider.readingFromDisk(),
+        clientFactory = SubprocessDaemonClientFactory(),
+      )
+    val server = DaemonMcpServer(supervisor)
+
+    parseProjects(args).forEach { (path, name) ->
+      runCatching { supervisor.registerProject(File(path), name) }
+        .onFailure {
+          System.err.println("compose-preview-mcp: failed to register $path: ${it.message}")
+        }
+    }
+
+    Runtime.getRuntime().addShutdownHook(Thread { runCatching { supervisor.shutdown() } })
+
+    val session = server.newSession(input = System.`in`, output = System.out)
+    session.start()
+    // Block main thread until stdin EOF (reader exits), then exit cleanly. The reader is a daemon
+    // thread so the JVM would otherwise terminate immediately; awaitClose pins main here.
+    session.awaitClose()
+    runCatching { supervisor.shutdown() }
+  }
+
+  private fun parseProjects(args: Array<String>): List<Pair<String, String?>> {
+    val out = mutableListOf<Pair<String, String?>>()
+    var i = 0
+    while (i < args.size) {
+      val a = args[i]
+      when {
+        a == "--project" && i + 1 < args.size -> {
+          val raw = args[i + 1]
+          val (path, name) = splitProjectArg(raw)
+          out.add(path to name)
+          i += 2
+        }
+        a.startsWith("--project=") -> {
+          val raw = a.removePrefix("--project=")
+          val (path, name) = splitProjectArg(raw)
+          out.add(path to name)
+          i++
+        }
+        else -> i++
+      }
+    }
+    return out
+  }
+
+  private fun splitProjectArg(raw: String): Pair<String, String?> {
+    // Format: <path>[:<rootProjectName>]. Path may itself contain ':' on non-Windows hosts (rare),
+    // so we split on the *last* colon. Empty name → null.
+    val idx = raw.lastIndexOf(':')
+    return if (idx <= 0) raw to null
+    else raw.substring(0, idx) to raw.substring(idx + 1).takeIf { it.isNotEmpty() }
+  }
+}
+
+/**
+ * Production [DaemonClientFactory]: forks a JVM per [DaemonLaunchDescriptor] and pipes its stdio
+ * into a [DaemonClient]. Mirrors `RealDesktopHarnessLauncher` from `:daemon:harness`.
+ */
+class SubprocessDaemonClientFactory : DaemonClientFactory {
+  override fun spawn(project: RegisteredProject, descriptor: DaemonLaunchDescriptor): DaemonSpawn {
+    require(descriptor.enabled) {
+      "daemon disabled for ${descriptor.modulePath} — set composePreview.experimental.daemon.enabled = true"
+    }
+    val javaBin =
+      descriptor.javaLauncher ?: File(System.getProperty("java.home"), "bin/java").absolutePath
+    val cpString = descriptor.classpath.joinToString(File.pathSeparator)
+    val command =
+      buildList<String> {
+        add(javaBin)
+        addAll(descriptor.jvmArgs)
+        descriptor.systemProperties.forEach { (k, v) -> add("-D$k=$v") }
+        add("-cp")
+        add(cpString)
+        add(descriptor.mainClass)
+      }
+    val process =
+      ProcessBuilder(command)
+        .directory(File(descriptor.workingDirectory))
+        .redirectErrorStream(false)
+        .redirectInput(ProcessBuilder.Redirect.PIPE)
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .redirectError(ProcessBuilder.Redirect.PIPE)
+        .start()
+    forwardStderr(process, "${project.workspaceId}/${descriptor.modulePath}")
+    return SubprocessDaemonSpawn(process)
+  }
+
+  private fun forwardStderr(process: Process, tag: String) {
+    Thread(
+        {
+          process.errorStream.bufferedReader().useLines { lines ->
+            lines.forEach { System.err.println("[daemon $tag] $it") }
+          }
+        },
+        "mcp-daemon-stderr-$tag",
+      )
+      .apply { isDaemon = true }
+      .start()
+  }
+}
+
+private class SubprocessDaemonSpawn(private val process: Process) : DaemonSpawn {
+  private lateinit var _client: DaemonClient
+
+  override val client: DaemonClient
+    get() = _client
+
+  override fun client(
+    onNotification: (method: String, params: JsonObject?) -> Unit,
+    onClose: () -> Unit,
+  ): DaemonClient {
+    _client =
+      DaemonClient(
+        input = process.inputStream,
+        output = process.outputStream,
+        onNotification = onNotification,
+        onClose = onClose,
+      )
+    return _client
+  }
+
+  override fun shutdown() {
+    runCatching { _client.shutdownAndExit() }
+    if (!process.waitFor(15, TimeUnit.SECONDS)) {
+      process.destroy()
+      if (!process.waitFor(2, TimeUnit.SECONDS)) process.destroyForcibly()
+    }
+    runCatching { _client.close() }
+  }
+}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -1,0 +1,569 @@
+package ee.schimke.composeai.mcp
+
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.mcp.protocol.CallToolResult
+import ee.schimke.composeai.mcp.protocol.ContentBlock
+import ee.schimke.composeai.mcp.protocol.Implementation
+import ee.schimke.composeai.mcp.protocol.ListResourcesResult
+import ee.schimke.composeai.mcp.protocol.ListToolsResult
+import ee.schimke.composeai.mcp.protocol.ReadResourceResult
+import ee.schimke.composeai.mcp.protocol.ResourceContents
+import ee.schimke.composeai.mcp.protocol.ResourceDescriptor
+import ee.schimke.composeai.mcp.protocol.ResourcesCapability
+import ee.schimke.composeai.mcp.protocol.ServerCapabilities
+import ee.schimke.composeai.mcp.protocol.ToolDef
+import ee.schimke.composeai.mcp.protocol.ToolsCapability
+import java.io.File
+import java.nio.file.Files
+import java.time.Instant
+import java.util.Base64
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+
+/**
+ * The load-bearing wiring layer. Owns:
+ *
+ * - The per-(workspace, module) **preview catalog** populated from daemon `discoveryUpdated`.
+ * - The MCP **resources** surface (`list`, `read`, `subscribe`, `unsubscribe`).
+ * - The MCP **tools** surface (`register_project`, `list_projects`, `unregister_project`,
+ *   `render_preview`, `watch`, `unwatch`, `list_watches`).
+ * - The translation of daemon `renderFinished` → `notifications/resources/updated` (for subscribed
+ *   clients and for clients whose watch sets cover the URI).
+ * - The translation of daemon `discoveryUpdated` → `notifications/resources/list_changed`.
+ * - Watch propagation back to daemons via [WatchPropagator].
+ * - History recording on every successful render via [HistoryStore].
+ *
+ * Renderer-agnostic: the catalog stores the daemon's preview ids verbatim (typically
+ * `<className>.<methodName>` per `DiscoverPreviewsTask`), and the URI builder pairs them with the
+ * (workspace, module) they came from.
+ */
+class DaemonMcpServer(
+  private val supervisor: DaemonSupervisor,
+  private val sessions: SessionRegistry = SessionRegistry(),
+  private val subscriptions: Subscriptions = Subscriptions(),
+  private val historyStore: HistoryStore = HistoryStore.NOOP,
+  private val serverInfo: Implementation =
+    Implementation(name = "compose-preview-mcp", version = "v0"),
+  private val renderTimeoutMs: Long = 60_000,
+) {
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = false
+  }
+
+  /**
+   * Per-(workspace, module) catalog: preview-id → minimal metadata. Updated from `discoveryUpdated`
+   * on the daemon's reader thread; read by `resources/list` and the watch propagator on session
+   * threads.
+   */
+  private val catalog: ConcurrentHashMap<DaemonAddr, ConcurrentHashMap<String, PreviewEntry>> =
+    ConcurrentHashMap()
+
+  /**
+   * Outstanding `resources/read` waiters, keyed by `(workspace, module, previewId)`. Awakened by
+   * `renderFinished` notifications. We block at most [renderTimeoutMs] on the queue, then time out.
+   */
+  private val pendingRenders = ConcurrentHashMap<RenderKey, LinkedBlockingQueue<RenderOutcome>>()
+
+  private val watchPropagator =
+    WatchPropagator(
+      subscriptions = subscriptions,
+      previewIdProvider = { daemon ->
+        val byId =
+          catalog[DaemonAddr(daemon.workspaceId, daemon.modulePath)]
+            ?: return@WatchPropagator emptyList()
+        byId.values.map { entry ->
+          PreviewUri(
+            workspaceId = daemon.workspaceId,
+            modulePath = daemon.modulePath,
+            previewFqn = entry.fqn,
+            config = entry.config,
+          )
+        }
+      },
+    )
+
+  init {
+    val router = supervisor.router()
+    router.on("discoveryUpdated") { daemon, params -> onDiscoveryUpdated(daemon, params) }
+    router.on("renderFinished") { daemon, params -> onRenderFinished(daemon, params) }
+    router.on("renderFailed") { daemon, params -> onRenderFailed(daemon, params) }
+    router.on("classpathDirty") { daemon, params ->
+      System.err.println(
+        "DaemonMcpServer: classpathDirty for ${daemon.workspaceId}/${daemon.modulePath}: " +
+          (params?.get("detail")?.jsonPrimitive?.contentOrNull ?: "<no detail>")
+      )
+      // v0: log only. Respawn on next render. Future: push a logging notification + auto-respawn.
+    }
+    router.onClose { daemon ->
+      catalog.remove(DaemonAddr(daemon.workspaceId, daemon.modulePath))
+      watchPropagator.forget(daemon)
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API consumed by McpSession via McpHandlers
+  // -------------------------------------------------------------------------
+
+  fun newSession(input: java.io.InputStream, output: java.io.OutputStream): McpSession {
+    lateinit var session: McpSession
+    val handlers =
+      object : McpHandlers {
+        override fun listTools(session: McpSession): JsonElement =
+          json.encodeToJsonElement(ListToolsResult.serializer(), ListToolsResult(toolDefs))
+
+        override fun callTool(
+          session: McpSession,
+          name: String,
+          arguments: JsonElement?,
+        ): CallToolResult = handleCallTool(session, name, arguments)
+
+        override fun listResources(session: McpSession): JsonElement {
+          val resources = catalogResources()
+          return json.encodeToJsonElement(
+            ListResourcesResult.serializer(),
+            ListResourcesResult(resources),
+          )
+        }
+
+        override fun readResource(session: McpSession, uri: String): ReadResourceResult =
+          handleReadResource(uri)
+
+        override fun subscribe(session: McpSession, uri: String) {
+          subscriptions.subscribe(uri, session)
+        }
+
+        override fun unsubscribe(session: McpSession, uri: String) {
+          subscriptions.unsubscribe(uri, session)
+        }
+
+        override fun onClose(session: McpSession) {
+          subscriptions.forget(session)
+          sessions.unregister(session)
+        }
+      }
+    session =
+      McpSession(
+        input = input,
+        output = output,
+        handlers = handlers,
+        serverInfo = serverInfo,
+        capabilities =
+          ServerCapabilities(
+            tools = ToolsCapability(listChanged = false),
+            resources = ResourcesCapability(subscribe = true, listChanged = true),
+          ),
+      )
+    sessions.register(session)
+    return session
+  }
+
+  // -------------------------------------------------------------------------
+  // Resource list / read
+  // -------------------------------------------------------------------------
+
+  private fun catalogResources(): List<ResourceDescriptor> {
+    val out = mutableListOf<ResourceDescriptor>()
+    for ((addr, byId) in catalog) {
+      for (entry in byId.values) {
+        val uri =
+          PreviewUri(
+            workspaceId = addr.workspaceId,
+            modulePath = addr.modulePath,
+            previewFqn = entry.fqn,
+            config = entry.config,
+          )
+        out.add(
+          ResourceDescriptor(
+            uri = uri.toUri(),
+            name = entry.fqn.substringAfterLast('.'),
+            description = entry.displayName ?: entry.fqn,
+            mimeType = "image/png",
+          )
+        )
+      }
+    }
+    return out.sortedBy { it.uri }
+  }
+
+  private fun handleReadResource(uri: String): ReadResourceResult {
+    val parsed = PreviewUri.parseOrNull(uri) ?: error("Invalid compose-preview URI: '$uri'")
+    val pngBytes = renderAndReadBytes(parsed)
+    val encoded = Base64.getEncoder().encodeToString(pngBytes)
+    return ReadResourceResult(
+      contents = listOf(ResourceContents.Blob(uri = uri, mimeType = "image/png", blob = encoded))
+    )
+  }
+
+  private fun renderAndReadBytes(uri: PreviewUri): ByteArray {
+    val daemon = supervisor.daemonFor(uri.workspaceId, uri.modulePath)
+    val key = RenderKey(uri.workspaceId, uri.modulePath, uri.previewFqn)
+    val slot = pendingRenders.computeIfAbsent(key) { LinkedBlockingQueue() }
+    daemon.client.renderNow(previews = listOf(uri.previewFqn), tier = RenderTier.FULL)
+    val outcome =
+      slot.poll(renderTimeoutMs, TimeUnit.MILLISECONDS)
+        ?: run {
+          pendingRenders.remove(key)
+          error("renderAndReadBytes: timed out after ${renderTimeoutMs}ms for $uri")
+        }
+    pendingRenders.remove(key)
+    when (outcome) {
+      is RenderOutcome.Failed ->
+        error("renderAndReadBytes failed for $uri: ${outcome.kind} ${outcome.message}")
+      is RenderOutcome.Finished -> {
+        val file = File(outcome.pngPath)
+        check(file.isFile) { "renderAndReadBytes: pngPath does not exist: ${outcome.pngPath}" }
+        return Files.readAllBytes(file.toPath())
+      }
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Tool surface
+  // -------------------------------------------------------------------------
+
+  private val toolDefs: List<ToolDef> =
+    listOf(
+      ToolDef(
+        name = "register_project",
+        description =
+          "Register a project (workspace) so its previews can be listed and watched. Returns the assigned workspaceId.",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type": "object",
+              "properties": {
+                "path": {"type": "string", "description": "Absolute path to the project root."},
+                "rootProjectName": {"type": "string", "description": "Optional override for the workspace's display name."},
+                "modules": {"type": "array", "items": {"type": "string"}, "description": "Optional initial set of preview-eligible Gradle module paths."}
+              },
+              "required": ["path"]
+            }
+            """
+              .trimIndent()
+          ),
+      ),
+      ToolDef(
+        name = "unregister_project",
+        description = "Forget a registered project; tears down its daemons.",
+        inputSchema =
+          parseSchema(
+            """
+            {"type":"object","properties":{"workspaceId":{"type":"string"}},"required":["workspaceId"]}
+            """
+              .trimIndent()
+          ),
+      ),
+      ToolDef(
+        name = "list_projects",
+        description = "List every registered project with its workspaceId, name, and path.",
+        inputSchema = parseSchema("""{"type":"object","properties":{}}"""),
+      ),
+      ToolDef(
+        name = "render_preview",
+        description =
+          "Force-render a preview by URI, bypassing any cache. Returns the rendered PNG inline.",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "uri":{"type":"string","description":"compose-preview://<workspace>/<module>/<fqn>?config=<qualifier>"}
+              },
+              "required":["uri"]
+            }
+            """
+              .trimIndent()
+          ),
+      ),
+      ToolDef(
+        name = "watch",
+        description =
+          "Register an area of interest. The server keeps the matched previews warm and pushes notifications/resources/updated as they re-render.",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "workspaceId":{"type":"string"},
+                "module":{"type":"string","description":"Optional Gradle module path; null = every module in the workspace."},
+                "fqnGlob":{"type":"string","description":"Optional FQN glob; '*' matches non-dot, '**' matches anything, '?' one non-dot char."}
+              },
+              "required":["workspaceId"]
+            }
+            """
+              .trimIndent()
+          ),
+      ),
+      ToolDef(
+        name = "unwatch",
+        description =
+          "Remove watches for the current session. With no args, removes every watch the session registered.",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "workspaceId":{"type":"string"},
+                "module":{"type":"string"},
+                "fqnGlob":{"type":"string"}
+              }
+            }
+            """
+              .trimIndent()
+          ),
+      ),
+      ToolDef(
+        name = "list_watches",
+        description = "List the watches registered by the current session.",
+        inputSchema = parseSchema("""{"type":"object","properties":{}}"""),
+      ),
+    )
+
+  private fun handleCallTool(
+    session: McpSession,
+    name: String,
+    arguments: JsonElement?,
+  ): CallToolResult {
+    val args = (arguments as? JsonObject) ?: JsonObject(emptyMap())
+    return when (name) {
+      "register_project" -> toolRegisterProject(args)
+      "unregister_project" -> toolUnregisterProject(args)
+      "list_projects" -> toolListProjects()
+      "render_preview" -> toolRenderPreview(args)
+      "watch" -> toolWatch(session, args)
+      "unwatch" -> toolUnwatch(session, args)
+      "list_watches" -> toolListWatches(session)
+      else -> errorCallToolResult("unknown tool: $name")
+    }
+  }
+
+  private fun toolRegisterProject(args: JsonObject): CallToolResult {
+    val path =
+      args["path"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("register_project: missing 'path'")
+    val rootName = args["rootProjectName"]?.jsonPrimitive?.contentOrNull
+    val modules =
+      (args["modules"] as? JsonArray)?.mapNotNull { it.jsonPrimitive.contentOrNull } ?: emptyList()
+    val file = File(path)
+    if (!file.isDirectory)
+      return errorCallToolResult("register_project: '$path' is not a directory")
+    val project = supervisor.registerProject(file, rootName, modules)
+    val payload = buildJsonObject {
+      put("workspaceId", project.workspaceId.value)
+      put("rootProjectName", project.rootProjectName)
+      put("path", project.path.absolutePath)
+      putJsonArray("modules") { project.knownModules.forEach { add(JsonPrimitive(it)) } }
+    }
+    sessions.forEach { it.notifyResourceListChanged() }
+    return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+  }
+
+  private fun toolUnregisterProject(args: JsonObject): CallToolResult {
+    val ws =
+      args["workspaceId"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("unregister_project: missing 'workspaceId'")
+    val id = WorkspaceId(ws)
+    supervisor.unregisterProject(id)
+    catalog.keys.removeIf { it.workspaceId == id }
+    sessions.forEach { it.notifyResourceListChanged() }
+    return textCallToolResult("unregistered $id")
+  }
+
+  private fun toolListProjects(): CallToolResult {
+    val payload = buildJsonObject {
+      putJsonArray("projects") {
+        supervisor.listProjects().forEach { project ->
+          add(
+            buildJsonObject {
+              put("workspaceId", project.workspaceId.value)
+              put("rootProjectName", project.rootProjectName)
+              put("path", project.path.absolutePath)
+              putJsonArray("modules") {
+                synchronized(project.knownModules) {
+                  project.knownModules.forEach { add(JsonPrimitive(it)) }
+                }
+              }
+              put("branch", JsonPrimitive(detectBranch(project.path)))
+            }
+          )
+        }
+      }
+    }
+    return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+  }
+
+  private fun toolRenderPreview(args: JsonObject): CallToolResult {
+    val uriStr =
+      args["uri"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("render_preview: missing 'uri'")
+    val uri = PreviewUri.parseOrNull(uriStr) ?: return errorCallToolResult("invalid uri: $uriStr")
+    return runCatching {
+        val bytes = renderAndReadBytes(uri)
+        pngCallToolResult(Base64.getEncoder().encodeToString(bytes))
+      }
+      .getOrElse { errorCallToolResult("render_preview failed: ${it.message}") }
+  }
+
+  private fun toolWatch(session: McpSession, args: JsonObject): CallToolResult {
+    val ws =
+      args["workspaceId"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("watch: missing 'workspaceId'")
+    val workspaceId = WorkspaceId(ws)
+    if (supervisor.project(workspaceId) == null) {
+      return errorCallToolResult(
+        "watch: workspace '$ws' not registered. Call register_project first."
+      )
+    }
+    val module = args["module"]?.jsonPrimitive?.contentOrNull
+    val glob = args["fqnGlob"]?.jsonPrimitive?.contentOrNull
+    val entry = WatchEntry(workspaceId = workspaceId, modulePath = module, fqnGlobPattern = glob)
+    subscriptions.watch(session, entry)
+    // Recompute every daemon's view; the propagator skips daemons whose URI set didn't change.
+    supervisor.project(workspaceId)?.daemons?.values?.forEach { watchPropagator.recompute(it) }
+    return textCallToolResult("watching $entry")
+  }
+
+  private fun toolUnwatch(session: McpSession, args: JsonObject): CallToolResult {
+    val workspaceId = args["workspaceId"]?.jsonPrimitive?.contentOrNull?.let(::WorkspaceId)
+    val module = args["module"]?.jsonPrimitive?.contentOrNull
+    val glob = args["fqnGlob"]?.jsonPrimitive?.contentOrNull
+    val removed =
+      subscriptions.unwatch(session) { e ->
+        (workspaceId == null || e.workspaceId == workspaceId) &&
+          (module == null || e.modulePath == module) &&
+          (glob == null || e.fqnGlob == glob)
+      }
+    // After unwatch the visible/focus set may shrink; recompute every affected daemon.
+    val workspaces =
+      if (workspaceId != null) listOfNotNull(supervisor.project(workspaceId))
+      else supervisor.listProjects()
+    workspaces.forEach { project ->
+      project.daemons.values.forEach { watchPropagator.recompute(it) }
+    }
+    return textCallToolResult("unwatched $removed entries")
+  }
+
+  private fun toolListWatches(session: McpSession): CallToolResult {
+    val payload = buildJsonObject {
+      putJsonArray("watches") {
+        subscriptions.watchesFor(session).forEach { e ->
+          add(
+            buildJsonObject {
+              put("workspaceId", e.workspaceId.value)
+              if (e.modulePath != null) put("module", e.modulePath)
+              if (e.fqnGlob != null) put("fqnGlob", e.fqnGlob)
+            }
+          )
+        }
+      }
+    }
+    return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+  }
+
+  // -------------------------------------------------------------------------
+  // Daemon notification handlers
+  // -------------------------------------------------------------------------
+
+  private fun onDiscoveryUpdated(daemon: SupervisedDaemon, params: JsonObject?) {
+    val addr = DaemonAddr(daemon.workspaceId, daemon.modulePath)
+    val byId = catalog.computeIfAbsent(addr) { ConcurrentHashMap() }
+    val added = (params?.get("added") as? JsonArray)?.mapNotNull { it as? JsonObject }.orEmpty()
+    val changed = (params?.get("changed") as? JsonArray)?.mapNotNull { it as? JsonObject }.orEmpty()
+    val removed =
+      (params?.get("removed") as? JsonArray)
+        ?.mapNotNull { it.jsonPrimitive.contentOrNull }
+        .orEmpty()
+    for (entry in added + changed) {
+      val id = entry["id"]?.jsonPrimitive?.contentOrNull ?: continue
+      byId[id] =
+        PreviewEntry(
+          fqn = id,
+          displayName = entry["displayName"]?.jsonPrimitive?.contentOrNull,
+          config = entry["config"]?.jsonPrimitive?.contentOrNull,
+        )
+    }
+    removed.forEach { byId.remove(it) }
+    sessions.forEach { it.notifyResourceListChanged() }
+    watchPropagator.recompute(daemon)
+  }
+
+  private fun onRenderFinished(daemon: SupervisedDaemon, params: JsonObject?) {
+    val previewId = params?.get("id")?.jsonPrimitive?.contentOrNull ?: return
+    val pngPath = params["pngPath"]?.jsonPrimitive?.contentOrNull ?: return
+    // 1. Wake any pending resources/read awaiter.
+    val key = RenderKey(daemon.workspaceId, daemon.modulePath, previewId)
+    pendingRenders[key]?.offer(RenderOutcome.Finished(pngPath))
+    // 2. Build the matching URI and notify subscribers + watchers.
+    val entry = catalog[DaemonAddr(daemon.workspaceId, daemon.modulePath)]?.get(previewId)
+    val uri =
+      PreviewUri(
+        workspaceId = daemon.workspaceId,
+        modulePath = daemon.modulePath,
+        previewFqn = previewId,
+        config = entry?.config,
+      )
+    val uriStr = uri.toUri()
+    val targets = mutableSetOf<Any>()
+    targets.addAll(subscriptions.sessionsSubscribedTo(uriStr))
+    targets.addAll(subscriptions.sessionsWatching(uri))
+    targets.forEach { (it as? McpSession)?.notifyResourceUpdated(uriStr) }
+    // 3. Record history (no-op default).
+    runCatching { historyStore.record(uri, pngPath, Instant.now()) }
+  }
+
+  private fun onRenderFailed(daemon: SupervisedDaemon, params: JsonObject?) {
+    val previewId = params?.get("id")?.jsonPrimitive?.contentOrNull ?: return
+    val errorObj = params["error"] as? JsonObject
+    val kind = errorObj?.get("kind")?.jsonPrimitive?.contentOrNull ?: "unknown"
+    val message = errorObj?.get("message")?.jsonPrimitive?.contentOrNull ?: "no message"
+    val key = RenderKey(daemon.workspaceId, daemon.modulePath, previewId)
+    pendingRenders[key]?.offer(RenderOutcome.Failed(kind, message))
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private data class DaemonAddr(val workspaceId: WorkspaceId, val modulePath: String)
+
+  private data class PreviewEntry(val fqn: String, val displayName: String?, val config: String?)
+
+  private data class RenderKey(
+    val workspaceId: WorkspaceId,
+    val modulePath: String,
+    val previewId: String,
+  )
+
+  private sealed interface RenderOutcome {
+    data class Finished(val pngPath: String) : RenderOutcome
+
+    data class Failed(val kind: String, val message: String) : RenderOutcome
+  }
+
+  private fun parseSchema(s: String): JsonElement = json.parseToJsonElement(s)
+
+  private fun detectBranch(workspacePath: File): String? {
+    val head = File(workspacePath, ".git/HEAD").takeIf { it.isFile } ?: return null
+    val content = runCatching { head.readText().trim() }.getOrNull() ?: return null
+    return if (content.startsWith("ref:"))
+      content.removePrefix("ref:").trim().substringAfterLast('/')
+    else content.take(8)
+  }
+}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -1,0 +1,308 @@
+package ee.schimke.composeai.mcp
+
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Owner of every per-(workspace, module) [DaemonClient] in this MCP server process. Multi-workspace
+ * by design — see the chat thread leading into this PR — so a single MCP server can host previews
+ * from multiple distinct projects, including two worktrees of the same repo.
+ *
+ * **Workspace registration is explicit.** Clients call the `register_project` MCP tool (or the
+ * server is started with `--project <path>` CLI args); the supervisor canonicalises the path,
+ * derives a [WorkspaceId], and remembers the project. Daemons within the workspace are spawned
+ * lazily on first `read`/`render_preview`/`watch` reference.
+ *
+ * **Notification routing.** The supervisor demultiplexes every daemon's notification stream by
+ * method and dispatches via the [NotificationRouter] handlers. Callers register one router up
+ * front; the supervisor never assumes only one client cares about a given event.
+ */
+class DaemonSupervisor(
+  private val descriptorProvider: DescriptorProvider,
+  private val clientFactory: DaemonClientFactory,
+  private val router: NotificationRouter = NotificationRouter(),
+) {
+
+  private val projects = ConcurrentHashMap<WorkspaceId, RegisteredProject>()
+
+  /**
+   * Registers a project at [absolutePath] (must already exist on disk). Returns the assigned
+   * [WorkspaceId]; idempotent — re-registering the same canonical path returns the existing id.
+   *
+   * [rootProjectName] may be supplied (e.g. parsed from `settings.gradle.kts`) for nicer ids; if
+   * null, the directory's basename is used.
+   *
+   * [knownModules] is the optional initial set of preview-eligible Gradle module paths in this
+   * project. The supervisor will not spawn daemons for them — that stays lazy — but `list_projects`
+   * and the resource list can advertise them up front so a client doesn't have to probe.
+   */
+  fun registerProject(
+    absolutePath: File,
+    rootProjectName: String? = null,
+    knownModules: List<String> = emptyList(),
+  ): RegisteredProject {
+    require(absolutePath.isDirectory) {
+      "registerProject: path '${absolutePath.absolutePath}' is not a directory"
+    }
+    val canonical =
+      runCatching { absolutePath.canonicalFile }.getOrDefault(absolutePath.absoluteFile)
+    val name = rootProjectName ?: canonical.name
+    val workspaceId = WorkspaceId.derive(name, canonical)
+    val project =
+      projects.computeIfAbsent(workspaceId) {
+        RegisteredProject(
+          workspaceId = workspaceId,
+          rootProjectName = name,
+          path = canonical,
+          knownModules = knownModules.toMutableList(),
+        )
+      }
+    // Idempotent: merge module hints if the second call learned more.
+    if (knownModules.isNotEmpty()) {
+      synchronized(project.knownModules) {
+        for (m in knownModules) if (m !in project.knownModules) project.knownModules.add(m)
+      }
+    }
+    return project
+  }
+
+  /**
+   * Tears down every daemon for [workspaceId] and forgets the project. Idempotent — unregistering
+   * an unknown id is a no-op.
+   */
+  fun unregisterProject(workspaceId: WorkspaceId) {
+    val project = projects.remove(workspaceId) ?: return
+    project.daemons.values.forEach { runCatching { it.shutdown() } }
+    project.daemons.clear()
+  }
+
+  fun listProjects(): List<RegisteredProject> = projects.values.toList()
+
+  fun project(workspaceId: WorkspaceId): RegisteredProject? = projects[workspaceId]
+
+  /**
+   * Returns (and lazily spawns) the daemon for [workspaceId] + [modulePath]. Throws when the
+   * workspace isn't registered or the module's daemon descriptor is missing.
+   *
+   * Spawn cost is paid by the calling thread — typical first-request latency is the daemon's
+   * cold-start time (3-10s for Robolectric, ~600ms for desktop).
+   */
+  fun daemonFor(workspaceId: WorkspaceId, modulePath: String): SupervisedDaemon {
+    val project = projects[workspaceId] ?: error("workspace not registered: $workspaceId")
+    return project.daemons.computeIfAbsent(modulePath) { spawn(project, modulePath) }
+  }
+
+  /** Closes every daemon. After this call the supervisor is unusable. */
+  fun shutdown() {
+    projects.values.forEach { project ->
+      project.daemons.values.forEach { runCatching { it.shutdown() } }
+      project.daemons.clear()
+    }
+    projects.clear()
+  }
+
+  /** Returns the [NotificationRouter] so callers can register handlers. */
+  fun router(): NotificationRouter = router
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private fun spawn(project: RegisteredProject, modulePath: String): SupervisedDaemon {
+    val descriptor = descriptorProvider.descriptorFor(project, modulePath)
+    val spawn = clientFactory.spawn(project, descriptor)
+    val supervised =
+      SupervisedDaemon(workspaceId = project.workspaceId, modulePath = modulePath, spawn = spawn)
+    spawn.client(
+      onNotification = { method, params -> router.dispatch(supervised, method, params) },
+      onClose = { router.dispatchClose(supervised) },
+    )
+    runCatching {
+      spawn.client.initialize(
+        workspaceRoot = project.path.absolutePath,
+        moduleId = modulePath,
+        moduleProjectDir = descriptor.workingDirectory,
+      )
+    }
+    return supervised
+  }
+}
+
+/**
+ * One registered project — a workspace. Holds the canonical path, the assigned id, the (lazily
+ * populated) daemon map, and the optional seed list of preview-eligible modules.
+ */
+data class RegisteredProject(
+  val workspaceId: WorkspaceId,
+  val rootProjectName: String,
+  val path: File,
+  val knownModules: MutableList<String>,
+  val daemons: ConcurrentHashMap<String, SupervisedDaemon> = ConcurrentHashMap(),
+)
+
+/** A live daemon — owned by [DaemonSupervisor]. */
+class SupervisedDaemon(
+  val workspaceId: WorkspaceId,
+  val modulePath: String,
+  private val spawn: DaemonSpawn,
+) {
+  val client: DaemonClient
+    get() = spawn.client
+
+  fun shutdown() = spawn.shutdown()
+}
+
+/**
+ * Pluggable seam for resolving the per-module daemon launch descriptor. The default implementation
+ * reads `<workingDir>/build/compose-previews/daemon-launch.json` written by
+ * [`composePreviewDaemonStart`][ee.schimke.composeai.plugin.daemon.DaemonBootstrapTask] in the
+ * gradle plugin. Tests substitute an in-memory provider.
+ */
+fun interface DescriptorProvider {
+  fun descriptorFor(project: RegisteredProject, modulePath: String): DaemonLaunchDescriptor
+
+  companion object {
+    /**
+     * Returns a descriptor provider that reads `build/compose-previews/daemon-launch.json` for each
+     * module from disk. The file is written by the user running `./gradlew
+     * :<module>:composePreviewDaemonStart` — the supervisor surfaces a clear error if it's missing.
+     * A future enhancement may invoke Gradle's Tooling API itself; for v0 we keep the seam clean
+     * and let the user (or VS Code) drive the bootstrap.
+     */
+    fun readingFromDisk(): DescriptorProvider = DescriptorProvider { project, modulePath ->
+      val moduleDir = gradlePathToFile(project.path, modulePath)
+      val descriptorFile = File(moduleDir, "build/compose-previews/daemon-launch.json")
+      check(descriptorFile.isFile) {
+        "Missing daemon launch descriptor for $modulePath under ${project.path.absolutePath}. " +
+          "Run `./gradlew $modulePath:composePreviewDaemonStart` first."
+      }
+      DaemonLaunchDescriptor.parse(descriptorFile.readText())
+    }
+
+    private fun gradlePathToFile(projectRoot: File, modulePath: String): File {
+      // ":" → root, ":a:b" → projectRoot/a/b
+      val trimmed = modulePath.trimStart(':')
+      if (trimmed.isEmpty()) return projectRoot
+      val rel = trimmed.replace(':', File.separatorChar)
+      return File(projectRoot, rel)
+    }
+  }
+}
+
+/**
+ * Trimmed parse of `build/compose-previews/daemon-launch.json`. Mirrors the field set written by
+ * [`DaemonClasspathDescriptor`][ee.schimke.composeai.plugin.daemon.DaemonClasspathDescriptor] in
+ * the gradle plugin; we re-declare the schema rather than depending on the plugin module so the MCP
+ * module's runtime classpath stays free of the plugin's AGP/Gradle deps.
+ */
+@Serializable
+data class DaemonLaunchDescriptor(
+  val schemaVersion: Int,
+  val modulePath: String,
+  val variant: String,
+  val enabled: Boolean,
+  val mainClass: String,
+  val javaLauncher: String? = null,
+  val classpath: List<String>,
+  val jvmArgs: List<String>,
+  val systemProperties: Map<String, String>,
+  val workingDirectory: String,
+  val manifestPath: String,
+) {
+  companion object {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun parse(jsonText: String): DaemonLaunchDescriptor =
+      json.decodeFromString(serializer(), jsonText)
+  }
+}
+
+/**
+ * Pluggable spawn — production [SubprocessDaemonClientFactory] forks a JVM via [ProcessBuilder];
+ * tests inject an in-memory factory that wires the [DaemonClient] to a fake daemon over piped
+ * streams. The factory returns a [DaemonSpawn] that owns the underlying resource (subprocess or
+ * coroutine).
+ */
+fun interface DaemonClientFactory {
+  fun spawn(project: RegisteredProject, descriptor: DaemonLaunchDescriptor): DaemonSpawn
+}
+
+/**
+ * Owns the resources behind a single live [DaemonClient]: the subprocess (in production) or the
+ * fake daemon side of a piped pair (in tests). The supervisor calls [client] once after spawn to
+ * wire the notification + close handlers.
+ */
+interface DaemonSpawn {
+  val client: DaemonClient
+
+  /**
+   * Wires the supervisor's notification + close handlers onto the underlying [client]. Called
+   * exactly once by [DaemonSupervisor.spawn] before any traffic flows. Implementations typically
+   * delay creating the [client] until this call so the handlers are baked in from the first frame.
+   */
+  fun client(
+    onNotification: (method: String, params: JsonObject?) -> Unit,
+    onClose: () -> Unit,
+  ): DaemonClient
+
+  fun shutdown()
+}
+
+// -----------------------------------------------------------------------------
+// Notification routing — keeps Subscriptions / WatchSets / classpathDirty handlers
+// out of the core supervisor wiring.
+// -----------------------------------------------------------------------------
+
+/**
+ * Demultiplexes daemon notifications by method name. Multiple handlers per method are supported;
+ * each is called in registration order on the daemon's reader thread, so handlers must be cheap and
+ * non-blocking.
+ */
+class NotificationRouter {
+  private val handlers =
+    ConcurrentHashMap<String, MutableList<(SupervisedDaemon, JsonObject?) -> Unit>>()
+  private val closeHandlers = mutableListOf<(SupervisedDaemon) -> Unit>()
+
+  fun on(method: String, handler: (SupervisedDaemon, JsonObject?) -> Unit) {
+    val list = handlers.computeIfAbsent(method) { mutableListOf() }
+    synchronized(list) { list.add(handler) }
+  }
+
+  fun onClose(handler: (SupervisedDaemon) -> Unit) {
+    synchronized(closeHandlers) { closeHandlers.add(handler) }
+  }
+
+  internal fun dispatch(daemon: SupervisedDaemon, method: String, params: JsonObject?) {
+    val list = handlers[method] ?: return
+    synchronized(list) { list.toList() }.forEach { runCatching { it(daemon, params) } }
+  }
+
+  internal fun dispatchClose(daemon: SupervisedDaemon) {
+    synchronized(closeHandlers) { closeHandlers.toList() }.forEach { runCatching { it(daemon) } }
+  }
+
+  /**
+   * Convenience: extract `params.id` from a `renderFinished` / `renderStarted` envelope. Returns
+   * null when missing so callers can treat malformed events as drops rather than throws.
+   */
+  fun previewIdOf(params: JsonObject?): String? = params?.get("id")?.jsonPrimitive?.contentOrNull
+
+  /** Convenience: extract `params.pngPath` from a `renderFinished` envelope. */
+  fun pngPathOf(params: JsonObject?): String? = params?.get("pngPath")?.jsonPrimitive?.contentOrNull
+
+  /** Convenience: extract a renderer-specific string field from any envelope. */
+  fun stringField(params: JsonObject?, name: String): String? =
+    params?.get(name)?.jsonPrimitive?.contentOrNull
+
+  /** Convenience: walk a `discoveryUpdated.added[]` / `discoveryUpdated.changed[]` array. */
+  fun previewsArray(params: JsonObject?, key: String): List<JsonObject> =
+    (params?.get(key) as? kotlinx.serialization.json.JsonArray)?.mapNotNull {
+      runCatching { it.jsonObject }.getOrNull()
+    } ?: emptyList()
+}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/HistoryStore.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/HistoryStore.kt
@@ -1,0 +1,51 @@
+package ee.schimke.composeai.mcp
+
+import java.time.Instant
+
+/**
+ * Pluggable seam for the per-preview history feature. **No real implementation in v0** — the
+ * concrete behaviour (storage layout, retention policy, diff support, MCP resource shape) is being
+ * designed separately and will land behind `docs/daemon/HISTORY.md`. The seam exists now so the
+ * supervisor can call [record] on every successful render without conditional code, and so a future
+ * PR can swap in the real store without re-plumbing notification routing.
+ *
+ * **Why an interface in the MCP module instead of `:daemon:core`?** History is currently scoped to
+ * MCP consumers — VS Code already has its own `.compose-preview-history/` view, and the PROTOCOL.md
+ * daemon contract has no opinion on history. If `HISTORY.md` decides the daemon should own the
+ * store, this interface migrates to `:daemon:core` and the MCP module depends on it from there.
+ * Until then, keeping it here means no daemon-side code is paying for an undecided API.
+ *
+ * **Threading.** Implementations must be safe for concurrent calls from any thread — the
+ * supervisor's notification router calls [record] from the daemon's reader thread, and history
+ * reads (once added as resources/tools) run on the MCP server's request handler thread.
+ */
+interface HistoryStore {
+
+  /**
+   * Records that [pngPath] is the rendered output for [uri] at [timestamp]. The default no-op
+   * implementation drops the call. Implementations should be idempotent on the (uri, timestamp) key
+   * so a duplicate notification (e.g. supervisor respawn replaying a queued event) doesn't create
+   * double entries.
+   */
+  fun record(uri: PreviewUri, pngPath: String, timestamp: Instant) {}
+
+  /**
+   * Lists history entries for [uri], newest first, capped at [limit]. The no-op default returns
+   * empty. Once the real impl lands, the MCP `list_history` tool delegates here.
+   */
+  fun list(uri: PreviewUri, limit: Int = 20): List<Entry> = emptyList()
+
+  /**
+   * Reads the PNG bytes of a specific historical entry. Returns null when the entry isn't available
+   * (no-op default, retention pruned, etc.).
+   */
+  fun read(uri: PreviewUri, timestamp: Instant): ByteArray? = null
+
+  /** One row in [list]. */
+  data class Entry(val timestamp: Instant, val pngPath: String, val sha256: String?)
+
+  companion object {
+    /** No-op store — the v0 default. */
+    val NOOP: HistoryStore = object : HistoryStore {}
+  }
+}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/McpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/McpServer.kt
@@ -1,0 +1,355 @@
+package ee.schimke.composeai.mcp
+
+import ee.schimke.composeai.mcp.protocol.CallToolParams
+import ee.schimke.composeai.mcp.protocol.CallToolResult
+import ee.schimke.composeai.mcp.protocol.ContentBlock
+import ee.schimke.composeai.mcp.protocol.Implementation
+import ee.schimke.composeai.mcp.protocol.InitializeParams
+import ee.schimke.composeai.mcp.protocol.InitializeResult
+import ee.schimke.composeai.mcp.protocol.ListResourcesResult
+import ee.schimke.composeai.mcp.protocol.ListToolsResult
+import ee.schimke.composeai.mcp.protocol.McpError
+import ee.schimke.composeai.mcp.protocol.McpErrorCodes
+import ee.schimke.composeai.mcp.protocol.McpNotification
+import ee.schimke.composeai.mcp.protocol.McpResponse
+import ee.schimke.composeai.mcp.protocol.ReadResourceParams
+import ee.schimke.composeai.mcp.protocol.ReadResourceResult
+import ee.schimke.composeai.mcp.protocol.ResourceDescriptor
+import ee.schimke.composeai.mcp.protocol.ResourceUpdatedParams
+import ee.schimke.composeai.mcp.protocol.ServerCapabilities
+import ee.schimke.composeai.mcp.protocol.SubscribeParams
+import ee.schimke.composeai.mcp.protocol.ToolDef
+import ee.schimke.composeai.mcp.protocol.UnsubscribeParams
+import java.io.ByteArrayOutputStream
+import java.io.Closeable
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * A single MCP session over `Content-Length`-framed stdio (matching MCP's stdio transport spec).
+ *
+ * Conceptually this is one connected MCP client. v0 ships one session per server process; HTTP
+ * transport will multiplex many. Sessions own:
+ *
+ * - A read thread that drains [input] and dispatches request frames to [handlers].
+ * - A write thread that serialises every reply + outgoing notification to [output].
+ * - The set of subscribed URIs and registered watch entries (stored externally in [subscriptions],
+ *   keyed by `this` reference so different sessions stay isolated).
+ *
+ * Method handlers are pluggable — [DaemonMcpServer] wires the resource/tool surface; tests can
+ * register their own handlers for protocol conformance assertions.
+ */
+class McpSession(
+  private val input: InputStream,
+  private val output: OutputStream,
+  private val handlers: McpHandlers,
+  private val serverInfo: Implementation,
+  private val capabilities: ServerCapabilities,
+  threadName: String = "mcp-session",
+) : Closeable {
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = false
+  }
+  private val closed = AtomicBoolean(false)
+  private val initialized = AtomicBoolean(false)
+
+  private val readerThread = Thread({ runReader() }, "$threadName-reader").apply { isDaemon = true }
+
+  fun start() {
+    readerThread.start()
+  }
+
+  /** Blocks until the reader thread exits (typically on stdin EOF). Used by stdio entry points. */
+  fun awaitClose() {
+    readerThread.join()
+  }
+
+  /** Sends a JSON-RPC notification. Safe to call from any thread; framed atomically on the wire. */
+  fun notify(method: String, params: JsonElement? = null) {
+    if (closed.get()) return
+    val n = McpNotification(method = method, params = params)
+    sendFrame(json.encodeToString(McpNotification.serializer(), n))
+  }
+
+  /** Sends `notifications/resources/updated` for [uri]. */
+  fun notifyResourceUpdated(uri: String) {
+    val params =
+      json.encodeToJsonElement(ResourceUpdatedParams.serializer(), ResourceUpdatedParams(uri))
+    notify("notifications/resources/updated", params)
+  }
+
+  /** Sends `notifications/resources/list_changed`. */
+  fun notifyResourceListChanged() {
+    notify("notifications/resources/list_changed")
+  }
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    runCatching { input.close() }
+    runCatching { output.close() }
+    readerThread.join(2_000)
+  }
+
+  // -------------------------------------------------------------------------
+  // Read loop
+  // -------------------------------------------------------------------------
+
+  private fun runReader() {
+    try {
+      while (!closed.get()) {
+        val frame = readFrame(input) ?: break
+        val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+        if (obj["id"] != null) dispatchRequest(obj) else dispatchNotification(obj)
+      }
+    } catch (_: IOException) {
+      // EOF — fall through
+    } catch (e: Throwable) {
+      System.err.println("McpSession reader: ${e.message}")
+      e.printStackTrace(System.err)
+    } finally {
+      runCatching { handlers.onClose(this) }
+    }
+  }
+
+  private fun dispatchRequest(obj: JsonObject) {
+    val id = obj["id"] ?: return
+    val method = obj["method"]?.jsonPrimitive?.contentOrNull
+    val params = obj["params"]
+    if (method == null) {
+      sendError(id, McpErrorCodes.INVALID_REQUEST, "missing method")
+      return
+    }
+    if (!initialized.get() && method != "initialize") {
+      sendError(id, McpErrorCodes.INVALID_REQUEST, "session not initialized (received $method)")
+      return
+    }
+    try {
+      when (method) {
+        "initialize" -> handleInitialize(id, params)
+        "ping" -> sendResult(id, JsonObject(emptyMap()))
+        "tools/list" -> sendResult(id, handlers.listTools(this))
+        "tools/call" -> handleCallTool(id, params)
+        "resources/list" -> sendResult(id, handlers.listResources(this))
+        "resources/read" -> handleReadResource(id, params)
+        "resources/subscribe" -> handleSubscribe(id, params)
+        "resources/unsubscribe" -> handleUnsubscribe(id, params)
+        else -> sendError(id, McpErrorCodes.METHOD_NOT_FOUND, "unknown method: $method")
+      }
+    } catch (e: Throwable) {
+      sendError(id, McpErrorCodes.INTERNAL_ERROR, e.message ?: "internal error")
+    }
+  }
+
+  private fun dispatchNotification(obj: JsonObject) {
+    val method = obj["method"]?.jsonPrimitive?.contentOrNull ?: return
+    when (method) {
+      "notifications/initialized" -> initialized.set(true)
+      "notifications/cancelled" -> {
+        /* v0 ignores cancellation */
+      }
+      else -> {
+        /* unknown notifications ignored per spec */
+      }
+    }
+  }
+
+  private fun handleInitialize(id: JsonElement, params: JsonElement?) {
+    val parsed = params?.let {
+      runCatching { json.decodeFromJsonElement(InitializeParams.serializer(), it) }.getOrNull()
+    }
+    val protocolVersion = parsed?.protocolVersion ?: "2025-06-18"
+    val result =
+      InitializeResult(
+        protocolVersion = protocolVersion,
+        capabilities = capabilities,
+        serverInfo = serverInfo,
+      )
+    sendResult(id, json.encodeToJsonElement(InitializeResult.serializer(), result))
+    // Some clients omit the `notifications/initialized` follow-up; treat the response as a
+    // gating signal so subsequent requests don't error out. The notification path still flips
+    // the flag if it arrives.
+    initialized.set(true)
+  }
+
+  private fun handleCallTool(id: JsonElement, params: JsonElement?) {
+    val parsed =
+      params?.let {
+        runCatching { json.decodeFromJsonElement(CallToolParams.serializer(), it) }.getOrNull()
+      } ?: return sendError(id, McpErrorCodes.INVALID_PARAMS, "tools/call: missing params")
+    val result = handlers.callTool(this, parsed.name, parsed.arguments)
+    sendResult(id, json.encodeToJsonElement(CallToolResult.serializer(), result))
+  }
+
+  private fun handleReadResource(id: JsonElement, params: JsonElement?) {
+    val parsed =
+      params?.let {
+        runCatching { json.decodeFromJsonElement(ReadResourceParams.serializer(), it) }.getOrNull()
+      } ?: return sendError(id, McpErrorCodes.INVALID_PARAMS, "resources/read: missing uri")
+    val result = handlers.readResource(this, parsed.uri)
+    sendResult(id, json.encodeToJsonElement(ReadResourceResult.serializer(), result))
+  }
+
+  private fun handleSubscribe(id: JsonElement, params: JsonElement?) {
+    val parsed =
+      params?.let {
+        runCatching { json.decodeFromJsonElement(SubscribeParams.serializer(), it) }.getOrNull()
+      } ?: return sendError(id, McpErrorCodes.INVALID_PARAMS, "resources/subscribe: missing uri")
+    handlers.subscribe(this, parsed.uri)
+    sendResult(id, JsonObject(emptyMap()))
+  }
+
+  private fun handleUnsubscribe(id: JsonElement, params: JsonElement?) {
+    val parsed =
+      params?.let {
+        runCatching { json.decodeFromJsonElement(UnsubscribeParams.serializer(), it) }.getOrNull()
+      } ?: return sendError(id, McpErrorCodes.INVALID_PARAMS, "resources/unsubscribe: missing uri")
+    handlers.unsubscribe(this, parsed.uri)
+    sendResult(id, JsonObject(emptyMap()))
+  }
+
+  // -------------------------------------------------------------------------
+  // Wire helpers
+  // -------------------------------------------------------------------------
+
+  private fun sendResult(id: JsonElement, result: JsonElement) {
+    val response = McpResponse(id = id, result = result)
+    sendFrame(json.encodeToString(McpResponse.serializer(), response))
+  }
+
+  private fun sendError(id: JsonElement, code: Int, message: String) {
+    val response = McpResponse(id = id, error = McpError(code = code, message = message))
+    sendFrame(json.encodeToString(McpResponse.serializer(), response))
+  }
+
+  private fun sendFrame(jsonText: String) {
+    val payload = jsonText.toByteArray(Charsets.UTF_8)
+    val header = "Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII)
+    synchronized(output) {
+      output.write(header)
+      output.write(payload)
+      output.flush()
+    }
+  }
+
+  private fun readFrame(input: InputStream): ByteArray? {
+    var contentLength = -1
+    val headerBuf = ByteArrayOutputStream(64)
+    var sawAny = false
+    while (true) {
+      val line = readHeaderLine(input, headerBuf) ?: return if (sawAny) null else null
+      sawAny = true
+      if (line.isEmpty()) break
+      val colon = line.indexOf(':')
+      if (colon <= 0) error("malformed header line: '$line'")
+      val name = line.substring(0, colon).trim()
+      val value = line.substring(colon + 1).trim()
+      if (name.equals("Content-Length", ignoreCase = true)) {
+        contentLength = value.toIntOrNull() ?: error("non-integer Content-Length: '$value'")
+      }
+    }
+    if (contentLength < 0) error("missing Content-Length header")
+    val payload = ByteArray(contentLength)
+    var off = 0
+    while (off < contentLength) {
+      val n = input.read(payload, off, contentLength - off)
+      if (n < 0) return null
+      off += n
+    }
+    return payload
+  }
+
+  private fun readHeaderLine(input: InputStream, buf: ByteArrayOutputStream): String? {
+    buf.reset()
+    while (true) {
+      val b = input.read()
+      if (b < 0) return if (buf.size() == 0) null else buf.toString(Charsets.US_ASCII.name())
+      if (b == '\n'.code) {
+        val bytes = buf.toByteArray()
+        val end =
+          if (bytes.isNotEmpty() && bytes.last() == '\r'.code.toByte()) bytes.size - 1
+          else bytes.size
+        return String(bytes, 0, end, Charsets.US_ASCII)
+      }
+      buf.write(b)
+    }
+  }
+}
+
+/**
+ * Pluggable handler set the [McpSession] dispatches to. [DaemonMcpServer] supplies the concrete
+ * instance; tests can stub it for protocol-level assertions without dragging in a supervisor.
+ *
+ * Every method is called from the session's reader thread. Implementations must not block on
+ * unrelated IO — the daemon's render path is already off-thread, so the main concern is keeping the
+ * reader pumping.
+ */
+interface McpHandlers {
+  fun listTools(session: McpSession): JsonElement
+
+  fun callTool(session: McpSession, name: String, arguments: JsonElement?): CallToolResult
+
+  fun listResources(session: McpSession): JsonElement
+
+  fun readResource(session: McpSession, uri: String): ReadResourceResult
+
+  fun subscribe(session: McpSession, uri: String)
+
+  fun unsubscribe(session: McpSession, uri: String)
+
+  fun onClose(session: McpSession)
+
+  companion object {
+    /**
+     * Sentinel: encode a [ListToolsResult] / [ListResourcesResult] for [listTools] /
+     * [listResources].
+     */
+    fun encodeTools(json: Json, tools: List<ToolDef>): JsonElement =
+      json.encodeToJsonElement(ListToolsResult.serializer(), ListToolsResult(tools))
+
+    fun encodeResources(json: Json, resources: List<ResourceDescriptor>): JsonElement =
+      json.encodeToJsonElement(ListResourcesResult.serializer(), ListResourcesResult(resources))
+  }
+}
+
+/**
+ * Convenience: plain text response — every tool that just confirms an action ("watched", "ok") uses
+ * this.
+ */
+fun textCallToolResult(text: String): CallToolResult =
+  CallToolResult(content = listOf(ContentBlock.Text(text)))
+
+/** Convenience: image PNG response, base64-encoded data. */
+fun pngCallToolResult(bytesBase64: String): CallToolResult =
+  CallToolResult(content = listOf(ContentBlock.Image(data = bytesBase64, mimeType = "image/png")))
+
+/** Convenience: error response — `isError = true` per MCP spec for tool-level errors. */
+fun errorCallToolResult(message: String): CallToolResult =
+  CallToolResult(content = listOf(ContentBlock.Text(message)), isError = true)
+
+/** Tracks every live [McpSession] so notifications can fan out to multiple connected clients. */
+class SessionRegistry {
+  private val sessions = ConcurrentHashMap.newKeySet<McpSession>()
+
+  fun register(session: McpSession) {
+    sessions.add(session)
+  }
+
+  fun unregister(session: McpSession) {
+    sessions.remove(session)
+  }
+
+  fun forEach(block: (McpSession) -> Unit) {
+    sessions.forEach { runCatching { block(it) } }
+  }
+}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/PreviewResource.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/PreviewResource.kt
@@ -1,0 +1,176 @@
+package ee.schimke.composeai.mcp
+
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * Stable id derived from a workspace's canonical absolute path. Two worktrees of the same repo
+ * (different paths, same `rootProject.name`) get distinct ids by construction — see
+ * docs/daemon/MCP.md and the chat thread leading up to this PR.
+ *
+ * Format: `<rootProjectName>-<8-char-hash>`. The hash is **always** present (not just on
+ * collisions) so the id encodes path identity unconditionally.
+ */
+data class WorkspaceId(val value: String) {
+  init {
+    require(value.isNotBlank()) { "WorkspaceId.value must not be blank" }
+    require(!value.contains('/')) { "WorkspaceId.value must not contain '/' (got '$value')" }
+  }
+
+  override fun toString(): String = value
+
+  companion object {
+    /**
+     * Builds a deterministic id from [rootProjectName] + the canonical absolute form of [path].
+     * Symlink aliases of the same physical path collapse to one id; distinct worktrees stay
+     * distinct.
+     */
+    fun derive(rootProjectName: String, path: File): WorkspaceId {
+      require(rootProjectName.isNotBlank()) { "rootProjectName must not be blank" }
+      val canonical = runCatching { path.canonicalFile }.getOrDefault(path.absoluteFile)
+      val hash = sha256Hex(canonical.absolutePath).take(SHORT_HASH_CHARS)
+      val sanitisedName = rootProjectName.replace(Regex("[^A-Za-z0-9_.-]"), "-")
+      return WorkspaceId("$sanitisedName-$hash")
+    }
+
+    private const val SHORT_HASH_CHARS = 8
+
+    private fun sha256Hex(s: String): String {
+      val bytes = MessageDigest.getInstance("SHA-256").digest(s.toByteArray(Charsets.UTF_8))
+      return bytes.joinToString("") { "%02x".format(it) }
+    }
+  }
+}
+
+/**
+ * Parsed `compose-preview://<workspace>/<module>/<fqn>?config=<qualifier>` URI. The three-segment
+ * form is load-bearing for multi-workspace operation: a single MCP server can host previews from
+ * many workspaces simultaneously, and the workspace segment is what disambiguates them.
+ *
+ * `module` keeps the leading `:` from a Gradle path encoded as `_` to play well with URL parsers
+ * (`:samples:android` becomes `_samples_android` on the wire). The reverse maps back when the
+ * supervisor needs to invoke a Gradle path.
+ */
+data class PreviewUri(
+  val workspaceId: WorkspaceId,
+  val modulePath: String,
+  val previewFqn: String,
+  val config: String? = null,
+) {
+  init {
+    require(modulePath.startsWith(":")) {
+      "PreviewUri.modulePath must start with ':' (got '$modulePath')"
+    }
+    require(!previewFqn.contains('/') && !previewFqn.contains('?')) {
+      "PreviewUri.previewFqn must not contain '/' or '?' (got '$previewFqn')"
+    }
+  }
+
+  fun toUri(): String {
+    val moduleSegment = encodeModule(modulePath)
+    val base = "$SCHEME://${workspaceId.value}/$moduleSegment/$previewFqn"
+    return if (config == null) base else "$base?config=$config"
+  }
+
+  override fun toString(): String = toUri()
+
+  companion object {
+    const val SCHEME: String = "compose-preview"
+
+    /**
+     * Strict parser. Returns null on malformed input rather than throwing — `resources/read` and
+     * the watch tools should surface "invalid URI" as a typed protocol error, not a stack trace.
+     */
+    fun parseOrNull(s: String): PreviewUri? {
+      val prefix = "$SCHEME://"
+      if (!s.startsWith(prefix)) return null
+      val rest = s.removePrefix(prefix)
+      val (path, query) = rest.split('?', limit = 2).let { it[0] to it.getOrNull(1) }
+      val parts = path.split('/')
+      if (parts.size < 3) return null
+      val workspace = parts[0]
+      val moduleEncoded = parts[1]
+      val fqn = parts.subList(2, parts.size).joinToString("/")
+      if (workspace.isBlank() || moduleEncoded.isBlank() || fqn.isBlank()) return null
+      val configValue =
+        query
+          ?.split('&')
+          ?.firstOrNull { it.startsWith("config=") }
+          ?.removePrefix("config=")
+          ?.takeIf { it.isNotEmpty() }
+      return PreviewUri(
+        workspaceId = WorkspaceId(workspace),
+        modulePath = decodeModule(moduleEncoded),
+        previewFqn = fqn,
+        config = configValue,
+      )
+    }
+
+    fun parse(s: String): PreviewUri =
+      requireNotNull(parseOrNull(s)) { "Malformed compose-preview URI: '$s'" }
+
+    /**
+     * `:samples:android` → `_samples_android`. Lossy iff a Gradle path contains `_`, which it
+     * can't.
+     */
+    fun encodeModule(modulePath: String): String = modulePath.replace(':', '_')
+
+    /** Reverse of [encodeModule]. */
+    fun decodeModule(encoded: String): String =
+      encoded.replace('_', ':').let { if (it.startsWith(":")) it else ":$it" }
+  }
+}
+
+/**
+ * Glob over preview FQN — used by the `watch` tool to register an "area of interest". A single `*`
+ * matches any sequence of non-`.` characters; `**` matches anything including dots; `?` matches one
+ * non-`.` character. Matching is case-sensitive — Kotlin FQNs are.
+ *
+ * The glob is always evaluated against `previewFqn`; the workspace + module dimensions are filtered
+ * separately by the watch tool itself.
+ */
+class FqnGlob(val pattern: String) {
+  private val regex: Regex = compile(pattern)
+
+  fun matches(fqn: String): Boolean = regex.matches(fqn)
+
+  override fun toString(): String = pattern
+
+  companion object {
+    private fun compile(pattern: String): Regex {
+      val sb = StringBuilder("^")
+      var i = 0
+      while (i < pattern.length) {
+        when (val c = pattern[i]) {
+          '*' ->
+            if (i + 1 < pattern.length && pattern[i + 1] == '*') {
+              sb.append(".*")
+              i++
+            } else {
+              sb.append("[^.]*")
+            }
+          '?' -> sb.append("[^.]")
+          '.',
+          '(',
+          ')',
+          '[',
+          ']',
+          '{',
+          '}',
+          '+',
+          '|',
+          '^',
+          '$',
+          '\\' -> {
+            sb.append('\\')
+            sb.append(c)
+          }
+          else -> sb.append(c)
+        }
+        i++
+      }
+      sb.append('$')
+      return Regex(sb.toString())
+    }
+  }
+}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/Subscriptions.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/Subscriptions.kt
@@ -1,0 +1,144 @@
+package ee.schimke.composeai.mcp
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Per-session subscription bookkeeping. The two operations every MCP server with the `subscribe`
+ * resources capability needs:
+ *
+ * - **Per-URI subscriptions** ([subscribe]/[unsubscribe]) — clients call `resources/subscribe` with
+ *   a specific URI; we forward `notifications/resources/updated` to that session whenever that
+ *   URI's bytes change.
+ * - **Area-of-interest watch sets** ([watch]/[unwatch]) — clients call the `watch` MCP tool with a
+ *   workspace + (optional) module + (optional) FQN glob, and the server expands that to a URI set,
+ *   prioritises rendering it via `setVisible`/`setFocus` on the appropriate daemons, and pushes
+ *   per-URI updates as renders complete. Re-expansion happens on `discoveryUpdated`.
+ *
+ * Sessions are opaque — we identify them by `Any` reference equality so the MCP transport layer
+ * (which owns the actual session object) decides what counts as a session. In v0 every connected
+ * MCP client is one session; HTTP transport later may multiplex.
+ */
+class Subscriptions {
+
+  /** URI → set of session refs subscribed to it. */
+  private val byUri = ConcurrentHashMap<String, MutableSet<Any>>()
+
+  /** Session ref → its watch sets. */
+  private val watches = ConcurrentHashMap<Any, MutableList<WatchEntry>>()
+
+  fun subscribe(uri: String, session: Any) {
+    val set = byUri.computeIfAbsent(uri) { ConcurrentHashMap.newKeySet() }
+    set.add(session)
+  }
+
+  fun unsubscribe(uri: String, session: Any) {
+    byUri[uri]?.remove(session)
+  }
+
+  /** Registers a watch entry for [session]. Returns the entry so the tool can echo it back. */
+  fun watch(session: Any, entry: WatchEntry): WatchEntry {
+    val list = watches.computeIfAbsent(session) { mutableListOf() }
+    synchronized(list) { list.add(entry) }
+    return entry
+  }
+
+  /** Removes every watch for [session] matching [predicate]. Returns the number removed. */
+  fun unwatch(session: Any, predicate: (WatchEntry) -> Boolean): Int {
+    val list = watches[session] ?: return 0
+    return synchronized(list) {
+      val before = list.size
+      list.removeAll(predicate)
+      before - list.size
+    }
+  }
+
+  /** Drops all subscriptions and watches owned by [session]. Called on session disconnect. */
+  fun forget(session: Any) {
+    byUri.values.forEach { it.remove(session) }
+    watches.remove(session)
+  }
+
+  /** Sessions currently subscribed to [uri]. */
+  fun sessionsSubscribedTo(uri: String): Set<Any> = byUri[uri]?.toSet() ?: emptySet()
+
+  /** Watch entries registered by [session], snapshot. */
+  fun watchesFor(session: Any): List<WatchEntry> =
+    watches[session]?.let { synchronized(it) { it.toList() } } ?: emptyList()
+
+  /**
+   * Returns every session whose watch set matches [uri]. Used to push per-URI updates to clients
+   * who didn't explicitly `subscribe` but did `watch` a glob covering the URI. A session that both
+   * subscribed AND watched is returned once (set semantics).
+   */
+  fun sessionsWatching(uri: PreviewUri): Set<Any> {
+    val out = mutableSetOf<Any>()
+    for ((session, entries) in watches) {
+      val list = synchronized(entries) { entries.toList() }
+      if (list.any { it.matches(uri) }) out.add(session)
+    }
+    return out
+  }
+
+  /**
+   * The aggregated URI set every watch (across all sessions) cares about for
+   * [workspaceId] + [modulePath]. Used by [WatchPropagator] to compute what to forward as
+   * `setVisible` on the daemon — the union, not the per-session view.
+   */
+  fun urisWatchedFor(
+    workspaceId: WorkspaceId,
+    modulePath: String,
+    candidatePreviews: Sequence<PreviewUri>,
+  ): Set<PreviewUri> {
+    val allEntries = watches.values.flatMap { synchronized(it) { it.toList() } }
+    if (allEntries.isEmpty()) return emptySet()
+    val out = mutableSetOf<PreviewUri>()
+    candidatePreviews.forEach { uri ->
+      if (uri.workspaceId != workspaceId || uri.modulePath != modulePath) return@forEach
+      if (allEntries.any { it.matches(uri) }) out.add(uri)
+    }
+    return out
+  }
+
+  /** Snapshot of every (session, watch) pair — for diagnostics / `list_watches` tool. */
+  fun snapshotAllWatches(): List<Pair<Any, WatchEntry>> {
+    val out = mutableListOf<Pair<Any, WatchEntry>>()
+    for ((session, entries) in watches) {
+      val list = synchronized(entries) { entries.toList() }
+      list.forEach { out.add(session to it) }
+    }
+    return out
+  }
+}
+
+/**
+ * One area-of-interest registration. The matching dimensions:
+ *
+ * - **workspaceId** — required. Cross-workspace watch is opt-in; the v0 watch tool requires callers
+ *   to register a workspace explicitly (via `register_project`) and pass its id.
+ * - **modulePath** — null means "any module in the workspace". Useful for "show me everything in
+ *   this project".
+ * - **fqnGlob** — null means "every preview in the matched module(s)". Otherwise a glob from
+ *   [FqnGlob].
+ *
+ * Pure-data; equality is structural.
+ */
+data class WatchEntry(
+  val workspaceId: WorkspaceId,
+  val modulePath: String? = null,
+  private val fqnGlobPattern: String? = null,
+) {
+  private val compiledGlob: FqnGlob? = fqnGlobPattern?.let { FqnGlob(it) }
+
+  val fqnGlob: String?
+    get() = fqnGlobPattern
+
+  fun matches(uri: PreviewUri): Boolean {
+    if (uri.workspaceId != workspaceId) return false
+    if (modulePath != null && uri.modulePath != modulePath) return false
+    if (compiledGlob != null && !compiledGlob.matches(uri.previewFqn)) return false
+    return true
+  }
+
+  override fun toString(): String =
+    "WatchEntry(workspace=$workspaceId, module=$modulePath, fqn=$fqnGlobPattern)"
+}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/WatchPropagator.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/WatchPropagator.kt
@@ -1,0 +1,81 @@
+package ee.schimke.composeai.mcp
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Translates the union of every session's watch set into per-daemon `setVisible` / `setFocus`
+ * notifications, so the daemon's render queue prioritises previews that any connected agent cares
+ * about and keeps them warm.
+ *
+ * Design notes:
+ *
+ * - **Per (workspace, module).** Each daemon serves exactly one (workspace, module) pair, and the
+ *   wire form of `setVisible` takes preview ids local to that daemon (the daemon doesn't know about
+ *   workspaces). So we partition the watched URI set by daemon and emit one `setVisible` per
+ *   affected daemon.
+ * - **Idempotent / rate-limited.** [recompute] is called on every relevant change (`watch`,
+ *   `unwatch`, `discoveryUpdated`, daemon spawn). We compare the new set against the last sent set
+ *   per daemon and skip the wire call if unchanged — ordinary client-side debouncing isn't enough
+ *   because `discoveryUpdated` can fire repeatedly in a short window.
+ * - **Focus = same set as visible in v0.** Splitting "user is interacting" vs "user might want to
+ *   look" requires sub-tool surface (e.g. `set_focus` MCP tool) we deliberately defer per
+ *   MCP-KOTLIN.md § "Tools surface (v0)".
+ *
+ * The propagator is intentionally stateless w.r.t. *which* previews exist. The [previewIdProvider]
+ * is supplied by the supervisor and reflects the daemon's current discovery state; the propagator
+ * filters those candidates by the watch sets and forwards the result.
+ */
+class WatchPropagator(
+  private val subscriptions: Subscriptions,
+  private val previewIdProvider: PreviewIdProvider,
+) {
+
+  private val lastSent = ConcurrentHashMap<DaemonKey, Set<String>>()
+
+  /**
+   * Recomputes the watched-URI set for [daemon] and forwards a `setVisible` + `setFocus` if it
+   * differs from the last sent set. Safe to call from any thread.
+   */
+  fun recompute(daemon: SupervisedDaemon) {
+    val candidates = previewIdProvider.previewsFor(daemon)
+    val watched =
+      subscriptions
+        .urisWatchedFor(
+          workspaceId = daemon.workspaceId,
+          modulePath = daemon.modulePath,
+          candidatePreviews = candidates.asSequence(),
+        )
+        .map { it.previewFqn }
+        .toSortedSet() // stable ordering = stable equality
+    val key = DaemonKey(daemon.workspaceId, daemon.modulePath)
+    val previous = lastSent[key]
+    // Treat null and empty as equivalent: the first recompute on a daemon that has no watches
+    // shouldn't fire an empty `setVisible` (the daemon already starts with nothing visible).
+    if ((previous ?: emptySet()) == watched) return
+    lastSent[key] = watched
+    val ids = watched.toList()
+    runCatching { daemon.client.setVisible(ids) }
+    runCatching { daemon.client.setFocus(ids) }
+  }
+
+  /**
+   * Drops the cached "last sent" entry for [daemon]. Called when a daemon is shut down or when we
+   * know the daemon's view has been reset (e.g. respawn after `classpathDirty`); a future
+   * [recompute] will then forward the current watched set even if it matches what we *thought* we
+   * sent.
+   */
+  fun forget(daemon: SupervisedDaemon) {
+    lastSent.remove(DaemonKey(daemon.workspaceId, daemon.modulePath))
+  }
+
+  private data class DaemonKey(val workspaceId: WorkspaceId, val modulePath: String)
+}
+
+/**
+ * Lookup the supervisor exposes: the current preview URI set advertised by [daemon]'s discovery
+ * state. Updated as `discoveryUpdated` notifications arrive — see `DaemonMcpServer` for the
+ * concrete wiring.
+ */
+fun interface PreviewIdProvider {
+  fun previewsFor(daemon: SupervisedDaemon): List<PreviewUri>
+}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/protocol/McpMessages.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/protocol/McpMessages.kt
@@ -1,0 +1,163 @@
+package ee.schimke.composeai.mcp.protocol
+
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+// ---------------------------------------------------------------------------
+// Trimmed MCP message shapes for the v0 server. We intentionally do not pull
+// in `io.modelcontextprotocol:kotlin-sdk`: the surface we need is small and
+// the SDK's auto-registered internal handlers complicate the dynamic catalog
+// model the supervisor wants. See ../build.gradle.kts for rationale.
+//
+// References:
+// - https://modelcontextprotocol.io/specification/2025-06-18/basic
+// - https://modelcontextprotocol.io/specification/2025-06-18/server/resources
+// - https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+// ---------------------------------------------------------------------------
+
+// =====================================================================
+// JSON-RPC envelope (id is string | number per spec; we accept both via
+// JsonElement and let the caller round-trip the original on responses).
+// =====================================================================
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class McpRequest(
+  @EncodeDefault val jsonrpc: String = "2.0",
+  val id: JsonElement,
+  val method: String,
+  val params: JsonElement? = null,
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class McpResponse(
+  @EncodeDefault val jsonrpc: String = "2.0",
+  val id: JsonElement,
+  val result: JsonElement? = null,
+  val error: McpError? = null,
+)
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class McpNotification(
+  @EncodeDefault val jsonrpc: String = "2.0",
+  val method: String,
+  val params: JsonElement? = null,
+)
+
+@Serializable data class McpError(val code: Int, val message: String, val data: JsonElement? = null)
+
+object McpErrorCodes {
+  const val PARSE_ERROR: Int = -32700
+  const val INVALID_REQUEST: Int = -32600
+  const val METHOD_NOT_FOUND: Int = -32601
+  const val INVALID_PARAMS: Int = -32602
+  const val INTERNAL_ERROR: Int = -32603
+}
+
+// =====================================================================
+// initialize
+// =====================================================================
+
+@Serializable
+data class InitializeParams(
+  val protocolVersion: String,
+  val capabilities: ClientCapabilities = ClientCapabilities(),
+  val clientInfo: Implementation? = null,
+)
+
+@Serializable
+data class InitializeResult(
+  val protocolVersion: String,
+  val capabilities: ServerCapabilities,
+  val serverInfo: Implementation,
+  val instructions: String? = null,
+)
+
+@Serializable data class Implementation(val name: String, val version: String)
+
+@Serializable data class ClientCapabilities(val experimental: Map<String, JsonElement>? = null)
+
+@Serializable
+data class ServerCapabilities(
+  val tools: ToolsCapability? = null,
+  val resources: ResourcesCapability? = null,
+)
+
+@Serializable data class ToolsCapability(val listChanged: Boolean = false)
+
+@Serializable
+data class ResourcesCapability(val subscribe: Boolean = false, val listChanged: Boolean = false)
+
+// =====================================================================
+// tools/list, tools/call
+// =====================================================================
+
+@Serializable data class ListToolsResult(val tools: List<ToolDef>)
+
+@Serializable
+data class ToolDef(val name: String, val description: String, val inputSchema: JsonElement)
+
+@Serializable data class CallToolParams(val name: String, val arguments: JsonElement? = null)
+
+@Serializable
+data class CallToolResult(val content: List<ContentBlock>, val isError: Boolean? = null)
+
+@Serializable
+sealed interface ContentBlock {
+  @Serializable @SerialName("text") data class Text(val text: String) : ContentBlock
+
+  @Serializable
+  @SerialName("image")
+  data class Image(val data: String, val mimeType: String) : ContentBlock
+}
+
+// =====================================================================
+// resources/list, resources/read, resources/subscribe, resources/unsubscribe
+// =====================================================================
+
+@Serializable
+data class ListResourcesResult(
+  val resources: List<ResourceDescriptor>,
+  val nextCursor: String? = null,
+)
+
+@Serializable
+data class ResourceDescriptor(
+  val uri: String,
+  val name: String,
+  val description: String? = null,
+  val mimeType: String? = null,
+  val size: Long? = null,
+)
+
+@Serializable data class ReadResourceParams(val uri: String)
+
+@Serializable data class ReadResourceResult(val contents: List<ResourceContents>)
+
+@Serializable
+sealed interface ResourceContents {
+  @Serializable
+  @SerialName("text")
+  data class Text(val uri: String, val mimeType: String? = null, val text: String) :
+    ResourceContents
+
+  @Serializable
+  @SerialName("blob")
+  data class Blob(val uri: String, val mimeType: String? = null, val blob: String) :
+    ResourceContents
+}
+
+@Serializable data class SubscribeParams(val uri: String)
+
+@Serializable data class UnsubscribeParams(val uri: String)
+
+// =====================================================================
+// notifications: resources/updated, resources/list_changed
+// =====================================================================
+
+@Serializable data class ResourceUpdatedParams(val uri: String)

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -1,0 +1,424 @@
+package ee.schimke.composeai.mcp
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.mcp.protocol.ListToolsResult
+import ee.schimke.composeai.mcp.protocol.ReadResourceResult
+import ee.schimke.composeai.mcp.protocol.ResourceContents
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.nio.file.Files
+import java.util.Base64
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end test of the MCP server: drives an [McpSession] via in-memory pipes with a synthetic
+ * MCP client and a [FakeDaemon]. Asserts the load-bearing behaviors:
+ *
+ * 1. `initialize` succeeds and `tools/list` returns the expected tool surface.
+ * 2. `register_project` returns a workspace id.
+ * 3. `discoveryUpdated` from a fake daemon → `notifications/resources/list_changed` to the client.
+ * 4. `resources/list` returns the catalog.
+ * 5. `resources/subscribe` + fake daemon `renderFinished` → `notifications/resources/updated`.
+ * 6. The `watch` tool propagates `setVisible`/`setFocus` to the matched fake daemon.
+ * 7. `resources/read` round-trips through `renderNow` → `renderFinished` and returns base64 PNG.
+ */
+class DaemonMcpServerTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  private lateinit var supervisor: DaemonSupervisor
+  private lateinit var factory: FakeDaemonClientFactory
+  private lateinit var server: DaemonMcpServer
+  private lateinit var client: McpTestClient
+  private lateinit var session: McpSession
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Before
+  fun setUp() {
+    factory = FakeDaemonClientFactory()
+    supervisor =
+      DaemonSupervisor(descriptorProvider = FakeDescriptorProvider(), clientFactory = factory)
+    server = DaemonMcpServer(supervisor)
+
+    val (clientToServer, serverFromClient) = pipedPair()
+    val (serverToClient, clientFromServer) = pipedPair()
+    session = server.newSession(input = serverFromClient, output = serverToClient)
+    session.start()
+    client = McpTestClient(input = clientFromServer, output = clientToServer)
+  }
+
+  @After
+  fun tearDown() {
+    runCatching { client.close() }
+    runCatching { session.close() }
+    runCatching { supervisor.shutdown() }
+  }
+
+  @Test
+  fun `initialize and tools list returns expected tool surface`() {
+    val initResult = client.initialize()
+    val caps = initResult["capabilities"]?.jsonObject
+    assertThat(caps?.get("resources")?.jsonObject?.get("subscribe")?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("true")
+
+    val toolsResult = client.request("tools/list")
+    val tools = json.decodeFromJsonElement(ListToolsResult.serializer(), toolsResult)
+    val names = tools.tools.map { it.name }.toSet()
+    assertThat(names)
+      .containsExactly(
+        "register_project",
+        "unregister_project",
+        "list_projects",
+        "render_preview",
+        "watch",
+        "unwatch",
+        "list_watches",
+      )
+  }
+
+  @Test
+  fun `register_project returns workspaceId and notifies list_changed`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    val callResult =
+      client.callTool(
+        "register_project",
+        buildJsonObject {
+          put("path", projectDir.absolutePath)
+          put("rootProjectName", "test-project")
+        },
+      )
+    val text = callResult.firstTextContent()
+    val payload = json.parseToJsonElement(text).jsonObject
+    assertThat(payload["workspaceId"]?.jsonPrimitive?.contentOrNull).startsWith("test-project-")
+    val n = client.expectNotification("notifications/resources/list_changed", 2_000)
+    assertThat(n.method).isEqualTo("notifications/resources/list_changed")
+  }
+
+  @Test
+  fun `subscribe receives resources updated push when daemon emits renderFinished`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    val moduleDir = tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    val previewId = "com.example.Red"
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val expectedUri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    client.notifyOnly("resources/subscribe", buildJsonObject { put("uri", expectedUri) })
+    // The subscribe is a request; use callRequest to await the response.
+    val subResp = client.request("resources/subscribe", buildJsonObject { put("uri", expectedUri) })
+    assertThat(subResp).isInstanceOf(JsonObject::class.java)
+
+    daemon.emitRenderFinished(previewId, "/tmp/fake.png")
+    val update = client.expectNotification("notifications/resources/updated", 2_000)
+    val updatedUri = update.params?.get("uri")?.jsonPrimitive?.contentOrNull
+    assertThat(updatedUri).isEqualTo(expectedUri)
+  }
+
+  @Test
+  fun `watch propagates setVisible and setFocus to matching daemon`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    daemon.emitDiscovery("com.example.Red")
+    daemon.emitDiscovery("com.example.Blue")
+    // Drain the two list_changed notifications produced.
+    repeat(2) { client.expectNotification("notifications/resources/list_changed", 2_000) }
+
+    // Watch only the Red preview.
+    val watchResp =
+      client.callTool(
+        "watch",
+        buildJsonObject {
+          put("workspaceId", workspaceId.value)
+          put("module", ":module")
+          put("fqnGlob", "com.example.Red")
+        },
+      )
+    assertThat(watchResp.firstTextContent()).contains("watching")
+
+    val visible = daemon.visibleSets.poll(2_000, TimeUnit.MILLISECONDS)
+    val focus = daemon.focusSets.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(visible).isEqualTo(listOf("com.example.Red"))
+    assertThat(focus).isEqualTo(listOf("com.example.Red"))
+  }
+
+  @Test
+  fun `resources read round-trips through renderNow and returns base64 PNG`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    // Pre-stage a fake PNG file the renderFinished notification will reference.
+    val pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3)
+    val pngFile = tmp.newFile("fake-render.png")
+    Files.write(pngFile.toPath(), pngBytes)
+
+    // Configure the fake to auto-emit renderFinished whenever it processes a renderNow for this
+    // preview id, pointing at the staged PNG. Avoids the spawn-a-thread-and-poll race the earlier
+    // test had.
+    daemon.autoRenderPngPath = { id -> if (id == previewId) pngFile.absolutePath else null }
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val response =
+      client.request("resources/read", buildJsonObject { put("uri", uri) }, timeoutMs = 10_000)
+    val parsed = json.decodeFromJsonElement(ReadResourceResult.serializer(), response)
+    val blob = parsed.contents.single() as ResourceContents.Blob
+    val decoded = Base64.getDecoder().decode(blob.blob)
+    assertThat(decoded).isEqualTo(pngBytes)
+    assertThat(blob.mimeType).isEqualTo("image/png")
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private fun registerWorkspace(projectDir: java.io.File, rootName: String): WorkspaceId {
+    val resp =
+      client.callTool(
+        "register_project",
+        buildJsonObject {
+          put("path", projectDir.absolutePath)
+          put("rootProjectName", rootName)
+        },
+      )
+    val text = resp.firstTextContent()
+    val payload = json.parseToJsonElement(text).jsonObject
+    val ws = payload["workspaceId"]!!.jsonPrimitive.content
+    // Drain the list_changed notification from registration.
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+    return WorkspaceId(ws)
+  }
+
+  private fun warmDaemonFor(workspaceId: WorkspaceId, modulePath: String): FakeDaemon {
+    // Trigger lazy spawn by accessing the daemon. Render request to /dev/null preview id is fine —
+    // the fake responds and the spawn is recorded in factory.daemons.
+    supervisor.daemonFor(workspaceId, modulePath)
+    return factory.daemons.getValue(workspaceId to modulePath)
+  }
+
+  private fun pipedPair(): Pair<OutputStream, InputStream> {
+    val out = PipedOutputStream()
+    val input = PipedInputStream(out, 64 * 1024)
+    return out to input
+  }
+}
+
+/**
+ * Minimal MCP client used by [DaemonMcpServerTest]. Speaks Content-Length-framed JSON-RPC over the
+ * pipes the McpSession exposes.
+ */
+class McpTestClient(private val input: InputStream, private val output: OutputStream) {
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = false
+  }
+  private val nextId = AtomicLong(1)
+  private val responses =
+    java.util.concurrent.ConcurrentHashMap<Long, LinkedBlockingQueue<JsonObject>>()
+  private val notifications = LinkedBlockingQueue<NotificationFrame>()
+  @Volatile private var closed = false
+
+  private val readerThread =
+    Thread({ runReader() }, "mcp-test-client-reader").apply { isDaemon = true }
+
+  init {
+    readerThread.start()
+  }
+
+  fun initialize(timeoutMs: Long = 5_000): JsonObject {
+    val params = buildJsonObject {
+      put("protocolVersion", "2025-06-18")
+      putJsonObject("capabilities") {}
+      putJsonObject("clientInfo") {
+        put("name", "mcp-test-client")
+        put("version", "0.0")
+      }
+    }
+    val resp = request("initialize", params, timeoutMs)
+    notifyOnly("notifications/initialized", null)
+    return resp
+  }
+
+  fun request(method: String, params: JsonElement? = null, timeoutMs: Long = 5_000): JsonObject {
+    val id = nextId.getAndIncrement()
+    val slot = responses.computeIfAbsent(id) { LinkedBlockingQueue() }
+    val payload = buildJsonObject {
+      put("jsonrpc", "2.0")
+      put("id", id)
+      put("method", method)
+      if (params != null) put("params", params)
+    }
+    sendFrame(payload.toString())
+    val resp =
+      slot.poll(timeoutMs, TimeUnit.MILLISECONDS)
+        ?: error("request($method) timed out after ${timeoutMs}ms")
+    responses.remove(id)
+    if (resp["error"] != null) {
+      error("request($method) error: ${resp["error"]}")
+    }
+    return resp["result"]?.jsonObject ?: error("request($method): no result in $resp")
+  }
+
+  fun callTool(
+    name: String,
+    arguments: JsonObject? = null,
+    timeoutMs: Long = 5_000,
+  ): McpToolResult {
+    val params = buildJsonObject {
+      put("name", name)
+      if (arguments != null) put("arguments", arguments)
+    }
+    val result = request("tools/call", params, timeoutMs)
+    return McpToolResult(result)
+  }
+
+  fun notifyOnly(method: String, params: JsonElement?) {
+    val payload = buildJsonObject {
+      put("jsonrpc", "2.0")
+      put("method", method)
+      if (params != null) put("params", params)
+    }
+    sendFrame(payload.toString())
+  }
+
+  fun expectNotification(method: String, timeoutMs: Long): NotificationFrame {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+      val n =
+        notifications.poll(deadline - System.currentTimeMillis(), TimeUnit.MILLISECONDS) ?: continue
+      if (n.method == method) return n
+      // Drop unrelated notifications.
+    }
+    error("expectNotification($method) timed out after ${timeoutMs}ms")
+  }
+
+  fun close() {
+    closed = true
+    runCatching { input.close() }
+    runCatching { output.close() }
+    readerThread.join(2_000)
+  }
+
+  private fun runReader() {
+    try {
+      while (!closed) {
+        val frame = readFrame(input) ?: break
+        val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+        val id = obj["id"]?.jsonPrimitive?.intOrNull()
+        if (id != null) {
+          responses.computeIfAbsent(id.toLong()) { LinkedBlockingQueue() }.put(obj)
+        } else {
+          val method = obj["method"]?.jsonPrimitive?.contentOrNull
+          if (method != null) {
+            notifications.put(NotificationFrame(method, obj["params"] as? JsonObject))
+          }
+        }
+      }
+    } catch (_: IOException) {
+      // EOF
+    }
+  }
+
+  private fun JsonPrimitive.intOrNull(): Int? = runCatching { content.toInt() }.getOrNull()
+
+  private fun sendFrame(jsonText: String) {
+    val payload = jsonText.toByteArray(Charsets.UTF_8)
+    val header = "Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII)
+    synchronized(output) {
+      output.write(header)
+      output.write(payload)
+      output.flush()
+    }
+  }
+
+  private fun readFrame(input: InputStream): ByteArray? {
+    var contentLength = -1
+    val buf = ByteArrayOutputStream(64)
+    var sawAny = false
+    while (true) {
+      val line = readHeaderLine(input, buf) ?: return if (sawAny) null else null
+      sawAny = true
+      if (line.isEmpty()) break
+      val colon = line.indexOf(':')
+      if (colon <= 0) error("malformed header: '$line'")
+      if (line.substring(0, colon).trim().equals("Content-Length", ignoreCase = true)) {
+        contentLength = line.substring(colon + 1).trim().toInt()
+      }
+    }
+    if (contentLength < 0) error("missing Content-Length")
+    val payload = ByteArray(contentLength)
+    var off = 0
+    while (off < contentLength) {
+      val n = input.read(payload, off, contentLength - off)
+      if (n < 0) return null
+      off += n
+    }
+    return payload
+  }
+
+  private fun readHeaderLine(input: InputStream, buf: ByteArrayOutputStream): String? {
+    buf.reset()
+    while (true) {
+      val b = input.read()
+      if (b < 0) return if (buf.size() == 0) null else buf.toString(Charsets.US_ASCII.name())
+      if (b == '\n'.code) {
+        val bytes = buf.toByteArray()
+        val end =
+          if (bytes.isNotEmpty() && bytes.last() == '\r'.code.toByte()) bytes.size - 1
+          else bytes.size
+        return String(bytes, 0, end, Charsets.US_ASCII)
+      }
+      buf.write(b)
+    }
+  }
+}
+
+data class NotificationFrame(val method: String, val params: JsonObject?)
+
+/** Wrapper around `tools/call` result for ergonomic content access. */
+class McpToolResult(val raw: JsonObject) {
+  fun firstTextContent(): String {
+    val content = raw["content"]?.jsonArray ?: error("tool result has no content array")
+    val first = content.first().jsonObject
+    return first["text"]?.jsonPrimitive?.content ?: error("first content block is not text")
+  }
+
+  fun isError(): Boolean = raw["isError"]?.jsonPrimitive?.contentOrNull == "true"
+}

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
@@ -1,0 +1,334 @@
+package ee.schimke.composeai.mcp
+
+import ee.schimke.composeai.daemon.protocol.InitializeResult
+import ee.schimke.composeai.daemon.protocol.Manifest
+import ee.schimke.composeai.daemon.protocol.RenderNowResult
+import ee.schimke.composeai.daemon.protocol.ServerCapabilities
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
+
+/**
+ * Test-only fake daemon. Speaks the daemon protocol (PROTOCOL.md) over piped streams so the MCP
+ * server can talk to it without a real subprocess. Just enough behavior to exercise:
+ *
+ * - `initialize` → returns a stub [InitializeResult] with empty capabilities.
+ * - `renderNow(previews)` → returns `queued = previews` and emits a [`renderFinished`][..]
+ *   notification for every queued id with a synthetic png path.
+ * - `setVisible` / `setFocus` → recorded so tests can assert watch propagation.
+ * - `shutdown` → returns null result; subsequent `exit` causes the reader to drain.
+ *
+ * The fake also lets the test push a [`discoveryUpdated`][..] notification on demand to trigger the
+ * MCP server's catalog update + resources/list_changed signal.
+ */
+class FakeDaemon : DaemonSpawn {
+
+  private val mcpToDaemon = PipedOutputStream()
+  private val daemonReadIn = PipedInputStream(mcpToDaemon, BUFFER)
+  private val daemonToMcp = PipedOutputStream()
+  private val mcpReadIn = PipedInputStream(daemonToMcp, BUFFER)
+
+  private val running = AtomicBoolean(true)
+  private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = false
+  }
+
+  /** Sent by the fake's reader when the MCP shim issues `setVisible`. Tests assert ordering. */
+  val visibleSets = java.util.concurrent.LinkedBlockingQueue<List<String>>()
+  /** Same for `setFocus`. */
+  val focusSets = java.util.concurrent.LinkedBlockingQueue<List<String>>()
+  /** `renderNow` invocations the fake observed. */
+  val renderRequests = java.util.concurrent.LinkedBlockingQueue<List<String>>()
+
+  /**
+   * When set, the fake auto-emits a `renderFinished` notification for every preview id in an
+   * incoming `renderNow` whose path the lambda returns non-null. Removes the
+   * spawn-a-thread-and-poll-renderRequests race in tests that just want "render → bytes back".
+   */
+  @Volatile var autoRenderPngPath: ((previewId: String) -> String?)? = null
+
+  private lateinit var _client: DaemonClient
+
+  override val client: DaemonClient
+    get() = _client
+
+  init {
+    Thread({ runDaemonReader() }, "fake-daemon-reader").apply { isDaemon = true }.start()
+  }
+
+  override fun client(
+    onNotification: (method: String, params: JsonObject?) -> Unit,
+    onClose: () -> Unit,
+  ): DaemonClient {
+    _client =
+      DaemonClient(
+        input = mcpReadIn,
+        output = mcpToDaemon,
+        onNotification = onNotification,
+        onClose = onClose,
+        threadName = "mcp-fake-daemon-client",
+      )
+    return _client
+  }
+
+  override fun shutdown() {
+    if (!running.compareAndSet(true, false)) return
+    runCatching { daemonToMcp.close() }
+    runCatching { daemonReadIn.close() }
+  }
+
+  /** Pushes a `discoveryUpdated` notification with one preview added. Test helper. */
+  fun emitDiscovery(previewId: String, displayName: String = previewId) {
+    val params = buildJsonObject {
+      putJsonArray("added") {
+        add(
+          buildJsonObject {
+            put("id", previewId)
+            put("className", previewId.substringBeforeLast('.'))
+            put("methodName", previewId.substringAfterLast('.'))
+            put("displayName", displayName)
+          }
+        )
+      }
+      putJsonArray("removed") {}
+      putJsonArray("changed") {}
+      put("totalPreviews", 1)
+    }
+    sendNotification("discoveryUpdated", params)
+  }
+
+  /** Pushes a `renderFinished` notification. Returns the synthetic pngPath emitted. */
+  fun emitRenderFinished(previewId: String, pngPath: String): String {
+    val params = buildJsonObject {
+      put("id", previewId)
+      put("pngPath", pngPath)
+      put("tookMs", 50L)
+    }
+    sendNotification("renderFinished", params)
+    return pngPath
+  }
+
+  // -------------------------------------------------------------------------
+  // Daemon-side reader: read framed JSON-RPC from the MCP shim, respond.
+  // -------------------------------------------------------------------------
+
+  private fun runDaemonReader() {
+    try {
+      while (running.get()) {
+        val frame = readFrame(daemonReadIn) ?: return
+        val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+        val responseId = obj["id"]?.jsonPrimitive?.long
+        val method = obj["method"]?.jsonPrimitive?.contentOrNull
+        val params = obj["params"] as? JsonObject
+        if (responseId != null && method != null) {
+          handleRequest(responseId, method, params)
+        } else if (method != null) {
+          handleNotification(method, params)
+        }
+      }
+    } catch (_: IOException) {
+      // EOF
+    }
+  }
+
+  private fun handleRequest(id: Long, method: String, params: JsonObject?) {
+    when (method) {
+      "initialize" -> {
+        val result =
+          InitializeResult(
+            protocolVersion = 1,
+            daemonVersion = "fake",
+            pid = 0,
+            capabilities =
+              ServerCapabilities(
+                incrementalDiscovery = true,
+                sandboxRecycle = false,
+                leakDetection = emptyList(),
+              ),
+            classpathFingerprint = "fake-fingerprint",
+            manifest = Manifest(path = "", previewCount = 0),
+          )
+        sendResponse(id, json.encodeToJsonElement(InitializeResult.serializer(), result))
+      }
+      "renderNow" -> {
+        val previews =
+          (params?.get("previews") as? kotlinx.serialization.json.JsonArray)?.mapNotNull {
+            it.jsonPrimitive.contentOrNull
+          } ?: emptyList()
+        renderRequests.offer(previews)
+        val result = RenderNowResult(queued = previews, rejected = emptyList())
+        sendResponse(id, json.encodeToJsonElement(RenderNowResult.serializer(), result))
+        // Auto-emit renderFinished for any preview whose path the test pre-registered. The
+        // emission happens AFTER the response so the daemon-protocol ordering matches what a
+        // real backend produces (queued → started → finished).
+        autoRenderPngPath?.let { provider ->
+          previews.forEach { pid ->
+            val path = provider(pid)
+            if (path != null) emitRenderFinished(pid, path)
+          }
+        }
+      }
+      "shutdown" -> {
+        sendResponse(id, kotlinx.serialization.json.JsonNull)
+      }
+      else -> {
+        // Unknown methods: error response so the client doesn't hang.
+        sendError(id, -32601, "method not found: $method")
+      }
+    }
+  }
+
+  private fun handleNotification(method: String, params: JsonObject?) {
+    when (method) {
+      "initialized" -> {}
+      "setVisible" -> {
+        val ids =
+          (params?.get("ids") as? kotlinx.serialization.json.JsonArray)?.mapNotNull {
+            it.jsonPrimitive.contentOrNull
+          } ?: emptyList()
+        visibleSets.offer(ids)
+      }
+      "setFocus" -> {
+        val ids =
+          (params?.get("ids") as? kotlinx.serialization.json.JsonArray)?.mapNotNull {
+            it.jsonPrimitive.contentOrNull
+          } ?: emptyList()
+        focusSets.offer(ids)
+      }
+      "exit" -> running.set(false)
+      else -> {}
+    }
+  }
+
+  private fun sendResponse(id: Long, result: JsonElement) {
+    val payload = buildJsonObject {
+      put("jsonrpc", "2.0")
+      put("id", id)
+      put("result", result)
+    }
+    sendFrame(payload.toString())
+  }
+
+  private fun sendError(id: Long, code: Int, message: String) {
+    val payload = buildJsonObject {
+      put("jsonrpc", "2.0")
+      put("id", id)
+      putJsonObject("error") {
+        put("code", code)
+        put("message", message)
+      }
+    }
+    sendFrame(payload.toString())
+  }
+
+  private fun sendNotification(method: String, params: JsonElement) {
+    val payload = buildJsonObject {
+      put("jsonrpc", "2.0")
+      put("method", method)
+      put("params", params)
+    }
+    sendFrame(payload.toString())
+  }
+
+  private fun sendFrame(jsonText: String) {
+    val bytes = jsonText.toByteArray(Charsets.UTF_8)
+    val header = "Content-Length: ${bytes.size}\r\n\r\n".toByteArray(Charsets.US_ASCII)
+    synchronized(daemonToMcp) {
+      daemonToMcp.write(header)
+      daemonToMcp.write(bytes)
+      daemonToMcp.flush()
+    }
+  }
+
+  private fun readFrame(input: InputStream): ByteArray? {
+    var contentLength = -1
+    val buf = ByteArrayOutputStream(64)
+    var sawAny = false
+    while (true) {
+      val line = readHeaderLine(input, buf) ?: return if (sawAny) null else null
+      sawAny = true
+      if (line.isEmpty()) break
+      val colon = line.indexOf(':')
+      if (colon <= 0) error("malformed header line: '$line'")
+      if (line.substring(0, colon).trim().equals("Content-Length", ignoreCase = true)) {
+        contentLength = line.substring(colon + 1).trim().toInt()
+      }
+    }
+    if (contentLength < 0) error("missing Content-Length")
+    val payload = ByteArray(contentLength)
+    var off = 0
+    while (off < contentLength) {
+      val n = input.read(payload, off, contentLength - off)
+      if (n < 0) return null
+      off += n
+    }
+    return payload
+  }
+
+  private fun readHeaderLine(input: InputStream, buf: ByteArrayOutputStream): String? {
+    buf.reset()
+    while (true) {
+      val b = input.read()
+      if (b < 0) return if (buf.size() == 0) null else buf.toString(Charsets.US_ASCII.name())
+      if (b == '\n'.code) {
+        val bytes = buf.toByteArray()
+        val end =
+          if (bytes.isNotEmpty() && bytes.last() == '\r'.code.toByte()) bytes.size - 1
+          else bytes.size
+        return String(bytes, 0, end, Charsets.US_ASCII)
+      }
+      buf.write(b)
+    }
+  }
+
+  companion object {
+    private const val BUFFER = 64 * 1024
+  }
+}
+
+/** Test [DaemonClientFactory] that always returns a [FakeDaemon]. */
+class FakeDaemonClientFactory : DaemonClientFactory {
+  /** Map of (workspaceId, modulePath) → fake. Tests assert/manipulate via this. */
+  val daemons: MutableMap<Pair<WorkspaceId, String>, FakeDaemon> = mutableMapOf()
+
+  override fun spawn(project: RegisteredProject, descriptor: DaemonLaunchDescriptor): DaemonSpawn {
+    val daemon = FakeDaemon()
+    daemons[project.workspaceId to descriptor.modulePath] = daemon
+    return daemon
+  }
+}
+
+/** Test [DescriptorProvider] returning a stub descriptor for any module. */
+class FakeDescriptorProvider : DescriptorProvider {
+  override fun descriptorFor(
+    project: RegisteredProject,
+    modulePath: String,
+  ): DaemonLaunchDescriptor =
+    DaemonLaunchDescriptor(
+      schemaVersion = 1,
+      modulePath = modulePath,
+      variant = "debug",
+      enabled = true,
+      mainClass = "fake.Main",
+      classpath = emptyList(),
+      jvmArgs = emptyList(),
+      systemProperties = emptyMap(),
+      workingDirectory = project.path.absolutePath,
+      manifestPath = "",
+    )
+}

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/PreviewResourceTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/PreviewResourceTest.kt
@@ -1,0 +1,102 @@
+package ee.schimke.composeai.mcp
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class PreviewResourceTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  @Test
+  fun `WorkspaceId derives stable id from canonical path`() {
+    val a = tmp.newFolder("a")
+    val b = tmp.newFolder("b")
+    val idA1 = WorkspaceId.derive("compose-ai-tools", a)
+    val idA2 = WorkspaceId.derive("compose-ai-tools", a)
+    val idB = WorkspaceId.derive("compose-ai-tools", b)
+    assertThat(idA1).isEqualTo(idA2)
+    assertThat(idA1).isNotEqualTo(idB)
+    assertThat(idA1.value).startsWith("compose-ai-tools-")
+    assertThat(idA1.value.removePrefix("compose-ai-tools-").length).isEqualTo(8)
+  }
+
+  @Test
+  fun `WorkspaceId distinguishes worktrees with the same project name`() {
+    val main = tmp.newFolder("repos", "main")
+    val feature = tmp.newFolder("repos", "feature")
+    val mainId = WorkspaceId.derive("compose-ai-tools", main)
+    val featureId = WorkspaceId.derive("compose-ai-tools", feature)
+    assertThat(mainId).isNotEqualTo(featureId)
+    assertThat(mainId.value.startsWith("compose-ai-tools-")).isTrue()
+    assertThat(featureId.value.startsWith("compose-ai-tools-")).isTrue()
+  }
+
+  @Test
+  fun `PreviewUri round-trip preserves all four segments`() {
+    val ws = WorkspaceId("compose-ai-tools-abc12345")
+    val uri =
+      PreviewUri(
+        workspaceId = ws,
+        modulePath = ":samples:android",
+        previewFqn = "com.example.app.RedSquare",
+        config = "phone-portrait",
+      )
+    val s = uri.toUri()
+    assertThat(s)
+      .isEqualTo(
+        "compose-preview://compose-ai-tools-abc12345/_samples_android/com.example.app.RedSquare?config=phone-portrait"
+      )
+    val parsed = PreviewUri.parse(s)
+    assertThat(parsed).isEqualTo(uri)
+  }
+
+  @Test
+  fun `PreviewUri rejects malformed input`() {
+    assertThat(PreviewUri.parseOrNull("file:///foo")).isNull()
+    assertThat(PreviewUri.parseOrNull("compose-preview://onlyws/")).isNull()
+    assertThat(PreviewUri.parseOrNull("compose-preview://")).isNull()
+  }
+
+  @Test
+  fun `FqnGlob matches single and double-star semantics`() {
+    val singleStar = FqnGlob("com.example.*")
+    assertThat(singleStar.matches("com.example.RedSquare")).isTrue()
+    // Single-star doesn't cross dot boundaries.
+    assertThat(singleStar.matches("com.example.sub.RedSquare")).isFalse()
+
+    val doubleStar = FqnGlob("com.example.**")
+    assertThat(doubleStar.matches("com.example.RedSquare")).isTrue()
+    assertThat(doubleStar.matches("com.example.sub.RedSquare")).isTrue()
+
+    val questionMark = FqnGlob("Red?quare")
+    assertThat(questionMark.matches("RedSquare")).isTrue()
+    assertThat(questionMark.matches("Red.quare")).isFalse()
+  }
+
+  @Test
+  fun `WatchEntry matches by workspace + module + glob`() {
+    val ws = WorkspaceId("ws-abc12345")
+    val other = WorkspaceId("other-abc12345")
+    val uri =
+      PreviewUri(
+        workspaceId = ws,
+        modulePath = ":samples:android",
+        previewFqn = "com.example.RedSquare",
+      )
+
+    // Workspace-only watch matches.
+    assertThat(WatchEntry(workspaceId = ws).matches(uri)).isTrue()
+    // Different workspace doesn't match.
+    assertThat(WatchEntry(workspaceId = other).matches(uri)).isFalse()
+    // Module filter matches.
+    assertThat(WatchEntry(workspaceId = ws, modulePath = ":samples:android").matches(uri)).isTrue()
+    // Wrong module doesn't match.
+    assertThat(WatchEntry(workspaceId = ws, modulePath = ":other").matches(uri)).isFalse()
+    // FQN glob matches.
+    assertThat(WatchEntry(workspaceId = ws, fqnGlobPattern = "com.example.*").matches(uri)).isTrue()
+    // Wrong glob doesn't match.
+    assertThat(WatchEntry(workspaceId = ws, fqnGlobPattern = "org.other.**").matches(uri)).isFalse()
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -52,3 +52,5 @@ include(":daemon:android")
 include(":daemon:desktop")
 
 include(":daemon:harness")
+
+include(":mcp")


### PR DESCRIPTION
Adds a top-level :mcp Gradle module that exposes the per-module preview daemon
as an MCP server. v0 is stdio-only; HTTP transport is a follow-up. The module
depends only on :daemon:core for protocol message types, keeping the
renderer-agnostic surface intact.

Surface

- compose-preview://<workspace>/<module>/<fqn>?config=<qualifier> resource URIs.
  Workspace ids are <rootProjectName>-<8charHashOfCanonicalPath>, so two
  worktrees of the same repo (different paths, same project name) get distinct
  ids by construction.
- Tools: register_project, unregister_project, list_projects, render_preview,
  watch, unwatch, list_watches.
- Resources: list (catalog populated from daemon discoveryUpdated), read
  (round-trips through renderNow, returns base64 PNG inline), subscribe,
  unsubscribe.
- Notifications: notifications/resources/list_changed (on discoveryUpdated),
  notifications/resources/updated (on renderFinished, fanned out to subscribed
  sessions and to sessions whose watch sets cover the URI).

Multi-workspace + watch sets

A single MCP server multiplexes per-(workspace, module) daemons across multiple
distinct projects or worktrees. The watch tool registers an "area of interest"
(workspace + optional module + optional FQN glob); the WatchPropagator
translates the union of every session's watch set into setVisible/setFocus on
the matched daemons so the daemon's render queue prioritises them and keeps
them warm. Re-expansion happens on discoveryUpdated.

History seam

A HistoryStore interface is wired in with a no-op default. The supervisor
calls record() on every successful render. The real implementation will land
behind docs/daemon/HISTORY.md as a separate PR; this seam keeps the supervisor
notification routing stable across that change.

Wire format

The MCP protocol is implemented directly with kotlinx-serialization rather
than via the official Kotlin SDK. The SDK auto-registers internal handlers
for resources/list and resources/read, which would complicate the dynamic
catalog model the supervisor needs. Rolling our own mirrors the proven
:daemon:core JsonRpcServer framing pattern, keeps the wire layer
self-contained, and avoids a 0.x SDK version-pin risk.

Tests

In-memory PipedInputStream/PipedOutputStream pairs drive an McpSession
end-to-end with a synthetic MCP client and a FakeDaemon that speaks the
:daemon:core wire protocol. Asserts: tools/list surface, register_project +
list_changed signal, subscribe + renderFinished -> resources/updated push,
watch -> setVisible/setFocus propagation, resources/read round-trip with
base64 PNG bytes, plus URI/glob/workspace-id parsing.