### PR TITLE
fix(ci): unblock format check + preview action self-references

### DIFF
--- a/.github/actions/preview-baselines/action.yml
+++ b/.github/actions/preview-baselines/action.yml
@@ -52,11 +52,11 @@ runs:
     # release by release-please (see release-please-config.json).
     - name: Install CLI from source
       if: inputs.cli-version == 'source'
-      uses: yschimke/compose-ai-tools/.github/actions/install-cli@v0.9.0 # x-release-please-version
+      uses: yschimke/compose-ai-tools/.github/actions/install-cli@v0.8.12 # x-release-please-version
 
     - name: Install CLI from release
       if: inputs.cli-version != 'source'
-      uses: yschimke/compose-ai-tools/.github/actions/install@v0.9.0 # x-release-please-version
+      uses: yschimke/compose-ai-tools/.github/actions/install@v0.8.12 # x-release-please-version
       with:
         version: ${{ inputs.cli-version }}
         catalog-path: ${{ inputs.catalog-path }}

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -66,11 +66,11 @@ runs:
     # use). The pinned tag is bumped per release by release-please.
     - name: Install CLI from source
       if: inputs.cli-version == 'source'
-      uses: yschimke/compose-ai-tools/.github/actions/install-cli@v0.9.0 # x-release-please-version
+      uses: yschimke/compose-ai-tools/.github/actions/install-cli@v0.8.12 # x-release-please-version
 
     - name: Install CLI from release
       if: inputs.cli-version != 'source'
-      uses: yschimke/compose-ai-tools/.github/actions/install@v0.9.0 # x-release-please-version
+      uses: yschimke/compose-ai-tools/.github/actions/install@v0.8.12 # x-release-please-version
       with:
         version: ${{ inputs.cli-version }}
         catalog-path: ${{ inputs.catalog-path }}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistorySource.kt
@@ -81,9 +81,9 @@ data class HistoryReadResult(
  *
  * `SKIPPED_DUPLICATE` — the bytes match the most recent existing entry for this `previewId`, so the
  * source skipped writing both the sidecar and the index line. `HistoryManager.recordRender` uses
- * this to suppress `historyAdded` and avoid cluttering the consumer's UI with redundant entries
- * for save-loops that produce identical pixels (e.g. saving a comment-only edit, repeated focus
- * cycles, sandbox warm-up renders against the same composition state).
+ * this to suppress `historyAdded` and avoid cluttering the consumer's UI with redundant entries for
+ * save-loops that produce identical pixels (e.g. saving a comment-only edit, repeated focus cycles,
+ * sandbox warm-up renders against the same composition state).
  *
  * The "most recent" rule is what distinguishes this from the dedup-by-hash PNG path (where any
  * earlier matching hash means we re-use the file). If render history goes A → B → A, the third

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySource.kt
@@ -37,18 +37,18 @@ import kotlinx.serialization.json.Json
  * 1. **Skip-on-most-recent-match.** When [write] is called with bytes whose SHA-256 matches the
  *    most-recent existing entry for the same `previewId`, [write] returns
  *    [WriteResult.SKIPPED_DUPLICATE] and writes nothing — no PNG, no sidecar, no index line. The
- *    consumer's UI doesn't see a redundant entry for save-loops that produce identical pixels
- *    (e.g. comment-only edits, sandbox warm-up renders against the same composition). Distinct
- *    from tier 2 below: the rule is the *most recent* match, not any match — render history
- *    A → B → A still keeps the third entry because going-back-to-A is a meaningful event.
+ *    consumer's UI doesn't see a redundant entry for save-loops that produce identical pixels (e.g.
+ *    comment-only edits, sandbox warm-up renders against the same composition). Distinct from tier
+ *    2 below: the rule is the *most recent* match, not any match — render history A → B → A still
+ *    keeps the third entry because going-back-to-A is a meaningful event.
  *
  * 2. **Pointer-on-any-match (fallback for non-consecutive matches).** When the new bytes don't
  *    match the most-recent entry but DO match an earlier one (the A → B → A case), the new
  *    sidecar's `pngPath` points at the older PNG and we don't re-write the bytes. The sidecar +
  *    index line still land so the provenance entry exists.
  *
- * Both tiers reduce on-disk PNG copies; tier 1 additionally suppresses sidecar churn. HISTORY.md
- * § "What this PR lands § H1" + § "Dedup".
+ * Both tiers reduce on-disk PNG copies; tier 1 additionally suppresses sidecar churn. HISTORY.md §
+ * "What this PR lands § H1" + § "Dedup".
  *
  * **Cross-restart correctness.** Dedup walks the per-preview directory listing for the most-recent
  * entry whose hash matches; this works whether that entry was written in the current daemon
@@ -127,11 +127,11 @@ class LocalFsHistorySource(private val historyDir: Path) : HistorySource {
   }
 
   /**
-   * Returns the [HistoryEntry.pngHash] of the absolute newest sidecar in [previewDir], or null
-   * when the dir is empty or all sidecars are unreadable. Used by tier 1 of the dedup ladder.
+   * Returns the [HistoryEntry.pngHash] of the absolute newest sidecar in [previewDir], or null when
+   * the dir is empty or all sidecars are unreadable. Used by tier 1 of the dedup ladder.
    *
-   * Sidecar filenames lead with a UTC timestamp in `yyyyMMdd-HHmmss-<hash>` shape, so reverse
-   * lex sort = newest first. We don't need to parse the timestamp — string compare is enough.
+   * Sidecar filenames lead with a UTC timestamp in `yyyyMMdd-HHmmss-<hash>` shape, so reverse lex
+   * sort = newest first. We don't need to parse the timestamp — string compare is enough.
    */
   private fun findMostRecentEntryHash(previewDir: Path, exclude: String): String? {
     if (!Files.exists(previewDir)) return null

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceWriteTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourceWriteTest.kt
@@ -143,11 +143,26 @@ class LocalFsHistorySourceWriteTest {
     val hashB = LocalFsHistorySource.sha256Hex(bytesB)
 
     val firstA =
-      makeEntry(id = "20260430-100000-${hashA.take(8)}", previewId = previewId, hash = hashA, size = 3)
+      makeEntry(
+        id = "20260430-100000-${hashA.take(8)}",
+        previewId = previewId,
+        hash = hashA,
+        size = 3,
+      )
     val midB =
-      makeEntry(id = "20260430-100001-${hashB.take(8)}", previewId = previewId, hash = hashB, size = 3)
+      makeEntry(
+        id = "20260430-100001-${hashB.take(8)}",
+        previewId = previewId,
+        hash = hashB,
+        size = 3,
+      )
     val secondA =
-      makeEntry(id = "20260430-100002-${hashA.take(8)}", previewId = previewId, hash = hashA, size = 3)
+      makeEntry(
+        id = "20260430-100002-${hashA.take(8)}",
+        previewId = previewId,
+        hash = hashA,
+        size = 3,
+      )
 
     assertEquals(WriteResult.WRITTEN, source.write(firstA, bytesA))
     assertEquals(WriteResult.WRITTEN, source.write(midB, bytesB))
@@ -197,7 +212,10 @@ class LocalFsHistorySourceWriteTest {
         hash = hash,
         size = bytes.size.toLong(),
       )
-    assertEquals(WriteResult.WRITTEN, LocalFsHistorySource(historyDir = tmpDir).write(firstEntry, bytes))
+    assertEquals(
+      WriteResult.WRITTEN,
+      LocalFsHistorySource(historyDir = tmpDir).write(firstEntry, bytes),
+    )
 
     val sourceB = LocalFsHistorySource(historyDir = tmpDir)
     val secondEntry =

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -94,6 +94,7 @@ The CLI ([cli/](cli/src/main/kotlin/ee/schimke/composeai/cli/)) and VS Code exte
 ## Git conventions
 
 - **Do not add `Co-Authored-By` trailers** to git commit messages. Commits should be attributed solely to the committer.
+- **Run the formatter before committing.** CI's `format` job runs `./gradlew ktfmtCheckAll` and it's a hard gate — `ktfmtCheck` aborts on the first unformatted file. Before each commit that touches `*.kt`/`*.kts`, run `./gradlew ktfmtFormat` (or `./gradlew :<module>:ktfmtFormatMain :<module>:ktfmtFormatTest` for the touched modules) and stage the result. For VS Code extension TypeScript changes, run `npm --prefix vscode-extension run format`. Don't push without re-running these — the fix-up round-trip costs more than running the formatter locally.
 
 ## Important constraints
 


### PR DESCRIPTION
## Summary

Two unrelated CI breakages, plus a docs nudge to keep the format one from coming back:

- **`ktfmt` failure** — three files in `daemon/core/.../history/` had drifted (`HistorySource.kt`, `LocalFsHistorySource.kt`, `LocalFsHistorySourceWriteTest.kt`). Re-ran `:daemon:core:ktfmtFormat{Main,Test}`; `ktfmtCheck{Main,Test}` is now clean.
- **`Unable to resolve action yschimke/compose-ai-tools@v0.9.0`** — PR #311 prematurely bumped the `# x-release-please-version` self-references in `preview-baselines/action.yml` and `preview-comment/action.yml` from `v0.8.12` to `v0.9.0`, but no `v0.9.0` tag exists yet (manifest is still at `0.8.12`). Reverted both to `v0.8.12`; release-please will re-bump them when 0.9.0 is actually cut, same as past releases.
- **`docs/AGENTS.md`** — added an explicit "run the formatter before committing" bullet under Git conventions, calling out `ktfmtCheckAll` as a hard CI gate, the `:<module>:ktfmtFormat{Main,Test}` granular tasks, and the VS Code `npm run format` equivalent. The kt drift in this PR is the kind of thing that bullet exists to prevent.

## Test plan

- [x] `./gradlew :daemon:core:ktfmtCheckMain :daemon:core:ktfmtCheckTest` — passes locally
- [ ] CI `format` job (`./gradlew ktfmtCheckAll`) green
- [ ] CI `preview-baselines` / `preview-comment` runs no longer error on `Unable to resolve action ...@v0.9.0`

---
_Generated by [Claude Code](https://claude.ai/code/session_012TkMFwL6JPmMNZMQx6N7qa)_