### PR TITLE
feat(vscode): Diff All Previews vs Main command

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -97,6 +97,11 @@
                 "command": "composePreview.restartDaemon",
                 "title": "Restart Preview Daemon (pick up rebuilt JAR)",
                 "category": "Compose Preview"
+            },
+            {
+                "command": "composePreview.diffAllVsMain",
+                "title": "Diff All Previews vs Main",
+                "category": "Compose Preview"
             }
         ],
         "configuration": {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as crypto from 'crypto';
 import { GradleService, GradleApi, TaskCancelledError } from './gradleService';
 import { JdkImageError } from './jdkImageErrorDetector';
 import { KotlinCompileError } from './kotlinCompileErrorDetector';
@@ -582,6 +583,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
                 refreshDoctor,
             );
         }),
+        vscode.commands.registerCommand('composePreview.diffAllVsMain', () => diffAllVsMain()),
     );
     // Refresh applied-markers in the background, then replay the doctor refresh
     // so it picks up any modules that only become visible via the authoritative
@@ -1736,6 +1738,143 @@ async function runLivePreviewDiff(
         leftImage: liveBytes.toString('base64'),
         rightLabel: `${against === 'main' ? 'main' : 'HEAD'} · ${formatRelativeShort(target.timestamp)}`,
         rightImage: rightBytes,
+    });
+}
+
+/**
+ * Walk every preview discovered in the currently scoped module's manifest,
+ * diff its live render against the latest archived render on `main` for
+ * the same preview, and surface the drifted ones in a quick-pick. Picking
+ * one focuses the live panel on that preview and triggers a Diff vs main
+ * so the user lands directly in the result.
+ *
+ * Hash-only check — answers "did anything change?" not "by how much".
+ * The opened diff result already shows pixel-stats for the selected one;
+ * scaling that up to per-preview stats is N PNG decodes which we skip
+ * for the dashboard until performance demands it.
+ */
+async function diffAllVsMain(): Promise<void> {
+    if (!gradleService || !panel || !historySource) {
+        vscode.window.showInformationMessage('Compose Preview is not ready yet.');
+        return;
+    }
+    if (!currentScopeFile) {
+        vscode.window.showInformationMessage(
+            'Open a Kotlin file with @Preview functions before running Diff All vs Main.',
+        );
+        return;
+    }
+    const moduleId = gradleService.resolveModule(currentScopeFile);
+    if (!moduleId) {
+        vscode.window.showInformationMessage('Active file is not part of a Compose Preview module.');
+        return;
+    }
+    const manifest = moduleManifestCache.get(moduleId);
+    if (!manifest || manifest.length === 0) {
+        vscode.window.showInformationMessage('No previews discovered yet — render once first.');
+        return;
+    }
+    const projectDir = path.join(gradleService.workspaceRoot, moduleId);
+
+    interface DriftItem extends vscode.QuickPickItem {
+        previewId: string;
+        driftKind: 'differs' | 'no-baseline' | 'no-live';
+    }
+    const drifted: DriftItem[] = [];
+    let identical = 0;
+
+    await vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: 'Compose Preview — diffing all vs main',
+        cancellable: false,
+    }, async (progress) => {
+        const total = manifest.length;
+        let done = 0;
+        for (const preview of manifest) {
+            done++;
+            progress.report({
+                message: `${done} / ${total} · ${preview.functionName}`,
+                increment: 100 / total,
+            });
+            const cap = preview.captures?.[0];
+            if (!cap?.renderOutput) { continue; }
+            const livePath = path.join(projectDir, cap.renderOutput);
+            const liveBytes = await fs.promises.readFile(livePath).catch(() => null);
+            const label = preview.functionName
+                + (preview.params.name ? ` — ${preview.params.name}` : '');
+            if (!liveBytes) {
+                drifted.push({
+                    label,
+                    description: 'no live render',
+                    detail: preview.id,
+                    previewId: preview.id,
+                    driftKind: 'no-live',
+                });
+                continue;
+            }
+            const liveHash = crypto.createHash('sha256').update(liveBytes).digest('hex');
+            let mainHash: string | null = null;
+            let mainTs = '';
+            try {
+                const list = await historySource!.list({
+                    moduleId, projectDir, previewId: preview.id,
+                });
+                for (const e of list.entries) {
+                    const entry = e as { git?: { branch?: string }; pngHash?: string; timestamp?: string };
+                    if (entry?.git?.branch !== 'main' || !entry.pngHash) { continue; }
+                    const ts = entry.timestamp ?? '';
+                    if (ts > mainTs) { mainTs = ts; mainHash = entry.pngHash; }
+                }
+            } catch {
+                // History unavailable for this preview — treat as no baseline.
+            }
+            if (!mainHash) {
+                drifted.push({
+                    label,
+                    description: 'no baseline on main',
+                    detail: preview.id,
+                    previewId: preview.id,
+                    driftKind: 'no-baseline',
+                });
+                continue;
+            }
+            if (liveHash === mainHash) {
+                identical++;
+                continue;
+            }
+            drifted.push({
+                label,
+                description: 'differs from main',
+                detail: preview.id,
+                previewId: preview.id,
+                driftKind: 'differs',
+            });
+        }
+    });
+
+    if (drifted.length === 0) {
+        vscode.window.showInformationMessage(
+            `All ${identical} preview${identical === 1 ? '' : 's'} match main.`,
+        );
+        return;
+    }
+
+    const driftCount = drifted.filter(i => i.driftKind === 'differs').length;
+    const placeholder = driftCount > 0
+        ? `${driftCount} preview${driftCount === 1 ? '' : 's'} differ from main · ${identical} identical`
+        : `${drifted.length} preview${drifted.length === 1 ? '' : 's'} need attention · ${identical} identical`;
+    const picked = await vscode.window.showQuickPick(drifted, {
+        title: `Compose Preview — drift vs main (${moduleId})`,
+        placeHolder: placeholder,
+        matchOnDescription: true,
+    });
+    if (!picked) { return; }
+
+    await vscode.commands.executeCommand(`${PreviewPanel.viewId}.focus`);
+    panel.postMessage({
+        command: 'focusAndDiff',
+        previewId: picked.previewId,
+        against: 'main',
     });
 }
 

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -1787,6 +1787,18 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     showDiffOverlay(card, msg.against, null, msg.message || 'Diff unavailable.');
                     break;
                 }
+                case 'focusAndDiff': {
+                    const card = document.getElementById('preview-' + sanitizeId(msg.previewId));
+                    if (!card) break;
+                    focusOnCard(card);
+                    showDiffOverlay(card, msg.against, null, null);
+                    vscode.postMessage({
+                        command: 'requestPreviewDiff',
+                        previewId: msg.previewId,
+                        against: msg.against,
+                    });
+                    break;
+                }
             }
         });
 

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -289,7 +289,13 @@ export type ExtensionToWebview =
           rightLabel: string;
           rightImage: string;
       }
-    | { command: 'previewDiffError'; previewId: string; against: 'head' | 'main'; message: string };
+    | { command: 'previewDiffError'; previewId: string; against: 'head' | 'main'; message: string }
+    /**
+     * Programmatic open of a preview in focus mode + immediate diff
+     * request. Used by the "Diff All vs Main" command so picking an item
+     * from its quick-pick lands the user directly on the diff result.
+     */
+    | { command: 'focusAndDiff'; previewId: string; against: 'head' | 'main' };
 
 /** Messages from webview to extension */
 export type WebviewToExtension =


### PR DESCRIPTION
## Summary

Step 3c of the diff feature: **`Compose Preview: Diff All Previews vs Main` command**.

Walks every preview in the active file's module, hashes the live render against the latest archived render on `main` for each, and surfaces the drifted ones in a quick-pick. Picking one focuses the live panel on that preview and immediately runs the existing **Diff vs main** so the user lands directly on the result.

UX:

- Run via the command palette (`Compose Preview: Diff All Previews vs Main`).
- Progress reports in the notification area as previews are hashed.
- Quick-pick title is module-scoped; placeholder summarises the count of drifted vs identical (`3 previews differ from main · 12 identical`).
- Items: `differs from main` (drift), `no baseline on main` (no archived main entry yet), `no live render` (build/compose-previews PNG missing).
- Selecting an item: `composePreview.panel.focus` → `focusAndDiff` message → live panel jumps into focus mode for that preview and replaces the focused image with a side-by-side diff vs main.

Hash-only check at the dashboard layer — answers "did anything change?" not "by how much"; the opened diff result already carries the pixel stats. Scaling stats to per-preview is N PNG decodes which we skip until a workload demands it.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 261 / 261 passing
- [ ] Manual: command palette → "Compose Preview: Diff All Previews vs Main" with a clean tree → "All N previews match main"
- [ ] Manual: introduce a single-preview UI change, save, run command → quick-pick lists exactly the changed preview
- [ ] Manual: pick the drifted item → live panel switches to focus mode and renders the diff
- [ ] Manual: run on a file whose module has previews without main baselines → items show "no baseline on main"


---
_Generated by [Claude Code](https://claude.ai/code/session_01A6AFhHNrHQNqUPKdmJRt94)_