### PR TITLE
Add notify_file_changed MCP tool and improve daemon initialization

### DIFF
--- a/mcp/scripts/README.md
+++ b/mcp/scripts/README.md
@@ -1,0 +1,70 @@
+# `:mcp` smoke scripts
+
+Runnable end-to-end demos that exercise `DaemonMcpMain` against live daemons.
+Not part of the gradle test surface — they mutate source files (and revert
+via `git`) and depend on `./gradlew` being available, so they're opt-in.
+
+## `real_e2e_smoke.py`
+
+Drives a live MCP server JVM against the `:samples:cmp` desktop daemon to
+demonstrate the full edit → notify → re-render → revert flow:
+
+1. `initialize` + `register_project` + `watch :samples:cmp`.
+2. `resources/read` the `RedBoxPreview` URI -> save `before.png`.
+3. Edit `Previews.kt` (`Text("Red", …)` -> `Text("Edited", …)`),
+   recompile, `notify_file_changed`, `resources/read` -> `after.png`.
+4. `git checkout -- Previews.kt` to revert, recompile,
+   `notify_file_changed`, `resources/read` -> `revert.png`.
+
+Asserts `before == revert` (byte-equal) and `before != after`.
+
+### Setup
+
+```bash
+# 1. Bootstrap descriptors and previews.json for the cmp sample.
+./gradlew \
+  :samples:cmp:composePreviewDaemonStart \
+  :samples:cmp:discoverPreviews \
+  -PcomposePreview.experimental.daemon.enabled=true
+
+# 2. Flip the descriptor's `enabled` flag (the gradle property override is
+#    intentionally not propagated into the descriptor JSON; see
+#    DaemonExtension.kt's KDoc + issue #314 follow-up).
+sed -i 's/"enabled": false/"enabled": true/' \
+  samples/cmp/build/compose-previews/daemon-launch.json
+
+# 3. Build the mcp + daemon-core jars.
+./gradlew :mcp:jar :daemon:core:jar
+
+# 4. Build a runtime classpath. Adjust paths to match your gradle cache layout.
+VERSION=$(grep -m1 -oP '"\.":\s*"\K[^"]+' .release-please-manifest.json)
+NEXT="${VERSION%.*}.$((${VERSION##*.} + 1))"
+CP="$(pwd)/mcp/build/libs/mcp-${NEXT}-SNAPSHOT.jar"
+CP="$CP:$(pwd)/daemon/core/build/libs/core-${NEXT}-SNAPSHOT.jar"
+for jar in \
+    "$HOME/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/2.3.21/"*"/kotlin-stdlib-2.3.21.jar" \
+    "$HOME/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm/1.10.2/"*"/kotlinx-coroutines-core-jvm-1.10.2.jar" \
+    "$HOME/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-serialization-json-jvm/1.11.0/"*"/kotlinx-serialization-json-jvm-1.11.0.jar" \
+    "$HOME/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm/1.11.0/"*"/kotlinx-serialization-core-jvm-1.11.0.jar" \
+    "$HOME/.gradle/caches/modules-2/files-2.1/io.github.classgraph/classgraph/4.8.184/"*"/classgraph-4.8.184.jar" \
+    "$HOME/.gradle/caches/modules-2/files-2.1/org.jetbrains/annotations/23.0.0/"*"/annotations-23.0.0.jar"; do
+  CP="$CP:$jar"
+done
+echo "$CP" > /tmp/mcp-cp.txt
+
+# 5. Run the smoke. Renders are written to /tmp/render-{before,after,revert}.png.
+python3 mcp/scripts/real_e2e_smoke.py
+```
+
+### Caveats
+
+- Mutates `samples/cmp/src/main/kotlin/com/example/samplecmp/Previews.kt` and
+  reverts via `git checkout`. Run only on a clean tree.
+- ~30s end-to-end on a warm machine, dominated by two `compileKotlin` runs.
+- The `MCP_WORKDIR` env var lets you point the script at a different repo
+  checkout; the workspace id is recomputed from the canonical path the same
+  way `WorkspaceId.derive` does.
+- Wear (Robolectric) version of the same flow is straightforward in principle
+  — the MCP server happily spawns the wear daemon — but Robolectric's cold
+  boot is ~5–10s, which slows the loop. The `samples:wear:RedBoxPreview`
+  equivalent isn't wired into this script; copy + paste and bump the timeouts.

--- a/mcp/scripts/real_e2e_smoke.py
+++ b/mcp/scripts/real_e2e_smoke.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Real end-to-end smoke for the :mcp module.
+
+Drives a live ``DaemonMcpMain`` JVM over real OS pipes against the live
+``:samples:cmp`` desktop daemon to demonstrate the full edit → notify →
+re-render → revert flow:
+
+1. ``initialize`` + ``register_project`` + ``watch :samples:cmp``.
+2. ``resources/read`` the ``RedBoxPreview`` URI -> save ``before.png``.
+3. ``sed`` the source file's ``Text("Red", ...)`` to ``Text("Edited", ...)``.
+4. ``./gradlew :samples:cmp:compileKotlin`` so the daemon's user-classloader
+   can pick up the new bytecode after the swap.
+5. ``notify_file_changed`` MCP tool call -> daemon receives ``fileChanged`` +
+   the supervisor re-issues ``renderNow`` for every watched URI.
+6. ``resources/read`` again -> save ``after.png``; expected to differ.
+7. ``git checkout -- Previews.kt`` to revert; recompile; ``notify_file_changed``
+   again; ``resources/read`` -> save ``revert.png``; expected to byte-match
+   ``before.png``.
+
+Prerequisites (all live on the host):
+
+- ``./gradlew :samples:cmp:composePreviewDaemonStart -PcomposePreview.experimental.daemon.enabled=true``
+  has been run.
+- The descriptor's ``enabled`` flag must be ``true`` (use ``sed`` to flip it
+  if your build hasn't wired the gradle property; see issue #314 follow-up).
+- ``./gradlew :samples:cmp:discoverPreviews`` has been run so
+  ``previews.json`` exists.
+- ``./gradlew :mcp:jar :daemon:core:jar`` has been built.
+- ``MCP_CP_FILE`` (env var or ``/tmp/mcp-cp.txt``) points at a colon-joined
+  classpath containing the mcp jar, daemon-core jar, and required kotlinx
+  runtime jars. See the ``classpath_from_gradle_caches`` shell snippet in
+  ``mcp/scripts/README.md``.
+
+Runs in ~30s on a warm machine. Mutates and reverts a tracked source file —
+only run on a clean tree.
+"""
+import base64
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+
+WORKDIR = os.environ.get("MCP_WORKDIR", "/home/user/compose-ai-tools")
+PREVIEWS_KT = (
+    f"{WORKDIR}/samples/cmp/src/main/kotlin/com/example/samplecmp/Previews.kt"
+)
+
+
+def framed(body: str) -> bytes:
+    payload = body.encode("utf-8")
+    return f"Content-Length: {len(payload)}\r\n\r\n".encode("ascii") + payload
+
+
+def parse_frames(buf: bytearray):
+    while True:
+        idx = buf.find(b"\r\n\r\n")
+        if idx < 0:
+            return
+        header = buf[:idx].decode("ascii", errors="replace")
+        m = re.search(r"Content-Length:\s*(\d+)", header)
+        if not m:
+            return
+        n = int(m.group(1))
+        body_end = idx + 4 + n
+        if len(buf) < body_end:
+            return
+        body = bytes(buf[idx + 4 : body_end])
+        del buf[:body_end]
+        try:
+            yield json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError:
+            print(f"!! bad frame: {body[:80]!r}", file=sys.stderr)
+
+
+class McpClient:
+    def __init__(self, classpath: str):
+        self.proc = subprocess.Popen(
+            ["java", "-cp", classpath, "ee.schimke.composeai.mcp.DaemonMcpMain"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+        )
+        self.lock = threading.Lock()
+        self.next_id = 1
+        self.responses: dict[int, dict] = {}
+        self.notifications: list[dict] = []
+        self.cv = threading.Condition()
+        threading.Thread(target=self._reader, daemon=True).start()
+        threading.Thread(target=self._stderr, daemon=True).start()
+
+    def _reader(self):
+        buf = bytearray()
+        while True:
+            chunk = self.proc.stdout.read(4096)
+            if not chunk:
+                return
+            buf.extend(chunk)
+            for obj in parse_frames(buf):
+                with self.cv:
+                    if "id" in obj and ("result" in obj or "error" in obj):
+                        self.responses[obj["id"]] = obj
+                    elif "method" in obj:
+                        self.notifications.append(obj)
+                    self.cv.notify_all()
+
+    def _stderr(self):
+        for line in self.proc.stderr:
+            sys.stderr.write("[mcp] " + line.decode("utf-8", "replace"))
+
+    def request(self, method, params=None, timeout=120):
+        with self.lock:
+            req_id = self.next_id
+            self.next_id += 1
+        body = {"jsonrpc": "2.0", "id": req_id, "method": method}
+        if params is not None:
+            body["params"] = params
+        self.proc.stdin.write(framed(json.dumps(body)))
+        self.proc.stdin.flush()
+        deadline = time.time() + timeout
+        with self.cv:
+            while req_id not in self.responses:
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    raise TimeoutError(f"{method} timed out")
+                self.cv.wait(remaining)
+            return self.responses.pop(req_id)
+
+    def notify(self, method, params=None):
+        body = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            body["params"] = params
+        self.proc.stdin.write(framed(json.dumps(body)))
+        self.proc.stdin.flush()
+
+    def call_tool(self, name, args=None, timeout=120):
+        return self.request(
+            "tools/call",
+            {"name": name, **({"arguments": args} if args else {})},
+            timeout=timeout,
+        )
+
+    def read_resource(self, uri, timeout=120):
+        return self.request("resources/read", {"uri": uri}, timeout=timeout)
+
+    def shutdown(self):
+        try:
+            self.proc.stdin.close()
+        except Exception:
+            pass
+        self.proc.wait(timeout=15)
+
+
+def extract_png(read_response: dict) -> bytes:
+    return base64.b64decode(read_response["result"]["contents"][0]["blob"])
+
+
+def gradle(*targets):
+    print(f"  $ ./gradlew {' '.join(targets)} -q", flush=True)
+    res = subprocess.run(
+        ["./gradlew", *targets, "-q"], cwd=WORKDIR, capture_output=True, text=True
+    )
+    if res.returncode != 0:
+        sys.stderr.write(res.stdout + "\n" + res.stderr + "\n")
+        raise RuntimeError(f"gradle {' '.join(targets)} failed")
+
+
+def main():
+    cp_file = os.environ.get("MCP_CP_FILE", "/tmp/mcp-cp.txt")
+    cp = open(cp_file).read().strip()
+
+    # Derive the workspace id the same way DaemonMcpServer does — sha256 of canonical path,
+    # first 8 hex chars, prefixed by `<rootProjectName>-`.
+    canonical = os.path.realpath(WORKDIR)
+    short = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:8]
+    ws_id = f"compose-ai-tools-{short}"
+    preview_uri = (
+        f"compose-preview://{ws_id}/_samples_cmp/"
+        "com.example.samplecmp.PreviewsKt.RedBoxPreview_Red Box"
+    )
+
+    print("=== Step 1: starting MCP server, registering project, watching :samples:cmp ===")
+    cli = McpClient(cp)
+    cli.request(
+        "initialize",
+        {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "real-e2e-smoke", "version": "0"},
+        },
+    )
+    cli.notify("notifications/initialized")
+    cli.call_tool(
+        "register_project",
+        {
+            "path": WORKDIR,
+            "rootProjectName": "compose-ai-tools",
+            "modules": [":samples:cmp"],
+        },
+    )
+    cli.call_tool("watch", {"workspaceId": ws_id, "module": ":samples:cmp"})
+    time.sleep(2)
+
+    print("=== Step 2: read RedBox BEFORE any edit ===")
+    before = extract_png(cli.read_resource(preview_uri))
+    open("/tmp/render-before.png", "wb").write(before)
+    print(f"  before.png: {len(before)} bytes")
+
+    print("=== Step 3: edit Previews.kt: 'Red' label → 'Edited' ===")
+    src = open(PREVIEWS_KT).read()
+    edited = src.replace(
+        'Text("Red", color = Color.White)', 'Text("Edited", color = Color.White)'
+    )
+    if edited == src:
+        raise RuntimeError("source-edit didn't change anything; check the regex")
+    open(PREVIEWS_KT, "w").write(edited)
+    gradle(":samples:cmp:compileKotlin")
+
+    print("=== Step 4: notify_file_changed, re-read RedBox ===")
+    notif = cli.call_tool(
+        "notify_file_changed",
+        {"workspaceId": ws_id, "path": PREVIEWS_KT, "kind": "source"},
+    )
+    print(f"  {notif['result']['content'][0]['text']}")
+    time.sleep(1)
+    after = extract_png(cli.read_resource(preview_uri))
+    open("/tmp/render-after.png", "wb").write(after)
+    print(f"  after.png: {len(after)} bytes")
+
+    print("=== Step 5: git checkout to revert + recompile ===")
+    subprocess.run(
+        ["git", "-C", WORKDIR, "checkout", "--", PREVIEWS_KT], check=True
+    )
+    gradle(":samples:cmp:compileKotlin")
+
+    print("=== Step 6: notify_file_changed (post-revert), re-read RedBox ===")
+    cli.call_tool(
+        "notify_file_changed",
+        {"workspaceId": ws_id, "path": PREVIEWS_KT, "kind": "source"},
+    )
+    time.sleep(1)
+    revert = extract_png(cli.read_resource(preview_uri))
+    open("/tmp/render-revert.png", "wb").write(revert)
+    print(f"  revert.png: {len(revert)} bytes")
+
+    print()
+    print("=== Verdict ===")
+    print(f"  before.sha256 = {hashlib.sha256(before).hexdigest()[:16]}")
+    print(f"  after.sha256  = {hashlib.sha256(after).hexdigest()[:16]}")
+    print(f"  revert.sha256 = {hashlib.sha256(revert).hexdigest()[:16]}")
+
+    if before != after and after != revert and before == revert:
+        print("  PASS: edit produced different bytes; revert restored original.")
+        rc = 0
+    else:
+        print("  FAIL: bytes don't match the expected pattern.")
+        rc = 1
+
+    cli.shutdown()
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
@@ -1,6 +1,9 @@
 package ee.schimke.composeai.mcp
 
+import ee.schimke.composeai.daemon.protocol.ChangeType
 import ee.schimke.composeai.daemon.protocol.ClientCapabilities
+import ee.schimke.composeai.daemon.protocol.FileChangedParams
+import ee.schimke.composeai.daemon.protocol.FileKind
 import ee.schimke.composeai.daemon.protocol.InitializeParams
 import ee.schimke.composeai.daemon.protocol.InitializeResult
 import ee.schimke.composeai.daemon.protocol.JsonRpcNotification
@@ -105,6 +108,19 @@ class DaemonClient(
     sendNotification(
       "setFocus",
       json.encodeToJsonElement(SetFocusParams.serializer(), SetFocusParams(ids = ids)),
+    )
+
+  fun fileChanged(
+    path: String,
+    kind: FileKind = FileKind.SOURCE,
+    changeType: ChangeType = ChangeType.MODIFIED,
+  ) =
+    sendNotification(
+      "fileChanged",
+      json.encodeToJsonElement(
+        FileChangedParams.serializer(),
+        FileChangedParams(path = path, kind = kind, changeType = changeType),
+      ),
     )
 
   /** Drives `renderNow` for the given preview ids at the given [tier]. */

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -99,6 +99,19 @@ class SubprocessDaemonClientFactory : DaemonClientFactory {
         add(javaBin)
         addAll(descriptor.jvmArgs)
         descriptor.systemProperties.forEach { (k, v) -> add("-D$k=$v") }
+        // Production daemon launches via the gradle-plugin descriptor don't set this; without it
+        // the desktop / Robolectric hosts fall back to stub PNG paths because
+        // `JsonRpcServer.handleRenderNow` only carries `previewId=<id>` in the payload, not the
+        // className+functionName the render engine needs. The previews.json the descriptor
+        // already points at via `manifestPath` is the exact shape `PreviewManifestRouter` expects
+        // (a `{"previews":[{id, className, functionName, …}]}` JSON), so wire it through here so
+        // real renders work without any plugin change.
+        if (
+          descriptor.manifestPath.isNotBlank() &&
+            !descriptor.systemProperties.containsKey("composeai.harness.previewsManifest")
+        ) {
+          add("-Dcomposeai.harness.previewsManifest=${descriptor.manifestPath}")
+        }
         add("-cp")
         add(cpString)
         add(descriptor.mainClass)

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.mcp
 
+import ee.schimke.composeai.daemon.protocol.ChangeType
+import ee.schimke.composeai.daemon.protocol.FileKind
 import ee.schimke.composeai.daemon.protocol.RenderTier
 import ee.schimke.composeai.mcp.protocol.CallToolResult
 import ee.schimke.composeai.mcp.protocol.ContentBlock
@@ -334,6 +336,27 @@ class DaemonMcpServer(
         description = "List the watches registered by the current session.",
         inputSchema = parseSchema("""{"type":"object","properties":{}}"""),
       ),
+      ToolDef(
+        name = "notify_file_changed",
+        description =
+          "Tell every daemon in the matched workspace that a file changed. Forwards a `fileChanged` notification to the daemon so it can re-run discovery / mark previews stale. Use after editing source files outside the MCP server's view (e.g. via a coding agent that doesn't run a file watcher).",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "workspaceId":{"type":"string"},
+                "path":{"type":"string","description":"Absolute path of the changed file."},
+                "kind":{"type":"string","enum":["source","resource","classpath"],"default":"source"},
+                "changeType":{"type":"string","enum":["modified","created","deleted"],"default":"modified"}
+              },
+              "required":["workspaceId","path"]
+            }
+            """
+              .trimIndent()
+          ),
+      ),
     )
 
   private fun handleCallTool(
@@ -350,6 +373,7 @@ class DaemonMcpServer(
       "watch" -> toolWatch(session, args)
       "unwatch" -> toolUnwatch(session, args)
       "list_watches" -> toolListWatches(session)
+      "notify_file_changed" -> toolNotifyFileChanged(args)
       else -> errorCallToolResult("unknown tool: $name")
     }
   }
@@ -426,18 +450,30 @@ class DaemonMcpServer(
       args["workspaceId"]?.jsonPrimitive?.contentOrNull
         ?: return errorCallToolResult("watch: missing 'workspaceId'")
     val workspaceId = WorkspaceId(ws)
-    if (supervisor.project(workspaceId) == null) {
-      return errorCallToolResult(
-        "watch: workspace '$ws' not registered. Call register_project first."
-      )
-    }
+    val project =
+      supervisor.project(workspaceId)
+        ?: return errorCallToolResult(
+          "watch: workspace '$ws' not registered. Call register_project first."
+        )
     val module = args["module"]?.jsonPrimitive?.contentOrNull
     val glob = args["fqnGlob"]?.jsonPrimitive?.contentOrNull
     val entry = WatchEntry(workspaceId = workspaceId, modulePath = module, fqnGlobPattern = glob)
     subscriptions.watch(session, entry)
+    // Eagerly spawn the daemons matching this watch so they begin emitting `discoveryUpdated`
+    // and the catalog populates without the client having to make a speculative `read` first.
+    // - With an explicit `module`, spawn just that one.
+    // - Without `module`, spawn every `knownModules` entry the workspace declared (typically
+    //   passed via `register_project`'s `modules` arg).
+    val toSpawn =
+      if (module != null) listOf(module)
+      else synchronized(project.knownModules) { project.knownModules.toList() }
+    toSpawn.forEach { mp ->
+      runCatching { supervisor.daemonFor(workspaceId, mp) }
+        .onFailure { System.err.println("watch: lazy spawn failed for $mp: ${it.message}") }
+    }
     // Recompute every daemon's view; the propagator skips daemons whose URI set didn't change.
-    supervisor.project(workspaceId)?.daemons?.values?.forEach { watchPropagator.recompute(it) }
-    return textCallToolResult("watching $entry")
+    project.daemons.values.forEach { watchPropagator.recompute(it) }
+    return textCallToolResult("watching $entry (spawned ${toSpawn.size} daemon(s))")
   }
 
   private fun toolUnwatch(session: McpSession, args: JsonObject): CallToolResult {
@@ -475,6 +511,70 @@ class DaemonMcpServer(
       }
     }
     return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+  }
+
+  private fun toolNotifyFileChanged(args: JsonObject): CallToolResult {
+    val ws =
+      args["workspaceId"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("notify_file_changed: missing 'workspaceId'")
+    val workspaceId = WorkspaceId(ws)
+    val project =
+      supervisor.project(workspaceId)
+        ?: return errorCallToolResult("notify_file_changed: unknown workspace '$ws'")
+    val path =
+      args["path"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("notify_file_changed: missing 'path'")
+    val kind =
+      when (args["kind"]?.jsonPrimitive?.contentOrNull) {
+        "resource" -> FileKind.RESOURCE
+        "classpath" -> FileKind.CLASSPATH
+        else -> FileKind.SOURCE
+      }
+    val changeType =
+      when (args["changeType"]?.jsonPrimitive?.contentOrNull) {
+        "created" -> ChangeType.CREATED
+        "deleted" -> ChangeType.DELETED
+        else -> ChangeType.MODIFIED
+      }
+    // Forward to every spawned daemon in the workspace. The daemon itself decides whether the
+    // file is in its module's source set; the supervisor doesn't try to be clever about
+    // dispatch. After the file change, also re-issue `renderNow` for every URI any session has
+    // watched/subscribed in this workspace, so the daemon produces fresh bytes that get pushed
+    // out via the existing `renderFinished` → `notifications/resources/updated` path.
+    var forwarded = 0
+    var rendered = 0
+    project.daemons.values.forEach { daemon ->
+      runCatching { daemon.client.fileChanged(path = path, kind = kind, changeType = changeType) }
+        .onSuccess { forwarded++ }
+      val byId = catalog[DaemonAddr(daemon.workspaceId, daemon.modulePath)] ?: return@forEach
+      // Build the candidate URI set for this daemon and intersect with current watches/subs.
+      val candidates =
+        byId.values.map { entry ->
+          PreviewUri(
+            workspaceId = daemon.workspaceId,
+            modulePath = daemon.modulePath,
+            previewFqn = entry.fqn,
+            config = entry.config,
+          )
+        }
+      val ofInterest = candidates.filter { uri ->
+        subscriptions.sessionsWatching(uri).isNotEmpty() ||
+          subscriptions.sessionsSubscribedTo(uri.toUri()).isNotEmpty()
+      }
+      if (ofInterest.isNotEmpty()) {
+        runCatching {
+          daemon.client.renderNow(
+            previews = ofInterest.map { it.previewFqn },
+            tier = RenderTier.FULL,
+            reason = "notify_file_changed:$path",
+          )
+        }
+        rendered += ofInterest.size
+      }
+    }
+    return textCallToolResult(
+      "fileChanged forwarded to $forwarded daemon(s); re-rendered $rendered watched preview(s)"
+    )
   }
 
   // -------------------------------------------------------------------------

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -124,13 +124,45 @@ class DaemonSupervisor(
       onClose = { router.dispatchClose(supervised) },
     )
     runCatching {
-      spawn.client.initialize(
-        workspaceRoot = project.path.absolutePath,
-        moduleId = modulePath,
-        moduleProjectDir = descriptor.workingDirectory,
-      )
+      val result =
+        spawn.client.initialize(
+          workspaceRoot = project.path.absolutePath,
+          moduleId = modulePath,
+          moduleProjectDir = descriptor.workingDirectory,
+        )
+      // The daemon only emits `discoveryUpdated` for *deltas* — the initial preview set comes via
+      // `initialize.manifest.path` (a `previews.json` written by the gradle plugin's
+      // `discoverPreviews` task). Synthesise an initial `discoveryUpdated` notification by reading
+      // that file and dispatching it through the router as if it were a wire-level event. This
+      // keeps every catalog-population code path (DaemonMcpServer.onDiscoveryUpdated) on a single
+      // shape rather than splitting "initial seed" vs "incremental".
+      synthesiseInitialDiscovery(supervised, result.manifest.path)
     }
     return supervised
+  }
+
+  private fun synthesiseInitialDiscovery(daemon: SupervisedDaemon, manifestPath: String) {
+    if (manifestPath.isBlank()) return
+    val file = File(manifestPath)
+    if (!file.isFile) return
+    val previews =
+      runCatching {
+          val text = file.readText()
+          val arr =
+            (Json.parseToJsonElement(text) as? JsonObject)?.get("previews")
+              as? kotlinx.serialization.json.JsonArray ?: return@runCatching null
+          arr.mapNotNull { it as? JsonObject }
+        }
+        .getOrNull() ?: return
+    if (previews.isEmpty()) return
+    val params =
+      kotlinx.serialization.json.buildJsonObject {
+        put("added", kotlinx.serialization.json.JsonArray(previews))
+        put("removed", kotlinx.serialization.json.JsonArray(emptyList()))
+        put("changed", kotlinx.serialization.json.JsonArray(emptyList()))
+        put("totalPreviews", kotlinx.serialization.json.JsonPrimitive(previews.size))
+      }
+    router.dispatch(daemon, "discoveryUpdated", params)
   }
 }
 

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -96,6 +96,7 @@ class DaemonMcpServerTest {
         "watch",
         "unwatch",
         "list_watches",
+        "notify_file_changed",
       )
   }
 


### PR DESCRIPTION
## Summary
This PR adds a new `notify_file_changed` MCP tool that allows external agents to notify daemons of file changes and trigger re-renders, along with improvements to daemon initialization and a comprehensive end-to-end smoke test.

## Key Changes

- **New `notify_file_changed` MCP tool**: Enables clients to notify all daemons in a workspace when files change (source, resource, or classpath), with support for change types (modified, created, deleted). After forwarding the notification, the tool re-issues `renderNow` for all watched previews to produce fresh bytes.

- **Improved daemon initialization**: 
  - `DaemonSupervisor` now synthesizes an initial `discoveryUpdated` notification from the `previews.json` manifest file, ensuring the catalog populates immediately without requiring a speculative read first.
  - `DaemonMcpMain` now automatically wires the `manifestPath` system property to the daemon subprocess so renders work correctly without plugin changes.

- **Eager daemon spawning in `watch` tool**: When a watch is registered, daemons are now spawned immediately (either the specified module or all known modules) so they begin emitting discovery updates and the catalog populates without client speculation.

- **End-to-end smoke test** (`real_e2e_smoke.py`): A comprehensive Python script that demonstrates the full edit → notify → re-render → revert flow against the `:samples:cmp` desktop daemon, validating that file changes trigger proper re-renders and reverts restore original state.

- **Documentation** (`mcp/scripts/README.md`): Setup and usage guide for the smoke test, including classpath construction and caveats.

## Implementation Details

- The `notify_file_changed` tool forwards `fileChanged` notifications to all spawned daemons in a workspace and intelligently re-renders only the previews that are currently watched or subscribed to by active sessions.
- Initial discovery synthesis reads the `previews.json` file and dispatches it through the existing router to maintain a single code path for catalog population.
- The smoke test validates the complete flow by comparing PNG bytes before/after edits and after reverts, ensuring the daemon properly responds to file change notifications.

https://claude.ai/code/session_019zojhG4CGDqnzxbsyPDRqc