### PR TITLE
feat(vscode): progress bar, glitch-free fast refresh, LSP compile-error gate

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -88,6 +88,94 @@ body {
     opacity: 0;
 }
 
+/* -- Compile-error banner --------------------------------------------
+ * Pinned under the progress bar when the LSP-driven gate has skipped a
+ * refresh because the active file has Error-severity diagnostics. Sits
+ * above the toolbar so the user notices it first; cards beneath get a
+ * subtle fade via .compile-stale so the user keeps the last-good render
+ * visible without confusing it for the current state.
+ */
+.compile-errors {
+    background: var(--vscode-inputValidation-errorBackground,
+        color-mix(in srgb, var(--vscode-errorForeground) 18%, transparent));
+    border: 1px solid var(--vscode-inputValidation-errorBorder, var(--vscode-errorForeground));
+    border-radius: 4px;
+    margin: 6px 8px 0;
+    padding: 8px 10px 4px;
+    color: var(--vscode-foreground);
+    font-size: calc(var(--vscode-font-size) - 1px);
+}
+.compile-errors[hidden] { display: none; }
+
+.compile-errors-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 600;
+    color: var(--vscode-errorForeground);
+    margin-bottom: 4px;
+}
+.compile-errors-header .codicon { font-size: 14px; }
+
+.compile-errors-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.compile-error-row {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    padding: 3px 6px;
+    background: transparent;
+    border: none;
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+    border-radius: 3px;
+    font-family: var(--vscode-editor-font-family);
+    font-size: calc(var(--vscode-font-size) - 1px);
+    width: 100%;
+}
+.compile-error-row:hover {
+    background: var(--vscode-list-hoverBackground, rgba(255, 255, 255, 0.06));
+}
+.compile-error-row:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: -1px;
+}
+.compile-error-loc {
+    flex: 0 0 auto;
+    color: var(--vscode-textLink-foreground);
+    text-decoration: underline;
+    font-variant-numeric: tabular-nums;
+}
+.compile-error-msg {
+    flex: 1;
+    min-width: 0;
+    color: var(--vscode-descriptionForeground);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.compile-errors-footnote {
+    font-size: calc(var(--vscode-font-size) - 3px);
+    color: var(--vscode-descriptionForeground);
+    margin-top: 4px;
+    opacity: 0.85;
+}
+
+/* Cards keep their last-good image but read as "this is stale" while
+ * the compile-error banner is up. Sibling-aware dim — applied to the
+ * whole grid so newly-arriving cards (rare during the gate, but
+ * possible) inherit the same look. */
+.preview-grid.compile-stale .preview-card {
+    opacity: 0.55;
+    filter: saturate(0.7);
+    transition: opacity 0.2s ease, filter 0.2s ease;
+}
+
 /* -- Toolbar ---------------------------------------------------------- */
 
 .toolbar {

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -63,6 +63,19 @@ body {
     opacity: 0.85;
 }
 
+/* "Slow" annotation: when a phase is running >2× its calibrated estimate
+ * we tint the bar with the warning colour and append "(slow)" to the
+ * label. Cheap signal that something unusual is happening (cold cache,
+ * a Compose / AGP version bump invalidating Robolectric caches) without
+ * popping a notification. */
+.progress-bar.progress-slow .progress-fill {
+    background: var(--vscode-editorWarning-foreground, #cca700);
+}
+.progress-bar.progress-slow .progress-label {
+    color: var(--vscode-editorWarning-foreground, #cca700);
+    opacity: 1;
+}
+
 /* Final-state flash before fade-out. Brightens the strip momentarily so
  * the eye registers the transition from "in-flight" to "done". */
 .progress-bar.progress-finishing .progress-fill {
@@ -399,9 +412,30 @@ body {
     justify-content: center;
 }
 
-/* Subtle variant used during stealth refresh — dims + blurs the stale image
-   and drops a clearly visible spinner in the corner so it reads as "updating"
-   at a glance without clobbering the image you're editing. */
+/* Minimal variant — first 500 ms of a stealth refresh. Just a tiny corner
+   spinner, NO dim, NO blur. Most daemon-served updates land in this window
+   so the user sees a clean image swap rather than the dim → undim flicker
+   that read as "the panel went glitchy" before. After 500 ms this gets
+   promoted to .subtle by the JS escalation timer for builds that need a
+   stronger affordance. */
+.loading-overlay.minimal {
+    background: transparent;
+    justify-content: flex-end;
+    align-items: flex-start;
+    padding: 6px;
+    pointer-events: none;
+}
+.loading-overlay.minimal .spinner {
+    width: 14px;
+    height: 14px;
+    border-width: 2px;
+    opacity: 0.85;
+}
+
+/* Subtle variant — escalated state, used after [OVERLAY_ESCALATE_MS] for
+   refreshes that take meaningful wall-clock time. Dims + blurs the stale
+   image and drops a clearly visible spinner in the corner so it reads as
+   "updating" at a glance without clobbering the image you're editing. */
 .loading-overlay.subtle {
     background: color-mix(in srgb, var(--vscode-editor-background) 35%, transparent);
     backdrop-filter: blur(1.5px);
@@ -420,7 +454,8 @@ body {
 }
 
 /* Fade the image a touch so the blur + spinner read as "refreshing". Uses
-   :has() so we don't have to touch the TS that manages the overlay DOM. */
+   :has() so we don't have to touch the TS that manages the overlay DOM.
+   Only the .subtle stage dims — .minimal leaves the image untouched. */
 .image-container:has(> .loading-overlay.subtle) img {
     opacity: 0.55;
     transition: opacity 0.15s ease-out;

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -20,6 +20,61 @@ body {
     color: var(--text-primary);
 }
 
+/* -- Top progress bar -------------------------------------------------
+ * Slim 2px strip pinned to the very top of the panel, animating during a
+ * refresh. Mirrors the affordance native VS Code views (Extensions, Source
+ * Control) use for background work — visible-but-quiet, with a label that
+ * names the current build phase. Hidden when no refresh is in flight.
+ */
+.progress-bar {
+    position: sticky;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: transparent;
+    z-index: 10;
+    overflow: visible;
+}
+.progress-bar[hidden] { display: none; }
+
+.progress-fill {
+    height: 100%;
+    width: 0%;
+    background: var(--vscode-progressBar-background, var(--vscode-focusBorder));
+    transition: width 200ms ease-out;
+}
+
+/* Phase label: tiny, lives just below the strip. Right-aligned so it
+ * doesn't fight with the toolbar selects on the left. Pointer-events
+ * disabled so the toolbar stays clickable through it. */
+.progress-label {
+    position: absolute;
+    top: 2px;
+    right: 8px;
+    font-size: calc(var(--vscode-font-size) - 3px);
+    color: var(--text-secondary);
+    background: var(--vscode-editor-background);
+    padding: 0 4px;
+    border-radius: 0 0 3px 3px;
+    pointer-events: none;
+    font-variant-numeric: tabular-nums;
+    line-height: 1.4;
+    opacity: 0.85;
+}
+
+/* Final-state flash before fade-out. Brightens the strip momentarily so
+ * the eye registers the transition from "in-flight" to "done". */
+.progress-bar.progress-finishing .progress-fill {
+    background: var(--vscode-progressBar-background, var(--vscode-focusBorder));
+    transition: width 200ms ease-out, opacity 500ms ease-out 100ms;
+    opacity: 0;
+}
+.progress-bar.progress-finishing .progress-label {
+    transition: opacity 500ms ease-out 100ms;
+    opacity: 0;
+}
+
 /* -- Toolbar ---------------------------------------------------------- */
 
 .toolbar {

--- a/vscode-extension/src/buildProgress.ts
+++ b/vscode-extension/src/buildProgress.ts
@@ -64,7 +64,21 @@ export interface ProgressState {
     label: string;
     /** [0, 1]. Monotonic within a single tracker. 1 only when phase === 'done'. */
     percent: number;
+    /**
+     * True when this phase has been running for more than [SLOW_RATIO]× its
+     * expected duration. Surfaces as a warning tint on the bar plus a
+     * "(slow)" label suffix — cheap signal that a cold cache or version
+     * bump is at play, without popping a notification.
+     */
+    slow: boolean;
 }
+
+/**
+ * How far past the expected phase duration counts as "slow". 2× chosen as a
+ * soft threshold — the asymptotic curve already absorbs short overruns
+ * gracefully, so we only flag when the estimate is meaningfully wrong.
+ */
+const SLOW_RATIO = 2;
 
 /** Recorded duration per phase, used to calibrate future estimates. */
 export type PhaseDurations = Partial<Record<PhaseId, number>>;
@@ -283,10 +297,10 @@ export class BuildProgressTracker {
     private computeState(): ProgressState {
         const phase = PHASES[PHASE_INDEX[this.currentPhase]];
         if (this.currentPhase === 'done') {
-            return { phase: 'done', label: 'Done', percent: 1 };
+            return { phase: 'done', label: 'Done', percent: 1, slow: false };
         }
         if (this.currentPhase === 'starting') {
-            return { phase: 'starting', label: phase.label, percent: 0 };
+            return { phase: 'starting', label: phase.label, percent: 0, slow: false };
         }
         const { phaseStart, phaseEnd } = this.phaseBoundaries(this.currentPhase);
         const expectedMs = this.expectedPhaseMs(this.currentPhase);
@@ -303,7 +317,8 @@ export class BuildProgressTracker {
         // jump forward to.
         const fraction = Math.min(0.95, ratio);
         const percent = phaseStart + (phaseEnd - phaseStart) * fraction;
-        return { phase: this.currentPhase, label: phase.label, percent };
+        const slow = expectedMs > 0 && elapsed > SLOW_RATIO * expectedMs;
+        return { phase: this.currentPhase, label: phase.label, percent, slow };
     }
 
     /**

--- a/vscode-extension/src/buildProgress.ts
+++ b/vscode-extension/src/buildProgress.ts
@@ -1,0 +1,389 @@
+/**
+ * Phase parser + progress estimator for Gradle-driven preview refreshes.
+ *
+ * Watches `:<module>:<task>` lines in Gradle stdout and maps them onto a
+ * coarse phase machine: configuring → compiling → resolving → discovering →
+ * rendering → loading. Each phase has a default weight (fraction of the
+ * progress bar it occupies); per-module historical durations override the
+ * default once we've seen at least one full refresh, so the bar's animation
+ * speed matches what that module actually takes.
+ *
+ * The estimator keeps the bar moving even when Gradle is silent for tens of
+ * seconds (Robolectric sandbox bring-up, kotlinc on a cold cache) by
+ * interpolating elapsed-time-in-phase against the phase's expected duration
+ * and asymptotically approaching the phase's upper boundary. It will never
+ * exceed that boundary until the next phase signal lands, so the bar can't
+ * lap itself or finish early.
+ */
+export type PhaseId =
+    | 'starting'
+    | 'configuring'
+    | 'compiling'
+    | 'resolving'
+    | 'discovering'
+    | 'rendering'
+    | 'loading'
+    | 'done';
+
+export interface PhaseDescriptor {
+    id: PhaseId;
+    /** User-facing label shown next to the bar. */
+    label: string;
+    /** Default fraction of the bar this phase occupies, in [0, 1]. */
+    weight: number;
+    /** Default expected duration in ms when no calibration data exists. */
+    defaultMs: number;
+}
+
+/**
+ * Order matters — the bar advances monotonically through this list. Phase
+ * weights are normalised at use-time so callers can tweak any single weight
+ * without re-balancing the rest. `starting` sits before configuring as a
+ * zero-weight slot so the bar can show "Starting…" before the first task
+ * line arrives without committing to a percent.
+ */
+export const PHASES: readonly PhaseDescriptor[] = [
+    { id: 'starting',    label: 'Starting',          weight: 0,    defaultMs: 200 },
+    { id: 'configuring', label: 'Configuring Gradle', weight: 0.08, defaultMs: 1500 },
+    { id: 'compiling',   label: 'Compiling Kotlin',  weight: 0.30, defaultMs: 4000 },
+    { id: 'resolving',   label: 'Resolving classpath', weight: 0.07, defaultMs: 1000 },
+    { id: 'discovering', label: 'Discovering @Preview', weight: 0.10, defaultMs: 1500 },
+    { id: 'rendering',   label: 'Rendering previews', weight: 0.35, defaultMs: 8000 },
+    { id: 'loading',     label: 'Loading images',    weight: 0.10, defaultMs: 600 },
+    { id: 'done',        label: 'Done',              weight: 0,    defaultMs: 0 },
+];
+
+const PHASE_INDEX: Record<PhaseId, number> = (() => {
+    const out: Partial<Record<PhaseId, number>> = {};
+    PHASES.forEach((p, i) => { out[p.id] = i; });
+    return out as Record<PhaseId, number>;
+})();
+
+export interface ProgressState {
+    phase: PhaseId;
+    label: string;
+    /** [0, 1]. Monotonic within a single tracker. 1 only when phase === 'done'. */
+    percent: number;
+}
+
+/** Recorded duration per phase, used to calibrate future estimates. */
+export type PhaseDurations = Partial<Record<PhaseId, number>>;
+
+/**
+ * Maps a parsed task name to the phase it belongs to. Returns null when the
+ * task is uninteresting (e.g. `composePreviewApplied` bootstrap, doctor,
+ * internal aggregators that fire near-instantly). Order in this dispatch
+ * matters: more-specific patterns first.
+ */
+export function classifyTask(taskName: string): PhaseId | null {
+    // Strip the leading ':' and any project path, focus on the task segment.
+    const segments = taskName.split(':').filter(s => s.length > 0);
+    const tail = segments[segments.length - 1] ?? taskName;
+    const lower = tail.toLowerCase();
+
+    if (lower.includes('renderpreviews') || lower.includes('renderallpreviews')
+        || lower.includes('renderandroidresources')) {
+        return 'rendering';
+    }
+    if (lower.includes('discoverpreviews') || lower.includes('discoverandroidresources')
+        || lower.includes('collectpreviewinfo')) {
+        return 'discovering';
+    }
+    if (lower.startsWith('compile')
+        && (lower.endsWith('kotlin') || lower.endsWith('java') || lower.endsWith('javac')
+            || lower.includes('javawith') || lower.includes('rendershards'))) {
+        return 'compiling';
+    }
+    // AGP task names embed the variant in the middle: `processDebugResources`,
+    // `mergeReleaseResources`. Match the verb prefix + the trailing
+    // `resources` suffix rather than a literal substring.
+    if (lower.includes('extractpreviewclasses') || lower.includes('generaterendershards')
+        || /^(merge|process)\w*resources$/.test(lower)) {
+        return 'resolving';
+    }
+    return null;
+}
+
+const TASK_LINE_RE = /^>\s*Task\s+(:[^\s]+)/;
+const CONFIGURE_LINE_RE = /^>\s*Configure project\b/;
+const BUILD_DONE_RE = /^BUILD (SUCCESSFUL|FAILED)\b/;
+
+export interface ProgressTrackerOptions {
+    /** Called every time the visible state changes (phase shift or percent tick). */
+    onProgress: (state: ProgressState) => void;
+    /** Per-phase calibration from prior runs. Falls back to phase defaults. */
+    calibration?: PhaseDurations;
+    /** Wall-clock source — injected for tests. Defaults to Date.now. */
+    now?: () => number;
+    /** Tick scheduler — injected for tests. Defaults to setInterval. */
+    setInterval?: (cb: () => void, ms: number) => unknown;
+    /** Tick canceller — injected for tests. Defaults to clearInterval. */
+    clearInterval?: (handle: unknown) => void;
+    /** Tick interval; the bar smooths between phase boundaries. */
+    tickMs?: number;
+}
+
+/**
+ * Streaming progress tracker. Single instance per refresh — call [start],
+ * feed Gradle stdout chunks via [consume], and [finish] when the build
+ * completes. Emits monotonic progress updates through the supplied callback
+ * and records per-phase durations into [phaseDurations] for the caller to
+ * persist as calibration.
+ */
+export class BuildProgressTracker {
+    private buffer = '';
+    private currentPhase: PhaseId = 'starting';
+    private phaseEnteredAt = 0;
+    private startedAt = 0;
+    private lastEmittedPercent = 0;
+    private finished = false;
+    private tickHandle: unknown = null;
+    private readonly nowFn: () => number;
+    private readonly setIntervalFn: (cb: () => void, ms: number) => unknown;
+    private readonly clearIntervalFn: (handle: unknown) => void;
+    private readonly tickMs: number;
+    private readonly calibration: PhaseDurations;
+    private readonly onProgress: (state: ProgressState) => void;
+    /**
+     * Wall-clock duration each phase actually took on this run. Populated as
+     * phases transition; the caller persists this map after a successful
+     * build so the next refresh of the same module can interpolate at the
+     * right rate instead of using global defaults.
+     */
+    public readonly phaseDurations: PhaseDurations = {};
+
+    constructor(opts: ProgressTrackerOptions) {
+        this.onProgress = opts.onProgress;
+        this.calibration = opts.calibration ?? {};
+        this.nowFn = opts.now ?? Date.now;
+        this.setIntervalFn = opts.setInterval ?? ((cb, ms) => setInterval(cb, ms));
+        this.clearIntervalFn = opts.clearInterval ?? ((h) => clearInterval(h as ReturnType<typeof setInterval>));
+        this.tickMs = opts.tickMs ?? 200;
+    }
+
+    start(): void {
+        const now = this.nowFn();
+        this.startedAt = now;
+        this.phaseEnteredAt = now;
+        this.currentPhase = 'starting';
+        this.lastEmittedPercent = 0;
+        this.finished = false;
+        this.emit();
+        this.tickHandle = this.setIntervalFn(() => this.tick(), this.tickMs);
+    }
+
+    /**
+     * Forces a phase transition independent of Gradle output. Used by the
+     * extension to announce the post-Gradle "loading images" phase, which
+     * Gradle itself doesn't surface (the work happens in the extension after
+     * the task returns).
+     */
+    enterPhase(phase: PhaseId): void {
+        if (this.finished) { return; }
+        this.transitionTo(phase);
+    }
+
+    /**
+     * Feed a chunk of Gradle stdout. Buffers partial lines; safe to call
+     * repeatedly with arbitrary chunk boundaries.
+     */
+    consume(chunk: string): void {
+        if (this.finished) { return; }
+        this.buffer += chunk;
+        let nl = this.buffer.indexOf('\n');
+        while (nl !== -1) {
+            const line = this.buffer.slice(0, nl);
+            this.buffer = this.buffer.slice(nl + 1);
+            this.scanLine(line);
+            nl = this.buffer.indexOf('\n');
+        }
+        // Bound runaway buffering when output arrives without newlines.
+        if (this.buffer.length > 16 * 1024) {
+            this.scanLine(this.buffer);
+            this.buffer = '';
+        }
+    }
+
+    /** Marks the build finished (success or failure). Drives the bar to 100%. */
+    finish(): void {
+        if (this.finished) { return; }
+        // Close out the running phase so its duration lands in phaseDurations.
+        this.recordPhaseDuration();
+        this.finished = true;
+        this.currentPhase = 'done';
+        this.lastEmittedPercent = 1;
+        this.emit();
+        this.stopTicking();
+    }
+
+    /** Cancel without driving to 100% — used when a refresh is superseded. */
+    abort(): void {
+        if (this.finished) { return; }
+        this.finished = true;
+        this.stopTicking();
+    }
+
+    private scanLine(line: string): void {
+        if (CONFIGURE_LINE_RE.test(line) && this.currentPhase === 'starting') {
+            this.transitionTo('configuring');
+            return;
+        }
+        const taskMatch = TASK_LINE_RE.exec(line);
+        if (taskMatch) {
+            const phase = classifyTask(taskMatch[1]);
+            if (phase) { this.transitionTo(phase); }
+            return;
+        }
+        if (BUILD_DONE_RE.test(line)) {
+            // Gradle reports BUILD SUCCESSFUL after every task completes; the
+            // extension still has post-task work to do (image loading), so we
+            // jump to `loading` rather than `done` here. The caller calls
+            // finish() once that work is complete.
+            this.transitionTo('loading');
+        }
+    }
+
+    private transitionTo(phase: PhaseId): void {
+        const targetIdx = PHASE_INDEX[phase];
+        const currentIdx = PHASE_INDEX[this.currentPhase];
+        // Phases are monotonic — a stray `discoverPreviews` line landing in the
+        // middle of a render doesn't drag the bar backward. Same-phase
+        // signals are no-ops.
+        if (targetIdx <= currentIdx) { return; }
+        this.recordPhaseDuration();
+        this.currentPhase = phase;
+        this.phaseEnteredAt = this.nowFn();
+        this.emit();
+    }
+
+    private recordPhaseDuration(): void {
+        const now = this.nowFn();
+        const elapsed = now - this.phaseEnteredAt;
+        if (elapsed > 0 && this.currentPhase !== 'starting' && this.currentPhase !== 'done') {
+            this.phaseDurations[this.currentPhase] = elapsed;
+        }
+    }
+
+    private tick(): void {
+        if (this.finished) { return; }
+        this.emit();
+    }
+
+    private emit(): void {
+        const state = this.computeState();
+        // Don't emit a percent that's lower than what we just sent — the bar
+        // is monotonic and going backward looks like a bug.
+        if (state.percent < this.lastEmittedPercent && state.phase !== 'done') {
+            state.percent = this.lastEmittedPercent;
+        }
+        this.lastEmittedPercent = state.percent;
+        this.onProgress(state);
+    }
+
+    private computeState(): ProgressState {
+        const phase = PHASES[PHASE_INDEX[this.currentPhase]];
+        if (this.currentPhase === 'done') {
+            return { phase: 'done', label: 'Done', percent: 1 };
+        }
+        if (this.currentPhase === 'starting') {
+            return { phase: 'starting', label: phase.label, percent: 0 };
+        }
+        const { phaseStart, phaseEnd } = this.phaseBoundaries(this.currentPhase);
+        const expectedMs = this.expectedPhaseMs(this.currentPhase);
+        const elapsed = this.nowFn() - this.phaseEnteredAt;
+        // Asymptotic curve: hits ~63% of the phase span at expectedMs, ~95%
+        // at 3*expectedMs. Never crosses the next phase boundary unless a
+        // task signal explicitly transitions us there. Keeps the bar honest
+        // when a phase outruns its estimate (cold Robolectric sandbox).
+        const ratio = expectedMs > 0
+            ? 1 - Math.exp(-elapsed / expectedMs)
+            : 0;
+        // Soft cap at 95% of the phase span — leaves visible headroom for the
+        // transition into the next phase, so the bar always has somewhere to
+        // jump forward to.
+        const fraction = Math.min(0.95, ratio);
+        const percent = phaseStart + (phaseEnd - phaseStart) * fraction;
+        return { phase: this.currentPhase, label: phase.label, percent };
+    }
+
+    /**
+     * Expected duration of a phase: calibrated from prior runs when available,
+     * otherwise the phase's default. Floors at 250ms to stop very-fast hot
+     * builds from snapping the bar instantaneously (which reads as no
+     * animation at all).
+     */
+    private expectedPhaseMs(phase: PhaseId): number {
+        const calibrated = this.calibration[phase];
+        const desc = PHASES[PHASE_INDEX[phase]];
+        const ms = calibrated ?? desc.defaultMs;
+        return Math.max(250, ms);
+    }
+
+    /**
+     * Returns the [start, end] percent-positions of `phase` on the bar. Built
+     * from this run's calibration so a slow `compiling` phase visibly takes
+     * up more of the bar than a fast one. Falls back to the static default
+     * weights when no calibration is supplied.
+     */
+    private phaseBoundaries(phase: PhaseId): { phaseStart: number; phaseEnd: number } {
+        const weights = this.normalisedWeights();
+        let acc = 0;
+        for (const p of PHASES) {
+            if (p.id === phase) {
+                return { phaseStart: acc, phaseEnd: acc + weights[p.id] };
+            }
+            acc += weights[p.id];
+        }
+        return { phaseStart: 0, phaseEnd: 1 };
+    }
+
+    private normalisedWeights(): Record<PhaseId, number> {
+        // Convert calibrated durations into weights when we have them. Falls
+        // back to the descriptor weights when a phase hasn't been observed
+        // yet (e.g. first run on a module). The mix is deliberate: we don't
+        // want a single missing observation to collapse a phase to 0.
+        const raw: Record<PhaseId, number> = {} as Record<PhaseId, number>;
+        let total = 0;
+        for (const p of PHASES) {
+            const fromCalib = this.calibration[p.id];
+            const w = fromCalib != null
+                ? Math.max(50, fromCalib) // ms — clamp so a 0ms phase doesn't vanish
+                : Math.max(50, p.defaultMs * (p.weight > 0 ? 1 : 0));
+            raw[p.id] = w;
+            total += w;
+        }
+        if (total <= 0) {
+            // No data anywhere — fall back to descriptor weights as-is.
+            const out: Record<PhaseId, number> = {} as Record<PhaseId, number>;
+            for (const p of PHASES) { out[p.id] = p.weight; }
+            return out;
+        }
+        const out: Record<PhaseId, number> = {} as Record<PhaseId, number>;
+        for (const p of PHASES) { out[p.id] = raw[p.id] / total; }
+        return out;
+    }
+
+    private stopTicking(): void {
+        if (this.tickHandle !== null) {
+            this.clearIntervalFn(this.tickHandle);
+            this.tickHandle = null;
+        }
+    }
+}
+
+/**
+ * Exponential moving average used by the extension to merge the durations
+ * recorded on this run into the persistent calibration store. Heavy weight
+ * on the latest sample (alpha=0.5) so a single fast or slow run is visible
+ * on the next refresh, without making estimates pure noise.
+ */
+export function mergeCalibration(prior: PhaseDurations, latest: PhaseDurations): PhaseDurations {
+    const out: PhaseDurations = { ...prior };
+    for (const key of Object.keys(latest) as PhaseId[]) {
+        const lv = latest[key];
+        if (lv == null) { continue; }
+        const pv = out[key];
+        out[key] = pv == null ? lv : Math.round(pv * 0.5 + lv * 0.5);
+    }
+    return out;
+}

--- a/vscode-extension/src/compileErrors.ts
+++ b/vscode-extension/src/compileErrors.ts
@@ -1,0 +1,108 @@
+/**
+ * LSP-driven compile-error gate. Reads `vscode.languages.getDiagnostics(uri)`
+ * upstream of every refresh and short-circuits the build when the active
+ * file has Error-severity diagnostics. Saves a 5–30 s round-trip through
+ * `compileKotlin` on a typo-fix loop.
+ *
+ * The gate is silent when no Kotlin language server is attached
+ * (`getDiagnostics` returns an empty array regardless of file content), so
+ * users without an LSP fall through to the existing Gradle-only path with
+ * no visible difference.
+ *
+ * This module deliberately avoids importing `vscode`: it operates on a
+ * structural subset of `vscode.Diagnostic` so the same parsing logic can
+ * be exercised from mocha unit tests that run outside the VS Code
+ * extension host. The production caller in `extension.ts` adapts
+ * `vscode.Diagnostic` to [DiagnosticLike] at the call site.
+ */
+
+/** Subset of `vscode.DiagnosticSeverity` used by [extractCompileErrors]. */
+export const DIAGNOSTIC_SEVERITY = {
+    /** Matches `vscode.DiagnosticSeverity.Error`. */
+    Error: 0,
+    /** Matches `vscode.DiagnosticSeverity.Warning`. */
+    Warning: 1,
+    /** Matches `vscode.DiagnosticSeverity.Information`. */
+    Information: 2,
+    /** Matches `vscode.DiagnosticSeverity.Hint`. */
+    Hint: 3,
+} as const;
+
+/** Structural shape we need from `vscode.Diagnostic`. */
+export interface DiagnosticLike {
+    severity: number;
+    message: string;
+    range: { start: { line: number; character: number } };
+    /**
+     * Diagnostic source (e.g. `'kotlin'`, `'gradle'`). Used to filter out
+     * non-Kotlin sources that happen to attach diagnostics to the file —
+     * spell-checkers, custom rules. Optional; missing source defaults to
+     * "trust this diagnostic".
+     */
+    source?: string;
+}
+
+/** Serialisable per-error record sent to the webview banner. */
+export interface CompileError {
+    /** Display label — basename of the file. */
+    file: string;
+    /** 1-based line for human display. The webview opens via this number. */
+    line: number;
+    /** 1-based column. */
+    column: number;
+    /** First line of the diagnostic message — keeps the banner row at one line. */
+    message: string;
+}
+
+/**
+ * Sources we trust as "this is a real compile error from the language
+ * tooling". An empty / missing source field still passes through (some
+ * LSPs don't populate it). Listed conservatively so a markdown-lint or
+ * spelling diagnostic can't accidentally gate a build.
+ */
+const TRUSTED_SOURCES = new Set([
+    'kotlin',
+    'kotlin-language-server',
+    'fwcd.kotlin',
+    'gradle',
+    'JetBrains',
+]);
+
+/**
+ * Return the subset of `diagnostics` that should block a refresh, in
+ * source-position order. Filters by:
+ *   1. Error severity only — warnings and hints are non-blocking.
+ *   2. Trusted source (or no declared source).
+ * Empty array means "go ahead and build".
+ */
+export function extractCompileErrors(
+    filePath: string,
+    diagnostics: readonly DiagnosticLike[],
+): CompileError[] {
+    const fileLabel = basename(filePath);
+    const errors: CompileError[] = [];
+    for (const d of diagnostics) {
+        if (d.severity !== DIAGNOSTIC_SEVERITY.Error) { continue; }
+        if (d.source && !TRUSTED_SOURCES.has(d.source)) { continue; }
+        errors.push({
+            file: fileLabel,
+            // VS Code's range is 0-indexed. Convert to 1-based for display
+            // and consistency with `kotlinc -e: file://…:42:5` output.
+            line: d.range.start.line + 1,
+            column: d.range.start.character + 1,
+            message: firstLine(d.message),
+        });
+    }
+    errors.sort((a, b) => (a.line - b.line) || (a.column - b.column));
+    return errors;
+}
+
+function firstLine(message: string): string {
+    const nl = message.indexOf('\n');
+    return nl >= 0 ? message.slice(0, nl) : message;
+}
+
+function basename(filePath: string): string {
+    const slash = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+    return slash >= 0 ? filePath.slice(slash + 1) : filePath;
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1119,6 +1119,7 @@ async function refresh(
             phase: state.phase,
             label: state.label,
             percent: state.percent,
+            slow: state.slow,
         });
     };
     const taskOpts = {
@@ -1235,7 +1236,7 @@ async function refresh(
         // to advance instead of sitting stuck at the end of `rendering` while
         // images stream in.
         if (!abort.signal.aborted) {
-            onProgress({ phase: 'loading', label: 'Loading images', percent: 0.92 });
+            onProgress({ phase: 'loading', label: 'Loading images', percent: 0.92, slow: false });
         }
 
         // Load images in parallel. Animated previews have multiple captures
@@ -1295,7 +1296,7 @@ async function refresh(
         }
         await Promise.all(imageJobs);
         if (!abort.signal.aborted) {
-            onProgress({ phase: 'done', label: 'Done', percent: 1 });
+            onProgress({ phase: 'done', label: 'Done', percent: 1, slow: false });
         }
 
         // NOTE: intentionally do NOT send `showMessage: ''` here. The webview's

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -20,6 +20,7 @@ import { DaemonScheduler, WarmState } from './daemon/daemonScheduler';
 import { buildHistorySource, HistoryPanel, HistoryScope } from './historyPanel';
 import { LogFilter, parseLogLevel } from './logFilter';
 import { pickRefreshModeFor, RefreshMode } from './refreshMode';
+import { mergeCalibration, PhaseDurations, ProgressState } from './buildProgress';
 
 const DEBOUNCE_MS = 1500;
 // Edits to the currently-scoped preview file (e.g. Claude Code's Edit tool
@@ -74,6 +75,11 @@ let debounceElapsed = true;
 let refreshInFlight = false;
 /** Workspace-state key that suppresses the "plugin not applied" notification. */
 const DISMISS_KEY = 'composePreview.dismissedMissingPluginWarning';
+/** Workspace-state key for per-module phase-duration calibration. Shape:
+ *  `Record<moduleId, PhaseDurations>`. Updated after every successful refresh
+ *  so the progress bar's animation rate matches what each module actually
+ *  takes (a Wear OS sample with Robolectric is much slower than a CMP one). */
+const PROGRESS_CALIBRATION_KEY = 'composePreview.progressCalibration';
 /** Captured in activate() so notification helpers can reach workspaceState. */
 let extensionContext: vscode.ExtensionContext | null = null;
 /** Module-scoped logger wired up in activate() so refresh() can trace state
@@ -829,6 +835,25 @@ function updateDaemonStatus(module: string, state: WarmState): void {
 /** Per-extension-session memo so bootstrap runs once per module. */
 const daemonBootstrappedModules = new Set<string>();
 
+/** Read calibrated phase durations for `module` from workspace state. Empty
+ *  on first run; the tracker falls back to its built-in phase defaults. */
+function readCalibration(module: string): PhaseDurations {
+    if (!extensionContext) { return {}; }
+    const all = extensionContext.workspaceState.get<Record<string, PhaseDurations>>(
+        PROGRESS_CALIBRATION_KEY, {});
+    return all[module] ?? {};
+}
+
+/** Persist updated calibration for `module`, blending into prior samples via
+ *  EMA so a single anomalous run doesn't dominate. */
+function writeCalibration(module: string, latest: PhaseDurations): void {
+    if (!extensionContext) { return; }
+    const all = extensionContext.workspaceState.get<Record<string, PhaseDurations>>(
+        PROGRESS_CALIBRATION_KEY, {});
+    all[module] = mergeCalibration(all[module] ?? {}, latest);
+    void extensionContext.workspaceState.update(PROGRESS_CALIBRATION_KEY, all);
+}
+
 /**
  * Coalesce save-driven refreshes. The next refresh fires when BOTH:
  *   1. `DEBOUNCE_MS` has elapsed since the last save (absorbs bursts), and
@@ -1083,6 +1108,25 @@ async function refresh(
     lastLoadedModules = modules;
     gradleService.cancel();
 
+    // Forward progress-bar updates to the webview. Single tracker per refresh
+    // — same instance feeds the Gradle phase signals (compile/discover/render)
+    // and the post-task `loading` phase the extension drives itself once
+    // Gradle returns. The webview hides the bar on its own once percent=1.
+    const onProgress = (state: ProgressState) => {
+        if (abort.signal.aborted) { return; }
+        panel?.postMessage({
+            command: 'setProgress',
+            phase: state.phase,
+            label: state.label,
+            percent: state.percent,
+        });
+    };
+    const taskOpts = {
+        progressCalibration: readCalibration(module),
+        onProgress,
+        onCalibration: (durations: PhaseDurations) => writeCalibration(module, durations),
+    };
+
     try {
         const allPreviews: PreviewInfo[] = [];
         previewModuleMap.clear();
@@ -1091,8 +1135,8 @@ async function refresh(
             if (abort.signal.aborted) { return 'cancelled'; }
 
             const manifest = forceRender
-                ? await gradleService.renderPreviews(mod, tier)
-                : await gradleService.discoverPreviews(mod);
+                ? await gradleService.renderPreviews(mod, tier, taskOpts)
+                : await gradleService.discoverPreviews(mod, taskOpts);
 
             // Track tier so the webview can mark heavy cards as stale after a
             // fast save. A successful full render clears the flag for this
@@ -1138,6 +1182,7 @@ async function refresh(
             // message isn't overlaid on old content from a prior scope.
             panel.postMessage({ command: 'clearAll' });
             panel.postMessage({ command: 'showMessage', text: 'No @Preview functions found in this module' });
+            panel.postMessage({ command: 'clearProgress' });
             hasPreviewsLoaded = false;
             logLine('done — module has no previews');
             return 'completed';
@@ -1158,6 +1203,7 @@ async function refresh(
                 command: 'showMessage',
                 text: `No @Preview functions in this file (${otherFiles} in other files in this module).`,
             });
+            panel.postMessage({ command: 'clearProgress' });
             hasPreviewsLoaded = false;
             logLine(`done — 0 visible previews in ${path.basename(activeFile)}, module has ${otherFiles}`);
             return 'completed';
@@ -1182,6 +1228,15 @@ async function refresh(
         });
         hasPreviewsLoaded = true;
         logLine(`rendered ${visiblePreviews.length} preview(s) for ${path.basename(activeFile)}`);
+
+        // Gradle is done; the rest of the work (reading PNGs, base64-encoding,
+        // pushing to webview) is extension-side. Push the bar into a "Loading
+        // images" phase with a known weight so the user sees the bar continue
+        // to advance instead of sitting stuck at the end of `rendering` while
+        // images stream in.
+        if (!abort.signal.aborted) {
+            onProgress({ phase: 'loading', label: 'Loading images', percent: 0.92 });
+        }
 
         // Load images in parallel. Animated previews have multiple captures
         // in `preview.captures`; one updateImage message per capture. The
@@ -1239,6 +1294,9 @@ async function refresh(
             }
         }
         await Promise.all(imageJobs);
+        if (!abort.signal.aborted) {
+            onProgress({ phase: 'done', label: 'Done', percent: 1 });
+        }
 
         // NOTE: intentionally do NOT send `showMessage: ''` here. The webview's
         // renderPreviews() clears the 'loading' Building… banner the moment
@@ -1254,6 +1312,7 @@ async function refresh(
         // would be misleading and noisy.
         if (err instanceof TaskCancelledError) {
             logLine(`cancelled — superseded by a newer refresh`);
+            panel.postMessage({ command: 'clearProgress' });
             return 'cancelled';
         }
         if (err instanceof JdkImageError) {
@@ -1262,6 +1321,7 @@ async function refresh(
                 command: 'showMessage',
                 text: 'Gradle is running on a JRE without jlink. Configure a full JDK to render previews.',
             });
+            panel.postMessage({ command: 'clearProgress' });
             showJdkImageRemediation(err);
             return 'failed';
         }
@@ -1271,6 +1331,7 @@ async function refresh(
             command: 'showMessage',
             text: message,
         });
+        panel.postMessage({ command: 'clearProgress' });
         return 'failed';
     } finally {
         if (pendingRefresh === abort) { pendingRefresh = null; }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -21,6 +21,7 @@ import { buildHistorySource, HistoryPanel, HistoryScope } from './historyPanel';
 import { LogFilter, parseLogLevel } from './logFilter';
 import { pickRefreshModeFor, RefreshMode } from './refreshMode';
 import { mergeCalibration, PhaseDurations, ProgressState } from './buildProgress';
+import { CompileError, extractCompileErrors, DiagnosticLike } from './compileErrors';
 
 const DEBOUNCE_MS = 1500;
 // Edits to the currently-scoped preview file (e.g. Claude Code's Edit tool
@@ -835,6 +836,28 @@ function updateDaemonStatus(module: string, state: WarmState): void {
 /** Per-extension-session memo so bootstrap runs once per module. */
 const daemonBootstrappedModules = new Set<string>();
 
+/**
+ * Read Error-severity diagnostics for `filePath` from whichever language
+ * server is active and adapt them to the vscode-free shape that
+ * [extractCompileErrors] consumes. Returns an empty array when no LSP is
+ * attached (`vscode.languages.getDiagnostics` returns `[]`), so workspaces
+ * without a Kotlin LSP fall through to the existing Gradle-only path with
+ * no visible difference.
+ *
+ * Cross-file errors (e.g. `Theme.kt` broken, `Previews.kt` clean but uses
+ * it) are NOT detected here — that's a deliberate trade-off to keep the
+ * gate cheap (one URI lookup, no import graph walk). Gradle still catches
+ * them on the slow path.
+ */
+function readCompileErrors(filePath: string): CompileError[] {
+    const uri = vscode.Uri.file(filePath);
+    const diagnostics = vscode.languages.getDiagnostics(uri);
+    // vscode.Diagnostic structurally matches DiagnosticLike — the field
+    // names and severity numeric values are the same. Cast through unknown
+    // to avoid pulling vscode types into the pure module.
+    return extractCompileErrors(filePath, diagnostics as unknown as readonly DiagnosticLike[]);
+}
+
 /** Read calibrated phase durations for `module` from workspace state. Empty
  *  on first run; the tracker falls back to its built-in phase defaults. */
 function readCalibration(module: string): PhaseDurations {
@@ -1021,8 +1044,12 @@ const fastTierModules = new Set<string>();
  *   the empty state; no Gradle work happened.
  * - `'failed'` — Gradle threw a non-cancellation error (build failure,
  *   missing `jlink`, etc.). The panel surfaces the error; no follow-up.
+ * - `'gated'` — LSP reported Error-severity diagnostics for the active
+ *   file, so the build was skipped. Panel shows the compile-error banner
+ *   over the previous (now stale) cards; the next save with a clean buffer
+ *   will run a real refresh.
  */
-type RefreshOutcome = 'completed' | 'cancelled' | 'no-module' | 'failed';
+type RefreshOutcome = 'completed' | 'cancelled' | 'no-module' | 'failed' | 'gated';
 
 async function refresh(
     forceRender: boolean,
@@ -1061,6 +1088,34 @@ async function refresh(
         return 'no-module';
     }
     logLine(`start forceRender=${forceRender} file=${path.basename(activeFile)} (${scopeSource}) module=${module}`);
+
+    // LSP gate. Saves a 5–30 s round-trip through compileKotlin when the
+    // user is mid-typo-fix — the active file's diagnostics already tell us
+    // the build will fail, so surface those instead of starting Gradle.
+    // Cards from the previous successful render stay visible (just dimmed)
+    // so the user keeps a reference while they fix the error.
+    //
+    // Gate fires before currentScopeFile assignment so a later refresh from
+    // a different file can still drop the banner via clearCompileErrors.
+    const compileErrors = readCompileErrors(activeFile);
+    if (compileErrors.length > 0) {
+        panel.postMessage({
+            command: 'setCompileErrors',
+            errors: compileErrors,
+            sourceFile: activeFile,
+        });
+        // No build is starting — make sure no stale progress bar lingers
+        // from a prior in-flight refresh that was just cancelled by the
+        // pendingRefresh.abort() at the top of this function.
+        panel.postMessage({ command: 'clearProgress' });
+        currentScopeFile = activeFile;
+        logLine(`gated — ${compileErrors.length} compile error(s) in ${path.basename(activeFile)}`);
+        return 'gated';
+    }
+    // Errors cleared since the previous gate fire — drop the banner before
+    // we begin the actual build so the user sees the panel return to its
+    // normal "working" state.
+    panel.postMessage({ command: 'clearCompileErrors' });
 
     currentScopeFile = activeFile;
     // Phase H7 — re-scope the History panel alongside the live panel.
@@ -1394,6 +1449,31 @@ function handleWebviewMessage(msg: WebviewToExtensionMessage) {
             historyPanel?.setScope(newScope);
             break;
         }
+        case 'openCompileError':
+            if (msg.sourceFile && typeof msg.line === 'number'
+                && typeof msg.column === 'number') {
+                void openSourcePosition(msg.sourceFile, msg.line, msg.column);
+            }
+            break;
+    }
+}
+
+/**
+ * Open `filePath` and reveal the given (1-based) position. Used by the
+ * compile-error banner — clicking a row jumps to the offending location.
+ * 1-based input here matches what we render in the banner; vscode's API
+ * is 0-based, so we subtract before constructing the Position.
+ */
+async function openSourcePosition(filePath: string, line: number, column: number): Promise<void> {
+    try {
+        const doc = await vscode.workspace.openTextDocument(filePath);
+        const editor = await vscode.window.showTextDocument(doc);
+        const pos = new vscode.Position(Math.max(0, line - 1), Math.max(0, column - 1));
+        editor.selection = new vscode.Selection(pos, pos);
+        editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+    } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : String(e);
+        logLine(`openSourcePosition failed for ${filePath}:${line}:${column} — ${message}`);
     }
 }
 
@@ -1448,6 +1528,9 @@ interface WebviewToExtensionMessage {
     previewId?: string | null;
     visible?: string[];
     predicted?: string[];
+    sourceFile?: string;
+    line?: number;
+    column?: number;
 }
 
 /**

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -4,6 +4,7 @@ import { AccessibilityFinding, AccessibilityReport, Capture, DoctorModuleReport,
 import { appliesPlugin } from './pluginDetection';
 import { JdkImageError, JdkImageErrorDetector } from './jdkImageErrorDetector';
 import { LogFilter } from './logFilter';
+import { BuildProgressTracker, PhaseDurations, ProgressState } from './buildProgress';
 
 /**
  * Expands a parameterized preview's single template capture into N captures
@@ -106,6 +107,21 @@ export interface Logger {
 const nullLogger: Logger = { appendLine() {}, append() {} };
 
 /**
+ * Per-call hooks for [GradleService.runTask] and friends. The progress
+ * tracker is owned by the caller (refresh()) so the same tracker spans
+ * Gradle's discover/render phases plus the post-task image-loading phase
+ * the extension drives itself.
+ */
+export interface TaskOptions {
+    /** Per-phase calibration to seed the tracker with (from prior runs). */
+    progressCalibration?: PhaseDurations;
+    /** Receives progress states as Gradle output streams in. */
+    onProgress?: (state: ProgressState) => void;
+    /** Called after the task ends with the durations recorded this run. */
+    onCalibration?: (durations: PhaseDurations) => void;
+}
+
+/**
  * Subset of vscjava.vscode-gradle's exported API.
  * See: https://github.com/microsoft/vscode-gradle/blob/main/extension/src/api/Api.ts
  */
@@ -148,12 +164,12 @@ export class GradleService {
         this.logFilter = logFilter ?? new LogFilter();
     }
 
-    async discoverPreviews(module: string): Promise<PreviewManifest | null> {
+    async discoverPreviews(module: string, opts?: TaskOptions): Promise<PreviewManifest | null> {
         const cached = this.manifestCache.get(module);
         if (cached && Date.now() - cached.timestamp < MANIFEST_CACHE_TTL_MS) {
             return cached.manifest;
         }
-        await this.runTask(`${gradleProjectPath(module)}:discoverPreviews`);
+        await this.runTask(`${gradleProjectPath(module)}:discoverPreviews`, [], opts);
         const manifest = this.readManifest(module);
         if (manifest) {
             this.manifestCache.set(module, { manifest, timestamp: Date.now() });
@@ -181,11 +197,13 @@ export class GradleService {
     async renderPreviews(
         module: string,
         tier: 'fast' | 'full' = 'full',
+        opts?: TaskOptions,
     ): Promise<PreviewManifest | null> {
         this.manifestCache.delete(module);
         await this.runTask(
             `${gradleProjectPath(module)}:renderAllPreviews`,
             [`-PcomposePreview.tier=${tier}`],
+            opts,
         );
         const manifest = this.readManifest(module);
         if (manifest) {
@@ -494,13 +512,27 @@ export class GradleService {
         this.cancel();
     }
 
-    private runTask(task: string, extraArgs: ReadonlyArray<string> = []): Promise<void> {
+    private runTask(
+        task: string,
+        extraArgs: ReadonlyArray<string> = [],
+        opts: TaskOptions = {},
+    ): Promise<void> {
         const cancellationKey = `compose-preview-${++this.taskCounter}|${task}`;
         this.activeKeys.add(cancellationKey);
         const startLine = `> ${task}`;
         if (this.logFilter.shouldEmitInformational(startLine)) { this.logger.appendLine(startLine); }
 
         const detector = new JdkImageErrorDetector();
+        // Progress tracker is wired only when the caller provided one of the
+        // hooks — keeps the no-op (test, doctor, applied-bootstrap) callers
+        // free of timer overhead.
+        const tracker = (opts.onProgress || opts.onCalibration)
+            ? new BuildProgressTracker({
+                onProgress: opts.onProgress ?? (() => { /* noop */ }),
+                calibration: opts.progressCalibration,
+            })
+            : null;
+        tracker?.start();
 
         const timeoutPromise = new Promise<never>((_, reject) => {
             setTimeout(() => {
@@ -527,6 +559,7 @@ export class GradleService {
                     // normal level (the noisy lines are exactly the ones that
                     // contain the diagnostic).
                     detector.consume(decoded);
+                    tracker?.consume(decoded);
                     const filtered = this.logFilter.filterGradleChunk(decoded);
                     if (filtered.length > 0) { this.logger.append(filtered); }
                 } catch { /* ignore */ }
@@ -535,9 +568,13 @@ export class GradleService {
             () => {
                 const line = `> ${task} completed`;
                 if (this.logFilter.shouldEmitInformational(line)) { this.logger.appendLine(line); }
+                if (tracker) {
+                    opts.onCalibration?.({ ...tracker.phaseDurations });
+                }
             },
             (err) => {
                 const message = err?.message ?? String(err);
+                tracker?.abort();
                 // vscode-gradle reports a superseded task as a gRPC CANCELLED
                 // error — that's the normal "new refresh replaced this one"
                 // path, not a build failure. Log it differently and throw a

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -119,29 +119,69 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         // beat so the user sees the completed state, then fades the strip
         // out so it doesn't permanently occupy a row of UI.
         let progressHideTimer = null;
+        // Deferred-mount state. The bar isn't shown until [PROGRESS_MOUNT_DELAY_MS]
+        // of in-flight work has accumulated — warm-cache refreshes that finish
+        // in <200ms never mount it at all, avoiding the "flash on, flash off"
+        // glitch. progressVisible flips true once we've actually rendered
+        // something into the DOM; subsequent setProgress updates within the
+        // same refresh apply directly without re-deferring.
+        const PROGRESS_MOUNT_DELAY_MS = 200;
+        let progressMountTimer = null;
+        let progressVisible = false;
+        let pendingProgressState = null;
 
-        function setProgress(label, percent) {
-            if (progressHideTimer) {
-                clearTimeout(progressHideTimer);
-                progressHideTimer = null;
-            }
-            const pct = Math.max(0, Math.min(1, percent));
+        function applyProgressState(state) {
+            const pct = Math.max(0, Math.min(1, state.percent));
             progressBar.hidden = false;
+            progressVisible = true;
             progressBar.classList.remove('progress-finishing');
+            progressBar.classList.toggle('progress-slow', !!state.slow);
             progressFill.style.width = (pct * 100).toFixed(1) + '%';
             progressBar.setAttribute('aria-valuenow', String(Math.round(pct * 100)));
-            progressLabel.textContent = label
-                ? label + ' · ' + Math.round(pct * 100) + '%'
+            const slowSuffix = state.slow ? ' (slow)' : '';
+            progressLabel.textContent = state.label
+                ? state.label + slowSuffix + ' · ' + Math.round(pct * 100) + '%'
                 : '';
             if (pct >= 1) {
                 progressBar.classList.add('progress-finishing');
                 progressHideTimer = setTimeout(() => {
                     progressBar.hidden = true;
-                    progressBar.classList.remove('progress-finishing');
+                    progressVisible = false;
+                    progressBar.classList.remove('progress-finishing', 'progress-slow');
                     progressFill.style.width = '0%';
                     progressLabel.textContent = '';
                     progressHideTimer = null;
                 }, 600);
+            }
+        }
+
+        function setProgress(label, percent, slow) {
+            if (progressHideTimer) {
+                clearTimeout(progressHideTimer);
+                progressHideTimer = null;
+            }
+            const state = { label: label || '', percent, slow: !!slow };
+            // Already visible (or mid-fade) — apply directly.
+            if (progressVisible) {
+                applyProgressState(state);
+                return;
+            }
+            // Latched state for whenever the deferral timer fires.
+            pendingProgressState = state;
+            // Already terminal — show immediately so the brief flash isn't
+            // missed (rare path: tracker emits an immediate done=100% before
+            // any phase work happens, e.g. up-to-date discover).
+            if (state.percent >= 1) {
+                applyProgressState(state);
+                return;
+            }
+            if (progressMountTimer === null) {
+                progressMountTimer = setTimeout(() => {
+                    progressMountTimer = null;
+                    if (pendingProgressState) {
+                        applyProgressState(pendingProgressState);
+                    }
+                }, PROGRESS_MOUNT_DELAY_MS);
             }
         }
 
@@ -150,8 +190,14 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 clearTimeout(progressHideTimer);
                 progressHideTimer = null;
             }
+            if (progressMountTimer) {
+                clearTimeout(progressMountTimer);
+                progressMountTimer = null;
+            }
+            pendingProgressState = null;
+            progressVisible = false;
             progressBar.hidden = true;
-            progressBar.classList.remove('progress-finishing');
+            progressBar.classList.remove('progress-finishing', 'progress-slow');
             progressFill.style.width = '0%';
             progressLabel.textContent = '';
         }
@@ -984,7 +1030,17 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             });
         }
 
-        /** Add a subtle spinner overlay to every card during a stealth refresh. */
+        // Two-stage overlay during stealth refresh:
+        //   stage 1 (0–500ms): tiny corner spinner, no dim, no blur. Most
+        //     daemon hits land in this window — image swap reads as a clean
+        //     update, no "dim → undim" flicker.
+        //   stage 2 (>500ms):  classic subtle (dim + blur + corner spinner).
+        //     The build is taking real time, escalate so the user sees the
+        //     panel is actually working.
+        // Cards whose updateImage arrives during stage 1 never see stage 2.
+        const OVERLAY_ESCALATE_MS = 500;
+        let overlayEscalationTimer = null;
+
         function markAllLoading() {
             document.querySelectorAll('.preview-card').forEach(card => {
                 const container = card.querySelector('.image-container');
@@ -994,10 +1050,32 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 // Don't add overlay if there's just a skeleton (nothing useful to cover)
                 if (container.querySelector('.skeleton') && !container.querySelector('img')) return;
                 const overlay = document.createElement('div');
-                overlay.className = 'loading-overlay subtle';
+                overlay.className = 'loading-overlay minimal';
                 overlay.innerHTML = '<div class="spinner" aria-label="Refreshing"></div>';
                 container.appendChild(overlay);
             });
+            scheduleOverlayEscalation();
+        }
+
+        function scheduleOverlayEscalation() {
+            if (overlayEscalationTimer) clearTimeout(overlayEscalationTimer);
+            overlayEscalationTimer = setTimeout(() => {
+                overlayEscalationTimer = null;
+                // Promote every still-present minimal overlay to subtle.
+                // Cards whose images already arrived have removed their
+                // overlays, so this only touches cards still waiting.
+                document.querySelectorAll('.loading-overlay.minimal').forEach(o => {
+                    o.classList.remove('minimal');
+                    o.classList.add('subtle');
+                });
+            }, OVERLAY_ESCALATE_MS);
+        }
+
+        function cancelOverlayEscalation() {
+            if (overlayEscalationTimer) {
+                clearTimeout(overlayEscalationTimer);
+                overlayEscalationTimer = null;
+            }
         }
 
         /**
@@ -1256,6 +1334,10 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     // stale id from the previous module would dedupe the
                     // first publish and the History panel would miss it.
                     lastScopedPreviewId = null;
+                    // Cards are gone — escalation timer has nothing left to
+                    // promote. Avoids a stray timer firing after the next
+                    // refresh has installed fresh minimal overlays.
+                    cancelOverlayEscalation();
                     // Don't clear the message here — if it came with a
                     // follow-up showMessage (the usual pattern) it'll be
                     // replaced; if not, ensureNotBlank will backstop a
@@ -1309,7 +1391,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     break;
 
                 case 'setProgress':
-                    setProgress(msg.label || '', msg.percent || 0);
+                    setProgress(msg.label || '', msg.percent || 0, msg.slow);
                     break;
 
                 case 'clearProgress':

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -58,6 +58,14 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         <div class="progress-fill"></div>
         <div class="progress-label" id="progress-label"></div>
     </div>
+    <div id="compile-errors" class="compile-errors" role="alert" hidden>
+        <div class="compile-errors-header">
+            <i class="codicon codicon-error" aria-hidden="true"></i>
+            <span id="compile-errors-title">Compile errors</span>
+        </div>
+        <div id="compile-errors-list" class="compile-errors-list"></div>
+        <div class="compile-errors-footnote">Showing last successful render.</div>
+    </div>
     <div class="toolbar" id="toolbar" role="toolbar" aria-label="Preview filters">
         <div class="select-wrapper">
             <select id="filter-function" title="Filter by function" aria-label="Function filter">
@@ -200,6 +208,56 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             progressBar.classList.remove('progress-finishing', 'progress-slow');
             progressFill.style.width = '0%';
             progressLabel.textContent = '';
+        }
+
+        // Compile-error banner state. Cards stay rendered while the banner
+        // is visible — they're decorated via .compile-stale on the grid so
+        // the user keeps the last-good render visible while reading the
+        // error list.
+        const compileErrorsBox = document.getElementById('compile-errors');
+        const compileErrorsList = document.getElementById('compile-errors-list');
+        const compileErrorsTitle = document.getElementById('compile-errors-title');
+
+        function setCompileErrors(errors, sourceFile) {
+            compileErrorsList.innerHTML = '';
+            const count = errors.length;
+            compileErrorsTitle.textContent = count === 1
+                ? '1 compile error'
+                : count + ' compile errors';
+            for (const e of errors) {
+                const row = document.createElement('button');
+                row.type = 'button';
+                row.className = 'compile-error-row';
+                row.title = 'Open ' + e.file + ':' + e.line + ':' + e.column;
+                const loc = document.createElement('span');
+                loc.className = 'compile-error-loc';
+                loc.textContent = e.file + ':' + e.line + ':' + e.column;
+                const msg = document.createElement('span');
+                msg.className = 'compile-error-msg';
+                msg.textContent = e.message;
+                row.appendChild(loc);
+                row.appendChild(msg);
+                row.addEventListener('click', () => {
+                    vscode.postMessage({
+                        command: 'openCompileError',
+                        sourceFile: sourceFile,
+                        line: e.line,
+                        column: e.column,
+                    });
+                });
+                compileErrorsList.appendChild(row);
+            }
+            compileErrorsBox.hidden = false;
+            // Dim existing cards via a grid-level class so the user sees
+            // they're stale relative to the buffer. CSS handles the visual.
+            grid.classList.add('compile-stale');
+        }
+
+        function clearCompileErrors() {
+            compileErrorsBox.hidden = true;
+            compileErrorsList.innerHTML = '';
+            compileErrorsTitle.textContent = '';
+            grid.classList.remove('compile-stale');
         }
 
         let allPreviews = [];
@@ -1396,6 +1454,14 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 
                 case 'clearProgress':
                     clearProgress();
+                    break;
+
+                case 'setCompileErrors':
+                    setCompileErrors(msg.errors || [], msg.sourceFile || '');
+                    break;
+
+                case 'clearCompileErrors':
+                    clearCompileErrors();
                     break;
 
                 case 'setError':

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -52,6 +52,12 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
     <link href="${styleUri}" rel="stylesheet">
 </head>
 <body>
+    <div id="progress-bar" class="progress-bar" role="progressbar"
+         aria-label="Refresh progress"
+         aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" hidden>
+        <div class="progress-fill"></div>
+        <div class="progress-label" id="progress-label"></div>
+    </div>
     <div class="toolbar" id="toolbar" role="toolbar" aria-label="Preview filters">
         <div class="select-wrapper">
             <select id="filter-function" title="Filter by function" aria-label="Function filter">
@@ -106,6 +112,49 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         const btnNext = document.getElementById('btn-next');
         const btnExitFocus = document.getElementById('btn-exit-focus');
         const focusPosition = document.getElementById('focus-position');
+        const progressBar = document.getElementById('progress-bar');
+        const progressFill = progressBar.querySelector('.progress-fill');
+        const progressLabel = document.getElementById('progress-label');
+        // Auto-hide timer for the bar after it lands at 100%. Holds for a
+        // beat so the user sees the completed state, then fades the strip
+        // out so it doesn't permanently occupy a row of UI.
+        let progressHideTimer = null;
+
+        function setProgress(label, percent) {
+            if (progressHideTimer) {
+                clearTimeout(progressHideTimer);
+                progressHideTimer = null;
+            }
+            const pct = Math.max(0, Math.min(1, percent));
+            progressBar.hidden = false;
+            progressBar.classList.remove('progress-finishing');
+            progressFill.style.width = (pct * 100).toFixed(1) + '%';
+            progressBar.setAttribute('aria-valuenow', String(Math.round(pct * 100)));
+            progressLabel.textContent = label
+                ? label + ' · ' + Math.round(pct * 100) + '%'
+                : '';
+            if (pct >= 1) {
+                progressBar.classList.add('progress-finishing');
+                progressHideTimer = setTimeout(() => {
+                    progressBar.hidden = true;
+                    progressBar.classList.remove('progress-finishing');
+                    progressFill.style.width = '0%';
+                    progressLabel.textContent = '';
+                    progressHideTimer = null;
+                }, 600);
+            }
+        }
+
+        function clearProgress() {
+            if (progressHideTimer) {
+                clearTimeout(progressHideTimer);
+                progressHideTimer = null;
+            }
+            progressBar.hidden = true;
+            progressBar.classList.remove('progress-finishing');
+            progressFill.style.width = '0%';
+            progressLabel.textContent = '';
+        }
 
         let allPreviews = [];
         let moduleDir = '';
@@ -1252,13 +1301,19 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                                 container.appendChild(overlay);
                             }
                         }
-                    } else {
-                        // 'loading' (not 'extension') so renderPreviews can
-                        // clear it the moment cards arrive — otherwise the
-                        // banner sits on top of skeleton cards while images
-                        // stream in, which looks like the build is stuck.
-                        setMessage('Building…', 'loading');
                     }
+                    // Whole-panel loading state is now carried by the slim
+                    // progress bar at the top of the view (setProgress).
+                    // Avoid double-signalling with a "Building…" banner —
+                    // it competes with the bar for visual attention.
+                    break;
+
+                case 'setProgress':
+                    setProgress(msg.label || '', msg.percent || 0);
+                    break;
+
+                case 'clearProgress':
+                    clearProgress();
                     break;
 
                 case 'setError':

--- a/vscode-extension/src/test/buildProgress.test.ts
+++ b/vscode-extension/src/test/buildProgress.test.ts
@@ -1,0 +1,273 @@
+import * as assert from 'assert';
+import {
+    BuildProgressTracker,
+    PHASES,
+    PhaseDurations,
+    PhaseId,
+    classifyTask,
+    mergeCalibration,
+} from '../buildProgress';
+
+/**
+ * Deterministic clock + tick scheduler so the tracker's behaviour is fully
+ * inspectable without timers. `advance(ms)` moves wall-clock forward and
+ * fires every scheduled tick whose interval elapses.
+ */
+class FakeClock {
+    private t = 0;
+    private timers: { interval: number; nextAt: number; cb: () => void }[] = [];
+    now = (): number => this.t;
+    setInterval = (cb: () => void, ms: number): unknown => {
+        const handle = { interval: ms, nextAt: this.t + ms, cb };
+        this.timers.push(handle);
+        return handle;
+    };
+    clearInterval = (handle: unknown): void => {
+        this.timers = this.timers.filter(h => h !== handle);
+    };
+    advance(ms: number): void {
+        const target = this.t + ms;
+        // Fire ticks deterministically in order.
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            const next = this.timers
+                .filter(h => h.nextAt <= target)
+                .sort((a, b) => a.nextAt - b.nextAt)[0];
+            if (!next) { break; }
+            this.t = next.nextAt;
+            next.nextAt += next.interval;
+            next.cb();
+        }
+        this.t = target;
+    }
+}
+
+interface Snapshot {
+    phase: PhaseId;
+    label: string;
+    percent: number;
+}
+
+function makeTracker(opts: {
+    calibration?: PhaseDurations;
+    clock: FakeClock;
+}): { tracker: BuildProgressTracker; states: Snapshot[] } {
+    const states: Snapshot[] = [];
+    const tracker = new BuildProgressTracker({
+        onProgress: (s) => states.push({ ...s }),
+        calibration: opts.calibration,
+        now: opts.clock.now,
+        setInterval: opts.clock.setInterval,
+        clearInterval: opts.clock.clearInterval,
+        tickMs: 100,
+    });
+    return { tracker, states };
+}
+
+describe('classifyTask', () => {
+    it('routes render tasks to the rendering phase', () => {
+        assert.strictEqual(classifyTask(':samples:android:renderPreviews'), 'rendering');
+        assert.strictEqual(classifyTask(':app:renderAllPreviews'), 'rendering');
+        assert.strictEqual(classifyTask(':app:renderAndroidResources'), 'rendering');
+    });
+
+    it('routes discover tasks to the discovering phase', () => {
+        assert.strictEqual(classifyTask(':samples:cmp:discoverPreviews'), 'discovering');
+        assert.strictEqual(classifyTask(':app:discoverAndroidResources'), 'discovering');
+    });
+
+    it('routes Kotlin/Java compile tasks to the compiling phase', () => {
+        assert.strictEqual(classifyTask(':app:compileDebugKotlin'), 'compiling');
+        assert.strictEqual(classifyTask(':app:compileDebugUnitTestKotlin'), 'compiling');
+        assert.strictEqual(classifyTask(':app:compileDebugJavaWithJavac'), 'compiling');
+        assert.strictEqual(classifyTask(':app:compileRenderShards'), 'compiling');
+    });
+
+    it('routes resource / classpath staging to resolving', () => {
+        assert.strictEqual(classifyTask(':app:extractPreviewClasses'), 'resolving');
+        assert.strictEqual(classifyTask(':app:generateRenderShards'), 'resolving');
+        assert.strictEqual(classifyTask(':app:processDebugResources'), 'resolving');
+    });
+
+    it('returns null for uninteresting tasks', () => {
+        assert.strictEqual(classifyTask(':composePreviewApplied'), null);
+        assert.strictEqual(classifyTask(':app:composePreviewDoctor'), null);
+    });
+});
+
+describe('BuildProgressTracker', () => {
+    it('starts at zero and advances through phases on task signals', () => {
+        const clock = new FakeClock();
+        const { tracker, states } = makeTracker({ clock });
+        tracker.start();
+        const initial = states[states.length - 1];
+        assert.strictEqual(initial.phase, 'starting');
+        assert.strictEqual(initial.percent, 0);
+
+        tracker.consume('> Configure project :samples:android\n');
+        assert.strictEqual(states[states.length - 1].phase, 'configuring');
+
+        tracker.consume('> Task :samples:android:compileDebugKotlin\n');
+        assert.strictEqual(states[states.length - 1].phase, 'compiling');
+
+        tracker.consume('> Task :samples:android:discoverPreviews\n');
+        assert.strictEqual(states[states.length - 1].phase, 'discovering');
+
+        tracker.consume('> Task :samples:android:renderPreviews\n');
+        assert.strictEqual(states[states.length - 1].phase, 'rendering');
+
+        tracker.finish();
+        const last = states[states.length - 1];
+        assert.strictEqual(last.phase, 'done');
+        assert.strictEqual(last.percent, 1);
+    });
+
+    it('is monotonic — late stray signals do not move the bar backward', () => {
+        const clock = new FakeClock();
+        const { tracker, states } = makeTracker({ clock });
+        tracker.start();
+        tracker.consume('> Task :a:renderPreviews\n');
+        const renderingPct = states[states.length - 1].percent;
+        // A stray discoverPreviews line after rendering started must not
+        // drag the bar backward — phase index is lower but tracker ignores
+        // it.
+        tracker.consume('> Task :a:discoverPreviews\n');
+        const afterStray = states[states.length - 1].percent;
+        assert.ok(afterStray >= renderingPct,
+            `expected ${afterStray} >= ${renderingPct} (no rewind on out-of-order signal)`);
+        assert.strictEqual(states[states.length - 1].phase, 'rendering');
+    });
+
+    it('animates within a phase via the tick timer without crossing phase boundary', () => {
+        const clock = new FakeClock();
+        const { tracker, states } = makeTracker({ clock });
+        tracker.start();
+        tracker.consume('> Task :a:compileDebugKotlin\n');
+        const compileStart = states[states.length - 1].percent;
+
+        // Advance well past the default compile duration. The bar should
+        // approach but not exceed the compile phase's upper boundary.
+        clock.advance(60_000);
+        const long = states[states.length - 1].percent;
+        assert.ok(long > compileStart, `expected progress to advance during ticks: ${long} > ${compileStart}`);
+
+        tracker.consume('> Task :a:renderPreviews\n');
+        const renderStart = states[states.length - 1].percent;
+        assert.ok(renderStart >= long,
+            `entering render must not rewind: ${renderStart} >= ${long}`);
+        tracker.finish();
+    });
+
+    it('records phase durations for caller-side calibration', () => {
+        const clock = new FakeClock();
+        const { tracker } = makeTracker({ clock });
+        tracker.start();
+        clock.advance(200);
+        tracker.consume('> Configure project :a\n');
+        clock.advance(800);
+        tracker.consume('> Task :a:compileDebugKotlin\n');
+        clock.advance(3500);
+        tracker.consume('> Task :a:discoverPreviews\n');
+        clock.advance(400);
+        tracker.consume('> Task :a:renderPreviews\n');
+        clock.advance(7000);
+        tracker.finish();
+        const d = tracker.phaseDurations;
+        assert.strictEqual(d.configuring, 800);
+        assert.strictEqual(d.compiling, 3500);
+        assert.strictEqual(d.discovering, 400);
+        assert.strictEqual(d.rendering, 7000);
+    });
+
+    it('jumps to 100% on finish() and stays there', () => {
+        const clock = new FakeClock();
+        const { tracker, states } = makeTracker({ clock });
+        tracker.start();
+        tracker.finish();
+        const last = states[states.length - 1];
+        assert.strictEqual(last.percent, 1);
+        // No ticks should fire after finish — the timer is cleared.
+        const stateCount = states.length;
+        clock.advance(5_000);
+        assert.strictEqual(states.length, stateCount,
+            'no progress events should fire after finish()');
+    });
+
+    it('abort() stops emitting without driving to 100%', () => {
+        const clock = new FakeClock();
+        const { tracker, states } = makeTracker({ clock });
+        tracker.start();
+        tracker.consume('> Task :a:renderPreviews\n');
+        const beforeAbort = states[states.length - 1].percent;
+        tracker.abort();
+        clock.advance(5_000);
+        const last = states[states.length - 1];
+        // We never emitted a synthetic 100% — the last percent we sent is
+        // whatever the renderer phase had reached.
+        assert.ok(last.percent < 1, `aborted progress should not reach 1: ${last.percent}`);
+        assert.ok(last.percent >= beforeAbort);
+    });
+
+    it('handles split chunks across newline boundaries', () => {
+        const clock = new FakeClock();
+        const { tracker, states } = makeTracker({ clock });
+        tracker.start();
+        // Split the same task line over four chunks — must still classify.
+        tracker.consume('> Task ');
+        tracker.consume(':app:co');
+        tracker.consume('mpileDebugKotlin');
+        tracker.consume('\n');
+        assert.strictEqual(states[states.length - 1].phase, 'compiling');
+    });
+
+    it('uses calibration data to expand slow phases on the bar', () => {
+        const clock = new FakeClock();
+        const calibration: PhaseDurations = {
+            configuring: 500,
+            compiling: 50_000, // pretend this module is very slow at compile
+            discovering: 200,
+            rendering: 1_000,
+            loading: 100,
+        };
+        const { tracker, states } = makeTracker({ clock, calibration });
+        tracker.start();
+        tracker.consume('> Task :a:compileDebugKotlin\n');
+        const compileStart = states[states.length - 1].percent;
+        tracker.consume('> Task :a:renderPreviews\n');
+        const renderStart = states[states.length - 1].percent;
+        const compileSpan = renderStart - compileStart;
+        // Compile owns ~50/51.8 of the bar after configure, so its span
+        // should dominate (>50% of the [compileStart, 1] tail).
+        assert.ok(compileSpan > 0.5,
+            `compile span should be large with this calibration, got ${compileSpan}`);
+        tracker.finish();
+    });
+
+    it('every phase descriptor has a non-empty label', () => {
+        for (const p of PHASES) {
+            assert.ok(p.label.length > 0, `phase ${p.id} missing label`);
+        }
+    });
+});
+
+describe('mergeCalibration', () => {
+    it('returns the latest sample when no prior exists', () => {
+        const merged = mergeCalibration({}, { compiling: 4000 });
+        assert.strictEqual(merged.compiling, 4000);
+    });
+
+    it('blends prior and latest with EMA', () => {
+        const merged = mergeCalibration({ compiling: 1000 }, { compiling: 3000 });
+        // 0.5 * 1000 + 0.5 * 3000 = 2000
+        assert.strictEqual(merged.compiling, 2000);
+    });
+
+    it('preserves prior samples for phases not seen this run', () => {
+        const merged = mergeCalibration(
+            { compiling: 1000, rendering: 5000 },
+            { compiling: 2000 },
+        );
+        assert.strictEqual(merged.rendering, 5000);
+        assert.strictEqual(merged.compiling, 1500);
+    });
+});

--- a/vscode-extension/src/test/buildProgress.test.ts
+++ b/vscode-extension/src/test/buildProgress.test.ts
@@ -46,6 +46,7 @@ interface Snapshot {
     phase: PhaseId;
     label: string;
     percent: number;
+    slow: boolean;
 }
 
 function makeTracker(opts: {
@@ -247,6 +248,35 @@ describe('BuildProgressTracker', () => {
         for (const p of PHASES) {
             assert.ok(p.label.length > 0, `phase ${p.id} missing label`);
         }
+    });
+
+    it('flags slow=true once elapsed exceeds 2x the phase estimate', () => {
+        const clock = new FakeClock();
+        // Calibrate compile to 1000ms — so any tick after 2000ms in compile
+        // counts as slow.
+        const calibration: PhaseDurations = { compiling: 1000 };
+        const { tracker, states } = makeTracker({ clock, calibration });
+        tracker.start();
+        tracker.consume('> Task :a:compileDebugKotlin\n');
+        const enteredCompile = states[states.length - 1];
+        assert.strictEqual(enteredCompile.slow, false,
+            'just-entered phase should not be slow');
+
+        clock.advance(1500);
+        const halfwayOver = states[states.length - 1];
+        assert.strictEqual(halfwayOver.slow, false,
+            '1.5x expected is not yet slow');
+
+        clock.advance(1000); // total 2500ms — past the 2x threshold
+        const slow = states[states.length - 1];
+        assert.strictEqual(slow.slow, true, '>2x expected should flag slow');
+
+        // Transition out of the slow phase — slow flag resets for the next.
+        tracker.consume('> Task :a:renderPreviews\n');
+        const renderJustStarted = states[states.length - 1];
+        assert.strictEqual(renderJustStarted.slow, false,
+            'fresh phase should reset the slow flag');
+        tracker.finish();
     });
 });
 

--- a/vscode-extension/src/test/compileErrors.test.ts
+++ b/vscode-extension/src/test/compileErrors.test.ts
@@ -1,0 +1,134 @@
+import * as assert from 'assert';
+import {
+    DIAGNOSTIC_SEVERITY,
+    DiagnosticLike,
+    extractCompileErrors,
+} from '../compileErrors';
+
+/** Minimal diagnostic builder mirroring the bits we use from vscode.Diagnostic. */
+function diag(opts: {
+    severity: number;
+    line: number;
+    column?: number;
+    message: string;
+    source?: string;
+}): DiagnosticLike {
+    return {
+        severity: opts.severity,
+        message: opts.message,
+        range: { start: { line: opts.line, character: opts.column ?? 0 } },
+        source: opts.source,
+    };
+}
+
+describe('extractCompileErrors', () => {
+    it('returns an empty array when no diagnostics are present', () => {
+        const out = extractCompileErrors('/ws/Foo.kt', []);
+        assert.deepStrictEqual(out, []);
+    });
+
+    it('returns an empty array when all diagnostics are warnings/hints', () => {
+        const out = extractCompileErrors('/ws/Foo.kt', [
+            diag({ severity: DIAGNOSTIC_SEVERITY.Warning, line: 0, message: 'unused import', source: 'kotlin' }),
+            diag({ severity: DIAGNOSTIC_SEVERITY.Hint, line: 1, message: 'spell', source: 'kotlin' }),
+        ]);
+        assert.deepStrictEqual(out, []);
+    });
+
+    it('extracts an Error diagnostic with 1-based line/column', () => {
+        const out = extractCompileErrors('/ws/Foo.kt', [
+            diag({
+                severity: DIAGNOSTIC_SEVERITY.Error,
+                line: 41,        // 0-based
+                column: 4,       // 0-based
+                message: 'Unresolved reference: Modfier',
+                source: 'kotlin',
+            }),
+        ]);
+        assert.strictEqual(out.length, 1);
+        assert.strictEqual(out[0].file, 'Foo.kt');
+        assert.strictEqual(out[0].line, 42);     // 1-based for display
+        assert.strictEqual(out[0].column, 5);    // 1-based for display
+        assert.strictEqual(out[0].message, 'Unresolved reference: Modfier');
+    });
+
+    it('mixes errors and warnings — only errors are returned', () => {
+        const out = extractCompileErrors('/ws/Foo.kt', [
+            diag({ severity: DIAGNOSTIC_SEVERITY.Warning, line: 5, message: 'shadows outer', source: 'kotlin' }),
+            diag({ severity: DIAGNOSTIC_SEVERITY.Error, line: 10, message: 'expected }', source: 'kotlin' }),
+            diag({ severity: DIAGNOSTIC_SEVERITY.Hint, line: 12, message: 'redundant', source: 'kotlin' }),
+        ]);
+        assert.strictEqual(out.length, 1);
+        assert.strictEqual(out[0].line, 11);
+    });
+
+    it('rejects errors from untrusted sources', () => {
+        // A markdown linter or a custom checker shouldn't be able to gate a
+        // Kotlin build — only diagnostics from known compile sources count.
+        const out = extractCompileErrors('/ws/Foo.kt', [
+            diag({
+                severity: DIAGNOSTIC_SEVERITY.Error,
+                line: 0,
+                message: 'spelling: Composble',
+                source: 'cspell',
+            }),
+        ]);
+        assert.deepStrictEqual(out, []);
+    });
+
+    it('accepts errors from trusted Kotlin LSP sources', () => {
+        for (const src of ['kotlin', 'kotlin-language-server', 'fwcd.kotlin', 'gradle', 'JetBrains']) {
+            const out = extractCompileErrors('/ws/Foo.kt', [
+                diag({ severity: DIAGNOSTIC_SEVERITY.Error, line: 0, message: 'x', source: src }),
+            ]);
+            assert.strictEqual(out.length, 1, `expected source "${src}" to be trusted`);
+        }
+    });
+
+    it('accepts errors with no source field set', () => {
+        // Some servers don't populate `source`. Default-trust those rather
+        // than silently swallowing the gate.
+        const out = extractCompileErrors('/ws/Foo.kt', [
+            diag({ severity: DIAGNOSTIC_SEVERITY.Error, line: 0, message: 'oops' }),
+        ]);
+        assert.strictEqual(out.length, 1);
+    });
+
+    it('returns errors sorted by line then column', () => {
+        const out = extractCompileErrors('/ws/Foo.kt', [
+            diag({ severity: DIAGNOSTIC_SEVERITY.Error, line: 50, column: 0, message: 'late', source: 'kotlin' }),
+            diag({ severity: DIAGNOSTIC_SEVERITY.Error, line: 10, column: 5, message: 'early B', source: 'kotlin' }),
+            diag({ severity: DIAGNOSTIC_SEVERITY.Error, line: 10, column: 1, message: 'early A', source: 'kotlin' }),
+        ]);
+        assert.deepStrictEqual(out.map(e => e.message), ['early A', 'early B', 'late']);
+    });
+
+    it('uses only the first line of multi-line diagnostic messages', () => {
+        // A long Kotlin error message with type-inference detail can run
+        // many lines. Banner rows are one line each so we trim — full
+        // detail still in the LSP hover / Problems panel.
+        const out = extractCompileErrors('/ws/Foo.kt', [
+            diag({
+                severity: DIAGNOSTIC_SEVERITY.Error,
+                line: 0,
+                message: 'Type mismatch.\nRequired: String\nFound: Int',
+                source: 'kotlin',
+            }),
+        ]);
+        assert.strictEqual(out[0].message, 'Type mismatch.');
+    });
+
+    it('extracts the file basename for display, even from absolute paths', () => {
+        const out = extractCompileErrors('/long/abs/path/to/Previews.kt', [
+            diag({ severity: DIAGNOSTIC_SEVERITY.Error, line: 0, message: 'x', source: 'kotlin' }),
+        ]);
+        assert.strictEqual(out[0].file, 'Previews.kt');
+    });
+
+    it('handles Windows-style paths', () => {
+        const out = extractCompileErrors('C:\\workspace\\src\\Previews.kt', [
+            diag({ severity: DIAGNOSTIC_SEVERITY.Error, line: 0, message: 'x', source: 'kotlin' }),
+        ]);
+        assert.strictEqual(out[0].file, 'Previews.kt');
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -260,9 +260,11 @@ export type ExtensionToWebview =
      * Drives the slim progress bar at the top of the panel. `percent` is
      * monotonic within a refresh and clamped to [0, 1]; `label` is the
      * user-facing phase name ("Compiling Kotlin", "Rendering previews"…).
-     * The webview hides the bar on its own when `percent` reaches 1.
+     * `slow` is true when the current phase is overrunning its calibrated
+     * estimate — the webview tints the bar and appends "(slow)" to the
+     * label. The webview hides the bar on its own when `percent` reaches 1.
      */
-    | { command: 'setProgress'; phase: string; label: string; percent: number }
+    | { command: 'setProgress'; phase: string; label: string; percent: number; slow?: boolean }
     /** Force-clear the progress bar (e.g. on cancellation or fatal error). */
     | { command: 'clearProgress' };
 

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -266,7 +266,16 @@ export type ExtensionToWebview =
      */
     | { command: 'setProgress'; phase: string; label: string; percent: number; slow?: boolean }
     /** Force-clear the progress bar (e.g. on cancellation or fatal error). */
-    | { command: 'clearProgress' };
+    | { command: 'clearProgress' }
+    /**
+     * Replace the compile-error banner. Each entry maps to one row in the
+     * banner with file:line:col + message; clicking opens the source.
+     * Cards stay rendered but get a "compile-stale" decoration so the user
+     * keeps the last successful render visible alongside the error list.
+     */
+    | { command: 'setCompileErrors'; errors: import('./compileErrors').CompileError[]; sourceFile: string }
+    /** Remove the compile-error banner and the compile-stale dim on cards. */
+    | { command: 'clearCompileErrors' };
 
 /** Messages from webview to extension */
 export type WebviewToExtension =
@@ -299,4 +308,11 @@ export type WebviewToExtension =
      * full module view — extension clears the previewId filter on the
      * History panel scope.
      */
-    | { command: 'previewScopeChanged'; previewId: string | null };
+    | { command: 'previewScopeChanged'; previewId: string | null }
+    /**
+     * Click on a compile-error banner row. Extension responds by opening the
+     * source file and revealing the position. `sourceFile` is the same
+     * absolute path the extension passed in `setCompileErrors`; the line /
+     * column come from the LSP diagnostic (1-based).
+     */
+    | { command: 'openCompileError'; sourceFile: string; line: number; column: number };

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -255,7 +255,16 @@ export type ExtensionToWebview =
     | { command: 'showMessage'; text: string }
     | { command: 'clearAll' }
     | { command: 'setModules'; modules: string[]; selected: string }
-    | { command: 'setFunctionFilter'; functionName: string };
+    | { command: 'setFunctionFilter'; functionName: string }
+    /**
+     * Drives the slim progress bar at the top of the panel. `percent` is
+     * monotonic within a refresh and clamped to [0, 1]; `label` is the
+     * user-facing phase name ("Compiling Kotlin", "Rendering previews"…).
+     * The webview hides the bar on its own when `percent` reaches 1.
+     */
+    | { command: 'setProgress'; phase: string; label: string; percent: number }
+    /** Force-clear the progress bar (e.g. on cancellation or fatal error). */
+    | { command: 'clearProgress' };
 
 /** Messages from webview to extension */
 export type WebviewToExtension =


### PR DESCRIPTION
## Summary

Three related changes to refresh feedback in the VS Code panel.

### 1. Phased progress bar

A slim 2px bar pinned to the top of the panel replaces the binary "Building…" banner. The bar names the current build phase (Configuring Gradle, Compiling Kotlin, Discovering @Preview, Rendering previews, Loading images) and animates against an estimated duration. The estimate uses default per-phase weights on first refresh, then switches to per-module calibration data persisted in `workspaceState` — a Wear sample running Robolectric is much slower than a CMP one, and the bar reflects that. Asymptotic curve so the bar never appears stuck or finishes early.

### 2. Fast refreshes look instantaneous

Three small follow-up changes so warm-cache and daemon hits read as instant updates instead of "dim → flash to fresh", while genuinely slow builds still get a clear visual:

- **Two-stage card overlay.** The stealth-refresh overlay starts as a tiny corner spinner with no dim and no blur; after 500 ms of in-flight work it escalates to the previous dim+blur. Daemon hits typically land inside the 500 ms window, so the user sees a clean image swap rather than the dim-then-undim flicker.
- **Deferred top-bar mount.** The progress bar is mounted 200 ms after the first `setProgress`, not synchronously. Hot refreshes that finish in under 200 ms never mount the bar at all.
- **Slow-phase annotation.** When a phase runs past 2× its calibrated expectation, the bar tints with the editor warning colour and the label appends "(slow)". Cheap signal that something unusual is happening (cold cache, version bump invalidating Robolectric caches) without a notification.

### 3. LSP-driven compile-error gate

Read Error-severity diagnostics from whichever Kotlin language server is active and short-circuit the refresh when the active file has any. Saves a 5–30 s round-trip through `compileKotlin` on a typo-fix loop, since Gradle would have failed at the same point. Errors surface as a banner above the toolbar, one row per diagnostic; clicking opens the file at the offending position. Cards from the previous successful render stay visible (dimmed via `.compile-stale`) so the user keeps a working reference while fixing the error.

The gate is silent on workspaces with no Kotlin LSP attached — `getDiagnostics` returns an empty array and refresh proceeds as before. Cross-file errors aren't detected (deliberate trade-off for cheap gating); Gradle still catches them. Diagnostics from untrusted sources (spell-checkers, custom rules) are filtered out so they can't gate a build.

### Files changed

- `src/buildProgress.ts` (new) — phase parser + estimator.
- `src/compileErrors.ts` (new) — vscode-free `extractCompileErrors` plus `DiagnosticLike` shape.
- `src/gradleService.ts` — `runTask` accepts `TaskOptions { progressCalibration, onProgress, onCalibration }`.
- `src/extension.ts` — calibration persistence in `workspaceState`, LSP gate before refresh, `openCompileError` click handler.
- `src/previewPanel.ts` + `media/preview.css` — slim sticky bar, two-stage overlay (`.minimal` → `.subtle`), deferred-mount, compile-error banner with click-to-open and `.compile-stale` dim.

### Test plan

- [x] `npm run compile` — clean
- [x] `npm test` — 219 passing (14 progress tests + 11 compile-error tests)
- [ ] Manual: F5-launch the extension, edit a Kotlin file in `samples/wear`, watch the bar advance through phases. Save a second time and confirm the bar's animation rate adapts to the calibrated durations.
- [ ] Manual: Trigger a fast refresh on a warm Gradle / daemon path. Verify the top bar does NOT mount (no flash) and the card overlay stays as a corner-only spinner that disappears when the new image lands.
- [ ] Manual: Type a deliberate syntax error (e.g. `Modfier` instead of `Modifier`), save, confirm the build is skipped, the error banner appears with the right line:column, and clicking the row jumps to that position. Fix the typo and confirm the next save proceeds with a normal refresh.
- [ ] Manual: Cancel a refresh mid-build (rapid consecutive saves) and confirm both the bar and any banners clear cleanly rather than freezing.
- [ ] Manual: Force a cold-cache build (e.g. `./gradlew clean` then save) and confirm the bar tints warning-coloured with "(slow)" appended once compile blows past 2× its calibrated estimate.
