### PR TITLE
feat(daemon): history/diff (metadata) + GitRefHistorySource read (H3 + H10a)

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -4,6 +4,7 @@ package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.bridge.DaemonHostBridge
 import ee.schimke.composeai.daemon.history.GitProvenance
+import ee.schimke.composeai.daemon.history.GitRefHistorySource
 import ee.schimke.composeai.daemon.history.HistoryManager
 import java.io.File
 import java.nio.file.Path
@@ -159,13 +160,19 @@ fun main(args: Array<String>) {
     if (historyDirProp != null) {
       GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of))
     } else null
+  // H10-read — see desktop DaemonMain for the design rationale.
+  val gitRefHistoryRefs = GitRefHistorySource.parseRefsSysprop()
   val historyManager: HistoryManager? =
     historyDirProp?.let { dir ->
-      System.err.println("compose-ai-tools daemon: HistoryManager active (dir=$dir)")
-      HistoryManager.forLocalFs(
+      System.err.println(
+        "compose-ai-tools daemon: HistoryManager active (dir=$dir, gitRefs=${gitRefHistoryRefs})"
+      )
+      HistoryManager.forLocalFsAndGitRefs(
         historyDir = Path.of(dir),
         module = System.getProperty(MODULE_ID_PROP) ?: "",
         gitProvenance = gitProvenance,
+        gitRefs = gitRefHistoryRefs,
+        repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
       )
     }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -10,6 +10,9 @@ import ee.schimke.composeai.daemon.protocol.DiscoveryUpdatedParams
 import ee.schimke.composeai.daemon.protocol.FileChangedParams
 import ee.schimke.composeai.daemon.protocol.FileKind
 import ee.schimke.composeai.daemon.protocol.HistoryAddedParams
+import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
+import ee.schimke.composeai.daemon.protocol.HistoryDiffParams
+import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
 import ee.schimke.composeai.daemon.protocol.HistoryListParams
 import ee.schimke.composeai.daemon.protocol.HistoryListResult
 import ee.schimke.composeai.daemon.protocol.HistoryReadParams
@@ -305,6 +308,7 @@ class JsonRpcServer(
       "shutdown" -> handleShutdown(req)
       "history/list" -> handleHistoryList(req)
       "history/read" -> handleHistoryRead(req)
+      "history/diff" -> handleHistoryDiff(req)
       else ->
         sendErrorResponse(
           id = req.id,
@@ -707,6 +711,110 @@ class JsonRpcServer(
         pngBytes = pngBase64,
       )
     sendResponse(req.id, encode(HistoryReadResultDto.serializer(), dto))
+  }
+
+  /**
+   * H3 — `history/diff` metadata mode. Resolves [from] and [to] entry ids via the [historyManager]
+   * (which iterates configured sources in priority order, so a cross-source diff "LocalFs vs
+   * GitRef preview/main" works the same as an intra-source diff). Emits:
+   *
+   * - `HistoryEntryNotFound` (-32010) when either id is missing.
+   * - `HistoryDiffMismatch` (-32011) when the two entries belong to different previews.
+   * - `ERR_HISTORY_PIXEL_NOT_IMPLEMENTED` (-32012) when the caller asks for `mode = pixel` (H5).
+   *
+   * The metadata-mode response is `pngHashChanged + fromMetadata + toMetadata` (full sidecars).
+   * Pixel-mode fields (`diffPx`, `ssim`, `diffPngPath`) stay null in METADATA mode by design — H5
+   * lands the pixel pass.
+   */
+  private fun handleHistoryDiff(req: JsonRpcRequest) {
+    val params =
+      try {
+        decodeParams(req.params, HistoryDiffParams.serializer())
+      } catch (e: Throwable) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INVALID_PARAMS,
+          message = "invalid history/diff params: ${e.message}",
+        )
+        return
+      }
+    val mgr = historyManager
+    if (mgr == null || !mgr.isEnabled) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_HISTORY_ENTRY_NOT_FOUND,
+        message = "history not configured",
+      )
+      return
+    }
+    if (params.mode == HistoryDiffMode.PIXEL) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_HISTORY_PIXEL_NOT_IMPLEMENTED,
+        message =
+          "history/diff: pixel mode is reserved for phase H5 and not implemented; " +
+            "call with mode='metadata' (the default) for now",
+      )
+      return
+    }
+    val from =
+      try {
+        mgr.read(params.from, includeBytes = false)
+      } catch (t: Throwable) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INTERNAL,
+          message = "history/diff: read(${params.from}) failed: ${t.message}",
+        )
+        return
+      }
+    if (from == null) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_HISTORY_ENTRY_NOT_FOUND,
+        message = "history entry not found: ${params.from}",
+      )
+      return
+    }
+    val to =
+      try {
+        mgr.read(params.to, includeBytes = false)
+      } catch (t: Throwable) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INTERNAL,
+          message = "history/diff: read(${params.to}) failed: ${t.message}",
+        )
+        return
+      }
+    if (to == null) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_HISTORY_ENTRY_NOT_FOUND,
+        message = "history entry not found: ${params.to}",
+      )
+      return
+    }
+    if (from.entry.previewId != to.entry.previewId) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_HISTORY_DIFF_MISMATCH,
+        message =
+          "history/diff: from.previewId='${from.entry.previewId}' but " +
+            "to.previewId='${to.entry.previewId}'; pixel diff would be meaningless",
+      )
+      return
+    }
+    val result =
+      HistoryDiffResult(
+        pngHashChanged = from.entry.pngHash != to.entry.pngHash,
+        fromMetadata = encodeHistoryEntry(from.entry),
+        toMetadata = encodeHistoryEntry(to.entry),
+        diffPx = null,
+        ssim = null,
+        diffPngPath = null,
+      )
+    sendResponse(req.id, encode(HistoryDiffResult.serializer(), result))
   }
 
   private fun emitRenderFailed(failure: RenderResultOrFailure.Failure) {
@@ -1184,6 +1292,15 @@ class JsonRpcServer(
      * in H3+); pinned here so the code constant is part of the locked surface.
      */
     const val ERR_HISTORY_DIFF_MISMATCH: Int = -32011
+
+    /**
+     * HISTORY.md § "Error codes" — `history/diff` was called with `mode = pixel`, which is
+     * reserved for phase H5 and not implemented in H3. We deliberately return a clean error code
+     * (rather than silently leaving the pixel fields null in METADATA mode) so callers can tell
+     * "I asked for pixel and the daemon isn't ready" apart from "I asked for metadata and got null
+     * pixel fields by design."
+     */
+    const val ERR_HISTORY_PIXEL_NOT_IMPLEMENTED: Int = -32012
 
     private val SHUTDOWN_SENTINEL = ByteArray(0)
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
@@ -1,0 +1,349 @@
+package ee.schimke.composeai.daemon.history
+
+import java.io.File
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.serialization.json.Json
+
+/**
+ * Read-only [HistorySource] backed by a git ref (e.g. `refs/heads/preview/main`).
+ *
+ * **Storage convention** (HISTORY.md § "GitRefHistorySource"):
+ * ```
+ * <ref>'s tree
+ * ├── <sanitisedPreviewId>/
+ * │   ├── <entryId>.png
+ * │   └── <entryId>.json
+ * ├── ...
+ * └── _index.jsonl                ← aggregate of every entry on this ref's HEAD commit
+ * ```
+ *
+ * **Implementation strategy.** Shells out to `git` via [ProcessBuilder] (mirrors [GitProvenance]'s
+ * pattern). No JGit dependency. The shell-out cost is fine for read operations and we cache results
+ * keyed by the ref's HEAD commit-sha so repeated calls during a single session don't re-extract
+ * blobs.
+ *
+ * **Ref-missing behaviour.** When `git rev-parse --verify <ref>` fails, [list] / [read] return
+ * empty / null and emit a one-time warn-level notification via [warnEmitter] explaining how to
+ * populate the ref. The daemon doesn't fail; the consumer just sees "no main-history available."
+ *
+ * **Source rewriting.** The on-ref sidecars carry whatever `source` field they were written with —
+ * but we know the source is *us* now. Both [list] and [read] rewrite `entry.source` to a
+ * `kind: "git"` shape stamped with this source's id, the ref name, and the ref's HEAD commit sha.
+ *
+ * **PNG extraction.** [read] writes the PNG blob into a daemon-managed cache dir
+ * (`<historyDir>/.git-ref-cache/`) keyed by `(refCommit, entryId)`. Subsequent reads of the same
+ * blob hit the cache. Tempfiles are cleaned up on JVM shutdown via [Runtime.addShutdownHook].
+ *
+ * @param repoRoot the working tree (or bare repo) the ref lives in.
+ * @param ref the full ref name (e.g. `refs/heads/preview/main`); use full form to avoid
+ *   ambiguity between heads, remotes, and tags.
+ * @param displayId stable identifier for `entry.source.id` rewriting; defaults to `git:$ref`.
+ * @param cacheDir where extracted PNG blobs land; defaults to `<repoRoot>/.compose-preview-history/.git-ref-cache`.
+ * @param gitExecutable git binary; defaults to `git` on PATH.
+ * @param warnEmitter logger for the ref-missing case. The production daemon passes
+ *   [JsonRpcServer]'s log emitter; tests pass a buffer-capturing lambda.
+ */
+class GitRefHistorySource(
+  private val repoRoot: Path,
+  private val ref: String,
+  displayId: String = "git:$ref",
+  private val cacheDir: Path =
+    repoRoot.resolve(".compose-preview-history").resolve(".git-ref-cache"),
+  private val gitExecutable: String = "git",
+  private val warnEmitter: (String) -> Unit = { System.err.println(it) },
+) : HistorySource {
+
+  override val id: String = displayId
+  override val kind: String = "git"
+
+  override fun supportsWrites(): Boolean = false
+
+  override fun write(entry: HistoryEntry, png: ByteArray) {
+    error("GitRefHistorySource is read-only (ref=$ref); writes go to a writable source.")
+  }
+
+  /**
+   * Cache of `(refCommit, _index.jsonl-bytes)`. Invalidated when [refHeadCommit] returns a
+   * different sha. Populated lazily on first [list] / [read].
+   */
+  private val cachedIndex: AtomicReference<CachedIndex?> = AtomicReference(null)
+
+  /** One-shot guard so a recurring "ref missing" doesn't flood the log. */
+  private val refMissingWarned = AtomicBoolean(false)
+
+  private data class CachedIndex(val refCommit: String, val entries: List<HistoryEntry>)
+
+  init {
+    // Best-effort: ensure the cache dir exists if the parent already does. Failures here don't
+    // fail the source — read() recreates as needed.
+    try {
+      Files.createDirectories(cacheDir)
+    } catch (_: Throwable) {
+      // ignore — we'll retry in read()
+    }
+  }
+
+  override fun list(filter: HistoryFilter): HistoryListPage {
+    val refCommit = refHeadCommit() ?: return emptyPage()
+    val entries = loadIndex(refCommit) ?: return emptyPage()
+    val rewritten = entries.map { rewriteSource(it, refCommit) }
+    val matched = rewritten.filter { HistoryFilters.matches(it, filter) }
+    val totalCount = matched.size
+    val slice = HistoryFilters.paginate(matched, filter)
+    return HistoryListPage(
+      entries = slice.entries,
+      nextCursor = slice.nextCursor,
+      totalCount = totalCount,
+    )
+  }
+
+  override fun read(entryId: String, includeBytes: Boolean): HistoryReadResult? {
+    val refCommit = refHeadCommit() ?: return null
+    val entries = loadIndex(refCommit) ?: return null
+    val match = entries.firstOrNull { it.id == entryId } ?: return null
+    val rewritten = rewriteSource(match, refCommit)
+
+    // Resolve the sidecar path on the ref. The on-disk layout uses a sanitised previewId dir, and
+    // entry.pngPath is "<entryId>.png" (relative to that dir). We re-fetch the *full* sidecar so
+    // we get the previewMetadata snapshot back.
+    val sanitised = PreviewIdSanitiser.sanitise(match.previewId)
+    val sidecarPath = "$sanitised/$entryId.json"
+    val sidecarText = catFile(refCommit, sidecarPath) ?: return null
+    val fullEntry =
+      try {
+        JSON.decodeFromString(HistoryEntry.serializer(), sidecarText)
+      } catch (t: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: GitRefHistorySource.read($entryId): malformed sidecar at " +
+            "$ref:$sidecarPath (${t.javaClass.simpleName}: ${t.message})"
+        )
+        return null
+      }
+    val rewrittenFull = rewriteSource(fullEntry, refCommit)
+
+    // Extract PNG blob to the cache dir.
+    val pngRel = "$sanitised/$entryId.png"
+    val pngFile = extractBlobToCache(refCommit, pngRel) ?: return null
+    val bytes = if (includeBytes) Files.readAllBytes(pngFile) else null
+
+    return HistoryReadResult(
+      entry = rewrittenFull,
+      previewMetadata = rewrittenFull.previewMetadata,
+      pngPath = pngFile.toAbsolutePath().toString(),
+      pngBytes = bytes,
+    )
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private fun rewriteSource(entry: HistoryEntry, refCommit: String): HistoryEntry =
+    entry.copy(
+      source =
+        HistorySourceInfo(
+          kind = "git",
+          // We embed the commit + ref into the id so cross-source dedup ("same render visible in
+          // both LocalFs and GitRef") can compare ids cheaply.
+          id = "$id@${refCommit.take(7)}",
+        )
+    )
+
+  /** Returns the ref's HEAD commit sha or null if the ref is missing. Emits one warn on miss. */
+  private fun refHeadCommit(): String? {
+    val out = runGit("rev-parse", "--verify", ref)
+    if (out == null) {
+      if (refMissingWarned.compareAndSet(false, true)) {
+        val branch = ref.removePrefix("refs/heads/")
+        warnEmitter(
+          "GitRefHistorySource: ref '$ref' is not present locally.\n" +
+            "  Hint: populate it by fetching from a remote (e.g. `git fetch origin $ref:$ref`)\n" +
+            "  or set up CI to push render history on each merge to $branch.\n" +
+            "  Until then, main-history comparison will not be available."
+        )
+      }
+      return null
+    }
+    return out.takeIf { it.isNotEmpty() }
+  }
+
+  /**
+   * Loads the `_index.jsonl` from the ref's tree, parsing line-by-line and tolerating truncated
+   * lines (skip + warn). Cached by ref-commit-sha; invalidated when the sha shifts.
+   */
+  private fun loadIndex(refCommit: String): List<HistoryEntry>? {
+    val cached = cachedIndex.get()
+    if (cached != null && cached.refCommit == refCommit) return cached.entries
+
+    val text = catFile(refCommit, INDEX_FILENAME)
+    if (text == null) {
+      // No index — empty ref. Cache the empty result so we don't re-shell for nothing.
+      cachedIndex.set(CachedIndex(refCommit, emptyList()))
+      return emptyList()
+    }
+    val parsed = ArrayList<HistoryEntry>()
+    for (line in text.split('\n')) {
+      val trimmed = line.trim()
+      if (trimmed.isEmpty()) continue
+      val entry =
+        try {
+          JSON.decodeFromString(HistoryEntry.serializer(), trimmed)
+        } catch (t: Throwable) {
+          System.err.println(
+            "compose-ai-daemon: GitRefHistorySource.list($ref): skipping malformed index line " +
+              "(${t.javaClass.simpleName}: ${t.message})"
+          )
+          continue
+        }
+      parsed.add(entry)
+    }
+    // _index.jsonl is append-order (oldest first); reverse for newest-first listing.
+    parsed.reverse()
+    val toCache = CachedIndex(refCommit, parsed)
+    cachedIndex.set(toCache)
+    return parsed
+  }
+
+  /**
+   * Returns the contents of `<refCommit>:<path>` as text, or null if the path isn't present in
+   * the tree. Uses `git show` with `--`. Trailing newline is preserved verbatim — the index
+   * parser handles blank lines.
+   */
+  private fun catFile(refCommit: String, path: String): String? =
+    runGit("show", "$refCommit:$path")
+
+  /**
+   * Extracts a binary blob from `<refCommit>:<path>` into [cacheDir]. Returns the cached file
+   * path or null on failure. Idempotent: subsequent reads with the same key see the existing file.
+   */
+  private fun extractBlobToCache(refCommit: String, path: String): Path? {
+    val safeName = "${refCommit.take(7)}-${path.replace('/', '_')}"
+    val target = cacheDir.resolve(safeName)
+    if (Files.exists(target)) return target
+
+    try {
+      Files.createDirectories(cacheDir)
+    } catch (t: Throwable) {
+      System.err.println(
+        "compose-ai-daemon: GitRefHistorySource.extractBlobToCache: failed to create cache dir " +
+          "$cacheDir (${t.javaClass.simpleName}: ${t.message})"
+      )
+      return null
+    }
+
+    // Use `git -C <repoRoot> show <refCommit>:<path>` and write stdout to the target tempfile via
+    // ProcessBuilder.redirectOutput. Avoids holding the full PNG in JVM memory.
+    val tmp =
+      try {
+        Files.createTempFile(cacheDir, "extract-", ".tmp")
+      } catch (t: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: GitRefHistorySource.extractBlobToCache: tempfile create failed " +
+            "(${t.javaClass.simpleName}: ${t.message})"
+        )
+        return null
+      }
+    try {
+      val process =
+        ProcessBuilder(listOf(gitExecutable, "show", "$refCommit:$path"))
+          .directory(repoRoot.toFile())
+          .redirectErrorStream(false)
+          .redirectOutput(tmp.toFile())
+          .start()
+      val finished = process.waitFor(30, TimeUnit.SECONDS)
+      if (!finished) {
+        process.destroyForcibly()
+        Files.deleteIfExists(tmp)
+        return null
+      }
+      if (process.exitValue() != 0) {
+        Files.deleteIfExists(tmp)
+        return null
+      }
+      // Atomic rename so concurrent reads don't see a half-written cache file. ATOMIC_MOVE may not
+      // be supported on all FSes — fall back to REPLACE_EXISTING when not.
+      try {
+        Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+      } catch (_: Throwable) {
+        Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING)
+      }
+      return target
+    } catch (t: IOException) {
+      System.err.println(
+        "compose-ai-daemon: GitRefHistorySource.extractBlobToCache: IO failure " +
+          "(${t.javaClass.simpleName}: ${t.message})"
+      )
+      Files.deleteIfExists(tmp)
+      return null
+    } catch (t: Throwable) {
+      Files.deleteIfExists(tmp)
+      throw t
+    }
+  }
+
+  private fun runGit(vararg args: String): String? {
+    return try {
+      val process =
+        ProcessBuilder(listOf(gitExecutable) + args.toList())
+          .directory(repoRoot.toFile())
+          .redirectErrorStream(false)
+          .start()
+      val finished = process.waitFor(10, TimeUnit.SECONDS)
+      if (!finished) {
+        process.destroyForcibly()
+        return null
+      }
+      if (process.exitValue() != 0) return null
+      process.inputStream.bufferedReader(StandardCharsets.UTF_8).use { it.readText() }.trimEnd('\n')
+    } catch (_: Throwable) {
+      null
+    }
+  }
+
+  private fun emptyPage(): HistoryListPage =
+    HistoryListPage(entries = emptyList(), nextCursor = null, totalCount = 0)
+
+  companion object {
+    /** Aggregate index filename on the ref's tree. HISTORY.md § "GitRefHistorySource". */
+    const val INDEX_FILENAME: String = "_index.jsonl"
+
+    /**
+     * Sysprop name — comma-separated list of refs (e.g.
+     * `refs/heads/preview/main,refs/heads/preview/agent/foo`). Wired by each per-target
+     * [DaemonMain] alongside [LocalFsHistorySource].
+     */
+    const val GIT_REF_HISTORY_PROP: String = "composeai.daemon.gitRefHistory"
+
+    private val JSON: Json = Json {
+      ignoreUnknownKeys = true
+      encodeDefaults = false
+    }
+
+    /**
+     * Parses the [GIT_REF_HISTORY_PROP] sysprop (or [propValue] when explicit) into a list of
+     * non-blank ref strings. Returns an empty list when the property is unset.
+     */
+    fun parseRefsSysprop(
+      propValue: String? = System.getProperty(GIT_REF_HISTORY_PROP)
+    ): List<String> =
+      propValue
+        ?.split(',', ';')
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        ?: emptyList()
+
+    /**
+     * Default cache dir for a given history dir. Mirrors the in-source default but exposed so
+     * [DaemonMain] callers can pin the cache adjacent to the local-fs history dir for symmetric
+     * lifecycle management.
+     */
+    fun defaultCacheDir(historyDir: Path): Path = historyDir.resolve(".git-ref-cache")
+  }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryFilters.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryFilters.kt
@@ -1,0 +1,87 @@
+package ee.schimke.composeai.daemon.history
+
+import java.util.Base64
+
+/**
+ * Shared `HistoryFilter` matchers and pagination cursor helpers.
+ *
+ * Extracted from [LocalFsHistorySource] (H1+H2) so [GitRefHistorySource] (H10-read) and any future
+ * read-only source ([HttpMirrorHistorySource], H13) apply identical filter / pagination logic
+ * without duplicating it across implementations. See HISTORY.md § "HistorySource interface" — every
+ * source returns the same shape; only the storage backend differs.
+ */
+internal object HistoryFilters {
+
+  const val DEFAULT_LIMIT: Int = 50
+  const val MAX_LIMIT: Int = 500
+
+  /**
+   * Returns true when [entry] satisfies every non-null clause of [filter]. Clauses match the
+   * `HistoryFilter` documentation in HISTORY.md § "Worktree-aware listing" + § "Wire-format
+   * effects".
+   */
+  fun matches(entry: HistoryEntry, filter: HistoryFilter): Boolean {
+    if (filter.previewId != null && entry.previewId != filter.previewId) return false
+    if (filter.since != null && entry.timestamp < filter.since) return false
+    if (filter.until != null && entry.timestamp > filter.until) return false
+    if (filter.branch != null && entry.git?.branch != filter.branch) return false
+    if (filter.branchPattern != null) {
+      val branch = entry.git?.branch ?: return false
+      if (!Regex(filter.branchPattern).matches(branch)) return false
+    }
+    if (filter.commit != null) {
+      val git = entry.git ?: return false
+      if (git.commit != filter.commit && git.shortCommit != filter.commit) return false
+    }
+    if (filter.worktreePath != null && entry.worktree?.path != filter.worktreePath) return false
+    if (filter.agentId != null && entry.worktree?.agentId != filter.agentId) return false
+    if (filter.sourceKind != null && entry.source.kind != filter.sourceKind) return false
+    if (filter.sourceId != null && entry.source.id != filter.sourceId) return false
+    return true
+  }
+
+  /**
+   * Applies pagination to a newest-first [matched] list using [filter]'s `cursor` and `limit`.
+   * Returns the page slice plus the next-cursor (or null when the page is the tail).
+   *
+   * Cursor is an opaque base64 of `<timestamp>|<id>`; we drop entries until we pass it.
+   */
+  fun paginate(matched: List<HistoryEntry>, filter: HistoryFilter): PaginatedSlice {
+    val afterCursor =
+      if (filter.cursor != null) {
+        val decoded = decodeCursor(filter.cursor) ?: return PaginatedSlice(emptyList(), null)
+        matched.dropWhile { it.timestamp != decoded.timestamp || it.id != decoded.id }.drop(1)
+      } else {
+        matched
+      }
+    val limit = (filter.limit ?: DEFAULT_LIMIT).coerceIn(1, MAX_LIMIT)
+    val page = afterCursor.take(limit)
+    val nextCursor =
+      if (afterCursor.size > limit) {
+        val last = page.last()
+        encodeCursor(last.timestamp, last.id)
+      } else null
+    return PaginatedSlice(entries = page, nextCursor = nextCursor)
+  }
+
+  data class PaginatedSlice(val entries: List<HistoryEntry>, val nextCursor: String?)
+
+  fun encodeCursor(timestamp: String, id: String): String {
+    val raw = "$timestamp|$id".toByteArray(Charsets.UTF_8)
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(raw)
+  }
+
+  data class CursorPosition(val timestamp: String, val id: String)
+
+  fun decodeCursor(cursor: String): CursorPosition? {
+    return try {
+      val raw = Base64.getUrlDecoder().decode(cursor)
+      val text = String(raw, Charsets.UTF_8)
+      val sep = text.indexOf('|')
+      if (sep < 0) return null
+      CursorPosition(timestamp = text.substring(0, sep), id = text.substring(sep + 1))
+    } catch (_: Throwable) {
+      null
+    }
+  }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
@@ -150,14 +150,59 @@ class HistoryManager(
     return entry
   }
 
-  /** Lists across all configured sources. H1+H2 has one source so this delegates trivially. */
+  /**
+   * Lists across all configured sources. With one source this delegates trivially; with multiple
+   * (H10-read onward — LocalFs + one or more `GitRefHistorySource`s) it merges per-source pages,
+   * dedups entries that surface in multiple sources by `(previewId, pngHash)` keeping the
+   * highest-priority source's copy, applies the filter, sorts newest-first, and re-paginates the
+   * combined result.
+   *
+   * Per-source filtering is intentionally NOT trusted to compose with cross-source pagination —
+   * we always re-filter the merged set so a `sourceKind` filter applied across sources behaves
+   * the same way it does inside one source.
+   *
+   * Source priority for dedup: the order in [sources]. LocalFs first means the writable source's
+   * canonical entry (with `source.kind = "fs"`) is what surfaces; a GitRef-only render still
+   * surfaces its `source.kind = "git"` entry.
+   */
   fun list(filter: HistoryFilter): HistoryListPage {
     if (sources.isEmpty()) return HistoryListPage(entries = emptyList(), totalCount = 0)
     if (sources.size == 1) return sources.single().list(filter)
-    // Multi-source merging is reserved for H9+. For H1+H2 we still take the first source's page
-    // verbatim, but the entry shape carries `source` so a future merge can dedup on
-    // `(pngHash, previewId, git.commit)`.
-    return sources.first().list(filter)
+
+    // Pull a generous page from each source (no pagination at the per-source layer; we apply
+    // pagination after merging). We pass the full filter so per-source `sourceKind` / `sourceId`
+    // narrows can short-circuit non-matching sources cheaply at the source layer.
+    val perSourceFilter = filter.copy(limit = HistoryFilters.MAX_LIMIT, cursor = null)
+    val merged = LinkedHashMap<Pair<String, String>, HistoryEntry>() // (previewId, pngHash) → entry
+    for (source in sources) {
+      val page =
+        try {
+          source.list(perSourceFilter)
+        } catch (t: Throwable) {
+          System.err.println(
+            "compose-ai-daemon: HistoryManager.list: source ${source.id} list() threw " +
+              "(${t.javaClass.simpleName}: ${t.message}); skipping"
+          )
+          continue
+        }
+      for (entry in page.entries) {
+        val key = entry.previewId to entry.pngHash
+        // Preserve first writer wins — earlier sources have priority.
+        merged.putIfAbsent(key, entry)
+      }
+    }
+    // Apply the user filter against the merged set; sort newest-first by timestamp; paginate.
+    val matched =
+      merged.values
+        .filter { HistoryFilters.matches(it, filter) }
+        .sortedWith(compareByDescending<HistoryEntry> { it.timestamp }.thenByDescending { it.id })
+    val totalCount = matched.size
+    val slice = HistoryFilters.paginate(matched, filter)
+    return HistoryListPage(
+      entries = slice.entries,
+      nextCursor = slice.nextCursor,
+      totalCount = totalCount,
+    )
   }
 
   /** Reads one entry. Falls through sources in order until a hit. */
@@ -186,6 +231,44 @@ class HistoryManager(
       val sources =
         if (historyDir == null) emptyList()
         else listOf(LocalFsHistorySource(historyDir = historyDir))
+      return HistoryManager(sources = sources, module = module, gitProvenance = gitProvenance)
+    }
+
+    /**
+     * H10-read — builds a manager with a writable [LocalFsHistorySource] plus zero or more
+     * read-only [GitRefHistorySource]s. The local source is always priority-0 (writes go there);
+     * git refs follow in declared order. See HISTORY.md § "Ordering semantics".
+     *
+     * @param gitRefs full ref names (`refs/heads/preview/main`); empty when no refs are configured.
+     * @param warnEmitter passed to each [GitRefHistorySource] for the ref-missing case. The
+     *   production daemon main passes a lambda that posts a warn-level `log` notification; tests
+     *   pass a buffer-capturing lambda.
+     */
+    fun forLocalFsAndGitRefs(
+      historyDir: java.nio.file.Path?,
+      module: String,
+      gitProvenance: GitProvenance?,
+      gitRefs: List<String> = emptyList(),
+      repoRoot: java.nio.file.Path? = historyDir?.parent,
+      warnEmitter: (String) -> Unit = { System.err.println(it) },
+    ): HistoryManager {
+      val sources = buildList {
+        if (historyDir != null) add(LocalFsHistorySource(historyDir = historyDir))
+        if (repoRoot != null) {
+          for (ref in gitRefs) {
+            add(
+              GitRefHistorySource(
+                repoRoot = repoRoot,
+                ref = ref,
+                cacheDir =
+                  historyDir?.let(GitRefHistorySource::defaultCacheDir)
+                    ?: repoRoot.resolve(".compose-preview-history").resolve(".git-ref-cache"),
+                warnEmitter = warnEmitter,
+              )
+            )
+          }
+        }
+      }
       return HistoryManager(sources = sources, module = module, gitProvenance = gitProvenance)
     }
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
@@ -102,30 +102,14 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
     val indexFile = historyDir.resolve(INDEX_FILENAME)
     if (!indexFile.exists()) return HistoryListPage(entries = emptyList(), totalCount = 0)
     val allEntries = readIndexNewestFirst(indexFile)
-    val matched = allEntries.filter { matchesFilter(it, filter) }
+    val matched = allEntries.filter { HistoryFilters.matches(it, filter) }
     val totalCount = matched.size
-
-    // Cursor is an opaque base64 of "<timestamp>|<id>"; we drop entries until we pass it.
-    val afterCursor =
-      if (filter.cursor != null) {
-        val decoded =
-          decodeCursor(filter.cursor)
-            ?: return HistoryListPage(emptyList(), totalCount = totalCount)
-        matched.dropWhile { it.timestamp != decoded.timestamp || it.id != decoded.id }.drop(1)
-      } else {
-        matched
-      }
-
-    val limit = (filter.limit ?: DEFAULT_LIMIT).coerceIn(1, MAX_LIMIT)
-    val page = afterCursor.take(limit)
-    val nextCursor =
-      if (afterCursor.size > limit) {
-        val last = page.last()
-        encodeCursor(last.timestamp, last.id)
-      } else {
-        null
-      }
-    return HistoryListPage(entries = page, nextCursor = nextCursor, totalCount = totalCount)
+    val slice = HistoryFilters.paginate(matched, filter)
+    return HistoryListPage(
+      entries = slice.entries,
+      nextCursor = slice.nextCursor,
+      totalCount = totalCount,
+    )
   }
 
   override fun read(entryId: String, includeBytes: Boolean): HistoryReadResult? {
@@ -252,30 +236,12 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
     return parsed
   }
 
-  private fun matchesFilter(entry: HistoryEntry, f: HistoryFilter): Boolean {
-    if (f.previewId != null && entry.previewId != f.previewId) return false
-    if (f.since != null && entry.timestamp < f.since) return false
-    if (f.until != null && entry.timestamp > f.until) return false
-    if (f.branch != null && entry.git?.branch != f.branch) return false
-    if (f.branchPattern != null) {
-      val branch = entry.git?.branch ?: return false
-      if (!Regex(f.branchPattern).matches(branch)) return false
-    }
-    if (f.commit != null) {
-      val git = entry.git ?: return false
-      if (git.commit != f.commit && git.shortCommit != f.commit) return false
-    }
-    if (f.worktreePath != null && entry.worktree?.path != f.worktreePath) return false
-    if (f.agentId != null && entry.worktree?.agentId != f.agentId) return false
-    if (f.sourceKind != null && entry.source.kind != f.sourceKind) return false
-    if (f.sourceId != null && entry.source.id != f.sourceId) return false
-    return true
-  }
-
   companion object {
     const val INDEX_FILENAME: String = "index.jsonl"
-    const val DEFAULT_LIMIT: Int = 50
-    const val MAX_LIMIT: Int = 500
+    /** Default limit for [HistoryFilter.limit]. Pinned in [HistoryFilters] for shared use. */
+    const val DEFAULT_LIMIT: Int = HistoryFilters.DEFAULT_LIMIT
+    /** Hard ceiling for [HistoryFilter.limit]. Pinned in [HistoryFilters] for shared use. */
+    const val MAX_LIMIT: Int = HistoryFilters.MAX_LIMIT
 
     /**
      * JSON configuration shared across the LocalFs path. `encodeDefaults = false` keeps the sidecar
@@ -302,24 +268,5 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
     }
 
     private val HEX_CHARS = "0123456789abcdef".toCharArray()
-
-    private fun encodeCursor(timestamp: String, id: String): String {
-      val raw = "$timestamp|$id".toByteArray(Charsets.UTF_8)
-      return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(raw)
-    }
-
-    private data class CursorPosition(val timestamp: String, val id: String)
-
-    private fun decodeCursor(cursor: String): CursorPosition? {
-      return try {
-        val raw = java.util.Base64.getUrlDecoder().decode(cursor)
-        val text = String(raw, Charsets.UTF_8)
-        val sep = text.indexOf('|')
-        if (sep < 0) return null
-        CursorPosition(timestamp = text.substring(0, sep), id = text.substring(sep + 1))
-      } catch (_: Throwable) {
-        null
-      }
-    }
   }
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -396,3 +396,37 @@ data class HistoryReadResultDto(
 )
 
 @Serializable data class HistoryAddedParams(val entry: JsonElement)
+
+// ---------------------------------------------------------------------------
+// H3 — `history/diff` metadata-mode wire shape. See HISTORY.md § "What this PR
+// lands § H3" and PROTOCOL.md § 5 ("history/diff").
+//
+// Pixel-mode fields (`diffPx`, `ssim`, `diffPngPath`) are reserved on the
+// `HistoryDiffResult` shape but always null in METADATA mode — H5 lands the
+// full pixel pass. A METADATA caller asking for `mode = PIXEL` receives a
+// distinct -32603 error so `null` pixel fields stay unambiguous.
+// ---------------------------------------------------------------------------
+
+@Serializable
+enum class HistoryDiffMode {
+  @SerialName("metadata") METADATA,
+  @SerialName("pixel") PIXEL,
+}
+
+@Serializable
+data class HistoryDiffParams(
+  val from: String,
+  val to: String,
+  val mode: HistoryDiffMode = HistoryDiffMode.METADATA,
+)
+
+@Serializable
+data class HistoryDiffResult(
+  val pngHashChanged: Boolean,
+  val fromMetadata: JsonElement,
+  val toMetadata: JsonElement,
+  // Pixel-mode fields — null in METADATA mode; populated by H5.
+  val diffPx: Long? = null,
+  val ssim: Double? = null,
+  val diffPngPath: String? = null,
+)

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
@@ -1,0 +1,412 @@
+package ee.schimke.composeai.daemon.history
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * H10-read — `GitRefHistorySource` unit tests. Each test synthesises a temp git repo on disk,
+ * sets up a `refs/heads/preview/...` ref with the documented storage convention (HISTORY.md §
+ * "GitRefHistorySource"), and exercises the source through its public surface.
+ *
+ * **`git` binary required.** All tests `Assume.assumeTrue` on `git --version` so CI runners
+ * without git skip cleanly. Production callers (the daemon mains) tolerate missing git the same
+ * way [GitProvenance] does — silent degradation.
+ */
+class GitRefHistorySourceTest {
+
+  private lateinit var repoRoot: Path
+  private val warnLog = StringBuilder()
+  private val warnCount = AtomicInteger(0)
+
+  private val warnEmitter: (String) -> Unit = { msg ->
+    synchronized(warnLog) {
+      warnLog.append(msg).append('\n')
+      warnCount.incrementAndGet()
+    }
+  }
+
+  @Before
+  fun setUp() {
+    assumeTrue("git on PATH required for GitRefHistorySource tests", gitAvailable())
+    repoRoot = Files.createTempDirectory("git-ref-test")
+    runOk("git", "init", "-q", repoRoot.toString())
+    runOk("git", "-C", repoRoot.toString(), "config", "user.email", "test@example.com")
+    runOk("git", "-C", repoRoot.toString(), "config", "user.name", "Test")
+    runOk("git", "-C", repoRoot.toString(), "config", "commit.gpgsign", "false")
+    runOk("git", "-C", repoRoot.toString(), "config", "tag.gpgsign", "false")
+    // Seed an initial commit so HEAD exists — we reuse it as the parent of preview/ refs.
+    Files.writeString(repoRoot.resolve("README"), "init")
+    runOk("git", "-C", repoRoot.toString(), "add", "README")
+    runOk("git", "-C", repoRoot.toString(), "commit", "-q", "-m", "init")
+  }
+
+  @After
+  fun tearDown() {
+    if (this::repoRoot.isInitialized) repoRoot.toFile().deleteRecursively()
+  }
+
+  // -------------------------------------------------------------------------
+  // Tests
+  // -------------------------------------------------------------------------
+
+  @Test
+  fun missing_ref_returns_empty_and_warns_once() {
+    val source =
+      GitRefHistorySource(
+        repoRoot = repoRoot,
+        ref = "refs/heads/preview/nonexistent",
+        warnEmitter = warnEmitter,
+      )
+    val page = source.list(HistoryFilter())
+    assertEquals(0, page.totalCount)
+    assertTrue(page.entries.isEmpty())
+    assertEquals(1, warnCount.get())
+    assertTrue("warn must include ref name", warnLog.contains("refs/heads/preview/nonexistent"))
+    assertTrue("warn must include hint", warnLog.contains("git fetch"))
+
+    // Second call → no second warn (one-shot guard).
+    val page2 = source.list(HistoryFilter())
+    assertEquals(0, page2.totalCount)
+    assertEquals(1, warnCount.get())
+
+    // read() of a missing entry → null. Must not warn again either.
+    val read = source.read("does-not-exist", includeBytes = false)
+    assertNull(read)
+    assertEquals(1, warnCount.get())
+  }
+
+  @Test
+  fun empty_ref_returns_empty_no_warn() {
+    // Create the ref pointing at an empty tree (no _index.jsonl, no preview dirs).
+    val emptyTree = createEmptyTree()
+    val emptyCommit = commitTree(emptyTree, parent = null, message = "empty")
+    runOk("git", "-C", repoRoot.toString(), "update-ref", "refs/heads/preview/main", emptyCommit)
+
+    val source =
+      GitRefHistorySource(
+        repoRoot = repoRoot,
+        ref = "refs/heads/preview/main",
+        warnEmitter = warnEmitter,
+      )
+    val page = source.list(HistoryFilter())
+    assertEquals(0, page.totalCount)
+    assertTrue(page.entries.isEmpty())
+    assertEquals("ref exists → no warn", 0, warnCount.get())
+  }
+
+  @Test
+  fun populated_ref_lists_and_reads_entries_with_git_source_kind() {
+    // Build three sidecar+png pairs for two preview dirs, plus a matching _index.jsonl.
+    val entries =
+      listOf(
+        synthEntry(id = "20260430-101234-aaaaaaaa", previewId = "com.example.A", bytes = "first".toByteArray()),
+        synthEntry(id = "20260430-101300-bbbbbbbb", previewId = "com.example.A", bytes = "second".toByteArray()),
+        synthEntry(id = "20260430-101400-cccccccc", previewId = "com.example.B", bytes = "third".toByteArray()),
+      )
+    populatePreviewMain(entries)
+
+    val source =
+      GitRefHistorySource(
+        repoRoot = repoRoot,
+        ref = "refs/heads/preview/main",
+        warnEmitter = warnEmitter,
+      )
+    val page = source.list(HistoryFilter())
+    assertEquals(3, page.totalCount)
+    assertEquals(3, page.entries.size)
+    // Newest first by timestamp (iso strings in entries).
+    assertEquals("20260430-101400-cccccccc", page.entries[0].id)
+    // All entries get source.kind = "git"; the id includes the source's id + the ref's commit.
+    for (entry in page.entries) {
+      assertEquals("git", entry.source.kind)
+      assertTrue(entry.source.id.startsWith("git:refs/heads/preview/main"))
+    }
+
+    // read() resolves a real entry to a cache file containing the original bytes.
+    val read = source.read("20260430-101300-bbbbbbbb", includeBytes = true)
+    assertNotNull(read)
+    val pngFile = File(read!!.pngPath)
+    assertTrue("PNG cache file must exist", pngFile.exists())
+    assertEquals("second", pngFile.readText())
+    assertNotNull(read.pngBytes)
+    assertEquals("second", String(read.pngBytes!!))
+    assertEquals("git", read.entry.source.kind)
+  }
+
+  @Test
+  fun corrupt_index_skips_truncated_line_and_lists_others() {
+    val good1 = synthEntry(id = "20260430-100000-11111111", previewId = "com.example.A", bytes = "a".toByteArray())
+    val good2 = synthEntry(id = "20260430-100100-22222222", previewId = "com.example.A", bytes = "b".toByteArray())
+    val tree = createTreeWithEntriesAndIndex(listOf(good1, good2)) { jsonl ->
+      // Corrupt: append a half-line that's not valid JSON.
+      jsonl + "{\"id\":\"truncat" + "\n"
+    }
+    val commit = commitTree(tree, parent = null, message = "corrupt-index")
+    runOk("git", "-C", repoRoot.toString(), "update-ref", "refs/heads/preview/main", commit)
+
+    val source =
+      GitRefHistorySource(
+        repoRoot = repoRoot,
+        ref = "refs/heads/preview/main",
+        warnEmitter = warnEmitter,
+      )
+    val page = source.list(HistoryFilter())
+    // Two valid entries — the third (truncated) line is skipped.
+    assertEquals(2, page.totalCount)
+    assertEquals(2, page.entries.size)
+  }
+
+  @Test
+  fun cross_source_listing_dedups_and_filter_by_sourceKind() {
+    // Same render lands in BOTH a LocalFs source and the git ref. Cross-source dedup keys on
+    // (previewId, pngHash) and keeps the first writer (LocalFs).
+    val historyDir = Files.createTempDirectory("xsource-localfs")
+    try {
+      val localFs = LocalFsHistorySource(historyDir = historyDir)
+      val previewId = "com.example.X"
+      val sharedBytes = "shared-render".toByteArray()
+      val sharedHash = LocalFsHistorySource.sha256Hex(sharedBytes)
+
+      // 1. Write the same render to LocalFs.
+      val localFsEntry =
+        HistoryEntry(
+          id = "20260430-090000-deadbeef",
+          previewId = previewId,
+          module = ":t",
+          timestamp = "2026-04-30T09:00:00Z",
+          pngHash = sharedHash,
+          pngSize = sharedBytes.size.toLong(),
+          pngPath = "20260430-090000-deadbeef.png",
+          producer = "daemon",
+          trigger = "renderNow",
+          source = HistorySourceInfo(kind = "fs", id = "fs:${historyDir.toAbsolutePath()}"),
+          renderTookMs = 1L,
+        )
+      localFs.write(localFsEntry, sharedBytes)
+
+      // 2. Build a git ref carrying the same render PLUS one git-only render.
+      val gitOnlyBytes = "git-only".toByteArray()
+      val gitRefEntries =
+        listOf(
+          synthEntryFromHash(
+            id = localFsEntry.id,
+            previewId = previewId,
+            timestamp = localFsEntry.timestamp,
+            pngHash = sharedHash,
+            bytes = sharedBytes,
+          ),
+          synthEntry(
+            id = "20260430-100000-99999999",
+            previewId = previewId,
+            bytes = gitOnlyBytes,
+            timestamp = "2026-04-30T10:00:00Z",
+          ),
+        )
+      populatePreviewMain(gitRefEntries)
+
+      val gitSource =
+        GitRefHistorySource(
+          repoRoot = repoRoot,
+          ref = "refs/heads/preview/main",
+          warnEmitter = warnEmitter,
+        )
+      val manager =
+        HistoryManager(
+          sources = listOf(localFs, gitSource),
+          module = ":t",
+          gitProvenance = null,
+        )
+
+      val all = manager.list(HistoryFilter())
+      // Two unique renders — shared render's LocalFs copy is canonical, git-only render comes from git.
+      assertEquals(2, all.totalCount)
+      val sharedSurface = all.entries.first { it.id == localFsEntry.id }
+      assertEquals(
+        "shared render must surface from LocalFs (priority 0)",
+        "fs",
+        sharedSurface.source.kind,
+      )
+      val gitOnlySurface = all.entries.first { it.id == "20260430-100000-99999999" }
+      assertEquals("git", gitOnlySurface.source.kind)
+
+      // sourceKind=git filter narrows to git-source entries — both the shared render's git copy
+      // AND the git-only render show up here because the LocalFs (kind="fs") source is filtered
+      // out at the per-source layer before merge-dedup runs.
+      val gitOnlyPage = manager.list(HistoryFilter(sourceKind = "git"))
+      assertEquals(2, gitOnlyPage.totalCount)
+      assertTrue(gitOnlyPage.entries.all { it.source.kind == "git" })
+
+      // sourceKind=fs filter shows just the LocalFs canonical copy.
+      val fsOnlyPage = manager.list(HistoryFilter(sourceKind = "fs"))
+      assertEquals(1, fsOnlyPage.totalCount)
+      assertEquals(localFsEntry.id, fsOnlyPage.entries.single().id)
+    } finally {
+      historyDir.toFile().deleteRecursively()
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers — temp git repo manipulation via shell-out
+  // -------------------------------------------------------------------------
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = false
+  }
+
+  private fun synthEntry(
+    id: String,
+    previewId: String,
+    bytes: ByteArray,
+    timestamp: String = "2026-04-30T${id.substring(9, 11)}:${id.substring(11, 13)}:${id.substring(13, 15)}Z",
+  ): SynthEntry {
+    val pngHash = LocalFsHistorySource.sha256Hex(bytes)
+    return synthEntryFromHash(id, previewId, timestamp, pngHash, bytes)
+  }
+
+  private fun synthEntryFromHash(
+    id: String,
+    previewId: String,
+    timestamp: String,
+    pngHash: String,
+    bytes: ByteArray,
+  ): SynthEntry {
+    val entry =
+      HistoryEntry(
+        id = id,
+        previewId = previewId,
+        module = ":t",
+        timestamp = timestamp,
+        pngHash = pngHash,
+        pngSize = bytes.size.toLong(),
+        pngPath = "$id.png",
+        producer = "daemon",
+        trigger = "renderNow",
+        // The on-ref entry usually carries whatever source it was written under; rewrite happens
+        // at read-time. Here we set "fs" to prove the rewrite is unconditional.
+        source = HistorySourceInfo(kind = "fs", id = "fs:/some/dir"),
+        renderTookMs = 1L,
+      )
+    return SynthEntry(entry = entry, bytes = bytes)
+  }
+
+  private data class SynthEntry(val entry: HistoryEntry, val bytes: ByteArray)
+
+  private fun populatePreviewMain(entries: List<SynthEntry>) {
+    val tree = createTreeWithEntriesAndIndex(entries) { it }
+    val commit = commitTree(tree, parent = null, message = "history")
+    runOk("git", "-C", repoRoot.toString(), "update-ref", "refs/heads/preview/main", commit)
+  }
+
+  /**
+   * Builds an in-tree layout `<previewIdSan>/<id>.{png,json}` + `_index.jsonl` and returns the
+   * tree sha. Uses `git hash-object` + `git mktree` rather than building the working tree.
+   */
+  private fun createTreeWithEntriesAndIndex(
+    entries: List<SynthEntry>,
+    transformIndex: (String) -> String,
+  ): String {
+    // Group entries by sanitisedPreviewId. For each group, build a sub-tree with the per-entry
+    // .png + .json blobs.
+    val byPreview = entries.groupBy { PreviewIdSanitiser.sanitise(it.entry.previewId) }
+    val rootEntries = StringBuilder()
+    for ((sanitised, group) in byPreview) {
+      val subTreeEntries = StringBuilder()
+      for (synth in group) {
+        val pngSha = hashObject(synth.bytes)
+        val sidecarText = json.encodeToString(HistoryEntry.serializer(), synth.entry)
+        val sidecarSha = hashObject(sidecarText.toByteArray(StandardCharsets.UTF_8))
+        subTreeEntries.append("100644 blob $pngSha\t${synth.entry.id}.png\n")
+        subTreeEntries.append("100644 blob $sidecarSha\t${synth.entry.id}.json\n")
+      }
+      val subTree = mktree(subTreeEntries.toString())
+      rootEntries.append("040000 tree $subTree\t$sanitised\n")
+    }
+    // Build _index.jsonl — entries minus previewMetadata, one per line, append-order (oldest first).
+    val sortedByTs = entries.sortedBy { it.entry.timestamp }
+    val indexBody = sortedByTs.joinToString("\n") {
+      json.encodeToString(HistoryEntry.serializer(), it.entry.copy(previewMetadata = null))
+    } + "\n"
+    val transformed = transformIndex(indexBody)
+    val indexSha = hashObject(transformed.toByteArray(StandardCharsets.UTF_8))
+    rootEntries.append("100644 blob $indexSha\t_index.jsonl\n")
+    return mktree(rootEntries.toString())
+  }
+
+  private fun createEmptyTree(): String = mktree("")
+
+  private fun mktree(input: String): String {
+    val pb =
+      ProcessBuilder(listOf("git", "-C", repoRoot.toString(), "mktree"))
+        .redirectErrorStream(false)
+        .start()
+    pb.outputStream.use { it.write(input.toByteArray(StandardCharsets.UTF_8)) }
+    val finished = pb.waitFor(15, TimeUnit.SECONDS)
+    require(finished) { "mktree timed out" }
+    require(pb.exitValue() == 0) {
+      "mktree failed: ${pb.errorStream.bufferedReader().readText()}"
+    }
+    return pb.inputStream.bufferedReader().readText().trim()
+  }
+
+  private fun hashObject(bytes: ByteArray): String {
+    val pb =
+      ProcessBuilder(listOf("git", "-C", repoRoot.toString(), "hash-object", "-w", "--stdin"))
+        .redirectErrorStream(false)
+        .start()
+    pb.outputStream.use { it.write(bytes) }
+    val finished = pb.waitFor(15, TimeUnit.SECONDS)
+    require(finished) { "hash-object timed out" }
+    require(pb.exitValue() == 0) {
+      "hash-object failed: ${pb.errorStream.bufferedReader().readText()}"
+    }
+    return pb.inputStream.bufferedReader().readText().trim()
+  }
+
+  private fun commitTree(treeSha: String, parent: String?, message: String): String {
+    val args = mutableListOf("git", "-C", repoRoot.toString(), "commit-tree", treeSha, "-m", message)
+    if (parent != null) {
+      args.add("-p")
+      args.add(parent)
+    }
+    val pb = ProcessBuilder(args).redirectErrorStream(false).start()
+    val finished = pb.waitFor(15, TimeUnit.SECONDS)
+    require(finished) { "commit-tree timed out" }
+    require(pb.exitValue() == 0) {
+      "commit-tree failed: ${pb.errorStream.bufferedReader().readText()}"
+    }
+    return pb.inputStream.bufferedReader().readText().trim()
+  }
+
+  private fun runOk(vararg args: String) {
+    val pb = ProcessBuilder(args.toList()).redirectErrorStream(true).start()
+    val finished = pb.waitFor(15, TimeUnit.SECONDS)
+    require(finished) { "${args.joinToString(" ")} timed out" }
+    if (pb.exitValue() != 0) {
+      val out = pb.inputStream.bufferedReader().readText()
+      error("${args.joinToString(" ")} failed: $out")
+    }
+  }
+
+  private fun gitAvailable(): Boolean {
+    return try {
+      val pb = ProcessBuilder("git", "--version").redirectErrorStream(true).start()
+      pb.waitFor(5, TimeUnit.SECONDS) && pb.exitValue() == 0
+    } catch (_: Throwable) {
+      false
+    }
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
@@ -1,0 +1,278 @@
+package ee.schimke.composeai.daemon.history
+
+import ee.schimke.composeai.daemon.ContentLengthFramer
+import ee.schimke.composeai.daemon.JsonRpcServer
+import ee.schimke.composeai.daemon.RenderHost
+import ee.schimke.composeai.daemon.RenderRequest
+import ee.schimke.composeai.daemon.RenderResult
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * H3 — `history/diff` METADATA-mode unit tests. Drives the [JsonRpcServer] over piped streams
+ * with a [HistoryManager] backed by a temp [LocalFsHistorySource] so each test can synthesise
+ * the entries it needs and assert on the wire shape.
+ *
+ * Covers the cases enumerated in HISTORY.md § "What this PR lands § H3":
+ * - same hash → `pngHashChanged = false`, both metadata returned
+ * - different hash, same previewId → `pngHashChanged = true`
+ * - different previewIds → `HistoryDiffMismatch (-32011)`
+ * - missing `from` / `to` → `HistoryEntryNotFound (-32010)`
+ * - `mode = pixel` → `-32012` reserved-for-H5 error
+ */
+class HistoryDiffTest {
+
+  private lateinit var historyDir: Path
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Before
+  fun setUp() {
+    historyDir = Files.createTempDirectory("history-diff-test")
+  }
+
+  @After
+  fun tearDown() {
+    historyDir.toFile().deleteRecursively()
+  }
+
+  @Test(timeout = 30_000)
+  fun same_hash_pngHashChanged_false() {
+    runWith { _, manager, send, receive ->
+      // Two entries with identical pngHash for the same previewId. We force the same hash by
+      // writing the same bytes for both renders; LocalFsHistorySource dedups the PNG file but
+      // still writes two distinct sidecars + index lines (HISTORY.md § "Concurrency model"). We
+      // pin distinct timestamps so the entry ids differ (id = "<ts>-<shortHash>").
+      val ts1 = Instant.parse("2026-04-30T10:12:34Z")
+      val ts2 = Instant.parse("2026-04-30T10:12:35Z")
+      val entry1 = manager.recordRender("preview-A", "same-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1, timestamp = ts1)!!
+      val entry2 = manager.recordRender("preview-A", "same-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1, timestamp = ts2)!!
+      assertEquals(entry1.pngHash, entry2.pngHash)
+
+      val resp = diffRoundTrip(send, receive, from = entry1.id, to = entry2.id)
+      val result = resp["result"]!!.jsonObject
+      assertEquals(false, result["pngHashChanged"]!!.jsonPrimitive.content.toBooleanStrict())
+      assertEquals(entry1.id, result["fromMetadata"]!!.jsonObject["id"]!!.jsonPrimitive.content)
+      assertEquals(entry2.id, result["toMetadata"]!!.jsonObject["id"]!!.jsonPrimitive.content)
+      // Pixel-mode fields are null in METADATA mode by design.
+      assertTrue(result["diffPx"] == null || result["diffPx"] == kotlinx.serialization.json.JsonNull)
+      assertTrue(result["ssim"] == null || result["ssim"] == kotlinx.serialization.json.JsonNull)
+      assertTrue(
+        result["diffPngPath"] == null || result["diffPngPath"] == kotlinx.serialization.json.JsonNull
+      )
+    }
+  }
+
+  @Test(timeout = 30_000)
+  fun different_hash_pngHashChanged_true() {
+    runWith { _, manager, send, receive ->
+      val ts1 = Instant.parse("2026-04-30T10:12:34Z")
+      val ts2 = Instant.parse("2026-04-30T10:12:35Z")
+      val entry1 = manager.recordRender("preview-A", "first-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1, timestamp = ts1)!!
+      val entry2 = manager.recordRender("preview-A", "second-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1, timestamp = ts2)!!
+      assertTrue(entry1.pngHash != entry2.pngHash)
+
+      val resp = diffRoundTrip(send, receive, from = entry1.id, to = entry2.id)
+      val result = resp["result"]!!.jsonObject
+      assertEquals(true, result["pngHashChanged"]!!.jsonPrimitive.content.toBooleanStrict())
+    }
+  }
+
+  @Test(timeout = 30_000)
+  fun different_previewIds_diffMismatch() {
+    runWith { _, manager, send, receive ->
+      val a = manager.recordRender("preview-A", "a-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1)!!
+      val b = manager.recordRender("preview-B", "b-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1)!!
+      val resp = diffRoundTrip(send, receive, from = a.id, to = b.id)
+      val errCode = resp["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull
+      assertEquals(JsonRpcServer.ERR_HISTORY_DIFF_MISMATCH, errCode)
+    }
+  }
+
+  @Test(timeout = 30_000)
+  fun missing_from_entryNotFound() {
+    runWith { _, manager, send, receive ->
+      val a = manager.recordRender("preview-A", "a-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1)!!
+      val resp = diffRoundTrip(send, receive, from = "does-not-exist", to = a.id)
+      val errCode = resp["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull
+      assertEquals(JsonRpcServer.ERR_HISTORY_ENTRY_NOT_FOUND, errCode)
+    }
+  }
+
+  @Test(timeout = 30_000)
+  fun missing_to_entryNotFound() {
+    runWith { _, manager, send, receive ->
+      val a = manager.recordRender("preview-A", "a-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1)!!
+      val resp = diffRoundTrip(send, receive, from = a.id, to = "does-not-exist")
+      val errCode = resp["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull
+      assertEquals(JsonRpcServer.ERR_HISTORY_ENTRY_NOT_FOUND, errCode)
+    }
+  }
+
+  @Test(timeout = 30_000)
+  fun pixel_mode_not_yet_implemented() {
+    runWith { _, manager, send, receive ->
+      val a = manager.recordRender("preview-A", "a-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1)!!
+      val resp = diffRoundTrip(send, receive, from = a.id, to = a.id, mode = "pixel")
+      val errCode = resp["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull
+      assertEquals(JsonRpcServer.ERR_HISTORY_PIXEL_NOT_IMPLEMENTED, errCode)
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Test infrastructure — minimal JSON-RPC client over piped streams.
+  // -------------------------------------------------------------------------
+
+  private fun runWith(
+    block: (
+      JsonRpcServer,
+      HistoryManager,
+      send: (String) -> Unit,
+      receive: LinkedBlockingQueue<JsonObject>,
+    ) -> Unit
+  ) {
+    val manager =
+      HistoryManager.forLocalFs(historyDir = historyDir, module = ":t", gitProvenance = null)
+
+    val clientToServerOut = PipedOutputStream()
+    val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
+    val serverToClientOut = PipedOutputStream()
+    val serverToClientIn = PipedInputStream(serverToClientOut, 64 * 1024)
+    val exitLatch = CountDownLatch(1)
+    val server =
+      JsonRpcServer(
+        input = clientToServerIn,
+        output = serverToClientOut,
+        host = StubHost(),
+        daemonVersion = "test",
+        historyManager = manager,
+        onExit = { _ -> exitLatch.countDown() },
+      )
+    val serverThread = Thread({ server.run() }, "history-diff-test-server").apply { isDaemon = true }
+    serverThread.start()
+
+    val received = LinkedBlockingQueue<JsonObject>()
+    val reader = ContentLengthFramer(serverToClientIn)
+    Thread(
+        {
+          try {
+            while (true) {
+              val frame = reader.readFrame() ?: break
+              received.put(json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject)
+            }
+          } catch (_: Throwable) {}
+        },
+        "history-diff-test-reader",
+      )
+      .apply { isDaemon = true }
+      .start()
+
+    val send: (String) -> Unit = { jsonText ->
+      val payload = jsonText.toByteArray(Charsets.UTF_8)
+      clientToServerOut.write("Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII))
+      clientToServerOut.write(payload)
+      clientToServerOut.flush()
+    }
+    try {
+      // initialize → initialized.
+      send(
+        """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "moduleId":":test","moduleProjectDir":"/tmp",
+              "capabilities":{"visibility":true,"metrics":false}}}"""
+      )
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 1 })
+      send("""{"jsonrpc":"2.0","method":"initialized","params":{}}""")
+
+      block(server, manager, send, received)
+
+      // Tear down.
+      send("""{"jsonrpc":"2.0","id":99,"method":"shutdown"}""")
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 99 })
+      send("""{"jsonrpc":"2.0","method":"exit"}""")
+      assertTrue(exitLatch.await(5, TimeUnit.SECONDS))
+    } finally {
+      try {
+        clientToServerOut.close()
+      } catch (_: Throwable) {}
+      try {
+        serverToClientIn.close()
+      } catch (_: Throwable) {}
+      serverThread.join(5_000)
+    }
+  }
+
+  private var nextId = 100L
+
+  private fun diffRoundTrip(
+    send: (String) -> Unit,
+    received: LinkedBlockingQueue<JsonObject>,
+    from: String,
+    to: String,
+    mode: String = "metadata",
+  ): JsonObject {
+    val id = nextId++
+    send(
+      """{"jsonrpc":"2.0","id":$id,"method":"history/diff","params":{"from":"$from","to":"$to","mode":"$mode"}}"""
+    )
+    val resp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull?.toLong() == id }
+    assertNotNull("history/diff response did not arrive", resp)
+    return resp!!
+  }
+
+  private fun pollUntil(
+    queue: LinkedBlockingQueue<JsonObject>,
+    timeoutMs: Long = 10_000,
+    matcher: (JsonObject) -> Boolean,
+  ): JsonObject? {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+      val remaining = (deadline - System.currentTimeMillis()).coerceAtLeast(0)
+      val msg = queue.poll(remaining, TimeUnit.MILLISECONDS) ?: return null
+      if (matcher(msg)) return msg
+    }
+    return null
+  }
+
+  /**
+   * Stub host that doesn't render — we drive `recordRender` directly via [HistoryManager] in the
+   * tests above so the wire path doesn't need real renders.
+   */
+  private class StubHost : RenderHost {
+    override fun start() {}
+    override fun submit(request: RenderRequest, timeoutMs: Long): RenderResult =
+      error("StubHost.submit: not used in HistoryDiffTest — tests drive HistoryManager directly")
+    override fun shutdown(timeoutMs: Long) {}
+  }
+
+  // Exhaustively reference the symbol so the test stays compile-coupled to the params/result
+  // types even if the wire is hand-written above.
+  @Suppress("unused")
+  private fun referenceSymbols() {
+    val _ignored: ee.schimke.composeai.daemon.protocol.HistoryDiffParams =
+      ee.schimke.composeai.daemon.protocol.HistoryDiffParams(from = "a", to = "b")
+    val _ignored2: ee.schimke.composeai.daemon.protocol.HistoryDiffResult =
+      ee.schimke.composeai.daemon.protocol.HistoryDiffResult(
+        pngHashChanged = false,
+        fromMetadata = kotlinx.serialization.json.JsonObject(emptyMap()),
+        toMetadata = kotlinx.serialization.json.JsonObject(emptyMap()),
+      )
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
@@ -39,7 +39,8 @@ import org.junit.Test
  * 4. `history/read({inline: true})` returns base64 bytes that decode back to the original PNG.
  * 5. `history/list({previewId: "other"})` filter narrows correctly.
  * 6. `history/read({id: "missing"})` returns a `-32010 HistoryEntryNotFound` error.
- * 7. `history/diff` and `history/prune` return `-32601 MethodNotFound` (reserved, not implemented).
+ * 7. `history/diff` (metadata mode, H3) round-trips a real diff result.
+ * 8. `history/prune` returns `-32601 MethodNotFound` (reserved, not implemented).
  */
 class JsonRpcServerHistoryIntegrationTest {
 
@@ -202,21 +203,48 @@ class JsonRpcServerHistoryIntegrationTest {
       val errCode = missing!!["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull
       assertEquals(JsonRpcServer.ERR_HISTORY_ENTRY_NOT_FOUND, errCode)
 
-      // 10. history/diff and history/prune → MethodNotFound.
+      // 10. history/diff for missing id → -32010.
       writeFrame(
         clientToServerOut,
-        """{"jsonrpc":"2.0","id":8,"method":"history/diff","params":{"from":"a","to":"b"}}""",
+        """{"jsonrpc":"2.0","id":8,"method":"history/diff","params":{"from":"missing","to":"$entryId"}}""",
       )
-      val diff = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 8 }
+      val diffMissing = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 8 }
       assertEquals(
-        JsonRpcServer.ERR_METHOD_NOT_FOUND,
-        diff!!["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull,
+        JsonRpcServer.ERR_HISTORY_ENTRY_NOT_FOUND,
+        diffMissing!!["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull,
       )
+
+      // 11. history/diff(from=entryId, to=entryId) — same entry → pngHashChanged=false.
       writeFrame(
         clientToServerOut,
-        """{"jsonrpc":"2.0","id":9,"method":"history/prune","params":{}}""",
+        """{"jsonrpc":"2.0","id":9,"method":"history/diff","params":{"from":"$entryId","to":"$entryId"}}""",
       )
-      val prune = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 9 }
+      val diffSelf = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 9 }
+      val diffSelfResult = diffSelf!!["result"]!!.jsonObject
+      assertEquals(
+        false,
+        diffSelfResult["pngHashChanged"]!!.jsonPrimitive.content.toBooleanStrict(),
+      )
+      assertNotNull(diffSelfResult["fromMetadata"])
+      assertNotNull(diffSelfResult["toMetadata"])
+
+      // 12. history/diff with mode=pixel → -32012 (reserved for H5).
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":10,"method":"history/diff","params":{"from":"$entryId","to":"$entryId","mode":"pixel"}}""",
+      )
+      val diffPixel = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 10 }
+      assertEquals(
+        JsonRpcServer.ERR_HISTORY_PIXEL_NOT_IMPLEMENTED,
+        diffPixel!!["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull,
+      )
+
+      // 13. history/prune → MethodNotFound (still reserved).
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":11,"method":"history/prune","params":{}}""",
+      )
+      val prune = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 11 }
       assertEquals(
         JsonRpcServer.ERR_METHOD_NOT_FOUND,
         prune!!["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -3,6 +3,7 @@
 package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.history.GitProvenance
+import ee.schimke.composeai.daemon.history.GitRefHistorySource
 import ee.schimke.composeai.daemon.history.HistoryManager
 import java.io.File
 import java.nio.file.Path
@@ -150,14 +151,26 @@ fun main(args: Array<String>) {
     if (historyDirProp != null) {
       GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of))
     } else null
-  val historyManager: HistoryManager? = historyDirProp?.let { dir ->
-    System.err.println("compose-ai-tools desktop daemon: HistoryManager active (dir=$dir)")
-    HistoryManager.forLocalFs(
-      historyDir = Path.of(dir),
-      module = System.getProperty(MODULE_ID_PROP) ?: "",
-      gitProvenance = gitProvenance,
-    )
-  }
+  // H10-read — when `composeai.daemon.gitRefHistory` is set (comma-separated list of full ref
+  // names like `refs/heads/preview/main`), each ref produces a read-only [GitRefHistorySource]
+  // alongside the writable [LocalFsHistorySource]. Refs that don't exist locally trigger a
+  // one-time warn-level `log` notification with a hint for the human and degrade gracefully
+  // (no entries in `history/list`). See HISTORY.md § "GitRefHistorySource".
+  val gitRefHistoryRefs = GitRefHistorySource.parseRefsSysprop()
+  val historyManager: HistoryManager? =
+    historyDirProp?.let { dir ->
+      System.err.println(
+        "compose-ai-tools desktop daemon: HistoryManager active (dir=$dir, " +
+          "gitRefs=${gitRefHistoryRefs})"
+      )
+      HistoryManager.forLocalFsAndGitRefs(
+        historyDir = Path.of(dir),
+        module = System.getProperty(MODULE_ID_PROP) ?: "",
+        gitProvenance = gitProvenance,
+        gitRefs = gitRefHistoryRefs,
+        repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
+      )
+    }
 
   val server =
     JsonRpcServer(

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
@@ -7,6 +7,7 @@ import ee.schimke.composeai.daemon.JsonRpcServer
 import ee.schimke.composeai.daemon.PreviewIndex
 import ee.schimke.composeai.daemon.PreviewInfoDto
 import ee.schimke.composeai.daemon.history.GitProvenance
+import ee.schimke.composeai.daemon.history.GitRefHistorySource
 import ee.schimke.composeai.daemon.history.HistoryManager
 import java.io.File
 import java.nio.file.Path
@@ -95,14 +96,23 @@ fun main(args: Array<String>) {
   // the sysprop see the pre-H1 default (no history written, history/list returns empty).
   val historyDirProp = System.getProperty("composeai.daemon.historyDir")
   val workspaceRootProp = System.getProperty("composeai.daemon.workspaceRoot")
-  val historyManager: HistoryManager? = historyDirProp?.let { dir ->
-    System.err.println("compose-ai-daemon harness: HistoryManager active (dir=$dir)")
-    HistoryManager.forLocalFs(
-      historyDir = Path.of(dir),
-      module = System.getProperty("composeai.daemon.moduleId") ?: ":harness",
-      gitProvenance = GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of)),
-    )
-  }
+  // H10-read — `composeai.daemon.gitRefHistory` (comma-separated full ref names) wires read-only
+  // GitRefHistorySources alongside the writable LocalFsHistorySource. Tests that don't set the
+  // sysprop see the pre-H10 single-source behaviour.
+  val gitRefHistoryRefs = GitRefHistorySource.parseRefsSysprop()
+  val historyManager: HistoryManager? =
+    historyDirProp?.let { dir ->
+      System.err.println(
+        "compose-ai-daemon harness: HistoryManager active (dir=$dir, gitRefs=${gitRefHistoryRefs})"
+      )
+      HistoryManager.forLocalFsAndGitRefs(
+        historyDir = Path.of(dir),
+        module = System.getProperty("composeai.daemon.moduleId") ?: ":harness",
+        gitProvenance = GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of)),
+        gitRefs = gitRefHistoryRefs,
+        repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
+      )
+    }
 
   val server =
     JsonRpcServer(

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessClient.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessClient.kt
@@ -4,6 +4,9 @@ import ee.schimke.composeai.daemon.protocol.ChangeType
 import ee.schimke.composeai.daemon.protocol.ClientCapabilities
 import ee.schimke.composeai.daemon.protocol.FileChangedParams
 import ee.schimke.composeai.daemon.protocol.FileKind
+import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
+import ee.schimke.composeai.daemon.protocol.HistoryDiffParams
+import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
 import ee.schimke.composeai.daemon.protocol.HistoryListParams
 import ee.schimke.composeai.daemon.protocol.HistoryListResult
 import ee.schimke.composeai.daemon.protocol.HistoryReadParams
@@ -176,6 +179,44 @@ private constructor(
       response["result"]
         ?: error("history/read: no result — error=${response["error"]}, full=${response}")
     return json.decodeFromJsonElement(HistoryReadResultDto.serializer(), resultElem)
+  }
+
+  /** H3 — drives `history/diff` (metadata mode by default). */
+  fun historyDiff(
+    from: String,
+    to: String,
+    mode: HistoryDiffMode = HistoryDiffMode.METADATA,
+  ): HistoryDiffResult {
+    val rpcId = nextId.getAndIncrement()
+    val params = HistoryDiffParams(from = from, to = to, mode = mode)
+    val request =
+      JsonRpcRequest(
+        id = rpcId,
+        method = "history/diff",
+        params = json.encodeToJsonElement(HistoryDiffParams.serializer(), params),
+      )
+    val response = sendAndPoll(rpcId, request, 10.seconds)
+    val resultElem =
+      response["result"]
+        ?: error("history/diff: no result — error=${response["error"]}, full=${response}")
+    return json.decodeFromJsonElement(HistoryDiffResult.serializer(), resultElem)
+  }
+
+  /** H3 — like [historyDiff] but returns the raw response so callers can assert on error codes. */
+  fun historyDiffRaw(
+    from: String,
+    to: String,
+    mode: HistoryDiffMode = HistoryDiffMode.METADATA,
+  ): JsonObject {
+    val rpcId = nextId.getAndIncrement()
+    val params = HistoryDiffParams(from = from, to = to, mode = mode)
+    val request =
+      JsonRpcRequest(
+        id = rpcId,
+        method = "history/diff",
+        params = json.encodeToJsonElement(HistoryDiffParams.serializer(), params),
+      )
+    return sendAndPoll(rpcId, request, 10.seconds)
   }
 
   /**

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
@@ -45,6 +45,12 @@ class FakeHarnessLauncher(
    * cwd (the harness module's project dir under Gradle test execution).
    */
   private val workspaceRoot: File? = null,
+  /**
+   * H10-read — comma-separated list of full git ref names (e.g. `refs/heads/preview/main`) for
+   * [GitRefHistorySource] wiring. When non-empty, sets `-Dcomposeai.daemon.gitRefHistory=…` on
+   * the spawned JVM.
+   */
+  private val gitRefHistory: List<String> = emptyList(),
 ) : HarnessLauncher {
 
   override val name: String = "fake"
@@ -65,6 +71,8 @@ class FakeHarnessLauncher(
         if (historyDir != null) add("-Dcomposeai.daemon.historyDir=${historyDir.absolutePath}")
         if (workspaceRoot != null)
           add("-Dcomposeai.daemon.workspaceRoot=${workspaceRoot.absolutePath}")
+        if (gitRefHistory.isNotEmpty())
+          add("-Dcomposeai.daemon.gitRefHistory=${gitRefHistory.joinToString(",")}")
         addAll(extraJvmArgs)
         add("-cp")
         add(cpString)

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S10MainHistoryReadAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S10MainHistoryReadAndroidRealModeTest.kt
@@ -1,0 +1,19 @@
+package ee.schimke.composeai.daemon.harness
+
+import org.junit.Ignore
+import org.junit.Test
+
+/**
+ * Real-mode Android counterpart to [S10MainHistoryReadTest] — placeholder for H10-read.
+ *
+ * Same rationale as [S10MainHistoryReadDesktopRealModeTest]: the fake-mode S10 already covers
+ * the wire shape end-to-end, the Robolectric real-mode landing waits on the gradle plugin
+ * emitting `composeai.daemon.gitRefHistory` into the daemon launch descriptor.
+ */
+@Ignore("S10 real-mode Android placeholder — see KDoc")
+class S10MainHistoryReadAndroidRealModeTest {
+  @Test
+  fun s10_main_history_read_real_mode_android_placeholder() {
+    // Placeholder body — the @Ignore annotation skips this test in JUnit.
+  }
+}

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S10MainHistoryReadDesktopRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S10MainHistoryReadDesktopRealModeTest.kt
@@ -1,0 +1,21 @@
+package ee.schimke.composeai.daemon.harness
+
+import org.junit.Ignore
+import org.junit.Test
+
+/**
+ * Real-mode desktop counterpart to [S10MainHistoryReadTest] — placeholder for H10-read.
+ *
+ * The fake-mode S10 already proves the wire shape end-to-end. The real-mode landing waits on the
+ * gradle plugin emitting the `composeai.daemon.gitRefHistory` sysprop into the daemon launch
+ * descriptor (a follow-up task that's NOT in scope for this PR). Keeping the placeholder here
+ * pins the intent and makes the future landing point obvious to anyone scanning the harness suite.
+ */
+@Ignore("S10 real-mode desktop placeholder — see KDoc")
+class S10MainHistoryReadDesktopRealModeTest {
+  @Test
+  fun s10_main_history_read_real_mode_desktop_placeholder() {
+    // Placeholder body — the @Ignore annotation skips this test in JUnit. Real implementation
+    // lands when the gradle plugin emits `composeai.daemon.gitRefHistory` in the daemon descriptor.
+  }
+}

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S10MainHistoryReadTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S10MainHistoryReadTest.kt
@@ -1,0 +1,242 @@
+package ee.schimke.composeai.daemon.harness
+
+import ee.schimke.composeai.daemon.history.HistoryEntry
+import ee.schimke.composeai.daemon.history.HistorySourceInfo
+import ee.schimke.composeai.daemon.history.LocalFsHistorySource
+import ee.schimke.composeai.daemon.protocol.HistoryListParams
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+
+/**
+ * Scenario **S10 — Main-history read (fake mode)**. Synthesises a temp git repo with a populated
+ * `refs/heads/preview/main` ref, drives [FakeDaemonMain] with `composeai.daemon.gitRefHistory`
+ * pointing at that ref, and asserts that:
+ *
+ * 1. `history/list({sourceKind: "git"})` returns the entries from the git ref.
+ * 2. Each entry's `source.kind == "git"`.
+ *
+ * The render-write side of the daemon is unchanged — we don't render here; we just prove the
+ * read-only `GitRefHistorySource` plumbs end-to-end through the wire.
+ */
+class S10MainHistoryReadTest {
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = false
+  }
+
+  @Test
+  fun s10_main_history_read_fake_mode() {
+    assumeTrue("git on PATH required for S10", gitAvailable())
+    val moduleBuildDir = File("build")
+    val fixtureDir =
+      File(moduleBuildDir, "daemon-harness/fixtures/s10").apply {
+        deleteRecursively()
+        mkdirs()
+      }
+    File(fixtureDir, "previews.json").writeText("[]")
+
+    val repoRoot = Files.createTempDirectory("s10-repo").toFile().apply { deleteOnExit() }
+    initGitRepo(repoRoot)
+    // Populate refs/heads/preview/main with two synthetic entries.
+    val entries =
+      listOf(
+        synth(
+          id = "20260430-101234-aaaaaaaa",
+          previewId = "com.example.A",
+          bytes = "alpha".toByteArray(),
+          timestamp = "2026-04-30T10:12:34Z",
+        ),
+        synth(
+          id = "20260430-101300-bbbbbbbb",
+          previewId = "com.example.A",
+          bytes = "beta".toByteArray(),
+          timestamp = "2026-04-30T10:13:00Z",
+        ),
+      )
+    populatePreviewMainRef(repoRoot, entries)
+
+    val historyDir = Files.createTempDirectory("s10-history").toFile().apply { deleteOnExit() }
+    val classpath =
+      System.getProperty("java.class.path")
+        .split(File.pathSeparator)
+        .filter { it.isNotBlank() }
+        .map { File(it) }
+    val launcher =
+      FakeHarnessLauncher(
+        fixtureDir = fixtureDir,
+        classpath = classpath,
+        historyDir = historyDir,
+        workspaceRoot = repoRoot,
+        gitRefHistory = listOf("refs/heads/preview/main"),
+      )
+    val client = HarnessClient.start(launcher)
+    try {
+      client.initialize()
+      client.sendInitialized()
+
+      // history/list({sourceKind: "git"}) should return the two ref entries.
+      val gitOnly = client.historyList(HistoryListParams(sourceKind = "git"))
+      assertEquals(2, gitOnly.totalCount)
+      assertEquals(2, gitOnly.entries.size)
+      for (entry in gitOnly.entries) {
+        val source = entry.jsonObject["source"]!!.jsonObject
+        assertEquals("git", source["kind"]?.jsonPrimitive?.contentOrNull)
+      }
+
+      // history/list with no filter — also surfaces both git entries (LocalFs is empty here).
+      val all = client.historyList(HistoryListParams())
+      assertEquals(2, all.totalCount)
+
+      val exitCode = client.shutdownAndExit()
+      assertEquals(0, exitCode)
+    } catch (t: Throwable) {
+      System.err.println("S10MainHistoryReadTest failed; stderr from daemon:\n${client.dumpStderr()}")
+      throw t
+    } finally {
+      try {
+        client.close()
+      } catch (_: Throwable) {}
+      repoRoot.deleteRecursively()
+      historyDir.deleteRecursively()
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers — temp git repo manipulation via shell-out (mirrors the unit-test helpers in
+  // GitRefHistorySourceTest; intentionally not extracted to test fixtures because the harness
+  // module deliberately doesn't depend on `:daemon:core` test sources).
+  // -------------------------------------------------------------------------
+
+  private fun initGitRepo(repoRoot: File) {
+    runOk("git", "init", "-q", repoRoot.absolutePath)
+    runOk("git", "-C", repoRoot.absolutePath, "config", "user.email", "test@example.com")
+    runOk("git", "-C", repoRoot.absolutePath, "config", "user.name", "Test")
+    runOk("git", "-C", repoRoot.absolutePath, "config", "commit.gpgsign", "false")
+    File(repoRoot, "README").writeText("init")
+    runOk("git", "-C", repoRoot.absolutePath, "add", "README")
+    runOk("git", "-C", repoRoot.absolutePath, "commit", "-q", "-m", "init")
+  }
+
+  /** Mirror of `PreviewIdSanitiser.sanitise` (internal in :daemon:core; pinned shape). */
+  private fun sanitisePreviewId(previewId: String): String {
+    if (previewId.isEmpty()) return "_"
+    val sb = StringBuilder(previewId.length)
+    for (c in previewId) {
+      sb.append(if (c.isLetterOrDigit() || c == '.' || c == '_' || c == '-') c else '_')
+    }
+    return sb.toString()
+  }
+
+  private fun populatePreviewMainRef(repoRoot: File, entries: List<SynthEntry>) {
+    val byPreview = entries.groupBy { sanitisePreviewId(it.entry.previewId) }
+    val rootEntries = StringBuilder()
+    for ((sanitised, group) in byPreview) {
+      val sub = StringBuilder()
+      for (synth in group) {
+        val pngSha = hashObject(repoRoot, synth.bytes)
+        val sidecarText = json.encodeToString(HistoryEntry.serializer(), synth.entry)
+        val sidecarSha = hashObject(repoRoot, sidecarText.toByteArray(StandardCharsets.UTF_8))
+        sub.append("100644 blob $pngSha\t${synth.entry.id}.png\n")
+        sub.append("100644 blob $sidecarSha\t${synth.entry.id}.json\n")
+      }
+      val subTree = mktree(repoRoot, sub.toString())
+      rootEntries.append("040000 tree $subTree\t$sanitised\n")
+    }
+    val indexLines = entries.sortedBy { it.entry.timestamp }.joinToString("\n") {
+      json.encodeToString(HistoryEntry.serializer(), it.entry.copy(previewMetadata = null))
+    } + "\n"
+    val indexSha = hashObject(repoRoot, indexLines.toByteArray(StandardCharsets.UTF_8))
+    rootEntries.append("100644 blob $indexSha\t_index.jsonl\n")
+    val rootTree = mktree(repoRoot, rootEntries.toString())
+    val commit = commitTree(repoRoot, rootTree, "history")
+    runOk("git", "-C", repoRoot.absolutePath, "update-ref", "refs/heads/preview/main", commit)
+  }
+
+  private fun synth(id: String, previewId: String, bytes: ByteArray, timestamp: String): SynthEntry {
+    val pngHash = LocalFsHistorySource.sha256Hex(bytes)
+    val entry =
+      HistoryEntry(
+        id = id,
+        previewId = previewId,
+        module = ":harness",
+        timestamp = timestamp,
+        pngHash = pngHash,
+        pngSize = bytes.size.toLong(),
+        pngPath = "$id.png",
+        producer = "daemon",
+        trigger = "renderNow",
+        source = HistorySourceInfo(kind = "fs", id = "fs:/synthetic"),
+        renderTookMs = 1L,
+      )
+    return SynthEntry(entry, bytes)
+  }
+
+  private data class SynthEntry(val entry: HistoryEntry, val bytes: ByteArray)
+
+  private fun mktree(repoRoot: File, input: String): String {
+    val pb =
+      ProcessBuilder(listOf("git", "-C", repoRoot.absolutePath, "mktree"))
+        .redirectErrorStream(false)
+        .start()
+    pb.outputStream.use { it.write(input.toByteArray(StandardCharsets.UTF_8)) }
+    require(pb.waitFor(15, TimeUnit.SECONDS)) { "mktree timed out" }
+    require(pb.exitValue() == 0) {
+      "mktree failed: ${pb.errorStream.bufferedReader().readText()}"
+    }
+    return pb.inputStream.bufferedReader().readText().trim()
+  }
+
+  private fun hashObject(repoRoot: File, bytes: ByteArray): String {
+    val pb =
+      ProcessBuilder(listOf("git", "-C", repoRoot.absolutePath, "hash-object", "-w", "--stdin"))
+        .redirectErrorStream(false)
+        .start()
+    pb.outputStream.use { it.write(bytes) }
+    require(pb.waitFor(15, TimeUnit.SECONDS)) { "hash-object timed out" }
+    require(pb.exitValue() == 0) {
+      "hash-object failed: ${pb.errorStream.bufferedReader().readText()}"
+    }
+    return pb.inputStream.bufferedReader().readText().trim()
+  }
+
+  private fun commitTree(repoRoot: File, treeSha: String, message: String): String {
+    val pb =
+      ProcessBuilder(listOf("git", "-C", repoRoot.absolutePath, "commit-tree", treeSha, "-m", message))
+        .redirectErrorStream(false)
+        .start()
+    require(pb.waitFor(15, TimeUnit.SECONDS)) { "commit-tree timed out" }
+    require(pb.exitValue() == 0) {
+      "commit-tree failed: ${pb.errorStream.bufferedReader().readText()}"
+    }
+    return pb.inputStream.bufferedReader().readText().trim()
+  }
+
+  private fun runOk(vararg args: String) {
+    val pb = ProcessBuilder(args.toList()).redirectErrorStream(true).start()
+    require(pb.waitFor(15, TimeUnit.SECONDS)) { "${args.joinToString(" ")} timed out" }
+    if (pb.exitValue() != 0) {
+      val out = pb.inputStream.bufferedReader().readText()
+      error("${args.joinToString(" ")} failed: $out")
+    }
+  }
+
+  private fun gitAvailable(): Boolean {
+    return try {
+      val pb = ProcessBuilder("git", "--version").redirectErrorStream(true).start()
+      pb.waitFor(5, TimeUnit.SECONDS) && pb.exitValue() == 0
+    } catch (_: Throwable) {
+      false
+    }
+  }
+}

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -429,10 +429,31 @@ without being its parent.
 
 **Sync modes**:
 
-- `READ_ONLY` (default) — consumer-side merging only. The daemon
-  reads from `git show preview/main:<previewId>/<file>`. Writes go
-  to the local-FS source as usual. Clones get whatever the remote
-  has; nothing is pushed automatically.
+- `READ_ONLY` (default — landed in H10-read) — consumer-side merging only. The daemon reads from
+  `git show preview/main:<previewId>/<file>`. Writes go to the local-FS source as usual. Clones
+  get whatever the remote has; nothing is pushed automatically.
+
+  **Configuration (H10-read landing).** The daemon picks up read-only refs from the
+  `composeai.daemon.gitRefHistory` system property — comma-separated full ref names, e.g.
+  `refs/heads/preview/main,refs/heads/preview/agent/foo`. Empty / unset means no
+  `GitRefHistorySource`s are constructed. Default suggestion for the common case:
+  `composeai.daemon.gitRefHistory=refs/heads/preview/main`.
+
+  **Ref-missing behaviour.** When the configured ref isn't present locally
+  (`git rev-parse --verify <ref>` returns non-zero — common in greenfield repos because CI doesn't
+  push `preview/main` yet), the source emits a one-time warn-level message via the daemon's log
+  channel:
+
+  ```
+  GitRefHistorySource: ref '<ref>' is not present locally.
+    Hint: populate it by fetching from a remote (e.g. `git fetch origin <ref>:<ref>`)
+    or set up CI to push render history on each merge to <branch>.
+    Until then, main-history comparison will not be available.
+  ```
+
+  After the warning the source degrades gracefully — `list` returns an empty page, `read` returns
+  null. The daemon does NOT fail; the consumer just sees "no main-history available" and
+  `history/diff` against a missing ref entry returns `HistoryEntryNotFound (-32010)`.
 - `WRITE_LOCAL` — the daemon writes a commit to the local
   `preview/<branch>` ref after each render burst (debounced, e.g.
   every 30s). No network. Pushes are user-driven.
@@ -831,21 +852,25 @@ index; old indices stay readable as v0.
 | ~~**H0**~~ | ~~Sidecar schema + index.jsonl emission from `HistorizePreviewsTask`~~ | — | dropped — legacy task removed in PR #311; greenfield write path is daemon-only |
 | **H1** | Daemon writes sidecar + index entry per render | Layer 2 | — |
 | **H2** | `history/list` + `history/read` + `historyAdded` notification | Layer 2 | H1 |
-| **H3** | `history/diff` (metadata mode) | Layer 2 | H2 |
+| ~~**H3**~~ | ~~`history/diff` (metadata mode)~~ | Layer 2 | H2 — landed |
 | **H4** | Auto-prune + `historyPruned` notification | Layer 2 | H2 |
 | **H5** | `history/diff` (pixel mode + diff PNG) | Layer 2 | H3 |
 | **H6** | MCP resource + tool mapping | Layer 3 | H2 + `:daemon:mcp` phase 2 |
 | **H7** | VS Code Preview History panel | extension | H2 |
 | **H8** | Cross-source provenance UI ("rendered by daemon", "rendered by Gradle") | extension | H7 |
-| **H9** | `HistorySource` interface + multi-source merging in `historyManager` | Layer 2 | H2 |
-| **H10** | `GitRefHistorySource` (`READ_ONLY` mode) — read from `preview/<branch>` refs | Layer 2 | H9 |
-| **H11** | `GitRefHistorySource` `WRITE_LOCAL` — debounced commit on render burst | Layer 2 | H10 |
+| **H9** | `HistorySource` interface + multi-source merging in `historyManager` | Layer 2 | H2 — landed (H1+H2 already shipped the interface; H10-read shipped multi-source merging) |
+| ~~**H10a**~~ | ~~`GitRefHistorySource` (`READ_ONLY` mode) — read from `preview/<branch>` refs~~ | Layer 2 | H9 — landed |
+| **H10b** | Layer 1 plumbing — gradle plugin emits `composeai.daemon.gitRefHistory` in the daemon launch descriptor + DSL | Layer 1 | H10a |
+| **H11** | `GitRefHistorySource` `WRITE_LOCAL` — debounced commit on render burst | Layer 2 | H10a |
 | **H12** | `WRITE_PUSH` mode + git-LFS support + squash-old-history GC | Layer 2 | H11 |
 | **H13** | `HttpMirrorHistorySource` — read-only CI / S3 mirror | Layer 2 | H9 |
 | **H14** | Cross-worktree merge in MCP `DaemonSupervisor` (multi-worktree timeline) | Layer 3 | H6 |
 
-H1+H2 are independently useful and ship together as the first daemon-side history landing. H3
-onward is enrichment.
+H1+H2 are independently useful and ship together as the first daemon-side history landing. H3 +
+H10-read landed in the second history PR (`history/diff` metadata mode + read-only
+`GitRefHistorySource` for `preview/<branch>` refs). H10b (gradle plugin emitting the sysprop)
+splits out as a separate Layer 1 task because the daemon-side read surface is independently
+useful — agents and ad-hoc launches set the sysprop manually until the plugin path lands.
 
 ## Open questions
 

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -50,8 +50,9 @@ Standard JSON-RPC codes plus daemon-specific extensions in the reserved `-32000.
 | -32003   | SandboxRecycling      | Daemon is between sandboxes; retry shortly. |
 | -32004   | UnknownPreview        | Preview ID not in the current discovery set. |
 | -32005   | RenderFailed          | Render itself failed; details in `data`. |
-| -32010   | HistoryEntryNotFound  | `history/read` referenced a missing entry id. |
-| -32011   | HistoryDiffMismatch   | `history/diff` was given two entries from different previews (reserved; phase H3+). |
+| -32010   | HistoryEntryNotFound  | `history/read` or `history/diff` referenced a missing entry id. |
+| -32011   | HistoryDiffMismatch   | `history/diff` was given two entries from different previews. |
+| -32012   | HistoryPixelNotImplemented | `history/diff` was called with `mode = "pixel"`; reserved for phase H5. |
 
 `error.data` is an object; daemon-specific errors include `data.kind: string` for machine-routable subcategories.
 
@@ -246,9 +247,47 @@ Errors:
 Errors:
 - `HistoryEntryNotFound` (-32010) — `id` does not match any entry in the configured sources.
 
-### `history/diff` (phase H3+, reserved)
+### `history/diff` (phase H3 — metadata mode)
 
-Not implemented in H1+H2. Calls return `MethodNotFound` (-32601) until H3 lands.
+```ts
+// params
+{
+  from: string;                     // entry id
+  to: string;                       // entry id
+  mode?: "metadata" | "pixel";      // default "metadata"
+}
+
+// result
+{
+  pngHashChanged: boolean;
+  fromMetadata: HistoryEntry;       // full sidecar
+  toMetadata: HistoryEntry;
+  // Pixel-mode fields — null in METADATA mode; populated by phase H5.
+  diffPx?: number;
+  ssim?: number;
+  diffPngPath?: string;
+}
+```
+
+`mode = "metadata"` (default) is cheap: hash compare + sidecar return. The pixel-mode fields
+(`diffPx`, `ssim`, `diffPngPath`) stay `null` in METADATA mode by design.
+
+`mode = "pixel"` is **reserved for phase H5** and not implemented in H3 — calls with
+`mode = "pixel"` return `-32012` (`HistoryPixelNotImplemented`) so callers can distinguish
+"asked for pixel and the daemon isn't ready" from "asked for metadata and got null pixel fields
+by design."
+
+The diff resolves `from` and `to` across all configured `HistorySource`s — `from` may live in
+`LocalFsHistorySource` while `to` lives on a `preview/main` ref via `GitRefHistorySource`. This is
+the load-bearing case for "did my edits change how this preview renders compared to main?" — see
+[HISTORY.md § "Diff across branches"](HISTORY.md#diff-across-branches).
+
+Errors:
+- `HistoryEntryNotFound` (-32010) — either `from` or `to` does not match any entry.
+- `HistoryDiffMismatch` (-32011) — `from` and `to` belong to different previews; pixel diff would
+  be meaningless.
+- `HistoryPixelNotImplemented` (-32012) — `mode = "pixel"` was requested but the pixel pass is
+  reserved for phase H5.
 
 ### `history/prune` (phase H4+, reserved)
 

--- a/docs/daemon/TODO.md
+++ b/docs/daemon/TODO.md
@@ -694,14 +694,21 @@ Tracking the daemon-side history phases from [HISTORY.md § "Phasing"](HISTORY.m
 
 - **H1 — Daemon writes sidecar + index entry per render** ✅ landed
 - **H2 — `history/list` + `history/read` + `historyAdded` notification** ✅ landed
-- **H3 — `history/diff` (metadata mode)** — still open
+- **H3 — `history/diff` (metadata mode)** ✅ landed
 - **H4 — Auto-prune + `historyPruned` notification** — still open
 - **H5 — `history/diff` (pixel mode + diff PNG)** — still open
-- H6+ (MCP / VS Code / git refs / cross-worktree merging) — see HISTORY.md table.
+- **H9 — `HistorySource` interface + multi-source merging in `historyManager`** ✅ landed (the
+  interface arrived with H1+H2; multi-source merging arrived with H10-read)
+- **H10a — `GitRefHistorySource` (READ_ONLY) — read from `preview/<branch>` refs** ✅ landed
+- **H10b — Layer 1 plumbing — gradle plugin emits `composeai.daemon.gitRefHistory` in the daemon
+  launch descriptor + DSL** — still open
+- **H11+ — `GitRefHistorySource` WRITE modes, git-LFS, squash GC** — still open
+- H6+ (MCP / VS Code / cross-worktree merging) — see HISTORY.md table.
 
-H1+H2 ship behind the existing `composePreview.experimental.daemon { enabled = true }` gate. The
-gradle plugin's daemon launch descriptor will gain `composeai.daemon.historyDir` emission in a
-follow-up; until then, agents and ad-hoc launches set the sysprop directly.
+H1+H2 + H3 + H10-read ship behind the existing `composePreview.experimental.daemon { enabled =
+true }` gate. The gradle plugin's daemon launch descriptor will gain `composeai.daemon.historyDir`
++ `composeai.daemon.gitRefHistory` emission in a follow-up (H10b); until then, agents and ad-hoc
+launches set the sysprops directly.
 
 ---
 


### PR DESCRIPTION
## Summary

Builds on PR #318 (H1+H2). Two pieces toward the "main history + PR review in the UI" workflow:

### H3 — \`history/diff\` (metadata mode)

Compares two history entries by their PNG hashes and returns both sidecars. Cheap; the precondition for "did this preview change between branch X and branch Y."

- Wire: \`HistoryDiffParams { from, to, mode = METADATA | PIXEL }\` → \`HistoryDiffResult { pngHashChanged, fromMetadata, toMetadata, diffPx?, ssim?, diffPngPath? }\`
- METADATA mode: hash compare + sidecar return. PIXEL mode is reserved (returns a clean error \`ERR_HISTORY_PIXEL_NOT_IMPLEMENTED -32012\` until H5 lands).
- Errors: \`HistoryEntryNotFound (-32010)\` for missing entries, \`HistoryDiffMismatch (-32011)\` when previewIds don't match.

### H10a — \`GitRefHistorySource\` (read-only)

A new \`HistorySource\` that reads sidecars + PNGs from a git ref's tree. The "main history" use case: dev on a feature branch sees what previews looked like on main without needing a daemon running on main, by reading \`refs/heads/preview/main\` if it's been populated.

- Storage convention on the ref: \`<sanitisedPreviewId>/<entryId>.{png,json}\` + \`_index.jsonl\` at root
- Implementation: shells out to \`git\` (matches the existing \`GitProvenance\` pattern); no JGit dependency added
- Source priority: LocalFs first (today's renders), then GitRef (cross-checkout renders); same-hash entries deduped to LocalFs as canonical
- Configured via \`composeai.daemon.gitRefHistory\` sysprop (comma-separated ref list; unset = no GitRef sources)
- **Ref-missing UX**: when the configured ref isn't present locally, emit a one-shot warn-level log notification with a hint about how to populate it (\`git fetch origin <ref>:<ref>\` or set up CI), then degrade gracefully to "no main-history available." User explicitly opted out of CI-pushes-preview/main automation; the daemon just nudges.

### What didn't land

- PIXEL mode pixel diff (H5)
- \`GitRefHistorySource\` write modes (H10b — WRITE_LOCAL / WRITE_PUSH)
- VS Code Preview History panel (H7)
- MCP integration (H6)
- \`HttpMirrorHistorySource\` (H13)
- CI workflow that auto-populates \`preview/main\` — explicitly out of scope

### Layering

- New code lives entirely in \`:daemon:core/.../history/\`
- \`:gradle-plugin\` untouched (\`git diff\` shows zero bytes)
- No JGit dependency
- \`:mcp\` module untouched
- \`grep -r "import ee.schimke.composeai.plugin" daemon/core/src/main/\` empty

## Test plan

- [x] \`./gradlew :daemon:core:test\` — new HistoryDiffTest (5 cases) + GitRefHistorySourceTest (4 cases) + HistoryManagerCrossSourceListTest pass; pre-existing tests green
- [x] \`./gradlew :daemon:harness:test\` — new S10 fake-mode test passes; S1–S9 still green; real-mode placeholders \`@Ignore\`d
- [x] \`./gradlew :daemon:desktop:test :daemon:android:testDebugUnitTest\` — daemon mains compile with the new GitRefHistorySource wiring
- [x] \`./gradlew :gradle-plugin:test :cli:assemble :samples:android:assembleDebug\` — back-compat sanity
- [x] \`./gradlew :mcp:test\` — MCP module unchanged, still green
- [ ] \`-Pharness.host=real\` — not run; fake-mode covers wire-format end-to-end