### PR TITLE
chore: cleanups from a code-review pass

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt
@@ -43,8 +43,8 @@ internal fun compareSemver(a: String, b: String): Int {
   fun parts(v: String): Pair<List<Int>, Boolean> {
     val (head, suffix) = v.split('-', limit = 2).let { it[0] to (it.getOrNull(1) ?: "") }
     val nums = head.split('.').map { it.toIntOrNull() }
-    val parsed = nums.all { it != null }
-    return (if (parsed) nums.map { it!! } else emptyList()) to suffix.isNotEmpty()
+    val parsed = nums.none { it == null }
+    return (if (parsed) nums.filterNotNull() else emptyList()) to suffix.isNotEmpty()
   }
   val (aNums, aPre) = parts(a)
   val (bNums, bPre) = parts(b)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/forensics/ClassloaderForensics.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/forensics/ClassloaderForensics.kt
@@ -105,8 +105,8 @@ object ClassloaderForensics {
   fun diff(a: File, b: File, mdOut: File, jsonOut: File) {
     val aRoot = json.parseToJsonElement(a.readText()).asObject()
     val bRoot = json.parseToJsonElement(b.readText()).asObject()
-    val aClasses = aRoot["classes"]!!.asArray().map { it.asObject() }.associateBy { it.fqn() }
-    val bClasses = bRoot["classes"]!!.asArray().map { it.asObject() }.associateBy { it.fqn() }
+    val aClasses = aRoot.classesArray(a).map { it.asObject() }.associateBy { it.fqn() }
+    val bClasses = bRoot.classesArray(b).map { it.asObject() }.associateBy { it.fqn() }
 
     val onlyInA = aClasses.keys - bClasses.keys
     val onlyInB = bClasses.keys - aClasses.keys
@@ -643,6 +643,10 @@ object ClassloaderForensics {
   private fun JsonElement.asObject(): JsonObject = this as JsonObject
 
   private fun JsonElement.asArray() = (this as kotlinx.serialization.json.JsonArray)
+
+  private fun JsonObject.classesArray(source: File): kotlinx.serialization.json.JsonArray =
+    this["classes"] as? kotlinx.serialization.json.JsonArray
+      ?: error("Forensics capture ${source.absolutePath} is missing the 'classes' array")
 
   private fun JsonObject.fqn(): String =
     (this["fqn"] as? kotlinx.serialization.json.JsonPrimitive)?.content ?: ""

--- a/renderer-desktop/build.gradle.kts
+++ b/renderer-desktop/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
   implementation(compose.material3)
   implementation(compose.runtime)
   implementation(compose.components.uiToolingPreview)
+
+  testImplementation(libs.junit)
 }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }

--- a/renderer-desktop/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterLabelsTest.kt
+++ b/renderer-desktop/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterLabelsTest.kt
@@ -1,0 +1,94 @@
+package ee.schimke.composeai.renderer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Mirrors the Android renderer's `PreviewParameterLabelsTest` so the desktop copy of
+ * [PreviewParameterLabels] (intentionally duplicated, not shared) keeps the same label-derivation
+ * contract: pair-first / property / `toString` fallback, sanitisation, collision handling, and
+ * length cap.
+ */
+class PreviewParameterLabelsTest {
+
+  @Test
+  fun `pair uses first as label`() {
+    val suffixes =
+      PreviewParameterLabels.suffixesFor(
+        listOf("on" to Any(), "off" to Any(), "unavailable" to Any())
+      )
+    assertEquals(listOf("_on", "_off", "_unavailable"), suffixes)
+  }
+
+  data class Named(val name: String, val value: Int)
+
+  @Test
+  fun `data class with name property derives label`() {
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf(Named("alpha", 1), Named("beta", 2)))
+    assertEquals(listOf("_alpha", "_beta"), suffixes)
+  }
+
+  data class Labeled(val label: String)
+
+  @Test
+  fun `label property is recognised`() {
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf(Labeled("red"), Labeled("blue")))
+    assertEquals(listOf("_red", "_blue"), suffixes)
+  }
+
+  data class WithId(val id: String)
+
+  @Test
+  fun `id property is recognised when name and label absent`() {
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf(WithId("a1"), WithId("b2")))
+    assertEquals(listOf("_a1", "_b2"), suffixes)
+  }
+
+  @Test
+  fun `toString fallback is used when no property matches`() {
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf("hello", "world"))
+    assertEquals(listOf("_hello", "_world"), suffixes)
+  }
+
+  @Test
+  fun `default object toString falls back to PARAM_idx`() {
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf(Any(), Any()))
+    assertEquals(listOf("_PARAM_0", "_PARAM_1"), suffixes)
+  }
+
+  @Test
+  fun `null values fall back to PARAM_idx`() {
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf<Any?>(null, "ok"))
+    assertEquals(listOf("_PARAM_0", "_ok"), suffixes)
+  }
+
+  @Test
+  fun `spaces and parens are sanitized`() {
+    val suffixes =
+      PreviewParameterLabels.suffixesFor(
+        listOf("tile light (light)" to Any(), "tile dark (dark)" to Any())
+      )
+    assertEquals(listOf("_tile_light_light", "_tile_dark_dark"), suffixes)
+  }
+
+  @Test
+  fun `shell-hostile characters are replaced with underscore`() {
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf("a&b/c", "x|y*z"))
+    assertEquals(listOf("_a_b_c", "_x_y_z"), suffixes)
+  }
+
+  @Test
+  fun `colliding labels fall back to PARAM_idx across the whole fan-out`() {
+    val suffixes =
+      PreviewParameterLabels.suffixesFor(listOf("dup" to Any(), "dup" to Any(), "unique" to Any()))
+    assertEquals(listOf("_PARAM_0", "_PARAM_1", "_PARAM_2"), suffixes)
+  }
+
+  @Test
+  fun `long labels are truncated`() {
+    val long = "x".repeat(64)
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf(long to Any()))
+    val expected = "_" + "x".repeat(32)
+    assertEquals(listOf(expected), suffixes)
+  }
+}


### PR DESCRIPTION
- Add PreviewParameterLabels unit tests for the desktop renderer,
  mirroring the renderer-android suite. Until now the desktop copy was
  exercised only end-to-end via :samples:cmp:renderAllPreviews.
- Replace `nums.map { it!! }` in compareSemver with `filterNotNull()`
  and switch the guard to `none { it == null }`. Same semantics, no
  bang.
- ClassloaderForensics.diff now fails with a clear message naming the
  capture file when its 'classes' array is missing, instead of a bare
  NPE from a `!!`.