### PR TITLE
fix(cli): derive BUNDLE_VERSION from build, not a hand-edited literal

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -43,4 +43,23 @@ dependencies {
 
 tasks.withType<Test>().configureEach { useJUnitPlatform() }
 
+// Bake the resolved Gradle build version into a properties resource the CLI reads at runtime
+// (see `Version.kt#BUNDLE_VERSION`). Avoids the previous hand-edited literal in source — which
+// drifted out of sync with the release manifest and made `compose-preview show` advertise a
+// nonexistent v0.9.0 release. Mirrors `gradle-plugin/build.gradle.kts`'s
+// `generatePluginVersionResource`.
+val generateCliVersionResource by tasks.registering {
+  val outputDir = layout.buildDirectory.dir("generated/cli-version-resource")
+  val cliVersion = project.version.toString()
+  inputs.property("version", cliVersion)
+  outputs.dir(outputDir)
+  doLast {
+    val file = outputDir.get().file("ee/schimke/composeai/cli/cli-version.properties").asFile
+    file.parentFile.mkdirs()
+    file.writeText("version=$cliVersion\n")
+  }
+}
+
+sourceSets.main.get().resources.srcDir(generateCliVersionResource)
+
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt
@@ -1,14 +1,30 @@
 package ee.schimke.composeai.cli
 
+import java.util.Properties
+
 /**
  * Release this CLI was built from. Surfaced via `compose-preview --version`, used as the default
  * `--plugin-version` in [DoctorCommand]'s remediation snippets, and compared against the latest
  * GitHub release tag in `doctor`'s update check.
  *
- * Updated by release-please — keep the trailing comment intact (see `release-please-config.json`,
- * `extra-files`).
+ * Resolved from `cli-version.properties`, baked into the jar by `cli/build.gradle.kts`'s
+ * `generateCliVersionResource`. The previous hand-edited literal here drifted out of sync with
+ * `.release-please-manifest.json` (`0.9.0` vs `0.8.12`) which made `compose-preview show` look for
+ * a release tag that didn't exist. The build-time resource derives the version from
+ * `project.version`, which already honours the `PLUGIN_VERSION` env override CI sets and the
+ * `.release-please-manifest.json` patch-bump fallback for local builds.
  */
-internal const val BUNDLE_VERSION = "0.9.0" // x-release-please-version
+internal val BUNDLE_VERSION: String by lazy {
+  val props = Properties()
+  val stream =
+    object {}
+      .javaClass
+      .classLoader
+      .getResourceAsStream("ee/schimke/composeai/cli/cli-version.properties")
+      ?: error("cli-version.properties missing from compose-preview jar")
+  stream.use { props.load(it) }
+  props.getProperty("version") ?: error("version property missing from cli-version.properties")
+}
 
 /** GitHub repo slug used to resolve releases and the `update` subcommand bootstrap. */
 internal const val REPO = "yschimke/compose-ai-tools"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -19,10 +19,6 @@
         "docs/RELEASING.md",
         {
           "type": "generic",
-          "path": "cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt"
-        },
-        {
-          "type": "generic",
           "path": ".github/actions/preview-baselines/action.yml"
         },
         {


### PR DESCRIPTION
## Summary

`BUNDLE_VERSION` in `cli/src/main/kotlin/.../Version.kt` was a hand-edited `const val "0.9.0"` annotated `// x-release-please-version`. Release-please's generic updater wasn't keeping it in sync — the literal had drifted ahead of `.release-please-manifest.json` (currently `0.8.12`), so `compose-preview --version` advertised a release tag (`v0.9.0`) that doesn't exist on GitHub. The CLI's doctor update check then resolved the bogus tag against `releases/latest`, which made downstream Compare-previews CI fail when it tried to fetch the matching release artefact.

Mirror the `gradle-plugin` pattern: a build-time `generateCliVersionResource` task writes `cli-version.properties` from `project.version` (which already honours `PLUGIN_VERSION` in CI and the `.release-please-manifest.json` patch-bump fallback locally). `Version.kt` reads the resource at first access via the same lazy `Properties` load that `PluginVersion.kt` already uses. The `release-please-config.json` extra-files entry for `Version.kt` is removed since the version is no longer source-resident.

## Test plan

- [x] `./gradlew :cli:installDist` and ran `bin/compose-preview --version` — prints `0.8.13-SNAPSHOT` (the actual build version from the manifest patch-bump fallback) instead of `0.9.0`.
- [x] `./gradlew :cli:test` — passes.
- [x] `./gradlew ktfmtFormatAll` — formatting clean.

## Notes

- Release-please will continue to bump `.release-please-manifest.json` and the other extra-files (READMEs, action.yml). The CLI version follows automatically because it reads from the resolved `project.version`.
- The previous `// x-release-please-version` marker on `BUNDLE_VERSION` is dropped — the version no longer lives at a string literal in source.

---
_Generated by [Claude Code](https://claude.ai/code/session_013wz4kGyJ8JvqRrGjUP3oTv)_