### PR TITLE
feat(vscode): discoverable focus mode + History panel scope chip

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -272,6 +272,11 @@ body {
     align-items: center;
     justify-content: center;
     background: var(--skeleton-bg);
+    cursor: zoom-in;
+}
+
+.preview-grid.layout-focus .preview-card.focused .image-container {
+    cursor: zoom-out;
 }
 
 .image-container img {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1218,16 +1218,32 @@ function handleWebviewMessage(msg: WebviewToExtensionMessage) {
             // module — the panel shows every preview's history.
             if (!historyScopeRef.current) { break; }
             const requested = msg.previewId ?? undefined;
-            if (historyScopeRef.current.previewId === requested) { break; }
+            const requestedLabel = requested ? lookupPreviewLabel(requested) : undefined;
+            if (historyScopeRef.current.previewId === requested
+                && historyScopeRef.current.previewLabel === requestedLabel) {
+                break;
+            }
             const newScope: HistoryScope = {
                 ...historyScopeRef.current,
                 previewId: requested,
+                previewLabel: requestedLabel,
             };
             historyScopeRef.current = newScope;
             historyPanel?.setScope(newScope);
             break;
         }
     }
+}
+
+function lookupPreviewLabel(previewId: string): string | undefined {
+    const mod = previewModuleMap.get(previewId);
+    if (!mod) { return undefined; }
+    const manifest = moduleManifestCache.get(mod);
+    const info = manifest?.find(p => p.id === previewId);
+    if (!info) { return undefined; }
+    return info.params.name
+        ? `${info.functionName} — ${info.params.name}`
+        : info.functionName;
 }
 
 async function notifyDaemonViewport(visible: string[], predicted: string[]): Promise<void> {

--- a/vscode-extension/src/historyPanel.ts
+++ b/vscode-extension/src/historyPanel.ts
@@ -82,8 +82,13 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
     async refresh(): Promise<void> {
         if (!this.view || !this.currentScope) {
             this.view?.webview.postMessage({ command: 'showMessage', text: 'Open a Kotlin file to see its render history.' });
+            this.view?.webview.postMessage({ command: 'setScopeLabel', label: null });
             return;
         }
+        const label = this.currentScope.previewId
+            ? this.currentScope.previewLabel ?? this.currentScope.previewId
+            : null;
+        this.view.webview.postMessage({ command: 'setScopeLabel', label });
         try {
             const result = await this.source.list(this.currentScope);
             this.view.webview.postMessage({ command: 'setEntries', result });
@@ -197,6 +202,15 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
                      background: var(--vscode-textCodeBlock-background); padding: 6px; }
       .diff-inline { padding: 8px; background: var(--vscode-editorWidget-background);
                      margin-top: 8px; border-left: 2px solid var(--vscode-focusBorder); }
+      .scope-chip { display: inline-flex; align-items: center; gap: 6px;
+                    padding: 2px 8px; margin-bottom: 8px;
+                    background: var(--vscode-badge-background);
+                    color: var(--vscode-badge-foreground);
+                    border-radius: 10px; font-size: 90%;
+                    max-width: 100%; overflow: hidden; text-overflow: ellipsis;
+                    white-space: nowrap; }
+      .scope-chip[hidden] { display: none; }
+      .scope-chip .codicon { font-size: 12px; opacity: 0.85; }
     </style>
 </head>
 <body>
@@ -212,6 +226,11 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
         <button id="btn-refresh" title="Refresh">⟳</button>
         <button id="btn-diff" disabled title="Pixel-diff two selected entries (metadata mode in current daemon)">Diff selected</button>
     </div>
+    <div id="scope-chip" class="scope-chip" role="status" aria-live="polite" hidden
+         title="History narrowed because a single preview is selected in the live panel — change focus or filters there to widen.">
+        <i class="codicon codicon-filter" aria-hidden="true"></i>
+        <span id="scope-chip-label"></span>
+    </div>
     <div id="message" class="message">Loading…</div>
     <div id="timeline" class="timeline" role="list" aria-label="History entries"></div>
 
@@ -224,6 +243,8 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
         const filterBranchEl = document.getElementById('filter-branch');
         const btnRefreshEl = document.getElementById('btn-refresh');
         const btnDiffEl = document.getElementById('btn-diff');
+        const scopeChipEl = document.getElementById('scope-chip');
+        const scopeChipLabelEl = document.getElementById('scope-chip-label');
 
         let entries = [];
         let selectedIds = new Set();
@@ -436,6 +457,15 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
                 case 'showMessage':
                     setMessage(msg.text || '');
                     break;
+                case 'setScopeLabel':
+                    if (msg.label) {
+                        scopeChipLabelEl.textContent = msg.label;
+                        scopeChipEl.hidden = false;
+                    } else {
+                        scopeChipLabelEl.textContent = '';
+                        scopeChipEl.hidden = true;
+                    }
+                    break;
                 case 'imageReady':
                     fillExpansion(msg.id, msg.imageData, msg.entry);
                     break;
@@ -478,6 +508,10 @@ export interface HistoryScope {
     /** Optional preview filter; when null, the panel shows every preview
      *  in the module's history. */
     previewId?: string;
+    /** Display name for the previewId filter (function or `@Preview` name).
+     *  Surfaced in the panel's toolbar as a chip when set so the user can
+     *  see why entries are narrowed. Not used for filtering. */
+    previewLabel?: string;
 }
 
 /**

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -85,6 +85,9 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         <button class="icon-button" id="btn-next" title="Next preview" aria-label="Next preview">
             <i class="codicon codicon-arrow-right" aria-hidden="true"></i>
         </button>
+        <button class="icon-button" id="btn-exit-focus" title="Exit focus mode" aria-label="Exit focus mode">
+            <i class="codicon codicon-close" aria-hidden="true"></i>
+        </button>
     </div>
     <div id="preview-grid" class="preview-grid" role="list" aria-label="Preview cards"></div>
 
@@ -101,6 +104,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         const focusControls = document.getElementById('focus-controls');
         const btnPrev = document.getElementById('btn-prev');
         const btnNext = document.getElementById('btn-next');
+        const btnExitFocus = document.getElementById('btn-exit-focus');
         const focusPosition = document.getElementById('focus-position');
 
         let allPreviews = [];
@@ -111,6 +115,11 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         // Tracked here so we don't spam the History panel with redundant
         // re-scopes (e.g. layout reapplies on every filter tweak).
         let lastScopedPreviewId = null;
+        // Layout to fall back to when the user exits focus mode. Captured
+        // whenever we transition into focus from another layout (dropdown
+        // change, dblclick on a card). Defaults to grid so the very first
+        // exit lands somewhere sensible.
+        let previousLayout = state.layout && state.layout !== 'focus' ? state.layout : 'grid';
 
         // Restore layout preference
         if (state.layout && ['grid', 'flow', 'column', 'focus'].includes(state.layout)) {
@@ -126,6 +135,9 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         message.dataset.owner = 'fallback';
 
         layoutMode.addEventListener('change', () => {
+            if (layoutMode.value === 'focus' && state.layout !== 'focus') {
+                previousLayout = state.layout || 'grid';
+            }
             state.layout = layoutMode.value;
             vscode.setState(state);
             applyLayout();
@@ -133,6 +145,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 
         btnPrev.addEventListener('click', () => navigateFocus(-1));
         btnNext.addEventListener('click', () => navigateFocus(1));
+        btnExitFocus.addEventListener('click', () => exitFocus());
 
         for (const sel of [filterFunction, filterGroup]) {
             sel.addEventListener('change', () => {
@@ -256,6 +269,8 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     card.classList.remove('focused', 'hidden-by-focus');
                 });
             }
+            const tooltip = mode === 'focus' ? 'Double-click to exit focus' : 'Double-click to focus';
+            document.querySelectorAll('.image-container').forEach(c => c.title = tooltip);
             publishScopedPreview();
         }
 
@@ -300,10 +315,19 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             if (idx === -1) return;
             focusIndex = idx;
             if (layoutMode.value !== 'focus') {
+                previousLayout = layoutMode.value;
                 layoutMode.value = 'focus';
                 state.layout = 'focus';
                 vscode.setState(state);
             }
+            applyLayout();
+        }
+
+        function exitFocus() {
+            if (layoutMode.value !== 'focus') return;
+            layoutMode.value = previousLayout;
+            state.layout = previousLayout;
+            vscode.setState(state);
             applyLayout();
         }
 
@@ -421,6 +445,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 
             const imgContainer = document.createElement('div');
             imgContainer.className = 'image-container';
+            imgContainer.title = 'Double-click to focus';
             const skeleton = document.createElement('div');
             skeleton.className = 'skeleton';
             skeleton.setAttribute('aria-label', 'Loading preview');
@@ -428,14 +453,16 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             card.appendChild(imgContainer);
 
             // Double-click the image to jump straight to focus mode on this
-            // preview. Useful when you spot something interesting in a grid
-            // and want a closer look without manually toggling the layout
-            // dropdown and arrowing through siblings. The dblclick handler
-            // stays on the image so single-clicks remain free for future
-            // selection affordances and don't interfere with the existing
-            // title / stale-badge / carousel buttons.
+            // preview, or back out of it. The dblclick handler stays on the
+            // image so single-clicks remain free for future selection
+            // affordances and don't interfere with the existing title /
+            // stale-badge / carousel buttons.
             imgContainer.addEventListener('dblclick', () => {
-                focusOnCard(card);
+                if (layoutMode.value === 'focus') {
+                    exitFocus();
+                } else {
+                    focusOnCard(card);
+                }
             });
 
             // ATF legend + overlay layer — rendered in the webview (not


### PR DESCRIPTION
## Summary

Three usability follow-ups to #343:

- **Discoverable focus gesture** — the image container now shows a `zoom-in` / `zoom-out` cursor and a `Double-click to focus` / `Double-click to exit focus` tooltip, so the dblclick affordance from #343 no longer relies on the user stumbling onto it.
- **Exit-focus button** — adds a close-icon button to the focus-controls bar that restores the layout the user came from (grid / flow / column), tracked across both dropdown- and dblclick-driven entries into focus. Dblclicking a focused image also exits, matching the entry gesture.
- **Scope chip in the History panel** — when the panel narrows to a single preview (focus mode, or filters reduced to one card) it now shows a chip with the preview's display name. The chip's tooltip explains the chip is driven by the live panel so users know where to widen back from.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 217 / 217 passing
- [ ] Manual: hover a preview in grid → see `Double-click to focus` tooltip and `zoom-in` cursor
- [ ] Manual: dblclick → enters focus, cursor becomes `zoom-out`, tooltip becomes `Double-click to exit focus`
- [ ] Manual: click the close button in focus controls → returns to the previous layout (grid/flow/column)
- [ ] Manual: dblclick the focused image → exits to the previous layout
- [ ] Manual: enter focus mode → chip appears in the History panel showing the preview name; exit → chip clears
- [ ] Manual: filter live panel down to one card in grid → chip appears with that preview's name


---
_Generated by [Claude Code](https://claude.ai/code/session_01A6AFhHNrHQNqUPKdmJRt94)_