### PR TITLE
chore(vscode): interactive-mode cleanups (stream flush + button micro-opt)

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -777,11 +777,47 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
 export function deactivate() {
     if (debounceTimer) { clearTimeout(debounceTimer); }
     pendingRefresh?.abort();
+    // Tell the daemon to release every interactive stream this session opened
+    // before the JVMs go away. Without this, a soft-leak window exists for
+    // streams the user toggled on but never explicitly toggled off — the
+    // daemon's slot would point at the orphan previewId until the JVM exits.
+    // Today's slot doesn't gate any background work so the leak is benign,
+    // but flushing here keeps things tidy for v2 where `interactive/start`
+    // pins a warm sandbox. Fire-and-forget — `flushInteractiveStreams` itself
+    // races against `daemonGate.dispose()` on a tight deadline.
+    void flushInteractiveStreams();
     // Drain any live daemon JVMs so the user doesn't end up with orphaned
     // processes after a window close. Fire-and-forget — VS Code won't wait
     // for an async deactivate beyond a few seconds anyway.
     void daemonGate?.dispose();
     disposePreviewMainBatches();
+}
+
+/**
+ * Sends `interactive/stop` for every entry in [activeInteractiveStreams] and
+ * clears the map. Called from {@link deactivate} so a window close doesn't
+ * leave the daemon thinking it has live targets. Idempotent — safe to call
+ * multiple times. Best-effort: failures (channel already closed, stop
+ * notification can't be written, daemon doesn't speak interactive RPC) are
+ * silently swallowed because we're on the way out anyway.
+ */
+async function flushInteractiveStreams(): Promise<void> {
+    if (activeInteractiveStreams.size === 0) { return; }
+    const entries = [...activeInteractiveStreams.entries()];
+    activeInteractiveStreams.clear();
+    if (!daemonGate?.isEnabled() || !daemonScheduler) { return; }
+    await Promise.all(entries.map(async ([previewId, streamId]) => {
+        try {
+            const moduleId = previewModuleMap.get(previewId);
+            if (!moduleId) { return; }
+            const client = await daemonGate?.getOrSpawn(
+                moduleId, daemonScheduler!.daemonEvents(moduleId),
+            );
+            client?.interactiveStop({ frameStreamId: streamId });
+        } catch {
+            /* deactivate path — best-effort */
+        }
+    }));
 }
 
 function sameScope(a: string[], b: string[]): boolean {

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -363,13 +363,24 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 
         function applyInteractiveButtonState() {
             const inFocus = layoutMode.value === 'focus';
-            const visible = getVisibleCards();
-            const card = inFocus ? visible[focusIndex] : null;
             // Hide outright when not in focus mode — the toolbar already
             // hides itself, but this keeps aria-pressed correct for tests
             // that snapshot the button in either layout.
             btnInteractive.hidden = !inFocus;
-            if (!inFocus || !card) {
+            if (!inFocus) {
+                // Cheap fast-path: applyLayout fires this on every layout
+                // change (filter tweaks, focus nav, every setPreviews). In
+                // non-focus modes the focus-controls strip is hidden by CSS,
+                // so nothing visible would change — skip the getVisibleCards
+                // DOM walk and the per-attribute writes. State on re-entry to
+                // focus mode is rebuilt fresh by the full path below.
+                btnInteractive.setAttribute('aria-pressed', 'false');
+                btnInteractive.classList.remove('live-on');
+                return;
+            }
+            const visible = getVisibleCards();
+            const card = visible[focusIndex];
+            if (!card) {
                 btnInteractive.disabled = true;
                 btnInteractive.setAttribute('aria-pressed', 'false');
                 btnInteractive.title = 'Daemon not ready — live mode unavailable';


### PR DESCRIPTION
Two small follow-ups to #400.

## 1. Flush interactive streams on extension deactivate

`extension.ts`'s `deactivate()` now calls a new `flushInteractiveStreams()` helper that walks `activeInteractiveStreams`, sends `interactive/stop` for each, and clears the map — before `daemonGate.dispose()` tears the JVMs down. Without this, any stream the user had toggled on but never explicitly toggled off would point at an orphan previewId in the daemon until the JVM exited.

Today's daemon-side slot doesn't gate any background work (no warm-sandbox lock yet — that lands with v2), so the leak is benign. But flushing here keeps things tidy for v2 where `interactive/start` actually pins a sandbox, and removes one zombie-state failure mode I'd flagged in #395 / #400 review.

Best-effort: failures (channel already closed, daemon doesn't speak interactive RPC, `getOrSpawn` rejects) are swallowed — we're on the way out anyway.

## 2. Early-return `applyInteractiveButtonState` when not in focus mode

The function fires on every `applyLayout` call — filter tweaks, focus nav, every `setPreviews` — and the previous form did a `getVisibleCards` DOM walk plus per-attribute writes even though the `focus-controls` strip is CSS-hidden in non-focus modes. The early-return now skips the DOM walk; state on re-entry to focus mode is rebuilt fresh by the full path.

Sub-millisecond either way; genuinely just tightening a hot-but-cheap path I called out in the original review.

## Test plan

- [x] `cd vscode-extension && npm run compile` — clean
- [x] `cd vscode-extension && npm test` — 304/304 pass
- [ ] Manual: toggle LIVE on a card, close VS Code, confirm no orphaned `interactive/start` slot in the daemon's next session — not exercised here (no running extension host)


---
_Generated by [Claude Code](https://claude.ai/code/session_017NDGZk17VhvctNNoSrVZsK)_