### PR TITLE
feat(vscode): focus-mode arrow-key nav + stable history scope on save

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -954,7 +954,16 @@ async function refresh(
     // it from workspaceRoot + module here because GradleService keeps
     // modules as relative slash-paths.
     const projectDir = path.join(gradleService.workspaceRoot, module);
-    const newScope: HistoryScope = { moduleId: module, projectDir };
+    // Preserve the previewId narrow across same-module refreshes so a
+    // save-driven refresh doesn't briefly widen the History panel to the
+    // module before the webview re-publishes the narrow on next layout.
+    // On a module switch the narrow no longer applies — the previewId is
+    // owned by the previous module's preview set.
+    const prior = historyScopeRef.current;
+    const sameModule = prior?.moduleId === module && prior.projectDir === projectDir;
+    const newScope: HistoryScope = sameModule
+        ? { moduleId: module, projectDir, previewId: prior!.previewId, previewLabel: prior!.previewLabel }
+        : { moduleId: module, projectDir };
     historyScopeRef.current = newScope;
     historyPanel?.setScope(newScope);
     const modules = [module];

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -147,6 +147,20 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         btnNext.addEventListener('click', () => navigateFocus(1));
         btnExitFocus.addEventListener('click', () => exitFocus());
 
+        // Document-level Left/Right in focus mode steps between cards. The
+        // animated-carousel frame-controls handler stops propagation so
+        // its arrow keys still walk captures within a single card. Skip
+        // when an input-like element has focus (the layout dropdown,
+        // future text inputs) so native keyboard semantics aren't stolen.
+        document.addEventListener('keydown', (e) => {
+            if (layoutMode.value !== 'focus') return;
+            if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+            const tag = e.target && e.target.tagName;
+            if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA') return;
+            navigateFocus(e.key === 'ArrowLeft' ? -1 : 1);
+            e.preventDefault();
+        });
+
         for (const sel of [filterFunction, filterGroup]) {
             sel.addEventListener('change', () => {
                 saveFilterState();
@@ -520,11 +534,15 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             bar.appendChild(indicator);
             bar.appendChild(next);
 
-            // Arrow keys when the carousel has focus.
+            // Arrow keys when the carousel has focus. Stop propagation so
+            // the document-level focus-mode nav doesn't also advance the card.
             bar.tabIndex = 0;
             bar.addEventListener('keydown', (e) => {
-                if (e.key === 'ArrowLeft') { stepFrame(card, -1); e.preventDefault(); }
-                else if (e.key === 'ArrowRight') { stepFrame(card, 1); e.preventDefault(); }
+                if (e.key === 'ArrowLeft') {
+                    stepFrame(card, -1); e.preventDefault(); e.stopPropagation();
+                } else if (e.key === 'ArrowRight') {
+                    stepFrame(card, 1); e.preventDefault(); e.stopPropagation();
+                }
             });
 
             // Seed indicator text so it's not blank before any image arrives.


### PR DESCRIPTION
## Summary

Two leftover usability touches from the focus-mode review:

- **Arrow-key navigation in focus mode.** Pressing Left / Right while the live panel is in focus mode now walks between cards. The animated-carousel `frame-controls` keep their own arrow bindings (via `stopPropagation`), and the document-level handler skips when an input / select / textarea has focus so the layout dropdown's native keys keep working.
- **Stable History scope across same-module refreshes.** `refresh()` used to drop the History panel's `previewId` filter on every save, briefly widening the timeline before the webview's next `previewScopeChanged` re-narrowed it. It now preserves `previewId` (and `previewLabel`) when the new scope's module + project dir match the prior one. Module switches still clear the narrow — the previewId belongs to the previous module's preview set.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 217 / 217 passing
- [ ] Manual: enter focus mode, press Left / Right → walks cards; arrow buttons (`btn-prev` / `btn-next`) update accordingly
- [ ] Manual: focus an animated card's `frame-controls` strip, press arrows → captures step within the card; cards do not change
- [ ] Manual: focus the layout dropdown, press arrows → dropdown options change; cards do not
- [ ] Manual: enter focus on a preview, save the file → History panel stays narrowed (no flicker to module-wide)
- [ ] Manual: switch to a Kotlin file in a different module → History panel widens to the new module


---
_Generated by [Claude Code](https://claude.ai/code/session_01A6AFhHNrHQNqUPKdmJRt94)_