### PR TITLE
feat(vscode): rich error card for runtime render failures

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -745,6 +745,95 @@ body {
     border-color: var(--vscode-errorForeground);
 }
 
+/* -- Structured runtime-error overlay --------------------------------
+ * Layered on top of the rendered preview when a @Preview function
+ * threw at render time and the renderer wrote a structured
+ * `<png>.error.json` sidecar. Reads top-down: exception class,
+ * message, click-to-open frame, collapsible stack trace.
+ *
+ * Background is mostly opaque (not fully) so a previously-rendered
+ * image is faintly visible underneath — the panel sits flush to the
+ * top so the image's interesting region (usually the bottom half of
+ * a Compose preview) stays readable for context.
+ */
+.render-error {
+    position: absolute;
+    inset: 0;
+    background: color-mix(in srgb, var(--vscode-editor-background) 92%, transparent);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
+    overflow: auto;
+    padding: 10px 12px;
+    text-align: left;
+    line-height: 1.4;
+}
+
+.render-error-class {
+    font-weight: 700;
+    color: var(--vscode-errorForeground);
+    font-family: var(--vscode-editor-font-family);
+    font-size: var(--vscode-font-size);
+    margin-bottom: 2px;
+    word-break: break-all;
+}
+
+.render-error-msg {
+    color: var(--text-primary);
+    font-size: calc(var(--vscode-font-size) - 1px);
+    margin-bottom: 6px;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.render-error-frame {
+    display: inline-block;
+    background: transparent;
+    border: none;
+    padding: 0;
+    color: var(--vscode-textLink-foreground);
+    text-decoration: underline;
+    cursor: pointer;
+    font-family: var(--vscode-editor-font-family);
+    font-size: calc(var(--vscode-font-size) - 1px);
+    text-align: left;
+    margin-bottom: 6px;
+}
+.render-error-frame:hover {
+    color: var(--vscode-textLink-activeForeground, var(--vscode-textLink-foreground));
+}
+.render-error-frame:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: 2px;
+}
+
+/* Stack-trace disclosure — native <details>. Closed by default since
+   most users only want the top-level message + frame; expanding gets
+   the full trace for the rare case where the top frame heuristic
+   missed the right call site. */
+.render-error-stack {
+    margin-top: 4px;
+    font-size: calc(var(--vscode-font-size) - 2px);
+}
+.render-error-stack > summary {
+    cursor: pointer;
+    color: var(--text-secondary);
+    user-select: none;
+}
+.render-error-stack > summary:hover {
+    color: var(--text-primary);
+}
+.render-error-stack > pre {
+    margin: 4px 0 0;
+    padding: 6px 8px;
+    background: color-mix(in srgb, var(--text-secondary) 12%, transparent);
+    border-radius: 3px;
+    font-family: var(--vscode-editor-font-family);
+    font-size: calc(var(--vscode-font-size) - 2px);
+    white-space: pre;
+    overflow-x: auto;
+    color: var(--text-secondary);
+}
+
 /* Stale heavy capture: dim the rendered image so the user notices it isn't
    fresh, and tint the warning icon. The badge button itself is the only
    click target — clicking re-runs render at tier=full for this module. */

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1912,6 +1912,11 @@ function handleWebviewMessage(msg: WebviewToExtensionMessage) {
                 void openSourcePosition(msg.sourceFile, msg.line, msg.column);
             }
             break;
+        case 'openSourceFile':
+            if (msg.fileName && typeof msg.line === 'number') {
+                void openSourceByFileName(msg.fileName, msg.line);
+            }
+            break;
         case 'requestPreviewDiff':
             if (msg.previewId && (msg.against === 'head' || msg.against === 'main')) {
                 void runLivePreviewDiff(msg.previewId, msg.against);
@@ -1936,6 +1941,39 @@ async function openSourcePosition(filePath: string, line: number, column: number
     } catch (e: unknown) {
         const message = e instanceof Error ? e.message : String(e);
         logLine(`openSourcePosition failed for ${filePath}:${line}:${column} — ${message}`);
+    }
+}
+
+/**
+ * Resolve a stack-trace `fileName` (a basename like `Previews.kt` from
+ * `StackTraceElement.fileName`) to an absolute path via workspace
+ * findFiles, then open it at [line]. Used by the runtime-error card —
+ * the JVM stack trace doesn't carry the absolute path of the source
+ * file, only its basename, so we glob and take the first hit outside
+ * `**\/build/**`. Ambiguous matches across same-named files in
+ * different modules fall back to the first hit; richer disambiguation
+ * (e.g. by function name) is a follow-up.
+ *
+ * Silently does nothing when no match is found — the user sees no
+ * editor change and a log line, since "open my Previews.kt" failing
+ * isn't worth a toast.
+ */
+async function openSourceByFileName(fileName: string, line: number): Promise<void> {
+    if (!fileName) { return; }
+    try {
+        const matches = await vscode.workspace.findFiles(`**/${fileName}`, '**/build/**', 1);
+        if (matches.length === 0) {
+            logLine(`openSourceByFileName: no match for ${fileName}`);
+            return;
+        }
+        const doc = await vscode.workspace.openTextDocument(matches[0]);
+        const editor = await vscode.window.showTextDocument(doc);
+        const pos = new vscode.Position(Math.max(0, line - 1), 0);
+        editor.selection = new vscode.Selection(pos, pos);
+        editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+    } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : String(e);
+        logLine(`openSourceByFileName failed for ${fileName}:${line} — ${message}`);
     }
 }
 
@@ -2278,6 +2316,7 @@ interface WebviewToExtensionMessage {
     visible?: string[];
     predicted?: string[];
     sourceFile?: string;
+    fileName?: string;
     line?: number;
     column?: number;
     against?: 'head' | 'main';

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -840,6 +840,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 renderOutput: c.renderOutput || '',
                 imageData: null,
                 errorMessage: null,
+                renderError: null,
             })));
 
             const header = document.createElement('div');
@@ -984,6 +985,75 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             showFrame(card, next);
         }
 
+        /**
+         * Build the error overlay DOM for a failing capture. When
+         * renderError is non-null the panel has structured detail:
+         * exception class, message, a clickable file:line frame, and a
+         * collapsible stack trace. Otherwise it falls back to the plain
+         * one-line message (the case for renderers that don't yet
+         * produce a sidecar, or when the sidecar was unreadable).
+         *
+         * Click on the frame button posts an openSourceFile message;
+         * the extension resolves the stack-trace basename to an
+         * absolute path via workspace.findFiles. The disclosure for
+         * the full trace is a native details element -- no JS state
+         * to manage, browser handles the toggle.
+         */
+        function buildErrorPanel(message, renderError) {
+            const panel = document.createElement('div');
+            panel.className = 'error-message render-error';
+            panel.setAttribute('role', 'alert');
+            if (!renderError) {
+                panel.textContent = message || '';
+                return panel;
+            }
+            const cls = (renderError.exception || '').split('.').pop()
+                || renderError.exception || 'Error';
+            const head = document.createElement('div');
+            head.className = 'render-error-class';
+            head.textContent = cls;
+            panel.appendChild(head);
+
+            if (renderError.message) {
+                const msg = document.createElement('div');
+                msg.className = 'render-error-msg';
+                msg.textContent = renderError.message;
+                panel.appendChild(msg);
+            }
+
+            const frame = renderError.topAppFrame;
+            if (frame && frame.file) {
+                const link = document.createElement('button');
+                link.className = 'render-error-frame';
+                link.type = 'button';
+                const fnSuffix = frame.function ? ' in ' + frame.function : '';
+                const lineSuffix = frame.line > 0 ? ':' + frame.line : '';
+                link.textContent = frame.file + lineSuffix + fnSuffix;
+                link.title = 'Open ' + frame.file + lineSuffix;
+                link.addEventListener('click', () => {
+                    vscode.postMessage({
+                        command: 'openSourceFile',
+                        fileName: frame.file,
+                        line: frame.line,
+                    });
+                });
+                panel.appendChild(link);
+            }
+
+            if (renderError.stackTrace) {
+                const details = document.createElement('details');
+                details.className = 'render-error-stack';
+                const summary = document.createElement('summary');
+                summary.textContent = 'Stack trace';
+                details.appendChild(summary);
+                const pre = document.createElement('pre');
+                pre.textContent = renderError.stackTrace;
+                details.appendChild(pre);
+                panel.appendChild(details);
+            }
+            return panel;
+        }
+
         function showFrame(card, index) {
             const caps = cardCaptures.get(card.dataset.previewId);
             if (!caps) return;
@@ -1006,8 +1076,10 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 }
                 img.src = 'data:' + mimeFor(capture.renderOutput) + ';base64,' + capture.imageData;
                 img.className = 'fade-in';
-            } else if (capture.errorMessage) {
-                container.innerHTML = '<div class="error-message" role="alert">' + escapeHtml(capture.errorMessage) + '</div>';
+            } else if (capture.errorMessage || capture.renderError) {
+                const existingErr = container.querySelector('.error-message');
+                if (existingErr) existingErr.remove();
+                container.appendChild(buildErrorPanel(capture.errorMessage, capture.renderError));
                 card.classList.add('has-error');
             } else {
                 // No data for this capture yet — render will fill it in later.
@@ -1062,6 +1134,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 renderOutput: nc.renderOutput || '',
                 imageData: prior[i]?.imageData ?? null,
                 errorMessage: prior[i]?.errorMessage ?? null,
+                renderError: prior[i]?.renderError ?? null,
             }));
             cardCaptures.set(p.id, mergedCaps);
             const curIdx = parseInt(card.dataset.currentIndex || '0', 10);
@@ -1470,6 +1543,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             if (caps && caps[captureIndex]) {
                 caps[captureIndex].imageData = imageData;
                 caps[captureIndex].errorMessage = null;
+                caps[captureIndex].renderError = null;
             }
 
             // Only paint the <img> if the currently-displayed capture is the
@@ -1763,9 +1837,11 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                         // (captureIndex defaulted to 0) — applies to the
                         // representative image container only.
                         const captureIndex = msg.command === 'setImageError' ? (msg.captureIndex || 0) : 0;
+                        const renderError = msg.command === 'setImageError' ? (msg.renderError || null) : null;
                         const caps = cardCaptures.get(msg.previewId);
                         if (caps && caps[captureIndex]) {
                             caps[captureIndex].errorMessage = msg.message;
+                            caps[captureIndex].renderError = renderError;
                             caps[captureIndex].imageData = null;
                         }
                         const cur = parseInt(errCard.dataset.currentIndex || '0', 10);
@@ -1773,15 +1849,20 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 
                         errCard.classList.add('has-error');
                         const container = errCard.querySelector('.image-container');
-                        // Keep existing image visible under the error for setImageError
-                        if (msg.command === 'setImageError') {
-                            const existing = container.querySelector('img');
-                            if (!existing) {
-                                container.innerHTML = '<div class="error-message" role="alert">' + escapeHtml(msg.message) + '</div>';
-                            }
-                        } else {
-                            container.innerHTML = '<div class="error-message" role="alert">' + escapeHtml(msg.message) + '</div>';
+                        const previousErr = container.querySelector('.error-message');
+                        if (previousErr) previousErr.remove();
+                        // setImageError keeps any existing rendered <img>
+                        // visible underneath the error overlay so the user
+                        // still has the previous render as a reference.
+                        // setError is the preview-wide path — wipe everything
+                        // and replace with just the error.
+                        if (msg.command === 'setError') {
+                            const existingImg = container.querySelector('img');
+                            if (existingImg) existingImg.remove();
+                            const skeleton = container.querySelector('.skeleton');
+                            if (skeleton) skeleton.remove();
                         }
+                        container.appendChild(buildErrorPanel(msg.message, renderError));
                     }
                     break;
                 }

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -396,6 +396,17 @@ export type WebviewToExtension =
      */
     | { command: 'openCompileError'; sourceFile: string; line: number; column: number }
     /**
+     * Click on a runtime-error card's "top app frame" link. Unlike the
+     * compile-error path, runtime errors only carry the source-file
+     * basename (from the stack trace's `StackTraceElement.fileName`) —
+     * so the extension does a workspace `findFiles('**\/<fileName>')`
+     * to resolve it, biased to the first match outside `**\/build/**`.
+     * Ambiguous matches across same-named files in different modules
+     * fall back to the first hit; a richer disambiguation could use
+     * the function name, but that's a follow-up.
+     */
+    | { command: 'openSourceFile'; fileName: string; line: number }
+    /**
      * Live panel asks the extension to compute a diff for the focused
      * preview against an anchor. `head` = latest archived render in
      * `.compose-preview-history/` for this preview; `main` = same, filtered


### PR DESCRIPTION
## Summary

The renderer-side sidecar pipeline (#385 desktop, #389 Android) produces structured exception detail per failing preview, but the panel was still showing only the one-line summary on the failing card. This change renders the full detail in place.

### Card layout

Replaces the flat `.error-message` div with a structured panel:

```
NullPointerException
LocalContext was null
Previews.kt:47 in HomeScreen          ← clickable, opens at line 47
▶ Stack trace                         ← native <details> disclosure
```

### Click-to-source

New webview → extension message: `openSourceFile { fileName, line }`. The extension resolves via `workspace.findFiles('**/<fileName>')` outside `**/build/**`. Unlike the compile-error banner (#344) which gets absolute paths from LSP diagnostics, stack-trace basenames carry only the file name (`StackTraceElement.fileName`) — the glob is the cheapest way to get from "Previews.kt" to a workspace URI. Ambiguous matches across same-named files in different modules fall back to the first hit.

### Layered over the previous render

The error panel is absolute-positioned over `.image-container` so the previously-rendered PNG stays faintly visible underneath as context — the *previous* render is usually still useful even when the *current* render threw. Backdrop blur + 92% opacity background so the panel is readable but not opaque.

### Carousel-aware

`cardCaptures` now stores `renderError` per capture so carousel navigation on animated previews restores the full structured detail when the user steps through frames, not just the one-line message.

### Stack disclosure

Native `<details>` element — browser owns the toggle state, no extra JS.

### Files

- `media/preview.css` — new `.render-error*` rule set; the existing `.error-message` rules are kept for the no-renderError fallback path.
- `src/previewPanel.ts` — new `buildErrorPanel(message, renderError)` helper used by both the carousel-step path (`showFrame`) and the initial `setImageError` post.
- `src/extension.ts` — new `openSourceByFileName` resolver, wired to the new `openSourceFile` message case in the webview handler.
- `src/types.ts` — `openSourceFile` added to `WebviewToExtension`.

### Test plan

- [x] `npm run compile` — clean
- [x] `npm test` — 280 passing (no test changes; the `renderError.formatRenderErrorMessage` formatter from #385 is the only pure unit covered by tests, the rest is DOM/CSS that needs manual verification)
- [ ] Manual: trigger a render error on a desktop CMP sample. Confirm the card shows the structured panel (class, message, frame, disclosure) over the previous PNG faintly visible.
- [ ] Manual: click the frame link — opens the source file at the right line.
- [ ] Manual: click "Stack trace" — disclosure reveals the full trace, monospace, scrollable.
- [ ] Manual: animated preview with one capture failing. Step through with the carousel arrows; the failing capture shows the structured error, the working captures show their images.
- [ ] Manual: a render that fails without a sidecar (e.g. on the Android path before #389 lands, or on a preview the renderer can't even start). Confirm the fallback shows the plain one-line "Render failed — see Output ▸ Compose Preview" message.

### Out of scope / next

The `openSourceFile` resolver picks the first basename match. If a workspace has `Previews.kt` in multiple modules, the wrong one might open. Disambiguation by class FQN (`preview.className`) or by function name is a follow-up — straightforward but adds a search pass per click.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rw5ZRtvu2VaXiTRE9KmNiC)_