### PR TITLE
fix(vscode,daemon): preview image updates after edit + self-diagnose

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -811,6 +811,17 @@ function maybeFirePendingRefresh(): void {
  *  unhealthy, the refresh is `forceRender=true` and Gradle does a full
  *  render as today.
  *
+ *  **Recompile-before-notify invariant.** In the daemon path the discover
+ *  refresh runs *first*, then the daemon is notified. The daemon's
+ *  `fileChanged({kind:source})` swaps its `URLClassLoader` and `renderNow`
+ *  reads `.class` files from `build/intermediates/.../classes/` — so those
+ *  files must be fresh when the swap happens. `compileKotlin` runs as an
+ *  upstream of `discoverPreviews` (we let Gradle drive Kotlin compilation
+ *  per `docs/daemon/DESIGN.md` § "Out of scope"); inverting the order would
+ *  let the daemon render stale bytecode matching the previous save and the
+ *  user would see the loading overlay flash without any actual content
+ *  change.
+ *
  *  Save-driven: always `tier='fast'`. Heavy captures (LONG / GIF / animated)
  *  keep their previous PNG/GIF on disk and surface as stale in the panel —
  *  the user re-renders them on demand via the refresh command, which uses
@@ -820,13 +831,14 @@ async function runRefreshExclusive(filePath: string): Promise<void> {
     try {
         const mode = pickRefreshMode(filePath);
         if (mode === 'daemon') {
-            // Daemon owns rendering for this save. Notify it about the
-            // change + focus the visible previews; Gradle does discovery
-            // only (cached) so the manifest is current without spinning up
-            // the slow renderPreviews task.
+            // Run discover first so `compileKotlin` (an upstream of
+            // discoverPreviews) updates the on-disk `.class` files the
+            // daemon's child URLClassLoader reads. Notifying the daemon
+            // before the recompile would race the swap against stale
+            // bytecode and the panel would flicker without updating.
+            await refresh(false, filePath);
             const accepted = await notifyDaemonOfSave(filePath);
             if (accepted) {
-                await refresh(false, filePath);
                 return;
             }
             // Daemon was healthy at decision time but the actual call


### PR DESCRIPTION
## Summary

Three commits on this branch fix the "panel flickers but content doesn't update on edit" save loop and add the diagnostics needed to confirm whether the right code is running on every save.

### `04f102b` — recompile before notifying daemon of save
Save → `fileChanged` → `renderNow` ran *before* `discoverPreviews`, so the daemon's child `URLClassLoader` swap read `.class` files that hadn't been recompiled yet. Reorders `runRefreshExclusive` to run `compileKotlin` (via `discoverPreviews`) first, then notify the daemon.

### `16a5a8d` — ktfmt fixups for files that drifted on main
Pure formatter output (no logic changes) for files that were already failing `./gradlew ktfmtCheckAll` on main. The `.githooks/pre-commit` hook ran the same check repo-wide so any subsequent commit was blocked.

### `329ec8a` — close cancellation hole + self-diagnose stale renders
The original fix had a hole: `refresh()` swallowed `TaskCancelledError` and returned `void`, so a superseded discover (compileKotlin cancelled mid-flight, `.class` files half-written) still fell through to `notifyDaemonOfSave` and the daemon rendered against stale bytecode.

Four pieces in this commit:

1. **Cancellation hole.** `refresh()` now returns a `RefreshOutcome` (`completed` / `cancelled` / `no-module` / `failed`). `runRefreshExclusive` skips the daemon notify on anything other than `completed` — the superseding save's own discover-then-notify owns the loop.

2. **Daemon self-diagnostic logging.** `UserClassLoaderHolder.swap()` and `allocateLocked()` emit one stderr line each, surfaced by the extension as `[daemon stderr] …`. `RenderEngine` (both backends) emits a `[render]` line per render carrying the loaded `.class` file's path, mtime, size, and a 6-byte SHA-256 prefix. The three failure modes are now scannable:
   - mtime never advances → `kotlinc` isn't recompiling.
   - mtime advances but sha repeats → comment-only edit (renderer is working as intended).
   - mtime/sha advance but the panel still shows old content → the bug isn't on the daemon's classloader path.

3. **Extension startup banner.** On activate the output channel logs `[startup] compose-preview vX.Y.Z loaded from <path>` so a stale install can be ruled out at a glance.

4. **S3.5 multi-iteration cycle (Red → Blue → Red → Blue).** The single Red → Blue swap couldn't see a regression where only the *first* swap takes hold. Every iteration now compares against every prior one — same-source iterations must produce byte-identical PNGs, different-source iterations must differ. Stuck-after-first-edit shows up as iteration 2 matching iteration 1 instead of iteration 0.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 190 passing
- [x] `./gradlew :daemon:core:test --tests UserClassLoaderHolderTest` passes
- [x] `./gradlew :daemon:desktop:test` passes
- [x] `./gradlew :daemon:harness:compileTestKotlin` clean
- [x] `./gradlew ktfmtCheckAll` clean (was failing on main before commit `16a5a8d`)
- [ ] Manual: enable the daemon flag, edit `samples/wear/Previews.kt`, save 3+ times, confirm the panel updates each time. Output channel should show `[startup] compose-preview …`, plus one `[classloader] swap requested`, one `[classloader] allocate child loader`, and one `[render] … classFile=… mtime=… sha=…` per save with monotonically advancing `mtime` and `sha`.
- [ ] Manual: `./gradlew :daemon:harness:test --tests S3_5RecompileSaveLoopRealModeTest -Pharness.host=real -Ptarget=desktop` passes (4 iterations, all colour-pair assertions hold).