### PR TITLE
feat(vscode): diff mode toggle — side / overlay / onion-skin

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -538,6 +538,82 @@ body {
     background: var(--card-bg);
 }
 
+/* Mode toggle bar — shared between live-panel and history-panel diff
+   surfaces so the look is consistent. Three buttons (side / overlay /
+   onion-skin); the active one carries an outline. */
+.diff-mode-bar {
+    display: inline-flex;
+    gap: 4px;
+    padding: 2px 4px;
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--text-secondary) 8%, transparent);
+}
+.diff-mode-bar button {
+    padding: 1px 8px;
+    font-size: calc(var(--vscode-font-size) - 1px);
+    background: transparent;
+    color: var(--text-secondary);
+    border: 1px solid transparent;
+    border-radius: 3px;
+    cursor: pointer;
+    line-height: 1.4;
+}
+.diff-mode-bar button:hover {
+    background: var(--toolbar-hover);
+    color: var(--text-primary);
+}
+.diff-mode-bar button.active {
+    background: var(--vscode-editor-background);
+    border-color: var(--vscode-focusBorder);
+    color: var(--text-primary);
+}
+
+/* Stacked-image presentation used by overlay and onion-skin modes. The
+   wrapper sizes to the natural width of the bottom (base) image; the
+   top image is absolutely positioned over it. */
+.diff-stack {
+    position: relative;
+    display: block;
+    max-width: 100%;
+    margin: 0 auto;
+}
+.diff-stack img {
+    display: block;
+    max-width: 100%;
+    height: auto;
+}
+.diff-stack .diff-stack-base { position: relative; z-index: 0; }
+.diff-stack .diff-stack-top {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+}
+/* Overlay: top layer mixes with the base via difference blend, so
+   identical pixels go black and any change shows up as a coloured
+   silhouette. */
+.diff-stack[data-mode="overlay"] .diff-stack-top {
+    mix-blend-mode: difference;
+}
+/* Onion-skin: top layer's opacity follows the slider. Slider value is
+   wired in JS to a CSS custom property; the top image starts at 50%
+   so the user sees both contributions. */
+.diff-stack[data-mode="onion"] .diff-stack-top {
+    opacity: var(--diff-onion-mix, 0.5);
+}
+.diff-stack-onion-slider {
+    width: 100%;
+    margin-top: 4px;
+    accent-color: var(--vscode-focusBorder);
+}
+.diff-stack-caption {
+    margin-top: 4px;
+    font-size: 90%;
+    color: var(--text-secondary);
+    text-align: center;
+}
+
 @keyframes fadeIn {
     from { opacity: 0; }
     to { opacity: 1; }

--- a/vscode-extension/src/historyPanel.ts
+++ b/vscode-extension/src/historyPanel.ts
@@ -594,11 +594,102 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
                 '.expanded[data-id="' + cssEscape(id) + '"][data-against="' + cssEscape(against) + '"]');
             if (!expansion) return;
             expansion.innerHTML = '';
-            const grid = document.createElement('div');
-            grid.className = 'diff-grid';
-            grid.appendChild(buildDiffPane(leftLabel, leftImage));
-            grid.appendChild(buildDiffPane(rightLabel, rightImage));
-            expansion.appendChild(grid);
+            const payload = { leftLabel, leftImage, rightLabel, rightImage };
+            const stored = vscode.getState() || {};
+            const initialMode = (stored.diffMode === 'overlay' || stored.diffMode === 'onion')
+                ? stored.diffMode : 'side';
+            const body = document.createElement('div');
+            body.className = 'diff-body';
+            const modeBar = buildHistoryDiffModeBar(initialMode, (mode) => {
+                const cur = vscode.getState() || {};
+                cur.diffMode = mode;
+                vscode.setState(cur);
+                renderHistoryDiffMode(body, mode, payload);
+            });
+            expansion.appendChild(modeBar);
+            expansion.appendChild(body);
+            renderHistoryDiffMode(body, initialMode, payload);
+        }
+
+        function buildHistoryDiffModeBar(initialMode, onChange) {
+            const bar = document.createElement('div');
+            bar.className = 'diff-mode-bar';
+            bar.setAttribute('role', 'tablist');
+            const modes = [
+                { id: 'side', label: 'Side' },
+                { id: 'overlay', label: 'Overlay' },
+                { id: 'onion', label: 'Onion' },
+            ];
+            for (const m of modes) {
+                const btn = document.createElement('button');
+                btn.type = 'button';
+                btn.textContent = m.label;
+                btn.dataset.mode = m.id;
+                btn.setAttribute('role', 'tab');
+                btn.setAttribute('aria-selected', m.id === initialMode ? 'true' : 'false');
+                if (m.id === initialMode) btn.classList.add('active');
+                btn.addEventListener('click', () => {
+                    bar.querySelectorAll('button').forEach(b => {
+                        b.classList.toggle('active', b.dataset.mode === m.id);
+                        b.setAttribute('aria-selected', b.dataset.mode === m.id ? 'true' : 'false');
+                    });
+                    onChange(m.id);
+                });
+                bar.appendChild(btn);
+            }
+            return bar;
+        }
+
+        function renderHistoryDiffMode(body, mode, payload) {
+            body.innerHTML = '';
+            if (mode === 'side') {
+                const grid = document.createElement('div');
+                grid.className = 'diff-grid';
+                grid.appendChild(buildDiffPane(payload.leftLabel, payload.leftImage));
+                grid.appendChild(buildDiffPane(payload.rightLabel, payload.rightImage));
+                body.appendChild(grid);
+                return;
+            }
+            body.appendChild(buildHistoryDiffStack(mode, payload));
+        }
+
+        function buildHistoryDiffStack(mode, payload) {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'diff-stack-wrapper';
+            const stack = document.createElement('div');
+            stack.className = 'diff-stack';
+            stack.dataset.mode = mode;
+            const base = document.createElement('img');
+            base.className = 'diff-stack-base';
+            base.alt = payload.leftLabel;
+            base.src = 'data:image/png;base64,' + payload.leftImage;
+            const top = document.createElement('img');
+            top.className = 'diff-stack-top';
+            top.alt = payload.rightLabel;
+            top.src = 'data:image/png;base64,' + payload.rightImage;
+            stack.appendChild(base);
+            stack.appendChild(top);
+            wrapper.appendChild(stack);
+            if (mode === 'onion') {
+                const slider = document.createElement('input');
+                slider.type = 'range';
+                slider.min = '0';
+                slider.max = '100';
+                slider.value = '50';
+                slider.className = 'diff-stack-onion-slider';
+                slider.setAttribute('aria-label',
+                    'Onion-skin mix between ' + payload.leftLabel + ' and ' + payload.rightLabel);
+                stack.style.setProperty('--diff-onion-mix', '0.5');
+                slider.addEventListener('input', () => {
+                    stack.style.setProperty('--diff-onion-mix', (slider.value / 100).toString());
+                });
+                wrapper.appendChild(slider);
+            }
+            const cap = document.createElement('div');
+            cap.className = 'diff-stack-caption';
+            cap.textContent = payload.leftLabel + '  ◄  ' + payload.rightLabel;
+            wrapper.appendChild(cap);
+            return wrapper;
         }
 
         function buildDiffPane(label, imageData) {

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -550,19 +550,114 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 err.className = 'preview-diff-error';
                 err.textContent = errorMessage;
                 overlay.appendChild(err);
-            } else if (payload) {
-                const grid = document.createElement('div');
-                grid.className = 'preview-diff-grid';
-                grid.appendChild(buildPreviewDiffPane(payload.leftLabel, payload.leftImage));
-                grid.appendChild(buildPreviewDiffPane(payload.rightLabel, payload.rightImage));
-                overlay.appendChild(grid);
-            } else {
+                container.appendChild(overlay);
+                return;
+            }
+            if (!payload) {
                 const loading = document.createElement('div');
                 loading.className = 'preview-diff-loading';
                 loading.textContent = 'Loading diff…';
                 overlay.appendChild(loading);
+                container.appendChild(overlay);
+                return;
             }
+            // Persist the user's last-picked mode so it sticks across diff
+            // requests within the same session.
+            const initialMode = (state.diffMode === 'overlay' || state.diffMode === 'onion')
+                ? state.diffMode : 'side';
+            const body = document.createElement('div');
+            body.className = 'preview-diff-body';
+            const modeBar = buildDiffModeBar(initialMode, (mode) => {
+                state.diffMode = mode;
+                vscode.setState(state);
+                renderPreviewDiffMode(body, mode, payload);
+            });
+            overlay.appendChild(modeBar);
+            overlay.appendChild(body);
             container.appendChild(overlay);
+            renderPreviewDiffMode(body, initialMode, payload);
+        }
+
+        function buildDiffModeBar(initialMode, onChange) {
+            const bar = document.createElement('div');
+            bar.className = 'diff-mode-bar';
+            bar.setAttribute('role', 'tablist');
+            const modes = [
+                { id: 'side', label: 'Side' },
+                { id: 'overlay', label: 'Overlay' },
+                { id: 'onion', label: 'Onion' },
+            ];
+            for (const m of modes) {
+                const btn = document.createElement('button');
+                btn.type = 'button';
+                btn.textContent = m.label;
+                btn.dataset.mode = m.id;
+                btn.setAttribute('role', 'tab');
+                btn.setAttribute('aria-selected', m.id === initialMode ? 'true' : 'false');
+                if (m.id === initialMode) btn.classList.add('active');
+                btn.addEventListener('click', () => {
+                    bar.querySelectorAll('button').forEach(b => {
+                        b.classList.toggle('active', b.dataset.mode === m.id);
+                        b.setAttribute('aria-selected', b.dataset.mode === m.id ? 'true' : 'false');
+                    });
+                    onChange(m.id);
+                });
+                bar.appendChild(btn);
+            }
+            return bar;
+        }
+
+        function renderPreviewDiffMode(body, mode, payload) {
+            body.innerHTML = '';
+            if (mode === 'side') {
+                const grid = document.createElement('div');
+                grid.className = 'preview-diff-grid';
+                grid.appendChild(buildPreviewDiffPane(payload.leftLabel, payload.leftImage));
+                grid.appendChild(buildPreviewDiffPane(payload.rightLabel, payload.rightImage));
+                body.appendChild(grid);
+                return;
+            }
+            const stack = buildDiffStack(mode, payload);
+            body.appendChild(stack);
+        }
+
+        function buildDiffStack(mode, payload) {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'preview-diff-stack-wrapper';
+            const stack = document.createElement('div');
+            stack.className = 'diff-stack';
+            stack.dataset.mode = mode;
+            const base = document.createElement('img');
+            base.className = 'diff-stack-base';
+            base.alt = payload.leftLabel;
+            base.src = 'data:image/png;base64,' + payload.leftImage;
+            const top = document.createElement('img');
+            top.className = 'diff-stack-top';
+            top.alt = payload.rightLabel;
+            top.src = 'data:image/png;base64,' + payload.rightImage;
+            stack.appendChild(base);
+            stack.appendChild(top);
+            wrapper.appendChild(stack);
+            if (mode === 'onion') {
+                const slider = document.createElement('input');
+                slider.type = 'range';
+                slider.min = '0';
+                slider.max = '100';
+                slider.value = '50';
+                slider.className = 'diff-stack-onion-slider';
+                slider.setAttribute('aria-label',
+                    'Onion-skin mix between ' + payload.leftLabel + ' and ' + payload.rightLabel);
+                stack.style.setProperty('--diff-onion-mix', '0.5');
+                slider.addEventListener('input', () => {
+                    stack.style.setProperty('--diff-onion-mix', (slider.value / 100).toString());
+                });
+                wrapper.appendChild(slider);
+            }
+            const cap = document.createElement('div');
+            cap.className = 'diff-stack-caption';
+            cap.textContent = payload.leftLabel + '  ◄  ' + payload.rightLabel;
+            wrapper.appendChild(cap);
+            return wrapper;
         }
 
         function buildPreviewDiffPane(label, imageData) {


### PR DESCRIPTION
## Summary

Step 3a of the diff feature: **mode toggle — side / overlay / onion-skin**, applied to both diff surfaces (history-row diff and live-panel focus diff).

- **Side** — existing two-pane grid (default).
- **Overlay** — stacks the two images with `mix-blend-mode: difference`. Identical pixels render black; any change shows up as a coloured silhouette. Best for spotting drift at a glance.
- **Onion** — stacks the two with an opacity slider. Drag to fade between A and B. Best for layout / repositioning changes where pixel diffs would be too noisy.

Selected mode persists in the webview's `vscode.setState`, so a session that prefers overlay keeps overlay across subsequent diff requests on either panel.

Purely client-side: CSS blend-modes + opacity. No new extension messages, no daemon changes.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 261 / 261 passing
- [ ] Manual: history-row → click diff button → mode bar shows three buttons; switching modes re-renders the body
- [ ] Manual: live panel focus → diff vs HEAD → same mode bar; identical pixels read black in Overlay
- [ ] Manual: switch to Onion, drag slider 0→100 → top image fades in over base
- [ ] Manual: pick a non-default mode in one diff, open another diff (different anchor or different row) → mode persists
- [ ] Manual: keyboard navigation through mode buttons (Tab / Enter) — ARIA `tablist`/`tab`/`aria-selected` should announce correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01A6AFhHNrHQNqUPKdmJRt94)_