### PR TITLE
feat(daemon): publish daemon-core, daemon-desktop, daemon-android to Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,11 @@ jobs:
   # Android renderer AAR — the plugin resolves it via matching version.
   # `preview-annotations` ships the `@ScrollingPreview` marker that Compose
   # apps add to their compileOnly classpath, so it must publish in lockstep.
+  # `daemon-core` / `daemon-desktop` / `daemon-android` are pre-1.0 — published
+  # alongside so embedders (Gradle plugin, future Maven/IntelliJ plugins,
+  # third-party tooling) can consume the daemon by coordinate. See
+  # docs/daemon/DESIGN.md § 17 for the publishing decision and § 19 for the
+  # captureToImage fallback if Roborazzi's API ever does break binary compat.
   publish-gradle-plugin:
     needs: [build-cli, build-vscode-extension]
     runs-on: ubuntu-latest
@@ -84,7 +89,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
-      - name: Publish plugin, renderer-android and preview-annotations to GitHub Packages
+      - name: Publish plugin, renderer-android, preview-annotations, daemon-* to GitHub Packages
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -93,8 +98,11 @@ jobs:
           ./gradlew \
             :gradle-plugin:publishAllPublicationsToGitHubPackagesRepository \
             :renderer-android:publishAllPublicationsToGitHubPackagesRepository \
-            :preview-annotations:publishAllPublicationsToGitHubPackagesRepository
-      - name: Publish plugin, renderer-android and preview-annotations to Maven Central
+            :preview-annotations:publishAllPublicationsToGitHubPackagesRepository \
+            :daemon:core:publishAllPublicationsToGitHubPackagesRepository \
+            :daemon:desktop:publishAllPublicationsToGitHubPackagesRepository \
+            :daemon:android:publishAllPublicationsToGitHubPackagesRepository
+      - name: Publish plugin, renderer-android, preview-annotations, daemon-* to Maven Central
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
@@ -102,7 +110,10 @@ jobs:
           ./gradlew \
             :gradle-plugin:publishAndReleaseToMavenCentral \
             :renderer-android:publishAndReleaseToMavenCentral \
-            :preview-annotations:publishAndReleaseToMavenCentral
+            :preview-annotations:publishAndReleaseToMavenCentral \
+            :daemon:core:publishAndReleaseToMavenCentral \
+            :daemon:desktop:publishAndReleaseToMavenCentral \
+            :daemon:android:publishAndReleaseToMavenCentral
 
   build-cli:
     runs-on: ubuntu-latest

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -53,7 +53,10 @@ jobs:
           ./gradlew \
             :gradle-plugin:publishToMavenCentral \
             :renderer-android:publishToMavenCentral \
-            :preview-annotations:publishToMavenCentral
+            :preview-annotations:publishToMavenCentral \
+            :daemon:core:publishToMavenCentral \
+            :daemon:desktop:publishToMavenCentral \
+            :daemon:android:publishToMavenCentral
           # Note: `--no-configuration-cache` is incompatible with
           # `org.gradle.unsafe.isolated-projects=true` set in gradle.properties
           # (Gradle fails with "Configuration Cache cannot be disabled when

--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -7,9 +7,14 @@
 // the render body into this module. For B1.1–B1.3 the runtime deps are present
 // but only the protocol types and the dummy-@Test sandbox holder are used.
 //
-// NOT published to Maven. The daemon is consumed only by the Gradle plugin's
-// DaemonBootstrapTask (Stream A) which builds a launch descriptor pointing at
-// the local module's classpath.
+// **Published to Maven Central** as `ee.schimke.composeai:daemon-android` —
+// pairs with `daemon-core` so the Android (Robolectric) daemon backend is
+// consumable by coordinate. Single artifact across the supported Compose +
+// Roborazzi range; Compose / Roborazzi / UI-test / activity-compose stay
+// `compileOnly` and are supplied by the consumer's runtime, same pattern
+// `:renderer-android` already uses (see DESIGN.md § 17 for the decision and
+// § 19 for the captureToImage fallback if Roborazzi's API ever does break).
+// Pre-1.0; expect API breakage across minor versions.
 
 plugins {
   alias(libs.plugins.android.library)
@@ -19,12 +24,14 @@ plugins {
   // the @Serializable processor; kotlinx-serialization-json is already on the classpath via
   // `:daemon:core`'s `api(libs.kotlinx.serialization.json)`.
   alias(libs.plugins.kotlin.serialization)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
 }
 
-// The daemon is launched as a local JVM process by the Gradle plugin, never
-// shipped as a published artifact, so the older-Kotlin-runtime ABI dance done
-// in :renderer-android (via tapmoc.configureKotlinCompatibility) is not
-// required here. We get the project's default Kotlin stdlib at runtime.
+// The daemon is launched as a local JVM process by the Gradle plugin (or
+// directly via the published JAR for embedders), so the older-Kotlin-runtime
+// ABI dance done in :renderer-android (via tapmoc.configureKotlinCompatibility)
+// is not required here. We get the project's default Kotlin stdlib at runtime.
 
 group = "ee.schimke.composeai"
 
@@ -252,6 +259,112 @@ val daemonHarnessClasspathFile by configurations.creating {
       Attribute.of("ee.schimke.composeai.daemon.harness.classpath", String::class.java),
       "android",
     )
+  }
+}
+
+// GitHub Packages mirror — same shape as `:renderer-android`.
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+// Use the new (non-deprecated) AndroidSingleVariantLibrary constructor — takes typed JavadocJar /
+// SourcesJar instead of booleans. `JavadocJar.Empty()` ships an empty javadoc jar (Maven Central
+// requires the file to exist) without invoking javadoc/Dokka. javadoc 17 fails on AndroidX
+// dependencies' Kotlin metadata version mismatch (`expected version is 1.4.2`); Dokka would work
+// but is heavyweight for an artifact whose value is in KDocs the sources jar carries anyway.
+// `:renderer-android` still uses the deprecated (Boolean, Boolean) overload — fine to migrate
+// independently when its release bumps next.
+val androidSingleVariantLibrary =
+  com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
+    javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
+    sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
+    variant = "release",
+  )
+
+// AGP `testFixtures { enable = true }` ships `daemon-android-<version>-test-fixtures.aar` as
+// part of the published `release` component. The fixture composables (`RedSquare`/`BlueSquare`/
+// etc.) are internal harness aids, not for consumers. Skip the testFixtures publication
+// configurations from the `release` component. The configuration names are AGP's own
+// `releaseTestFixturesVariantRelease{Api,Runtime,Source}Publication` (the "Variant…Publication"
+// suffix is the AGP-side naming, NOT the standard `releaseTestFixtures*Elements` from
+// `java-test-fixtures`); we observed them with a one-off diagnostic.
+//
+// In-build `testFixtures(project(":daemon:android"))` consumption from `:daemon:harness` is
+// unaffected — that uses the project dep, not the published artifact.
+afterEvaluate {
+  val releaseComponent =
+    components.findByName("release") as? org.gradle.api.component.AdhocComponentWithVariants
+  releaseComponent?.let { component ->
+    // Only the Api and Runtime publications are actually attached to the `release` component as
+    // variants — `releaseTestFixturesVariantReleaseSourcePublication` exists as a configuration
+    // but isn't part of the component, so trying to skip it errors with "Variant for
+    // configuration ... does not exist in component". The .module file confirms only Api and
+    // Runtime variants leak; skipping those two also drops the test-fixtures.aar artifact.
+    listOf(
+        "releaseTestFixturesVariantReleaseApiPublication",
+        "releaseTestFixturesVariantReleaseRuntimePublication",
+      )
+      .forEach { name ->
+        configurations.findByName(name)?.let {
+          component.withVariantsFromConfiguration(it) { skip() }
+        }
+      }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  configure(androidSingleVariantLibrary)
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+
+  coordinates("ee.schimke.composeai", "daemon-android", version.toString())
+
+  pom {
+    name.set("Compose Preview — Daemon Android")
+    description.set(
+      "Robolectric-based Android backend of the compose-preview daemon: holds a long-lived " +
+        "Robolectric sandbox open via the dummy-@Test trick, renders @Preview composables to " +
+        "PNG. Compose / Roborazzi / UI-test stay compileOnly — consumer supplies runtime " +
+        "versions, same as :renderer-android. Pre-1.0; pairs with daemon-core."
+    )
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2025")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
   }
 }
 

--- a/daemon/core/build.gradle.kts
+++ b/daemon/core/build.gradle.kts
@@ -3,17 +3,20 @@
 //
 // Plain JVM module: holds the JSON-RPC server, the @Serializable protocol
 // types, and the abstract `RenderHost` interface. Both
-// `:daemon:android` (Robolectric backend) and the future
-// `:daemon:desktop` depend on this module and contribute their own
-// concrete `RenderHost` implementation.
+// `:daemon:android` (Robolectric backend) and `:daemon:desktop` depend on
+// this module and contribute their own concrete `RenderHost` implementation.
 //
-// NOT published to Maven on its own. Bundled into the daemon launch
-// descriptor's classpath via `:daemon:android` (which depends on
-// this module).
+// **Published to Maven Central** as `ee.schimke.composeai:daemon-core` —
+// public surface for embedders (Gradle plugin, future Maven/IntelliJ plugins,
+// third-party tooling) so the daemon JAR can be consumed by coordinate rather
+// than included-build wiring. Pre-1.0; API may break across minor versions —
+// see DESIGN.md § 17 (decisions log).
 
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
@@ -47,3 +50,62 @@ dependencies {
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
+
+// GitHub Packages mirror — same shape as `:renderer-android` and `:preview-annotations`.
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+
+  coordinates("ee.schimke.composeai", "daemon-core", version.toString())
+
+  pom {
+    name.set("Compose Preview — Daemon Core")
+    description.set(
+      "Renderer-agnostic core of the compose-preview daemon: JSON-RPC server, " +
+        "protocol types (@Serializable), and the RenderHost abstraction. " +
+        "Pre-1.0; consumed by daemon-android and daemon-desktop."
+    )
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2025")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
+}

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -19,9 +19,9 @@
 // and so the test source set can declare `@Preview` / `@Composable` fixtures.
 // The same plugin set is used by `:renderer-desktop`.
 //
-// NOT published to Maven. Consumed only by the Gradle plugin's daemon launch
-// descriptor (Stream A); classpath wireup for the desktop target lands in a
-// later Stream A task.
+// **Published to Maven Central** as `ee.schimke.composeai:daemon-desktop` —
+// pairs with `daemon-core` so the desktop daemon is consumable by coordinate.
+// Pre-1.0; see DESIGN.md § 17.
 
 plugins {
   alias(libs.plugins.kotlin.jvm)
@@ -38,6 +38,8 @@ plugins {
   // `RedFixturePreviews` is unchanged; the testFixtures source set re-exports `RedSquare` for
   // cross-module consumers.
   `java-test-fixtures`
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
@@ -58,24 +60,24 @@ dependencies {
   // re-declare it here.
   implementation(project(":daemon:core"))
 
-  // Inherit the desktop renderer's Compose Multiplatform / Skiko stack.
-  // Compose Desktop ships per-platform native Skiko binaries via the
-  // `compose.desktop.currentOs` accessor used in :renderer-desktop, so this
-  // module gets the host platform's Skiko bundle for free — no extra config
-  // here. B-desktop.1.4 (RenderEngine) duplicates the desktop render body
-  // into this module on top of that classpath.
-  implementation(project(":renderer-desktop"))
-
   // Compose runtime / foundation / ui — the B-desktop.1.4 RenderEngine body
   // imports `ImageComposeScene`, `@Composable`, `currentComposer`,
-  // `getDeclaredComposableMethod`, and a few Modifier / layout helpers. These
-  // are runtime-transitive through `:renderer-desktop` but not compile-visible
-  // here; declare them explicitly so the duplicated render body compiles
-  // against the same coordinates `:renderer-desktop` resolves.
+  // `getDeclaredComposableMethod`, and a few Modifier / layout helpers.
+  // Platform-agnostic surface; resolves to `*-desktop` variants on JVM
+  // consumers via Compose Multiplatform's variant selection.
   implementation(compose.runtime)
   implementation(compose.foundation)
   implementation(compose.ui)
   implementation(compose.components.uiToolingPreview)
+
+  // `compose.desktop.currentOs` bakes the *build host's* Skiko platform into
+  // the published POM (e.g. `desktop-jvm-linux-x64` when CI builds on Linux),
+  // which would lock consumers to that platform. Declare as `compileOnly` so
+  // it stays on our compile/test classpath but does NOT escape into the
+  // published POM. Consumers resolve their own host's Skiko via
+  // `implementation(compose.desktop.currentOs)` in their own build, the
+  // standard Compose Desktop library pattern.
+  compileOnly(compose.desktop.currentOs)
 
   testImplementation(libs.junit)
   // Tests declare a small fixture composable + drive RenderEngine against it,
@@ -116,4 +118,85 @@ tasks.register<JavaExec>("runDaemonMain") {
   mainClass.set("ee.schimke.composeai.daemon.DaemonMain")
   standardInput = System.`in`
   dependsOn("jar")
+}
+
+// `java-test-fixtures` adds testFixtures-* "Elements" configurations that Vanniktech's
+// auto-detection picks up and ships as `-test-fixtures.jar` / `-test-fixtures-sources.jar`.
+// The fixtures (`RedSquare`, etc.) are internal harness aids — do not publish them. Skip the
+// publishable testFixtures variants from the `java` component. Done in `afterEvaluate` because
+// Vanniktech adds the sources/javadoc variants to the component lazily — calling
+// `withVariantsFromConfiguration` before `addVariantsFromConfiguration` fails (the variant
+// isn't yet attached to the component even though the configuration exists).
+afterEvaluate {
+  val javaComponent = components["java"] as org.gradle.api.component.AdhocComponentWithVariants
+  listOf(
+      "testFixturesApiElements",
+      "testFixturesRuntimeElements",
+      "testFixturesSourcesElements",
+      "testFixturesJavadocElements",
+    )
+    .forEach { name ->
+      configurations.findByName(name)?.let {
+        javaComponent.withVariantsFromConfiguration(it) { skip() }
+      }
+    }
+}
+
+// GitHub Packages mirror — same shape as `:renderer-android` and `:preview-annotations`.
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+
+  coordinates("ee.schimke.composeai", "daemon-desktop", version.toString())
+
+  pom {
+    name.set("Compose Preview — Daemon Desktop")
+    description.set(
+      "Compose Multiplatform desktop backend of the compose-preview daemon: " +
+        "long-lived JVM + Skiko render thread, per-render ImageComposeScene. " +
+        "Pre-1.0; pairs with daemon-core."
+    )
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2025")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
 }

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -37,10 +37,18 @@ Both fallbacks share the same concurrency group as the primary path, so they can
 
 ### What the `release.yml` workflow does
 
-1. Publishes the **Gradle plugin** (`ee.schimke.composeai:compose-preview-plugin`), the **Android renderer AAR** (`ee.schimke.composeai:renderer-android`), and the **preview annotations** (`ee.schimke.composeai:preview-annotations`) to **Maven Central** via the Central Portal, and mirrors them to GitHub Packages.
+1. Publishes to **Maven Central** via the Central Portal (and mirrors to GitHub Packages):
+   - **Gradle plugin** — `ee.schimke.composeai:compose-preview-plugin`
+   - **Android renderer AAR** — `ee.schimke.composeai:renderer-android`
+   - **Preview annotations** — `ee.schimke.composeai:preview-annotations`
+   - **Daemon core** (pre-1.0) — `ee.schimke.composeai:daemon-core` — renderer-agnostic JSON-RPC server, protocol types, RenderHost interface
+   - **Daemon desktop** (pre-1.0) — `ee.schimke.composeai:daemon-desktop` — Compose Multiplatform desktop backend (DesktopHost + DaemonMain)
+   - **Daemon android** (pre-1.0) — `ee.schimke.composeai:daemon-android` — Robolectric backend; Compose / Roborazzi / UI-test stay `compileOnly`, consumer supplies runtime versions
 2. Builds the **CLI** as `.zip` and `.tar.gz` distributions.
 3. Packages the **VS Code extension** as a `.vsix` file and publishes it to the **VS Code Marketplace** and **Open VSX** (runs alongside the Release upload, so a marketplace outage can't block the GitHub Release).
-4. Uploads all three artifacts onto the GitHub Release that release-please created (falling back to creating the Release itself if invoked outside the release-please path, e.g. from a manual tag push).
+4. Uploads the CLI + VS Code extension artifacts onto the GitHub Release that release-please created (falling back to creating the Release itself if invoked outside the release-please path, e.g. from a manual tag push).
+
+The `daemon-*` artifacts are **pre-1.0**; their public API is not yet stable. Expect breakage across minor versions until the surface settles. See [docs/daemon/DESIGN.md § 17](daemon/DESIGN.md) for the architectural decisions and § 19 for the captureToImage fallback path.
 
 Required secrets on the repository:
 


### PR DESCRIPTION
## Summary

Follows up #355's design decision (Roborazzi `compileOnly`, single artifact per daemon module) by actually wiring the publication. Three new pre-1.0 Maven Central coordinates:

- `ee.schimke.composeai:daemon-core` — renderer-agnostic JSON-RPC server, protocol types, RenderHost interface (plain JVM JAR).
- `ee.schimke.composeai:daemon-desktop` — Compose Multiplatform desktop backend (DesktopHost + DaemonMain). JVM JAR.
- `ee.schimke.composeai:daemon-android` — Robolectric backend. AAR. Compose / Roborazzi / UI-test stay `compileOnly` per the contract documented in DESIGN.md § 17.

Plus the `release.yml` + `snapshot.yml` wireup so they ship alongside the existing gradle-plugin / renderer-android / preview-annotations triple, and a `docs/RELEASING.md` update calling out the pre-1.0 status.

## Publication-shape gotchas surfaced via `publishToMavenLocal`

Each commit captures one. In short:

- **`daemon-desktop`** — three fixes: drop `project(":renderer-desktop")` (would emit `compose-ai-tools:renderer-desktop:unspecified` into POM); move `compose.desktop.currentOs` to `compileOnly` (otherwise bakes the build host's Skiko platform `desktop-jvm-linux-x64` into the published artifact); skip `testFixtures*Elements` variants from the Java component (otherwise leaks `RedSquare`/etc. fixture composables to consumers).
- **`daemon-android`** — use the new (non-deprecated) `AndroidSingleVariantLibrary` constructor with `JavadocJar.Empty()` (Dokka chokes on AndroidX Kotlin metadata mismatch under JDK 17); skip the AGP-specific `releaseTestFixturesVariantRelease{Api,Runtime}Publication` configurations from the `release` component (the AGP-side naming, NOT the standard `releaseTestFixtures*Elements` from `java-test-fixtures` — discovered via a one-off diagnostic).

In-build `testFixtures(project(":daemon:{android,desktop}"))` consumption from `:daemon:harness` is unaffected — verified post-change with `./gradlew :daemon:harness:compileTestKotlin`.

## Test plan

- [x] `./gradlew :daemon:core:publishToMavenLocal` produces clean JAR + sources + javadoc + .module + .pom; POM deps resolve to real coordinates (kotlinx-serialization-json, classgraph).
- [x] `./gradlew :daemon:desktop:publishToMavenLocal` — final variants `apiElements`, `runtimeElements`, `sourcesElements`. POM deps: kotlin-stdlib + daemon-core + Compose Multiplatform desktop variants. No platform-specific Skiko, no testFixtures.
- [x] `./gradlew :daemon:android:publishToMavenLocal` — final variants `releaseVariantRelease{Api,Runtime,Source}Publication`. POM deps: kotlin-stdlib, daemon-core, renderer-android, robolectric, junit. compose-bom 2025.11.01 in `<dependencyManagement>`. No `-test-fixtures.aar`, no broken project-coords, no Dokka.
- [x] `./gradlew :daemon:harness:compileTestKotlin` — testFixtures consumption via project dep still works.
- [ ] Real Maven Central / GitHub Packages publish — relies on the next `release.yml` run.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ohLWyrgJDumpCDtKvRtNY)_