### PR TITLE
feat(vscode): refresh open vs-main diff when preview_main ref moves

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -21,6 +21,7 @@ import { DaemonGate } from './daemon/daemonGate';
 import { DaemonScheduler, WarmState } from './daemon/daemonScheduler';
 import { buildHistorySource, HistoryPanel, HistoryScope, HistorySource } from './historyPanel';
 import { disposePreviewMainBatches, readPreviewMainPng } from './previewMainSource';
+import { watchPreviewMainRef } from './previewMainWatcher';
 import { LogFilter, parseLogLevel } from './logFilter';
 import { pickRefreshModeFor, RefreshMode } from './refreshMode';
 import { BuildProgressTracker, mergeCalibration, PhaseDurations } from './buildProgress';
@@ -365,6 +366,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     }
     context.subscriptions.push(
         vscode.window.registerWebviewViewProvider(PreviewPanel.viewId, panel),
+    );
+
+    // Watch the preview_main ref for fetch-driven changes. When the ref
+    // moves, any open "Diff vs main" overlay in the live panel needs to
+    // re-issue against the new bytes. The watcher coalesces fetch bursts
+    // internally; we just message the live panel and let it reissue.
+    context.subscriptions.push(
+        watchPreviewMainRef(workspaceRoot, () => {
+            panel?.postMessage({ command: 'previewMainRefChanged' });
+        }),
     );
 
     // Phase H7 — Preview History panel (HISTORY.md § "VS Code integration").

--- a/vscode-extension/src/previewMainWatcher.ts
+++ b/vscode-extension/src/previewMainWatcher.ts
@@ -1,0 +1,83 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Watch the git refs that back the "Diff vs main" anchor and fire a single
+ * coalesced callback whenever any of them changes — typically after a
+ * `git fetch` lands new objects, but also on local commit/branch ops.
+ *
+ * Targets:
+ *   - `.git/refs/remotes/origin/preview_main` — post-fetch view of the
+ *     remote baseline branch (the most common trigger).
+ *   - `.git/refs/heads/preview_main` — local branch, for repos that
+ *     publish baselines locally.
+ *   - `.git/packed-refs` — git packs loose refs into this file via
+ *     `git pack-refs` / `git gc`; when packed, the per-file refs above
+ *     disappear and updates land here instead.
+ *
+ * `fs.watch` on the parent dir + filename filter catches create / change /
+ * delete uniformly across platforms (`recursive: true` is Mac/Win-only).
+ * A 250ms debounce coalesces fetch bursts that touch packed-refs and
+ * the per-ref file in quick succession.
+ */
+export function watchPreviewMainRef(
+    workspaceRoot: string,
+    onChange: () => void,
+): { dispose(): void } {
+    const gitDir = path.join(workspaceRoot, '.git');
+    if (!fs.existsSync(gitDir) || !fs.statSync(gitDir).isDirectory()) {
+        // Worktree (`.git` is a file pointing elsewhere) or non-git
+        // workspace. Fall through to a no-op; callers don't gain
+        // automatic refresh, but explicit Diff vs main still works.
+        return { dispose: () => { /* nothing to clean up */ } };
+    }
+
+    let debounce: NodeJS.Timeout | null = null;
+    const fire = () => {
+        if (debounce) { return; }
+        debounce = setTimeout(() => {
+            debounce = null;
+            onChange();
+        }, 250);
+    };
+
+    interface DirWatch {
+        dir: string;
+        filenames: Set<string>;
+    }
+    const dirs: DirWatch[] = [
+        { dir: path.join(gitDir, 'refs', 'remotes', 'origin'), filenames: new Set(['preview_main']) },
+        { dir: path.join(gitDir, 'refs', 'heads'), filenames: new Set(['preview_main']) },
+        { dir: gitDir, filenames: new Set(['packed-refs']) },
+    ];
+
+    const watchers: fs.FSWatcher[] = [];
+    for (const { dir, filenames } of dirs) {
+        try {
+            // The dir might not exist yet (e.g. no remotes configured).
+            // We tolerate ENOENT silently — the user just doesn't get
+            // automatic refresh for that path until it appears.
+            if (!fs.existsSync(dir)) { continue; }
+            const watcher = fs.watch(dir, (_eventType, filename) => {
+                if (filename && filenames.has(filename.toString())) {
+                    fire();
+                }
+            });
+            watcher.on('error', () => { /* ignore — best-effort watcher */ });
+            watchers.push(watcher);
+        } catch {
+            // Platform-specific watcher failures (EMFILE on busy
+            // filesystems, etc.) — best-effort, don't propagate.
+        }
+    }
+
+    return {
+        dispose() {
+            if (debounce) { clearTimeout(debounce); debounce = null; }
+            for (const w of watchers) {
+                try { w.close(); } catch { /* already closed */ }
+            }
+            watchers.length = 0;
+        },
+    };
+}

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -1801,6 +1801,25 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     });
                     break;
                 }
+                case 'previewMainRefChanged': {
+                    // preview_main moved — re-issue any open vs-main diff
+                    // overlay so the user sees the new bytes without clicking.
+                    // Other diffs (HEAD, current, previous) are unaffected.
+                    document.querySelectorAll(
+                        '.preview-diff-overlay[data-against="main"]',
+                    ).forEach(overlay => {
+                        const card = overlay.closest('.preview-card');
+                        const previewId = card && card.dataset.previewId;
+                        if (!card || !previewId) return;
+                        showDiffOverlay(card, 'main', null, null);
+                        vscode.postMessage({
+                            command: 'requestPreviewDiff',
+                            previewId,
+                            against: 'main',
+                        });
+                    });
+                    break;
+                }
             }
         });
 

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -295,7 +295,14 @@ export type ExtensionToWebview =
      * request. Used by the "Diff All vs Main" command so picking an item
      * from its quick-pick lands the user directly on the diff result.
      */
-    | { command: 'focusAndDiff'; previewId: string; against: 'head' | 'main' };
+    | { command: 'focusAndDiff'; previewId: string; against: 'head' | 'main' }
+    /**
+     * `origin/preview_main` (or the local `preview_main` branch / packed
+     * refs) just changed on disk — typically because a `git fetch` landed
+     * a new baseline. The live panel re-issues any open "Diff vs main"
+     * overlay so the user sees the new bytes without manually clicking.
+     */
+    | { command: 'previewMainRefChanged' };
 
 /** Messages from webview to extension */
 export type WebviewToExtension =


### PR DESCRIPTION
## Summary

Watches the git refs that back **Diff vs main** and re-issues any open vs-main overlay when they change. Completes the "don't make them think they need to click" contract from the original design discussion: open a diff, run `git fetch` in another terminal, the diff updates silently in place.

Targets watched (`fs.watch` on the parent dir + filename filter, since the file may not exist initially):

- `.git/refs/remotes/origin/preview_main` — post-fetch view, the most common trigger.
- `.git/refs/heads/preview_main` — local branch, for repos publishing baselines locally.
- `.git/packed-refs` — git packs loose refs into here via `git pack-refs` / `git gc`; updates land here instead of the per-ref file.

A 250ms debounce inside the watcher coalesces fetch bursts that touch packed-refs and the per-ref file in quick succession.

The live panel handles the new `previewMainRefChanged` message by querying for `.preview-diff-overlay[data-against="main"]` and re-issuing `requestPreviewDiff` for each. Other anchors (HEAD, current, previous) aren't affected by ref changes so they're left alone.

`git cat-file --batch` (from PR #372) sees the new objects without restart — git's pack rescan handles new packs on demand — so the existing batch process serves the new bytes on the next read.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 269 / 269 passing
- [ ] Manual: open Diff vs main on a focused preview. From a terminal, push something to `preview_main` and `git fetch origin preview_main`. The diff updates silently in place.
- [ ] Manual: same setup, but run `git pack-refs --all` instead of fetch — handler still fires.
- [ ] Manual: open Diff vs HEAD (not main). Fetch landing new `preview_main` does not perturb the HEAD overlay.
- [ ] Manual: workspace without a `.git/` directory (e.g. plain checkout, no VCS) — extension activates without errors; `Diff vs main` falls back to its existing "no baseline" path.

## Stretch follow-ups still on the table

- Daemon pixel mode + SSIM via `historyDiff(mode='pixel')` when daemon is healthy.
- (Maybe) Watch the live render PNG path too, so "Diff vs HEAD" auto-refreshes when a new render lands. The daemon's render-finished signal already covers that for the daemon path; the Gradle path doesn't.


---
_Generated by [Claude Code](https://claude.ai/code/session_01A6AFhHNrHQNqUPKdmJRt94)_