### PR TITLE
feat(vscode): pixel-stats line on diff results

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -614,6 +614,35 @@ body {
     text-align: center;
 }
 
+/* Header strip above a diff result: mode toggle on the left, computed
+   pixel stats on the right. Stats line is computed client-side from
+   the two PNGs (canvas ImageData) — no daemon round-trip. */
+.diff-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+.diff-stats {
+    font-size: calc(var(--vscode-font-size) - 1px);
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+}
+.diff-stats[data-state="identical"] {
+    color: var(--vscode-charts-green, var(--text-secondary));
+}
+.diff-stats[data-state="changed"] {
+    color: var(--text-primary);
+}
+.diff-stats[data-state="size-mismatch"] {
+    color: var(--vscode-editorWarning-foreground, #cca700);
+}
+
 @keyframes fadeIn {
     from { opacity: 0; }
     to { opacity: 1; }

--- a/vscode-extension/src/historyPanel.ts
+++ b/vscode-extension/src/historyPanel.ts
@@ -598,6 +598,8 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
             const stored = vscode.getState() || {};
             const initialMode = (stored.diffMode === 'overlay' || stored.diffMode === 'onion')
                 ? stored.diffMode : 'side';
+            const header = document.createElement('div');
+            header.className = 'diff-header';
             const body = document.createElement('div');
             body.className = 'diff-body';
             const modeBar = buildHistoryDiffModeBar(initialMode, (mode) => {
@@ -606,9 +608,90 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
                 vscode.setState(cur);
                 renderHistoryDiffMode(body, mode, payload);
             });
-            expansion.appendChild(modeBar);
+            const stats = document.createElement('div');
+            stats.className = 'diff-stats';
+            stats.textContent = 'computing…';
+            header.appendChild(modeBar);
+            header.appendChild(stats);
+            expansion.appendChild(header);
             expansion.appendChild(body);
             renderHistoryDiffMode(body, initialMode, payload);
+            computeDiffStats(payload.leftImage, payload.rightImage).then(s => {
+                applyDiffStats(stats, s);
+            });
+        }
+
+        // Client-side pixel diff helpers — duplicated from the live panel
+        // so the History panel webview is self-contained. Same algorithm.
+        function computeDiffStats(leftBase64, rightBase64) {
+            return new Promise((resolve) => {
+                const left = new Image();
+                const right = new Image();
+                let loaded = 0;
+                const onErr = () => resolve({ error: 'image failed to load' });
+                const onOk = () => {
+                    if (++loaded < 2) return;
+                    try {
+                        if (left.naturalWidth !== right.naturalWidth
+                            || left.naturalHeight !== right.naturalHeight) {
+                            resolve({
+                                sameSize: false,
+                                leftW: left.naturalWidth, leftH: left.naturalHeight,
+                                rightW: right.naturalWidth, rightH: right.naturalHeight,
+                            });
+                            return;
+                        }
+                        const w = left.naturalWidth, h = left.naturalHeight;
+                        const c1 = document.createElement('canvas');
+                        c1.width = w; c1.height = h;
+                        c1.getContext('2d').drawImage(left, 0, 0);
+                        const d1 = c1.getContext('2d').getImageData(0, 0, w, h).data;
+                        const c2 = document.createElement('canvas');
+                        c2.width = w; c2.height = h;
+                        c2.getContext('2d').drawImage(right, 0, 0);
+                        const d2 = c2.getContext('2d').getImageData(0, 0, w, h).data;
+                        let diff = 0;
+                        const len = d1.length;
+                        for (let i = 0; i < len; i += 4) {
+                            if (d1[i] !== d2[i] || d1[i+1] !== d2[i+1]
+                                || d1[i+2] !== d2[i+2] || d1[i+3] !== d2[i+3]) diff++;
+                        }
+                        const total = w * h;
+                        resolve({
+                            sameSize: true, w, h, diffPx: diff, total,
+                            percent: total > 0 ? diff / total : 0,
+                        });
+                    } catch (err) {
+                        resolve({ error: (err && err.message) || 'stats unavailable' });
+                    }
+                };
+                left.onload = onOk; left.onerror = onErr;
+                right.onload = onOk; right.onerror = onErr;
+                left.src = 'data:image/png;base64,' + leftBase64;
+                right.src = 'data:image/png;base64,' + rightBase64;
+            });
+        }
+
+        function applyDiffStats(el, s) {
+            if (!s) { el.textContent = ''; el.removeAttribute('data-state'); return; }
+            if (s.error) { el.textContent = s.error; el.removeAttribute('data-state'); return; }
+            if (!s.sameSize) {
+                el.textContent = 'sizes differ — '
+                    + s.leftW + '×' + s.leftH + ' vs '
+                    + s.rightW + '×' + s.rightH;
+                el.dataset.state = 'size-mismatch';
+                return;
+            }
+            if (s.diffPx === 0) {
+                el.textContent = 'identical · ' + s.w + '×' + s.h;
+                el.dataset.state = 'identical';
+                return;
+            }
+            const p = s.percent * 100;
+            const pct = p < 0.01 ? p.toFixed(3) : p.toFixed(2);
+            el.textContent = s.diffPx.toLocaleString() + ' px ('
+                + pct + '%) · ' + s.w + '×' + s.h;
+            el.dataset.state = 'changed';
         }
 
         function buildHistoryDiffModeBar(initialMode, onChange) {

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -565,6 +565,8 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             // requests within the same session.
             const initialMode = (state.diffMode === 'overlay' || state.diffMode === 'onion')
                 ? state.diffMode : 'side';
+            const header = document.createElement('div');
+            header.className = 'diff-header';
             const body = document.createElement('div');
             body.className = 'preview-diff-body';
             const modeBar = buildDiffModeBar(initialMode, (mode) => {
@@ -572,10 +574,18 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 vscode.setState(state);
                 renderPreviewDiffMode(body, mode, payload);
             });
-            overlay.appendChild(modeBar);
+            const stats = document.createElement('div');
+            stats.className = 'diff-stats';
+            stats.textContent = 'computing…';
+            header.appendChild(modeBar);
+            header.appendChild(stats);
+            overlay.appendChild(header);
             overlay.appendChild(body);
             container.appendChild(overlay);
             renderPreviewDiffMode(body, initialMode, payload);
+            computeDiffStats(payload.leftImage, payload.rightImage).then(s => {
+                applyDiffStats(stats, s);
+            });
         }
 
         function buildDiffModeBar(initialMode, onChange) {
@@ -679,6 +689,82 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 pane.appendChild(empty);
             }
             return pane;
+        }
+
+        // Client-side pixel diff: load both base64 PNGs, draw to canvas,
+        // walk the ImageData buffers in parallel. Cheap on the typical
+        // preview size (< 0.5 megapixel); GIFs / very large captures will
+        // be slower but still bounded. Daemon-side pixel mode (with SSIM)
+        // can plug in here later via a different code path.
+        function computeDiffStats(leftBase64, rightBase64) {
+            return new Promise((resolve) => {
+                const left = new Image();
+                const right = new Image();
+                let loaded = 0;
+                const onErr = () => resolve({ error: 'image failed to load' });
+                const onOk = () => {
+                    if (++loaded < 2) return;
+                    try {
+                        if (left.naturalWidth !== right.naturalWidth
+                            || left.naturalHeight !== right.naturalHeight) {
+                            resolve({
+                                sameSize: false,
+                                leftW: left.naturalWidth, leftH: left.naturalHeight,
+                                rightW: right.naturalWidth, rightH: right.naturalHeight,
+                            });
+                            return;
+                        }
+                        const w = left.naturalWidth, h = left.naturalHeight;
+                        const c1 = document.createElement('canvas');
+                        c1.width = w; c1.height = h;
+                        c1.getContext('2d').drawImage(left, 0, 0);
+                        const d1 = c1.getContext('2d').getImageData(0, 0, w, h).data;
+                        const c2 = document.createElement('canvas');
+                        c2.width = w; c2.height = h;
+                        c2.getContext('2d').drawImage(right, 0, 0);
+                        const d2 = c2.getContext('2d').getImageData(0, 0, w, h).data;
+                        let diff = 0;
+                        const len = d1.length;
+                        for (let i = 0; i < len; i += 4) {
+                            if (d1[i] !== d2[i] || d1[i+1] !== d2[i+1]
+                                || d1[i+2] !== d2[i+2] || d1[i+3] !== d2[i+3]) diff++;
+                        }
+                        const total = w * h;
+                        resolve({
+                            sameSize: true, w, h, diffPx: diff, total,
+                            percent: total > 0 ? diff / total : 0,
+                        });
+                    } catch (err) {
+                        resolve({ error: (err && err.message) || 'stats unavailable' });
+                    }
+                };
+                left.onload = onOk; left.onerror = onErr;
+                right.onload = onOk; right.onerror = onErr;
+                left.src = 'data:image/png;base64,' + leftBase64;
+                right.src = 'data:image/png;base64,' + rightBase64;
+            });
+        }
+
+        function applyDiffStats(el, s) {
+            if (!s) { el.textContent = ''; el.removeAttribute('data-state'); return; }
+            if (s.error) { el.textContent = s.error; el.removeAttribute('data-state'); return; }
+            if (!s.sameSize) {
+                el.textContent = 'sizes differ — '
+                    + s.leftW + '×' + s.leftH + ' vs '
+                    + s.rightW + '×' + s.rightH;
+                el.dataset.state = 'size-mismatch';
+                return;
+            }
+            if (s.diffPx === 0) {
+                el.textContent = 'identical · ' + s.w + '×' + s.h;
+                el.dataset.state = 'identical';
+                return;
+            }
+            const p = s.percent * 100;
+            const pct = p < 0.01 ? p.toFixed(3) : p.toFixed(2);
+            el.textContent = s.diffPx.toLocaleString() + ' px ('
+                + pct + '%) · ' + s.w + '×' + s.h;
+            el.dataset.state = 'changed';
         }
 
         function populateFilter(select, values, label) {


### PR DESCRIPTION
## Summary

Step 3b of the diff feature: **pixel-stats line on diff results**, both surfaces.

Each diff result now shows a one-line summary alongside the mode toggle:

- `12,341 px (1.24%) · 320×640` — size-matched diff with the count of pixels where any RGBA channel differs.
- `identical · 320×640` — bytes round-tripped unchanged through the canvas pixel walk (tinted green).
- `sizes differ — 320×640 vs 360×640` — when the two captures have different dimensions, tinted warning so it's obvious before reading the digits.

Stats compute client-side via `canvas.getImageData` on the two base64 PNGs already in hand — no daemon round-trip, no extension message. Async, so the result lands once both images decode (typically <100ms for the preview-size captures we deal with).

Daemon-side pixel mode (with SSIM and a diff-overlay PNG) can plug in via a different code path later without re-doing the UI here.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 261 / 261 passing
- [ ] Manual: open a diff where both renders match → "identical · WxH" in green
- [ ] Manual: trivial pixel change (1 px) → ~"1 px (0.000%) · WxH" reads black/white
- [ ] Manual: bigger diff → percentage with two decimals
- [ ] Manual: trigger a same-preview diff where dimensions differ (e.g. font scale change between captures) → "sizes differ" warning tint, no `%` shown
- [ ] Manual: stats line shows "computing…" briefly on a slow load, then resolves

## Follow-ups in the design doc

- Per-row vs-main dot in the History panel (cheap O(N) hash compare against latest main entry).
- Daemon pixel mode + SSIM via a `mode='pixel'` `historyDiff` call when daemon is healthy.
- Step 4: ref-backed `main` via `git cat-file --batch` for repos without an archived main entry locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01A6AFhHNrHQNqUPKdmJRt94)_