### PR TITLE
build: clear Kotlin 2.3 warnings on renderer-android + daemon Android

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -137,6 +137,11 @@ class RenderEngine(
         android.content.ComponentName(appContext.packageName, ComponentActivity::class.java.name)
       )
 
+    // v2 `createAndroidComposeRule` (compose-ui-test 1.11.0-alpha03+) is the
+    // long-term replacement, but we share the renderer's `compose-bom-compat`
+    // (1.9.5) compile floor. Track [RobolectricRenderTest.renderDefault] when
+    // the floor moves up.
+    @Suppress("DEPRECATION")
     val rule = createAndroidComposeRule<ComponentActivity>()
     val description =
       org.junit.runner.Description.createTestDescription(

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -274,7 +274,13 @@ open class RobolectricHost(
       // the Android save-loop's classloader-identity skew. See
       // `docs/daemon/classloader-forensics-diff.md` and the `sandboxClassLoaderRef` KDoc on
       // `DaemonHostBridge`.
-      DaemonHostBridge.setSandboxClassLoader(this.javaClass.classLoader)
+      // `this.javaClass.classLoader` is platform-typed to `ClassLoader?`, but
+      // every JVM-loaded class except primitives / array stubs has a non-null
+      // loader (we'd be looking at the bootstrap loader's `null` only for
+      // primitive `Class` objects, which don't apply here — `SandboxRunner` is
+      // loaded by Robolectric's `InstrumentingClassLoader`). Assert non-null
+      // so the new strict Kotlin platform-type checks stop warning.
+      DaemonHostBridge.setSandboxClassLoader(this.javaClass.classLoader!!)
 
       while (!DaemonHostBridge.shutdown.get()) {
         val request =
@@ -404,7 +410,7 @@ open class RobolectricHost(
         val captureMethod =
           forensicsClass.getMethod(
             "capture",
-            java.util.List::class.java,
+            List::class.java,
             Class.forName(
               "ee.schimke.composeai.daemon.forensics.RobolectricConfigSnapshot",
               true,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -585,7 +585,10 @@ class JsonRpcServer(
     if (entry != null) {
       sendNotification(
         "historyAdded",
-        encode(HistoryAddedParams.serializer(), HistoryAddedParams(entry = encodeHistoryEntry(entry))),
+        encode(
+          HistoryAddedParams.serializer(),
+          HistoryAddedParams(entry = encodeHistoryEntry(entry)),
+        ),
       )
     }
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitProvenance.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitProvenance.kt
@@ -10,9 +10,9 @@ import java.util.concurrent.TimeUnit
  *
  * Two-phase resolution:
  *
- * 1. **Construction (cheap, called once per daemon).** Captures [worktree], [remote] — the
- *    worktree root and remote URL never change for a daemon's lifetime. Resolution failure leaves
- *    the fields as null. No exception escapes; a non-git directory is fine.
+ * 1. **Construction (cheap, called once per daemon).** Captures [worktree], [remote] — the worktree
+ *    root and remote URL never change for a daemon's lifetime. Resolution failure leaves the fields
+ *    as null. No exception escapes; a non-git directory is fine.
  * 2. **Per-render refresh ([snapshot]).** Re-resolves [GitInfo.branch], [GitInfo.commit],
  *    [GitInfo.dirty] each call (single `git rev-parse` + `git status --porcelain` is sub-50ms in
  *    the typical project). [GitInfo.remote] is taken from the cached value.
@@ -106,10 +106,15 @@ class GitProvenance(
   )
 
   companion object {
-    /** Environment variable populated by the harness / agent supervisor — HISTORY.md § "Agent attribution". */
+    /**
+     * Environment variable populated by the harness / agent supervisor — HISTORY.md § "Agent
+     * attribution".
+     */
     const val ENV_AGENT_ID: String = "COMPOSEAI_AGENT_ID"
 
-    /** Environment variable that overrides the worktree dir basename — HISTORY.md § "Worktree IDs". */
+    /**
+     * Environment variable that overrides the worktree dir basename — HISTORY.md § "Worktree IDs".
+     */
     const val ENV_WORKTREE_ID: String = "COMPOSEAI_WORKTREE_ID"
   }
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryEntry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryEntry.kt
@@ -59,8 +59,8 @@ data class HistoryEntry(
 @Serializable data class HistorySourceInfo(val kind: String, val id: String)
 
 /**
- * Worktree provenance. `path` is the absolute worktree root; `id` is a human label (defaults to
- * the dir basename or `COMPOSEAI_WORKTREE_ID` env); `agentId` is the optional automated-agent
+ * Worktree provenance. `path` is the absolute worktree root; `id` is a human label (defaults to the
+ * dir basename or `COMPOSEAI_WORKTREE_ID` env); `agentId` is the optional automated-agent
  * self-identifier from `COMPOSEAI_AGENT_ID`. All three are nullable so a non-git workspace still
  * produces a valid sidecar.
  */

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
@@ -38,14 +38,16 @@ class HistoryManager(
   private val gitProvenance: GitProvenance?,
 ) {
 
-  /** True when at least one writable source is configured — i.e. when `recordRender` is meaningful. */
+  /**
+   * True when at least one writable source is configured — i.e. when `recordRender` is meaningful.
+   */
   val isEnabled: Boolean
     get() = sources.any { it.supportsWrites() }
 
   /**
    * Tracks the most-recent entry per previewId so [recordRender] can fill in `previousId` +
-   * `deltaFromPrevious.pngHashChanged`. Carries `(entryId, pngHash)` so the delta pass doesn't
-   * have to re-read the previous sidecar off disk.
+   * `deltaFromPrevious.pngHashChanged`. Carries `(entryId, pngHash)` so the delta pass doesn't have
+   * to re-read the previous sidecar off disk.
    */
   private val previousByPreview: AtomicReference<Map<String, PreviousEntry>> =
     AtomicReference(emptyMap())
@@ -77,7 +79,8 @@ class HistoryManager(
     val shortHash = pngHash.substring(0, 8)
     val ts = timestamp.atOffset(ZoneOffset.UTC).format(TIMESTAMP_FORMAT)
     val id = "$ts-$shortHash"
-    val isoTimestamp = timestamp.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+    val isoTimestamp =
+      timestamp.atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
 
     val (worktreeInfo, gitInfo) = gitProvenance?.snapshot() ?: Pair(null, null)
     val previous = previousByPreview.get()[previewId]
@@ -86,11 +89,7 @@ class HistoryManager(
       if (previous != null) {
         // Cheap field — full pixel diff lands in H5. For H1 we flip pngHashChanged based on the
         // previous entry's full pngHash (cached so we don't have to re-read the prior sidecar).
-        HistoryDelta(
-          pngHashChanged = previous.pngHash != pngHash,
-          diffPx = null,
-          ssim = null,
-        )
+        HistoryDelta(pngHashChanged = previous.pngHash != pngHash, diffPx = null, ssim = null)
       } else null
 
     // pngPath is provisional — LocalFsHistorySource overwrites it when dedup hits. For non-FS
@@ -171,9 +170,7 @@ class HistoryManager(
   }
 
   companion object {
-    /**
-     * `yyyyMMdd-HHmmss` UTC. Pinned format — HISTORY.md § "On-disk schema" filename shape.
-     */
+    /** `yyyyMMdd-HHmmss` UTC. Pinned format — HISTORY.md § "On-disk schema" filename shape. */
     private val TIMESTAMP_FORMAT: DateTimeFormatter =
       DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss").withZone(ZoneOffset.UTC)
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
@@ -13,8 +13,8 @@ package ee.schimke.composeai.daemon.history
  * source so most filters land mostly-redundant, but the read API still honours them.
  *
  * `sourceKind` / `sourceId` filter by storage backend identity (HISTORY.md § "Wire-format
- * effects"); H1+H2 only have `LocalFsHistorySource` so these are effectively no-ops, but the
- * shape lets H9+ multi-source merging plug in without re-shaping the filter.
+ * effects"); H1+H2 only have `LocalFsHistorySource` so these are effectively no-ops, but the shape
+ * lets H9+ multi-source merging plug in without re-shaping the filter.
  */
 data class HistoryFilter(
   val previewId: String? = null,
@@ -76,11 +76,11 @@ data class HistoryReadResult(
 /**
  * Pluggable history backend — see HISTORY.md § "HistorySource interface".
  *
- * H1+H2 ships only [LocalFsHistorySource]. Future phases (H10 onward) will add `GitRefHistorySource`
- * and `HttpMirrorHistorySource`; the consumer side merges across configured sources by `pngHash +
- * previewId + git.commit`. The interface is intentionally narrow: write is a side-effect of
- * [HistoryManager.recordRender]; read is paginated; watch is reserved for future phases (a UI
- * doesn't poll, it subscribes to `historyAdded`).
+ * H1+H2 ships only [LocalFsHistorySource]. Future phases (H10 onward) will add
+ * `GitRefHistorySource` and `HttpMirrorHistorySource`; the consumer side merges across configured
+ * sources by `pngHash + previewId + git.commit`. The interface is intentionally narrow: write is a
+ * side-effect of [HistoryManager.recordRender]; read is paginated; watch is reserved for future
+ * phases (a UI doesn't poll, it subscribes to `historyAdded`).
  */
 interface HistorySource {
   /** Stable identifier — e.g. `"fs:/abs/historyDir"`, `"git:preview/main"`, `"http:https://…"`. */
@@ -93,8 +93,8 @@ interface HistorySource {
   fun supportsWrites(): Boolean
 
   /**
-   * Persists [entry] (and its associated PNG bytes) into the backing store. Throws when this
-   * source isn't writable — gate via [supportsWrites] first.
+   * Persists [entry] (and its associated PNG bytes) into the backing store. Throws when this source
+   * isn't writable — gate via [supportsWrites] first.
    *
    * Failures here must NOT be load-bearing for the render itself — `HistoryManager.recordRender`
    * catches and logs, then continues. The render succeeded; history is observation, not state.

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
@@ -18,6 +18,7 @@ import kotlinx.serialization.json.Json
  * "On-disk schema".
  *
  * **Layout:**
+ *
  * ```
  * <historyDir>/
  * ├── index.jsonl
@@ -77,7 +78,8 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
         pngFileName
       }
 
-    val canonicalEntry = if (entry.pngPath == effectivePngPath) entry else entry.copy(pngPath = effectivePngPath)
+    val canonicalEntry =
+      if (entry.pngPath == effectivePngPath) entry else entry.copy(pngPath = effectivePngPath)
     val sidecarText = JSON.encodeToString(HistoryEntry.serializer(), canonicalEntry)
     sidecarFile.writeText(sidecarText, StandardCharsets.UTF_8)
 
@@ -106,7 +108,9 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
     // Cursor is an opaque base64 of "<timestamp>|<id>"; we drop entries until we pass it.
     val afterCursor =
       if (filter.cursor != null) {
-        val decoded = decodeCursor(filter.cursor) ?: return HistoryListPage(emptyList(), totalCount = totalCount)
+        val decoded =
+          decodeCursor(filter.cursor)
+            ?: return HistoryListPage(emptyList(), totalCount = totalCount)
         matched.dropWhile { it.timestamp != decoded.timestamp || it.id != decoded.id }.drop(1)
       } else {
         matched
@@ -154,8 +158,8 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
   }
 
   /**
-   * Walks the per-preview directory looking for the most recent (lex-sorted) sidecar whose
-   * pngHash matches [hash]. Returns the relative PNG filename of the match, or null when no match.
+   * Walks the per-preview directory looking for the most recent (lex-sorted) sidecar whose pngHash
+   * matches [hash]. Returns the relative PNG filename of the match, or null when no match.
    */
   private fun findMostRecentEntryWithHash(
     previewDir: Path,
@@ -274,8 +278,8 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
     const val MAX_LIMIT: Int = 500
 
     /**
-     * JSON configuration shared across the LocalFs path. `encodeDefaults = false` keeps the
-     * sidecar JSON minimal — null fields don't land on disk; readers tolerate their absence.
+     * JSON configuration shared across the LocalFs path. `encodeDefaults = false` keeps the sidecar
+     * JSON minimal — null fields don't land on disk; readers tolerate their absence.
      * `ignoreUnknownKeys = true` keeps forward-compat: a v2 schema add doesn't break a v1 reader.
      */
     private val JSON: Json = Json {
@@ -319,4 +323,3 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
     }
   }
 }
-

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/PreviewIdSanitiser.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/PreviewIdSanitiser.kt
@@ -8,8 +8,8 @@ package ee.schimke.composeai.daemon.history
  * schema"): characters that satisfy [Char.isLetterOrDigit] OR are one of `.`, `_`, `-` are kept
  * verbatim; everything else collapses to `_`. Empty input yields the literal `_`.
  *
- * Stable across processes, locale-independent (the Kotlin `Char.isLetterOrDigit` extension delegates
- * to `Character.isLetterOrDigit(int)` which is Unicode-defined, not locale-dependent).
+ * Stable across processes, locale-independent (the Kotlin `Char.isLetterOrDigit` extension
+ * delegates to `Character.isLetterOrDigit(int)` which is Unicode-defined, not locale-dependent).
  */
 internal object PreviewIdSanitiser {
   fun sanitise(previewId: String): String {

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitProvenanceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitProvenanceTest.kt
@@ -21,8 +21,8 @@ import org.junit.Test
  *   says.
  *
  * Skipped when the test JVM has no `git` on the path (CI containers without git installed). The
- * brief explicitly says don't gate the harness's S9 on git availability — same here for the
- * core unit test.
+ * brief explicitly says don't gate the harness's S9 on git availability — same here for the core
+ * unit test.
  */
 class GitProvenanceTest {
 
@@ -54,10 +54,7 @@ class GitProvenanceTest {
     val provenance = GitProvenance(workspaceRoot = tmpDir, env = mapOf())
     val (worktree, git) = provenance.snapshot()
     assertNotNull("worktree must be non-null in a git repo", worktree)
-    assertEquals(
-      tmpDir.toRealPath().toString(),
-      Path.of(worktree!!.path!!).toRealPath().toString(),
-    )
+    assertEquals(tmpDir.toRealPath().toString(), Path.of(worktree!!.path!!).toRealPath().toString())
     assertNotNull("git provenance must be non-null in a git repo", git)
     assertNotNull("commit must be present", git!!.commit)
     assertEquals(7, git.shortCommit?.length)
@@ -90,8 +87,12 @@ class GitProvenanceTest {
     try {
       val provenance = GitProvenance(workspaceRoot = nonGitDir, env = mapOf())
       val (worktree, git) = provenance.snapshot()
-      // worktree may be null OR carry only id-label/agentId if any env was set; here env is empty so:
-      assertTrue(worktree == null || (worktree.path == null && worktree.id == null && worktree.agentId == null))
+      // worktree may be null OR carry only id-label/agentId if any env was set; here env is empty
+      // so:
+      assertTrue(
+        worktree == null ||
+          (worktree.path == null && worktree.id == null && worktree.agentId == null)
+      )
       assertNull(git)
     } finally {
       nonGitDir.toFile().deleteRecursively()
@@ -144,11 +145,7 @@ class GitProvenanceTest {
     }
 
   private fun runOrFail(workingDir: File, vararg cmd: String) {
-    val proc =
-      ProcessBuilder(*cmd)
-        .directory(workingDir)
-        .redirectErrorStream(true)
-        .start()
+    val proc = ProcessBuilder(*cmd).directory(workingDir).redirectErrorStream(true).start()
     val finished = proc.waitFor(15, TimeUnit.SECONDS)
     assertTrue("$cmd timed out", finished)
     assertEquals(

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryEntryRoundTripTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryEntryRoundTripTest.kt
@@ -8,16 +8,19 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 /**
- * Pins the kotlinx.serialization round-trip for [HistoryEntry] — every nested struct
- * (`worktree` / `git` / `source` / `triggerDetail` / `previewMetadata` / `metrics` /
- * `deltaFromPrevious`) must survive encode → decode without field loss.
+ * Pins the kotlinx.serialization round-trip for [HistoryEntry] — every nested struct (`worktree` /
+ * `git` / `source` / `triggerDetail` / `previewMetadata` / `metrics` / `deltaFromPrevious`) must
+ * survive encode → decode without field loss.
  *
- * The on-disk sidecar JSON is the wire format; this test is the one place where the schema's
- * shape is locked end-to-end. New fields added to [HistoryEntry] should grow this fixture.
+ * The on-disk sidecar JSON is the wire format; this test is the one place where the schema's shape
+ * is locked end-to-end. New fields added to [HistoryEntry] should grow this fixture.
  */
 class HistoryEntryRoundTripTest {
 
-  private val json = Json { ignoreUnknownKeys = true; encodeDefaults = false }
+  private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = false
+  }
 
   @Test
   fun fully_populated_entry_round_trips() {
@@ -77,7 +80,8 @@ class HistoryEntryRoundTripTest {
 
   @Test
   fun minimal_entry_round_trips() {
-    // Tests the "no provenance, no previous, no delta" path — the first render in a non-git workspace.
+    // Tests the "no provenance, no previous, no delta" path — the first render in a non-git
+    // workspace.
     val entry =
       HistoryEntry(
         id = "20260430-101234-deadbeef",

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
@@ -34,7 +34,8 @@ import org.junit.Test
  * 1. After a `renderNow` succeeds, a `historyAdded` notification arrives carrying a parseable
  *    [HistoryEntry] whose `pngHash` matches the rendered bytes.
  * 2. `history/list` returns the same entry.
- * 3. `history/read` (default) returns the entry + a non-null `pngPath` referencing the bytes on disk.
+ * 3. `history/read` (default) returns the entry + a non-null `pngPath` referencing the bytes on
+ *    disk.
  * 4. `history/read({inline: true})` returns base64 bytes that decode back to the original PNG.
  * 5. `history/list({previewId: "other"})` filter narrows correctly.
  * 6. `history/read({id: "missing"})` returns a `-32010 HistoryEntryNotFound` error.
@@ -83,7 +84,8 @@ class JsonRpcServerHistoryIntegrationTest {
         historyManager = historyManager,
         onExit = { _ -> exitLatch.countDown() },
       )
-    val serverThread = Thread({ server.run() }, "json-rpc-server-history-test").apply { isDaemon = true }
+    val serverThread =
+      Thread({ server.run() }, "json-rpc-server-history-test").apply { isDaemon = true }
     serverThread.start()
 
     val received = LinkedBlockingQueue<JsonObject>()
@@ -242,11 +244,13 @@ class JsonRpcServerHistoryIntegrationTest {
    * deterministic blob works.
    */
   private class RealPngHost(private val rendersDir: Path) : RenderHost {
-    @Volatile var lastPngBytes: ByteArray = ByteArray(0)
+    @Volatile
+    var lastPngBytes: ByteArray = ByteArray(0)
       private set
 
     private val queue = LinkedBlockingQueue<RenderRequest>()
-    private val results = java.util.concurrent.ConcurrentHashMap<Long, LinkedBlockingQueue<RenderResult>>()
+    private val results =
+      java.util.concurrent.ConcurrentHashMap<Long, LinkedBlockingQueue<RenderResult>>()
 
     @Volatile private var stopped = false
     private val worker =

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceCorruptionTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceCorruptionTest.kt
@@ -11,8 +11,8 @@ import org.junit.Test
 /**
  * Pins reader-side robustness from HISTORY.md § "Concurrency model" / § "Provenance trust":
  * - Truncated index lines are skipped with a warn log, not a parse exception.
- * - Index entries that reference a sidecar that doesn't exist on disk are silently dropped from
- *   the listing — "self-healing on next prune".
+ * - Index entries that reference a sidecar that doesn't exist on disk are silently dropped from the
+ *   listing — "self-healing on next prune".
  */
 class LocalFsHistorySourceCorruptionTest {
 
@@ -41,9 +41,10 @@ class LocalFsHistorySourceCorruptionTest {
     // Append a truncated line + a syntactically-valid line for an entry with no sidecar on disk.
     val orphanId = "ts-02-deadbeef"
     val orphanEntry =
-      makeEntry(id = orphanId, hash = "deadbeef".repeat(8), size = 100L).copy(timestamp = "2026-04-30T11:00:00Z")
+      makeEntry(id = orphanId, hash = "deadbeef".repeat(8), size = 100L)
+        .copy(timestamp = "2026-04-30T11:00:00Z")
     val indexFile = tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)
-    val truncated = "{\"id\":\"truncated\",\"previewId\":"  // Deliberately incomplete.
+    val truncated = "{\"id\":\"truncated\",\"previewId\":" // Deliberately incomplete.
     val orphanLine =
       kotlinx.serialization.json.Json.encodeToString(HistoryEntry.serializer(), orphanEntry)
     Files.write(
@@ -53,7 +54,8 @@ class LocalFsHistorySourceCorruptionTest {
     )
 
     val page = source.list(HistoryFilter())
-    // Only the original valid entry should survive — truncated line + orphan reference both filtered.
+    // Only the original valid entry should survive — truncated line + orphan reference both
+    // filtered.
     assertEquals(1, page.entries.size)
     assertEquals(validId, page.entries[0].id)
     assertNotNull(page.entries[0])

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceReadTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceReadTest.kt
@@ -67,9 +67,7 @@ class LocalFsHistorySourceReadTest {
     writeEntry(previewId = "A", timestampField = "2026-04-30T10:00:10Z", suffix = "03")
 
     val page =
-      source.list(
-        HistoryFilter(since = "2026-04-30T10:00:03Z", until = "2026-04-30T10:00:08Z")
-      )
+      source.list(HistoryFilter(since = "2026-04-30T10:00:03Z", until = "2026-04-30T10:00:08Z"))
     assertEquals(1, page.entries.size)
     assertEquals("2026-04-30T10:00:05Z", page.entries[0].timestamp)
   }
@@ -86,7 +84,8 @@ class LocalFsHistorySourceReadTest {
       previewId = "A",
       timestampField = "2026-04-30T10:00:05Z",
       suffix = "02",
-      git = GitInfo(branch = "agent/foo", commit = "cafef00d", shortCommit = "cafef00", dirty = false),
+      git =
+        GitInfo(branch = "agent/foo", commit = "cafef00d", shortCommit = "cafef00", dirty = false),
     )
     val page = source.list(HistoryFilter(branch = "agent/foo"))
     assertEquals(1, page.entries.size)
@@ -125,7 +124,8 @@ class LocalFsHistorySourceReadTest {
 
   @Test
   fun read_returns_entry_and_resolves_png_path() {
-    val (id, _) = writeEntry(previewId = "A", timestampField = "2026-04-30T10:00:00Z", suffix = "01")
+    val (id, _) =
+      writeEntry(previewId = "A", timestampField = "2026-04-30T10:00:00Z", suffix = "01")
     val read = source.read(id, includeBytes = false)
     assertNotNull(read)
     assertEquals(id, read!!.entry.id)
@@ -150,8 +150,8 @@ class LocalFsHistorySourceReadTest {
   }
 
   /**
-   * Writes one synthetic entry. Returns the id and the PNG bytes for callers that want to assert
-   * on round-trip identity (e.g. inline-bytes test).
+   * Writes one synthetic entry. Returns the id and the PNG bytes for callers that want to assert on
+   * round-trip identity (e.g. inline-bytes test).
    */
   private fun writeEntry(
     previewId: String,

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceWriteTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceWriteTest.kt
@@ -41,13 +41,20 @@ class LocalFsHistorySourceWriteTest {
     val previewId = "com.example.Foo"
     val sanitised = "com.example.Foo"
 
-    val entries = (1..3).map { i ->
-      val bytes = byteArrayOf(i.toByte(), 0x00, 0x01)
-      val hash = LocalFsHistorySource.sha256Hex(bytes)
-      val entry = makeEntry(id = "ts-$i-${hash.take(8)}", previewId = previewId, hash = hash, size = bytes.size.toLong())
-      source.write(entry, bytes)
-      Triple(entry, bytes, hash)
-    }
+    val entries =
+      (1..3).map { i ->
+        val bytes = byteArrayOf(i.toByte(), 0x00, 0x01)
+        val hash = LocalFsHistorySource.sha256Hex(bytes)
+        val entry =
+          makeEntry(
+            id = "ts-$i-${hash.take(8)}",
+            previewId = previewId,
+            hash = hash,
+            size = bytes.size.toLong(),
+          )
+        source.write(entry, bytes)
+        Triple(entry, bytes, hash)
+      }
 
     val previewDir = tmpDir.resolve(sanitised)
     assertTrue(Files.isDirectory(previewDir))
@@ -65,7 +72,9 @@ class LocalFsHistorySourceWriteTest {
     }
 
     val indexLines =
-      Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)).filter { it.isNotBlank() }
+      Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)).filter {
+        it.isNotBlank()
+      }
     assertEquals(3, indexLines.size)
     val ids = indexLines.map { json.decodeFromString(HistoryEntry.serializer(), it).id }
     assertEquals(entries.map { it.first.id }, ids)
@@ -78,8 +87,20 @@ class LocalFsHistorySourceWriteTest {
     val bytes = byteArrayOf(0x10, 0x20, 0x30, 0x40)
     val hash = LocalFsHistorySource.sha256Hex(bytes)
 
-    val firstEntry = makeEntry(id = "a-${hash.take(8)}", previewId = previewId, hash = hash, size = bytes.size.toLong())
-    val secondEntry = makeEntry(id = "b-${hash.take(8)}", previewId = previewId, hash = hash, size = bytes.size.toLong())
+    val firstEntry =
+      makeEntry(
+        id = "a-${hash.take(8)}",
+        previewId = previewId,
+        hash = hash,
+        size = bytes.size.toLong(),
+      )
+    val secondEntry =
+      makeEntry(
+        id = "b-${hash.take(8)}",
+        previewId = previewId,
+        hash = hash,
+        size = bytes.size.toLong(),
+      )
     source.write(firstEntry, bytes)
     source.write(secondEntry, bytes)
 
@@ -99,7 +120,9 @@ class LocalFsHistorySourceWriteTest {
 
     // Index has both lines, both readable.
     val indexLines =
-      Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)).filter { it.isNotBlank() }
+      Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)).filter {
+        it.isNotBlank()
+      }
     assertEquals(2, indexLines.size)
   }
 
@@ -110,11 +133,23 @@ class LocalFsHistorySourceWriteTest {
     val previewId = "Bar"
     val bytes = byteArrayOf(0x77, 0x77, 0x77)
     val hash = LocalFsHistorySource.sha256Hex(bytes)
-    val firstEntry = makeEntry(id = "old-${hash.take(8)}", previewId = previewId, hash = hash, size = bytes.size.toLong())
+    val firstEntry =
+      makeEntry(
+        id = "old-${hash.take(8)}",
+        previewId = previewId,
+        hash = hash,
+        size = bytes.size.toLong(),
+      )
     LocalFsHistorySource(historyDir = tmpDir).write(firstEntry, bytes)
 
     val sourceB = LocalFsHistorySource(historyDir = tmpDir)
-    val secondEntry = makeEntry(id = "new-${hash.take(8)}", previewId = previewId, hash = hash, size = bytes.size.toLong())
+    val secondEntry =
+      makeEntry(
+        id = "new-${hash.take(8)}",
+        previewId = previewId,
+        hash = hash,
+        size = bytes.size.toLong(),
+      )
     sourceB.write(secondEntry, bytes)
 
     val previewDir = tmpDir.resolve("Bar")
@@ -123,7 +158,11 @@ class LocalFsHistorySourceWriteTest {
     assertTrue(Files.exists(firstPng))
     assertFalse("Cross-restart dedup must skip the duplicate PNG", Files.exists(secondPng))
 
-    val sidecar = json.decodeFromString(HistoryEntry.serializer(), Files.readString(previewDir.resolve("${secondEntry.id}.json")))
+    val sidecar =
+      json.decodeFromString(
+        HistoryEntry.serializer(),
+        Files.readString(previewDir.resolve("${secondEntry.id}.json")),
+      )
     assertEquals("${firstEntry.id}.png", sidecar.pngPath)
   }
 
@@ -133,7 +172,13 @@ class LocalFsHistorySourceWriteTest {
     val rawId = "com/example/foo:bar"
     val bytes = byteArrayOf(1, 2, 3)
     val hash = LocalFsHistorySource.sha256Hex(bytes)
-    val entry = makeEntry(id = "ts-${hash.take(8)}", previewId = rawId, hash = hash, size = bytes.size.toLong())
+    val entry =
+      makeEntry(
+        id = "ts-${hash.take(8)}",
+        previewId = rawId,
+        hash = hash,
+        size = bytes.size.toLong(),
+      )
     source.write(entry, bytes)
 
     // sanitisation collapses '/' and ':' to '_'

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -150,15 +150,14 @@ fun main(args: Array<String>) {
     if (historyDirProp != null) {
       GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of))
     } else null
-  val historyManager: HistoryManager? =
-    historyDirProp?.let { dir ->
-      System.err.println("compose-ai-tools desktop daemon: HistoryManager active (dir=$dir)")
-      HistoryManager.forLocalFs(
-        historyDir = Path.of(dir),
-        module = System.getProperty(MODULE_ID_PROP) ?: "",
-        gitProvenance = gitProvenance,
-      )
-    }
+  val historyManager: HistoryManager? = historyDirProp?.let { dir ->
+    System.err.println("compose-ai-tools desktop daemon: HistoryManager active (dir=$dir)")
+    HistoryManager.forLocalFs(
+      historyDir = Path.of(dir),
+      module = System.getProperty(MODULE_ID_PROP) ?: "",
+      gitProvenance = gitProvenance,
+    )
+  }
 
   val server =
     JsonRpcServer(

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
@@ -95,15 +95,14 @@ fun main(args: Array<String>) {
   // the sysprop see the pre-H1 default (no history written, history/list returns empty).
   val historyDirProp = System.getProperty("composeai.daemon.historyDir")
   val workspaceRootProp = System.getProperty("composeai.daemon.workspaceRoot")
-  val historyManager: HistoryManager? =
-    historyDirProp?.let { dir ->
-      System.err.println("compose-ai-daemon harness: HistoryManager active (dir=$dir)")
-      HistoryManager.forLocalFs(
-        historyDir = Path.of(dir),
-        module = System.getProperty("composeai.daemon.moduleId") ?: ":harness",
-        gitProvenance = GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of)),
-      )
-    }
+  val historyManager: HistoryManager? = historyDirProp?.let { dir ->
+    System.err.println("compose-ai-daemon harness: HistoryManager active (dir=$dir)")
+    HistoryManager.forLocalFs(
+      historyDir = Path.of(dir),
+      module = System.getProperty("composeai.daemon.moduleId") ?: ":harness",
+      gitProvenance = GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of)),
+    )
+  }
 
   val server =
     JsonRpcServer(

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessClient.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessClient.kt
@@ -179,8 +179,8 @@ private constructor(
   }
 
   /**
-   * H1+H2 — like [historyRead] but returns the raw response so callers can assert on
-   * `error.code == -32010` (HistoryEntryNotFound).
+   * H1+H2 — like [historyRead] but returns the raw response so callers can assert on `error.code ==
+   * -32010` (HistoryEntryNotFound).
    */
   fun historyReadRaw(id: String, inline: Boolean = false): JsonObject {
     val rpcId = nextId.getAndIncrement()

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S9HistoryRecordingTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S9HistoryRecordingTest.kt
@@ -35,10 +35,11 @@ class S9HistoryRecordingTest {
   @Test
   fun s9_history_recording_fake_mode() {
     val moduleBuildDir = File("build")
-    val fixtureDir = File(moduleBuildDir, "daemon-harness/fixtures/s9").apply {
-      deleteRecursively()
-      mkdirs()
-    }
+    val fixtureDir =
+      File(moduleBuildDir, "daemon-harness/fixtures/s9").apply {
+        deleteRecursively()
+        mkdirs()
+      }
     val historyDir = Files.createTempDirectory("s9-history").toFile().apply { deleteOnExit() }
     val previewId = "preview-1"
     val pngBytes = TestPatterns.solidColour(64, 64, 0xFF202080.toInt())
@@ -52,18 +53,13 @@ class S9HistoryRecordingTest {
         .filter { it.isNotBlank() }
         .map { File(it) }
     val launcher =
-      FakeHarnessLauncher(
-        fixtureDir = fixtureDir,
-        classpath = classpath,
-        historyDir = historyDir,
-      )
+      FakeHarnessLauncher(fixtureDir = fixtureDir, classpath = classpath, historyDir = historyDir)
     val client = HarnessClient.start(launcher)
     try {
       client.initialize()
       client.sendInitialized()
 
-      val renderNowResult =
-        client.renderNow(previews = listOf(previewId), tier = RenderTier.FAST)
+      val renderNowResult = client.renderNow(previews = listOf(previewId), tier = RenderTier.FAST)
       assertEquals(listOf(previewId), renderNowResult.queued)
 
       // historyAdded notification — within 5s of renderFinished. We poll for it explicitly
@@ -93,10 +89,7 @@ class S9HistoryRecordingTest {
       val listResult = client.historyList(HistoryListParams())
       assertEquals(1, listResult.totalCount)
       assertEquals(1, listResult.entries.size)
-      assertEquals(
-        entryId,
-        listResult.entries[0].jsonObject["id"]?.jsonPrimitive?.contentOrNull,
-      )
+      assertEquals(entryId, listResult.entries[0].jsonObject["id"]?.jsonPrimitive?.contentOrNull)
 
       // history/read resolves the PNG path.
       val read = client.historyRead(entryId, inline = false)
@@ -107,7 +100,9 @@ class S9HistoryRecordingTest {
       val exitCode = client.shutdownAndExit()
       assertEquals(0, exitCode)
     } catch (t: Throwable) {
-      System.err.println("S9HistoryRecordingTest failed; stderr from daemon:\n${client.dumpStderr()}")
+      System.err.println(
+        "S9HistoryRecordingTest failed; stderr from daemon:\n${client.dumpStderr()}"
+      )
       throw t
     } finally {
       try {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,9 +9,10 @@ kotlin = "2.3.21"
 # language features in any published module so dropping to 2.0.21 has zero
 # cost on our source today.
 # Caveat: the 2.3.x compiler emits `Language version 2.0 is deprecated and
-# its support will be removed in a future version of Kotlin`. When that
-# removal lands (likely 2.4.x), bump this to `2.1.x` and accept that
-# Kotlin 2.0.x consumers will need to upgrade.
+# its support will be removed in a future version of Kotlin`. That warning
+# is silenced via `-Xsuppress-version-warnings` in the modules calling
+# `configureKotlinCompatibility(...)`; remove the flag (and bump this to
+# `2.1.x`) when the removal lands and we're ready to drop 2.0.x consumers.
 kotlinCoreLibraries = "2.0.21"
 agp = "9.2.0"
 ktfmt = "0.26.0"
@@ -75,6 +76,16 @@ maven-publish = "0.36.0"
 # driving Google's own `validate*ScreenshotTest` tasks. Still alpha —
 # re-check compatibility when bumping AGP.
 android-compose-screenshot = "0.0.1-alpha14"
+# Checker Framework qualifier annotations. ATF (`accessibility-test-framework`,
+# pulled in transitively by `roborazzi-accessibility-check`) annotates its
+# nullable getters with `@org.checkerframework.checker.nullness.qual.Nullable`.
+# When that annotation isn't on the renderer's compile classpath the Kotlin
+# 2.3+ compiler emits `INACCESSIBLE_TYPE` warnings (becomes an error in
+# language version 2.4 — KT-80247) on every call site that reads such a
+# getter. Adding `compileOnly(libs.checker.qual)` is enough to silence the
+# warning without exporting the annotation to consumers (it's marker-only;
+# zero runtime impact).
+checker-qual = "3.49.0"
 
 [libraries]
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
@@ -111,6 +122,7 @@ ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version = "1.59.0" }
 roborazzi-compose = { module = "io.github.takahirom.roborazzi:roborazzi-compose", version = "1.59.0" }
 roborazzi-accessibility-check = { module = "io.github.takahirom.roborazzi:roborazzi-accessibility-check", version = "1.59.0" }
+checker-qual = { module = "org.checkerframework:checker-qual", version.ref = "checker-qual" }
 roborazzi-annotations = { module = "io.github.takahirom.roborazzi:roborazzi-annotations", version = "1.59.0" }
 junit = { module = "junit:junit", version.ref = "junit" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }

--- a/preview-annotations/build.gradle.kts
+++ b/preview-annotations/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import tapmoc.TapmocExtension
 import tapmoc.configureKotlinCompatibility
 
@@ -13,6 +14,13 @@ plugins {
 // against this artifact. `checkDependencies()` fails the build if a
 // transitive API dep raises the floor.
 configureKotlinCompatibility(version = libs.versions.kotlinCoreLibraries.get())
+
+// Silence `Language version 2.0 is deprecated …` from the 2.3.x compiler.
+// We intentionally hold the floor at 2.0 (see `kotlinCoreLibraries` in
+// libs.versions.toml); drop this when that version bumps to 2.1+.
+tasks.withType<KotlinCompilationTask<*>>().configureEach {
+  compilerOptions.freeCompilerArgs.add("-Xsuppress-version-warnings")
+}
 
 extensions.configure<TapmocExtension> { checkDependencies() }
 

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -5,6 +5,7 @@
 // types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
 
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import tapmoc.TapmocExtension
 import tapmoc.configureKotlinCompatibility
 
@@ -19,6 +20,13 @@ plugins {
 
 // See preview-annotations/build.gradle.kts for the rationale.
 configureKotlinCompatibility(version = libs.versions.kotlinCoreLibraries.get())
+
+// Mirror preview-annotations: silence the 2.3.x compiler's
+// `Language version 2.0 is deprecated …` warning while we hold the floor
+// at 2.0 (see `kotlinCoreLibraries` in libs.versions.toml).
+tasks.withType<KotlinCompilationTask<*>>().configureEach {
+  compilerOptions.freeCompilerArgs.add("-Xsuppress-version-warnings")
+}
 
 extensions.configure<TapmocExtension> { checkDependencies() }
 
@@ -156,6 +164,16 @@ dependencies {
   // form `captureRoboImage { @Composable }` closes its ActivityScenario
   // eagerly, which detaches the view before ATF gets to run.
   implementation(libs.roborazzi.accessibility.check)
+  // ATF (`accessibility-test-framework`, transitively pulled in via
+  // roborazzi-accessibility-check) annotates its nullable getters with
+  // `@org.checkerframework.checker.nullness.qual.Nullable`. Without this
+  // annotation class on the compile classpath, Kotlin 2.3+ emits
+  // `INACCESSIBLE_TYPE` warnings (KT-80247 — error in language version 2.4)
+  // at every call site reading one of those getters (e.g. AccessibilityChecker's
+  // `el.className` / `el.resourceName` / etc.). compileOnly is enough — the
+  // annotations are marker-only and we don't want to widen consumers'
+  // runtime classpath.
+  compileOnly(libs.checker.qual)
 
   // Tiles rendering is reflection-driven at runtime (the consumer module
   // supplies the actual classes on the JUnit classpath), so we only need

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AnimationInspector.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AnimationInspector.kt
@@ -189,7 +189,7 @@ internal class AnimationInspector private constructor(
                 .filter { m ->
                     val name = m.name
                     m.parameterTypes.isEmpty() &&
-                        java.util.Map::class.java.isAssignableFrom(m.returnType) &&
+                        Map::class.java.isAssignableFrom(m.returnType) &&
                         (name.startsWith("get") && name.endsWith("Clocks\$ui_tooling"))
                 }
                 .onEach { it.isAccessible = true }
@@ -296,7 +296,7 @@ internal class AnimationInspector private constructor(
                 .filter { ctor ->
                     ctor.parameterTypes.isNotEmpty() &&
                         ctor.parameterTypes.all { p ->
-                            kotlin.jvm.functions.Function0::class.java.isAssignableFrom(p)
+                            Function0::class.java.isAssignableFrom(p)
                         }
                 }
                 .maxByOrNull { it.parameterTypes.size }
@@ -304,12 +304,12 @@ internal class AnimationInspector private constructor(
 
         private fun noOpCallbacks(count: Int): Array<Any> = Array(count) { NO_OP_CALLBACK }
 
-        private val NO_OP_CALLBACK = object : kotlin.jvm.functions.Function0<Unit> {
+        private val NO_OP_CALLBACK = object : Function0<Unit> {
             override fun invoke() = Unit
         }
     }
 
-    private class Function0Adapter<T>(private val produce: () -> T) : kotlin.jvm.functions.Function0<T> {
+    private class Function0Adapter<T>(private val produce: () -> T) : Function0<T> {
         override fun invoke(): T = produce()
     }
 }

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -460,6 +460,12 @@ abstract class RobolectricRenderTestBase(
         val a11yEnabled = System.getProperty("composeai.a11y.enabled") == "true"
         val annotate = a11yEnabled && System.getProperty("composeai.a11y.annotate") != "false"
 
+        // The v2 replacement (`androidx.compose.ui.test.junit4.v2.createAndroidComposeRule`)
+        // that the deprecation warning suggests was added in compose-ui-test
+        // 1.11.0-alpha03; the renderer compiles against `compose-bom-compat`
+        // (1.9.5) so the v2 entry point isn't on our compile classpath. Once
+        // the compat floor moves up, drop the suppression and switch.
+        @Suppress("DEPRECATION")
         val rule = createAndroidComposeRule<ComponentActivity>()
         val description = org.junit.runner.Description.createTestDescription(
             this::class.java,


### PR DESCRIPTION
## Summary

Clears every warning the 2.3.21 toolchain currently emits on `:renderer-android:compileDebugKotlin`, `:daemon:android:compileDebugKotlin`, and `:preview-annotations:compileKotlin`. Two commits:

1. **`style:`** — drive-by `./gradlew ktfmtFormatAll` so the pre-commit hook stops flagging files left over from #318.
2. **`build:`** — the actual warning fixes.

### Per-warning fix

| Warning | Fix |
|---|---|
| `Language version 2.0 is deprecated` (`:renderer-android`, `:preview-annotations`) | Hold `kotlinCoreLibraries = "2.0.21"` (we still want the 2.0.x consumer ABI floor) and silence the warning via `-Xsuppress-version-warnings`. Drop the flag when the floor moves to 2.1+. |
| Checker Framework `@Nullable` inaccessible on `AccessibilityChecker.kt` (ATF's `ViewHierarchyElement` getters) | Add `compileOnly(libs.checker.qual)` so the annotation class is on the compile classpath. Marker-only artifact, not exported to consumers. |
| `java.util.Map` / `kotlin.jvm.functions.Function0` not recommended in `AnimationInspector.kt` | Switch to the canonical Kotlin spellings (`Map::class.java`, `Function0`). No bytecode change. |
| Deprecated `createAndroidComposeRule` in `RobolectricRenderTest` and `RenderEngine` | The v2 replacement (`androidx.compose.ui.test.junit4.v2.createAndroidComposeRule`) only exists in compose-ui-test 1.11.0-alpha03+, but we compile against `compose-bom-compat` (1.9.5). `@Suppress("DEPRECATION")` with a TODO to switch when the floor moves. |
| `ClassLoader?` platform-type mismatch in `RobolectricHost.kt` | `this.javaClass.classLoader` is non-null for the sandbox-loaded `SandboxRunner`; assert with `!!`. |
| `java.util.List::class.java` reflection lookup in `RobolectricHost.kt` | Switch to `List::class.java` (same JVM `Class` object after Kotlin's mapping). |

## Test plan

- [x] `./gradlew :renderer-android:compileDebugKotlin :daemon:android:compileDebugKotlin :preview-annotations:compileKotlin --rerun-tasks` — clean, no warnings on the targeted tasks
- [ ] `./gradlew check`
- [ ] `./gradlew :samples:android:renderAllPreviews` (verify a11y check still works with checker-qual on the compile-only classpath)
- [ ] `./gradlew :samples:android-daemon-bench:renderAllPreviews` (RenderEngine deprecation suppression doesn't change behaviour)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4PYvS31npyU7HCD6FCuDb)_