### PR TITLE
feat(vscode): refresh open diff overlay when live render lands

### DIFF
--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -1508,6 +1508,24 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 
             if (caps) updateFrameIndicator(card);
 
+            // If a diff overlay is open on this card and uses the live render
+            // as its left anchor (head / main / current), the bytes the
+            // overlay is showing just went stale. Re-issue so the user sees
+            // the new render without clicking — symmetric with the
+            // preview_main ref watcher's auto-refresh on the right anchor.
+            const openDiff = container.querySelector('.preview-diff-overlay');
+            if (openDiff) {
+                const against = openDiff.dataset.against;
+                if (against === 'head' || against === 'main') {
+                    showDiffOverlay(card, against, null, null);
+                    vscode.postMessage({
+                        command: 'requestPreviewDiff',
+                        previewId,
+                        against,
+                    });
+                }
+            }
+
             // Re-build the a11y overlay once the image natural dimensions
             // are known. Data-URL srcs may resolve synchronously; in that
             // case img.complete is true and load will not fire, so we


### PR DESCRIPTION
## Summary

Completes the "don't make them click" contract for live-anchor diffs.

The `preview_main` ref watcher (#375) already auto-refreshes the **right** anchor of an open `Diff vs main` overlay. This PR does the symmetric thing on the **left** anchor: when `updateImage` delivers a fresh PNG for a focused preview that has an open diff overlay, the diff re-issues so the live side picks up the new bytes silently.

Triggered for `against === 'head'` and `against === 'main'` since those are the live-anchored variants. The History panel's `vs current` / `vs previous` diffs use archived entries on both sides — they're covered by the existing `historyAdded` push + list-driven re-render path.

## Test plan

- [x] `npm run compile` clean
- [x] `npm test` — 271 / 271 passing
- [ ] Manual: focus a preview, open Diff vs HEAD, save the source file → render lands → diff updates silently with the new live bytes.
- [ ] Manual: same setup, Diff vs main → also updates silently.
- [ ] Manual: open the live image (no diff overlay) → save → no spurious diff request fires.
- [ ] Manual: History panel vs-current diff → save → diff overlay there is untouched (it doesn't follow live-anchor refreshes; intentional).

## Stretch follow-up still on the table

- Daemon pixel mode + SSIM is **blocked**: the daemon returns `HistoryPixelNotImplemented` (-32012) for `mode='pixel'` per `daemonProtocol.ts` ("reserved for phase H5"). Wiring it on the consumer side now would be dead code — revisit when the daemon ships H5.


---
_Generated by [Claude Code](https://claude.ai/code/session_01A6AFhHNrHQNqUPKdmJRt94)_