### PR TITLE
fix(daemon): skip writing sidecars when bytes match the most recent entry

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/GitRefHistorySource.kt
@@ -65,7 +65,7 @@ class GitRefHistorySource(
 
   override fun supportsWrites(): Boolean = false
 
-  override fun write(entry: HistoryEntry, png: ByteArray) {
+  override fun write(entry: HistoryEntry, png: ByteArray): WriteResult {
     error("GitRefHistorySource is read-only (ref=$ref); writes go to a writable source.")
   }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
@@ -124,11 +124,19 @@ class HistoryManager(
       )
 
     var anyWritten = false
+    var anyAttempted = false
     for (source in sources) {
       if (!source.supportsWrites()) continue
+      anyAttempted = true
       try {
-        source.write(entry, pngBytes)
-        anyWritten = true
+        when (source.write(entry, pngBytes)) {
+          WriteResult.WRITTEN -> anyWritten = true
+          WriteResult.SKIPPED_DUPLICATE -> {
+            // Source decided this render's bytes match the most recent entry; nothing to do.
+            // We deliberately do NOT update previousByPreview — the previous still IS the most
+            // recent entry on disk, and its (id, pngHash) tuple is still correct.
+          }
+        }
       } catch (t: Throwable) {
         System.err.println(
           "compose-ai-daemon: HistoryManager.recordRender(${entry.id}): write to ${source.id} " +
@@ -136,7 +144,10 @@ class HistoryManager(
         )
       }
     }
-    if (!anyWritten) return null
+    // No writable source configured → return null (the disabled-by-default path).
+    // All writable sources skipped as duplicates → return null too; caller suppresses
+    // `historyAdded` and the consumer never sees a redundant entry for repeated identical renders.
+    if (!anyAttempted || !anyWritten) return null
 
     // Update the previousByPreview cache. CAS-loop so concurrent recordRender for the same
     // preview id stays consistent (though `JsonRpcServer.kt` runs history writes single-threaded

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
@@ -74,6 +74,28 @@ data class HistoryReadResult(
 }
 
 /**
+ * Outcome of [HistorySource.write].
+ *
+ * `WRITTEN` — entry persisted (sidecar + index line, and either a fresh PNG or a dedup-by-hash
+ * pointer at an existing one).
+ *
+ * `SKIPPED_DUPLICATE` — the bytes match the most recent existing entry for this `previewId`, so the
+ * source skipped writing both the sidecar and the index line. `HistoryManager.recordRender` uses
+ * this to suppress `historyAdded` and avoid cluttering the consumer's UI with redundant entries
+ * for save-loops that produce identical pixels (e.g. saving a comment-only edit, repeated focus
+ * cycles, sandbox warm-up renders against the same composition state).
+ *
+ * The "most recent" rule is what distinguishes this from the dedup-by-hash PNG path (where any
+ * earlier matching hash means we re-use the file). If render history goes A → B → A, the third
+ * render is a meaningful event ("we went back to A") and is kept; render history A → A → A skips
+ * everything after the first.
+ */
+enum class WriteResult {
+  WRITTEN,
+  SKIPPED_DUPLICATE,
+}
+
+/**
  * Pluggable history backend — see HISTORY.md § "HistorySource interface".
  *
  * H1+H2 ships only [LocalFsHistorySource]. Future phases (H10 onward) will add
@@ -96,10 +118,15 @@ interface HistorySource {
    * Persists [entry] (and its associated PNG bytes) into the backing store. Throws when this source
    * isn't writable — gate via [supportsWrites] first.
    *
+   * Returns [WriteResult.WRITTEN] when the entry landed and [WriteResult.SKIPPED_DUPLICATE] when
+   * the bytes match the most recent existing entry for the same `previewId` and the source elected
+   * to suppress the write. Callers (notably [HistoryManager.recordRender]) use that to decide
+   * whether to fan out a `historyAdded` notification.
+   *
    * Failures here must NOT be load-bearing for the render itself — `HistoryManager.recordRender`
    * catches and logs, then continues. The render succeeded; history is observation, not state.
    */
-  fun write(entry: HistoryEntry, png: ByteArray)
+  fun write(entry: HistoryEntry, png: ByteArray): WriteResult
 
   /** Lists history entries newest-first, applying [filter] and paginating. */
   fun list(filter: HistoryFilter): HistoryListPage

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
@@ -27,11 +27,23 @@ import kotlinx.serialization.json.Json
  *     └── <utc-yyyyMMdd-HHmmss>-<8hex>.json
  * ```
  *
- * **Dedup-by-hash.** When [write] is called with bytes whose SHA-256 matches the most recent
- * entry's [HistoryEntry.pngHash] for the same `previewId`, the PNG file is NOT re-written; the
- * sidecar's `pngPath` points at the already-on-disk PNG. The sidecar + index line still land —
- * "same hash" means no visible change, but the render still happened, so the provenance entry is
- * useful (e.g. "agent re-ran, output unchanged"). HISTORY.md § "What this PR lands § H1".
+ * **Dedup-by-hash, two tiers:**
+ *
+ * 1. **Skip-on-most-recent-match.** When [write] is called with bytes whose SHA-256 matches the
+ *    most-recent existing entry for the same `previewId`, [write] returns
+ *    [WriteResult.SKIPPED_DUPLICATE] and writes nothing — no PNG, no sidecar, no index line. The
+ *    consumer's UI doesn't see a redundant entry for save-loops that produce identical pixels
+ *    (e.g. comment-only edits, sandbox warm-up renders against the same composition). Distinct
+ *    from tier 2 below: the rule is the *most recent* match, not any match — render history
+ *    A → B → A still keeps the third entry because going-back-to-A is a meaningful event.
+ *
+ * 2. **Pointer-on-any-match (fallback for non-consecutive matches).** When the new bytes don't
+ *    match the most-recent entry but DO match an earlier one (the A → B → A case), the new
+ *    sidecar's `pngPath` points at the older PNG and we don't re-write the bytes. The sidecar +
+ *    index line still land so the provenance entry exists.
+ *
+ * Both tiers reduce on-disk PNG copies; tier 1 additionally suppresses sidecar churn. HISTORY.md
+ * § "What this PR lands § H1" + § "Dedup".
  *
  * **Cross-restart correctness.** Dedup walks the per-preview directory listing for the most-recent
  * entry whose hash matches; this works whether that entry was written in the current daemon
@@ -54,19 +66,29 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
     Files.createDirectories(historyDir)
   }
 
-  override fun write(entry: HistoryEntry, png: ByteArray) {
+  override fun write(entry: HistoryEntry, png: ByteArray): WriteResult {
     val sanitisedDir = PreviewIdSanitiser.sanitise(entry.previewId)
     val previewDir = historyDir.resolve(sanitisedDir)
     Files.createDirectories(previewDir)
+
+    // Tier 1 — skip-on-most-recent-match. If the absolute newest sidecar for this preview already
+    // has the same hash, this render is redundant from the consumer's perspective; skip everything.
+    // Different from tier 2 below: rule is "most recent", not "any match" — A → B → A keeps three
+    // entries (the third is a meaningful "we went back to A" event), but A → A → A keeps one.
+    val mostRecentHash = findMostRecentEntryHash(previewDir, exclude = entry.id)
+    if (mostRecentHash != null && mostRecentHash == entry.pngHash) {
+      return WriteResult.SKIPPED_DUPLICATE
+    }
 
     val pngFileName = "${entry.id}.png"
     val sidecarFileName = "${entry.id}.json"
     val pngFile = previewDir.resolve(pngFileName)
     val sidecarFile = previewDir.resolve(sidecarFileName)
 
-    // Dedup-by-hash. If the previous entry for this preview has the same pngHash, we point the
-    // new sidecar's `pngPath` at that older PNG and do NOT re-write the bytes. We still write
-    // the sidecar + index line so the render-event provenance is captured.
+    // Tier 2 — pointer-on-any-match. The bytes don't match the most-recent entry but DO match an
+    // earlier one (e.g. A → B → A). Point the new sidecar's `pngPath` at the older PNG so we
+    // don't write a duplicate file; the sidecar + index line still land because the entry itself
+    // is meaningful provenance.
     val dedupTarget = findMostRecentEntryWithHash(previewDir, entry.pngHash, exclude = entry.id)
     val effectivePngPath: String =
       if (dedupTarget != null) {
@@ -96,6 +118,43 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
       StandardOpenOption.WRITE,
       StandardOpenOption.APPEND,
     )
+    return WriteResult.WRITTEN
+  }
+
+  /**
+   * Returns the [HistoryEntry.pngHash] of the absolute newest sidecar in [previewDir], or null
+   * when the dir is empty or all sidecars are unreadable. Used by tier 1 of the dedup ladder.
+   *
+   * Sidecar filenames lead with a UTC timestamp in `yyyyMMdd-HHmmss-<hash>` shape, so reverse
+   * lex sort = newest first. We don't need to parse the timestamp — string compare is enough.
+   */
+  private fun findMostRecentEntryHash(previewDir: Path, exclude: String): String? {
+    if (!Files.exists(previewDir)) return null
+    val newest =
+      try {
+        Files.list(previewDir).use { stream ->
+          stream
+            .filter { it.fileName.toString().endsWith(".json") }
+            .filter { it.fileName.toString().removeSuffix(".json") != exclude }
+            .max(Comparator.comparing { it.fileName.toString() })
+            .orElse(null)
+        }
+      } catch (_: Throwable) {
+        return null
+      } ?: return null
+    val text =
+      try {
+        newest.readText(StandardCharsets.UTF_8)
+      } catch (_: Throwable) {
+        return null
+      }
+    val parsed =
+      try {
+        JSON.decodeFromString(HistoryEntry.serializer(), text)
+      } catch (_: Throwable) {
+        return null
+      }
+    return parsed.pngHash
   }
 
   override fun list(filter: HistoryFilter): HistoryListPage {

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/HistoryDiffTest.kt
@@ -55,12 +55,13 @@ class HistoryDiffTest {
   @Test(timeout = 30_000)
   fun same_hash_pngHashChanged_false() {
     runWith { _, manager, send, receive ->
-      // Two entries with identical pngHash for the same previewId. We force the same hash by
-      // writing the same bytes for both renders; LocalFsHistorySource dedups the PNG file but
-      // still writes two distinct sidecars + index lines (HISTORY.md § "Concurrency model"). We
-      // pin distinct timestamps so the entry ids differ (id = "<ts>-<shortHash>").
+      // Two entries with identical pngHash for the same previewId. The dedup ladder skips
+      // consecutive identical renders (tier 1), so we drive the A → B → A pattern: third render's
+      // bytes match the first's, and since the most-recent entry on disk (B) has a DIFFERENT
+      // hash, tier 1 doesn't fire and the third entry lands. We then diff first-A vs second-A.
       val ts1 = Instant.parse("2026-04-30T10:12:34Z")
       val ts2 = Instant.parse("2026-04-30T10:12:35Z")
+      val ts3 = Instant.parse("2026-04-30T10:12:36Z")
       val entry1 =
         manager.recordRender(
           "preview-A",
@@ -69,13 +70,20 @@ class HistoryDiffTest {
           renderTookMs = 1,
           timestamp = ts1,
         )!!
+      manager.recordRender(
+        "preview-A",
+        "different-bytes".toByteArray(),
+        trigger = "renderNow",
+        renderTookMs = 1,
+        timestamp = ts2,
+      )!!
       val entry2 =
         manager.recordRender(
           "preview-A",
           "same-bytes".toByteArray(),
           trigger = "renderNow",
           renderTookMs = 1,
-          timestamp = ts2,
+          timestamp = ts3,
         )!!
       assertEquals(entry1.pngHash, entry2.pngHash)
 

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceWriteTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceWriteTest.kt
@@ -81,7 +81,7 @@ class LocalFsHistorySourceWriteTest {
   }
 
   @Test
-  fun dedup_by_hash_does_not_write_a_duplicate_png_but_writes_a_sidecar_pointing_at_the_first() {
+  fun consecutive_identical_render_returns_SKIPPED_DUPLICATE_and_writes_nothing() {
     val source = LocalFsHistorySource(historyDir = tmpDir)
     val previewId = "Foo"
     val bytes = byteArrayOf(0x10, 0x20, 0x30, 0x40)
@@ -101,69 +101,134 @@ class LocalFsHistorySourceWriteTest {
         hash = hash,
         size = bytes.size.toLong(),
       )
-    source.write(firstEntry, bytes)
-    source.write(secondEntry, bytes)
+    val firstResult = source.write(firstEntry, bytes)
+    val secondResult = source.write(secondEntry, bytes)
+
+    assertEquals(WriteResult.WRITTEN, firstResult)
+    assertEquals(
+      "Tier 1 dedup: most-recent hash matches → skip everything",
+      WriteResult.SKIPPED_DUPLICATE,
+      secondResult,
+    )
 
     val previewDir = tmpDir.resolve("Foo")
     val firstPng = previewDir.resolve("${firstEntry.id}.png")
+    val firstSidecar = previewDir.resolve("${firstEntry.id}.json")
     val secondPng = previewDir.resolve("${secondEntry.id}.png")
     val secondSidecar = previewDir.resolve("${secondEntry.id}.json")
 
     assertTrue("First PNG must exist", Files.exists(firstPng))
-    assertFalse("Second PNG must NOT exist (dedup)", Files.exists(secondPng))
-    assertTrue("Second sidecar must exist", Files.exists(secondSidecar))
+    assertTrue("First sidecar must exist", Files.exists(firstSidecar))
+    assertFalse("Second PNG must NOT exist (skipped)", Files.exists(secondPng))
+    assertFalse("Second sidecar must NOT exist (skipped)", Files.exists(secondSidecar))
 
-    // Second sidecar's pngPath should point at the first PNG's filename.
-    val sidecarText = Files.readString(secondSidecar)
-    val decoded = json.decodeFromString(HistoryEntry.serializer(), sidecarText)
-    assertEquals("${firstEntry.id}.png", decoded.pngPath)
-
-    // Index has both lines, both readable.
+    // Index has exactly one line — the second write didn't append.
     val indexLines =
       Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)).filter {
         it.isNotBlank()
       }
-    assertEquals(2, indexLines.size)
+    assertEquals(1, indexLines.size)
   }
 
   @Test
-  fun dedup_survives_simulated_cross_restart() {
-    // Write entry 1 via source A; throw it away; create source B against the same dir; write entry
-    // 2 with the same bytes; assert dedup still hits.
+  fun A_then_B_then_A_keeps_three_entries_with_pngPath_pointer_on_third() {
+    // Tier 2 — non-consecutive matching hash. Render history A → B → A: the third entry IS a
+    // meaningful event ("we went back to A"), so a sidecar lands; but the PNG points at the
+    // first A's bytes rather than re-writing them.
+    val source = LocalFsHistorySource(historyDir = tmpDir)
+    val previewId = "Bouncy"
+    val bytesA = byteArrayOf(0x01, 0x02, 0x03)
+    val bytesB = byteArrayOf(0x09, 0x08, 0x07)
+    val hashA = LocalFsHistorySource.sha256Hex(bytesA)
+    val hashB = LocalFsHistorySource.sha256Hex(bytesB)
+
+    val firstA =
+      makeEntry(id = "20260430-100000-${hashA.take(8)}", previewId = previewId, hash = hashA, size = 3)
+    val midB =
+      makeEntry(id = "20260430-100001-${hashB.take(8)}", previewId = previewId, hash = hashB, size = 3)
+    val secondA =
+      makeEntry(id = "20260430-100002-${hashA.take(8)}", previewId = previewId, hash = hashA, size = 3)
+
+    assertEquals(WriteResult.WRITTEN, source.write(firstA, bytesA))
+    assertEquals(WriteResult.WRITTEN, source.write(midB, bytesB))
+    assertEquals(
+      "A → B → A: third write is meaningful, must land",
+      WriteResult.WRITTEN,
+      source.write(secondA, bytesA),
+    )
+
+    val previewDir = tmpDir.resolve("Bouncy")
+    val firstAPng = previewDir.resolve("${firstA.id}.png")
+    val midBPng = previewDir.resolve("${midB.id}.png")
+    val secondAPng = previewDir.resolve("${secondA.id}.png")
+    val secondASidecar = previewDir.resolve("${secondA.id}.json")
+
+    assertTrue("First A PNG exists", Files.exists(firstAPng))
+    assertTrue("Mid B PNG exists", Files.exists(midBPng))
+    assertFalse("Second A's PNG must NOT be rewritten — pointer-only", Files.exists(secondAPng))
+    assertTrue("Second A sidecar exists", Files.exists(secondASidecar))
+
+    val secondSidecarEntry =
+      json.decodeFromString(HistoryEntry.serializer(), Files.readString(secondASidecar))
+    assertEquals(
+      "Second A sidecar's pngPath points at first A's PNG",
+      "${firstA.id}.png",
+      secondSidecarEntry.pngPath,
+    )
+
+    val indexLines =
+      Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)).filter {
+        it.isNotBlank()
+      }
+    assertEquals(3, indexLines.size)
+  }
+
+  @Test
+  fun consecutive_identical_render_skip_survives_simulated_cross_restart() {
+    // Tier 1 dedup must hit even when the "first" entry was written by a previous daemon process
+    // and the in-memory cache is empty — the source walks the per-preview directory listing.
     val previewId = "Bar"
     val bytes = byteArrayOf(0x77, 0x77, 0x77)
     val hash = LocalFsHistorySource.sha256Hex(bytes)
     val firstEntry =
       makeEntry(
-        id = "old-${hash.take(8)}",
+        id = "20260430-101000-${hash.take(8)}",
         previewId = previewId,
         hash = hash,
         size = bytes.size.toLong(),
       )
-    LocalFsHistorySource(historyDir = tmpDir).write(firstEntry, bytes)
+    assertEquals(WriteResult.WRITTEN, LocalFsHistorySource(historyDir = tmpDir).write(firstEntry, bytes))
 
     val sourceB = LocalFsHistorySource(historyDir = tmpDir)
     val secondEntry =
       makeEntry(
-        id = "new-${hash.take(8)}",
+        id = "20260430-101005-${hash.take(8)}",
         previewId = previewId,
         hash = hash,
         size = bytes.size.toLong(),
       )
-    sourceB.write(secondEntry, bytes)
+    val secondResult = sourceB.write(secondEntry, bytes)
+
+    assertEquals(
+      "Cross-restart tier-1 dedup: most-recent hash on disk matches → SKIPPED_DUPLICATE",
+      WriteResult.SKIPPED_DUPLICATE,
+      secondResult,
+    )
 
     val previewDir = tmpDir.resolve("Bar")
     val firstPng = previewDir.resolve("${firstEntry.id}.png")
     val secondPng = previewDir.resolve("${secondEntry.id}.png")
+    val secondSidecar = previewDir.resolve("${secondEntry.id}.json")
     assertTrue(Files.exists(firstPng))
-    assertFalse("Cross-restart dedup must skip the duplicate PNG", Files.exists(secondPng))
+    assertFalse("Cross-restart skip must NOT write a duplicate PNG", Files.exists(secondPng))
+    assertFalse("Cross-restart skip must NOT write a sidecar", Files.exists(secondSidecar))
 
-    val sidecar =
-      json.decodeFromString(
-        HistoryEntry.serializer(),
-        Files.readString(previewDir.resolve("${secondEntry.id}.json")),
-      )
-    assertEquals("${firstEntry.id}.png", sidecar.pngPath)
+    // Index has exactly one line — the second write didn't append.
+    val indexLines =
+      Files.readAllLines(tmpDir.resolve(LocalFsHistorySource.INDEX_FILENAME)).filter {
+        it.isNotBlank()
+      }
+    assertEquals(1, indexLines.size)
   }
 
   @Test

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -180,6 +180,35 @@ the unused VS Code Preview History panel. H1 daemon writes are the only writer, 
 reader does NOT have to tolerate PNG-only entries — every entry on disk has a sibling sidecar
 because the daemon wrote both atomically.
 
+### Dedup-by-hash on write — two tiers
+
+Identical renders produce noisy timelines. The on-write dedup ladder eliminates both physical
+duplicates (same PNG bytes on disk twice) and visual duplicates (consecutive sidecars showing the
+same image to a consumer).
+
+1. **Tier 1 — skip-on-most-recent-match.** If the absolute newest existing entry for this
+   `previewId` has the same `pngHash` as the new render, the source returns
+   `WriteResult.SKIPPED_DUPLICATE` and writes nothing — no PNG, no sidecar, no index line, no
+   `historyAdded` notification. Save-loops that produce identical pixels (comment-only edits,
+   sandbox warm-up renders, repeated focus cycles, tab toggles that re-trigger render but not
+   recomposition) don't accumulate redundant entries.
+
+2. **Tier 2 — pointer-on-any-match.** If the new bytes don't match the most-recent entry but DO
+   match an earlier one, the new sidecar's `pngPath` points at the older PNG and the bytes aren't
+   re-written. The sidecar + index line still land because the entry itself is meaningful
+   provenance. Render history A → B → A keeps three entries — the third is a "we went back to A"
+   event the consumer wants to see.
+
+Why "most recent" for tier 1, not "any match"? A → A → A keeps one entry; A → B → A keeps three.
+The user-visible timeline tracks state transitions, not render-event counts. If the daemon
+re-renders a preview that nothing changed about, that's noise; if the daemon re-renders something
+back to a prior state, that's signal.
+
+Cross-restart correctness: the most-recent-hash check walks the per-preview directory listing,
+not an in-memory cache. A daemon restart loses the in-memory `previousByPreview` cache, but the
+on-disk newest sidecar's hash is still authoritative — so tier 1 still fires for "save → daemon
+restart → identical save" without re-emitting an entry.
+
 ## Trigger taxonomy
 
 The `trigger` field documents *why* the daemon (or Gradle) rendered


### PR DESCRIPTION
## Summary

User report: VS Code history view shows many entries that all look the same. Cause: H1+H2's dedup-by-hash logic was partial — when bytes matched an existing entry, the PNG file wasn't re-written, but the sidecar + index line still landed and \`historyAdded\` still fired. Save-loops that produce identical pixels (comment-only edits, sandbox warm-up renders, repeated focus cycles, tab toggles that re-trigger render but not recomposition) accumulated redundant entries.

This PR adds a tier-1 skip on top of the existing tier-2 pointer:

1. **Tier 1 — skip-on-most-recent-match (NEW).** If the absolute newest existing entry for this \`previewId\` has the same \`pngHash\` as the new render, \`source.write\` returns \`WriteResult.SKIPPED_DUPLICATE\` and writes nothing. \`HistoryManager.recordRender\` returns null on all-skipped, gating the \`historyAdded\` notification.
2. **Tier 2 — pointer-on-any-match (existing).** When the new bytes match an earlier *non-most-recent* entry, the new sidecar's \`pngPath\` points at the older PNG and the bytes aren't re-written. Sidecar + index line still land because the entry IS meaningful provenance.

The "most recent" rule for tier 1 is what distinguishes it from tier 2: render history A → A → A keeps one entry; A → B → A keeps three (the third is a meaningful "went back to A" event the consumer wants to see).

Cross-restart correctness: the most-recent-hash check walks the per-preview directory listing, so a daemon restart loses the in-memory \`previousByPreview\` cache but disk-authoritative state still produces the right behaviour for "save → restart → identical save."

## Wire surface

\`HistorySource.write\` returns \`WriteResult\` (\`WRITTEN\` or \`SKIPPED_DUPLICATE\`). \`GitRefHistorySource\` is read-only so its write still throws when called; the return-type change is a no-op for that source.

## Test plan

- [x] \`./gradlew :daemon:core:test\` — green; LocalFsHistorySourceWriteTest gains coverage for the A → B → A keep-three case + flips the consecutive-identical case to assert \`SKIPPED_DUPLICATE\` + no on-disk artefacts; \`HistoryDiffTest.same_hash_pngHashChanged_false\` updated to use A → B → A to obtain two distinct entries with the same hash (the only way given tier-1 dedup is on)
- [x] \`./gradlew :daemon:harness:test :daemon:desktop:test :daemon:android:testDebugUnitTest\` — green
- [x] \`./gradlew :gradle-plugin:test :cli:assemble :mcp:test\` — green
- [ ] Manual verification once merged: drive the daemon through a few identical renders, confirm \`historyAdded\` fires once and \`history/list\` returns one entry per identical-bytes burst