### PR TITLE
fix(vscode): silence daemon-stub-N.png ENOENT noise until daemon ships B1.4

### DIFF
--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -71,6 +71,10 @@ export class DaemonScheduler {
     /** Cards we've already speculatively requested so scrolling back over
      *  them doesn't re-queue identical work. Keyed by `${moduleId}::${id}`. */
     private speculated = new Set<string>();
+    /** Modules where we've already logged a "daemon at stub stage" notice.
+     *  Stops the per-render ENOENT spam when the daemon (B1.5) emits
+     *  synthetic `daemon-stub-N.png` paths that don't exist on disk. */
+    private warnedStubModules = new Set<string>();
 
     constructor(
         private readonly gate: DaemonGate,
@@ -280,6 +284,28 @@ export class DaemonScheduler {
             // same preview can re-render via the reactive path.
             this.speculated.delete(specKey(moduleId, params.id));
 
+            // Stub-render path: until B1.4 lands `RenderEngine` in the
+            // daemon, every "successful" render returns
+            // `<historyDir>/daemon-stub-<id>.{png,gif}` with no bytes
+            // actually written. Documented in JsonRpcServer.kt's
+            // `renderFinishedFromResult` KDoc. Silently no-op rather than
+            // log ENOENT per render — the user's panel is already painted
+            // by the existing Gradle path, and the daemon team will swap
+            // this to real rendering without an extension change. Once
+            // B1.4 ships, the path stops matching and this branch is dead
+            // weight; no harm in keeping it.
+            if (isDaemonStubPath(params.pngPath)) {
+                if (!this.warnedStubModules.has(moduleId)) {
+                    this.warnedStubModules.add(moduleId);
+                    this.logger.appendLine(
+                        `[daemon] ${moduleId} is at stub-render stage (B1.5); ` +
+                        'real renders arrive once :daemon:android ships B1.4 RenderEngine. ' +
+                        'Suppressing per-render ENOENT logs for stub paths.',
+                    );
+                }
+                return;
+            }
+
             const buf = fs.readFileSync(params.pngPath);
             this.events.onPreviewImageReady(
                 moduleId,
@@ -325,4 +351,19 @@ function sameSet(a: string[] | undefined, b: string[]): boolean {
 
 function specKey(moduleId: string, previewId: string): string {
     return `${moduleId}::${previewId}`;
+}
+
+/**
+ * True iff [pngPath]'s basename matches the documented daemon stub shape
+ * `daemon-stub-<id>.{png,gif}` from `JsonRpcServer.kt`. Once :daemon:android
+ * ships B1.4 (`RenderEngine`), real renders write to a different path and
+ * this returns false on every render.
+ *
+ * Loose match — the daemon team is free to rename the directory; the
+ * filename prefix is what's documented as the contract.
+ */
+function isDaemonStubPath(pngPath: string): boolean {
+    const slash = Math.max(pngPath.lastIndexOf('/'), pngPath.lastIndexOf('\\'));
+    const base = slash >= 0 ? pngPath.slice(slash + 1) : pngPath;
+    return /^daemon-stub-.+\.(png|gif)$/.test(base);
 }

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -216,6 +216,59 @@ describe('DaemonScheduler', () => {
         assert.match(failures[0].message, /unreadable/i);
     });
 
+    it('silently no-ops on daemon stub paths — once-per-module info log only', async () => {
+        // Until :daemon:android ships B1.4, every "successful" render
+        // returns `<historyDir>/daemon-stub-<id>.{png,gif}` with nothing
+        // on disk. Logging ENOENT per render drowns the output channel;
+        // the panel is already populated by the Gradle fallback. We
+        // detect the documented stub-filename shape and skip.
+        const { gate, scheduler, log, failures, images } = build();
+        await scheduler.ensureModule('mod');
+        const evts = gate.capturedEvents.get('mod')!;
+        for (let i = 1; i <= 5; i++) {
+            evts.onRenderFinished!({
+                id: `p${i}`,
+                pngPath: `.compose-preview-history/daemon-stub-${i}.png`,
+                tookMs: 1,
+            });
+        }
+        // No image read attempted, no failure surfaced.
+        assert.strictEqual(images.length, 0);
+        assert.strictEqual(failures.length, 0);
+        // One info log per module (rate-limited), not five.
+        const stubLogs = log.filter(l => l.includes('stub-render stage'));
+        assert.strictEqual(stubLogs.length, 1);
+    });
+
+    it('detects gif stub paths the same way as png stubs', async () => {
+        const { gate, scheduler, failures, images } = build();
+        await scheduler.ensureModule('mod');
+        const evts = gate.capturedEvents.get('mod')!;
+        evts.onRenderFinished!({
+            id: 'p1',
+            pngPath: '.compose-preview-history/daemon-stub-1.gif',
+            tookMs: 1,
+        });
+        assert.strictEqual(images.length, 0);
+        assert.strictEqual(failures.length, 0);
+    });
+
+    it('still surfaces ENOENT for non-stub paths (real-render misconfig)', async () => {
+        // The stub filter is precisely scoped — real-render paths that
+        // happen to be missing must still surface as a failure so the
+        // daemon's render bug is visible rather than silently swallowed.
+        const { gate, scheduler, failures } = build();
+        await scheduler.ensureModule('mod');
+        const evts = gate.capturedEvents.get('mod')!;
+        evts.onRenderFinished!({
+            id: 'pY',
+            pngPath: '/abs/build/compose-previews/renders/com.example.X.png',
+            tookMs: 1,
+        });
+        assert.strictEqual(failures.length, 1);
+        assert.match(failures[0].message, /unreadable/i);
+    });
+
     it('forwards onRenderFailed from the daemon directly to the caller', async () => {
         const { gate, scheduler, failures } = build();
         await scheduler.ensureModule('mod');


### PR DESCRIPTION
Stacks on top of #329. Targets that PR's branch (not `vscode-daemon` directly) so the fix lands in lockstep with the panel itself.

## Why

The daemon at B1.5 stage emits `renderFinished` with a synthetic path `<historyDir>/daemon-stub-<id>.{png,gif}` that is **documented to not exist on disk** — see `JsonRpcServer.kt`:

> "B1.4 (RenderEngine) replaces the body of `renderFinishedFromResult` with the real Compose/Robolectric render. For B1.5 the host returns a synthetic `RenderResult` and we materialise it as a placeholder PNG path of `${historyDir}/daemon-stub-${id}.png`. The placeholder file is not written to disk."

Until `:daemon:android` ships B1.4, every "successful" render trips an ENOENT through the scheduler's `renderFinished` path. The user's panel is already populated by the Gradle fallback so nothing is broken, but the per-render log noise drowns the output channel — observed in the wild on `samples/wear` (15+ ENOENT lines per save).

## Fix

`isDaemonStubPath` matches the documented stub-filename shape (`/^daemon-stub-.+\.(png|gif)$/` on the basename). When it matches, the scheduler silently no-ops rather than reading. One info-level log per module per session announces the suppression so users can see why daemon renders aren't landing visually.

Once B1.4 ships and real renders use a different path, this branch is dead weight — no harm in keeping it as a defensive belt-and-braces.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 176 passing (3 new), 104 ms
- [x] 3 new tests:
  - Stub paths skip without ENOENT, with **one** info log per module (rate-limited).
  - GIF stub paths filter the same way.
  - Non-stub-path ENOENTs still surface as `setImageError` so real render-bug regressions stay visible.

## Notes

- Filter is precisely scoped — only filenames matching `daemon-stub-N.{png,gif}`. A consumer who somehow names a real preview file `daemon-stub-foo.png` would also be filtered, but that's a contrived collision and the existing Gradle fallback would still paint the card.
- This is layer-coupling on a documented daemon contract, which is fine while we're tracking the same `:daemon:android` evolution. Removing it is a 5-line revert when B1.4 ships.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9eazQp7vhSYqgwxjazGNf)_