### PR TITLE
fix(vscode): deliberate daemon/gradle switch on save (no more parallel renders)

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -18,6 +18,7 @@ import { captureLabel } from './captureLabels';
 import { DaemonGate } from './daemon/daemonGate';
 import { DaemonScheduler, WarmState } from './daemon/daemonScheduler';
 import { buildHistorySource, HistoryPanel, HistoryScope } from './historyPanel';
+import { pickRefreshModeFor, RefreshMode } from './refreshMode';
 
 const DEBOUNCE_MS = 1500;
 // Edits to the currently-scoped preview file (e.g. Claude Code's Edit tool
@@ -483,15 +484,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     context.subscriptions.push(
         vscode.workspace.onDidSaveTextDocument(doc => {
             if (!isSourceFile(doc.uri.fsPath)) { return; }
-            // Side-channel: when the daemon path is enabled and healthy for
-            // this file's module, push a fileChanged notification + focused
-            // renderNow so the daemon can update the visible preview within
-            // its sub-second hot-sandbox latency budget. This runs alongside
-            // (not instead of) the Gradle refresh — the daemon's renderFinished
-            // typically arrives first; Gradle's slower full-fidelity pass
-            // backstops anything the daemon doesn't cover. When the daemon is
-            // disabled (default) `notifyDaemonOfSave` is a no-op.
-            void notifyDaemonOfSave(doc.uri.fsPath);
+            // The daemon-vs-Gradle decision is made inside runRefreshExclusive
+            // — either path runs, never both. See `pickRefreshMode` for the
+            // health gate. When the daemon flag is off (default) the gate
+            // always returns 'gradle' so behaviour is byte-identical to today.
             if (!firstSaveSeen.has(doc.uri.fsPath) && !refreshInFlight && pendingSavePath === null) {
                 firstSaveSeen.add(doc.uri.fsPath);
                 invalidateModuleCache(doc.uri.fsPath);
@@ -653,10 +649,10 @@ function invalidateModuleCache(filePath: string): void {
  * the daemon is disabled or unhealthy, this is a complete no-op — the
  * existing Gradle path is the entire user-facing behaviour.
  */
-async function notifyDaemonOfSave(filePath: string): Promise<void> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler || !gradleService) { return; }
+async function notifyDaemonOfSave(filePath: string): Promise<boolean> {
+    if (!daemonGate?.isEnabled() || !daemonScheduler || !gradleService) { return false; }
     const module = gradleService.resolveModule(filePath);
-    if (!module) { return; }
+    if (!module) { return false; }
 
     // Bootstrap (Gradle task + JVM spawn) happens once per module per
     // session. Normally it has already fired from the active-editor warm
@@ -671,20 +667,25 @@ async function notifyDaemonOfSave(filePath: string): Promise<void> {
     }
 
     const ok = await daemonScheduler.ensureModule(module);
-    if (!ok) { return; }
+    if (!ok) { return false; }
     await daemonScheduler.fileChanged(module, filePath);
 
     // Focus scope = the saved file's previews, derived from the most recent
     // manifest snapshot we got from Gradle's discoverPreviews. The daemon
     // reads this for queue ordering — focused first. If we don't yet have a
     // manifest for this module the focus call is skipped; the next refresh
-    // will populate moduleManifestCache.
+    // will populate moduleManifestCache. Returning true with no ids is
+    // intentional — the daemon already saw `fileChanged` so its internal
+    // discovery + render will catch any newly-discovered previews on its
+    // own; the caller just shouldn't escalate to a Gradle render in that
+    // case (the panel will repopulate via discover + the daemon's
+    // discoveryUpdated push).
     const filterFile = packageQualifiedSourcePath(filePath);
     const manifest = moduleManifestCache.get(module) ?? [];
     const ids = manifest.filter(p => p.sourceFile === filterFile).map(p => p.id);
-    if (ids.length === 0) { return; }
+    if (ids.length === 0) { return true; }
     await daemonScheduler.setFocus(module, ids);
-    await daemonScheduler.renderNow(module, ids, 'fast', 'save');
+    return await daemonScheduler.renderNow(module, ids, 'fast', 'save');
 }
 
 /**
@@ -802,6 +803,14 @@ function maybeFirePendingRefresh(): void {
  *  can tell whether to defer. On completion picks up anything that arrived
  *  during the run, re-applying the debounce-elapsed check.
  *
+ *  Picks daemon-vs-Gradle deliberately — never runs both for the same save.
+ *  When the daemon is healthy for the file's module, the save uses the
+ *  daemon's hot sandbox (sub-second updateImage via `renderFinished`); the
+ *  refresh itself is `forceRender=false` so Gradle does a cheap cached
+ *  discovery for the panel manifest only. When the daemon is disabled or
+ *  unhealthy, the refresh is `forceRender=true` and Gradle does a full
+ *  render as today.
+ *
  *  Save-driven: always `tier='fast'`. Heavy captures (LONG / GIF / animated)
  *  keep their previous PNG/GIF on disk and surface as stale in the panel —
  *  the user re-renders them on demand via the refresh command, which uses
@@ -809,11 +818,43 @@ function maybeFirePendingRefresh(): void {
 async function runRefreshExclusive(filePath: string): Promise<void> {
     refreshInFlight = true;
     try {
+        const mode = pickRefreshMode(filePath);
+        if (mode === 'daemon') {
+            // Daemon owns rendering for this save. Notify it about the
+            // change + focus the visible previews; Gradle does discovery
+            // only (cached) so the manifest is current without spinning up
+            // the slow renderPreviews task.
+            const accepted = await notifyDaemonOfSave(filePath);
+            if (accepted) {
+                await refresh(false, filePath);
+                return;
+            }
+            // Daemon was healthy at decision time but the actual call
+            // failed — race with channel close, sandbox died mid-save,
+            // gate unexpectedly returned null. Deliberate switch: run the
+            // Gradle render so the user still sees fresh previews.
+            logLine('daemon: rejected the work — falling back to Gradle render');
+        }
         await refresh(true, filePath, 'fast');
     } finally {
         refreshInFlight = false;
         maybeFirePendingRefresh();
     }
+}
+
+/**
+ * Decides which path handles a save. See `refreshMode.ts` for the pure
+ * predicate; this is the production wrapper that reads the live
+ * module-level state from the gate / gradle service.
+ */
+function pickRefreshMode(filePath: string): RefreshMode {
+    if (!daemonGate || !gradleService) { return 'gradle'; }
+    return pickRefreshModeFor(
+        filePath,
+        daemonGate.isEnabled(),
+        gradleService.resolveModule(filePath),
+        (m) => daemonGate!.isDaemonReady(m),
+    );
 }
 
 function sendModuleList() {

--- a/vscode-extension/src/refreshMode.ts
+++ b/vscode-extension/src/refreshMode.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure predicate for the daemon-vs-Gradle save decision. Extracted out
+ * of `extension.ts` so unit tests can exercise it without stubbing the
+ * VS Code API (extension.ts imports `vscode`).
+ *
+ * The production wrapper inside extension.ts reads the live
+ * `daemonGate` / `gradleService` state and forwards into here.
+ */
+
+export type RefreshMode = 'daemon' | 'gradle';
+
+/**
+ * - `'daemon'` — the experimental flag is on, the file resolves to a
+ *   module, and the daemon for that module is up and the sandbox has
+ *   finished bootstrapping (post-#327 `RobolectricHost.start` blocks
+ *   until ready, so `isDaemonReady` is the right signal). The save
+ *   path skips `renderPreviews` entirely.
+ * - `'gradle'` — daemon disabled, file outside any module, daemon not
+ *   yet warm, daemon spawn failed, or daemon exited (e.g. classpath
+ *   dirty). Existing Gradle render path runs.
+ *
+ * The decision is made fresh on each save — `isDaemonReady` reads the
+ * live registry, so a daemon that crashed mid-session silently flips
+ * back to the Gradle path on the next save without any extension state
+ * to manage.
+ */
+export function pickRefreshModeFor(
+    _filePath: string,
+    daemonEnabled: boolean,
+    moduleId: string | null,
+    isDaemonReady: (moduleId: string) => boolean,
+): RefreshMode {
+    if (!daemonEnabled) { return 'gradle'; }
+    if (!moduleId) { return 'gradle'; }
+    if (!isDaemonReady(moduleId)) { return 'gradle'; }
+    return 'daemon';
+}

--- a/vscode-extension/src/test/refreshMode.test.ts
+++ b/vscode-extension/src/test/refreshMode.test.ts
@@ -1,0 +1,55 @@
+import * as assert from 'assert';
+import { pickRefreshModeFor } from '../refreshMode';
+
+/**
+ * Pure predicate test — the production wrapper {@link pickRefreshMode}
+ * reads `daemonGate` and `gradleService` from module scope, but the
+ * decision logic is in {@link pickRefreshModeFor} so we can exercise
+ * every branch without stubbing the VS Code API.
+ */
+describe('pickRefreshModeFor', () => {
+    const ready = (id: string) => id === 'mod';
+    const notReady = () => false;
+
+    it('returns gradle when the daemon flag is off', () => {
+        assert.strictEqual(
+            pickRefreshModeFor('/x.kt', /* enabled */ false, 'mod', ready),
+            'gradle',
+        );
+    });
+
+    it('returns gradle when the file resolves to no module', () => {
+        assert.strictEqual(
+            pickRefreshModeFor('/outside.kt', true, null, ready),
+            'gradle',
+        );
+    });
+
+    it('returns gradle when the daemon for the module is not ready', () => {
+        assert.strictEqual(
+            pickRefreshModeFor('/x.kt', true, 'mod', notReady),
+            'gradle',
+        );
+    });
+
+    it('returns daemon only when all three preconditions hold', () => {
+        assert.strictEqual(
+            pickRefreshModeFor('/x.kt', true, 'mod', ready),
+            'daemon',
+        );
+    });
+
+    it('isDaemonReady is consulted per-module — a different module that\'s not warm stays on gradle', () => {
+        // Two modules in the same workspace; one daemon is up, the other
+        // isn't. The save picks the path keyed off the saved file's
+        // module, not the union of all daemon health.
+        assert.strictEqual(
+            pickRefreshModeFor('/x.kt', true, 'cold-module', ready),
+            'gradle',
+        );
+        assert.strictEqual(
+            pickRefreshModeFor('/x.kt', true, 'mod', ready),
+            'daemon',
+        );
+    });
+});


### PR DESCRIPTION
## What you reported

> "I'm seeing streaming results, with gaps between, and then finally all results come in at once from the gradle command. Can you check if both are running? Avoid that, and if daemon is failing, make it deliberate switch."

Yes — both were running. The save handler fired `notifyDaemonOfSave` (daemon: streaming `renderFinished` → `updateImage` per preview) AND `runRefreshExclusive` (Gradle: `renderPreviews` → batch `setPreviews` at the end) unconditionally. The original design was "additive" — daemon images arrive first, Gradle backstops anything daemon misses. In practice that visible double-render was confusing.

## Fix — deliberate switch per save

`pickRefreshMode(file)` returns `'daemon'` only when **all** of:

1. `composePreview.experimental.daemon.enabled` is on,
2. The file resolves to a Gradle module,
3. `daemonGate.isDaemonReady(module)` is true (post-#327 the daemon's `initialize` doesn't return until the Robolectric sandbox has finished bootstrapping, so this is the right "can render now" signal).

Otherwise → `'gradle'`. The decision is fresh on each save — `isDaemonReady` reads the live registry, so a daemon that crashes between saves silently flips back to Gradle. `onClasspathDirty` already evicts the entry; that path becomes the natural deliberate switch.

`runRefreshExclusive(file)` consults the picker:
- **daemon mode** → `notifyDaemonOfSave(file)` (fileChanged + setFocus + renderNow) + `refresh(forceRender=false)` (cached discovery only, no Gradle `renderPreviews` task). Daemon's `renderFinished` notifications fill the panel via the existing `updateImage` flow.
- **gradle mode** → `refresh(forceRender=true, tier='fast')` exactly as before.

## Mid-save fallback

If daemon mode is chosen at decision time but `notifyDaemonOfSave` fails (channel closed in the gap, gate unexpectedly returned null), the call escalates to a Gradle render — deliberate switch so the user still sees fresh previews on this save. The `outputChannel` logs the fallback line so the reason is visible.

## Disabled-default behaviour

Byte-identical to today. Picker returns `'gradle'` when the flag is off; `runRefreshExclusive` then runs the existing render path. No daemon code is invoked.

## Tests

`pickRefreshModeFor` extracted to `refreshMode.ts` as a pure predicate so the unit suite exercises it without stubbing the VS Code API. **5 new tests**, every branch covered:

- Flag off → gradle
- No module resolved → gradle
- Daemon not ready for this module → gradle
- Daemon ready → daemon
- Per-module isolation: a healthy daemon for module A doesn't make module B's save use the daemon path

**181 passing total, 105-113 ms per run, stable across 3 sequential runs.**

## Notes

- The `daemonScheduler.warmModule` path on scope-in is unchanged — the user opens a Kotlin file, daemon warms in the background, the **next** save uses the daemon path. Saves before warm completes hit Gradle.
- The status bar still shows the warm-up state machine (`bootstrapping → spawning → ready`). On steady-state daemon saves, the bar quietly hides.
- This is a pure UX fix — no protocol-level or daemon-side changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9eazQp7vhSYqgwxjazGNf)_