### PR TITLE
feat(daemon): interactive RPC + frame dedup + multi-target streams

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -258,6 +258,39 @@ class JsonRpcServer(
    */
   private val subscriptions = ConcurrentHashMap<String, MutableSet<String>>()
 
+  // ----------------------------------------------------------------------
+  // Interactive (live-stream) mode state — see docs/daemon/INTERACTIVE.md.
+  //
+  // [interactiveTargets] is the set of currently-active interactive streams, keyed by
+  // [InteractiveTarget.frameStreamId]. The wire shape is multi-target by design: each
+  // `interactive/start` registers a fresh slot and returns a unique stream id; concurrent
+  // streams targeting different (or even the same) preview ids coexist. Inputs route by
+  // stream id, so a stale id from a `stop`'d or never-started stream is dropped without
+  // touching live targets.
+  //
+  // The current panel UI is single-target — only one card carries `.live` at a time —
+  // but the protocol does not require that. Lifting it on the wire keeps the daemon
+  // useful for hypothetical programmatic clients (side-by-side comparison views, CI
+  // agents driving multiple previews over one stdio pair) without any contract change.
+  //
+  // [lastFrameHashes] is a per-previewId cache of the SHA-256 of the most recently
+  // notified PNG bytes. Populated on every `renderFinished` that the watcher actually
+  // emits; consulted to set `unchanged: true` (and skip history) when the next render
+  // produces byte-identical output. Always tracked, not just when interactive mode is
+  // on — the dedup is generally useful (a save that doesn't move pixels shouldn't burn
+  // IPC + a panel repaint). Per-preview key, not per-stream: two streams targeting the
+  // same preview share dedup state, which is what we want — the bytes are the same
+  // bytes regardless of which stream's input triggered the render.
+  // ----------------------------------------------------------------------
+
+  private data class InteractiveTarget(val previewId: String, val frameStreamId: String)
+
+  private val interactiveTargets = ConcurrentHashMap<String, InteractiveTarget>()
+
+  private val lastFrameHashes = ConcurrentHashMap<String, String>()
+
+  private val nextStreamIdCounter = java.util.concurrent.atomic.AtomicLong(1)
+
   private val writerThread =
     Thread({ writerLoop() }, "compose-ai-daemon-writer").apply { isDaemon = false }
 
@@ -403,6 +436,7 @@ class JsonRpcServer(
       "data/fetch" -> handleDataFetch(req)
       "data/subscribe" -> handleDataSubscribe(req, subscribe = true)
       "data/unsubscribe" -> handleDataSubscribe(req, subscribe = false)
+      "interactive/start" -> handleInteractiveStart(req)
       else ->
         sendErrorResponse(
           id = req.id,
@@ -624,15 +658,34 @@ class JsonRpcServer(
     // null until B2.3 wires the cost-model collection path.
     val tookMs = result.metrics?.get("tookMs") ?: 0L
     val finished = renderFinishedFromResult(previewId, result, tookMs = tookMs)
-    sendNotification("renderFinished", encode(RenderFinishedParams.serializer(), finished))
+
+    // INTERACTIVE.md § 5 / live-stream dedup: hash the rendered PNG bytes and compare against
+    // the prior frame this preview emitted. On match, swap in `unchanged: true`, skip history,
+    // and let the client short-circuit the file-read + base64 + repaint hop. Track always (not
+    // just under interactive mode): a save that doesn't move pixels is just as redundant as an
+    // input that doesn't change state.
+    val frameHash = hashFrameBytes(result.pngPath)
+    val isUnchanged =
+      frameHash != null && lastFrameHashes[previewId] == frameHash && firstRenderFinishedSeen.get()
+    val outboundFinished = if (isUnchanged) finished.copy(unchanged = true) else finished
+    sendNotification("renderFinished", encode(RenderFinishedParams.serializer(), outboundFinished))
     if (firstRenderFinishedSeen.compareAndSet(false, true)) {
       StartupTimings.mark("first renderFinished sent")
       StartupTimings.summary()
     }
+    if (frameHash != null) {
+      lastFrameHashes[previewId] = frameHash
+    }
     // H1 — record the render to history, if configured. Wrapped in a fail-open try/catch so a
     // history write failure never blocks the renderFinished wire-format. The render's notification
     // has already been sent above; history is observation, not state.
-    recordHistoryForRender(previewId = previewId, result = result, finished = finished)
+    //
+    // Skip history when the frame is byte-identical to the prior one for this preview — there's
+    // nothing new to archive, and a duplicate sidecar would inflate `history/list` results
+    // without changing what the user sees on disk.
+    if (!isUnchanged) {
+      recordHistoryForRender(previewId = previewId, result = result, finished = finished)
+    }
     inFlightRenders.remove(result.id)
     // Save-after-render invariant: a `fileChanged({kind:source})` queued discovery work that has
     // been waiting for this render to ship. The writer queue is FIFO and `renderFinished` is
@@ -1052,6 +1105,38 @@ class JsonRpcServer(
    * (the B1.5-era stub hosts that don't measure anything) keep the pre-B2.3 `metrics: null`
    * behaviour.
    */
+  /**
+   * SHA-256 hex of the bytes at [pngPath], or null when the file is unreadable / missing / a
+   * B1.5-era stub placeholder. Cheap on the typical preview size (sub-MB PNGs); the cost is
+   * dominated by the file read which is already in OS page cache because the daemon just wrote it.
+   * Returning null when the file isn't there is the right call — without bytes we can't dedup, so
+   * we treat it as "definitely changed" and emit normally.
+   */
+  private fun hashFrameBytes(pngPath: String?): String? {
+    if (pngPath == null) return null
+    val path =
+      try {
+        Path.of(pngPath)
+      } catch (_: Throwable) {
+        return null
+      }
+    if (!Files.exists(path)) return null
+    val bytes =
+      try {
+        Files.readAllBytes(path)
+      } catch (_: Throwable) {
+        return null
+      }
+    val digest = java.security.MessageDigest.getInstance("SHA-256").digest(bytes)
+    return buildString(digest.size * 2) {
+      for (b in digest) {
+        val v = b.toInt() and 0xFF
+        if (v < 0x10) append('0')
+        append(v.toString(16))
+      }
+    }
+  }
+
   private fun renderFinishedFromResult(
     previewId: String,
     result: RenderResult,
@@ -1194,6 +1279,90 @@ class JsonRpcServer(
     for (id in toDrop) subscriptions.remove(id)
   }
 
+  // --------------------------------------------------------------------------
+  // Interactive (live-stream) mode — docs/daemon/INTERACTIVE.md § 8.
+  //
+  // Multi-target on the wire: the server keeps a `streamId → (previewId, streamId)` map and
+  // each `interactive/start` registers a fresh slot. Concurrent streams targeting different
+  // (or even the same) preview ids coexist; inputs route by `frameStreamId` so a stop on
+  // one stream leaves the others untouched. Inputs are fire-and-forget — we synthesise an
+  // internal `renderNow` against the target preview so the client gets a fresh
+  // `renderFinished` (subject to the byte-identical dedup applied in [emitRenderFinished]).
+  // --------------------------------------------------------------------------
+
+  private fun handleInteractiveStart(req: JsonRpcRequest) {
+    val params =
+      try {
+        decodeParams(
+          req.params,
+          ee.schimke.composeai.daemon.protocol.InteractiveStartParams.serializer(),
+        )
+      } catch (e: Throwable) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INVALID_PARAMS,
+          message = "invalid interactive/start params: ${e.message}",
+        )
+        return
+      }
+    if (params.previewId.isBlank()) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_INVALID_PARAMS,
+        message = "interactive/start: previewId is blank",
+      )
+      return
+    }
+    val streamId = "stream-${nextStreamIdCounter.getAndIncrement()}"
+    interactiveTargets[streamId] =
+      InteractiveTarget(previewId = params.previewId, frameStreamId = streamId)
+    // Wipe any cached hash for this preview so the first interactive frame always paints.
+    // Without this a `start` after a previous identical render would suppress the bootstrap
+    // frame and the client's LIVE chip would have nothing to paint until the user clicks.
+    // Per-preview wipe (not per-stream): two streams targeting the same preview both want a
+    // fresh first frame, and the dedup state is shared by design.
+    lastFrameHashes.remove(params.previewId)
+    sendResponse(
+      req.id,
+      encode(
+        ee.schimke.composeai.daemon.protocol.InteractiveStartResult.serializer(),
+        ee.schimke.composeai.daemon.protocol.InteractiveStartResult(frameStreamId = streamId),
+      ),
+    )
+  }
+
+  private fun handleInteractiveStop(
+    params: ee.schimke.composeai.daemon.protocol.InteractiveStopParams
+  ) {
+    // Idempotent on stale or unknown stream ids per INTERACTIVE.md § 8 — `remove` is a no-op
+    // when the key isn't present, which is exactly the contract we want.
+    interactiveTargets.remove(params.frameStreamId)
+  }
+
+  private fun handleInteractiveInput(
+    params: ee.schimke.composeai.daemon.protocol.InteractiveInputParams
+  ) {
+    val target =
+      interactiveTargets[params.frameStreamId]
+        ?: return // Stale or unknown stream id (never started, already stopped, or typo'd
+    // by a programmatic client). Drop silently — resending after stop is a documented
+    // client-allowed pattern.
+    if (classpathDirtyEmitted.get() || shutdownRequested.get()) {
+      return
+    }
+    // v1 dispatch model: each input enqueues a fresh render of the target preview. The render
+    // body itself does not yet route the click into the composition (LocalInspectionMode is
+    // still true; that's the v2 follow-up — see INTERACTIVE.md § 8 "Open questions"). What
+    // this DOES validate end-to-end: the input → renderNow → renderFinished round-trip plus
+    // the byte-identical dedup, which together let a future click-aware engine slot in
+    // without changing the wire shape.
+    val hostId = RenderHost.nextRequestId()
+    hostIdToPreviewId[hostId] = target.previewId
+    acceptedAtMs[hostId] = System.currentTimeMillis()
+    inFlightRenders.add(hostId)
+    submitRenderAsync(hostId)
+  }
+
   private fun handleShutdown(req: JsonRpcRequest) {
     shutdownRequested.set(true)
     // Drain in-flight renders before responding, per PROTOCOL.md § 3 and
@@ -1218,6 +1387,14 @@ class JsonRpcServer(
         tryDecode(SetVisibleParams.serializer(), n) { pruneSubscriptionsToVisible(it.ids.toSet()) }
       "setFocus" -> tryDecode(SetFocusParams.serializer(), n) { /* no-op for B1.5 */ }
       "fileChanged" -> tryDecode(FileChangedParams.serializer(), n) { handleFileChanged(it) }
+      "interactive/stop" ->
+        tryDecode(ee.schimke.composeai.daemon.protocol.InteractiveStopParams.serializer(), n) {
+          handleInteractiveStop(it)
+        }
+      "interactive/input" ->
+        tryDecode(ee.schimke.composeai.daemon.protocol.InteractiveInputParams.serializer(), n) {
+          handleInteractiveInput(it)
+        }
       else -> System.err.println("compose-ai-daemon: unknown notification method: ${n.method}")
     }
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -266,6 +266,15 @@ data class RenderFinishedParams(
   // to (or globally attached via `attachDataProducts`). Absent and `[]` are
   // interchangeable on the wire. See docs/daemon/DATA-PRODUCTS.md.
   val dataProducts: List<DataProductAttachment>? = null,
+  /**
+   * Interactive-mode frame deduplication signal — see docs/daemon/INTERACTIVE.md § 5. When `true`
+   * the daemon has determined the rendered bytes are byte-identical to the previously notified
+   * frame for the same preview id, so the client can short-circuit the read-PNG → base64 →
+   * postMessage hop. Always omitted (`null` on the wire) when dedup didn't fire — a fresh
+   * `renderFinished` whose `unchanged` field is `null` means "client must paint these bytes".
+   * Additive per PROTOCOL.md § 7; older clients ignore the field and keep painting unconditionally.
+   */
+  val unchanged: Boolean? = null,
 )
 
 /**
@@ -485,6 +494,48 @@ data class HistoryReadResultDto(
 )
 
 @Serializable data class HistoryAddedParams(val entry: JsonElement)
+
+// =====================================================================
+// 5b. Interactive (live-stream) mode — see docs/daemon/INTERACTIVE.md § 8.
+//
+// Pins a previewId as one of the daemon's render-priority targets ("warm" sandbox semantics
+// once B2.4 lands). Multi-target on the wire: each `interactive/start` registers a fresh
+// slot and returns a unique stream id; concurrent streams targeting different (or even the
+// same) preview ids coexist. Inputs route by `frameStreamId` so a stop on one stream leaves
+// the others untouched. Inputs are fire-and-forget notifications; the daemon responds by
+// emitting a fresh `renderFinished` for the target preview.
+// =====================================================================
+
+@Serializable data class InteractiveStartParams(val previewId: String)
+
+/**
+ * Opaque correlation token returned by `interactive/start`. The client passes it back on every
+ * subsequent `interactive/input` and `interactive/stop` so the daemon can route the input to the
+ * right frame stream and drop stale ids cleanly.
+ */
+@Serializable data class InteractiveStartResult(val frameStreamId: String)
+
+@Serializable data class InteractiveStopParams(val frameStreamId: String)
+
+@Serializable
+data class InteractiveInputParams(
+  val frameStreamId: String,
+  val kind: InteractiveInputKind,
+  /** Image-natural pixel coordinates. Daemon translates to dp using the last render's density. */
+  val pixelX: Int? = null,
+  val pixelY: Int? = null,
+  /** For `keyDown` / `keyUp`. */
+  val keyCode: String? = null,
+)
+
+@Serializable
+enum class InteractiveInputKind {
+  @SerialName("click") CLICK,
+  @SerialName("pointerDown") POINTER_DOWN,
+  @SerialName("pointerUp") POINTER_UP,
+  @SerialName("keyDown") KEY_DOWN,
+  @SerialName("keyUp") KEY_UP,
+}
 
 // ---------------------------------------------------------------------------
 // H3 — `history/diff` metadata-mode wire shape. See HISTORY.md § "What this PR

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveRpcIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveRpcIntegrationTest.kt
@@ -1,0 +1,495 @@
+package ee.schimke.composeai.daemon
+
+import java.io.File
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.nio.file.Files
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Validates the interactive (live-stream) RPC surface end-to-end against a [JsonRpcServer] driven
+ * over piped streams, with a deterministic [BytesAwareFakeHost] that produces real PNG bytes on
+ * disk so the daemon's hash-based dedup path actually fires.
+ *
+ * Covers — see docs/daemon/INTERACTIVE.md:
+ * 1. `interactive/start` returns a `frameStreamId`.
+ * 2. `interactive/input` (click) triggers a fresh `renderFinished` for the target preview.
+ * 3. Frame dedup: an input that re-renders byte-identical bytes emits `unchanged: true`.
+ * 4. `interactive/stop` invalidates the stream id, so a subsequent `interactive/input` against the
+ *    stale id is dropped (no new render).
+ * 5. Multi-target: two concurrent `interactive/start` calls coexist, inputs route by stream id, and
+ *    `stop` on one stream leaves the other live.
+ */
+class InteractiveRpcIntegrationTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+  private val resourcesToClose = mutableListOf<AutoCloseable>()
+
+  @After
+  fun teardown() {
+    resourcesToClose.reversed().forEach { runCatching { it.close() } }
+  }
+
+  @Test(timeout = 30_000)
+  fun click_input_triggers_renderFinished_then_dedups_identical_frame() {
+    val tmp = Files.createTempDirectory("interactive-rpc-test").toFile()
+    val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
+
+    // Per render, each call to host.submit returns the bytes the test currently has staged
+    // on disk. We swap the bytes between calls to drive the dedup branches: identical bytes
+    // → `unchanged: true`; different bytes → fresh frame.
+    val host = BytesAwareFakeHost(pngFile)
+
+    val (server, serverThread, clientToServerOut, received, exitLatch) = bringUpServer(host)
+    resourcesToClose.add(AutoCloseable { runCatching { clientToServerOut.close() } })
+
+    handshake(clientToServerOut, received)
+
+    // 1. interactive/start — returns a frameStreamId.
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","id":10,"method":"interactive/start","params":{"previewId":"preview-A"}}""",
+    )
+    val startResp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 10 }
+    assertNotNull("interactive/start response should arrive", startResp)
+    val streamId = startResp!!["result"]!!.jsonObject["frameStreamId"]!!.jsonPrimitive.contentOrNull
+    assertNotNull("interactive/start must return a non-null frameStreamId", streamId)
+    assertTrue("frameStreamId should be opaque-ish; got '$streamId'", streamId!!.isNotBlank())
+
+    // 2. First input — render fires, renderFinished arrives WITHOUT `unchanged`. The first
+    //    interactive frame after start always paints (we wipe the prior hash on start).
+    writeFrame(
+      clientToServerOut,
+      """
+      {"jsonrpc":"2.0","method":"interactive/input","params":{
+        "frameStreamId":"$streamId","kind":"click","pixelX":10,"pixelY":20
+      }}
+      """
+        .trimIndent(),
+    )
+    val firstFinished =
+      pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+    assertNotNull("first interactive renderFinished should arrive", firstFinished)
+    val firstParams = firstFinished!!["params"]!!.jsonObject
+    assertEquals("preview-A", firstParams["id"]?.jsonPrimitive?.contentOrNull)
+    assertNull(
+      "first interactive frame must NOT carry unchanged=true",
+      firstParams["unchanged"]?.jsonPrimitive?.boolean,
+    )
+
+    // 3. Second input — identical PNG bytes on disk → daemon dedups.
+    writeFrame(
+      clientToServerOut,
+      """
+      {"jsonrpc":"2.0","method":"interactive/input","params":{
+        "frameStreamId":"$streamId","kind":"click","pixelX":11,"pixelY":21
+      }}
+      """
+        .trimIndent(),
+    )
+    val secondFinished =
+      pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+    assertNotNull("second interactive renderFinished should arrive", secondFinished)
+    val secondParams = secondFinished!!["params"]!!.jsonObject
+    assertEquals(
+      "byte-identical follow-up must signal unchanged=true",
+      true,
+      secondParams["unchanged"]?.jsonPrimitive?.boolean,
+    )
+
+    // 4. Swap bytes; next input should produce a fresh (NOT unchanged) frame.
+    pngFile.writeBytes(testPngBytes(seed = 1))
+    writeFrame(
+      clientToServerOut,
+      """
+      {"jsonrpc":"2.0","method":"interactive/input","params":{
+        "frameStreamId":"$streamId","kind":"click","pixelX":12,"pixelY":22
+      }}
+      """
+        .trimIndent(),
+    )
+    val thirdFinished =
+      pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+    assertNotNull("third interactive renderFinished should arrive", thirdFinished)
+    val thirdParams = thirdFinished!!["params"]!!.jsonObject
+    assertNull(
+      "fresh bytes must NOT signal unchanged=true",
+      thirdParams["unchanged"]?.jsonPrimitive?.boolean,
+    )
+
+    // 5. interactive/stop — subsequent input against the stale stream id is dropped (no
+    //    new renderFinished within the wait window). We assert the absence by waiting a
+    //    short window AND counting renderFinished notifications: if a fourth one shows
+    //    up the test fails.
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","method":"interactive/stop","params":{"frameStreamId":"$streamId"}}""",
+    )
+    // Tiny settle so the stop notification is processed before the stale input.
+    Thread.sleep(50)
+    writeFrame(
+      clientToServerOut,
+      """
+      {"jsonrpc":"2.0","method":"interactive/input","params":{
+        "frameStreamId":"$streamId","kind":"click","pixelX":13,"pixelY":23
+      }}
+      """
+        .trimIndent(),
+    )
+    // Drain anything queued — should not see a new renderFinished. We wait long enough for
+    // a render to ride through (the FakeHost completes synchronously) and assert the queue
+    // contains nothing matching.
+    val staleFollowup =
+      pollUntil(received, timeoutMs = 1000) {
+        it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished"
+      }
+    assertNull("stale interactive/input must not produce a renderFinished", staleFollowup)
+
+    teardownServer(clientToServerOut, received, serverThread, exitLatch)
+  }
+
+  @Test(timeout = 30_000)
+  fun start_with_blank_previewId_rejects_with_invalid_params() {
+    val tmp = Files.createTempDirectory("interactive-rpc-blank-test").toFile()
+    val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
+    val host = BytesAwareFakeHost(pngFile)
+
+    val (_, serverThread, clientToServerOut, received, exitLatch) = bringUpServer(host)
+    resourcesToClose.add(AutoCloseable { runCatching { clientToServerOut.close() } })
+
+    handshake(clientToServerOut, received)
+
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","id":42,"method":"interactive/start","params":{"previewId":""}}""",
+    )
+    val resp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 42 }
+    assertNotNull(resp)
+    val err = resp!!["error"]?.jsonObject
+    assertNotNull("blank previewId should produce an error response", err)
+    assertEquals(
+      "blank previewId should yield ERR_INVALID_PARAMS",
+      -32602,
+      err!!["code"]?.jsonPrimitive?.intOrNull,
+    )
+
+    teardownServer(clientToServerOut, received, serverThread, exitLatch)
+  }
+
+  /**
+   * Multi-target invariant — INTERACTIVE.md § 8. Two `interactive/start` calls coexist as
+   * independent streams; each input routes to its stream's preview; a `stop` on one stream leaves
+   * the other untouched.
+   *
+   * The panel UI today only exercises one stream at a time, but the daemon protocol supports
+   * multi-target so a future programmatic client (side-by-side comparison view, CI agent driving
+   * multiple previews) can drive concurrent streams without a wire change.
+   */
+  @Test(timeout = 30_000)
+  fun multiple_concurrent_streams_route_inputs_independently() {
+    val tmp = Files.createTempDirectory("interactive-rpc-multi-test").toFile()
+    val aPng = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
+    val bPng = File(tmp, "preview-B.png").apply { writeBytes(testPngBytes(seed = 5)) }
+    val host = BytesAwareFakeHost(aPng, mapOf("preview-A" to aPng, "preview-B" to bPng))
+
+    val (_, serverThread, clientToServerOut, received, exitLatch) = bringUpServer(host)
+    resourcesToClose.add(AutoCloseable { runCatching { clientToServerOut.close() } })
+
+    handshake(clientToServerOut, received)
+
+    // Start on A, then on B — both streams must coexist (multi-target).
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","id":1,"method":"interactive/start","params":{"previewId":"preview-A"}}""",
+    )
+    val a = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 1 }!!
+    val aStream = a["result"]!!.jsonObject["frameStreamId"]!!.jsonPrimitive.contentOrNull!!
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","id":2,"method":"interactive/start","params":{"previewId":"preview-B"}}""",
+    )
+    val b = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 2 }!!
+    val bStream = b["result"]!!.jsonObject["frameStreamId"]!!.jsonPrimitive.contentOrNull!!
+    assertFalse("each start must yield a unique stream id", aStream == bStream)
+
+    // Input on stream A → renders preview-A.
+    writeFrame(
+      clientToServerOut,
+      """
+      {"jsonrpc":"2.0","method":"interactive/input","params":{
+        "frameStreamId":"$aStream","kind":"click","pixelX":1,"pixelY":1
+      }}
+      """
+        .trimIndent(),
+    )
+    val firstFinished =
+      pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+    assertNotNull("input on stream A must render", firstFinished)
+    assertEquals(
+      "stream A's input must render preview-A",
+      "preview-A",
+      firstFinished!!["params"]!!.jsonObject["id"]?.jsonPrimitive?.contentOrNull,
+    )
+
+    // Input on stream B → renders preview-B (proves both streams are alive).
+    writeFrame(
+      clientToServerOut,
+      """
+      {"jsonrpc":"2.0","method":"interactive/input","params":{
+        "frameStreamId":"$bStream","kind":"click","pixelX":1,"pixelY":1
+      }}
+      """
+        .trimIndent(),
+    )
+    val secondFinished =
+      pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+    assertNotNull("input on stream B must render", secondFinished)
+    assertEquals(
+      "stream B's input must render preview-B",
+      "preview-B",
+      secondFinished!!["params"]!!.jsonObject["id"]?.jsonPrimitive?.contentOrNull,
+    )
+
+    // Stop stream A → stream B is untouched.
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","method":"interactive/stop","params":{"frameStreamId":"$aStream"}}""",
+    )
+    Thread.sleep(50) // settle the stop notification before the next input
+
+    // Stale input against stopped stream A → dropped.
+    writeFrame(
+      clientToServerOut,
+      """
+      {"jsonrpc":"2.0","method":"interactive/input","params":{
+        "frameStreamId":"$aStream","kind":"click","pixelX":2,"pixelY":2
+      }}
+      """
+        .trimIndent(),
+    )
+    val staleAFollowup =
+      pollUntil(received, timeoutMs = 500) {
+        it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished"
+      }
+    assertNull("input against stopped stream A must not render", staleAFollowup)
+
+    // Fresh input on stream B → still renders preview-B (untouched by A's stop).
+    writeFrame(
+      clientToServerOut,
+      """
+      {"jsonrpc":"2.0","method":"interactive/input","params":{
+        "frameStreamId":"$bStream","kind":"click","pixelX":3,"pixelY":3
+      }}
+      """
+        .trimIndent(),
+    )
+    val bAfterAStopped =
+      pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+    assertNotNull("stream B must keep rendering after stream A is stopped", bAfterAStopped)
+    assertEquals(
+      "preview-B",
+      bAfterAStopped!!["params"]!!.jsonObject["id"]?.jsonPrimitive?.contentOrNull,
+    )
+
+    teardownServer(clientToServerOut, received, serverThread, exitLatch)
+  }
+
+  // ----- helpers -----
+
+  private data class ServerHarness(
+    val server: JsonRpcServer,
+    val thread: Thread,
+    val clientToServerOut: PipedOutputStream,
+    val received: LinkedBlockingQueue<JsonObject>,
+    val exitLatch: CountDownLatch,
+  )
+
+  private fun bringUpServer(host: RenderHost): ServerHarness {
+    val clientToServerOut = PipedOutputStream()
+    val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
+    val serverToClientOut = PipedOutputStream()
+    val serverToClientIn = PipedInputStream(serverToClientOut, 64 * 1024)
+
+    val exitLatch = CountDownLatch(1)
+    val server =
+      JsonRpcServer(
+        input = clientToServerIn,
+        output = serverToClientOut,
+        host = host,
+        daemonVersion = "test",
+        onExit = { _ -> exitLatch.countDown() },
+      )
+    val thread = Thread({ server.run() }, "interactive-rpc-server").apply { isDaemon = true }
+    thread.start()
+
+    val reader = ContentLengthFramer(serverToClientIn)
+    val received = LinkedBlockingQueue<JsonObject>()
+    Thread(
+        {
+          try {
+            while (true) {
+              val frame = reader.readFrame() ?: break
+              val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+              received.put(obj)
+            }
+          } catch (_: Throwable) {}
+        },
+        "interactive-rpc-reader",
+      )
+      .apply { isDaemon = true }
+      .start()
+
+    return ServerHarness(server, thread, clientToServerOut, received, exitLatch)
+  }
+
+  private fun handshake(out: PipedOutputStream, received: LinkedBlockingQueue<JsonObject>) {
+    writeFrame(
+      out,
+      """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+        "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+        "moduleId":":test","moduleProjectDir":"/tmp",
+        "capabilities":{"visibility":true,"metrics":false}}}""",
+    )
+    val init = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 1 }
+    assertNotNull("initialize response should arrive", init)
+    writeFrame(out, """{"jsonrpc":"2.0","method":"initialized","params":{}}""")
+  }
+
+  private fun teardownServer(
+    out: PipedOutputStream,
+    received: LinkedBlockingQueue<JsonObject>,
+    thread: Thread,
+    exitLatch: CountDownLatch,
+  ) {
+    writeFrame(out, """{"jsonrpc":"2.0","id":99,"method":"shutdown"}""")
+    pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 99 }
+    writeFrame(out, """{"jsonrpc":"2.0","method":"exit"}""")
+    assertTrue("server should exit cleanly", exitLatch.await(5, TimeUnit.SECONDS))
+    thread.join(5_000)
+  }
+
+  private fun writeFrame(out: PipedOutputStream, json: String) {
+    val payload = json.toByteArray(Charsets.UTF_8)
+    out.write("Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII))
+    out.write(payload)
+    out.flush()
+  }
+
+  private fun pollUntil(
+    queue: LinkedBlockingQueue<JsonObject>,
+    timeoutMs: Long = 5_000,
+    matcher: (JsonObject) -> Boolean,
+  ): JsonObject? {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+      val remaining = (deadline - System.currentTimeMillis()).coerceAtLeast(0)
+      val msg = queue.poll(remaining, TimeUnit.MILLISECONDS) ?: return null
+      if (matcher(msg)) return msg
+    }
+    return null
+  }
+
+  /**
+   * Synthesises deterministic PNG-shaped bytes. We intentionally do NOT emit a real PNG — the
+   * daemon's dedup hashes raw bytes, not decoded pixels, so any byte-stable payload is sufficient.
+   * Different [seed]s produce different bytes; identical [seed]s produce identical bytes.
+   */
+  private fun testPngBytes(seed: Int): ByteArray {
+    // 8-byte PNG signature + 16 bytes payload keyed by seed. Doesn't need to be a valid
+    // PNG for the dedup path; the daemon does not decode the bytes.
+    val sig = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10)
+    val payload = ByteArray(16) { i -> ((i + seed * 13) and 0xFF).toByte() }
+    return sig + payload
+  }
+}
+
+/**
+ * Test-only [RenderHost] that returns a real on-disk PNG path on every render so the daemon's
+ * `hashFrameBytes` path actually runs. Driven by a single [defaultPng] file when the manifest is
+ * unset, or by a per-previewId map otherwise. The test mutates the file's bytes between renders to
+ * drive the dedup-hit / dedup-miss branches.
+ */
+private class BytesAwareFakeHost(
+  private val defaultPng: File,
+  private val perPreview: Map<String, File> = emptyMap(),
+) : RenderHost {
+
+  private val queue = LinkedBlockingQueue<RenderRequest>()
+
+  @Volatile private var stopped = false
+  val interruptCount = AtomicInteger(0)
+
+  private val results = ConcurrentHashMap<Long, LinkedBlockingQueue<RenderResult>>()
+
+  private val worker =
+    Thread(
+        {
+          while (!stopped) {
+            val req =
+              try {
+                queue.poll(100, TimeUnit.MILLISECONDS)
+              } catch (_: InterruptedException) {
+                interruptCount.incrementAndGet()
+                Thread.currentThread().interrupt()
+                return@Thread
+              } ?: continue
+            when (req) {
+              is RenderRequest.Render -> {
+                val previewId =
+                  if (req.payload.startsWith("previewId=")) req.payload.removePrefix("previewId=")
+                  else ""
+                val pngFile = perPreview[previewId] ?: defaultPng
+                val result =
+                  RenderResult(
+                    id = req.id,
+                    classLoaderHashCode = 0,
+                    classLoaderName = "fake",
+                    pngPath = pngFile.absolutePath,
+                    metrics = mapOf("tookMs" to 1L),
+                  )
+                results.computeIfAbsent(req.id) { LinkedBlockingQueue() }.put(result)
+              }
+              RenderRequest.Shutdown -> return@Thread
+            }
+          }
+        },
+        "bytes-aware-fake-host",
+      )
+      .apply { isDaemon = true }
+
+  override fun start() {
+    worker.start()
+  }
+
+  override fun submit(request: RenderRequest, timeoutMs: Long): RenderResult {
+    require(request is RenderRequest.Render)
+    queue.put(request)
+    val q = results.computeIfAbsent(request.id) { LinkedBlockingQueue() }
+    return q.poll(timeoutMs, TimeUnit.MILLISECONDS)
+      ?: error("BytesAwareFakeHost.submit($request) timed out")
+  }
+
+  override fun shutdown(timeoutMs: Long) {
+    stopped = true
+    queue.put(RenderRequest.Shutdown)
+    worker.join(timeoutMs)
+  }
+}

--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -1,10 +1,15 @@
 # Interactive mode (VS Code panel ↔ daemon)
 
-> **Status:** v0 — live-streaming surface in the VS Code webview, behind the
-> `composePreview.experimental.daemon.enabled` flag. Click-input is a
-> documented future extension; no protocol bump required to ship today's
-> behaviour. See [PROTOCOL.md](PROTOCOL.md) for the wire contract this builds
-> on.
+> **Status:** v1 — live-streaming surface plus `interactive/start` /
+> `interactive/stop` / `interactive/input` RPCs in the daemon, behind the
+> `composePreview.experimental.daemon.enabled` flag. Click coordinates are
+> forwarded to the daemon as `interactive/input` notifications; today the
+> daemon treats each input as a render trigger (LocalInspectionMode is still
+> true, so the renderer doesn't yet dispatch the click into the composition —
+> that's the v2 follow-up). Frame deduplication ships in v1: bytes-identical
+> follow-up renders carry `renderFinished.unchanged: true`, the client
+> short-circuits, and history is not re-archived. See
+> [PROTOCOL.md](PROTOCOL.md) for the wire contract this builds on.
 
 ## 1. What it is
 
@@ -107,7 +112,32 @@ Exit path is symmetric: `setInteractive { enabled: false }` clears the
 `.live` class and sends nothing further to the daemon (focus reverts to
 whatever the next save / focus-change publishes).
 
-## 5. What changes in the extension
+## 5. Frame deduplication
+
+Daemon-side, consulted on every `renderFinished` regardless of whether
+interactive mode is active:
+
+1. After the host returns a `RenderResult` whose `pngPath` points at a
+   real on-disk PNG, the daemon SHA-256s the bytes.
+2. If the hash matches the prior hash for the same `previewId`
+   (tracked in `lastFrameHashes: Map<String, String>`), the
+   `renderFinished` notification carries `unchanged: true` and the
+   history archiver is skipped — there's nothing new to write.
+3. The first `renderFinished` after `interactive/start` always paints
+   (the start handler wipes the cached hash). Without this a
+   `start` issued after a previous identical render would suppress
+   the bootstrap frame and the LIVE chip would have nothing to show
+   until the user clicks.
+
+Client side (`DaemonScheduler.handleRenderFinished` in
+`vscode-extension/src/daemon/daemonScheduler.ts`): `unchanged === true`
+short-circuits the disk read + base64 + `postMessage` hop, leaving the
+on-screen card untouched. Skipping work all the way to the webview is
+the whole point of the field — without it the panel would re-paint
+identical bytes and the user would see a tiny flicker on every
+no-op render.
+
+## 6. What changes in the extension
 
 - `vscode-extension/src/types.ts` — new `WebviewToExtension` variants
   `setInteractive`, `recordInteractiveClick`; new `ExtensionToWebview`
@@ -125,7 +155,7 @@ whatever the next save / focus-change publishes).
   the types co-located so a future daemon implementation lands in
   lockstep without a schema reshuffle.
 
-## 6. Click capture (today)
+## 7. Click capture
 
 The webview attaches a click handler to the focused card's `<img>`
 **only when `.live` is set**. On click it computes:
@@ -148,12 +178,14 @@ Extension logs the message to the output channel. **No daemon call is
 issued today.** Once `interactive/input` lands (§ 7) the same payload
 shape feeds the RPC.
 
-## 7. Future: click-input RPC (reserved)
+## 8. Click-input RPC (v1)
 
-The protocol additions are documented here so the wire contract is fixed
-before any daemon implementation. Adding these methods does **not** bump
+The protocol additions land in v1. Adding these methods does **not** bump
 `protocolVersion` — they're additive and unknown methods are dropped per
-[PROTOCOL.md § 7](PROTOCOL.md#7-versioning).
+[PROTOCOL.md § 7](PROTOCOL.md#7-versioning). Old clients drop the new
+notifications silently; old daemons reject `interactive/start` with
+`MethodNotFound (-32601)`, the panel logs and falls back to the legacy
+setFocus + renderNow path.
 
 ### `interactive/start` (request, client → daemon)
 
@@ -164,11 +196,19 @@ before any daemon implementation. Adding these methods does **not** bump
 { frameStreamId: string }           // opaque; passed back in interactive/input
 ```
 
-Tells the daemon "this preview is the user's interactive target — keep a
-warm sandbox for it, prefer it on every render-queue drain, do NOT recycle
-its sandbox on idle." Returns a stream id the client uses for input
-correlation. Multiple `start` calls overwrite the prior target (one
-interactive preview at a time — matches the panel's single-focus mode).
+Tells the daemon "this preview is an interactive target — keep a warm
+sandbox for it, prefer it on every render-queue drain, do NOT recycle
+its sandbox on idle." Returns a unique stream id the client uses for
+input correlation.
+
+**Multi-target on the wire.** Each `start` registers a fresh slot —
+concurrent streams targeting different (or even the same) preview ids
+coexist. Inputs route by `frameStreamId`, so a stop on one stream
+leaves the others untouched. The current panel UI is single-target
+(only one card carries `.live`), but the daemon does not require that;
+a programmatic client (side-by-side comparison view, CI agent driving
+multiple previews over one stdio pair) can drive concurrent streams
+without any wire change.
 
 ### `interactive/stop` (notification, client → daemon)
 
@@ -202,7 +242,29 @@ Backpressure is the panel's responsibility: don't send a new click before
 the prior frame arrives. Lost inputs are acceptable; the user will
 re-click.
 
-### Open questions for the future protocol
+### v1 implementation notes
+
+State lives in a `ConcurrentHashMap<String /*streamId*/, InteractiveTarget>` so
+multiple concurrent streams coexist. The dispatch flow inside `JsonRpcServer`:
+
+1. `interactive/start` — generate a unique `streamId` (monotonic), put a fresh
+   `(previewId, streamId)` entry into the targets map, wipe any cached frame
+   hash for that preview so the first interactive frame always paints, return
+   the stream id. Blank previewIds reject with `InvalidParams (-32602)`. The
+   wipe is per-preview (not per-stream) by design: two streams targeting the
+   same preview share dedup state because the bytes are the same bytes
+   regardless of which stream's input triggered the render.
+2. `interactive/stop` — `remove(streamId)` from the targets map. Idempotent
+   on stale or unknown ids — `remove` is a no-op when the key isn't present,
+   which is exactly the contract we want.
+3. `interactive/input` — look up the target by `streamId`; drop silently when
+   absent (the stream was never started, has been stopped, or the client
+   typo'd the id). Otherwise enqueue a render against the target preview
+   through the same `submitRenderAsync` path `renderNow` uses; the result
+   demuxes through the existing render-watcher thread back into
+   `renderFinished`.
+
+### Open questions for the v2 protocol
 
 1. **Coalescing.** Should the daemon coalesce a burst of `pointerMove` into
    one render, or render every event? Today's frame budget says coalesce
@@ -216,16 +278,32 @@ re-click.
    the click. For PNG-only output this is "send pixel coords, let Compose
    figure it out via its existing pointer-input pipeline." Works as long
    as `LocalInspectionMode = false` during interactive renders — see
-   [DESIGN § 8](DESIGN.md) on the inspection-mode trade-off.
+   [DESIGN § 8](DESIGN.md) on the inspection-mode trade-off. v1 leaves
+   `LocalInspectionMode = true`, so today's "click triggers a re-render"
+   doesn't yet route the input into the composition; v2 flips the local
+   to false during interactive frames and dispatches the pixel coords
+   into the active `ImageComposeScene`.
 
-## 8. Out of scope (v0)
+## 9. Out of scope (v1)
 
-- **Continuous-stream rendering** in the absence of edits/clicks. v0
+- **Continuous-stream rendering** in the absence of edits/clicks. v1
   treats `renderFinished` as the streaming heartbeat — no edits, no new
   frames. Animations remain the carousel's responsibility.
-- **Multi-preview simultaneous live mode.** One focused preview, one
-  `.live` card. The future `interactive/start` API formalises this with
-  the "overwrites prior target" semantics.
+- **Click-into-composition** dispatch. v1 routes the click coords as far
+  as the daemon's interactive/input RPC and triggers a fresh render of
+  the target preview, but the renderer body still composes with
+  `LocalInspectionMode = true` so the input doesn't reach the active
+  composition. v2 flips the local and dispatches the pixel coords
+  through `ImageComposeScene`'s pointer-input pipeline.
+- **Multi-preview simultaneous live mode in the panel UI.** The wire
+  protocol supports concurrent `interactive/start` streams (see § 8),
+  but the panel only renders a single `.live` card at a time. Lifting
+  the UI is purely a webview change — `interactivePreviewId` would
+  become a `Set<previewId>` and the LIVE chip / badge would attach per
+  card — but the affordance argument for surfacing multi-target to a
+  human is weak (the user can only meaningfully focus on one live
+  preview at a time). Programmatic clients are the load-bearing case
+  for multi-target on the wire today.
 - **Mouse-move / drag** events. Click is the smallest first surface; we
   reserve the wire shape but don't capture moves to keep the
   implementation honest.

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -213,6 +213,15 @@ export interface RenderFinishedParams {
      * attachments"; clients MUST treat the two interchangeably.
      */
     dataProducts?: DataProductAttachment[];
+    /**
+     * Interactive-mode dedup signal — see docs/daemon/INTERACTIVE.md § 5.
+     * `true` means the daemon already determined the rendered bytes are
+     * byte-identical to the last frame for this preview id, so the client
+     * can short-circuit the read-PNG → base64 → postMessage hop and leave
+     * the on-screen card untouched. `undefined` (the wire-side default
+     * when the daemon omits the field) means "client must paint".
+     */
+    unchanged?: boolean;
 }
 
 export interface RenderError {

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -296,6 +296,14 @@ export class DaemonScheduler {
             // same preview can re-render via the reactive path.
             this.speculated.delete(specKey(moduleId, params.id));
 
+            // INTERACTIVE.md § 5 frame dedup. Daemon already determined the bytes are
+            // byte-identical to the prior frame; skip the disk read + base64 + postMessage
+            // hop. The card stays painted with the bytes it's already showing — that's the
+            // whole point of the dedup signal.
+            if (params.unchanged === true) {
+                return;
+            }
+
             // Stub-render path: until B1.4 lands `RenderEngine` in the
             // daemon, every "successful" render returns
             // `<historyDir>/daemon-stub-<id>.{png,gif}` with no bytes

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1949,12 +1949,11 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             void handleSetInteractive(msg.previewId, msg.enabled);
             break;
         case 'recordInteractiveClick':
-            // v0 — log only. Once `interactive/input` ships (INTERACTIVE.md
-            // § 7) the same payload feeds the daemon notification.
             logLine(
                 `[interactive] click ${msg.previewId} px=${msg.pixelX},${msg.pixelY} `
                 + `image=${msg.imageWidth}x${msg.imageHeight}`,
             );
+            void forwardInteractiveClick(msg.previewId, msg.pixelX, msg.pixelY);
             break;
     }
 }
@@ -2527,15 +2526,15 @@ function lookupPreviewLabel(previewId: string): string | undefined {
 
 /**
  * Live-stream (interactive) mode entry/exit handler. See
- * docs/daemon/INTERACTIVE.md § 4 for the full lifecycle. v0 reuses the
- * existing setFocus + renderNow path — the panel-side LIVE chip is the
- * only user-visible difference. When the future `interactive/start` RPC
- * lands the daemon-side warm-sandbox lock plugs in here without touching
- * the panel.
+ * docs/daemon/INTERACTIVE.md § 4 for the full lifecycle. Calls
+ * `interactive/start` on the daemon to register the previewId as the
+ * priority target and stash the returned `frameStreamId` for click
+ * forwarding via [activeInteractiveStreams]. Exit calls `interactive/stop`
+ * (notification, drop-and-go) and clears the cached stream id.
  *
- * Exit (`enabled = false`) does not cancel anything daemon-side; it just
- * lets the next save-driven setFocus take over. Sending an explicit
- * setFocus([]) here would race with concurrent saves.
+ * Always falls back to the original setFocus + renderNow path so cards
+ * still receive a fresh first frame — `interactive/start` itself does
+ * not trigger a render, it just pins the slot.
  */
 async function handleSetInteractive(previewId: string, enabled: boolean): Promise<void> {
     if (!daemonGate?.isEnabled() || !daemonScheduler) { return; }
@@ -2545,11 +2544,21 @@ async function handleSetInteractive(previewId: string, enabled: boolean): Promis
         return;
     }
     if (!enabled) {
+        const stream = activeInteractiveStreams.get(previewId);
+        if (stream) {
+            activeInteractiveStreams.delete(previewId);
+            const client = await daemonGate?.getOrSpawn(
+                moduleId, daemonScheduler.daemonEvents(moduleId),
+            );
+            client?.interactiveStop({ frameStreamId: stream });
+        }
         logLine(`[interactive] live mode off for ${previewId}`);
         return;
     }
-    const ok = await daemonScheduler.ensureModule(moduleId);
-    if (!ok) {
+    const client = await daemonGate?.getOrSpawn(
+        moduleId, daemonScheduler.daemonEvents(moduleId),
+    );
+    if (!client) {
         // The webview already saw the toggle disabled — but the user could
         // have flipped settings between toggle render and click. Push a
         // fresh availability ping so the chip reverts cleanly.
@@ -2559,9 +2568,59 @@ async function handleSetInteractive(previewId: string, enabled: boolean): Promis
         });
         return;
     }
+    try {
+        const result = await client.interactiveStart({ previewId });
+        activeInteractiveStreams.set(previewId, result.frameStreamId);
+        logLine(
+            `[interactive] live mode on for ${previewId} (module=${moduleId}, ` +
+            `streamId=${result.frameStreamId})`,
+        );
+    } catch (err) {
+        // MethodNotFound on a daemon that predates the interactive RPC — fall through
+        // to the focus + renderNow path so the card still gets a fresh first frame.
+        logLine(
+            `[interactive] interactive/start unsupported for ${moduleId}: ` +
+            `${(err as Error).message}; falling back to setFocus + renderNow`,
+        );
+    }
     await daemonScheduler.setFocus(moduleId, [previewId]);
     await daemonScheduler.renderNow(moduleId, [previewId], 'fast', 'interactive-on');
-    logLine(`[interactive] live mode on for ${previewId} (module=${moduleId})`);
+}
+
+/**
+ * previewId → frameStreamId for currently-active interactive streams. Populated by
+ * [handleSetInteractive] on enter, cleared on exit. Click forwarding consults this
+ * to look up the stream id the daemon expects on `interactive/input` notifications;
+ * a missing entry means "interactive/start either wasn't issued, was rejected
+ * (MethodNotFound), or has already been stopped" — drop the click.
+ */
+const activeInteractiveStreams = new Map<string, string>();
+
+/**
+ * Forward a panel-side click on a live preview to the daemon's `interactive/input`
+ * notification. Drops silently when the previewId isn't currently in interactive mode
+ * — callers don't need to coordinate with the start/stop dance.
+ */
+async function forwardInteractiveClick(
+    previewId: string,
+    pixelX: number,
+    pixelY: number,
+): Promise<void> {
+    if (!daemonGate?.isEnabled() || !daemonScheduler) { return; }
+    const streamId = activeInteractiveStreams.get(previewId);
+    if (!streamId) { return; }
+    const moduleId = previewModuleMap.get(previewId);
+    if (!moduleId) { return; }
+    const client = await daemonGate?.getOrSpawn(
+        moduleId, daemonScheduler.daemonEvents(moduleId),
+    );
+    if (!client) { return; }
+    client.interactiveInput({
+        frameStreamId: streamId,
+        kind: 'click',
+        pixelX,
+        pixelY,
+    });
 }
 
 /**

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -211,6 +211,24 @@ describe('DaemonScheduler', () => {
         }
     });
 
+    it('short-circuits when renderFinished carries unchanged=true (frame dedup)', async () => {
+        // INTERACTIVE.md § 5 — the daemon already determined the bytes are byte-identical
+        // to the last frame for this preview id. The scheduler must skip the disk read +
+        // base64 + onPreviewImageReady hop so the panel doesn't repaint identical bytes.
+        const { gate, scheduler, images, failures } = build();
+        await scheduler.ensureModule('mod');
+        const evts = gate.capturedEvents.get('mod')!;
+        // Use a path that doesn't exist on disk — if the scheduler even tries to read it,
+        // it would emit onRenderFailed. The dedup short-circuit means it does neither:
+        // no image, no failure.
+        evts.onRenderFinished!({
+            id: 'p1', pngPath: '/no/such/dedup.png', tookMs: 5,
+            unchanged: true,
+        } as never);
+        assert.strictEqual(images.length, 0, 'unchanged=true must not emit onPreviewImageReady');
+        assert.strictEqual(failures.length, 0, 'unchanged=true must not trigger an unreadable-PNG failure path');
+    });
+
     it('reports onRenderFailed when the renderFinished PNG path is unreadable', async () => {
         const { gate, scheduler, failures } = build();
         await scheduler.ensureModule('mod');


### PR DESCRIPTION
Daemon-side counterpart to #394's panel work, rebased onto main after #397 (data products) and #398 (review cleanups) landed. Squashes the two original commits (`#395`'s daemon RPC + `#396`'s multi-target lift) into one linear commit so the diff is clean against current main.

`#395` and `#396` carried the original review history; both are still open against the now-stale base branch but contain no work that isn't here. Recommend closing them in favour of this PR once it merges.

## What this PR adds

- **`interactive/start` (request, client → daemon)** — `{ previewId } → { frameStreamId }`. Registers a new interactive target with a unique stream id; multiple concurrent starts coexist (multi-target on the wire). Wipes the cached frame hash for that preview so the bootstrap frame paints. Blank previewIds reject with `InvalidParams (-32602)`.
- **`interactive/stop` (notification)** — `{ frameStreamId }`. `remove(streamId)` from the targets map. Idempotent on stale or unknown ids.
- **`interactive/input` (notification)** — `{ frameStreamId, kind, pixelX?, pixelY?, keyCode? }`. Look up by streamId; drop silently when absent. Otherwise enqueue a render of the target preview through the same `submitRenderAsync` path `renderNow` uses; result demuxes via the existing render-watcher thread back into `renderFinished`.
- **Frame deduplication** — every `renderFinished` SHA-256s the rendered PNG bytes; on match against the prior hash for the same `previewId`, sets `renderFinished.unchanged: true` and skips the history archive. Tracked always (not just under interactive mode).
- **Click forwarding wired in `extension.ts`** — `recordInteractiveClick` from the panel feeds `client.interactiveInput(...)`; falls back to legacy `setFocus + renderNow` when the daemon doesn't speak the new RPC. The `unchanged: true` field short-circuits `DaemonScheduler.handleRenderFinished` so the panel never re-paints identical bytes.

## Multi-target on the wire, single-target in the UI

State is a `ConcurrentHashMap<String /*streamId*/, InteractiveTarget>` so concurrent streams targeting different (or even the same) preview ids coexist; inputs route by stream id. The panel UI deliberately keeps a single `.live` chip — the human-affordance argument for multi-target is weak — but programmatic clients (side-by-side comparison views, CI agents driving multiple previews over one stdio pair) can drive concurrent streams without any wire change. `INTERACTIVE.md § 9` documents this.

## Wire compatibility

Additive per [PROTOCOL.md § 7](docs/daemon/PROTOCOL.md#7-versioning) — no `protocolVersion` bump.
- Old daemons reject `interactive/start` with `MethodNotFound`; the panel logs and falls back.
- Old clients drop unknown notifications and ignore the unknown `unchanged` field on `renderFinished`.

The new `unchanged?` field on `RenderFinishedParams` sits next to the recently-merged `dataProducts?` field from #397 — both optional, both additive.

## What today's `interactive/input` does — and what it doesn't

v1 routes the click coords as far as the daemon and triggers a fresh render of the target preview, but the renderer body still composes with `LocalInspectionMode = true`, so the input does **not** reach the active composition. v2 flips that local during interactive frames and dispatches the pixel coords through `ImageComposeScene`'s pointer-input pipeline. This lets the wire shape settle before any renderer surgery — see `docs/daemon/INTERACTIVE.md` § 8 "Open questions".

## Tests

- New `daemon/core/.../InteractiveRpcIntegrationTest.kt` — drives a `JsonRpcServer` over piped streams against a deterministic bytes-aware fake host:
  - **`click_input_triggers_renderFinished_then_dedups_identical_frame`** — start → input → first frame paints → second input on identical bytes → `unchanged: true` → swap bytes → third input → fresh frame → stop → stale input is dropped.
  - **`start_with_blank_previewId_rejects_with_invalid_params`** — rejects blank ids.
  - **`multiple_concurrent_streams_route_inputs_independently`** — two starts coexist, inputs route correctly, stop on one leaves the other live.
- New `vscode-extension/.../daemonScheduler.test.ts` test asserts `unchanged: true` short-circuits the read+post hop without producing a failure path.

## Test plan

- [x] `LANG=C.UTF-8 LC_ALL=C.UTF-8 ./gradlew :daemon:core:test --tests "ee.schimke.composeai.daemon.InteractiveRpcIntegrationTest"` — 3/3 pass
- [x] `LANG=C.UTF-8 LC_ALL=C.UTF-8 ./gradlew :daemon:core:test --tests "ee.schimke.composeai.daemon.JsonRpcServerIntegrationTest"` — pre-existing suite still green
- [x] `cd vscode-extension && npm test` — 304/304 pass (including the new dedup short-circuit test)
- [ ] Manual smoke test in a running extension host (LIVE toggle → click → daemon roundtrip) — not exercised here


---
_Generated by [Claude Code](https://claude.ai/code/session_017NDGZk17VhvctNNoSrVZsK)_