### PR TITLE
feat(vscode): parse kotlinc errors from Gradle output

### DIFF
--- a/vscode-extension/src/compileErrors.ts
+++ b/vscode-extension/src/compileErrors.ts
@@ -46,6 +46,13 @@ export interface DiagnosticLike {
 export interface CompileError {
     /** Display label — basename of the file. */
     file: string;
+    /**
+     * Absolute path used by the click-to-open handler. Each error carries
+     * its own path so cross-file kotlinc failures (an error in `Theme.kt`
+     * surfaced while editing `Previews.kt`) deep-link to the right file
+     * rather than the panel's currently-scoped one.
+     */
+    path: string;
     /** 1-based line for human display. The webview opens via this number. */
     line: number;
     /** 1-based column. */
@@ -86,6 +93,7 @@ export function extractCompileErrors(
         if (d.source && !TRUSTED_SOURCES.has(d.source)) { continue; }
         errors.push({
             file: fileLabel,
+            path: filePath,
             // VS Code's range is 0-indexed. Convert to 1-based for display
             // and consistency with `kotlinc -e: file://…:42:5` output.
             line: d.range.start.line + 1,

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { GradleService, GradleApi, TaskCancelledError } from './gradleService';
 import { JdkImageError } from './jdkImageErrorDetector';
+import { KotlinCompileError } from './kotlinCompileErrorDetector';
 import { findPluginAppliedAncestor } from './pluginDetection';
 import { PreviewPanel } from './previewPanel';
 import { PreviewRegistry } from './previewRegistry';
@@ -1102,7 +1103,6 @@ async function refresh(
         panel.postMessage({
             command: 'setCompileErrors',
             errors: compileErrors,
-            sourceFile: activeFile,
         });
         // No build is starting — make sure no stale progress bar lingers
         // from a prior in-flight refresh that was just cancelled by the
@@ -1379,6 +1379,20 @@ async function refresh(
             });
             panel.postMessage({ command: 'clearProgress' });
             showJdkImageRemediation(err);
+            return 'failed';
+        }
+        if (err instanceof KotlinCompileError) {
+            logLine(`FAILED — ${err.errors.length} Kotlin compile error(s) in ${err.task}`);
+            // Reuse the same banner the LSP gate populates — the user
+            // sees identical UX whether the gate fired or Gradle's
+            // compile actually failed. Cards stay visible and dimmed so
+            // the previous successful render is still on screen as a
+            // reference while the error gets fixed.
+            panel.postMessage({
+                command: 'setCompileErrors',
+                errors: err.errors,
+            });
+            panel.postMessage({ command: 'clearProgress' });
             return 'failed';
         }
         const message = err instanceof Error ? err.message.slice(0, 300) : 'Build failed';

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import { AccessibilityFinding, AccessibilityReport, Capture, DoctorModuleReport, PreviewManifest, ResourceManifest } from './types';
 import { appliesPlugin } from './pluginDetection';
 import { JdkImageError, JdkImageErrorDetector } from './jdkImageErrorDetector';
+import { KotlinCompileError, KotlinCompileErrorDetector } from './kotlinCompileErrorDetector';
 import { LogFilter } from './logFilter';
 import { BuildProgressTracker, PhaseDurations, ProgressState } from './buildProgress';
 
@@ -523,6 +524,11 @@ export class GradleService {
         if (this.logFilter.shouldEmitInformational(startLine)) { this.logger.appendLine(startLine); }
 
         const detector = new JdkImageErrorDetector();
+        // Parse `e:` lines from the Kotlin compiler so the panel banner
+        // can show structured errors when a build fails. Catches the
+        // cross-file gap that the LSP-driven gate (compileErrors.ts)
+        // misses by design — that gate only inspects the active file.
+        const kotlinDetector = new KotlinCompileErrorDetector();
         // Progress tracker is wired only when the caller provided one of the
         // hooks — keeps the no-op (test, doctor, applied-bootstrap) callers
         // free of timer overhead.
@@ -559,6 +565,7 @@ export class GradleService {
                     // normal level (the noisy lines are exactly the ones that
                     // contain the diagnostic).
                     detector.consume(decoded);
+                    kotlinDetector.consume(decoded);
                     tracker?.consume(decoded);
                     const filtered = this.logFilter.filterGradleChunk(decoded);
                     if (filtered.length > 0) { this.logger.append(filtered); }
@@ -585,9 +592,14 @@ export class GradleService {
                 }
                 this.logger.appendLine(`> ${task} FAILED: ${message}`);
                 detector.end();
+                kotlinDetector.end();
                 const finding = detector.getFinding();
                 if (finding) {
                     throw new JdkImageError(finding, task);
+                }
+                const kotlinErrors = kotlinDetector.getErrors();
+                if (kotlinErrors.length > 0) {
+                    throw new KotlinCompileError(kotlinErrors, task);
                 }
                 throw new Error(`Gradle task ${task} failed. See Output > Compose Preview.`);
             },

--- a/vscode-extension/src/kotlinCompileErrorDetector.ts
+++ b/vscode-extension/src/kotlinCompileErrorDetector.ts
@@ -1,0 +1,131 @@
+/**
+ * Streaming detector for Kotlin compiler error lines in Gradle stdout.
+ *
+ * Catches the cross-file and build-script cases that the LSP-driven gate
+ * (compileErrors.ts) misses — the gate only inspects the active file's
+ * diagnostics, so an error in `Theme.kt` while editing `Previews.kt`
+ * sails past it. Gradle then fails at `compileDebugKotlin`; today the
+ * user sees a generic "Build failed. See Output > Compose Preview"
+ * message. This detector parses the same output stream we already
+ * consume for [JdkImageErrorDetector] and surfaces structured errors
+ * that the panel can render in its existing compile-error banner.
+ *
+ * Decision tree mirrors `JdkImageErrorDetector`: feed each `onOutput`
+ * chunk through [consume] (partial lines buffered), call [end] when the
+ * stream finishes, then read [getErrors]. An empty array means "no
+ * Kotlin compile errors were observed" — which is a fine outcome even
+ * for a failed build (e.g. configuration-cache failure, missing
+ * artifact, runtime crash in the test runner).
+ *
+ * Output format we parse, observed across Kotlin 1.9 / 2.0 / 2.1:
+ *
+ *   e: file:///abs/path/Foo.kt:42:5 Unresolved reference: Modfier
+ *   e: file:///abs/path/Foo.kt:42:5: error: Unresolved reference: Modfier
+ *   e: /abs/path/Foo.kt:42:5 Unresolved reference: Modfier
+ *
+ * Warnings (`w:` prefix) are intentionally NOT collected — the panel
+ * banner is for blocking failures only. Warnings still flow through
+ * the user-visible log via the normal logger path.
+ */
+
+import { CompileError } from './compileErrors';
+
+/**
+ * Match `e:` lines emitted by `kotlinc`. The path can be either a
+ * `file://` URL or a bare absolute path; both forms are seen in the
+ * wild depending on Kotlin version + how Gradle pipes the output.
+ *
+ * The capture groups are: 1=path, 2=line, 3=column, 4=message.
+ *
+ * The path matcher is non-greedy so it stops at the line-number colon
+ * — Windows paths with drive letters (`C:\...`) work because the
+ * non-greedy match pairs the path's colons with the regex's `:` only
+ * after we've matched the line/column digits, leaving the drive-letter
+ * `:` inside the path capture.
+ */
+const KOTLIN_ERROR_RE = /^e:\s+(?:file:\/\/)?(.+?):(\d+):(\d+)(?::?\s*(?:error:\s*)?)(.+)$/;
+
+export class KotlinCompileErrorDetector {
+    private buffer = '';
+    private errors: CompileError[] = [];
+    /** Bound the count we hold so a runaway compile (~100s of errors on
+     *  a broken refactor) doesn't grow the array without limit. The
+     *  banner truncates display anyway; capturing more than ~50 helps
+     *  nobody. */
+    private static readonly MAX_ERRORS = 50;
+
+    /**
+     * Accept a chunk of decoded stdout/stderr. Safe to call with partial
+     * lines — they're buffered until a newline arrives. Bounded to 16 KiB
+     * of unflushed buffer so a producer emitting megabytes without
+     * newlines can't grow the buffer without limit.
+     */
+    consume(chunk: string): void {
+        this.buffer += chunk;
+        let nl = this.buffer.indexOf('\n');
+        while (nl !== -1) {
+            const line = this.buffer.slice(0, nl);
+            this.buffer = this.buffer.slice(nl + 1);
+            this.scanLine(line);
+            nl = this.buffer.indexOf('\n');
+        }
+        if (this.buffer.length > 16 * 1024) {
+            this.scanLine(this.buffer);
+            this.buffer = '';
+        }
+    }
+
+    /** Flush the residual buffer. Call once after the stream ends. */
+    end(): void {
+        if (this.buffer.length > 0) {
+            this.scanLine(this.buffer);
+            this.buffer = '';
+        }
+    }
+
+    /** Snapshot of errors observed so far. Returns a copy — caller can
+     *  mutate the result without affecting subsequent parses. */
+    getErrors(): CompileError[] {
+        return this.errors.slice();
+    }
+
+    private scanLine(line: string): void {
+        if (this.errors.length >= KotlinCompileErrorDetector.MAX_ERRORS) { return; }
+        const trimmed = line.replace(/\r$/, ''); // strip CR from CRLF lines
+        const m = KOTLIN_ERROR_RE.exec(trimmed);
+        if (!m) { return; }
+        const path = m[1];
+        const lineNum = parseInt(m[2], 10);
+        const column = parseInt(m[3], 10);
+        const message = m[4].trim();
+        if (!Number.isFinite(lineNum) || !Number.isFinite(column)) { return; }
+        this.errors.push({
+            file: basename(path),
+            path,
+            // kotlinc emits 1-based positions, same as the banner expects.
+            line: lineNum,
+            column,
+            message,
+        });
+    }
+}
+
+/**
+ * Thrown by [GradleService] when a Gradle task fails AND the streaming
+ * Kotlin detector observed at least one structured error. Carries the
+ * parsed errors plus the failing task so the extension can drive the
+ * compile-error banner without re-parsing the log.
+ */
+export class KotlinCompileError extends Error {
+    constructor(readonly errors: CompileError[], readonly task: string) {
+        super(
+            `Gradle task ${task} failed: ${errors.length} Kotlin compile error(s).`,
+        );
+        this.name = 'KotlinCompileError';
+    }
+}
+
+function basename(filePath: string): string {
+    const slash = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+    return slash >= 0 ? filePath.slice(slash + 1) : filePath;
+}

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -218,7 +218,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         const compileErrorsList = document.getElementById('compile-errors-list');
         const compileErrorsTitle = document.getElementById('compile-errors-title');
 
-        function setCompileErrors(errors, sourceFile) {
+        function setCompileErrors(errors) {
             compileErrorsList.innerHTML = '';
             const count = errors.length;
             compileErrorsTitle.textContent = count === 1
@@ -237,10 +237,15 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 msg.textContent = e.message;
                 row.appendChild(loc);
                 row.appendChild(msg);
+                // Each error carries its own absolute path — required so
+                // a cross-file kotlinc error (e.g. broken Theme.kt while
+                // editing Previews.kt) opens the right file rather than
+                // whichever file the panel happened to be scoped to.
+                const path = e.path;
                 row.addEventListener('click', () => {
                     vscode.postMessage({
                         command: 'openCompileError',
-                        sourceFile: sourceFile,
+                        sourceFile: path,
                         line: e.line,
                         column: e.column,
                     });
@@ -1457,7 +1462,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     break;
 
                 case 'setCompileErrors':
-                    setCompileErrors(msg.errors || [], msg.sourceFile || '');
+                    setCompileErrors(msg.errors || []);
                     break;
 
                 case 'clearCompileErrors':

--- a/vscode-extension/src/test/kotlinCompileErrorDetector.test.ts
+++ b/vscode-extension/src/test/kotlinCompileErrorDetector.test.ts
@@ -1,0 +1,205 @@
+import * as assert from 'assert';
+import {
+    KotlinCompileError,
+    KotlinCompileErrorDetector,
+} from '../kotlinCompileErrorDetector';
+
+/**
+ * Fixture mirroring `compileDebugKotlin` output on a typo —
+ * representative of what Gradle pipes through `onOutput` when a Kotlin
+ * compile fails. Mixes the error lines with surrounding Gradle noise
+ * so the detector has to actually anchor on `e:`.
+ */
+const FIXTURE_SINGLE_ERROR = [
+    '> Task :samples:android:compileDebugKotlin',
+    'w: file:///home/user/proj/Other.kt:5:1 Variable \'x\' is never used',
+    'e: file:///home/user/proj/samples/android/src/main/kotlin/Previews.kt:42:5 Unresolved reference: Modfier',
+    '',
+    '> Task :samples:android:compileDebugKotlin FAILED',
+    '',
+    'FAILURE: Build failed with an exception.',
+].join('\n');
+
+/**
+ * Two errors across two files — the cross-file case the LSP-gate misses
+ * by design, since the gate only inspects diagnostics for the active
+ * editor's file. Detector must produce both, each with its own path.
+ */
+const FIXTURE_CROSS_FILE = [
+    '> Task :app:compileDebugKotlin',
+    'e: file:///proj/app/src/main/kotlin/Theme.kt:18:12 Type mismatch: inferred type is String but Int was expected',
+    'e: file:///proj/app/src/main/kotlin/Previews.kt:8:1 Expecting }',
+    '> Task :app:compileDebugKotlin FAILED',
+].join('\n');
+
+/** Kotlin 2.0+ form with an `: error:` segment between the position and message. */
+const FIXTURE_K2_FORMAT =
+    'e: file:///proj/Foo.kt:42:5: error: Unresolved reference: Modfier\n';
+
+/** Bare-path form (no file:// prefix) — seen on some Kotlin versions / shells. */
+const FIXTURE_BARE_PATH =
+    'e: /proj/Foo.kt:42:5 Unresolved reference: Modfier\n';
+
+describe('KotlinCompileErrorDetector', () => {
+    it('returns no errors for an empty stream', () => {
+        const d = new KotlinCompileErrorDetector();
+        d.end();
+        assert.deepStrictEqual(d.getErrors(), []);
+    });
+
+    it('extracts a single error from realistic compile output', () => {
+        const d = new KotlinCompileErrorDetector();
+        d.consume(FIXTURE_SINGLE_ERROR);
+        d.end();
+        const errors = d.getErrors();
+        assert.strictEqual(errors.length, 1, 'should capture one e: line');
+        assert.strictEqual(errors[0].file, 'Previews.kt');
+        assert.strictEqual(
+            errors[0].path,
+            '/home/user/proj/samples/android/src/main/kotlin/Previews.kt',
+        );
+        assert.strictEqual(errors[0].line, 42);
+        assert.strictEqual(errors[0].column, 5);
+        assert.strictEqual(errors[0].message, 'Unresolved reference: Modfier');
+    });
+
+    it('ignores w: warning lines', () => {
+        const d = new KotlinCompileErrorDetector();
+        d.consume(FIXTURE_SINGLE_ERROR);
+        d.end();
+        // The fixture has one warning + one error. Detector should
+        // only surface the error — warnings flow through the log
+        // channel but don't gate the build banner.
+        const messages = d.getErrors().map(e => e.message);
+        assert.ok(!messages.some(m => m.includes('never used')),
+            'warnings must not appear in error list');
+    });
+
+    it('captures cross-file errors with distinct paths', () => {
+        const d = new KotlinCompileErrorDetector();
+        d.consume(FIXTURE_CROSS_FILE);
+        d.end();
+        const errors = d.getErrors();
+        assert.strictEqual(errors.length, 2);
+        const files = errors.map(e => e.file).sort();
+        assert.deepStrictEqual(files, ['Previews.kt', 'Theme.kt']);
+        // Each error must carry its own path so the click handler
+        // routes to the right file.
+        const themePath = errors.find(e => e.file === 'Theme.kt')!.path;
+        const previewsPath = errors.find(e => e.file === 'Previews.kt')!.path;
+        assert.notStrictEqual(themePath, previewsPath);
+        assert.ok(themePath.endsWith('Theme.kt'));
+        assert.ok(previewsPath.endsWith('Previews.kt'));
+    });
+
+    it('parses the Kotlin 2.0+ "error:" segment between position and message', () => {
+        const d = new KotlinCompileErrorDetector();
+        d.consume(FIXTURE_K2_FORMAT);
+        d.end();
+        const errors = d.getErrors();
+        assert.strictEqual(errors.length, 1);
+        assert.strictEqual(errors[0].message, 'Unresolved reference: Modfier');
+        // The "error:" prefix should NOT leak into the message.
+        assert.ok(!errors[0].message.startsWith('error:'));
+    });
+
+    it('parses bare-path form (no file:// prefix)', () => {
+        const d = new KotlinCompileErrorDetector();
+        d.consume(FIXTURE_BARE_PATH);
+        d.end();
+        const errors = d.getErrors();
+        assert.strictEqual(errors.length, 1);
+        assert.strictEqual(errors[0].path, '/proj/Foo.kt');
+        assert.strictEqual(errors[0].line, 42);
+        assert.strictEqual(errors[0].column, 5);
+    });
+
+    it('handles partial chunks split mid-line', () => {
+        const d = new KotlinCompileErrorDetector();
+        // Split a single error across four reads to exercise buffering.
+        d.consume('e: file:///proj/Foo.kt:42:5 ');
+        d.consume('Unresolved');
+        d.consume(' reference: ');
+        d.consume('Modfier\n');
+        d.end();
+        const errors = d.getErrors();
+        assert.strictEqual(errors.length, 1);
+        assert.strictEqual(errors[0].message, 'Unresolved reference: Modfier');
+    });
+
+    it('catches a final line that lacks a trailing newline', () => {
+        const d = new KotlinCompileErrorDetector();
+        d.consume('e: file:///proj/Foo.kt:42:5 Unresolved reference: Modfier');
+        // No newline before end() — flush must scan the residual buffer.
+        d.end();
+        const errors = d.getErrors();
+        assert.strictEqual(errors.length, 1);
+    });
+
+    it('strips CR from CRLF-terminated lines', () => {
+        const d = new KotlinCompileErrorDetector();
+        d.consume('e: file:///proj/Foo.kt:42:5 Unresolved reference: Modfier\r\n');
+        d.end();
+        const errors = d.getErrors();
+        assert.strictEqual(errors.length, 1);
+        // Trailing CR must not leak into the message — would print as a
+        // mojibake glyph in the banner.
+        assert.ok(!errors[0].message.endsWith('\r'));
+    });
+
+    it('skips lines that have e: somewhere but not at the start', () => {
+        // A literal "see e: line" elsewhere in stdout shouldn't be
+        // mistaken for a kotlin error. The ^ anchor enforces this.
+        const d = new KotlinCompileErrorDetector();
+        d.consume('see e: file:///proj/Foo.kt:42:5 nope\n');
+        d.end();
+        assert.deepStrictEqual(d.getErrors(), []);
+    });
+
+    it('caps captures at MAX_ERRORS so a runaway compile cannot grow the buffer', () => {
+        const d = new KotlinCompileErrorDetector();
+        const lines = [];
+        for (let i = 0; i < 200; i++) {
+            lines.push(`e: file:///proj/Foo.kt:${i}:1 oops`);
+        }
+        d.consume(lines.join('\n') + '\n');
+        d.end();
+        const errors = d.getErrors();
+        assert.ok(errors.length <= 50,
+            `should cap at MAX_ERRORS, got ${errors.length}`);
+    });
+
+    it('extracts the basename from absolute Linux-style paths', () => {
+        const d = new KotlinCompileErrorDetector();
+        d.consume('e: file:///long/abs/path/to/Previews.kt:1:1 oops\n');
+        d.end();
+        assert.strictEqual(d.getErrors()[0].file, 'Previews.kt');
+    });
+
+    it('extracts the basename from Windows-style paths in a file URL', () => {
+        const d = new KotlinCompileErrorDetector();
+        d.consume('e: file:///C:/work/Previews.kt:1:1 oops\n');
+        d.end();
+        assert.strictEqual(d.getErrors()[0].file, 'Previews.kt');
+    });
+
+    it('extracts the basename from bare Windows paths', () => {
+        const d = new KotlinCompileErrorDetector();
+        d.consume('e: C:\\work\\Previews.kt:1:1 oops\n');
+        d.end();
+        assert.strictEqual(d.getErrors()[0].file, 'Previews.kt');
+    });
+});
+
+describe('KotlinCompileError', () => {
+    it('carries the parsed errors plus the failing task', () => {
+        const e = new KotlinCompileError(
+            [{ file: 'Foo.kt', path: '/p/Foo.kt', line: 1, column: 1, message: 'x' }],
+            ':app:compileDebugKotlin',
+        );
+        assert.strictEqual(e.errors.length, 1);
+        assert.strictEqual(e.task, ':app:compileDebugKotlin');
+        assert.ok(e instanceof Error);
+        assert.strictEqual(e.name, 'KotlinCompileError');
+    });
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -268,12 +268,14 @@ export type ExtensionToWebview =
     /** Force-clear the progress bar (e.g. on cancellation or fatal error). */
     | { command: 'clearProgress' }
     /**
-     * Replace the compile-error banner. Each entry maps to one row in the
-     * banner with file:line:col + message; clicking opens the source.
-     * Cards stay rendered but get a "compile-stale" decoration so the user
-     * keeps the last successful render visible alongside the error list.
+     * Replace the compile-error banner. Each entry carries its own
+     * absolute `path` so the click handler can deep-link to whatever
+     * file the diagnostic actually came from — important for the
+     * kotlinc detector where errors can span files. Cards stay rendered
+     * but get a "compile-stale" decoration so the user keeps the last
+     * successful render visible alongside the error list.
      */
-    | { command: 'setCompileErrors'; errors: import('./compileErrors').CompileError[]; sourceFile: string }
+    | { command: 'setCompileErrors'; errors: import('./compileErrors').CompileError[] }
     /** Remove the compile-error banner and the compile-stale dim on cards. */
     | { command: 'clearCompileErrors' };
 


### PR DESCRIPTION
## Summary

Catches the cross-file gap that the LSP-driven gate (PR #344) misses by design. The gate only inspects the active editor's diagnostics, so an error in `Theme.kt` while editing `Previews.kt` sails past it. Gradle then fails at `compileDebugKotlin` and today the user just sees a generic "Build failed. See Output > Compose Preview".

Now Gradle stdout is streamed through a new `KotlinCompileErrorDetector` parallel to `JdkImageErrorDetector`. Parses `e:` lines in the formats observed across Kotlin 1.9 / 2.0 / 2.1 (file:// URLs, bare paths, with or without the "error:" segment between position and message). Warnings are intentionally ignored — they flow through the log channel but don't gate the panel banner.

When a build fails AND the detector observed at least one error, `GradleService` throws a typed `KotlinCompileError` carrying the parsed records and the failing task name. The extension catches it and posts to the same `setCompileErrors` banner the LSP gate uses, so the UX is identical whether the gate fired or Gradle's compile actually ran.

Each `CompileError` now carries an absolute `path` field so cross-file errors deep-link to the right file when the user clicks a banner row, rather than always opening the panel's currently-scoped file.

### Files changed

- `src/kotlinCompileErrorDetector.ts` (new) — streaming detector + `KotlinCompileError` exception class.
- `src/compileErrors.ts` — added `path: string` to `CompileError` so cross-file errors carry their own click target.
- `src/gradleService.ts` — feed each output chunk through both detectors; on failure check jlink first (most specific remediation), then kotlinc errors, then the generic fallback.
- `src/extension.ts` — new `KotlinCompileError` catch arm next to `JdkImageError`; reuses the existing `setCompileErrors` post path.
- `src/previewPanel.ts` + `src/types.ts` — banner row uses `error.path` for the click handler instead of a panel-level `sourceFile` (which couldn't represent multiple files).

### Test plan

- [x] `npm run compile` — clean
- [x] `npm test` — 261 passing (15 new tests in `kotlinCompileErrorDetector.test.ts` covering all observed kotlinc output formats, chunk-split parsing, CR handling, MAX_ERRORS cap, Linux + Windows path basenames)
- [ ] Manual: deliberately break `Theme.kt` while editing `Previews.kt` (a typo in `Theme.kt` that doesn't prevent the LSP from also analysing the open `Previews.kt`). Confirm Gradle starts (LSP gate doesn't fire on `Previews.kt`), `compileDebugKotlin` fails, and the banner shows the `Theme.kt` error with click-to-open routing to that file rather than the open editor.
- [ ] Manual: a single-file error case the LSP gate would normally cover — disable the LSP (uninstall fwcd.kotlin temporarily) and confirm Gradle's failure now still produces a structured banner instead of the generic build-failed message.
- [ ] Manual: multiple errors across multiple files — confirm each row routes to its own file when clicked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rw5ZRtvu2VaXiTRE9KmNiC)_