### PR TITLE
feat(vscode): default the preview daemon to enabled

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -119,8 +119,8 @@
                 },
                 "composePreview.experimental.daemon.enabled": {
                     "type": "boolean",
-                    "default": false,
-                    "description": "EXPERIMENTAL. Use the persistent preview daemon for sub-second refresh on saves to files the user has open, plus scroll-ahead speculative renders. Requires `composePreview { experimental { daemon { enabled = true } } }` in the consumer's build.gradle.kts. When the daemon isn't healthy, the extension silently falls back to the Gradle `renderPreviews` task. See docs/daemon/DESIGN.md for status and caveats."
+                    "default": true,
+                    "description": "Use the persistent preview daemon for sub-second refresh on saves to files the user has open, plus scroll-ahead speculative renders. Requires `composePreview { experimental { daemon { enabled = true } } }` in the consumer's build.gradle.kts. When the daemon isn't healthy, the extension silently falls back to the Gradle `renderPreviews` task. See docs/daemon/DESIGN.md for caveats."
                 },
                 "composePreview.logging.level": {
                     "type": "string",

--- a/vscode-extension/src/daemon/daemonGate.ts
+++ b/vscode-extension/src/daemon/daemonGate.ts
@@ -9,13 +9,13 @@ const SETTING_ENABLED = 'experimental.daemon.enabled';
 /**
  * Source-of-truth for "is the daemon path live for this user/workspace?"
  *
- * The daemon is opt-in via the `composePreview.experimental.daemon.enabled`
- * setting (false by default — DESIGN.md § 1, "experimental design proposal").
- * Even when enabled, the gate falls back to `gradleService.renderPreviews`
- * whenever the daemon isn't healthy: descriptor missing, descriptor disabled
- * by the build config, JVM died, classpath dirty, or RPC failed. Failures
- * are logged but never thrown to the caller — the rest of the extension is
- * unaware whether a render came from the daemon or from Gradle.
+ * Controlled by the `composePreview.experimental.daemon.enabled` setting
+ * (true by default). Even when enabled, the gate falls back to
+ * `gradleService.renderPreviews` whenever the daemon isn't healthy:
+ * descriptor missing, descriptor disabled by the build config, JVM died,
+ * classpath dirty, or RPC failed. Failures are logged but never thrown to
+ * the caller — the rest of the extension is unaware whether a render came
+ * from the daemon or from Gradle.
  *
  * One daemon per Gradle module (per `:samples:android`, etc.). Modules are
  * spawned lazily on first use and shut down on extension dispose.
@@ -35,7 +35,7 @@ export class DaemonGate {
     isEnabled(): boolean {
         return vscode.workspace
             .getConfiguration('composePreview')
-            .get<boolean>(SETTING_ENABLED, false);
+            .get<boolean>(SETTING_ENABLED, true);
     }
 
     /**

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -290,10 +290,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         return args;
     }, logFilter);
 
-    // Daemon path is opt-in via composePreview.experimental.daemon.enabled.
-    // When disabled (default) the gate's `isEnabled()` returns false and the
-    // scheduler is never asked to spawn anything — the existing Gradle path
-    // is the entire user-facing behaviour. When enabled, the scheduler runs
+    // Daemon path is controlled by composePreview.experimental.daemon.enabled
+    // (true by default). When disabled the gate's `isEnabled()` returns false
+    // and the scheduler is never asked to spawn anything — the Gradle path is
+    // the entire user-facing behaviour. When enabled, the scheduler runs
     // *alongside* the existing refresh logic: saves and viewport changes push
     // notifications to the daemon, the daemon emits renderFinished, and the
     // extension forwards PNGs to the panel as they arrive (typically ahead
@@ -357,7 +357,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     // Status-bar slot for daemon lifecycle. Hidden when the daemon flag is
     // off or no module is currently warming. Surfacing the cold-bootstrap
     // pause (typically 2-4 s on first scope-in) avoids the "panel is stuck"
-    // perception on the experimental flag's first-time UX.
+    // perception on the daemon flag's first-time UX.
     daemonStatusItem = vscode.window.createStatusBarItem(
         vscode.StatusBarAlignment.Left, 90,
     );

--- a/vscode-extension/src/refreshMode.ts
+++ b/vscode-extension/src/refreshMode.ts
@@ -10,7 +10,7 @@
 export type RefreshMode = 'daemon' | 'gradle';
 
 /**
- * - `'daemon'` — the experimental flag is on, the file resolves to a
+ * - `'daemon'` — the daemon flag is on, the file resolves to a
  *   module, and the daemon for that module is up and the sandbox has
  *   finished bootstrapping (post-#327 `RobolectricHost.start` blocks
  *   until ready, so `isDaemonReady` is the right signal). The save


### PR DESCRIPTION
## Summary

- Flip `composePreview.experimental.daemon.enabled` to `true` by default so new installs get the persistent daemon's sub-second refresh out of the box. The Gradle `renderPreviews` path remains the silent fallback whenever the daemon isn't healthy.
- Drop the "EXPERIMENTAL." marker from the setting description, and update the matching source comments that called the daemon path "opt-in" / "off by default" / "the experimental flag".
- The setting key itself is left as `composePreview.experimental.daemon.enabled` because the Gradle plugin DSL still uses `composePreview { experimental { daemon { ... } } }` — renaming the VS Code key without also renaming the Gradle DSL would split the two.

## Test plan

- [x] `npm run compile` in `vscode-extension/` — clean.
- [x] `npm test` in `vscode-extension/` — 271 passing.
- [ ] Manual: fresh install of the extension on a workspace with the Gradle plugin applied — daemon spawns on first scope-in without the user toggling anything, and a workspace that sets `composePreview.experimental.daemon.enabled = false` still falls back to the Gradle path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXegqEoPbopcvxwfnVSypH)_