### PR TITLE
Add history resource URIs and progress notifications to MCP

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -715,8 +715,8 @@ class JsonRpcServer(
 
   /**
    * H3 — `history/diff` metadata mode. Resolves [from] and [to] entry ids via the [historyManager]
-   * (which iterates configured sources in priority order, so a cross-source diff "LocalFs vs
-   * GitRef preview/main" works the same as an intra-source diff). Emits:
+   * (which iterates configured sources in priority order, so a cross-source diff "LocalFs vs GitRef
+   * preview/main" works the same as an intra-source diff). Emits:
    *
    * - `HistoryEntryNotFound` (-32010) when either id is missing.
    * - `HistoryDiffMismatch` (-32011) when the two entries belong to different previews.
@@ -1294,11 +1294,11 @@ class JsonRpcServer(
     const val ERR_HISTORY_DIFF_MISMATCH: Int = -32011
 
     /**
-     * HISTORY.md § "Error codes" — `history/diff` was called with `mode = pixel`, which is
-     * reserved for phase H5 and not implemented in H3. We deliberately return a clean error code
-     * (rather than silently leaving the pixel fields null in METADATA mode) so callers can tell
-     * "I asked for pixel and the daemon isn't ready" apart from "I asked for metadata and got null
-     * pixel fields by design."
+     * HISTORY.md § "Error codes" — `history/diff` was called with `mode = pixel`, which is reserved
+     * for phase H5 and not implemented in H3. We deliberately return a clean error code (rather
+     * than silently leaving the pixel fields null in METADATA mode) so callers can tell "I asked
+     * for pixel and the daemon isn't ready" apart from "I asked for metadata and got null pixel
+     * fields by design."
      */
     const val ERR_HISTORY_PIXEL_NOT_IMPLEMENTED: Int = -32012
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
@@ -1,6 +1,5 @@
 package ee.schimke.composeai.daemon.history
 
-import java.io.File
 import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -34,18 +33,19 @@ import kotlinx.serialization.json.Json
  * populate the ref. The daemon doesn't fail; the consumer just sees "no main-history available."
  *
  * **Source rewriting.** The on-ref sidecars carry whatever `source` field they were written with —
- * but we know the source is *us* now. Both [list] and [read] rewrite `entry.source` to a
- * `kind: "git"` shape stamped with this source's id, the ref name, and the ref's HEAD commit sha.
+ * but we know the source is *us* now. Both [list] and [read] rewrite `entry.source` to a `kind:
+ * "git"` shape stamped with this source's id, the ref name, and the ref's HEAD commit sha.
  *
  * **PNG extraction.** [read] writes the PNG blob into a daemon-managed cache dir
  * (`<historyDir>/.git-ref-cache/`) keyed by `(refCommit, entryId)`. Subsequent reads of the same
  * blob hit the cache. Tempfiles are cleaned up on JVM shutdown via [Runtime.addShutdownHook].
  *
  * @param repoRoot the working tree (or bare repo) the ref lives in.
- * @param ref the full ref name (e.g. `refs/heads/preview/main`); use full form to avoid
- *   ambiguity between heads, remotes, and tags.
+ * @param ref the full ref name (e.g. `refs/heads/preview/main`); use full form to avoid ambiguity
+ *   between heads, remotes, and tags.
  * @param displayId stable identifier for `entry.source.id` rewriting; defaults to `git:$ref`.
- * @param cacheDir where extracted PNG blobs land; defaults to `<repoRoot>/.compose-preview-history/.git-ref-cache`.
+ * @param cacheDir where extracted PNG blobs land; defaults to
+ *   `<repoRoot>/.compose-preview-history/.git-ref-cache`.
  * @param gitExecutable git binary; defaults to `git` on PATH.
  * @param warnEmitter logger for the ref-missing case. The production daemon passes
  *   [JsonRpcServer]'s log emitter; tests pass a buffer-capturing lambda.
@@ -212,16 +212,15 @@ class GitRefHistorySource(
   }
 
   /**
-   * Returns the contents of `<refCommit>:<path>` as text, or null if the path isn't present in
-   * the tree. Uses `git show` with `--`. Trailing newline is preserved verbatim — the index
-   * parser handles blank lines.
+   * Returns the contents of `<refCommit>:<path>` as text, or null if the path isn't present in the
+   * tree. Uses `git show` with `--`. Trailing newline is preserved verbatim — the index parser
+   * handles blank lines.
    */
-  private fun catFile(refCommit: String, path: String): String? =
-    runGit("show", "$refCommit:$path")
+  private fun catFile(refCommit: String, path: String): String? = runGit("show", "$refCommit:$path")
 
   /**
-   * Extracts a binary blob from `<refCommit>:<path>` into [cacheDir]. Returns the cached file
-   * path or null on failure. Idempotent: subsequent reads with the same key see the existing file.
+   * Extracts a binary blob from `<refCommit>:<path>` into [cacheDir]. Returns the cached file path
+   * or null on failure. Idempotent: subsequent reads with the same key see the existing file.
    */
   private fun extractBlobToCache(refCommit: String, path: String): Path? {
     val safeName = "${refCommit.take(7)}-${path.replace('/', '_')}"
@@ -333,11 +332,7 @@ class GitRefHistorySource(
     fun parseRefsSysprop(
       propValue: String? = System.getProperty(GIT_REF_HISTORY_PROP)
     ): List<String> =
-      propValue
-        ?.split(',', ';')
-        ?.map { it.trim() }
-        ?.filter { it.isNotEmpty() }
-        ?: emptyList()
+      propValue?.split(',', ';')?.map { it.trim() }?.filter { it.isNotEmpty() } ?: emptyList()
 
     /**
      * Default cache dir for a given history dir. Mirrors the in-source default but exposed so

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
@@ -157,9 +157,9 @@ class HistoryManager(
    * highest-priority source's copy, applies the filter, sorts newest-first, and re-paginates the
    * combined result.
    *
-   * Per-source filtering is intentionally NOT trusted to compose with cross-source pagination —
-   * we always re-filter the merged set so a `sourceKind` filter applied across sources behaves
-   * the same way it does inside one source.
+   * Per-source filtering is intentionally NOT trusted to compose with cross-source pagination — we
+   * always re-filter the merged set so a `sourceKind` filter applied across sources behaves the
+   * same way it does inside one source.
    *
    * Source priority for dedup: the order in [sources]. LocalFs first means the writable source's
    * canonical entry (with `source.kind = "fs"`) is what surfaces; a GitRef-only render still

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySourceTest.kt
@@ -17,13 +17,13 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * H10-read — `GitRefHistorySource` unit tests. Each test synthesises a temp git repo on disk,
- * sets up a `refs/heads/preview/...` ref with the documented storage convention (HISTORY.md §
+ * H10-read — `GitRefHistorySource` unit tests. Each test synthesises a temp git repo on disk, sets
+ * up a `refs/heads/preview/...` ref with the documented storage convention (HISTORY.md §
  * "GitRefHistorySource"), and exercises the source through its public surface.
  *
- * **`git` binary required.** All tests `Assume.assumeTrue` on `git --version` so CI runners
- * without git skip cleanly. Production callers (the daemon mains) tolerate missing git the same
- * way [GitProvenance] does — silent degradation.
+ * **`git` binary required.** All tests `Assume.assumeTrue` on `git --version` so CI runners without
+ * git skip cleanly. Production callers (the daemon mains) tolerate missing git the same way
+ * [GitProvenance] does — silent degradation.
  */
 class GitRefHistorySourceTest {
 
@@ -112,9 +112,21 @@ class GitRefHistorySourceTest {
     // Build three sidecar+png pairs for two preview dirs, plus a matching _index.jsonl.
     val entries =
       listOf(
-        synthEntry(id = "20260430-101234-aaaaaaaa", previewId = "com.example.A", bytes = "first".toByteArray()),
-        synthEntry(id = "20260430-101300-bbbbbbbb", previewId = "com.example.A", bytes = "second".toByteArray()),
-        synthEntry(id = "20260430-101400-cccccccc", previewId = "com.example.B", bytes = "third".toByteArray()),
+        synthEntry(
+          id = "20260430-101234-aaaaaaaa",
+          previewId = "com.example.A",
+          bytes = "first".toByteArray(),
+        ),
+        synthEntry(
+          id = "20260430-101300-bbbbbbbb",
+          previewId = "com.example.A",
+          bytes = "second".toByteArray(),
+        ),
+        synthEntry(
+          id = "20260430-101400-cccccccc",
+          previewId = "com.example.B",
+          bytes = "third".toByteArray(),
+        ),
       )
     populatePreviewMain(entries)
 
@@ -148,12 +160,23 @@ class GitRefHistorySourceTest {
 
   @Test
   fun corrupt_index_skips_truncated_line_and_lists_others() {
-    val good1 = synthEntry(id = "20260430-100000-11111111", previewId = "com.example.A", bytes = "a".toByteArray())
-    val good2 = synthEntry(id = "20260430-100100-22222222", previewId = "com.example.A", bytes = "b".toByteArray())
-    val tree = createTreeWithEntriesAndIndex(listOf(good1, good2)) { jsonl ->
-      // Corrupt: append a half-line that's not valid JSON.
-      jsonl + "{\"id\":\"truncat" + "\n"
-    }
+    val good1 =
+      synthEntry(
+        id = "20260430-100000-11111111",
+        previewId = "com.example.A",
+        bytes = "a".toByteArray(),
+      )
+    val good2 =
+      synthEntry(
+        id = "20260430-100100-22222222",
+        previewId = "com.example.A",
+        bytes = "b".toByteArray(),
+      )
+    val tree =
+      createTreeWithEntriesAndIndex(listOf(good1, good2)) { jsonl ->
+        // Corrupt: append a half-line that's not valid JSON.
+        jsonl + "{\"id\":\"truncat" + "\n"
+      }
     val commit = commitTree(tree, parent = null, message = "corrupt-index")
     runOk("git", "-C", repoRoot.toString(), "update-ref", "refs/heads/preview/main", commit)
 
@@ -224,14 +247,11 @@ class GitRefHistorySourceTest {
           warnEmitter = warnEmitter,
         )
       val manager =
-        HistoryManager(
-          sources = listOf(localFs, gitSource),
-          module = ":t",
-          gitProvenance = null,
-        )
+        HistoryManager(sources = listOf(localFs, gitSource), module = ":t", gitProvenance = null)
 
       val all = manager.list(HistoryFilter())
-      // Two unique renders — shared render's LocalFs copy is canonical, git-only render comes from git.
+      // Two unique renders — shared render's LocalFs copy is canonical, git-only render comes from
+      // git.
       assertEquals(2, all.totalCount)
       val sharedSurface = all.entries.first { it.id == localFsEntry.id }
       assertEquals(
@@ -271,7 +291,8 @@ class GitRefHistorySourceTest {
     id: String,
     previewId: String,
     bytes: ByteArray,
-    timestamp: String = "2026-04-30T${id.substring(9, 11)}:${id.substring(11, 13)}:${id.substring(13, 15)}Z",
+    timestamp: String =
+      "2026-04-30T${id.substring(9, 11)}:${id.substring(11, 13)}:${id.substring(13, 15)}Z",
   ): SynthEntry {
     val pngHash = LocalFsHistorySource.sha256Hex(bytes)
     return synthEntryFromHash(id, previewId, timestamp, pngHash, bytes)
@@ -312,8 +333,8 @@ class GitRefHistorySourceTest {
   }
 
   /**
-   * Builds an in-tree layout `<previewIdSan>/<id>.{png,json}` + `_index.jsonl` and returns the
-   * tree sha. Uses `git hash-object` + `git mktree` rather than building the working tree.
+   * Builds an in-tree layout `<previewIdSan>/<id>.{png,json}` + `_index.jsonl` and returns the tree
+   * sha. Uses `git hash-object` + `git mktree` rather than building the working tree.
    */
   private fun createTreeWithEntriesAndIndex(
     entries: List<SynthEntry>,
@@ -335,11 +356,13 @@ class GitRefHistorySourceTest {
       val subTree = mktree(subTreeEntries.toString())
       rootEntries.append("040000 tree $subTree\t$sanitised\n")
     }
-    // Build _index.jsonl — entries minus previewMetadata, one per line, append-order (oldest first).
+    // Build _index.jsonl — entries minus previewMetadata, one per line, append-order (oldest
+    // first).
     val sortedByTs = entries.sortedBy { it.entry.timestamp }
-    val indexBody = sortedByTs.joinToString("\n") {
-      json.encodeToString(HistoryEntry.serializer(), it.entry.copy(previewMetadata = null))
-    } + "\n"
+    val indexBody =
+      sortedByTs.joinToString("\n") {
+        json.encodeToString(HistoryEntry.serializer(), it.entry.copy(previewMetadata = null))
+      } + "\n"
     val transformed = transformIndex(indexBody)
     val indexSha = hashObject(transformed.toByteArray(StandardCharsets.UTF_8))
     rootEntries.append("100644 blob $indexSha\t_index.jsonl\n")
@@ -356,9 +379,7 @@ class GitRefHistorySourceTest {
     pb.outputStream.use { it.write(input.toByteArray(StandardCharsets.UTF_8)) }
     val finished = pb.waitFor(15, TimeUnit.SECONDS)
     require(finished) { "mktree timed out" }
-    require(pb.exitValue() == 0) {
-      "mktree failed: ${pb.errorStream.bufferedReader().readText()}"
-    }
+    require(pb.exitValue() == 0) { "mktree failed: ${pb.errorStream.bufferedReader().readText()}" }
     return pb.inputStream.bufferedReader().readText().trim()
   }
 
@@ -377,7 +398,8 @@ class GitRefHistorySourceTest {
   }
 
   private fun commitTree(treeSha: String, parent: String?, message: String): String {
-    val args = mutableListOf("git", "-C", repoRoot.toString(), "commit-tree", treeSha, "-m", message)
+    val args =
+      mutableListOf("git", "-C", repoRoot.toString(), "commit-tree", treeSha, "-m", message)
     if (parent != null) {
       args.add("-p")
       args.add(parent)

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
@@ -15,7 +15,6 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -27,9 +26,9 @@ import org.junit.Before
 import org.junit.Test
 
 /**
- * H3 — `history/diff` METADATA-mode unit tests. Drives the [JsonRpcServer] over piped streams
- * with a [HistoryManager] backed by a temp [LocalFsHistorySource] so each test can synthesise
- * the entries it needs and assert on the wire shape.
+ * H3 — `history/diff` METADATA-mode unit tests. Drives the [JsonRpcServer] over piped streams with
+ * a [HistoryManager] backed by a temp [LocalFsHistorySource] so each test can synthesise the
+ * entries it needs and assert on the wire shape.
  *
  * Covers the cases enumerated in HISTORY.md § "What this PR lands § H3":
  * - same hash → `pngHashChanged = false`, both metadata returned
@@ -62,8 +61,22 @@ class HistoryDiffTest {
       // pin distinct timestamps so the entry ids differ (id = "<ts>-<shortHash>").
       val ts1 = Instant.parse("2026-04-30T10:12:34Z")
       val ts2 = Instant.parse("2026-04-30T10:12:35Z")
-      val entry1 = manager.recordRender("preview-A", "same-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1, timestamp = ts1)!!
-      val entry2 = manager.recordRender("preview-A", "same-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1, timestamp = ts2)!!
+      val entry1 =
+        manager.recordRender(
+          "preview-A",
+          "same-bytes".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+          timestamp = ts1,
+        )!!
+      val entry2 =
+        manager.recordRender(
+          "preview-A",
+          "same-bytes".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+          timestamp = ts2,
+        )!!
       assertEquals(entry1.pngHash, entry2.pngHash)
 
       val resp = diffRoundTrip(send, receive, from = entry1.id, to = entry2.id)
@@ -72,10 +85,13 @@ class HistoryDiffTest {
       assertEquals(entry1.id, result["fromMetadata"]!!.jsonObject["id"]!!.jsonPrimitive.content)
       assertEquals(entry2.id, result["toMetadata"]!!.jsonObject["id"]!!.jsonPrimitive.content)
       // Pixel-mode fields are null in METADATA mode by design.
-      assertTrue(result["diffPx"] == null || result["diffPx"] == kotlinx.serialization.json.JsonNull)
+      assertTrue(
+        result["diffPx"] == null || result["diffPx"] == kotlinx.serialization.json.JsonNull
+      )
       assertTrue(result["ssim"] == null || result["ssim"] == kotlinx.serialization.json.JsonNull)
       assertTrue(
-        result["diffPngPath"] == null || result["diffPngPath"] == kotlinx.serialization.json.JsonNull
+        result["diffPngPath"] == null ||
+          result["diffPngPath"] == kotlinx.serialization.json.JsonNull
       )
     }
   }
@@ -85,8 +101,22 @@ class HistoryDiffTest {
     runWith { _, manager, send, receive ->
       val ts1 = Instant.parse("2026-04-30T10:12:34Z")
       val ts2 = Instant.parse("2026-04-30T10:12:35Z")
-      val entry1 = manager.recordRender("preview-A", "first-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1, timestamp = ts1)!!
-      val entry2 = manager.recordRender("preview-A", "second-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1, timestamp = ts2)!!
+      val entry1 =
+        manager.recordRender(
+          "preview-A",
+          "first-bytes".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+          timestamp = ts1,
+        )!!
+      val entry2 =
+        manager.recordRender(
+          "preview-A",
+          "second-bytes".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+          timestamp = ts2,
+        )!!
       assertTrue(entry1.pngHash != entry2.pngHash)
 
       val resp = diffRoundTrip(send, receive, from = entry1.id, to = entry2.id)
@@ -98,8 +128,20 @@ class HistoryDiffTest {
   @Test(timeout = 30_000)
   fun different_previewIds_diffMismatch() {
     runWith { _, manager, send, receive ->
-      val a = manager.recordRender("preview-A", "a-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1)!!
-      val b = manager.recordRender("preview-B", "b-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1)!!
+      val a =
+        manager.recordRender(
+          "preview-A",
+          "a-bytes".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+        )!!
+      val b =
+        manager.recordRender(
+          "preview-B",
+          "b-bytes".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+        )!!
       val resp = diffRoundTrip(send, receive, from = a.id, to = b.id)
       val errCode = resp["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull
       assertEquals(JsonRpcServer.ERR_HISTORY_DIFF_MISMATCH, errCode)
@@ -109,7 +151,13 @@ class HistoryDiffTest {
   @Test(timeout = 30_000)
   fun missing_from_entryNotFound() {
     runWith { _, manager, send, receive ->
-      val a = manager.recordRender("preview-A", "a-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1)!!
+      val a =
+        manager.recordRender(
+          "preview-A",
+          "a-bytes".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+        )!!
       val resp = diffRoundTrip(send, receive, from = "does-not-exist", to = a.id)
       val errCode = resp["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull
       assertEquals(JsonRpcServer.ERR_HISTORY_ENTRY_NOT_FOUND, errCode)
@@ -119,7 +167,13 @@ class HistoryDiffTest {
   @Test(timeout = 30_000)
   fun missing_to_entryNotFound() {
     runWith { _, manager, send, receive ->
-      val a = manager.recordRender("preview-A", "a-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1)!!
+      val a =
+        manager.recordRender(
+          "preview-A",
+          "a-bytes".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+        )!!
       val resp = diffRoundTrip(send, receive, from = a.id, to = "does-not-exist")
       val errCode = resp["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull
       assertEquals(JsonRpcServer.ERR_HISTORY_ENTRY_NOT_FOUND, errCode)
@@ -129,7 +183,13 @@ class HistoryDiffTest {
   @Test(timeout = 30_000)
   fun pixel_mode_not_yet_implemented() {
     runWith { _, manager, send, receive ->
-      val a = manager.recordRender("preview-A", "a-bytes".toByteArray(), trigger = "renderNow", renderTookMs = 1)!!
+      val a =
+        manager.recordRender(
+          "preview-A",
+          "a-bytes".toByteArray(),
+          trigger = "renderNow",
+          renderTookMs = 1,
+        )!!
       val resp = diffRoundTrip(send, receive, from = a.id, to = a.id, mode = "pixel")
       val errCode = resp["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull
       assertEquals(JsonRpcServer.ERR_HISTORY_PIXEL_NOT_IMPLEMENTED, errCode)
@@ -141,12 +201,13 @@ class HistoryDiffTest {
   // -------------------------------------------------------------------------
 
   private fun runWith(
-    block: (
-      JsonRpcServer,
-      HistoryManager,
-      send: (String) -> Unit,
-      receive: LinkedBlockingQueue<JsonObject>,
-    ) -> Unit
+    block:
+      (
+        JsonRpcServer,
+        HistoryManager,
+        send: (String) -> Unit,
+        receive: LinkedBlockingQueue<JsonObject>,
+      ) -> Unit
   ) {
     val manager =
       HistoryManager.forLocalFs(historyDir = historyDir, module = ":t", gitProvenance = null)
@@ -165,7 +226,8 @@ class HistoryDiffTest {
         historyManager = manager,
         onExit = { _ -> exitLatch.countDown() },
       )
-    val serverThread = Thread({ server.run() }, "history-diff-test-server").apply { isDaemon = true }
+    val serverThread =
+      Thread({ server.run() }, "history-diff-test-server").apply { isDaemon = true }
     serverThread.start()
 
     val received = LinkedBlockingQueue<JsonObject>()
@@ -186,7 +248,9 @@ class HistoryDiffTest {
 
     val send: (String) -> Unit = { jsonText ->
       val payload = jsonText.toByteArray(Charsets.UTF_8)
-      clientToServerOut.write("Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII))
+      clientToServerOut.write(
+        "Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII)
+      )
       clientToServerOut.write(payload)
       clientToServerOut.flush()
     }
@@ -257,8 +321,10 @@ class HistoryDiffTest {
    */
   private class StubHost : RenderHost {
     override fun start() {}
+
     override fun submit(request: RenderRequest, timeoutMs: Long): RenderResult =
       error("StubHost.submit: not used in HistoryDiffTest — tests drive HistoryManager directly")
+
     override fun shutdown(timeoutMs: Long) {}
   }
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -157,20 +157,19 @@ fun main(args: Array<String>) {
   // one-time warn-level `log` notification with a hint for the human and degrade gracefully
   // (no entries in `history/list`). See HISTORY.md § "GitRefHistorySource".
   val gitRefHistoryRefs = GitRefHistorySource.parseRefsSysprop()
-  val historyManager: HistoryManager? =
-    historyDirProp?.let { dir ->
-      System.err.println(
-        "compose-ai-tools desktop daemon: HistoryManager active (dir=$dir, " +
-          "gitRefs=${gitRefHistoryRefs})"
-      )
-      HistoryManager.forLocalFsAndGitRefs(
-        historyDir = Path.of(dir),
-        module = System.getProperty(MODULE_ID_PROP) ?: "",
-        gitProvenance = gitProvenance,
-        gitRefs = gitRefHistoryRefs,
-        repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
-      )
-    }
+  val historyManager: HistoryManager? = historyDirProp?.let { dir ->
+    System.err.println(
+      "compose-ai-tools desktop daemon: HistoryManager active (dir=$dir, " +
+        "gitRefs=${gitRefHistoryRefs})"
+    )
+    HistoryManager.forLocalFsAndGitRefs(
+      historyDir = Path.of(dir),
+      module = System.getProperty(MODULE_ID_PROP) ?: "",
+      gitProvenance = gitProvenance,
+      gitRefs = gitRefHistoryRefs,
+      repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
+    )
+  }
 
   val server =
     JsonRpcServer(

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
@@ -100,19 +100,18 @@ fun main(args: Array<String>) {
   // GitRefHistorySources alongside the writable LocalFsHistorySource. Tests that don't set the
   // sysprop see the pre-H10 single-source behaviour.
   val gitRefHistoryRefs = GitRefHistorySource.parseRefsSysprop()
-  val historyManager: HistoryManager? =
-    historyDirProp?.let { dir ->
-      System.err.println(
-        "compose-ai-daemon harness: HistoryManager active (dir=$dir, gitRefs=${gitRefHistoryRefs})"
-      )
-      HistoryManager.forLocalFsAndGitRefs(
-        historyDir = Path.of(dir),
-        module = System.getProperty("composeai.daemon.moduleId") ?: ":harness",
-        gitProvenance = GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of)),
-        gitRefs = gitRefHistoryRefs,
-        repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
-      )
-    }
+  val historyManager: HistoryManager? = historyDirProp?.let { dir ->
+    System.err.println(
+      "compose-ai-daemon harness: HistoryManager active (dir=$dir, gitRefs=${gitRefHistoryRefs})"
+    )
+    HistoryManager.forLocalFsAndGitRefs(
+      historyDir = Path.of(dir),
+      module = System.getProperty("composeai.daemon.moduleId") ?: ":harness",
+      gitProvenance = GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of)),
+      gitRefs = gitRefHistoryRefs,
+      repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
+    )
+  }
 
   val server =
     JsonRpcServer(

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
@@ -47,8 +47,8 @@ class FakeHarnessLauncher(
   private val workspaceRoot: File? = null,
   /**
    * H10-read — comma-separated list of full git ref names (e.g. `refs/heads/preview/main`) for
-   * [GitRefHistorySource] wiring. When non-empty, sets `-Dcomposeai.daemon.gitRefHistory=…` on
-   * the spawned JVM.
+   * [GitRefHistorySource] wiring. When non-empty, sets `-Dcomposeai.daemon.gitRefHistory=…` on the
+   * spawned JVM.
    */
   private val gitRefHistory: List<String> = emptyList(),
 ) : HarnessLauncher {

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S10MainHistoryReadAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S10MainHistoryReadAndroidRealModeTest.kt
@@ -6,9 +6,9 @@ import org.junit.Test
 /**
  * Real-mode Android counterpart to [S10MainHistoryReadTest] — placeholder for H10-read.
  *
- * Same rationale as [S10MainHistoryReadDesktopRealModeTest]: the fake-mode S10 already covers
- * the wire shape end-to-end, the Robolectric real-mode landing waits on the gradle plugin
- * emitting `composeai.daemon.gitRefHistory` into the daemon launch descriptor.
+ * Same rationale as [S10MainHistoryReadDesktopRealModeTest]: the fake-mode S10 already covers the
+ * wire shape end-to-end, the Robolectric real-mode landing waits on the gradle plugin emitting
+ * `composeai.daemon.gitRefHistory` into the daemon launch descriptor.
  */
 @Ignore("S10 real-mode Android placeholder — see KDoc")
 class S10MainHistoryReadAndroidRealModeTest {

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S10MainHistoryReadDesktopRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S10MainHistoryReadDesktopRealModeTest.kt
@@ -8,8 +8,8 @@ import org.junit.Test
  *
  * The fake-mode S10 already proves the wire shape end-to-end. The real-mode landing waits on the
  * gradle plugin emitting the `composeai.daemon.gitRefHistory` sysprop into the daemon launch
- * descriptor (a follow-up task that's NOT in scope for this PR). Keeping the placeholder here
- * pins the intent and makes the future landing point obvious to anyone scanning the harness suite.
+ * descriptor (a follow-up task that's NOT in scope for this PR). Keeping the placeholder here pins
+ * the intent and makes the future landing point obvious to anyone scanning the harness suite.
  */
 @Ignore("S10 real-mode desktop placeholder — see KDoc")
 class S10MainHistoryReadDesktopRealModeTest {

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S10MainHistoryReadTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S10MainHistoryReadTest.kt
@@ -13,7 +13,6 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Assume.assumeTrue
 import org.junit.Test
 
@@ -101,7 +100,9 @@ class S10MainHistoryReadTest {
       val exitCode = client.shutdownAndExit()
       assertEquals(0, exitCode)
     } catch (t: Throwable) {
-      System.err.println("S10MainHistoryReadTest failed; stderr from daemon:\n${client.dumpStderr()}")
+      System.err.println(
+        "S10MainHistoryReadTest failed; stderr from daemon:\n${client.dumpStderr()}"
+      )
       throw t
     } finally {
       try {
@@ -153,9 +154,12 @@ class S10MainHistoryReadTest {
       val subTree = mktree(repoRoot, sub.toString())
       rootEntries.append("040000 tree $subTree\t$sanitised\n")
     }
-    val indexLines = entries.sortedBy { it.entry.timestamp }.joinToString("\n") {
-      json.encodeToString(HistoryEntry.serializer(), it.entry.copy(previewMetadata = null))
-    } + "\n"
+    val indexLines =
+      entries
+        .sortedBy { it.entry.timestamp }
+        .joinToString("\n") {
+          json.encodeToString(HistoryEntry.serializer(), it.entry.copy(previewMetadata = null))
+        } + "\n"
     val indexSha = hashObject(repoRoot, indexLines.toByteArray(StandardCharsets.UTF_8))
     rootEntries.append("100644 blob $indexSha\t_index.jsonl\n")
     val rootTree = mktree(repoRoot, rootEntries.toString())
@@ -163,7 +167,12 @@ class S10MainHistoryReadTest {
     runOk("git", "-C", repoRoot.absolutePath, "update-ref", "refs/heads/preview/main", commit)
   }
 
-  private fun synth(id: String, previewId: String, bytes: ByteArray, timestamp: String): SynthEntry {
+  private fun synth(
+    id: String,
+    previewId: String,
+    bytes: ByteArray,
+    timestamp: String,
+  ): SynthEntry {
     val pngHash = LocalFsHistorySource.sha256Hex(bytes)
     val entry =
       HistoryEntry(
@@ -191,9 +200,7 @@ class S10MainHistoryReadTest {
         .start()
     pb.outputStream.use { it.write(input.toByteArray(StandardCharsets.UTF_8)) }
     require(pb.waitFor(15, TimeUnit.SECONDS)) { "mktree timed out" }
-    require(pb.exitValue() == 0) {
-      "mktree failed: ${pb.errorStream.bufferedReader().readText()}"
-    }
+    require(pb.exitValue() == 0) { "mktree failed: ${pb.errorStream.bufferedReader().readText()}" }
     return pb.inputStream.bufferedReader().readText().trim()
   }
 
@@ -212,7 +219,9 @@ class S10MainHistoryReadTest {
 
   private fun commitTree(repoRoot: File, treeSha: String, message: String): String {
     val pb =
-      ProcessBuilder(listOf("git", "-C", repoRoot.absolutePath, "commit-tree", treeSha, "-m", message))
+      ProcessBuilder(
+          listOf("git", "-C", repoRoot.absolutePath, "commit-tree", treeSha, "-m", message)
+        )
         .redirectErrorStream(false)
         .start()
     require(pb.waitFor(15, TimeUnit.SECONDS)) { "commit-tree timed out" }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
@@ -4,6 +4,13 @@ import ee.schimke.composeai.daemon.protocol.ChangeType
 import ee.schimke.composeai.daemon.protocol.ClientCapabilities
 import ee.schimke.composeai.daemon.protocol.FileChangedParams
 import ee.schimke.composeai.daemon.protocol.FileKind
+import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
+import ee.schimke.composeai.daemon.protocol.HistoryDiffParams
+import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
+import ee.schimke.composeai.daemon.protocol.HistoryListParams
+import ee.schimke.composeai.daemon.protocol.HistoryListResult
+import ee.schimke.composeai.daemon.protocol.HistoryReadParams
+import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
 import ee.schimke.composeai.daemon.protocol.InitializeParams
 import ee.schimke.composeai.daemon.protocol.InitializeResult
 import ee.schimke.composeai.daemon.protocol.JsonRpcNotification
@@ -143,6 +150,73 @@ class DaemonClient(
       response["result"]
         ?: error("renderNow: no result — error=${response["error"]}, full=$response")
     return json.decodeFromJsonElement(RenderNowResult.serializer(), resultElem)
+  }
+
+  // ---------------------------------------------------------------------------
+  // History (H2 / H3) — see PROTOCOL.md § 5 (`history/list` / `history/read` /
+  // `history/diff`). The MCP server's history mapping (H6) calls these.
+  // ---------------------------------------------------------------------------
+
+  /** Drives `history/list`. Default no-filter call returns recent entries across all previews. */
+  fun historyList(
+    params: HistoryListParams = HistoryListParams(),
+    timeout: Duration = 30.seconds,
+  ): HistoryListResult {
+    val id = nextId.getAndIncrement()
+    val request =
+      JsonRpcRequest(
+        id = id,
+        method = "history/list",
+        params = json.encodeToJsonElement(HistoryListParams.serializer(), params),
+      )
+    val response = sendAndAwait(id, request, timeout)
+    val resultElem =
+      response["result"]
+        ?: error("history/list: no result — error=${response["error"]}, full=$response")
+    return json.decodeFromJsonElement(HistoryListResult.serializer(), resultElem)
+  }
+
+  /** Drives `history/read`. With [inline] = true the daemon returns base64 PNG bytes inline. */
+  fun historyRead(
+    entryId: String,
+    inline: Boolean = false,
+    timeout: Duration = 30.seconds,
+  ): HistoryReadResultDto {
+    val id = nextId.getAndIncrement()
+    val params = HistoryReadParams(id = entryId, inline = inline)
+    val request =
+      JsonRpcRequest(
+        id = id,
+        method = "history/read",
+        params = json.encodeToJsonElement(HistoryReadParams.serializer(), params),
+      )
+    val response = sendAndAwait(id, request, timeout)
+    val resultElem =
+      response["result"]
+        ?: error("history/read: no result — error=${response["error"]}, full=$response")
+    return json.decodeFromJsonElement(HistoryReadResultDto.serializer(), resultElem)
+  }
+
+  /** Drives `history/diff` (metadata mode by default). */
+  fun historyDiff(
+    fromId: String,
+    toId: String,
+    mode: HistoryDiffMode = HistoryDiffMode.METADATA,
+    timeout: Duration = 30.seconds,
+  ): HistoryDiffResult {
+    val id = nextId.getAndIncrement()
+    val params = HistoryDiffParams(from = fromId, to = toId, mode = mode)
+    val request =
+      JsonRpcRequest(
+        id = id,
+        method = "history/diff",
+        params = json.encodeToJsonElement(HistoryDiffParams.serializer(), params),
+      )
+    val response = sendAndAwait(id, request, timeout)
+    val resultElem =
+      response["result"]
+        ?: error("history/diff: no result — error=${response["error"]}, full=$response")
+    return json.decodeFromJsonElement(HistoryDiffResult.serializer(), resultElem)
   }
 
   /**

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -20,7 +20,6 @@ import java.nio.file.Files
 import java.time.Instant
 import java.util.Base64
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -74,10 +73,20 @@ class DaemonMcpServer(
     ConcurrentHashMap()
 
   /**
-   * Outstanding `resources/read` waiters, keyed by `(workspace, module, previewId)`. Awakened by
-   * `renderFinished` notifications. We block at most [renderTimeoutMs] on the queue, then time out.
+   * Outstanding `resources/read` waiters, keyed by `(workspace, module, previewId)`. Each call adds
+   * its own `CompletableFuture` so concurrent reads of the same URI all wake up on the next
+   * `renderFinished` — `LinkedBlockingQueue` semantics would have served the outcome to one waiter
+   * and timed out the rest. The list type is `CopyOnWriteArrayList` because the read path
+   * (snapshot-and-complete inside `compute`) is rare; each render produces one fan-out, while a
+   * single render-in-flight is a quiet line.
    */
-  private val pendingRenders = ConcurrentHashMap<RenderKey, LinkedBlockingQueue<RenderOutcome>>()
+  private val pendingRenders =
+    ConcurrentHashMap<
+      RenderKey,
+      java.util.concurrent.CopyOnWriteArrayList<
+        java.util.concurrent.CompletableFuture<RenderOutcome>
+      >,
+    >()
 
   /**
    * Per-(workspace, module) counter of consecutive `classpathDirty` self-loops since the last clean
@@ -105,13 +114,25 @@ class DaemonMcpServer(
     )
 
   /**
-   * Worker that runs the (slow) replacement-daemon spawn after a `classpathDirty` notification.
-   * Single-threaded and daemon-flagged so it never delays JVM shutdown. Bounded queue isn't needed
-   * — `classpathDirty` is at most once per daemon lifetime.
+   * Worker for slow daemon-lifecycle work — replacement-daemon spawn after a `classpathDirty`
+   * notification, and async first-spawn from the `watch` tool. Single-threaded so concurrent
+   * requests for the same module don't double-spawn (the supervisor's `daemonFor` is already
+   * `computeIfAbsent`-safe, but serialising here also keeps the McpSession reader thread free).
+   * Daemon-flagged so it never delays JVM shutdown.
    */
-  private val respawnExecutor: java.util.concurrent.ExecutorService =
+  private val daemonLifecycleExecutor: java.util.concurrent.ExecutorService =
     java.util.concurrent.Executors.newSingleThreadExecutor { r ->
-      Thread(r, "mcp-respawn-worker").apply { isDaemon = true }
+      Thread(r, "mcp-daemon-lifecycle").apply { isDaemon = true }
+    }
+
+  /**
+   * Scheduled worker for periodic `notifications/progress` beats during slow renders. Pool size 1
+   * is enough — beats fire at [PROGRESS_BEAT_INTERVAL_MS] and self-cancel as soon as the underlying
+   * [renderAndReadBytes] future completes.
+   */
+  private val progressBeatExecutor: java.util.concurrent.ScheduledExecutorService =
+    java.util.concurrent.Executors.newSingleThreadScheduledExecutor { r ->
+      Thread(r, "mcp-progress-beat").apply { isDaemon = true }
     }
 
   init {
@@ -120,6 +141,7 @@ class DaemonMcpServer(
     router.on("renderFinished") { daemon, params -> onRenderFinished(daemon, params) }
     router.on("renderFailed") { daemon, params -> onRenderFailed(daemon, params) }
     router.on("classpathDirty") { daemon, params -> onClasspathDirty(daemon, params) }
+    router.on("historyAdded") { daemon, params -> onHistoryAdded(daemon, params) }
     router.onClose { daemon ->
       catalog.remove(DaemonAddr(daemon.workspaceId, daemon.modulePath))
       watchPropagator.forget(daemon)
@@ -151,8 +173,11 @@ class DaemonMcpServer(
           )
         }
 
-        override fun readResource(session: McpSession, uri: String): ReadResourceResult =
-          handleReadResource(uri)
+        override fun readResource(
+          session: McpSession,
+          uri: String,
+          progressToken: JsonElement?,
+        ): ReadResourceResult = handleReadResource(session, uri, progressToken)
 
         override fun subscribe(session: McpSession, uri: String) {
           subscriptions.subscribe(uri, session)
@@ -211,27 +236,82 @@ class DaemonMcpServer(
     return out.sortedBy { it.uri }
   }
 
-  private fun handleReadResource(uri: String): ReadResourceResult {
+  private fun handleReadResource(
+    session: McpSession,
+    uri: String,
+    progressToken: JsonElement?,
+  ): ReadResourceResult {
+    // History URIs short-circuit to `history/read` against the daemon — historical bytes are
+    // immutable so there's no render path involved.
+    HistoryUri.parseOrNull(uri)?.let { historyUri ->
+      return readHistoryResource(uri, historyUri)
+    }
     val parsed = PreviewUri.parseOrNull(uri) ?: error("Invalid compose-preview URI: '$uri'")
-    val pngBytes = renderAndReadBytes(parsed)
+    val pngBytes = renderAndReadBytes(parsed, session, progressToken)
     val encoded = Base64.getEncoder().encodeToString(pngBytes)
     return ReadResourceResult(
       contents = listOf(ResourceContents.Blob(uri = uri, mimeType = "image/png", blob = encoded))
     )
   }
 
-  private fun renderAndReadBytes(uri: PreviewUri): ByteArray {
+  /**
+   * Reads a `compose-preview-history://…` resource by calling `history/read` on the matching daemon
+   * with `inline = true`. The daemon's response carries the PNG bytes already base64- encoded; we
+   * forward them verbatim to the MCP client.
+   *
+   * Falls back to reading the file from `pngPath` when `pngBytes` is unset (older daemons or non-FS
+   * sources where inline is opportunistic).
+   */
+  private fun readHistoryResource(uriString: String, uri: HistoryUri): ReadResourceResult {
+    val daemon = supervisor.daemonFor(uri.workspaceId, uri.modulePath)
+    val result = daemon.client.historyRead(entryId = uri.entryId, inline = true)
+    val blob =
+      result.pngBytes
+        ?: run {
+          val file = File(result.pngPath)
+          check(file.isFile) { "history/read pngPath does not exist: ${result.pngPath}" }
+          Base64.getEncoder().encodeToString(Files.readAllBytes(file.toPath()))
+        }
+    return ReadResourceResult(
+      contents = listOf(ResourceContents.Blob(uri = uriString, mimeType = "image/png", blob = blob))
+    )
+  }
+
+  private fun renderAndReadBytes(
+    uri: PreviewUri,
+    session: McpSession? = null,
+    progressToken: JsonElement? = null,
+  ): ByteArray {
     val daemon = supervisor.daemonFor(uri.workspaceId, uri.modulePath)
     val key = RenderKey(uri.workspaceId, uri.modulePath, uri.previewFqn)
-    val slot = pendingRenders.computeIfAbsent(key) { LinkedBlockingQueue() }
+    // Multi-waiter dedup: each call adds its own CompletableFuture to the per-key list, so
+    // concurrent `resources/read` for the same URI all wake up on the next `renderFinished`
+    // — they all asked "what's the current bytes for this preview?" and the daemon's reply
+    // satisfies every concurrent reader. Crucially, the future is published BEFORE
+    // `renderNow` is sent, so the daemon's notification can't arrive ahead of the wait.
+    val future = java.util.concurrent.CompletableFuture<RenderOutcome>()
+    pendingRenders.compute(key) { _, list ->
+      val l = list ?: java.util.concurrent.CopyOnWriteArrayList()
+      l.add(future)
+      l
+    }
     daemon.client.renderNow(previews = listOf(uri.previewFqn), tier = RenderTier.FULL)
+    // Optional `notifications/progress` beat: when the client opted in via
+    // `_meta.progressToken`, fire periodic monotonic progress notifications so a UI can show a
+    // spinner / progress bar while the slow render completes. Beat thread is daemon-flagged
+    // and exits as soon as the future completes (or the timeout cleanup path runs).
+    val progressBeat = startProgressBeatIfNeeded(session, progressToken, future, uri)
     val outcome =
-      slot.poll(renderTimeoutMs, TimeUnit.MILLISECONDS)
-        ?: run {
-          pendingRenders.remove(key)
-          error("renderAndReadBytes: timed out after ${renderTimeoutMs}ms for $uri")
-        }
-    pendingRenders.remove(key)
+      try {
+        future.get(renderTimeoutMs, TimeUnit.MILLISECONDS)
+      } catch (e: java.util.concurrent.TimeoutException) {
+        // Best-effort cleanup so a stuck daemon doesn't leak futures forever.
+        pendingRenders.computeIfPresent(key) { _, list -> list.also { it.remove(future) } }
+        progressBeat?.cancel(true)
+        error("renderAndReadBytes: timed out after ${renderTimeoutMs}ms for $uri")
+      } finally {
+        progressBeat?.cancel(false)
+      }
     when (outcome) {
       is RenderOutcome.Failed ->
         error("renderAndReadBytes failed for $uri: ${outcome.kind} ${outcome.message}")
@@ -368,6 +448,58 @@ class DaemonMcpServer(
               .trimIndent()
           ),
       ),
+      ToolDef(
+        name = "history_list",
+        description =
+          "List historical render entries for a workspace's daemon. Proxies the daemon's `history/list` JSON-RPC method (PROTOCOL.md § 5). Returns newest-first sidecar metadata; pair with `history_read` (or `resources/read` on a `compose-preview-history://` URI) to fetch bytes. Filters mirror the daemon: previewId / since / until / branch / commit / etc.",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "workspaceId":{"type":"string"},
+                "module":{"type":"string","description":"Gradle module path; required so the supervisor knows which daemon to ask."},
+                "previewId":{"type":"string","description":"Optional preview FQN filter (e.g. com.example.RedSquare)."},
+                "since":{"type":"string","description":"ISO-8601 lower bound, e.g. 2026-04-30T00:00:00Z."},
+                "until":{"type":"string","description":"ISO-8601 upper bound."},
+                "limit":{"type":"integer","description":"Default 50, max 500."},
+                "cursor":{"type":"string","description":"Opaque pagination token from a previous response."},
+                "branch":{"type":"string"},
+                "branchPattern":{"type":"string","description":"Regex over branch."},
+                "commit":{"type":"string","description":"Long or short SHA."},
+                "worktreePath":{"type":"string"},
+                "agentId":{"type":"string"},
+                "sourceKind":{"type":"string","enum":["fs","git","http"]},
+                "sourceId":{"type":"string"}
+              },
+              "required":["workspaceId","module"]
+            }
+            """
+              .trimIndent()
+          ),
+      ),
+      ToolDef(
+        name = "history_diff",
+        description =
+          "Diff two history entries by id (metadata mode only — pixel mode is reserved for daemon phase H5). Returns `{pngHashChanged, fromMetadata, toMetadata}`. Cross-source: `from` and `to` may live on different `HistorySource`s (LocalFs vs git-ref), so this is the load-bearing call for \"did my edit change rendered output vs the version on main?\".",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "workspaceId":{"type":"string"},
+                "module":{"type":"string"},
+                "from":{"type":"string","description":"Entry id (HistoryEntry.id)."},
+                "to":{"type":"string"}
+              },
+              "required":["workspaceId","module","from","to"]
+            }
+            """
+              .trimIndent()
+          ),
+      ),
     )
 
   private fun handleCallTool(
@@ -385,6 +517,8 @@ class DaemonMcpServer(
       "unwatch" -> toolUnwatch(session, args)
       "list_watches" -> toolListWatches(session)
       "notify_file_changed" -> toolNotifyFileChanged(args)
+      "history_list" -> toolHistoryList(args)
+      "history_diff" -> toolHistoryDiff(args)
       else -> errorCallToolResult("unknown tool: $name")
     }
   }
@@ -478,13 +612,28 @@ class DaemonMcpServer(
     val toSpawn =
       if (module != null) listOf(module)
       else synchronized(project.knownModules) { project.knownModules.toList() }
-    toSpawn.forEach { mp ->
-      runCatching { supervisor.daemonFor(workspaceId, mp) }
-        .onFailure { System.err.println("watch: lazy spawn failed for $mp: ${it.message}") }
+    // Spawn off-thread so the McpSession reader doesn't block on cold-start (Robolectric ~5–10s,
+    // desktop ~600ms). The supervisor's `daemonFor` is `computeIfAbsent`-safe so duplicate watches
+    // racing on the same module are fine. Each successful spawn calls
+    // `synthesiseInitialDiscovery`, which fires `discoveryUpdated` → `onDiscoveryUpdated` →
+    // `notifyResourceListChanged` + `watchPropagator.recompute(daemon)`, so the watch's set ends
+    // up forwarded to the daemon as `setVisible`/`setFocus` without a synchronous round-trip here.
+    val toSpawnSet = toSpawn.toSet()
+    val alreadySpawned = toSpawnSet.filter { project.daemons.containsKey(it) }
+    val pending = toSpawnSet - alreadySpawned.toSet()
+    pending.forEach { mp ->
+      daemonLifecycleExecutor.execute {
+        runCatching { supervisor.daemonFor(workspaceId, mp) }
+          .onFailure { System.err.println("watch: async spawn failed for $mp: ${it.message}") }
+      }
     }
-    // Recompute every daemon's view; the propagator skips daemons whose URI set didn't change.
-    project.daemons.values.forEach { watchPropagator.recompute(it) }
-    return textCallToolResult("watching $entry (spawned ${toSpawn.size} daemon(s))")
+    // For daemons that are ALREADY up, recompute synchronously — the propagator skips daemons
+    // whose URI set didn't change. The async spawns above will recompute themselves once their
+    // initial discovery lands in `onDiscoveryUpdated`.
+    alreadySpawned.forEach { mp -> project.daemons[mp]?.let { watchPropagator.recompute(it) } }
+    return textCallToolResult(
+      "watching $entry (already-up: ${alreadySpawned.size}, spawning: ${pending.size})"
+    )
   }
 
   private fun toolUnwatch(session: McpSession, args: JsonObject): CallToolResult {
@@ -520,6 +669,138 @@ class DaemonMcpServer(
           )
         }
       }
+    }
+    return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+  }
+
+  /**
+   * Resolves the (workspaceId, module) pair the history tools need plus the live daemon — the
+   * daemon owns the configured `HistoryManager`, so every history call goes through it.
+   */
+  private fun resolveHistoryDaemon(
+    args: JsonObject,
+    toolName: String,
+  ): Pair<SupervisedDaemon, String>? {
+    val ws =
+      args["workspaceId"]?.jsonPrimitive?.contentOrNull
+        ?: return null.also {
+          // Caller wraps this null into an errorCallToolResult; we surface the missing-field
+          // message there.
+        }
+    val workspaceId = WorkspaceId(ws)
+    if (supervisor.project(workspaceId) == null) return null
+    val module = args["module"]?.jsonPrimitive?.contentOrNull ?: return null
+    val daemon =
+      runCatching { supervisor.daemonFor(workspaceId, module) }.getOrNull() ?: return null
+    return daemon to module
+  }
+
+  private fun toolHistoryList(args: JsonObject): CallToolResult {
+    val ws =
+      args["workspaceId"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("history_list: missing 'workspaceId'")
+    val workspaceId = WorkspaceId(ws)
+    if (supervisor.project(workspaceId) == null) {
+      return errorCallToolResult("history_list: workspace '$ws' not registered")
+    }
+    val module =
+      args["module"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("history_list: missing 'module'")
+    val daemon =
+      runCatching { supervisor.daemonFor(workspaceId, module) }
+        .getOrElse {
+          return errorCallToolResult("history_list: daemon spawn failed: ${it.message}")
+        }
+    val params =
+      ee.schimke.composeai.daemon.protocol.HistoryListParams(
+        previewId = args["previewId"]?.jsonPrimitive?.contentOrNull,
+        since = args["since"]?.jsonPrimitive?.contentOrNull,
+        until = args["until"]?.jsonPrimitive?.contentOrNull,
+        limit = args["limit"]?.jsonPrimitive?.contentOrNull?.toIntOrNull(),
+        cursor = args["cursor"]?.jsonPrimitive?.contentOrNull,
+        branch = args["branch"]?.jsonPrimitive?.contentOrNull,
+        branchPattern = args["branchPattern"]?.jsonPrimitive?.contentOrNull,
+        commit = args["commit"]?.jsonPrimitive?.contentOrNull,
+        worktreePath = args["worktreePath"]?.jsonPrimitive?.contentOrNull,
+        agentId = args["agentId"]?.jsonPrimitive?.contentOrNull,
+        sourceKind = args["sourceKind"]?.jsonPrimitive?.contentOrNull,
+        sourceId = args["sourceId"]?.jsonPrimitive?.contentOrNull,
+      )
+    val result =
+      runCatching { daemon.client.historyList(params) }
+        .getOrElse {
+          return errorCallToolResult("history_list failed: ${it.message}")
+        }
+
+    // Decorate each entry with the matching `compose-preview-history://` URI so clients can
+    // call `resources/read` on it directly.
+    val annotated = buildJsonObject {
+      put("totalCount", JsonPrimitive(result.totalCount))
+      if (result.nextCursor != null) put("nextCursor", JsonPrimitive(result.nextCursor))
+      putJsonArray("entries") {
+        result.entries.forEach { entry ->
+          val obj = entry as? JsonObject ?: return@forEach
+          val previewId = obj["previewId"]?.jsonPrimitive?.contentOrNull
+          val entryId = obj["id"]?.jsonPrimitive?.contentOrNull
+          val uri =
+            if (previewId != null && entryId != null)
+              HistoryUri(workspaceId, module, previewId, entryId).toUri()
+            else null
+          add(
+            buildJsonObject {
+              obj.forEach { (k, v) -> put(k, v) }
+              if (uri != null) put("resourceUri", JsonPrimitive(uri))
+            }
+          )
+        }
+      }
+    }
+    return CallToolResult(content = listOf(ContentBlock.Text(annotated.toString())))
+  }
+
+  private fun toolHistoryDiff(args: JsonObject): CallToolResult {
+    val ws =
+      args["workspaceId"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("history_diff: missing 'workspaceId'")
+    val workspaceId = WorkspaceId(ws)
+    if (supervisor.project(workspaceId) == null) {
+      return errorCallToolResult("history_diff: workspace '$ws' not registered")
+    }
+    val module =
+      args["module"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("history_diff: missing 'module'")
+    val from =
+      args["from"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("history_diff: missing 'from'")
+    val to =
+      args["to"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("history_diff: missing 'to'")
+    val daemon =
+      runCatching { supervisor.daemonFor(workspaceId, module) }
+        .getOrElse {
+          return errorCallToolResult("history_diff: daemon spawn failed: ${it.message}")
+        }
+    val result =
+      runCatching {
+          daemon.client.historyDiff(
+            fromId = from,
+            toId = to,
+            mode = ee.schimke.composeai.daemon.protocol.HistoryDiffMode.METADATA,
+          )
+        }
+        .getOrElse {
+          return errorCallToolResult("history_diff failed: ${it.message}")
+        }
+
+    val payload = buildJsonObject {
+      put("pngHashChanged", JsonPrimitive(result.pngHashChanged))
+      put("fromMetadata", result.fromMetadata)
+      put("toMetadata", result.toMetadata)
+      // Pixel-mode fields are always null in METADATA mode by design (HISTORY.md § H3).
+      // We expose them so a client written against the H5-shape doesn't choke on missing keys.
+      if (result.diffPx != null) put("diffPx", JsonPrimitive(result.diffPx))
+      if (result.ssim != null) put("ssim", JsonPrimitive(result.ssim))
+      if (result.diffPngPath != null) put("diffPngPath", JsonPrimitive(result.diffPngPath))
     }
     return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
   }
@@ -618,9 +899,12 @@ class DaemonMcpServer(
   private fun onRenderFinished(daemon: SupervisedDaemon, params: JsonObject?) {
     val previewId = params?.get("id")?.jsonPrimitive?.contentOrNull ?: return
     val pngPath = params["pngPath"]?.jsonPrimitive?.contentOrNull ?: return
-    // 1. Wake any pending resources/read awaiter.
+    // 1. Wake every pending resources/read awaiter for this URI. We remove the list atomically
+    //    and complete each future outside the compute lambda so a slow consumer can't block
+    //    other waiters or the daemon's reader thread.
     val key = RenderKey(daemon.workspaceId, daemon.modulePath, previewId)
-    pendingRenders[key]?.offer(RenderOutcome.Finished(pngPath))
+    val toComplete = pendingRenders.remove(key)
+    toComplete?.forEach { it.complete(RenderOutcome.Finished(pngPath)) }
     // 2. Build the matching URI and notify subscribers + watchers.
     val entry = catalog[DaemonAddr(daemon.workspaceId, daemon.modulePath)]?.get(previewId)
     val uri =
@@ -645,7 +929,7 @@ class DaemonMcpServer(
     val kind = errorObj?.get("kind")?.jsonPrimitive?.contentOrNull ?: "unknown"
     val message = errorObj?.get("message")?.jsonPrimitive?.contentOrNull ?: "no message"
     val key = RenderKey(daemon.workspaceId, daemon.modulePath, previewId)
-    pendingRenders[key]?.offer(RenderOutcome.Failed(kind, message))
+    pendingRenders.remove(key)?.forEach { it.complete(RenderOutcome.Failed(kind, message)) }
   }
 
   /**
@@ -659,14 +943,35 @@ class DaemonMcpServer(
    *    `synthesiseInitialDiscovery` path, which repopulates the catalog.
    * 3. Tell connected clients the resource list is stale (`notifications/resources/list_changed`)
    *    so they re-list when ready.
-   * 4. Schedule a respawn on the [respawnExecutor] worker so the daemon's reader thread (which is
-   *    about to die anyway) doesn't block on the new daemon's cold-start.
+   * 4. Schedule a respawn on the [daemonLifecycleExecutor] worker so the daemon's reader thread
+   *    (which is about to die anyway) doesn't block on the new daemon's cold-start.
    *
    * If the descriptor on disk is itself stale (the user/VS Code hasn't re-run
    * `composePreviewDaemonStart`), the new daemon will hit `classpathDirty` again. We log that and
    * stop trying after one self-loop — repeated thrashing serves no one. Production users are
    * expected to re-bootstrap before the supervisor's respawn kicks in.
    */
+  /**
+   * The daemon's `historyAdded` notification carries one new [HistoryEntry] per render. Per
+   * HISTORY.md § Subscriptions, the MCP mapping fires `notifications/resources/list_changed` so:
+   *
+   * - clients that subscribed to a `compose-preview-history://…` URI for THIS preview re-list (the
+   *   entry set grew),
+   * - clients that subscribed to the *live* `compose-preview://…` URI also re-list (HISTORY.md §
+   *   "Resources/subscribe" makes this explicit — subscribers to the live URI receive
+   *   `list_changed` whenever a new history entry lands for it).
+   *
+   * Cheap signal: a single repo-wide `notifications/resources/list_changed` covers both cases
+   * without the supervisor having to remember which URIs are subscribed. Clients that care filter
+   * their next `resources/list` by URI prefix.
+   */
+  private fun onHistoryAdded(daemon: SupervisedDaemon, params: JsonObject?) {
+    // No state to update here — history is owned by the daemon, served on demand by
+    // history/list / history/read. We only need to tell connected MCP sessions that the resource
+    // list grew.
+    sessions.forEach { it.notifyResourceListChanged() }
+  }
+
   private fun onClasspathDirty(daemon: SupervisedDaemon, params: JsonObject?) {
     val detail = params?.get("detail")?.jsonPrimitive?.contentOrNull ?: "<no detail>"
     val reason = params?.get("reason")?.jsonPrimitive?.contentOrNull ?: "<no reason>"
@@ -683,9 +988,9 @@ class DaemonMcpServer(
     pendingRenders.keys
       .filter { it.workspaceId == workspaceId && it.modulePath == modulePath }
       .forEach { key ->
-        pendingRenders[key]?.offer(
-          RenderOutcome.Failed("classpathDirty", "daemon exiting: $detail")
-        )
+        pendingRenders.remove(key)?.forEach {
+          it.complete(RenderOutcome.Failed("classpathDirty", "daemon exiting: $detail"))
+        }
       }
 
     // Forget the daemon + cached state. (The daemon's wire close will also fire `onClose` and
@@ -709,7 +1014,7 @@ class DaemonMcpServer(
       return
     }
 
-    respawnExecutor.execute {
+    daemonLifecycleExecutor.execute {
       val outcome =
         runCatching { supervisor.daemonFor(workspaceId, modulePath) }
           .onFailure {
@@ -747,6 +1052,42 @@ class DaemonMcpServer(
 
   private fun parseSchema(s: String): JsonElement = json.parseToJsonElement(s)
 
+  /**
+   * Schedules `notifications/progress` beats to [session] every [PROGRESS_BEAT_INTERVAL_MS] until
+   * [future] completes. Returns the scheduled handle so the caller can cancel it on completion.
+   *
+   * No-op when [session] or [progressToken] is null — the client didn't opt in.
+   *
+   * The progress value is a wall-clock-elapsed-ms count rather than a render-progress estimate
+   * because the daemon doesn't currently expose render progress. Total is left unset (unknown);
+   * `message` carries a short status string the client can show as a tooltip / log line.
+   */
+  private fun startProgressBeatIfNeeded(
+    session: McpSession?,
+    progressToken: JsonElement?,
+    future: java.util.concurrent.CompletableFuture<*>,
+    uri: PreviewUri,
+  ): java.util.concurrent.ScheduledFuture<*>? {
+    if (session == null || progressToken == null) return null
+    val start = System.currentTimeMillis()
+    return progressBeatExecutor.scheduleAtFixedRate(
+      {
+        if (future.isDone) return@scheduleAtFixedRate
+        runCatching {
+          val elapsed = (System.currentTimeMillis() - start).toDouble()
+          session.notifyProgress(
+            token = progressToken,
+            progress = elapsed,
+            message = "rendering ${uri.previewFqn}",
+          )
+        }
+      },
+      PROGRESS_BEAT_INTERVAL_MS,
+      PROGRESS_BEAT_INTERVAL_MS,
+      TimeUnit.MILLISECONDS,
+    )
+  }
+
   private fun detectBranch(workspacePath: File): String? {
     val head = File(workspacePath, ".git/HEAD").takeIf { it.isFile } ?: return null
     val content = runCatching { head.readText().trim() }.getOrNull() ?: return null
@@ -763,5 +1104,11 @@ class DaemonMcpServer(
      * Higher caps would just thrash if the descriptor is actually stale.
      */
     private const val MAX_RESPAWN_ATTEMPTS_PER_LIFETIME: Int = 1
+
+    /**
+     * Cadence for `notifications/progress` beats during a slow `resources/read`. 500ms strikes a
+     * balance between "responsive UI updates" and "not flooding the wire on a fast render".
+     */
+    private const val PROGRESS_BEAT_INTERVAL_MS: Long = 500
   }
 }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/McpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/McpServer.kt
@@ -94,6 +94,30 @@ class McpSession(
     notify("notifications/resources/list_changed")
   }
 
+  /**
+   * Sends a `notifications/progress` per the MCP spec:
+   * https://modelcontextprotocol.io/specification/2025-06-18/basic#progress-notifications.
+   *
+   * Only meaningful when the originating request opted in via `_meta.progressToken` in its params;
+   * the [token] argument is the verbatim value the client sent. [progress] is monotonic (caller's
+   * responsibility); [total] is optional and may be unknown for streaming work.
+   */
+  fun notifyProgress(
+    token: kotlinx.serialization.json.JsonElement,
+    progress: Double,
+    total: Double? = null,
+    message: String? = null,
+  ) {
+    val params =
+      kotlinx.serialization.json.buildJsonObject {
+        put("progressToken", token)
+        put("progress", kotlinx.serialization.json.JsonPrimitive(progress))
+        if (total != null) put("total", kotlinx.serialization.json.JsonPrimitive(total))
+        if (message != null) put("message", kotlinx.serialization.json.JsonPrimitive(message))
+      }
+    notify("notifications/progress", params)
+  }
+
   override fun close() {
     if (!closed.compareAndSet(false, true)) return
     runCatching { input.close() }
@@ -196,7 +220,12 @@ class McpSession(
       params?.let {
         runCatching { json.decodeFromJsonElement(ReadResourceParams.serializer(), it) }.getOrNull()
       } ?: return sendError(id, McpErrorCodes.INVALID_PARAMS, "resources/read: missing uri")
-    val result = handlers.readResource(this, parsed.uri)
+    // Per MCP spec, clients opt in to progress notifications by including a
+    // `_meta.progressToken` (string | number) on the request's params. Pull it out so the
+    // handler can fire periodic `notifications/progress` while a slow render runs.
+    val progressToken =
+      (params as? JsonObject)?.get("_meta")?.let { it as? JsonObject }?.get("progressToken")
+    val result = handlers.readResource(this, parsed.uri, progressToken)
     sendResult(id, json.encodeToJsonElement(ReadResourceResult.serializer(), result))
   }
 
@@ -301,7 +330,16 @@ interface McpHandlers {
 
   fun listResources(session: McpSession): JsonElement
 
-  fun readResource(session: McpSession, uri: String): ReadResourceResult
+  /**
+   * Reads the resource at [uri]. [progressToken], when non-null, is the client's opt-in handle for
+   * `notifications/progress` — implementations that perform slow work should fan out periodic
+   * progress notifications via [McpSession.notifyProgress] using this token.
+   */
+  fun readResource(
+    session: McpSession,
+    uri: String,
+    progressToken: JsonElement? = null,
+  ): ReadResourceResult
 
   fun subscribe(session: McpSession, uri: String)
 

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/PreviewResource.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/PreviewResource.kt
@@ -122,6 +122,67 @@ data class PreviewUri(
 }
 
 /**
+ * History resource URI — `compose-preview-history://<workspace>/<module>/<previewFqn>/<entryId>`.
+ * Distinct from [PreviewUri] so clients can disambiguate "current state" (live preview) from
+ * "snapshot" (historical entry). Per [HISTORY.md § Layer 3 — MCP mapping](
+ * ../../../../../../docs/daemon/HISTORY.md#layer-3--mcp-mapping).
+ *
+ * The `entryId` is the stable hash-based id the daemon attaches to each `HistoryEntry`; it's opaque
+ * to MCP — the supervisor passes it back to the daemon's `history/read` / `history/diff` verbatim.
+ * We round-trip the value through the URI without any encoding because the daemon's id format
+ * already excludes `/` and `?`.
+ */
+data class HistoryUri(
+  val workspaceId: WorkspaceId,
+  val modulePath: String,
+  val previewFqn: String,
+  val entryId: String,
+) {
+  init {
+    require(modulePath.startsWith(":")) {
+      "HistoryUri.modulePath must start with ':' (got '$modulePath')"
+    }
+    require(!previewFqn.contains('/') && !previewFqn.contains('?')) {
+      "HistoryUri.previewFqn must not contain '/' or '?' (got '$previewFqn')"
+    }
+    require(!entryId.contains('/') && !entryId.contains('?')) {
+      "HistoryUri.entryId must not contain '/' or '?' (got '$entryId')"
+    }
+  }
+
+  fun toUri(): String =
+    "$SCHEME://${workspaceId.value}/${PreviewUri.encodeModule(modulePath)}/$previewFqn/$entryId"
+
+  override fun toString(): String = toUri()
+
+  companion object {
+    const val SCHEME: String = "compose-preview-history"
+
+    fun parseOrNull(s: String): HistoryUri? {
+      val prefix = "$SCHEME://"
+      if (!s.startsWith(prefix)) return null
+      val parts = s.removePrefix(prefix).split('/')
+      if (parts.size < 4) return null
+      val workspace = parts[0]
+      val moduleEncoded = parts[1]
+      val fqn = parts[2]
+      val entry = parts.subList(3, parts.size).joinToString("/")
+      if (workspace.isBlank() || moduleEncoded.isBlank() || fqn.isBlank() || entry.isBlank())
+        return null
+      return HistoryUri(
+        workspaceId = WorkspaceId(workspace),
+        modulePath = PreviewUri.decodeModule(moduleEncoded),
+        previewFqn = fqn,
+        entryId = entry,
+      )
+    }
+
+    fun parse(s: String): HistoryUri =
+      requireNotNull(parseOrNull(s)) { "Malformed compose-preview-history URI: '$s'" }
+  }
+}
+
+/**
  * Glob over preview FQN — used by the `watch` tool to register an "area of interest". A single `*`
  * matches any sequence of non-`.` characters; `**` matches anything including dots; `?` matches one
  * non-`.` character. Matching is case-sensitive — Kotlin FQNs are.

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -97,6 +97,8 @@ class DaemonMcpServerTest {
         "unwatch",
         "list_watches",
         "notify_file_changed",
+        "history_list",
+        "history_diff",
       )
   }
 
@@ -172,6 +174,331 @@ class DaemonMcpServerTest {
     val focus = daemon.focusSets.poll(2_000, TimeUnit.MILLISECONDS)
     assertThat(visible).isEqualTo(listOf("com.example.Red"))
     assertThat(focus).isEqualTo(listOf("com.example.Red"))
+  }
+
+  @Test
+  fun `classpathDirty respawn re-issues setVisible to the replacement daemon`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    // First daemon: spawn via watch, register interest, observe initial setVisible.
+    val firstDaemon = warmDaemonFor(workspaceId, ":module")
+    firstDaemon.emitDiscovery("com.example.Red")
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+    client.callTool(
+      "watch",
+      buildJsonObject {
+        put("workspaceId", workspaceId.value)
+        put("module", ":module")
+        put("fqnGlob", "com.example.Red")
+      },
+    )
+    val firstVisible = firstDaemon.visibleSets.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(firstVisible).isEqualTo(listOf("com.example.Red"))
+
+    // Trigger the classpathDirty respawn flow on the first daemon.
+    firstDaemon.emitClasspathDirty()
+
+    // Wait for the supervisor's async respawn to construct a second FakeDaemon. The supervisor
+    // hands ownership of the new daemon to factory.spawnHistory[1].
+    val deadline = System.currentTimeMillis() + 5_000
+    while (factory.spawnHistory.size < 2 && System.currentTimeMillis() < deadline) {
+      Thread.sleep(50)
+    }
+    assertThat(factory.spawnHistory.size).isAtLeast(2)
+    val secondDaemon = factory.spawnHistory[1]
+
+    // Replacement daemon emits its (newly-rebuilt) discovery — supervisor's
+    // `synthesiseInitialDiscovery` would normally do this from the manifest path, but the
+    // FakeDescriptorProvider's blank manifestPath skips that, so we drive it manually.
+    secondDaemon.emitDiscovery("com.example.Red")
+
+    // Existing watch should re-fire setVisible on the replacement daemon (the propagator's
+    // memo for this DaemonKey was forgotten by `onClasspathDirty`, so the same watched set
+    // counts as a delta against `previous=null` and is re-sent).
+    val secondVisible = secondDaemon.visibleSets.poll(2_000, TimeUnit.MILLISECONDS)
+    val secondFocus = secondDaemon.focusSets.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(secondVisible).isEqualTo(listOf("com.example.Red"))
+    assertThat(secondFocus).isEqualTo(listOf("com.example.Red"))
+  }
+
+  @Test
+  fun `history_list returns entries decorated with compose-preview-history URIs`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+
+    val entry1 = buildJsonObject {
+      put("id", "entry-1")
+      put("previewId", "com.example.RedSquare")
+      put("module", ":module")
+      put("timestamp", "2026-04-30T10:00:00Z")
+      put("pngHash", "deadbeef")
+      put("pngSize", 4218L)
+      put("pngPath", "/tmp/r1.png")
+      put("producer", "fake")
+      put("trigger", "manual")
+      putJsonObject("source") {
+        put("kind", "fs")
+        put("id", "fs:/tmp/h")
+      }
+      put("renderTookMs", 12L)
+    }
+    val entry2 = buildJsonObject {
+      put("id", "entry-2")
+      put("previewId", "com.example.RedSquare")
+      put("module", ":module")
+      put("timestamp", "2026-04-30T10:01:00Z")
+      put("pngHash", "cafef00d")
+      put("pngSize", 4218L)
+      put("pngPath", "/tmp/r2.png")
+      put("producer", "fake")
+      put("trigger", "manual")
+      putJsonObject("source") {
+        put("kind", "fs")
+        put("id", "fs:/tmp/h")
+      }
+      put("renderTookMs", 13L)
+    }
+    daemon.setHistory(listOf(entry1, entry2))
+
+    val resp =
+      client.callTool(
+        "history_list",
+        buildJsonObject {
+          put("workspaceId", workspaceId.value)
+          put("module", ":module")
+        },
+      )
+    val text = resp.firstTextContent()
+    val parsed = json.parseToJsonElement(text).jsonObject
+    assertThat(parsed["totalCount"]?.jsonPrimitive?.content?.toInt()).isEqualTo(2)
+    val entries = parsed["entries"]!!.jsonArray
+    assertThat(entries).hasSize(2)
+    val firstUri = entries[0].jsonObject["resourceUri"]?.jsonPrimitive?.contentOrNull
+    assertThat(firstUri)
+      .isEqualTo(
+        "compose-preview-history://${workspaceId.value}/_module/com.example.RedSquare/entry-1"
+      )
+  }
+
+  @Test
+  fun `history_diff forwards from to ids and decodes pngHashChanged`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+
+    val entryA = buildJsonObject {
+      put("id", "a")
+      put("previewId", "com.example.X")
+      put("module", ":module")
+      put("timestamp", "2026-04-30T10:00:00Z")
+      put("pngHash", "AAAA")
+      put("pngSize", 100L)
+      put("pngPath", "/tmp/a.png")
+      put("producer", "fake")
+      put("trigger", "manual")
+      putJsonObject("source") {
+        put("kind", "fs")
+        put("id", "fs:/tmp/h")
+      }
+      put("renderTookMs", 1L)
+    }
+    val entryB = buildJsonObject {
+      put("id", "b")
+      put("previewId", "com.example.X")
+      put("module", ":module")
+      put("timestamp", "2026-04-30T10:01:00Z")
+      put("pngHash", "BBBB")
+      put("pngSize", 100L)
+      put("pngPath", "/tmp/b.png")
+      put("producer", "fake")
+      put("trigger", "manual")
+      putJsonObject("source") {
+        put("kind", "fs")
+        put("id", "fs:/tmp/h")
+      }
+      put("renderTookMs", 1L)
+    }
+    daemon.setHistory(listOf(entryA, entryB))
+
+    val resp =
+      client.callTool(
+        "history_diff",
+        buildJsonObject {
+          put("workspaceId", workspaceId.value)
+          put("module", ":module")
+          put("from", "a")
+          put("to", "b")
+        },
+      )
+    val parsed = json.parseToJsonElement(resp.firstTextContent()).jsonObject
+    assertThat(parsed["pngHashChanged"]?.jsonPrimitive?.content?.toBoolean()).isTrue()
+    assertThat(parsed["fromMetadata"]?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("a")
+    assertThat(parsed["toMetadata"]?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("b")
+  }
+
+  @Test
+  fun `resources read on a compose-preview-history URI returns inline PNG bytes`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+
+    val entry = buildJsonObject {
+      put("id", "h-1")
+      put("previewId", "com.example.X")
+      put("module", ":module")
+      put("timestamp", "2026-04-30T10:00:00Z")
+      put("pngHash", "AAAA")
+      put("pngSize", 11L)
+      put("pngPath", "/tmp/h-1.png")
+      put("producer", "fake")
+      put("trigger", "manual")
+      putJsonObject("source") {
+        put("kind", "fs")
+        put("id", "fs:/tmp/h")
+      }
+      put("renderTookMs", 1L)
+    }
+    val pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3)
+    daemon.setHistory(listOf(entry))
+    daemon.setHistoryInlineBytes("h-1", pngBytes)
+
+    val historyUri = HistoryUri(workspaceId, ":module", "com.example.X", "h-1").toUri()
+    val resp = client.request("resources/read", buildJsonObject { put("uri", historyUri) })
+    val parsed = json.decodeFromJsonElement(ReadResourceResult.serializer(), resp)
+    val blob = (parsed.contents.single() as ResourceContents.Blob).blob
+    assertThat(java.util.Base64.getDecoder().decode(blob)).isEqualTo(pngBytes)
+  }
+
+  @Test
+  fun `historyAdded notification triggers resources list_changed push`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+
+    val entry = buildJsonObject {
+      put("id", "added-1")
+      put("previewId", "com.example.X")
+      put("module", ":module")
+      put("timestamp", "2026-04-30T10:00:00Z")
+      put("pngHash", "AAAA")
+      put("pngSize", 11L)
+      put("pngPath", "/tmp/added.png")
+      put("producer", "fake")
+      put("trigger", "manual")
+      putJsonObject("source") {
+        put("kind", "fs")
+        put("id", "fs:/tmp/h")
+      }
+      put("renderTookMs", 1L)
+    }
+    daemon.emitHistoryAdded(entry)
+    val n = client.expectNotification("notifications/resources/list_changed", 2_000)
+    assertThat(n.method).isEqualTo("notifications/resources/list_changed")
+  }
+
+  @Test
+  fun `resources read emits progress notifications when the client opts in`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Slow"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47)
+    val pngFile = tmp.newFile("slow.png")
+    Files.write(pngFile.toPath(), pngBytes)
+
+    // Stage the auto-emit but DELAY it for ~700ms so the 500ms progress-beat cadence has time
+    // to fire at least once before the renderFinished arrives.
+    daemon.autoRenderPngPath = { id ->
+      if (id == previewId) {
+        Thread.sleep(700)
+        pngFile.absolutePath
+      } else null
+    }
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val params = buildJsonObject {
+      put("uri", uri)
+      // Per MCP spec, `_meta.progressToken` is the client's opt-in handle.
+      putJsonObject("_meta") { put("progressToken", JsonPrimitive("read-1")) }
+    }
+    val pool = java.util.concurrent.Executors.newSingleThreadExecutor()
+    val readFuture =
+      pool.submit<JsonObject> { client.request("resources/read", params, timeoutMs = 10_000) }
+
+    val progress = client.expectNotification("notifications/progress", 5_000)
+    val progressParams = progress.params
+    assertThat(progressParams?.get("progressToken")?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("read-1")
+    // progress is a numeric millisecond elapsed counter
+    val progressVal = progressParams?.get("progress")?.jsonPrimitive?.content?.toDouble() ?: 0.0
+    assertThat(progressVal).isAtLeast(0.0)
+
+    val readResp = readFuture.get(15, TimeUnit.SECONDS)
+    pool.shutdown()
+    val parsed = json.decodeFromJsonElement(ReadResourceResult.serializer(), readResp)
+    val blob = (parsed.contents.single() as ResourceContents.Blob).blob
+    assertThat(java.util.Base64.getDecoder().decode(blob)).isEqualTo(pngBytes)
+  }
+
+  @Test
+  fun `concurrent resources read calls for the same URI both receive bytes`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3)
+    val pngFile = tmp.newFile("fake-render.png")
+    Files.write(pngFile.toPath(), pngBytes)
+    daemon.autoRenderPngPath = { id -> if (id == previewId) pngFile.absolutePath else null }
+
+    // Two concurrent reads of the same URI. Pre-dedup-fix this would race on a single queue
+    // slot: one waiter would get the bytes, the other would time out. With per-call futures,
+    // both complete on the same `renderFinished` (the daemon may emit one or two events
+    // depending on internal dedup; either way both waiters wake).
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val pool = java.util.concurrent.Executors.newFixedThreadPool(2)
+    val futA =
+      pool.submit<JsonObject> {
+        client.request("resources/read", buildJsonObject { put("uri", uri) }, timeoutMs = 10_000)
+      }
+    val futB =
+      pool.submit<JsonObject> {
+        client.request("resources/read", buildJsonObject { put("uri", uri) }, timeoutMs = 10_000)
+      }
+    val readA = futA.get(15, TimeUnit.SECONDS)
+    val readB = futB.get(15, TimeUnit.SECONDS)
+    pool.shutdown()
+
+    val parsedA = json.decodeFromJsonElement(ReadResourceResult.serializer(), readA)
+    val parsedB = json.decodeFromJsonElement(ReadResourceResult.serializer(), readB)
+    val blobA = (parsedA.contents.single() as ResourceContents.Blob).blob
+    val blobB = (parsedB.contents.single() as ResourceContents.Blob).blob
+    assertThat(java.util.Base64.getDecoder().decode(blobA)).isEqualTo(pngBytes)
+    assertThat(java.util.Base64.getDecoder().decode(blobB)).isEqualTo(pngBytes)
   }
 
   @Test

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
@@ -112,6 +112,21 @@ class FakeDaemon : DaemonSpawn {
     sendNotification("discoveryUpdated", params)
   }
 
+  /**
+   * Pushes a `classpathDirty` notification. PROTOCOL.md § 6 says this fires at most once per
+   * lifetime; tests should treat the daemon as dying after this call.
+   */
+  fun emitClasspathDirty(
+    reason: String = "fingerprintMismatch",
+    detail: String = "test-driven classpathDirty",
+  ) {
+    val params = buildJsonObject {
+      put("reason", reason)
+      put("detail", detail)
+    }
+    sendNotification("classpathDirty", params)
+  }
+
   /** Pushes a `renderFinished` notification. Returns the synthetic pngPath emitted. */
   fun emitRenderFinished(previewId: String, pngPath: String): String {
     val params = buildJsonObject {
@@ -186,11 +201,83 @@ class FakeDaemon : DaemonSpawn {
       "shutdown" -> {
         sendResponse(id, kotlinx.serialization.json.JsonNull)
       }
+      "history/list" -> {
+        // Tests preload `historyEntries` via `setHistory(...)`; we just echo them back wrapped
+        // in the wire shape. Filtering + cursor support are deliberately stubbed — the H6
+        // mapping forwards params verbatim, so unit tests don't need full filter coverage here.
+        val payload = buildJsonObject {
+          putJsonArray("entries") { historyEntries.forEach { add(it) } }
+          put("totalCount", historyEntries.size)
+        }
+        sendResponse(id, payload)
+      }
+      "history/read" -> {
+        val entryId = params?.get("id")?.jsonPrimitive?.contentOrNull
+        val entry = historyEntries.firstOrNull { it["id"]?.jsonPrimitive?.contentOrNull == entryId }
+        if (entry == null) {
+          sendError(id, -32010, "HistoryEntryNotFound: $entryId")
+        } else {
+          val inline = params?.get("inline")?.jsonPrimitive?.contentOrNull == "true"
+          val pngPath = entry["pngPath"]?.jsonPrimitive?.contentOrNull ?: "/tmp/missing.png"
+          val payload = buildJsonObject {
+            put("entry", entry)
+            put("pngPath", pngPath)
+            if (inline) {
+              val bytes =
+                historyInlineBytes[entryId] ?: byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47)
+              put("pngBytes", java.util.Base64.getEncoder().encodeToString(bytes))
+            }
+          }
+          sendResponse(id, payload)
+        }
+      }
+      "history/diff" -> {
+        val from = params?.get("from")?.jsonPrimitive?.contentOrNull
+        val to = params?.get("to")?.jsonPrimitive?.contentOrNull
+        val fromEntry = historyEntries.firstOrNull {
+          it["id"]?.jsonPrimitive?.contentOrNull == from
+        }
+        val toEntry = historyEntries.firstOrNull { it["id"]?.jsonPrimitive?.contentOrNull == to }
+        if (fromEntry == null || toEntry == null) {
+          sendError(id, -32010, "HistoryEntryNotFound: from=$from to=$to")
+        } else {
+          val payload = buildJsonObject {
+            put(
+              "pngHashChanged",
+              fromEntry["pngHash"]?.jsonPrimitive?.contentOrNull !=
+                toEntry["pngHash"]?.jsonPrimitive?.contentOrNull,
+            )
+            put("fromMetadata", fromEntry)
+            put("toMetadata", toEntry)
+          }
+          sendResponse(id, payload)
+        }
+      }
       else -> {
         // Unknown methods: error response so the client doesn't hang.
         sendError(id, -32601, "method not found: $method")
       }
     }
+  }
+
+  /** Test helper — preload `history/list`/`history/read`/`history/diff` results. */
+  private val historyEntries: MutableList<JsonObject> = java.util.concurrent.CopyOnWriteArrayList()
+  private val historyInlineBytes: MutableMap<String, ByteArray> =
+    java.util.concurrent.ConcurrentHashMap()
+
+  fun setHistory(entries: List<JsonObject>) {
+    historyEntries.clear()
+    historyEntries.addAll(entries)
+  }
+
+  fun setHistoryInlineBytes(entryId: String, bytes: ByteArray) {
+    historyInlineBytes[entryId] = bytes
+  }
+
+  /** Pushes a `historyAdded` notification carrying [entry]. */
+  fun emitHistoryAdded(entry: JsonObject) {
+    val params = buildJsonObject { put("entry", entry) }
+    sendNotification("historyAdded", params)
   }
 
   private fun handleNotification(method: String, params: JsonObject?) {
@@ -303,12 +390,22 @@ class FakeDaemon : DaemonSpawn {
 
 /** Test [DaemonClientFactory] that always returns a [FakeDaemon]. */
 class FakeDaemonClientFactory : DaemonClientFactory {
-  /** Map of (workspaceId, modulePath) → fake. Tests assert/manipulate via this. */
+  /** Map of (workspaceId, modulePath) → most-recent fake. */
   val daemons: MutableMap<Pair<WorkspaceId, String>, FakeDaemon> = mutableMapOf()
+
+  /**
+   * Every fake ever spawned by this factory, in spawn order. Useful for respawn-shaped tests (e.g.
+   * `classpathDirty` recovery): the first spawn lands at index 0 and the supervisor's replacement
+   * after `classpathDirty` lands at index 1.
+   */
+  val spawnHistory: MutableList<FakeDaemon> = java.util.concurrent.CopyOnWriteArrayList()
 
   override fun spawn(project: RegisteredProject, descriptor: DaemonLaunchDescriptor): DaemonSpawn {
     val daemon = FakeDaemon()
-    daemons[project.workspaceId to descriptor.modulePath] = daemon
+    synchronized(this) {
+      daemons[project.workspaceId to descriptor.modulePath] = daemon
+      spawnHistory.add(daemon)
+    }
     return daemon
   }
 }


### PR DESCRIPTION
## Summary
This PR extends the MCP server with support for historical render entries and progress notifications during slow renders. It introduces `compose-preview-history://` URIs for accessing historical snapshots, adds `history_list` and `history_diff` tools, implements progress beat notifications, and refactors render waiting from `LinkedBlockingQueue` to `CompletableFuture` to support concurrent readers.

## Key Changes

### History Resource Support
- Added `HistoryUri` data class to represent `compose-preview-history://<workspace>/<module>/<previewFqn>/<entryId>` URIs
- Implemented `readHistoryResource()` to fetch historical PNG bytes via daemon's `history/read` RPC
- Added `history_list` and `history_diff` tools that proxy daemon history methods with proper error handling
- Added `onHistoryAdded()` handler to emit `resources/list_changed` notifications when new history entries arrive

### Progress Notifications
- Added `progressBeatExecutor` scheduled executor for periodic progress beat notifications
- Implemented `startProgressBeatIfNeeded()` to fire `notifications/progress` at 500ms intervals when client opts in via `_meta.progressToken`
- Updated `readResource()` signature to accept optional `progressToken` parameter
- Added `notifyProgress()` method to `McpSession` for sending progress notifications per MCP spec

### Render Waiting Refactor
- Replaced `LinkedBlockingQueue<RenderOutcome>` with `CopyOnWriteArrayList<CompletableFuture<RenderOutcome>>` in `pendingRenders`
- This allows concurrent `resources/read` calls for the same URI to all receive the result (vs. queue semantics where only one waiter gets served)
- Updated `renderAndReadBytes()` to use `CompletableFuture.get()` with timeout and proper cleanup on timeout
- Improved multi-waiter dedup: each concurrent read adds its own future, all wake on next `renderFinished`

### Executor Refactoring
- Renamed `respawnExecutor` to `daemonLifecycleExecutor` and expanded its purpose to handle both daemon respawns and async first-spawn from watch tool
- Added `progressBeatExecutor` as a separate single-threaded scheduled executor for progress notifications
- Updated `toolWatch()` to spawn daemons asynchronously off-thread to avoid blocking the MCP reader during cold-start

### DaemonClient Extensions
- Added `historyList()`, `historyRead()`, and `historyDiff()` methods to proxy daemon history RPC calls
- These are called by the MCP server's history tool handlers

### Test Coverage
- Added tests for `classpathDirty` respawn re-issuing `setVisible` to replacement daemon
- Added tests for `history_list` returning entries with `compose-preview-history` URIs
- Added tests for `history_diff` forwarding entry ids and decoding `pngHashChanged`
- Added tests for reading history resources via `resources/read` on history URIs
- Added tests for `historyAdded` notifications triggering `resources/list_changed`
- Added tests for progress notifications during slow renders
- Added tests for concurrent `resources/read` calls receiving bytes

### FakeDaemon Enhancements
- Added `emitClasspathDirty()` method for test-driven notifications
- Implemented `history/list`, `history/read`, and `history/diff` RPC handlers
- Added `setHistory()` and `setHistoryInlineBytes()` test helpers for preloading history data

## Notable Implementation Details

- History URIs are parsed and handled separately from preview URIs in `handleReadResource()`, short-circuiting to `readHistoryResource()` without triggering a render
- Progress beats are daemon-flagged threads that self-cancel as soon as the underlying render future completes or timeout cleanup runs
- The `daemonLifecycleExecutor` serializes daemon spawns to prevent double-spawning on concurrent watch requests while keeping the MCP reader thread free
- Timeout cleanup for renders now uses `computeIfPresent()` to safely remove futures from the pending list without race conditions
- All history tool implementations include proper error handling and field validation

https://claude.ai/code/session_019zojhG4CGDqnzxbsyPDRqc