### PR TITLE
fix(daemon): apply wear-round circular crop end-to-end (renderer + production wiring)

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -74,6 +74,9 @@ class PreviewManifestRouter(
             append("heightPx=").append(entry.heightPx ?: 320).append(';')
             append("density=").append(entry.density ?: 2.0f).append(';')
             append("showBackground=").append(entry.showBackground ?: true).append(';')
+            entry.device?.takeIf { it.isNotBlank() }?.let {
+              append("device=").append(it).append(';')
+            }
             append("outputBaseName=").append(outputBaseName)
           },
       )
@@ -110,5 +113,11 @@ data class PreviewManifestEntry(
   val heightPx: Int? = null,
   val density: Float? = null,
   val showBackground: Boolean? = null,
+  /**
+   * Raw `@Preview(device = …)` string when the source preview has one set. Forwarded into the
+   * `RenderSpec` payload so the render body applies the wear-round crop / `round` resource
+   * qualifier for circular Wear devices.
+   */
+  val device: String? = null,
   val outputBaseName: String? = null,
 )

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -115,6 +115,14 @@ class RenderEngine(
     val clazz = Class.forName(spec.className, true, classLoader)
     val composableMethod: ComposableMethod = clazz.getDeclaredComposableMethod(spec.functionName)
 
+    // `device = "id:wearos_*_round"` / `isRound=true` previews need a circular crop matching the
+    // standalone renderer's `RobolectricRenderTest`. The standalone path also gates on
+    // `showSystemUi || kind == TILE` to skip the crop on non-fullscreen previews (the crop is a
+    // device frame, not part of the composable), but the daemon's v1 `RenderSpec` doesn't carry
+    // either field — assume any explicit round-device request wants the crop. Refine when those
+    // fields get plumbed through.
+    val isRound = isRoundDevice(spec.device)
+
     // Per-preview Robolectric configuration — qualifiers re-applied so a previous render's size /
     // density doesn't bleed into this one. Same entrypoints `RobolectricRenderTest` uses; both
     // mutate `RuntimeEnvironment` global state, which is OK here because the sandbox is single-
@@ -123,6 +131,7 @@ class RenderEngine(
       widthDp = pxToDp(spec.widthPx, spec.density),
       heightDp = pxToDp(spec.heightPx, spec.density),
       density = spec.density,
+      isRound = isRound,
     )
     org.robolectric.RuntimeEnvironment.setFontScale(1.0f)
 
@@ -169,9 +178,15 @@ class RenderEngine(
             rule.mainClock.advanceTimeBy(CAPTURE_ADVANCE_MS)
 
             outputFile.parentFile?.mkdirs()
+            // `applyDeviceCrop = true` is what produces the circular alpha mask Roborazzi paints
+            // over the captured bitmap; the `round` resource qualifier set above only affects
+            // `Configuration.isScreenRound`. Both are needed for parity with the standalone
+            // renderer's wear-round path.
+            val roborazziOptions =
+              RoborazziOptions(recordOptions = RoborazziOptions.RecordOptions(applyDeviceCrop = isRound))
             rule
               .onRoot()
-              .captureRoboImage(file = outputFile, roborazziOptions = ROBORAZZI_OPTIONS)
+              .captureRoboImage(file = outputFile, roborazziOptions = roborazziOptions)
           } finally {
             // DESIGN § 9 + § 10 cleanup epilogue. The Compose test rule does not allow a second
             // `setContent` on the same `ComponentActivity`, so we can't drive the
@@ -234,15 +249,17 @@ class RenderEngine(
   }
 
   /**
-   * Subset of `RobolectricRenderTest.applyPreviewQualifiers` — only the size + density qualifiers
-   * the daemon's v1 surface exercises. Locale / uiMode / round / orientation come from
+   * Subset of `RobolectricRenderTest.applyPreviewQualifiers` — only the size / density / round
+   * qualifiers the daemon's v1 surface exercises. Locale / uiMode / orientation come from
    * `@Preview` annotation fields the daemon doesn't yet thread through. Same `RuntimeEnvironment`
-   * entrypoints as the renderer — output dimensions match Studio's preview pane.
+   * entrypoints as the renderer — output dimensions match Studio's preview pane. Qualifier order
+   * follows Robolectric's strict grammar (locale, width, height, round, orientation, …, density).
    */
-  private fun applyPreviewQualifiers(widthDp: Int, heightDp: Int, density: Float) {
+  private fun applyPreviewQualifiers(widthDp: Int, heightDp: Int, density: Float, isRound: Boolean) {
     val qualifiers = buildList {
       if (widthDp > 0) add("w${widthDp}dp")
       if (heightDp > 0) add("h${heightDp}dp")
+      if (isRound) add("round")
       if (widthDp > 0 && heightDp > 0) {
         add(if (widthDp > heightDp) "land" else "port")
       }
@@ -266,9 +283,22 @@ class RenderEngine(
      * the standalone JUnit path's settle point.
      */
     private const val CAPTURE_ADVANCE_MS = 32L
-
-    private val ROBORAZZI_OPTIONS = RoborazziOptions()
   }
+}
+
+/**
+ * Detects whether a Compose `@Preview(device = ...)` string refers to a round (circular) display —
+ * matches Wear OS round devices the same way `:renderer-android`'s `RoundClip.kt` does. Inlined
+ * rather than depended on for the same reason `RenderEngine` itself is duplicated (see file kdoc):
+ * the daemon doesn't take a compile-time dep on the renderer's internals. Reconcile when the v2
+ * shared render-body extraction lands.
+ */
+internal fun isRoundDevice(device: String?): Boolean {
+  if (device.isNullOrBlank()) return false
+  val lower = device.lowercase()
+  return lower.contains("_round") ||
+    lower.contains("isround=true") ||
+    lower.contains("shape=round")
 }
 
 /**
@@ -306,6 +336,13 @@ data class RenderSpec(
   val density: Float = 2.0f,
   val showBackground: Boolean = true,
   val backgroundColor: Long = 0L,
+  /**
+   * Raw `@Preview(device = …)` string when known — `id:wearos_small_round`,
+   * `spec:width=…,isRound=true`, `id:pixel_5`, etc. Used by the render body to detect round Wear
+   * devices and apply the circular crop / `round` resource qualifier; non-round / null values are
+   * a no-op. Mirrors the standalone renderer's `RenderPreviewParams.device` for the v1 subset.
+   */
+  val device: String? = null,
   /** Stem used for the output PNG filename (e.g. "preview-A" → "<outputDir>/preview-A.png"). */
   val outputBaseName: String = "${className.substringAfterLast('.')}-$functionName",
 ) {
@@ -315,10 +352,10 @@ data class RenderSpec(
     /**
      * Parses [RenderRequest.Render.payload] — a `;`-delimited `key=value` string — into a
      * [RenderSpec]. Recognised keys: `className`, `functionName`, `widthPx`, `heightPx`, `density`,
-     * `showBackground`, `backgroundColor`, `outputBaseName`. `className` and `functionName` are
-     * required; everything else falls back to the defaults on this data class. Returns `null` when
-     * the payload doesn't carry a `className=` token (the discriminator the host uses to route
-     * legacy stub-payload requests through the classloader-identity path).
+     * `showBackground`, `backgroundColor`, `device`, `outputBaseName`. `className` and
+     * `functionName` are required; everything else falls back to the defaults on this data class.
+     * Returns `null` when the payload doesn't carry a `className=` token (the discriminator the
+     * host uses to route legacy stub-payload requests through the classloader-identity path).
      */
     fun parseFromPayloadOrNull(payload: String): RenderSpec? {
       if (!payload.contains("className=")) return null
@@ -341,6 +378,7 @@ data class RenderSpec(
         density = map["density"]?.toFloatOrNull() ?: defaults.density,
         showBackground = map["showBackground"]?.toBoolean() ?: defaults.showBackground,
         backgroundColor = map["backgroundColor"]?.toLongOrNull() ?: defaults.backgroundColor,
+        device = map["device"]?.takeIf { it.isNotBlank() } ?: defaults.device,
         outputBaseName = map["outputBaseName"] ?: defaults.outputBaseName,
       )
     }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/StartupTimings.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/StartupTimings.kt
@@ -8,14 +8,15 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Wall-clock timeline of the daemon's interesting boot events.
  *
  * Emit a [mark] at every stage that contributes meaningfully to startup latency. Each mark prints a
- * single stderr line `compose-ai-daemon: [+<elapsedMs>ms] <label>` and is buffered for [summary]
- * so the full timeline is reproducible after the fact. The reference clock is the JVM start time
- * (via [ManagementFactory.getRuntimeMXBean]) so events seen on the worker thread, the JSON-RPC
- * thread, and inside the Robolectric sandbox all line up against one shared origin.
+ * single stderr line `compose-ai-daemon: [+<elapsedMs>ms] <label>` and is buffered for [summary] so
+ * the full timeline is reproducible after the fact. The reference clock is the JVM start time (via
+ * [ManagementFactory.getRuntimeMXBean]) so events seen on the worker thread, the JSON-RPC thread,
+ * and inside the Robolectric sandbox all line up against one shared origin.
  *
  * The format is human-readable on purpose — operators reading daemon stderr (or the editor's
  * "daemon log" output channel) shouldn't need a JSON parser to see "step 3 took 8 seconds." For
- * machine consumption a future change can wire [marks] into a `daemonTimings` JSON-RPC notification.
+ * machine consumption a future change can wire [marks] into a `daemonTimings` JSON-RPC
+ * notification.
  *
  * Reasons to add a mark:
  *
@@ -27,8 +28,8 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Reasons NOT to add a mark:
  *
  * - Every queue insertion / dequeue (too noisy; spam dilutes the signal).
- * - Anything inside the steady-state render path (this is a *startup* timeline; render-time
- *   metrics already flow through `renderFinished.metrics`).
+ * - Anything inside the steady-state render path (this is a *startup* timeline; render-time metrics
+ *   already flow through `renderFinished.metrics`).
  *
  * See [docs/daemon/STARTUP.md](../../../../../../docs/daemon/STARTUP.md) for the analysis of where
  * the time actually goes and the menu of options to attack each stage.

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -68,6 +68,9 @@ class PreviewManifestRouter(
             append("heightPx=").append(entry.heightPx ?: 320).append(';')
             append("density=").append(entry.density ?: 2.0f).append(';')
             append("showBackground=").append(entry.showBackground ?: true).append(';')
+            entry.device
+              ?.takeIf { it.isNotBlank() }
+              ?.let { append("device=").append(it).append(';') }
             append("outputBaseName=").append(outputBaseName)
           },
       )
@@ -104,5 +107,11 @@ data class PreviewManifestEntry(
   val heightPx: Int? = null,
   val density: Float? = null,
   val showBackground: Boolean? = null,
+  /**
+   * Raw `@Preview(device = …)` string when the source preview has one set. Forwarded into
+   * `RenderSpec` so the Android render path can apply the wear-round crop / `round` resource
+   * qualifier; the desktop path ignores it (no circular crop on JVM rendering).
+   */
+  val device: String? = null,
   val outputBaseName: String? = null,
 )

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -189,6 +189,13 @@ data class RenderSpec(
   val density: Float = 2.0f,
   val showBackground: Boolean = true,
   val backgroundColor: Long = 0L,
+  /**
+   * Raw `@Preview(device = …)` string when known. The desktop render path is currently
+   * shape-agnostic (no circular crop — that's an Android/Robolectric-only mechanism), but the field
+   * is carried so the wire format stays identical to `:daemon:android`'s `RenderSpec` and a single
+   * payload can drive both backends.
+   */
+  val device: String? = null,
   /** Stem used for the output PNG filename (e.g. "preview-A" → "<outputDir>/preview-A.png"). */
   val outputBaseName: String = "${className.substringAfterLast('.')}-$functionName",
 ) {
@@ -198,8 +205,8 @@ data class RenderSpec(
     /**
      * Parses [RenderRequest.Render.payload] — a `;`-delimited `key=value` string — into a
      * [RenderSpec]. Recognised keys: `className`, `functionName`, `widthPx`, `heightPx`, `density`,
-     * `showBackground`, `backgroundColor`, `outputBaseName`. `className` and `functionName` are
-     * required; everything else falls back to the defaults on this data class.
+     * `showBackground`, `backgroundColor`, `device`, `outputBaseName`. `className` and
+     * `functionName` are required; everything else falls back to the defaults on this data class.
      *
      * Keeping this stringly-typed for v1 is deliberate (per the task brief). When `RenderRequest`
      * grows a typed `previewId: String?` field, [DesktopHost] will look the spec up in
@@ -229,6 +236,7 @@ data class RenderSpec(
         density = map["density"]?.toFloatOrNull() ?: defaults.density,
         showBackground = map["showBackground"]?.toBoolean() ?: defaults.showBackground,
         backgroundColor = map["backgroundColor"]?.toLongOrNull() ?: defaults.backgroundColor,
+        device = map["device"]?.takeIf { it.isNotBlank() } ?: defaults.device,
         outputBaseName = map["outputBaseName"] ?: defaults.outputBaseName,
       )
     }


### PR DESCRIPTION
## Summary

Wear-round previews rendered through the daemon (e.g. on save in the VS Code panel) came back uncropped after every recompile, even though the standalone `RobolectricRenderTest` in the same module produces correctly clipped circles. Two cooperating gaps:

1. The daemon's `RenderEngine` had no `device` field — even if a caller wanted a circular crop, there was no way to ask for one.
2. The production caller (`JsonRpcServer.handleRenderNow` → `submitRenderAsync`) only stuffed `previewId=<id>` into the payload. The host's `RenderSpec.parseFromPayloadOrNull` short-circuited on the missing `className=` token and fell through to `renderStub` — so the production daemon never ran a real render at all (the panel was showing stale gradle-path PNGs with one-off updates served by the stub path on lucky CI runs).

This PR closes both gaps.

### Renderer (commit `a52177a`)

- `daemon/android/.../RenderEngine.kt` — `RenderSpec` gains `device: String?`. `render()` computes `isRound = isRoundDevice(spec.device)` and emits both the `+round` Robolectric resource qualifier (so `Configuration.isScreenRound` reports correctly) and `RoborazziOptions(recordOptions = RecordOptions(applyDeviceCrop = isRound))` per-render. `isRoundDevice` is inlined to avoid taking a compile-time dep on `:renderer-android`'s internals — same duplication trade-off the file kdoc already documents.
- `daemon/desktop/.../RenderEngine.kt` — `RenderSpec` gains `device` for wire-format symmetry. The desktop renderer ignores it (no circular-crop mechanism on JVM rendering).
- `daemon/{android,desktop}/.../PreviewManifestRouter.kt` — `PreviewManifestEntry` gains `device`, forwarded into the routed payload.

### Production wiring (commit `3d864dc`)

- `daemon/core/.../PreviewIndex.kt` — `PreviewInfoDto` gains a nested `params: PreviewParamsDto` mirroring the subset the daemon's render path needs (`device`, `widthDp`, `heightDp`, `density`, `showBackground`, `backgroundColor`). Older `previews.json` fixtures without a `params` block parse unchanged via the default.
- `PreviewIndex.renderPayloadFor(id)` — new helper that builds a `;`-delimited `RenderSpec` payload (`previewId=…;className=…;…;device=…;…`) the host's parser can consume directly. `previewId=<id>;` leads the payload so legacy consumers (`FakeHost.resolvePreviewId`, `PreviewManifestRouter.parsePreviewId`) keep extracting the id without per-consumer changes.
- `daemon/core/.../JsonRpcServer.kt` — `submitRenderAsync` consults `previewIndex.renderPayloadFor(previewId)` first and falls back to the legacy `previewId=<id>` shape only when the id is unknown (preserves stub-host unit-test behaviour and empty-index fake-mode scenarios).
- `daemon/harness/.../FakeHost.kt` — `resolvePreviewId` now extracts `previewId=…` from any position in the payload (the old `substringAfter` mishandled the new payload's trailing `;…` segments).

### Pre-existing drift (commit `bab409e`)

- `daemon/core/.../StartupTimings.kt` — pure ktfmt comment line-rewrap pre-existing on `main`. Split out so the fix diff stays behaviour-only; without it the `ktfmtCheckAll` pre-commit hook would block any commit touching `:daemon:*`.

## Notes / follow-ups

- The standalone `RobolectricRenderTest` also gates the crop on `showSystemUi || kind == TILE` to skip non-fullscreen previews. The daemon's v1 `RenderSpec` carries neither field, so this PR uses simpler semantics: any explicit round device → crop. Refine when those fields get plumbed through.
- Adding a wear-round fixture to `:samples:android-daemon-bench` would close the regression-detection loop — the existing `RedFixturePreviews` are all rectangular and wouldn't catch a future revert. Out of scope here.
- v2's planned shared render-body extraction (`renderer-android` ↔ `daemon-android`) reconciles the duplicated `RenderEngine` + `isRoundDevice` at once; this PR keeps the duplication consistent with the file kdocs' explicit trade-off.

## Test plan

- [x] `./gradlew :daemon:core:test` — covers new `PreviewInfoDto.params` parse, `renderPayloadFor` round-device round-trip, sparse-preview omission, and unknown-id null return
- [x] `./gradlew :daemon:android:testDebugUnitTest` — passes
- [x] `./gradlew :daemon:desktop:test` — passes
- [x] `./gradlew :daemon:harness:test` — passes (S3 / S4 / cancellation invariants are flaky on contended boxes per `docs/daemon/TODO.md:573`; pass cleanly when CPU's available)
- [ ] CI: pixel-diff a wear-round preview through the daemon path (requires a round fixture in `:samples:android-daemon-bench`; tracked as follow-up)
- [ ] Manual: drive the VS Code preview panel through a save on a wear-round `@Preview` and confirm the resulting PNG carries the circular alpha mask