### PR TITLE
feat(renderer-android): structured per-preview runtime errors via sidecar

### DIFF
--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderErrorSidecar.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderErrorSidecar.kt
@@ -1,0 +1,138 @@
+package ee.schimke.composeai.renderer
+
+import java.io.File
+import java.io.PrintWriter
+import java.io.StringWriter
+
+/**
+ * Per-preview render-error sidecar writer for the Android (Robolectric)
+ * renderer path. Mirrors the convention established by the desktop
+ * renderer (`renderer-desktop/.../DesktopRendererMain.kt#writeErrorSidecar`)
+ * and the schema defined in the gradle plugin
+ * (`gradle-plugin/.../PreviewRenderError.kt`).
+ *
+ * Sibling placement of `<png>.error.json` keeps the renderer's filesystem
+ * layout self-contained — no aggregation step in the gradle plugin —
+ * and the VS Code extension finds the sidecar by trivial string-concat
+ * on the manifest's existing `renderOutput` path.
+ *
+ * Hand-rolled JSON. The renderer-android runtime classpath deliberately
+ * doesn't pull `kotlinx-serialization` (renderer-vs-consumer alignment;
+ * see `docs/RENDERER_COMPATIBILITY.md`), so we encode a shallow object
+ * directly. The schema is small and stable.
+ */
+internal object RenderErrorSidecar {
+
+  /** The sidecar that pairs with [pngFile] — same path with `.error.json` appended. */
+  fun pathFor(pngFile: File): File = File(pngFile.parentFile, pngFile.name + ".error.json")
+
+  /**
+   * Write the sidecar for a preview render that threw [e]. Drops any
+   * stale PNG at the same path so the panel doesn't surface yesterday's
+   * image alongside today's error message. Best-effort — failures here
+   * (filesystem ENOSPC, permissions) print to stderr but don't propagate,
+   * since the goal is to *avoid* derailing the test on a per-preview
+   * issue.
+   */
+  fun write(pngFile: File, e: Throwable) {
+    try {
+      val sidecar = pathFor(pngFile)
+      sidecar.parentFile?.mkdirs()
+      if (pngFile.exists()) pngFile.delete()
+      val stack = StringWriter().also { e.printStackTrace(PrintWriter(it)) }.toString()
+      val top = pickTopAppFrame(e)
+      val sb = StringBuilder()
+      sb.append('{')
+      sb.append("\"schema\":\"compose-preview-error/v1\",")
+      sb.append("\"exception\":").append(jsonString(e.javaClass.name)).append(',')
+      sb.append("\"message\":").append(jsonString(e.message ?: "")).append(',')
+      if (top != null) {
+        sb.append("\"topAppFrame\":{")
+        sb.append("\"file\":").append(jsonString(top.file)).append(',')
+        sb.append("\"line\":").append(top.line).append(',')
+        sb.append("\"function\":").append(jsonString(top.function))
+        sb.append("},")
+      }
+      sb.append("\"stackTrace\":").append(jsonString(stack))
+      sb.append('}')
+      sidecar.writeText(sb.toString())
+    } catch (sidecarWriteFailure: Throwable) {
+      System.err.println(
+        "Failed to write render-error sidecar for ${pngFile.name}: ${sidecarWriteFailure.message}"
+      )
+    }
+  }
+
+  /**
+   * Drop the sidecar for [pngFile] if one exists, regardless of whether
+   * the prior render succeeded. Called at the start of every render
+   * attempt so a fresh successful render doesn't leave yesterday's
+   * `.error.json` haunting the panel.
+   */
+  fun deleteStale(pngFile: File) {
+    val sidecar = pathFor(pngFile)
+    if (sidecar.exists()) sidecar.delete()
+  }
+
+  /**
+   * The first stack frame attributable to user code. Skips Compose
+   * scaffold, Kotlin stdlib, JDK frames, the renderer's own glue, the
+   * Robolectric harness, and JUnit so the `(at File.kt:42)` annotation
+   * the extension surfaces points where the bug actually is rather than
+   * deep into framework internals.
+   *
+   * Same idea as the desktop renderer's `pickTopAppFrame` plus the
+   * Android-specific framework prefixes that don't show up there
+   * (Robolectric, JUnit, Roborazzi).
+   */
+  private fun pickTopAppFrame(e: Throwable): TopFrame? {
+    val skipPrefixes =
+      listOf(
+        "androidx.compose.",
+        "androidx.lifecycle.",
+        "androidx.activity.",
+        "androidx.test.",
+        "kotlin.",
+        "kotlinx.",
+        "java.",
+        "javax.",
+        "jdk.",
+        "sun.",
+        "ee.schimke.composeai.renderer.",
+        "org.robolectric.",
+        "org.junit.",
+        "junit.",
+        "com.github.takahirom.roborazzi.",
+      )
+    for (frame in e.stackTrace) {
+      val cls = frame.className
+      if (skipPrefixes.any { cls.startsWith(it) }) continue
+      return TopFrame(
+        file = frame.fileName ?: "",
+        line = frame.lineNumber.coerceAtLeast(0),
+        function = frame.methodName ?: "",
+      )
+    }
+    return null
+  }
+
+  private data class TopFrame(val file: String, val line: Int, val function: String)
+
+  private fun jsonString(s: String): String {
+    val sb = StringBuilder(s.length + 2)
+    sb.append('"')
+    for (c in s) {
+      when (c) {
+        '"' -> sb.append("\\\"")
+        '\\' -> sb.append("\\\\")
+        '\b' -> sb.append("\\b")
+        '\n' -> sb.append("\\n")
+        '\r' -> sb.append("\\r")
+        '\t' -> sb.append("\\t")
+        else -> if (c < ' ') sb.append("\\u%04x".format(c.code)) else sb.append(c)
+      }
+    }
+    sb.append('"')
+    return sb.toString()
+  }
+}

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -351,16 +351,47 @@ abstract class RobolectricRenderTestBase(
             recordOptions = RoborazziOptions.RecordOptions(applyDeviceCrop = isRound),
         )
 
-        renderDefault(
-            params = params,
-            widthDp = widthDp,
-            heightDp = heightDp,
-            wrapWidth = wrapWidth,
-            wrapHeight = wrapHeight,
-            outputDir = outputDir,
-            roborazziOptions = roborazziOptions,
-            composeOptions = composeOptions,
-        )
+        // Drop any stale .error.json from a prior run before attempting a
+        // fresh render. If today's render succeeds, the panel doesn't want
+        // to surface yesterday's exception alongside the new PNG.
+        val pngFile = outputFileFor(preview.captures.first(), outputDir)
+        RenderErrorSidecar.deleteStale(pngFile)
+
+        // Catch Throwable per preview. Today, a throw inside the preview
+        // function fails the JUnit test, fails the Test task, and the
+        // panel shows a generic "Build failed" message — ONE broken
+        // preview hides every sibling preview's render. By catching here
+        // and writing a structured `.error.json` sidecar, the failing
+        // card surfaces the actual exception while every other preview
+        // still produces its PNG.
+        //
+        // Catching Throwable (not Exception) so AssertionErrors from
+        // `require`/`check` calls in user code surface the same way as
+        // RuntimeExceptions. JVM-fatal throwables already terminated the
+        // JVM before we got here.
+        try {
+            renderDefault(
+                params = params,
+                widthDp = widthDp,
+                heightDp = heightDp,
+                wrapWidth = wrapWidth,
+                wrapHeight = wrapHeight,
+                outputDir = outputDir,
+                roborazziOptions = roborazziOptions,
+                composeOptions = composeOptions,
+            )
+        } catch (e: Throwable) {
+            System.err.println(
+                "Render failed for ${preview.className}.${preview.functionName}: ${e.message}"
+            )
+            RenderErrorSidecar.write(pngFile, e)
+            // Don't rethrow — keep the JUnit test green so a single
+            // broken preview doesn't fail the Test task and prevent
+            // sibling previews from rendering. The structured error
+            // travels through the sidecar; VS Code reads it via
+            // `gradleService.readPreviewRenderError` and shows the
+            // exception detail on the failing card.
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Mirrors the desktop runtime-errors pipeline (#385) on the Android Robolectric path so broken `@Preview` functions on Android / Wear samples surface a structured exception on the failing card instead of the generic "Build failed" message — and so one broken preview no longer hides every sibling preview's render.

### The before/after

**Today**: a throw inside a preview function fails the JUnit test method, fails the `renderPreviews` Test task, the gradle invocation fails, and VS Code shows `Build failed. See Output ▸ Compose Preview` over the whole panel. ONE broken preview blocks every sibling.

**After**: `RobolectricRenderTest.renderPreview()` wraps `renderDefault(...)` in `try/catch (Throwable)` and on failure writes a `<png>.error.json` sidecar with structured exception detail. The test stays green so the Test task succeeds and sibling previews keep rendering normally. The VS Code extension (which already consumes the sidecar via #385) shows the structured error on the failing card:

```
NullPointerException: LocalContext was null (at MyScreen.kt:47 in MyScreen)
```

### Sidecar writer

Catches `Throwable` (not `Exception`) so `AssertionError` from `require` / `check` calls in user code surfaces the same way as `RuntimeException`. JVM-fatal throwables already terminated the JVM before we got here.

Top-app-frame heuristic skips the Android-specific framework prefixes that don't show up in the desktop renderer: `androidx.lifecycle`, `androidx.activity`, `androidx.test`, `org.robolectric`, `org.junit`, `junit`, `com.github.takahirom.roborazzi`.

Stale sidecars from a prior failed run are deleted at the start of every render attempt. The PNG itself is also dropped when a sidecar is written, so the panel doesn't surface yesterday's image alongside today's error.

Hand-rolled JSON encoder mirrors the desktop renderer — `kotlinx-serialization` is deliberately not on the `renderer-android` runtime classpath (see [`docs/RENDERER_COMPATIBILITY.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/RENDERER_COMPATIBILITY.md)), and the schema is small / stable enough that direct encoding beats vendoring a serializer. Schema string matches `gradle-plugin/.../PreviewRenderError.kt` and the TypeScript interface in the extension.

### No extension changes

The VS Code consumer added in #385 reads `<png>.error.json` siblings unconditionally — this PR just starts populating them on the Android path.

### Files

- `renderer-android/src/main/kotlin/.../RenderErrorSidecar.kt` (new) — module-private object that writes / deletes the sidecar.
- `renderer-android/src/main/kotlin/.../RobolectricRenderTest.kt` — wraps `renderDefault(...)` in try/catch; calls the writer.

### Test plan

- [x] `./gradlew ktfmtCheckAll` — clean
- [x] `./gradlew :renderer-android:compileDebugKotlin` — clean (verified in sandbox after installing Android SDK via `scripts/install.sh --android-sdk`)
- [ ] CI: full `./gradlew check` + functional tests
- [ ] Manual: introduce a `requireNotNull(null)` inside a `@Preview` in `:samples:wear` (or `:samples:android`). On `:samples:wear:renderAllPreviews`, confirm:
  - The Test task succeeds (no JUnit failure).
  - The failing preview's card shows `IllegalArgumentException: Required value was null. (at MyScreen.kt:42 in MyScreen)` rather than "Build failed".
  - Sibling previews in the same module still render normally.
  - Fix the `requireNotNull` and re-render: the `.error.json` sidecar is removed and the card returns to a normal image.
- [ ] Manual: inject a `LocalContext.current` in a context-free preview function (NPE inside Compose internals). Confirm the top-app-frame skips `androidx.compose.*` and lands on the user-code frame, not somewhere deep in Compose.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rw5ZRtvu2VaXiTRE9KmNiC)_