### PR TITLE
feat(vscode): live panel diff vs HEAD / vs main (MVP)

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -473,6 +473,63 @@ body {
     animation: fadeIn 0.2s ease-in;
 }
 
+/* Diff overlay — covers the focused image with a side-by-side comparison
+   when the user clicks Diff vs HEAD / vs main. Lives inside the
+   .image-container so it inherits the card's bounds and exits cleanly via
+   its own close button. */
+.preview-diff-overlay {
+    position: absolute;
+    inset: 0;
+    background: var(--vscode-editor-background);
+    z-index: 3;
+    display: flex;
+    flex-direction: column;
+    padding: 28px 8px 8px;
+    gap: 6px;
+    overflow: auto;
+    cursor: default;
+}
+.preview-diff-close {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+}
+.preview-diff-loading,
+.preview-diff-error {
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: calc(var(--vscode-font-size) - 1px);
+    padding: 12px;
+}
+.preview-diff-error { color: var(--vscode-errorForeground); }
+.preview-diff-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+    min-width: 0;
+}
+.preview-diff-pane { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.preview-diff-pane-label {
+    font-size: 90%;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.preview-diff-pane img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    background: var(--card-bg);
+}
+.preview-diff-pane-empty {
+    font-size: 90%;
+    padding: 12px;
+    text-align: center;
+    color: var(--text-secondary);
+    background: var(--card-bg);
+}
+
 @keyframes fadeIn {
     from { opacity: 0; }
     to { opacity: 1; }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -17,7 +17,7 @@ import { HEAVY_COST_THRESHOLD, PreviewInfo } from './types';
 import { captureLabel } from './captureLabels';
 import { DaemonGate } from './daemon/daemonGate';
 import { DaemonScheduler, WarmState } from './daemon/daemonScheduler';
-import { buildHistorySource, HistoryPanel, HistoryScope } from './historyPanel';
+import { buildHistorySource, HistoryPanel, HistoryScope, HistorySource } from './historyPanel';
 import { LogFilter, parseLogLevel } from './logFilter';
 import { pickRefreshModeFor, RefreshMode } from './refreshMode';
 import { mergeCalibration, PhaseDurations, ProgressState } from './buildProgress';
@@ -37,6 +37,9 @@ let daemonScheduler: DaemonScheduler | null = null;
 let daemonStatusItem: vscode.StatusBarItem | null = null;
 let daemonStatusClearTimer: NodeJS.Timeout | null = null;
 let historyPanel: HistoryPanel | null = null;
+/** Owned by activate(); reused by both the History panel and the live
+ *  panel's diff handler. */
+let historySource: HistorySource | null = null;
 /**
  * Mutable closure for the history panel's read/diff fall-back path.
  * `buildHistorySource` captures this object once at panel-construction time
@@ -303,39 +306,37 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     // is empty when no Kotlin file is in scope. The setScope() driver is
     // wired below into the active-editor change events.
     historyScopeRef.current = null;
-    historyPanel = new HistoryPanel(
-        context.extensionUri,
-        buildHistorySource({
-            isDaemonReady: (moduleId) => daemonGate?.isDaemonReady(moduleId) ?? false,
-            daemonList: async (scope) => {
-                const client = await daemonGate?.getOrSpawn(
-                    scope.moduleId, daemonScheduler!.daemonEvents(scope.moduleId),
-                );
-                if (!client) { throw new Error('daemon unavailable'); }
-                return client.historyList({ previewId: scope.previewId });
-            },
-            daemonRead: async (id) => {
-                const moduleId = historyScopeRef.current?.moduleId;
-                if (!moduleId) { throw new Error('no scope'); }
-                const client = await daemonGate?.getOrSpawn(
-                    moduleId, daemonScheduler!.daemonEvents(moduleId),
-                );
-                if (!client) { throw new Error('daemon unavailable'); }
-                return client.historyRead({ id, inline: false });
-            },
-            daemonDiff: async (fromId, toId) => {
-                const moduleId = historyScopeRef.current?.moduleId;
-                if (!moduleId) { throw new Error('no scope'); }
-                const client = await daemonGate?.getOrSpawn(
-                    moduleId, daemonScheduler!.daemonEvents(moduleId),
-                );
-                if (!client) { throw new Error('daemon unavailable'); }
-                return client.historyDiff({ from: fromId, to: toId, mode: 'metadata' });
-            },
-            getCurrentScope: () => historyScopeRef.current,
-            logger: outputChannel,
-        }),
-    );
+    historySource = buildHistorySource({
+        isDaemonReady: (moduleId) => daemonGate?.isDaemonReady(moduleId) ?? false,
+        daemonList: async (scope) => {
+            const client = await daemonGate?.getOrSpawn(
+                scope.moduleId, daemonScheduler!.daemonEvents(scope.moduleId),
+            );
+            if (!client) { throw new Error('daemon unavailable'); }
+            return client.historyList({ previewId: scope.previewId });
+        },
+        daemonRead: async (id) => {
+            const moduleId = historyScopeRef.current?.moduleId;
+            if (!moduleId) { throw new Error('no scope'); }
+            const client = await daemonGate?.getOrSpawn(
+                moduleId, daemonScheduler!.daemonEvents(moduleId),
+            );
+            if (!client) { throw new Error('daemon unavailable'); }
+            return client.historyRead({ id, inline: false });
+        },
+        daemonDiff: async (fromId, toId) => {
+            const moduleId = historyScopeRef.current?.moduleId;
+            if (!moduleId) { throw new Error('no scope'); }
+            const client = await daemonGate?.getOrSpawn(
+                moduleId, daemonScheduler!.daemonEvents(moduleId),
+            );
+            if (!client) { throw new Error('daemon unavailable'); }
+            return client.historyDiff({ from: fromId, to: toId, mode: 'metadata' });
+        },
+        getCurrentScope: () => historyScopeRef.current,
+        logger: outputChannel,
+    });
+    historyPanel = new HistoryPanel(context.extensionUri, historySource);
     context.subscriptions.push(
         vscode.window.registerWebviewViewProvider(HistoryPanel.viewId, historyPanel),
     );
@@ -1455,6 +1456,11 @@ function handleWebviewMessage(msg: WebviewToExtensionMessage) {
                 void openSourcePosition(msg.sourceFile, msg.line, msg.column);
             }
             break;
+        case 'requestPreviewDiff':
+            if (msg.previewId && (msg.against === 'head' || msg.against === 'main')) {
+                void runLivePreviewDiff(msg.previewId, msg.against);
+            }
+            break;
     }
 }
 
@@ -1475,6 +1481,109 @@ async function openSourcePosition(filePath: string, line: number, column: number
         const message = e instanceof Error ? e.message : String(e);
         logLine(`openSourcePosition failed for ${filePath}:${line}:${column} — ${message}`);
     }
+}
+
+async function runLivePreviewDiff(
+    previewId: string,
+    against: 'head' | 'main',
+): Promise<void> {
+    if (!panel || !historySource) { return; }
+    const moduleId = previewModuleMap.get(previewId);
+    const manifest = moduleId ? moduleManifestCache.get(moduleId) : undefined;
+    const info = manifest?.find(p => p.id === previewId);
+    if (!moduleId || !info || !gradleService) {
+        panel.postMessage({
+            command: 'previewDiffError', previewId, against,
+            message: 'Preview not found in the current scope.',
+        });
+        return;
+    }
+    const capture = info.captures?.[0];
+    if (!capture?.renderOutput) {
+        panel.postMessage({
+            command: 'previewDiffError', previewId, against,
+            message: 'No live render available for this preview.',
+        });
+        return;
+    }
+    const moduleDir = path.join(gradleService.workspaceRoot, moduleId);
+    const livePath = path.join(moduleDir, capture.renderOutput);
+    const liveBytes = await fs.promises.readFile(livePath).catch(() => null);
+    if (!liveBytes) {
+        panel.postMessage({
+            command: 'previewDiffError', previewId, against,
+            message: 'Live render not on disk yet — save the file once first.',
+        });
+        return;
+    }
+
+    const projectDir = path.join(gradleService.workspaceRoot, moduleId);
+    const scope: HistoryScope = { moduleId, projectDir, previewId };
+    let entries: unknown[];
+    try {
+        const result = await historySource.list(scope);
+        entries = result.entries ?? [];
+    } catch (err) {
+        panel.postMessage({
+            command: 'previewDiffError', previewId, against,
+            message: `History unavailable: ${(err as Error).message}`,
+        });
+        return;
+    }
+    const filtered = (against === 'main')
+        ? entries.filter(e => {
+            const branch = (e as { git?: { branch?: string } }).git?.branch;
+            return branch === 'main';
+        })
+        : entries;
+    const sorted = [...filtered].sort((a, b) => {
+        const at = (a as { timestamp?: string }).timestamp ?? '';
+        const bt = (b as { timestamp?: string }).timestamp ?? '';
+        return bt.localeCompare(at);
+    });
+    const target = sorted[0] as { id?: string; timestamp?: string } | undefined;
+    if (!target?.id) {
+        panel.postMessage({
+            command: 'previewDiffError', previewId, against,
+            message: against === 'main'
+                ? 'No archived render on main yet for this preview.'
+                : 'No archived history yet for this preview.',
+        });
+        return;
+    }
+    const right = await historySource.read(target.id);
+    if (!right) {
+        panel.postMessage({
+            command: 'previewDiffError', previewId, against,
+            message: 'Comparison entry not readable.',
+        });
+        return;
+    }
+    const rightBytes = right.pngBytes
+        ?? (await fs.promises.readFile(right.pngPath)).toString('base64');
+    panel.postMessage({
+        command: 'previewDiffReady',
+        previewId,
+        against,
+        leftLabel: 'Live · now',
+        leftImage: liveBytes.toString('base64'),
+        rightLabel: `${against === 'main' ? 'main' : 'HEAD'} · ${formatRelativeShort(target.timestamp)}`,
+        rightImage: rightBytes,
+    });
+}
+
+function formatRelativeShort(iso: string | undefined): string {
+    if (!iso) { return '(unknown)'; }
+    const t = Date.parse(iso);
+    if (isNaN(t)) { return iso; }
+    const s = Math.round((Date.now() - t) / 1000);
+    if (s < 60) { return s + 's ago'; }
+    const m = Math.round(s / 60);
+    if (m < 60) { return m + 'm ago'; }
+    const h = Math.round(m / 60);
+    if (h < 24) { return h + 'h ago'; }
+    const d = Math.round(h / 24);
+    return d + 'd ago';
 }
 
 function lookupPreviewLabel(previewId: string): string | undefined {
@@ -1531,6 +1640,7 @@ interface WebviewToExtensionMessage {
     sourceFile?: string;
     line?: number;
     column?: number;
+    against?: 'head' | 'main';
 }
 
 /**

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -99,6 +99,12 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         <button class="icon-button" id="btn-next" title="Next preview" aria-label="Next preview">
             <i class="codicon codicon-arrow-right" aria-hidden="true"></i>
         </button>
+        <button class="icon-button" id="btn-diff-head" title="Diff vs last archived render (HEAD)" aria-label="Diff vs HEAD">
+            <i class="codicon codicon-git-compare" aria-hidden="true"></i>
+        </button>
+        <button class="icon-button" id="btn-diff-main" title="Diff vs the latest render archived on main" aria-label="Diff vs main">
+            <i class="codicon codicon-source-control" aria-hidden="true"></i>
+        </button>
         <button class="icon-button" id="btn-exit-focus" title="Exit focus mode" aria-label="Exit focus mode">
             <i class="codicon codicon-close" aria-hidden="true"></i>
         </button>
@@ -118,6 +124,8 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         const focusControls = document.getElementById('focus-controls');
         const btnPrev = document.getElementById('btn-prev');
         const btnNext = document.getElementById('btn-next');
+        const btnDiffHead = document.getElementById('btn-diff-head');
+        const btnDiffMain = document.getElementById('btn-diff-main');
         const btnExitFocus = document.getElementById('btn-exit-focus');
         const focusPosition = document.getElementById('focus-position');
         const progressBar = document.getElementById('progress-bar');
@@ -298,6 +306,8 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 
         btnPrev.addEventListener('click', () => navigateFocus(-1));
         btnNext.addEventListener('click', () => navigateFocus(1));
+        btnDiffHead.addEventListener('click', () => requestFocusedDiff('head'));
+        btnDiffMain.addEventListener('click', () => requestFocusedDiff('main'));
         btnExitFocus.addEventListener('click', () => exitFocus());
 
         // Document-level Left/Right in focus mode steps between cards. The
@@ -496,6 +506,77 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             state.layout = previousLayout;
             vscode.setState(state);
             applyLayout();
+        }
+
+        // Live-panel diff: only meaningful when one preview is focused. Pulls
+        // the currently focused card's previewId and asks the extension to
+        // resolve the comparison anchor (HEAD = latest archived render,
+        // main = latest archived render on the main branch).
+        function requestFocusedDiff(against) {
+            if (layoutMode.value !== 'focus') return;
+            const visible = getVisibleCards();
+            const card = visible[focusIndex];
+            if (!card) return;
+            const previewId = card.dataset.previewId;
+            if (!previewId) return;
+            showDiffOverlay(card, against, null, null);
+            vscode.postMessage({ command: 'requestPreviewDiff', previewId, against });
+        }
+
+        function showDiffOverlay(card, against, payload, errorMessage) {
+            const container = card.querySelector('.image-container');
+            if (!container) return;
+            const existing = container.querySelector('.preview-diff-overlay');
+            if (existing) existing.remove();
+            const overlay = document.createElement('div');
+            overlay.className = 'preview-diff-overlay';
+            overlay.dataset.against = against;
+            const close = document.createElement('button');
+            close.className = 'icon-button preview-diff-close';
+            close.title = 'Exit diff';
+            close.setAttribute('aria-label', 'Exit diff');
+            close.innerHTML = '<i class="codicon codicon-close" aria-hidden="true"></i>';
+            close.addEventListener('click', () => overlay.remove());
+            overlay.appendChild(close);
+            if (errorMessage) {
+                const err = document.createElement('div');
+                err.className = 'preview-diff-error';
+                err.textContent = errorMessage;
+                overlay.appendChild(err);
+            } else if (payload) {
+                const grid = document.createElement('div');
+                grid.className = 'preview-diff-grid';
+                grid.appendChild(buildPreviewDiffPane(payload.leftLabel, payload.leftImage));
+                grid.appendChild(buildPreviewDiffPane(payload.rightLabel, payload.rightImage));
+                overlay.appendChild(grid);
+            } else {
+                const loading = document.createElement('div');
+                loading.className = 'preview-diff-loading';
+                loading.textContent = 'Loading diff…';
+                overlay.appendChild(loading);
+            }
+            container.appendChild(overlay);
+        }
+
+        function buildPreviewDiffPane(label, imageData) {
+            const pane = document.createElement('div');
+            pane.className = 'preview-diff-pane';
+            const cap = document.createElement('div');
+            cap.className = 'preview-diff-pane-label';
+            cap.textContent = label;
+            pane.appendChild(cap);
+            if (imageData) {
+                const img = document.createElement('img');
+                img.src = 'data:image/png;base64,' + imageData;
+                img.alt = label;
+                pane.appendChild(img);
+            } else {
+                const empty = document.createElement('div');
+                empty.className = 'preview-diff-pane-empty';
+                empty.textContent = '(no image)';
+                pane.appendChild(empty);
+            }
+            return pane;
         }
 
         function populateFilter(select, values, label) {
@@ -1500,6 +1581,24 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 case 'showMessage':
                     setMessage(msg.text, 'extension');
                     break;
+
+                case 'previewDiffReady': {
+                    const card = document.getElementById('preview-' + sanitizeId(msg.previewId));
+                    if (!card) break;
+                    showDiffOverlay(card, msg.against, {
+                        leftLabel: msg.leftLabel,
+                        leftImage: msg.leftImage,
+                        rightLabel: msg.rightLabel,
+                        rightImage: msg.rightImage,
+                    }, null);
+                    break;
+                }
+                case 'previewDiffError': {
+                    const card = document.getElementById('preview-' + sanitizeId(msg.previewId));
+                    if (!card) break;
+                    showDiffOverlay(card, msg.against, null, msg.message || 'Diff unavailable.');
+                    break;
+                }
             }
         });
 

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -275,7 +275,19 @@ export type ExtensionToWebview =
      */
     | { command: 'setCompileErrors'; errors: import('./compileErrors').CompileError[]; sourceFile: string }
     /** Remove the compile-error banner and the compile-stale dim on cards. */
-    | { command: 'clearCompileErrors' };
+    | { command: 'clearCompileErrors' }
+    /** Side-by-side diff result for a focused live preview. The webview
+     *  swaps in an overlay over the focused image with two labelled images. */
+    | {
+          command: 'previewDiffReady';
+          previewId: string;
+          against: 'head' | 'main';
+          leftLabel: string;
+          leftImage: string;
+          rightLabel: string;
+          rightImage: string;
+      }
+    | { command: 'previewDiffError'; previewId: string; against: 'head' | 'main'; message: string };
 
 /** Messages from webview to extension */
 export type WebviewToExtension =
@@ -315,4 +327,11 @@ export type WebviewToExtension =
      * absolute path the extension passed in `setCompileErrors`; the line /
      * column come from the LSP diagnostic (1-based).
      */
-    | { command: 'openCompileError'; sourceFile: string; line: number; column: number };
+    | { command: 'openCompileError'; sourceFile: string; line: number; column: number }
+    /**
+     * Live panel asks the extension to compute a diff for the focused
+     * preview against an anchor. `head` = latest archived render in
+     * `.compose-preview-history/` for this preview; `main` = same, filtered
+     * to entries whose `git.branch` is `main`.
+     */
+    | { command: 'requestPreviewDiff'; previewId: string; against: 'head' | 'main' };


### PR DESCRIPTION
## Summary

MVP step 2 of the diff feature: **live panel → diff vs HEAD / vs main, side-by-side**.

Two new buttons join the focus-controls bar (visible only in focus mode):

- **Diff vs HEAD** (`codicon-git-compare`) — pairs the focused preview's live render against the most recent archived entry in `.compose-preview-history/` for that preview, regardless of branch. Useful for "what did I change since the last save?".
- **Diff vs main** (`codicon-source-control`) — same, but filtered to entries whose `git.branch` is `main`. Useful for "have I drifted from baseline?".

Result is a side-by-side overlay layered over the focused image in the live panel, with its own close button. Errors (no history yet, live PNG not on disk yet, comparison entry not readable) surface in the overlay text instead of silently failing.

`historySource` is hoisted to module scope so the live panel and the History panel share the same daemon-or-FS resolution path.

Side-by-side mode only — overlay / onion / diff-image and ref-backed `main` via git plumbing (instead of branch-tagged history) follow.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 246 / 246 passing
- [ ] Manual: focus a preview → two new buttons appear between the next-arrow and the exit-focus close
- [ ] Manual: click `Diff vs HEAD` → side-by-side overlay shows live + most recent archived render
- [ ] Manual: click `Diff vs HEAD` with no history yet → overlay reads "No archived history yet for this preview"
- [ ] Manual: click `Diff vs main` after committing on a feature branch → overlay shows the most recent main-branch entry on the right
- [ ] Manual: close button on overlay → focused image returns
- [ ] Manual: navigate to next/prev preview while overlay is up → overlay clears on layout reapply (image element gets re-laid)


---
_Generated by [Claude Code](https://claude.ai/code/session_01A6AFhHNrHQNqUPKdmJRt94)_