### PR TITLE
fix(daemon,vscode): nested params schema + source-vs-PNG stale banner + auto-render on activate

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -62,7 +62,7 @@ class PreviewManifestRouter(
           "PreviewManifestRouter: no manifest entry for previewId='${previewId ?: "<missing>"}' " +
             "(payload='${typed.payload}'). Manifest knows: ${byId.keys}"
         )
-    val outputBaseName = entry.outputBaseName ?: entry.id
+    val resolved = entry.resolved()
     val routed =
       RenderRequest.Render(
         id = typed.id,
@@ -70,14 +70,17 @@ class PreviewManifestRouter(
           buildString {
             append("className=").append(entry.className).append(';')
             append("functionName=").append(entry.functionName).append(';')
-            append("widthPx=").append(entry.widthPx ?: 320).append(';')
-            append("heightPx=").append(entry.heightPx ?: 320).append(';')
-            append("density=").append(entry.density ?: 2.0f).append(';')
-            append("showBackground=").append(entry.showBackground ?: true).append(';')
-            entry.device?.takeIf { it.isNotBlank() }?.let {
+            append("widthPx=").append(resolved.widthPx).append(';')
+            append("heightPx=").append(resolved.heightPx).append(';')
+            append("density=").append(resolved.density).append(';')
+            append("showBackground=").append(resolved.showBackground).append(';')
+            if (resolved.backgroundColor != 0L) {
+              append("backgroundColor=").append(resolved.backgroundColor).append(';')
+            }
+            resolved.device?.takeIf { it.isNotBlank() }?.let {
               append("device=").append(it).append(';')
             }
-            append("outputBaseName=").append(outputBaseName)
+            append("outputBaseName=").append(resolved.outputBaseName)
           },
       )
     return super.submit(routed, timeoutMs)
@@ -104,15 +107,38 @@ class PreviewManifestRouter(
 
 @Serializable data class PreviewManifest(val previews: List<PreviewManifestEntry>)
 
+/**
+ * On-the-wire entry the router reads from `previews.json`. Two shapes coexist:
+ *
+ * - **Flat** (used by harness tests in `:daemon:harness`): top-level `widthPx` / `heightPx` /
+ *   `density` / `showBackground` / `device`. Hand-rolled JSON, easy to write inline.
+ * - **Nested** (emitted by the gradle plugin's `DiscoverPreviewsTask`): the canonical
+ *   [PreviewInfo][ee.schimke.composeai.plugin.PreviewInfo] schema with a `params` block carrying
+ *   `widthDp` / `heightDp` / `density` / `device` / `showBackground` / `backgroundColor`. Pre-fix
+ *   the daemon ignored the nested shape entirely (kotlinx.serialization with `ignoreUnknownKeys =
+ *   true`), so production always rendered at the daemon's hardcoded defaults (320×320, density 2.0,
+ *   no device, no wear-round crop) — diagnosed when the wear sample's circular crop went missing
+ *   after the URL-ordering fix exposed otherwise-stale renders.
+ *
+ * [resolved] returns a [ResolvedRenderParams] that prefers flat fields when set and falls back to
+ * the nested params, doing the dp→px conversion the plugin's schema requires.
+ */
 @Serializable
 data class PreviewManifestEntry(
   val id: String,
   val className: String,
   val functionName: String,
+  /**
+   * Production manifests written by the gradle plugin nest these fields under `params`. Optional
+   * because harness tests use the flat schema (see kdoc above); when null, the resolver consults
+   * the flat fields below.
+   */
+  val params: PreviewParamsEntry? = null,
   val widthPx: Int? = null,
   val heightPx: Int? = null,
   val density: Float? = null,
   val showBackground: Boolean? = null,
+  val backgroundColor: Long? = null,
   /**
    * Raw `@Preview(device = …)` string when the source preview has one set. Forwarded into the
    * `RenderSpec` payload so the render body applies the wear-round crop / `round` resource
@@ -120,4 +146,52 @@ data class PreviewManifestEntry(
    */
   val device: String? = null,
   val outputBaseName: String? = null,
+) {
+  fun resolved(): ResolvedRenderParams {
+    val p = params
+    val density = density ?: p?.density ?: 2.0f
+    val widthPx = widthPx ?: p?.widthDp?.let { (it * density).toInt() } ?: 320
+    val heightPx = heightPx ?: p?.heightDp?.let { (it * density).toInt() } ?: 320
+    val showBackground = showBackground ?: p?.showBackground ?: true
+    val backgroundColor = backgroundColor ?: p?.backgroundColor ?: 0L
+    val device = device ?: p?.device
+    return ResolvedRenderParams(
+      widthPx = widthPx,
+      heightPx = heightPx,
+      density = density,
+      showBackground = showBackground,
+      backgroundColor = backgroundColor,
+      device = device,
+      outputBaseName = outputBaseName ?: id,
+    )
+  }
+}
+
+/**
+ * Subset of the plugin's
+ * [PreviewParams][ee.schimke.composeai.plugin.PreviewParams] the daemon's render path consumes.
+ * Any plugin-side fields the daemon doesn't yet care about (fontScale, locale, uiMode, group, …)
+ * are silently dropped via `ignoreUnknownKeys = true`. Add them here when the daemon grows the
+ * matching render-path support.
+ */
+@Serializable
+data class PreviewParamsEntry(
+  val device: String? = null,
+  val widthDp: Int? = null,
+  val heightDp: Int? = null,
+  val density: Float? = null,
+  val showBackground: Boolean = false,
+  val backgroundColor: Long = 0L,
+)
+
+/** Output of [PreviewManifestEntry.resolved] — flat, fully-defaulted, ready to format into a
+ *  `RenderSpec` payload. */
+data class ResolvedRenderParams(
+  val widthPx: Int,
+  val heightPx: Int,
+  val density: Float,
+  val showBackground: Boolean,
+  val backgroundColor: Long,
+  val device: String?,
+  val outputBaseName: String,
 )

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -56,7 +56,7 @@ class PreviewManifestRouter(
           "PreviewManifestRouter: no manifest entry for previewId='${previewId ?: "<missing>"}' " +
             "(payload='${typed.payload}'). Manifest knows: ${byId.keys}"
         )
-    val outputBaseName = entry.outputBaseName ?: entry.id
+    val resolved = entry.resolved()
     val routed =
       RenderRequest.Render(
         id = typed.id,
@@ -64,14 +64,17 @@ class PreviewManifestRouter(
           buildString {
             append("className=").append(entry.className).append(';')
             append("functionName=").append(entry.functionName).append(';')
-            append("widthPx=").append(entry.widthPx ?: 320).append(';')
-            append("heightPx=").append(entry.heightPx ?: 320).append(';')
-            append("density=").append(entry.density ?: 2.0f).append(';')
-            append("showBackground=").append(entry.showBackground ?: true).append(';')
-            entry.device
+            append("widthPx=").append(resolved.widthPx).append(';')
+            append("heightPx=").append(resolved.heightPx).append(';')
+            append("density=").append(resolved.density).append(';')
+            append("showBackground=").append(resolved.showBackground).append(';')
+            if (resolved.backgroundColor != 0L) {
+              append("backgroundColor=").append(resolved.backgroundColor).append(';')
+            }
+            resolved.device
               ?.takeIf { it.isNotBlank() }
               ?.let { append("device=").append(it).append(';') }
-            append("outputBaseName=").append(outputBaseName)
+            append("outputBaseName=").append(resolved.outputBaseName)
           },
       )
     return super.submit(routed, timeoutMs)
@@ -98,15 +101,37 @@ class PreviewManifestRouter(
 
 @Serializable data class PreviewManifest(val previews: List<PreviewManifestEntry>)
 
+/**
+ * On-the-wire entry the router reads from `previews.json`. Two shapes coexist:
+ *
+ * - **Flat** (used by harness tests in `:daemon:harness`): top-level `widthPx` / `heightPx` /
+ *   `density` / `showBackground` / `device`. Hand-rolled JSON, easy to write inline.
+ * - **Nested** (emitted by the gradle plugin's `DiscoverPreviewsTask`): the canonical
+ *   [PreviewInfo][ee.schimke.composeai.plugin.PreviewInfo] schema with a `params` block carrying
+ *   `widthDp` / `heightDp` / `density` / `device` / `showBackground` / `backgroundColor`. Pre-fix
+ *   the daemon ignored the nested shape entirely (kotlinx.serialization with `ignoreUnknownKeys =
+ *   true`), so production always rendered at the daemon's hardcoded defaults — diagnosed from the
+ *   wear sample's missing circular crop after the URL-ordering fix exposed otherwise-stale renders.
+ *
+ * [resolved] returns a [ResolvedRenderParams] that prefers flat fields when set and falls back to
+ * the nested params, doing the dp→px conversion the plugin's schema requires.
+ */
 @Serializable
 data class PreviewManifestEntry(
   val id: String,
   val className: String,
   val functionName: String,
+  /**
+   * Production manifests written by the gradle plugin nest these fields under `params`. Optional
+   * because harness tests use the flat schema (see kdoc above); when null, the resolver consults
+   * the flat fields below.
+   */
+  val params: PreviewParamsEntry? = null,
   val widthPx: Int? = null,
   val heightPx: Int? = null,
   val density: Float? = null,
   val showBackground: Boolean? = null,
+  val backgroundColor: Long? = null,
   /**
    * Raw `@Preview(device = …)` string when the source preview has one set. Forwarded into
    * `RenderSpec` so the Android render path can apply the wear-round crop / `round` resource
@@ -114,4 +139,53 @@ data class PreviewManifestEntry(
    */
   val device: String? = null,
   val outputBaseName: String? = null,
+) {
+  fun resolved(): ResolvedRenderParams {
+    val p = params
+    val density = density ?: p?.density ?: 2.0f
+    val widthPx = widthPx ?: p?.widthDp?.let { (it * density).toInt() } ?: 320
+    val heightPx = heightPx ?: p?.heightDp?.let { (it * density).toInt() } ?: 320
+    val showBackground = showBackground ?: p?.showBackground ?: true
+    val backgroundColor = backgroundColor ?: p?.backgroundColor ?: 0L
+    val device = device ?: p?.device
+    return ResolvedRenderParams(
+      widthPx = widthPx,
+      heightPx = heightPx,
+      density = density,
+      showBackground = showBackground,
+      backgroundColor = backgroundColor,
+      device = device,
+      outputBaseName = outputBaseName ?: id,
+    )
+  }
+}
+
+/**
+ * Subset of the plugin's [PreviewParams][ee.schimke.composeai.plugin.PreviewParams] the daemon's
+ * render path consumes. Any plugin-side fields the daemon doesn't yet care about (fontScale,
+ * locale, uiMode, group, …) are silently dropped via `ignoreUnknownKeys = true`. Add them here when
+ * the daemon grows the matching render-path support.
+ */
+@Serializable
+data class PreviewParamsEntry(
+  val device: String? = null,
+  val widthDp: Int? = null,
+  val heightDp: Int? = null,
+  val density: Float? = null,
+  val showBackground: Boolean = false,
+  val backgroundColor: Long = 0L,
+)
+
+/**
+ * Output of [PreviewManifestEntry.resolved] — flat, fully-defaulted, ready to format into a
+ * `RenderSpec` payload.
+ */
+data class ResolvedRenderParams(
+  val widthPx: Int,
+  val heightPx: Int,
+  val density: Float,
+  val showBackground: Boolean,
+  val backgroundColor: Long,
+  val device: String?,
+  val outputBaseName: String,
 )

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestEntryResolveTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/PreviewManifestEntryResolveTest.kt
@@ -1,0 +1,103 @@
+package ee.schimke.composeai.daemon
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Resolver coverage for [PreviewManifestEntry] — the wear-clip fix lands the `params` nesting that
+ * the gradle plugin's `DiscoverPreviewsTask` actually emits, while keeping the harness's flat
+ * schema working. Pre-fix the daemon read the production manifest with the flat-schema reader,
+ * which made `device` / `widthDp` / `heightDp` / `density` silently null on every render and pinned
+ * the daemon to its hardcoded 320×320×2.0 defaults — visibly broken on Wear (no round crop, wrong
+ * aspect).
+ *
+ * The mirror class on the Android side (`:daemon:android`) carries identical logic and is exercised
+ * end-to-end by the harness's S3.5 / S4 tests; this unit test sits on the desktop module because
+ * desktop tests don't need a Robolectric sandbox to spin up.
+ */
+class PreviewManifestEntryResolveTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Test
+  fun `flat schema — harness shape — reads top-level fields`() {
+    val raw =
+      """{"id":"red-square","className":"X","functionName":"R","widthPx":64,""" +
+        """"heightPx":64,"density":1.0,"showBackground":true,"device":"id:wearos_small_round"}"""
+    val entry = json.decodeFromString(PreviewManifestEntry.serializer(), raw)
+    val resolved = entry.resolved()
+    assertEquals(64, resolved.widthPx)
+    assertEquals(64, resolved.heightPx)
+    assertEquals(1.0f, resolved.density, 0.0001f)
+    assertEquals(true, resolved.showBackground)
+    assertEquals("id:wearos_small_round", resolved.device)
+    assertEquals("red-square", resolved.outputBaseName)
+  }
+
+  @Test
+  fun `nested schema — plugin shape — reads params block`() {
+    // Mirrors what `DiscoverPreviewsTask` writes for a Wear preview annotated with
+    // `@Preview(device = "id:wearos_small_round")` — production manifest the daemon was silently
+    // dropping pre-fix. `widthDp` × `density` is the per-render sandbox size; the resolver does
+    // the dp→px conversion the plugin's schema requires.
+    val raw =
+      """{"id":"wear-1","className":"X","functionName":"R","sourceFile":"P.kt",""" +
+        """"params":{"device":"id:wearos_small_round","widthDp":192,"heightDp":192,""" +
+        """"density":2.625,"showBackground":true,"backgroundColor":4294967295},""" +
+        """"captures":[{"renderOutput":"renders/wear-1.png","cost":1.0}]}"""
+    val entry = json.decodeFromString(PreviewManifestEntry.serializer(), raw)
+    val resolved = entry.resolved()
+    assertEquals(504, resolved.widthPx) // 192 * 2.625
+    assertEquals(504, resolved.heightPx)
+    assertEquals(2.625f, resolved.density, 0.0001f)
+    assertEquals(true, resolved.showBackground)
+    assertEquals("id:wearos_small_round", resolved.device)
+    assertEquals(0xFFFFFFFFL, resolved.backgroundColor)
+    assertEquals("wear-1", resolved.outputBaseName)
+  }
+
+  @Test
+  fun `flat fields override nested params when both are set`() {
+    // Defensive — if a future tool emits a mixed shape we'd rather honour the explicit flat px
+    // than re-derive from dp. Same precedence rule on every field.
+    val raw =
+      """{"id":"mix","className":"X","functionName":"R","widthPx":100,"heightPx":50,""" +
+        """"params":{"widthDp":192,"heightDp":192,"density":2.0}}"""
+    val entry = json.decodeFromString(PreviewManifestEntry.serializer(), raw)
+    val resolved = entry.resolved()
+    assertEquals(100, resolved.widthPx)
+    assertEquals(50, resolved.heightPx)
+  }
+
+  @Test
+  fun `bare entry falls back to defaults — never crashes the routing path`() {
+    val raw = """{"id":"bare","className":"X","functionName":"R"}"""
+    val entry = json.decodeFromString(PreviewManifestEntry.serializer(), raw)
+    val resolved = entry.resolved()
+    assertEquals(320, resolved.widthPx)
+    assertEquals(320, resolved.heightPx)
+    assertEquals(2.0f, resolved.density, 0.0001f)
+    assertEquals(true, resolved.showBackground)
+    assertNull(resolved.device)
+    assertEquals(0L, resolved.backgroundColor)
+    assertEquals("bare", resolved.outputBaseName)
+  }
+
+  @Test
+  fun `unknown plugin-side fields don't break decoding`() {
+    // The plugin's PreviewParams carries fields the daemon doesn't yet read (fontScale, locale,
+    // uiMode, group, kind, etc.). With ignoreUnknownKeys = true the daemon should accept the full
+    // payload and resolve only what it understands.
+    val raw =
+      """{"id":"full","className":"X","functionName":"R",""" +
+        """"params":{"device":"id:wearos_small_round","widthDp":192,"heightDp":192,""" +
+        """"fontScale":1.12,"locale":"en-rUS","uiMode":32,"group":"Devices",""" +
+        """"showSystemUi":false,"kind":"COMPOSE","previewParameterLimit":2147483647}}"""
+    val entry = json.decodeFromString(PreviewManifestEntry.serializer(), raw)
+    val resolved = entry.resolved()
+    assertEquals("id:wearos_small_round", resolved.device)
+    assertEquals(384, resolved.widthPx) // 192 * 2.0 default density
+  }
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -49,6 +49,72 @@ const historyScopeRef: { current: HistoryScope | null } = { current: null };
  *  pushes `discoveryUpdated`. We mirror the latest snapshot here so save-
  *  scoped focus signals can map "active file → preview IDs" without an
  *  extension-side discovery round-trip. */
+/**
+ * Returns the mtime (ms since epoch) of the oldest on-disk PNG referenced by
+ * any rendered capture in [previews] across [modules], or null if none of the
+ * paths exist. Cheap stat call per capture; results are not cached because
+ * renders rewrite these files on every save.
+ */
+async function oldestRenderMtime(
+    previews: PreviewInfo[],
+    modules: string[],
+): Promise<number | null> {
+    if (!gradleService) { return null; }
+    let oldest: number | null = null;
+    for (const preview of previews) {
+        for (const capture of preview.captures) {
+            if (!capture.renderOutput) { continue; }
+            // Match the path the readPreviewImage resolver builds.
+            const mod = modules.find(m => previewModuleMap.get(preview.id) === m) ?? modules[0];
+            const pngPath = path.join(
+                gradleService.workspaceRoot, mod,
+                'build', 'compose-previews', capture.renderOutput,
+            );
+            try {
+                const stat = await fs.promises.stat(pngPath);
+                const mtime = stat.mtimeMs;
+                if (oldest == null || mtime < oldest) { oldest = mtime; }
+            } catch {
+                // File missing — discover-only pass on a never-rendered preview.
+                // Don't count toward oldest; the banner reflects what the user
+                // is actually seeing on screen.
+            }
+        }
+    }
+    return oldest;
+}
+
+/**
+ * "5 minutes ago", "2 hours ago", "3 days ago". Coarse — the banner exists to
+ * communicate "this is old", not to time-stamp anything.
+ */
+function formatRelativeAge(ageMs: number): string {
+    const seconds = Math.floor(ageMs / 1000);
+    if (seconds < 60) { return `${seconds}s ago`; }
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) { return `${minutes}m ago`; }
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) { return `${hours}h ago`; }
+    const days = Math.floor(hours / 24);
+    return `${days}d ago`;
+}
+
+/**
+ * True when the panel currently shows a "Showing previews from <ago>" banner
+ * the extension posted because the on-disk PNGs read by the activation /
+ * editor-change refresh were older than [STALE_BANNER_THRESHOLD_MS]. Used so
+ * we only clear the banner when one *we* set is up — not a build-error or
+ * filter-empty notice. Cleared when a fresh `updateImage` arrives from the
+ * daemon, or when a forceRender refresh completes.
+ */
+let staleBannerShown = false;
+
+/** PNGs older than this on the activation-time refresh trigger the
+ *  "Showing previews from <ago>" banner. 60s is enough to skip the
+ *  steady-state save-loop case (where renders are seconds old) but catches
+ *  the "opened the project an hour later" launch case. */
+const STALE_BANNER_THRESHOLD_MS = 60_000;
+
 const moduleManifestCache = new Map<string, PreviewInfo[]>();
 let panel: PreviewPanel | null = null;
 let debounceTimer: NodeJS.Timeout | null = null;
@@ -231,6 +297,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     daemonScheduler = new DaemonScheduler(daemonGate, {
         onPreviewImageReady: (_moduleId, previewId, imageBase64) => {
             if (!panel) { return; }
+            // Fresh daemon render arriving — if a stale banner is up, this is
+            // the moment to retire it. Guarded by staleBannerShown so we only
+            // clear a banner we set ourselves; legitimate showMessage banners
+            // (build error, filter-empty notice) are left alone.
+            if (staleBannerShown) {
+                panel.postMessage({ command: 'showMessage', text: '' });
+                staleBannerShown = false;
+            }
             // Capture index 0 — the daemon's v1 renderFinished targets the
             // representative capture only. Multi-capture (animated) renders
             // still come through the Gradle path; the daemon's predictive
@@ -1360,6 +1434,37 @@ async function refresh(
         // showMessage would also clobber legitimate extension-set messages
         // (filter empty notice, build errors), which was the original
         // "populate then go blank" regression.
+        //
+        // Stale-banner posting / clearing. The on-disk PNGs the discover path
+        // surfaces can be from a previous session — at activation time they
+        // typically are. Without a hint the user reads them as the live
+        // preview. After a successful refresh:
+        //   - forceRender=true → user explicitly re-rendered, anything stale
+        //     was just rewritten; clear any prior banner.
+        //   - forceRender=false → check the oldest visible PNG. If older than
+        //     [STALE_BANNER_THRESHOLD_MS], post a banner with relative time so
+        //     the user knows what they're looking at and where the next
+        //     refresh comes from. Cleared on the first daemon updateImage
+        //     (see daemonScheduler events) or on the next forceRender.
+        if (forceRender && staleBannerShown) {
+            panel.postMessage({ command: 'showMessage', text: '' });
+            staleBannerShown = false;
+        } else if (!forceRender) {
+            const oldestMtime = await oldestRenderMtime(visiblePreviews, modules);
+            if (oldestMtime != null) {
+                const ageMs = Date.now() - oldestMtime;
+                if (ageMs > STALE_BANNER_THRESHOLD_MS) {
+                    panel.postMessage({
+                        command: 'showMessage',
+                        text: `Showing previews from ${formatRelativeAge(ageMs)} (save to render fresh, or run "Compose Preview: Refresh").`,
+                    });
+                    staleBannerShown = true;
+                } else if (staleBannerShown) {
+                    panel.postMessage({ command: 'showMessage', text: '' });
+                    staleBannerShown = false;
+                }
+            }
+        }
         return abort.signal.aborted ? 'cancelled' : 'completed';
     } catch (err: unknown) {
         if (abort.signal.aborted) { return 'cancelled'; }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -84,6 +84,18 @@ async function oldestRenderMtime(
     return oldest;
 }
 
+/** Stat the source file and return its mtime, or null on any error. The
+ *  banner uses this as the "freshness reference" — `.kt` newer than the
+ *  oldest PNG = renders are stale relative to the source. */
+async function sourceFileMtime(filePath: string): Promise<number | null> {
+    try {
+        const stat = await fs.promises.stat(filePath);
+        return stat.mtimeMs;
+    } catch {
+        return null;
+    }
+}
+
 /**
  * "5 minutes ago", "2 hours ago", "3 days ago". Coarse — the banner exists to
  * communicate "this is old", not to time-stamp anything.
@@ -100,20 +112,14 @@ function formatRelativeAge(ageMs: number): string {
 }
 
 /**
- * True when the panel currently shows a "Showing previews from <ago>" banner
- * the extension posted because the on-disk PNGs read by the activation /
- * editor-change refresh were older than [STALE_BANNER_THRESHOLD_MS]. Used so
- * we only clear the banner when one *we* set is up — not a build-error or
+ * True when the panel currently shows a "Showing previews from <ago>, but
+ * <file> has changed since" banner the extension posted because the active
+ * source file's mtime is newer than the oldest on-disk PNG. Used so we only
+ * clear the banner when one *we* set is up — not a build-error or
  * filter-empty notice. Cleared when a fresh `updateImage` arrives from the
  * daemon, or when a forceRender refresh completes.
  */
 let staleBannerShown = false;
-
-/** PNGs older than this on the activation-time refresh trigger the
- *  "Showing previews from <ago>" banner. 60s is enough to skip the
- *  steady-state save-loop case (where renders are seconds old) but catches
- *  the "opened the project an hour later" launch case. */
-const STALE_BANNER_THRESHOLD_MS = 60_000;
 
 const moduleManifestCache = new Map<string, PreviewInfo[]>();
 let panel: PreviewPanel | null = null;
@@ -673,8 +679,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         setTimeout(() => {
             const active = vscode.window.activeTextEditor;
             if (active?.document.languageId === 'kotlin') {
-                refresh(false, active.document.uri.fsPath);
-                void warmDaemonForFile(active.document.uri.fsPath);
+                void runActivationRefresh(active.document.uri.fsPath);
             } else {
                 // No Kotlin file in focus — let refresh() emit the empty-state
                 // message without trying to load anything.
@@ -835,6 +840,42 @@ async function notifyDaemonOfSave(filePath: string): Promise<boolean> {
     if (ids.length === 0) { return true; }
     await daemonScheduler.setFocus(module, ids);
     return await daemonScheduler.renderNow(module, ids, 'fast', 'save');
+}
+
+/**
+ * Activation-time refresh sequence. Three phases, one after the other:
+ *
+ *   1. `refresh(false, filePath)` — populates the panel from on-disk PNGs so
+ *      the user sees *something* immediately (cards with cached images, plus
+ *      the "Showing previews from <ago>" banner if those PNGs are stale
+ *      relative to the source file).
+ *   2. `warmDaemonForFile(filePath)` — runs `composePreviewDaemonStart` and
+ *      spawns the daemon JVM. No-op if the daemon flag is off.
+ *   3. If the daemon is healthy by the time it's done warming, fire a
+ *      `notifyDaemonOfSave`-equivalent so the panel gets a fresh render even
+ *      without the user touching the file. Catches the "edited a file in
+ *      another module / `git pull`'d / agent rewrote a Composable" case
+ *      where the on-disk PNGs are stale relative to source even though the
+ *      source file the user is currently looking at is itself unchanged.
+ *      The banner from phase 1 stays up only long enough for phase 3's
+ *      first updateImage to clear it; on a hot daemon that's a couple of
+ *      seconds, on a cold spawn 5-10s.
+ *
+ * Failures in phases 2 or 3 silently fall back: phase 1 already gave the
+ * user something to look at, and the next save will re-trigger the whole
+ * pipeline through `runRefreshExclusive`.
+ */
+async function runActivationRefresh(filePath: string): Promise<void> {
+    await refresh(false, filePath);
+    await warmDaemonForFile(filePath);
+    if (!gradleService || !daemonGate) { return; }
+    const module = gradleService.resolveModule(filePath);
+    if (!module || !daemonGate.isDaemonReady(module)) { return; }
+    // Phase 3 — kick off a fresh render through the daemon. Reuses the same
+    // notify path the save-driven flow uses; the daemon does the swap +
+    // renderNow + the panel updates via the existing onPreviewImageReady
+    // wiring. No need for a separate code path.
+    await notifyDaemonOfSave(filePath);
 }
 
 /**
@@ -1435,34 +1476,41 @@ async function refresh(
         // (filter empty notice, build errors), which was the original
         // "populate then go blank" regression.
         //
-        // Stale-banner posting / clearing. The on-disk PNGs the discover path
-        // surfaces can be from a previous session — at activation time they
-        // typically are. Without a hint the user reads them as the live
-        // preview. After a successful refresh:
+        // Stale-banner posting / clearing. Compare the active source file's
+        // mtime against the oldest visible PNG: if the source has been edited
+        // since the renders were written, the user is looking at a render
+        // that doesn't reflect their current source. An absolute "older than
+        // X" threshold is wrong because a steady-state save loop produces
+        // PNGs seconds old that are nonetheless current — what matters is
+        // "did the source move since".
+        //
         //   - forceRender=true → user explicitly re-rendered, anything stale
         //     was just rewritten; clear any prior banner.
-        //   - forceRender=false → check the oldest visible PNG. If older than
-        //     [STALE_BANNER_THRESHOLD_MS], post a banner with relative time so
-        //     the user knows what they're looking at and where the next
-        //     refresh comes from. Cleared on the first daemon updateImage
-        //     (see daemonScheduler events) or on the next forceRender.
+        //   - forceRender=false → check source vs PNG; banner if source is
+        //     newer. Cleared on the first daemon `updateImage` (see
+        //     daemonScheduler events) or on the next forceRender.
         if (forceRender && staleBannerShown) {
             panel.postMessage({ command: 'showMessage', text: '' });
             staleBannerShown = false;
         } else if (!forceRender) {
-            const oldestMtime = await oldestRenderMtime(visiblePreviews, modules);
-            if (oldestMtime != null) {
-                const ageMs = Date.now() - oldestMtime;
-                if (ageMs > STALE_BANNER_THRESHOLD_MS) {
-                    panel.postMessage({
-                        command: 'showMessage',
-                        text: `Showing previews from ${formatRelativeAge(ageMs)} (save to render fresh, or run "Compose Preview: Refresh").`,
-                    });
-                    staleBannerShown = true;
-                } else if (staleBannerShown) {
-                    panel.postMessage({ command: 'showMessage', text: '' });
-                    staleBannerShown = false;
-                }
+            const [sourceMtime, oldestMtime] = await Promise.all([
+                sourceFileMtime(activeFile),
+                oldestRenderMtime(visiblePreviews, modules),
+            ]);
+            const sourceIsNewer =
+                sourceMtime != null && oldestMtime != null && sourceMtime > oldestMtime;
+            if (sourceIsNewer) {
+                const ago = formatRelativeAge(Date.now() - oldestMtime!);
+                panel.postMessage({
+                    command: 'showMessage',
+                    text:
+                        `Showing previews from ${ago}, but ${path.basename(activeFile)} ` +
+                        'has changed since (save to render fresh, or run "Compose Preview: Refresh").',
+                });
+                staleBannerShown = true;
+            } else if (staleBannerShown) {
+                panel.postMessage({ command: 'showMessage', text: '' });
+                staleBannerShown = false;
             }
         }
         return abort.signal.aborted ? 'cancelled' : 'completed';


### PR DESCRIPTION
Two follow-ups that didn't make #353's merge: a real wear-clip / sizing fix in the daemon, plus a launch-time staleness banner that compares source file mtime against rendered PNG mtime and auto-renders on activation.

## Commits

### `dfb936e` — launch banner when on-disk PNGs are stale
After a successful `refresh(false)`, posts a `showMessage` banner if the on-disk PNGs are older than the active source file. Cleared the moment a fresh `updateImage` arrives from the daemon, or on the next forceRender. Guarded by `staleBannerShown` so we never clobber legitimate banners (build error, filter empty, jlink missing).

### `89a2ba9` — read nested params from production previews.json
**Schema mismatch in the daemon's manifest reader.** The gradle plugin's `DiscoverPreviewsTask` emits `PreviewInfo` with a *nested* `params` block (`device`, `widthDp`, `heightDp`, `density`, `showBackground`, `backgroundColor`, …). Both daemon backends' `PreviewManifestEntry` declared a *flat* schema with top-level `widthPx` / `heightPx` / `density` / `device`. With `ignoreUnknownKeys = true` the entire `params` block was silently dropped, so production renders fell back to the daemon's hardcoded defaults: 320×320 px, density 2.0, no device, no wear-round crop. Visibly broken on Wear (missing circular crop, wrong aspect) and on any preview using a non-default device.

Surfaced once #353's URL-ordering fix let fresh code through to the daemon — pre-fix the staleness masked the size/crop errors because every render came back as the matching stale bundled JAR's pre-rendered shape.

`PreviewManifestEntry` now carries an optional `params: PreviewParamsEntry` mirroring the plugin's `PreviewParams` subset the render path consumes. A new `resolved()` helper returns a `ResolvedRenderParams` with all fields fully populated, preferring flat fields when set (so harness tests that hand-roll the flat shape keep working) and falling back to the nested params with the dp→px conversion the plugin's schema requires.

`PreviewManifestEntryResolveTest` covers all four shapes: flat-only, nested-only, mixed (flat wins), bare (defaults), plus the unknown-keys robustness contract.

### `ec2c840` — source-vs-PNG age compare + auto-render on activate

**Banner trigger:** the absolute `older than 60s` threshold was wrong in two directions — it fired in steady-state save loops where seconds-old PNGs are nonetheless current, and missed the case where a freshly-rendered PNG is wrong because some *other* file changed. Source-vs-render is the right invariant: source mtime > oldest visible PNG mtime → banner. Banner text names the file so the user knows what to save.

**Activation refresh:** previously the panel populated from on-disk PNGs and warmed the daemon JVM; users had to save before seeing fresh content. Now sequenced as `refresh(false) → warmDaemonForFile → notifyDaemonOfSave` so the panel self-updates on activation, catching cross-file edits, `git pull`, agent rewrites, classpath drift. The banner from phase 1 covers the cold-spawn window and clears the moment phase 3's first daemon `updateImage` arrives.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 246 passing
- [x] `./gradlew :daemon:desktop:test --tests PreviewManifestEntryResolveTest` — 5/5 passing (flat / nested / mixed / bare / unknown-keys)
- [ ] Manual: rebuild daemon (`./gradlew :daemon:android:assemble :samples:wear:composePreviewDaemonStart`), restart via *Compose Preview: Restart Preview Daemon*. On next activation:
  - Wear preview should render at 192×192 (or 227×227) with the round crop applied — verifies the schema fix.
  - If on-disk PNGs are stale, banner appears for ~2-10s and clears once auto-render's first `updateImage` lands — verifies the source-vs-PNG compare and the auto-render kick.

---
_Generated by [Claude Code](https://claude.ai/code/session_018AS96ABywGPit3rWVRr3q3)_