### PR TITLE
feat(vscode): pre-warm daemon on scope-in + status-bar progress

### DIFF
--- a/vscode-extension/src/daemon/daemonGate.ts
+++ b/vscode-extension/src/daemon/daemonGate.ts
@@ -106,9 +106,9 @@ export class DaemonGate {
 
     /**
      * Ensures the consumer's `daemon-launch.json` exists by running the
-     * Gradle bootstrap task once per module. Cheap on subsequent calls
-     * (cacheable). Swallows failures — a missing descriptor on first launch
-     * just means we silently fall back to Gradle, which is the safe default.
+     * Gradle bootstrap task once per module. Cheap and cacheable. Swallows
+     * failures — a missing descriptor on first launch just means we silently
+     * fall back to Gradle, which is the safe default.
      */
     async bootstrap(gradleService: GradleService, moduleId: string): Promise<void> {
         if (!this.isEnabled()) { return; }
@@ -119,6 +119,13 @@ export class DaemonGate {
                 `[daemon] bootstrap task failed for ${moduleId}: ${(err as Error).message}`,
             );
         }
+    }
+
+    /** True iff a healthy daemon is already up for this module — warm path
+     *  short-circuit. */
+    isDaemonReady(moduleId: string): boolean {
+        const existing = this.daemons.get(moduleId);
+        return existing != null && !existing.client.isClosed();
     }
 
     async dispose(): Promise<void> {

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import * as vscode from 'vscode';
-import { DaemonClient } from './daemonClient';
+import { GradleService } from '../gradleService';
 import { DaemonGate } from './daemonGate';
 import {
     FileChangeType,
@@ -9,6 +8,9 @@ import {
     RenderFinishedParams,
     RenderTier,
 } from './daemonProtocol';
+
+export type WarmProgress = (state: WarmState) => void;
+export type WarmState = 'bootstrapping' | 'spawning' | 'ready' | 'fallback';
 
 export interface SchedulerEvents {
     /**
@@ -81,6 +83,46 @@ export class DaemonScheduler {
     async ensureModule(moduleId: string): Promise<boolean> {
         const client = await this.gate.getOrSpawn(moduleId, this.daemonEvents(moduleId));
         return client !== null;
+    }
+
+    /**
+     * Pre-warms a module: runs the Gradle bootstrap task (writes
+     * `daemon-launch.json`) and spawns the JVM if not already up. Intended
+     * to be called when the user navigates to a Kotlin file in a
+     * daemon-enabled module, so the daemon is alive by the time they hit
+     * save — the first save then collapses to "kotlinc + render" instead
+     * of "Gradle bootstrap + JVM spawn + sandbox init + render".
+     *
+     * `progress` fires through `'bootstrapping'` while the Gradle task
+     * runs, `'spawning'` while the JVM comes up, and `'ready'` once
+     * `initialize` is acknowledged. `'fallback'` fires on any failure —
+     * the next save will run Gradle as today. No-op when the gate is
+     * disabled.
+     */
+    async warmModule(
+        gradleService: GradleService,
+        moduleId: string,
+        progress?: WarmProgress,
+    ): Promise<boolean> {
+        if (!this.gate.isEnabled()) { return false; }
+        if (this.gate.isDaemonReady(moduleId)) {
+            progress?.('ready');
+            return true;
+        }
+        try {
+            progress?.('bootstrapping');
+            await gradleService.runDaemonBootstrap(moduleId);
+        } catch (err) {
+            this.logger.appendLine(
+                `[daemon] bootstrap task failed for ${moduleId}: ${(err as Error).message}`,
+            );
+            progress?.('fallback');
+            return false;
+        }
+        progress?.('spawning');
+        const ok = await this.ensureModule(moduleId);
+        progress?.(ok ? 'ready' : 'fallback');
+        return ok;
     }
 
     /**

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -16,7 +16,7 @@ import { packageQualifiedSourcePath } from './sourcePath';
 import { HEAVY_COST_THRESHOLD, PreviewInfo } from './types';
 import { captureLabel } from './captureLabels';
 import { DaemonGate } from './daemon/daemonGate';
-import { DaemonScheduler } from './daemon/daemonScheduler';
+import { DaemonScheduler, WarmState } from './daemon/daemonScheduler';
 
 const DEBOUNCE_MS = 1500;
 // Edits to the currently-scoped preview file (e.g. Claude Code's Edit tool
@@ -29,6 +29,8 @@ const INIT_DELAY_MS = 1000;
 let gradleService: GradleService | null = null;
 let daemonGate: DaemonGate | null = null;
 let daemonScheduler: DaemonScheduler | null = null;
+let daemonStatusItem: vscode.StatusBarItem | null = null;
+let daemonStatusClearTimer: NodeJS.Timeout | null = null;
 /** Tracks the most recent preview set per module for daemon focus computation.
  *  The daemon path doesn't re-issue `discoverPreviews` on every save — it
  *  pushes `discoveryUpdated`. We mirror the latest snapshot here so save-
@@ -219,6 +221,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         },
     }, outputChannel);
 
+    // Status-bar slot for daemon lifecycle. Hidden when the daemon flag is
+    // off or no module is currently warming. Surfacing the cold-bootstrap
+    // pause (typically 2-4 s on first scope-in) avoids the "panel is stuck"
+    // perception on the experimental flag's first-time UX.
+    daemonStatusItem = vscode.window.createStatusBarItem(
+        vscode.StatusBarAlignment.Left, 90,
+    );
+    daemonStatusItem.command = 'workbench.action.output.toggleOutput';
+    context.subscriptions.push(daemonStatusItem);
+
     panel = new PreviewPanel(context.extensionUri, handleWebviewMessage);
     if (isTestMode) {
         // Tap into every outgoing webview message so the test API can assert
@@ -372,6 +384,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
                 // burns a Gradle invocation — all for a no-op.
                 if (filePath === currentScopeFile) { return; }
                 refresh(false, filePath);
+                // Pre-warm the daemon for this file's module so the first
+                // save in the session collapses to "kotlinc + render"
+                // instead of "Gradle bootstrap + JVM spawn + sandbox init
+                // + render". No-op when the daemon flag is off.
+                void warmDaemonForFile(filePath);
                 return;
             }
             // New active isn't a Kotlin editor (webview focus, Agent plan,
@@ -450,6 +467,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
             const active = vscode.window.activeTextEditor;
             if (active?.document.languageId === 'kotlin') {
                 refresh(false, active.document.uri.fsPath);
+                void warmDaemonForFile(active.document.uri.fsPath);
             } else {
                 // No Kotlin file in focus — let refresh() emit the empty-state
                 // message without trying to load anything.
@@ -578,11 +596,16 @@ async function notifyDaemonOfSave(filePath: string): Promise<void> {
     const module = gradleService.resolveModule(filePath);
     if (!module) { return; }
 
-    // First time we hit a module with the daemon enabled: kick the bootstrap
-    // task so daemon-launch.json exists. Cheap on subsequent calls (cacheable).
+    // Bootstrap (Gradle task + JVM spawn) happens once per module per
+    // session. Normally it has already fired from the active-editor warm
+    // path; on the rare case where the user saves before scope-in (e.g.
+    // external file save, another editor split) we cover ourselves here.
     if (!daemonBootstrappedModules.has(module)) {
         daemonBootstrappedModules.add(module);
-        await daemonGate.bootstrap(gradleService, module);
+        await daemonScheduler.warmModule(
+            gradleService, module,
+            (state) => updateDaemonStatus(module, state),
+        );
     }
 
     const ok = await daemonScheduler.ensureModule(module);
@@ -600,6 +623,76 @@ async function notifyDaemonOfSave(filePath: string): Promise<void> {
     if (ids.length === 0) { return; }
     await daemonScheduler.setFocus(module, ids);
     await daemonScheduler.renderNow(module, ids, 'fast', 'save');
+}
+
+/**
+ * Eager pre-warm path: when the user navigates to a Kotlin file in a
+ * daemon-enabled module, kick off `composePreviewDaemonStart` + JVM spawn
+ * in the background so the first save in the session collapses to
+ * "kotlinc + render" instead of paying the cold-bootstrap latency on the
+ * user's interactive path. No-op when the daemon flag is off, when the
+ * file isn't in a preview module, or when the daemon is already up.
+ */
+async function warmDaemonForFile(filePath: string): Promise<void> {
+    if (!daemonGate?.isEnabled() || !daemonScheduler || !gradleService) { return; }
+    const module = gradleService.resolveModule(filePath);
+    if (!module) { return; }
+    if (daemonBootstrappedModules.has(module)) { return; }
+    daemonBootstrappedModules.add(module);
+    await daemonScheduler.warmModule(
+        gradleService, module,
+        (state) => updateDaemonStatus(module, state),
+    );
+}
+
+/**
+ * Drives the status-bar item through the warm-up state machine. The
+ * "ready" state holds for a few seconds so the user sees the transition
+ * from "warming" before the indicator fades; "fallback" holds longer so
+ * the user can see why their file was rendered via Gradle. Hidden any
+ * time no module is in flight.
+ */
+function updateDaemonStatus(module: string, state: WarmState): void {
+    if (!daemonStatusItem) { return; }
+    if (daemonStatusClearTimer) {
+        clearTimeout(daemonStatusClearTimer);
+        daemonStatusClearTimer = null;
+    }
+    switch (state) {
+        case 'bootstrapping':
+            daemonStatusItem.text = `$(loading~spin) Daemon: bootstrapping ${module}…`;
+            // Cold-build context: composePreviewDaemonStart itself is a
+            // small JSON-emit task, but it depends on the consumer's
+            // compileKotlin / variant resolution. On a fresh checkout
+            // (or after `gradlew clean`, or after a Compose version
+            // bump) this can take minutes while Gradle builds the
+            // renderer's classpath. Subsequent runs are cacheable and
+            // collapse to ~1 s on a warm Gradle daemon.
+            daemonStatusItem.tooltip = 'Running composePreviewDaemonStart. '
+                + 'On a cold build (fresh checkout, after clean, or after a '
+                + 'Compose version bump) this may take a few minutes while '
+                + 'Gradle compiles the renderer classpath. Cacheable on '
+                + 'subsequent runs.';
+            daemonStatusItem.show();
+            break;
+        case 'spawning':
+            daemonStatusItem.text = `$(loading~spin) Daemon: spawning ${module}…`;
+            daemonStatusItem.tooltip = 'Launching the preview daemon JVM and running initialize';
+            daemonStatusItem.show();
+            break;
+        case 'ready':
+            daemonStatusItem.text = `$(check) Daemon: ${module}`;
+            daemonStatusItem.tooltip = 'Preview daemon is up and serving renders';
+            daemonStatusItem.show();
+            daemonStatusClearTimer = setTimeout(() => daemonStatusItem?.hide(), 4000);
+            break;
+        case 'fallback':
+            daemonStatusItem.text = `$(warning) Daemon: ${module} (using Gradle)`;
+            daemonStatusItem.tooltip = 'Daemon spawn failed — using the Gradle render path. See Output → Compose Preview.';
+            daemonStatusItem.show();
+            daemonStatusClearTimer = setTimeout(() => daemonStatusItem?.hide(), 8000);
+            break;
+    }
 }
 
 /** Per-extension-session memo so bootstrap runs once per module. */

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -35,6 +35,7 @@ class FakeClient {
 class FakeGate {
     public enabled = true;
     public client: FakeClient | null = new FakeClient();
+    public ready = false;
     public capturedEvents = new Map<string, {
         onRenderFinished?: (p: { id: string; pngPath: string; tookMs: number }) => void;
         onRenderFailed?: (p: { id: string; error: { message: string } }) => void;
@@ -43,9 +44,19 @@ class FakeGate {
     }>();
 
     isEnabled(): boolean { return this.enabled; }
+    isDaemonReady(_moduleId: string): boolean { return this.ready; }
     getOrSpawn(moduleId: string, events: unknown): Promise<FakeClient | null> {
         this.capturedEvents.set(moduleId, events as never);
         return Promise.resolve(this.client);
+    }
+}
+
+class FakeGradleService {
+    public bootstrapCalls: string[] = [];
+    public bootstrapShouldThrow: Error | null = null;
+    async runDaemonBootstrap(moduleId: string): Promise<void> {
+        this.bootstrapCalls.push(moduleId);
+        if (this.bootstrapShouldThrow) { throw this.bootstrapShouldThrow; }
     }
 }
 
@@ -260,5 +271,84 @@ describe('DaemonScheduler', () => {
         const ok = await scheduler.renderNow('mod', ['p1', 'pBad'], 'fast');
         assert.strictEqual(ok, true);
         assert.ok(log.some(l => l.includes('rejected pBad')), `expected rejected log, got: ${log.join(' / ')}`);
+    });
+
+    describe('warmModule', () => {
+        it('drives progress through bootstrapping → spawning → ready on the cold path', async () => {
+            const { scheduler } = build();
+            const gradle = new FakeGradleService();
+            const states: string[] = [];
+            const ok = await scheduler.warmModule(
+                gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
+                'mod',
+                (s) => states.push(s),
+            );
+            assert.strictEqual(ok, true);
+            assert.deepStrictEqual(states, ['bootstrapping', 'spawning', 'ready']);
+            assert.deepStrictEqual(gradle.bootstrapCalls, ['mod']);
+        });
+
+        it('short-circuits to ready without re-bootstrapping when the daemon is already up', async () => {
+            const { gate, scheduler } = build();
+            gate.ready = true;
+            const gradle = new FakeGradleService();
+            const states: string[] = [];
+            const ok = await scheduler.warmModule(
+                gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
+                'mod',
+                (s) => states.push(s),
+            );
+            assert.strictEqual(ok, true);
+            assert.deepStrictEqual(states, ['ready']);
+            assert.deepStrictEqual(gradle.bootstrapCalls, [], 'bootstrap should not run when daemon is ready');
+        });
+
+        it('reports fallback when the bootstrap task throws', async () => {
+            const { scheduler } = build();
+            const gradle = new FakeGradleService();
+            gradle.bootstrapShouldThrow = new Error('Gradle config-cache rejected');
+            const states: string[] = [];
+            const ok = await scheduler.warmModule(
+                gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
+                'mod',
+                (s) => states.push(s),
+            );
+            assert.strictEqual(ok, false);
+            assert.deepStrictEqual(states, ['bootstrapping', 'fallback']);
+        });
+
+        it('reports fallback when the JVM spawn fails', async () => {
+            // Disabled gate makes ensureModule return false (caller falls
+            // back to Gradle); warmModule should mirror that as 'fallback'.
+            const { gate, scheduler } = build();
+            const gradle = new FakeGradleService();
+            const states: string[] = [];
+            // After bootstrap the scheduler tries to spawn — flip the gate
+            // so spawn returns null on the second call only by clearing
+            // the client.
+            gate.client = null;
+            const ok = await scheduler.warmModule(
+                gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
+                'mod',
+                (s) => states.push(s),
+            );
+            assert.strictEqual(ok, false);
+            assert.deepStrictEqual(states, ['bootstrapping', 'spawning', 'fallback']);
+        });
+
+        it('returns false without progress events when the gate is disabled', async () => {
+            const { gate, scheduler } = build();
+            gate.enabled = false;
+            const gradle = new FakeGradleService();
+            const states: string[] = [];
+            const ok = await scheduler.warmModule(
+                gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
+                'mod',
+                (s) => states.push(s),
+            );
+            assert.strictEqual(ok, false);
+            assert.deepStrictEqual(states, []);
+            assert.deepStrictEqual(gradle.bootstrapCalls, []);
+        });
     });
 });


### PR DESCRIPTION
Stacked on the long-lived `vscode-daemon` integration branch.

## Summary

- Pre-warm the daemon when the user navigates to a Kotlin file in a daemon-enabled module, not when they save. Same total cost on a cold build, just earlier in the user's flow — the first save then collapses to "kotlinc + render" because the daemon is already alive.
- Status-bar item surfaces the warm-up state machine — `bootstrapping` / `spawning` / `ready` / `fallback` — with a tooltip that names the cold-build expectation explicitly. Multi-minute first-time waits on a fresh checkout stop looking like a freeze.
- Layering: `scheduler.warmModule` joins `scheduler.ensureModule` (both own the daemon-events bag); gate exposes `isDaemonReady` as the warm-path short-circuit. Disabled-default behavior is unchanged — no daemon code is invoked when the flag is off.

## Why

The previous behaviour fired `composePreviewDaemonStart` on the first save in a module. On a fresh checkout (or after `gradlew clean` / a Compose version bump) that bootstrap sits on top of a cold Gradle compile of the renderer's classpath — easily 2-3+ minutes — so the user's first save felt frozen with no indication that anything was happening. Hooking warm-up to the active-editor change moves that wait out of the interactive save path.

## Test plan

- [x] 5 new tests on `warmModule`: cold path drives `bootstrapping → spawning → ready`, already-up short-circuits to `ready` only, bootstrap-throws → `fallback`, spawn-fails → `fallback`, disabled-gate is a no-op.
- [x] 139 passing total, 106-135 ms per run, stable across 3 sequential invocations.
- [ ] Manual smoke: enable both flags, navigate to a Kotlin file, watch the status bar walk through `bootstrapping → spawning → ready` while the daemon comes up; save once it's ready and confirm the next save lands on the warm sandbox.
- [ ] Manual smoke (cold-build path): on a fresh checkout, confirm the tooltip's "this may take a few minutes" wording reads correctly while Gradle is compiling the renderer.

## Notes

- The status-bar item's command is `workbench.action.output.toggleOutput` so a click takes the user to the Output panel where the daemon's logs live.
- "ready" state auto-clears after 4 s, "fallback" after 8 s. Bootstrap and spawn states stay until they transition.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9eazQp7vhSYqgwxjazGNf)_