### PR TITLE
fix(plugin): emit composeai.daemon.historyDir from composePreviewDaemonStart (history view was empty)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ vscode-extension/out/
 # Python (for .github/actions/lib/ scripts and their tests)
 __pycache__/
 *.pyc
+
+# Daemon preview-history archive — written by the daemon's `HistoryManager` when running
+# (sysprop `composeai.daemon.historyDir`). Each module gets its own archive at
+# `<moduleDir>/.compose-preview-history/`. Ignore at any depth.
+.compose-preview-history/

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1329,6 +1329,15 @@ internal object AndroidPreviewSupport {
       // exist on disk — see issue #314. The "harness" prefix is historical (only the harness
       // launchers used to set this); now any production-mode launcher needs it.
       this.systemProperties.put("composeai.harness.previewsManifest", manifestFile)
+      // H1+H2 — `composeai.daemon.historyDir` flips daemon-side history recording on. Default
+      // location is `<projectDir>/.compose-preview-history` (matches the legacy convention;
+      // user-visible `.gitignore` pattern). Without this sysprop the daemon's `HistoryManager`
+      // stays null and the VS Code history view shows an empty drawer.
+      this.systemProperties.put(
+        "composeai.daemon.historyDir",
+        project.layout.projectDirectory.dir(".compose-preview-history").asFile.absolutePath,
+      )
+      this.systemProperties.put("composeai.daemon.workspaceRoot", project.rootDir.absolutePath)
       this.workingDirectory.set(project.projectDir.absolutePath)
       this.manifestPath.set(manifestFile)
       this.outputFile.set(previewOutputDir.map { it.file("daemon-launch.json") })

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -295,6 +295,15 @@ internal object ComposePreviewTasks {
       // exist on disk — see issue #314. The "harness" prefix is historical (only the harness
       // launchers used to set this); now any production-mode launcher needs it.
       systemProperties.put("composeai.harness.previewsManifest", previewsJsonProvider)
+      // H1+H2 — `composeai.daemon.historyDir` is what flips daemon-side history recording from
+      // off to on. Default location is `<projectDir>/.compose-preview-history` (matches the
+      // legacy convention; user-visible `.gitignore` pattern). Without this sysprop the daemon's
+      // `HistoryManager` stays null and the VS Code history view shows an empty drawer.
+      systemProperties.put(
+        "composeai.daemon.historyDir",
+        project.layout.projectDirectory.dir(".compose-preview-history").asFile.absolutePath,
+      )
+      systemProperties.put("composeai.daemon.workspaceRoot", project.rootDir.absolutePath)
 
       workingDirectory.set(project.projectDir.absolutePath)
       manifestPath.set(previewsJsonProvider)


### PR DESCRIPTION
## Summary

The daemon's history-recording surface (PR #318 H1+H2) was never actually opted in by the production launch path. The harness sets \`-Dcomposeai.daemon.historyDir=...\` (which is why fake-mode tests shipped green), but \`composePreviewDaemonStart\` doesn't, so when VS Code launches the daemon via the gradle-emitted descriptor, \`HistoryManager\` stays null and nothing gets written. VS Code's history drawer shows empty for every preview because the archive on disk is empty.

This PR closes that gap:

- \`composeai.daemon.historyDir\` → \`<projectDir>/.compose-preview-history\` (matches the legacy convention; the daemon writes per-module)
- \`composeai.daemon.workspaceRoot\` → \`rootDir.absolutePath\` so \`GitProvenance\` populates branch / commit / dirty / remote on every sidecar
- Wired in both \`ComposePreviewTasks.kt\` (desktop daemon path) and \`AndroidPreviewSupport.kt\` (Android daemon path)
- \`.gitignore\` adds \`.compose-preview-history/\` so daemon-emitted entries don't accidentally end up in commits

## Test plan

- [x] \`./gradlew :gradle-plugin:test\` — green (existing \`DaemonBootstrapTaskTest\` uses \`containsEntry\`-style assertions, additive-tolerant)
- [x] \`./gradlew :daemon:core:test :cli:assemble :samples:android:assembleDebug\` — green (back-compat sanity)
- [ ] Manual VS Code verification: launch daemon, render a preview, confirm \`<projectDir>/.compose-preview-history/<previewId>/<timestamp>-<hash>.{png,json}\` lands and the VS Code history drawer is no longer empty

## What's next

Pruning is needed before this is left on long-term — H4 PR follows so the archive has bounded growth.