### PR TITLE
fix(vscode): no layout shift on refresh; auto-render stale source; no stale-image flash

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -21,11 +21,14 @@ body {
 }
 
 /* -- Top progress strip ------------------------------------------------
- * A slim two-row strip pinned to the very top of the panel during a
- * refresh: phase label on top (≈13px text), 2px progress bar beneath.
- * The strip reserves its own vertical space rather than overlaying the
- * toolbar — `display: none` (via the `hidden` attribute) when no
- * refresh is in flight, so it costs nothing visually when idle.
+ * A slim two-row strip permanently pinned to the very top of the panel:
+ * phase-label row on top (≈13px text), 2px progress bar beneath.
+ *
+ * The strip is ALWAYS rendered (no display:none on idle) so the rest of
+ * the panel never reflows when a refresh starts or finishes — the user
+ * sees content updates inside the existing layout instead of rows
+ * shifting up/down. When idle the label is empty and the fill is at 0%,
+ * so the strip degrades to a thin inactive lane that's visually quiet.
  */
 .progress-bar {
     position: sticky;
@@ -38,7 +41,6 @@ body {
        banner). Keeps the strip visually distinct from the next row. */
     border-bottom: 1px solid var(--card-border);
 }
-.progress-bar[hidden] { display: none; }
 
 /* Track is the 2px lane the fill animates inside. A subtle inactive
    background so the empty portion of the bar is visible at low percent —

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -88,9 +88,8 @@ async function oldestRenderMtime(
     return oldest;
 }
 
-/** Stat the source file and return its mtime, or null on any error. The
- *  banner uses this as the "freshness reference" — `.kt` newer than the
- *  oldest PNG = renders are stale relative to the source. */
+/** Stat the source file and return its mtime, or null on any error.
+ *  Used to detect "user edited since the rendered PNGs were written". */
 async function sourceFileMtime(filePath: string): Promise<number | null> {
     try {
         const stat = await fs.promises.stat(filePath);
@@ -101,29 +100,24 @@ async function sourceFileMtime(filePath: string): Promise<number | null> {
 }
 
 /**
- * "5 minutes ago", "2 hours ago", "3 days ago". Coarse — the banner exists to
- * communicate "this is old", not to time-stamp anything.
+ * True when the active source file's mtime is newer than the oldest visible
+ * preview's PNG. Cheap signal that the on-disk renders don't reflect the
+ * current buffer — used both to suppress reading those stale bytes into the
+ * webview and to schedule an automatic re-render. Conservative: any
+ * unreadable file (missing PNG, source-stat failure) yields `false` so we
+ * default to "use what's on disk" rather than spuriously trigger renders.
  */
-function formatRelativeAge(ageMs: number): string {
-    const seconds = Math.floor(ageMs / 1000);
-    if (seconds < 60) { return `${seconds}s ago`; }
-    const minutes = Math.floor(seconds / 60);
-    if (minutes < 60) { return `${minutes}m ago`; }
-    const hours = Math.floor(minutes / 60);
-    if (hours < 24) { return `${hours}h ago`; }
-    const days = Math.floor(hours / 24);
-    return `${days}d ago`;
+async function isSourceNewerThanRenders(
+    activeFile: string,
+    previews: PreviewInfo[],
+    modules: string[],
+): Promise<boolean> {
+    const [sourceMtime, oldestMtime] = await Promise.all([
+        sourceFileMtime(activeFile),
+        oldestRenderMtime(previews, modules),
+    ]);
+    return sourceMtime != null && oldestMtime != null && sourceMtime > oldestMtime;
 }
-
-/**
- * True when the panel currently shows a "Showing previews from <ago>, but
- * <file> has changed since" banner the extension posted because the active
- * source file's mtime is newer than the oldest on-disk PNG. Used so we only
- * clear the banner when one *we* set is up — not a build-error or
- * filter-empty notice. Cleared when a fresh `updateImage` arrives from the
- * daemon, or when a forceRender refresh completes.
- */
-let staleBannerShown = false;
 
 const moduleManifestCache = new Map<string, PreviewInfo[]>();
 let panel: PreviewPanel | null = null;
@@ -307,14 +301,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     daemonScheduler = new DaemonScheduler(daemonGate, {
         onPreviewImageReady: (_moduleId, previewId, imageBase64) => {
             if (!panel) { return; }
-            // Fresh daemon render arriving — if a stale banner is up, this is
-            // the moment to retire it. Guarded by staleBannerShown so we only
-            // clear a banner we set ourselves; legitimate showMessage banners
-            // (build error, filter-empty notice) are left alone.
-            if (staleBannerShown) {
-                panel.postMessage({ command: 'showMessage', text: '' });
-                staleBannerShown = false;
-            }
             // Capture index 0 — the daemon's v1 renderFinished targets the
             // representative capture only. Multi-capture (animated) renders
             // still come through the Gradle path; the daemon's predictive
@@ -1430,52 +1416,64 @@ async function refresh(
         // base64 encode. Streaming them concurrently lets each card paint
         // as soon as its bytes arrive rather than waiting for an arbitrary
         // serial position.
-        const imageJobs: Promise<void>[] = [];
-        for (const preview of visiblePreviews) {
-            const captures = preview.captures;
-            if (captures.length === 0) { continue; }
+        //
+        // Skip the imageJobs entirely when discover-only AND the source is
+        // newer than the PNGs on disk: those bytes are stale relative to
+        // the user's current buffer, and pushing them via updateImage would
+        // remove the loading overlay and surface yesterday's render as if
+        // it were the current state. Cards keep their cached imageData
+        // (last known good) under the loading overlay until the auto-render
+        // we kick off below replaces them with fresh bytes.
+        const sourceIsStale = !forceRender
+            && await isSourceNewerThanRenders(activeFile, visiblePreviews, modules);
+        if (!sourceIsStale) {
+            const imageJobs: Promise<void>[] = [];
+            for (const preview of visiblePreviews) {
+                const captures = preview.captures;
+                if (captures.length === 0) { continue; }
 
-            const mod = previewModuleMap.get(preview.id);
-            if (!mod) { continue; }
+                const mod = previewModuleMap.get(preview.id);
+                if (!mod) { continue; }
 
-            for (let captureIndex = 0; captureIndex < captures.length; captureIndex++) {
-                const capture = captures[captureIndex];
-                if (!capture.renderOutput) { continue; }
-                const idx = captureIndex;
-                imageJobs.push((async () => {
-                    if (abort.signal.aborted) { return; }
-                    const imageData = await gradleService!.readPreviewImage(mod, capture.renderOutput);
-                    if (abort.signal.aborted || !panel) { return; }
+                for (let captureIndex = 0; captureIndex < captures.length; captureIndex++) {
+                    const capture = captures[captureIndex];
+                    if (!capture.renderOutput) { continue; }
+                    const idx = captureIndex;
+                    imageJobs.push((async () => {
+                        if (abort.signal.aborted) { return; }
+                        const imageData = await gradleService!.readPreviewImage(mod, capture.renderOutput);
+                        if (abort.signal.aborted || !panel) { return; }
 
-                    if (imageData) {
-                        if (idx === 0) {
-                            registry.setImage(preview.id, imageData);
+                        if (imageData) {
+                            if (idx === 0) {
+                                registry.setImage(preview.id, imageData);
+                            }
+                            panel.postMessage({
+                                command: 'updateImage',
+                                previewId: preview.id,
+                                captureIndex: idx,
+                                imageData,
+                            });
+                        } else if (forceRender) {
+                            // Render task completed but produced no PNG for this
+                            // capture — a per-capture failure that didn't fail the
+                            // whole task. Surface it on the card; root-cause log is
+                            // in Output ▸ Compose Preview.
+                            panel.postMessage({
+                                command: 'setImageError',
+                                previewId: preview.id,
+                                captureIndex: idx,
+                                message: 'Render failed — see Output ▸ Compose Preview',
+                            });
                         }
-                        panel.postMessage({
-                            command: 'updateImage',
-                            previewId: preview.id,
-                            captureIndex: idx,
-                            imageData,
-                        });
-                    } else if (forceRender) {
-                        // Render task completed but produced no PNG for this
-                        // capture — a per-capture failure that didn't fail the
-                        // whole task. Surface it on the card; root-cause log is
-                        // in Output ▸ Compose Preview.
-                        panel.postMessage({
-                            command: 'setImageError',
-                            previewId: preview.id,
-                            captureIndex: idx,
-                            message: 'Render failed — see Output ▸ Compose Preview',
-                        });
-                    }
-                    // else: discover-only pass, PNG not produced yet. Leave
-                    // the skeleton in place; the next save-triggered render
-                    // will populate it.
-                })());
+                        // else: discover-only pass, PNG not produced yet. Leave
+                        // the skeleton in place; the next save-triggered render
+                        // will populate it.
+                    })());
+                }
             }
+            await Promise.all(imageJobs);
         }
-        await Promise.all(imageJobs);
         if (!abort.signal.aborted) {
             // Drive the bar to 100% and stop the tick. The webview holds
             // the completed state for ~600ms then fades the strip away.
@@ -1485,49 +1483,18 @@ async function refresh(
             writeCalibration(module, tracker.phaseDurations);
         }
 
-        // NOTE: intentionally do NOT send `showMessage: ''` here. The webview's
-        // renderPreviews() clears the 'loading' Building… banner the moment
-        // cards arrive, so the happy path is already covered. Posting a blank
-        // showMessage would also clobber legitimate extension-set messages
-        // (filter empty notice, build errors), which was the original
-        // "populate then go blank" regression.
+        // Source-newer-than-renders auto-refresh. Replaces the old "Showing
+        // previews from <ago>" banner — the banner pushed the work onto the
+        // user, this just re-renders. Scheduled via setTimeout(0) so the
+        // current refresh resolves cleanly first; the new refresh's
+        // pendingRefresh.abort() then takes over.
         //
-        // Stale-banner posting / clearing. Compare the active source file's
-        // mtime against the oldest visible PNG: if the source has been edited
-        // since the renders were written, the user is looking at a render
-        // that doesn't reflect their current source. An absolute "older than
-        // X" threshold is wrong because a steady-state save loop produces
-        // PNGs seconds old that are nonetheless current — what matters is
-        // "did the source move since".
-        //
-        //   - forceRender=true → user explicitly re-rendered, anything stale
-        //     was just rewritten; clear any prior banner.
-        //   - forceRender=false → check source vs PNG; banner if source is
-        //     newer. Cleared on the first daemon `updateImage` (see
-        //     daemonScheduler events) or on the next forceRender.
-        if (forceRender && staleBannerShown) {
-            panel.postMessage({ command: 'showMessage', text: '' });
-            staleBannerShown = false;
-        } else if (!forceRender) {
-            const [sourceMtime, oldestMtime] = await Promise.all([
-                sourceFileMtime(activeFile),
-                oldestRenderMtime(visiblePreviews, modules),
-            ]);
-            const sourceIsNewer =
-                sourceMtime != null && oldestMtime != null && sourceMtime > oldestMtime;
-            if (sourceIsNewer) {
-                const ago = formatRelativeAge(Date.now() - oldestMtime!);
-                panel.postMessage({
-                    command: 'showMessage',
-                    text:
-                        `Showing previews from ${ago}, but ${path.basename(activeFile)} ` +
-                        'has changed since (save to render fresh, or run "Compose Preview: Refresh").',
-                });
-                staleBannerShown = true;
-            } else if (staleBannerShown) {
-                panel.postMessage({ command: 'showMessage', text: '' });
-                staleBannerShown = false;
-            }
+        // Only fires from the discover-only path: forceRender=true paths
+        // just rendered, so PNGs are fresh by definition. Without that
+        // gate we'd loop on every save-driven refresh.
+        if (sourceIsStale) {
+            logLine(`auto-render: ${path.basename(activeFile)} newer than rendered PNGs — kicking fresh render`);
+            setTimeout(() => { void refresh(true, activeFile, 'fast'); }, 0);
         }
         return abort.signal.aborted ? 'cancelled' : 'completed';
     } catch (err: unknown) {

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -54,7 +54,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 <body>
     <div id="progress-bar" class="progress-bar" role="progressbar"
          aria-label="Refresh progress"
-         aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" hidden>
+         aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
         <div class="progress-label" id="progress-label"></div>
         <div class="progress-track">
             <div class="progress-fill"></div>
@@ -133,25 +133,32 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         const progressBar = document.getElementById('progress-bar');
         const progressFill = progressBar.querySelector('.progress-fill');
         const progressLabel = document.getElementById('progress-label');
-        // Auto-hide timer for the bar after it lands at 100%. Holds for a
-        // beat so the user sees the completed state, then fades the strip
-        // out so it doesn't permanently occupy a row of UI.
+        // Auto-reset-to-idle timer for the bar after it lands at 100%.
+        // Holds for a beat so the user sees the completed state, then
+        // resets the fill + label to their idle look. The strip itself
+        // stays mounted — see notes in setProgress().
         let progressHideTimer = null;
-        // Deferred-mount state. The bar isn't shown until [PROGRESS_MOUNT_DELAY_MS]
-        // of in-flight work has accumulated — warm-cache refreshes that finish
-        // in <200ms never mount it at all, avoiding the "flash on, flash off"
-        // glitch. progressVisible flips true once we've actually rendered
-        // something into the DOM; subsequent setProgress updates within the
-        // same refresh apply directly without re-deferring.
-        const PROGRESS_MOUNT_DELAY_MS = 200;
-        let progressMountTimer = null;
-        let progressVisible = false;
+        // Deferred-paint state. We don't paint a fill until ~200ms of
+        // in-flight work has accumulated, so warm-cache refreshes never
+        // pulse the bar. The strip itself is ALWAYS mounted (no
+        // display:none toggle), so deferring the paint keeps the layout
+        // identical between idle and pending — only the fill width and
+        // label text change once the deferral elapses.
+        const PROGRESS_PAINT_DELAY_MS = 200;
+        let progressPaintTimer = null;
+        let progressActive = false;
         let pendingProgressState = null;
+
+        function resetProgressVisuals() {
+            progressBar.classList.remove('progress-finishing', 'progress-slow');
+            progressFill.style.width = '0%';
+            progressBar.setAttribute('aria-valuenow', '0');
+            progressLabel.textContent = '';
+        }
 
         function applyProgressState(state) {
             const pct = Math.max(0, Math.min(1, state.percent));
-            progressBar.hidden = false;
-            progressVisible = true;
+            progressActive = true;
             progressBar.classList.remove('progress-finishing');
             progressBar.classList.toggle('progress-slow', !!state.slow);
             progressFill.style.width = (pct * 100).toFixed(1) + '%';
@@ -163,11 +170,8 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             if (pct >= 1) {
                 progressBar.classList.add('progress-finishing');
                 progressHideTimer = setTimeout(() => {
-                    progressBar.hidden = true;
-                    progressVisible = false;
-                    progressBar.classList.remove('progress-finishing', 'progress-slow');
-                    progressFill.style.width = '0%';
-                    progressLabel.textContent = '';
+                    progressActive = false;
+                    resetProgressVisuals();
                     progressHideTimer = null;
                 }, 600);
             }
@@ -179,27 +183,28 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 progressHideTimer = null;
             }
             const state = { label: label || '', percent, slow: !!slow };
-            // Already visible (or mid-fade) — apply directly.
-            if (progressVisible) {
+            // Already painting — apply directly so the bar stays in lockstep
+            // with the tracker rather than re-entering the deferral window.
+            if (progressActive) {
                 applyProgressState(state);
                 return;
             }
-            // Latched state for whenever the deferral timer fires.
+            // Latched state for when the deferral timer fires.
             pendingProgressState = state;
-            // Already terminal — show immediately so the brief flash isn't
-            // missed (rare path: tracker emits an immediate done=100% before
-            // any phase work happens, e.g. up-to-date discover).
+            // Terminal state: paint immediately so the user gets a visible
+            // completion even on instant refreshes (rare path — tracker
+            // emits an immediate done=100% on an up-to-date discover).
             if (state.percent >= 1) {
                 applyProgressState(state);
                 return;
             }
-            if (progressMountTimer === null) {
-                progressMountTimer = setTimeout(() => {
-                    progressMountTimer = null;
+            if (progressPaintTimer === null) {
+                progressPaintTimer = setTimeout(() => {
+                    progressPaintTimer = null;
                     if (pendingProgressState) {
                         applyProgressState(pendingProgressState);
                     }
-                }, PROGRESS_MOUNT_DELAY_MS);
+                }, PROGRESS_PAINT_DELAY_MS);
             }
         }
 
@@ -208,16 +213,13 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 clearTimeout(progressHideTimer);
                 progressHideTimer = null;
             }
-            if (progressMountTimer) {
-                clearTimeout(progressMountTimer);
-                progressMountTimer = null;
+            if (progressPaintTimer) {
+                clearTimeout(progressPaintTimer);
+                progressPaintTimer = null;
             }
             pendingProgressState = null;
-            progressVisible = false;
-            progressBar.hidden = true;
-            progressBar.classList.remove('progress-finishing', 'progress-slow');
-            progressFill.style.width = '0%';
-            progressLabel.textContent = '';
+            progressActive = false;
+            resetProgressVisuals();
         }
 
         // Compile-error banner state. Cards stay rendered while the banner


### PR DESCRIPTION
## Summary

Three closely-related changes that together make a save read as "content updates inside the existing layout" rather than a sequence of banners and rows shifting in and out.

### 1. Auto-render when the source is newer than the on-disk PNGs

The "Showing previews from 1d ago, but `Previews.kt` has changed since (save to render fresh, or run `Compose Preview: Refresh`)" banner is gone. When a discover-only refresh detects that the active file's mtime is newer than the oldest visible preview's PNG, the extension schedules `refresh(true, file, 'fast')` via `setTimeout(0)` and lets the refresh chain own the rest. No nudge to click — the panel just catches up to the buffer.

Drops `staleBannerShown` state, the `formatRelativeAge` helper, and the daemon-side banner-clearing branch in `onPreviewImageReady`.

### 2. Skip stale `imageJobs` on discover-only refreshes

When the source is newer than the PNGs, the bytes on disk don't reflect the current buffer. Pushing them via `updateImage` was the cause of the "old image flashes briefly before the new one arrives" glitch: `updateImage` removed the loading overlay and surfaced yesterday's render as if it were the current state, then the daemon's `renderFinished` arrived ~500ms–2s later with the real bytes. The image-loading loop is now gated behind `!sourceIsStale`, so cards keep their cached `imageData` (last known good) under the loading overlay until the auto-render or daemon push replaces them with fresh bytes.

### 3. Make the progress strip permanent

The strip used to be `display: none` when idle, so any refresh start / end shifted the toolbar and cards down / up by ~15px. The strip is now always rendered — when idle, the label is empty and the fill is at 0%, so it degrades to a thin inactive lane that's visually quiet but reserves its row. The internal state renames `progressVisible` → `progressActive` and `PROGRESS_MOUNT_DELAY_MS` → `PROGRESS_PAINT_DELAY_MS`, since the deferral now affects when we *paint* the fill rather than when we *mount* the element. `clearProgress()` resets the visuals to the idle look but no longer hides the element.

### Test plan

- [x] `npm run compile` — clean
- [x] `npm test` — 261 passing
- [ ] Manual: edit + save a Kotlin file. Confirm the panel layout doesn't shift up or down — only the cards' images update in place, and the progress strip's fill animates inside its existing reserved row.
- [ ] Manual: open a workspace where the rendered PNGs are stale (older than the source) — confirm the panel does NOT show the "1d ago" banner, and instead automatically kicks a fresh render. Cards keep showing the previous image (under the loading overlay) until the new bytes arrive.
- [ ] Manual: a successful render leaves PNGs newer than the source. Switching files away and back should NOT re-trigger an auto-render (no loop).
- [ ] Manual: warm-cache fast refresh — confirm the strip's fill stays at 0% the whole time (the 200ms paint deferral suppresses the brief animation), so the user sees no movement at all.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rw5ZRtvu2VaXiTRE9KmNiC)_