### PR TITLE
fix(build): apply maven.publish in root with apply false

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,13 @@ plugins {
   alias(libs.plugins.android.application) apply false
   alias(libs.plugins.android.library) apply false
   alias(libs.plugins.ktfmt) apply false
+  // Loaded into the root scope so :renderer-android and :daemon:android (and
+  // any future sibling) share the plugin's ClassLoader. Without this, each
+  // sibling instantiates its own MavenCentralBuildService class and Gradle
+  // refuses to share the build service across them — fails configuration
+  // with "Cannot set the value of task ':daemon:android:dropMavenCentral
+  // Deployment' property 'buildService'".
+  alias(libs.plugins.maven.publish) apply false
 }
 
 allprojects {


### PR DESCRIPTION
## Summary

Both `:renderer-android` and `:daemon:android` apply `com.vanniktech.maven.publish` at the subproject level. Each gets its own `ClassLoaderScopeIdentifier`, so the shared `MavenCentralBuildService` is loaded as two distinct types. Gradle then refuses to wire one project's task with a provider produced by the other and configuration fails:

```
> Cannot set the value of task ':daemon:android:dropMavenCentralDeployment'
  property 'buildService' of type ...MavenCentralBuildService loaded with
  ...{...:project-daemon:project-android(export)} using a provider of type
  ...MavenCentralBuildService loaded with ...{...:project-renderer-android(export)}.
```

The error message itself names the fix: load the plugin in the root build with `apply false` so siblings share the parent ClassLoader scope.

Came in via #373 which added the publish plugin to `:daemon:android` alongside the pre-existing `:renderer-android` application.

## Test plan

- [x] `./gradlew help` configures cleanly (BUILD SUCCESSFUL).
- [ ] Manual: open the workspace in VS Code → no startup error.
- [ ] Manual: `./gradlew :daemon:android:publishToMavenLocal` still works.
- [ ] Manual: `./gradlew :renderer-android:publishToMavenLocal` still works.


---
_Generated by [Claude Code](https://claude.ai/code/session_01A6AFhHNrHQNqUPKdmJRt94)_