### PR TITLE
feat(mcp): supervisor wire-up — replicasPerDaemon = in-JVM sandbox pool

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -87,6 +87,30 @@ fun main(args: Array<String>) {
       )
     } else null
 
+  // SANDBOX-POOL.md (Layer 3) — read the supervisor-supplied sandbox-count knob. The
+  // DaemonSupervisor passes `composeai.daemon.sandboxCount = 1 + replicasPerDaemon` via the
+  // launch descriptor's systemProperties; sandbox pooling collapses what used to be N separate
+  // daemon JVMs into one JVM with N sandbox slots. Default 1 preserves the pre-pool single-
+  // sandbox behaviour bit-for-bit.
+  //
+  // Constraint: sandboxCount > 1 isn't compatible with a non-null userClassloaderHolder in v1
+  // (per-slot child URLClassLoaders are layered work — see RobolectricHost's init-block check).
+  // Force sandboxCount = 1 with a clear warning when both are requested so the daemon still
+  // boots; otherwise the host's `require` would fire and the daemon would fail to start.
+  val requestedSandboxCount =
+    (System.getProperty(SANDBOX_COUNT_PROP)?.toIntOrNull() ?: 1).coerceAtLeast(1)
+  val effectiveSandboxCount =
+    if (requestedSandboxCount > 1 && userClassloaderHolder != null) {
+      System.err.println(
+        "compose-ai-tools daemon: requested sandboxCount=$requestedSandboxCount but a user-class " +
+          "loader holder is active; sandbox pooling is not yet compatible with the disposable " +
+          "child loader (per-slot child loaders are follow-up work). Falling back to sandboxCount=1."
+      )
+      1
+    } else {
+      requestedSandboxCount
+    }
+
   val manifestPath = System.getProperty("composeai.harness.previewsManifest")
   val host: RenderHost =
     if (manifestPath != null && manifestPath.isNotBlank()) {
@@ -95,9 +119,20 @@ fun main(args: Array<String>) {
         "compose-ai-tools daemon: PreviewManifestRouter active " +
           "(manifest=$manifestPath, previews=${manifest.previews.map { it.id }})"
       )
+      // The harness's PreviewManifestRouter wraps a single RobolectricHost; sandbox pooling is
+      // an optimisation for the production daemon path, not the harness mode (which exists to
+      // exercise the wire protocol against in-process fakes). Stay at sandboxCount=1 here.
       PreviewManifestRouter(manifest = manifest, userClassloaderHolder = userClassloaderHolder)
     } else {
-      RobolectricHost(userClassloaderHolder = userClassloaderHolder)
+      if (effectiveSandboxCount > 1) {
+        System.err.println(
+          "compose-ai-tools daemon: sandbox pool active (sandboxCount=$effectiveSandboxCount)"
+        )
+      }
+      RobolectricHost(
+        userClassloaderHolder = userClassloaderHolder,
+        sandboxCount = effectiveSandboxCount,
+      )
     }
 
   // B2.1 — wire Tier-1 classpath fingerprinting (DESIGN § 8). Mirrors the desktop daemon's
@@ -202,3 +237,10 @@ private const val WORKSPACE_ROOT_PROP = "composeai.daemon.workspaceRoot"
 
 /** Module project path stamped into every history entry's `module` field. */
 private const val MODULE_ID_PROP = "composeai.daemon.moduleId"
+
+/**
+ * SANDBOX-POOL.md (Layer 3) — sandbox-pool size knob. Set by [DaemonSupervisor] from
+ * `1 + replicasPerDaemon`. Default 1 preserves the pre-pool single-sandbox behaviour. Values < 1
+ * are coerced to 1.
+ */
+private const val SANDBOX_COUNT_PROP = "composeai.daemon.sandboxCount"

--- a/docs/daemon/SANDBOX-POOL.md
+++ b/docs/daemon/SANDBOX-POOL.md
@@ -1,14 +1,19 @@
 # Preview daemon — in-JVM sandbox pool
 
-> **Status:** Layer 1 (bridge multi-slot foundation) and Layer 2 (RobolectricHost as a sandbox
-> pool) are landed and working. `RobolectricHost(sandboxCount = N)` boots N distinct Robolectric
-> sandboxes in one JVM, each with its own `InstrumentingClassLoader` and `SDK Main Thread`;
-> renders dispatch to slots via `Math.floorMod(id, N)`. Two-sandbox boot completes in ~7s on a
-> warm cache. The `RobolectricHostPoolTest` asserts distinct classloaders + stable per-slot
-> dispatch.
+> **Status:** All three layers landed.
 >
-> Layer 3 (supervisor wire-up — make `replicasPerDaemon` translate into `sandboxCount` on a single
-> daemon JVM rather than spawning N JVMs) is a follow-up.
+> - **Layer 1** — bridge multi-slot foundation.
+> - **Layer 2** — `RobolectricHost(sandboxCount = N)` boots N distinct Robolectric sandboxes in
+>   one JVM, each with its own `InstrumentingClassLoader` and `SDK Main Thread`; renders dispatch
+>   to slots via `Math.floorMod(id, N)`. Two-sandbox boot completes in ~7s on warm cache.
+> - **Layer 3** — `DaemonSupervisor` passes `composeai.daemon.sandboxCount = 1 + replicasPerDaemon`
+>   on the launch descriptor instead of spawning N+1 JVM subprocesses. The supervisor's public
+>   surface (`SupervisedDaemon.client`, `allClients`, `clientForRender`) is unchanged; the daemon
+>   handles render fan-out internally. `replicasPerDaemon = 0` (default) preserves bit-identical
+>   pre-pool behaviour on disk.
+>
+> Memory math (replicasPerDaemon = 4 on one module): pre-Layer-3 ~8 GB across 5 JVMs;
+> post-Layer-3 ~5 GB in one JVM with 5 sandbox classloaders.
 
 ## Motivation
 
@@ -142,21 +147,29 @@ The fix lives in [`SandboxHoldingRunner.kt`](../../daemon/android/src/main/kotli
 KDoc on `poolWorkerIndex` and `SandboxHoldingHints.workerIndex` warn future maintainers not to
 read the ThreadLocal directly inside `createClassLoaderConfig`.
 
-### Layer 3 — supervisor wire-up [follow-up]
+### Layer 3 — supervisor wire-up [landed]
 
-`DaemonSupervisor` keeps its `replicasPerDaemon` knob as the public surface. Behaviour change:
-instead of forking N extra JVMs via `SubprocessDaemonClientFactory`, the supervisor spawns **one**
-JVM per module and passes `composeai.daemon.sandboxCount = 1 + replicasPerDaemon` as a sysprop on
-the launch descriptor. The daemon's `DaemonMain` reads it and configures
-`RobolectricHost(sandboxCount = N)`.
+`DaemonSupervisor` keeps its `replicasPerDaemon` knob as the public surface. Implementation:
 
-`SupervisedDaemon` collapses to a single `DaemonClient`; `clientForRender(previewId)` becomes a
-no-op (the daemon handles affinity internally). The wire `render` call grows an optional
-affinity-key param (or relies on the existing `previewId` payload) so the daemon's pool router can
-land repeat renders on the same sandbox for cache locality.
+- `spawn(project, modulePath)` reads the descriptor, calls `descriptor.withSandboxCount(1 + replicasPerDaemon)`
+  to inject `composeai.daemon.sandboxCount` into `systemProperties`, and forks a **single** JVM via
+  `clientFactory.spawn`. The previous N+1-JVM-fork loop and its `replicaSpawnExecutor` thread pool
+  are gone.
+- `SupervisedDaemon` is now backed by a single `DaemonSpawn` (was a `CopyOnWriteArrayList`); the
+  public surface — `client`, `allClients()`, `clientForRender(previewId)`, `replicaCount()` — is
+  unchanged so existing fan-out callers (`DaemonMcpServer`, `WatchPropagator`) keep working.
+  `clientForRender` is now a degenerate no-op (always returns the single client) but the
+  `previewId` argument is preserved for a future affinity-aware wire change.
+- `DaemonMain` reads `composeai.daemon.sandboxCount` (default 1) and constructs
+  `RobolectricHost(sandboxCount = N)`. When the user-class loader holder is wired (the gradle
+  plugin's hot-reload path), sandboxCount falls back to 1 with a stderr warning — per-slot child
+  loaders are layered work.
+- Wire-protocol-visible behaviour (`initialize`, `renderNow`, `fileChanged` fan-out,
+  `classpathDirty` respawn) is unchanged from the consumer's perspective.
 
-The `replicasPerDaemon == 0` default keeps a single sandbox — bit-identical with today's behaviour
-on disk.
+`replicasPerDaemon == 0` keeps a single sandbox in a single JVM — bit-identical with the
+pre-pool behaviour on disk (the sysprop is omitted from the descriptor entirely at count=1, so
+descriptors don't change shape for users who never opted in).
 
 ## What this does NOT solve
 

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -2,10 +2,6 @@ package ee.schimke.composeai.mcp
 
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -32,12 +28,18 @@ class DaemonSupervisor(
   private val clientFactory: DaemonClientFactory,
   private val router: NotificationRouter = NotificationRouter(),
   /**
-   * Extra in-process replicas to spawn per (workspace, module) once the primary is up. The primary
-   * is always spawned synchronously and seeds the catalog via `synthesiseInitialDiscovery`; the
-   * replicas come up off-thread, share the (now-warm) Maven cache, and absorb render fan-out so
-   * concurrent `renderNow` requests for different previews don't queue behind each other on a
-   * single render thread. `replicasPerDaemon = 0` (the default) preserves the original
-   * 1-daemon-per-module behaviour. Total daemons per module = `1 + replicasPerDaemon`.
+   * Concurrent render slots per (workspace, module) beyond the first. SANDBOX-POOL.md Layer 3 — the
+   * supervisor passes `composeai.daemon.sandboxCount = 1 + replicasPerDaemon` as a sysprop on the
+   * launch descriptor; the daemon's
+   * [`RobolectricHost`][ee.schimke.composeai.daemon.RobolectricHost] boots that many in-JVM
+   * Robolectric sandboxes and dispatches concurrent `renderNow` requests across them.
+   * `replicasPerDaemon = 0` (the default) keeps the daemon at sandboxCount=1 — bit-identical with
+   * the pre-pool single-sandbox path on disk.
+   *
+   * Pre-Layer-3 this knob spawned N additional **JVM subprocesses**; that wasted ~2 GB per replica
+   * on shared per-JVM cost (native heap, JVM baseline, instrumented framework). Layer 3 collapses
+   * those into a single daemon JVM with N sandbox classloaders. Wire-protocol-visible behaviour
+   * (initialize, renderNow, fileChanged fan-out) is unchanged from the consumer's perspective.
    */
   private val replicasPerDaemon: Int = 0,
 ) {
@@ -47,18 +49,6 @@ class DaemonSupervisor(
   }
 
   private val projects = ConcurrentHashMap<WorkspaceId, RegisteredProject>()
-
-  /**
-   * Off-thread spawner for **additional replicas** beyond the primary. Sized to the configured
-   * replica count so all replicas of one module can come up in parallel; capped so several modules
-   * spawning concurrently don't fork an unbounded number of JVMs.
-   */
-  private val replicaSpawnExecutor: ExecutorService =
-    Executors.newFixedThreadPool(
-      maxOf(1, replicasPerDaemon).coerceAtMost(REPLICA_SPAWN_POOL_CAP)
-    ) { r ->
-      Thread(r, "mcp-daemon-replica-spawn").apply { isDaemon = true }
-    }
 
   /**
    * Registers a project at [absolutePath] (must already exist on disk). Returns the assigned
@@ -153,8 +143,6 @@ class DaemonSupervisor(
       project.daemons.clear()
     }
     projects.clear()
-    replicaSpawnExecutor.shutdown()
-    runCatching { replicaSpawnExecutor.awaitTermination(2, TimeUnit.SECONDS) }
   }
 
   /** Returns the [NotificationRouter] so callers can register handlers. */
@@ -165,60 +153,29 @@ class DaemonSupervisor(
   // -------------------------------------------------------------------------
 
   private fun spawn(project: RegisteredProject, modulePath: String): SupervisedDaemon {
-    val descriptor = descriptorProvider.descriptorFor(project, modulePath)
+    val baseDescriptor = descriptorProvider.descriptorFor(project, modulePath)
+    // SANDBOX-POOL.md Layer 3 — inject `composeai.daemon.sandboxCount = 1 + replicasPerDaemon`
+    // into the descriptor's systemProperties so the spawned daemon JVM boots that many in-JVM
+    // sandboxes. The daemon's DaemonMain reads this sysprop and passes it to RobolectricHost. We
+    // merge into a copy rather than mutating the original — the descriptor object is cached by
+    // `DescriptorProvider.readingFromDisk` and shared across `daemonFor` calls.
+    val descriptor = baseDescriptor.withSandboxCount(1 + replicasPerDaemon)
     val supervised = SupervisedDaemon(workspaceId = project.workspaceId, modulePath = modulePath)
 
-    // Primary spawn is synchronous so the calling thread blocks on cold-start and the catalog is
-    // seeded before any subsequent `daemonFor` returns. Subsequent replicas piggy-back on the
-    // (now-warm) Maven cache — see `replicasPerDaemon` KDoc.
-    spawnReplica(project, descriptor, supervised, isPrimary = true)
-
-    // Fire off replica spawns in parallel. They share the warmed Maven cache and the JIT'd
-    // classloader cache from the primary, so cold-start cost is dominated by the primary; the
-    // replicas come up in roughly max(replica) instead of sum(replicas).
-    repeat(replicasPerDaemon) { idx ->
-      replicaSpawnExecutor.execute {
-        runCatching { spawnReplica(project, descriptor, supervised, isPrimary = false) }
-          .onFailure {
-            System.err.println(
-              "DaemonSupervisor: replica spawn ${idx + 1} failed for " +
-                "${project.workspaceId}/$modulePath: ${it.message}"
-            )
-          }
-      }
-    }
-
-    return supervised
-  }
-
-  /**
-   * Spawns one client (primary or replica) and attaches it to [supervised]. The primary blocks on
-   * `initialize` and seeds the catalog via [synthesiseInitialDiscovery]; replicas only need to
-   * `initialize` (catalog is already populated by the primary's manifest read).
-   */
-  private fun spawnReplica(
-    project: RegisteredProject,
-    descriptor: DaemonLaunchDescriptor,
-    supervised: SupervisedDaemon,
-    isPrimary: Boolean,
-  ) {
+    // Single synchronous spawn — the calling thread blocks on cold-start and the catalog is seeded
+    // before `daemonFor` returns. With sandboxCount > 1 the daemon's per-sandbox bootstrap is
+    // sequenced internally (RobolectricHost.start), so the wall-clock here is roughly
+    // (1 + replicasPerDaemon) × per-sandbox-boot.
     val spawn = clientFactory.spawn(project, descriptor)
-    // Wire the client BEFORE publishing the spawn to the replica list — otherwise a concurrent
-    // `clientForRender` reader could pick this index and call `.client` before the spawn's
-    // internal lazy client field is initialised (DaemonSpawn implementations construct the
-    // DaemonClient inside `client(onNotification, onClose)`).
     spawn.client(
       onNotification = { method, params -> router.dispatch(supervised, method, params) },
       onClose = {
-        // Only fire dispatchClose to handlers (which drop catalog state etc.) when the *last*
-        // replica is gone — otherwise a single replica's wire close would tear down state shared
-        // with its still-alive peers.
-        if (supervised.removeReplica(spawn)) {
+        if (supervised.detachSpawn(spawn)) {
           router.dispatchClose(supervised)
         }
       },
     )
-    supervised.addReplica(spawn)
+    supervised.attachSpawn(spawn)
     runCatching {
       val result =
         spawn.client.initialize(
@@ -226,25 +183,15 @@ class DaemonSupervisor(
           moduleId = descriptor.modulePath,
           moduleProjectDir = descriptor.workingDirectory,
         )
-      if (isPrimary) {
-        // The daemon only emits `discoveryUpdated` for *deltas* — the initial preview set comes
-        // via `initialize.manifest.path` (a `previews.json` written by the gradle plugin's
-        // `discoverPreviews` task). Synthesise an initial `discoveryUpdated` notification by
-        // reading that file and dispatching it through the router as if it were a wire-level
-        // event. Replicas of the same module would synthesise the same set, so we skip them.
-        synthesiseInitialDiscovery(supervised, result.manifest.path)
-      }
+      // The daemon only emits `discoveryUpdated` for *deltas* — the initial preview set comes
+      // via `initialize.manifest.path` (a `previews.json` written by the gradle plugin's
+      // `discoverPreviews` task). Synthesise an initial `discoveryUpdated` notification by
+      // reading that file and dispatching it through the router as if it were a wire-level
+      // event.
+      synthesiseInitialDiscovery(supervised, result.manifest.path)
     }
-  }
 
-  companion object {
-    /**
-     * Cap on the replica-spawn thread pool. With many modules each requesting `replicasPerDaemon`
-     * extra replicas, an unbounded pool would fork tens of JVMs at once and trash the host. Cold
-     * Robolectric bootstraps are CPU + I/O heavy, so eight concurrent forks is the comfortable
-     * upper bound on a typical dev machine.
-     */
-    private const val REPLICA_SPAWN_POOL_CAP: Int = 8
+    return supervised
   }
 
   private fun synthesiseInitialDiscovery(daemon: SupervisedDaemon, manifestPath: String) {
@@ -285,71 +232,82 @@ data class RegisteredProject(
 )
 
 /**
- * A live daemon — owned by [DaemonSupervisor]. May front 1+N underlying replicas (see
- * [DaemonSupervisor.replicasPerDaemon]). All replicas serve the same (workspaceId, modulePath); the
- * supervisor uses the group to fan out invalidations and shard render fan-out.
+ * A live daemon — owned by [DaemonSupervisor]. SANDBOX-POOL.md Layer 3: one daemon JVM per
+ * (workspaceId, modulePath); concurrent render capacity comes from in-JVM sandbox pooling
+ * configured via `composeai.daemon.sandboxCount` on the launch descriptor (the supervisor passes
+ * `1 + replicasPerDaemon`).
+ *
+ * Pre-Layer-3 this class fronted N+1 separate JVM subprocesses; the public surface ([client],
+ * [allClients], [clientForRender]) survives that change because the daemon-side slot dispatch
+ * handles render affinity internally.
  */
 class SupervisedDaemon(val workspaceId: WorkspaceId, val modulePath: String) {
 
   /**
-   * Replicas in spawn order. The primary is at index 0, populated by the synchronous spawn path;
-   * extra replicas append as their async spawns finish. Iterations take a snapshot — the list is
-   * copy-on-write so concurrent appends + reads are safe.
+   * The single [DaemonSpawn] backing this supervised daemon. `null` between construction and
+   * [attachSpawn]; set once and cleared by [detachSpawn] / [shutdown]. `@Volatile` because the
+   * onNotification / onClose callbacks fire on the spawn's reader thread and the supervisor's
+   * caller thread reads this through [client] / [allClients] without external synchronisation.
    */
-  private val replicas: CopyOnWriteArrayList<DaemonSpawn> = CopyOnWriteArrayList()
+  @Volatile private var spawn: DaemonSpawn? = null
 
   /**
-   * The primary [DaemonClient]. Used for control-plane operations (`initialize`, `history*`,
-   * `setVisible`/`setFocus` — though propagation fans out to every replica, see [allClients]).
-   * Throws if no replica has been registered yet (only possible during the brief window before the
-   * primary's synchronous spawn returns).
+   * The single [DaemonClient]. Used for everything — control-plane operations (`initialize`,
+   * `history*`), render dispatch, and fan-out broadcasts. Throws if [attachSpawn] hasn't run yet
+   * (only possible during the brief window before the synchronous spawn returns).
    */
   val client: DaemonClient
     get() {
-      val list = replicas
-      check(list.isNotEmpty()) { "SupervisedDaemon($workspaceId/$modulePath): no replicas" }
-      return list[0].client
+      val s = spawn
+      check(s != null) { "SupervisedDaemon($workspaceId/$modulePath): no spawn attached yet" }
+      return s.client
     }
 
-  /** Snapshot of every active replica's client — for fan-out (e.g. `fileChanged`, `setVisible`). */
-  fun allClients(): List<DaemonClient> = replicas.map { it.client }
+  /**
+   * Snapshot of every active client — for fan-out APIs (e.g. `fileChanged`, `setVisible`). Always a
+   * singleton list under Layer 3; kept as a list for source-compatibility with callers that iterate
+   * it (they keep working unchanged).
+   */
+  fun allClients(): List<DaemonClient> = spawn?.let { listOf(it.client) } ?: emptyList()
 
   /**
-   * Picks a replica's client for a render keyed on [previewId]. Hash-based so the same preview
-   * lands on the same replica every time (cache locality + render dedup); different previews spread
-   * across replicas so concurrent renders run in parallel. Falls back to the primary when no
-   * replica is yet registered.
+   * Returns the client for a render keyed on [previewId]. Layer 3: always the single client; the
+   * daemon-side `RobolectricHost.submit` dispatches across in-JVM sandbox slots internally. The
+   * [previewId] argument is informational — kept on the API so a future affinity-aware wire change
+   * can use it without breaking callers.
    */
-  fun clientForRender(previewId: String): DaemonClient {
-    val list = replicas
-    if (list.isEmpty()) error("SupervisedDaemon($workspaceId/$modulePath): no replicas")
-    if (list.size == 1) return list[0].client
-    // Math.floorMod gives a non-negative index even for negative hashCodes.
-    val idx = Math.floorMod(previewId.hashCode(), list.size)
-    return list[idx].client
-  }
+  fun clientForRender(@Suppress("UNUSED_PARAMETER") previewId: String): DaemonClient = client
 
-  /** Number of currently-active replicas (primary + extras). */
-  fun replicaCount(): Int = replicas.size
+  /**
+   * Always 1 under Layer 3 (one JVM subprocess per supervised daemon). Concurrent render capacity
+   * is `1 + replicasPerDaemon` and is realised inside the daemon JVM's sandbox pool, not at the
+   * subprocess level. Kept for source-compatibility with callers that previously asserted "primary
+   * plus N replicas" — those assertions are now wrong, but the method itself doesn't lie.
+   */
+  fun replicaCount(): Int = if (spawn != null) 1 else 0
 
-  internal fun addReplica(spawn: DaemonSpawn) {
-    replicas.add(spawn)
+  internal fun attachSpawn(spawn: DaemonSpawn) {
+    check(this.spawn == null) {
+      "SupervisedDaemon($workspaceId/$modulePath): spawn already attached"
+    }
+    this.spawn = spawn
   }
 
   /**
-   * Removes [spawn] from the replica set. Returns `true` if this was the *last* replica — callers
-   * use this to decide whether to fire group-level cleanup (e.g. dispatching `onClose` to handlers
-   * that own per-(workspace, module) state).
+   * Detaches [s] if it's the current spawn. Returns `true` if a spawn was actually removed —
+   * callers use this to decide whether to fire group-level cleanup (e.g. dispatching `onClose` to
+   * handlers that own per-(workspace, module) state).
    */
-  internal fun removeReplica(spawn: DaemonSpawn): Boolean {
-    replicas.remove(spawn)
-    return replicas.isEmpty()
+  internal fun detachSpawn(s: DaemonSpawn): Boolean {
+    if (this.spawn !== s) return false
+    this.spawn = null
+    return true
   }
 
   fun shutdown() {
-    val snapshot = replicas.toList()
-    replicas.clear()
-    snapshot.forEach { runCatching { it.shutdown() } }
+    val s = spawn ?: return
+    spawn = null
+    runCatching { s.shutdown() }
   }
 }
 
@@ -410,7 +368,31 @@ data class DaemonLaunchDescriptor(
   val workingDirectory: String,
   val manifestPath: String,
 ) {
+
+  /**
+   * SANDBOX-POOL.md Layer 3 — returns a copy with `composeai.daemon.sandboxCount` merged into
+   * [systemProperties]. The supervisor calls this on the descriptor read from disk before passing
+   * it to [DaemonClientFactory.spawn] so the daemon JVM picks up the right pool size at boot.
+   *
+   * Idempotent at [count] = 1 (the daemon's default; the sysprop is omitted to keep the disk
+   * descriptor trivially diffable across replicas-per-daemon settings of 0).
+   */
+  fun withSandboxCount(count: Int): DaemonLaunchDescriptor {
+    require(count >= 1) { "sandboxCount must be >= 1, got $count" }
+    if (count == 1) return this
+    val merged = systemProperties.toMutableMap()
+    merged[SANDBOX_COUNT_PROP] = count.toString()
+    return copy(systemProperties = merged)
+  }
+
   companion object {
+    /**
+     * Sysprop key the daemon reads to configure
+     * [`RobolectricHost.sandboxCount`][ee.schimke.composeai.daemon.RobolectricHost.sandboxCount].
+     * Mirrored on the daemon side as a private const in `DaemonMain.kt`; both sides MUST agree.
+     */
+    const val SANDBOX_COUNT_PROP: String = "composeai.daemon.sandboxCount"
+
     private val json = Json { ignoreUnknownKeys = true }
 
     fun parse(jsonText: String): DaemonLaunchDescriptor =

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonSupervisorReplicaTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonSupervisorReplicaTest.kt
@@ -22,11 +22,23 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
 /**
- * Exercises the 1+N replica model: per-(workspace, module) daemons fan out across replicas so
- * concurrent renders run in parallel. The default `replicasPerDaemon = 0` is covered by the
- * existing [DaemonMcpServerTest]; here we wire `replicasPerDaemon = 2` so each `daemonFor` results
- * in three [FakeDaemon] instances (1 primary + 2 extras), and assert the supervisor shards renders,
- * fans out invalidations, and dispatches close only when the LAST replica is gone.
+ * SANDBOX-POOL.md Layer 3 — exercises the supervisor's single-JVM-with-sandbox-pool model.
+ * `replicasPerDaemon = 2` no longer spawns 1+2 JVM subprocesses; it spawns **one** subprocess
+ * configured (via the launch descriptor's `composeai.daemon.sandboxCount` sysprop) to host 3
+ * sandboxes in-JVM. The daemon's `RobolectricHost` dispatches concurrent renders across those
+ * sandboxes internally, so the wire-protocol-visible behaviour (one client per (workspace, module),
+ * fan-out broadcasts, classpathDirty respawn) is preserved.
+ *
+ * The default `replicasPerDaemon = 0` is covered by [DaemonMcpServerTest]. Here we wire
+ * `replicasPerDaemon = 2` and assert:
+ *
+ * - `daemonFor` produces exactly **one** [FakeDaemon] (not three) and its descriptor carries
+ *   `composeai.daemon.sandboxCount = "3"`.
+ * - `setVisible` / `notify_file_changed` fan out to that single daemon (callers that previously
+ *   iterated `allClients()` see a singleton list — the loop runs once).
+ * - `renderNow` lands on the single daemon for any preview id.
+ * - `classpathDirty` tears down the single subprocess and respawns one fresh subprocess (still
+ *   carrying the sandboxCount sysprop).
  */
 class DaemonSupervisorReplicaTest {
 
@@ -66,53 +78,53 @@ class DaemonSupervisorReplicaTest {
   }
 
   @Test
-  fun `daemonFor spawns 1 primary plus N replicas`() {
+  fun `daemonFor spawns one subprocess with sandboxCount sysprop`() {
     client.initialize()
     val projectDir = tmp.newFolder("workspace")
     tmp.newFolder("workspace", "module")
     val workspaceId = registerWorkspace(projectDir, "demo")
 
     supervisor.daemonFor(workspaceId, ":module")
-    waitForReplicas(expected = 3)
-    assertThat(factory.spawnHistory.size).isEqualTo(3)
+    waitForSpawns(expected = 1)
+    // Layer 3 — one subprocess, not 1 + replicasPerDaemon. Concurrent capacity comes from the
+    // daemon's in-JVM sandbox pool, not extra subprocesses.
+    assertThat(factory.spawnHistory.size).isEqualTo(1)
     val daemon = supervisor.daemonFor(workspaceId, ":module")
-    assertThat(daemon.replicaCount()).isEqualTo(3)
-    // All three are wired to the same logical SupervisedDaemon — exiting any one of them must
-    // not drop catalog state until the LAST one closes (asserted in `closeOnly...` below).
-    assertThat(daemon.allClients()).hasSize(3)
+    assertThat(daemon.replicaCount()).isEqualTo(1)
+    assertThat(daemon.allClients()).hasSize(1)
+
+    // The descriptor handed to `clientFactory.spawn` must carry the sandboxCount sysprop the
+    // daemon's DaemonMain reads on boot. With replicasPerDaemon = 2 that's 1 + 2 = 3.
+    val descriptor = factory.spawnDescriptors.single()
+    assertThat(descriptor.systemProperties)
+      .containsEntry(DaemonLaunchDescriptor.SANDBOX_COUNT_PROP, "3")
   }
 
   @Test
-  fun `renderNow shards previews across replicas by hash`() {
+  fun `renderNow lands on the single daemon for any preview id`() {
     client.initialize()
     val projectDir = tmp.newFolder("workspace")
     tmp.newFolder("workspace", "module")
     val workspaceId = registerWorkspace(projectDir, "demo")
 
     supervisor.daemonFor(workspaceId, ":module")
-    waitForReplicas(expected = 3)
-    val replicas = factory.spawnHistory.toList()
+    waitForSpawns(expected = 1)
+    val fake = factory.spawnHistory.single()
 
-    // Stage a PNG and arm every replica to auto-emit renderFinished — only the chosen replica
-    // for each preview will actually receive the renderNow, so only its emit fires; others stay
-    // idle. We register the auto-emitter on every replica defensively so a routing bug shows up
-    // as "the wrong replica produced the bytes" rather than a hung test.
+    // Stage a PNG and arm the daemon to auto-emit renderFinished. With Layer 3, sharding across
+    // sandboxes happens INSIDE the daemon (RobolectricHost.submit dispatches via slot id);
+    // from the supervisor's vantage there's just one client, so every render request lands here.
     val pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3)
-    val pngFile = tmp.newFile("replica-fake-render.png")
+    val pngFile = tmp.newFile("layer3-fake-render.png")
     Files.write(pngFile.toPath(), pngBytes)
     val previewIds =
       listOf("com.example.Alpha", "com.example.Bravo", "com.example.Charlie", "com.example.Delta")
-    replicas.forEach { it.autoRenderPngPath = { _ -> pngFile.absolutePath } }
-    // Drive discoveryUpdated through the primary so the catalog populates; replicas would emit
-    // the same set, which is idempotent in onDiscoveryUpdated.
-    val primary = replicas[0]
-    previewIds.forEach { primary.emitDiscovery(it) }
+    fake.autoRenderPngPath = { _ -> pngFile.absolutePath }
+    previewIds.forEach { fake.emitDiscovery(it) }
     repeat(previewIds.size) {
       client.expectNotification("notifications/resources/list_changed", 2_000)
     }
 
-    // Issue a render for each preview id and verify the renderNow lands on the replica chosen by
-    // the same hash function the supervisor uses.
     previewIds.forEach { previewId ->
       val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
       val resp =
@@ -121,30 +133,22 @@ class DaemonSupervisorReplicaTest {
       val blob = parsed.contents.single() as ResourceContents.Blob
       assertThat(Base64.getDecoder().decode(blob.blob)).isEqualTo(pngBytes)
 
-      val expectedReplica = replicas[Math.floorMod(previewId.hashCode(), replicas.size)]
-      val rendered = expectedReplica.renderRequests.poll(2_000, TimeUnit.MILLISECONDS)
+      val rendered = fake.renderRequests.poll(2_000, TimeUnit.MILLISECONDS)
       assertThat(rendered).isEqualTo(listOf(previewId))
-      // No OTHER replica should have observed a renderNow for this preview — drains stale state.
-      replicas
-        .filter { it !== expectedReplica }
-        .forEach {
-          val stray = it.renderRequests.poll(50, TimeUnit.MILLISECONDS)
-          assertThat(stray).isNull()
-        }
     }
   }
 
   @Test
-  fun `setVisible fans out to every replica`() {
+  fun `setVisible reaches the single daemon`() {
     client.initialize()
     val projectDir = tmp.newFolder("workspace")
     tmp.newFolder("workspace", "module")
     val workspaceId = registerWorkspace(projectDir, "demo")
 
     supervisor.daemonFor(workspaceId, ":module")
-    waitForReplicas(expected = 3)
-    val replicas = factory.spawnHistory.toList()
-    replicas[0].emitDiscovery("com.example.Red")
+    waitForSpawns(expected = 1)
+    val fake = factory.spawnHistory.single()
+    fake.emitDiscovery("com.example.Red")
     client.expectNotification("notifications/resources/list_changed", 2_000)
 
     client.callTool(
@@ -156,26 +160,24 @@ class DaemonSupervisorReplicaTest {
       },
     )
 
-    // Each replica must observe its own setVisible/setFocus — render queues are per-replica,
-    // so only fanning out to the primary would leave peers blind to user attention.
-    replicas.forEach { fake ->
-      val visible = fake.visibleSets.poll(2_000, TimeUnit.MILLISECONDS)
-      val focus = fake.focusSets.poll(2_000, TimeUnit.MILLISECONDS)
-      assertThat(visible).isEqualTo(listOf("com.example.Red"))
-      assertThat(focus).isEqualTo(listOf("com.example.Red"))
-    }
+    // Fan-out callers (`daemon.allClients().forEach { … }` in DaemonMcpServer / WatchPropagator)
+    // iterate a singleton list under Layer 3. The single daemon must observe its setVisible /
+    // setFocus exactly once.
+    val visible = fake.visibleSets.poll(2_000, TimeUnit.MILLISECONDS)
+    val focus = fake.focusSets.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(visible).isEqualTo(listOf("com.example.Red"))
+    assertThat(focus).isEqualTo(listOf("com.example.Red"))
   }
 
   @Test
-  fun `notify_file_changed forwards fileChanged to every replica`() {
+  fun `notify_file_changed forwards fileChanged to the single daemon`() {
     client.initialize()
     val projectDir = tmp.newFolder("workspace")
     tmp.newFolder("workspace", "module")
     val workspaceId = registerWorkspace(projectDir, "demo")
 
     supervisor.daemonFor(workspaceId, ":module")
-    waitForReplicas(expected = 3)
-    val replicas = factory.spawnHistory.toList()
+    waitForSpawns(expected = 1)
 
     val callResp =
       client.callTool(
@@ -186,42 +188,45 @@ class DaemonSupervisorReplicaTest {
         },
       )
     val text = callResp.firstTextContent()
-    // Server reports total fileChanged forwards across (replica × daemon) — with one daemon and
-    // three replicas that's 3.
-    assertThat(text).contains("forwarded to 3 daemon(s)")
+    // Layer 3: one daemon per module, so the count drops from 1 + replicasPerDaemon to 1 — the
+    // forwarded-to count reflects the new single-subprocess shape.
+    assertThat(text).contains("forwarded to 1 daemon(s)")
   }
 
   @Test
-  fun `classpathDirty on one replica tears down peers and respawns the group`() {
+  fun `classpathDirty tears down the single subprocess and respawns one`() {
     client.initialize()
     val projectDir = tmp.newFolder("workspace")
     tmp.newFolder("workspace", "module")
     val workspaceId = registerWorkspace(projectDir, "demo")
 
     supervisor.daemonFor(workspaceId, ":module")
-    waitForReplicas(expected = 3)
-    val firstGroup = factory.spawnHistory.toList()
+    waitForSpawns(expected = 1)
+    val firstSpawn = factory.spawnHistory.single()
 
-    // Fire classpathDirty on the primary — peers are still up, so the supervisor must shutdown
-    // them explicitly before respawning a fresh group.
-    firstGroup[0].emitClasspathDirty()
+    firstSpawn.emitClasspathDirty()
 
-    // Wait for the supervisor's async respawn to construct three more FakeDaemons (1 primary +
-    // 2 replicas of the new group).
+    // Wait for the supervisor's async respawn to construct a single fresh FakeDaemon.
     val deadline = System.currentTimeMillis() + 10_000
-    while (factory.spawnHistory.size < 6 && System.currentTimeMillis() < deadline) {
+    while (factory.spawnHistory.size < 2 && System.currentTimeMillis() < deadline) {
       Thread.sleep(50)
     }
-    assertThat(factory.spawnHistory.size).isAtLeast(6)
-    val secondGroup = factory.spawnHistory.subList(3, factory.spawnHistory.size)
-    assertThat(secondGroup).hasSize(3)
+    assertThat(factory.spawnHistory.size).isAtLeast(2)
+    val second = factory.spawnHistory[1]
+    assertThat(second).isNotSameInstanceAs(firstSpawn)
     val newDaemon = supervisor.daemonFor(workspaceId, ":module")
-    assertThat(newDaemon.replicaCount()).isEqualTo(3)
+    assertThat(newDaemon.replicaCount()).isEqualTo(1)
+
+    // The respawn descriptor must still carry the sandboxCount sysprop — otherwise a respawned
+    // pool would silently downgrade to a single-sandbox daemon and the user's render concurrency
+    // would halve after the first classpathDirty event.
+    val secondDescriptor = factory.spawnDescriptors[1]
+    assertThat(secondDescriptor.systemProperties)
+      .containsEntry(DaemonLaunchDescriptor.SANDBOX_COUNT_PROP, "3")
   }
 
   // -------------------------------------------------------------------------
-  // Helpers (mirror DaemonMcpServerTest's helpers — kept private here to avoid a shared base
-  // class for two test files).
+  // Helpers
   // -------------------------------------------------------------------------
 
   private fun registerWorkspace(projectDir: java.io.File, rootName: String): WorkspaceId {
@@ -240,10 +245,9 @@ class DaemonSupervisorReplicaTest {
   }
 
   /**
-   * Polls [FakeDaemonClientFactory.spawnHistory] until [expected] replicas have been spawned. The
-   * primary is synchronous but extras come up off-thread on the supervisor's replica spawn pool.
+   * Polls [FakeDaemonClientFactory.spawnHistory] until [expected] subprocesses have been spawned.
    */
-  private fun waitForReplicas(expected: Int, timeoutMs: Long = 5_000) {
+  private fun waitForSpawns(expected: Int, timeoutMs: Long = 5_000) {
     val deadline = System.currentTimeMillis() + timeoutMs
     while (factory.spawnHistory.size < expected && System.currentTimeMillis() < deadline) {
       Thread.sleep(20)

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
@@ -400,11 +400,21 @@ class FakeDaemonClientFactory : DaemonClientFactory {
    */
   val spawnHistory: MutableList<FakeDaemon> = java.util.concurrent.CopyOnWriteArrayList()
 
+  /**
+   * Descriptors handed to [spawn], parallel-indexed with [spawnHistory]. SANDBOX-POOL.md Layer 3:
+   * the supervisor mutates the descriptor's `systemProperties` to inject
+   * `composeai.daemon.sandboxCount`; tests assert against this list to verify the supervisor passed
+   * the right pool size to the daemon.
+   */
+  val spawnDescriptors: MutableList<DaemonLaunchDescriptor> =
+    java.util.concurrent.CopyOnWriteArrayList()
+
   override fun spawn(project: RegisteredProject, descriptor: DaemonLaunchDescriptor): DaemonSpawn {
     val daemon = FakeDaemon()
     synchronized(this) {
       daemons[project.workspaceId to descriptor.modulePath] = daemon
       spawnHistory.add(daemon)
+      spawnDescriptors.add(descriptor)
     }
     return daemon
   }


### PR DESCRIPTION
## Summary

Layer 3 of `docs/daemon/SANDBOX-POOL.md` — the MCP supervisor now realises the memory win that PR #350 (Layer 2) made possible at the daemon layer.

`DaemonSupervisor` passes `composeai.daemon.sandboxCount = 1 + replicasPerDaemon` as a sysprop on the launch descriptor and spawns **one** daemon JVM per (workspace, module), instead of forking N+1 separate JVMs. The daemon's `DaemonMain` reads the sysprop and constructs `RobolectricHost(sandboxCount = N)`; concurrent render capacity comes from the in-JVM sandbox pool, not extra subprocesses.

**Memory math**: `replicasPerDaemon = 4` on one module went from ~8 GB across 5 JVMs to ~5 GB in one JVM with 5 sandbox classloaders, reclaiming the JVM baseline (~200 MB) and native heap (~540 MB) per replica that the old supervisor was duplicating.

## What changes

- `DaemonSupervisor.spawn`: single subprocess instead of 1+N. The `replicaSpawnExecutor` thread pool and `REPLICA_SPAWN_POOL_CAP` are gone — there's nothing left to fan out at the subprocess level. The supervisor calls `descriptor.withSandboxCount(1 + replicasPerDaemon)` to inject the sysprop.
- `SupervisedDaemon`: single `DaemonSpawn` (was a `CopyOnWriteArrayList`). Public surface (`client`, `allClients()`, `clientForRender`, `replicaCount`) is preserved so existing fan-out callers in `DaemonMcpServer` and `WatchPropagator` keep working — they just iterate a singleton list.
- `DaemonLaunchDescriptor.withSandboxCount(N)`: copy-with-merged-sysprop helper. Idempotent at N=1 (omits the sysprop) so users with `replicasPerDaemon = 0` see no descriptor shape change on disk.
- `DaemonMain` (Android): reads `composeai.daemon.sandboxCount` (default 1). When the user-class loader holder is active (gradle plugin's hot-reload path), forces `sandboxCount = 1` with a stderr warning — per-slot child loaders remain layered work, and the holder needs them.

## What's preserved

- Wire-protocol-visible behaviour: `initialize`, `renderNow`, `fileChanged` fan-out, `classpathDirty` respawn — unchanged from the consumer's perspective.
- `replicasPerDaemon = 0` (default): bit-identical with pre-pool path on disk (sysprop omitted entirely).

## Test plan

- [x] `:mcp:test` — all 25 tests pass. `DaemonSupervisorReplicaTest` reworked to assert the new shape:
  - one subprocess per module (not 1+N);
  - descriptor carries `composeai.daemon.sandboxCount = "3"` for `replicasPerDaemon = 2`;
  - fan-out callers see a singleton list (`forwarded to 1 daemon(s)`, not 3);
  - `classpathDirty` respawn produces one fresh subprocess **still** carrying the sysprop (otherwise pool size silently halves on every restart).
- [x] `:daemon:android:testDebugUnitTest` — 4 test classes pass unchanged.

## Layer status (SANDBOX-POOL.md)

- Layer 1 (bridge multi-slot foundation) — landed (PR #341).
- Layer 2 (`RobolectricHost(sandboxCount = N)`) — landed (PR #350).
- Layer 3 (supervisor wire-up) — **this PR**.

After this lands, all three layers are in main and the in-JVM pool is reachable from production via the existing `replicasPerDaemon` knob.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SDmE1Uu28mX8yVjHeTMFJE)_