### PR TITLE
refactor(vscode): tighten webview message typing + className-aware error frame

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -15,7 +15,7 @@ import { AndroidManifestCodeLensProvider } from './androidManifestCodeLensProvid
 import { PreviewA11yDiagnostics } from './previewA11yDiagnostics';
 import { PreviewDoctorDiagnostics } from './previewDoctorDiagnostics';
 import { packageQualifiedSourcePath } from './sourcePath';
-import { HEAVY_COST_THRESHOLD, PreviewInfo } from './types';
+import { HEAVY_COST_THRESHOLD, PreviewInfo, WebviewToExtension } from './types';
 import { formatRenderErrorMessage } from './renderError';
 import { captureLabel } from './captureLabels';
 import { DaemonGate } from './daemon/daemonGate';
@@ -1851,35 +1851,40 @@ async function refresh(
     }
 }
 
-function handleWebviewMessage(msg: WebviewToExtensionMessage) {
+function handleWebviewMessage(msg: WebviewToExtension) {
+    // Discriminated-union dispatch: inside each `case` TypeScript narrows
+    // `msg` to the matching variant, so the field accesses below are
+    // type-checked. Defensive runtime checks remain only where the
+    // webview's untyped postMessage could deliver a structurally-broken
+    // payload (e.g. arrays that aren't actually arrays).
     switch (msg.command) {
         case 'openFile':
-            if (msg.className && msg.functionName) {
-                openPreviewSource(msg.className, msg.functionName);
-            }
+            openPreviewSource(msg.className, msg.functionName);
             break;
         case 'selectModule':
             selectedModule = msg.value || null;
             sendModuleList();
             if (selectedModule) { refresh(false); }
             break;
-        case 'refreshHeavy':
+        case 'refreshHeavy': {
             // Click on the stale badge → full-tier render of the owning
             // module. Once we have a `-PcomposePreview.previewIds=` filter
             // we can scope this to just the requested capture; for now the
             // user pays a full-module render for the freshness guarantee.
-            if (msg.previewId) {
-                const mod = previewModuleMap.get(msg.previewId);
-                if (mod) {
-                    void refresh(true, currentScopeFile ?? undefined, 'full');
-                }
+            const mod = previewModuleMap.get(msg.previewId);
+            if (mod) {
+                void refresh(true, currentScopeFile ?? undefined, 'full');
             }
             break;
+        }
         case 'viewportUpdated':
             // Daemon-only: route geometric visibility + scroll-ahead
             // predictions to the scheduler so it can `setVisible` and
             // queue speculative renders. When the daemon is disabled
-            // (default) `notifyDaemonViewport` is a no-op.
+            // (default) `notifyDaemonViewport` is a no-op. Array.isArray
+            // is the one defensive check we keep — postMessage's typing
+            // doesn't survive across the bridge so a buggy webview build
+            // could send a string here.
             if (Array.isArray(msg.visible) && Array.isArray(msg.predicted)) {
                 void notifyDaemonViewport(msg.visible, msg.predicted);
             }
@@ -1907,20 +1912,13 @@ function handleWebviewMessage(msg: WebviewToExtensionMessage) {
             break;
         }
         case 'openCompileError':
-            if (msg.sourceFile && typeof msg.line === 'number'
-                && typeof msg.column === 'number') {
-                void openSourcePosition(msg.sourceFile, msg.line, msg.column);
-            }
+            void openSourcePosition(msg.sourceFile, msg.line, msg.column);
             break;
         case 'openSourceFile':
-            if (msg.fileName && typeof msg.line === 'number') {
-                void openSourceByFileName(msg.fileName, msg.line);
-            }
+            void openSourceByFileName(msg.fileName, msg.line, msg.className);
             break;
         case 'requestPreviewDiff':
-            if (msg.previewId && (msg.against === 'head' || msg.against === 'main')) {
-                void runLivePreviewDiff(msg.previewId, msg.against);
-            }
+            void runLivePreviewDiff(msg.previewId, msg.against);
             break;
     }
 }
@@ -1946,35 +1944,74 @@ async function openSourcePosition(filePath: string, line: number, column: number
 
 /**
  * Resolve a stack-trace `fileName` (a basename like `Previews.kt` from
- * `StackTraceElement.fileName`) to an absolute path via workspace
- * findFiles, then open it at [line]. Used by the runtime-error card —
- * the JVM stack trace doesn't carry the absolute path of the source
- * file, only its basename, so we glob and take the first hit outside
- * `**\/build/**`. Ambiguous matches across same-named files in
- * different modules fall back to the first hit; richer disambiguation
- * (e.g. by function name) is a follow-up.
+ * `StackTraceElement.fileName`) to an absolute path, then open it at
+ * [line]. The JVM stack trace doesn't carry the absolute path of the
+ * source file — only the basename — so we have to search.
+ *
+ * Two-pass resolution:
+ *
+ *  1. **Class-derived path** when [className] is supplied (the preview's
+ *     compiled class FQN, e.g. `com.example.app.PreviewsKt`) AND the
+ *     basename of that path matches [fileName]. Maps `com.example.app.
+ *     PreviewsKt` → `com/example/app/Previews.kt`, then globs for that
+ *     suffix. Disambiguates same-named files across modules: a click on
+ *     a frame that's IN the preview's own class file lands on the right
+ *     `Previews.kt` rather than the first one workspace-wide.
+ *  2. **Basename glob** as fallback. The top app frame can be in a
+ *     different file from the preview's class (cross-file throws —
+ *     `Theme.kt` referenced from `Previews.kt`'s preview function), so
+ *     a class-FQN-derived path won't match. Falls back to the same
+ *     `**\/<fileName>` glob the resolver originally used.
  *
  * Silently does nothing when no match is found — the user sees no
  * editor change and a log line, since "open my Previews.kt" failing
  * isn't worth a toast.
  */
-async function openSourceByFileName(fileName: string, line: number): Promise<void> {
+async function openSourceByFileName(
+    fileName: string,
+    line: number,
+    className?: string,
+): Promise<void> {
     if (!fileName) { return; }
     try {
+        // Class-derived path. The Kotlin compiler emits one .class per
+        // top-level Kotlin file, named `<File>Kt`; strip the trailing
+        // "Kt" and convert package-dots to slashes to recover the
+        // original `.kt` source path. Skip when the FQN's basename
+        // doesn't match the stack-trace's basename — the throw isn't in
+        // this preview's own file, so the class-derived path would point
+        // at the wrong source.
+        if (className) {
+            const classFile = className.replace(/Kt$/, '').replace(/\./g, '/') + '.kt';
+            if (path.posix.basename(classFile) === fileName) {
+                const exact = await vscode.workspace.findFiles(`**/${classFile}`, '**/build/**', 1);
+                if (exact.length > 0) {
+                    await openAt(exact[0], line);
+                    return;
+                }
+            }
+        }
+        // Basename fallback for cross-file throws.
         const matches = await vscode.workspace.findFiles(`**/${fileName}`, '**/build/**', 1);
         if (matches.length === 0) {
             logLine(`openSourceByFileName: no match for ${fileName}`);
             return;
         }
-        const doc = await vscode.workspace.openTextDocument(matches[0]);
-        const editor = await vscode.window.showTextDocument(doc);
-        const pos = new vscode.Position(Math.max(0, line - 1), 0);
-        editor.selection = new vscode.Selection(pos, pos);
-        editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+        await openAt(matches[0], line);
     } catch (e: unknown) {
         const message = e instanceof Error ? e.message : String(e);
         logLine(`openSourceByFileName failed for ${fileName}:${line} — ${message}`);
     }
+}
+
+/** Shared open-at-line helper — same shape as the inline body in
+ *  openSourcePosition but takes a Uri instead of a string path. */
+async function openAt(uri: vscode.Uri, line: number): Promise<void> {
+    const doc = await vscode.workspace.openTextDocument(uri);
+    const editor = await vscode.window.showTextDocument(doc);
+    const pos = new vscode.Position(Math.max(0, line - 1), 0);
+    editor.selection = new vscode.Selection(pos, pos);
+    editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
 }
 
 async function runLivePreviewDiff(
@@ -2302,24 +2339,6 @@ async function notifyDaemonViewport(visible: string[], predicted: string[]): Pro
             predictedByModule.get(mod) ?? [],
         );
     }
-}
-
-// Loose type for incoming webview messages (validated per-case above).
-// Field union accommodates every case in handleWebviewMessage so no cast
-// gymnastics are needed at the use site.
-interface WebviewToExtensionMessage {
-    command: string;
-    className?: string;
-    functionName?: string;
-    value?: string;
-    previewId?: string | null;
-    visible?: string[];
-    predicted?: string[];
-    sourceFile?: string;
-    fileName?: string;
-    line?: number;
-    column?: number;
-    against?: 'head' | 'main';
 }
 
 /**

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -999,7 +999,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
          * the full trace is a native details element -- no JS state
          * to manage, browser handles the toggle.
          */
-        function buildErrorPanel(message, renderError) {
+        function buildErrorPanel(message, renderError, className) {
             const panel = document.createElement('div');
             panel.className = 'error-message render-error';
             panel.setAttribute('role', 'alert');
@@ -1035,6 +1035,12 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                         command: 'openSourceFile',
                         fileName: frame.file,
                         line: frame.line,
+                        // className lets the extension disambiguate same-
+                        // named files across modules — when the throw is
+                        // in this preview's own file, the class-derived
+                        // path matches and we pick the right one without
+                        // a workspace-wide first-hit guess.
+                        className: className || undefined,
                     });
                 });
                 panel.appendChild(link);
@@ -1079,7 +1085,9 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             } else if (capture.errorMessage || capture.renderError) {
                 const existingErr = container.querySelector('.error-message');
                 if (existingErr) existingErr.remove();
-                container.appendChild(buildErrorPanel(capture.errorMessage, capture.renderError));
+                container.appendChild(
+                    buildErrorPanel(capture.errorMessage, capture.renderError, card.dataset.className),
+                );
                 card.classList.add('has-error');
             } else {
                 // No data for this capture yet — render will fill it in later.
@@ -1862,7 +1870,9 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                             const skeleton = container.querySelector('.skeleton');
                             if (skeleton) skeleton.remove();
                         }
-                        container.appendChild(buildErrorPanel(msg.message, renderError));
+                        container.appendChild(
+                            buildErrorPanel(msg.message, renderError, errCard.dataset.className),
+                        );
                     }
                     break;
                 }

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -401,11 +401,15 @@ export type WebviewToExtension =
      * basename (from the stack trace's `StackTraceElement.fileName`) —
      * so the extension does a workspace `findFiles('**\/<fileName>')`
      * to resolve it, biased to the first match outside `**\/build/**`.
-     * Ambiguous matches across same-named files in different modules
-     * fall back to the first hit; a richer disambiguation could use
-     * the function name, but that's a follow-up.
+     *
+     * Optional `className` is the FQN of the preview's compiled class
+     * (e.g. `com.example.app.PreviewsKt`) which the extension uses to
+     * disambiguate workspaces with same-named files across modules. If
+     * the basename of the class-derived path matches `fileName` we look
+     * for that exact path first; on no hit (or no `className`) we fall
+     * back to the basename glob.
      */
-    | { command: 'openSourceFile'; fileName: string; line: number }
+    | { command: 'openSourceFile'; fileName: string; line: number; className?: string }
     /**
      * Live panel asks the extension to compute a diff for the focused
      * preview against an anchor. `head` = latest archived render in


### PR DESCRIPTION
> Stacked on top of #390 — re-target to `main` once #390 lands.

Two small follow-ups to the runtime-error work, each independent but small enough to share a PR.

## 1. FQN disambiguation for `openSourceFile`

The card already knows the preview's class FQN (`card.dataset.className` from the manifest); we now forward it along with the stack-frame fileName so the extension can pick the right file when multiple modules contain a same-named source.

The resolver runs two passes:

- **Class-derived path.** When the className-derived path's basename matches the stack-trace fileName (`com.example.app.PreviewsKt` → `com/example/app/Previews.kt`, basename `Previews.kt` matches the stack-trace fileName), glob for that exact path and use it. Fixes the `samples/wear/Previews.kt` vs `samples/cmp/Previews.kt` ambiguity for the common case where the throw is in the preview's own file.
- **Basename glob fallback.** On no hit (or when the throw is cross-file — e.g. a `Theme.kt` referenced from `Previews.kt`'s `@Preview` function), fall back to the original basename glob from #390.

The shared open-at-line body is hoisted into a small `openAt(uri, line)` helper since both passes need the same `vscode.window.showTextDocument` + `revealRange` dance.

## 2. Discriminated-union message typing

`handleWebviewMessage` is now typed against `WebviewToExtension` from `types.ts`. The previous loose interface (every field optional) defeated TypeScript's narrowing inside the switch, so per-case field accesses needed runtime guards just to satisfy the type-checker — the type-checker wasn't actually verifying the message contracts, just the per-field presence.

Now each `case` narrows `msg` to the matching variant. Field accesses are type-guaranteed.

- Dropped redundant runtime checks for fields the union declares as required (`if (msg.previewId)` for `refreshHeavy`, the `typeof msg.line === 'number'` checks on `openCompileError`, etc.).
- Kept the one defensive check that's actually doing work: `Array.isArray(msg.visible)` on `viewportUpdated`. `postMessage`'s typing doesn't survive across the webview ↔ extension bridge, so a buggy webview build could send a string where an array is expected, and we shouldn't crash on that.
- Deleted the `WebviewToExtensionMessage` interface.

## Test plan

- [x] `npm run compile` — clean (and the new typing actually catches mistakes the old interface would have let through)
- [x] `npm test` — 280 passing, no test changes
- [ ] Manual: workspace with `Previews.kt` in two different modules, trigger a render error in one of them. Click the frame link — confirm it opens the file in the *right* module rather than the first hit. Without this PR, would open whichever `Previews.kt` `findFiles` returned first.
- [ ] Manual: cross-file throw (preview function references a broken helper in `Theme.kt`). Click the frame link — confirm it falls through to the basename glob and opens `Theme.kt` (not the preview's own `Previews.kt`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rw5ZRtvu2VaXiTRE9KmNiC)_