### PR TITLE
test(daemon): pin S3 to render-before-discovery ordering; bump fake watchdog

### DIFF
--- a/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
+++ b/daemon/harness/src/main/kotlin/ee/schimke/composeai/daemon/harness/HarnessLauncher.kt
@@ -78,8 +78,9 @@ class FakeHarnessLauncher(
         add("-Dcomposeai.daemon.idleTimeoutMs=2000")
         // Save-after-render ordering: tests that don't drive a render between `fileChanged` and
         // their `discoveryUpdated` assertion lean on the watchdog. Production default is 1500ms;
-        // the fake-mode harness shortens it so scenarios stay sub-second.
-        add("-Dcomposeai.daemon.discoveryWatchdogMs=200")
+        // the fake-mode harness shortens it so scenarios stay sub-second. 500ms gives the cold
+        // ClassGraph scan enough JIT-warmup margin not to flake under CI load.
+        add("-Dcomposeai.daemon.discoveryWatchdogMs=500")
         if (historyDir != null) add("-Dcomposeai.daemon.historyDir=${historyDir.absolutePath}")
         if (workspaceRoot != null)
           add("-Dcomposeai.daemon.workspaceRoot=${workspaceRoot.absolutePath}")
@@ -166,7 +167,7 @@ class RealDesktopHarnessLauncher(
         add("-Dcomposeai.harness.previewsManifest=${previewsManifest.absolutePath}")
         add("-Dcomposeai.daemon.idleTimeoutMs=2000")
         // Save-after-render ordering watchdog — same justification as `FakeHarnessLauncher` above.
-        add("-Dcomposeai.daemon.discoveryWatchdogMs=200")
+        add("-Dcomposeai.daemon.discoveryWatchdogMs=500")
         addAll(extraJvmArgs)
         add("-cp")
         add(cpString)

--- a/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3RenderAfterEditTest.kt
+++ b/daemon/harness/src/test/kotlin/ee/schimke/composeai/daemon/harness/S3RenderAfterEditTest.kt
@@ -105,9 +105,24 @@ class S3RenderAfterEditTest {
           changeType = ChangeType.MODIFIED,
         )
 
-        // 4. Assert the daemon emits `discoveryUpdated`. B2.2 phase 2 — pre-phase-2 this assertion
-        //    was the *absence* of the notification (the regression marker). Now we tighten.
-        val discovery = client.pollNotification("discoveryUpdated", 2.seconds)
+        // 4. Second render — must serve v2.
+        //    The new save-after-render invariant gates `discoveryUpdated` on the next
+        //    `renderFinished`, so the test asserts the render lands first (matching what a real
+        //    editor's save loop would do) and only then polls for the deferred metadata
+        //    notification.
+        val secondStart = System.currentTimeMillis()
+        val rn2 = client.renderNow(previews = listOf(previewId), tier = RenderTier.FAST)
+        assertEquals(listOf(previewId), rn2.queued)
+        val finished2 = client.pollRenderFinishedFor(previewId, timeout = 15.seconds)
+        val secondFinishedAt = System.currentTimeMillis()
+        val v2ReportedPath =
+          finished2["params"]?.jsonObject?.get("pngPath")?.jsonPrimitive?.contentOrNull
+            ?: error("renderFinished missing pngPath: $finished2")
+
+        // 5. Assert the daemon emits `discoveryUpdated` AFTER the render finished. B2.2 phase 2 —
+        //    pre-phase-2 this assertion was the *absence* of the notification (the regression
+        //    marker); now we tighten and pin the new render-before-metadata ordering.
+        val discovery = client.pollNotification("discoveryUpdated", 5.seconds)
         val params =
           discovery["params"]?.jsonObject ?: error("discoveryUpdated missing params: $discovery")
         val removedIds =
@@ -120,15 +135,6 @@ class S3RenderAfterEditTest {
         assertEquals(emptyList<Any?>(), params["added"]?.jsonArray?.toList() ?: emptyList<Any?>())
         assertEquals(0, params["totalPreviews"]?.jsonPrimitive?.intOrNull)
 
-        // 5. Second render — must serve v2.
-        val secondStart = System.currentTimeMillis()
-        val rn2 = client.renderNow(previews = listOf(previewId), tier = RenderTier.FAST)
-        assertEquals(listOf(previewId), rn2.queued)
-        val finished2 = client.pollRenderFinishedFor(previewId, timeout = 15.seconds)
-        val secondFinishedAt = System.currentTimeMillis()
-        val v2ReportedPath =
-          finished2["params"]?.jsonObject?.get("pngPath")?.jsonPrimitive?.contentOrNull
-            ?: error("renderFinished missing pngPath: $finished2")
         val v2Actual = File(v2ReportedPath).readBytes()
         val diffV2 = PixelDiff.compare(actual = v2Actual, expected = v2Bytes)
         if (!diffV2.ok) {


### PR DESCRIPTION
## Summary

Pre-existing flake on `Daemon Harness (desktop, real renderer)`: the fake-mode `S3RenderAfterEditTest` polled for `discoveryUpdated` immediately after `fileChanged` — before issuing the second `renderNow`. After PR #378 introduced the "metadata-after-first-renderFinished" invariant, the test now leans on the watchdog fallback to satisfy the assertion within its 2-second timeout, which races a cold-JIT ClassGraph scan under CI load.

Two coordinated tweaks:

- **Test ordering** — move the second `renderNow` ahead of the `discoveryUpdated` poll so the queue drains via `emitRenderFinished` (the production save-loop pattern). Bump the poll timeout from 2s → 5s for headroom.
- **Watchdog default** — bump `FakeHarnessLauncher` / `RealDesktopHarnessLauncher` watchdog from 200ms → 500ms so scenarios that genuinely lean on the watchdog still fit a JIT-warm cold start.

## Test plan

- [x] `./gradlew :daemon:harness:test -Pharness.host=real` (locally repros the flake on `main` + PR #378's daemon changes; passes after this fix).
- [x] `./gradlew :daemon:harness:test` (fake mode unchanged, passes).

---
_Generated by [Claude Code](https://claude.ai/code/session_013wz4kGyJ8JvqRrGjUP3oTv)_