### PR TITLE
fix(vscode): stop progress bar getting stuck after a slow refresh

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -21,7 +21,7 @@ import { DaemonScheduler, WarmState } from './daemon/daemonScheduler';
 import { buildHistorySource, HistoryPanel, HistoryScope, HistorySource } from './historyPanel';
 import { LogFilter, parseLogLevel } from './logFilter';
 import { pickRefreshModeFor, RefreshMode } from './refreshMode';
-import { mergeCalibration, PhaseDurations, ProgressState } from './buildProgress';
+import { BuildProgressTracker, mergeCalibration, PhaseDurations } from './buildProgress';
 import { CompileError, extractCompileErrors, DiagnosticLike } from './compileErrors';
 
 const DEBOUNCE_MS = 1500;
@@ -1280,23 +1280,31 @@ async function refresh(
     gradleService.cancel();
 
     // Forward progress-bar updates to the webview. Single tracker per refresh
-    // — same instance feeds the Gradle phase signals (compile/discover/render)
-    // and the post-task `loading` phase the extension drives itself once
-    // Gradle returns. The webview hides the bar on its own once percent=1.
-    const onProgress = (state: ProgressState) => {
-        if (abort.signal.aborted) { return; }
-        panel?.postMessage({
-            command: 'setProgress',
-            phase: state.phase,
-            label: state.label,
-            percent: state.percent,
-            slow: state.slow,
-        });
-    };
+    // — single instance feeds the Gradle phase signals (compile/discover/
+    // render) AND the post-Gradle `loading` phase that the tracker
+    // auto-detects from the `BUILD SUCCESSFUL` line. Lifecycle is owned
+    // here, not by gradleService, so the tick interval can survive past
+    // `runTask` returning while we read manifests + base64-encode PNGs,
+    // and so failure / cancellation paths can shut it down deterministically.
+    // Without local ownership the tracker's tick kept emitting setProgress
+    // messages after Gradle finished, freezing the bar on whatever state
+    // it last computed (typically "(slow) · 99%").
+    const tracker = new BuildProgressTracker({
+        onProgress: (state) => {
+            if (abort.signal.aborted) { return; }
+            panel?.postMessage({
+                command: 'setProgress',
+                phase: state.phase,
+                label: state.label,
+                percent: state.percent,
+                slow: state.slow,
+            });
+        },
+        calibration: readCalibration(module),
+    });
+    tracker.start();
     const taskOpts = {
-        progressCalibration: readCalibration(module),
-        onProgress,
-        onCalibration: (durations: PhaseDurations) => writeCalibration(module, durations),
+        onTaskOutput: (chunk: string) => tracker.consume(chunk),
     };
 
     try {
@@ -1402,12 +1410,14 @@ async function refresh(
         logLine(`rendered ${visiblePreviews.length} preview(s) for ${path.basename(activeFile)}`);
 
         // Gradle is done; the rest of the work (reading PNGs, base64-encoding,
-        // pushing to webview) is extension-side. Push the bar into a "Loading
-        // images" phase with a known weight so the user sees the bar continue
-        // to advance instead of sitting stuck at the end of `rendering` while
-        // images stream in.
+        // pushing to webview) is extension-side. The tracker has already
+        // transitioned to its `loading` phase via the `BUILD SUCCESSFUL`
+        // marker in Gradle's stdout — it'll keep ticking the bar through
+        // that phase asymptotically while the imageJobs run, with no
+        // explicit signal needed from this side. tracker.finish() at the
+        // end of the happy path drives the bar to 100% and stops the tick.
         if (!abort.signal.aborted) {
-            onProgress({ phase: 'loading', label: 'Loading images', percent: 0.92, slow: false });
+            tracker.enterPhase('loading');
         }
 
         // Load images in parallel. Animated previews have multiple captures
@@ -1467,7 +1477,12 @@ async function refresh(
         }
         await Promise.all(imageJobs);
         if (!abort.signal.aborted) {
-            onProgress({ phase: 'done', label: 'Done', percent: 1, slow: false });
+            // Drive the bar to 100% and stop the tick. The webview holds
+            // the completed state for ~600ms then fades the strip away.
+            // The finally block's tracker.abort() is a no-op once we've
+            // called finish().
+            tracker.finish();
+            writeCalibration(module, tracker.phaseDurations);
         }
 
         // NOTE: intentionally do NOT send `showMessage: ''` here. The webview's
@@ -1558,6 +1573,12 @@ async function refresh(
         panel.postMessage({ command: 'clearProgress' });
         return 'failed';
     } finally {
+        // Idempotent — happy-path tracker.finish() already flipped the
+        // tracker's `finished` flag, so this is a no-op there. Failure /
+        // cancellation / abort paths come through here too and need the
+        // tick interval shut down so the bar doesn't keep emitting after
+        // we've moved on.
+        tracker.abort();
         if (pendingRefresh === abort) { pendingRefresh = null; }
     }
 }

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -5,7 +5,6 @@ import { appliesPlugin } from './pluginDetection';
 import { JdkImageError, JdkImageErrorDetector } from './jdkImageErrorDetector';
 import { KotlinCompileError, KotlinCompileErrorDetector } from './kotlinCompileErrorDetector';
 import { LogFilter } from './logFilter';
-import { BuildProgressTracker, PhaseDurations, ProgressState } from './buildProgress';
 
 /**
  * Expands a parameterized preview's single template capture into N captures
@@ -108,18 +107,23 @@ export interface Logger {
 const nullLogger: Logger = { appendLine() {}, append() {} };
 
 /**
- * Per-call hooks for [GradleService.runTask] and friends. The progress
- * tracker is owned by the caller (refresh()) so the same tracker spans
- * Gradle's discover/render phases plus the post-task image-loading phase
- * the extension drives itself.
+ * Per-call hooks for [GradleService.runTask] and friends.
+ *
+ * Tracker ownership lives outside this module — the caller (refresh())
+ * constructs a [BuildProgressTracker] whose lifecycle spans the whole
+ * refresh, including the post-Gradle image-loading phase, and feeds it
+ * Gradle's stdout via [onTaskOutput]. Keeping the tracker here would
+ * orphan its tick interval after `runTask` resolved, leaving the bar
+ * stuck at the last rendering-phase percent until the next refresh.
  */
 export interface TaskOptions {
-    /** Per-phase calibration to seed the tracker with (from prior runs). */
-    progressCalibration?: PhaseDurations;
-    /** Receives progress states as Gradle output streams in. */
-    onProgress?: (state: ProgressState) => void;
-    /** Called after the task ends with the durations recorded this run. */
-    onCalibration?: (durations: PhaseDurations) => void;
+    /**
+     * Receives every decoded chunk of stdout/stderr from the running task.
+     * Called after the gradleService's internal detectors and log filter
+     * have processed the chunk, so the caller never gets bytes that have
+     * already triggered a JdkImageError or KotlinCompileError.
+     */
+    onTaskOutput?: (chunk: string) => void;
 }
 
 /**
@@ -529,16 +533,6 @@ export class GradleService {
         // cross-file gap that the LSP-driven gate (compileErrors.ts)
         // misses by design — that gate only inspects the active file.
         const kotlinDetector = new KotlinCompileErrorDetector();
-        // Progress tracker is wired only when the caller provided one of the
-        // hooks — keeps the no-op (test, doctor, applied-bootstrap) callers
-        // free of timer overhead.
-        const tracker = (opts.onProgress || opts.onCalibration)
-            ? new BuildProgressTracker({
-                onProgress: opts.onProgress ?? (() => { /* noop */ }),
-                calibration: opts.progressCalibration,
-            })
-            : null;
-        tracker?.start();
 
         const timeoutPromise = new Promise<never>((_, reject) => {
             setTimeout(() => {
@@ -566,22 +560,18 @@ export class GradleService {
                     // contain the diagnostic).
                     detector.consume(decoded);
                     kotlinDetector.consume(decoded);
-                    tracker?.consume(decoded);
                     const filtered = this.logFilter.filterGradleChunk(decoded);
                     if (filtered.length > 0) { this.logger.append(filtered); }
+                    opts.onTaskOutput?.(decoded);
                 } catch { /* ignore */ }
             },
         }).then(
             () => {
                 const line = `> ${task} completed`;
                 if (this.logFilter.shouldEmitInformational(line)) { this.logger.appendLine(line); }
-                if (tracker) {
-                    opts.onCalibration?.({ ...tracker.phaseDurations });
-                }
             },
             (err) => {
                 const message = err?.message ?? String(err);
-                tracker?.abort();
                 // vscode-gradle reports a superseded task as a gRPC CANCELLED
                 // error — that's the normal "new refresh replaced this one"
                 // path, not a build failure. Log it differently and throw a


### PR DESCRIPTION
## Summary

Fixes the bug visible in the screenshot below — the bar freezes on `Loading images (slow) · 99%` even after the previews have rendered.

### Root cause

`BuildProgressTracker` was constructed inside `GradleService.runTask` and its tick interval kept firing `setProgress` messages every 200 ms after `runTask` resolved. While `extension.ts` was reading manifests, base64-encoding PNGs, and posting the synthetic `Done · 100%` emit, the still-alive tick kept overwriting `Done` with whatever the tracker had last computed (typically `(slow) · 99%`). The webview's `progress-finishing` fade was cancelled on every overlap because each new `setProgress` removed the class.

### Fix

Move tracker ownership to `refresh()` so its lifecycle matches the whole refresh, including the post-Gradle image-loading phase. The tracker auto-detects `BUILD SUCCESSFUL` in Gradle's stdout and transitions to its `loading` phase; `refresh()` calls `tracker.enterPhase('loading')` as a belt-and-braces fallback if that line never appeared, then `tracker.finish()` once `Promise.all(imageJobs)` settles. `tracker.abort()` in the `finally` block (idempotent — `finish()` already flips the same flag) handles every cancellation, error, and early-return path with no per-path bookkeeping.

`GradleService.TaskOptions` reduces to a single `onTaskOutput` hook — the caller wires it to `tracker.consume`. `progressCalibration` / `onProgress` / `onCalibration` are gone; `refresh()` reads/writes calibration directly from `tracker.phaseDurations` after a successful run.

The synthetic `onProgress({phase:'loading', percent:0.92})` and `onProgress({phase:'done', percent:1})` emits are gone too — the tracker's natural phase progression covers both, and they were the exact mechanism the runaway tick was undoing.

### Test plan

- [x] `npm run compile` — clean
- [x] `npm test` — 261 passing (no test changes; the tracker's behaviour didn't change, only its ownership)
- [ ] Manual: trigger a slow render that crosses the `(slow)` threshold. Confirm the bar drives to 100% on success and fades cleanly afterwards instead of getting stuck on the `(slow)` warning tint.
- [ ] Manual: trigger a fast warm-cache refresh. Confirm the bar still doesn't mount (the 200 ms deferred-mount logic is unchanged).
- [ ] Manual: rapid consecutive saves. Confirm the bar from the cancelled refresh disappears cleanly when the new refresh starts; no double-bar.
- [ ] Manual: trigger a failed render. Confirm the bar clears and the failure banner appears.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rw5ZRtvu2VaXiTRE9KmNiC)_