### PR TITLE
feat(mcp): default replicasPerDaemon to 3 (4 sandboxes per daemon)

### DIFF
--- a/docs/daemon/SANDBOX-POOL.md
+++ b/docs/daemon/SANDBOX-POOL.md
@@ -9,8 +9,9 @@
 > - **Layer 3** — `DaemonSupervisor` passes `composeai.daemon.sandboxCount = 1 + replicasPerDaemon`
 >   on the launch descriptor instead of spawning N+1 JVM subprocesses. The supervisor's public
 >   surface (`SupervisedDaemon.client`, `allClients`, `clientForRender`) is unchanged; the daemon
->   handles render fan-out internally. `replicasPerDaemon = 0` (default) preserves bit-identical
->   pre-pool behaviour on disk.
+>   handles render fan-out internally. **Default `replicasPerDaemon = 3`** — out of the box every
+>   daemon comes up with 4 in-JVM sandboxes so a typical preview grid renders in parallel without
+>   the user opting in. Set `0` to opt out and keep a single sandbox per daemon.
 >
 > Memory math (replicasPerDaemon = 4 on one module): pre-Layer-3 ~8 GB across 5 JVMs;
 > post-Layer-3 ~5 GB in one JVM with 5 sandbox classloaders.

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -18,9 +18,12 @@ import kotlinx.serialization.json.JsonObject
  * clients see the project in `list_projects` immediately. Projects can also be added at runtime via
  * the `register_project` MCP tool.
  *
- * `--replicas-per-daemon N` (or the `composeai.mcp.replicasPerDaemon` system property) spawns N
- * extra in-process replicas per (workspace, module) for render fan-out — see
- * [DaemonSupervisor.replicasPerDaemon]. Default 0 (one daemon per module).
+ * `--replicas-per-daemon N` (or the `composeai.mcp.replicasPerDaemon` system property) configures
+ * the in-JVM sandbox pool size: total sandboxes per (workspace, module) = `1 + N`. SANDBOX-POOL.md
+ * Layer 3 collapsed what used to be N+1 separate JVM subprocesses into a single daemon JVM hosting
+ * N+1 Robolectric sandboxes, so this knob no longer multiplies the JVM-baseline cost. Default
+ * [DaemonSupervisor.DEFAULT_REPLICAS_PER_DAEMON] (= 3, i.e. 4 sandboxes per daemon). Set `0` to opt
+ * out and run a single sandbox per daemon.
  *
  * On stdin EOF the server tears down every supervised daemon (sending `shutdown` + `exit` per
  * PROTOCOL.md § 3) and exits cleanly.
@@ -89,8 +92,9 @@ object DaemonMcpMain {
 
   private fun parseReplicasPerDaemon(args: Array<String>): Int {
     // CLI flag wins over the system property; system property wins over the default. Negative
-    // or unparseable values fall back to 0 with a stderr warning rather than crashing the server
-    // — replication is an opt-in optimisation, not load-bearing.
+    // or unparseable values fall back to the default with a stderr warning rather than crashing
+    // the server — replication is non-load-bearing, so prefer "did something reasonable" to
+    // refusing to start.
     val fromArgs =
       generateSequence(0) { it + 1 }
         .takeWhile { it < args.size }
@@ -103,13 +107,14 @@ object DaemonMcpMain {
           }
         }
     val raw = fromArgs ?: System.getProperty("composeai.mcp.replicasPerDaemon")
-    if (raw.isNullOrBlank()) return 0
+    if (raw.isNullOrBlank()) return DaemonSupervisor.DEFAULT_REPLICAS_PER_DAEMON
     val parsed = raw.toIntOrNull()
     if (parsed == null || parsed < 0) {
       System.err.println(
-        "compose-preview-mcp: ignoring invalid --replicas-per-daemon='$raw' (want non-negative int)"
+        "compose-preview-mcp: ignoring invalid --replicas-per-daemon='$raw' (want non-negative int); " +
+          "falling back to default ${DaemonSupervisor.DEFAULT_REPLICAS_PER_DAEMON}"
       )
-      return 0
+      return DaemonSupervisor.DEFAULT_REPLICAS_PER_DAEMON
     }
     return parsed
   }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -33,15 +33,19 @@ class DaemonSupervisor(
    * launch descriptor; the daemon's
    * [`RobolectricHost`][ee.schimke.composeai.daemon.RobolectricHost] boots that many in-JVM
    * Robolectric sandboxes and dispatches concurrent `renderNow` requests across them.
-   * `replicasPerDaemon = 0` (the default) keeps the daemon at sandboxCount=1 — bit-identical with
-   * the pre-pool single-sandbox path on disk.
+   *
+   * **Default 3** — the daemon comes up with **4** in-JVM sandboxes (1 + 3) so a typical preview
+   * grid can render in parallel without the user opting in. This is cheap thanks to Layer 3: extra
+   * sandboxes share the JVM baseline + native heap, so the marginal cost per slot is the sandbox
+   * classloader's instrumented bytecode (~ a few hundred MB each at peak). `0` opts out and keeps a
+   * single sandbox — bit-identical with the pre-pool path on disk.
    *
    * Pre-Layer-3 this knob spawned N additional **JVM subprocesses**; that wasted ~2 GB per replica
    * on shared per-JVM cost (native heap, JVM baseline, instrumented framework). Layer 3 collapses
    * those into a single daemon JVM with N sandbox classloaders. Wire-protocol-visible behaviour
    * (initialize, renderNow, fileChanged fan-out) is unchanged from the consumer's perspective.
    */
-  private val replicasPerDaemon: Int = 0,
+  private val replicasPerDaemon: Int = DEFAULT_REPLICAS_PER_DAEMON,
 ) {
 
   init {
@@ -216,6 +220,17 @@ class DaemonSupervisor(
         put("totalPreviews", kotlinx.serialization.json.JsonPrimitive(previews.size))
       }
     router.dispatch(daemon, "discoveryUpdated", params)
+  }
+
+  companion object {
+    /**
+     * Out-of-the-box value for [replicasPerDaemon]. Picked so a typical preview grid renders
+     * concurrently without the user opting in: 4 sandboxes per daemon (1 primary + 3 replicas). The
+     * marginal cost is per-sandbox instrumented bytecode in one shared JVM, not a whole extra JVM
+     * each — see SANDBOX-POOL.md Layer 3 for the memory math. Override via the MCP CLI's
+     * `--replicas-per-daemon N` flag or the `composeai.mcp.replicasPerDaemon` system property.
+     */
+    const val DEFAULT_REPLICAS_PER_DAEMON: Int = 3
   }
 }
 


### PR DESCRIPTION
Re-PR of #362, which GitHub closed as "merged" when its base branch (`agent/sandbox-pool-supervisor-wire`) was deleted on #357's squash-merge — but the default-3 commit itself was **not** in #357's squash, so the change never reached `main`. Verified: `git show origin/main:.../DaemonSupervisor.kt` still has `replicasPerDaemon: Int = 0` and no `DEFAULT_REPLICAS_PER_DAEMON` constant.

This PR re-applies the original commit on top of current main.

## Summary

Out of the box, every daemon now comes up with **4 in-JVM sandboxes** (1 primary + 3 replicas) so a typical preview grid renders in parallel without the user opting in. Cheap thanks to Layer 3's in-JVM pool: extra sandboxes share the JVM baseline + native heap (~750 MB that used to be duplicated per replica), so the marginal cost per slot is just the sandbox classloader's instrumented bytecode.

Set `--replicas-per-daemon 0` (or `-Dcomposeai.mcp.replicasPerDaemon=0`) to opt out and keep a single sandbox per daemon — bit-identical with the pre-pool path on disk.

## What changes

- New constant `DaemonSupervisor.DEFAULT_REPLICAS_PER_DAEMON = 3` so the constructor default and the MCP CLI fallback in `DaemonMcpMain` can't drift.
- `DaemonSupervisor` constructor default flips from `0` to `DEFAULT_REPLICAS_PER_DAEMON`.
- `DaemonMcpMain.parseReplicasPerDaemon` falls back to the same constant when the CLI flag / sysprop is unset, and logs the chosen default on parse failures.
- KDoc + `SANDBOX-POOL.md` Layer 3 status updated to reflect the new default.

## Test plan

- [x] `:mcp:test` — all 25 tests pass on the cherry-picked branch. `DaemonSupervisorReplicaTest` explicitly passes `replicasPerDaemon = 2` so its `"3"` sysprop assertion is unaffected. `DaemonMcpServerTest` and the other MCP tests use the constructor default — they pass FakeDaemons that don't actually boot Robolectric.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SDmE1Uu28mX8yVjHeTMFJE)_