### PR TITLE
docs(daemon): scope VS Code history panel to single-preview for v1

### DIFF
--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -746,16 +746,34 @@ from the archive.
 
 ## VS Code integration
 
-A new "Preview History" panel:
+### Scope guidance — v1 is single-preview only
 
-- Scrollable timeline per preview, newest first
+Until the workflow proves itself, the panel **shows the timeline for
+exactly one preview at a time** — the one whose card the user clicked
+the history button on. No cross-preview aggregated view. No "everything
+that happened across the module" feed. Reasons:
+
+- Reduces UI surface (no filters, no preview-selector dropdown).
+- Reduces wire load — `history/list` is called with a `previewId`
+  filter, not unbounded.
+- The cross-preview view is genuinely speculative — it's not clear yet
+  what shape the user actually wants when they're looking at "history
+  for this whole module." Single-preview is the cheap, obviously
+  useful thing to ship first.
+
+Cross-preview / module-wide views are a follow-up once we have user
+signal on the per-preview flow.
+
+### Per-preview panel (v1)
+
+A "Preview History" drawer on each preview card:
+
+- Scrollable timeline for the one preview, newest first
 - Each row: thumbnail + timestamp + trigger reason + bytes-changed indicator
 - Click to expand: full PNG + metadata table
 - Select two rows + "Diff" button → runs `history/diff(mode:"pixel")`,
   shows the marked diff PNG inline
 - "Open in Editor" reveals the source file at `previewMetadata.sourceFile`
-- Filter dropdown: "all" / "only previews that changed" / "only saves
-  that came from <file>"
 
 Storage assumptions:
 - Daemon running → calls `history/list` over the existing JSON-RPC.


### PR DESCRIPTION
## Summary

User guidance: the VS Code history panel should show the timeline for **exactly one preview at a time** in v1 — no cross-preview aggregated view, no module-wide feed. Single-preview is the cheap, obviously-useful thing to ship first; cross-preview views become a follow-up once there's signal on the per-preview flow.

This PR captures that direction in [HISTORY.md § VS Code integration](https://github.com/yschimke/compose-ai-tools/blob/agent/history-vscode-scope-note/docs/daemon/HISTORY.md#vs-code-integration) so the agent currently working on the panel sees it.

## Test plan

- [x] No code changes — markdown only