### PR TITLE
feat(daemon): record history per render + history/list + history/read (H1+H2)

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -3,6 +3,8 @@
 package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.bridge.DaemonHostBridge
+import ee.schimke.composeai.daemon.history.GitProvenance
+import ee.schimke.composeai.daemon.history.HistoryManager
 import java.io.File
 import java.nio.file.Path
 
@@ -148,6 +150,25 @@ fun main(args: Array<String>) {
       IncrementalDiscovery(classpath = classpath)
     } else null
 
+  // H1+H2 — wire the per-render history archive. Path comes from `composeai.daemon.historyDir`;
+  // workspace root for git-provenance resolution comes from `composeai.daemon.workspaceRoot` (JVM
+  // CWD when unset). Mirrors the desktop daemon's wireup. See HISTORY.md § "What this PR lands".
+  val historyDirProp = System.getProperty(HISTORY_DIR_PROP)
+  val workspaceRootProp = System.getProperty(WORKSPACE_ROOT_PROP)
+  val gitProvenance =
+    if (historyDirProp != null) {
+      GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of))
+    } else null
+  val historyManager: HistoryManager? =
+    historyDirProp?.let { dir ->
+      System.err.println("compose-ai-tools daemon: HistoryManager active (dir=$dir)")
+      HistoryManager.forLocalFs(
+        historyDir = Path.of(dir),
+        module = System.getProperty(MODULE_ID_PROP) ?: "",
+        gitProvenance = gitProvenance,
+      )
+    }
+
   val server =
     JsonRpcServer(
       input = System.`in`,
@@ -156,6 +177,16 @@ fun main(args: Array<String>) {
       classpathFingerprint = classpathFingerprint,
       previewIndex = previewIndex,
       incrementalDiscovery = incrementalDiscovery,
+      historyManager = historyManager,
     )
   server.run()
 }
+
+/** HISTORY.md § "What this PR lands § H1" — null disables history. */
+private const val HISTORY_DIR_PROP = "composeai.daemon.historyDir"
+
+/** Optional override for git-provenance resolution; defaults to JVM CWD. */
+private const val WORKSPACE_ROOT_PROP = "composeai.daemon.workspaceRoot"
+
+/** Module project path stamped into every history entry's `module` field. */
+private const val MODULE_ID_PROP = "composeai.daemon.moduleId"

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1,10 +1,19 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.history.HistoryEntry
+import ee.schimke.composeai.daemon.history.HistoryFilter
+import ee.schimke.composeai.daemon.history.HistoryManager
+import ee.schimke.composeai.daemon.history.PreviewMetadataSnapshot
 import ee.schimke.composeai.daemon.protocol.ClasspathDirtyParams
 import ee.schimke.composeai.daemon.protocol.ClasspathDirtyReason
 import ee.schimke.composeai.daemon.protocol.DiscoveryUpdatedParams
 import ee.schimke.composeai.daemon.protocol.FileChangedParams
 import ee.schimke.composeai.daemon.protocol.FileKind
+import ee.schimke.composeai.daemon.protocol.HistoryAddedParams
+import ee.schimke.composeai.daemon.protocol.HistoryListParams
+import ee.schimke.composeai.daemon.protocol.HistoryListResult
+import ee.schimke.composeai.daemon.protocol.HistoryReadParams
+import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
 import ee.schimke.composeai.daemon.protocol.InitializeParams
 import ee.schimke.composeai.daemon.protocol.InitializeResult
 import ee.schimke.composeai.daemon.protocol.JsonRpcNotification
@@ -27,7 +36,9 @@ import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 import java.lang.management.ManagementFactory
+import java.nio.file.Files
 import java.nio.file.Path
+import java.util.Base64
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
@@ -116,6 +127,14 @@ class JsonRpcServer(
    * behaviour as before phase 2 landed.
    */
   private val incrementalDiscovery: IncrementalDiscovery? = null,
+  /**
+   * H1+H2 — when non-null, every successful render produces a sidecar + index entry on disk
+   * (HISTORY.md § "What this PR lands § H1") and emits a `historyAdded` notification. The
+   * `history/list` and `history/read` requests dispatch into this manager. When null (in-process
+   * tests, fake-mode harness scenarios that don't opt in), history calls return empty / not-found
+   * and `historyAdded` notifications never fire — pre-H1 behaviour.
+   */
+  private val historyManager: HistoryManager? = null,
   private val onExit: (Int) -> Unit = { code -> System.exit(code) },
 ) {
 
@@ -284,6 +303,8 @@ class JsonRpcServer(
       "initialize" -> handleInitialize(req)
       "renderNow" -> handleRenderNow(req)
       "shutdown" -> handleShutdown(req)
+      "history/list" -> handleHistoryList(req)
+      "history/read" -> handleHistoryRead(req)
       else ->
         sendErrorResponse(
           id = req.id,
@@ -491,7 +512,198 @@ class JsonRpcServer(
     val tookMs = result.metrics?.get("tookMs") ?: 0L
     val finished = renderFinishedFromResult(previewId, result, tookMs = tookMs)
     sendNotification("renderFinished", encode(RenderFinishedParams.serializer(), finished))
+    // H1 — record the render to history, if configured. Wrapped in a fail-open try/catch so a
+    // history write failure never blocks the renderFinished wire-format. The render's notification
+    // has already been sent above; history is observation, not state.
+    recordHistoryForRender(previewId = previewId, result = result, finished = finished)
     inFlightRenders.remove(result.id)
+  }
+
+  /**
+   * H1 — reads the render's PNG bytes off disk (when [RenderResult.pngPath] is non-null and the
+   * file exists), sha256s them, and writes a sidecar + index entry via [historyManager]. Emits
+   * `historyAdded` after the entry has been persisted.
+   *
+   * Skips when:
+   * - [historyManager] is null or disabled (the pre-H1 default for in-process tests).
+   * - `result.pngPath` is null or the file doesn't exist (B1.5-era stub hosts; the daemon-stub
+   *   placeholder path that was never written to disk).
+   *
+   * Failures are logged to stderr and swallowed. The render itself is unaffected.
+   */
+  private fun recordHistoryForRender(
+    previewId: String,
+    result: RenderResult,
+    finished: RenderFinishedParams,
+  ) {
+    val mgr = historyManager ?: return
+    if (!mgr.isEnabled) return
+    val pngPath = result.pngPath ?: return
+    val pngFile = Path.of(pngPath)
+    if (!Files.exists(pngFile)) {
+      // Stub-host path — pngPath is the deterministic `daemon-stub-${id}.png` placeholder that
+      // never actually lands on disk. Skip silently; this is the pre-H1 behaviour for stub hosts.
+      return
+    }
+    val pngBytes =
+      try {
+        Files.readAllBytes(pngFile)
+      } catch (t: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: history: failed to read PNG bytes for $previewId at $pngPath " +
+            "(${t.javaClass.simpleName}: ${t.message}); skipping history entry"
+        )
+        return
+      }
+    val previewMetadata =
+      previewIndex.byId(previewId)?.let {
+        PreviewMetadataSnapshot(
+          displayName = it.displayName,
+          group = it.group,
+          sourceFile = it.sourceFile,
+          config = null,
+        )
+      }
+    val entry =
+      try {
+        mgr.recordRender(
+          previewId = previewId,
+          pngBytes = pngBytes,
+          trigger = "renderNow",
+          triggerDetail = null,
+          renderTookMs = finished.tookMs,
+          metrics = finished.metrics,
+          previewMetadata = previewMetadata,
+        )
+      } catch (t: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: history: HistoryManager.recordRender($previewId) threw " +
+            "(${t.javaClass.simpleName}: ${t.message}); continuing"
+        )
+        return
+      }
+    if (entry != null) {
+      sendNotification(
+        "historyAdded",
+        encode(HistoryAddedParams.serializer(), HistoryAddedParams(entry = encodeHistoryEntry(entry))),
+      )
+    }
+  }
+
+  private fun encodeHistoryEntry(entry: HistoryEntry): JsonElement =
+    json.encodeToJsonElement(HistoryEntry.serializer(), entry)
+
+  private fun handleHistoryList(req: JsonRpcRequest) {
+    val params =
+      try {
+        decodeParams(req.params, HistoryListParams.serializer())
+      } catch (e: Throwable) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INVALID_PARAMS,
+          message = "invalid history/list params: ${e.message}",
+        )
+        return
+      }
+    val mgr = historyManager
+    if (mgr == null || !mgr.isEnabled) {
+      sendResponse(
+        req.id,
+        encode(
+          HistoryListResult.serializer(),
+          HistoryListResult(entries = emptyList(), nextCursor = null, totalCount = 0),
+        ),
+      )
+      return
+    }
+    val filter =
+      HistoryFilter(
+        previewId = params.previewId,
+        since = params.since,
+        until = params.until,
+        limit = params.limit,
+        cursor = params.cursor,
+        branch = params.branch,
+        branchPattern = params.branchPattern,
+        commit = params.commit,
+        worktreePath = params.worktreePath,
+        agentId = params.agentId,
+        sourceKind = params.sourceKind,
+        sourceId = params.sourceId,
+      )
+    val page =
+      try {
+        mgr.list(filter)
+      } catch (t: Throwable) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INTERNAL,
+          message = "history/list failed: ${t.message}",
+        )
+        return
+      }
+    val result =
+      HistoryListResult(
+        entries = page.entries.map { encodeHistoryEntry(it) },
+        nextCursor = page.nextCursor,
+        totalCount = page.totalCount,
+      )
+    sendResponse(req.id, encode(HistoryListResult.serializer(), result))
+  }
+
+  private fun handleHistoryRead(req: JsonRpcRequest) {
+    val params =
+      try {
+        decodeParams(req.params, HistoryReadParams.serializer())
+      } catch (e: Throwable) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INVALID_PARAMS,
+          message = "invalid history/read params: ${e.message}",
+        )
+        return
+      }
+    val mgr = historyManager
+    if (mgr == null || !mgr.isEnabled) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_HISTORY_ENTRY_NOT_FOUND,
+        message = "history not configured",
+      )
+      return
+    }
+    val read =
+      try {
+        mgr.read(params.id, includeBytes = params.inline)
+      } catch (t: Throwable) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INTERNAL,
+          message = "history/read failed: ${t.message}",
+        )
+        return
+      }
+    if (read == null) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_HISTORY_ENTRY_NOT_FOUND,
+        message = "history entry not found: ${params.id}",
+      )
+      return
+    }
+    val previewMetadataElem =
+      read.previewMetadata?.let {
+        json.encodeToJsonElement(PreviewMetadataSnapshot.serializer(), it)
+      }
+    val pngBase64 = read.pngBytes?.let { Base64.getEncoder().encodeToString(it) }
+    val dto =
+      HistoryReadResultDto(
+        entry = encodeHistoryEntry(read.entry),
+        previewMetadata = previewMetadataElem,
+        pngPath = read.pngPath,
+        pngBytes = pngBase64,
+      )
+    sendResponse(req.id, encode(HistoryReadResultDto.serializer(), dto))
   }
 
   private fun emitRenderFailed(failure: RenderResultOrFailure.Failure) {
@@ -959,6 +1171,16 @@ class JsonRpcServer(
 
     /** PROTOCOL.md § 5 — `renderNow` rejected because the daemon will exit imminently. */
     const val ERR_CLASSPATH_DIRTY: Int = -32002
+
+    /** HISTORY.md § "Error codes" — `history/read` referenced a missing entry id. */
+    const val ERR_HISTORY_ENTRY_NOT_FOUND: Int = -32010
+
+    /**
+     * HISTORY.md § "Error codes" — `history/diff` was given two entries from different previews.
+     * Reserved in the wire enum even though `history/diff` itself isn't implemented in H1+H2 (lands
+     * in H3+); pinned here so the code constant is part of the locked surface.
+     */
+    const val ERR_HISTORY_DIFF_MISMATCH: Int = -32011
 
     private val SHUTDOWN_SENTINEL = ByteArray(0)
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitProvenance.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitProvenance.kt
@@ -1,0 +1,115 @@
+package ee.schimke.composeai.daemon.history
+
+import java.io.File
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+/**
+ * Resolves the per-render `git.*` and `worktree.*` provenance fields for [HistoryEntry] — see
+ * HISTORY.md § "Initialize-time provenance".
+ *
+ * Two-phase resolution:
+ *
+ * 1. **Construction (cheap, called once per daemon).** Captures [worktree], [remote] — the
+ *    worktree root and remote URL never change for a daemon's lifetime. Resolution failure leaves
+ *    the fields as null. No exception escapes; a non-git directory is fine.
+ * 2. **Per-render refresh ([snapshot]).** Re-resolves [GitInfo.branch], [GitInfo.commit],
+ *    [GitInfo.dirty] each call (single `git rev-parse` + `git status --porcelain` is sub-50ms in
+ *    the typical project). [GitInfo.remote] is taken from the cached value.
+ *
+ * **Safety against subprocess failures.** Every shell-out is wrapped in [runGit] which times out
+ * after 5s, captures stderr, and returns null on any error. The daemon never blocks on a misbehaved
+ * git binary.
+ *
+ * @param workspaceRoot the directory under which `git rev-parse --show-toplevel` runs; defaults to
+ *   the daemon's CWD when null. Production callers pass the InitializeParams.workspaceRoot.
+ * @param env environment overrides for tests — production passes `System.getenv()`.
+ */
+class GitProvenance(
+  private val workspaceRoot: Path?,
+  private val env: Map<String, String> = System.getenv(),
+) {
+
+  /** Captured once at construction. Stable for the daemon's lifetime. */
+  private val cached: WorktreeRoot = resolveWorktreeRoot()
+
+  /**
+   * Returns a fresh [WorktreeInfo] / [GitInfo] pair. Cheap (refreshes branch/commit/dirty per
+   * call); safe to invoke per-render.
+   */
+  fun snapshot(): Pair<WorktreeInfo?, GitInfo?> {
+    val worktreePath = cached.worktreePath
+    val worktreeInfo =
+      WorktreeInfo(
+        path = worktreePath,
+        id = cached.worktreeId,
+        agentId = env[ENV_AGENT_ID]?.takeIf { it.isNotEmpty() },
+      )
+    if (worktreePath == null) {
+      // Not a git working tree — emit only the agentId/id label fields.
+      val anyPopulated =
+        worktreeInfo.path != null || worktreeInfo.id != null || worktreeInfo.agentId != null
+      return Pair(if (anyPopulated) worktreeInfo else null, null)
+    }
+    val branch = runGit(worktreePath, "symbolic-ref", "--short", "HEAD")?.takeIf { it.isNotEmpty() }
+    val commit = runGit(worktreePath, "rev-parse", "HEAD")?.takeIf { it.isNotEmpty() }
+    val dirty = runGit(worktreePath, "status", "--porcelain")?.let { it.isNotEmpty() }
+    val gitInfo =
+      GitInfo(
+        branch = branch,
+        commit = commit,
+        shortCommit = commit?.take(7),
+        dirty = dirty,
+        remote = cached.remote,
+      )
+    return Pair(worktreeInfo, gitInfo)
+  }
+
+  /** Resolves the worktree root + remote once at construction. Returns null fields on failure. */
+  private fun resolveWorktreeRoot(): WorktreeRoot {
+    val cwd = workspaceRoot?.toAbsolutePath()?.toFile() ?: File(".").absoluteFile
+    val worktreePath =
+      runGit(cwd.absolutePath, "rev-parse", "--show-toplevel")?.takeIf { it.isNotEmpty() }
+    val remote =
+      worktreePath?.let { runGit(it, "remote", "get-url", "origin") }?.takeIf { it.isNotEmpty() }
+    val worktreeId =
+      env[ENV_WORKTREE_ID]?.takeIf { it.isNotEmpty() }
+        ?: worktreePath?.let { File(it).name.takeIf { name -> name.isNotEmpty() } }
+    return WorktreeRoot(worktreePath = worktreePath, worktreeId = worktreeId, remote = remote)
+  }
+
+  private fun runGit(workingDir: String, vararg args: String): String? {
+    return try {
+      val process =
+        ProcessBuilder(listOf("git") + args.toList())
+          .directory(File(workingDir))
+          .redirectErrorStream(false)
+          .start()
+      val finished = process.waitFor(5, TimeUnit.SECONDS)
+      if (!finished) {
+        process.destroyForcibly()
+        return null
+      }
+      if (process.exitValue() != 0) return null
+      process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText().trim() }
+    } catch (t: Throwable) {
+      // Swallow — non-git workspace, missing git binary, exotic file-system permission errors.
+      // History still works without git provenance; the daemon log captures the cause.
+      null
+    }
+  }
+
+  private data class WorktreeRoot(
+    val worktreePath: String?,
+    val worktreeId: String?,
+    val remote: String?,
+  )
+
+  companion object {
+    /** Environment variable populated by the harness / agent supervisor — HISTORY.md § "Agent attribution". */
+    const val ENV_AGENT_ID: String = "COMPOSEAI_AGENT_ID"
+
+    /** Environment variable that overrides the worktree dir basename — HISTORY.md § "Worktree IDs". */
+    const val ENV_WORKTREE_ID: String = "COMPOSEAI_WORKTREE_ID"
+  }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryEntry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryEntry.kt
@@ -1,0 +1,105 @@
+package ee.schimke.composeai.daemon.history
+
+import ee.schimke.composeai.daemon.protocol.RenderMetrics
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+// ---------------------------------------------------------------------------
+// Sidecar metadata schema — see docs/daemon/HISTORY.md § "Sidecar metadata
+// schema". The kotlinx-serialization JSON shape is the on-disk format the
+// daemon writes (and that consumers read back via `history/list` and
+// `history/read`) so any field added or renamed here is wire-format-visible.
+// Schema versioning rules (HISTORY.md § "File-format versioning") allow new
+// optional fields without a version bump; readers ignore unknowns.
+// ---------------------------------------------------------------------------
+
+/**
+ * One history entry — a single render observation captured to disk by the daemon.
+ *
+ * Field-by-field cross-reference to HISTORY.md § "Sidecar metadata schema":
+ * - **Identity** — [id], [previewId], [module], [timestamp].
+ * - **Bytes** — [pngHash] (full hex SHA-256), [pngSize], [pngPath] (relative to the sidecar).
+ * - **Provenance (producer)** — [producer] (always `"daemon"` for entries this server writes;
+ *   `"gradle"` / `"manual"` reserved for future producers), [trigger], [triggerDetail].
+ * - **Provenance (storage source)** — [source]. For H1 always `kind: "fs"`.
+ * - **Provenance (worktree + git)** — [worktree], [git]. Resolved at daemon startup; refreshed
+ *   per-render where cheap. Both are nullable so a non-git workspace still produces valid entries.
+ * - **Render context** — [renderTookMs], [metrics] (mirrors `RenderFinishedParams.metrics`).
+ * - **Preview metadata** — [previewMetadata]. Frozen at render time.
+ * - **Optional delta** — [previousId] + [deltaFromPrevious]. The first render of a preview has
+ *   `previousId == null` and `deltaFromPrevious == null`. H1 leaves the pixel-mode fields
+ *   ([HistoryDelta.diffPx], [HistoryDelta.ssim]) as `null`; H5 will populate them.
+ */
+@Serializable
+data class HistoryEntry(
+  val id: String,
+  val previewId: String,
+  val module: String,
+  val timestamp: String,
+  val pngHash: String,
+  val pngSize: Long,
+  val pngPath: String,
+  val producer: String,
+  val trigger: String,
+  val triggerDetail: JsonElement? = null,
+  val source: HistorySourceInfo,
+  val worktree: WorktreeInfo? = null,
+  val git: GitInfo? = null,
+  val renderTookMs: Long,
+  val metrics: RenderMetrics? = null,
+  val previewMetadata: PreviewMetadataSnapshot? = null,
+  val previousId: String? = null,
+  val deltaFromPrevious: HistoryDelta? = null,
+)
+
+/**
+ * Storage-backend identity. `kind` is one of `"fs"`, `"git"`, `"http"` (HISTORY.md § "Wire-format
+ * effects"); `id` is the source's stable identifier (e.g. `"fs:/abs/historyDir"`).
+ */
+@Serializable data class HistorySourceInfo(val kind: String, val id: String)
+
+/**
+ * Worktree provenance. `path` is the absolute worktree root; `id` is a human label (defaults to
+ * the dir basename or `COMPOSEAI_WORKTREE_ID` env); `agentId` is the optional automated-agent
+ * self-identifier from `COMPOSEAI_AGENT_ID`. All three are nullable so a non-git workspace still
+ * produces a valid sidecar.
+ */
+@Serializable
+data class WorktreeInfo(
+  val path: String? = null,
+  val id: String? = null,
+  val agentId: String? = null,
+)
+
+/** Git provenance captured per-render. Any subfield may be null when resolution failed. */
+@Serializable
+data class GitInfo(
+  val branch: String? = null,
+  val commit: String? = null,
+  val shortCommit: String? = null,
+  val dirty: Boolean? = null,
+  val remote: String? = null,
+)
+
+/**
+ * Preview metadata snapshot — frozen at render time so future discovery changes don't rewrite
+ * history. The current "live" metadata for a preview lives in the daemon's `PreviewIndex`.
+ */
+@Serializable
+data class PreviewMetadataSnapshot(
+  val displayName: String? = null,
+  val group: String? = null,
+  val sourceFile: String? = null,
+  val config: String? = null,
+)
+
+/**
+ * Diff against the previous entry of the same preview. H1 only carries the cheap hash-equality
+ * signal; H5 will populate [diffPx] / [ssim] when pixel mode lands.
+ */
+@Serializable
+data class HistoryDelta(
+  val pngHashChanged: Boolean,
+  val diffPx: Long? = null,
+  val ssim: Double? = null,
+)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
@@ -1,0 +1,195 @@
+package ee.schimke.composeai.daemon.history
+
+import ee.schimke.composeai.daemon.protocol.RenderMetrics
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Daemon-side history orchestrator — see HISTORY.md § "What this PR lands § H1" / § "H2".
+ *
+ * Holds the configured [HistorySource]s in priority order. H1+H2 ships only [LocalFsHistorySource];
+ * future phases (H10+) add `GitRefHistorySource` / `HttpMirrorHistorySource` here without changing
+ * [JsonRpcServer]'s call site.
+ *
+ * **Read** ([list], [read]) merges across all configured sources. For H1+H2 with one source this is
+ * trivially that source's response; the merge code-path lives here so H9+ multi-source merging
+ * lands without re-shaping [JsonRpcServer].
+ *
+ * **Write** ([recordRender]) goes to every writable source in priority order. A failure in any
+ * single source's write does NOT fail the render — [JsonRpcServer] catches and logs but keeps the
+ * render's success notification flowing.
+ *
+ * **Notifications.** After a successful write [recordRender] returns the persisted [HistoryEntry]
+ * so the caller can emit a `historyAdded` JSON-RPC notification.
+ *
+ * @param sources writable + readable backends in priority order. Pass `emptyList()` to disable
+ *   history (the daemon's no-op default — production callers wire one [LocalFsHistorySource]).
+ * @param module the module project path (e.g. `":samples:android"`); stamped into every entry's
+ *   `module` field. Defaults to empty string.
+ * @param gitProvenance per-render provenance source. When null (e.g. fake-mode test paths), the
+ *   `git` / `worktree` fields land null on entries.
+ */
+class HistoryManager(
+  private val sources: List<HistorySource>,
+  private val module: String,
+  private val gitProvenance: GitProvenance?,
+) {
+
+  /** True when at least one writable source is configured — i.e. when `recordRender` is meaningful. */
+  val isEnabled: Boolean
+    get() = sources.any { it.supportsWrites() }
+
+  /**
+   * Tracks the most-recent entry per previewId so [recordRender] can fill in `previousId` +
+   * `deltaFromPrevious.pngHashChanged`. Carries `(entryId, pngHash)` so the delta pass doesn't
+   * have to re-read the previous sidecar off disk.
+   */
+  private val previousByPreview: AtomicReference<Map<String, PreviousEntry>> =
+    AtomicReference(emptyMap())
+
+  private data class PreviousEntry(val id: String, val pngHash: String)
+
+  /**
+   * Records one render. Computes [HistoryEntry.id], `pngHash`, the dedup-aware `pngPath`, and the
+   * `previousId` / `deltaFromPrevious` fields, then writes to every writable source.
+   *
+   * Returns the persisted entry on success, or null when no writable source is configured (the
+   * disabled-by-default state).
+   *
+   * **Failure semantics.** If a source's [HistorySource.write] throws, this method logs to stderr
+   * but does NOT propagate — history is observation, the render itself is unaffected.
+   */
+  fun recordRender(
+    previewId: String,
+    pngBytes: ByteArray,
+    trigger: String,
+    triggerDetail: JsonElement? = null,
+    renderTookMs: Long,
+    metrics: RenderMetrics? = null,
+    previewMetadata: PreviewMetadataSnapshot? = null,
+    timestamp: Instant = Instant.now(),
+  ): HistoryEntry? {
+    if (!isEnabled) return null
+    val pngHash = LocalFsHistorySource.sha256Hex(pngBytes)
+    val shortHash = pngHash.substring(0, 8)
+    val ts = timestamp.atOffset(ZoneOffset.UTC).format(TIMESTAMP_FORMAT)
+    val id = "$ts-$shortHash"
+    val isoTimestamp = timestamp.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+
+    val (worktreeInfo, gitInfo) = gitProvenance?.snapshot() ?: Pair(null, null)
+    val previous = previousByPreview.get()[previewId]
+    val previousId = previous?.id
+    val delta =
+      if (previous != null) {
+        // Cheap field — full pixel diff lands in H5. For H1 we flip pngHashChanged based on the
+        // previous entry's full pngHash (cached so we don't have to re-read the prior sidecar).
+        HistoryDelta(
+          pngHashChanged = previous.pngHash != pngHash,
+          diffPx = null,
+          ssim = null,
+        )
+      } else null
+
+    // pngPath is provisional — LocalFsHistorySource overwrites it when dedup hits. For non-FS
+    // sources or for fresh writes the first source's response shape is what lands; we keep the
+    // local-relative filename as the default sidecar value.
+    val pngPath = "$id.png"
+    val firstWritableSource =
+      sources.firstOrNull { it.supportsWrites() }
+        ?: return null // Defensive — isEnabled was true, so this shouldn't happen; guard anyway.
+    val sourceInfo = HistorySourceInfo(kind = firstWritableSource.kind, id = firstWritableSource.id)
+
+    val entry =
+      HistoryEntry(
+        id = id,
+        previewId = previewId,
+        module = module,
+        timestamp = isoTimestamp,
+        pngHash = pngHash,
+        pngSize = pngBytes.size.toLong(),
+        pngPath = pngPath,
+        producer = "daemon",
+        trigger = trigger,
+        triggerDetail = triggerDetail,
+        source = sourceInfo,
+        worktree = worktreeInfo,
+        git = gitInfo,
+        renderTookMs = renderTookMs,
+        metrics = metrics,
+        previewMetadata = previewMetadata,
+        previousId = previousId,
+        deltaFromPrevious = delta,
+      )
+
+    var anyWritten = false
+    for (source in sources) {
+      if (!source.supportsWrites()) continue
+      try {
+        source.write(entry, pngBytes)
+        anyWritten = true
+      } catch (t: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: HistoryManager.recordRender(${entry.id}): write to ${source.id} " +
+            "failed (${t.javaClass.simpleName}: ${t.message})"
+        )
+      }
+    }
+    if (!anyWritten) return null
+
+    // Update the previousByPreview cache. CAS-loop so concurrent recordRender for the same
+    // preview id stays consistent (though `JsonRpcServer.kt` runs history writes single-threaded
+    // on the render-watcher path today).
+    val newPrev = PreviousEntry(id = id, pngHash = pngHash)
+    while (true) {
+      val current = previousByPreview.get()
+      val updated = current.toMutableMap().also { it[previewId] = newPrev }
+      if (previousByPreview.compareAndSet(current, updated)) break
+    }
+    return entry
+  }
+
+  /** Lists across all configured sources. H1+H2 has one source so this delegates trivially. */
+  fun list(filter: HistoryFilter): HistoryListPage {
+    if (sources.isEmpty()) return HistoryListPage(entries = emptyList(), totalCount = 0)
+    if (sources.size == 1) return sources.single().list(filter)
+    // Multi-source merging is reserved for H9+. For H1+H2 we still take the first source's page
+    // verbatim, but the entry shape carries `source` so a future merge can dedup on
+    // `(pngHash, previewId, git.commit)`.
+    return sources.first().list(filter)
+  }
+
+  /** Reads one entry. Falls through sources in order until a hit. */
+  fun read(entryId: String, includeBytes: Boolean): HistoryReadResult? {
+    for (source in sources) {
+      val result = source.read(entryId, includeBytes = includeBytes)
+      if (result != null) return result
+    }
+    return null
+  }
+
+  companion object {
+    /**
+     * `yyyyMMdd-HHmmss` UTC. Pinned format — HISTORY.md § "On-disk schema" filename shape.
+     */
+    private val TIMESTAMP_FORMAT: DateTimeFormatter =
+      DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss").withZone(ZoneOffset.UTC)
+
+    /**
+     * Builds the default H1 manager wiring — one [LocalFsHistorySource] under [historyDir]. Pass
+     * `null` historyDir to get a disabled (`isEnabled = false`) manager.
+     */
+    fun forLocalFs(
+      historyDir: java.nio.file.Path?,
+      module: String,
+      gitProvenance: GitProvenance?,
+    ): HistoryManager {
+      val sources =
+        if (historyDir == null) emptyList()
+        else listOf(LocalFsHistorySource(historyDir = historyDir))
+      return HistoryManager(sources = sources, module = module, gitProvenance = gitProvenance)
+    }
+  }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
@@ -1,0 +1,109 @@
+package ee.schimke.composeai.daemon.history
+
+/**
+ * Filter for [HistorySource.list]. Mirrors `history/list` params from HISTORY.md § "Layer 2 —
+ * JSON-RPC API" / § "Worktree-aware listing". All filters are optional; missing filter ⇒ no
+ * constraint on that dimension.
+ *
+ * `since` / `until` accept ISO-8601 timestamps; the source applies a string-comparison range over
+ * `HistoryEntry.timestamp` (which is itself ISO-8601 UTC, so lexical order = chronological order).
+ *
+ * `branch` is exact match; [branchPattern] is a regex for "branch starts with `agent/`" style
+ * filters. Forward-compat for cross-worktree merging in H6+ — H1+H2 only see entries from one
+ * source so most filters land mostly-redundant, but the read API still honours them.
+ *
+ * `sourceKind` / `sourceId` filter by storage backend identity (HISTORY.md § "Wire-format
+ * effects"); H1+H2 only have `LocalFsHistorySource` so these are effectively no-ops, but the
+ * shape lets H9+ multi-source merging plug in without re-shaping the filter.
+ */
+data class HistoryFilter(
+  val previewId: String? = null,
+  val since: String? = null,
+  val until: String? = null,
+  val limit: Int? = null,
+  val cursor: String? = null,
+  val branch: String? = null,
+  val branchPattern: String? = null,
+  val commit: String? = null,
+  val worktreePath: String? = null,
+  val agentId: String? = null,
+  val sourceKind: String? = null,
+  val sourceId: String? = null,
+)
+
+/**
+ * One page of history entries returned by [HistorySource.list]. [entries] are newest-first;
+ * [nextCursor] is non-null when more entries match the filter beyond [HistoryFilter.limit];
+ * [totalCount] is the count of entries matching the filter BEFORE pagination, so a UI can show
+ * "showing 50 of 312".
+ */
+data class HistoryListPage(
+  val entries: List<HistoryEntry>,
+  val nextCursor: String? = null,
+  val totalCount: Int,
+)
+
+/**
+ * Result of [HistorySource.read]. [pngPath] is the absolute path to the bytes; [pngBytes] is
+ * non-null only when the caller asked for inline bytes (e.g. an MCP client over a remote stdio).
+ */
+data class HistoryReadResult(
+  val entry: HistoryEntry,
+  val previewMetadata: PreviewMetadataSnapshot?,
+  val pngPath: String,
+  val pngBytes: ByteArray? = null,
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is HistoryReadResult) return false
+    if (entry != other.entry) return false
+    if (previewMetadata != other.previewMetadata) return false
+    if (pngPath != other.pngPath) return false
+    if (pngBytes == null) return other.pngBytes == null
+    if (other.pngBytes == null) return false
+    return pngBytes.contentEquals(other.pngBytes)
+  }
+
+  override fun hashCode(): Int {
+    var result = entry.hashCode()
+    result = 31 * result + (previewMetadata?.hashCode() ?: 0)
+    result = 31 * result + pngPath.hashCode()
+    result = 31 * result + (pngBytes?.contentHashCode() ?: 0)
+    return result
+  }
+}
+
+/**
+ * Pluggable history backend — see HISTORY.md § "HistorySource interface".
+ *
+ * H1+H2 ships only [LocalFsHistorySource]. Future phases (H10 onward) will add `GitRefHistorySource`
+ * and `HttpMirrorHistorySource`; the consumer side merges across configured sources by `pngHash +
+ * previewId + git.commit`. The interface is intentionally narrow: write is a side-effect of
+ * [HistoryManager.recordRender]; read is paginated; watch is reserved for future phases (a UI
+ * doesn't poll, it subscribes to `historyAdded`).
+ */
+interface HistorySource {
+  /** Stable identifier — e.g. `"fs:/abs/historyDir"`, `"git:preview/main"`, `"http:https://…"`. */
+  val id: String
+
+  /** `kind` from [HistorySourceInfo] — `"fs"`, `"git"`, `"http"`. */
+  val kind: String
+
+  /** True when this source can accept [write] calls. FS=true; git/HTTP read-only sources=false. */
+  fun supportsWrites(): Boolean
+
+  /**
+   * Persists [entry] (and its associated PNG bytes) into the backing store. Throws when this
+   * source isn't writable — gate via [supportsWrites] first.
+   *
+   * Failures here must NOT be load-bearing for the render itself — `HistoryManager.recordRender`
+   * catches and logs, then continues. The render succeeded; history is observation, not state.
+   */
+  fun write(entry: HistoryEntry, png: ByteArray)
+
+  /** Lists history entries newest-first, applying [filter] and paginating. */
+  fun list(filter: HistoryFilter): HistoryListPage
+
+  /** Reads one entry by id. Returns null when the id isn't present in this source. */
+  fun read(entryId: String, includeBytes: Boolean = false): HistoryReadResult?
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
@@ -1,0 +1,322 @@
+package ee.schimke.composeai.daemon.history
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import java.security.MessageDigest
+import kotlin.io.path.exists
+import kotlin.io.path.readBytes
+import kotlin.io.path.readText
+import kotlin.io.path.writeBytes
+import kotlin.io.path.writeText
+import kotlinx.serialization.json.Json
+
+/**
+ * Filesystem-backed [HistorySource] — the H1 default. Writes PNGs + sidecar JSON files plus an
+ * append-only `index.jsonl` under [historyDir], following the layout pinned in HISTORY.md §
+ * "On-disk schema".
+ *
+ * **Layout:**
+ * ```
+ * <historyDir>/
+ * ├── index.jsonl
+ * └── <sanitisedPreviewId>/
+ *     ├── <utc-yyyyMMdd-HHmmss>-<8hex>.png
+ *     └── <utc-yyyyMMdd-HHmmss>-<8hex>.json
+ * ```
+ *
+ * **Dedup-by-hash.** When [write] is called with bytes whose SHA-256 matches the most recent
+ * entry's [HistoryEntry.pngHash] for the same `previewId`, the PNG file is NOT re-written; the
+ * sidecar's `pngPath` points at the already-on-disk PNG. The sidecar + index line still land —
+ * "same hash" means no visible change, but the render still happened, so the provenance entry is
+ * useful (e.g. "agent re-ran, output unchanged"). HISTORY.md § "What this PR lands § H1".
+ *
+ * **Cross-restart correctness.** Dedup walks the per-preview directory listing for the most-recent
+ * entry whose hash matches; this works whether that entry was written in the current daemon
+ * lifetime or a previous one.
+ *
+ * **Concurrency.** Designed for the single-writer daemon model from HISTORY.md § "Concurrency
+ * model". `index.jsonl` writes use [StandardOpenOption.APPEND] (POSIX `O_APPEND`); PNGs and
+ * sidecars use distinct filenames per render so two writes never race on the same file.
+ */
+class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
+
+  /** `fs:<absoluteHistoryDir>` — HISTORY.md § "Built-in sources § LocalFsHistorySource". */
+  override val id: String = "fs:${historyDir.toAbsolutePath()}"
+
+  override val kind: String = "fs"
+
+  override fun supportsWrites(): Boolean = true
+
+  init {
+    Files.createDirectories(historyDir)
+  }
+
+  override fun write(entry: HistoryEntry, png: ByteArray) {
+    val sanitisedDir = PreviewIdSanitiser.sanitise(entry.previewId)
+    val previewDir = historyDir.resolve(sanitisedDir)
+    Files.createDirectories(previewDir)
+
+    val pngFileName = "${entry.id}.png"
+    val sidecarFileName = "${entry.id}.json"
+    val pngFile = previewDir.resolve(pngFileName)
+    val sidecarFile = previewDir.resolve(sidecarFileName)
+
+    // Dedup-by-hash. If the previous entry for this preview has the same pngHash, we point the
+    // new sidecar's `pngPath` at that older PNG and do NOT re-write the bytes. We still write
+    // the sidecar + index line so the render-event provenance is captured.
+    val dedupTarget = findMostRecentEntryWithHash(previewDir, entry.pngHash, exclude = entry.id)
+    val effectivePngPath: String =
+      if (dedupTarget != null) {
+        // Sidecar's pngPath is relative to the sidecar's own directory; we keep that convention.
+        dedupTarget
+      } else {
+        // Fresh bytes — write the PNG.
+        pngFile.writeBytes(png)
+        pngFileName
+      }
+
+    val canonicalEntry = if (entry.pngPath == effectivePngPath) entry else entry.copy(pngPath = effectivePngPath)
+    val sidecarText = JSON.encodeToString(HistoryEntry.serializer(), canonicalEntry)
+    sidecarFile.writeText(sidecarText, StandardCharsets.UTF_8)
+
+    // index.jsonl append. Build a "lite" form by encoding the same entry minus the heavy
+    // previewMetadata snapshot — readers fetch the full sidecar via `history/read`. HISTORY.md
+    // § "index.jsonl" says: "same fields as the sidecar minus `previewMetadata`".
+    val indexEntry = canonicalEntry.copy(previewMetadata = null)
+    val indexLine = JSON.encodeToString(HistoryEntry.serializer(), indexEntry) + "\n"
+    val indexFile = historyDir.resolve(INDEX_FILENAME)
+    Files.write(
+      indexFile,
+      indexLine.toByteArray(StandardCharsets.UTF_8),
+      StandardOpenOption.CREATE,
+      StandardOpenOption.WRITE,
+      StandardOpenOption.APPEND,
+    )
+  }
+
+  override fun list(filter: HistoryFilter): HistoryListPage {
+    val indexFile = historyDir.resolve(INDEX_FILENAME)
+    if (!indexFile.exists()) return HistoryListPage(entries = emptyList(), totalCount = 0)
+    val allEntries = readIndexNewestFirst(indexFile)
+    val matched = allEntries.filter { matchesFilter(it, filter) }
+    val totalCount = matched.size
+
+    // Cursor is an opaque base64 of "<timestamp>|<id>"; we drop entries until we pass it.
+    val afterCursor =
+      if (filter.cursor != null) {
+        val decoded = decodeCursor(filter.cursor) ?: return HistoryListPage(emptyList(), totalCount = totalCount)
+        matched.dropWhile { it.timestamp != decoded.timestamp || it.id != decoded.id }.drop(1)
+      } else {
+        matched
+      }
+
+    val limit = (filter.limit ?: DEFAULT_LIMIT).coerceIn(1, MAX_LIMIT)
+    val page = afterCursor.take(limit)
+    val nextCursor =
+      if (afterCursor.size > limit) {
+        val last = page.last()
+        encodeCursor(last.timestamp, last.id)
+      } else {
+        null
+      }
+    return HistoryListPage(entries = page, nextCursor = nextCursor, totalCount = totalCount)
+  }
+
+  override fun read(entryId: String, includeBytes: Boolean): HistoryReadResult? {
+    val sidecar = findSidecar(entryId) ?: return null
+    val entry =
+      try {
+        JSON.decodeFromString(HistoryEntry.serializer(), sidecar.readText(StandardCharsets.UTF_8))
+      } catch (t: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: LocalFsHistorySource.read($entryId): malformed sidecar at $sidecar " +
+            "(${t.javaClass.simpleName}: ${t.message})"
+        )
+        return null
+      }
+    val pngPath = sidecar.parent.resolve(entry.pngPath).toAbsolutePath()
+    if (!pngPath.exists()) {
+      System.err.println(
+        "compose-ai-daemon: LocalFsHistorySource.read($entryId): sidecar references missing PNG " +
+          "$pngPath"
+      )
+      return null
+    }
+    val bytes = if (includeBytes) pngPath.readBytes() else null
+    return HistoryReadResult(
+      entry = entry,
+      previewMetadata = entry.previewMetadata,
+      pngPath = pngPath.toString(),
+      pngBytes = bytes,
+    )
+  }
+
+  /**
+   * Walks the per-preview directory looking for the most recent (lex-sorted) sidecar whose
+   * pngHash matches [hash]. Returns the relative PNG filename of the match, or null when no match.
+   */
+  private fun findMostRecentEntryWithHash(
+    previewDir: Path,
+    hash: String,
+    exclude: String,
+  ): String? {
+    if (!Files.exists(previewDir)) return null
+    val sidecars =
+      try {
+        Files.list(previewDir).use { stream ->
+          stream
+            .filter { it.fileName.toString().endsWith(".json") }
+            .filter { it.fileName.toString().removeSuffix(".json") != exclude }
+            .sorted(Comparator.reverseOrder())
+            .toArray()
+            .map { it as Path }
+        }
+      } catch (t: Throwable) {
+        return null
+      }
+    for (sidecar in sidecars) {
+      val text =
+        try {
+          sidecar.readText(StandardCharsets.UTF_8)
+        } catch (_: Throwable) {
+          continue
+        }
+      val parsed =
+        try {
+          JSON.decodeFromString(HistoryEntry.serializer(), text)
+        } catch (_: Throwable) {
+          continue
+        }
+      if (parsed.pngHash == hash) {
+        // Verify the referenced PNG actually exists; if not, fall through.
+        val pngPath = sidecar.parent.resolve(parsed.pngPath)
+        if (Files.exists(pngPath)) return parsed.pngPath
+      }
+    }
+    return null
+  }
+
+  /**
+   * Locates a sidecar by [entryId]. Walks per-preview directories under [historyDir] until the
+   * matching `<entryId>.json` is found.
+   */
+  private fun findSidecar(entryId: String): Path? {
+    if (!Files.exists(historyDir)) return null
+    return Files.list(historyDir).use { stream ->
+      stream
+        .filter { Files.isDirectory(it) }
+        .map { it.resolve("$entryId.json") }
+        .filter { Files.exists(it) }
+        .findFirst()
+        .orElse(null)
+    }
+  }
+
+  private fun readIndexNewestFirst(indexFile: Path): List<HistoryEntry> {
+    val lines = Files.readAllLines(indexFile, StandardCharsets.UTF_8)
+    val parsed = ArrayList<HistoryEntry>(lines.size)
+    for (line in lines) {
+      val trimmed = line.trim()
+      if (trimmed.isEmpty()) continue
+      val entry =
+        try {
+          JSON.decodeFromString(HistoryEntry.serializer(), trimmed)
+        } catch (t: Throwable) {
+          System.err.println(
+            "compose-ai-daemon: LocalFsHistorySource.list: skipping malformed index line " +
+              "(${t.javaClass.simpleName}: ${t.message})"
+          )
+          continue
+        }
+      // Self-heal: drop entries whose sidecar isn't on disk. HISTORY.md § "Compatibility with
+      // today's layout" / § "Provenance trust" — a missing sidecar is treated as corruption and
+      // the entry is dropped from listings.
+      val sanitised = PreviewIdSanitiser.sanitise(entry.previewId)
+      val sidecar = historyDir.resolve(sanitised).resolve("${entry.id}.json")
+      if (!Files.exists(sidecar)) {
+        System.err.println(
+          "compose-ai-daemon: LocalFsHistorySource.list: dropping index entry ${entry.id} " +
+            "(sidecar missing at $sidecar)"
+        )
+        continue
+      }
+      parsed.add(entry)
+    }
+    parsed.reverse()
+    return parsed
+  }
+
+  private fun matchesFilter(entry: HistoryEntry, f: HistoryFilter): Boolean {
+    if (f.previewId != null && entry.previewId != f.previewId) return false
+    if (f.since != null && entry.timestamp < f.since) return false
+    if (f.until != null && entry.timestamp > f.until) return false
+    if (f.branch != null && entry.git?.branch != f.branch) return false
+    if (f.branchPattern != null) {
+      val branch = entry.git?.branch ?: return false
+      if (!Regex(f.branchPattern).matches(branch)) return false
+    }
+    if (f.commit != null) {
+      val git = entry.git ?: return false
+      if (git.commit != f.commit && git.shortCommit != f.commit) return false
+    }
+    if (f.worktreePath != null && entry.worktree?.path != f.worktreePath) return false
+    if (f.agentId != null && entry.worktree?.agentId != f.agentId) return false
+    if (f.sourceKind != null && entry.source.kind != f.sourceKind) return false
+    if (f.sourceId != null && entry.source.id != f.sourceId) return false
+    return true
+  }
+
+  companion object {
+    const val INDEX_FILENAME: String = "index.jsonl"
+    const val DEFAULT_LIMIT: Int = 50
+    const val MAX_LIMIT: Int = 500
+
+    /**
+     * JSON configuration shared across the LocalFs path. `encodeDefaults = false` keeps the
+     * sidecar JSON minimal — null fields don't land on disk; readers tolerate their absence.
+     * `ignoreUnknownKeys = true` keeps forward-compat: a v2 schema add doesn't break a v1 reader.
+     */
+    private val JSON: Json = Json {
+      ignoreUnknownKeys = true
+      encodeDefaults = false
+      prettyPrint = false
+    }
+
+    /** SHA-256 hex of [bytes]. */
+    fun sha256Hex(bytes: ByteArray): String {
+      val digest = MessageDigest.getInstance("SHA-256")
+      val hash = digest.digest(bytes)
+      val sb = StringBuilder(hash.size * 2)
+      for (b in hash) {
+        val v = b.toInt() and 0xff
+        sb.append(HEX_CHARS[v ushr 4])
+        sb.append(HEX_CHARS[v and 0x0f])
+      }
+      return sb.toString()
+    }
+
+    private val HEX_CHARS = "0123456789abcdef".toCharArray()
+
+    private fun encodeCursor(timestamp: String, id: String): String {
+      val raw = "$timestamp|$id".toByteArray(Charsets.UTF_8)
+      return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(raw)
+    }
+
+    private data class CursorPosition(val timestamp: String, val id: String)
+
+    private fun decodeCursor(cursor: String): CursorPosition? {
+      return try {
+        val raw = java.util.Base64.getUrlDecoder().decode(cursor)
+        val text = String(raw, Charsets.UTF_8)
+        val sep = text.indexOf('|')
+        if (sep < 0) return null
+        CursorPosition(timestamp = text.substring(0, sep), id = text.substring(sep + 1))
+      } catch (_: Throwable) {
+        null
+      }
+    }
+  }
+}
+

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/PreviewIdSanitiser.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/PreviewIdSanitiser.kt
@@ -1,0 +1,23 @@
+package ee.schimke.composeai.daemon.history
+
+/**
+ * Sanitises a `previewId` into a filesystem-safe directory name.
+ *
+ * Pinned convention from the legacy `HistorizePreviewsTask.sanitize` (removed in PR #311 but the
+ * shape of the on-disk archive is preserved for forward consistency — see HISTORY.md § "On-disk
+ * schema"): characters that satisfy [Char.isLetterOrDigit] OR are one of `.`, `_`, `-` are kept
+ * verbatim; everything else collapses to `_`. Empty input yields the literal `_`.
+ *
+ * Stable across processes, locale-independent (the Kotlin `Char.isLetterOrDigit` extension delegates
+ * to `Character.isLetterOrDigit(int)` which is Unicode-defined, not locale-dependent).
+ */
+internal object PreviewIdSanitiser {
+  fun sanitise(previewId: String): String {
+    if (previewId.isEmpty()) return "_"
+    val builder = StringBuilder(previewId.length)
+    for (c in previewId) {
+      builder.append(if (c.isLetterOrDigit() || c == '.' || c == '_' || c == '-') c else '_')
+    }
+    return builder.toString()
+  }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -347,3 +347,52 @@ enum class LogLevel {
   @SerialName("warn") WARN,
   @SerialName("error") ERROR,
 }
+
+// =====================================================================
+// 6. History — H1 + H2 wire-format. See docs/daemon/HISTORY.md § "Layer 2 —
+//    JSON-RPC API" and `HistoryEntry` in
+//    ee.schimke.composeai.daemon.history.
+//
+// The `entry`, `previewMetadata` fields below carry already-encoded JSON
+// rather than typed Kotlin classes — kotlinx.serialization can't reach
+// across the package boundary into ee.schimke.composeai.daemon.history
+// without pulling its types onto the Messages.kt import surface, which
+// would create a circular include for the JsonRpcServer dispatch path.
+// We use JsonElement + the dispatch layer encodes/decodes against the
+// real `HistoryEntry` / `PreviewInfoDto` serializers at the call site.
+// =====================================================================
+
+@Serializable
+data class HistoryListParams(
+  val previewId: String? = null,
+  val since: String? = null,
+  val until: String? = null,
+  val limit: Int? = null,
+  val cursor: String? = null,
+  val branch: String? = null,
+  val branchPattern: String? = null,
+  val commit: String? = null,
+  val worktreePath: String? = null,
+  val agentId: String? = null,
+  val sourceKind: String? = null,
+  val sourceId: String? = null,
+)
+
+@Serializable
+data class HistoryListResult(
+  val entries: List<JsonElement>,
+  val nextCursor: String? = null,
+  val totalCount: Int,
+)
+
+@Serializable data class HistoryReadParams(val id: String, val inline: Boolean = false)
+
+@Serializable
+data class HistoryReadResultDto(
+  val entry: JsonElement,
+  val previewMetadata: JsonElement? = null,
+  val pngPath: String,
+  val pngBytes: String? = null,
+)
+
+@Serializable data class HistoryAddedParams(val entry: JsonElement)

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitProvenanceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitProvenanceTest.kt
@@ -1,0 +1,160 @@
+package ee.schimke.composeai.daemon.history
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pins [GitProvenance] resolution against:
+ * - A synthetic `git init`'d directory — must populate worktree.path / git.branch / git.commit /
+ *   git.dirty without any of those being null.
+ * - A non-git directory — every git/worktree-path field is null; agentId stays whatever the env
+ *   says.
+ *
+ * Skipped when the test JVM has no `git` on the path (CI containers without git installed). The
+ * brief explicitly says don't gate the harness's S9 on git availability — same here for the
+ * core unit test.
+ */
+class GitProvenanceTest {
+
+  private lateinit var tmpDir: Path
+
+  @Before
+  fun setUp() {
+    tmpDir = Files.createTempDirectory("git-provenance-test")
+    assumeTrue("git on PATH required for GitProvenanceTest", isGitAvailable())
+  }
+
+  @After
+  fun tearDown() {
+    tmpDir.toFile().deleteRecursively()
+  }
+
+  @Test
+  fun synthetic_git_repo_populates_branch_commit_dirty_remote() {
+    initGitRepo(tmpDir.toFile())
+    // Configure user.name + user.email so commit doesn't fail on a clean-room machine.
+    runOrFail(tmpDir.toFile(), "git", "config", "user.email", "test@example.com")
+    runOrFail(tmpDir.toFile(), "git", "config", "user.name", "Test User")
+    runOrFail(tmpDir.toFile(), "git", "remote", "add", "origin", "https://example.com/repo.git")
+    val testFile = tmpDir.resolve("hello.txt")
+    Files.writeString(testFile, "hello\n")
+    runOrFail(tmpDir.toFile(), "git", "add", "hello.txt")
+    runOrFail(tmpDir.toFile(), "git", "commit", "-m", "initial", "--no-gpg-sign")
+
+    val provenance = GitProvenance(workspaceRoot = tmpDir, env = mapOf())
+    val (worktree, git) = provenance.snapshot()
+    assertNotNull("worktree must be non-null in a git repo", worktree)
+    assertEquals(
+      tmpDir.toRealPath().toString(),
+      Path.of(worktree!!.path!!).toRealPath().toString(),
+    )
+    assertNotNull("git provenance must be non-null in a git repo", git)
+    assertNotNull("commit must be present", git!!.commit)
+    assertEquals(7, git.shortCommit?.length)
+    assertEquals(false, git.dirty)
+    assertEquals("https://example.com/repo.git", git.remote)
+    // worktree.id defaults to dir basename.
+    assertEquals(tmpDir.fileName.toString(), worktree.id)
+  }
+
+  @Test
+  fun dirty_flag_flips_when_working_tree_has_uncommitted_changes() {
+    initGitRepo(tmpDir.toFile())
+    runOrFail(tmpDir.toFile(), "git", "config", "user.email", "test@example.com")
+    runOrFail(tmpDir.toFile(), "git", "config", "user.name", "Test User")
+    val initialFile = tmpDir.resolve("a.txt")
+    Files.writeString(initialFile, "x\n")
+    runOrFail(tmpDir.toFile(), "git", "add", "a.txt")
+    runOrFail(tmpDir.toFile(), "git", "commit", "-m", "init", "--no-gpg-sign")
+    // Add an uncommitted change.
+    Files.writeString(tmpDir.resolve("a.txt"), "y\n")
+
+    val provenance = GitProvenance(workspaceRoot = tmpDir, env = mapOf())
+    val (_, git) = provenance.snapshot()
+    assertEquals(true, git!!.dirty)
+  }
+
+  @Test
+  fun non_git_directory_yields_null_git_and_null_worktree_path() {
+    val nonGitDir = Files.createTempDirectory("non-git-")
+    try {
+      val provenance = GitProvenance(workspaceRoot = nonGitDir, env = mapOf())
+      val (worktree, git) = provenance.snapshot()
+      // worktree may be null OR carry only id-label/agentId if any env was set; here env is empty so:
+      assertTrue(worktree == null || (worktree.path == null && worktree.id == null && worktree.agentId == null))
+      assertNull(git)
+    } finally {
+      nonGitDir.toFile().deleteRecursively()
+    }
+  }
+
+  @Test
+  fun agentId_env_populates_worktree_agentId() {
+    val nonGitDir = Files.createTempDirectory("agent-env-")
+    try {
+      val provenance =
+        GitProvenance(
+          workspaceRoot = nonGitDir,
+          env = mapOf(GitProvenance.ENV_AGENT_ID to "agent-foo"),
+        )
+      val (worktree, _) = provenance.snapshot()
+      assertNotNull(worktree)
+      assertEquals("agent-foo", worktree!!.agentId)
+    } finally {
+      nonGitDir.toFile().deleteRecursively()
+    }
+  }
+
+  @Test
+  fun worktreeId_env_overrides_basename() {
+    initGitRepo(tmpDir.toFile())
+    runOrFail(tmpDir.toFile(), "git", "config", "user.email", "test@example.com")
+    runOrFail(tmpDir.toFile(), "git", "config", "user.name", "Test User")
+    Files.writeString(tmpDir.resolve("x"), "x")
+    runOrFail(tmpDir.toFile(), "git", "add", "x")
+    runOrFail(tmpDir.toFile(), "git", "commit", "-m", "init", "--no-gpg-sign")
+
+    val provenance =
+      GitProvenance(workspaceRoot = tmpDir, env = mapOf(GitProvenance.ENV_WORKTREE_ID to "main"))
+    val (worktree, _) = provenance.snapshot()
+    assertEquals("main", worktree!!.id)
+  }
+
+  private fun initGitRepo(dir: File) {
+    runOrFail(dir, "git", "init", "-b", "main")
+  }
+
+  private fun isGitAvailable(): Boolean =
+    try {
+      val proc = ProcessBuilder("git", "--version").redirectErrorStream(true).start()
+      proc.waitFor(5, TimeUnit.SECONDS)
+      proc.exitValue() == 0
+    } catch (_: Throwable) {
+      false
+    }
+
+  private fun runOrFail(workingDir: File, vararg cmd: String) {
+    val proc =
+      ProcessBuilder(*cmd)
+        .directory(workingDir)
+        .redirectErrorStream(true)
+        .start()
+    val finished = proc.waitFor(15, TimeUnit.SECONDS)
+    assertTrue("$cmd timed out", finished)
+    assertEquals(
+      "command failed: ${cmd.joinToString(" ")} → ${proc.inputStream.bufferedReader().readText()}",
+      0,
+      proc.exitValue(),
+    )
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryEntryRoundTripTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryEntryRoundTripTest.kt
@@ -1,0 +1,99 @@
+package ee.schimke.composeai.daemon.history
+
+import ee.schimke.composeai.daemon.protocol.RenderMetrics
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pins the kotlinx.serialization round-trip for [HistoryEntry] — every nested struct
+ * (`worktree` / `git` / `source` / `triggerDetail` / `previewMetadata` / `metrics` /
+ * `deltaFromPrevious`) must survive encode → decode without field loss.
+ *
+ * The on-disk sidecar JSON is the wire format; this test is the one place where the schema's
+ * shape is locked end-to-end. New fields added to [HistoryEntry] should grow this fixture.
+ */
+class HistoryEntryRoundTripTest {
+
+  private val json = Json { ignoreUnknownKeys = true; encodeDefaults = false }
+
+  @Test
+  fun fully_populated_entry_round_trips() {
+    val entry =
+      HistoryEntry(
+        id = "20260430-101234-a1b2c3d4",
+        previewId = "com.example.RedSquare",
+        module = ":samples:android",
+        timestamp = "2026-04-30T10:12:34Z",
+        pngHash = "a1b2c3d4e5f6789012345678901234567890123456789012345678901234aaaa",
+        pngSize = 4218L,
+        pngPath = "20260430-101234-a1b2c3d4.png",
+        producer = "daemon",
+        trigger = "fileChanged",
+        triggerDetail =
+          buildJsonObject {
+            put("kind", JsonPrimitive("source"))
+            put("path", JsonPrimitive("/abs/path/Foo.kt"))
+          },
+        source = HistorySourceInfo(kind = "fs", id = "fs:/home/yuri/.compose-preview-history"),
+        worktree =
+          WorktreeInfo(
+            path = "/home/yuri/workspace/compose-ai-tools",
+            id = "main",
+            agentId = "agent-foo",
+          ),
+        git =
+          GitInfo(
+            branch = "agent/preview-daemon-streamAB",
+            commit = "6af6b8c1d4e2f7a8b9c0d1e2f3a4b5c6d7e8f9a0",
+            shortCommit = "6af6b8c",
+            dirty = true,
+            remote = "https://github.com/yschimke/compose-ai-tools",
+          ),
+        renderTookMs = 234L,
+        metrics =
+          RenderMetrics(
+            heapAfterGcMb = 312L,
+            nativeHeapMb = 540L,
+            sandboxAgeRenders = 17L,
+            sandboxAgeMs = 81234L,
+          ),
+        previewMetadata =
+          PreviewMetadataSnapshot(
+            displayName = "Red square",
+            group = "buttons",
+            sourceFile = "/abs/path/Foo.kt",
+            config = "phone-portrait",
+          ),
+        previousId = "20260430-101207-9f8e7d6c",
+        deltaFromPrevious = HistoryDelta(pngHashChanged = true, diffPx = 142L, ssim = 0.97),
+      )
+    val text = json.encodeToString(HistoryEntry.serializer(), entry)
+    val decoded = json.decodeFromString(HistoryEntry.serializer(), text)
+    assertEquals(entry, decoded)
+  }
+
+  @Test
+  fun minimal_entry_round_trips() {
+    // Tests the "no provenance, no previous, no delta" path — the first render in a non-git workspace.
+    val entry =
+      HistoryEntry(
+        id = "20260430-101234-deadbeef",
+        previewId = "com.example.Foo",
+        module = "",
+        timestamp = "2026-04-30T10:12:34Z",
+        pngHash = "deadbeef00000000000000000000000000000000000000000000000000000000",
+        pngSize = 100L,
+        pngPath = "20260430-101234-deadbeef.png",
+        producer = "daemon",
+        trigger = "renderNow",
+        source = HistorySourceInfo(kind = "fs", id = "fs:/tmp"),
+        renderTookMs = 5L,
+      )
+    val text = json.encodeToString(HistoryEntry.serializer(), entry)
+    val decoded = json.decodeFromString(HistoryEntry.serializer(), text)
+    assertEquals(entry, decoded)
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
@@ -1,0 +1,328 @@
+package ee.schimke.composeai.daemon.history
+
+import ee.schimke.composeai.daemon.ContentLengthFramer
+import ee.schimke.composeai.daemon.JsonRpcServer
+import ee.schimke.composeai.daemon.RenderHost
+import ee.schimke.composeai.daemon.RenderRequest
+import ee.schimke.composeai.daemon.RenderResult
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Base64
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * End-to-end integration test for the history wire surface — see HISTORY.md § "Layer 2 — JSON-RPC
+ * API". Drives a `JsonRpcServer` configured with a [HistoryManager] over piped streams and asserts:
+ *
+ * 1. After a `renderNow` succeeds, a `historyAdded` notification arrives carrying a parseable
+ *    [HistoryEntry] whose `pngHash` matches the rendered bytes.
+ * 2. `history/list` returns the same entry.
+ * 3. `history/read` (default) returns the entry + a non-null `pngPath` referencing the bytes on disk.
+ * 4. `history/read({inline: true})` returns base64 bytes that decode back to the original PNG.
+ * 5. `history/list({previewId: "other"})` filter narrows correctly.
+ * 6. `history/read({id: "missing"})` returns a `-32010 HistoryEntryNotFound` error.
+ * 7. `history/diff` and `history/prune` return `-32601 MethodNotFound` (reserved, not implemented).
+ */
+class JsonRpcServerHistoryIntegrationTest {
+
+  private lateinit var historyDir: Path
+  private lateinit var rendersDir: Path
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Before
+  fun setUp() {
+    historyDir = Files.createTempDirectory("history-int-test")
+    rendersDir = Files.createTempDirectory("history-int-test-renders")
+  }
+
+  @After
+  fun tearDown() {
+    historyDir.toFile().deleteRecursively()
+    rendersDir.toFile().deleteRecursively()
+  }
+
+  @Test(timeout = 30_000)
+  fun history_full_lifecycle() {
+    val host = RealPngHost(rendersDir)
+    val historyManager =
+      HistoryManager.forLocalFs(
+        historyDir = historyDir,
+        module = ":t",
+        gitProvenance = null, // No git; entries land with git=null/worktree=null. Fine for H1.
+      )
+
+    val clientToServerOut = PipedOutputStream()
+    val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
+    val serverToClientOut = PipedOutputStream()
+    val serverToClientIn = PipedInputStream(serverToClientOut, 64 * 1024)
+    val exitLatch = CountDownLatch(1)
+    val server =
+      JsonRpcServer(
+        input = clientToServerIn,
+        output = serverToClientOut,
+        host = host,
+        daemonVersion = "test",
+        historyManager = historyManager,
+        onExit = { _ -> exitLatch.countDown() },
+      )
+    val serverThread = Thread({ server.run() }, "json-rpc-server-history-test").apply { isDaemon = true }
+    serverThread.start()
+
+    val received = LinkedBlockingQueue<JsonObject>()
+    val reader = ContentLengthFramer(serverToClientIn)
+    Thread(
+        {
+          try {
+            while (true) {
+              val frame = reader.readFrame() ?: break
+              val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+              received.put(obj)
+            }
+          } catch (_: Throwable) {}
+        },
+        "json-rpc-server-history-reader",
+      )
+      .apply { isDaemon = true }
+      .start()
+
+    try {
+      // 1. initialize → initialized.
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "moduleId":":test","moduleProjectDir":"/tmp",
+              "capabilities":{"visibility":true,"metrics":false}}}""",
+      )
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 1 })
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"initialized","params":{}}""")
+
+      // 2. renderNow.
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":2,"method":"renderNow","params":{
+              "previews":["preview-A"],"tier":"fast"}}""",
+      )
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 2 })
+
+      // 3. historyAdded notification arrives.
+      val historyAdded =
+        pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "historyAdded" }
+      assertNotNull("historyAdded notification must arrive within 1s", historyAdded)
+      val entryJson = historyAdded!!["params"]!!.jsonObject["entry"]!!.jsonObject
+      val entryId = entryJson["id"]!!.jsonPrimitive.content
+      assertEquals("preview-A", entryJson["previewId"]!!.jsonPrimitive.content)
+      assertEquals("daemon", entryJson["producer"]!!.jsonPrimitive.content)
+      assertEquals("renderNow", entryJson["trigger"]!!.jsonPrimitive.content)
+      assertEquals("fs", entryJson["source"]!!.jsonObject["kind"]!!.jsonPrimitive.content)
+
+      // 4. Disk has PNG + sidecar + index entry.
+      val previewDir = historyDir.resolve("preview-A")
+      assertTrue(Files.exists(previewDir.resolve("$entryId.png")))
+      assertTrue(Files.exists(previewDir.resolve("$entryId.json")))
+      val indexLines = Files.readAllLines(historyDir.resolve(LocalFsHistorySource.INDEX_FILENAME))
+      assertEquals(1, indexLines.filter { it.isNotBlank() }.size)
+
+      // 5. history/list returns the entry.
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":3,"method":"history/list","params":{}}""",
+      )
+      val listResp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 3 }
+      val listResult = listResp!!["result"]!!.jsonObject
+      assertEquals(1, listResult["totalCount"]!!.jsonPrimitive.intOrNull)
+      assertEquals(1, listResult["entries"]!!.jsonArray.size)
+      assertEquals(
+        entryId,
+        listResult["entries"]!!.jsonArray[0].jsonObject["id"]!!.jsonPrimitive.content,
+      )
+
+      // 6. history/read default — pngBytes null.
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":4,"method":"history/read","params":{"id":"$entryId"}}""",
+      )
+      val readResp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 4 }
+      val readResult = readResp!!["result"]!!.jsonObject
+      val pngPath = readResult["pngPath"]!!.jsonPrimitive.content
+      assertTrue("pngPath must point at an existing file", Files.exists(Path.of(pngPath)))
+      assertTrue(
+        "default read must NOT inline pngBytes",
+        readResult["pngBytes"] == null ||
+          readResult["pngBytes"] == kotlinx.serialization.json.JsonNull,
+      )
+
+      // 7. history/read inline=true — base64 decodes to original PNG bytes.
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":5,"method":"history/read","params":{"id":"$entryId","inline":true}}""",
+      )
+      val readInlineResp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 5 }
+      val readInlineResult = readInlineResp!!["result"]!!.jsonObject
+      val base64 = readInlineResult["pngBytes"]!!.jsonPrimitive.content
+      val decoded = Base64.getDecoder().decode(base64)
+      assertTrue(decoded.contentEquals(host.lastPngBytes))
+
+      // 8. history/list({previewId: "preview-B"}) returns empty.
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":6,"method":"history/list","params":{"previewId":"preview-B"}}""",
+      )
+      val emptyResp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 6 }
+      val emptyList = emptyResp!!["result"]!!.jsonObject
+      assertEquals(0, emptyList["totalCount"]!!.jsonPrimitive.intOrNull)
+      assertEquals(0, emptyList["entries"]!!.jsonArray.size)
+
+      // 9. history/read for missing id → -32010.
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":7,"method":"history/read","params":{"id":"does-not-exist"}}""",
+      )
+      val missing = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 7 }
+      val errCode = missing!!["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull
+      assertEquals(JsonRpcServer.ERR_HISTORY_ENTRY_NOT_FOUND, errCode)
+
+      // 10. history/diff and history/prune → MethodNotFound.
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":8,"method":"history/diff","params":{"from":"a","to":"b"}}""",
+      )
+      val diff = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 8 }
+      assertEquals(
+        JsonRpcServer.ERR_METHOD_NOT_FOUND,
+        diff!!["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull,
+      )
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":9,"method":"history/prune","params":{}}""",
+      )
+      val prune = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 9 }
+      assertEquals(
+        JsonRpcServer.ERR_METHOD_NOT_FOUND,
+        prune!!["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull,
+      )
+
+      // Tear down cleanly.
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","id":99,"method":"shutdown"}""")
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 99 })
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"exit"}""")
+      assertTrue(exitLatch.await(5, TimeUnit.SECONDS))
+    } finally {
+      try {
+        clientToServerOut.close()
+      } catch (_: Throwable) {}
+      try {
+        serverToClientIn.close()
+      } catch (_: Throwable) {}
+      serverThread.join(5_000)
+    }
+  }
+
+  /**
+   * Test [RenderHost] that writes a deterministic PNG-shaped byte sequence to disk and returns its
+   * path. We don't need a real PNG decoder — H1's history pipeline only sha256s the bytes, so any
+   * deterministic blob works.
+   */
+  private class RealPngHost(private val rendersDir: Path) : RenderHost {
+    @Volatile var lastPngBytes: ByteArray = ByteArray(0)
+      private set
+
+    private val queue = LinkedBlockingQueue<RenderRequest>()
+    private val results = java.util.concurrent.ConcurrentHashMap<Long, LinkedBlockingQueue<RenderResult>>()
+
+    @Volatile private var stopped = false
+    private val worker =
+      Thread(
+          {
+            while (!stopped) {
+              val req =
+                try {
+                  queue.poll(100, TimeUnit.MILLISECONDS)
+                } catch (_: InterruptedException) {
+                  Thread.currentThread().interrupt()
+                  return@Thread
+                } ?: continue
+              when (req) {
+                is RenderRequest.Render -> {
+                  val pngFile = rendersDir.resolve("render-${req.id}.png")
+                  val payload = "synthetic-render-${req.id}".toByteArray()
+                  Files.write(pngFile, payload)
+                  lastPngBytes = payload
+                  val cl = Thread.currentThread().contextClassLoader
+                  results
+                    .computeIfAbsent(req.id) { LinkedBlockingQueue() }
+                    .put(
+                      RenderResult(
+                        id = req.id,
+                        classLoaderHashCode = System.identityHashCode(cl),
+                        classLoaderName = cl?.javaClass?.name ?: "<null>",
+                        pngPath = pngFile.toAbsolutePath().toString(),
+                        metrics = mapOf("tookMs" to 1L),
+                      )
+                    )
+                }
+                RenderRequest.Shutdown -> return@Thread
+              }
+            }
+          },
+          "history-int-test-host",
+        )
+        .apply { isDaemon = true }
+
+    override fun start() {
+      worker.start()
+    }
+
+    override fun submit(request: RenderRequest, timeoutMs: Long): RenderResult {
+      require(request is RenderRequest.Render)
+      queue.put(request)
+      val q = results.computeIfAbsent(request.id) { LinkedBlockingQueue() }
+      return q.poll(timeoutMs, TimeUnit.MILLISECONDS) ?: error("RealPngHost.submit timed out")
+    }
+
+    override fun shutdown(timeoutMs: Long) {
+      stopped = true
+      queue.put(RenderRequest.Shutdown)
+      worker.join(timeoutMs)
+    }
+  }
+
+  private fun writeFrame(out: PipedOutputStream, jsonText: String) {
+    val payload = jsonText.toByteArray(Charsets.UTF_8)
+    out.write("Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII))
+    out.write(payload)
+    out.flush()
+  }
+
+  private fun pollUntil(
+    queue: LinkedBlockingQueue<JsonObject>,
+    timeoutMs: Long = 10_000,
+    matcher: (JsonObject) -> Boolean,
+  ): JsonObject? {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+      val remaining = (deadline - System.currentTimeMillis()).coerceAtLeast(0)
+      val msg = queue.poll(remaining, TimeUnit.MILLISECONDS) ?: return null
+      if (matcher(msg)) return msg
+    }
+    return null
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceCorruptionTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceCorruptionTest.kt
@@ -1,0 +1,76 @@
+package ee.schimke.composeai.daemon.history
+
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pins reader-side robustness from HISTORY.md § "Concurrency model" / § "Provenance trust":
+ * - Truncated index lines are skipped with a warn log, not a parse exception.
+ * - Index entries that reference a sidecar that doesn't exist on disk are silently dropped from
+ *   the listing — "self-healing on next prune".
+ */
+class LocalFsHistorySourceCorruptionTest {
+
+  private lateinit var tmpDir: java.nio.file.Path
+
+  @Before
+  fun setUp() {
+    tmpDir = Files.createTempDirectory("history-corruption-test")
+  }
+
+  @After
+  fun tearDown() {
+    tmpDir.toFile().deleteRecursively()
+  }
+
+  @Test
+  fun truncated_index_lines_and_missing_sidecars_are_skipped() {
+    val source = LocalFsHistorySource(historyDir = tmpDir)
+    // Write one valid entry — establishes the per-preview directory + index.
+    val bytes = byteArrayOf(1, 2, 3)
+    val hash = LocalFsHistorySource.sha256Hex(bytes)
+    val validId = "ts-01-${hash.take(8)}"
+    val validEntry = makeEntry(id = validId, hash = hash, size = bytes.size.toLong())
+    source.write(validEntry, bytes)
+
+    // Append a truncated line + a syntactically-valid line for an entry with no sidecar on disk.
+    val orphanId = "ts-02-deadbeef"
+    val orphanEntry =
+      makeEntry(id = orphanId, hash = "deadbeef".repeat(8), size = 100L).copy(timestamp = "2026-04-30T11:00:00Z")
+    val indexFile = tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)
+    val truncated = "{\"id\":\"truncated\",\"previewId\":"  // Deliberately incomplete.
+    val orphanLine =
+      kotlinx.serialization.json.Json.encodeToString(HistoryEntry.serializer(), orphanEntry)
+    Files.write(
+      indexFile,
+      ("\n" + truncated + "\n" + orphanLine + "\n").toByteArray(),
+      StandardOpenOption.APPEND,
+    )
+
+    val page = source.list(HistoryFilter())
+    // Only the original valid entry should survive — truncated line + orphan reference both filtered.
+    assertEquals(1, page.entries.size)
+    assertEquals(validId, page.entries[0].id)
+    assertNotNull(page.entries[0])
+  }
+
+  private fun makeEntry(id: String, hash: String, size: Long): HistoryEntry =
+    HistoryEntry(
+      id = id,
+      previewId = "Foo",
+      module = ":t",
+      timestamp = "2026-04-30T10:00:00Z",
+      pngHash = hash,
+      pngSize = size,
+      pngPath = "$id.png",
+      producer = "daemon",
+      trigger = "renderNow",
+      source = HistorySourceInfo(kind = "fs", id = "fs:${tmpDir.toAbsolutePath()}"),
+      renderTookMs = 1L,
+    )
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceReadTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceReadTest.kt
@@ -1,0 +1,183 @@
+package ee.schimke.composeai.daemon.history
+
+import java.nio.file.Files
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pins the read contract for [LocalFsHistorySource]:
+ * - [list] returns newest-first by `timestamp` field (lexical order matches chronological since
+ *   ISO-8601 UTC).
+ * - `previewId` / `since` / `until` / `branch` filters narrow the result.
+ * - Pagination cursor is opaque, round-trips correctly, and the second page picks up where the
+ *   first left off.
+ * - [read] resolves an entry by id and returns the absolute PNG path; missing entries return null.
+ */
+class LocalFsHistorySourceReadTest {
+
+  private lateinit var tmpDir: java.nio.file.Path
+  private lateinit var source: LocalFsHistorySource
+
+  @Before
+  fun setUp() {
+    tmpDir = Files.createTempDirectory("history-read-test")
+    source = LocalFsHistorySource(historyDir = tmpDir)
+  }
+
+  @After
+  fun tearDown() {
+    tmpDir.toFile().deleteRecursively()
+  }
+
+  @Test
+  fun list_returns_newest_first_across_multiple_previews() {
+    writeEntry(previewId = "A", timestampField = "2026-04-30T10:00:00Z", suffix = "01")
+    writeEntry(previewId = "B", timestampField = "2026-04-30T10:00:05Z", suffix = "02")
+    writeEntry(previewId = "A", timestampField = "2026-04-30T10:00:10Z", suffix = "03")
+
+    val page = source.list(HistoryFilter())
+    assertEquals(3, page.entries.size)
+    assertEquals(3, page.totalCount)
+    // Newest first.
+    assertEquals("2026-04-30T10:00:10Z", page.entries[0].timestamp)
+    assertEquals("2026-04-30T10:00:05Z", page.entries[1].timestamp)
+    assertEquals("2026-04-30T10:00:00Z", page.entries[2].timestamp)
+  }
+
+  @Test
+  fun previewId_filter_narrows_result() {
+    writeEntry(previewId = "A", timestampField = "2026-04-30T10:00:00Z", suffix = "01")
+    writeEntry(previewId = "B", timestampField = "2026-04-30T10:00:05Z", suffix = "02")
+    writeEntry(previewId = "A", timestampField = "2026-04-30T10:00:10Z", suffix = "03")
+
+    val page = source.list(HistoryFilter(previewId = "A"))
+    assertEquals(2, page.entries.size)
+    assertTrue(page.entries.all { it.previewId == "A" })
+  }
+
+  @Test
+  fun since_until_filter_narrows_result() {
+    writeEntry(previewId = "A", timestampField = "2026-04-30T10:00:00Z", suffix = "01")
+    writeEntry(previewId = "A", timestampField = "2026-04-30T10:00:05Z", suffix = "02")
+    writeEntry(previewId = "A", timestampField = "2026-04-30T10:00:10Z", suffix = "03")
+
+    val page =
+      source.list(
+        HistoryFilter(since = "2026-04-30T10:00:03Z", until = "2026-04-30T10:00:08Z")
+      )
+    assertEquals(1, page.entries.size)
+    assertEquals("2026-04-30T10:00:05Z", page.entries[0].timestamp)
+  }
+
+  @Test
+  fun branch_filter_narrows_result() {
+    writeEntry(
+      previewId = "A",
+      timestampField = "2026-04-30T10:00:00Z",
+      suffix = "01",
+      git = GitInfo(branch = "main", commit = "deadbeef", shortCommit = "deadbee", dirty = false),
+    )
+    writeEntry(
+      previewId = "A",
+      timestampField = "2026-04-30T10:00:05Z",
+      suffix = "02",
+      git = GitInfo(branch = "agent/foo", commit = "cafef00d", shortCommit = "cafef00", dirty = false),
+    )
+    val page = source.list(HistoryFilter(branch = "agent/foo"))
+    assertEquals(1, page.entries.size)
+    assertEquals("agent/foo", page.entries[0].git?.branch)
+  }
+
+  @Test
+  fun pagination_cursor_round_trips_correctly() {
+    // Five entries, limit = 2, so we expect: page1 (newest 2) → cursor → page2 (next 2) → cursor →
+    // page3 (last 1, no cursor).
+    val timestamps =
+      listOf(
+        "2026-04-30T10:00:00Z",
+        "2026-04-30T10:00:01Z",
+        "2026-04-30T10:00:02Z",
+        "2026-04-30T10:00:03Z",
+        "2026-04-30T10:00:04Z",
+      )
+    timestamps.forEachIndexed { idx, ts ->
+      writeEntry(previewId = "A", timestampField = ts, suffix = "%02d".format(idx))
+    }
+    val page1 = source.list(HistoryFilter(limit = 2))
+    assertEquals(2, page1.entries.size)
+    assertEquals(5, page1.totalCount)
+    assertNotNull(page1.nextCursor)
+    val page2 = source.list(HistoryFilter(limit = 2, cursor = page1.nextCursor))
+    assertEquals(2, page2.entries.size)
+    assertNotNull(page2.nextCursor)
+    val page3 = source.list(HistoryFilter(limit = 2, cursor = page2.nextCursor))
+    assertEquals(1, page3.entries.size)
+    assertNull("last page must not return a cursor", page3.nextCursor)
+    // Concatenated entries must equal the entire newest-first order.
+    val all = (page1.entries + page2.entries + page3.entries).map { it.timestamp }
+    assertEquals(timestamps.reversed(), all)
+  }
+
+  @Test
+  fun read_returns_entry_and_resolves_png_path() {
+    val (id, _) = writeEntry(previewId = "A", timestampField = "2026-04-30T10:00:00Z", suffix = "01")
+    val read = source.read(id, includeBytes = false)
+    assertNotNull(read)
+    assertEquals(id, read!!.entry.id)
+    assertTrue(Files.exists(java.nio.file.Path.of(read.pngPath)))
+    assertNull(read.pngBytes)
+  }
+
+  @Test
+  fun read_with_inline_returns_bytes() {
+    val (id, bytes) =
+      writeEntry(previewId = "A", timestampField = "2026-04-30T10:00:00Z", suffix = "01")
+    val read = source.read(id, includeBytes = true)
+    assertNotNull(read)
+    assertNotNull(read!!.pngBytes)
+    assertTrue(bytes.contentEquals(read.pngBytes!!))
+  }
+
+  @Test
+  fun read_returns_null_for_missing_id() {
+    val read = source.read("does-not-exist", includeBytes = false)
+    assertNull(read)
+  }
+
+  /**
+   * Writes one synthetic entry. Returns the id and the PNG bytes for callers that want to assert
+   * on round-trip identity (e.g. inline-bytes test).
+   */
+  private fun writeEntry(
+    previewId: String,
+    timestampField: String,
+    suffix: String,
+    git: GitInfo? = null,
+  ): Pair<String, ByteArray> {
+    val bytes = "preview-$previewId-$suffix".toByteArray()
+    val hash = LocalFsHistorySource.sha256Hex(bytes)
+    val id = "$timestampField-$suffix-${hash.take(8)}"
+    val entry =
+      HistoryEntry(
+        id = id,
+        previewId = previewId,
+        module = ":t",
+        timestamp = timestampField,
+        pngHash = hash,
+        pngSize = bytes.size.toLong(),
+        pngPath = "$id.png",
+        producer = "daemon",
+        trigger = "renderNow",
+        source = HistorySourceInfo(kind = "fs", id = "fs:${tmpDir.toAbsolutePath()}"),
+        git = git,
+        renderTookMs = 1L,
+      )
+    source.write(entry, bytes)
+    return Pair(id, bytes)
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceWriteTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceWriteTest.kt
@@ -1,0 +1,158 @@
+package ee.schimke.composeai.daemon.history
+
+import java.nio.file.Files
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pins the on-disk write contract from HISTORY.md § "On-disk schema":
+ * - PNG file lands at `<historyDir>/<sanitisedPreviewId>/<id>.png`.
+ * - Sidecar JSON lands at `<historyDir>/<sanitisedPreviewId>/<id>.json` and parses back into the
+ *   same [HistoryEntry].
+ * - `index.jsonl` accumulates one line per write in append order.
+ * - Dedup-by-hash: a second write of identical bytes does NOT re-write the PNG, but DOES write a
+ *   sidecar + index line whose `pngPath` points at the original PNG.
+ */
+class LocalFsHistorySourceWriteTest {
+
+  private lateinit var tmpDir: java.nio.file.Path
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Before
+  fun setUp() {
+    tmpDir = Files.createTempDirectory("history-write-test")
+  }
+
+  @After
+  fun tearDown() {
+    tmpDir.toFile().deleteRecursively()
+  }
+
+  @Test
+  fun three_distinct_writes_produce_three_pngs_three_sidecars_three_index_lines() {
+    val source = LocalFsHistorySource(historyDir = tmpDir)
+    val previewId = "com.example.Foo"
+    val sanitised = "com.example.Foo"
+
+    val entries = (1..3).map { i ->
+      val bytes = byteArrayOf(i.toByte(), 0x00, 0x01)
+      val hash = LocalFsHistorySource.sha256Hex(bytes)
+      val entry = makeEntry(id = "ts-$i-${hash.take(8)}", previewId = previewId, hash = hash, size = bytes.size.toLong())
+      source.write(entry, bytes)
+      Triple(entry, bytes, hash)
+    }
+
+    val previewDir = tmpDir.resolve(sanitised)
+    assertTrue(Files.isDirectory(previewDir))
+    for ((entry, _, _) in entries) {
+      val pngFile = previewDir.resolve("${entry.id}.png")
+      val sidecarFile = previewDir.resolve("${entry.id}.json")
+      assertTrue("PNG missing for ${entry.id}", Files.exists(pngFile))
+      assertTrue("Sidecar missing for ${entry.id}", Files.exists(sidecarFile))
+      val text = Files.readString(sidecarFile)
+      val decoded = json.decodeFromString(HistoryEntry.serializer(), text)
+      assertEquals(entry.id, decoded.id)
+      assertEquals(entry.previewId, decoded.previewId)
+      assertEquals(entry.pngHash, decoded.pngHash)
+      assertEquals("${entry.id}.png", decoded.pngPath)
+    }
+
+    val indexLines =
+      Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)).filter { it.isNotBlank() }
+    assertEquals(3, indexLines.size)
+    val ids = indexLines.map { json.decodeFromString(HistoryEntry.serializer(), it).id }
+    assertEquals(entries.map { it.first.id }, ids)
+  }
+
+  @Test
+  fun dedup_by_hash_does_not_write_a_duplicate_png_but_writes_a_sidecar_pointing_at_the_first() {
+    val source = LocalFsHistorySource(historyDir = tmpDir)
+    val previewId = "Foo"
+    val bytes = byteArrayOf(0x10, 0x20, 0x30, 0x40)
+    val hash = LocalFsHistorySource.sha256Hex(bytes)
+
+    val firstEntry = makeEntry(id = "a-${hash.take(8)}", previewId = previewId, hash = hash, size = bytes.size.toLong())
+    val secondEntry = makeEntry(id = "b-${hash.take(8)}", previewId = previewId, hash = hash, size = bytes.size.toLong())
+    source.write(firstEntry, bytes)
+    source.write(secondEntry, bytes)
+
+    val previewDir = tmpDir.resolve("Foo")
+    val firstPng = previewDir.resolve("${firstEntry.id}.png")
+    val secondPng = previewDir.resolve("${secondEntry.id}.png")
+    val secondSidecar = previewDir.resolve("${secondEntry.id}.json")
+
+    assertTrue("First PNG must exist", Files.exists(firstPng))
+    assertFalse("Second PNG must NOT exist (dedup)", Files.exists(secondPng))
+    assertTrue("Second sidecar must exist", Files.exists(secondSidecar))
+
+    // Second sidecar's pngPath should point at the first PNG's filename.
+    val sidecarText = Files.readString(secondSidecar)
+    val decoded = json.decodeFromString(HistoryEntry.serializer(), sidecarText)
+    assertEquals("${firstEntry.id}.png", decoded.pngPath)
+
+    // Index has both lines, both readable.
+    val indexLines =
+      Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)).filter { it.isNotBlank() }
+    assertEquals(2, indexLines.size)
+  }
+
+  @Test
+  fun dedup_survives_simulated_cross_restart() {
+    // Write entry 1 via source A; throw it away; create source B against the same dir; write entry
+    // 2 with the same bytes; assert dedup still hits.
+    val previewId = "Bar"
+    val bytes = byteArrayOf(0x77, 0x77, 0x77)
+    val hash = LocalFsHistorySource.sha256Hex(bytes)
+    val firstEntry = makeEntry(id = "old-${hash.take(8)}", previewId = previewId, hash = hash, size = bytes.size.toLong())
+    LocalFsHistorySource(historyDir = tmpDir).write(firstEntry, bytes)
+
+    val sourceB = LocalFsHistorySource(historyDir = tmpDir)
+    val secondEntry = makeEntry(id = "new-${hash.take(8)}", previewId = previewId, hash = hash, size = bytes.size.toLong())
+    sourceB.write(secondEntry, bytes)
+
+    val previewDir = tmpDir.resolve("Bar")
+    val firstPng = previewDir.resolve("${firstEntry.id}.png")
+    val secondPng = previewDir.resolve("${secondEntry.id}.png")
+    assertTrue(Files.exists(firstPng))
+    assertFalse("Cross-restart dedup must skip the duplicate PNG", Files.exists(secondPng))
+
+    val sidecar = json.decodeFromString(HistoryEntry.serializer(), Files.readString(previewDir.resolve("${secondEntry.id}.json")))
+    assertEquals("${firstEntry.id}.png", sidecar.pngPath)
+  }
+
+  @Test
+  fun previewId_with_path_separator_is_sanitised() {
+    val source = LocalFsHistorySource(historyDir = tmpDir)
+    val rawId = "com/example/foo:bar"
+    val bytes = byteArrayOf(1, 2, 3)
+    val hash = LocalFsHistorySource.sha256Hex(bytes)
+    val entry = makeEntry(id = "ts-${hash.take(8)}", previewId = rawId, hash = hash, size = bytes.size.toLong())
+    source.write(entry, bytes)
+
+    // sanitisation collapses '/' and ':' to '_'
+    assertTrue(Files.isDirectory(tmpDir.resolve("com_example_foo_bar")))
+    assertNotNull(Files.list(tmpDir.resolve("com_example_foo_bar")).findFirst().orElse(null))
+  }
+
+  private fun makeEntry(id: String, previewId: String, hash: String, size: Long): HistoryEntry =
+    HistoryEntry(
+      id = id,
+      previewId = previewId,
+      module = ":t",
+      timestamp = "2026-04-30T10:12:34Z",
+      pngHash = hash,
+      pngSize = size,
+      pngPath = "$id.png",
+      producer = "daemon",
+      trigger = "renderNow",
+      source = HistorySourceInfo(kind = "fs", id = "fs:${tmpDir.toAbsolutePath()}"),
+      renderTookMs = 1L,
+    )
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -2,6 +2,8 @@
 
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.history.GitProvenance
+import ee.schimke.composeai.daemon.history.HistoryManager
 import java.io.File
 import java.nio.file.Path
 
@@ -137,6 +139,27 @@ fun main(args: Array<String>) {
       IncrementalDiscovery(classpath = classpath)
     } else null
 
+  // H1+H2 — wire the per-render history archive. Path comes from `composeai.daemon.historyDir`
+  // (the gradle plugin's daemon launch descriptor will emit this in a future task; for now agents
+  // and ad-hoc launches set it manually). The default is null = no history written. Workspace
+  // root for git-provenance resolution comes from `composeai.daemon.workspaceRoot`, with the JVM
+  // CWD as the fallback. See HISTORY.md § "What this PR lands § H1".
+  val historyDirProp = System.getProperty(HISTORY_DIR_PROP)
+  val workspaceRootProp = System.getProperty(WORKSPACE_ROOT_PROP)
+  val gitProvenance =
+    if (historyDirProp != null) {
+      GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of))
+    } else null
+  val historyManager: HistoryManager? =
+    historyDirProp?.let { dir ->
+      System.err.println("compose-ai-tools desktop daemon: HistoryManager active (dir=$dir)")
+      HistoryManager.forLocalFs(
+        historyDir = Path.of(dir),
+        module = System.getProperty(MODULE_ID_PROP) ?: "",
+        gitProvenance = gitProvenance,
+      )
+    }
+
   val server =
     JsonRpcServer(
       input = System.`in`,
@@ -145,6 +168,7 @@ fun main(args: Array<String>) {
       classpathFingerprint = classpathFingerprint,
       previewIndex = previewIndex,
       incrementalDiscovery = incrementalDiscovery,
+      historyManager = historyManager,
     )
 
   installSigtermShutdownHook(host, originalStdin = System.`in`)
@@ -202,6 +226,15 @@ fun main(args: Array<String>) {
  * EOF→idleTimeout-sleep walk; the latter is bounded by the `composeai.daemon.idleTimeoutMs` system
  * property, default 5s).
  */
+/** HISTORY.md § "What this PR lands § H1" — null disables history. */
+private const val HISTORY_DIR_PROP = "composeai.daemon.historyDir"
+
+/** Optional override for git-provenance resolution; defaults to JVM CWD. */
+private const val WORKSPACE_ROOT_PROP = "composeai.daemon.workspaceRoot"
+
+/** Module project path stamped into every history entry's `module` field. */
+private const val MODULE_ID_PROP = "composeai.daemon.moduleId"
+
 private fun installSigtermShutdownHook(host: RenderHost, originalStdin: java.io.InputStream) {
   // Same property the JsonRpcServer reads, so a single sysprop tunes both timeouts coherently.
   // Default 30s — matches the existing `finally`-block defensive shutdown above and most JVMs'

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
@@ -6,6 +6,8 @@ import ee.schimke.composeai.daemon.IncrementalDiscovery
 import ee.schimke.composeai.daemon.JsonRpcServer
 import ee.schimke.composeai.daemon.PreviewIndex
 import ee.schimke.composeai.daemon.PreviewInfoDto
+import ee.schimke.composeai.daemon.history.GitProvenance
+import ee.schimke.composeai.daemon.history.HistoryManager
 import java.io.File
 import java.nio.file.Path
 
@@ -88,6 +90,21 @@ fun main(args: Array<String>) {
       IncrementalDiscovery(classpath = classpath)
     } else null
 
+  // H1+H2 — wire the per-render history archive when the harness opted in via
+  // `composeai.daemon.historyDir`. Mirrors the production daemon main wireup. Tests that don't set
+  // the sysprop see the pre-H1 default (no history written, history/list returns empty).
+  val historyDirProp = System.getProperty("composeai.daemon.historyDir")
+  val workspaceRootProp = System.getProperty("composeai.daemon.workspaceRoot")
+  val historyManager: HistoryManager? =
+    historyDirProp?.let { dir ->
+      System.err.println("compose-ai-daemon harness: HistoryManager active (dir=$dir)")
+      HistoryManager.forLocalFs(
+        historyDir = Path.of(dir),
+        module = System.getProperty("composeai.daemon.moduleId") ?: ":harness",
+        gitProvenance = GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of)),
+      )
+    }
+
   val server =
     JsonRpcServer(
       input = System.`in`,
@@ -96,6 +113,7 @@ fun main(args: Array<String>) {
       daemonVersion = "harness-fake",
       previewIndex = previewIndex,
       incrementalDiscovery = incrementalDiscovery,
+      historyManager = historyManager,
     )
   server.run()
 }

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessClient.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessClient.kt
@@ -4,6 +4,10 @@ import ee.schimke.composeai.daemon.protocol.ChangeType
 import ee.schimke.composeai.daemon.protocol.ClientCapabilities
 import ee.schimke.composeai.daemon.protocol.FileChangedParams
 import ee.schimke.composeai.daemon.protocol.FileKind
+import ee.schimke.composeai.daemon.protocol.HistoryListParams
+import ee.schimke.composeai.daemon.protocol.HistoryListResult
+import ee.schimke.composeai.daemon.protocol.HistoryReadParams
+import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
 import ee.schimke.composeai.daemon.protocol.InitializeParams
 import ee.schimke.composeai.daemon.protocol.InitializeResult
 import ee.schimke.composeai.daemon.protocol.JsonRpcNotification
@@ -139,6 +143,55 @@ private constructor(
   ) {
     val n = JsonRpcNotification(method = method, params = params)
     sendFrame(json.encodeToString(JsonRpcNotification.serializer(), n))
+  }
+
+  /** H1+H2 — drives `history/list`. Mirrors the wire shape from HISTORY.md § "Layer 2". */
+  fun historyList(params: HistoryListParams = HistoryListParams()): HistoryListResult {
+    val id = nextId.getAndIncrement()
+    val request =
+      JsonRpcRequest(
+        id = id,
+        method = "history/list",
+        params = json.encodeToJsonElement(HistoryListParams.serializer(), params),
+      )
+    val response = sendAndPoll(id, request, 10.seconds)
+    val resultElem =
+      response["result"]
+        ?: error("history/list: no result — error=${response["error"]}, full=${response}")
+    return json.decodeFromJsonElement(HistoryListResult.serializer(), resultElem)
+  }
+
+  /** H1+H2 — drives `history/read`. */
+  fun historyRead(id: String, inline: Boolean = false): HistoryReadResultDto {
+    val rpcId = nextId.getAndIncrement()
+    val params = HistoryReadParams(id = id, inline = inline)
+    val request =
+      JsonRpcRequest(
+        id = rpcId,
+        method = "history/read",
+        params = json.encodeToJsonElement(HistoryReadParams.serializer(), params),
+      )
+    val response = sendAndPoll(rpcId, request, 10.seconds)
+    val resultElem =
+      response["result"]
+        ?: error("history/read: no result — error=${response["error"]}, full=${response}")
+    return json.decodeFromJsonElement(HistoryReadResultDto.serializer(), resultElem)
+  }
+
+  /**
+   * H1+H2 — like [historyRead] but returns the raw response so callers can assert on
+   * `error.code == -32010` (HistoryEntryNotFound).
+   */
+  fun historyReadRaw(id: String, inline: Boolean = false): JsonObject {
+    val rpcId = nextId.getAndIncrement()
+    val params = HistoryReadParams(id = id, inline = inline)
+    val request =
+      JsonRpcRequest(
+        id = rpcId,
+        method = "history/read",
+        params = json.encodeToJsonElement(HistoryReadParams.serializer(), params),
+      )
+    return sendAndPoll(rpcId, request, 10.seconds)
   }
 
   /** Drives `renderNow` for the given preview ids at the given [tier]. */

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
@@ -35,6 +35,16 @@ class FakeHarnessLauncher(
   private val classpath: List<File>,
   private val mainClass: String = "ee.schimke.composeai.daemon.harness.FakeDaemonMain",
   private val extraJvmArgs: List<String> = emptyList(),
+  /**
+   * H1+H2 — when non-null, sets `-Dcomposeai.daemon.historyDir=<path>` on the spawned JVM so
+   * [FakeDaemonMain] wires a [HistoryManager]. Default null = no history, pre-H1 behaviour.
+   */
+  private val historyDir: File? = null,
+  /**
+   * H1+H2 — workspace root for git-provenance resolution. Optional; defaults to the spawned JVM's
+   * cwd (the harness module's project dir under Gradle test execution).
+   */
+  private val workspaceRoot: File? = null,
 ) : HarnessLauncher {
 
   override val name: String = "fake"
@@ -52,6 +62,9 @@ class FakeHarnessLauncher(
         // Match the in-process integration test's idle timeout — keeps harness scenarios snappy
         // when a misbehaving test forgets to send `exit`.
         add("-Dcomposeai.daemon.idleTimeoutMs=2000")
+        if (historyDir != null) add("-Dcomposeai.daemon.historyDir=${historyDir.absolutePath}")
+        if (workspaceRoot != null)
+          add("-Dcomposeai.daemon.workspaceRoot=${workspaceRoot.absolutePath}")
         addAll(extraJvmArgs)
         add("-cp")
         add(cpString)

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S9HistoryRecordingAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S9HistoryRecordingAndroidRealModeTest.kt
@@ -1,0 +1,18 @@
+package ee.schimke.composeai.daemon.harness
+
+import org.junit.Ignore
+import org.junit.Test
+
+/**
+ * Real-mode Android counterpart to [S9HistoryRecordingTest] — placeholder for H1+H2.
+ *
+ * Same shape as [S9HistoryRecordingDesktopRealModeTest]. The Android Robolectric daemon path lands
+ * once the gradle plugin emits the `composeai.daemon.historyDir` sysprop in the descriptor.
+ */
+@Ignore("S9 real-mode android placeholder — see KDoc")
+class S9HistoryRecordingAndroidRealModeTest {
+  @Test
+  fun s9_history_recording_real_mode_android_placeholder() {
+    // Placeholder body — see [S9HistoryRecordingDesktopRealModeTest].
+  }
+}

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S9HistoryRecordingDesktopRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S9HistoryRecordingDesktopRealModeTest.kt
@@ -1,0 +1,22 @@
+package ee.schimke.composeai.daemon.harness
+
+import org.junit.Ignore
+import org.junit.Test
+
+/**
+ * Real-mode desktop counterpart to [S9HistoryRecordingTest] — placeholder for H1+H2.
+ *
+ * The fake-mode S9 already covers the wire-format end-to-end. The real-mode landing belongs
+ * alongside the rest of the desktop real-mode catalogue once the gradle plugin's daemon launch
+ * descriptor wires the `composeai.daemon.historyDir` sysprop (a follow-up task that's NOT in scope
+ * for this PR). Keeping the placeholder here pins the intent and makes the future landing point
+ * obvious to anyone scanning the harness suite.
+ */
+@Ignore("S9 real-mode desktop placeholder — see KDoc")
+class S9HistoryRecordingDesktopRealModeTest {
+  @Test
+  fun s9_history_recording_real_mode_desktop_placeholder() {
+    // Placeholder body — the @Ignore annotation skips this test in JUnit. Real implementation
+    // lands when the gradle plugin emits `composeai.daemon.historyDir` in the daemon descriptor.
+  }
+}

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S9HistoryRecordingTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S9HistoryRecordingTest.kt
@@ -1,0 +1,118 @@
+package ee.schimke.composeai.daemon.harness
+
+import ee.schimke.composeai.daemon.protocol.HistoryListParams
+import ee.schimke.composeai.daemon.protocol.RenderTier
+import java.io.File
+import java.nio.file.Files
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Scenario **S9 — History recording (fake mode)**. Drives the [FakeDaemonMain] with a
+ * `composeai.daemon.historyDir` sysprop set to a per-test temp dir, renders one preview, and
+ * asserts:
+ * 1. A `historyAdded` notification arrives within the polling window with the expected schema.
+ * 2. A sidecar JSON file lives on disk under `<historyDir>/<sanitisedPreviewId>/<id>.json`.
+ * 3. The sidecar's `producer == "daemon"`, `trigger == "renderNow"`, and `source.kind == "fs"`.
+ * 4. `history/list` over the wire returns the same entry; `history/read` resolves the PNG path.
+ *
+ * **Git provenance is not gated.** The harness's CI environment may or may not have git on the
+ * path; the brief explicitly says don't gate this test on it. We assert the `git` field's PRESENCE
+ * (it serializes as either an object with all-nullable fields or as `null`), not on any specific
+ * branch/commit value.
+ */
+class S9HistoryRecordingTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Test
+  fun s9_history_recording_fake_mode() {
+    val moduleBuildDir = File("build")
+    val fixtureDir = File(moduleBuildDir, "daemon-harness/fixtures/s9").apply {
+      deleteRecursively()
+      mkdirs()
+    }
+    val historyDir = Files.createTempDirectory("s9-history").toFile().apply { deleteOnExit() }
+    val previewId = "preview-1"
+    val pngBytes = TestPatterns.solidColour(64, 64, 0xFF202080.toInt())
+    val pngFile = File(fixtureDir, "$previewId.png").apply { writeBytes(pngBytes) }
+    File(fixtureDir, "previews.json")
+      .writeText("""[{"id":"$previewId","className":"fake.S9","functionName":"S9"}]""")
+
+    val classpath =
+      System.getProperty("java.class.path")
+        .split(File.pathSeparator)
+        .filter { it.isNotBlank() }
+        .map { File(it) }
+    val launcher =
+      FakeHarnessLauncher(
+        fixtureDir = fixtureDir,
+        classpath = classpath,
+        historyDir = historyDir,
+      )
+    val client = HarnessClient.start(launcher)
+    try {
+      client.initialize()
+      client.sendInitialized()
+
+      val renderNowResult =
+        client.renderNow(previews = listOf(previewId), tier = RenderTier.FAST)
+      assertEquals(listOf(previewId), renderNowResult.queued)
+
+      // historyAdded notification — within 5s of renderFinished. We poll for it explicitly
+      // (not via pollNotificationMatching("historyAdded")) so the diagnostic on timeout is clear.
+      val added = client.pollNotification("historyAdded", 5.seconds)
+      val entryJson = added["params"]!!.jsonObject["entry"]!!.jsonObject
+      val entryId = entryJson["id"]!!.jsonPrimitive.content
+      assertEquals(previewId, entryJson["previewId"]?.jsonPrimitive?.contentOrNull)
+      assertEquals("daemon", entryJson["producer"]?.jsonPrimitive?.contentOrNull)
+      assertEquals("renderNow", entryJson["trigger"]?.jsonPrimitive?.contentOrNull)
+      val sourceObj = entryJson["source"]!!.jsonObject
+      assertEquals("fs", sourceObj["kind"]?.jsonPrimitive?.contentOrNull)
+
+      // Sidecar on disk — under <historyDir>/preview-1/<entryId>.json. The previewId "preview-1"
+      // sanitises to itself (alnum + '-').
+      val sidecarFile = File(File(historyDir, "preview-1"), "$entryId.json")
+      assertTrue("sidecar must exist on disk: $sidecarFile", sidecarFile.exists())
+      val sidecarText = sidecarFile.readText()
+      assertTrue("sidecar must be valid JSON", sidecarText.startsWith("{"))
+      // We re-decode to assert producer/trigger came through the disk write too.
+      val parsedSidecar = json.parseToJsonElement(sidecarText).jsonObject
+      assertEquals("daemon", parsedSidecar["producer"]?.jsonPrimitive?.contentOrNull)
+      assertEquals("renderNow", parsedSidecar["trigger"]?.jsonPrimitive?.contentOrNull)
+      assertEquals("fs", parsedSidecar["source"]!!.jsonObject["kind"]?.jsonPrimitive?.contentOrNull)
+
+      // history/list returns the entry over the wire.
+      val listResult = client.historyList(HistoryListParams())
+      assertEquals(1, listResult.totalCount)
+      assertEquals(1, listResult.entries.size)
+      assertEquals(
+        entryId,
+        listResult.entries[0].jsonObject["id"]?.jsonPrimitive?.contentOrNull,
+      )
+
+      // history/read resolves the PNG path.
+      val read = client.historyRead(entryId, inline = false)
+      assertNotNull(read.pngPath)
+      assertTrue("history/read pngPath must exist on disk", File(read.pngPath).exists())
+
+      // Tear down.
+      val exitCode = client.shutdownAndExit()
+      assertEquals(0, exitCode)
+    } catch (t: Throwable) {
+      System.err.println("S9HistoryRecordingTest failed; stderr from daemon:\n${client.dumpStderr()}")
+      throw t
+    } finally {
+      try {
+        client.close()
+      } catch (_: Throwable) {}
+    }
+  }
+}

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -173,18 +173,12 @@ under POSIX `PIPE_BUF` so writes are atomic. Readers seeing torn
 lines on macOS edge cases skip them — the per-preview sidecars are
 the source of truth, the index is the convenience.
 
-### Compatibility with today's layout
+### Greenfield — no legacy data
 
-Pre-design entries (PNGs without sidecars) stay readable. The Layer
-2 reader treats them as `source: "unknown"`, infers `previewId` from
-the parent folder name, parses the timestamp from the filename, and
-omits everything else. Listing degrades gracefully; reading degrades
-to "PNG bytes plus filename-derived metadata".
-
-The Gradle `HistorizePreviewsTask` keeps writing PNG-only today.
-Phase 1 of this design adds sidecar emission to that task too —
-the dedup-by-SHA logic stays, but every kept PNG gets a `.json`
-sibling. Old entries don't get retroactively annotated.
+The legacy `HistorizePreviewsTask` (Gradle-side PNG-only writer) was removed in PR #311 along with
+the unused VS Code Preview History panel. H1 daemon writes are the only writer, so the Layer 2
+reader does NOT have to tolerate PNG-only entries — every entry on disk has a sibling sidecar
+because the daemon wrote both atomically.
 
 ## Trigger taxonomy
 
@@ -193,13 +187,13 @@ this preview. Vocabulary:
 
 | trigger              | who emits | meaning |
 |----------------------|-----------|---------|
-| `initial`            | both      | first render after daemon start / cold Gradle invocation |
+| `initial`            | daemon    | first render after daemon start |
 | `renderNow`          | daemon    | explicit `renderNow` request from a client |
 | `fileChanged`        | daemon    | source/resource/classpath edit triggered the render |
 | `discoveryUpdated`   | daemon    | preview was newly discovered or its metadata changed |
 | `setVisible`         | daemon    | preview entered the visible set (B2.5+ — focus-driven) |
 | `recycleResume`      | daemon    | sandbox recycle re-rendered visible previews |
-| `gradleTask`         | gradle    | `renderAllPreviews` or `renderPreviews` invocation |
+| `gradleTask`         | —         | reserved (legacy `HistorizePreviewsTask` was removed in PR #311); not currently emitted |
 | `manual`             | either    | external trigger (CLI flag, MCP `render_preview` tool) |
 
 `triggerDetail` is a free-form object whose shape is per-trigger
@@ -751,33 +745,18 @@ Storage assumptions:
 The VS Code extension does NOT mutate history. Pruning happens
 daemon-side or via the Gradle path's pruning hook (see § Pruning).
 
-## Layer 1 — Gradle path
-
-The existing `HistorizePreviewsTask` keeps working. Phase 1 changes:
-
-1. Emit a sidecar `.json` for each PNG it writes. Schema matches the
-   sidecar above, with `source: "gradle"` and `trigger: "gradleTask"`.
-2. Append a line to `index.jsonl`.
-3. Run pruning at task end (configurable; default off — Gradle runs
-   are infrequent enough that the daemon's auto-prune covers most
-   cases).
-
-These are additive. No existing behaviour changes.
-
 ## Concurrency model
 
-- **Single writer at a time.** Daemon and Gradle don't render the
-  same module concurrently; the daemon shuts down or refuses
-  `renderNow` while a Gradle build holds the project lock, and the
-  daemon's own `classpathDirty` exit happens before any Gradle
-  re-resolve. So there's never two writers actually colliding.
+The daemon is the only writer. The legacy Gradle-side `HistorizePreviewsTask` was removed in
+PR #311; there is no second writer to coordinate with.
+
 - **Filenames are collision-free.** Timestamp + 8-hex-of-SHA gives
-  practical uniqueness. If two writers somehow land in the same
-  millisecond on identical bytes, the dedup-by-SHA logic skips one.
+  practical uniqueness. The dedup-by-SHA logic on top suppresses
+  re-writing identical bytes for the same preview.
 - **Index `O_APPEND` writes.** Atomic for sub-`PIPE_BUF` lines, which
   the schema fits comfortably.
 - **Reader-side robustness.** Readers tolerate truncated index lines
-  (skip), missing sidecars (degrade to PNG-only metadata), and
+  (skip), missing sidecars (drop the entry from listings — self-healing on next prune), and
   symlinked entries (follow once).
 
 ## Pruning policy
@@ -820,18 +799,16 @@ removed set.
 
 | Module | Reads history? | Writes history? | Imports |
 |---|---|---|---|
-| `:gradle-plugin` (Layer 1) | no | yes (`HistorizePreviewsTask`) | nothing daemon-side |
+| `:gradle-plugin` (Layer 1) | no | no (legacy writer removed in PR #311) | nothing daemon-side |
 | `:daemon:core` (Layer 2) | yes (`history/list`, `history/read`, `history/diff`) | yes (per render) | none beyond Messages.kt |
-| `:daemon:android`, `:daemon:desktop` (Layer 2) | no — they call `renderHost.recordHistory()` which lives in `:daemon:core` | no | `:daemon:core` |
+| `:daemon:android`, `:daemon:desktop` (Layer 2) | no — they call into `:daemon:core` `JsonRpcServer` | no | `:daemon:core` |
 | `:daemon:mcp` (Layer 3) | yes — JSON-RPC client of Layer 2; merges across worktrees consumer-side | no | `:daemon:core` (types only) |
 | VS Code extension | yes — JSON-RPC client of Layer 2, OR direct filesystem | no | nothing daemon-side |
 
-The daemon is the only writer to its own LocalFs source while
-running. The Gradle plugin writes to that same LocalFs source when
-no daemon is up. Git / HTTP sources are Layer 2 plug-ins that don't
-escape the daemon's process. Cross-worktree merging happens above
-Layer 2 — at the MCP server or in the editor — never inside a
-daemon.
+The daemon is the only writer to its own LocalFs source. Git / HTTP
+sources are Layer 2 plug-ins that don't escape the daemon's process.
+Cross-worktree merging happens above Layer 2 — at the MCP server or
+in the editor — never inside a daemon.
 
 ## File-format versioning
 
@@ -851,8 +828,8 @@ index; old indices stay readable as v0.
 
 | Phase | Scope | Owner | Depends on |
 |---|---|---|---|
-| **H0** | Sidecar schema + index.jsonl emission from `HistorizePreviewsTask` | Layer 1 | — |
-| **H1** | Daemon writes sidecar + index entry per render | Layer 2 | H0 schema lock |
+| ~~**H0**~~ | ~~Sidecar schema + index.jsonl emission from `HistorizePreviewsTask`~~ | — | dropped — legacy task removed in PR #311; greenfield write path is daemon-only |
+| **H1** | Daemon writes sidecar + index entry per render | Layer 2 | — |
 | **H2** | `history/list` + `history/read` + `historyAdded` notification | Layer 2 | H1 |
 | **H3** | `history/diff` (metadata mode) | Layer 2 | H2 |
 | **H4** | Auto-prune + `historyPruned` notification | Layer 2 | H2 |
@@ -867,7 +844,8 @@ index; old indices stay readable as v0.
 | **H13** | `HttpMirrorHistorySource` — read-only CI / S3 mirror | Layer 2 | H9 |
 | **H14** | Cross-worktree merge in MCP `DaemonSupervisor` (multi-worktree timeline) | Layer 3 | H6 |
 
-H0–H2 are independently useful. H3 onward is enrichment.
+H1+H2 are independently useful and ship together as the first daemon-side history landing. H3
+onward is enrichment.
 
 ## Open questions
 

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -50,6 +50,8 @@ Standard JSON-RPC codes plus daemon-specific extensions in the reserved `-32000.
 | -32003   | SandboxRecycling      | Daemon is between sandboxes; retry shortly. |
 | -32004   | UnknownPreview        | Preview ID not in the current discovery set. |
 | -32005   | RenderFailed          | Render itself failed; details in `data`. |
+| -32010   | HistoryEntryNotFound  | `history/read` referenced a missing entry id. |
+| -32011   | HistoryDiffMismatch   | `history/diff` was given two entries from different previews (reserved; phase H3+). |
 
 `error.data` is an object; daemon-specific errors include `data.kind: string` for machine-routable subcategories.
 
@@ -197,6 +199,61 @@ Errors:
 - `ClasspathDirty` (-32002) — daemon will not render until restarted.
 - `SandboxRecycling` (-32003) — retry after the next `daemonReady` notification.
 
+### `history/list` (phase H2)
+
+```ts
+// params
+{
+  previewId?: string;
+  since?: string;                   // ISO timestamp lower bound
+  until?: string;                   // ISO timestamp upper bound
+  limit?: number;                   // default 50, max 500
+  cursor?: string;                  // opaque pagination token
+  branch?: string;
+  branchPattern?: string;           // regex
+  commit?: string;                  // long or short SHA
+  worktreePath?: string;
+  agentId?: string;
+  sourceKind?: "fs" | "git" | "http";
+  sourceId?: string;
+}
+
+// result
+{
+  entries: HistoryEntry[];          // newest first
+  nextCursor?: string;
+  totalCount: number;
+}
+```
+
+`HistoryEntry` is the sidecar JSON shape from [HISTORY.md § "Sidecar metadata schema"](HISTORY.md#sidecar-metadata-schema).
+
+### `history/read` (phase H2)
+
+```ts
+// params
+{ id: string; inline?: boolean }
+
+// result
+{
+  entry: HistoryEntry;
+  previewMetadata?: PreviewMetadataSnapshot;
+  pngPath: string;                  // absolute
+  pngBytes?: string;                // base64; populated when inline=true
+}
+```
+
+Errors:
+- `HistoryEntryNotFound` (-32010) — `id` does not match any entry in the configured sources.
+
+### `history/diff` (phase H3+, reserved)
+
+Not implemented in H1+H2. Calls return `MethodNotFound` (-32601) until H3 lands.
+
+### `history/prune` (phase H4+, reserved)
+
+Not implemented in H1+H2. Calls return `MethodNotFound` (-32601) until H4 lands.
+
 ## 6. Daemon → client notifications
 
 ### `discoveryUpdated`
@@ -321,6 +378,22 @@ Render service is available again after a `daemonWarming` interval.
 ```
 
 Optional channel; client routes to the daemon output channel. Stderr remains the unstructured fallback.
+
+### `historyAdded` (phase H2)
+
+```ts
+{ entry: HistoryEntry }
+```
+
+Emitted whenever a render lands a new entry on disk via the configured `HistoryManager`. Mirrors
+the shape of `discoveryUpdated`. Clients that subscribe avoid polling `history/list`.
+
+The `pngHash` field on `entry` lets a subscriber decide cheaply whether the bytes are different
+from the previous render — if not, skip re-fetching. See [HISTORY.md § "historyAdded"](HISTORY.md#historyadded-notification-daemon--client).
+
+### `historyPruned` (phase H4+, reserved)
+
+Not implemented in H1+H2. Documented in [HISTORY.md § "historyPruned"](HISTORY.md#historypruned-notification-daemon--client) for the H4 landing.
 
 ## 7. Versioning
 

--- a/docs/daemon/TODO.md
+++ b/docs/daemon/TODO.md
@@ -688,6 +688,23 @@ A1.1 unblocks C1.2; B1.5 unblocks C1.3; B2.5 unblocks C2.3. Otherwise streams ar
 
 ---
 
+## Phase H — Preview history (parallel to Phase 2)
+
+Tracking the daemon-side history phases from [HISTORY.md § "Phasing"](HISTORY.md#phasing).
+
+- **H1 — Daemon writes sidecar + index entry per render** ✅ landed
+- **H2 — `history/list` + `history/read` + `historyAdded` notification** ✅ landed
+- **H3 — `history/diff` (metadata mode)** — still open
+- **H4 — Auto-prune + `historyPruned` notification** — still open
+- **H5 — `history/diff` (pixel mode + diff PNG)** — still open
+- H6+ (MCP / VS Code / git refs / cross-worktree merging) — see HISTORY.md table.
+
+H1+H2 ship behind the existing `composePreview.experimental.daemon { enabled = true }` gate. The
+gradle plugin's daemon launch descriptor will gain `composeai.daemon.historyDir` emission in a
+follow-up; until then, agents and ad-hoc launches set the sysprop directly.
+
+---
+
 ## Risks to track per task
 
 If an agent hits one of these mid-task, raise immediately rather than working around it:


### PR DESCRIPTION
## Summary

Implements phases H1 + H2 of [docs/daemon/HISTORY.md](https://github.com/yschimke/compose-ai-tools/blob/main/docs/daemon/HISTORY.md) — daemon-side history recording + read API.

After every successful render the daemon writes a sidecar JSON + appends to \`index.jsonl\` next to the rendered PNG. Clients can browse via JSON-RPC; \`historyAdded\` notifications stream new entries.

### What landed

- \`HistorySource\` interface + \`LocalFsHistorySource\` + \`HistoryManager\` wired into \`JsonRpcServer\`
- Sidecar schema per [HISTORY.md § \"Sidecar metadata schema\"](https://github.com/yschimke/compose-ai-tools/blob/main/docs/daemon/HISTORY.md): id, previewId, module, timestamp, pngHash/Size/Path, producer, trigger/triggerDetail, source, worktree, git (branch/commit/dirty/remote), renderTookMs, metrics, previewMetadata snapshot, previousId, deltaFromPrevious
- Dedup-by-hash: identical bytes don't write a duplicate PNG; sidecar still emitted (provenance is still useful)
- Git provenance resolver: \`git rev-parse\` at startup; cheap refresh per render for branch/commit/dirty
- Three new JSON-RPC methods: \`history/list\`, \`history/read\` (and \`historyAdded\` notification)
- Reserved (return MethodNotFound for now): \`history/diff\`, \`history/prune\`
- Reserved error codes: \`HistoryEntryNotFound (-32010)\`, \`HistoryDiffMismatch (-32011)\`
- New harness scenario: \`S9HistoryRecordingTest\` (fake-mode end-to-end); \`@Ignore\`d real-mode placeholders

### What didn't

- \`history/diff\` (H3), auto-prune (H4), pixel-mode diff (H5)
- MCP mapping (H6) — separate landing
- VS Code Preview History panel (H7) — separate landing
- \`GitRefHistorySource\`, \`HttpMirrorHistorySource\` (H10+) — interface designed, no impls yet

### Layering

- New code lives entirely in \`:daemon:core\` under a \`history\` subpackage
- \`:gradle-plugin\` doesn't import any new daemon code; \`build.gradle.kts\` deps unchanged
- \`grep -r \"import ee.schimke.composeai.plugin\" daemon/core/src/main/\` empty

## Test plan

- [x] \`./gradlew :daemon:core:test\` — 21 new history tests + pre-existing all green
- [x] \`./gradlew :daemon:harness:test\` — S9 fake-mode test passes; pre-existing scenarios green
- [x] \`./gradlew :daemon:desktop:test :daemon:android:testDebugUnitTest\` — daemon mains compile and pass
- [x] \`./gradlew :gradle-plugin:test :cli:assemble :samples:android:assembleDebug\` — back-compat sanity
- [ ] \`-Pharness.host=real\` — not run (slow); fake-mode harness covers H1+H2 wire-format end-to-end