### PR TITLE
feat(vscode): add Launch on Device button to preview view

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -102,8 +102,28 @@
                 "command": "composePreview.diffAllVsMain",
                 "title": "Diff All Previews vs Main",
                 "category": "Compose Preview"
+            },
+            {
+                "command": "composePreview.launchOnDevice",
+                "title": "Launch on Device",
+                "category": "Compose Preview",
+                "icon": "$(device-mobile)"
             }
         ],
+        "menus": {
+            "view/title": [
+                {
+                    "command": "composePreview.launchOnDevice",
+                    "when": "view == composePreview.panel",
+                    "group": "navigation@1"
+                },
+                {
+                    "command": "composePreview.refresh",
+                    "when": "view == composePreview.panel",
+                    "group": "navigation@2"
+                }
+            ]
+        },
         "configuration": {
             "title": "Compose Preview",
             "properties": {

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -27,6 +27,12 @@ import { LogFilter, parseLogLevel } from './logFilter';
 import { pickRefreshModeFor, RefreshMode } from './refreshMode';
 import { BuildProgressTracker, mergeCalibration, PhaseDurations } from './buildProgress';
 import { CompileError, extractCompileErrors, DiagnosticLike } from './compileErrors';
+import {
+    collectAndroidApplicationModules,
+    findAndroidSdkRoot,
+    resolveAdbPath,
+    runAdb,
+} from './launchOnDevice';
 
 const DEBOUNCE_MS = 1500;
 // Edits to the currently-scoped preview file (e.g. Claude Code's Edit tool
@@ -608,6 +614,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
             );
         }),
         vscode.commands.registerCommand('composePreview.diffAllVsMain', () => diffAllVsMain()),
+        vscode.commands.registerCommand('composePreview.launchOnDevice',
+            (previewId?: string) => launchOnDevice(previewId)),
     );
     // Refresh applied-markers in the background, then replay the doctor refresh
     // so it picks up any modules that only become visible via the authoritative
@@ -1922,6 +1930,11 @@ function handleWebviewMessage(msg: WebviewToExtensionMessage) {
                 void runLivePreviewDiff(msg.previewId, msg.against);
             }
             break;
+        case 'requestLaunchOnDevice':
+            if (msg.previewId) {
+                void launchOnDevice(msg.previewId);
+            }
+            break;
     }
 }
 
@@ -2100,6 +2113,125 @@ async function runLivePreviewDiff(
  * scaling that up to per-preview stats is N PNG decodes which we skip
  * for the dashboard until performance demands it.
  */
+/**
+ * Builds and installs the consumer module's debug APK and launches its
+ * launcher activity on a connected Android device. Wired up to the
+ * "Launch on Device" panel button (focus-mode toolbar) and the
+ * `composePreview.launchOnDevice` command (view title bar).
+ *
+ * Module resolution, in order:
+ *   1. The owner of [focusedPreviewId], when supplied (the panel button).
+ *   2. The active file's module via [GradleService.resolveModule].
+ *   3. A quick-pick across every Android-application module that applies
+ *      the preview plugin.
+ *
+ * Modules without `id("com.android.application")` (CMP shared, libraries,
+ * Desktop, …) don't have an `installDebug` task, so they're filtered out
+ * before the resolution falls through. When no Android-application module
+ * is found at all, the user gets an explanatory information message
+ * rather than a Gradle "task not found" failure.
+ *
+ * The launch step uses `adb shell monkey -p <id> -c LAUNCHER 1` so the
+ * activity name doesn't need to be hard-coded — `monkey` discovers the
+ * declared launcher activity from the installed package. This is the
+ * same trick AGP's own `:app:run` task uses internally.
+ */
+async function launchOnDevice(focusedPreviewId?: string): Promise<void> {
+    if (!gradleService) {
+        vscode.window.showInformationMessage('Compose Preview is not ready yet.');
+        return;
+    }
+    const previewModules = gradleService.findPreviewModules();
+    const candidates = collectAndroidApplicationModules(
+        gradleService.workspaceRoot, previewModules,
+    );
+    if (candidates.length === 0) {
+        vscode.window.showInformationMessage(
+            'Compose Preview: no Android application module to launch. '
+            + 'Apply id("com.android.application") with an applicationId to a preview module.',
+        );
+        return;
+    }
+
+    let target: { module: string; applicationId: string } | undefined;
+    if (focusedPreviewId) {
+        const owner = previewModuleMap.get(focusedPreviewId);
+        if (owner) { target = candidates.find(c => c.module === owner); }
+    }
+    if (!target && currentScopeFile) {
+        const scoped = gradleService.resolveModule(currentScopeFile);
+        if (scoped) { target = candidates.find(c => c.module === scoped); }
+    }
+    if (!target) {
+        if (candidates.length === 1) {
+            target = candidates[0];
+        } else {
+            const picked = await vscode.window.showQuickPick(
+                candidates.map(c => ({
+                    label: c.module,
+                    description: c.applicationId,
+                    candidate: c,
+                })),
+                { placeHolder: 'Pick an Android application module to launch' },
+            );
+            if (!picked) { return; }
+            target = picked.candidate;
+        }
+    }
+
+    const { module, applicationId } = target;
+    logLine(`launchOnDevice: ${module} (${applicationId})`);
+
+    await vscode.window.withProgress(
+        {
+            location: vscode.ProgressLocation.Notification,
+            title: `Compose Preview: launching ${applicationId} on device`,
+            cancellable: false,
+        },
+        async (progress) => {
+            progress.report({ message: 'Building & installing (installDebug)…' });
+            try {
+                await gradleService!.installDebug(module);
+            } catch (e: unknown) {
+                if (e instanceof TaskCancelledError) { return; }
+                const m = e instanceof Error ? e.message : String(e);
+                vscode.window.showErrorMessage(
+                    `Compose Preview: installDebug failed — ${m}`,
+                );
+                return;
+            }
+
+            progress.report({ message: 'Starting launcher activity (adb)…' });
+            const sdkRoot = findAndroidSdkRoot(gradleService!.workspaceRoot);
+            const adbPath = resolveAdbPath(sdkRoot);
+            try {
+                const result = await runAdb(adbPath, [
+                    'shell', 'monkey', '-p', applicationId,
+                    '-c', 'android.intent.category.LAUNCHER', '1',
+                ]);
+                if (result.code !== 0) {
+                    const detail = (result.stderr || result.stdout || '').trim();
+                    vscode.window.showErrorMessage(
+                        `Compose Preview: adb failed to start ${applicationId}` +
+                        (detail ? ` — ${detail}` : '.'),
+                    );
+                    return;
+                }
+            } catch (e: unknown) {
+                const m = e instanceof Error ? e.message : String(e);
+                vscode.window.showErrorMessage(
+                    `Compose Preview: could not run adb (${adbPath}) — ${m}. ` +
+                    'Set ANDROID_HOME or sdk.dir in local.properties.',
+                );
+                return;
+            }
+            vscode.window.showInformationMessage(
+                `Compose Preview: launched ${applicationId} on device.`,
+            );
+        },
+    );
+}
+
 async function diffAllVsMain(): Promise<void> {
     if (!gradleService || !panel || !historySource) {
         vscode.window.showInformationMessage('Compose Preview is not ready yet.');

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -236,6 +236,17 @@ export class GradleService {
     }
 
     /**
+     * Runs `:<module>:installDebug` to build and install the consumer's
+     * `com.android.application` APK on the connected device. Used by the
+     * "Launch on Device" panel button — `adb shell am start` follows
+     * separately. Throws on failure (e.g. no device, build error) so the
+     * caller can surface the message to the user.
+     */
+    async installDebug(module: string, opts?: TaskOptions): Promise<void> {
+        await this.runTask(`${gradleProjectPath(module)}:installDebug`, [], opts);
+    }
+
+    /**
      * Runs `:<module>:composePreviewDoctor` and returns the parsed sidecar
      * report. Same JSON schema as `compose-preview doctor --json`'s per-
      * module shape — see `ComposePreviewDoctorTask.kt` in `gradle-plugin`.

--- a/vscode-extension/src/launchOnDevice.ts
+++ b/vscode-extension/src/launchOnDevice.ts
@@ -1,0 +1,161 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { spawn } from 'child_process';
+
+/**
+ * Helpers for the "Launch on Device" panel button. This module is
+ * intentionally `vscode`-free so it can be unit-tested under plain mocha.
+ *
+ * The flow is: detect Android-application modules among the workspace's
+ * preview modules, resolve their `applicationId`, then drive `adb shell
+ * monkey -p <applicationId> -c android.intent.category.LAUNCHER 1` to
+ * start the consumer's app on a connected device. Build + install is
+ * handled separately via Gradle's `:<module>:installDebug` task.
+ */
+
+const ANDROID_APPLICATION_PLUGIN_ID_RE =
+    /\bid\s*[(\s]\s*["']com\.android\.application["']/;
+const ANDROID_APPLICATION_ALIAS_RE =
+    /\balias\s*\(\s*libs\.plugins\.android\.application\s*\)/;
+const APPLICATION_ID_RE = /\bapplicationId\s*=\s*["']([^"']+)["']/;
+const APPLY_FALSE_RE = /\bapply\s+false\b/;
+
+export interface AndroidApplicationInfo {
+    /** Fully-qualified `applicationId` declared in `defaultConfig`. */
+    applicationId: string;
+}
+
+/**
+ * Parse `build.gradle.kts` content to determine whether the module is an
+ * Android *application* (not a library) and, if so, extract its
+ * `applicationId`. Returns `null` when the module isn't an Android app
+ * or when no `applicationId` is declared.
+ *
+ * Only the literal-id form (`id("com.android.application")`) and the
+ * version-catalog alias form (`alias(libs.plugins.android.application)`)
+ * are recognised — that covers every sample in this repo and the typical
+ * AGP-bootstrapped consumer project. Lines containing `apply false` are
+ * skipped (root-build pattern where the plugin is declared but not
+ * applied in the current module).
+ */
+export function parseAndroidApplicationInfo(
+    buildGradleContent: string,
+): AndroidApplicationInfo | null {
+    const lines = buildGradleContent.split(/\r?\n/);
+    let isAndroidApp = false;
+    for (const line of lines) {
+        if (APPLY_FALSE_RE.test(line)) { continue; }
+        if (ANDROID_APPLICATION_PLUGIN_ID_RE.test(line)
+            || ANDROID_APPLICATION_ALIAS_RE.test(line)) {
+            isAndroidApp = true;
+            break;
+        }
+    }
+    if (!isAndroidApp) { return null; }
+    const m = APPLICATION_ID_RE.exec(buildGradleContent);
+    if (!m) { return null; }
+    return { applicationId: m[1] };
+}
+
+/**
+ * Resolve the Android SDK root, in the order Android Studio / Gradle
+ * themselves use:
+ *
+ *   1. `$ANDROID_HOME` / `$ANDROID_SDK_ROOT`
+ *   2. `local.properties`'s `sdk.dir=` line at the workspace root
+ *   3. `~/Library/Android/sdk` (macOS) or `~/Android/Sdk` (Linux), if it exists
+ *
+ * Returns null when no path is found — callers should fall back to
+ * resolving `adb` from `PATH`.
+ */
+export function findAndroidSdkRoot(workspaceRoot: string): string | null {
+    const fromEnv = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT;
+    if (fromEnv && fs.existsSync(fromEnv)) { return fromEnv; }
+    const localProps = path.join(workspaceRoot, 'local.properties');
+    try {
+        const content = fs.readFileSync(localProps, 'utf-8');
+        for (const line of content.split(/\r?\n/)) {
+            const m = /^\s*sdk\.dir\s*=\s*(.+?)\s*$/.exec(line);
+            if (m) {
+                const dir = m[1].trim();
+                if (fs.existsSync(dir)) { return dir; }
+            }
+        }
+    } catch { /* no local.properties — fall through */ }
+    const home = os.homedir();
+    const candidates = [
+        path.join(home, 'Library', 'Android', 'sdk'),
+        path.join(home, 'Android', 'Sdk'),
+    ];
+    for (const c of candidates) {
+        if (fs.existsSync(c)) { return c; }
+    }
+    return null;
+}
+
+/**
+ * Resolve the path to `adb`. When [sdkRoot] is provided we point at
+ * `<sdk>/platform-tools/adb` (or `adb.exe` on Windows); otherwise we
+ * return the bare name and trust the caller's `PATH`.
+ */
+export function resolveAdbPath(sdkRoot: string | null): string {
+    if (!sdkRoot) { return 'adb'; }
+    const exe = process.platform === 'win32' ? 'adb.exe' : 'adb';
+    return path.join(sdkRoot, 'platform-tools', exe);
+}
+
+export interface AdbResult {
+    code: number;
+    stdout: string;
+    stderr: string;
+}
+
+/**
+ * Run `adb` with the given arguments. Resolves on exit regardless of
+ * status code — callers inspect [AdbResult.code] to distinguish success
+ * from failure (adb returns non-zero on "no devices", "no app installed",
+ * etc., and we want to surface those as readable messages rather than
+ * generic spawn failures).
+ *
+ * Rejects only when `adb` itself can't be spawned (binary not found).
+ */
+export function runAdb(adbPath: string, args: string[]): Promise<AdbResult> {
+    return new Promise((resolve, reject) => {
+        const proc = spawn(adbPath, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+        let stdout = '';
+        let stderr = '';
+        proc.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+        proc.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+        proc.on('error', reject);
+        proc.on('close', (code) => {
+            resolve({ code: code ?? -1, stdout, stderr });
+        });
+    });
+}
+
+/**
+ * Filter [modules] to those whose `build.gradle.kts` applies the
+ * Android-application plugin and declares an `applicationId`. Returns a
+ * sorted list of `{module, applicationId}` pairs. Modules that can't be
+ * read or aren't Android applications are silently skipped.
+ */
+export function collectAndroidApplicationModules(
+    workspaceRoot: string,
+    modules: Iterable<string>,
+): Array<{ module: string; applicationId: string }> {
+    const out: Array<{ module: string; applicationId: string }> = [];
+    for (const module of modules) {
+        const buildFile = path.join(workspaceRoot, module, 'build.gradle.kts');
+        let content: string;
+        try {
+            content = fs.readFileSync(buildFile, 'utf-8');
+        } catch {
+            continue;
+        }
+        const info = parseAndroidApplicationInfo(content);
+        if (info) { out.push({ module, applicationId: info.applicationId }); }
+    }
+    out.sort((a, b) => a.module.localeCompare(b.module));
+    return out;
+}

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -107,6 +107,9 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         <button class="icon-button" id="btn-diff-main" title="Diff vs the latest render archived on main" aria-label="Diff vs main">
             <i class="codicon codicon-source-control" aria-hidden="true"></i>
         </button>
+        <button class="icon-button" id="btn-launch-device" title="Launch on connected Android device" aria-label="Launch on device">
+            <i class="codicon codicon-device-mobile" aria-hidden="true"></i>
+        </button>
         <button class="icon-button" id="btn-exit-focus" title="Exit focus mode" aria-label="Exit focus mode">
             <i class="codicon codicon-close" aria-hidden="true"></i>
         </button>
@@ -128,6 +131,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         const btnNext = document.getElementById('btn-next');
         const btnDiffHead = document.getElementById('btn-diff-head');
         const btnDiffMain = document.getElementById('btn-diff-main');
+        const btnLaunchDevice = document.getElementById('btn-launch-device');
         const btnExitFocus = document.getElementById('btn-exit-focus');
         const focusPosition = document.getElementById('focus-position');
         const progressBar = document.getElementById('progress-bar');
@@ -317,6 +321,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         btnNext.addEventListener('click', () => navigateFocus(1));
         btnDiffHead.addEventListener('click', () => requestFocusedDiff('head'));
         btnDiffMain.addEventListener('click', () => requestFocusedDiff('main'));
+        btnLaunchDevice.addEventListener('click', () => requestLaunchOnDevice());
         btnExitFocus.addEventListener('click', () => exitFocus());
 
         // Document-level Left/Right in focus mode steps between cards. The
@@ -530,6 +535,21 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             if (!previewId) return;
             showDiffOverlay(card, against, null, null);
             vscode.postMessage({ command: 'requestPreviewDiff', previewId, against });
+        }
+
+        // Live-panel "Launch on Device": runs the consumer's
+        // installDebug task and uses adb to start the launcher activity on
+        // a connected device. Only meaningful when one preview is focused
+        // -- the extension uses the focused previewId to pick the owning
+        // module before falling back to a quick-pick.
+        function requestLaunchOnDevice() {
+            if (layoutMode.value !== 'focus') return;
+            const visible = getVisibleCards();
+            const card = visible[focusIndex];
+            if (!card) return;
+            const previewId = card.dataset.previewId;
+            if (!previewId) return;
+            vscode.postMessage({ command: 'requestLaunchOnDevice', previewId });
         }
 
         function showDiffOverlay(card, against, payload, errorMessage) {

--- a/vscode-extension/src/test/launchOnDevice.test.ts
+++ b/vscode-extension/src/test/launchOnDevice.test.ts
@@ -1,0 +1,196 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    collectAndroidApplicationModules,
+    findAndroidSdkRoot,
+    parseAndroidApplicationInfo,
+    resolveAdbPath,
+} from '../launchOnDevice';
+
+function withTempDir(fn: (dir: string) => void | Promise<void>): () => Promise<void> {
+    return async () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'compose-preview-launch-'));
+        try {
+            await fn(dir);
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    };
+}
+
+describe('parseAndroidApplicationInfo', () => {
+    it('extracts applicationId when literal id() is used', () => {
+        const content = `
+            plugins {
+                id("com.android.application")
+                id("ee.schimke.composeai.preview")
+            }
+            android {
+                namespace = "com.example.foo"
+                defaultConfig {
+                    applicationId = "com.example.foo"
+                }
+            }
+        `;
+        assert.deepStrictEqual(
+            parseAndroidApplicationInfo(content),
+            { applicationId: 'com.example.foo' },
+        );
+    });
+
+    it('extracts applicationId when version-catalog alias is used', () => {
+        const content = `
+            plugins {
+                alias(libs.plugins.android.application)
+            }
+            android {
+                defaultConfig { applicationId = "com.example.bar" }
+            }
+        `;
+        assert.deepStrictEqual(
+            parseAndroidApplicationInfo(content),
+            { applicationId: 'com.example.bar' },
+        );
+    });
+
+    it('returns null for an Android library', () => {
+        const content = `
+            plugins {
+                id("com.android.library")
+            }
+            android {
+                defaultConfig { applicationId = "ignored.because.library" }
+            }
+        `;
+        assert.strictEqual(parseAndroidApplicationInfo(content), null);
+    });
+
+    it('returns null when applicationId is missing', () => {
+        const content = `
+            plugins { id("com.android.application") }
+            android { defaultConfig { } }
+        `;
+        assert.strictEqual(parseAndroidApplicationInfo(content), null);
+    });
+
+    it('skips apply-false declarations (root build pattern)', () => {
+        const content = `
+            plugins {
+                id("com.android.application") apply false
+            }
+            applicationId = "ignored.because.apply.false"
+        `;
+        assert.strictEqual(parseAndroidApplicationInfo(content), null);
+    });
+
+    it('handles single-quoted id()', () => {
+        const content = `
+            plugins { id 'com.android.application' }
+            applicationId = "com.example.sq"
+        `;
+        assert.deepStrictEqual(
+            parseAndroidApplicationInfo(content),
+            { applicationId: 'com.example.sq' },
+        );
+    });
+});
+
+describe('resolveAdbPath', () => {
+    it('returns the bare name when no sdk root is given', () => {
+        assert.strictEqual(resolveAdbPath(null), 'adb');
+    });
+
+    it('joins platform-tools when sdk root is given', () => {
+        const sdk = path.join(os.tmpdir(), 'fake-sdk');
+        const got = resolveAdbPath(sdk);
+        const expected = path.join(
+            sdk,
+            'platform-tools',
+            process.platform === 'win32' ? 'adb.exe' : 'adb',
+        );
+        assert.strictEqual(got, expected);
+    });
+});
+
+describe('findAndroidSdkRoot', () => {
+    it('reads sdk.dir from local.properties', withTempDir((dir) => {
+        const fakeSdk = fs.mkdtempSync(path.join(os.tmpdir(), 'fake-sdk-'));
+        try {
+            fs.writeFileSync(path.join(dir, 'local.properties'), `sdk.dir=${fakeSdk}\n`);
+            const original = { home: process.env.ANDROID_HOME, root: process.env.ANDROID_SDK_ROOT };
+            delete process.env.ANDROID_HOME;
+            delete process.env.ANDROID_SDK_ROOT;
+            try {
+                assert.strictEqual(findAndroidSdkRoot(dir), fakeSdk);
+            } finally {
+                if (original.home !== undefined) { process.env.ANDROID_HOME = original.home; }
+                if (original.root !== undefined) { process.env.ANDROID_SDK_ROOT = original.root; }
+            }
+        } finally {
+            fs.rmSync(fakeSdk, { recursive: true, force: true });
+        }
+    }));
+
+    it('prefers ANDROID_HOME over local.properties when both are set', withTempDir((dir) => {
+        const fakeEnvSdk = fs.mkdtempSync(path.join(os.tmpdir(), 'env-sdk-'));
+        const fakePropsSdk = fs.mkdtempSync(path.join(os.tmpdir(), 'props-sdk-'));
+        try {
+            fs.writeFileSync(path.join(dir, 'local.properties'), `sdk.dir=${fakePropsSdk}\n`);
+            const originalHome = process.env.ANDROID_HOME;
+            process.env.ANDROID_HOME = fakeEnvSdk;
+            try {
+                assert.strictEqual(findAndroidSdkRoot(dir), fakeEnvSdk);
+            } finally {
+                if (originalHome !== undefined) {
+                    process.env.ANDROID_HOME = originalHome;
+                } else {
+                    delete process.env.ANDROID_HOME;
+                }
+            }
+        } finally {
+            fs.rmSync(fakeEnvSdk, { recursive: true, force: true });
+            fs.rmSync(fakePropsSdk, { recursive: true, force: true });
+        }
+    }));
+});
+
+describe('collectAndroidApplicationModules', () => {
+    it('keeps only modules with com.android.application + applicationId', withTempDir((dir) => {
+        const app = path.join(dir, 'samples', 'app');
+        const lib = path.join(dir, 'samples', 'lib');
+        const cmp = path.join(dir, 'samples', 'cmp');
+        for (const d of [app, lib, cmp]) { fs.mkdirSync(d, { recursive: true }); }
+        fs.writeFileSync(path.join(app, 'build.gradle.kts'), `
+            plugins { id("com.android.application") }
+            android { defaultConfig { applicationId = "com.example.app" } }
+        `);
+        fs.writeFileSync(path.join(lib, 'build.gradle.kts'), `
+            plugins { id("com.android.library") }
+        `);
+        fs.writeFileSync(path.join(cmp, 'build.gradle.kts'), `
+            plugins { kotlin("multiplatform") }
+        `);
+
+        const got = collectAndroidApplicationModules(dir, [
+            'samples/app', 'samples/lib', 'samples/cmp',
+        ]);
+        assert.deepStrictEqual(got, [
+            { module: 'samples/app', applicationId: 'com.example.app' },
+        ]);
+    }));
+
+    it('returns sorted output', withTempDir((dir) => {
+        for (const name of ['z-app', 'a-app']) {
+            const m = path.join(dir, name);
+            fs.mkdirSync(m, { recursive: true });
+            fs.writeFileSync(path.join(m, 'build.gradle.kts'), `
+                plugins { id("com.android.application") }
+                android { defaultConfig { applicationId = "com.example.${name.replace('-', '')}" } }
+            `);
+        }
+        const got = collectAndroidApplicationModules(dir, ['z-app', 'a-app']);
+        assert.deepStrictEqual(got.map(x => x.module), ['a-app', 'z-app']);
+    }));
+});

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -412,4 +412,13 @@ export type WebviewToExtension =
      * `.compose-preview-history/` for this preview; `main` = same, filtered
      * to entries whose `git.branch` is `main`.
      */
-    | { command: 'requestPreviewDiff'; previewId: string; against: 'head' | 'main' };
+    | { command: 'requestPreviewDiff'; previewId: string; against: 'head' | 'main' }
+    /**
+     * Click on the "Launch on Device" button in the focus-mode toolbar.
+     * The extension uses [previewId] to bias module selection (the owner
+     * of the focused preview), then runs the consumer module's
+     * `installDebug` task and starts its launcher activity via `adb`.
+     * Falls back to a quick-pick when more than one Android-application
+     * module applies the plugin.
+     */
+    | { command: 'requestLaunchOnDevice'; previewId: string };


### PR DESCRIPTION
Adds a `composePreview.launchOnDevice` command, surfaced both as a
view-title button on the Previews panel and as an icon in the
focus-mode toolbar. The handler picks the focused preview's owning
module (or falls back to the active scope / a quick-pick across
Android-application modules), runs `:<module>:installDebug`, then
starts the launcher activity via `adb shell monkey -p <id> -c
LAUNCHER 1`. SDK root is resolved from $ANDROID_HOME, local.properties
or the standard per-OS user paths.