### PR TITLE
cleanups + dedup-prune test fix from a code-review pass

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Version.kt
@@ -43,8 +43,8 @@ internal fun compareSemver(a: String, b: String): Int {
   fun parts(v: String): Pair<List<Int>, Boolean> {
     val (head, suffix) = v.split('-', limit = 2).let { it[0] to (it.getOrNull(1) ?: "") }
     val nums = head.split('.').map { it.toIntOrNull() }
-    val parsed = nums.all { it != null }
-    return (if (parsed) nums.map { it!! } else emptyList()) to suffix.isNotEmpty()
+    val parsed = nums.none { it == null }
+    return (if (parsed) nums.filterNotNull() else emptyList()) to suffix.isNotEmpty()
   }
   val (aNums, aPre) = parts(a)
   val (bNums, bPre) = parts(b)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/forensics/ClassloaderForensics.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/forensics/ClassloaderForensics.kt
@@ -105,8 +105,8 @@ object ClassloaderForensics {
   fun diff(a: File, b: File, mdOut: File, jsonOut: File) {
     val aRoot = json.parseToJsonElement(a.readText()).asObject()
     val bRoot = json.parseToJsonElement(b.readText()).asObject()
-    val aClasses = aRoot["classes"]!!.asArray().map { it.asObject() }.associateBy { it.fqn() }
-    val bClasses = bRoot["classes"]!!.asArray().map { it.asObject() }.associateBy { it.fqn() }
+    val aClasses = aRoot.classesArray(a).map { it.asObject() }.associateBy { it.fqn() }
+    val bClasses = bRoot.classesArray(b).map { it.asObject() }.associateBy { it.fqn() }
 
     val onlyInA = aClasses.keys - bClasses.keys
     val onlyInB = bClasses.keys - aClasses.keys
@@ -643,6 +643,10 @@ object ClassloaderForensics {
   private fun JsonElement.asObject(): JsonObject = this as JsonObject
 
   private fun JsonElement.asArray() = (this as kotlinx.serialization.json.JsonArray)
+
+  private fun JsonObject.classesArray(source: File): kotlinx.serialization.json.JsonArray =
+    this["classes"] as? kotlinx.serialization.json.JsonArray
+      ?: error("Forensics capture ${source.absolutePath} is missing the 'classes' array")
 
   private fun JsonObject.fqn(): String =
     (this["fqn"] as? kotlinx.serialization.json.JsonPrimitive)?.content ?: ""

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourcePruneTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/LocalFsHistorySourcePruneTest.kt
@@ -248,43 +248,53 @@ class LocalFsHistorySourcePruneTest {
 
   @Test
   fun dedup_by_hash_preserves_png_when_other_sidecar_still_references_it() {
-    // Two entries share the same bytes (and therefore same pngHash). Source dedups: only the first
-    // PNG file is on disk; both sidecars' pngPath points at it. Pruning the SECOND sidecar must
-    // leave the PNG intact (the first sidecar still references it). Pruning the FIRST sidecar
-    // alone is the same: the second sidecar still references the file via the same name.
+    // Exercises tier 2 dedup (pointer-on-any-match), the only path that produces two sidecars
+    // referencing one PNG. Sequence is A → B → A: the third write's bytes don't match the
+    // most-recent (B), so tier 1 doesn't skip; they DO match an earlier entry (A), so tier 2
+    // points the third sidecar's pngPath at A's existing PNG file. Pruning the first entry must
+    // leave that PNG on disk because the third sidecar still references it via the same pngPath.
     val previewId = "Dedup"
-    val sharedBytes = "shared-bytes".toByteArray()
+    val bytesA = "alpha".toByteArray()
+    val bytesB = "beta".toByteArray()
     val now = Instant.now()
     val first =
       writeEntry(
         previewId = previewId,
-        timestamp = now.minusSeconds(3600),
-        bytes = sharedBytes,
+        timestamp = now.minusSeconds(7200),
+        bytes = bytesA,
         suffix = "first",
       )
-    val second =
-      writeEntry(previewId = previewId, timestamp = now, bytes = sharedBytes, suffix = "second")
+    val middle =
+      writeEntry(
+        previewId = previewId,
+        timestamp = now.minusSeconds(3600),
+        bytes = bytesB,
+        suffix = "middle",
+      )
+    val third = writeEntry(previewId = previewId, timestamp = now, bytes = bytesA, suffix = "third")
 
     val previewDir = tmpDir.resolve(previewId)
     val firstPng = previewDir.resolve("${first.id}.png")
-    val secondPng = previewDir.resolve("${second.id}.png")
+    val thirdPng = previewDir.resolve("${third.id}.png")
     assertTrue(Files.exists(firstPng))
-    assertFalse("dedup → second PNG file should not exist", Files.exists(secondPng))
+    assertFalse("tier 2 dedup → third PNG file should not exist", Files.exists(thirdPng))
 
-    // Prune with maxEntriesPerPreview=1 → second survives (it's the newest), first removed.
+    // Prune with maxEntriesPerPreview=2 → middle + third survive (newest 2), first removed.
     val result =
       source.prune(
-        HistoryPruneConfig(maxEntriesPerPreview = 1, maxAgeDays = 0, maxTotalSizeBytes = 0L)
+        HistoryPruneConfig(maxEntriesPerPreview = 2, maxAgeDays = 0, maxTotalSizeBytes = 0L)
       )
     assertEquals(listOf(first.id), result.removedEntryIds)
-    // freedBytes is 0 because the surviving sidecar's pngPath still references "${first.id}.png".
+    // freedBytes is 0 because the surviving third sidecar's pngPath still references
+    // "${first.id}.png".
     assertEquals(0L, result.freedBytes)
     assertTrue("PNG must remain — dedup target still referenced", Files.exists(firstPng))
 
     // Sidecar for the removed entry is gone.
     assertFalse("first sidecar must be gone", Files.exists(previewDir.resolve("${first.id}.json")))
-    // Survivor sidecar still on disk.
-    assertTrue(Files.exists(previewDir.resolve("${second.id}.json")))
+    // Survivor sidecars still on disk.
+    assertTrue(Files.exists(previewDir.resolve("${middle.id}.json")))
+    assertTrue(Files.exists(previewDir.resolve("${third.id}.json")))
   }
 
   @Test

--- a/renderer-desktop/build.gradle.kts
+++ b/renderer-desktop/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
   implementation(compose.material3)
   implementation(compose.runtime)
   implementation(compose.components.uiToolingPreview)
+
+  testImplementation(libs.junit)
 }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }

--- a/renderer-desktop/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterLabelsTest.kt
+++ b/renderer-desktop/src/test/kotlin/ee/schimke/composeai/renderer/PreviewParameterLabelsTest.kt
@@ -1,0 +1,94 @@
+package ee.schimke.composeai.renderer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Mirrors the Android renderer's `PreviewParameterLabelsTest` so the desktop copy of
+ * [PreviewParameterLabels] (intentionally duplicated, not shared) keeps the same label-derivation
+ * contract: pair-first / property / `toString` fallback, sanitisation, collision handling, and
+ * length cap.
+ */
+class PreviewParameterLabelsTest {
+
+  @Test
+  fun `pair uses first as label`() {
+    val suffixes =
+      PreviewParameterLabels.suffixesFor(
+        listOf("on" to Any(), "off" to Any(), "unavailable" to Any())
+      )
+    assertEquals(listOf("_on", "_off", "_unavailable"), suffixes)
+  }
+
+  data class Named(val name: String, val value: Int)
+
+  @Test
+  fun `data class with name property derives label`() {
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf(Named("alpha", 1), Named("beta", 2)))
+    assertEquals(listOf("_alpha", "_beta"), suffixes)
+  }
+
+  data class Labeled(val label: String)
+
+  @Test
+  fun `label property is recognised`() {
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf(Labeled("red"), Labeled("blue")))
+    assertEquals(listOf("_red", "_blue"), suffixes)
+  }
+
+  data class WithId(val id: String)
+
+  @Test
+  fun `id property is recognised when name and label absent`() {
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf(WithId("a1"), WithId("b2")))
+    assertEquals(listOf("_a1", "_b2"), suffixes)
+  }
+
+  @Test
+  fun `toString fallback is used when no property matches`() {
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf("hello", "world"))
+    assertEquals(listOf("_hello", "_world"), suffixes)
+  }
+
+  @Test
+  fun `default object toString falls back to PARAM_idx`() {
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf(Any(), Any()))
+    assertEquals(listOf("_PARAM_0", "_PARAM_1"), suffixes)
+  }
+
+  @Test
+  fun `null values fall back to PARAM_idx`() {
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf<Any?>(null, "ok"))
+    assertEquals(listOf("_PARAM_0", "_ok"), suffixes)
+  }
+
+  @Test
+  fun `spaces and parens are sanitized`() {
+    val suffixes =
+      PreviewParameterLabels.suffixesFor(
+        listOf("tile light (light)" to Any(), "tile dark (dark)" to Any())
+      )
+    assertEquals(listOf("_tile_light_light", "_tile_dark_dark"), suffixes)
+  }
+
+  @Test
+  fun `shell-hostile characters are replaced with underscore`() {
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf("a&b/c", "x|y*z"))
+    assertEquals(listOf("_a_b_c", "_x_y_z"), suffixes)
+  }
+
+  @Test
+  fun `colliding labels fall back to PARAM_idx across the whole fan-out`() {
+    val suffixes =
+      PreviewParameterLabels.suffixesFor(listOf("dup" to Any(), "dup" to Any(), "unique" to Any()))
+    assertEquals(listOf("_PARAM_0", "_PARAM_1", "_PARAM_2"), suffixes)
+  }
+
+  @Test
+  fun `long labels are truncated`() {
+    val long = "x".repeat(64)
+    val suffixes = PreviewParameterLabels.suffixesFor(listOf(long to Any()))
+    val expected = "_" + "x".repeat(32)
+    assertEquals(listOf(expected), suffixes)
+  }
+}


### PR DESCRIPTION
## Summary

- **`renderer-desktop`: add `PreviewParameterLabelsTest`** mirroring the renderer-android suite (10 cases). The desktop copy of `PreviewParameterLabels` was previously exercised only end-to-end via `:samples:cmp:renderAllPreviews`. Adds `testImplementation(libs.junit)` to the module.
- **`cli/Version.kt`: drop the `!!` in `compareSemver`.** `nums.map { it!! }` becomes `nums.filterNotNull()` and the guard switches from `all { it != null }` to `none { it == null }`. Same semantics, no bang.
- **`ClassloaderForensics.diff`: clearer error on malformed capture.** Replaces `aRoot["classes"]!!.asArray()` / `bRoot["classes"]!!.asArray()` with a `classesArray(file)` helper that fails with a message naming the capture file path instead of a bare NPE.
- **Fix `LocalFsHistorySourcePruneTest.dedup_by_hash_preserves_png_when_other_sidecar_still_references_it`.** The test was setting up two consecutive same-bytes writes and expecting both sidecars to land sharing one PNG, but `LocalFsHistorySource`'s tier 1 dedup (skip-on-most-recent-match) returns `SKIPPED_DUPLICATE` for that pattern — the second sidecar was never written, the index had a single entry, and the most-recent-per-preview floor then protected it from any prune. Rewritten to A → B → A so the third write goes through tier 2 (pointer-on-any-match), producing two sidecars genuinely referencing one PNG. `maxEntriesPerPreview` bumped from 1 to 2 so the existing `[first.id]` / `freedBytes == 0` assertions still hold.

## Test plan

- [x] `./gradlew :renderer-desktop:test`
- [x] `./gradlew :cli:test`
- [x] `./gradlew :daemon:core:test` (the previously-failing prune test now passes; all 132 tests green)
- [x] `./gradlew :renderer-desktop:ktfmtCheck :cli:ktfmtCheck :daemon:core:ktfmtCheck`

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7Re3z3Lhif1Z9EDqXWFKC)_