### PR TITLE
fix(vscode,daemon): cancellation gate, classloader URL ordering, restart command, self-diagnostic logs

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -115,6 +115,18 @@ class RenderEngine(
     val clazz = Class.forName(spec.className, true, classLoader)
     val composableMethod: ComposableMethod = clazz.getDeclaredComposableMethod(spec.functionName)
 
+    // Self-diagnostic — surfaces in the VS Code extension's output channel as `[daemon stderr] …`.
+    // Pairs with `[classloader] swap requested` / `allocate child loader` lines from
+    // [UserClassLoaderHolder]. If `classFile` doesn't advance across saves the daemon is
+    // re-rendering against bytecode that wasn't actually recompiled.
+    val fingerprint =
+      UserClassLoaderHolder.classFileFingerprint(classLoader, spec.className)
+        ?: "fingerprint unavailable (class not on a file: URL)"
+    System.err.println(
+      "compose-ai-daemon: [render] ${spec.className}#${spec.functionName} " +
+        "loaderId=${System.identityHashCode(classLoader).toString(16)} classFile=$fingerprint"
+    )
+
     // `device = "id:wearos_*_round"` / `isRound=true` previews need a circular crop matching the
     // standalone renderer's `RobolectricRenderTest`. The standalone path also gates on
     // `showSystemUi || kind == TILE` to skip the crop on non-fullscreen previews (the crop is a

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt
@@ -219,18 +219,41 @@ class UserClassLoaderHolder(
 
     /**
      * Resolves [USER_CLASS_DIRS_PROP] into a list of [URL]s, dropping entries that don't exist on
-     * disk. Returns an empty list if the sysprop is unset.
+     * disk and **ordering directories before jars**. Returns an empty list if the sysprop is unset.
+     *
+     * **Why directories first.** AGP's variant classpath surfaces both the kotlinc output directory
+     * (`build/intermediates/built_in_kotlinc/<variant>/compileDebugKotlin/classes/`) and the
+     * runtime-bundled jar (`build/intermediates/runtime_app_classes_jar/<variant>/.../classes.jar`)
+     * for the same set of user classes. The kotlinc directory is rewritten by `compileDebugKotlin`
+     * — an upstream of every save's `discoverPreviews` — so it carries the fresh bytecode. The
+     * runtime jar is rewritten by `bundleDebugClassesToRuntimeJar`, which is **not** on the
+     * `discoverPreviews` task graph; it only runs as part of `composePreviewDaemonStart` (once at
+     * bootstrap) and the unit-test packaging path. After the first save the jar is therefore stale
+     * relative to the `.class` directory.
+     *
+     * `URLClassLoader.findClass` walks URLs in declaration order and returns the first match. AGP's
+     * natural ordering puts the runtime jar before the kotlinc directory; without this sort the
+     * daemon resolves every user class out of the stale jar and the freshly-recompiled directory is
+     * never read — the "first edit updates, subsequent edits stick" symptom that the cancellation
+     * hole / classloader-swap diagnostics couldn't explain on their own. Moving directories to the
+     * front lets the kotlinc output win for any class it carries; bundled jars stay on the path as
+     * a fallback for kapt/ksp-generated classes and the AGP `R.jar`.
+     *
+     * Sort is stable (`sortedBy` uses TimSort), so directories among themselves and jars among
+     * themselves keep their relative order — important because AGP's main-vs-test classpath
+     * ordering carries semantics we don't want to scramble.
      */
     fun urlsFromSysprop(): List<URL> {
       val raw = System.getProperty(USER_CLASS_DIRS_PROP) ?: return emptyList()
       if (raw.isBlank()) return emptyList()
-      return raw
-        .split(java.io.File.pathSeparator)
-        .map { it.trim() }
-        .filter { it.isNotEmpty() }
-        .map { java.io.File(it) }
-        .filter { it.exists() }
-        .map { it.toURI().toURL() }
+      val files =
+        raw
+          .split(java.io.File.pathSeparator)
+          .map { it.trim() }
+          .filter { it.isNotEmpty() }
+          .map { java.io.File(it) }
+          .filter { it.exists() }
+      return files.sortedBy { if (it.isDirectory) 0 else 1 }.map { it.toURI().toURL() }
     }
 
     /**

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt
@@ -89,6 +89,14 @@ class UserClassLoaderHolder(
   fun swap() {
     synchronized(lock) {
       current = null
+      // Self-diagnostic log — surfaces as `[daemon stderr] [classloader] swap …` in the VS Code
+      // extension's Compose Preview output channel. Pairs with the `allocate` line emitted on the
+      // next currentChildLoader() read; if a save loop produces "swap" but never the matching
+      // "allocate" the host's render thread isn't picking up the swap, and if "allocate" fires but
+      // the .class fingerprint doesn't move across saves the disk hasn't actually been recompiled.
+      System.err.println(
+        "compose-ai-daemon: [classloader] swap requested urlCount=${urls.size} liveLoaders=${trackedLoaders.size}"
+      )
       // Force the next currentChildLoader read to do the allocation; we deliberately don't
       // pre-allocate here because the next render is what cares, and pre-allocating would
       // double the loader objects in flight when fileChanged arrives faster than renders.
@@ -131,6 +139,14 @@ class UserClassLoaderHolder(
     val fresh = ChildFirstURLClassLoader(urls.toTypedArray(), resolvedParent)
     current = fresh
     trackedLoaders.add(WeakReference(fresh))
+    // Self-diagnostic log — pairs with `swap requested` above. Surfaces the URL list so we can see
+    // exactly which directories the next render's findClass walks. The `urlsSummary` helper
+    // reports the directory mtime for each entry; an mtime that doesn't advance across saves means
+    // `compileKotlin` didn't actually rewrite anything (Gradle up-to-date, no-op edit, etc.).
+    System.err.println(
+      "compose-ai-daemon: [classloader] allocate child loader parent=${resolvedParent.javaClass.name} " +
+        "loaderId=${System.identityHashCode(fresh).toString(16)} urls=${urlsSummary(urls)}"
+    )
     onSwap?.invoke(fresh)
     return fresh
   }
@@ -215,6 +231,65 @@ class UserClassLoaderHolder(
         .map { java.io.File(it) }
         .filter { it.exists() }
         .map { it.toURI().toURL() }
+    }
+
+    /**
+     * Compact one-line dump of [urls] suitable for stderr — each entry is `<path>(mtime=…)` so the
+     * directory's most-recent write is visible at a glance. Only `file:` URLs are statted; other
+     * schemes are reported by URL string only.
+     */
+    internal fun urlsSummary(urls: List<URL>): String =
+      urls.joinToString(prefix = "[", postfix = "]") { url ->
+        if (url.protocol == "file") {
+          val file = java.io.File(url.toURI())
+          val mtime =
+            if (file.exists()) java.time.Instant.ofEpochMilli(file.lastModified()).toString()
+            else "missing"
+          "${file.absolutePath}(mtime=$mtime)"
+        } else {
+          url.toString()
+        }
+      }
+
+    /**
+     * Resolves [className] to its on-disk `.class` file via [loader]'s resource lookup and returns
+     * a compact `path=… mtime=… size=… sha=…` string. Returns `null` if the class isn't on a
+     * `file:` URL (jar entry, network, missing) — we only fingerprint disk-backed user classes
+     * since those are the ones that should change across save → recompile cycles.
+     *
+     * The SHA is the first 6 bytes of SHA-256 hex (12 chars) — enough to disambiguate consecutive
+     * recompiles in a save loop without bloating each log line.
+     */
+    fun classFileFingerprint(loader: ClassLoader, className: String): String? {
+      val resourceName = className.replace('.', '/') + ".class"
+      val url = loader.getResource(resourceName) ?: return null
+      if (url.protocol != "file") return null
+      val file =
+        try {
+          java.io.File(url.toURI())
+        } catch (_: Throwable) {
+          return null
+        }
+      if (!file.exists()) return null
+      val mtime = java.time.Instant.ofEpochMilli(file.lastModified()).toString()
+      return "path=${file.absolutePath} mtime=$mtime size=${file.length()} sha=${sha256Short(file)}"
+    }
+
+    private fun sha256Short(file: java.io.File): String {
+      val md = java.security.MessageDigest.getInstance("SHA-256")
+      try {
+        file.inputStream().use { input ->
+          val buffer = ByteArray(8192)
+          while (true) {
+            val read = input.read(buffer)
+            if (read <= 0) break
+            md.update(buffer, 0, read)
+          }
+        }
+      } catch (_: Throwable) {
+        return "unreadable"
+      }
+      return md.digest().take(6).joinToString("") { "%02x".format(it) }
     }
   }
 }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolderTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolderTest.kt
@@ -88,6 +88,49 @@ class UserClassLoaderHolderTest {
   }
 
   @Test
+  fun `urlsFromSysprop sorts directories before jars`() {
+    // AGP's variant classpath lists the runtime-bundled jar before the kotlinc output directory
+    // for the same set of user classes; the daemon must consult the directory first because that's
+    // where compileDebugKotlin writes fresh bytes on every save. URLClassLoader.findClass walks
+    // declaration order and returns the first match, so this ordering is load-bearing for the
+    // edit → render save loop. Regression marker for the "first edit updates, subsequent edits
+    // stick" symptom diagnosed via the user-class-dirs log line in DaemonMain.
+    val parent =
+      Files.createTempDirectory("user-classes-order-").toFile().also { it.deleteOnExit() }
+    val jarFirst = File(parent, "runtime_app_classes_jar.jar").apply { writeBytes(byteArrayOf()) }
+    val dirSecond = File(parent, "compileDebugKotlin-classes").apply { mkdirs() }
+    val jarThird = File(parent, "R.jar").apply { writeBytes(byteArrayOf()) }
+    val dirFourth = File(parent, "kotlin-classes").apply { mkdirs() }
+    val raw =
+      listOf(
+          jarFirst.absolutePath,
+          dirSecond.absolutePath,
+          jarThird.absolutePath,
+          dirFourth.absolutePath,
+        )
+        .joinToString(File.pathSeparator)
+    val previous = System.getProperty(UserClassLoaderHolder.USER_CLASS_DIRS_PROP)
+    System.setProperty(UserClassLoaderHolder.USER_CLASS_DIRS_PROP, raw)
+    try {
+      val urls = UserClassLoaderHolder.urlsFromSysprop()
+      assertEquals(4, urls.size)
+      // First two are directories; relative order preserved (dirSecond → dirFourth).
+      assertTrue("urls[0] should be a directory: ${urls[0]}", urls[0].path.endsWith("/"))
+      assertTrue("urls[1] should be a directory: ${urls[1]}", urls[1].path.endsWith("/"))
+      assertTrue(urls[0].path.contains(dirSecond.name))
+      assertTrue(urls[1].path.contains(dirFourth.name))
+      // Last two are jars; relative order preserved (jarFirst → jarThird).
+      assertTrue("urls[2] should be a jar: ${urls[2]}", urls[2].path.endsWith(".jar"))
+      assertTrue("urls[3] should be a jar: ${urls[3]}", urls[3].path.endsWith(".jar"))
+      assertTrue(urls[2].path.contains(jarFirst.name))
+      assertTrue(urls[3].path.contains(jarThird.name))
+    } finally {
+      if (previous != null) System.setProperty(UserClassLoaderHolder.USER_CLASS_DIRS_PROP, previous)
+      else System.clearProperty(UserClassLoaderHolder.USER_CLASS_DIRS_PROP)
+    }
+  }
+
+  @Test
   fun `soak loop GCs recycled loaders within bounded window`() {
     // CLASSLOADER.md § Risks 1: assert that recycled loaders collect within 2 GCs (roughly — see
     // liveLoaderCount which forces 2 system.gc() calls). After 50 swaps with no work between

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -96,6 +96,18 @@ class RenderEngine(
     val clazz = Class.forName(spec.className, true, classLoader)
     val composableMethod: ComposableMethod = clazz.getDeclaredComposableMethod(spec.functionName)
 
+    // Self-diagnostic — surfaces in the VS Code extension's output channel as `[daemon stderr] …`.
+    // Pairs with `[classloader] swap requested` / `allocate child loader` lines from
+    // [UserClassLoaderHolder]. If `classFile` doesn't advance across saves the daemon is
+    // re-rendering against bytecode that wasn't actually recompiled.
+    val fingerprint =
+      UserClassLoaderHolder.classFileFingerprint(classLoader, spec.className)
+        ?: "fingerprint unavailable (class not on a file: URL)"
+    System.err.println(
+      "compose-ai-daemon: [render] ${spec.className}#${spec.functionName} " +
+        "loaderId=${System.identityHashCode(classLoader).toString(16)} classFile=$fingerprint"
+    )
+
     // Install the child classloader as the context classloader for the duration of the render
     // dispatch. Compose's reflection paths (notably PreviewParameter providers — see
     // CLASSLOADER.md § Risks 2) consult the context classloader; without this install they would

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3_5RecompileSaveLoopRealModeTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3_5RecompileSaveLoopRealModeTest.kt
@@ -106,24 +106,30 @@ class S3_5RecompileSaveLoopRealModeTest {
             "the testFixtures dependency must expose it"
         )
 
-    val v1Bytes =
-      cloneAsMutableSquare(
-        sourceBytes,
-        sourceInternal = sourceInternal,
-        targetInternal = mutableInternalName,
-        sourceMethod = "RedSquare",
-        targetMethod = "MutableSquare",
-      )
-    val v2Bytes =
-      cloneAsMutableSquare(
-        sourceBytes,
-        sourceInternal = sourceInternal,
-        targetInternal = mutableInternalName,
-        sourceMethod = "BlueSquare",
-        targetMethod = "MutableSquare",
-      )
-
-    mutableClassPath.writeBytes(v1Bytes)
+    // Multi-iteration cycle exposes the "first edit updates, subsequent edits stick" failure mode
+    // — a single recompile pass (red → blue) was sufficient to verify the disposable child loader
+    // swap in B2.0, but it can't see a regression where only the *first* swap takes hold and a
+    // stale loader / cached `Class<?>` survives subsequent swaps. Cycling red → blue → red → blue
+    // across four versions forces the swap path to work repeatedly; the assertion at every step
+    // catches a failure the moment it happens rather than letting a hidden cache mask it.
+    val versions: List<Pair<String, ByteArray>> =
+      listOf(
+          "RedSquare" to "RedSquare",
+          "BlueSquare" to "BlueSquare",
+          "RedSquare" to "RedSquare",
+          "BlueSquare" to "BlueSquare",
+        )
+        .map { (label, sourceMethod) ->
+          label to
+            cloneAsMutableSquare(
+              sourceBytes,
+              sourceInternal = sourceInternal,
+              targetInternal = mutableInternalName,
+              sourceMethod = sourceMethod,
+              targetMethod = "MutableSquare",
+            )
+        }
+    mutableClassPath.writeBytes(versions[0].second)
 
     val rendersDir =
       File("build/daemon-harness/renders/s3.5").apply {
@@ -187,71 +193,87 @@ class S3_5RecompileSaveLoopRealModeTest {
         }
       }
 
-    val firstStart = System.currentTimeMillis()
     val client = HarnessClient.start(launcher)
+    val recorder = LatencyRecorder(csvFile = HarnessTestSupport.LATENCY_CSV)
+    val perIterationBytes = mutableListOf<ByteArray>()
     try {
       assertEquals(1, client.initialize().protocolVersion)
       client.sendInitialized()
 
-      // 1. First render — MutableSquare cloned from RedSquare. Expect red.
-      val rn1 = client.renderNow(previews = listOf("mutable-square"), tier = RenderTier.FAST)
-      assertEquals(listOf("mutable-square"), rn1.queued)
-      val finished1 = client.pollRenderFinishedFor("mutable-square", timeout = 120.seconds)
-      val firstFinishedAt = System.currentTimeMillis()
-      val redPath =
-        finished1["params"]?.jsonObject?.get("pngPath")?.jsonPrimitive?.contentOrNull
-          ?: error("renderFinished missing pngPath: $finished1")
-      val redBytes = File(redPath).readBytes()
+      versions.forEachIndexed { index, (label, bytes) ->
+        // First iteration uses the bytes already written to disk + the daemon's initial loader; no
+        // fileChanged needed. Subsequent iterations are the post-recompile save-loop step we want
+        // to verify: overwrite the .class on disk → notify the daemon → next render must reflect
+        // the new bytecode.
+        if (index > 0) {
+          mutableClassPath.writeBytes(bytes)
+          client.fileChanged(path = mutableClassPath.absolutePath, kind = FileKind.SOURCE)
+        }
 
-      // 2. Recompile — overwrite MutableSquare.class with BlueSquare bytes. Notify the daemon.
-      mutableClassPath.writeBytes(v2Bytes)
-      client.fileChanged(path = mutableClassPath.absolutePath, kind = FileKind.SOURCE)
+        val iterationStart = System.currentTimeMillis()
+        val rn = client.renderNow(previews = listOf("mutable-square"), tier = RenderTier.FAST)
+        assertEquals(listOf("mutable-square"), rn.queued)
+        val finished = client.pollRenderFinishedFor("mutable-square", timeout = 120.seconds)
+        val iterationFinishedAt = System.currentTimeMillis()
+        val pngPath =
+          finished["params"]?.jsonObject?.get("pngPath")?.jsonPrimitive?.contentOrNull
+            ?: error("renderFinished missing pngPath: $finished")
+        val rendered = File(pngPath).readBytes()
+        perIterationBytes += rendered
 
-      // 3. Second render — MutableSquare cloned from BlueSquare. Expect blue.
-      val secondStart = System.currentTimeMillis()
-      val rn2 = client.renderNow(previews = listOf("mutable-square"), tier = RenderTier.FAST)
-      assertEquals(listOf("mutable-square"), rn2.queued)
-      val finished2 = client.pollRenderFinishedFor("mutable-square", timeout = 120.seconds)
-      val secondFinishedAt = System.currentTimeMillis()
-      val bluePath =
-        finished2["params"]?.jsonObject?.get("pngPath")?.jsonPrimitive?.contentOrNull
-          ?: error("renderFinished missing pngPath: $finished2")
-      val blueBytes = File(bluePath).readBytes()
+        // Same-version iterations must produce byte-identical PNGs (renderer is deterministic
+        // when the bytecode is the same); different-version iterations must differ. The pattern
+        // [Red, Blue, Red, Blue] gives us both shapes — iterations 0/2 must match, 1/3 must
+        // match, but 0 vs 1 and 2 vs 3 must differ. The "stuck after first edit" bug shows up as
+        // index 2 matching index 1 (still blue) instead of index 0 (red again).
+        for (priorIndex in 0 until index) {
+          val priorBytes = perIterationBytes[priorIndex]
+          val priorLabel = versions[priorIndex].first
+          val sameLabel = priorLabel == label
+          val diff = PixelDiff.compare(actual = rendered, expected = priorBytes)
+          if (sameLabel && !diff.ok) {
+            PixelDiff.writeDiffArtefacts(
+              actual = rendered,
+              expected = priorBytes,
+              outDir = File(reportsDir, "iter-$index-vs-$priorIndex"),
+            )
+            throw AssertionError(
+              "S3.5 [$target]: iteration $index ($label) produced different bytes than " +
+                "iteration $priorIndex ($priorLabel) — same bytecode should render identical PNGs. " +
+                "${diff.message}. Stderr=\n${client.dumpStderr()}"
+            )
+          }
+          if (!sameLabel && diff.ok) {
+            PixelDiff.writeDiffArtefacts(
+              actual = rendered,
+              expected = priorBytes,
+              outDir = File(reportsDir, "iter-$index-vs-$priorIndex"),
+            )
+            throw AssertionError(
+              "S3.5 [$target]: iteration $index ($label) produced identical bytes to " +
+                "iteration $priorIndex ($priorLabel) — daemon served stale user-classloader " +
+                "bytecode after a recompile-and-fileChanged. " +
+                "${if (priorIndex == 0) "B2.0's disposable child loader is not swapping at all." else "Disposable child loader works for the first edit but not subsequent edits — the failure mode this multi-iteration cycle was added to expose."} " +
+                "Stderr=\n${client.dumpStderr()}"
+            )
+          }
+        }
 
-      // 4. The load-bearing assertion: red and blue must differ. Pre-B2.0 the second render
-      //    returned the cached red bytecode and the bytes were identical — exactly the staleness
-      //    failure mode B2.0 fixes.
-      val diff = PixelDiff.compare(actual = redBytes, expected = blueBytes)
-      if (diff.ok) {
-        PixelDiff.writeDiffArtefacts(actual = redBytes, expected = blueBytes, outDir = reportsDir)
-        throw AssertionError(
-          "S3.5 [$target]: post-fileChanged render produced identical bytes — daemon served stale " +
-            "user-classloader bytecode. B2.0's disposable child loader is not swapping. " +
-            "Stderr=\n${client.dumpStderr()}"
+        recorder.record(
+          scenario = "s3.5-real-$target",
+          preview = "mutable-square@iter$index-$label",
+          actualMs = iterationFinishedAt - iterationStart,
+          notes = "S3.5 real $target: iteration $index ($label)",
+        )
+        assertTrue(
+          "S3.5 iteration $index render took unreasonably long (>120s); B2.0 child-loader swap may be stalling.",
+          iterationFinishedAt - iterationStart < 120_000,
         )
       }
 
-      // 5. Clean shutdown.
+      // Clean shutdown.
       val exitCode = client.shutdownAndExit(timeout = 30.seconds)
       assertEquals("Daemon must exit cleanly. Stderr=\n${client.dumpStderr()}", 0, exitCode)
-
-      val recorder = LatencyRecorder(csvFile = HarnessTestSupport.LATENCY_CSV)
-      recorder.record(
-        scenario = "s3.5-real-$target",
-        preview = "mutable-square@v1",
-        actualMs = firstFinishedAt - firstStart,
-        notes = "S3.5 real $target: pre-recompile render (red)",
-      )
-      recorder.record(
-        scenario = "s3.5-real-$target",
-        preview = "mutable-square@v2",
-        actualMs = secondFinishedAt - secondStart,
-        notes = "S3.5 real $target: post-recompile render (blue, after fileChanged swap)",
-      )
-      assertTrue(
-        "S3.5 second render took unreasonably long (>120s); B2.0 child-loader swap may be stalling.",
-        secondFinishedAt - secondStart < 120_000,
-      )
     } catch (t: Throwable) {
       System.err.println(
         "S3_5RecompileSaveLoopRealModeTest [$target] failed; daemon stderr:\n${client.dumpStderr()}"

--- a/scripts/kill-daemon.sh
+++ b/scripts/kill-daemon.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Kill any running preview daemon JVM.
+#
+# Companion to scripts/run-daemon.sh — the inverse operation. Useful when
+# iterating on daemon code: the running JVM keeps serving renders from the
+# JAR it was spawned with even after a `./gradlew :daemon:android:assemble`,
+# so a manual kill is required to pick up the rebuilt JAR. The VS Code
+# extension also exposes `Compose Preview: Restart Preview Daemon` for the
+# same purpose; this script is the equivalent for terminal-driven workflows.
+#
+# Usage:
+#   scripts/kill-daemon.sh           # SIGTERM (graceful — shutdown handlers run)
+#   scripts/kill-daemon.sh --force   # SIGKILL (only if SIGTERM is ignored)
+#   scripts/kill-daemon.sh --list    # list matching processes, kill nothing
+#
+# Pattern matches the daemon's main class — `ee.schimke.composeai.daemon.DaemonMain`
+# — which is unique enough to avoid clipping the Gradle daemon, the Kotlin daemon,
+# or anything else on PATH.
+
+set -euo pipefail
+
+PATTERN='ee\.schimke\.composeai\.daemon\.DaemonMain'
+
+case "${1:-}" in
+  --list)
+    pgrep -fl "$PATTERN" || {
+      echo "no compose-ai-daemon process matches $PATTERN" >&2
+      exit 0
+    }
+    ;;
+  --force)
+    if pgrep -f "$PATTERN" > /dev/null; then
+      pkill -9 -f "$PATTERN"
+      echo "SIGKILL sent" >&2
+    else
+      echo "no compose-ai-daemon process to kill" >&2
+    fi
+    ;;
+  ""|--help|-h)
+    if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+      sed -n '3,21p' "$0"
+      exit 0
+    fi
+    if pgrep -f "$PATTERN" > /dev/null; then
+      pkill -f "$PATTERN"
+      echo "SIGTERM sent — JsonRpcServer shutdown handlers will run before exit" >&2
+    else
+      echo "no compose-ai-daemon process to kill" >&2
+    fi
+    ;;
+  *)
+    echo "unknown argument: $1" >&2
+    echo "usage: $0 [--list|--force|--help]" >&2
+    exit 2
+    ;;
+esac

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -92,6 +92,11 @@
                 "command": "composePreview.runDoctor",
                 "title": "Run Doctor (refresh compatibility diagnostics)",
                 "category": "Compose Preview"
+            },
+            {
+                "command": "composePreview.restartDaemon",
+                "title": "Restart Preview Daemon (pick up rebuilt JAR)",
+                "category": "Compose Preview"
             }
         ],
         "configuration": {

--- a/vscode-extension/src/daemon/daemonGate.ts
+++ b/vscode-extension/src/daemon/daemonGate.ts
@@ -152,6 +152,39 @@ export class DaemonGate {
             try { entry.spawned.process.kill('SIGTERM'); } catch { /* ignore */ }
         }));
     }
+
+    /**
+     * Cleanly shuts down every running daemon JVM and clears the registry, so
+     * the next `getOrSpawn` reads `daemon-launch.json` afresh and spawns a
+     * brand-new JVM. Returns the moduleIds that were running so the caller can
+     * report what was restarted.
+     *
+     * The same protocol as [dispose] (shutdown → exit → SIGTERM) but the gate
+     * stays usable afterwards. This is the manual escape hatch the user
+     * triggers via `composePreview.restartDaemon` after rebuilding the daemon
+     * JAR — without it the running JVM keeps serving renders from the JAR it
+     * was spawned with even after the on-disk JAR has been replaced.
+     */
+    async restartAll(): Promise<string[]> {
+        if (this.disposed) { return []; }
+        const entries = [...this.daemons.entries()];
+        this.daemons.clear();
+        await Promise.all(entries.map(async ([_moduleId, entry]) => {
+            try {
+                if (!entry.client.isClosed()) {
+                    await Promise.race([
+                        entry.client.shutdown(),
+                        new Promise((resolve) => setTimeout(resolve, 2000)),
+                    ]);
+                    entry.client.exit();
+                }
+            } catch {
+                /* best-effort shutdown */
+            }
+            try { entry.spawned.process.kill('SIGTERM'); } catch { /* ignore */ }
+        }));
+        return entries.map(([moduleId]) => moduleId);
+    }
 }
 
 interface ManagedDaemon {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -379,6 +379,44 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
                 panel.postMessage({ command: 'setFunctionFilter', functionName });
             },
         ),
+        // The daemon JVM caches the renderer JAR + sandbox state across every
+        // render in a session — that's the whole point of the daemon. The
+        // downside is that rebuilding the daemon (`./gradlew :daemon:android:…`
+        // or any change to the renderer/host code) doesn't take effect until
+        // the running JVM dies. Idle timeout is 5s, but a user actively saving
+        // never trips it. This command is the explicit escape hatch: shut
+        // down every running daemon, clear the bootstrapped-modules memo, and
+        // re-run the bootstrap task so the next save picks up the new JAR.
+        vscode.commands.registerCommand('composePreview.restartDaemon', async () => {
+            if (!daemonGate || !daemonScheduler) {
+                vscode.window.showInformationMessage(
+                    'Compose Preview: daemon gate not initialised yet.',
+                );
+                return;
+            }
+            const restarted = await daemonGate.restartAll();
+            // Clear the per-session bootstrap memo so the next save re-runs
+            // `composePreviewDaemonStart`, which writes a fresh
+            // `daemon-launch.json` pointing at the rebuilt JAR. Without
+            // clearing this the spawn would skip the bootstrap and the
+            // descriptor on disk could still reference the previous build.
+            daemonBootstrappedModules.clear();
+            // Hide the status-bar item — its text references a specific module
+            // that's no longer relevant; the next warmModule call will repopulate
+            // it through its progress callback.
+            daemonStatusItem?.hide();
+            outputChannel.appendLine(
+                `[daemon] restartDaemon: shut down ${restarted.length} running daemon(s)` +
+                (restarted.length > 0 ? ` [${restarted.join(', ')}]` : '') +
+                ` — next save will respawn from the on-disk JAR`,
+            );
+            vscode.window.showInformationMessage(
+                restarted.length === 0
+                    ? 'Compose Preview: no daemon was running.'
+                    : `Compose Preview: restarted ${restarted.length} daemon(s). ` +
+                      'Next save will respawn from the on-disk JAR.',
+            );
+        }),
     );
 
     const detectLog = (msg: string) => {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -169,6 +169,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         if (logFilter.shouldEmitInformational(line)) { outputChannel.appendLine(line); }
     };
 
+    // Startup fingerprint — answers "is the build I think I installed
+    // actually loaded?" when triaging a save-loop bug. The extension version
+    // comes from package.json (bumped by release-please); the path locates
+    // the loaded module on disk so an old install lingering from a prior
+    // session is obvious.
+    const extId = 'yuri-schimke.compose-preview';
+    const ext = vscode.extensions.getExtension(extId);
+    const extVersion = ext?.packageJSON?.version ?? 'unknown';
+    const extPath = ext?.extensionPath ?? '<unresolved>';
+    outputChannel.appendLine(
+        `[startup] compose-preview v${extVersion} loaded from ${extPath}`,
+    );
+
     const isTestMode = process.env.COMPOSE_PREVIEW_TEST_MODE === '1';
 
     // vscjava.vscode-gradle is declared as an extensionDependency, so it's
@@ -564,7 +577,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
                 }, logFilter);
             },
             triggerRefresh(filePath: string, force = false, tier: 'fast' | 'full' = 'full'): Promise<void> {
-                return refresh(force, filePath, tier);
+                return refresh(force, filePath, tier).then(() => {});
             },
             getPostedMessages(): unknown[] {
                 return [...postedMessageLog];
@@ -853,7 +866,24 @@ async function runRefreshExclusive(filePath: string): Promise<void> {
             // daemon's child URLClassLoader reads. Notifying the daemon
             // before the recompile would race the swap against stale
             // bytecode and the panel would flicker without updating.
-            await refresh(false, filePath);
+            const outcome = await refresh(false, filePath);
+            if (outcome !== 'completed') {
+                // Discover didn't finish to completion. Three cases, all
+                // equally bad for daemon notify:
+                //   - 'cancelled': a newer save aborted us mid-flight, so
+                //     compileKotlin was killed too — `.class` files are
+                //     half-written. The newer save's runRefreshExclusive
+                //     will own the daemon notify.
+                //   - 'failed': Gradle failed (build error, missing jlink).
+                //     `.class` files weren't refreshed; stale bytecode.
+                //   - 'no-module': nothing happened.
+                // In all three, sending fileChanged + renderNow now would
+                // re-render against stale bytes and produce the
+                // flicker-without-update symptom — exactly the bug this
+                // ordering fix was meant to close.
+                logLine(`daemon: skipped notify (refresh outcome=${outcome})`);
+                return;
+            }
             const accepted = await notifyDaemonOfSave(filePath);
             if (accepted) {
                 return;
@@ -910,12 +940,33 @@ const fastTierModules = new Set<string>();
  *                     overrides to `'fast'` (see {@link runRefreshExclusive}).
  *                     Ignored when `forceRender` is false (discover-only).
  */
+/**
+ * Outcome of a {@link refresh} call. Callers (notably {@link runRefreshExclusive})
+ * use this to decide whether to take follow-up steps that depend on the
+ * Gradle work having actually run to completion — e.g. notifying the daemon
+ * after a discover, which only makes sense when `compileKotlin` (an
+ * upstream of `discoverPreviews`) finished and the on-disk `.class` files
+ * are fresh.
+ *
+ * - `'completed'` — the requested Gradle task ran end-to-end and the panel
+ *   is up to date.
+ * - `'cancelled'` — a newer refresh aborted this one (or Gradle reported
+ *   `CANCELLED`). Whoever superseded us owns the panel state from here;
+ *   no follow-up should run.
+ * - `'no-module'` — no preview module resolved for the requested file
+ *   (file outside the workspace, build script, etc.). Panel was reset to
+ *   the empty state; no Gradle work happened.
+ * - `'failed'` — Gradle threw a non-cancellation error (build failure,
+ *   missing `jlink`, etc.). The panel surfaces the error; no follow-up.
+ */
+type RefreshOutcome = 'completed' | 'cancelled' | 'no-module' | 'failed';
+
 async function refresh(
     forceRender: boolean,
     forFilePath?: string,
     tier: 'fast' | 'full' = 'full',
-) {
-    if (!gradleService || !panel) { return; }
+): Promise<RefreshOutcome> {
+    if (!gradleService || !panel) { return 'no-module'; }
 
     // Cancel any in-flight refresh
     pendingRefresh?.abort();
@@ -944,7 +995,7 @@ async function refresh(
         if (activeFile && isPreviewSourceFile(activeFile)) {
             maybeShowSetupPrompt(activeFile);
         }
-        return;
+        return 'no-module';
     }
     logLine(`start forceRender=${forceRender} file=${path.basename(activeFile)} (${scopeSource}) module=${module}`);
 
@@ -999,7 +1050,7 @@ async function refresh(
         previewModuleMap.clear();
 
         for (const mod of modules) {
-            if (abort.signal.aborted) { return; }
+            if (abort.signal.aborted) { return 'cancelled'; }
 
             const manifest = forceRender
                 ? await gradleService.renderPreviews(mod, tier)
@@ -1042,7 +1093,7 @@ async function refresh(
             }
         }
 
-        if (abort.signal.aborted) { return; }
+        if (abort.signal.aborted) { return 'cancelled'; }
 
         if (allPreviews.length === 0) {
             // Module has no previews at all. Wipe any stale cards so the
@@ -1051,7 +1102,7 @@ async function refresh(
             panel.postMessage({ command: 'showMessage', text: 'No @Preview functions found in this module' });
             hasPreviewsLoaded = false;
             logLine('done — module has no previews');
-            return;
+            return 'completed';
         }
 
         // Scope strictly to the active file. If the file has no @Preview
@@ -1071,7 +1122,7 @@ async function refresh(
             });
             hasPreviewsLoaded = false;
             logLine(`done — 0 visible previews in ${path.basename(activeFile)}, module has ${otherFiles}`);
-            return;
+            return 'completed';
         }
 
         // A preview is "heavyStale" when this module's most recent render was
@@ -1157,14 +1208,15 @@ async function refresh(
         // showMessage would also clobber legitimate extension-set messages
         // (filter empty notice, build errors), which was the original
         // "populate then go blank" regression.
+        return abort.signal.aborted ? 'cancelled' : 'completed';
     } catch (err: unknown) {
-        if (abort.signal.aborted) { return; }
+        if (abort.signal.aborted) { return 'cancelled'; }
         // Cancellation = a follow-up refresh superseded this one. The new
         // refresh owns the panel state from here; surfacing a "FAILED" toast
         // would be misleading and noisy.
         if (err instanceof TaskCancelledError) {
             logLine(`cancelled — superseded by a newer refresh`);
-            return;
+            return 'cancelled';
         }
         if (err instanceof JdkImageError) {
             logLine(`FAILED (jlink missing): ${err.finding.jlinkPath}`);
@@ -1173,7 +1225,7 @@ async function refresh(
                 text: 'Gradle is running on a JRE without jlink. Configure a full JDK to render previews.',
             });
             showJdkImageRemediation(err);
-            return;
+            return 'failed';
         }
         const message = err instanceof Error ? err.message.slice(0, 300) : 'Build failed';
         logLine(`FAILED: ${message}`);
@@ -1181,6 +1233,7 @@ async function refresh(
             command: 'showMessage',
             text: message,
         });
+        return 'failed';
     } finally {
         if (pendingRefresh === abort) { pendingRefresh = null; }
     }


### PR DESCRIPTION
Rebased onto main (after #342, #341 landed and several `vscode` PRs since). Carries the four commits that didn't make it into the original merge.

## Commits

### `0c848d5` — close cancellation hole + self-diagnose stale renders
The earlier ordering fix (#342) had a hole: `refresh()` swallowed `TaskCancelledError` and returned `void`, so a superseded discover (compileKotlin cancelled mid-flight, `.class` files half-written) still fell through to `notifyDaemonOfSave` and the daemon rendered against stale bytecode.

Four pieces:
1. **Cancellation gate.** `refresh()` returns a `RefreshOutcome` (`completed` / `cancelled` / `no-module` / `failed`); `runRefreshExclusive` skips the daemon notify on anything other than `completed` so the superseding save's own discover-then-notify owns the loop.
2. **Daemon stderr fingerprints.** `UserClassLoaderHolder.swap()` and `allocateLocked()` emit one stderr line each. `RenderEngine` (both backends) emits a per-render `[render] <fqn> classFile=path=… mtime=… size=… sha=…` line. Three failure modes become scannable from the **Compose Preview** output channel: mtime never advances → kotlinc isn't recompiling; mtime advances but sha repeats → comment-only edit; mtime/sha advance but panel is stale → bug is past the classloader path.
3. **Extension startup banner.** `[startup] compose-preview vX.Y.Z loaded from <path>` on activate so a stale install can be ruled out at a glance.
4. **S3.5 multi-iteration cycle (Red → Blue → Red → Blue).** The single Red → Blue swap couldn't see a regression where only the first swap takes hold; every iteration now compares against every prior one.

### `fdb1cda` — `composePreview.restartDaemon` command
Rebuilding the daemon JAR doesn't take effect until the running JVM dies; idle timeout is 5s but a user actively saving never trips it. Tears down every running daemon (clean shutdown → exit → SIGTERM fallback), clears the per-session bootstrap memo, hides the daemon status-bar item.

### `7c3c952` — order user-class directories before bundled jars
Diagnosed from the `UserClassLoaderHolder active (urls=…)` line in the daemon's spawn log. AGP's variant classpath surfaces both `built_in_kotlinc/<variant>/.../classes/` (rewritten by every save's `compileDebugKotlin`) and `runtime_app_classes_jar/<variant>/.../classes.jar` (rewritten only by `bundleDebugClassesToRuntimeJar`, which is *not* on the `discoverPreviews` task graph). `URLClassLoader.findClass` walks declaration order; AGP's natural order has the runtime jar first, so the daemon resolves every user class out of the stale jar and never reads the freshly-recompiled directory — this is the "first edit updates, subsequent edits stick" symptom.

`urlsFromSysprop` now stable-sorts directories before jars; the kotlinc output wins for any class it carries, bundled jars stay as a fallback for kapt/ksp generated classes and `R.jar`.

### `64ff84d` — `scripts/kill-daemon.sh`
Companion to `scripts/run-daemon.sh` for terminal-driven daemon iteration. Default SIGTERM (shutdown handlers run); `--force` for SIGKILL; `--list` to show matching processes. Pattern is the unique main class FQN — won't clip the Gradle daemon or the Kotlin daemon.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 217 passing
- [x] `./gradlew :daemon:core:test --tests UserClassLoaderHolderTest` passes (5/5, including the new `urlsFromSysprop sorts directories before jars`)
- [ ] Manual: rebuild daemon (`./gradlew :daemon:android:assemble :samples:wear:composePreviewDaemonStart`), restart via the new command, save Previews.kt twice — both saves should update the panel and the new `[classloader] swap`, `[classloader] allocate`, `[render] classFile=…` stderr lines should show monotonically advancing mtime/sha.
- [ ] Manual: `./gradlew :daemon:harness:test --tests S3_5RecompileSaveLoopRealModeTest -Pharness.host=real -Ptarget=desktop` passes (4 iterations).

---
_Generated by [Claude Code](https://claude.ai/code/session_018AS96ABywGPit3rWVRr3q3)_