### PR TITLE
fix(vscode): scope history to focused preview, dblclick-to-focus

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1193,6 +1193,23 @@ function handleWebviewMessage(msg: WebviewToExtensionMessage) {
                 void notifyDaemonViewport(msg.visible, msg.predicted);
             }
             break;
+        case 'previewScopeChanged': {
+            // Live panel has narrowed to a single preview (focus mode, or
+            // filters reduced visible cards to one). Re-scope the History
+            // panel's previewId filter so it only lists entries for that
+            // preview. `previewId` null means widen the scope back to the
+            // module — the panel shows every preview's history.
+            if (!historyScopeRef.current) { break; }
+            const requested = msg.previewId ?? undefined;
+            if (historyScopeRef.current.previewId === requested) { break; }
+            const newScope: HistoryScope = {
+                ...historyScopeRef.current,
+                previewId: requested,
+            };
+            historyScopeRef.current = newScope;
+            historyPanel?.setScope(newScope);
+            break;
+        }
     }
 }
 
@@ -1233,7 +1250,7 @@ interface WebviewToExtensionMessage {
     className?: string;
     functionName?: string;
     value?: string;
-    previewId?: string;
+    previewId?: string | null;
     visible?: string[];
     predicted?: string[];
 }

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -107,6 +107,10 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         let moduleDir = '';
         let filterDebounce = null;
         let focusIndex = 0;
+        // Last previewId published to the extension via previewScopeChanged.
+        // Tracked here so we don't spam the History panel with redundant
+        // re-scopes (e.g. layout reapplies on every filter tweak).
+        let lastScopedPreviewId = null;
 
         // Restore layout preference
         if (state.layout && ['grid', 'flow', 'column', 'focus'].includes(state.layout)) {
@@ -228,6 +232,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 const visible = getVisibleCards();
                 if (visible.length === 0) {
                     focusPosition.textContent = '0 / 0';
+                    publishScopedPreview();
                     return;
                 }
                 if (focusIndex >= visible.length) focusIndex = visible.length - 1;
@@ -251,12 +256,54 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     card.classList.remove('focused', 'hidden-by-focus');
                 });
             }
+            publishScopedPreview();
+        }
+
+        // Compute the previewId the panel is currently narrowed to, if any:
+        //   - focus mode: the focused card
+        //   - non-focus: the sole visible card when filters narrowed to one
+        //   - otherwise: null (panel shows multiple previews — module-level history)
+        // Posts the current value to the extension only when it changes so
+        // the History panel re-lists at most once per user-driven narrowing.
+        function publishScopedPreview() {
+            const visible = getVisibleCards();
+            let previewId = null;
+            if (layoutMode.value === 'focus') {
+                if (visible.length > 0 && focusIndex >= 0 && focusIndex < visible.length) {
+                    previewId = visible[focusIndex].dataset.previewId || null;
+                }
+            } else if (visible.length === 1) {
+                previewId = visible[0].dataset.previewId || null;
+            }
+            if (previewId === lastScopedPreviewId) return;
+            lastScopedPreviewId = previewId;
+            vscode.postMessage({
+                command: 'previewScopeChanged',
+                previewId,
+            });
         }
 
         function navigateFocus(delta) {
             const visible = getVisibleCards();
             if (visible.length === 0) return;
             focusIndex = Math.max(0, Math.min(visible.length - 1, focusIndex + delta));
+            applyLayout();
+        }
+
+        // Switch the layout to focus mode and target the supplied card.
+        // No-op when the card is filtered out (it wouldn't be in the visible
+        // set anyway, and forcing focus on an invisible card surfaces an
+        // empty pane).
+        function focusOnCard(card) {
+            const visible = getVisibleCards();
+            const idx = visible.indexOf(card);
+            if (idx === -1) return;
+            focusIndex = idx;
+            if (layoutMode.value !== 'focus') {
+                layoutMode.value = 'focus';
+                state.layout = 'focus';
+                vscode.setState(state);
+            }
             applyLayout();
         }
 
@@ -379,6 +426,17 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             skeleton.setAttribute('aria-label', 'Loading preview');
             imgContainer.appendChild(skeleton);
             card.appendChild(imgContainer);
+
+            // Double-click the image to jump straight to focus mode on this
+            // preview. Useful when you spot something interesting in a grid
+            // and want a closer look without manually toggling the layout
+            // dropdown and arrowing through siblings. The dblclick handler
+            // stays on the image so single-clicks remain free for future
+            // selection affordances and don't interfere with the existing
+            // title / stale-badge / carousel buttons.
+            imgContainer.addEventListener('dblclick', () => {
+                focusOnCard(card);
+            });
 
             // ATF legend + overlay layer — rendered in the webview (not
             // baked into the PNG) so rows stay interactive: hovering a
@@ -1099,6 +1157,11 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 case 'clearAll':
                     allPreviews = [];
                     grid.innerHTML = '';
+                    // Reset so the next setPreviews can re-publish the
+                    // narrowed-preview scope if applicable — otherwise a
+                    // stale id from the previous module would dedupe the
+                    // first publish and the History panel would miss it.
+                    lastScopedPreviewId = null;
                     // Don't clear the message here — if it came with a
                     // follow-up showMessage (the usual pattern) it'll be
                     // replaced; if not, ensureNotBlank will backstop a

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -279,4 +279,13 @@ export type WebviewToExtension =
      * previous send. `predicted` excludes IDs already in `visible` because
      * those are reactively rendered by the visible queue.
      */
-    | { command: 'viewportUpdated'; visible: string[]; predicted: string[] };
+    | { command: 'viewportUpdated'; visible: string[]; predicted: string[] }
+    /**
+     * Webview reports which preview the user has narrowed the live panel to.
+     * Drives the History panel's `previewId` filter so it shows only entries
+     * for the currently-focused (focus mode) or sole-visible (filter narrowed
+     * to one card) preview. `previewId` is `null` when the panel shows the
+     * full module view — extension clears the previewId filter on the
+     * History panel scope.
+     */
+    | { command: 'previewScopeChanged'; previewId: string | null };


### PR DESCRIPTION
## Summary

- Live preview panel publishes a `previewScopeChanged` message whenever the visible set narrows to a single preview — focus mode (focused card) or filters reduced to one card — so the History panel re-lists scoped to that previewId. When the panel widens back to multiple cards the scope reverts to module-level.
- Double-clicking a preview image switches the layout to focus mode and targets that card.
- `clearAll` resets the last-published scope so a stale id from the previous module can't dedupe the first publish on the new one.

## Test plan

- [x] `npm run compile` — clean
- [x] `npm test` — 190/190 passing
- [ ] Manual: open a Kotlin file with multiple `@Preview`s, narrow to focus mode → History panel lists only that preview's renders; arrow through focus → History re-scopes to each preview
- [ ] Manual: in grid layout, filter the function dropdown down to one preview → History scopes; reset filter → History widens back to module
- [ ] Manual: double-click a preview image in grid/flow/column → layout switches to focus on that card


---
_Generated by [Claude Code](https://claude.ai/code/session_01A6AFhHNrHQNqUPKdmJRt94)_