### PR TITLE
feat(daemon): silent metadata reconcile on save; render PNGs before discoveryUpdated

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -50,6 +50,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.Base64
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -137,6 +138,19 @@ class JsonRpcServer(
    * behaviour as before phase 2 landed.
    */
   private val incrementalDiscovery: IncrementalDiscovery? = null,
+  /**
+   * Watchdog window for the deferred-discovery cascade — see [queueDiscoveryAfterRender]. A
+   * `fileChanged({kind: source})` notification queues the file for a background scan + diff, but
+   * holds the resulting `discoveryUpdated` notification until either (a) the next `renderFinished`
+   * for any preview flushes the queue, or (b) this many milliseconds elapse and we drain anyway.
+   * The point is that the user sees the new PNG first; the metadata reconcile arrives behind it and
+   * is silent when the diff is empty.
+   *
+   * Configurable via the [DISCOVERY_WATCHDOG_PROP] sysprop; the harness lowers it to a few hundred
+   * ms in scenarios that don't issue a render between the save and the assertion.
+   */
+  private val discoveryWatchdogMs: Long =
+    System.getProperty(DISCOVERY_WATCHDOG_PROP)?.toLongOrNull() ?: DEFAULT_DISCOVERY_WATCHDOG_MS,
   /**
    * H1+H2 — when non-null, every successful render produces a sidecar + index entry on disk
    * (HISTORY.md § "What this PR lands § H1") and emits a `historyAdded` notification. The
@@ -580,6 +594,11 @@ class JsonRpcServer(
     // has already been sent above; history is observation, not state.
     recordHistoryForRender(previewId = previewId, result = result, finished = finished)
     inFlightRenders.remove(result.id)
+    // Save-after-render invariant: a `fileChanged({kind:source})` queued discovery work that has
+    // been waiting for this render to ship. The writer queue is FIFO and `renderFinished` is
+    // already in it — kicking the discovery scan now guarantees its `discoveryUpdated`
+    // notification (if any) lands strictly after the render the user just saw.
+    drainPendingDiscovery()
   }
 
   /**
@@ -1075,7 +1094,7 @@ class JsonRpcServer(
     when (params.kind) {
       FileKind.SOURCE -> {
         host.userClassloaderHolder?.swap()
-        runIncrementalDiscovery(params.path)
+        queueDiscoveryAfterRender(params.path)
       }
       FileKind.CLASSPATH -> {
         handleClasspathFileChanged(params)
@@ -1090,20 +1109,75 @@ class JsonRpcServer(
   }
 
   /**
+   * Paths waiting on a deferred discovery scan — populated by [queueDiscoveryAfterRender] from the
+   * `fileChanged({kind:source})` handler, drained by either [emitRenderFinished] (after the next
+   * render notification has flushed) or by a watchdog timer (when no render arrives within
+   * [discoveryWatchdogMs]).
+   *
+   * Identity dedup isn't worth it: two saves of the same file in quick succession scan twice, but
+   * each scan is scoped (one classpath element) and the daemon is bounded by the user's editor
+   * cadence anyway. The queue is correctness-safe under contention thanks to the atomic poll.
+   */
+  private val pendingDiscoveryPaths = ConcurrentLinkedQueue<String>()
+
+  /**
+   * Queues [path] for a deferred discovery cascade and starts a watchdog so the work always runs
+   * eventually — even when the save lands on a file with no focused previews and no `renderNow`
+   * follows.
+   *
+   * The user-visible invariant this enforces (matching the editor save-loop design): a save NEVER
+   * surfaces a metadata event before the corresponding render. Renders are what the user actually
+   * looks at; the metadata reconcile is a quiet background pass that only paints the panel when the
+   * preview set actually drifted (`discoveryUpdated` is silent on an empty diff — see
+   * [runIncrementalDiscoveryNow]).
+   *
+   * No-op when [incrementalDiscovery] is null — preserves the pre-phase-2 contract for in-process
+   * integration tests and the fake-mode harness scenarios that don't wire one.
+   */
+  private fun queueDiscoveryAfterRender(path: String) {
+    if (incrementalDiscovery == null) return
+    pendingDiscoveryPaths.add(path)
+    Thread(
+        {
+          try {
+            Thread.sleep(discoveryWatchdogMs)
+          } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            return@Thread
+          }
+          drainPendingDiscovery()
+        },
+        "compose-ai-daemon-discovery-watchdog",
+      )
+      .apply { isDaemon = true }
+      .start()
+  }
+
+  /**
+   * Drains [pendingDiscoveryPaths] and runs the discovery cascade for each path. Idempotent:
+   * concurrent callers (the watchdog vs. [emitRenderFinished]) compete via the atomic queue poll,
+   * so each path runs at most once.
+   */
+  private fun drainPendingDiscovery() {
+    while (true) {
+      val path = pendingDiscoveryPaths.poll() ?: return
+      runIncrementalDiscoveryNow(path)
+    }
+  }
+
+  /**
    * B2.2 phase 2 — runs the daemon-side cheap-prefilter / scoped-scan / diff cascade for one
    * source-file `fileChanged` notification, applies the resulting diff in-place to [previewIndex],
    * and emits `discoveryUpdated` if non-empty.
    *
-   * Runs the heavy work on a fresh daemon thread so the JSON-RPC read loop never blocks on a scan.
-   * Mirrors the fire-and-forget pattern [submitRenderAsync] uses for renders. We deliberately pick
-   * a fresh thread (rather than reusing an executor) for symmetry with the render path; saved-file
-   * events arrive O(seconds) apart in a typical save loop, so the cost of one short-lived `Thread`
-   * per save is negligible compared to a ClassGraph scan.
-   *
-   * No-op when [incrementalDiscovery] is null — preserves the pre-phase-2 contract for in-process
-   * integration tests.
+   * Runs the heavy work on a fresh daemon thread so neither the JSON-RPC read loop nor the
+   * render-watcher loop blocks on a scan. Mirrors the fire-and-forget pattern [submitRenderAsync]
+   * uses for renders. We deliberately pick a fresh thread (rather than reusing an executor) for
+   * symmetry with the render path; saved-file events arrive O(seconds) apart in a typical save
+   * loop, so the cost of one short-lived `Thread` per save is negligible compared to a ClassGraph
+   * scan.
    */
-  private fun runIncrementalDiscovery(path: String) {
+  private fun runIncrementalDiscoveryNow(path: String) {
     val discovery = incrementalDiscovery ?: return
     Thread(
         {
@@ -1407,6 +1481,17 @@ class JsonRpcServer(
     /** PROTOCOL.md § 6 — `daemon.classpathDirtyGraceMs`, default 2000ms. */
     const val CLASSPATH_DIRTY_GRACE_PROP: String = "composeai.daemon.classpathDirtyGraceMs"
     const val DEFAULT_CLASSPATH_DIRTY_GRACE_MS: Long = 2_000L
+
+    /**
+     * Watchdog window between `fileChanged({kind:source})` and the (deferred) discovery scan. The
+     * server prefers to drain the pending-discovery queue from `emitRenderFinished` so the user's
+     * new PNG always lands before any `discoveryUpdated`; the watchdog is the fallback for saves
+     * that don't drive a render (e.g. file changed but not focused). 1500ms in production keeps the
+     * metadata reconcile responsive without racing fast renders. Tests override to a few hundred ms
+     * via the sysprop.
+     */
+    const val DISCOVERY_WATCHDOG_PROP: String = "composeai.daemon.discoveryWatchdogMs"
+    const val DEFAULT_DISCOVERY_WATCHDOG_MS: Long = 1_500L
 
     /**
      * Ceiling on shutdown drain. Renders that take longer than this are still allowed to finish —

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
@@ -648,6 +648,9 @@ class JsonRpcServerIntegrationTest {
         daemonVersion = "test",
         previewIndex = index,
         incrementalDiscovery = discovery,
+        // No `renderNow` between the `fileChanged` and the assertion — drive the watchdog fallback
+        // path on a short window so the test isn't blocked on the production 1500ms default.
+        discoveryWatchdogMs = 100,
         onExit = { _ -> exitLatch.countDown() },
       )
     val serverThread =
@@ -708,6 +711,235 @@ class JsonRpcServerIntegrationTest {
       assertEquals(0, index.size)
 
       // Tear down.
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","id":99,"method":"shutdown"}""")
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 99 })
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"exit"}""")
+      assertTrue(exitLatch.await(5, TimeUnit.SECONDS))
+    } finally {
+      try {
+        clientToServerOut.close()
+      } catch (_: Throwable) {}
+      try {
+        serverToClientIn.close()
+      } catch (_: Throwable) {}
+      tmpDir.toFile().deleteRecursively()
+      serverThread.join(10_000)
+    }
+  }
+
+  /**
+   * Save-after-render ordering invariant: when a `fileChanged({kind:source})` and a `renderNow`
+   * arrive in close succession, the daemon emits `renderFinished` strictly before
+   * `discoveryUpdated`. The user sees the new PNG first; the metadata reconcile lands behind it.
+   *
+   * The watchdog is set to a value much larger than the render's wall-clock so the only way
+   * `discoveryUpdated` can arrive is via the post-`renderFinished` drain.
+   */
+  @Test(timeout = 30_000)
+  fun fileChanged_then_renderNow_emits_renderFinished_before_discoveryUpdated() {
+    val tmpDir = java.nio.file.Files.createTempDirectory("ordering-test")
+    val sourceKt = tmpDir.resolve("Foo.kt")
+    java.nio.file.Files.writeString(sourceKt, "@Preview\nfun Foo() {}\n")
+
+    val previewDto =
+      PreviewInfoDto(
+        id = "Foo",
+        className = "com.example.FooKt",
+        methodName = "Foo",
+        sourceFile = sourceKt.toAbsolutePath().toString(),
+      )
+    val index = PreviewIndex.fromMap(path = sourceKt, byId = mapOf("Foo" to previewDto))
+    val discovery =
+      IncrementalDiscovery(
+        classpath = listOf(tmpDir),
+        knownPreviewAnnotationFqns = setOf("androidx.compose.ui.tooling.preview.Preview"),
+      )
+
+    val clientToServerOut = PipedOutputStream()
+    val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
+    val serverToClientOut = PipedOutputStream()
+    val serverToClientIn = PipedInputStream(serverToClientOut, 64 * 1024)
+
+    val host = FakeRenderHost()
+    val exitLatch = CountDownLatch(1)
+    val server =
+      JsonRpcServer(
+        input = clientToServerIn,
+        output = serverToClientOut,
+        host = host,
+        daemonVersion = "test",
+        previewIndex = index,
+        incrementalDiscovery = discovery,
+        // Deliberately well above the FakeRenderHost render wall-clock so the only way
+        // `discoveryUpdated` lands within the test budget is via the post-renderFinished drain.
+        // If the ordering invariant regresses we'd see `discoveryUpdated` arrive at +5s instead.
+        discoveryWatchdogMs = 5_000,
+        onExit = { _ -> exitLatch.countDown() },
+      )
+    val serverThread =
+      Thread({ server.run() }, "json-rpc-server-test-ordering").apply { isDaemon = true }
+    serverThread.start()
+
+    val reader = ContentLengthFramer(serverToClientIn)
+    val received = LinkedBlockingQueue<JsonObject>()
+    Thread(
+        {
+          try {
+            while (true) {
+              val frame = reader.readFrame() ?: break
+              val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+              received.put(obj)
+            }
+          } catch (_: Throwable) {}
+        },
+        "json-rpc-server-test-ordering-reader",
+      )
+      .apply { isDaemon = true }
+      .start()
+
+    try {
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "moduleId":":test","moduleProjectDir":"/tmp",
+              "capabilities":{"visibility":true,"metrics":false}}}""",
+      )
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 1 })
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"initialized","params":{}}""")
+
+      // Save: queues discovery, classloader swap, no scan emission yet.
+      val abs = sourceKt.toAbsolutePath().toString().replace("\\", "\\\\")
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","method":"fileChanged","params":{
+              "path":"$abs","kind":"source","changeType":"modified"}}""",
+      )
+      // Render: drives the post-renderFinished drain.
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":2,"method":"renderNow","params":{
+              "previews":["Foo"],"tier":"fast"}}""",
+      )
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 2 })
+
+      // Walk the notification stream; renderFinished must precede discoveryUpdated.
+      var sawRenderFinished = false
+      var sawDiscoveryUpdated = false
+      val deadline = System.currentTimeMillis() + 10_000
+      while (System.currentTimeMillis() < deadline && !sawDiscoveryUpdated) {
+        val msg = received.poll(500, TimeUnit.MILLISECONDS) ?: continue
+        when (msg["method"]?.jsonPrimitive?.contentOrNull) {
+          "renderFinished" -> sawRenderFinished = true
+          "discoveryUpdated" -> {
+            assertTrue("renderFinished must arrive before discoveryUpdated", sawRenderFinished)
+            sawDiscoveryUpdated = true
+          }
+        }
+      }
+      assertTrue("renderFinished must arrive", sawRenderFinished)
+      assertTrue("discoveryUpdated must arrive after renderFinished", sawDiscoveryUpdated)
+
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","id":99,"method":"shutdown"}""")
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 99 })
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"exit"}""")
+      assertTrue(exitLatch.await(5, TimeUnit.SECONDS))
+    } finally {
+      try {
+        clientToServerOut.close()
+      } catch (_: Throwable) {}
+      try {
+        serverToClientIn.close()
+      } catch (_: Throwable) {}
+      tmpDir.toFile().deleteRecursively()
+      serverThread.join(10_000)
+    }
+  }
+
+  /**
+   * Save-with-no-diff invariant: a `fileChanged({kind:source})` whose scoped scan returns the same
+   * preview set already on the index emits **no** `discoveryUpdated`. The watchdog still fires
+   * (drains the queue) but [`runIncrementalDiscoveryNow`] short-circuits on `discoveryDiffEmpty`.
+   */
+  @Test(timeout = 15_000)
+  fun fileChanged_with_no_diff_emits_no_discoveryUpdated() {
+    val tmpDir = java.nio.file.Files.createTempDirectory("identity-save-test")
+    val sourceKt = tmpDir.resolve("NoChange.kt")
+    // No `@Preview` text and no index hit on this file → cheapPrefilter returns false, the scan
+    // never runs, and no notification is ever emitted. This is the "save unrelated file" path.
+    java.nio.file.Files.writeString(sourceKt, "package com.example\nfun helper() {}\n")
+
+    val discovery =
+      IncrementalDiscovery(
+        classpath = listOf(tmpDir),
+        knownPreviewAnnotationFqns = setOf("androidx.compose.ui.tooling.preview.Preview"),
+      )
+    val index = PreviewIndex.empty()
+
+    val clientToServerOut = PipedOutputStream()
+    val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
+    val serverToClientOut = PipedOutputStream()
+    val serverToClientIn = PipedInputStream(serverToClientOut, 64 * 1024)
+
+    val host = FakeRenderHost()
+    val exitLatch = CountDownLatch(1)
+    val server =
+      JsonRpcServer(
+        input = clientToServerIn,
+        output = serverToClientOut,
+        host = host,
+        daemonVersion = "test",
+        previewIndex = index,
+        incrementalDiscovery = discovery,
+        discoveryWatchdogMs = 100,
+        onExit = { _ -> exitLatch.countDown() },
+      )
+    val serverThread =
+      Thread({ server.run() }, "json-rpc-server-test-identity").apply { isDaemon = true }
+    serverThread.start()
+
+    val reader = ContentLengthFramer(serverToClientIn)
+    val received = LinkedBlockingQueue<JsonObject>()
+    Thread(
+        {
+          try {
+            while (true) {
+              val frame = reader.readFrame() ?: break
+              val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+              received.put(obj)
+            }
+          } catch (_: Throwable) {}
+        },
+        "json-rpc-server-test-identity-reader",
+      )
+      .apply { isDaemon = true }
+      .start()
+
+    try {
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "moduleId":":test","moduleProjectDir":"/tmp",
+              "capabilities":{"visibility":true,"metrics":false}}}""",
+      )
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 1 })
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"initialized","params":{}}""")
+
+      val abs = sourceKt.toAbsolutePath().toString().replace("\\", "\\\\")
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","method":"fileChanged","params":{
+              "path":"$abs","kind":"source","changeType":"modified"}}""",
+      )
+
+      // Wait well past the watchdog; assert no `discoveryUpdated` was emitted.
+      val spurious =
+        pollUntil(received, timeoutMs = 1_000) {
+          it["method"]?.jsonPrimitive?.contentOrNull == "discoveryUpdated"
+        }
+      assertNull("identity save must not emit discoveryUpdated, got: $spurious", spurious)
+
       writeFrame(clientToServerOut, """{"jsonrpc":"2.0","id":99,"method":"shutdown"}""")
       assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 99 })
       writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"exit"}""")

--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
@@ -76,6 +76,10 @@ class FakeHarnessLauncher(
         // Match the in-process integration test's idle timeout — keeps harness scenarios snappy
         // when a misbehaving test forgets to send `exit`.
         add("-Dcomposeai.daemon.idleTimeoutMs=2000")
+        // Save-after-render ordering: tests that don't drive a render between `fileChanged` and
+        // their `discoveryUpdated` assertion lean on the watchdog. Production default is 1500ms;
+        // the fake-mode harness shortens it so scenarios stay sub-second.
+        add("-Dcomposeai.daemon.discoveryWatchdogMs=200")
         if (historyDir != null) add("-Dcomposeai.daemon.historyDir=${historyDir.absolutePath}")
         if (workspaceRoot != null)
           add("-Dcomposeai.daemon.workspaceRoot=${workspaceRoot.absolutePath}")
@@ -161,6 +165,8 @@ class RealDesktopHarnessLauncher(
         add("-Dcomposeai.render.outputDir=${rendersDir.absolutePath}")
         add("-Dcomposeai.harness.previewsManifest=${previewsManifest.absolutePath}")
         add("-Dcomposeai.daemon.idleTimeoutMs=2000")
+        // Save-after-render ordering watchdog — same justification as `FakeHarnessLauncher` above.
+        add("-Dcomposeai.daemon.discoveryWatchdogMs=200")
         addAll(extraJvmArgs)
         add("-cp")
         add(cpString)

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -281,6 +281,8 @@ internal object AndroidPreviewSupport {
         project.configurations.findByName("${variantName}ScreenshotTestRuntimeClasspath")
       } else null
 
+    val mainCompileTaskName = "compile${capVariant}Kotlin"
+    val screenshotCompileTaskName = "compile${capVariant}ScreenshotTestKotlin"
     val discoverTask =
       ComposePreviewTasks.registerDiscoverTask(
         project,
@@ -289,9 +291,9 @@ internal object AndroidPreviewSupport {
         previewOutputDir,
         extension,
       ) {
-        dependsOn("compile${capVariant}Kotlin")
+        dependsOn(mainCompileTaskName)
         if (screenshotTestEnabled) {
-          dependsOn("compile${capVariant}ScreenshotTestKotlin")
+          dependsOn(screenshotCompileTaskName)
           screenshotTestRuntimeConfig?.let { stConfig ->
             dependencyJars.from(
               stConfig.incoming.artifactView { attributes.attribute(artifactType, "jar") }.files
@@ -304,6 +306,16 @@ internal object AndroidPreviewSupport {
           }
         }
       }
+    // `composePreviewCompile` — the daemon-mode save loop calls this instead of `discoverPreviews`
+    // so the recompile (and on-disk `.class` refresh) runs without re-walking the dependency-JAR
+    // classpath through ClassGraph on every keystroke. We deliberately stop at the main compile —
+    // ScreenshotTest sources matter only for `discoverPreviews`'s dependency-JAR scan, not for the
+    // user's edited preview-bearing file.
+    ComposePreviewTasks.registerCompileOnlyTask(
+      project,
+      extension,
+      compileTaskNames = listOf(mainCompileTaskName),
+    )
 
     // Writes the plugin-side compat findings (CompatRules) to
     // `build/compose-previews/doctor.json`. The CLI doesn't need this

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -18,6 +18,14 @@ private val previewManifestJson = Json { ignoreUnknownKeys = true }
  * means the desktop path can reuse these helpers without dragging AGP onto the classpath.
  */
 internal object ComposePreviewTasks {
+  /**
+   * Candidate Kotlin compile task names for the desktop / KMP-flavoured side, in priority order.
+   * The first name that resolves at configuration time is wired as the upstream of both
+   * `discoverPreviews` and `composePreviewCompile`.
+   */
+  private val DESKTOP_COMPILE_TASK_CANDIDATES: List<String> =
+    listOf("compileKotlinJvm", "compileKotlinDesktop", "compileAndroidMain", "compileKotlin")
+
   fun registerDesktopTasks(project: Project, extension: PreviewExtension) {
     val previewOutputDir = project.layout.buildDirectory.dir("compose-previews")
 
@@ -69,19 +77,14 @@ internal object ComposePreviewTasks {
         // `compileAndroidMainKotlin`-shaped Kotlin compile under the hood).
         // Listed alongside the JVM/Desktop siblings so we wire up exactly
         // one — whichever the consumer's applied plugins actually register.
-        for (name in
-          listOf(
-            "compileKotlinJvm",
-            "compileKotlinDesktop",
-            "compileAndroidMain",
-            "compileKotlin",
-          )) {
+        for (name in DESKTOP_COMPILE_TASK_CANDIDATES) {
           if (project.tasks.findByName(name) != null) {
             dependsOn(name)
             break
           }
         }
       }
+    registerCompileOnlyTask(project, extension, DESKTOP_COMPILE_TASK_CANDIDATES)
 
     val rendererConfigName = "composePreviewRenderer"
     val rendererConfig = project.configurations.maybeCreate(rendererConfigName)
@@ -398,6 +401,36 @@ internal object ComposePreviewTasks {
       group = "compose preview"
       description = "Discover @Preview annotations in compiled classes"
       configureDeps()
+    }
+  }
+
+  /**
+   * Registers a `composePreviewCompile` lifecycle task whose only job is to run the same Kotlin
+   * compile task `discoverPreviews` depends on, without the discovery action itself. Wired so the
+   * VS Code extension can keep `.class` files fresh on save without re-walking the dependency-JAR
+   * classpath through ClassGraph — the daemon owns the metadata reconcile via its
+   * `IncrementalDiscovery` cascade and `discoveryUpdated` notification, so the editor save loop no
+   * longer needs `:discoverPreviews` on every keystroke.
+   *
+   * Caller passes the set of candidate compile task names; we wire the first that exists at
+   * configuration time. When none are found (consumer hasn't applied a Kotlin plugin) the task is
+   * still registered but is a no-op — same `onlyIf(false)` shape as the disabled-by-extension
+   * gating below.
+   */
+  fun registerCompileOnlyTask(
+    project: Project,
+    extension: PreviewExtension,
+    compileTaskNames: List<String>,
+  ): TaskProvider<DefaultTask> {
+    val resolvedCompileTask = compileTaskNames.firstOrNull { project.tasks.findByName(it) != null }
+    return project.tasks.register("composePreviewCompile", DefaultTask::class.java) {
+      group = "compose preview"
+      description =
+        "Compile sources without running discoverPreviews — used by the VS Code daemon save path."
+      onlyIf { extension.enabled.get() }
+      if (resolvedCompileTask != null) {
+        dependsOn(resolvedCompileTask)
+      }
     }
   }
 

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -114,10 +114,25 @@ export interface RenderNowResult {
 
 // Daemon → client notifications (PROTOCOL.md § 6)
 
+/**
+ * Per-preview shape inside `discoveryUpdated.added` / `.changed`. Mirrors the
+ * `PreviewInfoDto` JSON serialised by `daemon/core/.../PreviewIndex.kt` —
+ * which uses `@SerialName("functionName")` so the wire field is `functionName`,
+ * not `methodName`.
+ */
+export interface DiscoveryPreviewInfo {
+    id: string;
+    className: string;
+    functionName: string;
+    sourceFile?: string | null;
+    displayName?: string | null;
+    group?: string | null;
+}
+
 export interface DiscoveryUpdatedParams {
-    added: unknown[];
+    added: DiscoveryPreviewInfo[];
     removed: string[];
-    changed: unknown[];
+    changed: DiscoveryPreviewInfo[];
     totalPreviews: number;
 }
 

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import { GradleService } from '../gradleService';
 import { DaemonGate } from './daemonGate';
 import {
+    DiscoveryUpdatedParams,
     FileChangeType,
     FileKind,
     HistoryAddedParams,
@@ -32,6 +33,14 @@ export interface SchedulerEvents {
      * renders for this module and the caller should re-run Gradle.
      */
     onClasspathDirty: (moduleId: string, detail: string) => void;
+    /**
+     * Daemon's incremental-discovery cascade emitted a non-empty diff —
+     * `added`/`removed`/`changed` against its in-memory preview index for
+     * this module. The daemon is silent on identity-only saves (empty
+     * diff), so receiving this event always means the panel needs to
+     * reshape. Optional because tests may not wire it.
+     */
+    onDiscoveryUpdated?: (moduleId: string, params: DiscoveryUpdatedParams) => void;
     /** Phase H2 — daemon archived a render. Forwarded to the History
      *  panel; optional because the panel may not exist in test mode. */
     onHistoryAdded?: (moduleId: string, params: HistoryAddedParams) => void;
@@ -261,6 +270,9 @@ export class DaemonScheduler {
                     if (k.startsWith(`${moduleId}::`)) { this.speculated.delete(k); }
                 }
                 this.events.onClasspathDirty(moduleId, params.detail);
+            },
+            onDiscoveryUpdated: (params: DiscoveryUpdatedParams) => {
+                this.events.onDiscoveryUpdated?.(moduleId, params);
             },
             onHistoryAdded: (params: HistoryAddedParams) => {
                 this.events.onHistoryAdded?.(moduleId, params);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -332,6 +332,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
             // Gradle, which re-bootstraps a fresh daemon when the user
             // re-enables it via composePreviewDaemonStart.
         },
+        onDiscoveryUpdated: (moduleId, params) => {
+            // Daemon emits this only when the in-memory preview index drifted
+            // (added / removed / changed against the snapshot it held before
+            // the save). Identity-only saves are silent. Apply the diff to
+            // the extension-side mirror used for daemon focus computation —
+            // we deliberately don't post a "loading" or progress message;
+            // the user already saw the new PNG arrive via `renderFinished`,
+            // and a webview reshape is only needed when the preview set
+            // actually changed.
+            applyDiscoveryDiff(moduleId, params);
+        },
         onHistoryAdded: (_moduleId, params) => {
             // Phase H7 — daemon push: a fresh render landed and was
             // archived. Forward to the History panel; the panel filters
@@ -787,6 +798,78 @@ function invalidateModuleCache(filePath: string): void {
 }
 
 /**
+ * Applies a daemon-emitted `discoveryUpdated` diff silently. Only fires on a
+ * non-empty diff (the daemon stays quiet when the in-memory preview index
+ * matches a fresh scan), so reaching this code path always means the panel
+ * needs to reshape.
+ *
+ * The daemon's lightweight `DiscoveryPreviewInfo` doesn't carry capture paths,
+ * device dimensions, or a11y data — only id / className / functionName /
+ * sourceFile / displayName / group. We need full `PreviewInfo` to repaint
+ * cards, so we run a silent `discoverPreviews` here (no progress bar, no
+ * "Building..." banner, no setLoading message). The user already saw the new
+ * PNG via `renderFinished`; the panel reshape lands behind it.
+ *
+ * Identity-only saves never reach this function — the daemon's
+ * `discoveryDiffEmpty(diff)` guard short-circuits before emitting. So we don't
+ * pay for the gradle discover round-trip on every keystroke; only when the
+ * preview set genuinely drifted.
+ *
+ * Errors are logged and dropped — the next user-driven refresh will reconcile.
+ */
+async function applyDiscoveryDiff(moduleId: string, params: { added: unknown[]; removed: string[]; changed: unknown[]; totalPreviews: number }): Promise<void> {
+    if (!gradleService || !panel) { return; }
+
+    const removedIds = params.removed ?? [];
+    const addedCount = params.added?.length ?? 0;
+    const changedCount = params.changed?.length ?? 0;
+    if (removedIds.length === 0 && addedCount === 0 && changedCount === 0) {
+        return;
+    }
+
+    gradleService.invalidateCache(moduleId);
+    let manifest;
+    try {
+        manifest = await gradleService.discoverPreviews(moduleId);
+    } catch (err) {
+        logLine(`[daemon] silent discover after discoveryUpdated failed for ${moduleId}: ${(err as Error).message}`);
+        return;
+    }
+    if (!manifest) { return; }
+
+    const fresh = manifest.previews;
+    for (const p of fresh) {
+        for (const capture of p.captures) {
+            capture.label = captureLabel(capture);
+        }
+        previewModuleMap.set(p.id, moduleId);
+    }
+    // Drop module-map entries for removed previews so a subsequent webview
+    // action keyed by previewId doesn't resolve to the stale module.
+    for (const id of removedIds) { previewModuleMap.delete(id); }
+    moduleManifestCache.set(moduleId, fresh);
+    registry.replaceModule(moduleId, fresh);
+
+    // Re-filter against `currentScopeFile` so the panel stays scoped to the
+    // file the user is editing — same shape as the gradle path's setPreviews.
+    if (!currentScopeFile) { return; }
+    const filterFile = packageQualifiedSourcePath(currentScopeFile);
+    const visiblePreviews = fresh.filter(p => p.sourceFile === filterFile);
+    const moduleIsFastTier = fastTierModules.has(moduleId);
+    const heavyStaleIds = moduleIsFastTier
+        ? visiblePreviews
+            .filter(p => p.captures.some(c => (c.cost ?? 1) > HEAVY_COST_THRESHOLD))
+            .map(p => p.id)
+        : [];
+    panel.postMessage({
+        command: 'setPreviews',
+        previews: visiblePreviews,
+        moduleDir: moduleId,
+        heavyStaleIds,
+    });
+}
+
+/**
  * Side-channel save handler that pushes a `fileChanged` + focus-scoped
  * `renderNow` to the daemon when the daemon path is enabled and a daemon
  * exists for this file's module. Runs alongside the Gradle refresh, never
@@ -1033,16 +1116,16 @@ function maybeFirePendingRefresh(): void {
  *  unhealthy, the refresh is `forceRender=true` and Gradle does a full
  *  render as today.
  *
- *  **Recompile-before-notify invariant.** In the daemon path the discover
- *  refresh runs *first*, then the daemon is notified. The daemon's
+ *  **Recompile-before-notify invariant.** In the daemon path the compile
+ *  step runs *first*, then the daemon is notified. The daemon's
  *  `fileChanged({kind:source})` swaps its `URLClassLoader` and `renderNow`
  *  reads `.class` files from `build/intermediates/.../classes/` — so those
- *  files must be fresh when the swap happens. `compileKotlin` runs as an
- *  upstream of `discoverPreviews` (we let Gradle drive Kotlin compilation
- *  per `docs/daemon/DESIGN.md` § "Out of scope"); inverting the order would
- *  let the daemon render stale bytecode matching the previous save and the
- *  user would see the loading overlay flash without any actual content
- *  change.
+ *  files must be fresh when the swap happens. We invoke
+ *  `composePreviewCompile` (the same `compileKotlin*` upstream that
+ *  `discoverPreviews` depends on, minus the ClassGraph scan over every
+ *  dependency JAR) — the heavy classpath walk is now the daemon's job via
+ *  `IncrementalDiscovery`, surfaced through `discoveryUpdated` only when
+ *  the preview set actually drifted.
  *
  *  Save-driven: always `tier='fast'`. Heavy captures (LONG / GIF / animated)
  *  keep their previous PNG/GIF on disk and surface as stale in the panel —
@@ -1053,27 +1136,9 @@ async function runRefreshExclusive(filePath: string): Promise<void> {
     try {
         const mode = pickRefreshMode(filePath);
         if (mode === 'daemon') {
-            // Run discover first so `compileKotlin` (an upstream of
-            // discoverPreviews) updates the on-disk `.class` files the
-            // daemon's child URLClassLoader reads. Notifying the daemon
-            // before the recompile would race the swap against stale
-            // bytecode and the panel would flicker without updating.
-            const outcome = await refresh(false, filePath);
-            if (outcome !== 'completed') {
-                // Discover didn't finish to completion. Three cases, all
-                // equally bad for daemon notify:
-                //   - 'cancelled': a newer save aborted us mid-flight, so
-                //     compileKotlin was killed too — `.class` files are
-                //     half-written. The newer save's runRefreshExclusive
-                //     will own the daemon notify.
-                //   - 'failed': Gradle failed (build error, missing jlink).
-                //     `.class` files weren't refreshed; stale bytecode.
-                //   - 'no-module': nothing happened.
-                // In all three, sending fileChanged + renderNow now would
-                // re-render against stale bytes and produce the
-                // flicker-without-update symptom — exactly the bug this
-                // ordering fix was meant to close.
-                logLine(`daemon: skipped notify (refresh outcome=${outcome})`);
+            const compileOk = await runDaemonCompileOnly(filePath);
+            if (!compileOk) {
+                logLine('daemon: skipped notify (compile failed or no module)');
                 return;
             }
             const accepted = await notifyDaemonOfSave(filePath);
@@ -1091,6 +1156,47 @@ async function runRefreshExclusive(filePath: string): Promise<void> {
         refreshInFlight = false;
         maybeFirePendingRefresh();
     }
+}
+
+/**
+ * Daemon-mode save: compile the upstream Kotlin task only — no `discoverPreviews`
+ * round-trip, no progress UI, no spinner overlays. The `.class` files land on
+ * disk fresh; the daemon then runs incremental discovery internally and emits
+ * `discoveryUpdated` when (and only when) the preview set changed.
+ *
+ * Returns `false` if the file resolves to no module or the compile failed —
+ * caller falls back to the Gradle render path. Errors are logged silently;
+ * the user-visible LSP gate (`compileErrors.ts`) still surfaces compile
+ * failures, this just keeps the panel quiet during the happy path.
+ */
+async function runDaemonCompileOnly(filePath: string): Promise<boolean> {
+    if (!gradleService) { return false; }
+    const module = gradleService.resolveModule(filePath);
+    if (!module) { return false; }
+
+    // Honour the existing LSP-error gate — same predicate `refresh()` uses to
+    // skip Gradle when the active buffer has Error-severity diagnostics. We
+    // don't need to surface the banner here (the gradle path handles that on
+    // an explicit refresh); just skip the compile so we don't burn cycles
+    // recompiling a file the LSP already says is broken.
+    const compileErrors = readCompileErrors(filePath);
+    if (compileErrors.length > 0) {
+        logLine(`daemon: gated — ${compileErrors.length} compile error(s) in ${path.basename(filePath)}`);
+        return false;
+    }
+
+    invalidateModuleCache(filePath);
+    try {
+        await gradleService.compileOnly(module);
+    } catch (err) {
+        if (err instanceof TaskCancelledError) {
+            logLine(`daemon: compileOnly cancelled for ${module}`);
+        } else {
+            logLine(`daemon: compileOnly failed for ${module}: ${(err as Error).message}`);
+        }
+        return false;
+    }
+    return true;
 }
 
 /**

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -183,6 +183,24 @@ export class GradleService {
     }
 
     /**
+     * Runs the upstream Kotlin compile only — same task `discoverPreviews` depends on, minus the
+     * ClassGraph scan over every dependency JAR. The daemon save loop calls this so that on-disk
+     * `.class` files are fresh before we send `fileChanged` to the daemon, without paying for a
+     * full preview-manifest reconcile on every keystroke. The metadata reconcile is handled
+     * silently by the daemon's `discoveryUpdated` notification when (and only when) the diff is
+     * non-empty.
+     *
+     * Mirrors the cache invalidation behaviour of {@link discoverPreviews}: we drop the cached
+     * manifest because the user-visible source-of-truth is now the daemon's in-memory index, not
+     * the on-disk `previews.json`. A subsequent gradle-mode save (daemon disabled or unhealthy)
+     * will repopulate the cache through `discoverPreviews`.
+     */
+    async compileOnly(module: string, opts?: TaskOptions): Promise<void> {
+        this.manifestCache.delete(module);
+        await this.runTask(`${gradleProjectPath(module)}:composePreviewCompile`, [], opts);
+    }
+
+    /**
      * Runs `:<module>:renderAllPreviews` and returns the parsed manifest.
      *
      * `tier` controls which captures the renderer produces:

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -40,6 +40,7 @@ class FakeGate {
         onRenderFinished?: (p: { id: string; pngPath: string; tookMs: number }) => void;
         onRenderFailed?: (p: { id: string; error: { message: string } }) => void;
         onClasspathDirty?: (p: { detail: string }) => void;
+        onDiscoveryUpdated?: (p: { added: unknown[]; removed: string[]; changed: unknown[]; totalPreviews: number }) => void;
         onChannelClosed?: () => void;
     }>();
 
@@ -73,6 +74,7 @@ function build() {
     const images: CapturedImage[] = [];
     const failures: { moduleId: string; previewId: string; message: string }[] = [];
     const dirty: { moduleId: string; detail: string }[] = [];
+    const discovery: { moduleId: string; params: { added: unknown[]; removed: string[]; changed: unknown[]; totalPreviews: number } }[] = [];
     const events = {
         onPreviewImageReady: (moduleId: string, previewId: string, base64: string, pngPath: string) => {
             images.push({ moduleId, previewId, base64, pngPath });
@@ -83,13 +85,16 @@ function build() {
         onClasspathDirty: (moduleId: string, detail: string) => {
             dirty.push({ moduleId, detail });
         },
+        onDiscoveryUpdated: (moduleId: string, params: { added: unknown[]; removed: string[]; changed: unknown[]; totalPreviews: number }) => {
+            discovery.push({ moduleId, params });
+        },
     };
     const scheduler = new DaemonScheduler(
         gate as unknown as ConstructorParameters<typeof DaemonScheduler>[0],
         events,
         { appendLine: (s) => log.push(s) },
     );
-    return { gate, scheduler, log, images, failures, dirty };
+    return { gate, scheduler, log, images, failures, dirty, discovery };
 }
 
 describe('DaemonScheduler', () => {
@@ -302,6 +307,23 @@ describe('DaemonScheduler', () => {
         evts.onClasspathDirty!({ detail: 'libs.versions.toml SHA changed' });
         assert.strictEqual(dirty.length, 1);
         assert.strictEqual(dirty[0].moduleId, 'mod');
+    });
+
+    it('forwards discoveryUpdated to the caller with the moduleId attached', async () => {
+        const { gate, scheduler, discovery } = build();
+        // First call any scheduler method that goes through getOrSpawn so the
+        // events bag for `mod` is registered; setFocus is the cheapest.
+        await scheduler.setFocus('mod', ['p1']);
+        const evts = gate.capturedEvents.get('mod')!;
+        evts.onDiscoveryUpdated!({
+            added: [],
+            removed: ['p1'],
+            changed: [],
+            totalPreviews: 0,
+        });
+        assert.strictEqual(discovery.length, 1);
+        assert.strictEqual(discovery[0].moduleId, 'mod');
+        assert.deepStrictEqual(discovery[0].params.removed, ['p1']);
     });
 
     it('renderNow returns true on accept and false when no daemon is available', async () => {

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -395,6 +395,33 @@ describe('GradleService', () => {
             assert.strictEqual(api.runCalls.length, 1);
         }));
 
+        it('compileOnly invokes :module:composePreviewCompile and drops the manifest cache',
+            withTempDir(async (dir, api) => {
+                fs.mkdirSync(path.join(dir, 'mod'));
+                const manifestDir = path.join(dir, 'mod', 'build', 'compose-previews');
+                fs.mkdirSync(manifestDir, { recursive: true });
+                fs.copyFileSync(
+                    path.join(__dirname, '..', '..', 'src', 'test', 'fixtures', 'previews.json'),
+                    path.join(manifestDir, 'previews.json'),
+                );
+
+                const service = new GradleService(dir, api);
+                // Prime the cache via a discoverPreviews invocation.
+                await service.discoverPreviews('mod');
+                assert.strictEqual(api.runCalls.length, 1);
+                assert.strictEqual(api.runCalls[0].taskName, ':mod:discoverPreviews');
+
+                // compileOnly runs a different task and invalidates the cache.
+                await service.compileOnly('mod');
+                assert.strictEqual(api.runCalls.length, 2);
+                assert.strictEqual(api.runCalls[1].taskName, ':mod:composePreviewCompile');
+
+                // Cache was dropped, so the next discoverPreviews calls Gradle again.
+                await service.discoverPreviews('mod');
+                assert.strictEqual(api.runCalls.length, 3);
+                assert.strictEqual(api.runCalls[2].taskName, ':mod:discoverPreviews');
+            }));
+
         it('bypasses cache after invalidateCache', withTempDir(async (dir, api) => {
             fs.mkdirSync(path.join(dir, 'mod'));
             const manifestDir = path.join(dir, 'mod', 'build', 'compose-previews');


### PR DESCRIPTION
## Summary

The VS Code extension was running Gradle `:discoverPreviews` on every save in daemon mode, re-walking the full dependency-JAR classpath through ClassGraph just to refresh `previews.json` — even though the daemon already owns an in-memory `PreviewIndex` and has `IncrementalDiscovery` for the scoped per-file rescan. Every save paid for that walk.

This PR locks in the save-loop invariant the user described:

> **The save loop is silent unless metadata changed; renders land before any metadata event.**

### Daemon (`JsonRpcServer.kt`)

- `fileChanged({kind:source})` swaps the classloader synchronously and queues the path on `pendingDiscoveryPaths` instead of kicking the scan immediately.
- `emitRenderFinished` drains the queue after the `renderFinished` notification is enqueued for the writer, so the user always sees the new PNG **before** any `discoveryUpdated`.
- A 1500ms watchdog drains the queue when no render arrives (e.g. save on a file with no focused previews). Sysprop-overridable for tests.
- Empty-diff short-circuit preserved: identity-only saves stay completely silent on the wire.

### Extension

- New `gradleService.compileOnly(module)` → `:module:composePreviewCompile`, a thin lifecycle task added by the plugin that depends on the same `compileKotlin*` upstream as `:discoverPreviews`. Wired in both desktop and Android paths.
- The daemon save path replaces `refresh(false, filePath)` with `runDaemonCompileOnly(filePath)` — no Gradle `discoverPreviews` round-trip, no `markAllLoading` / `setLoading` / `setProgress` messages on save.
- `DaemonScheduler.SchedulerEvents` gains `onDiscoveryUpdated`; `applyDiscoveryDiff` silently invalidates the manifest cache, runs `:discoverPreviews` once to fetch full `PreviewInfo` (capture paths / device / dimensions the daemon's lightweight DTO doesn't carry), and posts `setPreviews`.
- Because the daemon is silent on identity-only saves, `applyDiscoveryDiff` only runs on actual preview-set drift — the user pays the `discoverPreviews` cost in the rare cases that actually require it, never in the per-keystroke hot loop.

## Test plan

- [x] `./gradlew :daemon:core:test` — new integration tests pin render-before-discovery ordering and identity-save silence.
- [x] `./gradlew :gradle-plugin:test :gradle-plugin:functionalTest` — plugin still applies cleanly with the new `composePreviewCompile` task.
- [x] `./gradlew :daemon:harness:compileKotlin :daemon:harness:compileTestKotlin` — harness picks up the watchdog sysprop.
- [x] `cd vscode-extension && npm test` — 263 tests pass; new tests cover scheduler `onDiscoveryUpdated` forwarding and `gradleService.compileOnly` task name + cache invalidation.
- [x] `./gradlew ktfmtCheckAll` — formatting clean.
- [ ] Manual verification: open a sample in VS Code (daemon mode), save a `.kt` file repeatedly with no annotation drift — panel should never show "Building…" / progress bar / loading overlay; only the PNG should refresh on the focused card. Save again with a fresh `@Preview` added — panel reshapes silently after the new render lands.

## Notes

- One pre-existing `:daemon:core:test` failure (`LocalFsHistorySourcePruneTest.dedup_by_hash_preserves_png_when_other_sidecar_still_references_it`) reproduces on `main` with these changes stashed — unrelated to this PR.
- Branch named per global convention; `claude/fix-classpath-recalculation-9v1lx` was renamed to `agent/fix-classpath-recalculation` before push.

---
_Generated by [Claude Code](https://claude.ai/code/session_013wz4kGyJ8JvqRrGjUP3oTv)_