### PR TITLE
feat(daemon): auto-prune + history/prune RPC + historyPruned notification (H4)

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -6,6 +6,7 @@ import ee.schimke.composeai.daemon.bridge.DaemonHostBridge
 import ee.schimke.composeai.daemon.history.GitProvenance
 import ee.schimke.composeai.daemon.history.GitRefHistorySource
 import ee.schimke.composeai.daemon.history.HistoryManager
+import ee.schimke.composeai.daemon.history.HistoryPruneConfig
 import java.io.File
 import java.nio.file.Path
 
@@ -162,10 +163,13 @@ fun main(args: Array<String>) {
     } else null
   // H10-read — see desktop DaemonMain for the design rationale.
   val gitRefHistoryRefs = GitRefHistorySource.parseRefsSysprop()
+  // H4 — prune config from sysprops (defaults: 50 entries / 14 days / 500 MB / 1h auto interval).
+  val pruneConfig = HistoryPruneConfig.fromSysprops()
   val historyManager: HistoryManager? =
     historyDirProp?.let { dir ->
       System.err.println(
-        "compose-ai-tools daemon: HistoryManager active (dir=$dir, gitRefs=${gitRefHistoryRefs})"
+        "compose-ai-tools daemon: HistoryManager active (dir=$dir, gitRefs=${gitRefHistoryRefs}, " +
+          "pruneConfig=$pruneConfig)"
       )
       HistoryManager.forLocalFsAndGitRefs(
         historyDir = Path.of(dir),
@@ -173,6 +177,7 @@ fun main(args: Array<String>) {
         gitProvenance = gitProvenance,
         gitRefs = gitRefHistoryRefs,
         repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
+        pruneConfig = pruneConfig,
       )
     }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -3,7 +3,9 @@ package ee.schimke.composeai.daemon
 import ee.schimke.composeai.daemon.history.HistoryEntry
 import ee.schimke.composeai.daemon.history.HistoryFilter
 import ee.schimke.composeai.daemon.history.HistoryManager
+import ee.schimke.composeai.daemon.history.HistoryPruneConfig
 import ee.schimke.composeai.daemon.history.PreviewMetadataSnapshot
+import ee.schimke.composeai.daemon.history.PruneReason
 import ee.schimke.composeai.daemon.protocol.ClasspathDirtyParams
 import ee.schimke.composeai.daemon.protocol.ClasspathDirtyReason
 import ee.schimke.composeai.daemon.protocol.DiscoveryUpdatedParams
@@ -15,8 +17,13 @@ import ee.schimke.composeai.daemon.protocol.HistoryDiffParams
 import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
 import ee.schimke.composeai.daemon.protocol.HistoryListParams
 import ee.schimke.composeai.daemon.protocol.HistoryListResult
+import ee.schimke.composeai.daemon.protocol.HistoryPrunedParams
+import ee.schimke.composeai.daemon.protocol.HistoryPruneParams
+import ee.schimke.composeai.daemon.protocol.HistoryPruneResult
+import ee.schimke.composeai.daemon.protocol.HistoryPruneSourceResult
 import ee.schimke.composeai.daemon.protocol.HistoryReadParams
 import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
+import ee.schimke.composeai.daemon.protocol.PruneReasonWire
 import ee.schimke.composeai.daemon.protocol.InitializeParams
 import ee.schimke.composeai.daemon.protocol.InitializeResult
 import ee.schimke.composeai.daemon.protocol.JsonRpcNotification
@@ -138,12 +145,43 @@ class JsonRpcServer(
    * and `historyAdded` notifications never fire — pre-H1 behaviour.
    */
   private val historyManager: HistoryManager? = null,
+  /**
+   * H4 — initial delay for the auto-prune scheduler. Defaults to
+   * [HistoryManager.DEFAULT_INITIAL_DELAY_MS] (5s — runs after sandbox bootstrap). Tests pass a
+   * very small value (e.g. 50ms) to drive the schedule deterministically.
+   */
+  private val autoPruneInitialDelayMs: Long = HistoryManager.DEFAULT_INITIAL_DELAY_MS,
   private val onExit: (Int) -> Unit = { code -> System.exit(code) },
 ) {
 
   private val json = Json {
     ignoreUnknownKeys = true
     encodeDefaults = false
+  }
+
+  init {
+    // H4 — wire the manager's prune listener so non-empty prune passes (auto or manual) emit a
+    // `historyPruned` JSON-RPC notification. The listener is invoked on whatever thread runs the
+    // prune (the auto-prune scheduler thread, or the read thread for manual calls); both eventually
+    // route through the writer queue, so frame ordering is preserved.
+    historyManager?.setPruneListener { notif ->
+      val wireReason =
+        when (notif.reason) {
+          PruneReason.AUTO -> PruneReasonWire.AUTO
+          PruneReason.MANUAL -> PruneReasonWire.MANUAL
+        }
+      sendNotification(
+        "historyPruned",
+        encode(
+          HistoryPrunedParams.serializer(),
+          HistoryPrunedParams(
+            removedIds = notif.removedIds,
+            freedBytes = notif.freedBytes,
+            reason = wireReason,
+          ),
+        ),
+      )
+    }
   }
 
   private val initialized = AtomicBoolean(false)
@@ -197,6 +235,10 @@ class JsonRpcServer(
     StartupTimings.mark("JsonRpcServer.run() entered")
     host.start()
     StartupTimings.mark("host.start() returned (sandbox ready)")
+    // H4 — kick off the auto-prune scheduler now that the sandbox is up. The first pass fires
+    // after `autoPruneInitialDelayMs` (5s default; small in tests). All-off configs short-circuit
+    // inside `startAutoPrune` so we don't spin a thread for nothing.
+    historyManager?.startAutoPrune(initialDelayMs = autoPruneInitialDelayMs)
     writerThread.start()
     renderWatcherThread.start()
     StartupTimings.mark("read loop entering")
@@ -316,6 +358,7 @@ class JsonRpcServer(
       "history/list" -> handleHistoryList(req)
       "history/read" -> handleHistoryRead(req)
       "history/diff" -> handleHistoryDiff(req)
+      "history/prune" -> handleHistoryPrune(req)
       else ->
         sendErrorResponse(
           id = req.id,
@@ -833,6 +876,88 @@ class JsonRpcServer(
     sendResponse(req.id, encode(HistoryDiffResult.serializer(), result))
   }
 
+  /**
+   * H4 — `history/prune` manual prune trigger. Resolves [HistoryPruneParams] over the daemon's
+   * configured defaults (explicit param wins; null leaves the default). When [HistoryPruneParams.dryRun]
+   * is true, returns the would-remove set without touching disk and does NOT emit a `historyPruned`
+   * notification. Otherwise mutates and (if non-empty) emits `historyPruned` with `reason: "manual"`.
+   *
+   * See HISTORY.md § "Pruning policy" for the order-of-passes contract.
+   */
+  private fun handleHistoryPrune(req: JsonRpcRequest) {
+    val params =
+      try {
+        decodeParams(req.params, HistoryPruneParams.serializer())
+      } catch (e: Throwable) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INVALID_PARAMS,
+          message = "invalid history/prune params: ${e.message}",
+        )
+        return
+      }
+    val mgr = historyManager
+    if (mgr == null || !mgr.isEnabled) {
+      // No history is configured → returns an empty result rather than a hard error. Mirrors how
+      // history/list degrades: the consumer asked "did anything get pruned?" and the answer is
+      // honestly "no" because nothing's recorded.
+      sendResponse(
+        req.id,
+        encode(
+          HistoryPruneResult.serializer(),
+          HistoryPruneResult(
+            removedEntries = emptyList(),
+            freedBytes = 0L,
+            sourceResults = emptyMap(),
+          ),
+        ),
+      )
+      return
+    }
+    // Compose effective config from the manager's defaults + per-call overrides.
+    val baseConfig = mgr.pruneConfig
+    val effective =
+      HistoryPruneConfig(
+        maxEntriesPerPreview = params.maxEntriesPerPreview ?: baseConfig.maxEntriesPerPreview,
+        maxAgeDays = params.maxAgeDays ?: baseConfig.maxAgeDays,
+        maxTotalSizeBytes = params.maxTotalSizeBytes ?: baseConfig.maxTotalSizeBytes,
+        autoPruneIntervalMs = baseConfig.autoPruneIntervalMs,
+      )
+    val aggregate =
+      try {
+        mgr.pruneNow(
+          config = effective,
+          dryRun = params.dryRun,
+          reason = if (params.dryRun) null else PruneReason.MANUAL,
+        )
+      } catch (t: Throwable) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INTERNAL,
+          message = "history/prune failed: ${t.message}",
+        )
+        return
+      }
+    val perSource =
+      aggregate.sourceResults.mapValues { (_, r) ->
+        HistoryPruneSourceResult(
+          removedEntryIds = r.removedEntryIds,
+          freedBytes = r.freedBytes,
+        )
+      }
+    sendResponse(
+      req.id,
+      encode(
+        HistoryPruneResult.serializer(),
+        HistoryPruneResult(
+          removedEntries = aggregate.removedEntryIds,
+          freedBytes = aggregate.freedBytes,
+          sourceResults = perSource,
+        ),
+      ),
+    )
+  }
+
   private fun emitRenderFailed(failure: RenderResultOrFailure.Failure) {
     val previewId = hostIdToPreviewId.remove(failure.hostId) ?: failure.hostId.toString()
     acceptedAtMs.remove(failure.hostId)
@@ -1227,6 +1352,12 @@ class JsonRpcServer(
         Thread.currentThread().interrupt()
         break
       }
+    }
+    // H4 — stop the auto-prune scheduler before the host. Idempotent; safe under racing exits.
+    try {
+      historyManager?.stopAutoPrune()
+    } catch (e: Throwable) {
+      System.err.println("compose-ai-daemon: historyManager.stopAutoPrune failed: ${e.message}")
     }
     try {
       host.shutdown()

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
@@ -4,6 +4,11 @@ import ee.schimke.composeai.daemon.protocol.RenderMetrics
 import java.time.Instant
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.serialization.json.JsonElement
 
@@ -36,6 +41,12 @@ class HistoryManager(
   private val sources: List<HistorySource>,
   private val module: String,
   private val gitProvenance: GitProvenance?,
+  /**
+   * H4 — pruning config. Production mains read from sysprops via [HistoryPruneConfig.fromSysprops];
+   * tests pass an explicit instance. The auto-prune scheduler reads this at construction time;
+   * manual `history/prune` RPC calls override individual fields per-call.
+   */
+  val pruneConfig: HistoryPruneConfig = HistoryPruneConfig(),
 ) {
 
   /**
@@ -214,7 +225,169 @@ class HistoryManager(
     return null
   }
 
+  // ---------------------------------------------------------------------------------------
+  // H4 — Pruning + auto-prune scheduler.
+  // ---------------------------------------------------------------------------------------
+
+  /**
+   * Listener for `historyPruned` notifications. Set by [JsonRpcServer] at construction; null when
+   * unwired (in-process tests, fake-mode harness scenarios that don't care).
+   */
+  @Volatile private var pruneListener: ((PruneNotification) -> Unit)? = null
+
+  /** Auto-prune scheduler — null until [startAutoPrune] is called; null forever when disabled. */
+  private val scheduler: AtomicReference<ScheduledExecutorService?> = AtomicReference(null)
+
+  private val autoPruneFuture: AtomicReference<ScheduledFuture<*>?> = AtomicReference(null)
+
+  private val autoPruneStopped = AtomicBoolean(false)
+
+  /**
+   * H4 — registers a listener invoked after each non-empty prune pass (auto or manual) so the
+   * caller can emit a `historyPruned` JSON-RPC notification. [JsonRpcServer.runHistoryManager]
+   * wires this on construction; tests pass a buffer-capturing lambda or leave it null.
+   */
+  fun setPruneListener(listener: ((PruneNotification) -> Unit)?) {
+    pruneListener = listener
+  }
+
+  /**
+   * H4 — runs one prune pass across writable [LocalFsHistorySource]s. Read-only sources (git-ref,
+   * HTTP) are intentionally skipped — pruning them is the producer's concern.
+   *
+   * Returns `(removedIds across all sources, totalFreedBytes, perSourceResults)`. When [reason] is
+   * non-null and the combined removed set is non-empty, fires the [pruneListener] (if set).
+   *
+   * @param config the pruning policy to apply. The auto-prune scheduler passes [pruneConfig];
+   *   manual `history/prune` callers pass a per-call overlay (explicit params over defaults).
+   * @param dryRun when true, no disk mutations happen; returns the would-remove set.
+   * @param reason controls the [PruneNotification.reason] field — `AUTO` for the scheduler,
+   *   `MANUAL` for `history/prune`. Null suppresses the listener (used by dry-run probes).
+   */
+  fun pruneNow(
+    config: HistoryPruneConfig = pruneConfig,
+    dryRun: Boolean = false,
+    reason: PruneReason? = null,
+  ): PruneAggregateResult {
+    val perSource = LinkedHashMap<String, PruneResult>()
+    val combinedRemoved = mutableListOf<String>()
+    var combinedFreed = 0L
+    for (source in sources) {
+      if (!source.supportsWrites()) continue
+      val result =
+        try {
+          source.prune(config, dryRun = dryRun)
+        } catch (t: Throwable) {
+          System.err.println(
+            "compose-ai-daemon: HistoryManager.prune: source ${source.id} prune() threw " +
+              "(${t.javaClass.simpleName}: ${t.message}); skipping"
+          )
+          PruneResult.EMPTY
+        }
+      perSource[source.id] = result
+      combinedRemoved.addAll(result.removedEntryIds)
+      combinedFreed += result.freedBytes
+    }
+    val aggregate =
+      PruneAggregateResult(
+        removedEntryIds = combinedRemoved,
+        freedBytes = combinedFreed,
+        sourceResults = perSource,
+      )
+    if (!dryRun && reason != null && combinedRemoved.isNotEmpty()) {
+      val listener = pruneListener
+      if (listener != null) {
+        try {
+          listener(
+            PruneNotification(
+              removedIds = combinedRemoved.toList(),
+              freedBytes = combinedFreed,
+              reason = reason,
+            )
+          )
+        } catch (t: Throwable) {
+          System.err.println(
+            "compose-ai-daemon: HistoryManager.pruneNow: pruneListener threw " +
+              "(${t.javaClass.simpleName}: ${t.message}); ignoring"
+          )
+        }
+      }
+    }
+    return aggregate
+  }
+
+  /**
+   * H4 — starts the auto-prune scheduler.
+   *
+   * **Lifecycle.** Schedules one initial pass after [initialDelayMs] (default few seconds — runs
+   * after the daemon's sandbox bootstrap, so first prune doesn't compete with cold-start I/O), then
+   * repeats every [HistoryPruneConfig.autoPruneIntervalMs]. [stopAutoPrune] cancels and joins the
+   * scheduler.
+   *
+   * **All-off short-circuit.** When [pruneConfig].isAllOff is true, this is a no-op — the
+   * scheduler thread is never created. Same for any non-positive [HistoryPruneConfig.autoPruneIntervalMs].
+   *
+   * **Safety.** Reentrancy-guarded — second call with the scheduler already running is a no-op.
+   * The scheduler thread is daemonised so the JVM can exit even if [stopAutoPrune] isn't called.
+   */
+  fun startAutoPrune(initialDelayMs: Long = DEFAULT_INITIAL_DELAY_MS) {
+    if (pruneConfig.isAllOff) return
+    if (pruneConfig.autoPruneIntervalMs <= 0L) return
+    if (!isEnabled) return
+    if (autoPruneStopped.get()) return
+    val existing = scheduler.get()
+    if (existing != null) return
+    val exec =
+      Executors.newSingleThreadScheduledExecutor { runnable ->
+        Thread(runnable, "compose-ai-daemon-history-auto-prune").apply { isDaemon = true }
+      }
+    if (!scheduler.compareAndSet(null, exec)) {
+      // Lost a race — another thread set the scheduler first. Shut down our redundant exec.
+      exec.shutdownNow()
+      return
+    }
+    val future =
+      exec.scheduleWithFixedDelay(
+        {
+          try {
+            pruneNow(config = pruneConfig, dryRun = false, reason = PruneReason.AUTO)
+          } catch (t: Throwable) {
+            System.err.println(
+              "compose-ai-daemon: HistoryManager auto-prune pass failed " +
+                "(${t.javaClass.simpleName}: ${t.message}); will retry on next interval"
+            )
+          }
+        },
+        initialDelayMs.coerceAtLeast(0L),
+        pruneConfig.autoPruneIntervalMs,
+        TimeUnit.MILLISECONDS,
+      )
+    autoPruneFuture.set(future)
+  }
+
+  /**
+   * H4 — stops the auto-prune scheduler. Idempotent. Cancels any in-flight pass via interrupt; the
+   * pass observes the interrupt at its next syscall and exits without leaving the index in a
+   * partial state (the rewrite is atomic).
+   */
+  fun stopAutoPrune() {
+    autoPruneStopped.set(true)
+    val future = autoPruneFuture.getAndSet(null)
+    future?.cancel(true)
+    val exec = scheduler.getAndSet(null) ?: return
+    exec.shutdownNow()
+    try {
+      exec.awaitTermination(2, TimeUnit.SECONDS)
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+    }
+  }
+
   companion object {
+
+    /** Initial delay for [startAutoPrune] — a few seconds, after the sandbox is up. */
+    const val DEFAULT_INITIAL_DELAY_MS: Long = 5_000L
+
     /** `yyyyMMdd-HHmmss` UTC. Pinned format — HISTORY.md § "On-disk schema" filename shape. */
     private val TIMESTAMP_FORMAT: DateTimeFormatter =
       DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss").withZone(ZoneOffset.UTC)
@@ -227,11 +400,17 @@ class HistoryManager(
       historyDir: java.nio.file.Path?,
       module: String,
       gitProvenance: GitProvenance?,
+      pruneConfig: HistoryPruneConfig = HistoryPruneConfig(),
     ): HistoryManager {
       val sources =
         if (historyDir == null) emptyList()
         else listOf(LocalFsHistorySource(historyDir = historyDir))
-      return HistoryManager(sources = sources, module = module, gitProvenance = gitProvenance)
+      return HistoryManager(
+        sources = sources,
+        module = module,
+        gitProvenance = gitProvenance,
+        pruneConfig = pruneConfig,
+      )
     }
 
     /**
@@ -251,6 +430,7 @@ class HistoryManager(
       gitRefs: List<String> = emptyList(),
       repoRoot: java.nio.file.Path? = historyDir?.parent,
       warnEmitter: (String) -> Unit = { System.err.println(it) },
+      pruneConfig: HistoryPruneConfig = HistoryPruneConfig(),
     ): HistoryManager {
       val sources = buildList {
         if (historyDir != null) add(LocalFsHistorySource(historyDir = historyDir))
@@ -269,7 +449,12 @@ class HistoryManager(
           }
         }
       }
-      return HistoryManager(sources = sources, module = module, gitProvenance = gitProvenance)
+      return HistoryManager(
+        sources = sources,
+        module = module,
+        gitProvenance = gitProvenance,
+        pruneConfig = pruneConfig,
+      )
     }
   }
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryPruneConfig.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryPruneConfig.kt
@@ -1,0 +1,115 @@
+package ee.schimke.composeai.daemon.history
+
+/**
+ * H4 — pruning policy configuration. See HISTORY.md § "Pruning policy".
+ *
+ * Each of the four knobs is independently disable-able by setting it to `0` or negative; that knob
+ * is then skipped on the [LocalFsHistorySource.prune] cascade. When ALL four values are `≤ 0` the
+ * config is "all-off" — [HistoryManager] suppresses the auto-prune scheduler entirely.
+ *
+ * **Defaults** are pinned in HISTORY.md and read by the production daemon mains from sysprops:
+ *
+ * | knob | default | sysprop |
+ * |---|---|---|
+ * | [maxEntriesPerPreview] | 50 | `composeai.daemon.history.maxEntriesPerPreview` |
+ * | [maxAgeDays] | 14 | `composeai.daemon.history.maxAgeDays` |
+ * | [maxTotalSizeBytes] | 500_000_000 (500 MB) | `composeai.daemon.history.maxTotalSizeBytes` |
+ * | [autoPruneIntervalMs] | 1h | `composeai.daemon.history.autoPruneIntervalMs` |
+ *
+ * Manual `history/prune` RPC calls override these per-call (via [HistoryPruneParams][
+ * ee.schimke.composeai.daemon.protocol.HistoryPruneParams]); the auto-prune scheduler always uses
+ * the configured defaults.
+ */
+data class HistoryPruneConfig(
+  val maxEntriesPerPreview: Int = 50,
+  val maxAgeDays: Int = 14,
+  val maxTotalSizeBytes: Long = 500_000_000L,
+  val autoPruneIntervalMs: Long = 60L * 60L * 1000L,
+) {
+
+  /**
+   * True when every individual knob is "off" (`≤ 0`). [HistoryManager] uses this to suppress the
+   * auto-prune scheduler entirely (HISTORY.md § "Pruning policy" — "all-off disables scheduler").
+   */
+  val isAllOff: Boolean
+    get() =
+      maxEntriesPerPreview <= 0 &&
+        maxAgeDays <= 0 &&
+        maxTotalSizeBytes <= 0L &&
+        autoPruneIntervalMs <= 0L
+
+  companion object {
+    const val PROP_MAX_ENTRIES: String = "composeai.daemon.history.maxEntriesPerPreview"
+    const val PROP_MAX_AGE_DAYS: String = "composeai.daemon.history.maxAgeDays"
+    const val PROP_MAX_TOTAL_SIZE_BYTES: String = "composeai.daemon.history.maxTotalSizeBytes"
+    const val PROP_AUTO_PRUNE_INTERVAL_MS: String = "composeai.daemon.history.autoPruneIntervalMs"
+
+    /**
+     * Builds a config from system properties, falling back to defaults for any unset / unparseable
+     * value. Production daemon mains call this; tests construct [HistoryPruneConfig] directly.
+     */
+    fun fromSysprops(props: (String) -> String? = System::getProperty): HistoryPruneConfig {
+      val defaults = HistoryPruneConfig()
+      return HistoryPruneConfig(
+        maxEntriesPerPreview =
+          props(PROP_MAX_ENTRIES)?.toIntOrNull() ?: defaults.maxEntriesPerPreview,
+        maxAgeDays = props(PROP_MAX_AGE_DAYS)?.toIntOrNull() ?: defaults.maxAgeDays,
+        maxTotalSizeBytes =
+          props(PROP_MAX_TOTAL_SIZE_BYTES)?.toLongOrNull() ?: defaults.maxTotalSizeBytes,
+        autoPruneIntervalMs =
+          props(PROP_AUTO_PRUNE_INTERVAL_MS)?.toLongOrNull() ?: defaults.autoPruneIntervalMs,
+      )
+    }
+  }
+}
+
+/**
+ * Result of [HistorySource.prune]. [removedEntryIds] is the set of entry ids whose sidecars were
+ * removed (or would be in dry-run mode). [freedBytes] sums the `pngSize` of entries whose PNG file
+ * actually got deleted — entries that surrendered their sidecar but whose PNG was retained because
+ * a surviving sidecar still references it (dedup-by-hash) do NOT contribute to [freedBytes].
+ */
+data class PruneResult(val removedEntryIds: List<String>, val freedBytes: Long) {
+  companion object {
+    val EMPTY: PruneResult = PruneResult(emptyList(), 0L)
+  }
+}
+
+/**
+ * Aggregate prune result across every writable [HistorySource] in a [HistoryManager].
+ *
+ * - [removedEntryIds] — concatenation of every per-source `removedEntryIds`.
+ * - [freedBytes] — sum across sources.
+ * - [sourceResults] — per-source breakdown keyed by [HistorySource.id]. Read-only sources are NOT
+ *   listed (they're skipped by the manager).
+ */
+data class PruneAggregateResult(
+  val removedEntryIds: List<String>,
+  val freedBytes: Long,
+  val sourceResults: Map<String, PruneResult>,
+) {
+  companion object {
+    val EMPTY: PruneAggregateResult =
+      PruneAggregateResult(emptyList(), 0L, emptyMap())
+  }
+}
+
+/**
+ * Reason for a `historyPruned` notification — see HISTORY.md § "historyPruned".
+ *
+ * - [AUTO] — the auto-prune scheduler ran a non-empty pass.
+ * - [MANUAL] — a `history/prune` JSON-RPC call ran a non-empty pass.
+ *
+ * Empty (no-op) passes do NOT emit a notification at all (don't spam clients).
+ */
+enum class PruneReason {
+  AUTO,
+  MANUAL,
+}
+
+/** Internal payload [HistoryManager] hands to its `pruneListener`. */
+data class PruneNotification(
+  val removedIds: List<String>,
+  val freedBytes: Long,
+  val reason: PruneReason,
+)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
@@ -106,4 +106,25 @@ interface HistorySource {
 
   /** Reads one entry by id. Returns null when the id isn't present in this source. */
   fun read(entryId: String, includeBytes: Boolean = false): HistoryReadResult?
+
+  /**
+   * H4 — applies the pruning policy from [config] to this source's storage. Read-only sources
+   * (git-ref, HTTP) return [PruneResult.EMPTY] without touching anything; the daemon doesn't write
+   * to those backends, so cleanup is the producer's concern.
+   *
+   * **Pruning order** (HISTORY.md § "Pruning policy"):
+   * 1. Age — drop entries with `timestamp < now - maxAgeDays`.
+   * 2. Per-preview count — keep newest [HistoryPruneConfig.maxEntriesPerPreview] per preview.
+   * 3. Total size — if surviving set still exceeds [HistoryPruneConfig.maxTotalSizeBytes], drop
+   *    oldest entries across all previews until under threshold.
+   *
+   * Each pass operates on the survivor set from the previous; the most-recent entry per preview
+   * is NEVER dropped (HISTORY.md: "diff requires at least one prior entry to be useful").
+   *
+   * **Dry-run mode** ([dryRun] = true) computes the removal set + freed bytes without touching
+   * disk. Useful for "what would auto-prune do?" probes from a consumer.
+   *
+   * Each individual knob set to `0` or negative is treated as disabled — that pass is skipped.
+   */
+  fun prune(config: HistoryPruneConfig, dryRun: Boolean = false): PruneResult = PruneResult.EMPTY
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
@@ -3,8 +3,13 @@ package ee.schimke.composeai.daemon.history
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
 import java.security.MessageDigest
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import kotlin.io.path.exists
 import kotlin.io.path.readBytes
 import kotlin.io.path.readText
@@ -142,6 +147,211 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
   }
 
   /**
+   * H4 — applies the pruning policy from HISTORY.md § "Pruning policy". Loads the index newest-
+   * first, runs the three-pass cascade (age → per-preview count → total size), enforces the
+   * "never drop the most recent entry per preview" floor, then either:
+   *
+   * - **Dry run** ([dryRun] = true): returns the would-remove set + freed bytes; does NOT touch
+   *   disk.
+   * - **Live** ([dryRun] = false): deletes sidecar `.json` files; deletes PNG files only when no
+   *   surviving sidecar references the same file (dedup-by-hash means N sidecars may share one
+   *   PNG); rewrites `index.jsonl` atomically (write-temp-then-atomic-rename) so an interrupted
+   *   prune leaves either the old or the new index — never partial.
+   *
+   * Failures in individual file deletes are logged to stderr and swallowed — pruning never fails
+   * the daemon. The on-disk archive is self-healing on the next pass.
+   */
+  override fun prune(config: HistoryPruneConfig, dryRun: Boolean): PruneResult {
+    val indexFile = historyDir.resolve(INDEX_FILENAME)
+    if (!indexFile.exists()) return PruneResult.EMPTY
+
+    // Load every entry from the index — self-heals against missing sidecars + malformed lines.
+    // Sort newest-first by `timestamp` then `id`. The append-order from production writes is
+    // already chronological, but explicit sort makes prune robust against backdated entries
+    // (e.g. tests that write in reversed temporal order, or future migration tools).
+    val all: List<HistoryEntry> =
+      readIndexNewestFirst(indexFile)
+        .sortedWith(compareByDescending<HistoryEntry> { it.timestamp }.thenByDescending { it.id })
+    if (all.isEmpty()) return PruneResult.EMPTY
+
+    // Compute the "must always survive" set: most recent entry per previewId. This floor applies
+    // throughout — every pruning pass intersects against this set so a violator who happens to be
+    // the only/most-recent entry for its preview survives.
+    val mostRecentPerPreview: Map<String, String> =
+      buildMap {
+        // `all` is newest-first, so the FIRST occurrence of each previewId is the most recent.
+        for (entry in all) {
+          if (!containsKey(entry.previewId)) put(entry.previewId, entry.id)
+        }
+      }
+
+    // Tracks ids marked for removal. Uses LinkedHashSet for stable iteration (= test-friendly).
+    val toRemove = LinkedHashSet<String>()
+
+    fun protect(entry: HistoryEntry): Boolean = mostRecentPerPreview[entry.previewId] == entry.id
+
+    // -----------------------------------------------------------------------------------
+    // Pass 1 — age. Drop entries with timestamp < (now - maxAgeDays).
+    // -----------------------------------------------------------------------------------
+    if (config.maxAgeDays > 0) {
+      val cutoff = Instant.now().minusSeconds(config.maxAgeDays.toLong() * 86_400L)
+      val cutoffString = OffsetDateTime.ofInstant(cutoff, ZoneOffset.UTC).format(ISO_TS)
+      for (entry in all) {
+        if (entry.id in toRemove) continue
+        if (protect(entry)) continue
+        if (entry.timestamp < cutoffString) toRemove.add(entry.id)
+      }
+    }
+
+    // -----------------------------------------------------------------------------------
+    // Pass 2 — per-preview count. Keep newest N per preview; mark the rest for removal.
+    // -----------------------------------------------------------------------------------
+    if (config.maxEntriesPerPreview > 0) {
+      val grouped: Map<String, List<HistoryEntry>> =
+        all.filter { it.id !in toRemove }.groupBy { it.previewId }
+      for ((_, group) in grouped) {
+        // group is in original (newest-first) order — Kotlin's groupBy preserves first-encounter
+        // order. Survivors = first N; older are pruned.
+        val excess = group.drop(config.maxEntriesPerPreview)
+        for (entry in excess) {
+          if (protect(entry)) continue
+          toRemove.add(entry.id)
+        }
+      }
+    }
+
+    // -----------------------------------------------------------------------------------
+    // Pass 3 — total size. If surviving set still exceeds maxTotalSizeBytes, drop oldest first.
+    // -----------------------------------------------------------------------------------
+    if (config.maxTotalSizeBytes > 0L) {
+      val survivors = all.filter { it.id !in toRemove }
+      var totalSize = survivors.sumOf { it.pngSize }
+      if (totalSize > config.maxTotalSizeBytes) {
+        // Walk oldest → newest, drop until under threshold. `survivors` is newest-first, so iterate
+        // in reverse.
+        for (entry in survivors.asReversed()) {
+          if (totalSize <= config.maxTotalSizeBytes) break
+          if (protect(entry)) continue
+          if (entry.id in toRemove) continue
+          toRemove.add(entry.id)
+          totalSize -= entry.pngSize
+        }
+      }
+    }
+
+    if (toRemove.isEmpty()) return PruneResult.EMPTY
+
+    val removedEntries = all.filter { it.id in toRemove }
+    val survivors = all.filter { it.id !in toRemove }
+
+    // Compute freedBytes — only count entries whose PNG file actually goes away. A sidecar B'
+    // pointing at the same `<id>.png` filename as a surviving sidecar B leaves the PNG on disk.
+    // For dedup-by-hash, multiple sidecars may share one PNG: the dedup-target's sidecar's pngPath
+    // is the *original* PNG's filename, so survivors[].pngPath stays referenced as long as one
+    // sidecar with that pngPath survives.
+    val survivingPngPaths: Set<Pair<String, String>> = // (sanitisedPreviewDir, pngPath)
+      survivors.mapTo(HashSet()) { PreviewIdSanitiser.sanitise(it.previewId) to it.pngPath }
+    val freedBytes =
+      removedEntries.sumOf { entry ->
+        val key = PreviewIdSanitiser.sanitise(entry.previewId) to entry.pngPath
+        if (key in survivingPngPaths) 0L else entry.pngSize
+      }
+
+    if (dryRun) {
+      return PruneResult(
+        removedEntryIds = removedEntries.map { it.id },
+        freedBytes = freedBytes,
+      )
+    }
+
+    // -----------------------------------------------------------------------------------
+    // Live mode — actually mutate disk.
+    // -----------------------------------------------------------------------------------
+    // 1. Rewrite the index first (atomic via tempfile + rename). If anything below fails, the
+    //    survivor entries are still readable; orphaned PNGs are tolerable (they're effectively
+    //    leaked bytes that the next prune can re-discover via timestamp comparison).
+    val indexTempFile = historyDir.resolve("$INDEX_FILENAME.tmp")
+    try {
+      val sb = StringBuilder()
+      // index.jsonl is append-order = oldest first. survivors is newest-first; reverse for write.
+      for (entry in survivors.asReversed()) {
+        // Match the live append shape: same fields as the sidecar, minus previewMetadata.
+        val indexEntry = entry.copy(previewMetadata = null)
+        sb.append(JSON.encodeToString(HistoryEntry.serializer(), indexEntry))
+        sb.append('\n')
+      }
+      Files.write(
+        indexTempFile,
+        sb.toString().toByteArray(StandardCharsets.UTF_8),
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING,
+        StandardOpenOption.WRITE,
+      )
+      try {
+        Files.move(
+          indexTempFile,
+          indexFile,
+          StandardCopyOption.ATOMIC_MOVE,
+          StandardCopyOption.REPLACE_EXISTING,
+        )
+      } catch (_: Throwable) {
+        // ATOMIC_MOVE is not supported on every filesystem (older NFS, some Windows configs);
+        // fall back to a non-atomic rename. The window between the two is tiny and the survivors
+        // are still bytewise complete on disk in the tempfile until rename finishes.
+        Files.move(indexTempFile, indexFile, StandardCopyOption.REPLACE_EXISTING)
+      }
+    } catch (t: Throwable) {
+      // Index rewrite failed → bail out without touching sidecars / PNGs. Leaves the on-disk
+      // state untouched (since the index move never landed). Try to clean the tempfile.
+      try {
+        Files.deleteIfExists(indexTempFile)
+      } catch (_: Throwable) {
+        // ignore
+      }
+      System.err.println(
+        "compose-ai-daemon: LocalFsHistorySource.prune: index rewrite failed " +
+          "(${t.javaClass.simpleName}: ${t.message}); leaving archive untouched"
+      )
+      return PruneResult.EMPTY
+    }
+
+    // 2. Delete sidecars for every removed entry.
+    for (entry in removedEntries) {
+      val sanitised = PreviewIdSanitiser.sanitise(entry.previewId)
+      val sidecar = historyDir.resolve(sanitised).resolve("${entry.id}.json")
+      try {
+        Files.deleteIfExists(sidecar)
+      } catch (t: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: LocalFsHistorySource.prune: sidecar delete failed for " +
+            "$sidecar (${t.javaClass.simpleName}: ${t.message})"
+        )
+      }
+    }
+
+    // 3. Delete PNGs for removed entries — only when no surviving sidecar references the file.
+    for (entry in removedEntries) {
+      val sanitised = PreviewIdSanitiser.sanitise(entry.previewId)
+      val key = sanitised to entry.pngPath
+      if (key in survivingPngPaths) continue
+      val pngFile = historyDir.resolve(sanitised).resolve(entry.pngPath)
+      try {
+        Files.deleteIfExists(pngFile)
+      } catch (t: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: LocalFsHistorySource.prune: PNG delete failed for " +
+            "$pngFile (${t.javaClass.simpleName}: ${t.message})"
+        )
+      }
+    }
+
+    return PruneResult(
+      removedEntryIds = removedEntries.map { it.id },
+      freedBytes = freedBytes,
+    )
+  }
+
+  /**
    * Walks the per-preview directory looking for the most recent (lex-sorted) sidecar whose pngHash
    * matches [hash]. Returns the relative PNG filename of the match, or null when no match.
    */
@@ -253,6 +463,9 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
       encodeDefaults = false
       prettyPrint = false
     }
+
+    /** Pinned ISO-8601 UTC formatter for prune-cutoff comparisons. */
+    private val ISO_TS: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
 
     /** SHA-256 hex of [bytes]. */
     fun sha256Hex(bytes: ByteArray): String {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -430,3 +430,58 @@ data class HistoryDiffResult(
   val ssim: Double? = null,
   val diffPngPath: String? = null,
 )
+
+// ---------------------------------------------------------------------------
+// H4 — `history/prune` request + `historyPruned` notification. See HISTORY.md
+// § "Pruning policy" + § "historyPruned".
+// ---------------------------------------------------------------------------
+
+/**
+ * Manual prune trigger. Each parameter is optional and overrides the daemon's configured default
+ * for THIS call only — the auto-prune scheduler keeps using its configured defaults. Set any value
+ * to `0` or negative to disable that knob (e.g. `maxAgeDays: 0` → no age-based pruning).
+ *
+ * `dryRun = true` returns the would-remove set without touching disk.
+ */
+@Serializable
+data class HistoryPruneParams(
+  val maxEntriesPerPreview: Int? = null,
+  val maxAgeDays: Int? = null,
+  val maxTotalSizeBytes: Long? = null,
+  val dryRun: Boolean = false,
+)
+
+@Serializable
+data class HistoryPruneSourceResult(
+  val removedEntryIds: List<String>,
+  val freedBytes: Long,
+)
+
+/**
+ * Result of `history/prune`. [removedEntries] / [freedBytes] are the cross-source aggregate;
+ * [sourceResults] is the per-source breakdown keyed by `HistorySource.id` (only writable sources
+ * are listed — read-only git/HTTP sources don't participate in pruning).
+ */
+@Serializable
+data class HistoryPruneResult(
+  val removedEntries: List<String>,
+  val freedBytes: Long,
+  val sourceResults: Map<String, HistoryPruneSourceResult>,
+)
+
+/**
+ * `historyPruned` notification (HISTORY.md § "historyPruned"). Emitted after each NON-EMPTY prune
+ * pass — auto-prune passes that removed nothing produce no notification.
+ */
+@Serializable
+data class HistoryPrunedParams(
+  val removedIds: List<String>,
+  val freedBytes: Long,
+  val reason: PruneReasonWire,
+)
+
+@Serializable
+enum class PruneReasonWire {
+  @SerialName("auto") AUTO,
+  @SerialName("manual") MANUAL,
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryManagerAutoPruneTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryManagerAutoPruneTest.kt
@@ -1,0 +1,177 @@
+package ee.schimke.composeai.daemon.history
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pins the H4 auto-prune scheduler contract on [HistoryManager].
+ *
+ * - Schedule fires periodic prune passes; each non-empty pass invokes the listener with `reason: AUTO`.
+ * - All-off config (every knob ≤ 0) suppresses the scheduler entirely; no thread is started.
+ * - Idempotent: a second pass with no new entries does NOT emit a notification.
+ */
+class HistoryManagerAutoPruneTest {
+
+  private lateinit var tmpDir: Path
+
+  @Before
+  fun setUp() {
+    tmpDir = Files.createTempDirectory("history-auto-prune-test")
+  }
+
+  @After
+  fun tearDown() {
+    tmpDir.toFile().deleteRecursively()
+  }
+
+  @Test
+  fun auto_prune_fires_when_an_entry_is_over_age() {
+    val source = LocalFsHistorySource(historyDir = tmpDir)
+    val previewId = "P"
+    val now = Instant.now()
+    // 5 entries on a single preview: 3 over-age (100 days), 2 within cutoff. The newest survives
+    // via floor; the 2 within cutoff survive age; the 3 over-age (other than the newest) get
+    // pruned. Total removed = 2.
+    writeEntry(source, previewId, now, suffix = "r0")
+    writeEntry(source, previewId, now.minusSeconds(60), suffix = "r1")
+    writeEntry(source, previewId, now.minusSeconds(101L * 24 * 3600), suffix = "o0")
+    writeEntry(source, previewId, now.minusSeconds(102L * 24 * 3600), suffix = "o1")
+    writeEntry(source, previewId, now.minusSeconds(103L * 24 * 3600), suffix = "o2")
+
+    val notifications = LinkedBlockingQueue<PruneNotification>()
+    val mgr =
+      HistoryManager(
+        sources = listOf(source),
+        module = ":t",
+        gitProvenance = null,
+        pruneConfig =
+          HistoryPruneConfig(
+            maxEntriesPerPreview = 0,
+            maxAgeDays = 14,
+            maxTotalSizeBytes = 0L,
+            autoPruneIntervalMs = 100L, // fast schedule for the test
+          ),
+      )
+    mgr.setPruneListener { notifications.put(it) }
+    try {
+      mgr.startAutoPrune(initialDelayMs = 50L)
+      val notif = notifications.poll(5, TimeUnit.SECONDS)
+      assertTrue("auto-prune notification must arrive", notif != null)
+      assertEquals(PruneReason.AUTO, notif!!.reason)
+      assertEquals(3, notif.removedIds.size) // o0, o1, o2 — the newest of those three is also
+      // pruned because the per-preview floor only protects one entry per preview (the global
+      // newest, "r0"); the 3 over-age entries are all dropped.
+    } finally {
+      mgr.stopAutoPrune()
+    }
+  }
+
+  @Test
+  fun auto_prune_idempotent_no_notification_after_steady_state() {
+    val source = LocalFsHistorySource(historyDir = tmpDir)
+    val previewId = "P"
+    writeEntry(source, previewId, Instant.now())
+
+    val notifications = LinkedBlockingQueue<PruneNotification>()
+    val mgr =
+      HistoryManager(
+        sources = listOf(source),
+        module = ":t",
+        gitProvenance = null,
+        pruneConfig =
+          HistoryPruneConfig(
+            maxEntriesPerPreview = 50,
+            maxAgeDays = 14,
+            maxTotalSizeBytes = 500_000_000,
+            autoPruneIntervalMs = 50L,
+          ),
+      )
+    mgr.setPruneListener { notifications.put(it) }
+    try {
+      mgr.startAutoPrune(initialDelayMs = 30L)
+      // Wait long enough for several passes — none should fire because the single entry is within
+      // every threshold.
+      Thread.sleep(400)
+      assertNull(
+        "no-op auto-prune passes must NOT emit historyPruned",
+        notifications.poll(0, TimeUnit.MILLISECONDS),
+      )
+    } finally {
+      mgr.stopAutoPrune()
+    }
+  }
+
+  @Test
+  fun all_off_config_disables_scheduler_entirely() {
+    val source = LocalFsHistorySource(historyDir = tmpDir)
+    val invokeCount = AtomicInteger(0)
+    val mgr =
+      HistoryManager(
+        sources = listOf(source),
+        module = ":t",
+        gitProvenance = null,
+        pruneConfig =
+          HistoryPruneConfig(
+            maxEntriesPerPreview = 0,
+            maxAgeDays = 0,
+            maxTotalSizeBytes = 0L,
+            autoPruneIntervalMs = 0L,
+          ),
+      )
+    mgr.setPruneListener { invokeCount.incrementAndGet() }
+    try {
+      mgr.startAutoPrune(initialDelayMs = 5L)
+      Thread.sleep(200)
+      // Listener never fires; the scheduler thread is never created.
+      assertEquals(0, invokeCount.get())
+    } finally {
+      mgr.stopAutoPrune()
+    }
+  }
+
+  private fun writeEntry(
+    source: LocalFsHistorySource,
+    previewId: String,
+    timestamp: Instant,
+    suffix: String = "",
+  ): HistoryEntry {
+    val bytes = ("preview-$previewId-$suffix-${timestamp.toEpochMilli()}").toByteArray()
+    val hash = LocalFsHistorySource.sha256Hex(bytes)
+    val tsId =
+      OffsetDateTime.ofInstant(timestamp, ZoneOffset.UTC)
+        .format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
+    val isoTs =
+      OffsetDateTime.ofInstant(timestamp, ZoneOffset.UTC)
+        .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+    val id = "$tsId-$suffix-${hash.take(8)}"
+    val entry =
+      HistoryEntry(
+        id = id,
+        previewId = previewId,
+        module = ":t",
+        timestamp = isoTs,
+        pngHash = hash,
+        pngSize = bytes.size.toLong(),
+        pngPath = "$id.png",
+        producer = "daemon",
+        trigger = "renderNow",
+        source = HistorySourceInfo(kind = "fs", id = "fs:${tmpDir.toAbsolutePath()}"),
+        renderTookMs = 1L,
+      )
+    source.write(entry, bytes)
+    return entry
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
@@ -239,16 +239,75 @@ class JsonRpcServerHistoryIntegrationTest {
         diffPixel!!["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull,
       )
 
-      // 13. history/prune → MethodNotFound (still reserved).
+      // 13. history/prune (H4) — dryRun with a tight policy returns the would-remove set
+      //     without mutating disk + does NOT emit a `historyPruned` notification.
+      val sidecarBefore = Files.exists(historyDir.resolve("preview-A").resolve("$entryId.png"))
+      assertTrue("PNG must exist before dry-run prune", sidecarBefore)
       writeFrame(
         clientToServerOut,
-        """{"jsonrpc":"2.0","id":11,"method":"history/prune","params":{}}""",
+        """{"jsonrpc":"2.0","id":11,"method":"history/prune","params":{
+              "maxEntriesPerPreview":0,"maxAgeDays":0,"maxTotalSizeBytes":1,
+              "dryRun":true}}""",
       )
-      val prune = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 11 }
-      assertEquals(
-        JsonRpcServer.ERR_METHOD_NOT_FOUND,
-        prune!!["error"]!!.jsonObject["code"]!!.jsonPrimitive.intOrNull,
+      val pruneDry = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 11 }
+      assertNotNull("dry-run prune must respond", pruneDry)
+      val pruneDryResult = pruneDry!!["result"]!!.jsonObject
+      // Policy: only "total size" knob active (limit=1 byte) + "never drop most recent per
+      // preview" floor — so removed list is empty (one entry, one preview, must survive).
+      assertEquals(0, pruneDryResult["removedEntries"]!!.jsonArray.size)
+      assertEquals(0, pruneDryResult["freedBytes"]!!.jsonPrimitive.intOrNull)
+      assertTrue(
+        "dry-run must NOT delete the PNG",
+        Files.exists(historyDir.resolve("preview-A").resolve("$entryId.png")),
       )
+
+      // 14. history/prune (H4) — manual prune with all-survive policy returns empty + no notif.
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":12,"method":"history/prune","params":{}}""",
+      )
+      val prune = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 12 }
+      assertNotNull("manual prune must respond", prune)
+      val pruneResult = prune!!["result"]!!.jsonObject
+      assertEquals(0, pruneResult["removedEntries"]!!.jsonArray.size)
+      assertEquals(0, pruneResult["freedBytes"]!!.jsonPrimitive.intOrNull)
+
+      // 15. history/prune (H4) — render a second preview, then prune with maxEntriesPerPreview=1
+      //     and force a removal on the first preview. Asserts the historyPruned notification
+      //     arrives with reason=manual.
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":13,"method":"renderNow","params":{
+              "previews":["preview-A"],"tier":"fast"}}""",
+      )
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 13 })
+      // Wait for the second historyAdded notification to ensure the entry is on disk.
+      val secondHistoryAdded =
+        pollUntil(received) {
+          it["method"]?.jsonPrimitive?.contentOrNull == "historyAdded" &&
+            it["params"]?.jsonObject?.get("entry")?.jsonObject?.get("id")
+              ?.jsonPrimitive?.content != entryId
+        }
+      assertNotNull("second historyAdded must arrive", secondHistoryAdded)
+
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":14,"method":"history/prune","params":{
+              "maxEntriesPerPreview":1,"maxAgeDays":0,"maxTotalSizeBytes":0}}""",
+      )
+      // Notification fires before the response (listener runs synchronously inside pruneNow,
+      // which runs before sendResponse). Poll historyPruned first so we don't accidentally
+      // discard it while waiting for the response.
+      val pruneNotif =
+        pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "historyPruned" }
+      assertNotNull("historyPruned notification must arrive after non-empty manual prune", pruneNotif)
+      val pruneNotifParams = pruneNotif!!["params"]!!.jsonObject
+      assertEquals("manual", pruneNotifParams["reason"]!!.jsonPrimitive.content)
+      assertEquals(1, pruneNotifParams["removedIds"]!!.jsonArray.size)
+      val prune2 = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 14 }
+      val prune2Result = prune2!!["result"]!!.jsonObject
+      // One preview "preview-A" with 2 entries; cap=1 → 1 removed (the older one).
+      assertEquals(1, prune2Result["removedEntries"]!!.jsonArray.size)
 
       // Tear down cleanly.
       writeFrame(clientToServerOut, """{"jsonrpc":"2.0","id":99,"method":"shutdown"}""")

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourcePruneTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourcePruneTest.kt
@@ -1,0 +1,391 @@
+package ee.schimke.composeai.daemon.history
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Pins the H4 prune contract on [LocalFsHistorySource] — see HISTORY.md § "Pruning policy".
+ *
+ * The pruning passes (age → per-preview count → total size) compose: each runs against the
+ * survivor set from the previous. The "never drop most recent per preview" floor is enforced
+ * throughout — even an over-age single-entry preview survives.
+ */
+class LocalFsHistorySourcePruneTest {
+
+  private lateinit var tmpDir: Path
+  private lateinit var source: LocalFsHistorySource
+
+  @Before
+  fun setUp() {
+    tmpDir = Files.createTempDirectory("history-prune-test")
+    source = LocalFsHistorySource(historyDir = tmpDir)
+  }
+
+  @After
+  fun tearDown() {
+    tmpDir.toFile().deleteRecursively()
+  }
+
+  @Test
+  fun age_pass_drops_entries_older_than_cutoff() {
+    val now = Instant.now()
+    // 20 entries spread across 30 days: 0, 1.5, 3, ... 28.5 days ago (15 over the 14-day cutoff,
+    // 5 under it). Newest is at index 0; oldest at index 19.
+    val entries =
+      (0 until 20).map { i ->
+        val ts = now.minusSeconds(((30 * 24 * 3600) * i / 20).toLong())
+        writeEntry(previewId = "P$i", timestamp = ts)
+      }
+
+    val result = source.prune(HistoryPruneConfig(maxEntriesPerPreview = 0, maxAgeDays = 14, maxTotalSizeBytes = 0L))
+
+    // Survivors: newest 14 days. Floor protects most-recent-per-preview but every preview here is
+    // unique, so the floor protects every entry. Hence every entry survives despite age cutoff.
+    // Re-run with same preview ids to actually exercise the age cutoff.
+    val survivorIds = readIndexIds(tmpDir)
+    assertTrue(
+      "every preview is unique → floor protects every entry from age pass",
+      survivorIds.containsAll(entries.map { it.id }),
+    )
+    assertEquals(0, result.removedEntryIds.size)
+  }
+
+  @Test
+  fun age_pass_drops_old_entries_when_floor_does_not_protect_them() {
+    val now = Instant.now()
+    // Single previewId, 20 entries spread over 30 days. The newest survives (floor); 14 of the
+    // remaining 19 are within the cutoff (over 14 days old gets dropped).
+    val previewId = "OnePreview"
+    val entries =
+      (0 until 20).map { i ->
+        val ts = now.minusSeconds(((30 * 24 * 3600) * i / 20).toLong())
+        writeEntry(previewId = previewId, timestamp = ts, suffix = "%02d".format(i))
+      }
+
+    val result = source.prune(HistoryPruneConfig(maxEntriesPerPreview = 0, maxAgeDays = 14, maxTotalSizeBytes = 0L))
+
+    // Compute expected: newest entry survives (floor); plus all entries that are NOT older than 14 days.
+    val cutoff = now.minusSeconds(14L * 24 * 3600)
+    val cutoffString =
+      OffsetDateTime.ofInstant(cutoff, ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+    val expectedSurvivors =
+      entries.filter { it.timestamp >= cutoffString }.map { it.id }.toMutableSet()
+    expectedSurvivors.add(entries.first().id) // floor
+
+    val survivorIds = readIndexIds(tmpDir)
+    assertEquals(expectedSurvivors, survivorIds.toSet())
+    assertEquals(entries.size - expectedSurvivors.size, result.removedEntryIds.size)
+  }
+
+  @Test
+  fun per_preview_count_keeps_newest_n_per_preview() {
+    val now = Instant.now()
+    // 3 previews × 30 entries each. Total 90.
+    val byPreview =
+      ('A'..'C').map { c ->
+        (0 until 30).map { i ->
+          writeEntry(
+            previewId = "Preview$c",
+            timestamp = now.minusSeconds(i.toLong() * 60),
+            suffix = "%02d".format(i),
+          )
+        }
+      }
+
+    val result = source.prune(HistoryPruneConfig(maxEntriesPerPreview = 10, maxAgeDays = 0, maxTotalSizeBytes = 0L))
+
+    // 30 entries survive (10 newest per preview).
+    val survivors = readIndexIds(tmpDir)
+    assertEquals(30, survivors.size)
+    for (group in byPreview) {
+      val newest10 = group.take(10).map { it.id }.toSet()
+      assertTrue("newest 10 of group must survive", survivors.containsAll(newest10))
+    }
+    // 60 entries removed (20 oldest per preview).
+    assertEquals(60, result.removedEntryIds.size)
+  }
+
+  @Test
+  fun total_size_pass_drops_oldest_until_under_threshold() {
+    val now = Instant.now()
+    // 50 entries × 10 MB each = 500 MB. Cap at 300 MB → 30 newest survive.
+    val tenMb = ByteArray(10 * 1024 * 1024) { (it and 0xff).toByte() }
+    val entries =
+      (0 until 50).map { i ->
+        // Each entry has a unique pngHash to defeat dedup.
+        val bytes = tenMb.copyOf().apply { this[0] = i.toByte() }
+        val ts = now.minusSeconds(i.toLong() * 60)
+        writeEntry(previewId = "P$i", timestamp = ts, bytes = bytes, suffix = "%02d".format(i))
+      }
+
+    val result =
+      source.prune(
+        HistoryPruneConfig(
+          maxEntriesPerPreview = 0,
+          maxAgeDays = 0,
+          maxTotalSizeBytes = 300L * 1024 * 1024,
+        )
+      )
+
+    // 50 unique previews, each entry has a unique previewId → floor protects every entry → no
+    // entries can be pruned by the size pass. Use a single-preview variant below.
+    assertEquals(0, result.removedEntryIds.size)
+    val survivors = readIndexIds(tmpDir)
+    assertEquals(entries.map { it.id }.toSet(), survivors.toSet())
+  }
+
+  @Test
+  fun total_size_pass_drops_oldest_for_single_preview_until_under_threshold() {
+    val now = Instant.now()
+    val tenMb = ByteArray(10 * 1024 * 1024) { (it and 0xff).toByte() }
+    val previewId = "OnePreview"
+    val entries =
+      (0 until 50).map { i ->
+        val bytes = tenMb.copyOf().apply { this[0] = i.toByte() }
+        val ts = now.minusSeconds(i.toLong() * 60)
+        writeEntry(
+          previewId = previewId,
+          timestamp = ts,
+          bytes = bytes,
+          suffix = "%02d".format(i),
+        )
+      }
+
+    val result =
+      source.prune(
+        HistoryPruneConfig(
+          maxEntriesPerPreview = 0,
+          maxAgeDays = 0,
+          maxTotalSizeBytes = 300L * 1024 * 1024,
+        )
+      )
+
+    val survivors = readIndexIds(tmpDir)
+    // 30 newest survive (300 MB / 10 MB = 30).
+    assertEquals(30, survivors.size)
+    assertEquals(entries.take(30).map { it.id }.toSet(), survivors.toSet())
+    assertEquals(20, result.removedEntryIds.size)
+    assertEquals(20L * 10 * 1024 * 1024, result.freedBytes)
+  }
+
+  @Test
+  fun most_recent_per_preview_always_survives_even_when_over_age() {
+    val now = Instant.now()
+    val veryOld = now.minusSeconds(100L * 24 * 3600) // 100 days old
+    val entry = writeEntry(previewId = "OldOnly", timestamp = veryOld)
+
+    val result = source.prune(HistoryPruneConfig(maxEntriesPerPreview = 0, maxAgeDays = 14, maxTotalSizeBytes = 0L))
+
+    val survivors = readIndexIds(tmpDir)
+    assertTrue("most recent of each preview survives even when over-age", survivors.contains(entry.id))
+    assertEquals(0, result.removedEntryIds.size)
+  }
+
+  @Test
+  fun dry_run_returns_removal_set_without_mutating_disk() {
+    val now = Instant.now()
+    val previewId = "P"
+    val entries =
+      (0 until 5).map { i ->
+        writeEntry(previewId = previewId, timestamp = now.minusSeconds(i.toLong() * 3600), suffix = "%02d".format(i))
+      }
+
+    val sidecarsBefore =
+      entries.map { tmpDir.resolve("P").resolve("${it.id}.json") }.filter { Files.exists(it) }
+    val pngsBefore = entries.map { tmpDir.resolve("P").resolve("${it.id}.png") }.filter { Files.exists(it) }
+    val indexBefore = Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME))
+
+    val result =
+      source.prune(
+        HistoryPruneConfig(maxEntriesPerPreview = 1, maxAgeDays = 0, maxTotalSizeBytes = 0L),
+        dryRun = true,
+      )
+
+    // 4 of 5 marked for removal (newest one survives via floor + newest-1 via per-preview cap).
+    assertEquals(4, result.removedEntryIds.size)
+    // Disk unchanged.
+    assertEquals(
+      sidecarsBefore,
+      entries.map { tmpDir.resolve("P").resolve("${it.id}.json") }.filter { Files.exists(it) },
+    )
+    assertEquals(
+      pngsBefore,
+      entries.map { tmpDir.resolve("P").resolve("${it.id}.png") }.filter { Files.exists(it) },
+    )
+    assertEquals(indexBefore, Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)))
+  }
+
+  @Test
+  fun dedup_by_hash_preserves_png_when_other_sidecar_still_references_it() {
+    // Two entries share the same bytes (and therefore same pngHash). Source dedups: only the first
+    // PNG file is on disk; both sidecars' pngPath points at it. Pruning the SECOND sidecar must
+    // leave the PNG intact (the first sidecar still references it). Pruning the FIRST sidecar
+    // alone is the same: the second sidecar still references the file via the same name.
+    val previewId = "Dedup"
+    val sharedBytes = "shared-bytes".toByteArray()
+    val now = Instant.now()
+    val first =
+      writeEntry(
+        previewId = previewId,
+        timestamp = now.minusSeconds(3600),
+        bytes = sharedBytes,
+        suffix = "first",
+      )
+    val second =
+      writeEntry(
+        previewId = previewId,
+        timestamp = now,
+        bytes = sharedBytes,
+        suffix = "second",
+      )
+
+    val previewDir = tmpDir.resolve(previewId)
+    val firstPng = previewDir.resolve("${first.id}.png")
+    val secondPng = previewDir.resolve("${second.id}.png")
+    assertTrue(Files.exists(firstPng))
+    assertFalse("dedup → second PNG file should not exist", Files.exists(secondPng))
+
+    // Prune with maxEntriesPerPreview=1 → second survives (it's the newest), first removed.
+    val result = source.prune(HistoryPruneConfig(maxEntriesPerPreview = 1, maxAgeDays = 0, maxTotalSizeBytes = 0L))
+    assertEquals(listOf(first.id), result.removedEntryIds)
+    // freedBytes is 0 because the surviving sidecar's pngPath still references "${first.id}.png".
+    assertEquals(0L, result.freedBytes)
+    assertTrue("PNG must remain — dedup target still referenced", Files.exists(firstPng))
+
+    // Sidecar for the removed entry is gone.
+    assertFalse("first sidecar must be gone", Files.exists(previewDir.resolve("${first.id}.json")))
+    // Survivor sidecar still on disk.
+    assertTrue(Files.exists(previewDir.resolve("${second.id}.json")))
+  }
+
+  @Test
+  fun index_rewrite_is_atomic_against_failures() {
+    // Synthesise N entries; verify the index is bytewise rewritten cleanly. We can't easily simulate
+    // a mid-write crash without injecting a filesystem error, so we instead verify the contract: the
+    // tempfile-then-rename sequence leaves no partial index. Approximation: assert the temp file
+    // does not exist after a successful prune, and that the index lines are exactly the surviving
+    // entries (no torn lines, no orphaned entries).
+    val now = Instant.now()
+    val previewId = "P"
+    val entries =
+      (0 until 10).map { i ->
+        writeEntry(
+          previewId = previewId,
+          timestamp = now.minusSeconds(i.toLong() * 60),
+          suffix = "%02d".format(i),
+        )
+      }
+    source.prune(HistoryPruneConfig(maxEntriesPerPreview = 3, maxAgeDays = 0, maxTotalSizeBytes = 0L))
+    val tempfile = tmpDir.resolve("${LocalFsHistorySource.INDEX_FILENAME}.tmp")
+    assertFalse("prune temp file must be cleaned up after success", Files.exists(tempfile))
+    val indexLines =
+      Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)).filter { it.isNotBlank() }
+    assertEquals(3, indexLines.size)
+    // Every line is bytewise complete JSON (no torn lines).
+    val json = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
+    for (line in indexLines) {
+      assertNotNull(json.decodeFromString(HistoryEntry.serializer(), line))
+    }
+  }
+
+  @Test
+  fun pass_order_is_age_then_count_then_size() {
+    // Compose: 10 entries with one preview-id, mixed timestamps + sizes. Age cuts 4; count cap of
+    // 3 should then survive newest 3 (one is dropped by age, count cap means more drop). Size cap
+    // is loose so it's a no-op.
+    val now = Instant.now()
+    val previewId = "P"
+    // entries 0..3 are recent (within 14 days), 4..9 are over 100 days old.
+    val recent =
+      (0 until 4).map { i ->
+        writeEntry(
+          previewId = previewId,
+          timestamp = now.minusSeconds(i.toLong() * 60),
+          suffix = "r$i",
+        )
+      }
+    val old =
+      (0 until 6).map { i ->
+        writeEntry(
+          previewId = previewId,
+          timestamp = now.minusSeconds(100L * 24 * 3600 + i.toLong() * 60),
+          suffix = "o$i",
+        )
+      }
+
+    val result =
+      source.prune(
+        HistoryPruneConfig(
+          maxEntriesPerPreview = 3,
+          maxAgeDays = 14,
+          maxTotalSizeBytes = 0L,
+        )
+      )
+
+    // After age pass: recent (4) + the floor-protected oldest survives. So 5 entries survive age pass.
+    // Then per-preview count of 3 caps surviving recent entries: actually the floor is just one per
+    // preview (the *newest* of all entries), so count cap drops 5 - 3 = 2 more, but the floor
+    // protects entry recent[0]. We expect: recent[0,1,2] survive (newest 3); the rest pruned.
+    val survivors = readIndexIds(tmpDir)
+    assertEquals(setOf(recent[0].id, recent[1].id, recent[2].id), survivors.toSet())
+    // Removed: recent[3] (per-preview cap kicks in), all 6 old (age pass), so 7 removals.
+    assertEquals(7, result.removedEntryIds.size)
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Helpers — write a synthetic entry directly via the source's write path so dedup / index /
+  // sidecars all match the production shape.
+  // ---------------------------------------------------------------------------------------
+
+  private fun writeEntry(
+    previewId: String,
+    timestamp: Instant,
+    bytes: ByteArray = ("preview-$previewId-${timestamp.toEpochMilli()}").toByteArray(),
+    suffix: String = "",
+  ): HistoryEntry {
+    val isoTimestamp =
+      OffsetDateTime.ofInstant(timestamp, ZoneOffset.UTC)
+        .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+    val hash = LocalFsHistorySource.sha256Hex(bytes)
+    val tsId =
+      OffsetDateTime.ofInstant(timestamp, ZoneOffset.UTC)
+        .format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
+    val id = "$tsId-$suffix-${hash.take(8)}"
+    val entry =
+      HistoryEntry(
+        id = id,
+        previewId = previewId,
+        module = ":t",
+        timestamp = isoTimestamp,
+        pngHash = hash,
+        pngSize = bytes.size.toLong(),
+        pngPath = "$id.png",
+        producer = "daemon",
+        trigger = "renderNow",
+        source = HistorySourceInfo(kind = "fs", id = "fs:${tmpDir.toAbsolutePath()}"),
+        renderTookMs = 1L,
+      )
+    source.write(entry, bytes)
+    return entry
+  }
+
+  private fun readIndexIds(historyDir: Path): List<String> {
+    val indexFile = historyDir.resolve(LocalFsHistorySource.INDEX_FILENAME)
+    if (!Files.exists(indexFile)) return emptyList()
+    val json = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
+    return Files.readAllLines(indexFile).filter { it.isNotBlank() }.map {
+      json.decodeFromString(HistoryEntry.serializer(), it).id
+    }
+  }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -5,6 +5,7 @@ package ee.schimke.composeai.daemon
 import ee.schimke.composeai.daemon.history.GitProvenance
 import ee.schimke.composeai.daemon.history.GitRefHistorySource
 import ee.schimke.composeai.daemon.history.HistoryManager
+import ee.schimke.composeai.daemon.history.HistoryPruneConfig
 import java.io.File
 import java.nio.file.Path
 
@@ -157,19 +158,23 @@ fun main(args: Array<String>) {
   // one-time warn-level `log` notification with a hint for the human and degrade gracefully
   // (no entries in `history/list`). See HISTORY.md § "GitRefHistorySource".
   val gitRefHistoryRefs = GitRefHistorySource.parseRefsSysprop()
-  val historyManager: HistoryManager? = historyDirProp?.let { dir ->
-    System.err.println(
-      "compose-ai-tools desktop daemon: HistoryManager active (dir=$dir, " +
-        "gitRefs=${gitRefHistoryRefs})"
-    )
-    HistoryManager.forLocalFsAndGitRefs(
-      historyDir = Path.of(dir),
-      module = System.getProperty(MODULE_ID_PROP) ?: "",
-      gitProvenance = gitProvenance,
-      gitRefs = gitRefHistoryRefs,
-      repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
-    )
-  }
+  // H4 — prune config from sysprops (defaults: 50 entries / 14 days / 500 MB / 1h auto interval).
+  val pruneConfig = HistoryPruneConfig.fromSysprops()
+  val historyManager: HistoryManager? =
+    historyDirProp?.let { dir ->
+      System.err.println(
+        "compose-ai-tools desktop daemon: HistoryManager active (dir=$dir, " +
+          "gitRefs=${gitRefHistoryRefs}, pruneConfig=$pruneConfig)"
+      )
+      HistoryManager.forLocalFsAndGitRefs(
+        historyDir = Path.of(dir),
+        module = System.getProperty(MODULE_ID_PROP) ?: "",
+        gitProvenance = gitProvenance,
+        gitRefs = gitRefHistoryRefs,
+        repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
+        pruneConfig = pruneConfig,
+      )
+    }
 
   val server =
     JsonRpcServer(

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/FakeDaemonMain.kt
@@ -9,6 +9,7 @@ import ee.schimke.composeai.daemon.PreviewInfoDto
 import ee.schimke.composeai.daemon.history.GitProvenance
 import ee.schimke.composeai.daemon.history.GitRefHistorySource
 import ee.schimke.composeai.daemon.history.HistoryManager
+import ee.schimke.composeai.daemon.history.HistoryPruneConfig
 import java.io.File
 import java.nio.file.Path
 
@@ -100,18 +101,23 @@ fun main(args: Array<String>) {
   // GitRefHistorySources alongside the writable LocalFsHistorySource. Tests that don't set the
   // sysprop see the pre-H10 single-source behaviour.
   val gitRefHistoryRefs = GitRefHistorySource.parseRefsSysprop()
-  val historyManager: HistoryManager? = historyDirProp?.let { dir ->
-    System.err.println(
-      "compose-ai-daemon harness: HistoryManager active (dir=$dir, gitRefs=${gitRefHistoryRefs})"
-    )
-    HistoryManager.forLocalFsAndGitRefs(
-      historyDir = Path.of(dir),
-      module = System.getProperty("composeai.daemon.moduleId") ?: ":harness",
-      gitProvenance = GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of)),
-      gitRefs = gitRefHistoryRefs,
-      repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
-    )
-  }
+  // H4 — prune config from sysprops. Tests pass tight values via FakeHarnessLauncher.
+  val pruneConfig = HistoryPruneConfig.fromSysprops()
+  val historyManager: HistoryManager? =
+    historyDirProp?.let { dir ->
+      System.err.println(
+        "compose-ai-daemon harness: HistoryManager active (dir=$dir, gitRefs=${gitRefHistoryRefs}, " +
+          "pruneConfig=$pruneConfig)"
+      )
+      HistoryManager.forLocalFsAndGitRefs(
+        historyDir = Path.of(dir),
+        module = System.getProperty("composeai.daemon.moduleId") ?: ":harness",
+        gitProvenance = GitProvenance(workspaceRoot = workspaceRootProp?.let(Path::of)),
+        gitRefs = gitRefHistoryRefs,
+        repoRoot = workspaceRootProp?.let(Path::of) ?: Path.of(dir).parent,
+        pruneConfig = pruneConfig,
+      )
+    }
 
   val server =
     JsonRpcServer(

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessClient.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessClient.kt
@@ -9,6 +9,8 @@ import ee.schimke.composeai.daemon.protocol.HistoryDiffParams
 import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
 import ee.schimke.composeai.daemon.protocol.HistoryListParams
 import ee.schimke.composeai.daemon.protocol.HistoryListResult
+import ee.schimke.composeai.daemon.protocol.HistoryPruneParams
+import ee.schimke.composeai.daemon.protocol.HistoryPruneResult
 import ee.schimke.composeai.daemon.protocol.HistoryReadParams
 import ee.schimke.composeai.daemon.protocol.HistoryReadResultDto
 import ee.schimke.composeai.daemon.protocol.InitializeParams
@@ -200,6 +202,22 @@ private constructor(
       response["result"]
         ?: error("history/diff: no result — error=${response["error"]}, full=${response}")
     return json.decodeFromJsonElement(HistoryDiffResult.serializer(), resultElem)
+  }
+
+  /** H4 — drives `history/prune`. Returns the typed result. */
+  fun historyPrune(params: HistoryPruneParams = HistoryPruneParams()): HistoryPruneResult {
+    val rpcId = nextId.getAndIncrement()
+    val request =
+      JsonRpcRequest(
+        id = rpcId,
+        method = "history/prune",
+        params = json.encodeToJsonElement(HistoryPruneParams.serializer(), params),
+      )
+    val response = sendAndPoll(rpcId, request, 10.seconds)
+    val resultElem =
+      response["result"]
+        ?: error("history/prune: no result — error=${response["error"]}, full=${response}")
+    return json.decodeFromJsonElement(HistoryPruneResult.serializer(), resultElem)
   }
 
   /** H3 — like [historyDiff] but returns the raw response so callers can assert on error codes. */

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
@@ -51,6 +51,14 @@ class FakeHarnessLauncher(
    * spawned JVM.
    */
   private val gitRefHistory: List<String> = emptyList(),
+  /** H4 — when non-null, sets `-Dcomposeai.daemon.history.maxEntriesPerPreview=…` on the JVM. */
+  private val pruneMaxEntriesPerPreview: Int? = null,
+  /** H4 — when non-null, sets `-Dcomposeai.daemon.history.maxAgeDays=…` on the JVM. */
+  private val pruneMaxAgeDays: Int? = null,
+  /** H4 — when non-null, sets `-Dcomposeai.daemon.history.maxTotalSizeBytes=…` on the JVM. */
+  private val pruneMaxTotalSizeBytes: Long? = null,
+  /** H4 — when non-null, sets `-Dcomposeai.daemon.history.autoPruneIntervalMs=…` on the JVM. */
+  private val pruneAutoIntervalMs: Long? = null,
 ) : HarnessLauncher {
 
   override val name: String = "fake"
@@ -73,6 +81,14 @@ class FakeHarnessLauncher(
           add("-Dcomposeai.daemon.workspaceRoot=${workspaceRoot.absolutePath}")
         if (gitRefHistory.isNotEmpty())
           add("-Dcomposeai.daemon.gitRefHistory=${gitRefHistory.joinToString(",")}")
+        if (pruneMaxEntriesPerPreview != null)
+          add("-Dcomposeai.daemon.history.maxEntriesPerPreview=$pruneMaxEntriesPerPreview")
+        if (pruneMaxAgeDays != null)
+          add("-Dcomposeai.daemon.history.maxAgeDays=$pruneMaxAgeDays")
+        if (pruneMaxTotalSizeBytes != null)
+          add("-Dcomposeai.daemon.history.maxTotalSizeBytes=$pruneMaxTotalSizeBytes")
+        if (pruneAutoIntervalMs != null)
+          add("-Dcomposeai.daemon.history.autoPruneIntervalMs=$pruneAutoIntervalMs")
         addAll(extraJvmArgs)
         add("-cp")
         add(cpString)

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S11HistoryPruneAndroidRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S11HistoryPruneAndroidRealModeTest.kt
@@ -1,0 +1,19 @@
+package ee.schimke.composeai.daemon.harness
+
+import org.junit.Ignore
+import org.junit.Test
+
+/**
+ * Real-mode android counterpart to [S11HistoryPruneTest] — placeholder for H4 prune.
+ *
+ * The fake-mode S11 proves the wire shape end-to-end. The real-mode android landing waits on the
+ * Robolectric sandbox + history feedback loop being driven through a renderNow burst that
+ * generates entries to prune. Out of scope for the H4 PR.
+ */
+@Ignore("S11 real-mode android placeholder — see KDoc")
+class S11HistoryPruneAndroidRealModeTest {
+  @Test
+  fun s11_history_prune_real_mode_android_placeholder() {
+    // Placeholder body — the @Ignore annotation skips this test in JUnit.
+  }
+}

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S11HistoryPruneDesktopRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S11HistoryPruneDesktopRealModeTest.kt
@@ -1,0 +1,19 @@
+package ee.schimke.composeai.daemon.harness
+
+import org.junit.Ignore
+import org.junit.Test
+
+/**
+ * Real-mode desktop counterpart to [S11HistoryPruneTest] — placeholder for H4 prune.
+ *
+ * The fake-mode S11 proves the wire shape end-to-end (params + result + disk effect). The
+ * real-mode landing waits on the production daemon being driven through a real renderNow loop
+ * that produces history entries before pruning runs against them. Out of scope for the H4 PR.
+ */
+@Ignore("S11 real-mode desktop placeholder — see KDoc")
+class S11HistoryPruneDesktopRealModeTest {
+  @Test
+  fun s11_history_prune_real_mode_desktop_placeholder() {
+    // Placeholder body — the @Ignore annotation skips this test in JUnit.
+  }
+}

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S11HistoryPruneTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S11HistoryPruneTest.kt
@@ -1,0 +1,160 @@
+package ee.schimke.composeai.daemon.harness
+
+import ee.schimke.composeai.daemon.history.HistoryEntry
+import ee.schimke.composeai.daemon.history.HistorySourceInfo
+import ee.schimke.composeai.daemon.history.LocalFsHistorySource
+import ee.schimke.composeai.daemon.protocol.HistoryListParams
+import ee.schimke.composeai.daemon.protocol.HistoryPruneParams
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Scenario **S11 — History prune (fake mode)**. Pre-populates a [LocalFsHistorySource] under
+ * `<tmpHistoryDir>` with N entries on a single preview, drives [FakeDaemonMain] (no rendering)
+ * with `composeai.daemon.history.maxEntriesPerPreview=3`, calls `history/prune` over the wire,
+ * and asserts the wire-shape result matches the disk effect.
+ *
+ * Mirrors the S* fake-mode pattern: the daemon only sees the pre-populated history dir; nothing is
+ * rendered during the test. We exercise the prune wire-format end-to-end without any renderer.
+ */
+class S11HistoryPruneTest {
+
+  private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = false
+  }
+
+  @Test
+  fun s11_history_prune_fake_mode() {
+    val moduleBuildDir = File("build")
+    val fixtureDir =
+      File(moduleBuildDir, "daemon-harness/fixtures/s11").apply {
+        deleteRecursively()
+        mkdirs()
+      }
+    File(fixtureDir, "previews.json").writeText("[]")
+
+    val historyDir = Files.createTempDirectory("s11-history").toFile().apply { deleteOnExit() }
+    // Populate the history dir with 5 entries on a single preview. We write directly via
+    // LocalFsHistorySource so the index.jsonl + sidecars + PNGs land in the same shape the daemon
+    // would produce.
+    val previewId = "preview-A"
+    val previewDir = File(historyDir, previewId)
+    val source = LocalFsHistorySource(historyDir = historyDir.toPath())
+    val written =
+      (0 until 5).map { i ->
+        val ts = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(i.toLong())
+        val isoTs = ts.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        val tsStem = ts.format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
+        val bytes = "render-$i".toByteArray(StandardCharsets.UTF_8)
+        val hash = LocalFsHistorySource.sha256Hex(bytes)
+        val id = "$tsStem-${hash.take(8)}"
+        val entry =
+          HistoryEntry(
+            id = id,
+            previewId = previewId,
+            module = ":harness",
+            timestamp = isoTs,
+            pngHash = hash,
+            pngSize = bytes.size.toLong(),
+            pngPath = "$id.png",
+            producer = "daemon",
+            trigger = "renderNow",
+            source =
+              HistorySourceInfo(kind = "fs", id = "fs:${historyDir.toPath().toAbsolutePath()}"),
+            renderTookMs = 1L,
+          )
+        source.write(entry, bytes)
+        entry
+      }
+
+    // Sanity check: 5 sidecars + 5 PNGs + 1 index.
+    assertEquals(5, previewDir.listFiles { _, name -> name.endsWith(".json") }!!.size)
+    assertEquals(5, previewDir.listFiles { _, name -> name.endsWith(".png") }!!.size)
+
+    val classpath =
+      System.getProperty("java.class.path")
+        .split(File.pathSeparator)
+        .filter { it.isNotBlank() }
+        .map { File(it) }
+    val launcher =
+      FakeHarnessLauncher(
+        fixtureDir = fixtureDir,
+        classpath = classpath,
+        historyDir = historyDir,
+        // Disable auto-prune by setting interval to 0 — the test drives prune manually.
+        pruneAutoIntervalMs = 0L,
+      )
+    val client = HarnessClient.start(launcher)
+    try {
+      client.initialize()
+      client.sendInitialized()
+
+      // Manual prune with maxEntriesPerPreview=2: 5 entries → 2 newest survive (newest by floor +
+      // newest-1 by cap), 3 dropped.
+      val result =
+        client.historyPrune(
+          HistoryPruneParams(
+            maxEntriesPerPreview = 2,
+            maxAgeDays = 0,
+            maxTotalSizeBytes = 0L,
+          )
+        )
+      assertEquals(3, result.removedEntries.size)
+      assertTrue("freedBytes must be positive after live prune", result.freedBytes > 0L)
+      assertEquals(1, result.sourceResults.size)
+
+      // Disk effect: 2 sidecars + 2 PNGs survive.
+      val sidecarsAfter = previewDir.listFiles { _, name -> name.endsWith(".json") }!!.toList()
+      val pngsAfter = previewDir.listFiles { _, name -> name.endsWith(".png") }!!.toList()
+      assertEquals(2, sidecarsAfter.size)
+      assertEquals(2, pngsAfter.size)
+
+      // The two surviving sidecars must be the 2 newest (lowest index in our `written` list).
+      val survivingIds = sidecarsAfter.map { it.nameWithoutExtension }.toSet()
+      assertEquals(setOf(written[0].id, written[1].id), survivingIds)
+
+      // history/list confirms over the wire.
+      val listed = client.historyList(HistoryListParams(previewId = previewId))
+      assertEquals(2, listed.totalCount)
+
+      // Dry-run prune with a tighter budget — would-remove returned, no further mutation.
+      val dryResult =
+        client.historyPrune(
+          HistoryPruneParams(
+            maxEntriesPerPreview = 1,
+            maxAgeDays = 0,
+            maxTotalSizeBytes = 0L,
+            dryRun = true,
+          )
+        )
+      assertEquals(1, dryResult.removedEntries.size)
+      // Disk state unchanged from before the dry-run.
+      assertEquals(2, previewDir.listFiles { _, name -> name.endsWith(".json") }!!.size)
+      assertFalse(
+        "dry-run must NOT delete the to-be-removed sidecar",
+        !File(previewDir, "${dryResult.removedEntries[0]}.json").exists(),
+      )
+
+      val exitCode = client.shutdownAndExit()
+      assertEquals(0, exitCode)
+    } catch (t: Throwable) {
+      System.err.println("S11HistoryPruneTest failed; stderr from daemon:\n${client.dumpStderr()}")
+      throw t
+    } finally {
+      try {
+        client.close()
+      } catch (_: Throwable) {}
+      historyDir.deleteRecursively()
+    }
+  }
+}

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -635,25 +635,30 @@ result: {
 `mode = "pixel"` runs a real pixel comparison and writes a diff PNG
 into a sibling `.diffs/` subfolder for the consumer to read.
 
-### `history/prune` (request, client → daemon)
+### `history/prune` (request, client → daemon) — H4 landed
 
 ```ts
 params: {
-  maxEntriesPerPreview?: number;
+  maxEntriesPerPreview?: number;     // null → daemon-configured default; 0 / negative → disabled
   maxAgeDays?: number;
-  maxSizeBytes?: number;
-  dryRun?: boolean;
+  maxTotalSizeBytes?: number;
+  dryRun?: boolean;                  // default false
 }
 result: {
-  removedEntries: string[];        // ids
+  removedEntries: string[];          // ids removed (or would be in dry-run)
   freedBytes: number;
+  sourceResults: { [sourceId: string]: { removedEntryIds: string[]; freedBytes: number } };
 }
 ```
 
 Manual prune trigger. Auto-prune runs on a configurable interval
-(default 1h) using the same logic with config defaults. The dry-run
-mode lets a consumer ask "what would auto-prune do?" without
+(default 1h) using the same logic with the daemon's defaults. The
+dry-run mode lets a consumer ask "what would auto-prune do?" without
 mutating the archive.
+
+`sourceResults` is keyed by `HistorySource.id`. Only WRITABLE sources
+participate — read-only `GitRefHistorySource` / HTTP backends are
+skipped (their pruning is the producer's concern).
 
 ### `historyAdded` (notification, daemon → client)
 
@@ -782,18 +787,37 @@ PR #311; there is no second writer to coordinate with.
 
 ## Pruning policy
 
-Configured via the existing `composePreview { … }` DSL plus a new
-nested block:
+H4 — landed via `HistoryPruneConfig` in `:daemon:core`. The production
+daemon mains read defaults from sysprops on the spawned JVM:
+
+| knob | default | sysprop |
+|---|---|---|
+| `maxEntriesPerPreview` | 50 | `composeai.daemon.history.maxEntriesPerPreview` |
+| `maxAgeDays` | 14 | `composeai.daemon.history.maxAgeDays` |
+| `maxTotalSizeBytes` | 500_000_000 (500 MB) | `composeai.daemon.history.maxTotalSizeBytes` |
+| `autoPruneIntervalMs` | 3_600_000 (1 hour) | `composeai.daemon.history.autoPruneIntervalMs` |
+
+Setting any individual knob to `0` or negative disables that knob — e.g.
+`-Dcomposeai.daemon.history.maxAgeDays=0` skips the age pass entirely.
+
+**All-off behaviour.** When EVERY knob is `≤ 0`, the auto-prune scheduler
+never starts — no thread, no work, zero overhead. This is the safety
+hatch for users who want to manage prune cadence externally (e.g. a
+nightly Gradle task) or who prefer never to prune at all.
+
+The Layer 1 DSL nested block lands separately (out of scope for H4 —
+gradle plugin will translate `composePreview { history { … } }` to the
+sysprops above in a follow-up):
 
 ```kotlin
 composePreview {
   history {
     enabled = true                 // existing
     dir = file(".history")         // existing
-    maxEntriesPerPreview = 50      // new; default 50
-    maxAgeDays = 14                // new; default 14
-    maxTotalSizeBytes = 500_000_000 // new; default 500 MB
-    autoPruneIntervalMin = 60      // new; daemon-only; default 60min
+    maxEntriesPerPreview = 50      // future Layer-1 wiring
+    maxAgeDays = 14
+    maxTotalSizeBytes = 500_000_000
+    autoPruneIntervalMin = 60
   }
 }
 ```
@@ -810,9 +834,25 @@ Pruning never drops the most recent entry per preview, even if it
 violates a size cap — the diff feature requires at least one prior
 entry to be useful.
 
-The daemon emits `historyPruned` after each auto-prune. Manual
-prunes (via `history/prune`) emit one notification with the full
-removed set.
+**Index atomicity.** The index rewrite is tempfile-then-atomic-rename so
+an interrupted prune leaves either the old or the new index — never a
+partial one. Sidecar / PNG deletes are best-effort (a failure logs to
+stderr but doesn't abort the prune; orphaned files self-heal on the
+next pass).
+
+**PNG dedup-aware delete.** Multiple sidecars may share one PNG file
+(dedup-by-hash). When a sidecar is removed but a SURVIVING sidecar
+still references the same PNG, the PNG file stays on disk. `freedBytes`
+in [PruneResult] only counts entries whose PNG actually got deleted.
+
+**Read-only sources.** `GitRefHistorySource` and any future read-only
+backend (HTTP) skip pruning entirely — read-only from the daemon's
+perspective; cleanup is the producer's concern.
+
+The daemon emits `historyPruned` after each NON-EMPTY auto-prune pass.
+Empty (no-op) passes do not emit a notification (don't spam clients).
+Manual prunes (via `history/prune`) emit one notification with the full
+removed set, with `reason: "manual"`. Dry-run prunes never emit.
 
 ## Layering rules
 
@@ -853,7 +893,7 @@ index; old indices stay readable as v0.
 | **H1** | Daemon writes sidecar + index entry per render | Layer 2 | — |
 | **H2** | `history/list` + `history/read` + `historyAdded` notification | Layer 2 | H1 |
 | ~~**H3**~~ | ~~`history/diff` (metadata mode)~~ | Layer 2 | H2 — landed |
-| **H4** | Auto-prune + `historyPruned` notification | Layer 2 | H2 |
+| ~~**H4**~~ | ~~Auto-prune + `historyPruned` notification~~ | Layer 2 | H2 — landed |
 | **H5** | `history/diff` (pixel mode + diff PNG) | Layer 2 | H3 |
 | **H6** | MCP resource + tool mapping | Layer 3 | H2 + `:daemon:mcp` phase 2 |
 | **H7** | VS Code Preview History panel | extension | H2 |

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -289,9 +289,44 @@ Errors:
 - `HistoryPixelNotImplemented` (-32012) — `mode = "pixel"` was requested but the pixel pass is
   reserved for phase H5.
 
-### `history/prune` (phase H4+, reserved)
+### `history/prune` (phase H4)
 
-Not implemented in H1+H2. Calls return `MethodNotFound` (-32601) until H4 lands.
+```ts
+params: {
+  maxEntriesPerPreview?: number;     // null → use daemon-configured default
+  maxAgeDays?: number;               // null → use daemon-configured default
+  maxTotalSizeBytes?: number;        // null → use daemon-configured default
+  dryRun?: boolean;                  // default false
+}
+result: {
+  removedEntries: string[];          // entry ids removed (or would be in dry-run)
+  freedBytes: number;                // sum of pngSize for entries whose PNG actually got deleted
+  sourceResults: {                   // per-source breakdown; only writable sources are listed
+    [sourceId: string]: {
+      removedEntryIds: string[];
+      freedBytes: number;
+    };
+  };
+}
+```
+
+Each per-call parameter overrides the daemon's configured default for THIS call only — the
+auto-prune scheduler keeps using its configured defaults. Set any value to `0` or negative to
+disable that knob (e.g. `maxAgeDays: 0` → no age-based pruning).
+
+`dryRun = true` returns the would-remove set without touching disk; does NOT emit
+`historyPruned`. `dryRun = false` (default) mutates and emits a `historyPruned` notification
+when the prune removed at least one entry.
+
+**Pass order.** Age → per-preview count → total size, with the "never drop the most recent
+entry per preview" floor enforced throughout. See HISTORY.md § "Pruning policy".
+
+**Read-only sources.** `GitRefHistorySource` and any other read-only backend skip pruning
+entirely (read-only from the daemon's perspective; cleanup is the producer's concern). Their
+ids do not appear in `sourceResults`.
+
+**No history configured.** When the daemon has no writable history source, returns an empty
+result rather than an error.
 
 ## 6. Daemon → client notifications
 
@@ -430,9 +465,18 @@ the shape of `discoveryUpdated`. Clients that subscribe avoid polling `history/l
 The `pngHash` field on `entry` lets a subscriber decide cheaply whether the bytes are different
 from the previous render — if not, skip re-fetching. See [HISTORY.md § "historyAdded"](HISTORY.md#historyadded-notification-daemon--client).
 
-### `historyPruned` (phase H4+, reserved)
+### `historyPruned` (phase H4)
 
-Not implemented in H1+H2. Documented in [HISTORY.md § "historyPruned"](HISTORY.md#historypruned-notification-daemon--client) for the H4 landing.
+```ts
+{
+  removedIds: string[];               // entry ids removed
+  freedBytes: number;                 // sum of pngSize for entries whose PNG actually got deleted
+  reason: "auto" | "manual";          // AUTO = scheduler; MANUAL = history/prune RPC
+}
+```
+
+Emitted after each NON-EMPTY prune pass. Empty (no-op) passes produce no notification.
+`dryRun` calls never emit. See HISTORY.md § "Pruning policy".
 
 ## 7. Versioning
 

--- a/docs/daemon/TODO.md
+++ b/docs/daemon/TODO.md
@@ -695,7 +695,7 @@ Tracking the daemon-side history phases from [HISTORY.md § "Phasing"](HISTORY.m
 - **H1 — Daemon writes sidecar + index entry per render** ✅ landed
 - **H2 — `history/list` + `history/read` + `historyAdded` notification** ✅ landed
 - **H3 — `history/diff` (metadata mode)** ✅ landed
-- **H4 — Auto-prune + `historyPruned` notification** — still open
+- **H4 — Auto-prune + `historyPruned` notification** ✅ landed
 - **H5 — `history/diff` (pixel mode + diff PNG)** — still open
 - **H9 — `HistorySource` interface + multi-source merging in `historyManager`** ✅ landed (the
   interface arrived with H1+H2; multi-source merging arrived with H10-read)


### PR DESCRIPTION
## Summary

Implements phase H4 of [docs/daemon/HISTORY.md](https://github.com/yschimke/compose-ai-tools/blob/main/docs/daemon/HISTORY.md): pruning. Without this the \`.compose-preview-history/\` archive grows unbounded; H4 is what makes it safe to leave history on by default (paired with PR #334 which actually turns it on in production).

### Configuration

\`HistoryPruneConfig\` with four knobs, all sysprop-overridable; set ≤ 0 to disable any individual one; all-off disables auto-prune entirely.

| Knob | Default | Sysprop |
|---|---|---|
| \`maxEntriesPerPreview\` | 50 | \`composeai.daemon.history.maxEntriesPerPreview\` |
| \`maxAgeDays\` | 14 | \`composeai.daemon.history.maxAgeDays\` |
| \`maxTotalSizeBytes\` | 500 MB | \`composeai.daemon.history.maxTotalSizeBytes\` |
| \`autoPruneIntervalMs\` | 1 h | \`composeai.daemon.history.autoPruneIntervalMs\` |

### Pruning order

Three passes, each on the survivor set from the previous:

1. **Age** — drop entries older than \`maxAgeDays\`
2. **Per-preview count** — keep newest N per \`previewId\`
3. **Total size** — if still over the cap, drop oldest until under

Floor: never drop the most recent entry per preview (diff requires at least one prior entry; the freshest render is what the user is most likely looking at right now).

### Wire surface

- New JSON-RPC method: \`history/prune\` (params accept all four overrides plus \`dryRun\`); result \`{ removedEntries, freedBytes, sourceResults }\`
- New notification: \`historyPruned\` with \`{ removedIds, freedBytes, reason: AUTO | MANUAL }\`
- Auto-prune scheduler runs at startup-plus-a-few-seconds (after sandbox boot to avoid I/O contention) then on the configured interval; emits \`historyPruned\` only on non-empty passes
- Manual \`history/prune\` always emits when there's a removal; \`dryRun=true\` returns the plan without touching disk

### Other notes

- \`LocalFsHistorySource.prune\` writes the new \`index.jsonl\` to a sibling tempfile then atomic-renames so the index is never half-written
- Dedup-by-hash respected: pruning sidecar A doesn't delete the PNG when sidecar B still references it
- \`GitRefHistorySource.prune\` is a no-op (read-only from the daemon's perspective)
- MCP \`history_prune\` tool deliberately NOT exposed (HISTORY.md §"Tools" — clients shouldn't be able to delete bytes from the archive)

## Test plan

- [x] \`./gradlew :daemon:core:test\` — green (10 LocalFsHistorySourcePruneTest cases, 3 HistoryManagerAutoPruneTest cases, JsonRpcServerHistoryIntegrationTest extended for prune)
- [x] \`./gradlew :daemon:harness:test\` — green (S11HistoryPruneTest fake-mode passes; \`@Ignore\`d real-mode placeholders for desktop + android)
- [x] \`./gradlew :daemon:desktop:test :daemon:android:testDebugUnitTest\` — green
- [x] \`./gradlew :gradle-plugin:test :cli:assemble :samples:android:assembleDebug\` — green
- [x] \`./gradlew :mcp:test\` — green (MCP module untouched)
- [ ] \`-Pharness.host=real\` — not run; fake-mode covers wire-format end-to-end