### PR TITLE
refactor: rename CI preview branches to compose-preview/ convention

### DIFF
--- a/.github/actions/a11y-report/action.yml
+++ b/.github/actions/a11y-report/action.yml
@@ -2,25 +2,25 @@ name: 'Compose A11y Report'
 description: >
   Render @Preview functions with ATF accessibility checks enabled, generate
   an annotated screenshot + finding table per preview, and publish to a
-  shared branch (`a11y_main` for `push`, `a11y_pr` for `pull_request`). For
-  PRs, also upserts a comment with finding counts and SHA-pinned image
-  links. Mirrors the push-and-retry / comment-upsert pattern used by
-  preview-comment, but is a separate action so a11y churn doesn't block the
-  pixel-diff hot path.
+  shared branch (`compose-preview/a11y/main` for `push`,
+  `compose-preview/a11y/pr` for `pull_request`). For PRs, also upserts a
+  comment with finding counts and SHA-pinned image links. Mirrors the
+  push-and-retry / comment-upsert pattern used by preview-comment, but is
+  a separate action so a11y churn doesn't block the pixel-diff hot path.
 
 inputs:
   mode:
-    description: "'baseline' (push to `a11y_main`) or 'comment' (push to `a11y_pr` + upsert PR comment)"
+    description: "'baseline' (push to `compose-preview/a11y/main`) or 'comment' (push to `compose-preview/a11y/pr` + upsert PR comment)"
     required: true
   module:
     description: 'Gradle module path to render (e.g. `samples:wear`)'
     default: 'samples:wear'
   baseline-branch:
     description: 'Long-lived branch holding the baseline a11y report'
-    default: 'a11y_main'
+    default: 'compose-preview/a11y/main'
   pr-branch:
     description: 'Shared branch that accumulates per-PR a11y renders'
-    default: 'a11y_pr'
+    default: 'compose-preview/a11y/pr'
   pr-number:
     description: 'Pull request number (auto-detected from context if omitted)'
     default: ''
@@ -64,7 +64,7 @@ runs:
         BASELINE_BRANCH: ${{ inputs.baseline-branch }}
       run: |
         set -euo pipefail
-        # Pull `findings.json` from a11y_main so the comment subcommand can
+        # Pull `findings.json` from compose-preview/a11y/main so the comment subcommand can
         # compare and stay silent when nothing changed. Default to an empty
         # entries list when the branch hasn't been seeded yet — the python
         # treats a missing baseline the same as an empty one.
@@ -165,8 +165,9 @@ runs:
 
         # Append commit on top of existing tip so older PR comments pinned
         # to past SHAs stay reachable. Retry loop handles the push race
-        # when two PRs finish concurrently against the shared `a11y_pr`
-        # branch — same recipe as preview-comment/action.yml.
+        # when two PRs finish concurrently against the shared
+        # `compose-preview/a11y/pr` branch — same recipe as
+        # preview-comment/action.yml.
         attempt=1
         while :; do
           PARENT=""
@@ -216,7 +217,7 @@ runs:
         # The earlier comment-generation step used the branch name as a
         # provisional ref because the SHA wasn't known yet. Now that push
         # has run, swap in the actual SHA so the comment's image URLs stay
-        # resolvable after a11y_pr advances or the PR merges.
+        # resolvable after compose-preview/a11y/pr advances or the PR merges.
         HEAD_REF="${HEAD_SHA:-$PR_BRANCH}"
         python3 "$ACTION_PATH/../lib/a11y-report.py" comment \
           _a11y_renders/findings.json \

--- a/.github/actions/lib/a11y-report.py
+++ b/.github/actions/lib/a11y-report.py
@@ -4,8 +4,9 @@
 Reads the per-module ``previews.json`` (from the Gradle plugin) and its
 sidecar ``accessibility.json`` (written by ``verifyAccessibility``), filters
 each preview function down to a single canonical Wear variant, and emits
-either a browsable ``README.md`` for the ``a11y_main`` baseline branch or a
-Markdown PR comment body for the ``a11y_pr`` branch.
+either a browsable ``README.md`` for the ``compose-preview/a11y/main``
+baseline branch or a Markdown PR comment body for the
+``compose-preview/a11y/pr`` branch.
 
 Subcommands
 -----------
@@ -382,7 +383,7 @@ def cmd_comment(args: argparse.Namespace) -> int:
     payload = json.loads(findings_path.read_text())
     entries: list[dict] = payload.get("entries", [])
 
-    # When a baseline (the on-`a11y_main` findings.json) is provided, stay
+    # When a baseline (the on-`compose-preview/a11y/main` findings.json) is provided, stay
     # silent if nothing has changed — the workflow runs on every PR and a
     # comment that says "no findings" on PRs that don't touch a11y was
     # noted as distracting in user feedback. Empty stdout signals the
@@ -482,13 +483,13 @@ def main() -> int:
     cm.add_argument("--repo", required=True)
     cm.add_argument(
         "--head-ref", required=True,
-        help="a11y_pr commit SHA (or branch) for image URLs",
+        help="compose-preview/a11y/pr commit SHA (or branch) for image URLs",
     )
     cm.add_argument(
         "--baseline", default=None,
-        help="Optional baseline findings.json (from a11y_main). When set, "
-             "the comment subcommand emits empty stdout if findings haven't "
-             "changed vs the baseline — the action takes that as 'skip'.",
+        help="Optional baseline findings.json (from compose-preview/a11y/main). "
+             "When set, the comment subcommand emits empty stdout if findings "
+             "haven't changed vs the baseline — the action takes that as 'skip'.",
     )
 
     args = ap.parse_args()

--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -45,12 +45,12 @@ def _load_baselines(path: Path) -> dict:
     truncates `path` to zero bytes BEFORE the command runs — so when the
     target file doesn't exist on the base branch (the typical case for the
     first run after a new baseline file is added, e.g. `resource-baselines.json`
-    landing on `preview_main`), the action ends up with an existing-but-empty
-    file. `json.loads("")` then raises `JSONDecodeError`, breaking the
-    diff-on-PR comment for everyone — including the composable side, which
-    has historically dodged this only because the composable `baselines.json`
-    has been on `preview_main` for so long that nobody re-runs the
-    bootstrap path.
+    landing on `compose-preview/main`), the action ends up with an
+    existing-but-empty file. `json.loads("")` then raises `JSONDecodeError`,
+    breaking the diff-on-PR comment for everyone — including the composable
+    side, which has historically dodged this only because the composable
+    `baselines.json` has been on `compose-preview/main` for so long that
+    nobody re-runs the bootstrap path.
 
     Treat any of (missing path, empty file, unparseable JSON, non-dict
     payload) as "no baselines to compare against" — strictly more permissive
@@ -563,7 +563,7 @@ def cmd_copy_changed(args: argparse.Namespace) -> int:
 # Sibling of `generate`. Reads `compose-preview show-resources --json` output
 # and copies each rendered PNG / GIF into
 # `<output_dir>/renders/<module>/resources/<...>` so they land in
-# `preview_resources_main` alongside the existing composable baselines.
+# `compose-preview/resources/main` alongside the existing composable baselines.
 # Writes `resource-baselines.json` and appends a section to the README.
 #
 # Mirrors the composable side's `cmd_generate` shape — a single CLI envelope
@@ -590,7 +590,7 @@ def load_resource_results(cli_json_path: Path) -> dict[str, dict]:
 
     Key shape: `<module>::<resourceId>::<renderOutput>` — same convention the
     earlier filesystem-walk variant used, so existing
-    `resource-baselines.json` files on `preview_resources_main` keep
+    `resource-baselines.json` files on `compose-preview/resources/main` keep
     matching. Module identifiers in the envelope are gradle paths
     (`samples:android`); we translate `:` → `/` so the rendered tree under
     `renders/<module>/...` keeps its filesystem-friendly layout.
@@ -737,18 +737,18 @@ def cmd_copy_changed_resources(args: argparse.Namespace) -> int:
     ones into `<output>/renders/<module>/resources/<...>`.
 
     Output layout matches [cmd_generate_resources] so the push to
-    `preview_resources_pr` lands these PNGs at paths the comment markdown
-    can `_resource_url` to. Empty CLI envelope (no Android modules) is a
-    silent no-op — same behaviour as `cmd_generate_resources`.
+    `compose-preview/resources/pr` lands these PNGs at paths the comment
+    markdown can `_resource_url` to. Empty CLI envelope (no Android modules)
+    is a silent no-op — same behaviour as `cmd_generate_resources`.
 
     When ``--baseline-renders`` points at the extracted
-    `preview_resources_main/renders/` tree, sha-mismatched pairs run through
-    the same pixelmatch-based perceptual filter as the composable side
-    (issue #190 / PR #270). Adaptive icons are particularly susceptible to
-    sub-pixel jitter from the AA mask + ``PorterDuff.SRC_IN`` composite, so
-    skipping the filter for resources made every adaptive-icon capture a
+    `compose-preview/resources/main/renders/` tree, sha-mismatched pairs run
+    through the same pixelmatch-based perceptual filter as the composable
+    side (issue #190 / PR #270). Adaptive icons are particularly susceptible
+    to sub-pixel jitter from the AA mask + ``PorterDuff.SRC_IN`` composite,
+    so skipping the filter for resources made every adaptive-icon capture a
     likely false positive. Falls back to strict-bytes when the flag isn't
-    passed (e.g. first-ever PR before `preview_resources_main` exists).
+    passed (e.g. first-ever PR before `compose-preview/resources/main` exists).
     """
     cli_json = Path(args.cli_json)
     baselines_path = Path(args.baselines)
@@ -950,19 +950,19 @@ def main() -> int:
     gen.add_argument("cli_json", help="Path to compose-preview show --json output")
     gen.add_argument("--output-dir", required=True)
     gen.add_argument("--repo", required=True, help="owner/repo")
-    gen.add_argument("--branch", default="preview_main")
+    gen.add_argument("--branch", default="compose-preview/main")
 
     cmp = sub.add_parser("compare", help="Compare CLI output against baselines")
     cmp.add_argument("cli_json", help="Path to compose-preview show --json output")
     cmp.add_argument("--baselines", required=True, help="Path to baselines.json")
     cmp.add_argument("--repo", required=True)
     # SHA-pin both sides so the PR comment's images keep resolving after
-    # `preview_main` advances and after the PR merges. Branch names are
-    # accepted as a first-run fallback when no commit exists yet.
-    cmp.add_argument("--base-ref", default="preview_main",
-                     help="preview_main commit SHA (or branch name) for Before URLs")
+    # `compose-preview/main` advances and after the PR merges. Branch names
+    # are accepted as a first-run fallback when no commit exists yet.
+    cmp.add_argument("--base-ref", default="compose-preview/main",
+                     help="compose-preview/main commit SHA (or branch name) for Before URLs")
     cmp.add_argument("--head-ref", required=True,
-                     help="preview_pr commit SHA (or branch name) for After URLs")
+                     help="compose-preview/pr commit SHA (or branch name) for After URLs")
     # Optional. When supplied, sha-mismatched pairs run through pixelmatch
     # before being flagged as Changed so renderer-side AA noise (issue #190)
     # doesn't appear in the comment. Falls back to strict-bytes when omitted.
@@ -993,7 +993,7 @@ def main() -> int:
     cp_res.add_argument("cli_json",
                         help="Path to compose-preview show-resources --json output")
     cp_res.add_argument("--baselines", required=True,
-                        help="Path to resource-baselines.json (fetched from preview_resources_main)")
+                        help="Path to resource-baselines.json (fetched from compose-preview/resources/main)")
     cp_res.add_argument("--output-dir", required=True)
     # Same perceptual-filter knob as `copy-changed` — when provided,
     # sha-mismatched pairs run through pixelmatch before being copied as
@@ -1011,9 +1011,9 @@ def main() -> int:
     cmp_res.add_argument("cli_json",
                          help="Path to compose-preview show-resources --json output")
     cmp_res.add_argument("--baselines", required=True,
-                         help="Path to resource-baselines.json (fetched from preview_resources_main)")
+                         help="Path to resource-baselines.json (fetched from compose-preview/resources/main)")
     cmp_res.add_argument("--repo", required=True)
-    cmp_res.add_argument("--base-ref", default="preview_resources_main")
+    cmp_res.add_argument("--base-ref", default="compose-preview/resources/main")
     cmp_res.add_argument("--head-ref", required=True)
     cmp_res.add_argument("--baseline-renders",
                          help="Directory containing baseline resource PNGs "

--- a/.github/actions/lib/test_a11y_report.py
+++ b/.github/actions/lib/test_a11y_report.py
@@ -251,7 +251,7 @@ class ReadmeTest(unittest.TestCase):
         ar.cmd_readme(argparse.Namespace(
             findings=str(findings_path),
             repo="org/repo",
-            branch="a11y_main",
+            branch="compose-preview/a11y/main",
             output=str(out),
         ))
         body = out.read_text()
@@ -259,7 +259,7 @@ class ReadmeTest(unittest.TestCase):
         self.assertIn("BadWearButtonPreview", body)
         # The annotated PNG wins over the clean one when there are findings.
         self.assertIn("Bad_small.a11y.png", body)
-        self.assertIn("a11y_main", body)
+        self.assertIn("compose-preview/a11y/main", body)
         self.assertIn("WARNING", body)
         self.assertIn("TouchTargetSizeCheck", body)
 
@@ -279,7 +279,7 @@ class ReadmeTest(unittest.TestCase):
         ar.cmd_readme(argparse.Namespace(
             findings=str(findings_path),
             repo="org/repo",
-            branch="a11y_main",
+            branch="compose-preview/a11y/main",
             output=str(out),
         ))
         body = out.read_text()

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -350,7 +350,7 @@ class GenerateTest(unittest.TestCase):
                 _entry(id="B", module="m", function="FnB", png="", sha=""),
             ],
         }))
-        self.out = self.tmp / "preview_main"
+        self.out = self.tmp / "out"
 
     def test_writes_baselines_and_readme_and_copies_pngs(self):
         from types import SimpleNamespace
@@ -358,7 +358,7 @@ class GenerateTest(unittest.TestCase):
             cli_json=str(self.cli_path),
             output_dir=str(self.out),
             repo="owner/repo",
-            branch="preview_main",
+            branch="compose-preview/main",
         ))
         self.assertEqual(rc, 0)
 
@@ -369,7 +369,7 @@ class GenerateTest(unittest.TestCase):
 
         readme = (self.out / "README.md").read_text()
         # README references the rendered PNG via the raw GitHub URL.
-        self.assertIn("raw.githubusercontent.com/owner/repo/preview_main", readme)
+        self.assertIn("raw.githubusercontent.com/owner/repo/compose-preview/main", readme)
         self.assertIn("`Fn`", readme)
 
         # PNG copied under renders/<module>/<id>.png.
@@ -507,8 +507,9 @@ class CompareMarkdownTest(unittest.TestCase):
 
     def test_urls_pin_to_sha_refs_not_branch_names(self):
         # The whole point of using refs over branch names: the comment
-        # survives preview_main/preview_pr advancing after merge. Assert
-        # the SHAs we pass in actually land in the generated img src URLs.
+        # survives compose-preview/main and compose-preview/pr advancing
+        # after merge. Assert the SHAs we pass in actually land in the
+        # generated img src URLs.
         out = self._run(
             {"previews": [_entry(id="Changed", function="F", sha="new", png="/c.png")]},
             {"app/Changed": {"sha256": "old", "functionName": "F"}},
@@ -635,7 +636,7 @@ class MultiCaptureGenerateTest(unittest.TestCase):
                 ],
             )],
         }))
-        self.out = self.tmp / "preview_main"
+        self.out = self.tmp / "out"
 
     def test_copies_each_capture_under_its_renderer_basename(self):
         from types import SimpleNamespace
@@ -643,7 +644,7 @@ class MultiCaptureGenerateTest(unittest.TestCase):
             cli_json=str(self.cli_path),
             output_dir=str(self.out),
             repo="owner/repo",
-            branch="preview_main",
+            branch="compose-preview/main",
         ))
         self.assertEqual(rc, 0)
 
@@ -1256,7 +1257,7 @@ class ResourcePerceptualFilterTest(unittest.TestCase):
         self.addCleanup(setattr, cp, "_perceptually_changed", self._real)
 
         # Resource baseline tree mimics what the action's
-        # `git archive preview_resources_main renders | tar -x` produces.
+        # `git archive compose-preview/resources/main renders | tar -x` produces.
         baseline_root = self.tmp / "_resource_baselines" / "renders" / "app" / "resources" / "mipmap"
         baseline_root.mkdir(parents=True)
         (baseline_root / "ic_launcher_xhdpi_SHAPE_circle_noise.png").write_bytes(b"baseline-noise")
@@ -1332,16 +1333,16 @@ class ResourcePerceptualFilterTest(unittest.TestCase):
         ))
         self.assertEqual(rc, 0)
         # Only the real-diff PNG should be copied; the AA-noise capture is
-        # filtered before it gets staged for the preview_resources_pr push.
+        # filtered before it gets staged for the compose-preview/resources/pr push.
         copied = sorted(p.name for p in
                         (out_dir / "renders" / "app" / "resources" / "mipmap").iterdir())
         self.assertEqual(copied, ["ic_launcher_xhdpi_SHAPE_square.png"])
 
     def test_strict_bytes_fallback_when_baseline_renders_omitted(self) -> None:
         # No `baseline_renders` argument → falls back to strict-sha behaviour
-        # (the first-ever-PR shape, when preview_resources_main has no
-        # renders/ tree to extract). Both captures are sha-different so both
-        # should surface as Changed.
+        # (the first-ever-PR shape, when compose-preview/resources/main has
+        # no renders/ tree to extract). Both captures are sha-different so
+        # both should surface as Changed.
         from types import SimpleNamespace
         import io
         import contextlib
@@ -1361,7 +1362,7 @@ class ResourcePerceptualFilterTest(unittest.TestCase):
 class CompareResourcesAgainstEmptyBaselineTest(unittest.TestCase):
     """End-to-end regression for the failure mode that broke PR comments
     after #269 landed: `git show … > resource-baselines.json` truncated the
-    file to zero bytes when `preview_main` didn't yet have a
+    file to zero bytes when `compose-preview/main` didn't yet have a
     `resource-baselines.json`, and `cmd_compare_resources` blew up with
     `JSONDecodeError`."""
 

--- a/.github/actions/preview-baselines/action.yml
+++ b/.github/actions/preview-baselines/action.yml
@@ -1,10 +1,11 @@
 name: 'Compose Preview Baselines'
 description: >
   Render all @Preview functions via the compose-preview CLI and push
-  PNGs + baselines.json as a new commit on the preview_main branch. The
-  branch is browsable on GitHub (README with inline images) and serves as
-  the "before" state for PR diff comments — old commit SHAs stay reachable
-  so PR comments pinned to a past baseline keep resolving forever.
+  PNGs + baselines.json as a new commit on the compose-preview/main
+  branch. The branch is browsable on GitHub (README with inline images)
+  and serves as the "before" state for PR diff comments — old commit
+  SHAs stay reachable so PR comments pinned to a past baseline keep
+  resolving forever.
 
 inputs:
   cli-version:
@@ -24,7 +25,7 @@ inputs:
     default: '600'
   branch:
     description: 'Branch name for composable @Preview baselines.'
-    default: 'preview_main'
+    default: 'compose-preview/main'
   resource-branch:
     description: >
       Branch name for Android XML resource baselines (vector / animated-vector /
@@ -32,7 +33,7 @@ inputs:
       previews are disjoint workflows — independent push cadence, independent
       bisect history, independent diff comments. Set to '' to skip the resource
       push entirely.
-    default: 'preview_resources_main'
+    default: 'compose-preview/resources/main'
 
 runs:
   using: 'composite'
@@ -122,8 +123,9 @@ runs:
 
         # Fetch the existing tip (if any) so the new commit lands on top of
         # history rather than force-pushing a fresh orphan commit each run.
-        # Keeping history means a PR comment pinned to any past preview_main
-        # SHA stays resolvable: the blob is reachable via the branch chain.
+        # Keeping history means a PR comment pinned to any past
+        # compose-preview/main SHA stays resolvable: the blob is reachable
+        # via the branch chain.
         PARENT=""
         if git fetch --depth=1 --quiet origin "$BASELINE_BRANCH" 2>/dev/null; then
           PARENT=$(git rev-parse FETCH_HEAD)
@@ -147,7 +149,7 @@ runs:
         git push --quiet origin "${COMMIT}:refs/heads/${BASELINE_BRANCH}"
 
     # ─── Android XML resource previews ────────────────────────────────────
-    # Sibling pipeline pushing to its own branch (default `preview_resources_main`).
+    # Sibling pipeline pushing to its own branch (default `compose-preview/resources/main`).
     # Workflows are disjoint from composable @Preview, so we keep the histories
     # separate — independent bisect, independent diff comments, independent
     # push cadence. See the `resource-branch` input docstring above.

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -1,9 +1,10 @@
 name: 'Compose Preview Comment'
 description: >
-  Render previews on a PR, compare against the baselines on preview_main,
-  and post a before/after comment. Changed PNGs are appended as a new
-  commit on the shared preview_pr branch; the PR comment pins Before/After
-  URLs to commit SHAs so the images keep resolving after merge.
+  Render previews on a PR, compare against the baselines on
+  compose-preview/main, and post a before/after comment. Changed PNGs
+  are appended as a new commit on the shared compose-preview/pr branch;
+  the PR comment pins Before/After URLs to commit SHAs so the images
+  keep resolving after merge.
 
 inputs:
   cli-version:
@@ -23,26 +24,26 @@ inputs:
     default: '600'
   base-branch:
     description: 'Branch name for composable @Preview baselines.'
-    default: 'preview_main'
+    default: 'compose-preview/main'
   resource-base-branch:
     description: >
       Branch name for Android XML resource baselines. Kept separate from
       `base-branch` because resource and composable previews are disjoint
       workflows (sibling sticky comments, sibling baseline branches). Set
       to '' to skip the resource compare entirely.
-    default: 'preview_resources_main'
+    default: 'compose-preview/resources/main'
   head-branch:
     description: 'Shared branch that accumulates per-PR composable render commits.'
-    default: 'preview_pr'
+    default: 'compose-preview/pr'
   resource-head-branch:
     description: >
       Shared branch that accumulates per-PR Android XML resource render
       commits. Sibling of `head-branch` for the resource pipeline — the After
       URLs in the resource sticky comment pin to commits on this branch, so
-      it stays disjoint from `preview_pr` for the same reason
-      `preview_resources_main` is disjoint from `preview_main`. Set to '' to
-      skip the resource push entirely.
-    default: 'preview_resources_pr'
+      it stays disjoint from `compose-preview/pr` for the same reason
+      `compose-preview/resources/main` is disjoint from `compose-preview/main`.
+      Set to '' to skip the resource push entirely.
+    default: 'compose-preview/resources/pr'
   pr-number:
     description: 'Pull request number (auto-detected from context if omitted).'
     default: ''
@@ -126,7 +127,7 @@ runs:
           # Extract the baseline renders/ tree alongside baselines.json so
           # the pixelmatch-based perceptual filter in compare-previews.py
           # has both PNGs to diff. `git archive` writes to stdout so the
-          # working tree is left untouched; failures (e.g. preview_main
+          # working tree is left untouched; failures (e.g. compose-preview/main
           # has no renders/ tree yet) fall back to the strict-bytes path.
           git archive "origin/${BASE_BRANCH}" renders 2>/dev/null \
             | tar -x -C _baselines/ 2>/dev/null || true
@@ -134,15 +135,16 @@ runs:
           echo "No $BASE_BRANCH branch yet — treating all previews as new."
         fi
         # Resource baselines live on their own branch (default
-        # `preview_resources_main`) — disjoint workflow from the composable
-        # `preview_main`. First-ever resource render on a project hasn't
-        # populated it yet; absent branch falls back to "treat every
-        # resource as new". Resource renders extract to a sibling directory
-        # so the two trees can't shadow each other (preview_main and
-        # preview_resources_main both lay PNGs out as `renders/<module>/...`,
-        # and even though resource paths carry a `resources/` segment after
-        # the module, keeping the staging dirs separate avoids any chance
-        # of cross-branch tar extraction stomping on a composable render).
+        # `compose-preview/resources/main`) — disjoint workflow from the
+        # composable `compose-preview/main`. First-ever resource render on
+        # a project hasn't populated it yet; absent branch falls back to
+        # "treat every resource as new". Resource renders extract to a
+        # sibling directory so the two trees can't shadow each other
+        # (compose-preview/main and compose-preview/resources/main both
+        # lay PNGs out as `renders/<module>/...`, and even though resource
+        # paths carry a `resources/` segment after the module, keeping the
+        # staging dirs separate avoids any chance of cross-branch tar
+        # extraction stomping on a composable render).
         mkdir -p _resource_baselines
         if [ -n "$RESOURCE_BASE_BRANCH" ] && \
            git ls-remote --exit-code origin "$RESOURCE_BASE_BRANCH" >/dev/null 2>&1; then
@@ -180,23 +182,24 @@ runs:
         GITHUB_TOKEN_INLINE: ${{ github.token }}
       run: |
         set -euo pipefail
-        # Pin Before URLs to the current preview_main tip SHA. Because the
-        # preview-baselines action now appends to history rather than
-        # force-pushing fresh orphans, this SHA stays reachable forever.
+        # Pin Before URLs to the current compose-preview/main tip SHA.
+        # Because the preview-baselines action now appends to history
+        # rather than force-pushing fresh orphans, this SHA stays
+        # reachable forever.
         BASE_SHA=$(git ls-remote \
           "https://x-access-token:${GITHUB_TOKEN_INLINE}@github.com/${REPO}.git" \
           "refs/heads/${BASE_BRANCH}" | awk '{print $1}')
         if [ -z "$BASE_SHA" ]; then
-          # First-ever run (no preview_main yet). Fall back to the branch
-          # name; Before images will 404 until the first baseline push lands,
-          # after which new PR comments resolve to a SHA.
+          # First-ever run (no compose-preview/main yet). Fall back to the
+          # branch name; Before images will 404 until the first baseline
+          # push lands, after which new PR comments resolve to a SHA.
           BASE_SHA="$BASE_BRANCH"
         fi
         echo "$BASE_SHA" > _base_sha
         # Sibling Before SHA for the resources comment — pins to its own
-        # branch (default `preview_resources_main`). When the input is
-        # blank the resources comment is skipped further down anyway, so
-        # we also blank `_resource_base_sha` to be defensive.
+        # branch (default `compose-preview/resources/main`). When the input
+        # is blank the resources comment is skipped further down anyway,
+        # so we also blank `_resource_base_sha` to be defensive.
         if [ -n "$RESOURCE_BASE_BRANCH" ]; then
           RESOURCE_BASE_SHA=$(git ls-remote \
             "https://x-access-token:${GITHUB_TOKEN_INLINE}@github.com/${REPO}.git" \
@@ -219,12 +222,12 @@ runs:
           --baseline-renders _baselines/renders \
           --output-dir _pr_renders
         # Resource captures stage into a sibling tree (`_pr_resource_renders/`)
-        # so they push to a separate branch (`preview_resources_pr` by
-        # default). Same disjoint-workflow rationale as the
-        # `preview_main` / `preview_resources_main` baseline split: each
-        # kind of preview gets its own per-PR After-URL history, separate
-        # bisect lineage, separate sticky comment. Silent no-op when the
-        # `_resources.json` envelope has no Android modules.
+        # so they push to a separate branch (`compose-preview/resources/pr`
+        # by default). Same disjoint-workflow rationale as the
+        # `compose-preview/main` / `compose-preview/resources/main` baseline
+        # split: each kind of preview gets its own per-PR After-URL history,
+        # separate bisect lineage, separate sticky comment. Silent no-op
+        # when the `_resources.json` envelope has no Android modules.
         python3 "$ACTION_PATH/../lib/compare-previews.py" copy-changed-resources \
           _resources.json \
           --baselines _baselines/resource-baselines.json \
@@ -398,14 +401,14 @@ runs:
         # be edited / scrolled past independently. Empty stdout when nothing
         # diffed; the post step below skips emitting an empty comment.
         # Before URL pins to the resource base branch (default
-        # `preview_resources_main`), distinct from the composable BASE_REF
-        # so the markdown image links resolve to the right tree.
+        # `compose-preview/resources/main`), distinct from the composable
+        # BASE_REF so the markdown image links resolve to the right tree.
         RESOURCE_BASE_REF=$(cat _resource_base_sha 2>/dev/null || true)
         if [ -z "$RESOURCE_BASE_REF" ]; then
           RESOURCE_BASE_REF="$BASE_REF"
         fi
         # After URL pins to the resource PR-renders branch (default
-        # `preview_resources_pr`) — sibling of HEAD_REF for resources.
+        # `compose-preview/resources/pr`) — sibling of HEAD_REF for resources.
         # Falls back to the branch name when nothing was pushed (the
         # comment body won't contain any new/changed image tags in that
         # case so the unresolved ref doesn't matter).

--- a/.github/workflows/a11y-report.yml
+++ b/.github/workflows/a11y-report.yml
@@ -2,10 +2,11 @@ name: A11y Report
 
 # Demo of the accessibility-checking pipeline on `samples:wear`. Mirrors the
 # preview-baselines / preview-comment split: pushes to `main` refresh the
-# `a11y_main` baseline branch; PRs render their own report on the shared
-# `a11y_pr` branch and post a comment with the findings table. Wired only
-# for `samples:wear` for now — the deliberately-broken `BadWearButtonPreview`
-# is what makes the annotated overlay non-empty.
+# `compose-preview/a11y/main` baseline branch; PRs render their own report
+# on the shared `compose-preview/a11y/pr` branch and post a comment with
+# the findings table. Wired only for `samples:wear` for now — the
+# deliberately-broken `BadWearButtonPreview` is what makes the annotated
+# overlay non-empty.
 
 on:
   push:
@@ -31,8 +32,8 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
-      # Composite action appends a commit to the long-lived `a11y_main`
-      # branch.
+      # Composite action appends a commit to the long-lived
+      # `compose-preview/a11y/main` branch.
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -48,8 +49,8 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
-      # Push annotated PNGs to the shared `a11y_pr` branch and upsert a
-      # comment on the PR.
+      # Push annotated PNGs to the shared `compose-preview/a11y/pr` branch
+      # and upsert a comment on the PR.
       contents: write
       pull-requests: write
     steps:

--- a/.github/workflows/preview-baselines.yml
+++ b/.github/workflows/preview-baselines.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   update:
-    name: Update preview_main
+    name: Update compose-preview/main
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -20,7 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       # preview-comment composite action appends a commit to the shared
-      # preview_pr branch and upserts a PR comment with before/after images.
+      # compose-preview/pr branch and upserts a PR comment with
+      # before/after images.
       contents: write
       pull-requests: write
     steps:

--- a/README.md
+++ b/README.md
@@ -66,16 +66,16 @@ Compose Multiplatform 1.10.3 (Desktop).
 
 Source under [`samples/`](samples/). Rendered baselines (PNGs and animation
 GIFs, regenerated on every push to `main`) are browsable inline on the
-[`preview_main`](https://github.com/yschimke/compose-ai-tools/tree/preview_main)
+[`compose-preview/main`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main)
 branch:
 
-- [`samples:android`](https://github.com/yschimke/compose-ai-tools/tree/preview_main#samplesandroid) — phone, font-family showcase, scrolling captures, animation timelines.
-- [`samples:wear`](https://github.com/yschimke/compose-ai-tools/tree/preview_main#sampleswear) — Wear OS Material 3 Expressive, `EdgeButton`, tile previews.
-- [`samples:cmp`](https://github.com/yschimke/compose-ai-tools/tree/preview_main#samplescmp) — Compose Multiplatform Desktop.
-- [`samples:remotecompose`](https://github.com/yschimke/compose-ai-tools/tree/preview_main#samplesremotecompose) — Remote Compose against `wear-compose-remote-material3`.
+- [`samples:android`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main#samplesandroid) — phone, font-family showcase, scrolling captures, animation timelines.
+- [`samples:wear`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main#sampleswear) — Wear OS Material 3 Expressive, `EdgeButton`, tile previews.
+- [`samples:cmp`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main#samplescmp) — Compose Multiplatform Desktop.
+- [`samples:remotecompose`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/main#samplesremotecompose) — Remote Compose against `wear-compose-remote-material3`.
 
 ATF a11y findings for the same samples are on the
-[`a11y_main`](https://github.com/yschimke/compose-ai-tools/tree/a11y_main)
+[`compose-preview/a11y/main`](https://github.com/yschimke/compose-ai-tools/tree/compose-preview/a11y/main)
 branch.
 
 ## Agent PR hall of fame
@@ -94,7 +94,7 @@ Have one to add? Open a PR or [an issue](https://github.com/yschimke/compose-ai-
 - [How it works](docs/HOW_IT_WORKS.md) — discovery, renderer, caching, project structure, plugin configuration.
 - [CI install action](.github/actions/install/README.md) — pin the CLI on `$PATH` in any GitHub Actions job, with version-catalog + Renovate recipes.
 - [Cloud sandbox setup](skills/compose-preview/design/CLAUDE_CLOUD.md) — Claude Code on the web, network allowlist.
-- [CI workflows](skills/compose-preview-review/design/CI_PREVIEWS.md) — `preview_main` baselines, PR diff comments.
+- [CI workflows](skills/compose-preview-review/design/CI_PREVIEWS.md) — `compose-preview/main` baselines, PR diff comments.
 - [Development](docs/DEVELOPMENT.md) — building plugin, CLI, and extension from source; consuming `-SNAPSHOT` builds.
 - [Architecture (contributor)](docs/AGENTS.md) — class-by-class map of the four-stage pipeline.
 - [Releases](https://github.com/yschimke/compose-ai-tools/releases) ·

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -115,7 +115,7 @@ private fun printUsage() {
       a11y             Render previews and print ATF accessibility findings
       doctor           Verify Java 17 + Compose/AGP environment before editing Gradle files
       share-gist       Create a gist from a markdown file plus image attachments
-      publish-images   Push a directory of rendered PNGs to a shared branch (default preview_pr)
+      publish-images   Push a directory of rendered PNGs to a shared branch (default compose-preview/pr)
       update           Re-run the bootstrap installer to pull the latest release
       version          Print the installed bundle version and exit
       help             Show this help message

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/PublishImagesCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/PublishImagesCommand.kt
@@ -8,13 +8,13 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
 /**
- * `compose-preview publish-images DIR [--branch preview_pr] [--remote origin] [--pr-number N]
- * [--message MSG] [--json]`
+ * `compose-preview publish-images DIR [--branch compose-preview/pr] [--remote origin]
+ * [--pr-number N] [--message MSG] [--json]`
  *
  * Pushes the contents of a staging directory as a single commit on a shared rendered-PNG branch
- * (default `preview_pr`), mirroring what the `preview-comment` GitHub Action does in CI. Lets an
- * agent that already has a populated `_pr_renders/`-shape directory get stable raw URLs without
- * scripting the `git init` / `commit-tree` / race-loop dance by hand.
+ * (default `compose-preview/pr`), mirroring what the `preview-comment` GitHub Action does in CI.
+ * Lets an agent that already has a populated `_pr_renders/`-shape directory get stable raw URLs
+ * without scripting the `git init` / `commit-tree` / race-loop dance by hand.
  *
  * Deliberately small: this is the push primitive, not the whole `preview-comment` workflow. The
  * agent decides what to put in the staging directory (typically the changed/new PNGs from a
@@ -23,12 +23,13 @@ import kotlinx.serialization.json.Json
  */
 class PublishImagesCommand(args: List<String>) {
   private val jsonOut = "--json" in args
-  private val branch: String = args.flagValue("--branch") ?: "preview_pr"
+  private val branch: String = args.flagValue("--branch") ?: "compose-preview/pr"
   private val remote: String = args.flagValue("--remote") ?: "origin"
   private val prNumber: String? = args.flagValue("--pr-number")
   private val customMessage: String? = args.flagValue("--message")
   /**
-   * Opt-in escape hatch for branch names outside the `preview_*` allowlist. Hard-blocked names
+   * Opt-in escape hatch for branch names outside the preview allowlist (any branch starting with
+   * `compose-preview/`, or the legacy `preview_` prefix). Hard-blocked names
    * ([HARD_BLOCKED_BRANCHES]) stay rejected even with this flag — pushing rendered PNGs onto
    * `main`/`master`/etc. is never the intended use of this command.
    */
@@ -319,10 +320,17 @@ class PublishImagesCommand(args: List<String>) {
      * Branches `publish-images` will never push to, regardless of `--allow-non-preview-branch`.
      * This is policy on top of the allowlist: pushing rendered PNGs onto a project's mainline or
      * release branches is never the intended use of this command, so we hard-block even with the
-     * escape hatch. Anything else outside the `preview_*` allowlist requires the flag.
+     * escape hatch. Anything else outside the preview allowlist requires the flag.
      */
     private val HARD_BLOCKED_BRANCHES = setOf("main", "master", "develop", "trunk", "HEAD")
     private val HARD_BLOCKED_PREFIXES = listOf("release/", "releases/")
+
+    /**
+     * Allowed branch-name prefixes for `publish-images` without `--allow-non-preview-branch`.
+     * `compose-preview/` is the current convention; `preview_` is the legacy prefix kept around so
+     * repos that haven't migrated their `preview_main` / `preview_pr` branches keep working.
+     */
+    private val PREVIEW_BRANCH_PREFIXES = listOf("compose-preview/", "preview_")
 
     /**
      * Conservative subset of `git check-ref-format`. Real refnames allow more, but for this
@@ -358,7 +366,8 @@ class PublishImagesCommand(args: List<String>) {
      * 2. Refname must not be in [HARD_BLOCKED_BRANCHES] or under [HARD_BLOCKED_PREFIXES] — pushing
      *    rendered PNGs onto mainline / release branches is never the intended use, even with the
      *    escape hatch.
-     * 3. Refname must match the `preview_` prefix, OR `--allow-non-preview-branch` must be set.
+     * 3. Refname must match one of [PREVIEW_BRANCH_PREFIXES], OR `--allow-non-preview-branch` must
+     *    be set.
      *
      * The first failing rule wins so error messages stay focused.
      */
@@ -371,10 +380,10 @@ class PublishImagesCommand(args: List<String>) {
         return "refusing to push to '$branch': mainline / release branches are never a valid " +
           "destination for publish-images, even with --allow-non-preview-branch."
       }
-      if (!branch.startsWith("preview_") && !allowNonPreview) {
-        return "branch '$branch' is outside the preview_* allowlist. Pass " +
-          "--allow-non-preview-branch to push to a custom branch (mainline branches stay " +
-          "blocked regardless)."
+      if (PREVIEW_BRANCH_PREFIXES.none { branch.startsWith(it) } && !allowNonPreview) {
+        return "branch '$branch' is outside the preview allowlist (compose-preview/* or " +
+          "legacy preview_*). Pass --allow-non-preview-branch to push to a custom branch " +
+          "(mainline branches stay blocked regardless)."
       }
       return null
     }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PublishImagesCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PublishImagesCommandTest.kt
@@ -13,7 +13,7 @@ class PublishImagesArgParsingTest {
       listOf(
         "_pr_renders",
         "--branch",
-        "preview_pr",
+        "compose-preview/pr",
         "--remote",
         "origin",
         "--pr-number",
@@ -66,12 +66,29 @@ class PublishImagesMessageTest {
 
 class PublishImagesBranchValidationTest {
   @Test
-  fun `preview_pr passes by default`() {
+  fun `compose-preview pr passes by default`() {
+    assertNull(PublishImagesCommand.validateBranch("compose-preview/pr", allowNonPreview = false))
+  }
+
+  @Test
+  fun `compose-preview main passes by default`() {
+    assertNull(PublishImagesCommand.validateBranch("compose-preview/main", allowNonPreview = false))
+  }
+
+  @Test
+  fun `compose-preview nested resources branch passes by default`() {
+    assertNull(
+      PublishImagesCommand.validateBranch("compose-preview/resources/pr", allowNonPreview = false)
+    )
+  }
+
+  @Test
+  fun `legacy preview_pr still passes by default`() {
     assertNull(PublishImagesCommand.validateBranch("preview_pr", allowNonPreview = false))
   }
 
   @Test
-  fun `preview_main passes by default`() {
+  fun `legacy preview_main still passes by default`() {
     assertNull(PublishImagesCommand.validateBranch("preview_main", allowNonPreview = false))
   }
 
@@ -79,8 +96,11 @@ class PublishImagesBranchValidationTest {
   fun `non-preview branch rejected without escape hatch`() {
     val message = PublishImagesCommand.validateBranch("screenshots", allowNonPreview = false)
     assertTrue(
-      message != null && "preview_*" in message && "--allow-non-preview-branch" in message,
-      "expected reject mentioning the allowlist and escape flag, got $message",
+      message != null &&
+        "compose-preview/" in message &&
+        "preview_" in message &&
+        "--allow-non-preview-branch" in message,
+      "expected reject mentioning both allowlist prefixes and escape flag, got $message",
     )
   }
 
@@ -122,7 +142,9 @@ class PublishImagesBranchValidationTest {
 
   @Test
   fun `refspec colon rejected`() {
-    assertNotNull(PublishImagesCommand.validateBranch("preview_pr:main", allowNonPreview = false))
+    assertNotNull(
+      PublishImagesCommand.validateBranch("compose-preview/pr:main", allowNonPreview = false)
+    )
   }
 
   @Test
@@ -134,7 +156,9 @@ class PublishImagesBranchValidationTest {
   fun `at-brace rejected`() {
     // `branch@{1}` is a reflog selector; pushing to it is meaningless and we don't want exotic
     // git syntax leaking through.
-    assertNotNull(PublishImagesCommand.validateBranch("preview_pr@{1}", allowNonPreview = false))
+    assertNotNull(
+      PublishImagesCommand.validateBranch("compose-preview/pr@{1}", allowNonPreview = false)
+    )
   }
 }
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -23,9 +23,9 @@ Two audiences, two doc trees. Don't conflate them:
   - [`REMOTE_COMPOSE.md`](../skills/compose-preview/design/REMOTE_COMPOSE.md) — Remote Compose (RemoteDocument byte stream for watch faces, tiles, widgets)
   - [`RESOURCE_PREVIEWS.md`](../skills/compose-preview/design/RESOURCE_PREVIEWS.md) — Android XML resource captures (`<vector>`, `<adaptive-icon>`)
   - [`VSCODE.md`](../skills/compose-preview/design/VSCODE.md) — VS Code extension (humans, not agents)
-- **[`skills/compose-preview-review/`](../skills/compose-preview-review/)** — sibling skill covering the PR-review surface: authoring agent-opened PRs, reviewing UI PRs locally (base + head render, diff, comment), and wiring `preview_main` baselines + PR-comment GitHub Actions.
+- **[`skills/compose-preview-review/`](../skills/compose-preview-review/)** — sibling skill covering the PR-review surface: authoring agent-opened PRs, reviewing UI PRs locally (base + head render, diff, comment), and wiring `compose-preview/main` baselines + PR-comment GitHub Actions.
   - [`AGENT_PR.md`](../skills/compose-preview-review/design/AGENT_PR.md) — authoring agent-opened PRs and reviewing PRs opened by other agents
-  - [`CI_PREVIEWS.md`](../skills/compose-preview-review/design/CI_PREVIEWS.md) — maintaining a `preview_main` branch with rendered PNGs and a `baselines.json` for diff-on-PR workflows
+  - [`CI_PREVIEWS.md`](../skills/compose-preview-review/design/CI_PREVIEWS.md) — maintaining a `compose-preview/main` branch with rendered PNGs and a `baselines.json` for diff-on-PR workflows
 
 Each skill is bundled into its own `<name>-skill-<ver>.tar.gz` at release time and ends up under `~/.claude/skills/<name>/` after `scripts/install.sh` runs — so anything you change in `skills/` is what consumers (and their agents) see, not what contributors editing this repo see. When you change consumer-facing behaviour (a new flag, a network requirement, a setup-script step), update `skills/...`, not this file. Cross-link from here when contributors need the same information for sandbox setup (e.g. the Android SDK bootstrap referenced from "Bringing up a fresh sandbox" below).
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1066,7 +1066,7 @@ internal object AndroidPreviewSupport {
         // output so the build cache round-trips the PNGs alongside the
         // test reports; without this the task gets a cache hit on a fresh
         // checkout but the renders are never restored, which is exactly
-        // how previous modules silently vanished from `preview_main`.
+        // how previous modules silently vanished from `compose-preview/main`.
         outputs.dir(rendersDirectory).withPropertyName("rendersDir")
 
         dependsOn(discoverTask)

--- a/skills/compose-preview-review/SKILL.md
+++ b/skills/compose-preview-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compose-preview-review
-description: Review pull requests that change Compose UI by rendering @Preview composables on base and head and diffing them. Use when reviewing a UI PR locally, authoring an agent-opened PR that touches UI, or wiring preview_main baselines and PR-comment GitHub Actions for a project. Pairs with the compose-preview skill.
+description: Review pull requests that change Compose UI by rendering @Preview composables on base and head and diffing them. Use when reviewing a UI PR locally, authoring an agent-opened PR that touches UI, or wiring compose-preview/main baselines and PR-comment GitHub Actions for a project. Pairs with the compose-preview skill.
 ---
 
 # Compose Preview — Review
@@ -33,7 +33,7 @@ Pick the workflow that matches the task:
 |---|---|
 | Review a PR locally that touches UI | [design/AGENT_PR.md § Reviewing a PR](./design/AGENT_PR.md#reviewing-a-pr-agent-workflow) |
 | Author an agent-opened PR that touches UI | [design/AGENT_PR.md § Authoring an Agent PR](./design/AGENT_PR.md#authoring-an-agent-pr-body-structure) |
-| Wire `preview_main` baselines + PR-comment CI for a project | [design/CI_PREVIEWS.md](./design/CI_PREVIEWS.md) |
+| Wire `compose-preview/main` baselines + PR-comment CI for a project | [design/CI_PREVIEWS.md](./design/CI_PREVIEWS.md) |
 | Render previews on base and head and diff them | [design/AGENT_PR.md § Render base and head locally](./design/AGENT_PR.md#1-render-base-and-head-locally) |
 
 ## Quick reference: review a UI PR locally
@@ -67,7 +67,7 @@ Pick the workflow that matches the task:
 | Path | When to read |
 |---|---|
 | [design/AGENT_PR.md](./design/AGENT_PR.md) | Full PR review + agent PR authoring guidance: comment structure, image hosting choices, things to flag, integration with `preview-comment` CI when present. |
-| [design/CI_PREVIEWS.md](./design/CI_PREVIEWS.md) | `preview_main` baselines branch + PR-comment GitHub Actions: workflow YAML, action inputs, branch durability. |
+| [design/CI_PREVIEWS.md](./design/CI_PREVIEWS.md) | `compose-preview/main` baselines branch + PR-comment GitHub Actions: workflow YAML, action inputs, branch durability. |
 
 ## Related
 

--- a/skills/compose-preview-review/design/AGENT_PR.md
+++ b/skills/compose-preview-review/design/AGENT_PR.md
@@ -125,20 +125,22 @@ destination before acting:
   somewhere in the global/local chain (used only as the commit
   identity in the throwaway clone).
 - **Dedicated branch in the repo** (`compose-preview publish-images
-  DIR [--branch preview_pr] [--remote origin] [--pr-number N] [--json]`).
-  Pushes the staging directory's contents as a single commit on the
-  shared `preview_pr` branch, mirroring what the `preview-comment` CI
-  integration does — same retry-on-race loop for parallel pushes from
-  sibling PRs. Output is the resulting commit SHA and a raw URL pattern
-  (`https://raw.githubusercontent.com/<owner>/<repo>/<sha>/{path}`)
-  that pins images to the SHA so they survive merges. `--json` emits a
+  DIR [--branch compose-preview/pr] [--remote origin] [--pr-number N]
+  [--json]`). Pushes the staging directory's contents as a single commit
+  on the shared `compose-preview/pr` branch, mirroring what the
+  `preview-comment` CI integration does — same retry-on-race loop for
+  parallel pushes from sibling PRs. Output is the resulting commit SHA
+  and a raw URL pattern
+  (`https://raw.githubusercontent.com/<owner>/<repo>/<sha>/{path}`) that
+  pins images to the SHA so they survive merges. `--json` emits a
   `compose-preview-publish-images/v1` envelope. Prefer this over the
   gist when you want clean GitHub-hosted URLs and the user's confirmed
   they want a branch created — the CLI does NOT auto-detect prior
-  consent; it just runs the push. Branch names must match `preview_*`
-  by default; `--allow-non-preview-branch` opts into a custom name.
-  Mainline / release branches (`main`, `master`, `develop`, `trunk`,
-  `HEAD`, `release/*`) are hard-blocked regardless of the flag.
+  consent; it just runs the push. Branch names must match the preview
+  allowlist by default (`compose-preview/*` or the legacy `preview_*`);
+  `--allow-non-preview-branch` opts into a custom name. Mainline /
+  release branches (`main`, `master`, `develop`, `trunk`, `HEAD`,
+  `release/*`) are hard-blocked regardless of the flag.
 - **Issue/PR attachment upload** — not reliably available via `gh`; skip.
 
 Never use inline base64 or data URIs — GitHub strips them. Never push images
@@ -197,8 +199,8 @@ surfaces:
 A small number of repos wire up the `preview-comment` GitHub Action (see
 [CI_PREVIEWS.md](CI_PREVIEWS.md)). When it's installed, it posts a sticky
 comment keyed by `<!-- preview-diff -->` with before/after images hosted
-on a shared `preview_pr` branch, pinned to commit SHAs so they survive
-merge.
+on a shared `compose-preview/pr` branch, pinned to commit SHAs so they
+survive merge.
 
 Only do this if you've already confirmed it exists:
 

--- a/skills/compose-preview-review/design/CI_PREVIEWS.md
+++ b/skills/compose-preview-review/design/CI_PREVIEWS.md
@@ -1,8 +1,9 @@
-# CI preview baselines (`preview_main` branch)
+# CI preview baselines (`compose-preview/main` branch)
 
 Projects that use the Gradle plugin can wire up two GitHub Actions
-workflows to maintain a `preview_main` branch with rendered PNGs and a
-`baselines.json` file (preview ID → SHA-256). This serves two purposes:
+workflows to maintain a `compose-preview/main` branch with rendered PNGs
+and a `baselines.json` file (preview ID → SHA-256). This serves two
+purposes:
 
 1. **Browsable gallery** — the branch has a `README.md` with inline images,
    viewable directly on GitHub.
@@ -64,7 +65,7 @@ jobs:
   compare:
     runs-on: ubuntu-latest
     permissions:
-      contents: write          # appends to preview_pr branch
+      contents: write          # appends to compose-preview/pr branch
       pull-requests: write     # upserts the PR comment
     steps:
       - uses: actions/checkout@v6
@@ -105,7 +106,7 @@ when needed.
 | `catalog-path` | `gradle/libs.versions.toml` | Catalog file when `cli-version=catalog`. |
 | `catalog-key` | `composePreviewCli` | `[versions]` key when `cli-version=catalog`. |
 | `timeout` | `600` | CLI render timeout in seconds. |
-| `branch` | `preview_main` | Branch the baselines push to. |
+| `branch` | `compose-preview/main` | Branch the baselines push to. |
 
 `preview-comment`:
 
@@ -115,8 +116,8 @@ when needed.
 | `catalog-path` | `gradle/libs.versions.toml` | Catalog file when `cli-version=catalog`. |
 | `catalog-key` | `composePreviewCli` | `[versions]` key when `cli-version=catalog`. |
 | `timeout` | `600` | CLI render timeout in seconds. |
-| `base-branch` | `preview_main` | Branch the baselines were pushed to. |
-| `head-branch` | `preview_pr` | Shared branch for per-PR render commits. |
+| `base-branch` | `compose-preview/main` | Branch the baselines were pushed to. |
+| `head-branch` | `compose-preview/pr` | Shared branch for per-PR render commits. |
 | `pr-number` | (event) | PR number, auto-detected from the `pull_request` event. |
 
 ## Mobile readability
@@ -139,36 +140,36 @@ vertical-friendly:
 ## Querying baselines outside CI
 
 ```bash
-git ls-remote --exit-code origin preview_main          # check existence
-git fetch origin preview_main
-git show origin/preview_main:baselines.json            # read manifest
-git show origin/preview_main:renders/<module>/<id>.png # read PNG
+git ls-remote --exit-code origin compose-preview/main          # check existence
+git fetch origin compose-preview/main
+git show origin/compose-preview/main:baselines.json            # read manifest
+git show origin/compose-preview/main:renders/<module>/<id>.png # read PNG
 ```
 
 Or via raw URL:
 
 ```
-https://raw.githubusercontent.com/<owner>/<repo>/preview_main/renders/<module>/<id>.png
+https://raw.githubusercontent.com/<owner>/<repo>/compose-preview/main/renders/<module>/<id>.png
 ```
 
 ## Branch durability
 
-Both `preview_main` and `preview_pr` are append-only:
+Both `compose-preview/main` and `compose-preview/pr` are append-only:
 
 - `preview-baselines` adds one commit per push to `main` (parented on
   the previous tip; skipped when the rendered tree is unchanged). A
   fast-forward push on a serialised concurrency group means no
   rewrites.
-- `preview-comment` appends one commit per PR push to `preview_pr`
-  (tree = that PR's changed PNGs). The PR comment pins `<img>` URLs
-  to commit SHAs on `preview_main` and `preview_pr`, not branch
-  names — so images keep resolving after the PR merges and after
-  later PRs advance either branch.
+- `preview-comment` appends one commit per PR push to
+  `compose-preview/pr` (tree = that PR's changed PNGs). The PR comment
+  pins `<img>` URLs to commit SHAs on `compose-preview/main` and
+  `compose-preview/pr`, not branch names — so images keep resolving
+  after the PR merges and after later PRs advance either branch.
 
 ## Local persistent state: `.compose-preview-history/fonts/`
 
-CI keeps long-lived state on the `preview_main` and `preview_pr`
-branches. There's also a per-module local cache —
+CI keeps long-lived state on the `compose-preview/main` and
+`compose-preview/pr` branches. There's also a per-module local cache —
 `<module>/.compose-preview-history/fonts/`, deliberately outside
 `build/` so it survives `./gradlew clean`. The directory holds the
 **downloadable-font cache**, populated automatically the first time a

--- a/skills/compose-preview/SKILL.md
+++ b/skills/compose-preview/SKILL.md
@@ -186,8 +186,8 @@ Loaded on demand. Read only what the current task needs.
 PR-review and CI workflows live in the sibling
 [**compose-preview-review** skill](../compose-preview-review/SKILL.md):
 authoring agent-opened PRs, reviewing UI PRs locally (base + head render,
-diff, text comment), and wiring `preview_main` baselines + PR-comment
-GitHub Actions. The bootstrap installer
+diff, text comment), and wiring `compose-preview/main` baselines +
+PR-comment GitHub Actions. The bootstrap installer
 ([`scripts/install.sh`](https://raw.githubusercontent.com/yschimke/compose-ai-tools/main/scripts/install.sh))
 sets up both skills together.
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -393,7 +393,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         vscode.window.registerWebviewViewProvider(PreviewPanel.viewId, panel),
     );
 
-    // Watch the preview_main ref for fetch-driven changes. When the ref
+    // Watch the compose-preview/main ref for fetch-driven changes. When the ref
     // moves, any open "Diff vs main" overlay in the live panel needs to
     // re-issue against the new bytes. The watcher coalesces fetch bursts
     // internally; we just message the live panel and let it reissue.
@@ -1915,9 +1915,10 @@ async function runLivePreviewDiff(
         return;
     }
     // No local archived entry. For "vs main" we can still try the
-    // preview_main baselines branch — repos using the CI baseline workflow
-    // publish every main build's PNGs there. Avoids requiring a daemon or
-    // a one-off local archive for the user's first diff against main.
+    // compose-preview/main baselines branch (with legacy preview_main
+    // fallback) — repos using the CI baseline workflow publish every main
+    // build's PNGs there. Avoids requiring a daemon or a one-off local
+    // archive for the user's first diff against main.
     if (against === 'main') {
         const baseline = await readPreviewMainPng(
             gradleService.workspaceRoot, moduleId, previewId,
@@ -1938,7 +1939,7 @@ async function runLivePreviewDiff(
     panel.postMessage({
         command: 'previewDiffError', previewId, against,
         message: against === 'main'
-            ? 'No archived render on main yet for this preview, and no preview_main baseline.'
+            ? 'No archived render on main yet for this preview, and no compose-preview/main baseline.'
             : 'No archived history yet for this preview.',
     });
 }
@@ -2031,11 +2032,12 @@ async function diffAllVsMain(): Promise<void> {
                 // History unavailable for this preview — treat as no baseline.
             }
             if (!mainHash) {
-                // Fall back to the preview_main baselines branch — repos
-                // using the CI baseline workflow publish PNGs there even
-                // when nothing has been archived locally yet. The lookup
-                // also exposes a sha256 in the manifest, which we compare
-                // against the live hash to skip identical previews.
+                // Fall back to the compose-preview/main baselines branch
+                // (with legacy preview_main fallback) — repos using the CI
+                // baseline workflow publish PNGs there even when nothing
+                // has been archived locally yet. The lookup also exposes a
+                // sha256 in the manifest, which we compare against the
+                // live hash to skip identical previews.
                 const baseline = await readPreviewMainPng(
                     gradleService!.workspaceRoot, moduleId, preview.id,
                 );

--- a/vscode-extension/src/previewMainSource.ts
+++ b/vscode-extension/src/previewMainSource.ts
@@ -3,13 +3,13 @@ import type { Readable, Writable } from 'stream';
 
 /**
  * Read PNG bytes for a preview's `main` baseline directly from the
- * `preview_main` branch via git plumbing. Used as a fallback when the
- * local `.compose-preview-history/` has no entry for `git.branch === 'main'`
- * — repos that follow the CI baseline workflow (see
- * [.github/actions/preview-baselines/action.yml]) push every `main` build's
- * rendered PNGs to a `preview_main` branch alongside a `baselines.json`
- * manifest. Reading from the ref means "vs main" works without local
- * archived history and without a daemon.
+ * `compose-preview/main` branch via git plumbing. Used as a fallback when
+ * the local `.compose-preview-history/` has no entry for
+ * `git.branch === 'main'` — repos that follow the CI baseline workflow
+ * (see [.github/actions/preview-baselines/action.yml]) push every `main`
+ * build's rendered PNGs to a `compose-preview/main` branch alongside a
+ * `baselines.json` manifest. Reading from the ref means "vs main" works
+ * without local archived history and without a daemon.
  *
  * Layout on the baseline branch (matches `compare-previews.py`'s writer):
  *
@@ -18,9 +18,9 @@ import type { Readable, Writable } from 'stream';
  *       └── <module>/
  *           └── <renderBasename>  // typically "<previewId>.png"
  *
- * The reader prefers `origin/preview_main` (post-fetch view of the
- * remote) and falls back to a local `preview_main` branch if no remote
- * tracking ref exists.
+ * The reader prefers `origin/compose-preview/main` (post-fetch view of the
+ * remote) and falls back to the local branch and then the legacy
+ * `preview_main` flat ref so repos that haven't migrated keep working.
  */
 export async function readPreviewMainPng(
     workspaceRoot: string,
@@ -28,7 +28,13 @@ export async function readPreviewMainPng(
     previewId: string,
 ): Promise<PreviewMainResult | null> {
     const batch = getBatch(workspaceRoot);
-    for (const ref of ['origin/preview_main', 'preview_main']) {
+    const candidateRefs = [
+        'origin/compose-preview/main',
+        'compose-preview/main',
+        'origin/preview_main',
+        'preview_main',
+    ];
+    for (const ref of candidateRefs) {
         const baselineBuf = await batch.read(`${ref}:baselines.json`);
         if (!baselineBuf) { continue; }
         const baselines = parseBaselines(baselineBuf.toString('utf8'));
@@ -44,7 +50,7 @@ export async function readPreviewMainPng(
 }
 
 export interface PreviewMainResult {
-    /** e.g. `'origin/preview_main'` — the ref that resolved. */
+    /** e.g. `'origin/compose-preview/main'` — the ref that resolved. */
     ref: string;
     /** e.g. `':samples:android/com.example.RedSquare'`. */
     baselineKey: string;

--- a/vscode-extension/src/previewMainWatcher.ts
+++ b/vscode-extension/src/previewMainWatcher.ts
@@ -6,11 +6,14 @@ import * as path from 'path';
  * coalesced callback whenever any of them changes — typically after a
  * `git fetch` lands new objects, but also on local commit/branch ops.
  *
- * Targets:
- *   - `.git/refs/remotes/origin/preview_main` — post-fetch view of the
- *     remote baseline branch (the most common trigger).
- *   - `.git/refs/heads/preview_main` — local branch, for repos that
- *     publish baselines locally.
+ * Targets (new convention first; the legacy `preview_main` flat ref is
+ * still watched so repos that haven't migrated keep auto-refreshing):
+ *   - `.git/refs/remotes/origin/compose-preview/main` — post-fetch view of
+ *     the remote baseline branch (the most common trigger).
+ *   - `.git/refs/heads/compose-preview/main` — local branch, for repos
+ *     that publish baselines locally.
+ *   - `.git/refs/remotes/origin/preview_main`, `.git/refs/heads/preview_main`
+ *     — legacy flat refs, kept for back-compat.
  *   - `.git/packed-refs` — git packs loose refs into this file via
  *     `git pack-refs` / `git gc`; when packed, the per-file refs above
  *     disappear and updates land here instead.
@@ -46,6 +49,13 @@ export function watchPreviewMainRef(
         filenames: Set<string>;
     }
     const dirs: DirWatch[] = [
+        // New convention: nested under `compose-preview/`. Watch the parent
+        // dir for `main` filename — the parent itself may not exist yet on
+        // first checkout, in which case the existsSync check below skips
+        // until the first fetch creates it.
+        { dir: path.join(gitDir, 'refs', 'remotes', 'origin', 'compose-preview'), filenames: new Set(['main']) },
+        { dir: path.join(gitDir, 'refs', 'heads', 'compose-preview'), filenames: new Set(['main']) },
+        // Legacy flat refs — kept so repos that haven't migrated keep working.
         { dir: path.join(gitDir, 'refs', 'remotes', 'origin'), filenames: new Set(['preview_main']) },
         { dir: path.join(gitDir, 'refs', 'heads'), filenames: new Set(['preview_main']) },
         { dir: gitDir, filenames: new Set(['packed-refs']) },

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -1512,7 +1512,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             // as its left anchor (head / main / current), the bytes the
             // overlay is showing just went stale. Re-issue so the user sees
             // the new render without clicking — symmetric with the
-            // preview_main ref watcher's auto-refresh on the right anchor.
+            // compose-preview/main ref watcher's auto-refresh on the right anchor.
             const openDiff = container.querySelector('.preview-diff-overlay');
             if (openDiff) {
                 const against = openDiff.dataset.against;
@@ -1820,9 +1820,10 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     break;
                 }
                 case 'previewMainRefChanged': {
-                    // preview_main moved — re-issue any open vs-main diff
-                    // overlay so the user sees the new bytes without clicking.
-                    // Other diffs (HEAD, current, previous) are unaffected.
+                    // compose-preview/main moved — re-issue any open vs-main
+                    // diff overlay so the user sees the new bytes without
+                    // clicking. Other diffs (HEAD, current, previous) are
+                    // unaffected.
                     document.querySelectorAll(
                         '.preview-diff-overlay[data-against="main"]',
                     ).forEach(overlay => {

--- a/vscode-extension/src/test/previewMainBatchParser.test.ts
+++ b/vscode-extension/src/test/previewMainBatchParser.test.ts
@@ -31,7 +31,7 @@ describe('CatFileBatchParser', () => {
 
     it('parses a missing response', () => {
         const parser = new CatFileBatchParser();
-        const out = parser.feed(missing('origin/preview_main:no/such/path'));
+        const out = parser.feed(missing('origin/compose-preview/main:no/such/path'));
         assert.deepStrictEqual(out, [null]);
     });
 

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -297,10 +297,11 @@ export type ExtensionToWebview =
      */
     | { command: 'focusAndDiff'; previewId: string; against: 'head' | 'main' }
     /**
-     * `origin/preview_main` (or the local `preview_main` branch / packed
-     * refs) just changed on disk — typically because a `git fetch` landed
-     * a new baseline. The live panel re-issues any open "Diff vs main"
-     * overlay so the user sees the new bytes without manually clicking.
+     * `origin/compose-preview/main` (or the local `compose-preview/main`
+     * branch, the legacy `preview_main` flat refs, or `packed-refs`) just
+     * changed on disk — typically because a `git fetch` landed a new
+     * baseline. The live panel re-issues any open "Diff vs main" overlay
+     * so the user sees the new bytes without manually clicking.
      */
     | { command: 'previewMainRefChanged' };
 


### PR DESCRIPTION
## Summary

Switch from flat `preview_*` / `a11y_*` branch names to a `compose-preview/` namespace with `/`-separated sub-axes:

| Old | New |
|---|---|
| `preview_main` | `compose-preview/main` |
| `preview_pr` | `compose-preview/pr` |
| `preview_resources_main` | `compose-preview/resources/main` |
| `preview_resources_pr` | `compose-preview/resources/pr` |
| `a11y_main` | `compose-preview/a11y/main` |
| `a11y_pr` | `compose-preview/a11y/pr` |

Composables stay the bare default (`compose-preview/main`, `compose-preview/pr`); the secondary tracks (`resources/`, `a11y/`) get an extra path segment.

### Changes

- **CLI** (`PublishImagesCommand.kt`) — `publish-images --branch` default is now `compose-preview/pr`. Allowlist accepts both `compose-preview/` and the legacy `preview_` prefix; help text + tests updated.
- **GitHub Actions** — `preview-baselines`, `preview-comment`, `a11y-report` composite actions: every input default updated to the new names; comment text inside each action follows.
- **Workflows** — job names and inline comments in `preview-baselines.yml`, `preview-comment.yml`, `a11y-report.yml`.
- **Python lib** — `compare-previews.py` and `a11y-report.py` argparse defaults plus their tests.
- **VS Code extension** — `previewMainSource.ts` reader and `previewMainWatcher.ts` ref watcher prefer `origin/compose-preview/main` then fall back to `origin/preview_main`, so unmigrated repos keep working.
- **Docs** — `README.md`, `docs/AGENTS.md`, both skills (`compose-preview/SKILL.md`, `compose-preview-review/SKILL.md`, `design/CI_PREVIEWS.md`, `design/AGENT_PR.md`), and the AndroidPreviewSupport comment.

### Backward compat

- CLI `publish-images` still accepts the legacy `preview_*` prefix without `--allow-non-preview-branch`.
- VS Code extension reads the new ref first, falls back to the legacy ref.

### Migration for this repo (post-merge)

```bash
# Composables baseline
git push origin refs/remotes/origin/preview_main:refs/heads/compose-preview/main
git push origin :preview_main

# PR previews
git push origin refs/remotes/origin/preview_pr:refs/heads/compose-preview/pr
git push origin :preview_pr

# Resources baselines + PR previews
git push origin refs/remotes/origin/preview_resources_main:refs/heads/compose-preview/resources/main
git push origin refs/remotes/origin/preview_resources_pr:refs/heads/compose-preview/resources/pr
git push origin :preview_resources_main :preview_resources_pr

# A11y baselines + PR previews
git push origin refs/remotes/origin/a11y_main:refs/heads/compose-preview/a11y/main
git push origin refs/remotes/origin/a11y_pr:refs/heads/compose-preview/a11y/pr
git push origin :a11y_main :a11y_pr
```

External consumers of the composite actions either rename their branches (same shape as above) or pin the old name explicitly via the `branch` / `head-branch` / `base-branch` inputs.

## Test plan

- [x] `./gradlew :cli:test` (incl. updated PublishImages branch-validation cases)
- [x] `./gradlew :gradle-plugin:test`
- [x] `python3 -m unittest test_compare_previews.py test_a11y_report.py`
- [x] `npm test` in `vscode-extension/` (271 passing)
- [ ] Verify the `Update compose-preview/main` job runs on the next push to `main` after the branches are renamed
- [ ] Verify the next PR's `Compare previews` job posts to `compose-preview/pr` and resolves Before URLs against the new branch

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoLd2oMvFB8gDAE7qxYiQ7)_