### PR TITLE
feat(mcp): 1+N replica model per (workspace, module) for parallel renders

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/StartupTimings.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/StartupTimings.kt
@@ -8,14 +8,15 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Wall-clock timeline of the daemon's interesting boot events.
  *
  * Emit a [mark] at every stage that contributes meaningfully to startup latency. Each mark prints a
- * single stderr line `compose-ai-daemon: [+<elapsedMs>ms] <label>` and is buffered for [summary]
- * so the full timeline is reproducible after the fact. The reference clock is the JVM start time
- * (via [ManagementFactory.getRuntimeMXBean]) so events seen on the worker thread, the JSON-RPC
- * thread, and inside the Robolectric sandbox all line up against one shared origin.
+ * single stderr line `compose-ai-daemon: [+<elapsedMs>ms] <label>` and is buffered for [summary] so
+ * the full timeline is reproducible after the fact. The reference clock is the JVM start time (via
+ * [ManagementFactory.getRuntimeMXBean]) so events seen on the worker thread, the JSON-RPC thread,
+ * and inside the Robolectric sandbox all line up against one shared origin.
  *
  * The format is human-readable on purpose — operators reading daemon stderr (or the editor's
  * "daemon log" output channel) shouldn't need a JSON parser to see "step 3 took 8 seconds." For
- * machine consumption a future change can wire [marks] into a `daemonTimings` JSON-RPC notification.
+ * machine consumption a future change can wire [marks] into a `daemonTimings` JSON-RPC
+ * notification.
  *
  * Reasons to add a mark:
  *
@@ -27,8 +28,8 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Reasons NOT to add a mark:
  *
  * - Every queue insertion / dequeue (too noisy; spam dilutes the signal).
- * - Anything inside the steady-state render path (this is a *startup* timeline; render-time
- *   metrics already flow through `renderFinished.metrics`).
+ * - Anything inside the steady-state render path (this is a *startup* timeline; render-time metrics
+ *   already flow through `renderFinished.metrics`).
  *
  * See [docs/daemon/STARTUP.md](../../../../../../docs/daemon/STARTUP.md) for the analysis of where
  * the time actually goes and the menu of options to attack each stage.

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -11,12 +11,16 @@ import kotlinx.serialization.json.JsonObject
  * **CLI:**
  *
  * ```
- * compose-preview-mcp [--project <path>[:<rootProjectName>]]...
+ * compose-preview-mcp [--project <path>[:<rootProjectName>]]... [--replicas-per-daemon <N>]
  * ```
  *
  * Each `--project` flag pre-registers a workspace with the supervisor at startup so connecting
  * clients see the project in `list_projects` immediately. Projects can also be added at runtime via
  * the `register_project` MCP tool.
+ *
+ * `--replicas-per-daemon N` (or the `composeai.mcp.replicasPerDaemon` system property) spawns N
+ * extra in-process replicas per (workspace, module) for render fan-out — see
+ * [DaemonSupervisor.replicasPerDaemon]. Default 0 (one daemon per module).
  *
  * On stdin EOF the server tears down every supervised daemon (sending `shutdown` + `exit` per
  * PROTOCOL.md § 3) and exits cleanly.
@@ -25,10 +29,12 @@ object DaemonMcpMain {
 
   @JvmStatic
   fun main(args: Array<String>) {
+    val replicasPerDaemon = parseReplicasPerDaemon(args)
     val supervisor =
       DaemonSupervisor(
         descriptorProvider = DescriptorProvider.readingFromDisk(),
         clientFactory = SubprocessDaemonClientFactory(),
+        replicasPerDaemon = replicasPerDaemon,
       )
     val server = DaemonMcpServer(supervisor)
 
@@ -79,6 +85,33 @@ object DaemonMcpMain {
     val idx = raw.lastIndexOf(':')
     return if (idx <= 0) raw to null
     else raw.substring(0, idx) to raw.substring(idx + 1).takeIf { it.isNotEmpty() }
+  }
+
+  private fun parseReplicasPerDaemon(args: Array<String>): Int {
+    // CLI flag wins over the system property; system property wins over the default. Negative
+    // or unparseable values fall back to 0 with a stderr warning rather than crashing the server
+    // — replication is an opt-in optimisation, not load-bearing.
+    val fromArgs =
+      generateSequence(0) { it + 1 }
+        .takeWhile { it < args.size }
+        .firstNotNullOfOrNull { i ->
+          when {
+            args[i] == "--replicas-per-daemon" && i + 1 < args.size -> args[i + 1]
+            args[i].startsWith("--replicas-per-daemon=") ->
+              args[i].removePrefix("--replicas-per-daemon=")
+            else -> null
+          }
+        }
+    val raw = fromArgs ?: System.getProperty("composeai.mcp.replicasPerDaemon")
+    if (raw.isNullOrBlank()) return 0
+    val parsed = raw.toIntOrNull()
+    if (parsed == null || parsed < 0) {
+      System.err.println(
+        "compose-preview-mcp: ignoring invalid --replicas-per-daemon='$raw' (want non-negative int)"
+      )
+      return 0
+    }
+    return parsed
   }
 }
 

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -115,13 +115,14 @@ class DaemonMcpServer(
 
   /**
    * Worker for slow daemon-lifecycle work — replacement-daemon spawn after a `classpathDirty`
-   * notification, and async first-spawn from the `watch` tool. Single-threaded so concurrent
-   * requests for the same module don't double-spawn (the supervisor's `daemonFor` is already
-   * `computeIfAbsent`-safe, but serialising here also keeps the McpSession reader thread free).
-   * Daemon-flagged so it never delays JVM shutdown.
+   * notification, and async first-spawn from the `watch` tool. Bounded multi-threaded so several
+   * modules can cold-start in parallel — without this, a workspace with N preview modules paid `N ×
+   * cold-start` (Robolectric: minutes on a cold Maven cache). The supervisor's `daemonFor` is
+   * `computeIfAbsent`-safe so concurrent requests for the same module still de-dup. Daemon-flagged
+   * so the executor never delays JVM shutdown.
    */
   private val daemonLifecycleExecutor: java.util.concurrent.ExecutorService =
-    java.util.concurrent.Executors.newSingleThreadExecutor { r ->
+    java.util.concurrent.Executors.newFixedThreadPool(DAEMON_LIFECYCLE_THREADS) { r ->
       Thread(r, "mcp-daemon-lifecycle").apply { isDaemon = true }
     }
 
@@ -295,7 +296,13 @@ class DaemonMcpServer(
       l.add(future)
       l
     }
-    daemon.client.renderNow(previews = listOf(uri.previewFqn), tier = RenderTier.FULL)
+    // Shard render fan-out across replicas: same previewFqn → same replica (cache locality +
+    // dedup), different previewFqns → spread across replicas so concurrent renders run in
+    // parallel. With replicasPerDaemon = 0 this collapses to the primary, preserving the
+    // single-daemon path.
+    daemon
+      .clientForRender(uri.previewFqn)
+      .renderNow(previews = listOf(uri.previewFqn), tier = RenderTier.FULL)
     // Optional `notifications/progress` beat: when the client opted in via
     // `_meta.progressToken`, fire periodic monotonic progress notifications so a UI can show a
     // spinner / progress bar while the slow render completes. Beat thread is daemon-flagged
@@ -836,8 +843,12 @@ class DaemonMcpServer(
     var forwarded = 0
     var rendered = 0
     project.daemons.values.forEach { daemon ->
-      runCatching { daemon.client.fileChanged(path = path, kind = kind, changeType = changeType) }
-        .onSuccess { forwarded++ }
+      // File invalidation must reach EVERY replica — each replica has its own independent
+      // discovery + render cache, so missing one would leave it serving stale bytes.
+      daemon.allClients().forEach { client ->
+        runCatching { client.fileChanged(path = path, kind = kind, changeType = changeType) }
+          .onSuccess { forwarded++ }
+      }
       val byId = catalog[DaemonAddr(daemon.workspaceId, daemon.modulePath)] ?: return@forEach
       // Build the candidate URI set for this daemon and intersect with current watches/subs.
       val candidates =
@@ -854,14 +865,20 @@ class DaemonMcpServer(
           subscriptions.sessionsSubscribedTo(uri.toUri()).isNotEmpty()
       }
       if (ofInterest.isNotEmpty()) {
-        runCatching {
-          daemon.client.renderNow(
-            previews = ofInterest.map { it.previewFqn },
-            tier = RenderTier.FULL,
-            reason = "notify_file_changed:$path",
-          )
+        // Group renders by their target replica so we issue one renderNow per replica with the
+        // subset of previews it owns. Same hash function as `clientForRender` so the dispatch
+        // here matches what `renderAndReadBytes` would do for the same previewFqn.
+        val byReplica = ofInterest.groupBy { daemon.clientForRender(it.previewFqn) }
+        byReplica.forEach { (client, group) ->
+          runCatching {
+            client.renderNow(
+              previews = group.map { it.previewFqn },
+              tier = RenderTier.FULL,
+              reason = "notify_file_changed:$path",
+            )
+          }
+          rendered += group.size
         }
-        rendered += ofInterest.size
       }
     }
     return textCallToolResult(
@@ -993,12 +1010,15 @@ class DaemonMcpServer(
         }
       }
 
-    // Forget the daemon + cached state. (The daemon's wire close will also fire `onClose` and
-    // try to remove the same catalog entry — a second remove is a no-op.)
-    supervisor.forgetDaemon(workspaceId, modulePath)
+    // Forget the daemon + cached state. With `replicasPerDaemon > 0`, multiple replicas of the
+    // same group may race to emit `classpathDirty` (they all see the same stale classpath). The
+    // first call wins — `forgetDaemon` returns false on subsequent calls so we skip the
+    // respawn-counter bump and the respawn schedule, avoiding double-spawn under the race.
+    val firstClassedDirty = supervisor.forgetDaemon(workspaceId, modulePath)
     catalog.remove(DaemonAddr(workspaceId, modulePath))
     watchPropagator.forget(daemon)
     sessions.forEach { it.notifyResourceListChanged() }
+    if (!firstClassedDirty) return
 
     // Track respawn attempts so a permanently-stale descriptor (one whose own classpath
     // fingerprint disagrees with reality) doesn't loop forever.
@@ -1110,5 +1130,12 @@ class DaemonMcpServer(
      * balance between "responsive UI updates" and "not flooding the wire on a fast render".
      */
     private const val PROGRESS_BEAT_INTERVAL_MS: Long = 500
+
+    /**
+     * Worker count for [daemonLifecycleExecutor]. Sized so a few modules can cold-start in parallel
+     * without forking enough JVMs to thrash the host; aligns with the supervisor's own
+     * replica-spawn pool cap.
+     */
+    private const val DAEMON_LIFECYCLE_THREADS: Int = 4
   }
 }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -2,6 +2,10 @@ package ee.schimke.composeai.mcp
 
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -27,9 +31,34 @@ class DaemonSupervisor(
   private val descriptorProvider: DescriptorProvider,
   private val clientFactory: DaemonClientFactory,
   private val router: NotificationRouter = NotificationRouter(),
+  /**
+   * Extra in-process replicas to spawn per (workspace, module) once the primary is up. The primary
+   * is always spawned synchronously and seeds the catalog via `synthesiseInitialDiscovery`; the
+   * replicas come up off-thread, share the (now-warm) Maven cache, and absorb render fan-out so
+   * concurrent `renderNow` requests for different previews don't queue behind each other on a
+   * single render thread. `replicasPerDaemon = 0` (the default) preserves the original
+   * 1-daemon-per-module behaviour. Total daemons per module = `1 + replicasPerDaemon`.
+   */
+  private val replicasPerDaemon: Int = 0,
 ) {
 
+  init {
+    require(replicasPerDaemon >= 0) { "replicasPerDaemon must be >= 0, got $replicasPerDaemon" }
+  }
+
   private val projects = ConcurrentHashMap<WorkspaceId, RegisteredProject>()
+
+  /**
+   * Off-thread spawner for **additional replicas** beyond the primary. Sized to the configured
+   * replica count so all replicas of one module can come up in parallel; capped so several modules
+   * spawning concurrently don't fork an unbounded number of JVMs.
+   */
+  private val replicaSpawnExecutor: ExecutorService =
+    Executors.newFixedThreadPool(
+      maxOf(1, replicasPerDaemon).coerceAtMost(REPLICA_SPAWN_POOL_CAP)
+    ) { r ->
+      Thread(r, "mcp-daemon-replica-spawn").apply { isDaemon = true }
+    }
 
   /**
    * Registers a project at [absolutePath] (must already exist on disk). Returns the assigned
@@ -87,17 +116,22 @@ class DaemonSupervisor(
   fun project(workspaceId: WorkspaceId): RegisteredProject? = projects[workspaceId]
 
   /**
-   * Forgets the [SupervisedDaemon] for [workspaceId] + [modulePath] without ordering a shutdown —
-   * the daemon already announced it's exiting (classpathDirty) and will close the wire on its own.
-   * The next [daemonFor] for the same coordinates spawns afresh against the (presumably refreshed)
-   * descriptor.
+   * Forgets the [SupervisedDaemon] for [workspaceId] + [modulePath] and tears down any peer
+   * replicas. Intended for the `classpathDirty` respawn flow: the dirty replica is already exiting
+   * on its own, but with `replicasPerDaemon > 0` the peers are still alive on the same stale
+   * classpath and must be killed explicitly. Shutdown of the dirty replica is a no-op (its wire is
+   * already closing); peer shutdowns send `shutdown`/`exit` per protocol.
    *
-   * Intended for the `classpathDirty` respawn flow only. Returns `true` if a daemon entry was
-   * actually removed.
+   * The next [daemonFor] for the same coordinates spawns afresh against the (presumably refreshed)
+   * descriptor. Returns `true` if a daemon entry was actually removed — the second of two racing
+   * `classpathDirty` events from different replicas of the same group sees `false` and can skip the
+   * respawn-counter bump.
    */
   fun forgetDaemon(workspaceId: WorkspaceId, modulePath: String): Boolean {
     val project = projects[workspaceId] ?: return false
-    return project.daemons.remove(modulePath) != null
+    val removed = project.daemons.remove(modulePath) ?: return false
+    runCatching { removed.shutdown() }
+    return true
   }
 
   /**
@@ -119,6 +153,8 @@ class DaemonSupervisor(
       project.daemons.clear()
     }
     projects.clear()
+    replicaSpawnExecutor.shutdown()
+    runCatching { replicaSpawnExecutor.awaitTermination(2, TimeUnit.SECONDS) }
   }
 
   /** Returns the [NotificationRouter] so callers can register handlers. */
@@ -130,29 +166,85 @@ class DaemonSupervisor(
 
   private fun spawn(project: RegisteredProject, modulePath: String): SupervisedDaemon {
     val descriptor = descriptorProvider.descriptorFor(project, modulePath)
+    val supervised = SupervisedDaemon(workspaceId = project.workspaceId, modulePath = modulePath)
+
+    // Primary spawn is synchronous so the calling thread blocks on cold-start and the catalog is
+    // seeded before any subsequent `daemonFor` returns. Subsequent replicas piggy-back on the
+    // (now-warm) Maven cache — see `replicasPerDaemon` KDoc.
+    spawnReplica(project, descriptor, supervised, isPrimary = true)
+
+    // Fire off replica spawns in parallel. They share the warmed Maven cache and the JIT'd
+    // classloader cache from the primary, so cold-start cost is dominated by the primary; the
+    // replicas come up in roughly max(replica) instead of sum(replicas).
+    repeat(replicasPerDaemon) { idx ->
+      replicaSpawnExecutor.execute {
+        runCatching { spawnReplica(project, descriptor, supervised, isPrimary = false) }
+          .onFailure {
+            System.err.println(
+              "DaemonSupervisor: replica spawn ${idx + 1} failed for " +
+                "${project.workspaceId}/$modulePath: ${it.message}"
+            )
+          }
+      }
+    }
+
+    return supervised
+  }
+
+  /**
+   * Spawns one client (primary or replica) and attaches it to [supervised]. The primary blocks on
+   * `initialize` and seeds the catalog via [synthesiseInitialDiscovery]; replicas only need to
+   * `initialize` (catalog is already populated by the primary's manifest read).
+   */
+  private fun spawnReplica(
+    project: RegisteredProject,
+    descriptor: DaemonLaunchDescriptor,
+    supervised: SupervisedDaemon,
+    isPrimary: Boolean,
+  ) {
     val spawn = clientFactory.spawn(project, descriptor)
-    val supervised =
-      SupervisedDaemon(workspaceId = project.workspaceId, modulePath = modulePath, spawn = spawn)
+    // Wire the client BEFORE publishing the spawn to the replica list — otherwise a concurrent
+    // `clientForRender` reader could pick this index and call `.client` before the spawn's
+    // internal lazy client field is initialised (DaemonSpawn implementations construct the
+    // DaemonClient inside `client(onNotification, onClose)`).
     spawn.client(
       onNotification = { method, params -> router.dispatch(supervised, method, params) },
-      onClose = { router.dispatchClose(supervised) },
+      onClose = {
+        // Only fire dispatchClose to handlers (which drop catalog state etc.) when the *last*
+        // replica is gone — otherwise a single replica's wire close would tear down state shared
+        // with its still-alive peers.
+        if (supervised.removeReplica(spawn)) {
+          router.dispatchClose(supervised)
+        }
+      },
     )
+    supervised.addReplica(spawn)
     runCatching {
       val result =
         spawn.client.initialize(
           workspaceRoot = project.path.absolutePath,
-          moduleId = modulePath,
+          moduleId = descriptor.modulePath,
           moduleProjectDir = descriptor.workingDirectory,
         )
-      // The daemon only emits `discoveryUpdated` for *deltas* — the initial preview set comes via
-      // `initialize.manifest.path` (a `previews.json` written by the gradle plugin's
-      // `discoverPreviews` task). Synthesise an initial `discoveryUpdated` notification by reading
-      // that file and dispatching it through the router as if it were a wire-level event. This
-      // keeps every catalog-population code path (DaemonMcpServer.onDiscoveryUpdated) on a single
-      // shape rather than splitting "initial seed" vs "incremental".
-      synthesiseInitialDiscovery(supervised, result.manifest.path)
+      if (isPrimary) {
+        // The daemon only emits `discoveryUpdated` for *deltas* — the initial preview set comes
+        // via `initialize.manifest.path` (a `previews.json` written by the gradle plugin's
+        // `discoverPreviews` task). Synthesise an initial `discoveryUpdated` notification by
+        // reading that file and dispatching it through the router as if it were a wire-level
+        // event. Replicas of the same module would synthesise the same set, so we skip them.
+        synthesiseInitialDiscovery(supervised, result.manifest.path)
+      }
     }
-    return supervised
+  }
+
+  companion object {
+    /**
+     * Cap on the replica-spawn thread pool. With many modules each requesting `replicasPerDaemon`
+     * extra replicas, an unbounded pool would fork tens of JVMs at once and trash the host. Cold
+     * Robolectric bootstraps are CPU + I/O heavy, so eight concurrent forks is the comfortable
+     * upper bound on a typical dev machine.
+     */
+    private const val REPLICA_SPAWN_POOL_CAP: Int = 8
   }
 
   private fun synthesiseInitialDiscovery(daemon: SupervisedDaemon, manifestPath: String) {
@@ -192,16 +284,73 @@ data class RegisteredProject(
   val daemons: ConcurrentHashMap<String, SupervisedDaemon> = ConcurrentHashMap(),
 )
 
-/** A live daemon — owned by [DaemonSupervisor]. */
-class SupervisedDaemon(
-  val workspaceId: WorkspaceId,
-  val modulePath: String,
-  private val spawn: DaemonSpawn,
-) {
-  val client: DaemonClient
-    get() = spawn.client
+/**
+ * A live daemon — owned by [DaemonSupervisor]. May front 1+N underlying replicas (see
+ * [DaemonSupervisor.replicasPerDaemon]). All replicas serve the same (workspaceId, modulePath); the
+ * supervisor uses the group to fan out invalidations and shard render fan-out.
+ */
+class SupervisedDaemon(val workspaceId: WorkspaceId, val modulePath: String) {
 
-  fun shutdown() = spawn.shutdown()
+  /**
+   * Replicas in spawn order. The primary is at index 0, populated by the synchronous spawn path;
+   * extra replicas append as their async spawns finish. Iterations take a snapshot — the list is
+   * copy-on-write so concurrent appends + reads are safe.
+   */
+  private val replicas: CopyOnWriteArrayList<DaemonSpawn> = CopyOnWriteArrayList()
+
+  /**
+   * The primary [DaemonClient]. Used for control-plane operations (`initialize`, `history*`,
+   * `setVisible`/`setFocus` — though propagation fans out to every replica, see [allClients]).
+   * Throws if no replica has been registered yet (only possible during the brief window before the
+   * primary's synchronous spawn returns).
+   */
+  val client: DaemonClient
+    get() {
+      val list = replicas
+      check(list.isNotEmpty()) { "SupervisedDaemon($workspaceId/$modulePath): no replicas" }
+      return list[0].client
+    }
+
+  /** Snapshot of every active replica's client — for fan-out (e.g. `fileChanged`, `setVisible`). */
+  fun allClients(): List<DaemonClient> = replicas.map { it.client }
+
+  /**
+   * Picks a replica's client for a render keyed on [previewId]. Hash-based so the same preview
+   * lands on the same replica every time (cache locality + render dedup); different previews spread
+   * across replicas so concurrent renders run in parallel. Falls back to the primary when no
+   * replica is yet registered.
+   */
+  fun clientForRender(previewId: String): DaemonClient {
+    val list = replicas
+    if (list.isEmpty()) error("SupervisedDaemon($workspaceId/$modulePath): no replicas")
+    if (list.size == 1) return list[0].client
+    // Math.floorMod gives a non-negative index even for negative hashCodes.
+    val idx = Math.floorMod(previewId.hashCode(), list.size)
+    return list[idx].client
+  }
+
+  /** Number of currently-active replicas (primary + extras). */
+  fun replicaCount(): Int = replicas.size
+
+  internal fun addReplica(spawn: DaemonSpawn) {
+    replicas.add(spawn)
+  }
+
+  /**
+   * Removes [spawn] from the replica set. Returns `true` if this was the *last* replica — callers
+   * use this to decide whether to fire group-level cleanup (e.g. dispatching `onClose` to handlers
+   * that own per-(workspace, module) state).
+   */
+  internal fun removeReplica(spawn: DaemonSpawn): Boolean {
+    replicas.remove(spawn)
+    return replicas.isEmpty()
+  }
+
+  fun shutdown() {
+    val snapshot = replicas.toList()
+    replicas.clear()
+    snapshot.forEach { runCatching { it.shutdown() } }
+  }
 }
 
 /**

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/WatchPropagator.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/WatchPropagator.kt
@@ -54,8 +54,14 @@ class WatchPropagator(
     if ((previous ?: emptySet()) == watched) return
     lastSent[key] = watched
     val ids = watched.toList()
-    runCatching { daemon.client.setVisible(ids) }
-    runCatching { daemon.client.setFocus(ids) }
+    // Fan out to every replica — each replica has its own render queue + visible-set state and
+    // consults it when prioritising background renders, so they all need the same view of "what
+    // the user is looking at". With `replicasPerDaemon = 0` this collapses to one call to the
+    // primary, preserving existing behaviour.
+    daemon.allClients().forEach { client ->
+      runCatching { client.setVisible(ids) }
+      runCatching { client.setFocus(ids) }
+    }
   }
 
   /**

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonSupervisorReplicaTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonSupervisorReplicaTest.kt
@@ -1,0 +1,259 @@
+package ee.schimke.composeai.mcp
+
+import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.mcp.protocol.ReadResourceResult
+import ee.schimke.composeai.mcp.protocol.ResourceContents
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.nio.file.Files
+import java.util.Base64
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Exercises the 1+N replica model: per-(workspace, module) daemons fan out across replicas so
+ * concurrent renders run in parallel. The default `replicasPerDaemon = 0` is covered by the
+ * existing [DaemonMcpServerTest]; here we wire `replicasPerDaemon = 2` so each `daemonFor` results
+ * in three [FakeDaemon] instances (1 primary + 2 extras), and assert the supervisor shards renders,
+ * fans out invalidations, and dispatches close only when the LAST replica is gone.
+ */
+class DaemonSupervisorReplicaTest {
+
+  @get:Rule val tmp = TemporaryFolder()
+
+  private lateinit var supervisor: DaemonSupervisor
+  private lateinit var factory: FakeDaemonClientFactory
+  private lateinit var server: DaemonMcpServer
+  private lateinit var client: McpTestClient
+  private lateinit var session: McpSession
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Before
+  fun setUp() {
+    factory = FakeDaemonClientFactory()
+    supervisor =
+      DaemonSupervisor(
+        descriptorProvider = FakeDescriptorProvider(),
+        clientFactory = factory,
+        replicasPerDaemon = 2,
+      )
+    server = DaemonMcpServer(supervisor)
+
+    val (clientToServer, serverFromClient) = pipedPair()
+    val (serverToClient, clientFromServer) = pipedPair()
+    session = server.newSession(input = serverFromClient, output = serverToClient)
+    session.start()
+    client = McpTestClient(input = clientFromServer, output = clientToServer)
+  }
+
+  @After
+  fun tearDown() {
+    runCatching { client.close() }
+    runCatching { session.close() }
+    runCatching { supervisor.shutdown() }
+  }
+
+  @Test
+  fun `daemonFor spawns 1 primary plus N replicas`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    supervisor.daemonFor(workspaceId, ":module")
+    waitForReplicas(expected = 3)
+    assertThat(factory.spawnHistory.size).isEqualTo(3)
+    val daemon = supervisor.daemonFor(workspaceId, ":module")
+    assertThat(daemon.replicaCount()).isEqualTo(3)
+    // All three are wired to the same logical SupervisedDaemon — exiting any one of them must
+    // not drop catalog state until the LAST one closes (asserted in `closeOnly...` below).
+    assertThat(daemon.allClients()).hasSize(3)
+  }
+
+  @Test
+  fun `renderNow shards previews across replicas by hash`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    supervisor.daemonFor(workspaceId, ":module")
+    waitForReplicas(expected = 3)
+    val replicas = factory.spawnHistory.toList()
+
+    // Stage a PNG and arm every replica to auto-emit renderFinished — only the chosen replica
+    // for each preview will actually receive the renderNow, so only its emit fires; others stay
+    // idle. We register the auto-emitter on every replica defensively so a routing bug shows up
+    // as "the wrong replica produced the bytes" rather than a hung test.
+    val pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3)
+    val pngFile = tmp.newFile("replica-fake-render.png")
+    Files.write(pngFile.toPath(), pngBytes)
+    val previewIds =
+      listOf("com.example.Alpha", "com.example.Bravo", "com.example.Charlie", "com.example.Delta")
+    replicas.forEach { it.autoRenderPngPath = { _ -> pngFile.absolutePath } }
+    // Drive discoveryUpdated through the primary so the catalog populates; replicas would emit
+    // the same set, which is idempotent in onDiscoveryUpdated.
+    val primary = replicas[0]
+    previewIds.forEach { primary.emitDiscovery(it) }
+    repeat(previewIds.size) {
+      client.expectNotification("notifications/resources/list_changed", 2_000)
+    }
+
+    // Issue a render for each preview id and verify the renderNow lands on the replica chosen by
+    // the same hash function the supervisor uses.
+    previewIds.forEach { previewId ->
+      val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+      val resp =
+        client.request("resources/read", buildJsonObject { put("uri", uri) }, timeoutMs = 5_000)
+      val parsed = json.decodeFromJsonElement(ReadResourceResult.serializer(), resp)
+      val blob = parsed.contents.single() as ResourceContents.Blob
+      assertThat(Base64.getDecoder().decode(blob.blob)).isEqualTo(pngBytes)
+
+      val expectedReplica = replicas[Math.floorMod(previewId.hashCode(), replicas.size)]
+      val rendered = expectedReplica.renderRequests.poll(2_000, TimeUnit.MILLISECONDS)
+      assertThat(rendered).isEqualTo(listOf(previewId))
+      // No OTHER replica should have observed a renderNow for this preview — drains stale state.
+      replicas
+        .filter { it !== expectedReplica }
+        .forEach {
+          val stray = it.renderRequests.poll(50, TimeUnit.MILLISECONDS)
+          assertThat(stray).isNull()
+        }
+    }
+  }
+
+  @Test
+  fun `setVisible fans out to every replica`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    supervisor.daemonFor(workspaceId, ":module")
+    waitForReplicas(expected = 3)
+    val replicas = factory.spawnHistory.toList()
+    replicas[0].emitDiscovery("com.example.Red")
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    client.callTool(
+      "watch",
+      buildJsonObject {
+        put("workspaceId", workspaceId.value)
+        put("module", ":module")
+        put("fqnGlob", "com.example.Red")
+      },
+    )
+
+    // Each replica must observe its own setVisible/setFocus — render queues are per-replica,
+    // so only fanning out to the primary would leave peers blind to user attention.
+    replicas.forEach { fake ->
+      val visible = fake.visibleSets.poll(2_000, TimeUnit.MILLISECONDS)
+      val focus = fake.focusSets.poll(2_000, TimeUnit.MILLISECONDS)
+      assertThat(visible).isEqualTo(listOf("com.example.Red"))
+      assertThat(focus).isEqualTo(listOf("com.example.Red"))
+    }
+  }
+
+  @Test
+  fun `notify_file_changed forwards fileChanged to every replica`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    supervisor.daemonFor(workspaceId, ":module")
+    waitForReplicas(expected = 3)
+    val replicas = factory.spawnHistory.toList()
+
+    val callResp =
+      client.callTool(
+        "notify_file_changed",
+        buildJsonObject {
+          put("workspaceId", workspaceId.value)
+          put("path", "/tmp/example.kt")
+        },
+      )
+    val text = callResp.firstTextContent()
+    // Server reports total fileChanged forwards across (replica × daemon) — with one daemon and
+    // three replicas that's 3.
+    assertThat(text).contains("forwarded to 3 daemon(s)")
+  }
+
+  @Test
+  fun `classpathDirty on one replica tears down peers and respawns the group`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    supervisor.daemonFor(workspaceId, ":module")
+    waitForReplicas(expected = 3)
+    val firstGroup = factory.spawnHistory.toList()
+
+    // Fire classpathDirty on the primary — peers are still up, so the supervisor must shutdown
+    // them explicitly before respawning a fresh group.
+    firstGroup[0].emitClasspathDirty()
+
+    // Wait for the supervisor's async respawn to construct three more FakeDaemons (1 primary +
+    // 2 replicas of the new group).
+    val deadline = System.currentTimeMillis() + 10_000
+    while (factory.spawnHistory.size < 6 && System.currentTimeMillis() < deadline) {
+      Thread.sleep(50)
+    }
+    assertThat(factory.spawnHistory.size).isAtLeast(6)
+    val secondGroup = factory.spawnHistory.subList(3, factory.spawnHistory.size)
+    assertThat(secondGroup).hasSize(3)
+    val newDaemon = supervisor.daemonFor(workspaceId, ":module")
+    assertThat(newDaemon.replicaCount()).isEqualTo(3)
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers (mirror DaemonMcpServerTest's helpers — kept private here to avoid a shared base
+  // class for two test files).
+  // -------------------------------------------------------------------------
+
+  private fun registerWorkspace(projectDir: java.io.File, rootName: String): WorkspaceId {
+    val resp =
+      client.callTool(
+        "register_project",
+        buildJsonObject {
+          put("path", projectDir.absolutePath)
+          put("rootProjectName", rootName)
+        },
+      )
+    val payload = json.parseToJsonElement(resp.firstTextContent()).jsonObject
+    val ws = payload["workspaceId"]!!.jsonPrimitive.content
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+    return WorkspaceId(ws)
+  }
+
+  /**
+   * Polls [FakeDaemonClientFactory.spawnHistory] until [expected] replicas have been spawned. The
+   * primary is synchronous but extras come up off-thread on the supervisor's replica spawn pool.
+   */
+  private fun waitForReplicas(expected: Int, timeoutMs: Long = 5_000) {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (factory.spawnHistory.size < expected && System.currentTimeMillis() < deadline) {
+      Thread.sleep(20)
+    }
+    assertThat(factory.spawnHistory.size).isAtLeast(expected)
+  }
+
+  private fun pipedPair(): Pair<OutputStream, InputStream> {
+    val out = PipedOutputStream()
+    val input = PipedInputStream(out, 64 * 1024)
+    return out to input
+  }
+}


### PR DESCRIPTION
## Summary

- Each daemon group spawns one synchronous **primary** plus `replicasPerDaemon` extra replicas in parallel on a bounded pool. Primary seeds the catalog; replicas piggy-back on the now-warm Maven cache, so cold-start cost is dominated by the primary instead of `sum(replicas)`.
- `renderNow` shards across replicas by `previewId.hashCode()` so concurrent renders for different previews run in parallel instead of queuing behind a single render thread. `setVisible`/`setFocus` and `fileChanged` fan out to every replica so per-replica state stays consistent.
- `DaemonMcpServer.daemonLifecycleExecutor` swapped from `newSingleThreadExecutor` to a 4-thread fixed pool — a workspace with N preview modules previously paid `N × cold-start` serially when `tool_watch` enrolled all modules at once.
- `forgetDaemon` now tears down peer replicas on `classpathDirty` (the dirty replica exits on its own; peers were on the same stale classpath). Racing dirty events from peer replicas dedupe via the boolean return.
- Default `replicasPerDaemon = 0` preserves the existing 1-daemon-per-module behaviour. Opt in via `--replicas-per-daemon N` or `-Dcomposeai.mcp.replicasPerDaemon=N`.

The first commit on this branch is an unrelated KDoc paragraph rewrap in `daemon/core/.../StartupTimings.kt` — pre-existing ktfmt drift caught by the repo-wide `ktfmtCheckAll` pre-commit hook, no behaviour change.

## Test plan

- [x] `./gradlew :mcp:test` — pre-existing `DaemonMcpServerTest` (and friends) still pass at the default `replicasPerDaemon = 0`.
- [x] New `DaemonSupervisorReplicaTest` covers, with `replicasPerDaemon = 2` (3 fakes per group):
  - [x] `daemonFor` spawns 1 primary + N replicas
  - [x] `renderNow` sharding lands on the replica selected by `Math.floorMod(previewId.hashCode(), replicas)`
  - [x] `setVisible`/`setFocus` fan out to every replica
  - [x] `notify_file_changed` forwards `fileChanged` to every replica
  - [x] `classpathDirty` on one replica tears down peers and respawns a fresh group
- [x] `./gradlew :mcp:ktfmtCheck` clean.
- [ ] Real subprocess soak with `--replicas-per-daemon 3` against a multi-module sample (Robolectric on cold cache) — not run locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKcveB6Scmru8iKnou4w9U)_