### PR TITLE
fix(vscode): empty history when unscoped + read() through live scope

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -312,7 +312,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
                 if (!client) { throw new Error('daemon unavailable'); }
                 return client.historyDiff({ from: fromId, to: toId, mode: 'metadata' });
             },
-            currentScope: historyScopeRef.current,
+            getCurrentScope: () => historyScopeRef.current,
             logger: outputChannel,
         }),
     );

--- a/vscode-extension/src/historyPanel.ts
+++ b/vscode-extension/src/historyPanel.ts
@@ -85,9 +85,20 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
             this.view?.webview.postMessage({ command: 'setScopeLabel', label: null });
             return;
         }
-        const label = this.currentScope.previewId
-            ? this.currentScope.previewLabel ?? this.currentScope.previewId
-            : null;
+        if (!this.currentScope.previewId) {
+            // Module-wide history would mix entries from every preview in the
+            // file, which is rarely what the user wants and obscures whose
+            // timeline they're looking at. Require a single preview be
+            // selected (focus mode, or filters narrowed to one card) and
+            // show a hint until then.
+            this.view.webview.postMessage({ command: 'setScopeLabel', label: null });
+            this.view.webview.postMessage({
+                command: 'showMessage',
+                text: 'Select a single preview (focus mode, or narrow the filter to one card) to see its render history.',
+            });
+            return;
+        }
+        const label = this.currentScope.previewLabel ?? this.currentScope.previewId;
         this.view.webview.postMessage({ command: 'setScopeLabel', label });
         try {
             const result = await this.source.list(this.currentScope);
@@ -549,11 +560,12 @@ export function buildHistorySource(opts: BuildSourceOptions): HistorySource {
             return result;
         },
         read: async (id) => {
-            if (!opts.currentScope) { return null; }
+            const scope = opts.getCurrentScope();
+            if (!scope) { return null; }
             if (CurrentRendersHistory.isSyntheticId(id)) {
-                return currentRendersFor(opts.currentScope).read(id);
+                return currentRendersFor(scope).read(id);
             }
-            if (opts.isDaemonReady(opts.currentScope.moduleId)) {
+            if (opts.isDaemonReady(scope.moduleId)) {
                 try {
                     return await opts.daemonRead(id);
                 } catch (err) {
@@ -562,10 +574,11 @@ export function buildHistorySource(opts: BuildSourceOptions): HistorySource {
                     );
                 }
             }
-            return new HistoryReader(historyDirFor(opts.currentScope)).read(id);
+            return new HistoryReader(historyDirFor(scope)).read(id);
         },
         diff: async (fromId, toId) => {
-            if (!opts.currentScope) { return null; }
+            const scope = opts.getCurrentScope();
+            if (!scope) { return null; }
             // Synthetic "current render" entries don't have a stable prior
             // — diffing them is meaningless. Fall through to null so the
             // panel surfaces "Diff unavailable" instead of crashing.
@@ -573,7 +586,7 @@ export function buildHistorySource(opts: BuildSourceOptions): HistorySource {
                 || CurrentRendersHistory.isSyntheticId(toId)) {
                 return null;
             }
-            if (opts.isDaemonReady(opts.currentScope.moduleId)) {
+            if (opts.isDaemonReady(scope.moduleId)) {
                 try {
                     return await opts.daemonDiff(fromId, toId);
                 } catch (err) {
@@ -582,7 +595,7 @@ export function buildHistorySource(opts: BuildSourceOptions): HistorySource {
                     );
                 }
             }
-            return new HistoryReader(historyDirFor(opts.currentScope))
+            return new HistoryReader(historyDirFor(scope))
                 .diff(fromId, toId, 'metadata');
         },
     };
@@ -604,11 +617,11 @@ interface BuildSourceOptions {
     daemonList: (scope: HistoryScope) => Promise<HistoryListResult>;
     daemonRead: (id: string) => Promise<HistoryReadResult>;
     daemonDiff: (fromId: string, toId: string) => Promise<unknown>;
-    /** Mutable closure — extension.ts updates this on every scope change so
-     *  the panel's `read` / `diff` callbacks know which module's FS to fall
-     *  back to. We don't bake it into the `HistorySource` shape because
-     *  list() takes scope as an arg but read() / diff() don't. */
-    currentScope: HistoryScope | null;
+    /** Live accessor for the active scope. The panel's read() / diff()
+     *  callbacks don't get scope as an argument (unlike list), so they
+     *  reach into the extension's mutable scope ref through this getter
+     *  rather than capturing a stale snapshot at construction time. */
+    getCurrentScope: () => HistoryScope | null;
     logger?: { appendLine(s: string): void };
 }
 
@@ -624,12 +637,9 @@ function matchesScope(
     entry: { previewId?: string; module?: string },
     scope: HistoryScope | null,
 ): boolean {
-    if (!scope) { return false; }
-    // The panel scope is keyed on Gradle moduleId — entries carry it as
-    // `module`. previewId filter is optional; absent → any preview in the
-    // module matches.
+    if (!scope || !scope.previewId) { return false; }
     if (entry.module !== scope.moduleId) { return false; }
-    if (scope.previewId && entry.previewId !== scope.previewId) { return false; }
+    if (entry.previewId !== scope.previewId) { return false; }
     return true;
 }
 


### PR DESCRIPTION
## Summary

Two bugs in the History panel that surfaced once it had a real workload:

- **"Failed to load image: Entry not found."** Clicking any timeline entry to expand it always failed. `buildHistorySource` captured `currentScope` by value at panel-construction time — when the ref was still `null` — so `read()` and `diff()` always saw a stale `null` and bailed out. The "mutable closure" the comment promised wasn't actually mutable. Fix: replace the captured value with a `getCurrentScope()` getter that reads through to the extension's `historyScopeRef`.
- **Module-wide list when nothing was narrowed.** With a Kotlin file open but no preview in focus / filter, the panel listed every preview's renders interleaved under one timeline. Confusing — and it's why the chip from #348 was hidden in that state to begin with. Fix: `refresh()` now shows a hint ("Select a single preview …") instead of listing, and `matchesScope` drops push notifications when there's no narrow.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 217 / 217 passing
- [ ] Manual: open a Kotlin file with multiple `@Preview`s, panel in grid → History panel shows the hint, no entries
- [ ] Manual: enter focus mode → History narrows to that preview's entries; chip shows the name
- [ ] Manual: click a timeline entry → image expands (no "Entry not found")
- [ ] Manual: arrow through focus mode → History re-narrows for each preview; entries remain clickable
- [ ] Manual: exit focus → panel reverts to the hint


---
_Generated by [Claude Code](https://claude.ai/code/session_01A6AFhHNrHQNqUPKdmJRt94)_