### PR TITLE
feat(vscode): live-stream interactive mode in focus view (daemon-only)

### DIFF
--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -1,0 +1,235 @@
+# Interactive mode (VS Code panel ↔ daemon)
+
+> **Status:** v0 — live-streaming surface in the VS Code webview, behind the
+> `composePreview.experimental.daemon.enabled` flag. Click-input is a
+> documented future extension; no protocol bump required to ship today's
+> behaviour. See [PROTOCOL.md](PROTOCOL.md) for the wire contract this builds
+> on.
+
+## 1. What it is
+
+A new **focus-mode toggle** in the live preview panel that turns a single
+focused preview into a "live" stream: every render the daemon pushes lands
+on the card immediately, with a visible affordance (a pulsing **LIVE**
+badge) so the user knows they're looking at the freshest possible bytes
+rather than the last save's render.
+
+Today this rides entirely on the existing `renderFinished` notification —
+the daemon is already pushing per-render PNG paths over the v1 protocol
+(see [PROTOCOL.md § 6](PROTOCOL.md#6-daemon--client-notifications)) and the
+panel is already wired to swap them in via `updateImage`. Interactive mode
+is the **UI shell** that:
+
+1. Pins the focused preview as the daemon's render priority (`setFocus`).
+2. Swaps `<img>` bytes without the `fade-in` animation that normally tags a
+   one-off render — successive frames need to read as a stream, not as a
+   sequence of independent reloads.
+3. Surfaces "daemon not ready for this module" cleanly: the toggle is
+   disabled with a tooltip rather than failing silently.
+4. Captures mouse-click coordinates on the rendered image and **logs them
+   to the extension output channel** for now, so the wire shape is
+   exercised and the click-target geometry is debuggable before any
+   round-trip RPC ships.
+
+## 2. Why daemon-only
+
+The Gradle path's "render previews" task takes seconds even on a warm
+build. Streaming a sequence of frames at that latency would feel like
+nothing — the user can't tell the difference between live mode and the
+existing save-debounce loop. Sub-second push is the whole point.
+
+A toggle that's silently a no-op when the daemon is off is worse than no
+toggle. So the affordance is **only rendered** when the gate reports the
+daemon is healthy for the focused preview's owning module
+(`DaemonGate.isDaemonReady(moduleId)`). If the daemon dies mid-session the
+toggle disables itself; if the user toggles the daemon flag off in
+settings, the toggle vanishes on the next focus change.
+
+## 3. UI surface
+
+Lives inside `focus-controls` next to the existing diff / launch-on-device
+buttons. Visible only when:
+
+- `layout-mode === 'focus'`
+- The currently focused preview's module has a healthy daemon (extension
+  pushes a `setInteractiveAvailability` message on daemon up/down).
+
+```
+[ ◄ ] 1/3 [ ► ]  [ ⟂HEAD ] [ ⟂main ] [ 🌐 device ]  [ 🔴 LIVE ] [ × ]
+                                                       ──new──
+```
+
+Toggle states:
+
+| State        | Icon                                 | Tooltip                                    |
+|--------------|--------------------------------------|--------------------------------------------|
+| Disabled     | `circle-large-outline` (codicon)     | "Daemon not ready — live mode unavailable" |
+| Off (ready)  | `circle-large-outline`               | "Enter live mode (stream renders)"         |
+| On           | `record` (red)                       | "Live · click to exit"                     |
+
+When ON, the focused card carries:
+
+- `.preview-card.live` class (CSS adds a 1-pixel red border and a
+  bottom-right pulsing **LIVE** chip).
+- `<img>` swaps clear `.fade-in`, so the next paint reads as a frame
+  update, not a card reload.
+- Click on the image is handled by `recordInteractiveClick(card, event)`
+  which dispatches a `recordInteractiveClick` webview→extension message
+  with image-pixel coordinates (see § 6).
+
+## 4. Lifecycle
+
+```
+user clicks LIVE
+   │
+   ▼
+webview→ext: { command: 'setInteractive', previewId, enabled: true }
+   │
+   ▼
+extension:
+  - resolves moduleId from previewModuleMap
+  - daemonScheduler.setFocus(moduleId, [previewId])      // pin priority
+  - daemonScheduler.renderNow(moduleId, [previewId],
+                              tier='fast', reason='interactive-on')
+  - logs '[interactive] live mode on for <previewId>'
+   │
+   ▼
+daemon emits renderFinished(previewId, pngPath)
+   │
+   ▼
+scheduler reads PNG, posts updateImage to webview
+   │
+   ▼
+webview repaints the focused card (no fade-in when .live is active)
+```
+
+Exit path is symmetric: `setInteractive { enabled: false }` clears the
+`.live` class and sends nothing further to the daemon (focus reverts to
+whatever the next save / focus-change publishes).
+
+## 5. What changes in the extension
+
+- `vscode-extension/src/types.ts` — new `WebviewToExtension` variants
+  `setInteractive`, `recordInteractiveClick`; new `ExtensionToWebview`
+  variant `setInteractiveAvailability` (per-module ready/not-ready
+  signal).
+- `vscode-extension/src/previewPanel.ts` — toggle button, LIVE badge,
+  click handler, gate visibility on `setInteractiveAvailability`.
+- `vscode-extension/src/extension.ts` — `setInteractive` handler that
+  drives `daemonScheduler.setFocus` + `renderNow`. Polls
+  `daemonGate.isDaemonReady` on focus changes / daemon channel
+  open/close events and pushes availability to the panel.
+- `vscode-extension/src/daemon/daemonProtocol.ts` — reserved type
+  shapes for the future `interactive/start`, `interactive/stop`,
+  `interactive/input` methods (§ 7). **No wire calls today** — we keep
+  the types co-located so a future daemon implementation lands in
+  lockstep without a schema reshuffle.
+
+## 6. Click capture (today)
+
+The webview attaches a click handler to the focused card's `<img>`
+**only when `.live` is set**. On click it computes:
+
+```ts
+{
+  command: 'recordInteractiveClick',
+  previewId,
+  // Coordinates in IMAGE-NATURAL pixel space (i.e. the same pixel space
+  // the daemon's renderer thinks in). Webview reads naturalWidth/Height
+  // and scales the offsetX/Y by their displayed-vs-natural ratio.
+  pixelX: number,
+  pixelY: number,
+  imageWidth: number,
+  imageHeight: number,
+}
+```
+
+Extension logs the message to the output channel. **No daemon call is
+issued today.** Once `interactive/input` lands (§ 7) the same payload
+shape feeds the RPC.
+
+## 7. Future: click-input RPC (reserved)
+
+The protocol additions are documented here so the wire contract is fixed
+before any daemon implementation. Adding these methods does **not** bump
+`protocolVersion` — they're additive and unknown methods are dropped per
+[PROTOCOL.md § 7](PROTOCOL.md#7-versioning).
+
+### `interactive/start` (request, client → daemon)
+
+```ts
+// params
+{ previewId: string }
+// result
+{ frameStreamId: string }           // opaque; passed back in interactive/input
+```
+
+Tells the daemon "this preview is the user's interactive target — keep a
+warm sandbox for it, prefer it on every render-queue drain, do NOT recycle
+its sandbox on idle." Returns a stream id the client uses for input
+correlation. Multiple `start` calls overwrite the prior target (one
+interactive preview at a time — matches the panel's single-focus mode).
+
+### `interactive/stop` (notification, client → daemon)
+
+```ts
+{ frameStreamId: string }
+```
+
+Releases the warm-sandbox lock. Daemon resumes normal recycling
+heuristics. Idempotent — a stop after stop is a no-op.
+
+### `interactive/input` (notification, client → daemon)
+
+```ts
+{
+  frameStreamId: string;
+  kind: 'click' | 'pointerDown' | 'pointerUp' | 'keyDown' | 'keyUp';
+  // Image-natural pixel coordinates. Daemon translates to dp using the
+  // last render's density. Null for keyboard events.
+  pixelX?: number;
+  pixelY?: number;
+  // For 'keyDown'/'keyUp' only.
+  keyCode?: string;
+}
+```
+
+Notification not request: input fires-and-forgets. The daemon dispatches
+the input into the active composition (mechanism TBD — likely
+`@TestSemantics` paths in the renderer) and emits a fresh
+`renderFinished` for the same `previewId` once the composition settles.
+Backpressure is the panel's responsibility: don't send a new click before
+the prior frame arrives. Lost inputs are acceptable; the user will
+re-click.
+
+### Open questions for the future protocol
+
+1. **Coalescing.** Should the daemon coalesce a burst of `pointerMove` into
+   one render, or render every event? Today's frame budget says coalesce
+   to ~60 Hz max with the most recent state. Defer until pointer events
+   ship — click-only is fine without coalescing.
+2. **Input-only vs full re-render.** A click that mutates Compose state
+   only needs to recompose; we can probably skip the
+   `setQualifiers`/sandbox setup. Daemon-side optimisation, not visible
+   on the wire.
+3. **Hit testing.** The renderer needs to know which composable received
+   the click. For PNG-only output this is "send pixel coords, let Compose
+   figure it out via its existing pointer-input pipeline." Works as long
+   as `LocalInspectionMode = false` during interactive renders — see
+   [DESIGN § 8](DESIGN.md) on the inspection-mode trade-off.
+
+## 8. Out of scope (v0)
+
+- **Continuous-stream rendering** in the absence of edits/clicks. v0
+  treats `renderFinished` as the streaming heartbeat — no edits, no new
+  frames. Animations remain the carousel's responsibility.
+- **Multi-preview simultaneous live mode.** One focused preview, one
+  `.live` card. The future `interactive/start` API formalises this with
+  the "overwrites prior target" semantics.
+- **Mouse-move / drag** events. Click is the smallest first surface; we
+  reserve the wire shape but don't capture moves to keep the
+  implementation honest.
+- **Pixel-accurate pointer mapping** for previews with non-default
+  density / scaling. v0 sends pixel coords and lets the future daemon
+  resolve density. The webview reports both displayed and natural sizes
+  in case a future client wants to do the math itself.

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -483,6 +483,60 @@ body {
     animation: fadeIn 0.2s ease-in;
 }
 
+/* Interactive (live-stream) mode — see docs/daemon/INTERACTIVE.md.
+   Successive frames carry .live-frame instead of .fade-in so the user
+   reads the swap as a stream, not as independent reloads. */
+.image-container img.live-frame {
+    /* No animation: the next frame replaces the current one with no fade. */
+    animation: none;
+}
+
+/* Subtle red border telegraphs that the focused card is the current
+   live target. Bottom-right pill shows LIVE + a pulsing dot — the same
+   visual language as recording indicators in screen-share apps so the
+   meaning lands without a tooltip. */
+.preview-card.live {
+    border-color: color-mix(in srgb, var(--vscode-errorForeground, #f55) 60%, transparent);
+}
+.preview-card.live .image-container {
+    cursor: crosshair; /* hint at the future click-input surface */
+}
+.live-badge {
+    position: absolute;
+    bottom: 6px;
+    right: 6px;
+    z-index: 4;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: color-mix(in srgb, var(--vscode-editor-background) 70%, transparent);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    color: var(--vscode-errorForeground, #f55);
+    font-size: calc(var(--vscode-font-size) - 2px);
+    font-weight: 600;
+    letter-spacing: 0.5px;
+    pointer-events: none;
+}
+.live-badge-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--vscode-errorForeground, #f55);
+    animation: liveBlink 1.2s ease-in-out infinite;
+}
+@keyframes liveBlink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.35; }
+}
+
+/* Toggle button "live-on" state: red glyph echoing the badge. */
+.icon-button.live-on {
+    color: var(--vscode-errorForeground, #f55);
+}
+
 /* Diff overlay — covers the focused image with a side-by-side comparison
    when the user clicks Diff vs HEAD / vs main. Lives inside the
    .image-container so it inherits the card's bounds and exits cleanly via

--- a/vscode-extension/src/daemon/daemonClient.ts
+++ b/vscode-extension/src/daemon/daemonClient.ts
@@ -14,6 +14,10 @@ import {
     HistoryReadResult,
     InitializeParams,
     InitializeResult,
+    InteractiveInputParams,
+    InteractiveStartParams,
+    InteractiveStartResult,
+    InteractiveStopParams,
     JsonRpcError,
     JsonRpcNotification,
     JsonRpcRequest,
@@ -149,6 +153,34 @@ export class DaemonClient {
      *  PROTOCOL.md § 5 (history/diff). */
     historyDiff(params: HistoryDiffParams): Promise<HistoryDiffResult> {
         return this.request<HistoryDiffResult>('history/diff', params);
+    }
+
+    /**
+     * Interactive mode (reserved — see docs/daemon/INTERACTIVE.md § 7).
+     *
+     * Tells the daemon "this preview is the user's interactive target." Pins
+     * a warm sandbox to it and returns an opaque stream id used to correlate
+     * later `interactiveInput` notifications. **Not yet implemented by any
+     * shipped daemon** — calling against a v1.0 daemon rejects with
+     * `MethodNotFound (-32601)`. The wire shape is locked so a future
+     * lockstep landing in `daemon/core` doesn't reshuffle the client.
+     */
+    interactiveStart(params: InteractiveStartParams): Promise<InteractiveStartResult> {
+        return this.request<InteractiveStartResult>('interactive/start', params);
+    }
+
+    /** Symmetric to {@link interactiveStart}. Idempotent — extra stops are
+     *  no-ops. Notification, not request: drop-and-go semantics. */
+    interactiveStop(params: InteractiveStopParams): void {
+        this.notify('interactive/stop', params);
+    }
+
+    /** Notification (drop-and-go). The daemon dispatches the input into the
+     *  active composition and emits a fresh `renderFinished` once it
+     *  settles. Backpressure is the caller's job — don't issue a new input
+     *  before the prior frame arrives. */
+    interactiveInput(params: InteractiveInputParams): void {
+        this.notify('interactive/input', params);
     }
 
     /** Drains in-flight renders, then resolves. Daemon will not exit until `exit` fires. */

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -264,6 +264,42 @@ export interface HistoryAddedParams {
     entry: unknown;
 }
 
+// Interactive mode (reserved — see docs/daemon/INTERACTIVE.md § 7).
+//
+// The wire shapes below are documented but **not** spoken by today's daemon.
+// They live here so a future protocol implementation lands without a schema
+// reshuffle, and so the TypeScript client can grow input-emission code in
+// lockstep with the daemon work. Adding these methods is additive per
+// PROTOCOL.md § 7 — no `protocolVersion` bump required.
+
+export interface InteractiveStartParams { previewId: string }
+export interface InteractiveStartResult {
+    /** Opaque correlation id; the client passes it back on every input
+     *  notification so the daemon can route inputs to the right warm
+     *  sandbox even if the user toggles between previews. */
+    frameStreamId: string;
+}
+
+export interface InteractiveStopParams { frameStreamId: string }
+
+export type InteractiveInputKind =
+    | 'click'
+    | 'pointerDown'
+    | 'pointerUp'
+    | 'keyDown'
+    | 'keyUp';
+
+export interface InteractiveInputParams {
+    frameStreamId: string;
+    kind: InteractiveInputKind;
+    /** Image-natural pixel coordinates. Daemon resolves to dp using the
+     *  last-render density. Omit for keyboard events. */
+    pixelX?: number;
+    pixelY?: number;
+    /** For `keyDown` / `keyUp`. */
+    keyCode?: string;
+}
+
 /**
  * Wire format of `<module>/build/compose-previews/daemon-launch.json`,
  * authored by `DaemonBootstrapTask`. See

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -353,6 +353,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
             // closed handler in DaemonGate evicts the entry. Next save runs
             // Gradle, which re-bootstraps a fresh daemon when the user
             // re-enables it via composePreviewDaemonStart.
+            // Drop the interactive-mode availability so any open LIVE chip
+            // disables itself instead of streaming stale frames from a
+            // soon-to-die daemon.
+            publishInteractiveAvailability(moduleId);
         },
         onDiscoveryUpdated: (moduleId, params) => {
             // Daemon emits this only when the in-memory preview index drifted
@@ -1125,6 +1129,13 @@ async function warmDaemonForFile(filePath: string): Promise<void> {
  * time no module is in flight.
  */
 function updateDaemonStatus(module: string, state: WarmState): void {
+    // Push availability for the interactive (live-stream) toggle on every
+    // state transition. Done outside the !daemonStatusItem early-return so
+    // tests that drive activate() without a status bar still see the
+    // panel-side state propagate. Cheap: a no-op when panel isn't open.
+    if (state === 'ready' || state === 'fallback') {
+        publishInteractiveAvailability(module);
+    }
     if (!daemonStatusItem) { return; }
     if (daemonStatusClearTimer) {
         clearTimeout(daemonStatusClearTimer);
@@ -1933,6 +1944,17 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                 void launchOnDevice(msg.previewId);
             }
             break;
+        case 'setInteractive':
+            void handleSetInteractive(msg.previewId, msg.enabled);
+            break;
+        case 'recordInteractiveClick':
+            // v0 — log only. Once `interactive/input` ships (INTERACTIVE.md
+            // § 7) the same payload feeds the daemon notification.
+            logLine(
+                `[interactive] click ${msg.previewId} px=${msg.pixelX},${msg.pixelY} `
+                + `image=${msg.imageWidth}x${msg.imageHeight}`,
+            );
+            break;
     }
 }
 
@@ -2442,6 +2464,61 @@ function lookupPreviewLabel(previewId: string): string | undefined {
     return info.params.name
         ? `${info.functionName} — ${info.params.name}`
         : info.functionName;
+}
+
+/**
+ * Live-stream (interactive) mode entry/exit handler. See
+ * docs/daemon/INTERACTIVE.md § 4 for the full lifecycle. v0 reuses the
+ * existing setFocus + renderNow path — the panel-side LIVE chip is the
+ * only user-visible difference. When the future `interactive/start` RPC
+ * lands the daemon-side warm-sandbox lock plugs in here without touching
+ * the panel.
+ *
+ * Exit (`enabled = false`) does not cancel anything daemon-side; it just
+ * lets the next save-driven setFocus take over. Sending an explicit
+ * setFocus([]) here would race with concurrent saves.
+ */
+async function handleSetInteractive(previewId: string, enabled: boolean): Promise<void> {
+    if (!daemonGate?.isEnabled() || !daemonScheduler) { return; }
+    const moduleId = previewModuleMap.get(previewId);
+    if (!moduleId) {
+        logLine(`[interactive] no module for ${previewId}; ignoring setInteractive`);
+        return;
+    }
+    if (!enabled) {
+        logLine(`[interactive] live mode off for ${previewId}`);
+        return;
+    }
+    const ok = await daemonScheduler.ensureModule(moduleId);
+    if (!ok) {
+        // The webview already saw the toggle disabled — but the user could
+        // have flipped settings between toggle render and click. Push a
+        // fresh availability ping so the chip reverts cleanly.
+        panel?.postMessage({
+            command: 'setInteractiveAvailability',
+            moduleId, ready: false,
+        });
+        return;
+    }
+    await daemonScheduler.setFocus(moduleId, [previewId]);
+    await daemonScheduler.renderNow(moduleId, [previewId], 'fast', 'interactive-on');
+    logLine(`[interactive] live mode on for ${previewId} (module=${moduleId})`);
+}
+
+/**
+ * Push the daemon-readiness state for [moduleId] to the live panel so the
+ * focus-mode LIVE toggle can enable/disable itself. Cheap; no-op when the
+ * panel isn't open. Called from every code path that flips daemon state
+ * for a module — warm-up completion, channel-close, classpath-dirty.
+ */
+function publishInteractiveAvailability(moduleId: string): void {
+    if (!panel) { return; }
+    const ready = daemonGate?.isDaemonReady(moduleId) ?? false;
+    panel.postMessage({
+        command: 'setInteractiveAvailability',
+        moduleId,
+        ready,
+    });
 }
 
 async function notifyDaemonViewport(visible: string[], predicted: string[]): Promise<void> {

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -110,6 +110,10 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         <button class="icon-button" id="btn-launch-device" title="Launch on connected Android device" aria-label="Launch on device">
             <i class="codicon codicon-device-mobile" aria-hidden="true"></i>
         </button>
+        <button class="icon-button" id="btn-interactive" title="Daemon not ready — live mode unavailable"
+                aria-label="Toggle live (interactive) mode" aria-pressed="false" disabled hidden>
+            <i class="codicon codicon-circle-large-outline" aria-hidden="true"></i>
+        </button>
         <button class="icon-button" id="btn-exit-focus" title="Exit focus mode" aria-label="Exit focus mode">
             <i class="codicon codicon-close" aria-hidden="true"></i>
         </button>
@@ -132,6 +136,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         const btnDiffHead = document.getElementById('btn-diff-head');
         const btnDiffMain = document.getElementById('btn-diff-main');
         const btnLaunchDevice = document.getElementById('btn-launch-device');
+        const btnInteractive = document.getElementById('btn-interactive');
         const btnExitFocus = document.getElementById('btn-exit-focus');
         const focusPosition = document.getElementById('focus-position');
         const progressBar = document.getElementById('progress-bar');
@@ -295,6 +300,17 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         // exit lands somewhere sensible.
         let previousLayout = state.layout && state.layout !== 'focus' ? state.layout : 'grid';
 
+        // Interactive (live-stream) mode state. Declared up here — *before*
+        // the first applyLayout() call below — because applyLayout reads
+        // interactivePreviewId via the early-exit-on-focus-change path.
+        // moduleDaemonReady tracks per-module daemon readiness pushed by the
+        // extension via setInteractiveAvailability; the button enables only
+        // when the focused card's owning module is ready. interactivePreviewId
+        // is the single live target — see INTERACTIVE.md § 8 (one card at
+        // a time).
+        const moduleDaemonReady = new Map();
+        let interactivePreviewId = null;
+
         // Restore layout preference
         if (state.layout && ['grid', 'flow', 'column', 'focus'].includes(state.layout)) {
             layoutMode.value = state.layout;
@@ -322,7 +338,157 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         btnDiffHead.addEventListener('click', () => requestFocusedDiff('head'));
         btnDiffMain.addEventListener('click', () => requestFocusedDiff('main'));
         btnLaunchDevice.addEventListener('click', () => requestLaunchOnDevice());
+        btnInteractive.addEventListener('click', () => toggleInteractive());
         btnExitFocus.addEventListener('click', () => exitFocus());
+
+        // ----- Interactive (live-stream) mode helpers -----
+        // State (moduleDaemonReady, interactivePreviewId) is declared
+        // earlier so the first applyLayout() can reach it. The function
+        // declarations below are hoisted, so call sites above this block
+        // resolve fine.
+
+        function isFocusedDaemonReady() {
+            // The webview doesn't know moduleId per preview today. We fall
+            // back to "any module ready" because the extension-side panel
+            // is single-module-scoped (it only ever holds one module's
+            // previews at a time) — so the readiness of the sole module is
+            // also the readiness for whatever's focused. If the panel ever
+            // shows multiple modules at once, swap this to lookup by the
+            // focused card's data-module-id.
+            for (const ready of moduleDaemonReady.values()) {
+                if (ready) return true;
+            }
+            return false;
+        }
+
+        function applyInteractiveButtonState() {
+            const inFocus = layoutMode.value === 'focus';
+            const visible = getVisibleCards();
+            const card = inFocus ? visible[focusIndex] : null;
+            // Hide outright when not in focus mode — the toolbar already
+            // hides itself, but this keeps aria-pressed correct for tests
+            // that snapshot the button in either layout.
+            btnInteractive.hidden = !inFocus;
+            if (!inFocus || !card) {
+                btnInteractive.disabled = true;
+                btnInteractive.setAttribute('aria-pressed', 'false');
+                btnInteractive.title = 'Daemon not ready — live mode unavailable';
+                btnInteractive.innerHTML =
+                    '<i class="codicon codicon-circle-large-outline" aria-hidden="true"></i>';
+                return;
+            }
+            const previewId = card.dataset.previewId;
+            const ready = isFocusedDaemonReady();
+            const live = previewId === interactivePreviewId && interactivePreviewId !== null;
+            btnInteractive.disabled = !ready && !live;
+            btnInteractive.setAttribute('aria-pressed', live ? 'true' : 'false');
+            btnInteractive.classList.toggle('live-on', live);
+            btnInteractive.title = !ready
+                ? 'Daemon not ready — live mode unavailable'
+                : (live ? 'Live · click to exit' : 'Enter live mode (stream renders)');
+            btnInteractive.innerHTML = live
+                ? '<i class="codicon codicon-record" aria-hidden="true"></i>'
+                : '<i class="codicon codicon-circle-large-outline" aria-hidden="true"></i>';
+        }
+
+        function applyLiveBadge() {
+            // Tear down all prior live decorations first so a focus change
+            // doesn't leave a stale badge on an unfocused card.
+            document.querySelectorAll('.preview-card.live').forEach(c => {
+                c.classList.remove('live');
+                const badge = c.querySelector('.live-badge');
+                if (badge) badge.remove();
+            });
+            if (!interactivePreviewId) return;
+            const card = document.getElementById('preview-' + sanitizeId(interactivePreviewId));
+            if (!card) return;
+            card.classList.add('live');
+            if (!card.querySelector('.live-badge')) {
+                const badge = document.createElement('div');
+                badge.className = 'live-badge';
+                badge.setAttribute('aria-hidden', 'true');
+                const dot = document.createElement('span');
+                dot.className = 'live-badge-dot';
+                badge.appendChild(dot);
+                const text = document.createElement('span');
+                text.textContent = 'LIVE';
+                badge.appendChild(text);
+                card.appendChild(badge);
+            }
+        }
+
+        function toggleInteractive() {
+            if (layoutMode.value !== 'focus') return;
+            const visible = getVisibleCards();
+            const card = visible[focusIndex];
+            if (!card) return;
+            const previewId = card.dataset.previewId;
+            if (!previewId) return;
+            const turnOn = previewId !== interactivePreviewId;
+            // Exit any prior live target before announcing the new one — the
+            // extension/daemon contract is single-target (INTERACTIVE.md § 8),
+            // so we never want two cards reporting .live at once.
+            if (interactivePreviewId && interactivePreviewId !== previewId) {
+                vscode.postMessage({
+                    command: 'setInteractive',
+                    previewId: interactivePreviewId,
+                    enabled: false,
+                });
+            }
+            interactivePreviewId = turnOn ? previewId : null;
+            vscode.postMessage({
+                command: 'setInteractive',
+                previewId,
+                enabled: turnOn,
+            });
+            applyLiveBadge();
+            applyInteractiveButtonState();
+        }
+
+        // Idempotent attach. Adds a click listener to the live card's image
+        // exactly once; flagged via dataset so a second updateImage on the
+        // same element doesn't stack listeners. Detached the moment live
+        // mode exits, so non-live cards never carry the handler.
+        function ensureInteractiveClickHandler(card, img) {
+            const previewId = card.dataset.previewId;
+            const shouldHandle = previewId === interactivePreviewId;
+            if (shouldHandle && img.dataset.interactiveBound !== '1') {
+                img.dataset.interactiveBound = '1';
+                img.addEventListener('click', (evt) => {
+                    if (card.dataset.previewId !== interactivePreviewId) return;
+                    recordInteractiveClick(previewId, img, evt);
+                });
+            } else if (!shouldHandle && img.dataset.interactiveBound === '1') {
+                // Listener leak isn't worth a clone+replace dance — set the
+                // flag so the early-return inside the listener short-circuits
+                // future clicks, and let the element's lifetime clean things
+                // up. Re-entering live mode rebinds via the bound check above.
+                delete img.dataset.interactiveBound;
+            }
+        }
+
+        function recordInteractiveClick(previewId, img, evt) {
+            // Image-natural pixel coords — same space the daemon's renderer
+            // works in. The webview's offsetX/Y is in CSS pixels of the
+            // displayed image; scale by the displayed/natural ratio to
+            // recover the pixel the user actually clicked.
+            const natW = img.naturalWidth || 0;
+            const natH = img.naturalHeight || 0;
+            const rect = img.getBoundingClientRect();
+            if (!natW || !natH || rect.width === 0 || rect.height === 0) return;
+            const clientX = evt.clientX - rect.left;
+            const clientY = evt.clientY - rect.top;
+            const pixelX = Math.round(clientX * (natW / rect.width));
+            const pixelY = Math.round(clientY * (natH / rect.height));
+            vscode.postMessage({
+                command: 'recordInteractiveClick',
+                previewId,
+                pixelX,
+                pixelY,
+                imageWidth: natW,
+                imageHeight: natH,
+            });
+        }
 
         // Document-level Left/Right in focus mode steps between cards. The
         // animated-carousel frame-controls handler stops propagation so
@@ -463,6 +629,22 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             const tooltip = mode === 'focus' ? 'Double-click to exit focus' : 'Double-click to focus';
             document.querySelectorAll('.image-container').forEach(c => c.title = tooltip);
             publishScopedPreview();
+            // If the user navigated focus off the live preview, drop the
+            // live state so the badge and the "is live" UI follow the user.
+            if (interactivePreviewId) {
+                const visible = getVisibleCards();
+                const card = mode === 'focus' ? visible[focusIndex] : null;
+                if (!card || card.dataset.previewId !== interactivePreviewId) {
+                    vscode.postMessage({
+                        command: 'setInteractive',
+                        previewId: interactivePreviewId,
+                        enabled: false,
+                    });
+                    interactivePreviewId = null;
+                    applyLiveBadge();
+                }
+            }
+            applyInteractiveButtonState();
         }
 
         // Compute the previewId the panel is currently narrowed to, if any:
@@ -1606,7 +1788,12 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 container.appendChild(img);
             }
             img.src = newSrc;
-            img.className = 'fade-in';
+            // In live mode the new bytes are a frame, not a card reload —
+            // skip the fade-in so successive frames read as a stream rather
+            // than a sequence of independent renders. See INTERACTIVE.md § 3.
+            const isLive = previewId === interactivePreviewId;
+            img.className = isLive ? 'live-frame' : 'fade-in';
+            ensureInteractiveClickHandler(card, img);
 
             if (caps) updateFrameIndicator(card);
 
@@ -1768,6 +1955,16 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     restoreFilterState();
                     applyFilters();
                     applyLayout();
+                    // setPreviews can rebuild the focused card from scratch;
+                    // re-stamp the live badge so the LIVE chip reattaches to
+                    // the right card. If the previously-live preview is gone
+                    // from the new manifest, drop the live state outright.
+                    if (interactivePreviewId
+                        && !msg.previews.some(p => p.id === interactivePreviewId)) {
+                        interactivePreviewId = null;
+                    }
+                    applyLiveBadge();
+                    applyInteractiveButtonState();
                     break;
                 }
 
@@ -1928,6 +2125,18 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                         previewId: msg.previewId,
                         against: msg.against,
                     });
+                    break;
+                }
+                case 'setInteractiveAvailability': {
+                    moduleDaemonReady.set(msg.moduleId, !!msg.ready);
+                    // Daemon went away while a card was live — drop the live
+                    // state so the user doesn't keep seeing a LIVE badge on
+                    // a card whose stream has stopped.
+                    if (!msg.ready && interactivePreviewId) {
+                        interactivePreviewId = null;
+                        applyLiveBadge();
+                    }
+                    applyInteractiveButtonState();
                     break;
                 }
                 case 'previewMainRefChanged': {

--- a/vscode-extension/src/test/daemonClient.test.ts
+++ b/vscode-extension/src/test/daemonClient.test.ts
@@ -173,6 +173,62 @@ describe('DaemonClient', () => {
         assert.deepStrictEqual(b.queued, ['second']);
     });
 
+    it('interactiveStart sends a request with previewId and awaits a frameStreamId result', async () => {
+        // Reserved per docs/daemon/INTERACTIVE.md § 7. v0 daemons reject
+        // with MethodNotFound, but the wire shape is locked here so the
+        // caller-side machinery is ready when the daemon implementation
+        // lands.
+        const { toServer, toClient } = bidiPair();
+        const frames = captureFrames(toServer);
+        const client = new DaemonClient(toServer, toClient, {});
+        const promise = client.interactiveStart({ previewId: 'com.example.PreviewA' });
+        const sent = (await frames.take()) as JsonRpcRequest;
+        assert.strictEqual(sent.method, 'interactive/start');
+        assert.deepStrictEqual(sent.params, { previewId: 'com.example.PreviewA' });
+        toClient.write(encodeFrame({
+            jsonrpc: '2.0',
+            id: sent.id,
+            result: { frameStreamId: 'stream-42' },
+        }));
+        const result = await promise;
+        assert.strictEqual(result.frameStreamId, 'stream-42');
+        client.exit();
+    });
+
+    it('interactiveStop emits a notification (no id) carrying the stream id', async () => {
+        const { toServer, toClient } = bidiPair();
+        const frames = captureFrames(toServer);
+        const client = new DaemonClient(toServer, toClient, {});
+        client.interactiveStop({ frameStreamId: 'stream-42' });
+        const sent = (await frames.take()) as JsonRpcRequest;
+        assert.strictEqual(sent.method, 'interactive/stop');
+        assert.strictEqual((sent as unknown as { id?: number }).id, undefined);
+        assert.deepStrictEqual(sent.params, { frameStreamId: 'stream-42' });
+        client.exit();
+    });
+
+    it('interactiveInput emits a notification carrying click coordinates', async () => {
+        const { toServer, toClient } = bidiPair();
+        const frames = captureFrames(toServer);
+        const client = new DaemonClient(toServer, toClient, {});
+        client.interactiveInput({
+            frameStreamId: 'stream-42',
+            kind: 'click',
+            pixelX: 120,
+            pixelY: 64,
+        });
+        const sent = (await frames.take()) as JsonRpcRequest;
+        assert.strictEqual(sent.method, 'interactive/input');
+        assert.strictEqual((sent as unknown as { id?: number }).id, undefined);
+        assert.deepStrictEqual(sent.params, {
+            frameStreamId: 'stream-42',
+            kind: 'click',
+            pixelX: 120,
+            pixelY: 64,
+        });
+        client.exit();
+    });
+
     it('issues monotonically increasing ids', async () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -354,7 +354,15 @@ export type ExtensionToWebview =
      * baseline. The live panel re-issues any open "Diff vs main" overlay
      * so the user sees the new bytes without manually clicking.
      */
-    | { command: 'previewMainRefChanged' };
+    | { command: 'previewMainRefChanged' }
+    /**
+     * Interactive (live-stream) mode availability for a given module.
+     * Posted by the extension whenever the daemon for [moduleId] becomes
+     * ready or unhealthy. The webview uses this to enable/disable the
+     * focus-mode "LIVE" toggle for any focused preview owned by the
+     * module. See docs/daemon/INTERACTIVE.md § 3 for the UI surface.
+     */
+    | { command: 'setInteractiveAvailability'; moduleId: string; ready: boolean };
 
 /** Messages from webview to extension */
 export type WebviewToExtension =
@@ -425,4 +433,29 @@ export type WebviewToExtension =
      * Falls back to a quick-pick when more than one Android-application
      * module applies the plugin.
      */
-    | { command: 'requestLaunchOnDevice'; previewId: string };
+    | { command: 'requestLaunchOnDevice'; previewId: string }
+    /**
+     * Toggle interactive (live-stream) mode for [previewId]. Daemon-only —
+     * the extension routes this into a `setFocus` + `renderNow(tier='fast')`
+     * call so the focused preview is the daemon's render priority. Exit
+     * (`enabled = false`) does not issue any daemon call: the next
+     * save/focus-change publishes a fresh focus set on its own. See
+     * docs/daemon/INTERACTIVE.md § 4 for the lifecycle.
+     */
+    | { command: 'setInteractive'; previewId: string; enabled: boolean }
+    /**
+     * Click on the focused image while interactive mode is on. v0 logs
+     * the coordinates to the output channel (no daemon call yet); the
+     * payload shape matches the future `interactive/input` RPC so the
+     * panel side won't change when the daemon implementation lands.
+     * Coordinates are in IMAGE-NATURAL pixel space — the same coordinate
+     * system the renderer thinks in. See docs/daemon/INTERACTIVE.md § 6/§ 7.
+     */
+    | {
+          command: 'recordInteractiveClick';
+          previewId: string;
+          pixelX: number;
+          pixelY: number;
+          imageWidth: number;
+          imageHeight: number;
+      };


### PR DESCRIPTION
Adds a focus-mode LIVE toggle that pins the focused preview as the
daemon's render priority, swaps in successive renderFinished frames
without the per-card fade animation, and surfaces a pulsing LIVE badge
so the user knows they're looking at the freshest possible bytes. The
toggle is hidden when not in focus mode and disabled when the daemon
isn't healthy for the focused module.

Mouse-click coords on the live image are captured and logged to the
output channel today; the payload shape mirrors the future
interactive/input RPC so the panel side won't change when the daemon
implementation lands. Reserved interactive/start, interactive/stop,
interactive/input methods are added to the daemon client (they reject
with MethodNotFound on v1.0 daemons; additive per PROTOCOL.md § 7).

Design + click-input groundwork in docs/daemon/INTERACTIVE.md.