### PR TITLE
docs: update daemon and MCP documentation to reflect implementation

### DIFF
--- a/docs/daemon/CLASSLOADER-FORENSICS.md
+++ b/docs/daemon/CLASSLOADER-FORENSICS.md
@@ -1,12 +1,14 @@
 # Classloader forensics — what loads what, from where
 
-> **Status:** design proposal for a diagnostic tool. No implementation
-> shipped yet. Born out of the B2.0 Android S3.5 follow-up failures —
-> two distinct attempts (ASM bytecode swap; dual-sourceset pre-compile)
-> both tripped on Compose-Android reflection in different ways, and we
-> don't have ground truth on *what's actually loaded by which
-> classloader* in either path. This doc spec's the dump that gives us
-> ground truth.
+> **Status:** implemented. The forensic-dump library lives in
+> [`:daemon:core/.../forensics/ClassloaderForensics.kt`](../../daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/forensics/ClassloaderForensics.kt);
+> the daemon-side dispatch is gated on a `forensic-dump=` payload prefix
+> in [`RobolectricHost.SandboxRunner`](../../daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt).
+> Born out of the Android S3.5 follow-up failures — two distinct attempts
+> (ASM bytecode swap; dual-sourceset pre-compile) both tripped on
+> Compose-Android reflection in different ways. The captured dump pair
+> lives at [`classloader-forensics-diff.{json,md}`](classloader-forensics-diff.md).
+> This doc is the schema reference + investigation context.
 
 ## Why
 

--- a/docs/daemon/CLASSLOADER.md
+++ b/docs/daemon/CLASSLOADER.md
@@ -1,10 +1,16 @@
-# Disposable user classloader (B2.0)
+# Disposable user classloader
 
-> **Status:** design proposal. Captures the architecture for fixing the
-> daemon's actual save-loop blocker. Implementation lands as
-> [TODO.md B2.0](TODO.md#b20--disposable-user-classloader-shared-seam).
+> **Status:** implemented. The parent/child classloader split landed in
+> `:daemon:core`'s [`UserClassLoaderHolder`](../../daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt)
+> and both backends. Per-render fresh-`Recomposer` invariant verified;
+> the soak `WeakReference` probe is live. This doc is the architecture
+> reference + risk register; the implementation now matches it.
 > Cross-referenced from
 > [DESIGN.md § 8](DESIGN.md#8-staleness-cascade--when-do-we-actually-re-render).
+>
+> Outstanding follow-ups: B2.0c (per-preview resource-read tracking) is
+> still open — see § Resource changes below. Android `S3_5` is gated on
+> a Compose-Android compiler-mangled-method-name fix.
 
 ## Why this exists
 

--- a/docs/daemon/DESIGN.md
+++ b/docs/daemon/DESIGN.md
@@ -1,6 +1,6 @@
 # Persistent preview server — design
 
-> **Status:** experimental design proposal. v1 ships behind `composePreview.experimental.daemon=true`. The Gradle `renderPreviews` task remains the always-available fallback and the CI-canonical render path.
+> **Status:** v1 implemented and ships behind `composePreview.experimental.daemon=true`. Render loop, classloader split, classpath fingerprint, incremental discovery, history, and the renderer-agnostic surface have landed across `:daemon:core` / `:daemon:android` / `:daemon:desktop`. Sandbox recycle, warm spare, and active leak detection (§ 9 + § 10 below) remain designed-but-not-implemented — wire-format surface is reserved in PROTOCOL.md but the daemon does not yet emit those notifications. The Gradle `renderPreviews` task remains the always-available fallback and the CI-canonical render path.
 
 ## 1. Goals & non-goals
 
@@ -13,7 +13,7 @@
 **Non-goals (v1)**
 
 - Per-project (cross-module) sandbox sharing — each consumer module gets its own daemon JVM.
-- CLI / MCP daemon mode — the `compose-preview` binary keeps using the Gradle task.
+- The `compose-preview` CLI binary keeps using the Gradle task. (MCP daemon mode is shipped separately as `:mcp` — see [MCP.md](MCP.md).)
 - Replacing `renderPreviews` — daemon fronts it for the editor loop only.
 - Hot kotlinc / compile-daemon integration — out of scope; we still let Gradle drive Kotlin compilation.
 - Tier-3 dependency-graph reachability index — v1 uses a conservative "module-changed = all previews stale, filtered by visibility" rule.
@@ -268,6 +268,13 @@ Enforced in code (so accidental cancellation can't sneak in):
 
 ### Recycle policy
 
+> **Not yet implemented (TODO B2.4 / B2.5 / B2.6).** The wire-format
+> surface (`sandboxRecycle`, `daemonWarming`, `daemonReady`,
+> `LeakDetectionMode`) is reserved in PROTOCOL.md but never emitted by
+> the daemon today. Sandbox age counters keep growing for the host's
+> lifetime. Designed shape below; implementation lands when the work
+> ships.
+
 Trigger on any:
 
 - **Heap (post-GC) >** `daemon.maxHeapMb` (default 1024). Hard ceiling.
@@ -311,6 +318,9 @@ Cheap (<5ms), in-band, emitted on `renderFinished`:
 Bench harness consumes this as CSV; CI soak test asserts bounded growth.
 
 ### Layer 2 — active leak detection (periodic, opt-in)
+
+> **Not yet implemented (TODO B2.4).** `ServerCapabilities.leakDetection`
+> on the wire is always `[]`. Designed shape below.
 
 Every Nth render (default 50) or via `--detect-leaks` daemon flag:
 

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -1,9 +1,16 @@
 # Preview history — design
 
-> **Status:** design only. Capturing the on-disk schema, JSON-RPC surface,
-> and consumer mappings so the daemon, the existing Gradle path, the
-> MCP server, and the VS Code extension can all agree on what "history"
-> means before any of them ship code.
+> **Status:** H1, H2, H3, H9, H10a have shipped — daemon writes
+> sidecars + index entries, exposes `history/list` / `history/read` /
+> `history/diff` (metadata mode), and the `HistorySource` interface
+> with multi-source merging is live including read-only
+> `GitRefHistorySource`. MCP layer (H6) ships `history_list` /
+> `history_diff` tools and `compose-preview-history://` resource URIs.
+> Outstanding: H4 (auto-prune), H5 (pixel-mode diff), H10b (gradle
+> plugin emits `composeai.daemon.gitRefHistory`), H11+ (`WRITE_LOCAL` /
+> `WRITE_PUSH` / LFS / squash GC), H7+ (VS Code panel — gated on the
+> extension picking up the surface). Full phase status in
+> [TODO.md § Phase H](TODO.md#phase-h--preview-history-parallel-to-phase-2).
 
 ## What this is
 

--- a/docs/daemon/LAYERING.md
+++ b/docs/daemon/LAYERING.md
@@ -1,9 +1,10 @@
 # Layering — keeping CLI, daemon, and MCP additive
 
-> **Status:** design rule, not implementation. Pins the architectural
-> contract that lets [DESIGN.md](DESIGN.md), [MCP.md](MCP.md), and
-> [MCP-KOTLIN.md](MCP-KOTLIN.md) ship without making the existing
-> Gradle/CLI paths a mess.
+> **Status:** active architectural rule. The daemon and MCP server
+> ([DESIGN.md](DESIGN.md), [MCP.md](MCP.md), [MCP-KOTLIN.md](MCP-KOTLIN.md))
+> have shipped without entangling the existing Gradle/CLI paths because
+> these constraints held. Mandatory reading before adding a new
+> cross-layer hook.
 
 ## What this doc fixes
 
@@ -29,7 +30,7 @@ isolation rules that prevent that.
 ```
    ┌──────────────────────────────────────────────────────────────┐
    │ Layer 3 — MCP server                          [opt-in, v2+]  │
-   │   :daemon:mcp — separate module, separate process by         │
+   │   :mcp — top-level module, separate process by default.      │
    │   default. JSON-RPC client of Layer 2.                       │
    └─────────────────────────┬────────────────────────────────────┘
                              │  PROTOCOL.md JSON-RPC over stdio
@@ -131,9 +132,9 @@ What Layer 2 must **not** be consumed by:
 ## Layer 3 — what the MCP server owns
 
 The MCP server is a thin JSON-RPC ↔ MCP translation shim, in its own
-module `:daemon:mcp`. Constraints:
+module `:mcp`. Constraints:
 
-- **MCP code lives only in `:daemon:mcp`.** Neither
+- **MCP code lives only in `:mcp`.** Neither
   `:daemon:core` nor any per-target daemon module imports
   the Kotlin MCP SDK or Ktor. The daemon stays a JSON-RPC server
   with no MCP awareness.
@@ -151,7 +152,7 @@ module `:daemon:mcp`. Constraints:
   be:
   - A deliberate launch mode flag (`--embed-daemon` or equivalent),
     not the default.
-  - Implemented with the *same* `:daemon:mcp` ↔ daemon
+  - Implemented with the *same* `:mcp` ↔ daemon
     JSON-RPC link, just over an in-memory channel transport instead
     of stdio. The MCP-side code never reaches into daemon internals
     even when colocated.
@@ -184,7 +185,7 @@ not on this list is a layering violation.
 | `composePreview.experimental.daemon { enabled }` DSL | user → L1 | Gradle DSL property | L1 |
 | `composePreviewDaemonStart` task → launch descriptor JSON | L1 → L2 | file in `build/preview-daemon/launch.json` | L1 emits, L2 reads |
 | Daemon JSON-RPC over stdio | L2 ↔ extension/supervisor | `PROTOCOL.md` | L2 |
-| MCP wire format ↔ daemon JSON-RPC translation | L3 ↔ L2 | `:daemon:mcp` shim | L3 |
+| MCP wire format ↔ daemon JSON-RPC translation | L3 ↔ L2 | `:mcp` shim | L3 |
 | `:daemon:core` `Messages.kt` types | shared by L2 + L3 | Kotlin data classes | L2 |
 | `composePreviewDaemonStart` → spawn-daemon helper used by L3's `DaemonSupervisor` | L3 → L1 | shells out to Gradle | L3 |
 
@@ -198,14 +199,14 @@ in disguise.
 Each layer can be removed without breaking the layers below it.
 
 **Removing Layer 3 (MCP):**
-- Delete `:daemon:mcp` and its task wiring.
+- Delete `:mcp` and its task wiring.
 - No other module imports it. No other module references its types.
 - Daemon and Layer 1 unaffected.
 
 **Removing Layer 2 (daemon):**
 - Delete `:daemon:core`, `:daemon:android`,
   `:daemon:desktop`, `:daemon:harness`,
-  `:daemon:mcp`.
+  `:mcp`.
 - Remove the `experimental.daemon` DSL block and the
   `composePreviewDaemonStart` task registration from `:gradle-plugin`.
 - The base `composePreview { … }` DSL and `renderPreviews` task work
@@ -247,7 +248,7 @@ Concrete rules to keep the existing paths simple:
   daemon or MCP code. The plugin's footprint stays small.
 - A user who opts into the daemon for VS Code never compiles the
   MCP module.
-- An agent author who wants MCP gets it via `:daemon:mcp` —
+- An agent author who wants MCP gets it via `:mcp` —
   one extra module to publish, one extra process to spawn, no
   changes to anyone else's flow.
 - The "may eat your laundry" daemon rollout (see DESIGN § 17) doesn't

--- a/docs/daemon/MCP-KOTLIN.md
+++ b/docs/daemon/MCP-KOTLIN.md
@@ -101,7 +101,7 @@ The load-bearing wiring layer. Owns:
 - The per-(workspace, module) preview catalog populated from daemon
   `discoveryUpdated`.
 - The MCP resources surface (`list`, `read`, `subscribe`, `unsubscribe`).
-- The MCP tools surface (10 tools — see [MCP.md § Tools](MCP.md#tools)).
+- The MCP tools surface (12 tools — see [MCP.md § Tools](MCP.md#tools)).
 - The translation of daemon `renderFinished` →
   `notifications/resources/updated`.
 - The translation of daemon `discoveryUpdated` →
@@ -168,10 +168,17 @@ notification (set semantics).
 daemon and forwards it as `setVisible` + `setFocus`. Idempotent — caches
 the last sent set per daemon and skips the wire call when unchanged.
 
-Note: the daemon currently treats `setVisible`/`setFocus` as no-ops
-(B2.5 + predictive prefetch territory). The propagator's wire calls are
-correct but not yet observable; once focus-driven priority lands the
-plumbing is already there.
+The MCP-side `set_visible` / `set_focus` tools (#332) provide a direct
+passthrough alongside the watch-driven path: an agent can express
+"render this one ahead of others" without registering a long-lived
+watch. The next `WatchPropagator.recompute` (e.g. on the next
+`discoveryUpdated` or `watch`/`unwatch`) replaces whatever the explicit
+tool set.
+
+Note: the daemon's render queue is still single-priority FIFO today, so
+the wire calls flow through but don't yet reorder the queue. The
+plumbing is there for B2.5 / predictive prefetch to start honouring
+focus.
 
 ### `PreviewUri` / `HistoryUri` / `WorkspaceId`
 

--- a/docs/daemon/MCP-KOTLIN.md
+++ b/docs/daemon/MCP-KOTLIN.md
@@ -1,425 +1,307 @@
-# MCP server in Kotlin + Ktor — implementation design
+# MCP server — implementation reference
 
-> **Status:** design proposal. Concretes the Option A architecture
-> sketched in [MCP.md](MCP.md) — separate Kotlin process, MCP-server
-> shim that JSON-RPC-clients the existing daemon. Uses
-> [`io.modelcontextprotocol:kotlin-sdk`](https://github.com/modelcontextprotocol/kotlin-sdk)
-> + Ktor for the transport layer. No implementation yet; this captures
-> the build shape so an agent (or human) can land it directly.
+> **Status:** implemented in `:mcp` (top-level module).
+> See [MCP.md](MCP.md) for the high-level mapping; this doc covers the
+> implementation specifics: module layout, transport, wire format, key
+> classes, multi-workspace lifecycle.
 
-## Why Ktor + the Kotlin MCP SDK
+## Module location
 
-The MCP SDK ships first-party from the MCP project. It has:
+`:mcp` is a top-level module (NOT `:daemon:mcp`), parallel to
+`:daemon:core` etc. It depends only on `:daemon:core` for the protocol
+message types and spawns daemon JVMs over stdio via launch descriptors
+emitted by `composePreviewDaemonStart`.
 
-- **Server / Client class abstractions** that handle the JSON-RPC
-  envelope, capability negotiation, and notification routing — so we
-  don't reimplement framing or schema validation.
-- **Transport plug-ins** for stdio, streamable HTTP, SSE, WebSocket,
-  and an in-memory `ChannelTransport` used for unit tests.
-- **Ktor integration helpers** (`mcpStreamableHttp()`, `mcp { ... }`)
-  that mount an MCP server at a configurable path inside an arbitrary
-  Ktor application — so the same server jar can run as a stdio
-  process for a local agent *or* be embedded in an HTTP server for
-  remote agents.
-- **Logging + progress + completion APIs** for free — `sendLoggingMessage`,
-  progress notifications, URI-template completion.
+## Why we don't use the MCP Kotlin SDK
 
-Building this from scratch on top of `:daemon:core`'s
-existing `JsonRpcServer` would mean re-implementing capability
-negotiation, paging, sampling, and the wire-shape conformance tests.
-The SDK is ~2KB of dep weight and saves a real chunk of work.
+The implementation is hand-rolled rather than built on
+[`io.modelcontextprotocol:kotlin-sdk`](https://github.com/modelcontextprotocol/kotlin-sdk).
+Rationale (per `mcp/build.gradle.kts:40-45`):
 
-Ktor specifically because:
+- The SDK auto-registers internal handlers for `resources/list` /
+  `resources/read` / `subscribe`, making the dynamic catalog + push
+  subscription model we want awkward to bolt on.
+- Rolling our own keeps the wire layer self-contained, mirrors the
+  proven `:daemon:core` `JsonRpcServer` framing, and removes a
+  0.x-version-pin risk.
+- The SDK can be reintroduced as an internal refactor once the surface
+  stabilises.
 
-- The existing project already uses Kotlin/JVM end-to-end; another
-  Kotlin module fits the build matrix.
-- Streamable-HTTP for remote agents needs an HTTP server. Ktor's
-  `Application` model is the canonical Kotlin choice; the MCP SDK's
-  Ktor helpers expect it.
-- Coroutine-native — matches the daemon's existing concurrency
-  discipline (no callbacks, no Future juggling).
+The wire-shape work the SDK would do is small: capability negotiation,
+JSON-RPC envelope, LSP-style framing. The daemon already does all three
+in `:daemon:core` and we reuse the patterns.
 
-## Module structure
+## Transport
 
-New top-level module `:daemon:mcp` (mirroring the existing
-`:daemon:harness` pattern):
+**stdio only.** The MCP server reads framed JSON-RPC from stdin, writes
+to stdout. Same `Content-Length:` framing as the daemon
+([PROTOCOL.md § 1](PROTOCOL.md#1-transport)).
+
+HTTP / SSE / streamable-HTTP transports are out of scope today. If a
+remote-agent use case materialises, the right next step is to factor
+[`McpSession`](../../mcp/src/main/kotlin/ee/schimke/composeai/mcp/McpServer.kt)'s
+read/write loops behind a transport interface and add an HTTP variant
+alongside. The wire-shape code (request dispatch, notification fan-out)
+stays.
+
+## Module layout
 
 ```
-daemon/mcp/
-  build.gradle.kts
-  src/main/kotlin/ee/schimke/composeai/daemon/mcp/
-    DaemonMcpMain.kt          ← entry point: stdio by default, --http for HTTP server
-    DaemonMcpServer.kt        ← the SDK Server wired with our tools/resources
-    DaemonClient.kt           ← thin wrapper that JSON-RPC-clients the daemon JVM
-    DaemonSupervisor.kt       ← spawns + lifecycle-manages per-module daemons
-    PreviewResource.kt        ← compose-preview:// URI parsing + Resource construction
-    Subscriptions.kt          ← maps daemon's renderFinished notifications →
-                               notifications/resources/updated for subscribed URIs
-    HttpTransport.kt          ← Ktor app for streamable-HTTP mode
-  src/test/kotlin/...
-    DaemonMcpServerTest.kt    ← uses the SDK's ChannelTransport for in-process testing
-    SubscriptionsTest.kt
-    StreamableHttpIntegrationTest.kt  ← spawns the server with --http, drives via real HTTP
+mcp/
+├── build.gradle.kts
+├── scripts/
+│   ├── README.md
+│   └── real_e2e_smoke.py
+└── src/main/kotlin/ee/schimke/composeai/mcp/
+    ├── DaemonMcpMain.kt        — entry point; arg parsing; supervisor wiring
+    ├── DaemonMcpServer.kt      — the load-bearing wiring layer
+    ├── McpServer.kt            — McpSession (one connected client) + handler interface
+    ├── DaemonClient.kt         — JSON-RPC client of one daemon JVM
+    ├── DaemonSupervisor.kt     — owns per-(workspace, module) daemons
+    ├── PreviewResource.kt      — URI parsing (PreviewUri / HistoryUri / WorkspaceId / FqnGlob)
+    ├── Subscriptions.kt        — per-session subscription bookkeeping + watch entries
+    ├── WatchPropagator.kt      — translates watch unions to per-daemon setVisible/setFocus
+    ├── HistoryStore.kt         — pluggable seam (NOOP default; daemon owns history today)
+    └── protocol/
+        └── McpMessages.kt      — MCP wire-shape types
 ```
 
-Production deps:
+Test sources cover protocol conformance (`DaemonMcpServerTest`),
+fake-daemon end-to-end (`FakeDaemon` + `RealMcpEndToEndTest` gated on
+`-Pmcp.real=true`), and resource-read flows (`PreviewResourceTest`).
+
+## Key classes
+
+### `DaemonSupervisor`
+
+Owns the per-(workspace, module) daemon map. Workspaces are registered
+explicitly via the `register_project` MCP tool (or `--project <path>`
+CLI args at startup). Daemons within a workspace spawn lazily on first
+reference.
+
+`DescriptorProvider` is a pluggable seam — production reads
+`<moduleDir>/build/compose-previews/daemon-launch.json` from disk; tests
+substitute an in-memory provider.
+
+`DaemonClientFactory` is the spawn seam — production
+([`SubprocessDaemonClientFactory`](../../mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt))
+forks a JVM via `ProcessBuilder` and pipes its stdio into a
+`DaemonClient`; tests inject an in-memory factory wiring the client to a
+fake daemon over piped streams.
+
+The supervisor demultiplexes every daemon's notification stream by method
+name through `NotificationRouter`. `DaemonMcpServer` registers handlers
+for `discoveryUpdated`, `renderFinished`, `renderFailed`,
+`classpathDirty`, `historyAdded` plus an `onClose` for daemon death.
+
+### `DaemonMcpServer`
+
+The load-bearing wiring layer. Owns:
+
+- The per-(workspace, module) preview catalog populated from daemon
+  `discoveryUpdated`.
+- The MCP resources surface (`list`, `read`, `subscribe`, `unsubscribe`).
+- The MCP tools surface (10 tools — see [MCP.md § Tools](MCP.md#tools)).
+- The translation of daemon `renderFinished` →
+  `notifications/resources/updated`.
+- The translation of daemon `discoveryUpdated` →
+  `notifications/resources/list_changed`.
+- Watch propagation back to daemons via `WatchPropagator`.
+- A multi-waiter dedup map (`pendingRenders`) so concurrent reads of the
+  same URI all wake up on one `renderFinished`.
+- Two single-thread executors: `daemonLifecycleExecutor` for
+  classpath-dirty respawns, `progressBeatExecutor` for periodic
+  `notifications/progress` beats during slow renders.
+
+The render path:
+
+1. `resources/read(uri)` parses the URI, picks the right daemon, adds a
+   `CompletableFuture<RenderOutcome>` to `pendingRenders` BEFORE sending
+   `renderNow` (so the daemon's notification can't arrive ahead of the
+   wait).
+2. Optionally schedules `notifications/progress` beats every 500 ms if
+   the client opted in via `_meta.progressToken`.
+3. Awaits the future with `renderTimeoutMs` (default 60 s).
+4. Reads the PNG from disk (the daemon writes it; the MCP server reads
+   it back), encodes as base64, returns as a `BlobResourceContents`.
+
+History URIs (`compose-preview-history://…`) bypass step 1 and call
+`history/read({ inline: true })` against the daemon directly — historical
+bytes are immutable so there's no render path involved.
+
+### `McpSession`
+
+One connected MCP client. Owns a reader thread (drains stdin, dispatches
+to handlers) and serialises writes through a synchronised `OutputStream`.
+
+Method handlers are pluggable via the `McpHandlers` interface so tests
+can drive the session without a supervisor. `DaemonMcpServer.newSession`
+wires the production handler set.
+
+Capability negotiation advertises:
 
 ```kotlin
-dependencies {
-  implementation("io.modelcontextprotocol:kotlin-sdk-server:$mcpVersion")
-  implementation(project(":daemon:core"))   // for Messages.kt + JsonRpcServer types
-  implementation(libs.ktor.server.core)
-  implementation(libs.ktor.server.cio)               // CIO engine — small, coroutine-native
-  implementation(libs.ktor.server.content.negotiation)
-  implementation(libs.kotlinx.serialization.json)
-  implementation(libs.kotlinx.coroutines.core)
-}
+ServerCapabilities(
+  tools = ToolsCapability(listChanged = false),
+  resources = ResourcesCapability(subscribe = true, listChanged = true),
+)
 ```
 
-`:daemon:core` is the only daemon-side dep — same renderer-
-agnostic surface invariant that `:daemon:harness` honours. The
-shim never depends on `:daemon:android` or
-`:daemon:desktop` directly; it spawns the launch descriptor
-the same way the harness's `RealHarnessLauncher` does.
+`notifications/initialized` is optional — the response to `initialize`
+already flips the gating flag, since some clients omit the
+follow-up notification.
 
-## Server bootstrap
+### `Subscriptions` + `WatchPropagator`
 
-`DaemonMcpServer.kt` (sketch):
+Two-tier subscription model:
 
-```kotlin
-class DaemonMcpServer(
-  private val supervisor: DaemonSupervisor,
-  private val subscriptions: Subscriptions,
-) {
-  fun build(): Server {
-    val server = Server(
-      serverInfo = Implementation(name = "compose-preview-daemon", version = PluginVersion.value),
-      options = ServerOptions(
-        capabilities = ServerCapabilities(
-          tools = ServerCapabilities.Tools(listChanged = true),
-          resources = ServerCapabilities.Resources(
-            subscribe = true,         // load-bearing: push notifications
-            listChanged = true,       // discoveryUpdated → list_changed
-          ),
-          logging = ServerCapabilities.Logging(),
-        ),
-      ),
-    )
+- **Per-URI subscriptions** (`resources/subscribe(uri)`) — direct.
+- **Watch entries** (`watch` tool) — `(workspaceId, modulePath?,
+  fqnGlob?)` matchers. Expanded against the live catalog on every
+  `discoveryUpdated`.
 
-    server.addTool(
-      name = "render_preview",
-      description = "Re-render a Compose @Preview by URI; returns the rendered PNG.",
-      inputSchema = Tool.Input(
-        properties = JsonObject(mapOf(
-          "uri" to JsonObject(mapOf("type" to JsonPrimitive("string"))),
-          "tier" to JsonObject(mapOf(
-            "type" to JsonPrimitive("string"),
-            "enum" to JsonArray(listOf(JsonPrimitive("fast"), JsonPrimitive("full"))),
-          )),
-        )),
-        required = listOf("uri"),
-      ),
-    ) { request ->
-      val uri = request.arguments?.get("uri")?.jsonPrimitive?.content
-        ?: return@addTool errorResult("missing uri")
-      val tier = request.arguments?.get("tier")?.jsonPrimitive?.content ?: "full"
-      val pngBytes = supervisor.renderNow(PreviewUri.parse(uri), tier)
-      CallToolResult(content = listOf(ImageContent(data = pngBytes.encodeBase64(), mimeType = "image/png")))
-    }
+On every `renderFinished`, both the per-URI subscribers and the
+watch-matchers fire. A session subscribed AND watching gets one
+notification (set semantics).
 
-    server.addResourceProvider { listResources, readResource, subscribe, unsubscribe ->
-      // listResources: aggregates `discoverPreviews` across every supervised daemon
-      // readResource:  triggers `renderNow` if URI's PNG is stale; returns blob
-      // subscribe:     calls `subscriptions.subscribe(uri, server)` so renderFinished
-      //                pushes notifications/resources/updated
-      // unsubscribe:   inverse
-    }
+`WatchPropagator` aggregates the union of all sessions' watches per
+daemon and forwards it as `setVisible` + `setFocus`. Idempotent — caches
+the last sent set per daemon and skips the wire call when unchanged.
 
-    // Hook the supervisor's classpathDirty handler to send a logging message
-    // before exit; clients see "module classpath changed" → reconnect.
-    supervisor.onClasspathDirty { module, reason ->
-      server.sendLoggingMessage(
-        level = LoggingLevel.warning,
-        data = JsonObject(mapOf("module" to JsonPrimitive(module), "reason" to JsonPrimitive(reason))),
-      )
-      // The supervisor handles the actual respawn; the server stays up.
-    }
+Note: the daemon currently treats `setVisible`/`setFocus` as no-ops
+(B2.5 + predictive prefetch territory). The propagator's wire calls are
+correct but not yet observable; once focus-driven priority lands the
+plumbing is already there.
 
-    return server
-  }
-}
-```
+### `PreviewUri` / `HistoryUri` / `WorkspaceId`
 
-The `Server` instance is then attached to a transport in
-`DaemonMcpMain`:
+URI shape:
 
-```kotlin
-fun main(args: Array<String>) {
-  val httpPort = args.firstOrNull { it.startsWith("--http=") }?.removePrefix("--http=")?.toInt()
-  val supervisor = DaemonSupervisor(workspaceRoot = File(System.getProperty("user.dir")))
-  val subscriptions = Subscriptions()
-  val server = DaemonMcpServer(supervisor, subscriptions).build()
+- `compose-preview://<workspaceId>/<encodedModulePath>/<previewFqn>?config=<qualifier>`
+- `compose-preview-history://<workspaceId>/<encodedModulePath>/<previewFqn>/<entryId>`
 
-  if (httpPort == null) {
-    // Local agent — stdio. The supervisor's daemons live in the same process tree.
-    val transport = StdioServerTransport()
-    runBlocking {
-      server.connect(transport)
-      transport.run()
-    }
-  } else {
-    // Remote agent — Ktor streamable-HTTP. Same server, different transport.
-    embeddedServer(CIO, port = httpPort) {
-      install(ContentNegotiation) { json(McpJson) }
-      mcp { server }                  // SDK helper from io.modelcontextprotocol:kotlin-sdk
-    }.start(wait = true)
-  }
-}
-```
+`WorkspaceId` is `<sanitised-rootProjectName>-<8-char-sha256>` over the
+canonical absolute path. Two worktrees of the same repo get distinct IDs
+by construction; symlink aliases collapse.
 
-## Tools surface (v0)
+`encodedModulePath` swaps `:` for `_` so `:samples:android` rides as
+`_samples_android` inside a URI hostname segment.
 
-| Tool | Purpose | Maps to daemon's |
-|---|---|---|
-| `render_preview(uri, tier)` | Force a render, bypassing cache. Returns PNG bytes inline. | `renderNow` |
-| `discover_previews(module)` | Explicit list-now for a module. Returns a list of preview URIs + display names. Mostly redundant with `resources/list`. | `initialize` + `discoveryUpdated` |
-| `list_modules()` | What modules have a live daemon. | `DaemonSupervisor`'s in-memory state |
+`FqnGlob` compiles a glob over preview FQNs — `*` matches non-dot
+characters, `**` matches anything including dots, `?` matches one
+non-dot. Used by the `watch` tool's `fqnGlobPattern` field.
 
-`set_focus`, `set_visible`, etc. — deferred to v1+. Reactive priority
-falls out naturally from "most recent `resources/read` is highest
-priority"; explicit tools only earn their keep once an agent loop
-shows the implicit heuristic isn't enough.
+## Lifecycle
 
-## Resources surface
+### Server start
 
-URI scheme: `compose-preview://<module>/<preview-fqn>?config=<qualifier>`.
+`DaemonMcpMain.main` builds a supervisor with disk-reading descriptor
+provider + subprocess factory, instantiates `DaemonMcpServer`, registers
+any `--project <path>[:<rootProjectName>]` CLI args, hooks a JVM shutdown
+hook for graceful supervisor teardown, and starts a single `McpSession`
+on stdin/stdout. Blocks main thread on `awaitClose()` until stdin EOF.
 
-`PreviewResource.kt`:
+### First preview request for a module
 
-```kotlin
-data class PreviewUri(val module: String, val previewFqn: String, val config: String?) {
-  fun toUri(): String =
-    "compose-preview://${module.removePrefix(":")}/$previewFqn" +
-      if (config != null) "?config=$config" else ""
+Supervisor's `daemonFor(workspaceId, modulePath)` does a
+`computeIfAbsent` over the per-project daemon map; on miss, reads the
+descriptor, spawns the JVM, wires the notification stream, calls
+`initialize`. Initial preview set comes from
+`initialize.manifest.path` — supervisor reads that file and synthesises
+a `discoveryUpdated` notification through the router so the catalog
+populates on the same code path as incremental updates.
 
-  companion object {
-    fun parse(s: String): PreviewUri = ...   // strict parser; rejects malformed URIs
-  }
-}
+Spawn cost is the daemon's cold-start time: ~5–10 s for Robolectric,
+~600 ms for desktop.
 
-fun PreviewUri.toMcpResource(displayName: String, lastModified: Instant?, sizeBytes: Long?): Resource =
-  Resource(
-    uri = toUri(),
-    name = previewFqn.substringAfterLast('.'),
-    title = displayName,
-    description = "Compose @Preview rendered by the preview daemon",
-    mimeType = "image/png",
-    size = sizeBytes,
-    annotations = ResourceAnnotations(
-      audience = listOf(ResourceAudience.user, ResourceAudience.assistant),
-      priority = 0.5,
-      lastModified = lastModified,
-    ),
-  )
-```
+### `classpathDirty`
 
-`resources/list` aggregates across every supervised module:
-`supervisor.allDaemons.flatMap { it.previews().map { it.toMcpResource(...) } }`.
+The daemon emits exactly once per lifetime then exits within
+`classpathDirtyGraceMs` (default 2 s). The MCP server:
 
-`resources/read` parses the URI, dispatches to the right daemon,
-checks freshness, blocks on `renderFinished`, returns the bytes as a
-`BlobResourceContents` (base64-encoded PNG).
+1. Fails any in-flight render waiters for that daemon with
+   `RenderOutcome.Failed("classpathDirty", …)`.
+2. Removes the daemon from the supervisor and clears catalog +
+   `WatchPropagator` state.
+3. Emits `notifications/resources/list_changed` so connected clients
+   re-list.
+4. Schedules a respawn on `daemonLifecycleExecutor`. If the new daemon
+   also emits `classpathDirty` before any successful render, the
+   supervisor stops respawning (cap of 1) — the descriptor is genuinely
+   stale and the user needs to re-run `composePreviewDaemonStart`.
 
-## Subscriptions — the push path
+The respawn cap is a workspace-lifetime counter; it doesn't decay. A
+workspace stuck against the cap recovers when the user re-registers via
+`register_project` (which clears the supervisor's cached entry).
 
-`Subscriptions.kt` is the load-bearing translation layer.
+### Daemon dies for other reasons
 
-```kotlin
-class Subscriptions {
-  private val byUri = ConcurrentHashMap<String, MutableSet<ServerSession>>()
+`onClose` handler runs catalog + propagator cleanup; the next reference
+to the same `(workspaceId, modulePath)` triggers a fresh spawn via
+`computeIfAbsent`. No automatic respawn — the next user request drives
+recovery.
 
-  fun subscribe(uri: String, session: ServerSession) {
-    byUri.compute(uri) { _, set -> (set ?: mutableSetOf()).also { it.add(session) } }
-  }
+### MCP client disconnect
 
-  fun unsubscribe(uri: String, session: ServerSession) { ... }
+`McpSession.runReader` exits on stdin EOF; `onClose` handler unregisters
+from the session registry and forgets the session's subscriptions /
+watches. `DaemonMcpMain.main` calls `supervisor.shutdown()` after the
+session exits, which sends `shutdown` + `exit` to every daemon and waits
+for them to drain.
 
-  /** Called by DaemonSupervisor when any daemon emits renderFinished. */
-  suspend fun notifyUpdated(uri: String) {
-    byUri[uri]?.forEach { session ->
-      session.sendResourceUpdated(uri)   // SDK helper that emits notifications/resources/updated
-    }
-  }
+## Tools surface
 
-  /** Called when discoveryUpdated arrives — the *set* of resources changed. */
-  suspend fun notifyListChanged() {
-    byUri.values.flatten().toSet().forEach { session ->
-      session.sendResourceListChanged()
-    }
-  }
-}
-```
+See [MCP.md § Tools](MCP.md#tools) for the full table. Implementation
+notes:
 
-The `DaemonSupervisor` hooks the daemon's existing notification stream:
+- `register_project` canonicalises the path, derives the `WorkspaceId`,
+  and stores the optional `modules` hint on the project record. Does not
+  spawn daemons.
+- `watch` eagerly spawns daemons matching the watch (synchronously for
+  daemons already up, asynchronously via `daemonLifecycleExecutor` for
+  fresh ones) so the catalog populates without the client having to
+  speculatively `read` first.
+- `notify_file_changed` forwards the `fileChanged` notification to every
+  daemon in the workspace AND re-issues `renderNow` for every URI any
+  session has watched/subscribed in this workspace. The daemon's
+  `fileChanged({source})` is a classloader swap, not an auto-render —
+  the explicit re-render is what drives push notifications back out.
+- `history_list` decorates each entry with a
+  `compose-preview-history://` URI so clients can call `resources/read`
+  on it directly.
+- `history_diff` is metadata-mode only (pixel-mode reserved for daemon
+  phase H5).
 
-```kotlin
-class DaemonSupervisor(...) {
-  fun onRenderFinished(handler: suspend (uri: String) -> Unit) { ... }
-  fun onDiscoveryUpdated(handler: suspend (module: String) -> Unit) { ... }
-  fun onClasspathDirty(handler: suspend (module: String, reason: String) -> Unit) { ... }
-  // Implementation: each daemon's stdio JSON-RPC notification stream is
-  // demuxed by method name and dispatched to registered handlers.
-}
-```
+## Reliability invariants
 
-`DaemonMcpServer.build()` wires:
-
-```kotlin
-supervisor.onRenderFinished { uri -> subscriptions.notifyUpdated(uri) }
-supervisor.onDiscoveryUpdated { module -> subscriptions.notifyListChanged() }
-supervisor.onClasspathDirty { module, reason ->
-  server.sendLoggingMessage(level = LoggingLevel.warning, data = ...)
-  // supervisor handles respawn internally
-}
-```
-
-That's the entire push story: existing daemon notification → MCP
-notification, with the URI as the join key.
-
-## Multi-module multiplexing
-
-`DaemonSupervisor` owns a `Map<ModulePath, DaemonClient>`. On first
-`render_preview` for a new module, it:
-
-1. Runs `composePreviewDaemonStart` for that module via Gradle (using
-   the existing Tooling API path the harness's launchers use).
-2. Spawns the daemon JVM from the emitted descriptor.
-3. Wires the daemon's stdio notification stream into the supervisor's
-   handlers.
-4. Caches the `DaemonClient` keyed by module path.
-
-`list_modules()` returns the cache's keys. Daemons that go quiet are
-torn down lazily after `daemon.idleTimeoutMs` (matches the per-daemon
-idle policy from PROTOCOL.md § 3).
-
-The supervisor is the only piece that touches Gradle. Everything
-downstream (the MCP server, the subscription routing, the resource
-provider) is JSON-RPC-over-stdio against an opaque `DaemonClient`.
-
-## Transports
-
-### Stdio — the default for local agents
-
-```bash
-$ claude mcp add compose-preview ./gradlew :daemon:mcp:run
-```
-
-`StdioServerTransport()` from the SDK. Server's stdin/stdout speaks
-MCP; logs go to stderr. The supervisor's spawned daemons inherit
-stderr-redirection from the SDK's stdio plumbing, so daemon logs are
-visible in the parent's stderr without corrupting the wire.
-
-### Streamable-HTTP — for remote / multi-agent setups
-
-```bash
-$ ./gradlew :daemon:mcp:run --args='--http=8080'
-```
-
-Ktor `embeddedServer(CIO, port = 8080) { mcp { server } }`. The MCP
-SDK's `mcp { ... }` route DSL handles the streamable-HTTP transport's
-single-endpoint pattern (one URL accepts JSON or SSE depending on the
-client's `Accept` header). Ktor handles connection management,
-content-negotiation, and the SSE keepalive.
-
-This unlocks **remote agents** — an agent running on a different
-machine can connect over HTTP, render previews via the daemon, and
-receive subscription notifications via SSE. CLI can't do this without
-a network wrapper.
-
-### In-memory — for unit tests
-
-```kotlin
-class DaemonMcpServerTest {
-  @Test
-  fun `subscribed client receives notifications/resources/updated when daemon renders`() = runTest {
-    val (clientTransport, serverTransport) = ChannelTransport.pair()
-    val supervisor = FakeDaemonSupervisor()
-    val server = DaemonMcpServer(supervisor, Subscriptions()).build()
-    server.connect(serverTransport)
-
-    val client = Client(...)
-    client.connect(clientTransport)
-    client.subscribe("compose-preview://samples-android/RedSquare")
-
-    val notification = client.expectNotification("notifications/resources/updated", timeout = 5.seconds)
-    supervisor.simulateRenderFinished("compose-preview://samples-android/RedSquare")
-
-    assertEquals("compose-preview://samples-android/RedSquare", notification.params["uri"])
-  }
-}
-```
-
-The `ChannelTransport` from the SDK is in-memory — no subprocess, no
-file I/O, no port allocation. Same SDK code path the production stdio
-transport uses, just bound to a Kotlin `Channel` instead of stdin /
-stdout.
+- **Multi-waiter dedup.** A `CompletableFuture` is published BEFORE
+  `renderNow` is sent so the daemon's notification can't race ahead of
+  the wait.
+- **Render-result completion outside the daemon's reader-thread compute
+  lambda.** `pendingRenders.remove(key)` returns the list atomically;
+  futures are completed afterwards so a slow consumer can't block the
+  daemon's reader thread.
+- **Single-threaded daemon-lifecycle executor.** Classpath-dirty
+  respawns serialise so concurrent saves can't double-spawn (the
+  supervisor's `daemonFor` is already `computeIfAbsent`-safe; the
+  executor adds belt-and-braces).
+- **Daemon-flagged executors for everything.** Lifecycle and progress-beat
+  executors don't delay JVM shutdown.
 
 ## What this provides that the CLI can't
 
-The existing `compose-preview` CLI (one-shot render via Gradle):
-
 | Capability | CLI | MCP server |
-|---|---|---|
-| **Push on render-complete** | ❌ Process exits; no channel for notifications | ✅ `notifications/resources/updated` over the persistent stdio/HTTP connection |
-| **Push on discovery change** | ❌ Re-running discovery means re-running the CLI | ✅ `notifications/resources/list_changed` |
-| **Sub-second warm renders** | ❌ Cold Gradle config + sandbox init every invocation (~5–10s) | ✅ Daemon stays warm; second render is ~50ms |
-| **Subscription back-pressure** | ❌ No subscription concept | ✅ Client subscribes to specific URIs; server tracks who wants what |
-| **Multi-module multiplexing** | ❌ One CLI call → one Gradle module | ✅ Supervisor multiplexes per-module daemons behind one MCP surface |
-| **Cross-render cache** | ❌ Each invocation starts fresh | ✅ Daemon caches PNGs; freshness driven by `fileChanged` (B2.0/B2.1) |
-| **Progress notifications** | ❌ stdout/stderr text; client parses | ✅ `notifications/progress` typed events for long renders |
-| **Structured failures** | ❌ Non-zero exit + stderr text | ✅ `renderFailed` → typed `notifications/message({ level: "error", data: { kind, message, stackTrace } })` |
-| **URI-template completion** | ❌ Client has to know preview FQNs upfront | ✅ MCP completion API — agent can ask "what previews exist matching pattern X?" |
-| **Capability negotiation** | ❌ All-or-nothing CLI flags | ✅ Client declares which features it supports (`subscribe`, `listChanged`); server tailors notifications |
-| **Remote / cross-machine** | ❌ CLI is local-only | ✅ Streamable-HTTP transport lets remote agents render previews |
-| **Multiple concurrent agent sessions** | ❌ One CLI per call | ✅ One server, many connected agents (sharing the same warm daemons) |
-| **Sampling / elicitation** | ❌ One-shot input/output | ✅ Server can ask the client for input mid-render (e.g. "this preview has 3 device variants — which?"). Future hook; not v1. |
-| **Resource priority annotations** | ❌ No annotations | ✅ `audience: ["assistant"]` lets the server hint which previews are most relevant for an agent's context |
-| **Image bytes inline** | ❌ Writes PNG to disk; client reads it | ✅ `BlobResourceContents` returns base64 PNG inline; no file-system juggling |
-
-The four most load-bearing wins:
-
-1. **Subscriptions** — the user's original question. Push notifications
-   replace polling. An agent rendering a preview while a developer
-   edits gets fresh bytes pushed at it within tens of milliseconds of
-   `fileChanged`.
-2. **Persistent warm sandbox** — sub-second renders compound across an
-   agent session. CLI's 10s cold-start is a session killer.
-3. **Multi-module multiplexing** — agent sees the whole project as one
-   resource list, not "rerun the CLI for each module".
-4. **Streamable-HTTP** — remote / cross-machine setups become
-   first-class. Useful for hosted-agent setups where the daemon JVM
-   runs on a build server but the agent loop runs in the cloud.
-
-## Lifecycle + supervision
-
-The MCP server's lifecycle owns its supervised daemons, not the
-client's. Three explicit transitions:
-
-- **MCP server start**: connects transport, registers tools/resources,
-  doesn't spawn any daemons yet (lazy on first preview request).
-- **First preview request for a module**: supervisor checks if a
-  daemon for that module exists; if not, runs
-  `composePreviewDaemonStart` + spawns. Cold path; ~5s.
-- **Idle module**: supervisor reaps daemons whose last-render is older
-  than `daemon.idleTimeoutMs`. Reaped daemon's URIs become
-  "list-but-not-readable-without-respawn"; next `resources/read` for
-  one of those URIs respawns the daemon (lazy).
-- **MCP server shutdown**: gracefully shuts every supervised daemon
-  (sends `shutdown` + `exit`, awaits drain, checks SIGTERM handler
-  result), then exits.
-- **classpathDirty**: supervisor handles transparently — daemon exits,
-  supervisor respawns, MCP server stays up. Pushes a logging message
-  so the agent sees the transition.
+|------------|-----|------------|
+| **Push on render-complete** | ❌ Process exits; no notification channel | ✅ `notifications/resources/updated` |
+| **Push on discovery change** | ❌ Re-run the CLI | ✅ `notifications/resources/list_changed` |
+| **Sub-second warm renders** | ❌ Cold Gradle config + sandbox init every invocation | ✅ Daemon stays warm |
+| **Subscription back-pressure** | ❌ No subscription concept | ✅ Per-URI + watch-glob subscriptions |
+| **Multi-module multiplexing** | ❌ One CLI call → one Gradle module | ✅ Supervisor multiplexes per-module daemons |
+| **Multi-workspace** | ❌ One CLI per project root | ✅ Multiple `register_project` calls; one MCP server hosts many |
+| **Progress notifications** | ❌ stdout text; client parses | ✅ `notifications/progress` typed events |
+| **Structured failures** | ❌ Non-zero exit + stderr text | ✅ `RenderOutcome.Failed` typed back to caller |
+| **Image bytes inline** | ❌ Writes PNG; client reads disk | ✅ `BlobResourceContents` returns base64 PNG inline |
+| **History resources** | ❌ Walks `.compose-preview-history/` directly | ✅ `compose-preview-history://` URIs + `history_list` / `history_diff` tools |
 
 ## Phasing
 
@@ -495,63 +377,14 @@ selection). Speculative; gate on actual demand.
 PIXEL and surfaces the `diffPx` / `ssim` / `diffPngPath` fields the
 wire shape already reserves.
 
-## Risks
-
-1. **MCP SDK is young** (Kotlin SDK 0.x as of this writing). Wire-shape
-   stability across SDK upgrades is not guaranteed; the shim should
-   pin the SDK version and bump deliberately.
-2. **PNG bytes over stdio are base64**. A 1MB PNG = ~1.4MB on the
-   wire. For an agent rendering a few previews per minute, fine. For
-   bulk renders (e.g. an agent reviewing a 200-preview module), the
-   streamable-HTTP transport has fewer constraints.
-3. **Per-module daemon spawn cost (~5s)** is paid lazily on first
-   request per module per MCP-server lifetime. Not amortised across
-   different agent sessions if the MCP server is per-session.
-   Alternative: long-lived MCP server, multiple agents share the same
-   warm daemon pool. v2 territory.
-4. **Capability negotiation with old clients**. Clients that don't
-   support `subscribe` get cold reads on every `resources/read` —
-   correct behaviour, just slower. Should be documented in the
-   user-facing MCP server README.
-5. **Daemon classpath updates** mid-agent-session require the agent
-   to handle classpathDirty respawns. The MCP server hides this with
-   the "logging message + supervisor respawn" pattern, but the next
-   resource-read after respawn could hit a stale subscription
-   (subscriptions tracked by URI; URIs survive respawn unless the
-   set of previews changed). Solution: on respawn, supervisor re-emits
-   `notifications/resources/list_changed` so subscribed clients
-   re-list. Documented inline.
-
-## Decisions to surface
-
-1. **Module name**: `:daemon:mcp` (recommended; mirrors
-   `:daemon:harness`) vs `:tools:mcp-server` (less specific but
-   future-proofs for non-daemon MCP needs). Recommend `:daemon:mcp`.
-2. **Ktor engine**: CIO (smaller, coroutine-native) vs Netty (more
-   mature). Recommend CIO; daemon-side traffic is tiny.
-3. **Tool naming**: `render_preview` (snake_case, MCP convention) vs
-   `renderPreview` (camelCase, Kotlin convention). MCP convention wins
-   per public-facing tool surface.
-4. **URI scheme**: confirm `compose-preview://` is fine (vs `file://`).
-   Recommend custom; covered in MCP.md decision 2.
-5. **Spawn responsibility**: MCP server spawns daemons via the
-   supervisor (recommended) vs MCP server requires the daemons to be
-   already-running. Recommended path means the agent doesn't need any
-   pre-flight setup; trade-off is the supervisor has to know how to
-   invoke Gradle (Tooling API or shell-out).
-6. **HTTP auth model for v2**: bearer-token? mTLS? OAuth (since MCP
-   spec has hooks for it)? Defer; gate on actual remote-agent demand.
-
 ## Cross-references
 
-- [MCP.md](MCP.md) — high-level design; this doc is the
-  Option-A-implementation specifics.
-- [PROTOCOL.md](PROTOCOL.md) — the daemon's wire format the MCP shim
+- [MCP.md](MCP.md) — high-level mapping.
+- [PROTOCOL.md](PROTOCOL.md) — the daemon wire format the MCP shim
   translates from.
-- [DESIGN.md § 4](DESIGN.md#4-architecture) — daemon architecture; MCP
-  server is one of the consumers enumerated there.
-- [TEST-HARNESS.md](TEST-HARNESS.md) — pattern to follow for an MCP
-  integration test that spawns the server as a subprocess and drives
-  it with a real client (extends to MCP via the SDK's `Client` class).
-- [io.modelcontextprotocol/kotlin-sdk](https://github.com/modelcontextprotocol/kotlin-sdk)
-  — the SDK; pin a version once we start work.
+- [LAYERING.md](LAYERING.md) — module-boundary rules; MCP is Layer 3.
+- [TEST-HARNESS.md](TEST-HARNESS.md) — pattern the harness follows for
+  spawning real daemons; MCP's `RealMcpEndToEndTest` reuses the same
+  shape.
+- [HISTORY.md § "Layer 3 — MCP mapping"](HISTORY.md#layer-3--mcp-mapping)
+  — history-resource mapping details.

--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -1,33 +1,32 @@
-# Preview daemon — MCP server design
+# Preview daemon — MCP server overview
 
-> **Status:** design proposal. No implementation shipped. Researched
-> against [MCP spec 2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/server/resources).
-> Cross-referenced from [DESIGN.md](DESIGN.md) and
-> [PROTOCOL.md](PROTOCOL.md). Out of scope for v1; this captures the
-> shape so we don't paint ourselves into a corner.
+> **Status:** implemented in `:mcp` (top-level module). This doc is the
+> high-level mapping of daemon ↔ MCP semantics; concrete implementation
+> notes live in [MCP-KOTLIN.md](MCP-KOTLIN.md).
+>
+> Researched against [MCP spec 2025-06-18](https://modelcontextprotocol.io/specification/2025-06-18/server/resources).
+> Cross-referenced from [DESIGN.md](DESIGN.md) and [PROTOCOL.md](PROTOCOL.md).
 
 ## Why
 
-An AI agent that wants to "see" what a `@Preview` renders today has
-two unappealing options:
+An AI agent that wants to "see" what a `@Preview` renders has two
+unappealing options without an MCP server:
 
-1. **Run Gradle.** Invoke `:samples:android:renderAllPreviews`, wait
-   for cold-config + sandbox-init + render — 10s+ end to end. Useless
-   for an iterative agent loop.
-2. **Read PNGs from disk.** Assume a known render-history directory
-   exists and is fresh. No way to request a re-render or know when one
-   completes.
+1. **Run Gradle.** Invoke `:samples:android:renderAllPreviews`, wait for
+   cold-config + sandbox-init + render — 10s+ end to end. Useless for an
+   iterative agent loop.
+2. **Read PNGs from disk.** Assume a known render-history directory exists
+   and is fresh. No way to request a re-render or know when one completes.
 
 The preview daemon already solves both for VS Code over JSON-RPC.
-Exposing it as an MCP server lets any MCP-aware agent — Claude Code,
-the SDK, a custom agent — render previews on demand and receive
-notifications when bytes change.
+Exposing it as an MCP server lets any MCP-aware agent — Claude Code, the
+SDK, a custom agent — render previews on demand and receive notifications
+when bytes change.
 
-## Push, not poll: how MCP actually does it
+## Push, not poll: how MCP does it
 
-This was the user's load-bearing question. **MCP supports server →
-client notifications.** Two relevant capabilities under the
-`resources` namespace, both optional, both standard:
+MCP supports server → client notifications. Two relevant capabilities under
+the `resources` namespace, both standard:
 
 ```json
 {
@@ -48,336 +47,201 @@ client notifications.** Two relevant capabilities under the
   every time that one resource's content changes. The client then calls
   `resources/read` to fetch the new bytes.
 
-Plus the generic JSON-RPC notification facilities MCP inherits:
-progress notifications (`notifications/progress` for long-running
-tool calls), logging messages, and sampling/elicitation flows.
+Plus `notifications/progress` for long-running tool calls.
 
-**Transports that support push**: stdio (the default for local
-servers), SSE, and the newer streamable-HTTP transport. All of these
-hold a persistent connection. **No polling required for any of them.**
-A long-running MCP server keeps the channel open and pushes
-notifications as state changes. Pure HTTP without SSE would force
-polling — but that's a transport choice, not an MCP-spec choice, and
-no one builds MCP servers that way.
-
-For the daemon, **stdio** is the natural fit: the daemon already
-speaks JSON-RPC over stdio for VS Code. An MCP variant of the
-daemon's protocol layer would reuse the same framing (LSP-style
-`Content-Length`).
+The `:mcp` module advertises both capabilities and uses **stdio** as its
+transport — the same framing the daemon uses, so the MCP shim and the
+underlying daemon JSON-RPC channel are wire-shape-compatible.
 
 ## Daemon ↔ MCP surface mapping
 
-The daemon's [PROTOCOL.md v1](PROTOCOL.md) maps cleanly onto MCP
-primitives.
+The daemon's [PROTOCOL.md v1](PROTOCOL.md) maps onto MCP primitives as
+follows. The implementation lives in
+[`mcp/src/main/kotlin/.../DaemonMcpServer.kt`](../../mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt).
 
-### Resources — one per `@Preview`
+### Resources
 
-Each preview becomes an MCP `Resource`:
+Each `@Preview` becomes one MCP `Resource`:
 
 ```jsonc
 {
-  "uri": "compose-preview://samples-android/com.example.app.RedSquare?config=phone-portrait",
+  "uri": "compose-preview://<workspaceId>/<encodedModulePath>/<previewFqn>",
   "name": "RedSquare",
-  "title": "Red square preview",
-  "mimeType": "image/png",
-  "size": 4218,
-  "annotations": {
-    "audience": ["user", "assistant"],
-    "priority": 0.6,
-    "lastModified": "2026-04-29T10:23:51Z"
-  }
+  "description": "Red square preview",
+  "mimeType": "image/png"
 }
 ```
 
-- **URI scheme**: custom `compose-preview://`. Avoids `file://` because
-  the on-disk path is implementation-detail; the daemon owns the
-  rendering and may produce bytes without ever writing a file.
-- **Module + preview ID**: `compose-preview://<module-id>/<preview-fqn>?config=<qualifier-string>`.
-  Module-id matches the launch descriptor's `modulePath`
-  (`:samples:android` etc.); the qualifier suffix lets one
-  `@Preview` with multiple device variants be addressed independently.
-- **Content**: binary PNG via the standard `blob` field (base64).
+URI scheme details (parsed by [`PreviewUri`](../../mcp/src/main/kotlin/ee/schimke/composeai/mcp/PreviewResource.kt)):
 
-`resources/list` returns every preview the daemon currently knows
-about — same data the existing `discoveryUpdated` notification carries.
-Pagination via the standard cursor mechanic for large modules.
+- **Scheme**: `compose-preview://` for live previews,
+  `compose-preview-history://` for historical entries.
+- **`workspaceId`**: derived from `(rootProjectName, canonicalPath)` —
+  `<sanitised-name>-<8-char-hash>`. Two worktrees of the same repo get
+  distinct IDs by construction.
+- **`encodedModulePath`**: gradle module path with `:` → `_`
+  (`:samples:android` → `_samples_android`).
+- **`previewFqn`**: the daemon's preview ID (typically
+  `<className>.<methodName>`).
+- Optional **`?config=<qualifier>`** for previews with multiple device
+  variants.
 
-`resources/read` triggers a render. If the preview's PNG is current
-(no `fileChanged` since the last render), return the cached bytes
-immediately. Otherwise enqueue a render and block until
-`renderFinished` arrives — same drain semantics the daemon already
-honours (no mid-render cancellation; PROTOCOL.md § 3 + DESIGN.md § 9).
+`resources/list` returns every preview in every supervised daemon's
+discovery state. `resources/read` triggers a render via the daemon's
+`renderNow` and blocks until `renderFinished` arrives, then returns the
+PNG inline as base64-encoded `BlobResourceContents`.
 
-### Subscriptions — push instead of poll
+### Subscriptions
 
-Client subscribes to a preview's URI:
+Two subscription paths fan into per-URI updates:
 
-```jsonc
-{ "jsonrpc": "2.0", "id": 7, "method": "resources/subscribe",
-  "params": { "uri": "compose-preview://samples-android/com.example.app.RedSquare" } }
-```
+1. **`resources/subscribe(uri)`** — explicit per-URI subscription.
+2. **`watch` tool** — area-of-interest registration over
+   `(workspaceId, modulePath?, fqnGlob?)`. The MCP server expands a watch
+   to a URI set on every `discoveryUpdated`.
 
-The daemon's existing wire signal — `renderFinished({ id, pngPath, … })`
-— maps to:
+Both feed the daemon's `renderFinished` → `notifications/resources/updated`
+translation. A session subscribed AND watching a URI receives one update,
+not two (set semantics in [`Subscriptions`](../../mcp/src/main/kotlin/ee/schimke/composeai/mcp/Subscriptions.kt)).
 
-```jsonc
-{ "jsonrpc": "2.0", "method": "notifications/resources/updated",
-  "params": { "uri": "compose-preview://samples-android/com.example.app.RedSquare" } }
-```
+`discoveryUpdated` (the daemon's "set of previews changed" signal) maps
+to `notifications/resources/list_changed`.
 
-The client's next `resources/read` returns fresh bytes.
+`historyAdded` (a new history entry landed for a preview) also maps to
+`notifications/resources/list_changed` — the entry-set for that preview
+grew by one, and a subscriber filtering on the `compose-preview-history://`
+prefix can re-list.
 
-`discoveryUpdated` (the daemon's "set of previews changed" signal,
-emitted on Tier 2 incremental rescan) maps to:
+`classpathDirty` triggers an MCP-side respawn flow rather than
+propagating to the client: the supervisor spawns a fresh daemon for the
+affected module, fails any in-flight render waiters with
+`{kind:"classpathDirty"}`, and emits `list_changed` so subscribers
+re-list. After one self-loop the supervisor stops respawning to avoid
+thrashing on a permanently-stale descriptor.
 
-```jsonc
-{ "jsonrpc": "2.0", "method": "notifications/resources/list_changed" }
-```
+### Tools
 
-`classpathDirty` (B2.1's daemon → "the world has fundamentally
-changed, restart me") doesn't have a clean MCP analogue. The cleanest
-mapping is to **exit the MCP server with a non-zero code**; MCP
-clients treat a closed connection as "server died, reconnect" and
-re-`initialize`. For interactive clients we could also push a
-`notifications/message` (the MCP logging notification) before exit so
-the user sees *why* the server is going away.
+Ten tools in v0:
 
-`renderFailed` maps to `notifications/message({ level: "error", … })`
-on the subscribed URI's logging channel. The resource itself stays in
-the list; the client sees "render failed" as a log event and can
-choose to retry (`resources/read` again) or move on.
+| Tool | Purpose | Maps to daemon's |
+|------|---------|------------------|
+| `register_project(path, rootProjectName?, modules?)` | Add a workspace to the supervisor. Returns the assigned `workspaceId`. | — (supervisor-side) |
+| `unregister_project(workspaceId)` | Tear down a workspace's daemons. | — (supervisor-side) |
+| `list_projects()` | List registered projects. | — (supervisor-side) |
+| `render_preview(uri)` | Force-render a preview, returning the PNG inline. | `renderNow` |
+| `watch(workspaceId, module?, fqnGlob?)` | Register an area of interest. | — (subscription bookkeeping) |
+| `unwatch(workspaceId?, module?, fqnGlob?)` | Drop matching watches. | — |
+| `list_watches()` | List the current session's watches. | — |
+| `notify_file_changed(workspaceId, path, kind?, changeType?)` | Forward a file-edit notification to every daemon in the workspace. | `fileChanged` |
+| `history_list(workspaceId, module, …)` | List history entries; decorates each with a `compose-preview-history://` URI. | `history/list` |
+| `history_diff(workspaceId, module, from, to)` | Diff two entries (metadata mode). | `history/diff` |
 
-### Tools — explicit user actions
+`set_focus` / `set_visible` are not currently exposed as tools — the
+daemon's queue doesn't yet honour them (B2.5+). When predictive prefetch
+ships ([PREDICTIVE.md](PREDICTIVE.md)), MCP either gains a `set_focus`
+tool or the propagator's existing watch→`setVisible` translation becomes
+load-bearing.
 
-Pure-`renderNow` style "force a fresh render even if cached" is a tool:
+## Architecture
 
-```jsonc
-{
-  "name": "render_preview",
-  "description": "Re-render a preview, bypassing the cache. Returns the rendered PNG.",
-  "inputSchema": {
-    "type": "object",
-    "properties": {
-      "uri":  { "type": "string", "description": "compose-preview:// URI" },
-      "tier": { "type": "string", "enum": ["fast", "full"], "default": "full" }
-    },
-    "required": ["uri"]
-  }
-}
-```
-
-Other tools worth considering:
-
-- `discover_previews(module)` — explicit list-now. Mostly redundant with
-  `resources/list`, but lets an agent ask for "everything in this
-  module" without traversing the resource list.
-- `list_modules()` — what modules have a live daemon. Useful when the
-  MCP server multiplexes across multiple per-module daemons.
-- `set_focus(uri)` — agent declaring "I'm about to read this preview;
-  prioritise its render over background work". Maps to the daemon's
-  `setFocus` notification. Mostly relevant if the agent is rendering a
-  large set and wants to express interactive priority. Could be
-  inferred automatically from the most-recent `resources/read` — start
-  there.
-
-`setVisible` doesn't have a clean MCP analogue — an agent doesn't
-have a viewport. Probably skip in v1; reactive priority alone (focus =
-most-recently-read) is enough.
-
-### Prompts — the "look at this preview" pattern
-
-A small `prompts` namespace that templates a "review this preview" or
-"compare these two previews side-by-side" agent loop. Optional;
-not load-bearing for the core mapping.
-
-## Architecture options
-
-### Option A — separate MCP server process, JSON-RPC client of the daemon
+The MCP server runs as a separate process that JSON-RPC-clients the
+existing daemon:
 
 ```
-MCP client ── stdio ──▶ MCP server ── stdio JSON-RPC ──▶ daemon JVM
-                       (Kotlin/JVM             (existing)
-                        or TypeScript)
+MCP client ── stdio ──▶ MCP server ── stdio JSON-RPC ──▶ daemon JVM (per module)
+                       (`:mcp`)                        (`:daemon:android` / `:daemon:desktop`)
 ```
 
-The MCP server is a thin shim that translates MCP wire shape ↔ daemon
-PROTOCOL.md. Reuses the existing daemon. Multiplexes potentially
-multiple per-module daemons behind one MCP surface.
+The MCP server is renderer-agnostic — it depends only on `:daemon:core`
+for protocol message types and spawns daemon JVMs via launch descriptors
+emitted by `composePreviewDaemonStart`. It never depends on
+`:daemon:android` or `:daemon:desktop` directly.
 
-**Pros**: clean separation; the daemon stays a JSON-RPC server with
-no MCP-specific code. The MCP server can be in TypeScript (matching
-the VS Code extension's existing `daemonClient.ts`) or Kotlin (matching
-the daemon's existing JsonRpcServer + Messages.kt). MCP server is
-stateless modulo subscription bookkeeping.
+One MCP server multiplexes multiple per-(workspace, module) daemons. A
+single agent session can list resources from multiple workspaces (e.g.
+two worktrees of the same repo) without re-running Gradle bootstrap for
+each.
 
-**Cons**: two processes; lifecycle gets fiddlier (who spawns the
-daemon? does the MCP server own it? what happens on classpathDirty?).
-Wire-format translation cost (negligible at the message-rate the
-daemon operates at).
-
-### Option B — daemon learns an MCP mode
-
-```
-MCP client ── stdio ──▶ daemon JVM (PROTOCOL.md or MCP, decided at startup)
-```
-
-The daemon's `JsonRpcServer` gains a `--mcp` flag that switches the
-wire format from PROTOCOL.md to MCP semantics. Same framing
-(`Content-Length`), different message names + capability handshake +
-notification shapes.
-
-**Pros**: one process. Daemon's existing render loop, sandbox holding,
-classloader handling all transparent to the wire-format choice.
-
-**Cons**: couples the daemon to MCP's evolution. Two protocol surfaces
-to maintain in lockstep. The renderer-agnostic surface invariant
-(DESIGN § 4) gets murkier — MCP isn't strictly renderer-agnostic but
-it's not Compose-specific either, so probably still fine.
-
-### Option C — VS Code extension exposes the MCP surface
-
-```
-MCP client ── stdio ──▶ vscode-extension MCP server ── existing daemonClient.ts ──▶ daemon JVM
-```
-
-The existing TypeScript `daemonClient.ts` from Stream C already speaks
-PROTOCOL.md to a daemon. Wrap it in an MCP-server adapter; expose via
-VS Code's existing MCP-server publishing mechanism. Reuses everything
-the extension already does (gating, multi-module, fallback to Gradle).
-
-**Pros**: zero work on the JVM side; reuses existing TypeScript code.
-**Cons**: requires VS Code as the host. Doesn't help non-VS Code
-agent setups (Claude Code CLI, custom MCP harnesses).
-
-### Recommendation
-
-**Option A for v1** — separate Kotlin MCP server process that JSON-RPC-
-clients the existing daemon. Reasons:
-
-- Doesn't constrain the daemon's evolution to MCP's spec cadence.
-- Doesn't require VS Code (works for headless agent loops, CI, and
-  the harness's eventual MCP integration test).
-- Reuses `:daemon:core`'s `Messages.kt` types verbatim — the
-  shim translates *between* two strongly-typed Kotlin schemas, which
-  is a tiny amount of code (~300 LOC).
-- The shim's renderer-agnosticism is automatic since
-  `:daemon:core` is.
-
-**Option C as a follow-up** for VS Code-hosted MCP. Lives alongside
-Option A, doesn't replace it.
-
-**Option B** stays available if A turns out to be too much shim for
-the value; revisit with data, not speculation.
+See [LAYERING.md](LAYERING.md) for the architectural rules that keep this
+clean.
 
 ## Lifecycle
 
 ### Spawn
 
-The MCP server's `initialize` handshake captures workspace + module
-selection from the client (or its environment — `cwd` typically). For
-each module the client wants previews from, the MCP server runs
-`composePreviewDaemonStart` once (the existing Gradle task that emits
-the launch descriptor) and spawns the daemon. Multi-module: one
-daemon JVM per module, multiplexed behind one MCP surface.
+The MCP server starts with no daemons. Daemons spawn lazily on first
+`render_preview` / `resources/read` / `watch` reference for a module. The
+supervisor reads `<moduleDir>/build/compose-previews/daemon-launch.json`
+written by `composePreviewDaemonStart` (the user must run this once
+per module before driving the MCP surface).
 
 ### `classpathDirty` / daemon death
 
-When the daemon emits `classpathDirty` and exits, the MCP server has
-two options:
+When a daemon emits `classpathDirty` and exits, the supervisor:
 
-1. **Eager re-bootstrap** — spawn a fresh daemon for that module
-   immediately. Push `notifications/resources/list_changed` so clients
-   re-list (the in-flight resource set may have shifted).
-2. **Lazy re-bootstrap** — emit `notifications/message({ level: "warn",
-   data: "module classpath changed, daemon restarting" })`, wait for
-   the next tool call to trigger respawn.
+1. Forgets the daemon and clears cached state (catalog, watch propagator
+   memo, in-flight render waiters).
+2. Pushes `notifications/resources/list_changed` so connected clients
+   re-list.
+3. Schedules a respawn on a single-threaded worker. After one self-loop
+   without successful re-discovery, gives up and surfaces the failure
+   on the next tool call.
 
-v1 should pick eager — simpler. Lazy is an optimisation if cold spawn
-becomes a measurable cost.
-
-If the daemon dies for non-`classpathDirty` reasons (crash, OOM, etc.),
-the MCP server logs `notifications/message({ level: "error", … })`
-and respawns once. Repeated crashes — back off and surface an error
-on the next tool call.
+If the daemon dies for non-`classpathDirty` reasons (crash, OOM), the
+supervisor logs and respawns once. Repeated crashes back off; the user
+sees an error on the next tool call.
 
 ### MCP client disconnect
 
-The MCP server gracefully shuts down its daemon JVMs (sends
-`shutdown` + `exit`, awaits drain) before exiting itself. Mirrors
-the desktop daemon's existing SIGTERM handler from B-desktop.1.6.
+The MCP server gracefully shuts down its daemon JVMs (sends `shutdown` +
+`exit`, awaits drain) before exiting itself.
 
 ## Caching & resource freshness
 
-The daemon already maintains preview PNGs on disk. The MCP server's
-caching layer is then trivial:
+The daemon already serialises render output to disk. The MCP server does
+not maintain its own cache:
 
-1. `resources/read({ uri })` checks a per-preview "current PNG mtime"
-   cache.
-2. If the PNG mtime is recent enough (no `fileChanged` since the
-   last successful render), return cached bytes.
-3. Otherwise force a render via the daemon's `renderNow`, await
-   `renderFinished`, return fresh bytes.
+1. `resources/read({ uri })` always issues `renderNow` to the daemon.
+2. Multi-waiter dedup: concurrent reads of the same URI all wake up on
+   the next `renderFinished` (per-key `CompletableFuture` list in
+   `pendingRenders`).
+3. The daemon decides whether the render is genuinely needed (B2.0+
+   classloader swap on `fileChanged`, etc.); MCP just asks for fresh
+   bytes.
 
-The "freshness" threshold is the daemon's own staleness cascade
-(DESIGN § 8). The MCP server doesn't reimplement it; it just asks the
-daemon "is this current?" implicitly by always preferring a fresh
-render when subscriptions are active.
+History resource URIs (`compose-preview-history://…`) short-circuit to
+`history/read` rather than triggering a render — historical entries are
+immutable.
 
 ## Security & trust model
 
-- The MCP server inherits the daemon's existing trust model:
-  parent-PID-bound, no network sockets, stdio only.
-- Resource URIs are validated to match the `compose-preview://` scheme
-  + a known module ID + a known preview FQN. URI fuzzing doesn't reach
-  arbitrary files.
-- `resources/read` returns rendered PNG bytes — not source files,
-  not project metadata. Read access is bounded to the daemon's render
-  surface.
-- No write operations exposed via tools in v1. (`render_preview` writes
-  PNGs to the daemon's render directory but the client only sees
-  bytes back, not write permissions.)
+- The MCP server inherits the daemon's trust model: parent-PID-bound,
+  stdio-only.
+- Resource URIs are validated to match the `compose-preview://` /
+  `compose-preview-history://` schemes plus a known workspace ID +
+  module path + preview FQN.
+- `resources/read` returns rendered PNG bytes — not source files, not
+  project metadata.
+- No write operations exposed via tools.
 
 ## What this isn't
 
 - **Not a replacement for the VS Code path.** PROTOCOL.md v1 stays the
-  authoritative wire format for VS Code; MCP is an additional surface
-  for agent loops.
+  authoritative wire format for VS Code; MCP is an additional surface for
+  agent loops.
 - **Not a renderer rewrite.** Same daemon, same render engines, same
   classloader story. Only the protocol-translation shim is new.
-- **Not implemented.** This doc captures the shape; the work lands as
-  a Phase 3+ task once the underlying daemon is stable enough to
-  expose.
-
-## Decisions to surface
-
-1. **Architecture: A, B, or C** for v1. Recommendation: A. User's call.
-2. **URI scheme** — `compose-preview://` (cleanly custom, fits MCP's
-   URI guidance) vs `file://` (uses standard scheme but couples to
-   on-disk paths). Recommend custom.
-3. **Multi-module multiplexing** — one MCP server multiplexing
-   per-module daemons (recommended) vs one MCP server per daemon
-   (simpler but harder for the agent to reason about).
-4. **`classpathDirty` UX** — eager re-bootstrap (recommended) vs
-   lazy. Affects cold-spawn-cost vs invariant-stability trade.
-5. **Tools surface scope** — minimal (`render_preview` only) or rich
-   (`set_focus`, `list_modules`, `discover_previews` as explicit
-   tools). Recommend minimal v1; add tools as agent loops surface
-   actual needs.
-6. **Subscriptions opt-in by default?** — clients that don't
-   explicitly subscribe still get fresh bytes via `resources/read`
-   (they just don't get push notifications). v1 should advertise
-   `subscribe: true` so capable clients can use it; clients that
-   don't care simply ignore the capability.
 
 ## Cross-references
 
-- [PROTOCOL.md](PROTOCOL.md) — v1 daemon wire format the MCP shim
-  translates from.
-- [DESIGN.md](DESIGN.md) — daemon architecture; MCP server is one of
-  the "consumers" enumerated in § 4.
-- [TEST-HARNESS.md](TEST-HARNESS.md) — pattern for an integration test
-  spawning the MCP shim as a subprocess + driving via JSON-RPC, once
-  the implementation lands.
+- [MCP-KOTLIN.md](MCP-KOTLIN.md) — implementation reference for the
+  `:mcp` module.
+- [PROTOCOL.md](PROTOCOL.md) — daemon wire format the MCP shim translates
+  from.
+- [LAYERING.md](LAYERING.md) — how MCP sits above the daemon without
+  entangling either.
+- [HISTORY.md § "Layer 3 — MCP mapping"](HISTORY.md#layer-3--mcp-mapping)
+  — history-resource mapping details.
 - [MCP spec — Resources](https://modelcontextprotocol.io/specification/2025-06-18/server/resources)
-  — canonical reference for `resources/subscribe`, `notifications/resources/updated`,
-  and capability negotiation.
+  — canonical reference for `resources/subscribe`,
+  `notifications/resources/updated`, and capability negotiation.

--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -121,7 +121,7 @@ thrashing on a permanently-stale descriptor.
 
 ### Tools
 
-Ten tools in v0:
+Twelve tools today:
 
 | Tool | Purpose | Maps to daemon's |
 |------|---------|------------------|
@@ -132,15 +132,16 @@ Ten tools in v0:
 | `watch(workspaceId, module?, fqnGlob?)` | Register an area of interest. | — (subscription bookkeeping) |
 | `unwatch(workspaceId?, module?, fqnGlob?)` | Drop matching watches. | — |
 | `list_watches()` | List the current session's watches. | — |
+| `set_visible(workspaceId, module, ids)` | Override the daemon's visible-preview set directly (without a long-lived watch). | `setVisible` |
+| `set_focus(workspaceId, module, ids)` | Override the daemon's focused-preview set (higher-priority slice for queue draining). | `setFocus` |
 | `notify_file_changed(workspaceId, path, kind?, changeType?)` | Forward a file-edit notification to every daemon in the workspace. | `fileChanged` |
 | `history_list(workspaceId, module, …)` | List history entries; decorates each with a `compose-preview-history://` URI. | `history/list` |
 | `history_diff(workspaceId, module, from, to)` | Diff two entries (metadata mode). | `history/diff` |
 
-`set_focus` / `set_visible` are not currently exposed as tools — the
-daemon's queue doesn't yet honour them (B2.5+). When predictive prefetch
-ships ([PREDICTIVE.md](PREDICTIVE.md)), MCP either gains a `set_focus`
-tool or the propagator's existing watch→`setVisible` translation becomes
-load-bearing.
+Note: the daemon's render queue is still single-priority FIFO today, so
+`setVisible` / `setFocus` traffic flows through the wire but doesn't yet
+reorder the queue. The plumbing is in place for B2.5 / predictive
+prefetch ([PREDICTIVE.md](PREDICTIVE.md)) to start honouring focus.
 
 ## Architecture
 

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -113,7 +113,7 @@ Result:
   capabilities: {
     incrementalDiscovery: boolean;   // false in v1.0; true once Tier-2 lands
     sandboxRecycle: boolean;
-    leakDetection: ("light" | "heavy")[];
+    leakDetection: ("light" | "heavy")[];   // reserved; always [] today (TODO B2.4)
   };
   classpathFingerprint: string;      // SHA-256 hex of the resolved test classpath
   manifest: {
@@ -363,6 +363,8 @@ Emitted after every Tier-2 incremental discovery that changed the set.
 
 Render failures are not protocol errors — `renderNow` succeeded in queueing the work. A failure here means the render itself blew up.
 
+> **Implementation gap:** the daemon currently emits `kind: "internal"` for every render failure regardless of the underlying cause; the `compile` / `runtime` / `capture` / `timeout` discriminants are reserved on the wire but not yet populated. Clients should treat any `kind` value as opaque text until this lands.
+
 ### `classpathDirty`
 
 ```ts
@@ -375,7 +377,12 @@ Render failures are not protocol errors — `renderNow` succeeded in queueing th
 
 Sent at most once per daemon lifetime. After this notification the daemon refuses all `renderNow` (returning `ClasspathDirty`) and exits within `daemon.classpathDirtyGraceMs` (default 2000ms) to give the client time to consume the message and re-bootstrap.
 
-### `sandboxRecycle`
+### `sandboxRecycle` (reserved; not yet emitted)
+
+> Reserved for the sandbox-recycle work (TODO B2.4 / B2.5 / B2.6). The
+> wire shape is locked so a future client can be coded against it; the
+> daemon does not currently emit it. Sandbox age counters keep growing
+> for the host's lifetime today.
 
 ```ts
 {
@@ -389,7 +396,9 @@ Sent at most once per daemon lifetime. After this notification the daemon refuse
 
 Informational. Always followed by either an immediate resumption or a `daemonWarming`.
 
-### `daemonWarming`
+### `daemonWarming` (reserved; not yet emitted)
+
+> Reserved alongside `sandboxRecycle`. Not emitted today.
 
 ```ts
 { etaMs: number }                    // best-effort estimate; client shows spinner
@@ -397,7 +406,9 @@ Informational. Always followed by either an immediate resumption or a `daemonWar
 
 Sent when no warm spare is ready and the next render is blocked on sandbox build. Followed by `daemonReady` when render service resumes.
 
-### `daemonReady`
+### `daemonReady` (reserved; not yet emitted)
+
+> Reserved alongside `daemonWarming`. Not emitted today.
 
 ```ts
 {}

--- a/docs/daemon/README.md
+++ b/docs/daemon/README.md
@@ -1,44 +1,76 @@
 # Preview daemon — design docs
 
-Design and planning for an experimental persistent preview server that replaces the per-save Gradle invocation with a long-lived JVM holding a hot Robolectric sandbox.
+A persistent preview server that replaces the per-save Gradle invocation with a long-lived JVM holding a hot Robolectric (Android) or Compose-Desktop renderer. Plus an MCP server that exposes the daemon to MCP-aware agents.
 
-> **Status:** design only. No code shipped yet. v1 will land behind `composePreview.experimental.daemon=true` with a "may eat your laundry" warning.
+## What ships today
 
-## What this is
+- **`:daemon:core`** — renderer-agnostic JSON-RPC server, protocol types, preview index, classloader holder, classpath fingerprint, history manager.
+- **`:daemon:android`** — Robolectric backend; `RobolectricHost` holds a sandbox open across renders.
+- **`:daemon:desktop`** — Compose-Desktop backend; `DesktopHost` holds a warm render thread.
+- **`:daemon:harness`** — end-to-end harness driving real daemons over JSON-RPC; ten scenarios (S1–S10) covering lifecycle, drain, render-after-edit, visibility, failures, latency-record, classpath-dirty, history.
+- **`:mcp`** — top-level MCP server multiplexing per-(workspace, module) daemons behind one MCP surface; tools for project registration, watches, render, history; resource subscriptions for push.
 
-Today, every preview refresh in the VS Code extension runs the Gradle `renderPreviews` task: Gradle config + classpath up-to-date checks + JVM fork + Robolectric sandbox init + render. Cold this is 10–20s; warm with a no-code-change save it's still 5–10s, dominated by Gradle config and Robolectric bootstrap.
+The daemon ships behind `composePreview.experimental.daemon { enabled = true }`. The Gradle `renderPreviews` task remains the always-available fallback and the CI-canonical render path.
 
-The daemon keeps the Robolectric sandbox alive between saves so the per-save hot path collapses to just kotlinc + N renders. Target: **sub-second refresh for a single focused preview after a no-classpath-change save.**
+## What's open
+
+- **B2.4 / B2.5 / B2.6** — sandbox recycle, warm spare, leak detection. Wire-format surface (`sandboxRecycle`, `daemonReady`, `daemonWarming`, `LeakDetectionMode`) is reserved in PROTOCOL.md but not yet emitted.
+- **B2.0c** — per-preview resource-read tracking (smart `fileChanged({ kind: "resource" })` invalidation).
+- **H4 / H5** — history auto-prune + pixel-mode `history/diff`.
+- **H10b / H11+** — gradle-plugin emission of `composeai.daemon.gitRefHistory`; `GitRefHistorySource` write modes; LFS / squash GC.
+- **P2.5.x** — predictive prefetch (multi-tier render queue, `setPredicted` IPC, scroll-ahead, filter-dropdown).
+- **STARTUP.md follow-ups** — machine-resident daemon (option A), AppCDS (B), instrumented-bytecode cache (C).
 
 ## Files
 
-- **[DESIGN.md](DESIGN.md)** — the full architecture: scope, module layout, staleness cascade, lifecycle, leak defense, validation strategy, decisions log.
-- **[PROTOCOL.md](PROTOCOL.md)** — locked JSON-RPC wire-format contract between the VS Code extension and the daemon. Stream B (daemon) and Stream C (extension) implement against this in parallel.
-- **[CONFIG.md](CONFIG.md)** — `composePreview.experimental.daemon { … }` DSL reference: defaults, ranges, and effects for `enabled` / `maxHeapMb` / `maxRendersPerSandbox` / `warmSpare`.
-- **[CLASSLOADER.md](CLASSLOADER.md)** — design for the disposable user classloader (B2.0). The save-loop blocker; without it the daemon's "warm render" numbers don't apply across recompiles. Compose Hot Reload prior-art analysis included.
-- **[CLASSLOADER-FORENSICS.md](CLASSLOADER-FORENSICS.md)** — design for the classloader / Robolectric-config dump tool that produces a diffable manifest of the working standalone vs broken daemon path. Empirical diagnostic for the Android S3.5 mystery — until we run the dumps we're guessing about which classloader skew is the actual blocker.
-- **[ROBOLECTRIC-PRIMER.md](ROBOLECTRIC-PRIMER.md)** — a primer on how Robolectric itself works: sandbox lifecycle, `SandboxClassLoader` delegation rules, bytecode instrumentation + shadows, `@Config` / qualifiers / native code. Read this when reasoning about classloader behaviour while debugging the daemon. Distinct from this project's design — it covers Robolectric upstream, not our integration with it.
-- **[MCP.md](MCP.md)** — overview design for exposing the daemon as an MCP server: resource subscriptions for push (no polling), tools for explicit render requests, three architecture options compared. Empirical answer to "can MCP push instead of poll?" — yes, via `notifications/resources/updated`.
-- **[MCP-KOTLIN.md](MCP-KOTLIN.md)** — concrete Kotlin/Ktor implementation design for the MCP server (Option A from MCP.md): module layout, code samples using `io.modelcontextprotocol:kotlin-sdk`, what an MCP server unlocks that the existing CLI can't.
-- **[LAYERING.md](LAYERING.md)** — the architectural rule that keeps Gradle/CLI, daemon, and MCP additive. Explicit module-boundary list, integration seams, removal procedures, and the "no `if (daemonAvailable) …`" complexity rule. Read after DESIGN if you want the whole picture; mandatory before adding a new cross-layer hook.
-- **[HISTORY.md](HISTORY.md)** — preview history design: on-disk schema, JSON-RPC API (`history/list`, `history/read`, `history/diff`), MCP and VS Code consumer mappings, branch + worktree provenance, pluggable `HistorySource` backends (LocalFs / `preview/<branch>` git refs / HTTP mirrors). Same archive consumed by Gradle, daemon, MCP, and VS Code; cross-worktree merging happens above Layer 2.
-- **[STARTUP.md](STARTUP.md)** — daemon startup latency analysis: where the time actually goes (JVM start / Robolectric instrumentation / android-all jar download), the in-flight `RobolectricHost.start()` blocking fix, and the menu of options to attack each cost (machine-resident daemon, AppCDS, instrumented-bytecode cache, JVM checkpoint/restore, Layoutlib swap). Plus the wire-format for the `StartupTimings` instrumentation that makes the timeline observable per-boot.
-- **[PREDICTIVE.md](PREDICTIVE.md)** — predictive prefetch design (v1.1+). Adds a multi-tier render queue + speculative renders on scroll-ahead / dropdown signals; observability built in.
-- **[TEST-HARNESS.md](TEST-HARNESS.md)** — the harness's design: what scenarios it covers, FakeHost vs real-mode, image-baseline strategy, CI workflow.
-- **[TODO.md](TODO.md)** — work breakdown with parallelisation guidance: which streams can run in parallel, which agents own what, definition-of-done per chunk.
+### Architecture
+
+- **[DESIGN.md](DESIGN.md)** — daemon architecture: scope, module layout, staleness cascade, lifecycle, leak defense, validation strategy, decisions log.
+- **[LAYERING.md](LAYERING.md)** — the rule that keeps Gradle/CLI, daemon, and MCP additive. Module-boundary list, integration seams, removal procedures.
+- **[PROTOCOL.md](PROTOCOL.md)** — locked v1 wire format between client (VS Code, harness, MCP shim) and daemon.
+- **[CONFIG.md](CONFIG.md)** — `composePreview.experimental.daemon { … }` DSL reference.
+
+### Subsystems
+
+- **[CLASSLOADER.md](CLASSLOADER.md)** — disposable user classloader (B2.0). The save-loop fix.
+- **[CLASSLOADER-FORENSICS.md](CLASSLOADER-FORENSICS.md)** — forensic-dump library used to diagnose the Android save-loop classloader-identity skew.
+- **[ROBOLECTRIC-PRIMER.md](ROBOLECTRIC-PRIMER.md)** — primer on Robolectric internals (sandbox lifecycle, classloader delegation, bytecode instrumentation, shadows). Read when reasoning about classloader behaviour while debugging.
+- **[STARTUP.md](STARTUP.md)** — daemon startup latency analysis. Where the time goes; menu of options to attack each cost.
+- **[HISTORY.md](HISTORY.md)** — preview history archive: on-disk schema, JSON-RPC API, MCP and VS Code mappings, branch/worktree provenance, pluggable `HistorySource` backends.
+
+### MCP
+
+- **[MCP.md](MCP.md)** — MCP server overview: how the daemon's JSON-RPC surface maps onto MCP resources, subscriptions, and tools.
+- **[MCP-KOTLIN.md](MCP-KOTLIN.md)** — concrete implementation reference for the `:mcp` module.
+
+### Future work
+
+- **[PREDICTIVE.md](PREDICTIVE.md)** — predictive prefetch design (v1.1+).
+- **[TEST-HARNESS.md](TEST-HARNESS.md)** — harness design: scenarios, FakeHost vs real-mode, image-baseline strategy, CI workflow.
+
+### Reference data
+
+- **[baseline-latency.md](baseline-latency.md)** + **[baseline-latency.csv](baseline-latency.csv)** — captured per-target / per-scenario timing baselines from the bench harnesses.
+- **[classloader-forensics-diff.md](classloader-forensics-diff.md)** + **[classloader-forensics-diff.json](classloader-forensics-diff.json)** — captured forensic dumps from the Android save-loop investigation.
+- **[protocol-fixtures/](protocol-fixtures/)** — golden JSON message corpus consumed by both the Kotlin and TypeScript test suites.
+
+### Planning
+
+- **[TODO.md](TODO.md)** — work breakdown. Most items are landed; remaining open work is enumerated in the "What's open" section above.
 
 ## Non-goals (v1)
 
-- Per-project (multi-module) sandbox sharing — deferred. Each module gets its own daemon.
-- CLI / MCP daemon mode — CLI keeps using the Gradle task.
+- Per-project (multi-module) sandbox sharing — each module gets its own daemon.
 - Replacing the Gradle `renderPreviews` task — kept as fallback and CI-canonical path indefinitely.
 - Hot kotlinc / compile daemon integration — v2.
 - Tier-3 dependency-graph reachability index — v1 ships with conservative "module-changed = all previews stale, filtered by visibility."
 
 ## How to use these docs
 
-If you're reviewing the proposal: read [DESIGN.md](DESIGN.md) end to end (~30 min).
+If you're reviewing the architecture: read [DESIGN.md](DESIGN.md) end to end (~30 min), then [LAYERING.md](LAYERING.md).
 
-If you're implementing or about to assign work to agents: read [DESIGN.md](DESIGN.md) for context, then drive the work from [TODO.md](TODO.md) which has the dependency graph and parallel work streams.
+If you're implementing or reviewing daemon code: [PROTOCOL.md](PROTOCOL.md) is the wire-format authority; [CLASSLOADER.md](CLASSLOADER.md) is the save-loop story.
 
-If you're triaging a daemon bug: future `docs/daemon/TROUBLESHOOTING.md` once the thing exists.
+If you're working on the MCP surface: [MCP.md](MCP.md) for the high-level mapping, [MCP-KOTLIN.md](MCP-KOTLIN.md) for the implementation specifics.
+
+If you're triaging a daemon bug: [`daemon/desktop/CONTRIBUTING.md`](../../daemon/desktop/CONTRIBUTING.md) has the no-mid-render-cancellation reviewer checklist.

--- a/docs/daemon/TEST-HARNESS.md
+++ b/docs/daemon/TEST-HARNESS.md
@@ -1,8 +1,14 @@
 # Preview daemon — end-to-end test harness
 
-> **Status:** design proposal. No code yet. Ladder ships in v0..v3 (§ 9). Not
-> in scope for any current Stream B/C task; lives under Stream D alongside
-> the bench harnesses (P0.1 / P0.6 / D2.1 / D2.2 / D2.3).
+> **Status:** implemented as `:daemon:harness`. Scenarios S1–S10 ship
+> across both desktop and android targets in fake and real modes (per
+> [TODO.md § Phase D-harness](TODO.md)); CI runs `desktop-fake`,
+> `desktop-real`, and `android-real` jobs in
+> `.github/workflows/daemon-harness.yml`. Outstanding work tracked in
+> the v3 ladder (§ 9): session-mode soak, weekly drift-report workflow,
+> S6/S9/S10 lifting once their gating features (B2.1 ✅, B2.5, P2.5.2)
+> ship. This doc is the design + scenario reference; the implementation
+> matches it.
 
 This document specifies a **VS-Code-shaped driver** that exercises a real
 daemon JVM over JSON-RPC the way the editor will, but without any editor in


### PR DESCRIPTION
## Summary

Update design documentation to reflect the completed implementation of the preview daemon and MCP server. The docs now describe the shipped code rather than design proposals, with implementation details moved to appropriate reference sections.

## Key Changes

- **MCP-KOTLIN.md**: Converted from design proposal to implementation reference
  - Removed speculative architecture sections (Option A/B/C analysis)
  - Added concrete module layout for `:mcp` (top-level, not `:daemon:mcp`)
  - Documented why the MCP Kotlin SDK was not used (auto-registration of handlers, wire-layer self-containment)
  - Added detailed sections on key classes: `DaemonSupervisor`, `DaemonMcpServer`, `McpSession`, `Subscriptions`, `WatchPropagator`, URI types
  - Documented full lifecycle: server start, first preview request, classpath-dirty handling, daemon death, client disconnect
  - Clarified transport: stdio only (HTTP/SSE deferred)

- **MCP.md**: Reframed from design proposal to high-level overview
  - Updated status to "implemented in `:mcp`"
  - Simplified "Why" section (removed "two unappealing options" framing)
  - Condensed push-notification explanation (removed transport options discussion)
  - Moved architecture details to MCP-KOTLIN.md
  - Kept high-level daemon↔MCP mapping (resources, subscriptions, tools)
  - Added concrete tool table with v0 surface (10 tools)
  - Clarified that `classpathDirty` triggers MCP-side respawn, not client propagation

- **README.md**: Updated status and structure
  - Changed from "design only" to listing what ships today
  - Reorganized to show implemented components (`:daemon:core`, `:daemon:android`, `:daemon:desktop`, `:daemon:harness`, `:mcp`)
  - Moved open work to separate section (B2.4/B2.5/B2.6, history features, predictive prefetch)

- **LAYERING.md**: Updated status from design rule to active architectural rule
  - Noted that constraints held and prevented entanglement
  - Added note that this is mandatory reading before adding cross-layer hooks

- **PROTOCOL.md**: Minor clarification
  - Added comment that `leakDetection` is reserved but always empty today (TODO B2.4)

- **CLASSLOADER-FORENSICS.md, HISTORY.md, CLASSLOADER.md, DESIGN.md, TEST-HARNESS.md**: Updated status headers
  - Changed from "design proposal" / "design only" to "implemented"
  - Added references to shipped code locations where applicable

## Notable Implementation Details

- The `:mcp` module is a top-level module (parallel to `:daemon:core`), not nested under `:daemon:`
- Transport is stdio-only with LSP-style `Content-Length:` framing (same as daemon)
- Wire-shape code is hand-rolled rather than using the MCP Kotlin SDK to maintain control over the dynamic resource catalog and push subscription model
- Multi-workspace support via `WorkspaceId` derived from `(rootProjectName, canonicalPath)` hash
- Two-tier subscription model: per-URI subscriptions + watch entries with glob matching
- Classpath-dirty handling includes respawn cap (1 self-loop) to prevent thrashing on stale descriptors

https://claude.ai/code/session_01LpcrKtheq4CdU2XBP9cwMh