### PR TITLE
feat(vscode): vs-main fallback to preview_main baselines branch

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -20,6 +20,7 @@ import { captureLabel } from './captureLabels';
 import { DaemonGate } from './daemon/daemonGate';
 import { DaemonScheduler, WarmState } from './daemon/daemonScheduler';
 import { buildHistorySource, HistoryPanel, HistoryScope, HistorySource } from './historyPanel';
+import { readPreviewMainPng } from './previewMainSource';
 import { LogFilter, parseLogLevel } from './logFilter';
 import { pickRefreshModeFor, RefreshMode } from './refreshMode';
 import { BuildProgressTracker, mergeCalibration, PhaseDurations } from './buildProgress';
@@ -1732,33 +1733,54 @@ async function runLivePreviewDiff(
         return bt.localeCompare(at);
     });
     const target = sorted[0] as { id?: string; timestamp?: string } | undefined;
-    if (!target?.id) {
+    if (target?.id) {
+        const right = await historySource.read(target.id);
+        if (!right) {
+            panel.postMessage({
+                command: 'previewDiffError', previewId, against,
+                message: 'Comparison entry not readable.',
+            });
+            return;
+        }
+        const rightBytes = right.pngBytes
+            ?? (await fs.promises.readFile(right.pngPath)).toString('base64');
         panel.postMessage({
-            command: 'previewDiffError', previewId, against,
-            message: against === 'main'
-                ? 'No archived render on main yet for this preview.'
-                : 'No archived history yet for this preview.',
+            command: 'previewDiffReady',
+            previewId,
+            against,
+            leftLabel: 'Live · now',
+            leftImage: liveBytes.toString('base64'),
+            rightLabel: `${against === 'main' ? 'main' : 'HEAD'} · ${formatRelativeShort(target.timestamp)}`,
+            rightImage: rightBytes,
         });
         return;
     }
-    const right = await historySource.read(target.id);
-    if (!right) {
-        panel.postMessage({
-            command: 'previewDiffError', previewId, against,
-            message: 'Comparison entry not readable.',
-        });
-        return;
+    // No local archived entry. For "vs main" we can still try the
+    // preview_main baselines branch — repos using the CI baseline workflow
+    // publish every main build's PNGs there. Avoids requiring a daemon or
+    // a one-off local archive for the user's first diff against main.
+    if (against === 'main') {
+        const baseline = await readPreviewMainPng(
+            gradleService.workspaceRoot, moduleId, previewId,
+        );
+        if (baseline) {
+            panel.postMessage({
+                command: 'previewDiffReady',
+                previewId,
+                against,
+                leftLabel: 'Live · now',
+                leftImage: liveBytes.toString('base64'),
+                rightLabel: `main · ${baseline.ref}`,
+                rightImage: baseline.png.toString('base64'),
+            });
+            return;
+        }
     }
-    const rightBytes = right.pngBytes
-        ?? (await fs.promises.readFile(right.pngPath)).toString('base64');
     panel.postMessage({
-        command: 'previewDiffReady',
-        previewId,
-        against,
-        leftLabel: 'Live · now',
-        leftImage: liveBytes.toString('base64'),
-        rightLabel: `${against === 'main' ? 'main' : 'HEAD'} · ${formatRelativeShort(target.timestamp)}`,
-        rightImage: rightBytes,
+        command: 'previewDiffError', previewId, against,
+        message: against === 'main'
+            ? 'No archived render on main yet for this preview, and no preview_main baseline.'
+            : 'No archived history yet for this preview.',
     });
 }
 
@@ -1850,12 +1872,36 @@ async function diffAllVsMain(): Promise<void> {
                 // History unavailable for this preview — treat as no baseline.
             }
             if (!mainHash) {
+                // Fall back to the preview_main baselines branch — repos
+                // using the CI baseline workflow publish PNGs there even
+                // when nothing has been archived locally yet. The lookup
+                // also exposes a sha256 in the manifest, which we compare
+                // against the live hash to skip identical previews.
+                const baseline = await readPreviewMainPng(
+                    gradleService!.workspaceRoot, moduleId, preview.id,
+                );
+                if (!baseline) {
+                    drifted.push({
+                        label,
+                        description: 'no baseline on main',
+                        detail: preview.id,
+                        previewId: preview.id,
+                        driftKind: 'no-baseline',
+                    });
+                    continue;
+                }
+                const baselineHash = baseline.sha256
+                    ?? crypto.createHash('sha256').update(baseline.png).digest('hex');
+                if (liveHash === baselineHash) {
+                    identical++;
+                    continue;
+                }
                 drifted.push({
                     label,
-                    description: 'no baseline on main',
+                    description: 'differs from main',
                     detail: preview.id,
                     previewId: preview.id,
-                    driftKind: 'no-baseline',
+                    driftKind: 'differs',
                 });
                 continue;
             }

--- a/vscode-extension/src/previewMainSource.ts
+++ b/vscode-extension/src/previewMainSource.ts
@@ -1,0 +1,131 @@
+import { spawn } from 'child_process';
+
+/**
+ * Read PNG bytes for a preview's `main` baseline directly from the
+ * `preview_main` branch via git plumbing. Used as a fallback when the
+ * local `.compose-preview-history/` has no entry for `git.branch === 'main'`
+ * — repos that follow the CI baseline workflow (see
+ * [.github/actions/preview-baselines/action.yml]) push every `main` build's
+ * rendered PNGs to a `preview_main` branch alongside a `baselines.json`
+ * manifest. Reading from the ref means "vs main" works without local
+ * archived history and without a daemon.
+ *
+ * Layout on the baseline branch (matches `compare-previews.py`'s writer):
+ *
+ *   ├── baselines.json            // { "<module>/<previewId>": { sha256, renderBasename, ... } }
+ *   └── renders/
+ *       └── <module>/
+ *           └── <renderBasename>  // typically "<previewId>.png"
+ *
+ * The reader prefers `origin/preview_main` (post-fetch view of the
+ * remote) and falls back to a local `preview_main` branch if no remote
+ * tracking ref exists.
+ */
+export async function readPreviewMainPng(
+    workspaceRoot: string,
+    moduleId: string,
+    previewId: string,
+): Promise<PreviewMainResult | null> {
+    for (const ref of ['origin/preview_main', 'preview_main']) {
+        const baselineText = await gitShowText(workspaceRoot, ref, 'baselines.json');
+        if (!baselineText) { continue; }
+        const baselines = parseBaselines(baselineText);
+        if (!baselines) { continue; }
+        const entry = lookupBaselineEntry(baselines, moduleId, previewId);
+        if (!entry) { continue; }
+        const basename = entry.renderBasename || `${previewId}.png`;
+        const pngPath = `renders/${entry.module ?? moduleId}/${basename}`;
+        const png = await gitShowBytes(workspaceRoot, ref, pngPath);
+        if (!png) { continue; }
+        return { ref, baselineKey: entry.key, sha256: entry.sha256, png };
+    }
+    return null;
+}
+
+export interface PreviewMainResult {
+    /** e.g. `'origin/preview_main'` — the ref that resolved. */
+    ref: string;
+    /** e.g. `':samples:android/com.example.RedSquare'`. */
+    baselineKey: string;
+    /** PNG SHA-256 the manifest claims. Diff stats can verify against
+     *  the actual fetched bytes if needed. */
+    sha256?: string;
+    png: Buffer;
+}
+
+interface BaselineEntry {
+    key: string;
+    module?: string;
+    sha256?: string;
+    renderBasename?: string;
+}
+
+function lookupBaselineEntry(
+    baselines: Record<string, unknown>,
+    moduleId: string,
+    previewId: string,
+): BaselineEntry | null {
+    const direct = baselines[`${moduleId}/${previewId}`];
+    if (direct && typeof direct === 'object') {
+        return makeEntry(`${moduleId}/${previewId}`, direct as Record<string, unknown>);
+    }
+    // Fall back to endswith match. Different module-key encodings (with /
+    // without leading colon) shouldn't drop a hit for an unambiguous
+    // previewId. If two modules share a previewId, pick whichever the
+    // manifest enumerates first — the caller can't tell us which they
+    // meant from previewId alone.
+    const suffix = `/${previewId}`;
+    for (const k of Object.keys(baselines)) {
+        if (!k.endsWith(suffix)) { continue; }
+        const v = baselines[k];
+        if (v && typeof v === 'object') {
+            return makeEntry(k, v as Record<string, unknown>);
+        }
+    }
+    return null;
+}
+
+function makeEntry(key: string, raw: Record<string, unknown>): BaselineEntry {
+    return {
+        key,
+        module: typeof raw.module === 'string' ? raw.module : undefined,
+        sha256: typeof raw.sha256 === 'string' ? raw.sha256 : undefined,
+        renderBasename: typeof raw.renderBasename === 'string' ? raw.renderBasename : undefined,
+    };
+}
+
+function parseBaselines(text: string): Record<string, unknown> | null {
+    try {
+        const parsed = JSON.parse(text);
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) { return null; }
+        return parsed as Record<string, unknown>;
+    } catch {
+        return null;
+    }
+}
+
+function gitShow(
+    workspaceRoot: string,
+    ref: string,
+    path: string,
+): Promise<Buffer | null> {
+    return new Promise((resolve) => {
+        const child = spawn('git', ['show', `${ref}:${path}`], {
+            cwd: workspaceRoot,
+            stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        const chunks: Buffer[] = [];
+        child.stdout.on('data', (c: Buffer) => chunks.push(c));
+        child.on('close', (code) => resolve(code === 0 ? Buffer.concat(chunks) : null));
+        child.on('error', () => resolve(null));
+    });
+}
+
+async function gitShowText(workspaceRoot: string, ref: string, path: string): Promise<string | null> {
+    const buf = await gitShow(workspaceRoot, ref, path);
+    return buf ? buf.toString('utf8') : null;
+}
+
+async function gitShowBytes(workspaceRoot: string, ref: string, path: string): Promise<Buffer | null> {
+    return gitShow(workspaceRoot, ref, path);
+}


### PR DESCRIPTION
## Summary

Step 4 of the diff feature: **vs-main fallback via the `preview_main` baselines branch**.

When the user clicks **Diff vs main** in the live panel, or runs the **Diff All Previews vs Main** command, and no local `main`-tagged entry exists in `.compose-preview-history/`, the diff path now reads PNGs directly from the `preview_main` branch via git plumbing. The branch is the one [`.github/actions/preview-baselines/action.yml`](https://github.com/yschimke/compose-ai-tools/blob/main/.github/actions/preview-baselines/action.yml) already publishes to: `baselines.json` at the root + PNGs under `renders/<module>/<basename>`.

Lookup order:

1. `refs/remotes/origin/preview_main` (post-fetch view of the remote).
2. `refs/heads/preview_main` (local branch, if any).

Read flow:

- `git show <ref>:baselines.json` → JSON manifest.
- Lookup by `<module>/<previewId>`; fall back to `endsWith('/<previewId>')` if module-key encoding differs.
- `git show <ref>:renders/<module>/<renderBasename>` → PNG bytes streamed straight into the diff result.

The **Diff All Previews vs Main** command applies the same fallback per-preview, so a clean checkout that just fetched `preview_main` reports drift even with empty local history.

No daemon dependency, no extra files written: git's object store is the storage.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 261 / 261 passing
- [ ] Manual: clean checkout, no local history → click Diff vs main → diff result populates from `origin/preview_main`
- [ ] Manual: same setup → run Diff All Previews vs Main → quick-pick lists the drifted previews using the baselines manifest's `sha256`
- [ ] Manual: repo without a `preview_main` branch → falls through to "no archived render on main yet for this preview, and no preview_main baseline"
- [ ] Manual: local main entry already in history → uses the local entry, no git plumbing path

## Stretch follow-ups

- Daemon pixel mode + SSIM via `historyDiff(mode='pixel')` when daemon is healthy.
- Background `git cat-file --batch` process so repeated lookups in a session don't pay the per-call git fork cost.
- Watcher on `.git/refs/remotes/origin/preview_main` to invalidate any open diff result when a fetch lands.


---
_Generated by [Claude Code](https://claude.ai/code/session_01A6AFhHNrHQNqUPKdmJRt94)_