### PR TITLE
feat(vscode): history protocol types + client methods (H7 phase A)

### DIFF
--- a/vscode-extension/src/daemon/daemonClient.ts
+++ b/vscode-extension/src/daemon/daemonClient.ts
@@ -5,6 +5,13 @@ import {
     DaemonWarmingParams,
     DiscoveryUpdatedParams,
     FileChangedParams,
+    HistoryAddedParams,
+    HistoryDiffParams,
+    HistoryDiffResult,
+    HistoryListParams,
+    HistoryListResult,
+    HistoryReadParams,
+    HistoryReadResult,
     InitializeParams,
     InitializeResult,
     JsonRpcError,
@@ -44,6 +51,9 @@ export interface DaemonClientEvents {
     onDaemonWarming?: (params: DaemonWarmingParams) => void;
     onDaemonReady?: () => void;
     onLog?: (params: LogParams) => void;
+    /** Phase H2 — daemon emits this after writing each render's sidecar +
+     *  index entry. Subscribers avoid polling `history/list`. */
+    onHistoryAdded?: (params: HistoryAddedParams) => void;
     /** Stream end / framing collapse. After this fires, the client is dead. */
     onChannelClosed?: (err?: Error) => void;
 }
@@ -118,6 +128,27 @@ export class DaemonClient {
 
     renderNow(params: RenderNowParams): Promise<RenderNowResult> {
         return this.request<RenderNowResult>('renderNow', params);
+    }
+
+    /** Phase H2. Returns recent history entries newest-first; pass back
+     *  `result.nextCursor` as `params.cursor` to paginate. Filter fields are
+     *  cumulative (AND semantics). See PROTOCOL.md § 5 (history/list). */
+    historyList(params: HistoryListParams = {}): Promise<HistoryListResult> {
+        return this.request<HistoryListResult>('history/list', params);
+    }
+
+    /** Phase H2. `inline: false` (default) returns `pngPath` only —
+     *  preferred for local same-host clients; the bytes never traverse the
+     *  wire. `inline: true` returns base64 `pngBytes`. See PROTOCOL.md § 5. */
+    historyRead(params: HistoryReadParams): Promise<HistoryReadResult> {
+        return this.request<HistoryReadResult>('history/read', params);
+    }
+
+    /** Phase H3 (metadata mode). `mode: 'pixel'` is reserved for H5 and
+     *  rejects with `HistoryPixelNotImplemented` until then. See
+     *  PROTOCOL.md § 5 (history/diff). */
+    historyDiff(params: HistoryDiffParams): Promise<HistoryDiffResult> {
+        return this.request<HistoryDiffResult>('history/diff', params);
     }
 
     /** Drains in-flight renders, then resolves. Daemon will not exit until `exit` fires. */
@@ -228,6 +259,9 @@ export class DaemonClient {
                 break;
             case 'log':
                 this.events.onLog?.(params as LogParams);
+                break;
+            case 'historyAdded':
+                this.events.onHistoryAdded?.(params as HistoryAddedParams);
                 break;
             default:
                 this.logger.appendLine(`[daemon] ignoring unknown notification: ${method}`);

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -47,6 +47,11 @@ export const ERROR_CLASSPATH_DIRTY = -32002;
 export const ERROR_SANDBOX_RECYCLING = -32003;
 export const ERROR_UNKNOWN_PREVIEW = -32004;
 export const ERROR_RENDER_FAILED = -32005;
+// History (phase H2 / H3) — see PROTOCOL.md § 5 (history/list, history/read,
+// history/diff) and HISTORY.md § "Layer 2 — JSON-RPC API".
+export const ERROR_HISTORY_ENTRY_NOT_FOUND = -32010;
+export const ERROR_HISTORY_DIFF_MISMATCH = -32011;
+export const ERROR_HISTORY_PIXEL_NOT_IMPLEMENTED = -32012;
 
 // initialize (PROTOCOL.md § 3)
 
@@ -161,6 +166,87 @@ export interface LogParams {
     message: string;
     category?: string;
     context?: Record<string, unknown>;
+}
+
+// History (phase H1+H2+H3) — see PROTOCOL.md § 5 / § 6 and HISTORY.md
+// "Layer 2 — JSON-RPC API" + "Sidecar metadata schema" for the canonical
+// shapes. The Kotlin counterpart lives in `Messages.kt` and carries the
+// payload fields as `JsonElement` to avoid pulling history-package types
+// onto the dispatch surface; we mirror that with `unknown` here so the
+// types stay schema-agnostic against future additive fields.
+
+export type HistorySourceKind = 'fs' | 'git' | 'http';
+
+export interface HistoryListParams {
+    previewId?: string;
+    since?: string;                   // ISO 8601 lower bound
+    until?: string;                   // ISO 8601 upper bound
+    limit?: number;                   // daemon defaults to 50, max 500
+    cursor?: string;                  // opaque token from a previous response
+    branch?: string;
+    branchPattern?: string;           // regex
+    commit?: string;                  // long or short SHA
+    worktreePath?: string;
+    agentId?: string;
+    sourceKind?: HistorySourceKind;
+    sourceId?: string;
+}
+
+export interface HistoryListResult {
+    /** Sidecar JSON shape per HISTORY.md § "Sidecar metadata schema". */
+    entries: unknown[];
+    /** Present iff more entries match — feed back as `cursor` to paginate. */
+    nextCursor?: string;
+    totalCount: number;
+}
+
+export interface HistoryReadParams {
+    id: string;
+    /** When true, daemon returns base64 PNG bytes inline (`pngBytes`). When
+     *  false, the client reads `pngPath` from disk — preferred for local
+     *  same-host clients (VS Code) to avoid the wire round-trip. */
+    inline?: boolean;
+}
+
+export interface HistoryReadResult {
+    /** Sidecar JSON. */
+    entry: unknown;
+    /** PreviewMetadataSnapshot — frozen at render time. May be null when
+     *  the originating manifest is gone. */
+    previewMetadata?: unknown;
+    /** Absolute path; the client reads bytes from here when `inline=false`. */
+    pngPath: string;
+    /** Base64 PNG; populated only when the request set `inline: true`. */
+    pngBytes?: string;
+}
+
+export type HistoryDiffMode = 'metadata' | 'pixel';
+
+export interface HistoryDiffParams {
+    from: string;
+    to: string;
+    mode?: HistoryDiffMode;           // default 'metadata'
+}
+
+/**
+ * `mode = 'metadata'` (default) is cheap: daemon hashes both PNGs and
+ * returns the sidecars. Pixel-mode fields are reserved for phase H5; in
+ * METADATA mode they are always undefined/null. A caller asking for
+ * `mode = 'pixel'` against a current daemon receives error
+ * `HistoryPixelNotImplemented` (-32012).
+ */
+export interface HistoryDiffResult {
+    pngHashChanged: boolean;
+    fromMetadata: unknown;
+    toMetadata: unknown;
+    diffPx?: number;
+    ssim?: number;
+    diffPngPath?: string;
+}
+
+export interface HistoryAddedParams {
+    /** Sidecar JSON of the newly-written entry. */
+    entry: unknown;
 }
 
 /**

--- a/vscode-extension/src/test/daemonClient.test.ts
+++ b/vscode-extension/src/test/daemonClient.test.ts
@@ -272,6 +272,104 @@ describe('DaemonClient', () => {
         assert.strictEqual(client.isClosed(), true);
     });
 
+    it('dispatches historyAdded notifications to the right handler', async () => {
+        const { toServer, toClient } = bidiPair();
+        const seen: unknown[] = [];
+        const client = new DaemonClient(toServer, toClient, {
+            onHistoryAdded: (params) => seen.push(params.entry),
+        });
+        toClient.write(encodeFrame({
+            jsonrpc: '2.0',
+            method: 'historyAdded',
+            params: {
+                entry: {
+                    id: '20260430-101234-a1b2c3d4',
+                    previewId: 'com.example.X',
+                    pngHash: 'abcdef',
+                },
+            },
+        }));
+        await new Promise((r) => setImmediate(r));
+        assert.strictEqual(seen.length, 1);
+        assert.strictEqual((seen[0] as { previewId: string }).previewId, 'com.example.X');
+        client.exit();
+    });
+
+    it('history/list passes every filter through verbatim', async () => {
+        const { toServer, toClient } = bidiPair();
+        const frames = captureFrames(toServer);
+        const client = new DaemonClient(toServer, toClient, {});
+        const filters = {
+            previewId: 'com.example.X',
+            since: '2026-04-30T00:00:00Z',
+            limit: 10,
+            branch: 'main',
+            sourceKind: 'fs' as const,
+        };
+        const p = client.historyList(filters);
+        const sent = (await frames.take()) as JsonRpcRequest;
+        assert.strictEqual(sent.method, 'history/list');
+        assert.deepStrictEqual(sent.params, filters);
+        toClient.write(encodeFrame({
+            jsonrpc: '2.0', id: sent.id,
+            result: { entries: [], totalCount: 0 },
+        }));
+        const res = await p;
+        assert.strictEqual(res.totalCount, 0);
+    });
+
+    it('history/read default omits inline and reads pngPath from disk', async () => {
+        const { toServer, toClient } = bidiPair();
+        const frames = captureFrames(toServer);
+        const client = new DaemonClient(toServer, toClient, {});
+        const p = client.historyRead({ id: 'a1' });
+        const sent = (await frames.take()) as JsonRpcRequest;
+        assert.strictEqual(sent.method, 'history/read');
+        assert.deepStrictEqual(sent.params, { id: 'a1' });
+        toClient.write(encodeFrame({
+            jsonrpc: '2.0', id: sent.id,
+            result: { entry: { id: 'a1' }, pngPath: '/abs/a1.png' },
+        }));
+        const res = await p;
+        assert.strictEqual(res.pngPath, '/abs/a1.png');
+        assert.strictEqual(res.pngBytes, undefined);
+    });
+
+    it('history/diff defaults to metadata mode and tolerates null pixel fields', async () => {
+        const { toServer, toClient } = bidiPair();
+        const frames = captureFrames(toServer);
+        const client = new DaemonClient(toServer, toClient, {});
+        const p = client.historyDiff({ from: 'a1', to: 'a2' });
+        const sent = (await frames.take()) as JsonRpcRequest;
+        assert.strictEqual(sent.method, 'history/diff');
+        assert.deepStrictEqual(sent.params, { from: 'a1', to: 'a2' });
+        toClient.write(encodeFrame({
+            jsonrpc: '2.0', id: sent.id,
+            result: {
+                pngHashChanged: true,
+                fromMetadata: { id: 'a1' },
+                toMetadata: { id: 'a2' },
+            },
+        }));
+        const res = await p;
+        assert.strictEqual(res.pngHashChanged, true);
+        assert.strictEqual(res.diffPx, undefined);
+    });
+
+    it('history/diff with mode=pixel surfaces the reserved-for-H5 error', async () => {
+        const { toServer, toClient } = bidiPair();
+        const frames = captureFrames(toServer);
+        const client = new DaemonClient(toServer, toClient, {});
+        const p = client.historyDiff({ from: 'a1', to: 'a2', mode: 'pixel' });
+        const sent = (await frames.take()) as JsonRpcRequest;
+        toClient.write(encodeFrame({
+            jsonrpc: '2.0', id: sent.id,
+            error: { code: -32012, message: 'pixel mode reserved for H5' },
+        }));
+        await assert.rejects(p, (err: Error) =>
+            err instanceof DaemonRpcError && (err as DaemonRpcError).rpc.code === -32012);
+    });
+
     it('initialize stamps protocolVersion = 1 and sends initialized after', async () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);

--- a/vscode-extension/src/test/daemonProtocol.test.ts
+++ b/vscode-extension/src/test/daemonProtocol.test.ts
@@ -4,7 +4,17 @@ import * as path from 'path';
 import {
     DAEMON_DESCRIPTOR_SCHEMA_VERSION,
     DaemonLaunchDescriptor,
+    ERROR_HISTORY_DIFF_MISMATCH,
+    ERROR_HISTORY_ENTRY_NOT_FOUND,
+    ERROR_HISTORY_PIXEL_NOT_IMPLEMENTED,
     FileChangedParams,
+    HistoryAddedParams,
+    HistoryDiffParams,
+    HistoryDiffResult,
+    HistoryListParams,
+    HistoryListResult,
+    HistoryReadParams,
+    HistoryReadResult,
     InitializeParams,
     InitializeResult,
     PROTOCOL_VERSION,
@@ -111,5 +121,100 @@ describe('daemon launch descriptor', () => {
         };
         const round = JSON.parse(JSON.stringify(desc)) as DaemonLaunchDescriptor;
         assert.deepStrictEqual(round, desc);
+    });
+});
+
+/**
+ * H1+H2+H3 wire shapes. No fixtures shipped under
+ * `docs/daemon/protocol-fixtures/` for history methods yet (the Kotlin side
+ * keeps `entry`/`previewMetadata` as JsonElement and there's no golden
+ * corpus); we instead pin the documented sidecar JSON structure from
+ * HISTORY.md § "Sidecar metadata schema" so any drift on the doc surface is
+ * a test failure here.
+ */
+describe('history protocol shapes', () => {
+    it('error codes match PROTOCOL.md § 5', () => {
+        // Pinned constants — change in lockstep with the Kotlin side. The
+        // daemon's `JsonRpcServer` returns these literal codes from
+        // history/list / history/read / history/diff dispatch.
+        assert.strictEqual(ERROR_HISTORY_ENTRY_NOT_FOUND, -32010);
+        assert.strictEqual(ERROR_HISTORY_DIFF_MISMATCH, -32011);
+        assert.strictEqual(ERROR_HISTORY_PIXEL_NOT_IMPLEMENTED, -32012);
+    });
+
+    it('history/list params accept every documented filter', () => {
+        // Compile-time + runtime check: every filter listed in PROTOCOL.md
+        // § 5 ("history/list") must be assignable to HistoryListParams.
+        const params: HistoryListParams = {
+            previewId: 'com.example.RedSquare',
+            since: '2026-04-29T00:00:00Z',
+            until: '2026-04-30T23:59:59Z',
+            limit: 50,
+            cursor: 'opaque-token',
+            branch: 'main',
+            branchPattern: '^agent/.*',
+            commit: '6af6b8c',
+            worktreePath: '/home/yuri/workspace/compose-ai-tools',
+            agentId: 'claude-code',
+            sourceKind: 'git',
+            sourceId: 'git:preview/main@abc123',
+        };
+        const round = JSON.parse(JSON.stringify(params));
+        assert.deepStrictEqual(round, params);
+    });
+
+    it('history/list result mirrors the documented field set', () => {
+        const result: HistoryListResult = {
+            entries: [{ id: '20260430-101234-a1b2c3d4', previewId: 'com.example.X' }],
+            nextCursor: 'next-page',
+            totalCount: 142,
+        };
+        assert.strictEqual(result.entries.length, 1);
+        assert.strictEqual(result.totalCount, 142);
+    });
+
+    it('history/read params + result round-trip', () => {
+        const params: HistoryReadParams = { id: '20260430-101234-a1b2c3d4', inline: false };
+        const result: HistoryReadResult = {
+            entry: { id: params.id, previewId: 'com.example.X' },
+            previewMetadata: { displayName: 'X', sourceFile: '/abs/X.kt' },
+            pngPath: '/abs/.compose-preview-history/com.example.X/20260430-101234-a1b2c3d4.png',
+        };
+        assert.strictEqual(result.pngPath.endsWith('.png'), true);
+        assert.strictEqual(result.pngBytes, undefined,
+            'inline=false omits pngBytes; the client reads from disk');
+        assert.deepStrictEqual(JSON.parse(JSON.stringify(params)), params);
+    });
+
+    it('history/diff metadata-mode result keeps pixel fields nullable', () => {
+        // Per PROTOCOL.md § 5: `diffPx` / `ssim` / `diffPngPath` are reserved
+        // for phase H5; in metadata mode they are always undefined or null.
+        // A result asserting them as required would lock us into H5 prematurely.
+        const params: HistoryDiffParams = { from: 'a1', to: 'a2', mode: 'metadata' };
+        const result: HistoryDiffResult = {
+            pngHashChanged: true,
+            fromMetadata: { id: 'a1' },
+            toMetadata: { id: 'a2' },
+        };
+        assert.strictEqual(params.mode, 'metadata');
+        assert.strictEqual(result.diffPx, undefined);
+        assert.strictEqual(result.ssim, undefined);
+        assert.strictEqual(result.diffPngPath, undefined);
+    });
+
+    it('historyAdded notification carries an entry payload', () => {
+        // The wire shape from PROTOCOL.md § 6 ("historyAdded"): a single
+        // `entry` field whose value is the sidecar JSON. We don't pin the
+        // sidecar's full shape here — that lives in HISTORY.md and changes
+        // additively — but we do pin the envelope.
+        const params: HistoryAddedParams = {
+            entry: {
+                id: '20260430-101234-a1b2c3d4',
+                previewId: 'com.example.RedSquare',
+                pngHash: 'a1b2c3d4e5f6789',
+            },
+        };
+        const round = JSON.parse(JSON.stringify(params)) as HistoryAddedParams;
+        assert.deepStrictEqual(round, params);
     });
 });


### PR DESCRIPTION
Stacked on the long-lived `vscode-daemon` integration branch.

Additive wire surface for the H1+H2+H3 history work that landed on `main` via #318/#321/#322. No user-visible behaviour change — this PR only adds the TypeScript types, request methods, and notification dispatch so the future Preview History panel (HISTORY.md § "VS Code integration", phase H7) can call the daemon directly without re-deriving the contract.

## Summary

Mirrored from `PROTOCOL.md` § 5 / § 6 and `Messages.kt`:

- `HistoryListParams` / `HistoryListResult` — every documented filter (`previewId`, `since`, `until`, `limit`, `cursor`, `branch`, `branchPattern`, `commit`, `worktreePath`, `agentId`, `sourceKind`, `sourceId`).
- `HistoryReadParams` / `HistoryReadResult` — `inline: false` (default) returns `pngPath` only, `inline: true` returns base64 `pngBytes`.
- `HistoryDiffParams` / `HistoryDiffResult` — metadata mode by default; pixel fields (`diffPx`, `ssim`, `diffPngPath`) optional and reserved for phase H5.
- `HistoryAddedParams` — push notification carrying the freshly-written sidecar entry.
- Error codes: `HistoryEntryNotFound` (-32010), `HistoryDiffMismatch` (-32011), `HistoryPixelNotImplemented` (-32012).

Three new request methods on `DaemonClient`: `historyList`, `historyRead`, `historyDiff`. One new event handler: `onHistoryAdded`.

## Why `unknown` for sidecar entries

`HistoryEntry` / `previewMetadata` are typed as `unknown` rather than a frozen TS interface. The Kotlin side carries them as `JsonElement` for the same reason — the schema grows additively (per HISTORY.md § "File-format versioning") and locking the dispatch surface to a specific shape today would force every additive doc change to also touch the extension. Phase B (sidecar-aware FS reader) and the panel itself will pin a structural type at the use site.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 150 passing (was 139), 84-91 ms per run, stable across 3 sequential runs
- [x] 11 new tests:
  - Error-code constants pinned (PROTOCOL.md § 5)
  - Every `history/list` filter round-trips through JSON
  - `history/list` result mirrors documented field set
  - `history/read` defaults to `inline=false` and omits `pngBytes`
  - `history/diff` metadata mode keeps pixel fields nullable
  - `history/diff` `mode=pixel` surfaces -32012
  - `historyAdded` notification dispatches to the right handler
  - Three `DaemonClient` method tests (params verbatim, result decode, error path)
- [ ] No fixtures shipped under `docs/daemon/protocol-fixtures/` for history methods yet — when the daemon team adds them, this suite should pick them up the same way the existing fixtures are exercised in `daemon protocol — golden fixtures`.

## Notes

- This unblocks H7 (Preview History panel) — the next branch can wire a webview against `historyList` + `historyRead` directly without speculative type design.
- No history feature reaches the user from this PR. The webview UI, FS-fallback reader (HISTORY.md § "VS Code integration") and `historyAdded`-driven refresh come in subsequent branches.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9eazQp7vhSYqgwxjazGNf)_