### PR TITLE
feat(vscode): show current renders in history panel when no recorded history

### DIFF
--- a/vscode-extension/src/daemon/currentRendersHistory.ts
+++ b/vscode-extension/src/daemon/currentRendersHistory.ts
@@ -1,0 +1,169 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { HistoryListResult, HistoryReadResult } from './daemonProtocol';
+
+/**
+ * UX fallback that surfaces "what's currently on disk under
+ * `<projectDir>/build/compose-previews/renders/`" as if it were a single-page
+ * history listing. Used by the Preview History panel when neither the daemon
+ * nor `index.jsonl` has anything recorded yet — that's the default path,
+ * since the legacy `HistorizePreviewsTask` was removed in #311 and the daemon
+ * is opt-in. Without this, a user who's just rendered their first preview
+ * sees an empty "No history yet" message even though there's a fresh PNG
+ * sitting on disk.
+ *
+ * These entries are ephemeral: re-derived from the manifest on every call,
+ * never written. They use the `current:` id prefix so {@link read} can route
+ * them back to the right file without a disk-side index. Diff is intentionally
+ * unsupported — the only history-shaped operations that make sense for a
+ * point-in-time snapshot are list and read.
+ */
+export class CurrentRendersHistory {
+    constructor(private readonly opts: CurrentRendersOptions) {}
+
+    /**
+     * Synthesises one entry per capture currently on disk in the module's
+     * renders directory. Honours the same `previewId` filter the panel feeds
+     * down. Returns the entries newest-first (by file mtime); an animated
+     * preview's multiple captures collapse to a single representative entry
+     * to keep the timeline readable.
+     */
+    list(previewIdFilter?: string): HistoryListResult {
+        const manifest = this.readManifest();
+        const entries: SyntheticHistoryEntry[] = [];
+        if (!manifest) { return { entries: [], totalCount: 0 }; }
+
+        for (const preview of manifest.previews ?? []) {
+            if (previewIdFilter && preview.id !== previewIdFilter) { continue; }
+            const captures = Array.isArray(preview.captures) ? preview.captures : [];
+            // Only the representative (first) capture per preview gets a row;
+            // the panel doesn't have UI for sibling captures yet, and showing
+            // every animation frame as a separate history entry would drown
+            // the static previews in the same module.
+            const representative = captures.find(c => c?.renderOutput);
+            if (!representative?.renderOutput) { continue; }
+            const pngPath = path.join(this.opts.buildDir, representative.renderOutput);
+            const stat = statOrNull(pngPath);
+            if (!stat) { continue; }
+            entries.push({
+                id: syntheticId(representative.renderOutput),
+                previewId: preview.id,
+                module: this.opts.moduleId,
+                timestamp: stat.mtime.toISOString(),
+                pngPath: representative.renderOutput,
+                producer: 'gradle',
+                trigger: 'current',
+                source: { kind: 'fs', id: `current:${this.opts.moduleId}` },
+                previewMetadata: {
+                    sourceFile: preview.sourceFile ?? null,
+                },
+            });
+        }
+
+        entries.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+        return { entries, totalCount: entries.length };
+    }
+
+    /**
+     * Resolves a synthetic id back to its on-disk PNG. Returns null when the
+     * id is unknown, the manifest no longer references it, or the file has
+     * been deleted between list and read (e.g. a `clean` ran).
+     */
+    read(id: string): HistoryReadResult | null {
+        if (!id.startsWith(SYNTHETIC_ID_PREFIX)) { return null; }
+        const renderOutput = decodeSyntheticId(id);
+        if (!renderOutput) { return null; }
+        const manifest = this.readManifest();
+        if (!manifest) { return null; }
+        const owner = (manifest.previews ?? []).find(p =>
+            (p.captures ?? []).some(c => c?.renderOutput === renderOutput),
+        );
+        if (!owner) { return null; }
+        const pngPath = path.join(this.opts.buildDir, renderOutput);
+        const stat = statOrNull(pngPath);
+        if (!stat) { return null; }
+        const entry: SyntheticHistoryEntry = {
+            id,
+            previewId: owner.id,
+            module: this.opts.moduleId,
+            timestamp: stat.mtime.toISOString(),
+            pngPath: renderOutput,
+            producer: 'gradle',
+            trigger: 'current',
+            source: { kind: 'fs', id: `current:${this.opts.moduleId}` },
+            previewMetadata: {
+                sourceFile: owner.sourceFile ?? null,
+            },
+        };
+        return { entry, previewMetadata: entry.previewMetadata, pngPath };
+    }
+
+    static isSyntheticId(id: string): boolean {
+        return id.startsWith(SYNTHETIC_ID_PREFIX);
+    }
+
+    private readManifest(): ManifestShape | null {
+        const manifestPath = path.join(this.opts.buildDir, 'previews.json');
+        if (!fs.existsSync(manifestPath)) { return null; }
+        try {
+            const raw = fs.readFileSync(manifestPath, 'utf-8');
+            const parsed = JSON.parse(raw) as ManifestShape;
+            if (!Array.isArray(parsed.previews)) { return null; }
+            return parsed;
+        } catch {
+            return null;
+        }
+    }
+}
+
+export interface CurrentRendersOptions {
+    /** Absolute path to `<projectDir>/build/compose-previews`. */
+    buildDir: string;
+    /** Gradle moduleId — copied onto each synth entry's `module` field so
+     *  the panel's daemon-push scope filter still matches if a real entry
+     *  later lands for the same module. */
+    moduleId: string;
+}
+
+const SYNTHETIC_ID_PREFIX = 'current:';
+
+function syntheticId(renderOutput: string): string {
+    // Base64url of the renderOutput keeps the id opaque to the panel and
+    // round-trippable without a separate index. Path separators and dots
+    // would otherwise clash with the panel's CSS-escape attribute selector.
+    return SYNTHETIC_ID_PREFIX + Buffer.from(renderOutput, 'utf-8').toString('base64url');
+}
+
+function decodeSyntheticId(id: string): string | null {
+    try {
+        return Buffer.from(id.slice(SYNTHETIC_ID_PREFIX.length), 'base64url').toString('utf-8');
+    } catch {
+        return null;
+    }
+}
+
+function statOrNull(p: string): fs.Stats | null {
+    try { return fs.statSync(p); } catch { return null; }
+}
+
+interface ManifestShape {
+    previews?: ManifestPreview[];
+}
+
+interface ManifestPreview {
+    id: string;
+    sourceFile?: string | null;
+    captures?: { renderOutput?: string }[];
+}
+
+interface SyntheticHistoryEntry {
+    id: string;
+    previewId: string;
+    module: string;
+    timestamp: string;
+    pngPath: string;
+    producer: string;
+    trigger: string;
+    source: { kind: string; id: string };
+    previewMetadata: { sourceFile: string | null };
+}

--- a/vscode-extension/src/historyPanel.ts
+++ b/vscode-extension/src/historyPanel.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as vscode from 'vscode';
 import { HistoryReader } from './daemon/historyReader';
+import { CurrentRendersHistory } from './daemon/currentRendersHistory';
 import {
     HistoryAddedParams,
     HistoryListResult,
@@ -486,55 +487,82 @@ export interface HistoryScope {
 export function buildHistorySource(opts: BuildSourceOptions): HistorySource {
     return {
         list: async (scope) => {
+            let result: HistoryListResult | null = null;
             if (opts.isDaemonReady(scope.moduleId)) {
                 try {
-                    return await opts.daemonList(scope);
+                    result = await opts.daemonList(scope);
                 } catch (err) {
                     opts.logger?.appendLine(
                         `[history] daemon list failed for ${scope.moduleId}, falling back to FS: ${(err as Error).message}`,
                     );
                 }
             }
-            return new HistoryReader(historyDirFor(scope)).list({
-                previewId: scope.previewId,
-            });
+            if (!result) {
+                result = new HistoryReader(historyDirFor(scope)).list({
+                    previewId: scope.previewId,
+                });
+            }
+            // Greenfield UX: when no recorded history exists yet (default
+            // path with the daemon disabled, or a freshly-warmed daemon
+            // that hasn't yet observed a render) but the Gradle render
+            // path has already produced PNGs, surface those as a single
+            // synthetic page so the panel isn't empty after the user's
+            // first render.
+            if (result.entries.length === 0) {
+                const synth = currentRendersFor(scope).list(scope.previewId);
+                if (synth.entries.length > 0) { return synth; }
+            }
+            return result;
         },
         read: async (id) => {
-            if (opts.currentScope) {
-                if (opts.isDaemonReady(opts.currentScope.moduleId)) {
-                    try {
-                        return await opts.daemonRead(id);
-                    } catch (err) {
-                        opts.logger?.appendLine(
-                            `[history] daemon read failed for ${id}, falling back to FS: ${(err as Error).message}`,
-                        );
-                    }
-                }
-                return new HistoryReader(historyDirFor(opts.currentScope)).read(id);
+            if (!opts.currentScope) { return null; }
+            if (CurrentRendersHistory.isSyntheticId(id)) {
+                return currentRendersFor(opts.currentScope).read(id);
             }
-            return null;
+            if (opts.isDaemonReady(opts.currentScope.moduleId)) {
+                try {
+                    return await opts.daemonRead(id);
+                } catch (err) {
+                    opts.logger?.appendLine(
+                        `[history] daemon read failed for ${id}, falling back to FS: ${(err as Error).message}`,
+                    );
+                }
+            }
+            return new HistoryReader(historyDirFor(opts.currentScope)).read(id);
         },
         diff: async (fromId, toId) => {
-            if (opts.currentScope) {
-                if (opts.isDaemonReady(opts.currentScope.moduleId)) {
-                    try {
-                        return await opts.daemonDiff(fromId, toId);
-                    } catch (err) {
-                        opts.logger?.appendLine(
-                            `[history] daemon diff failed, falling back to FS: ${(err as Error).message}`,
-                        );
-                    }
-                }
-                return new HistoryReader(historyDirFor(opts.currentScope))
-                    .diff(fromId, toId, 'metadata');
+            if (!opts.currentScope) { return null; }
+            // Synthetic "current render" entries don't have a stable prior
+            // — diffing them is meaningless. Fall through to null so the
+            // panel surfaces "Diff unavailable" instead of crashing.
+            if (CurrentRendersHistory.isSyntheticId(fromId)
+                || CurrentRendersHistory.isSyntheticId(toId)) {
+                return null;
             }
-            return null;
+            if (opts.isDaemonReady(opts.currentScope.moduleId)) {
+                try {
+                    return await opts.daemonDiff(fromId, toId);
+                } catch (err) {
+                    opts.logger?.appendLine(
+                        `[history] daemon diff failed, falling back to FS: ${(err as Error).message}`,
+                    );
+                }
+            }
+            return new HistoryReader(historyDirFor(opts.currentScope))
+                .diff(fromId, toId, 'metadata');
         },
     };
 }
 
 function historyDirFor(scope: HistoryScope): string {
     return `${scope.projectDir}/.compose-preview-history`;
+}
+
+function currentRendersFor(scope: HistoryScope): CurrentRendersHistory {
+    return new CurrentRendersHistory({
+        buildDir: `${scope.projectDir}/build/compose-previews`,
+        moduleId: scope.moduleId,
+    });
 }
 
 interface BuildSourceOptions {

--- a/vscode-extension/src/test/currentRendersHistory.test.ts
+++ b/vscode-extension/src/test/currentRendersHistory.test.ts
@@ -1,0 +1,139 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { CurrentRendersHistory } from '../daemon/currentRendersHistory';
+
+interface ManifestPreview {
+    id: string;
+    sourceFile?: string | null;
+    captures: { renderOutput: string }[];
+}
+
+function withFixture<T>(
+    previews: ManifestPreview[],
+    pngFiles: Record<string, string>,
+    fn: (buildDir: string) => T | Promise<T>,
+): () => Promise<T> {
+    return async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'current-renders-'));
+        try {
+            const buildDir = path.join(root, 'build', 'compose-previews');
+            fs.mkdirSync(path.join(buildDir, 'renders'), { recursive: true });
+            fs.writeFileSync(
+                path.join(buildDir, 'previews.json'),
+                JSON.stringify({ module: 'test', variant: 'debug', previews }),
+            );
+            for (const [rel, body] of Object.entries(pngFiles)) {
+                const full = path.join(buildDir, rel);
+                fs.mkdirSync(path.dirname(full), { recursive: true });
+                fs.writeFileSync(full, body);
+            }
+            return await fn(buildDir);
+        } finally {
+            fs.rmSync(root, { recursive: true });
+        }
+    };
+}
+
+const PREVIEWS: ManifestPreview[] = [
+    {
+        id: 'com.example.A',
+        sourceFile: 'com/example/Previews.kt',
+        captures: [{ renderOutput: 'renders/com.example.A.png' }],
+    },
+    {
+        id: 'com.example.B',
+        sourceFile: 'com/example/Previews.kt',
+        captures: [{ renderOutput: 'renders/com.example.B.png' }],
+    },
+];
+
+const PNGS = {
+    'renders/com.example.A.png': 'png-A',
+    'renders/com.example.B.png': 'png-B',
+};
+
+describe('CurrentRendersHistory', () => {
+    it('returns one synthetic entry per preview with a render on disk',
+        withFixture(PREVIEWS, PNGS, (buildDir) => {
+            const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample' });
+            const result = reader.list();
+            assert.strictEqual(result.totalCount, 2);
+            const ids = result.entries.map(e => (e as { previewId: string }).previewId).sort();
+            assert.deepStrictEqual(ids, ['com.example.A', 'com.example.B']);
+        }),
+    );
+
+    it('honours the previewId filter', withFixture(PREVIEWS, PNGS, (buildDir) => {
+        const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample' });
+        const result = reader.list('com.example.A');
+        assert.strictEqual(result.totalCount, 1);
+        assert.strictEqual((result.entries[0] as { previewId: string }).previewId, 'com.example.A');
+    }));
+
+    it('skips previews whose render file is missing on disk',
+        withFixture(PREVIEWS, { 'renders/com.example.A.png': 'p' }, (buildDir) => {
+            const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample' });
+            const result = reader.list();
+            assert.strictEqual(result.totalCount, 1);
+            assert.strictEqual((result.entries[0] as { previewId: string }).previewId, 'com.example.A');
+        }),
+    );
+
+    it('returns empty list when previews.json is missing', async () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'current-renders-empty-'));
+        try {
+            const buildDir = path.join(root, 'build', 'compose-previews');
+            fs.mkdirSync(buildDir, { recursive: true });
+            const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample' });
+            const result = reader.list();
+            assert.strictEqual(result.totalCount, 0);
+            assert.strictEqual(result.entries.length, 0);
+        } finally {
+            fs.rmSync(root, { recursive: true });
+        }
+    });
+
+    it('round-trips list ids through read', withFixture(PREVIEWS, PNGS, (buildDir) => {
+        const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample' });
+        const list = reader.list();
+        const id = (list.entries[0] as { id: string }).id;
+        assert.ok(CurrentRendersHistory.isSyntheticId(id),
+            `expected synthetic id, got ${id}`);
+        const read = reader.read(id);
+        assert.notStrictEqual(read, null);
+        assert.ok(fs.existsSync(read!.pngPath), `png missing: ${read!.pngPath}`);
+    }));
+
+    it('read returns null for non-synthetic ids', withFixture(PREVIEWS, PNGS, (buildDir) => {
+        const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample' });
+        assert.strictEqual(reader.read('20260430-aaaaaaaa'), null);
+    }));
+
+    it('read returns null for malformed synthetic ids',
+        withFixture(PREVIEWS, PNGS, (buildDir) => {
+            const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample' });
+            assert.strictEqual(reader.read('current:not-base64-of-anything-known'), null);
+        }),
+    );
+
+    it('orders entries newest-first by mtime', withFixture(PREVIEWS, PNGS, async (buildDir) => {
+        // Backdate B so A is newer.
+        const past = new Date(Date.now() - 60_000);
+        fs.utimesSync(path.join(buildDir, 'renders/com.example.B.png'), past, past);
+        const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample' });
+        const ids = reader.list().entries.map(e => (e as { previewId: string }).previewId);
+        assert.deepStrictEqual(ids, ['com.example.A', 'com.example.B']);
+    }));
+
+    it('tags entries with the moduleId so the panel scope filter matches',
+        withFixture(PREVIEWS, PNGS, (buildDir) => {
+            const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample/wear' });
+            const result = reader.list();
+            for (const entry of result.entries) {
+                assert.strictEqual((entry as { module: string }).module, 'sample/wear');
+            }
+        }),
+    );
+});


### PR DESCRIPTION
## Summary

When the daemon hasn't recorded any history (default config: opt-in daemon, legacy `HistorizePreviewsTask` removed in #311), the Preview History panel was empty even after a render had landed on disk. This adds a `CurrentRendersHistory` fallback that scans `build/compose-previews/previews.json` + `renders/` and surfaces one synthetic entry per preview, so the panel shows the just-rendered image instead of "No history yet".

- Synthetic ids use a `current:` prefix so `read()` can route back to the file without a disk-side index.
- `diff()` is a no-op for synthetic entries (no stable prior to compare against).
- The fallback only fires when the daemon/FS list returns zero entries — once a real history entry exists, the panel shows real history.

## Test plan

- [x] `npm test` — 185 passing, including 9 new cases for `CurrentRendersHistory` (list, previewId filter, missing files, missing manifest, mtime ordering, id round-trip, malformed ids, moduleId tagging).
- [ ] Manual: open a Kotlin file in a sample, run `:samples:cmp:renderAllPreviews`, confirm the just-rendered preview appears in the History panel without enabling the daemon.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHFAaZujJM5aApmnpiWujA)_