### PR TITLE
feat(daemon): per-slot user-class child loaders — pool now hot-reload-compatible

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -62,54 +62,32 @@ fun main(args: Array<String>) {
   // swap. When the sysprop is unset (legacy/in-process tests), the holder is null and the legacy
   // sandbox-classpath path stays — pre-B2.0 behaviour.
   val userClassUrls = UserClassLoaderHolder.urlsFromSysprop()
-  val userClassloaderHolder: UserClassLoaderHolder? =
-    if (userClassUrls.isNotEmpty()) {
-      System.err.println(
-        "compose-ai-tools daemon: UserClassLoaderHolder active " +
-          "(urls=${userClassUrls.size}, dirs=${userClassUrls.map { it.path }})"
-      )
-      // B2.0-followup — the child URLClassLoader's parent must be the **sandbox** classloader
-      // (not the host thread's app loader). DaemonHostBridge.sandboxClassLoaderRef is set inside
-      // SandboxHoldingRunner.holdSandboxOpen once the sandbox boots; the supplier here is
-      // evaluated lazily on first allocation, by which time the bridge ref is non-null because
-      // RobolectricHost.publishChildLoader awaits sandbox-ready before invoking the supplier.
-      // Forensics-confirmed root cause for the previous Android save-loop failure.
-      UserClassLoaderHolder(
-        urls = userClassUrls,
-        parentSupplier = {
-          DaemonHostBridge.currentSandboxClassLoader()
-            ?: error(
-              "DaemonHostBridge.sandboxClassLoaderRef is null — sandbox prologue didn't run. " +
-                "Did SandboxHoldingRunner.holdSandboxOpen execute setSandboxClassLoader before " +
-                "the host called publishChildLoader?"
-            )
-        },
-      )
-    } else null
+  val hasUserClasses = userClassUrls.isNotEmpty()
+  if (hasUserClasses) {
+    System.err.println(
+      "compose-ai-tools daemon: UserClassLoaderHolder active " +
+        "(urls=${userClassUrls.size}, dirs=${userClassUrls.map { it.path }})"
+    )
+  }
 
   // SANDBOX-POOL.md (Layer 3) — read the supervisor-supplied sandbox-count knob. The
   // DaemonSupervisor passes `composeai.daemon.sandboxCount = 1 + replicasPerDaemon` via the
   // launch descriptor's systemProperties; sandbox pooling collapses what used to be N separate
   // daemon JVMs into one JVM with N sandbox slots. Default 1 preserves the pre-pool single-
   // sandbox behaviour bit-for-bit.
-  //
-  // Constraint: sandboxCount > 1 isn't compatible with a non-null userClassloaderHolder in v1
-  // (per-slot child URLClassLoaders are layered work — see RobolectricHost's init-block check).
-  // Force sandboxCount = 1 with a clear warning when both are requested so the daemon still
-  // boots; otherwise the host's `require` would fire and the daemon would fail to start.
-  val requestedSandboxCount =
+  val sandboxCount =
     (System.getProperty(SANDBOX_COUNT_PROP)?.toIntOrNull() ?: 1).coerceAtLeast(1)
-  val effectiveSandboxCount =
-    if (requestedSandboxCount > 1 && userClassloaderHolder != null) {
-      System.err.println(
-        "compose-ai-tools daemon: requested sandboxCount=$requestedSandboxCount but a user-class " +
-          "loader holder is active; sandbox pooling is not yet compatible with the disposable " +
-          "child loader (per-slot child loaders are follow-up work). Falling back to sandboxCount=1."
-      )
-      1
-    } else {
-      requestedSandboxCount
-    }
+
+  // SANDBOX-POOL-FOLLOWUPS.md (#1) — per-slot child loaders. The factory closes over the URL
+  // list and constructs one holder per slot, parented to the slot's own sandbox classloader. The
+  // host invokes the factory lazily on first dispatch to each slot, after the sandbox prologue
+  // has registered its loader on `DaemonHostBridge.slot(i).sandboxClassLoaderRef`.
+  val userClassloaderHolderFactory: ((sandboxClassLoader: ClassLoader) -> UserClassLoaderHolder)? =
+    if (hasUserClasses) {
+      { sandboxClassLoader ->
+        UserClassLoaderHolder(urls = userClassUrls, parentSupplier = { sandboxClassLoader })
+      }
+    } else null
 
   val manifestPath = System.getProperty("composeai.harness.previewsManifest")
   val host: RenderHost =
@@ -121,17 +99,32 @@ fun main(args: Array<String>) {
       )
       // The harness's PreviewManifestRouter wraps a single RobolectricHost; sandbox pooling is
       // an optimisation for the production daemon path, not the harness mode (which exists to
-      // exercise the wire protocol against in-process fakes). Stay at sandboxCount=1 here.
-      PreviewManifestRouter(manifest = manifest, userClassloaderHolder = userClassloaderHolder)
+      // exercise the wire protocol against in-process fakes). Stay at sandboxCount=1 here and
+      // use the legacy single-instance holder (PreviewManifestRouter still takes that form).
+      val singletonHolder: UserClassLoaderHolder? =
+        userClassloaderHolderFactory?.let { factory ->
+          UserClassLoaderHolder(
+            urls = userClassUrls,
+            parentSupplier = {
+              DaemonHostBridge.currentSandboxClassLoader()
+                ?: error(
+                  "DaemonHostBridge.sandboxClassLoaderRef is null — sandbox prologue didn't run. " +
+                    "Did SandboxHoldingRunner.holdSandboxOpen execute setSandboxClassLoader before " +
+                    "the host called publishChildLoader?"
+                )
+            },
+          )
+        }
+      PreviewManifestRouter(manifest = manifest, userClassloaderHolder = singletonHolder)
     } else {
-      if (effectiveSandboxCount > 1) {
+      if (sandboxCount > 1) {
         System.err.println(
-          "compose-ai-tools daemon: sandbox pool active (sandboxCount=$effectiveSandboxCount)"
+          "compose-ai-tools daemon: sandbox pool active (sandboxCount=$sandboxCount)"
         )
       }
       RobolectricHost(
-        userClassloaderHolder = userClassloaderHolder,
-        sandboxCount = effectiveSandboxCount,
+        userClassloaderHolderFactory = userClassloaderHolderFactory,
+        sandboxCount = sandboxCount,
       )
     }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -80,27 +80,58 @@ open class RobolectricHost(
   /**
    * Number of Robolectric sandboxes to host in parallel — see
    * [SANDBOX-POOL.md](../../../../../../docs/daemon/SANDBOX-POOL.md). Default `1` preserves the
-   * pre-pool single-sandbox behaviour bit-for-bit. `> 1` is **experimental and currently broken
-   * via the JUnit-runner approach**: see SANDBOX-POOL.md "Layer 2 — empirical finding" for the
-   * stall on the second sandbox's bootstrap.
+   * pre-pool single-sandbox behaviour bit-for-bit. `> 1` boots N sandboxes in this JVM and
+   * dispatches concurrent renders across them via affinity-aware slot routing in [submit].
    *
-   * When [sandboxCount] > 1, [start] sequences boots, sets [SandboxHoldingHints.workerIndex] per
-   * worker so each sandbox lands on a distinct cache key, and dumps every thread's stack to
-   * stderr if any slot misses its ready latch — the diagnostic that informs the pivot to
-   * Robolectric's lower-level `Sandbox` API.
-   *
-   * **Restricted in v1:** [sandboxCount] > 1 requires [userClassloaderHolder] to be `null`.
+   * For the legacy single-instance [userClassloaderHolder] param (sandboxCount=1 only): set
+   * [userClassloaderHolderFactory] instead when you need the pool. Both paths are otherwise
+   * equivalent.
    */
   val sandboxCount: Int = 1,
+  /**
+   * Per-slot user-class loader factory — SANDBOX-POOL-FOLLOWUPS.md (#1, per-slot child loaders).
+   * When non-null, the host invokes the factory once per sandbox slot at first dispatch (with the
+   * slot's sandbox classloader) to allocate that slot's [UserClassLoaderHolder]. Each slot's
+   * holder owns a child `URLClassLoader` parented to its own sandbox loader, so the framework
+   * classes the child resolves match the sandbox the render runs in (no classloader-identity
+   * skew across slots).
+   *
+   * Mutually exclusive with the legacy single-instance [userClassloaderHolder] — at most one of
+   * the two may be non-null. Per-slot is required for `sandboxCount > 1` when hot-reload (file
+   * changed → swap user classloaders) is wired; the single-instance form is retained for
+   * single-sandbox callers and existing tests.
+   */
+  val userClassloaderHolderFactory: ((sandboxClassLoader: ClassLoader) -> UserClassLoaderHolder)? =
+    null,
 ) : RenderHost {
 
   init {
     require(sandboxCount >= 1) { "sandboxCount must be >= 1, got $sandboxCount" }
+    require(userClassloaderHolder == null || userClassloaderHolderFactory == null) {
+      "RobolectricHost: pass either userClassloaderHolder OR userClassloaderHolderFactory, not " +
+        "both. The factory form supersedes the single-instance form for sandboxCount > 1."
+    }
     require(sandboxCount == 1 || userClassloaderHolder == null) {
-      "sandboxCount > 1 with a non-null userClassloaderHolder is not supported in v1: per-slot " +
-        "child URLClassLoaders need separate work (SANDBOX-POOL.md). Got sandboxCount=$sandboxCount."
+      "RobolectricHost: sandboxCount > 1 with a non-null userClassloaderHolder is not supported " +
+        "(per-slot child URLClassLoaders need their own per-slot parent). Use " +
+        "userClassloaderHolderFactory for the pool path. Got sandboxCount=$sandboxCount."
     }
   }
+
+  /**
+   * Per-slot holders, allocated lazily on first dispatch to each slot. `null` when the host runs
+   * without any user-class isolation (factory unset, holder unset) — that's the default for the
+   * harness's in-process tests where testFixtures live on the sandbox classpath.
+   *
+   * Slot 0 is also populated by the legacy [userClassloaderHolder] path, so single-sandbox
+   * callers using either constructor form end up with a holder at index 0.
+   */
+  private val perSlotHolders: java.util.concurrent.atomic.AtomicReferenceArray<UserClassLoaderHolder?> =
+    java.util.concurrent.atomic.AtomicReferenceArray<UserClassLoaderHolder?>(sandboxCount).also {
+      // Seed slot 0 with the legacy single-instance holder so `swapUserClassLoaders()` and
+      // `publishChildLoader()` see one consistent source of truth.
+      if (userClassloaderHolder != null) it.set(0, userClassloaderHolder)
+    }
 
   private val workerThreads: List<Thread> =
     (0 until sandboxCount).map { i ->
@@ -215,19 +246,51 @@ open class RobolectricHost(
   }
 
   /**
-   * Mirrors the holder's current child classloader into [DaemonHostBridge.childLoaderRef] so the
-   * sandbox-side render thread can read it (the host-side holder lives in a package Robolectric
-   * re-loads inside the sandbox; the bridge package is do-not-acquire). Called before every
-   * [submit] so a fileChanged-driven swap on the JSON-RPC thread is visible to the next render —
-   * see B2.0's no-mid-render-cancellation discipline.
-   *
-   * The sandbox-ready latch is already 0 by the time [submit] runs — [start] blocked on it. The
-   * holder's `parentSupplier` (which reads `DaemonHostBridge.sandboxClassLoaderRef`) sees the
-   * sandbox loader directly, no per-submit wait, no race.
+   * SANDBOX-POOL-FOLLOWUPS.md (#1) — lazily allocate the holder for [slotIdx] from
+   * [userClassloaderHolderFactory], using the slot's already-claimed sandbox classloader as
+   * parent. Idempotent (CAS); subsequent calls return the same instance until [swapUserClassLoaders]
+   * drops it. Returns `null` when no factory is wired, in which case slot 0's
+   * [DaemonHostBridge.SandboxSlot.childLoaderRef] may already hold the legacy single-instance
+   * holder's child loader (seeded into [perSlotHolders]).
    */
-  private fun publishChildLoader() {
-    val holder = userClassloaderHolder ?: return
-    DaemonHostBridge.setCurrentChildLoader(holder.currentChildLoader())
+  private fun ensureHolderForSlot(slotIdx: Int): UserClassLoaderHolder? {
+    perSlotHolders.get(slotIdx)?.let { return it }
+    val factory = userClassloaderHolderFactory ?: return null
+    val sandboxLoader =
+      DaemonHostBridge.slot(slotIdx).sandboxClassLoaderRef.get()
+        ?: error(
+          "RobolectricHost.ensureHolderForSlot($slotIdx): slot's sandbox classloader is null — " +
+            "submit() should only be called after start() returns, by which point every slot has " +
+            "registered its loader."
+        )
+    val candidate = factory(sandboxLoader)
+    return if (perSlotHolders.compareAndSet(slotIdx, null, candidate)) candidate
+    else perSlotHolders.get(slotIdx)
+  }
+
+  /**
+   * Mirrors the slot's holder's current child classloader into the slot's
+   * [DaemonHostBridge.SandboxSlot.childLoaderRef] so the sandbox-side render thread can read it.
+   * Called per-submit so a fileChanged-driven [swapUserClassLoaders] on the JSON-RPC thread is
+   * visible to the next render — preserves B2.0's no-mid-render-cancellation discipline.
+   *
+   * Per-slot since the affinity-aware dispatch can land each preview on a different sandbox; the
+   * mirror needs to land on the slot the render is about to dispatch to.
+   */
+  private fun publishChildLoaderForSlot(slotIdx: Int) {
+    val holder = ensureHolderForSlot(slotIdx) ?: return
+    DaemonHostBridge.slot(slotIdx).childLoaderRef.set(holder.currentChildLoader())
+  }
+
+  /**
+   * SANDBOX-POOL-FOLLOWUPS.md (#1) — broadcast `swap()` to every slot's holder. Each holder
+   * lazily re-allocates its child `URLClassLoader` on next read, so the next render to that slot
+   * sees the recompiled bytecode. No-op when no holder is wired (default in-process tests).
+   */
+  override fun swapUserClassLoaders() {
+    for (i in 0 until sandboxCount) {
+      perSlotHolders.get(i)?.swap()
+    }
   }
 
   /**
@@ -242,11 +305,6 @@ open class RobolectricHost(
       "Use shutdown() to stop the host, not submit(Shutdown)."
     }
     val typed = request as RenderRequest.Render
-    // B2.0 — publish the (possibly-just-swapped) child classloader to the bridge so the
-    // sandbox-side render dispatch picks it up. `holder.currentChildLoader()` is lazily allocated
-    // on first read after a swap, so this also amortises the allocation onto the host thread
-    // rather than the render thread.
-    publishChildLoader()
     // SANDBOX-POOL.md — slot dispatch. Hash the **previewId** to a slot so the same preview always
     // lands on the same sandbox; Compose snapshot caches and Robolectric shadow caches accumulate
     // per-sandbox and pay off on repeat renders. Falls back to the request id when the payload
@@ -257,6 +315,11 @@ open class RobolectricHost(
     // queue).
     val slotIdx = chooseSlotIndex(typed)
     val slot = DaemonHostBridge.slot(slotIdx)
+    // SANDBOX-POOL-FOLLOWUPS.md (#1) — publish the (possibly-just-swapped) child classloader to
+    // the slot the render is about to land on. `currentChildLoader()` is lazily allocated on
+    // first read after a swap, so this also amortises the allocation onto the host thread rather
+    // than the render thread.
+    publishChildLoaderForSlot(slotIdx)
     slot.requests.put(typed)
     val resultQueue = DaemonHostBridge.results.computeIfAbsent(typed.id) { LinkedBlockingQueue() }
     val raw =

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RobolectricHostPoolTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RobolectricHostPoolTest.kt
@@ -140,7 +140,30 @@ class RobolectricHostPoolTest {
   }
 
   @Test
-  fun rejectsHolderWithSandboxCountAboveOne() {
+  fun rejectsLegacyHolderPlusFactory() {
+    // SANDBOX-POOL-FOLLOWUPS.md (#1) — the two constructor paths are mutually exclusive. Pre-#1
+    // the constraint was "no holder when sandboxCount > 1"; now the constraint is "use either
+    // form, not both."
+    val holder =
+      UserClassLoaderHolder(
+        urls = emptyList(),
+        parentSupplier = { ClassLoader.getSystemClassLoader() },
+      )
+    val ex =
+      assertThrows(IllegalArgumentException::class.java) {
+        RobolectricHost(
+          userClassloaderHolder = holder,
+          userClassloaderHolderFactory = { _ -> holder },
+        )
+      }
+    assertTrue(
+      "error should call out the holder-vs-factory exclusivity, got: ${ex.message}",
+      ex.message?.contains("not both") == true,
+    )
+  }
+
+  @Test
+  fun rejectsLegacyHolderWithSandboxCountAboveOne() {
     val holder =
       UserClassLoaderHolder(
         urls = emptyList(),
@@ -151,9 +174,97 @@ class RobolectricHostPoolTest {
         RobolectricHost(userClassloaderHolder = holder, sandboxCount = 2)
       }
     assertTrue(
-      "error should explain why holder + sandboxCount>1 is forbidden, got: ${ex.message}",
-      ex.message?.contains("per-slot") == true,
+      "error should explain that pool callers should use the factory form, got: ${ex.message}",
+      ex.message?.contains("userClassloaderHolderFactory") == true,
     )
+  }
+
+  @Test
+  fun perSlotHoldersHaveDistinctChildLoadersParentedToTheirSandbox() {
+    // SANDBOX-POOL-FOLLOWUPS.md (#1) — the load-bearing per-slot guarantee: each slot's holder is
+    // parented to that slot's sandbox classloader, so a render that lands on slot N resolves user
+    // classes against sandbox N's framework classes (no classloader-identity skew across slots).
+    //
+    // Implementation note: we record the sandbox classloader the factory was invoked with for
+    // each slot, then assert the recorded set matches the sandbox classloaders the renders
+    // actually saw. This proves the factory was invoked with the right parent — without trying to
+    // build a real child URLClassLoader (which would require URL resources we don't have here).
+    val recordedParents = java.util.concurrent.ConcurrentHashMap<Int, ClassLoader>()
+    val factory: (ClassLoader) -> UserClassLoaderHolder = { sandboxClassLoader ->
+      val slotIndex =
+        // Each slot has a unique sandbox classloader; use its identity as the key. We don't know
+        // the slot index from inside the factory but identityHash is unique-per-instance.
+        System.identityHashCode(sandboxClassLoader)
+      recordedParents[slotIndex] = sandboxClassLoader
+      UserClassLoaderHolder(urls = emptyList(), parentSupplier = { sandboxClassLoader })
+    }
+    val host = RobolectricHost(sandboxCount = 2, userClassloaderHolderFactory = factory)
+    try {
+      host.start()
+      // Drive enough renders that each slot is exercised at least once.
+      val results =
+        (1..8).map { i ->
+          host.submit(RenderRequest.Render(payload = "previewId=com.example.Preview$i"))
+        }
+      val sandboxCls = results.map { it.classLoaderHashCode }.toSet()
+      assertEquals(
+        "two slots must produce two distinct sandbox classloaders, saw $sandboxCls",
+        2,
+        sandboxCls.size,
+      )
+      // The factory must have been invoked exactly once per slot (idempotent CAS in the host).
+      assertEquals(
+        "factory should be invoked once per slot, saw ${recordedParents.size}: ${recordedParents.keys}",
+        2,
+        recordedParents.size,
+      )
+      // Recorded parent classloaders match the classloaders the renders actually observed.
+      assertEquals(
+        "recorded parents must equal the rendered-against classloaders",
+        sandboxCls,
+        recordedParents.keys.toSet(),
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun swapUserClassLoadersBroadcastsToEverySlot() {
+    // SANDBOX-POOL-FOLLOWUPS.md (#1) — `fileChanged({ kind: "source" })` calls
+    // `host.swapUserClassLoaders()`, which must invalidate every slot's holder so the next render
+    // to any slot allocates a fresh child loader. Pre-#1 the equivalent code only swapped one
+    // shared holder.
+    val swapCallsPerSlot = java.util.concurrent.ConcurrentHashMap<Int, java.util.concurrent.atomic.AtomicInteger>()
+    val factory: (ClassLoader) -> UserClassLoaderHolder = { sandboxClassLoader ->
+      val key = System.identityHashCode(sandboxClassLoader)
+      val counter = swapCallsPerSlot.computeIfAbsent(key) { java.util.concurrent.atomic.AtomicInteger() }
+      UserClassLoaderHolder(
+        urls = emptyList(),
+        parentSupplier = { sandboxClassLoader },
+        onSwap = { counter.incrementAndGet() },
+      )
+    }
+    val host = RobolectricHost(sandboxCount = 2, userClassloaderHolderFactory = factory)
+    try {
+      host.start()
+      // Warm both slots so both holders are allocated. Without this the swap is a no-op for slots
+      // whose factory has never been invoked.
+      (1..8).forEach { i -> host.submit(RenderRequest.Render(payload = "previewId=com.example.P$i")) }
+      assertEquals("expected both slots warmed", 2, swapCallsPerSlot.size)
+      // Trigger the broadcast.
+      host.swapUserClassLoaders()
+      // Each slot's holder must have observed exactly one swap.
+      for ((key, counter) in swapCallsPerSlot) {
+        assertEquals(
+          "slot identityHash=$key should observe exactly one swap broadcast",
+          1,
+          counter.get(),
+        )
+      }
+    } finally {
+      host.shutdown()
+    }
   }
 
   private fun <T : Throwable> assertThrows(expected: Class<T>, block: () -> Unit): T {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1093,7 +1093,11 @@ class JsonRpcServer(
   private fun handleFileChanged(params: FileChangedParams) {
     when (params.kind) {
       FileKind.SOURCE -> {
-        host.userClassloaderHolder?.swap()
+        // SANDBOX-POOL-FOLLOWUPS.md (#1) — broadcast to every slot's holder under sandboxCount>1.
+        // For single-sandbox hosts this is the same `swap()` call the previous code made on
+        // `userClassloaderHolder`; the default-no-op on hosts without holders (FakeHost, B1.3
+        // stubs) keeps the v1 fake-mode scenarios unchanged.
+        host.swapUserClassLoaders()
         queueDiscoveryAfterRender(params.path)
       }
       FileKind.CLASSPATH -> {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -52,17 +52,35 @@ interface RenderHost {
 
   /**
    * The disposable user-class [UserClassLoaderHolder] this host renders against (B2.0 — see
-   * [CLASSLOADER.md](../../../../../../docs/daemon/CLASSLOADER.md)). The
-   * [JsonRpcServer.handleFileChanged] path mutates it (`swap()` on `kind: "source"`); the host's
-   * render path reads `currentChildLoader()` to resolve preview classes via `Class.forName`.
+   * [CLASSLOADER.md](../../../../../../docs/daemon/CLASSLOADER.md)). The host's render path reads
+   * `currentChildLoader()` to resolve preview classes via `Class.forName`.
    *
    * Returns `null` when the host doesn't participate in the parent/child split (the harness's
    * `FakeHost`, the Stream A B1.3 stub-render hosts, etc.) — those hosts don't load user classes,
-   * so `JsonRpcServer.handleFileChanged` simply skips the swap and the existing v1 fake-mode
-   * scenarios stay unchanged. Real backends (`DesktopHost`, `RobolectricHost`) override.
+   * so the swap is a no-op and the existing v1 fake-mode scenarios stay unchanged. Real backends
+   * (`DesktopHost`, `RobolectricHost`) override.
+   *
+   * **Sandbox pool note (SANDBOX-POOL.md).** Under multi-sandbox mode `RobolectricHost` carries one
+   * holder per slot rather than a single shared instance. This property still returns one
+   * representative holder (slot 0) so callers that only need "is this host classloader-aware?" keep
+   * working; callers that mutate state should use [swapUserClassLoaders] for the broadcast.
    */
   val userClassloaderHolder: UserClassLoaderHolder?
     get() = null
+
+  /**
+   * Swap (drop and lazily re-allocate on next read) every user-class child classloader this host
+   * holds. SANDBOX-POOL.md (per-slot child loaders): a host with `sandboxCount > 1` broadcasts to
+   * every slot's holder so all slots see the recompiled bytecode on their next render.
+   *
+   * Default no-op for hosts that don't participate in the parent/child split.
+   * [JsonRpcServer.handleFileChanged] calls this on `kind: "source"` instead of dereferencing
+   * [userClassloaderHolder]?.swap() directly so the broadcast is the same call site for both
+   * single-sandbox and pool modes.
+   */
+  fun swapUserClassLoaders() {
+    userClassloaderHolder?.swap()
+  }
 
   companion object {
     /**

--- a/docs/daemon/CONFIG.md
+++ b/docs/daemon/CONFIG.md
@@ -79,10 +79,12 @@ Cheap to raise thanks to the in-JVM pool: extra sandboxes share the JVM baseline
 bytecode (~75 MB). Pre-Layer-3 this knob spawned N+1 separate JVM subprocesses; ~750 MB per
 replica was wasted on duplicated baselines.
 
-`sandboxCount > 1` requires the user-class loader holder to be **null** (i.e. the gradle plugin's
-hot-reload path is incompatible with the pool in v1 — per-slot child loaders are tracked as a
-follow-up in [SANDBOX-POOL.md](SANDBOX-POOL.md)). When both are requested the daemon falls back
-to `sandboxCount = 1` with a stderr warning.
+Compatible with the gradle plugin's hot-reload path. Each sandbox slot allocates its own child
+`URLClassLoader` parented to its own sandbox classloader, so `fileChanged({ kind: "source" })`
+broadcasts a `swap()` to every slot's holder — see
+[SANDBOX-POOL-FOLLOWUPS.md](SANDBOX-POOL-FOLLOWUPS.md) "#1 Per-slot user-class child loaders" for
+the design and the per-slot factory the host accepts in place of the legacy single-instance
+holder.
 
 ## Gradle properties
 

--- a/docs/daemon/SANDBOX-POOL-FOLLOWUPS.md
+++ b/docs/daemon/SANDBOX-POOL-FOLLOWUPS.md
@@ -9,7 +9,7 @@ constraints from that work remain:
 
 | # | Follow-up | Why deferred | Cost of doing nothing |
 |--:|-----------|--------------|-----------------------|
-| 1 | Per-slot user-class child loaders | Hot-reload uses a single shared `URLClassLoader`; per-slot needs design + invalidation discipline | Daemons that opt into hot-reload silently fall back to `sandboxCount = 1` and lose pool concurrency |
+| 1 | Per-slot user-class child loaders **— landed** | Hot-reload uses a single shared `URLClassLoader`; per-slot needs design + invalidation discipline | Daemons that opt into hot-reload silently fall back to `sandboxCount = 1` and lose pool concurrency |
 | 2 | Per-slot sandbox recycle | Recycle thresholds (heap drift, render-time drift) attribute to "the sandbox" not "this sandbox among N"; pool muddies the math | Whole pool tears down on any heap event — bigger user-visible pause than necessary |
 | 3 | Affinity-aware dispatch (previewId-keyed) **— landed** | Today's dispatch is `Math.floorMod(requestId, N)`; same preview hits a different sandbox each render | Compose state cache + Robolectric shadow caches don't carry across renders of the same preview |
 
@@ -17,7 +17,7 @@ This doc sketches each. Implementation lands in separate PRs once the sketches s
 
 ---
 
-## 1. Per-slot user-class child loaders
+## 1. Per-slot user-class child loaders — landed
 
 ### Problem
 


### PR DESCRIPTION
SANDBOX-POOL-FOLLOWUPS.md item #1. Lifts the v1 constraint that `sandboxCount > 1` required `userClassloaderHolder == null`. Each sandbox slot now allocates its own child `URLClassLoader` parented to its own sandbox classloader; `fileChanged({ kind: "source" })` broadcasts a `swap()` to every slot's holder so all slots see the recompiled bytecode on their next render. The gradle plugin's hot-reload path is now compatible with `sandboxCount > 1` (i.e. with the default `replicasPerDaemon = 3`).

## What changes

- **`RenderHost.swapUserClassLoaders()`** (new) — default calls `swap()` on the singleton holder if any. `JsonRpcServer.handleFileChanged` now invokes this in place of `host.userClassloaderHolder?.swap()` so the same call site works for single-sandbox and pool modes.
- **`RobolectricHost.userClassloaderHolderFactory`** (new constructor param) — `(sandboxClassLoader: ClassLoader) -> UserClassLoaderHolder`. The host invokes the factory lazily on first dispatch to each slot, passing that slot's sandbox classloader. Per-slot allocations are CAS'd into a single `AtomicReferenceArray` so multiple submits to the same slot can race safely.
- **Legacy `userClassloaderHolder` retained** for `sandboxCount = 1` callers (back-compat for `ClassloaderForensicsDaemonTest` and the existing `PreviewManifestRouter` path); mutually exclusive with the factory form.
- **`RobolectricHost.swapUserClassLoaders()`** broadcasts across all per-slot holders. Skips slots whose factory hasn't been invoked yet (they'll allocate fresh on next dispatch anyway).
- **`DaemonMain` (Android)**: drops the `effectiveSandboxCount` fallback that forced `sandboxCount = 1` when a user-class holder was wired. Passes the factory through directly.
- **`CONFIG.md`** + **`SANDBOX-POOL-FOLLOWUPS.md`** updated to mark #1 landed.

## Tests

New tests in `RobolectricHostPoolTest`:

- `perSlotHoldersHaveDistinctChildLoadersParentedToTheirSandbox` — factory invoked once per slot, with each slot's own sandbox loader as parent. Recorded factory args match the rendered-against classloaders.
- `swapUserClassLoadersBroadcastsToEverySlot` — one `host.swapUserClassLoaders()` fires `onSwap` exactly once per slot's holder.
- `rejectsLegacyHolderPlusFactory` — exclusivity check.
- `rejectsLegacyHolderWithSandboxCountAboveOne` — error message now points users to the factory form.

## Test plan

- [x] `:daemon:android:testDebugUnitTest` — all tests pass.
- [x] `:daemon:core:test` — `JsonRpcServerIntegrationTest` and other tests using the legacy `userClassloaderHolder` property are unchanged. (Pre-existing flake in `LocalFsHistorySourcePruneTest.dedup_by_hash_preserves_png_when_other_sidecar_still_references_it` is unrelated to this change — fails on clean main too with a date-dependent assertion.)

## Stack

- #374 (affinity-aware dispatch) — open, independent.
- #2 (per-slot sandbox recycle) — separate PR, next.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SDmE1Uu28mX8yVjHeTMFJE)_