### PR TITLE
feat(daemon): support multiple concurrent interactive streams

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -234,23 +234,31 @@ class JsonRpcServer(
   // ----------------------------------------------------------------------
   // Interactive (live-stream) mode state — see docs/daemon/INTERACTIVE.md.
   //
-  // [interactiveTarget] is the single (previewId, frameStreamId) tuple the daemon is
-  // serving as the user's interactive target. Single-target by design: a second
-  // `interactive/start` overwrites this slot, and any input notification carrying a
-  // stale frameStreamId is silently dropped.
+  // [interactiveTargets] is the set of currently-active interactive streams, keyed by
+  // [InteractiveTarget.frameStreamId]. The wire shape is multi-target by design: each
+  // `interactive/start` registers a fresh slot and returns a unique stream id; concurrent
+  // streams targeting different (or even the same) preview ids coexist. Inputs route by
+  // stream id, so a stale id from a `stop`'d or never-started stream is dropped without
+  // touching live targets.
+  //
+  // The current panel UI is single-target — only one card carries `.live` at a time —
+  // but the protocol does not require that. Lifting it on the wire keeps the daemon
+  // useful for hypothetical programmatic clients (side-by-side comparison views, CI
+  // agents driving multiple previews over one stdio pair) without any contract change.
   //
   // [lastFrameHashes] is a per-previewId cache of the SHA-256 of the most recently
   // notified PNG bytes. Populated on every `renderFinished` that the watcher actually
   // emits; consulted to set `unchanged: true` (and skip history) when the next render
   // produces byte-identical output. Always tracked, not just when interactive mode is
-  // on — the dedup is generally useful (a save that doesn't move pixels shouldn't
-  // burn IPC + a panel repaint).
+  // on — the dedup is generally useful (a save that doesn't move pixels shouldn't burn
+  // IPC + a panel repaint). Per-preview key, not per-stream: two streams targeting the
+  // same preview share dedup state, which is what we want — the bytes are the same
+  // bytes regardless of which stream's input triggered the render.
   // ----------------------------------------------------------------------
 
   private data class InteractiveTarget(val previewId: String, val frameStreamId: String)
 
-  private val interactiveTarget =
-    java.util.concurrent.atomic.AtomicReference<InteractiveTarget?>(null)
+  private val interactiveTargets = ConcurrentHashMap<String, InteractiveTarget>()
 
   private val lastFrameHashes = ConcurrentHashMap<String, String>()
 
@@ -1153,10 +1161,13 @@ class JsonRpcServer(
       return
     }
     val streamId = "stream-${nextStreamIdCounter.getAndIncrement()}"
-    interactiveTarget.set(InteractiveTarget(previewId = params.previewId, frameStreamId = streamId))
+    interactiveTargets[streamId] =
+      InteractiveTarget(previewId = params.previewId, frameStreamId = streamId)
     // Wipe any cached hash for this preview so the first interactive frame always paints.
     // Without this a `start` after a previous identical render would suppress the bootstrap
     // frame and the client's LIVE chip would have nothing to paint until the user clicks.
+    // Per-preview wipe (not per-stream): two streams targeting the same preview both want a
+    // fresh first frame, and the dedup state is shared by design.
     lastFrameHashes.remove(params.previewId)
     sendResponse(
       req.id,
@@ -1170,34 +1181,30 @@ class JsonRpcServer(
   private fun handleInteractiveStop(
     params: ee.schimke.composeai.daemon.protocol.InteractiveStopParams
   ) {
-    val current = interactiveTarget.get()
-    if (current != null && current.frameStreamId == params.frameStreamId) {
-      interactiveTarget.compareAndSet(current, null)
-    }
-    // Idempotent on stale or unknown stream ids per INTERACTIVE.md § 7.
+    // Idempotent on stale or unknown stream ids per INTERACTIVE.md § 8 — `remove` is a no-op
+    // when the key isn't present, which is exactly the contract we want.
+    interactiveTargets.remove(params.frameStreamId)
   }
 
   private fun handleInteractiveInput(
     params: ee.schimke.composeai.daemon.protocol.InteractiveInputParams
   ) {
-    val current = interactiveTarget.get()
-    if (current == null || current.frameStreamId != params.frameStreamId) {
-      // Stale stream id (from a prior start, or before any start). Drop silently —
-      // resending after a stop or an overwrite is a documented client-allowed pattern.
-      return
-    }
+    val target =
+      interactiveTargets[params.frameStreamId]
+        ?: return // Stale or unknown stream id (never started, already stopped, or typo'd
+    // by a programmatic client). Drop silently — resending after stop is a documented
+    // client-allowed pattern.
     if (classpathDirtyEmitted.get() || shutdownRequested.get()) {
       return
     }
-    // v0 dispatch model: each input enqueues a fresh render of the target preview. The render
+    // v1 dispatch model: each input enqueues a fresh render of the target preview. The render
     // body itself does not yet route the click into the composition (LocalInspectionMode is
-    // still true; that's the v1 follow-up — see INTERACTIVE.md § 7 "Open questions"). What
+    // still true; that's the v2 follow-up — see INTERACTIVE.md § 8 "Open questions"). What
     // this DOES validate end-to-end: the input → renderNow → renderFinished round-trip plus
     // the byte-identical dedup, which together let a future click-aware engine slot in
     // without changing the wire shape.
-    val previewId = current.previewId
     val hostId = RenderHost.nextRequestId()
-    hostIdToPreviewId[hostId] = previewId
+    hostIdToPreviewId[hostId] = target.previewId
     acceptedAtMs[hostId] = System.currentTimeMillis()
     inFlightRenders.add(hostId)
     submitRenderAsync(hostId)

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveRpcIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveRpcIntegrationTest.kt
@@ -35,6 +35,8 @@ import org.junit.Test
  * 3. Frame dedup: an input that re-renders byte-identical bytes emits `unchanged: true`.
  * 4. `interactive/stop` invalidates the stream id, so a subsequent `interactive/input` against the
  *    stale id is dropped (no new render).
+ * 5. Multi-target: two concurrent `interactive/start` calls coexist, inputs route by stream id, and
+ *    `stop` on one stream leaves the other live.
  */
 class InteractiveRpcIntegrationTest {
 
@@ -192,9 +194,18 @@ class InteractiveRpcIntegrationTest {
     teardownServer(clientToServerOut, received, serverThread, exitLatch)
   }
 
+  /**
+   * Multi-target invariant — INTERACTIVE.md § 8. Two `interactive/start` calls coexist as
+   * independent streams; each input routes to its stream's preview; a `stop` on one stream leaves
+   * the other untouched.
+   *
+   * The panel UI today only exercises one stream at a time, but the daemon protocol supports
+   * multi-target so a future programmatic client (side-by-side comparison view, CI agent driving
+   * multiple previews) can drive concurrent streams without a wire change.
+   */
   @Test(timeout = 30_000)
-  fun start_overwrites_prior_target_so_input_against_stale_streamId_is_dropped() {
-    val tmp = Files.createTempDirectory("interactive-rpc-overwrite-test").toFile()
+  fun multiple_concurrent_streams_route_inputs_independently() {
+    val tmp = Files.createTempDirectory("interactive-rpc-multi-test").toFile()
     val aPng = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
     val bPng = File(tmp, "preview-B.png").apply { writeBytes(testPngBytes(seed = 5)) }
     val host = BytesAwareFakeHost(aPng, mapOf("preview-A" to aPng, "preview-B" to bPng))
@@ -204,7 +215,7 @@ class InteractiveRpcIntegrationTest {
 
     handshake(clientToServerOut, received)
 
-    // Start on A, then on B — A's stream id becomes stale.
+    // Start on A, then on B — both streams must coexist (multi-target).
     writeFrame(
       clientToServerOut,
       """{"jsonrpc":"2.0","id":1,"method":"interactive/start","params":{"previewId":"preview-A"}}""",
@@ -217,12 +228,9 @@ class InteractiveRpcIntegrationTest {
     )
     val b = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 2 }!!
     val bStream = b["result"]!!.jsonObject["frameStreamId"]!!.jsonPrimitive.contentOrNull!!
-    assertFalse("subsequent start must yield a new stream id", aStream == bStream)
+    assertFalse("each start must yield a unique stream id", aStream == bStream)
 
-    // Stale input against the old (preview-A) stream → dropped. We assert the absence
-    // by waiting a window long enough for a render to ride through; the FakeHost completes
-    // synchronously so any accepted submission would emit a renderFinished within that
-    // window.
+    // Input on stream A → renders preview-A.
     writeFrame(
       clientToServerOut,
       """
@@ -232,16 +240,16 @@ class InteractiveRpcIntegrationTest {
       """
         .trimIndent(),
     )
-    val staleAfterOverwrite =
-      pollUntil(received, timeoutMs = 500) {
-        it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished"
-      }
-    assertNull(
-      "input against the overwritten (preview-A) stream must not render",
-      staleAfterOverwrite,
+    val firstFinished =
+      pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+    assertNotNull("input on stream A must render", firstFinished)
+    assertEquals(
+      "stream A's input must render preview-A",
+      "preview-A",
+      firstFinished!!["params"]!!.jsonObject["id"]?.jsonPrimitive?.contentOrNull,
     )
 
-    // Fresh input against the current (preview-B) stream → renders.
+    // Input on stream B → renders preview-B (proves both streams are alive).
     writeFrame(
       clientToServerOut,
       """
@@ -251,13 +259,54 @@ class InteractiveRpcIntegrationTest {
       """
         .trimIndent(),
     )
-    val freshFinished =
+    val secondFinished =
       pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
-    assertNotNull("input against the live preview-B stream must render", freshFinished)
+    assertNotNull("input on stream B must render", secondFinished)
     assertEquals(
-      "rendered preview must be the new target",
+      "stream B's input must render preview-B",
       "preview-B",
-      freshFinished!!["params"]!!.jsonObject["id"]?.jsonPrimitive?.contentOrNull,
+      secondFinished!!["params"]!!.jsonObject["id"]?.jsonPrimitive?.contentOrNull,
+    )
+
+    // Stop stream A → stream B is untouched.
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","method":"interactive/stop","params":{"frameStreamId":"$aStream"}}""",
+    )
+    Thread.sleep(50) // settle the stop notification before the next input
+
+    // Stale input against stopped stream A → dropped.
+    writeFrame(
+      clientToServerOut,
+      """
+      {"jsonrpc":"2.0","method":"interactive/input","params":{
+        "frameStreamId":"$aStream","kind":"click","pixelX":2,"pixelY":2
+      }}
+      """
+        .trimIndent(),
+    )
+    val staleAFollowup =
+      pollUntil(received, timeoutMs = 500) {
+        it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished"
+      }
+    assertNull("input against stopped stream A must not render", staleAFollowup)
+
+    // Fresh input on stream B → still renders preview-B (untouched by A's stop).
+    writeFrame(
+      clientToServerOut,
+      """
+      {"jsonrpc":"2.0","method":"interactive/input","params":{
+        "frameStreamId":"$bStream","kind":"click","pixelX":3,"pixelY":3
+      }}
+      """
+        .trimIndent(),
+    )
+    val bAfterAStopped =
+      pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+    assertNotNull("stream B must keep rendering after stream A is stopped", bAfterAStopped)
+    assertEquals(
+      "preview-B",
+      bAfterAStopped!!["params"]!!.jsonObject["id"]?.jsonPrimitive?.contentOrNull,
     )
 
     teardownServer(clientToServerOut, received, serverThread, exitLatch)

--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -196,11 +196,19 @@ setFocus + renderNow path.
 { frameStreamId: string }           // opaque; passed back in interactive/input
 ```
 
-Tells the daemon "this preview is the user's interactive target — keep a
-warm sandbox for it, prefer it on every render-queue drain, do NOT recycle
-its sandbox on idle." Returns a stream id the client uses for input
-correlation. Multiple `start` calls overwrite the prior target (one
-interactive preview at a time — matches the panel's single-focus mode).
+Tells the daemon "this preview is an interactive target — keep a warm
+sandbox for it, prefer it on every render-queue drain, do NOT recycle
+its sandbox on idle." Returns a unique stream id the client uses for
+input correlation.
+
+**Multi-target on the wire.** Each `start` registers a fresh slot —
+concurrent streams targeting different (or even the same) preview ids
+coexist. Inputs route by `frameStreamId`, so a stop on one stream
+leaves the others untouched. The current panel UI is single-target
+(only one card carries `.live`), but the daemon does not require that;
+a programmatic client (side-by-side comparison view, CI agent driving
+multiple previews over one stdio pair) can drive concurrent streams
+without any wire change.
 
 ### `interactive/stop` (notification, client → daemon)
 
@@ -236,19 +244,25 @@ re-click.
 
 ### v1 implementation notes
 
-The current dispatch flow inside `JsonRpcServer`:
+State lives in a `ConcurrentHashMap<String /*streamId*/, InteractiveTarget>` so
+multiple concurrent streams coexist. The dispatch flow inside `JsonRpcServer`:
 
-1. `interactive/start` — stash the `(previewId, frameStreamId)` pair as the
-   single active target, wipe any cached frame hash for that preview so the
-   first interactive frame always paints, return the stream id. Blank
-   previewIds reject with `InvalidParams (-32602)`.
-2. `interactive/stop` — clear the slot iff the supplied `frameStreamId`
-   matches the active one. Idempotent on stale or unknown ids.
-3. `interactive/input` — drop silently when the stream id doesn't match the
-   active target (handles the "start was overwritten" race). Otherwise
-   enqueue a render against the target preview through the same
-   `submitRenderAsync` path `renderNow` uses; the result demuxes through
-   the existing render-watcher thread back into `renderFinished`.
+1. `interactive/start` — generate a unique `streamId` (monotonic), put a fresh
+   `(previewId, streamId)` entry into the targets map, wipe any cached frame
+   hash for that preview so the first interactive frame always paints, return
+   the stream id. Blank previewIds reject with `InvalidParams (-32602)`. The
+   wipe is per-preview (not per-stream) by design: two streams targeting the
+   same preview share dedup state because the bytes are the same bytes
+   regardless of which stream's input triggered the render.
+2. `interactive/stop` — `remove(streamId)` from the targets map. Idempotent
+   on stale or unknown ids — `remove` is a no-op when the key isn't present,
+   which is exactly the contract we want.
+3. `interactive/input` — look up the target by `streamId`; drop silently when
+   absent (the stream was never started, has been stopped, or the client
+   typo'd the id). Otherwise enqueue a render against the target preview
+   through the same `submitRenderAsync` path `renderNow` uses; the result
+   demuxes through the existing render-watcher thread back into
+   `renderFinished`.
 
 ### Open questions for the v2 protocol
 
@@ -281,9 +295,15 @@ The current dispatch flow inside `JsonRpcServer`:
   `LocalInspectionMode = true` so the input doesn't reach the active
   composition. v2 flips the local and dispatches the pixel coords
   through `ImageComposeScene`'s pointer-input pipeline.
-- **Multi-preview simultaneous live mode.** One focused preview, one
-  `.live` card. The future `interactive/start` API formalises this with
-  the "overwrites prior target" semantics.
+- **Multi-preview simultaneous live mode in the panel UI.** The wire
+  protocol supports concurrent `interactive/start` streams (see § 8),
+  but the panel only renders a single `.live` card at a time. Lifting
+  the UI is purely a webview change — `interactivePreviewId` would
+  become a `Set<previewId>` and the LIVE chip / badge would attach per
+  card — but the affordance argument for surfacing multi-target to a
+  human is weak (the user can only meaningfully focus on one live
+  preview at a time). Programmatic clients are the load-bearing case
+  for multi-target on the wire today.
 - **Mouse-move / drag** events. Click is the smallest first surface; we
   reserve the wire shape but don't capture moves to keep the
   implementation honest.


### PR DESCRIPTION
**Stacked on #395.** Targets that PR's branch so the diff here shows only the multi-target lift; rebase to `main` once #395 merges.

## What changes

Lifts the daemon-side single-target enforcement that #395 documented as a "for the next agent" follow-up. The wire shape didn't preclude multi-target — each `interactive/start` already returned a fresh monotonic streamId — so no protocol bump.

- **State**: `AtomicReference<InteractiveTarget?>` → `ConcurrentHashMap<String /*streamId*/, InteractiveTarget>`.
- **`interactive/start`**: `put(streamId, …)` instead of `set(...)`. Each start registers a fresh slot; concurrent streams targeting different (or even the same) preview ids coexist. Dedup hash wipe stays per-preview by design — two streams on the same preview share dedup state because the bytes are the same bytes regardless of which stream's input triggered the render.
- **`interactive/stop`**: `remove(streamId)`. Idempotent on stale or unknown ids — `remove` is a no-op when the key isn't present, which is exactly the contract we want.
- **`interactive/input`**: `interactiveTargets[streamId] ?: return`. Stale or unknown stream ids drop silently without touching live targets.

## Why the panel UI stays single-target

The webview's `interactivePreviewId` stays a single value and only one card carries `.live`. The argument for surfacing multi-target to a human is weak — the user can only meaningfully focus on one live preview at a time, and a multi-`.live` view would mostly burn renders without changing what the user is looking at. Programmatic clients are the load-bearing case for multi-target on the wire today (side-by-side comparison views, CI agents driving multiple previews over one stdio pair).

`INTERACTIVE.md § 9` documents this: wire supports multi-target, UI doesn't surface it.

## Test changes

Replaces `start_overwrites_prior_target_so_input_against_stale_streamId_is_dropped` (which asserted the old single-target invariant) with `multiple_concurrent_streams_route_inputs_independently`:

1. Start on preview-A → streamA; start on preview-B → streamB. Assert distinct streamIds.
2. Input on streamA → renderFinished for preview-A.
3. Input on streamB → renderFinished for preview-B (proves both streams alive).
4. Stop streamA. Stale input on streamA → no renderFinished within the wait window.
5. Input on streamB → still renders preview-B (untouched by A's stop).

The other two tests (`click_input_triggers_renderFinished_then_dedups_identical_frame`, `start_with_blank_previewId_rejects_with_invalid_params`) are unchanged — single-stream behaviour is identical to #395.

## Test plan

- [x] `LANG=C.UTF-8 LC_ALL=C.UTF-8 ./gradlew :daemon:core:test --tests "ee.schimke.composeai.daemon.InteractiveRpcIntegrationTest"` — 3/3 pass
- [x] `LANG=C.UTF-8 LC_ALL=C.UTF-8 ./gradlew :daemon:core:test --tests "ee.schimke.composeai.daemon.JsonRpcServerIntegrationTest"` — pre-existing suite still green
- [x] `LANG=C.UTF-8 LC_ALL=C.UTF-8 ./gradlew :daemon:core:ktfmtFormatMain :daemon:core:ktfmtFormatTest` — clean
- [ ] Manual smoke test with two simultaneous programmatic streams against the daemon — not exercised here (no current consumer)


---
_Generated by [Claude Code](https://claude.ai/code/session_017NDGZk17VhvctNNoSrVZsK)_