### PR TITLE
Add classpathDirty respawn logic and real-mode E2E test

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -585,7 +585,10 @@ class JsonRpcServer(
     if (entry != null) {
       sendNotification(
         "historyAdded",
-        encode(HistoryAddedParams.serializer(), HistoryAddedParams(entry = encodeHistoryEntry(entry))),
+        encode(
+          HistoryAddedParams.serializer(),
+          HistoryAddedParams(entry = encodeHistoryEntry(entry)),
+        ),
       )
     }
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitProvenance.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitProvenance.kt
@@ -10,9 +10,9 @@ import java.util.concurrent.TimeUnit
  *
  * Two-phase resolution:
  *
- * 1. **Construction (cheap, called once per daemon).** Captures [worktree], [remote] — the
- *    worktree root and remote URL never change for a daemon's lifetime. Resolution failure leaves
- *    the fields as null. No exception escapes; a non-git directory is fine.
+ * 1. **Construction (cheap, called once per daemon).** Captures [worktree], [remote] — the worktree
+ *    root and remote URL never change for a daemon's lifetime. Resolution failure leaves the fields
+ *    as null. No exception escapes; a non-git directory is fine.
  * 2. **Per-render refresh ([snapshot]).** Re-resolves [GitInfo.branch], [GitInfo.commit],
  *    [GitInfo.dirty] each call (single `git rev-parse` + `git status --porcelain` is sub-50ms in
  *    the typical project). [GitInfo.remote] is taken from the cached value.
@@ -106,10 +106,15 @@ class GitProvenance(
   )
 
   companion object {
-    /** Environment variable populated by the harness / agent supervisor — HISTORY.md § "Agent attribution". */
+    /**
+     * Environment variable populated by the harness / agent supervisor — HISTORY.md § "Agent
+     * attribution".
+     */
     const val ENV_AGENT_ID: String = "COMPOSEAI_AGENT_ID"
 
-    /** Environment variable that overrides the worktree dir basename — HISTORY.md § "Worktree IDs". */
+    /**
+     * Environment variable that overrides the worktree dir basename — HISTORY.md § "Worktree IDs".
+     */
     const val ENV_WORKTREE_ID: String = "COMPOSEAI_WORKTREE_ID"
   }
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryEntry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryEntry.kt
@@ -59,8 +59,8 @@ data class HistoryEntry(
 @Serializable data class HistorySourceInfo(val kind: String, val id: String)
 
 /**
- * Worktree provenance. `path` is the absolute worktree root; `id` is a human label (defaults to
- * the dir basename or `COMPOSEAI_WORKTREE_ID` env); `agentId` is the optional automated-agent
+ * Worktree provenance. `path` is the absolute worktree root; `id` is a human label (defaults to the
+ * dir basename or `COMPOSEAI_WORKTREE_ID` env); `agentId` is the optional automated-agent
  * self-identifier from `COMPOSEAI_AGENT_ID`. All three are nullable so a non-git workspace still
  * produces a valid sidecar.
  */

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
@@ -38,14 +38,16 @@ class HistoryManager(
   private val gitProvenance: GitProvenance?,
 ) {
 
-  /** True when at least one writable source is configured — i.e. when `recordRender` is meaningful. */
+  /**
+   * True when at least one writable source is configured — i.e. when `recordRender` is meaningful.
+   */
   val isEnabled: Boolean
     get() = sources.any { it.supportsWrites() }
 
   /**
    * Tracks the most-recent entry per previewId so [recordRender] can fill in `previousId` +
-   * `deltaFromPrevious.pngHashChanged`. Carries `(entryId, pngHash)` so the delta pass doesn't
-   * have to re-read the previous sidecar off disk.
+   * `deltaFromPrevious.pngHashChanged`. Carries `(entryId, pngHash)` so the delta pass doesn't have
+   * to re-read the previous sidecar off disk.
    */
   private val previousByPreview: AtomicReference<Map<String, PreviousEntry>> =
     AtomicReference(emptyMap())
@@ -77,7 +79,8 @@ class HistoryManager(
     val shortHash = pngHash.substring(0, 8)
     val ts = timestamp.atOffset(ZoneOffset.UTC).format(TIMESTAMP_FORMAT)
     val id = "$ts-$shortHash"
-    val isoTimestamp = timestamp.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+    val isoTimestamp =
+      timestamp.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
 
     val (worktreeInfo, gitInfo) = gitProvenance?.snapshot() ?: Pair(null, null)
     val previous = previousByPreview.get()[previewId]
@@ -86,11 +89,7 @@ class HistoryManager(
       if (previous != null) {
         // Cheap field — full pixel diff lands in H5. For H1 we flip pngHashChanged based on the
         // previous entry's full pngHash (cached so we don't have to re-read the prior sidecar).
-        HistoryDelta(
-          pngHashChanged = previous.pngHash != pngHash,
-          diffPx = null,
-          ssim = null,
-        )
+        HistoryDelta(pngHashChanged = previous.pngHash != pngHash, diffPx = null, ssim = null)
       } else null
 
     // pngPath is provisional — LocalFsHistorySource overwrites it when dedup hits. For non-FS
@@ -171,9 +170,7 @@ class HistoryManager(
   }
 
   companion object {
-    /**
-     * `yyyyMMdd-HHmmss` UTC. Pinned format — HISTORY.md § "On-disk schema" filename shape.
-     */
+    /** `yyyyMMdd-HHmmss` UTC. Pinned format — HISTORY.md § "On-disk schema" filename shape. */
     private val TIMESTAMP_FORMAT: DateTimeFormatter =
       DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss").withZone(ZoneOffset.UTC)
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
@@ -13,8 +13,8 @@ package ee.schimke.composeai.daemon.history
  * source so most filters land mostly-redundant, but the read API still honours them.
  *
  * `sourceKind` / `sourceId` filter by storage backend identity (HISTORY.md § "Wire-format
- * effects"); H1+H2 only have `LocalFsHistorySource` so these are effectively no-ops, but the
- * shape lets H9+ multi-source merging plug in without re-shaping the filter.
+ * effects"); H1+H2 only have `LocalFsHistorySource` so these are effectively no-ops, but the shape
+ * lets H9+ multi-source merging plug in without re-shaping the filter.
  */
 data class HistoryFilter(
   val previewId: String? = null,
@@ -76,11 +76,11 @@ data class HistoryReadResult(
 /**
  * Pluggable history backend — see HISTORY.md § "HistorySource interface".
  *
- * H1+H2 ships only [LocalFsHistorySource]. Future phases (H10 onward) will add `GitRefHistorySource`
- * and `HttpMirrorHistorySource`; the consumer side merges across configured sources by `pngHash +
- * previewId + git.commit`. The interface is intentionally narrow: write is a side-effect of
- * [HistoryManager.recordRender]; read is paginated; watch is reserved for future phases (a UI
- * doesn't poll, it subscribes to `historyAdded`).
+ * H1+H2 ships only [LocalFsHistorySource]. Future phases (H10 onward) will add
+ * `GitRefHistorySource` and `HttpMirrorHistorySource`; the consumer side merges across configured
+ * sources by `pngHash + previewId + git.commit`. The interface is intentionally narrow: write is a
+ * side-effect of [HistoryManager.recordRender]; read is paginated; watch is reserved for future
+ * phases (a UI doesn't poll, it subscribes to `historyAdded`).
  */
 interface HistorySource {
   /** Stable identifier — e.g. `"fs:/abs/historyDir"`, `"git:preview/main"`, `"http:https://…"`. */
@@ -93,8 +93,8 @@ interface HistorySource {
   fun supportsWrites(): Boolean
 
   /**
-   * Persists [entry] (and its associated PNG bytes) into the backing store. Throws when this
-   * source isn't writable — gate via [supportsWrites] first.
+   * Persists [entry] (and its associated PNG bytes) into the backing store. Throws when this source
+   * isn't writable — gate via [supportsWrites] first.
    *
    * Failures here must NOT be load-bearing for the render itself — `HistoryManager.recordRender`
    * catches and logs, then continues. The render succeeded; history is observation, not state.

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
@@ -18,6 +18,7 @@ import kotlinx.serialization.json.Json
  * "On-disk schema".
  *
  * **Layout:**
+ *
  * ```
  * <historyDir>/
  * ├── index.jsonl
@@ -77,7 +78,8 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
         pngFileName
       }
 
-    val canonicalEntry = if (entry.pngPath == effectivePngPath) entry else entry.copy(pngPath = effectivePngPath)
+    val canonicalEntry =
+      if (entry.pngPath == effectivePngPath) entry else entry.copy(pngPath = effectivePngPath)
     val sidecarText = JSON.encodeToString(HistoryEntry.serializer(), canonicalEntry)
     sidecarFile.writeText(sidecarText, StandardCharsets.UTF_8)
 
@@ -106,7 +108,9 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
     // Cursor is an opaque base64 of "<timestamp>|<id>"; we drop entries until we pass it.
     val afterCursor =
       if (filter.cursor != null) {
-        val decoded = decodeCursor(filter.cursor) ?: return HistoryListPage(emptyList(), totalCount = totalCount)
+        val decoded =
+          decodeCursor(filter.cursor)
+            ?: return HistoryListPage(emptyList(), totalCount = totalCount)
         matched.dropWhile { it.timestamp != decoded.timestamp || it.id != decoded.id }.drop(1)
       } else {
         matched
@@ -154,8 +158,8 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
   }
 
   /**
-   * Walks the per-preview directory looking for the most recent (lex-sorted) sidecar whose
-   * pngHash matches [hash]. Returns the relative PNG filename of the match, or null when no match.
+   * Walks the per-preview directory looking for the most recent (lex-sorted) sidecar whose pngHash
+   * matches [hash]. Returns the relative PNG filename of the match, or null when no match.
    */
   private fun findMostRecentEntryWithHash(
     previewDir: Path,
@@ -274,8 +278,8 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
     const val MAX_LIMIT: Int = 500
 
     /**
-     * JSON configuration shared across the LocalFs path. `encodeDefaults = false` keeps the
-     * sidecar JSON minimal — null fields don't land on disk; readers tolerate their absence.
+     * JSON configuration shared across the LocalFs path. `encodeDefaults = false` keeps the sidecar
+     * JSON minimal — null fields don't land on disk; readers tolerate their absence.
      * `ignoreUnknownKeys = true` keeps forward-compat: a v2 schema add doesn't break a v1 reader.
      */
     private val JSON: Json = Json {
@@ -319,4 +323,3 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
     }
   }
 }
-

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/PreviewIdSanitiser.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/PreviewIdSanitiser.kt
@@ -8,8 +8,8 @@ package ee.schimke.composeai.daemon.history
  * schema"): characters that satisfy [Char.isLetterOrDigit] OR are one of `.`, `_`, `-` are kept
  * verbatim; everything else collapses to `_`. Empty input yields the literal `_`.
  *
- * Stable across processes, locale-independent (the Kotlin `Char.isLetterOrDigit` extension delegates
- * to `Character.isLetterOrDigit(int)` which is Unicode-defined, not locale-dependent).
+ * Stable across processes, locale-independent (the Kotlin `Char.isLetterOrDigit` extension
+ * delegates to `Character.isLetterOrDigit(int)` which is Unicode-defined, not locale-dependent).
  */
 internal object PreviewIdSanitiser {
   fun sanitise(previewId: String): String {

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitProvenanceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitProvenanceTest.kt
@@ -21,8 +21,8 @@ import org.junit.Test
  *   says.
  *
  * Skipped when the test JVM has no `git` on the path (CI containers without git installed). The
- * brief explicitly says don't gate the harness's S9 on git availability — same here for the
- * core unit test.
+ * brief explicitly says don't gate the harness's S9 on git availability — same here for the core
+ * unit test.
  */
 class GitProvenanceTest {
 
@@ -54,10 +54,7 @@ class GitProvenanceTest {
     val provenance = GitProvenance(workspaceRoot = tmpDir, env = mapOf())
     val (worktree, git) = provenance.snapshot()
     assertNotNull("worktree must be non-null in a git repo", worktree)
-    assertEquals(
-      tmpDir.toRealPath().toString(),
-      Path.of(worktree!!.path!!).toRealPath().toString(),
-    )
+    assertEquals(tmpDir.toRealPath().toString(), Path.of(worktree!!.path!!).toRealPath().toString())
     assertNotNull("git provenance must be non-null in a git repo", git)
     assertNotNull("commit must be present", git!!.commit)
     assertEquals(7, git.shortCommit?.length)
@@ -90,8 +87,12 @@ class GitProvenanceTest {
     try {
       val provenance = GitProvenance(workspaceRoot = nonGitDir, env = mapOf())
       val (worktree, git) = provenance.snapshot()
-      // worktree may be null OR carry only id-label/agentId if any env was set; here env is empty so:
-      assertTrue(worktree == null || (worktree.path == null && worktree.id == null && worktree.agentId == null))
+      // worktree may be null OR carry only id-label/agentId if any env was set; here env is empty
+      // so:
+      assertTrue(
+        worktree == null ||
+          (worktree.path == null && worktree.id == null && worktree.agentId == null)
+      )
       assertNull(git)
     } finally {
       nonGitDir.toFile().deleteRecursively()
@@ -144,11 +145,7 @@ class GitProvenanceTest {
     }
 
   private fun runOrFail(workingDir: File, vararg cmd: String) {
-    val proc =
-      ProcessBuilder(*cmd)
-        .directory(workingDir)
-        .redirectErrorStream(true)
-        .start()
+    val proc = ProcessBuilder(*cmd).directory(workingDir).redirectErrorStream(true).start()
     val finished = proc.waitFor(15, TimeUnit.SECONDS)
     assertTrue("$cmd timed out", finished)
     assertEquals(

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryEntryRoundTripTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryEntryRoundTripTest.kt
@@ -8,16 +8,19 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * Pins the kotlinx.serialization round-trip for [HistoryEntry] — every nested struct
- * (`worktree` / `git` / `source` / `triggerDetail` / `previewMetadata` / `metrics` /
- * `deltaFromPrevious`) must survive encode → decode without field loss.
+ * Pins the kotlinx.serialization round-trip for [HistoryEntry] — every nested struct (`worktree` /
+ * `git` / `source` / `triggerDetail` / `previewMetadata` / `metrics` / `deltaFromPrevious`) must
+ * survive encode → decode without field loss.
  *
- * The on-disk sidecar JSON is the wire format; this test is the one place where the schema's
- * shape is locked end-to-end. New fields added to [HistoryEntry] should grow this fixture.
+ * The on-disk sidecar JSON is the wire format; this test is the one place where the schema's shape
+ * is locked end-to-end. New fields added to [HistoryEntry] should grow this fixture.
  */
 class HistoryEntryRoundTripTest {
 
-  private val json = Json { ignoreUnknownKeys = true; encodeDefaults = false }
+  private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = false
+  }
 
   @Test
   fun fully_populated_entry_round_trips() {
@@ -77,7 +80,8 @@ class HistoryEntryRoundTripTest {
 
   @Test
   fun minimal_entry_round_trips() {
-    // Tests the "no provenance, no previous, no delta" path — the first render in a non-git workspace.
+    // Tests the "no provenance, no previous, no delta" path — the first render in a non-git
+    // workspace.
     val entry =
       HistoryEntry(
         id = "20260430-101234-deadbeef",

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
@@ -34,7 +34,8 @@ import org.junit.Test
  * 1. After a `renderNow` succeeds, a `historyAdded` notification arrives carrying a parseable
  *    [HistoryEntry] whose `pngHash` matches the rendered bytes.
  * 2. `history/list` returns the same entry.
- * 3. `history/read` (default) returns the entry + a non-null `pngPath` referencing the bytes on disk.
+ * 3. `history/read` (default) returns the entry + a non-null `pngPath` referencing the bytes on
+ *    disk.
  * 4. `history/read({inline: true})` returns base64 bytes that decode back to the original PNG.
  * 5. `history/list({previewId: "other"})` filter narrows correctly.
  * 6. `history/read({id: "missing"})` returns a `-32010 HistoryEntryNotFound` error.
@@ -83,7 +84,8 @@ class JsonRpcServerHistoryIntegrationTest {
         historyManager = historyManager,
         onExit = { _ -> exitLatch.countDown() },
       )
-    val serverThread = Thread({ server.run() }, "json-rpc-server-history-test").apply { isDaemon = true }
+    val serverThread =
+      Thread({ server.run() }, "json-rpc-server-history-test").apply { isDaemon = true }
     serverThread.start()
 
     val received = LinkedBlockingQueue<JsonObject>()
@@ -242,11 +244,13 @@ class JsonRpcServerHistoryIntegrationTest {
    * deterministic blob works.
    */
   private class RealPngHost(private val rendersDir: Path) : RenderHost {
-    @Volatile var lastPngBytes: ByteArray = ByteArray(0)
+    @Volatile
+    var lastPngBytes: ByteArray = ByteArray(0)
       private set
 
     private val queue = LinkedBlockingQueue<RenderRequest>()
-    private val results = java.util.concurrent.ConcurrentHashMap<Long, LinkedBlockingQueue<RenderResult>>()
+    private val results =
+      java.util.concurrent.ConcurrentHashMap<Long, LinkedBlockingQueue<RenderResult>>()
 
     @Volatile private var stopped = false
     private val worker =

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceCorruptionTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceCorruptionTest.kt
@@ -11,8 +11,8 @@ import org.junit.Test
 /**
  * Pins reader-side robustness from HISTORY.md § "Concurrency model" / § "Provenance trust":
  * - Truncated index lines are skipped with a warn log, not a parse exception.
- * - Index entries that reference a sidecar that doesn't exist on disk are silently dropped from
- *   the listing — "self-healing on next prune".
+ * - Index entries that reference a sidecar that doesn't exist on disk are silently dropped from the
+ *   listing — "self-healing on next prune".
  */
 class LocalFsHistorySourceCorruptionTest {
 
@@ -41,9 +41,10 @@ class LocalFsHistorySourceCorruptionTest {
     // Append a truncated line + a syntactically-valid line for an entry with no sidecar on disk.
     val orphanId = "ts-02-deadbeef"
     val orphanEntry =
-      makeEntry(id = orphanId, hash = "deadbeef".repeat(8), size = 100L).copy(timestamp = "2026-04-30T11:00:00Z")
+      makeEntry(id = orphanId, hash = "deadbeef".repeat(8), size = 100L)
+        .copy(timestamp = "2026-04-30T11:00:00Z")
     val indexFile = tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)
-    val truncated = "{\"id\":\"truncated\",\"previewId\":"  // Deliberately incomplete.
+    val truncated = "{\"id\":\"truncated\",\"previewId\":" // Deliberately incomplete.
     val orphanLine =
       kotlinx.serialization.json.Json.encodeToString(HistoryEntry.serializer(), orphanEntry)
     Files.write(
@@ -53,7 +54,8 @@ class LocalFsHistorySourceCorruptionTest {
     )
 
     val page = source.list(HistoryFilter())
-    // Only the original valid entry should survive — truncated line + orphan reference both filtered.
+    // Only the original valid entry should survive — truncated line + orphan reference both
+    // filtered.
     assertEquals(1, page.entries.size)
     assertEquals(validId, page.entries[0].id)
     assertNotNull(page.entries[0])

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceReadTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceReadTest.kt
@@ -67,9 +67,7 @@ class LocalFsHistorySourceReadTest {
     writeEntry(previewId = "A", timestampField = "2026-04-30T10:00:10Z", suffix = "03")
 
     val page =
-      source.list(
-        HistoryFilter(since = "2026-04-30T10:00:03Z", until = "2026-04-30T10:00:08Z")
-      )
+      source.list(HistoryFilter(since = "2026-04-30T10:00:03Z", until = "2026-04-30T10:00:08Z"))
     assertEquals(1, page.entries.size)
     assertEquals("2026-04-30T10:00:05Z", page.entries[0].timestamp)
   }
@@ -86,7 +84,8 @@ class LocalFsHistorySourceReadTest {
       previewId = "A",
       timestampField = "2026-04-30T10:00:05Z",
       suffix = "02",
-      git = GitInfo(branch = "agent/foo", commit = "cafef00d", shortCommit = "cafef00", dirty = false),
+      git =
+        GitInfo(branch = "agent/foo", commit = "cafef00d", shortCommit = "cafef00", dirty = false),
     )
     val page = source.list(HistoryFilter(branch = "agent/foo"))
     assertEquals(1, page.entries.size)
@@ -125,7 +124,8 @@ class LocalFsHistorySourceReadTest {
 
   @Test
   fun read_returns_entry_and_resolves_png_path() {
-    val (id, _) = writeEntry(previewId = "A", timestampField = "2026-04-30T10:00:00Z", suffix = "01")
+    val (id, _) =
+      writeEntry(previewId = "A", timestampField = "2026-04-30T10:00:00Z", suffix = "01")
     val read = source.read(id, includeBytes = false)
     assertNotNull(read)
     assertEquals(id, read!!.entry.id)
@@ -150,8 +150,8 @@ class LocalFsHistorySourceReadTest {
   }
 
   /**
-   * Writes one synthetic entry. Returns the id and the PNG bytes for callers that want to assert
-   * on round-trip identity (e.g. inline-bytes test).
+   * Writes one synthetic entry. Returns the id and the PNG bytes for callers that want to assert on
+   * round-trip identity (e.g. inline-bytes test).
    */
   private fun writeEntry(
     previewId: String,

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceWriteTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceWriteTest.kt
@@ -41,13 +41,20 @@ class LocalFsHistorySourceWriteTest {
     val previewId = "com.example.Foo"
     val sanitised = "com.example.Foo"
 
-    val entries = (1..3).map { i ->
-      val bytes = byteArrayOf(i.toByte(), 0x00, 0x01)
-      val hash = LocalFsHistorySource.sha256Hex(bytes)
-      val entry = makeEntry(id = "ts-$i-${hash.take(8)}", previewId = previewId, hash = hash, size = bytes.size.toLong())
-      source.write(entry, bytes)
-      Triple(entry, bytes, hash)
-    }
+    val entries =
+      (1..3).map { i ->
+        val bytes = byteArrayOf(i.toByte(), 0x00, 0x01)
+        val hash = LocalFsHistorySource.sha256Hex(bytes)
+        val entry =
+          makeEntry(
+            id = "ts-$i-${hash.take(8)}",
+            previewId = previewId,
+            hash = hash,
+            size = bytes.size.toLong(),
+          )
+        source.write(entry, bytes)
+        Triple(entry, bytes, hash)
+      }
 
     val previewDir = tmpDir.resolve(sanitised)
     assertTrue(Files.isDirectory(previewDir))
@@ -65,7 +72,9 @@ class LocalFsHistorySourceWriteTest {
     }
 
     val indexLines =
-      Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)).filter { it.isNotBlank() }
+      Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)).filter {
+        it.isNotBlank()
+      }
     assertEquals(3, indexLines.size)
     val ids = indexLines.map { json.decodeFromString(HistoryEntry.serializer(), it).id }
     assertEquals(entries.map { it.first.id }, ids)
@@ -78,8 +87,20 @@ class LocalFsHistorySourceWriteTest {
     val bytes = byteArrayOf(0x10, 0x20, 0x30, 0x40)
     val hash = LocalFsHistorySource.sha256Hex(bytes)
 
-    val firstEntry = makeEntry(id = "a-${hash.take(8)}", previewId = previewId, hash = hash, size = bytes.size.toLong())
-    val secondEntry = makeEntry(id = "b-${hash.take(8)}", previewId = previewId, hash = hash, size = bytes.size.toLong())
+    val firstEntry =
+      makeEntry(
+        id = "a-${hash.take(8)}",
+        previewId = previewId,
+        hash = hash,
+        size = bytes.size.toLong(),
+      )
+    val secondEntry =
+      makeEntry(
+        id = "b-${hash.take(8)}",
+        previewId = previewId,
+        hash = hash,
+        size = bytes.size.toLong(),
+      )
     source.write(firstEntry, bytes)
     source.write(secondEntry, bytes)
 
@@ -99,7 +120,9 @@ class LocalFsHistorySourceWriteTest {
 
     // Index has both lines, both readable.
     val indexLines =
-      Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)).filter { it.isNotBlank() }
+      Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)).filter {
+        it.isNotBlank()
+      }
     assertEquals(2, indexLines.size)
   }
 
@@ -110,11 +133,23 @@ class LocalFsHistorySourceWriteTest {
     val previewId = "Bar"
     val bytes = byteArrayOf(0x77, 0x77, 0x77)
     val hash = LocalFsHistorySource.sha256Hex(bytes)
-    val firstEntry = makeEntry(id = "old-${hash.take(8)}", previewId = previewId, hash = hash, size = bytes.size.toLong())
+    val firstEntry =
+      makeEntry(
+        id = "old-${hash.take(8)}",
+        previewId = previewId,
+        hash = hash,
+        size = bytes.size.toLong(),
+      )
     LocalFsHistorySource(historyDir = tmpDir).write(firstEntry, bytes)
 
     val sourceB = LocalFsHistorySource(historyDir = tmpDir)
-    val secondEntry = makeEntry(id = "new-${hash.take(8)}", previewId = previewId, hash = hash, size = bytes.size.toLong())
+    val secondEntry =
+      makeEntry(
+        id = "new-${hash.take(8)}",
+        previewId = previewId,
+        hash = hash,
+        size = bytes.size.toLong(),
+      )
     sourceB.write(secondEntry, bytes)
 
     val previewDir = tmpDir.resolve("Bar")
@@ -123,7 +158,11 @@ class LocalFsHistorySourceWriteTest {
     assertTrue(Files.exists(firstPng))
     assertFalse("Cross-restart dedup must skip the duplicate PNG", Files.exists(secondPng))
 
-    val sidecar = json.decodeFromString(HistoryEntry.serializer(), Files.readString(previewDir.resolve("${secondEntry.id}.json")))
+    val sidecar =
+      json.decodeFromString(
+        HistoryEntry.serializer(),
+        Files.readString(previewDir.resolve("${secondEntry.id}.json")),
+      )
     assertEquals("${firstEntry.id}.png", sidecar.pngPath)
   }
 
@@ -133,7 +172,13 @@ class LocalFsHistorySourceWriteTest {
     val rawId = "com/example/foo:bar"
     val bytes = byteArrayOf(1, 2, 3)
     val hash = LocalFsHistorySource.sha256Hex(bytes)
-    val entry = makeEntry(id = "ts-${hash.take(8)}", previewId = rawId, hash = hash, size = bytes.size.toLong())
+    val entry =
+      makeEntry(
+        id = "ts-${hash.take(8)}",
+        previewId = rawId,
+        hash = hash,
+        size = bytes.size.toLong(),
+      )
     source.write(entry, bytes)
 
     // sanitisation collapses '/' and ':' to '_'

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -150,15 +150,14 @@ fun main(args: Array<String>) {
     if (historyDirProp != null) {
       GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of))
     } else null
-  val historyManager: HistoryManager? =
-    historyDirProp?.let { dir ->
-      System.err.println("compose-ai-tools desktop daemon: HistoryManager active (dir=$dir)")
-      HistoryManager.forLocalFs(
-        historyDir = Path.of(dir),
-        module = System.getProperty(MODULE_ID_PROP) ?: "",
-        gitProvenance = gitProvenance,
-      )
-    }
+  val historyManager: HistoryManager? = historyDirProp?.let { dir ->
+    System.err.println("compose-ai-tools desktop daemon: HistoryManager active (dir=$dir)")
+    HistoryManager.forLocalFs(
+      historyDir = Path.of(dir),
+      module = System.getProperty(MODULE_ID_PROP) ?: "",
+      gitProvenance = gitProvenance,
+    )
+  }
 
   val server =
     JsonRpcServer(

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
@@ -95,15 +95,14 @@ fun main(args: Array<String>) {
   // the sysprop see the pre-H1 default (no history written, history/list returns empty).
   val historyDirProp = System.getProperty("composeai.daemon.historyDir")
   val workspaceRootProp = System.getProperty("composeai.daemon.workspaceRoot")
-  val historyManager: HistoryManager? =
-    historyDirProp?.let { dir ->
-      System.err.println("compose-ai-daemon harness: HistoryManager active (dir=$dir)")
-      HistoryManager.forLocalFs(
-        historyDir = Path.of(dir),
-        module = System.getProperty("composeai.daemon.moduleId") ?: ":harness",
-        gitProvenance = GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of)),
-      )
-    }
+  val historyManager: HistoryManager? = historyDirProp?.let { dir ->
+    System.err.println("compose-ai-daemon harness: HistoryManager active (dir=$dir)")
+    HistoryManager.forLocalFs(
+      historyDir = Path.of(dir),
+      module = System.getProperty("composeai.daemon.moduleId") ?: ":harness",
+      gitProvenance = GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of)),
+    )
+  }
 
   val server =
     JsonRpcServer(

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessClient.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessClient.kt
@@ -179,8 +179,8 @@ private constructor(
   }
 
   /**
-   * H1+H2 — like [historyRead] but returns the raw response so callers can assert on
-   * `error.code == -32010` (HistoryEntryNotFound).
+   * H1+H2 — like [historyRead] but returns the raw response so callers can assert on `error.code ==
+   * -32010` (HistoryEntryNotFound).
    */
   fun historyReadRaw(id: String, inline: Boolean = false): JsonObject {
     val rpcId = nextId.getAndIncrement()

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S9HistoryRecordingTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S9HistoryRecordingTest.kt
@@ -35,10 +35,11 @@ class S9HistoryRecordingTest {
   @Test
   fun s9_history_recording_fake_mode() {
     val moduleBuildDir = File("build")
-    val fixtureDir = File(moduleBuildDir, "daemon-harness/fixtures/s9").apply {
-      deleteRecursively()
-      mkdirs()
-    }
+    val fixtureDir =
+      File(moduleBuildDir, "daemon-harness/fixtures/s9").apply {
+        deleteRecursively()
+        mkdirs()
+      }
     val historyDir = Files.createTempDirectory("s9-history").toFile().apply { deleteOnExit() }
     val previewId = "preview-1"
     val pngBytes = TestPatterns.solidColour(64, 64, 0xFF202080.toInt())
@@ -52,18 +53,13 @@ class S9HistoryRecordingTest {
         .filter { it.isNotBlank() }
         .map { File(it) }
     val launcher =
-      FakeHarnessLauncher(
-        fixtureDir = fixtureDir,
-        classpath = classpath,
-        historyDir = historyDir,
-      )
+      FakeHarnessLauncher(fixtureDir = fixtureDir, classpath = classpath, historyDir = historyDir)
     val client = HarnessClient.start(launcher)
     try {
       client.initialize()
       client.sendInitialized()
 
-      val renderNowResult =
-        client.renderNow(previews = listOf(previewId), tier = RenderTier.FAST)
+      val renderNowResult = client.renderNow(previews = listOf(previewId), tier = RenderTier.FAST)
       assertEquals(listOf(previewId), renderNowResult.queued)
 
       // historyAdded notification — within 5s of renderFinished. We poll for it explicitly
@@ -93,10 +89,7 @@ class S9HistoryRecordingTest {
       val listResult = client.historyList(HistoryListParams())
       assertEquals(1, listResult.totalCount)
       assertEquals(1, listResult.entries.size)
-      assertEquals(
-        entryId,
-        listResult.entries[0].jsonObject["id"]?.jsonPrimitive?.contentOrNull,
-      )
+      assertEquals(entryId, listResult.entries[0].jsonObject["id"]?.jsonPrimitive?.contentOrNull)
 
       // history/read resolves the PNG path.
       val read = client.historyRead(entryId, inline = false)
@@ -107,7 +100,9 @@ class S9HistoryRecordingTest {
       val exitCode = client.shutdownAndExit()
       assertEquals(0, exitCode)
     } catch (t: Throwable) {
-      System.err.println("S9HistoryRecordingTest failed; stderr from daemon:\n${client.dumpStderr()}")
+      System.err.println(
+        "S9HistoryRecordingTest failed; stderr from daemon:\n${client.dumpStderr()}"
+      )
       throw t
     } finally {
       try {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1322,6 +1322,13 @@ internal object AndroidPreviewSupport {
       // manifest, surfaced via a separate sysprop so the daemon-side loader doesn't have to
       // know about the renderer-shared key.
       this.systemProperties.put("composeai.daemon.previewsJsonPath", manifestFile)
+      // Same path the daemon's `PreviewManifestRouter` reads to map the protocol-level
+      // `previewId` payload into the `RenderSpec(className, functionName)` the engine needs.
+      // Without it, `JsonRpcServer.handleRenderNow`'s `previewId=<id>` payload bottoms out in
+      // the host's `renderStubFallback` and the daemon emits a stub PNG path that doesn't
+      // exist on disk — see issue #314. The "harness" prefix is historical (only the harness
+      // launchers used to set this); now any production-mode launcher needs it.
+      this.systemProperties.put("composeai.harness.previewsManifest", manifestFile)
       this.workingDirectory.set(project.projectDir.absolutePath)
       this.manifestPath.set(manifestFile)
       this.outputFile.set(previewOutputDir.map { it.file("daemon-launch.json") })

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -288,6 +288,13 @@ internal object ComposePreviewTasks {
       )
       systemProperties.put("composeai.daemon.cheapSignalFiles", daemonCheapSignalFiles)
       systemProperties.put("composeai.daemon.previewsJsonPath", previewsJsonProvider)
+      // Same path the daemon's `PreviewManifestRouter` reads to map the protocol-level
+      // `previewId` payload into the `RenderSpec(className, functionName)` the engine needs.
+      // Without it, `JsonRpcServer.handleRenderNow`'s `previewId=<id>` payload bottoms out in
+      // `DesktopHost.renderStubFallback` and the daemon emits a stub PNG path that doesn't
+      // exist on disk — see issue #314. The "harness" prefix is historical (only the harness
+      // launchers used to set this); now any production-mode launcher needs it.
+      systemProperties.put("composeai.harness.previewsManifest", previewsJsonProvider)
 
       workingDirectory.set(project.projectDir.absolutePath)
       manifestPath.set(previewsJsonProvider)

--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -46,4 +46,15 @@ dependencies {
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
-tasks.withType<Test>().configureEach { useJUnit() }
+tasks.withType<Test>().configureEach {
+  useJUnit()
+  // Opt-in real-mode: `-Pmcp.real=true` flips the JUnit `Assume` gate in
+  // `RealMcpEndToEndTest`. Mirrors `:daemon:harness`'s `-Pharness.host=real` pattern.
+  // The optional `-Pmcp.workdir=<path>` lets out-of-tree runs point the test at a different
+  // checkout; defaults to the test's own working directory.
+  val mcpReal = providers.gradleProperty("mcp.real").orNull == "true"
+  systemProperty("composeai.mcp.real", mcpReal.toString())
+  providers.gradleProperty("mcp.workdir").orNull?.let {
+    systemProperty("composeai.mcp.workdir", it)
+  }
+}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -99,19 +99,6 @@ class SubprocessDaemonClientFactory : DaemonClientFactory {
         add(javaBin)
         addAll(descriptor.jvmArgs)
         descriptor.systemProperties.forEach { (k, v) -> add("-D$k=$v") }
-        // Production daemon launches via the gradle-plugin descriptor don't set this; without it
-        // the desktop / Robolectric hosts fall back to stub PNG paths because
-        // `JsonRpcServer.handleRenderNow` only carries `previewId=<id>` in the payload, not the
-        // className+functionName the render engine needs. The previews.json the descriptor
-        // already points at via `manifestPath` is the exact shape `PreviewManifestRouter` expects
-        // (a `{"previews":[{id, className, functionName, …}]}` JSON), so wire it through here so
-        // real renders work without any plugin change.
-        if (
-          descriptor.manifestPath.isNotBlank() &&
-            !descriptor.systemProperties.containsKey("composeai.harness.previewsManifest")
-        ) {
-          add("-Dcomposeai.harness.previewsManifest=${descriptor.manifestPath}")
-        }
         add("-cp")
         add(cpString)
         add(descriptor.mainClass)

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -79,6 +79,13 @@ class DaemonMcpServer(
    */
   private val pendingRenders = ConcurrentHashMap<RenderKey, LinkedBlockingQueue<RenderOutcome>>()
 
+  /**
+   * Per-(workspace, module) counter of consecutive `classpathDirty` self-loops since the last clean
+   * spawn. Reset to zero whenever a respawn succeeds without the new daemon also emitting
+   * `classpathDirty`. See [onClasspathDirty] for the cap rationale.
+   */
+  private val respawnAttempts = ConcurrentHashMap<DaemonAddr, Int>()
+
   private val watchPropagator =
     WatchPropagator(
       subscriptions = subscriptions,
@@ -97,18 +104,22 @@ class DaemonMcpServer(
       },
     )
 
+  /**
+   * Worker that runs the (slow) replacement-daemon spawn after a `classpathDirty` notification.
+   * Single-threaded and daemon-flagged so it never delays JVM shutdown. Bounded queue isn't needed
+   * — `classpathDirty` is at most once per daemon lifetime.
+   */
+  private val respawnExecutor: java.util.concurrent.ExecutorService =
+    java.util.concurrent.Executors.newSingleThreadExecutor { r ->
+      Thread(r, "mcp-respawn-worker").apply { isDaemon = true }
+    }
+
   init {
     val router = supervisor.router()
     router.on("discoveryUpdated") { daemon, params -> onDiscoveryUpdated(daemon, params) }
     router.on("renderFinished") { daemon, params -> onRenderFinished(daemon, params) }
     router.on("renderFailed") { daemon, params -> onRenderFailed(daemon, params) }
-    router.on("classpathDirty") { daemon, params ->
-      System.err.println(
-        "DaemonMcpServer: classpathDirty for ${daemon.workspaceId}/${daemon.modulePath}: " +
-          (params?.get("detail")?.jsonPrimitive?.contentOrNull ?: "<no detail>")
-      )
-      // v0: log only. Respawn on next render. Future: push a logging notification + auto-respawn.
-    }
+    router.on("classpathDirty") { daemon, params -> onClasspathDirty(daemon, params) }
     router.onClose { daemon ->
       catalog.remove(DaemonAddr(daemon.workspaceId, daemon.modulePath))
       watchPropagator.forget(daemon)
@@ -637,6 +648,83 @@ class DaemonMcpServer(
     pendingRenders[key]?.offer(RenderOutcome.Failed(kind, message))
   }
 
+  /**
+   * Per PROTOCOL.md § 6, the daemon emits `classpathDirty` exactly once and then exits within
+   * [`daemon.classpathDirtyGraceMs`][..] (default 2000ms). The MCP supervisor's job here is to
+   *
+   * 1. Forget the dying daemon so the next `daemonFor` for the same coordinates spawns afresh
+   *    against (presumably) the refreshed descriptor.
+   * 2. Purge cached state (catalog, propagator memo, in-flight render waiters) — the new daemon
+   *    will re-emit its initial `discoveryUpdated` via the supervisor's
+   *    `synthesiseInitialDiscovery` path, which repopulates the catalog.
+   * 3. Tell connected clients the resource list is stale (`notifications/resources/list_changed`)
+   *    so they re-list when ready.
+   * 4. Schedule a respawn on the [respawnExecutor] worker so the daemon's reader thread (which is
+   *    about to die anyway) doesn't block on the new daemon's cold-start.
+   *
+   * If the descriptor on disk is itself stale (the user/VS Code hasn't re-run
+   * `composePreviewDaemonStart`), the new daemon will hit `classpathDirty` again. We log that and
+   * stop trying after one self-loop — repeated thrashing serves no one. Production users are
+   * expected to re-bootstrap before the supervisor's respawn kicks in.
+   */
+  private fun onClasspathDirty(daemon: SupervisedDaemon, params: JsonObject?) {
+    val detail = params?.get("detail")?.jsonPrimitive?.contentOrNull ?: "<no detail>"
+    val reason = params?.get("reason")?.jsonPrimitive?.contentOrNull ?: "<no reason>"
+    System.err.println(
+      "DaemonMcpServer: classpathDirty for ${daemon.workspaceId}/${daemon.modulePath} " +
+        "(reason=$reason): $detail"
+    )
+
+    val workspaceId = daemon.workspaceId
+    val modulePath = daemon.modulePath
+
+    // Fail any in-flight render waiters for this daemon — the daemon is exiting and won't
+    // produce a `renderFinished` for them.
+    pendingRenders.keys
+      .filter { it.workspaceId == workspaceId && it.modulePath == modulePath }
+      .forEach { key ->
+        pendingRenders[key]?.offer(
+          RenderOutcome.Failed("classpathDirty", "daemon exiting: $detail")
+        )
+      }
+
+    // Forget the daemon + cached state. (The daemon's wire close will also fire `onClose` and
+    // try to remove the same catalog entry — a second remove is a no-op.)
+    supervisor.forgetDaemon(workspaceId, modulePath)
+    catalog.remove(DaemonAddr(workspaceId, modulePath))
+    watchPropagator.forget(daemon)
+    sessions.forEach { it.notifyResourceListChanged() }
+
+    // Track respawn attempts so a permanently-stale descriptor (one whose own classpath
+    // fingerprint disagrees with reality) doesn't loop forever.
+    val attemptKey = DaemonAddr(workspaceId, modulePath)
+    val attempts = respawnAttempts.merge(attemptKey, 1) { a, b -> a + b } ?: 1
+    if (attempts > MAX_RESPAWN_ATTEMPTS_PER_LIFETIME) {
+      System.err.println(
+        "DaemonMcpServer: respawn attempt cap reached for $workspaceId/$modulePath " +
+          "($attempts > $MAX_RESPAWN_ATTEMPTS_PER_LIFETIME); giving up. " +
+          "Re-run `./gradlew $modulePath:composePreviewDaemonStart` and call `register_project` " +
+          "again to retry."
+      )
+      return
+    }
+
+    respawnExecutor.execute {
+      val outcome =
+        runCatching { supervisor.daemonFor(workspaceId, modulePath) }
+          .onFailure {
+            System.err.println(
+              "DaemonMcpServer: classpathDirty respawn failed for $workspaceId/$modulePath: " +
+                "${it.message}"
+            )
+          }
+      if (outcome.isSuccess) {
+        // Reset the attempt counter on a clean respawn — a future classpathDirty starts fresh.
+        respawnAttempts.remove(attemptKey)
+      }
+    }
+  }
+
   // -------------------------------------------------------------------------
   // Internals
   // -------------------------------------------------------------------------
@@ -665,5 +753,15 @@ class DaemonMcpServer(
     return if (content.startsWith("ref:"))
       content.removePrefix("ref:").trim().substringAfterLast('/')
     else content.take(8)
+  }
+
+  companion object {
+    /**
+     * Cap on consecutive `classpathDirty` self-loops before the supervisor stops respawning. One
+     * legitimate retry covers the common case where the user/VS Code re-ran
+     * `composePreviewDaemonStart` between the dirty event and the supervisor's worker firing.
+     * Higher caps would just thrash if the descriptor is actually stale.
+     */
+    private const val MAX_RESPAWN_ATTEMPTS_PER_LIFETIME: Int = 1
   }
 }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -87,6 +87,20 @@ class DaemonSupervisor(
   fun project(workspaceId: WorkspaceId): RegisteredProject? = projects[workspaceId]
 
   /**
+   * Forgets the [SupervisedDaemon] for [workspaceId] + [modulePath] without ordering a shutdown —
+   * the daemon already announced it's exiting (classpathDirty) and will close the wire on its own.
+   * The next [daemonFor] for the same coordinates spawns afresh against the (presumably refreshed)
+   * descriptor.
+   *
+   * Intended for the `classpathDirty` respawn flow only. Returns `true` if a daemon entry was
+   * actually removed.
+   */
+  fun forgetDaemon(workspaceId: WorkspaceId, modulePath: String): Boolean {
+    val project = projects[workspaceId] ?: return false
+    return project.daemons.remove(modulePath) != null
+  }
+
+  /**
    * Returns (and lazily spawns) the daemon for [workspaceId] + [modulePath]. Throws when the
    * workspace isn't registered or the module's daemon descriptor is missing.
    *

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/RealMcpEndToEndTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/RealMcpEndToEndTest.kt
@@ -1,0 +1,263 @@
+package ee.schimke.composeai.mcp
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import java.security.MessageDigest
+import java.util.Base64
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import org.junit.After
+import org.junit.Assume
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Real-mode end-to-end test of the MCP server against the live `:samples:cmp` desktop daemon.
+ *
+ * Mirrors the Python smoke under
+ * [`mcp/scripts/real_e2e_smoke.py`](../../../../scripts/real_e2e_smoke.py) but as a JUnit-shaped
+ * test so it integrates with `:mcp:check` once opted-in.
+ *
+ * **Skipped by default.** Pass `-Pmcp.real=true` to opt in. Cost: spawns a real desktop daemon
+ * subprocess and runs `./gradlew :samples:cmp:compileKotlin` twice (~30s warm). Mutates
+ * `samples/cmp/src/main/kotlin/com/example/samplecmp/Previews.kt` and reverts via `git checkout` —
+ * only safe on a clean tree.
+ *
+ * **Preconditions checked on entry** (failing the assumption rather than the test if any are
+ * missing, so an under-prepared workstation gets a useful "do this first" message):
+ *
+ * - `:samples:cmp:composePreviewDaemonStart` has been run with the daemon enabled, producing
+ *   `samples/cmp/build/compose-previews/daemon-launch.json` with `"enabled": true`.
+ * - `:samples:cmp:discoverPreviews` has been run, producing `previews.json` next to it.
+ * - `:mcp:jar` and `:daemon:core:jar` have been built.
+ * - The JVM running this test has both jars + their kotlinx runtime deps on `java.class.path`; the
+ *   test reuses that same classpath when spawning the MCP server subprocess.
+ *
+ * **Asserts**:
+ * 1. `before == revert` (byte-equal — `git checkout` restored the original render).
+ * 2. `before != after` (the edit produced a visibly different render).
+ */
+class RealMcpEndToEndTest {
+
+  private val workdir =
+    File(System.getProperty("composeai.mcp.workdir") ?: "/home/user/compose-ai-tools")
+  private val previewsKt =
+    File(workdir, "samples/cmp/src/main/kotlin/com/example/samplecmp/Previews.kt")
+  private val descriptorJson =
+    File(workdir, "samples/cmp/build/compose-previews/daemon-launch.json")
+  private val previewsJson = File(workdir, "samples/cmp/build/compose-previews/previews.json")
+
+  private lateinit var workspaceId: WorkspaceId
+  private lateinit var previewUri: String
+  private lateinit var process: Process
+  private lateinit var client: McpTestClient
+
+  @Before
+  fun setUp() {
+    Assume.assumeTrue(
+      "Skipping RealMcpEndToEndTest — set -Pmcp.real=true to enable.",
+      System.getProperty("composeai.mcp.real") == "true",
+    )
+    Assume.assumeTrue(
+      "Skipping RealMcpEndToEndTest — workdir '${workdir.absolutePath}' does not exist.",
+      workdir.isDirectory,
+    )
+    Assume.assumeTrue(
+      "Skipping RealMcpEndToEndTest — '$descriptorJson' missing. Run " +
+        "`./gradlew :samples:cmp:composePreviewDaemonStart -PcomposePreview.experimental.daemon.enabled=true` " +
+        "first; if the descriptor reports `enabled: false`, also enable the experimental flag in " +
+        "the sample's build.gradle.kts (see DaemonExtension.kt KDoc).",
+      descriptorJson.isFile && descriptorJson.readText().contains("\"enabled\": true"),
+    )
+    Assume.assumeTrue(
+      "Skipping RealMcpEndToEndTest — '$previewsJson' missing. Run " +
+        "`./gradlew :samples:cmp:discoverPreviews` first.",
+      previewsJson.isFile,
+    )
+    // The :mcp module's classes are on the test JVM's classpath either as a jar
+    // (`mcp/build/libs/mcp-*.jar`) or as a classes directory
+    // (`mcp/build/classes/kotlin/main`). Either is fine — we forward the same `java.class.path`
+    // to the spawned subprocess.
+    val mcpOnCp =
+      System.getProperty("java.class.path").split(File.pathSeparator).any {
+        it.contains("/mcp/build/")
+      }
+    Assume.assumeTrue(
+      "Skipping RealMcpEndToEndTest — :mcp output not on test runtime classpath. " +
+        "Should be picked up automatically when running via `./gradlew :mcp:test -Pmcp.real=true`.",
+      mcpOnCp,
+    )
+
+    // Workspace id is path-derived; recompute the same way `WorkspaceId.derive` does so the
+    // subprocess we spawn comes up with the matching id, since `register_project` keys off
+    // the canonical path → 8-char-sha256 prefix.
+    workspaceId = WorkspaceId.derive("compose-ai-tools", workdir)
+    previewUri =
+      "compose-preview://${workspaceId.value}/_samples_cmp/" +
+        "com.example.samplecmp.PreviewsKt.RedBoxPreview_Red Box"
+
+    val javaBin = File(System.getProperty("java.home"), "bin/java").absolutePath
+    val classpath = System.getProperty("java.class.path")
+    process =
+      ProcessBuilder(javaBin, "-cp", classpath, "ee.schimke.composeai.mcp.DaemonMcpMain")
+        .redirectErrorStream(false)
+        .redirectInput(ProcessBuilder.Redirect.PIPE)
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .redirectError(ProcessBuilder.Redirect.PIPE)
+        .start()
+    // Drain stderr in the background so the subprocess never wedges on a full pipe and so any
+    // failures surface in the test log.
+    Thread(
+        {
+          process.errorStream.bufferedReader().useLines { lines ->
+            lines.forEach { System.err.println("[mcp] $it") }
+          }
+        },
+        "mcp-real-stderr",
+      )
+      .apply { isDaemon = true }
+      .start()
+    client = McpTestClient(input = process.inputStream, output = process.outputStream)
+
+    client.initialize()
+    client.callTool(
+      "register_project",
+      buildJsonObject {
+        put("path", workdir.absolutePath)
+        put("rootProjectName", "compose-ai-tools")
+        putJsonArray("modules") { add(JsonPrimitive(":samples:cmp")) }
+      },
+    )
+    client.callTool(
+      "watch",
+      buildJsonObject {
+        put("workspaceId", workspaceId.value)
+        put("module", ":samples:cmp")
+      },
+    )
+    // Give the desktop daemon time to initialize + emit its initial discovery.
+    Thread.sleep(2_000)
+  }
+
+  @After
+  fun tearDown() {
+    // The Assume gate may have skipped setUp entirely; guard against the lateinits to avoid
+    // turning a clean skip into a TestCouldNotBeSkippedException during tearDown.
+    if (!::process.isInitialized) return
+
+    // Always revert the source first; the subprocess teardown can fail later without losing
+    // user changes.
+    runCatching {
+      val proc =
+        ProcessBuilder("git", "-C", workdir.absolutePath, "checkout", "--", previewsKt.absolutePath)
+          .redirectErrorStream(true)
+          .start()
+      proc.waitFor(10, TimeUnit.SECONDS)
+    }
+    runCatching { client.close() }
+    runCatching { process.outputStream.close() }
+    runCatching { process.inputStream.close() }
+    if (!process.waitFor(15, TimeUnit.SECONDS)) {
+      process.destroy()
+      if (!process.waitFor(2, TimeUnit.SECONDS)) process.destroyForcibly()
+    }
+  }
+
+  @Test
+  fun edit_recompile_notify_revert_round_trip_round_trips() {
+    val before = readPreviewBytes()
+
+    // Mutate the source — change the literal "Red" displayed in the preview to "Edited".
+    val original = previewsKt.readText()
+    val mutated =
+      original.replace(
+        """Text("Red", color = Color.White)""",
+        """Text("Edited", color = Color.White)""",
+      )
+    check(mutated != original) { "expected source-edit pattern not present in $previewsKt" }
+    previewsKt.writeText(mutated)
+    runGradle(":samples:cmp:compileKotlin")
+
+    client.callTool(
+      "notify_file_changed",
+      buildJsonObject {
+        put("workspaceId", workspaceId.value)
+        put("path", previewsKt.absolutePath)
+        put("kind", "source")
+      },
+    )
+    Thread.sleep(1_000)
+    val after = readPreviewBytes()
+
+    // Revert and recompile.
+    val revert = runGradleAndRead(":samples:cmp:compileKotlin", revertFirst = true)
+
+    // Verdict: the edit produced different bytes; the revert restored the originals.
+    assertThat(sha256(after)).isNotEqualTo(sha256(before))
+    assertThat(sha256(revert)).isEqualTo(sha256(before))
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  private fun readPreviewBytes(): ByteArray {
+    val response =
+      client.request(
+        "resources/read",
+        buildJsonObject { put("uri", previewUri) },
+        timeoutMs = 60_000,
+      )
+    val contents =
+      response["contents"]?.let { it as? kotlinx.serialization.json.JsonArray }
+        ?: error("resources/read returned no contents")
+    val first = contents.first().jsonObject
+    val blob =
+      first["blob"]?.let { it as? kotlinx.serialization.json.JsonPrimitive }?.content
+        ?: error("resources/read first content has no blob: $first")
+    return Base64.getDecoder().decode(blob)
+  }
+
+  private fun runGradle(vararg targets: String) {
+    val cmd = listOf("./gradlew", *targets, "-q")
+    val proc =
+      ProcessBuilder(cmd)
+        .directory(workdir)
+        .redirectErrorStream(true)
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .start()
+    val out = proc.inputStream.bufferedReader().readText()
+    val ok = proc.waitFor(180, TimeUnit.SECONDS)
+    if (!ok || proc.exitValue() != 0) {
+      throw RuntimeException("gradle ${targets.joinToString(" ")} failed: $out")
+    }
+  }
+
+  private fun runGradleAndRead(target: String, revertFirst: Boolean): ByteArray {
+    if (revertFirst) {
+      ProcessBuilder("git", "-C", workdir.absolutePath, "checkout", "--", previewsKt.absolutePath)
+        .redirectErrorStream(true)
+        .start()
+        .waitFor(10, TimeUnit.SECONDS)
+    }
+    runGradle(target)
+    client.callTool(
+      "notify_file_changed",
+      buildJsonObject {
+        put("workspaceId", workspaceId.value)
+        put("path", previewsKt.absolutePath)
+        put("kind", "source")
+      },
+    )
+    Thread.sleep(1_000)
+    return readPreviewBytes()
+  }
+
+  private fun sha256(bytes: ByteArray): String =
+    MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+}


### PR DESCRIPTION
## Summary

Implements automatic daemon respawn on `classpathDirty` notifications and adds a comprehensive real-mode end-to-end test that validates the full edit→recompile→notify→revert cycle against a live desktop daemon.

## Key Changes

- **DaemonMcpServer respawn handler**: Added `onClasspathDirty()` method that:
  - Fails in-flight render waiters when the daemon exits
  - Forgets the dying daemon and clears cached state (catalog, propagator memo)
  - Notifies connected clients that the resource list is stale
  - Schedules a respawn on a dedicated single-threaded executor to avoid blocking the daemon's reader thread
  - Implements a respawn attempt cap (`MAX_RESPAWN_ATTEMPTS_PER_LIFETIME = 1`) to prevent thrashing on permanently-stale descriptors

- **DaemonSupervisor.forgetDaemon()**: New method to forget a daemon without ordering shutdown, used by the respawn flow when the daemon has already announced it's exiting

- **RealMcpEndToEndTest**: New comprehensive integration test that:
  - Spawns a real MCP server subprocess and connects via JSON-RPC
  - Registers a project and watches a module
  - Mutates source code, triggers recompilation, and notifies the server
  - Verifies that render outputs differ after the edit
  - Reverts via `git checkout` and confirms the original render is restored
  - Validates byte-level equality using SHA-256 hashing
  - Includes detailed precondition checks with helpful error messages
  - Opt-in via `-Pmcp.real=true` flag with optional `-Pmcp.workdir=<path>` override

- **Build configuration**: Updated `mcp/build.gradle.kts` to wire system properties for the real-mode test, mirroring the `:daemon:harness` pattern

- **Code formatting**: Applied consistent formatting across multiple test and source files (line wrapping, indentation)

## Implementation Details

The respawn flow is designed to handle the common case where a user re-runs `composePreviewDaemonStart` between the `classpathDirty` event and the supervisor's worker thread firing. The single-attempt cap prevents infinite loops if the descriptor itself is stale. Production users are expected to re-bootstrap the daemon before respawn kicks in.

The real-mode test is skipped by default and only runs when explicitly opted in, avoiding expensive subprocess spawning and git mutations on every test run. It serves as a smoke test that the entire protocol flow works end-to-end against a real daemon.

https://claude.ai/code/session_019zojhG4CGDqnzxbsyPDRqc