### PR TITLE
feat(daemon): affinity-aware sandbox-pool dispatch (previewId-keyed)

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -247,11 +247,15 @@ open class RobolectricHost(
     // on first read after a swap, so this also amortises the allocation onto the host thread
     // rather than the render thread.
     publishChildLoader()
-    // SANDBOX-POOL.md — slot dispatch. Hash the request id to a slot so concurrent submits with
-    // distinct ids fan out across the pool. With sandboxCount=1 this collapses to slot 0, which
-    // is byte-identical with the pre-pool path (slot 0's `requests` queue is the same instance as
-    // the legacy top-level queue).
-    val slotIdx = Math.floorMod(typed.id, sandboxCount.toLong()).toInt()
+    // SANDBOX-POOL.md — slot dispatch. Hash the **previewId** to a slot so the same preview always
+    // lands on the same sandbox; Compose snapshot caches and Robolectric shadow caches accumulate
+    // per-sandbox and pay off on repeat renders. Falls back to the request id when the payload
+    // doesn't carry `previewId=<id>` (legacy stub-render-N test payloads, or any future caller
+    // that bypasses the manifest path) so legacy callers keep their stable-id hashing. With
+    // sandboxCount=1 either dispatch path collapses to slot 0, which is byte-identical with the
+    // pre-pool path (slot 0's `requests` queue is the same instance as the legacy top-level
+    // queue).
+    val slotIdx = chooseSlotIndex(typed)
     val slot = DaemonHostBridge.slot(slotIdx)
     slot.requests.put(typed)
     val resultQueue = DaemonHostBridge.results.computeIfAbsent(typed.id) { LinkedBlockingQueue() }
@@ -270,6 +274,39 @@ open class RobolectricHost(
     // their fields out via reflection so the host-side caller gets an
     // instance of the host-side RenderResult class.
     return raw as? RenderResult ?: copyResultAcrossClassloaders(raw)
+  }
+
+  /**
+   * SANDBOX-POOL.md (affinity-aware dispatch) — picks a slot for [render]. Uses the previewId
+   * extracted from the payload as the affinity key when present so the same preview always lands
+   * on the same sandbox; falls back to the monotonic request id when the payload is the legacy
+   * stub form (`render-N`) or has no `previewId=` key.
+   *
+   * `Math.floorMod` keeps the slot index non-negative for any hash. With `sandboxCount = 1` both
+   * paths collapse to slot 0 — bit-identical with the pre-pool single-sandbox dispatch.
+   */
+  private fun chooseSlotIndex(render: RenderRequest.Render): Int {
+    if (sandboxCount == 1) return 0
+    val previewId = parsePreviewIdFromPayload(render.payload)
+    val key: Int = previewId?.hashCode() ?: render.id.hashCode()
+    return Math.floorMod(key, sandboxCount)
+  }
+
+  /**
+   * Extracts `previewId=<id>` from a `;`-delimited payload. Mirrors the parsing
+   * `PreviewManifestRouter.parsePreviewId` does in the same package — duplicated here rather than
+   * shared via a top-level helper so the dispatch path stays a self-contained one-line read.
+   * Returns `null` when the payload doesn't carry a previewId (legacy stub-payload tests).
+   */
+  private fun parsePreviewIdFromPayload(payload: String): String? {
+    if (payload.isEmpty()) return null
+    for (entry in payload.split(';')) {
+      val trimmed = entry.trim()
+      if (trimmed.startsWith(PREVIEW_ID_KEY)) {
+        return trimmed.substring(PREVIEW_ID_KEY.length).trim().takeIf { it.isNotEmpty() }
+      }
+    }
+    return null
   }
 
   private fun copyResultAcrossClassloaders(raw: Any): RenderResult {
@@ -329,6 +366,14 @@ open class RobolectricHost(
 
     /** Survey-set key inside the forensic payload — comma-separated FQNs. */
     const val FORENSIC_SURVEY_KEY: String = "survey"
+
+    /**
+     * Affinity-key prefix in the [RenderRequest.Render.payload] used by
+     * [chooseSlotIndex]. `JsonRpcServer.handleRenderNow` and `PreviewManifestRouter` both encode
+     * the previewId here; the dispatch path reads it to pin renders of the same preview to the
+     * same sandbox slot. Mirrors the prefix `PreviewManifestRouter.parsePreviewId` recognises.
+     */
+    private const val PREVIEW_ID_KEY: String = "previewId="
   }
 
   override fun shutdown(timeoutMs: Long) {

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RobolectricHostPoolTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RobolectricHostPoolTest.kt
@@ -17,9 +17,13 @@ import org.junit.Test
  *    dispatch in [RobolectricHost.submit] is stable — `Math.floorMod(id, sandboxCount)` is keyed
  *    on the request id which is monotonic per process).
  *
- * **Why ids are bucketed by `id and 1`**: [RobolectricHost.submit] dispatches via
- * `Math.floorMod(id, sandboxCount.toLong())`. With sandboxCount=2 that's `id mod 2 = id and 1`.
- * Result.id matches the request id, so we bucket the observed results that way.
+ * **Why ids are bucketed by `id and 1`**: when the payload doesn't carry a `previewId=` key
+ * (legacy stub payloads like `render-N`), [RobolectricHost.submit] hashes the request id instead.
+ * For small positive Long ids `Long.hashCode()` is the low 32 bits as a signed int, so its parity
+ * matches `id and 1L`; bucketing by that aligns with the actual dispatch path.
+ *
+ * Affinity-aware dispatch (`previewId=<id>` in the payload) is covered by
+ * [samePreviewIdAlwaysLandsOnSameSlot] below.
  *
  * **Why `legacyStubPayload` and not real RenderSpecs**: [RobolectricHostTest] already submits the
  * `payload="render-N"` shape that the B1.3-era stub path was built for. Reusing that path keeps
@@ -82,6 +86,54 @@ class RobolectricHostPoolTest {
           cl.contains("Instrument") || cl.contains("Sandbox") || cl.contains("Robolectric"),
         )
       }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun samePreviewIdAlwaysLandsOnSameSlot() {
+    // SANDBOX-POOL-FOLLOWUPS.md (#3, affinity-aware dispatch). Same previewId across many
+    // submits must hit the same sandbox slot every time so per-sandbox Compose snapshot caches +
+    // Robolectric shadow caches accumulate as intended; without this, repeat renders of the same
+    // preview never warm a single sandbox.
+    val host = RobolectricHost(sandboxCount = 2)
+    try {
+      host.start()
+
+      // Use many previewIds so at least one lands on each slot regardless of how the hash
+      // distributes — the per-previewId stability assertion below is the load-bearing one,
+      // independent of which slot any individual id lands on.
+      val previewIds = (0 until 16).map { i -> "com.example.preview.Foo$i.method" }
+      val rendersPerPreview = 4
+      val byPreview =
+        previewIds.associateWith { previewId ->
+          (1..rendersPerPreview).map { _ ->
+            host.submit(RenderRequest.Render(payload = "previewId=$previewId"))
+          }
+        }
+
+      // Load-bearing: each previewId's renders all land on a single classloader (= same slot).
+      for ((previewId, results) in byPreview) {
+        val classloaderHashes = results.map { it.classLoaderHashCode }.toSet()
+        assertEquals(
+          "previewId='$previewId' should always land on one slot, saw $classloaderHashes",
+          1,
+          classloaderHashes.size,
+        )
+      }
+
+      // Sanity: across 16 previewIds, at least both slots got something. If everything pinned to
+      // slot 0 the test would silently pass the per-id stability assertion on a degenerate hash.
+      val allClassloaderHashes =
+        previewIds
+          .flatMap { previewId -> byPreview.getValue(previewId).map { it.classLoaderHashCode } }
+          .toSet()
+      assertEquals(
+        "16 previewIds should spread across both slots, saw $allClassloaderHashes",
+        2,
+        allClassloaderHashes.size,
+      )
     } finally {
       host.shutdown()
     }

--- a/docs/daemon/SANDBOX-POOL-FOLLOWUPS.md
+++ b/docs/daemon/SANDBOX-POOL-FOLLOWUPS.md
@@ -11,7 +11,7 @@ constraints from that work remain:
 |--:|-----------|--------------|-----------------------|
 | 1 | Per-slot user-class child loaders | Hot-reload uses a single shared `URLClassLoader`; per-slot needs design + invalidation discipline | Daemons that opt into hot-reload silently fall back to `sandboxCount = 1` and lose pool concurrency |
 | 2 | Per-slot sandbox recycle | Recycle thresholds (heap drift, render-time drift) attribute to "the sandbox" not "this sandbox among N"; pool muddies the math | Whole pool tears down on any heap event — bigger user-visible pause than necessary |
-| 3 | Affinity-aware dispatch (previewId-keyed) | Today's dispatch is `Math.floorMod(requestId, N)`; same preview hits a different sandbox each render | Compose state cache + Robolectric shadow caches don't carry across renders of the same preview |
+| 3 | Affinity-aware dispatch (previewId-keyed) **— landed** | Today's dispatch is `Math.floorMod(requestId, N)`; same preview hits a different sandbox each render | Compose state cache + Robolectric shadow caches don't carry across renders of the same preview |
 
 This doc sketches each. Implementation lands in separate PRs once the sketches survive review.
 
@@ -199,7 +199,7 @@ old clients keep working.
 
 ---
 
-## 3. Affinity-aware dispatch (previewId-keyed)
+## 3. Affinity-aware dispatch (previewId-keyed) — landed
 
 ### Problem
 


### PR DESCRIPTION
SANDBOX-POOL-FOLLOWUPS.md item #3 (the smallest follow-up of the three).

`RobolectricHost.submit` now hashes the **previewId** (parsed from the payload's `previewId=<id>` key) for slot selection instead of the monotonic request id. Same preview always lands on the same sandbox; per-sandbox Compose snapshot caches and Robolectric shadow caches accumulate as intended on repeat renders, paying off on the second-and-later renders of any preview.

Falls back to the request id when the payload has no `previewId=` key (legacy stub-render-N test payloads, the forensic-dump path) so existing callers keep their stable-id hashing without protocol churn. For `sandboxCount = 1` either dispatch path collapses to slot 0 — bit-identical with the pre-pool single-sandbox dispatch.

## Test

New `samePreviewIdAlwaysLandsOnSameSlot` in `RobolectricHostPoolTest` submits 16 previewIds × 4 renders each into a `sandboxCount = 2` host and asserts:

1. Every previewId's renders observe **one** sandbox classloader (slot is stable for that id).
2. The 16 ids spread across **both** slots so the test isn't silently passing on a degenerate hash that pins everything to slot 0.

## Test plan

- [x] `:daemon:android:testDebugUnitTest` — 5 test classes pass (4 existing + the new affinity test inside the existing `RobolectricHostPoolTest`).

## Stack

- Item #1 (per-slot user-class child loaders) — separate PR, next.
- Item #2 (per-slot sandbox recycle) — separate PR, after #1.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SDmE1Uu28mX8yVjHeTMFJE)_