### PR TITLE
feat(daemon): per-call display-property overrides on renderNow

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -55,7 +55,8 @@ class PreviewManifestRouter(
       "Use shutdown() to stop the host, not submit(Shutdown)."
     }
     val typed = request as RenderRequest.Render
-    val previewId = parsePreviewId(typed.payload)
+    val inbound = parseInboundPayload(typed.payload)
+    val previewId = inbound["previewId"]
     val entry =
       previewId?.let { byId[it] }
         ?: error(
@@ -70,9 +71,10 @@ class PreviewManifestRouter(
           buildString {
             append("className=").append(entry.className).append(';')
             append("functionName=").append(entry.functionName).append(';')
-            append("widthPx=").append(resolved.widthPx).append(';')
-            append("heightPx=").append(resolved.heightPx).append(';')
-            append("density=").append(resolved.density).append(';')
+            // Inbound override wins over the per-preview manifest default.
+            append("widthPx=").append(inbound["widthPx"] ?: resolved.widthPx).append(';')
+            append("heightPx=").append(inbound["heightPx"] ?: resolved.heightPx).append(';')
+            append("density=").append(inbound["density"] ?: resolved.density).append(';')
             append("showBackground=").append(resolved.showBackground).append(';')
             if (resolved.backgroundColor != 0L) {
               append("backgroundColor=").append(resolved.backgroundColor).append(';')
@@ -80,18 +82,31 @@ class PreviewManifestRouter(
             resolved.device?.takeIf { it.isNotBlank() }?.let {
               append("device=").append(it).append(';')
             }
+            // PROTOCOL.md § 5 (`renderNow.overrides`) — locale / fontScale / uiMode / orientation
+            // pass straight through to the qualifier builder in `RenderEngine`. Wire-format twin
+            // of the desktop router; keep both in lockstep so a single payload drives both.
+            inbound["localeTag"]?.let { append("localeTag=").append(it).append(';') }
+            inbound["fontScale"]?.let { append("fontScale=").append(it).append(';') }
+            inbound["uiMode"]?.let { append("uiMode=").append(it).append(';') }
+            inbound["orientation"]?.let { append("orientation=").append(it).append(';') }
             append("outputBaseName=").append(resolved.outputBaseName)
           },
       )
     return super.submit(routed, timeoutMs)
   }
 
-  private fun parsePreviewId(payload: String): String? {
+  private fun parseInboundPayload(payload: String): Map<String, String> {
+    val map = mutableMapOf<String, String>()
     for (entry in payload.split(';')) {
       val trimmed = entry.trim()
-      if (trimmed.startsWith("previewId=")) return trimmed.substring("previewId=".length).trim()
+      if (trimmed.isEmpty()) continue
+      val eq = trimmed.indexOf('=')
+      if (eq <= 0) continue
+      val k = trimmed.substring(0, eq).trim()
+      val v = trimmed.substring(eq + 1).trim()
+      if (v.isNotEmpty()) map[k] = v
     }
-    return null
+    return map
   }
 
   companion object {

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -144,8 +144,11 @@ class RenderEngine(
       heightDp = pxToDp(spec.heightPx, spec.density),
       density = spec.density,
       isRound = isRound,
+      localeTag = spec.localeTag,
+      uiMode = spec.uiMode,
+      orientation = spec.orientation,
     )
-    org.robolectric.RuntimeEnvironment.setFontScale(1.0f)
+    org.robolectric.RuntimeEnvironment.setFontScale(spec.fontScale ?: 1.0f)
 
     // Activity registration mirrors `RobolectricRenderTest.renderDefault` — Robolectric 4.13+
     // requires the activity to be resolvable through `ShadowPackageManager` before
@@ -261,25 +264,59 @@ class RenderEngine(
   }
 
   /**
-   * Subset of `RobolectricRenderTest.applyPreviewQualifiers` — only the size / density / round
-   * qualifiers the daemon's v1 surface exercises. Locale / uiMode / orientation come from
-   * `@Preview` annotation fields the daemon doesn't yet thread through. Same `RuntimeEnvironment`
-   * entrypoints as the renderer — output dimensions match Studio's preview pane. Qualifier order
-   * follows Robolectric's strict grammar (locale, width, height, round, orientation, …, density).
+   * Builds and applies the Robolectric resource qualifier string for one render. Same
+   * `RuntimeEnvironment` entrypoint as `RobolectricRenderTest.applyPreviewQualifiers`; the
+   * difference is that the daemon takes locale / uiMode / orientation as overrides on the
+   * [RenderSpec] (see PROTOCOL.md § 5 `renderNow.overrides`) rather than reading them off
+   * `@Preview` annotation fields. Qualifier grammar is order-sensitive — locale, width, height,
+   * round, orientation, uiMode (notnight/night), density.
    */
-  private fun applyPreviewQualifiers(widthDp: Int, heightDp: Int, density: Float, isRound: Boolean) {
+  private fun applyPreviewQualifiers(
+    widthDp: Int,
+    heightDp: Int,
+    density: Float,
+    isRound: Boolean,
+    localeTag: String?,
+    uiMode: RenderSpec.SpecUiMode?,
+    orientation: RenderSpec.SpecOrientation?,
+  ) {
     val qualifiers = buildList {
+      if (!localeTag.isNullOrBlank()) add(localeTagToQualifier(localeTag))
       if (widthDp > 0) add("w${widthDp}dp")
       if (heightDp > 0) add("h${heightDp}dp")
       if (isRound) add("round")
-      if (widthDp > 0 && heightDp > 0) {
-        add(if (widthDp > heightDp) "land" else "port")
+      val derivedOrientation =
+        when (orientation) {
+          RenderSpec.SpecOrientation.PORTRAIT -> "port"
+          RenderSpec.SpecOrientation.LANDSCAPE -> "land"
+          null ->
+            if (widthDp > 0 && heightDp > 0) {
+              if (widthDp > heightDp) "land" else "port"
+            } else null
+        }
+      if (derivedOrientation != null) add(derivedOrientation)
+      when (uiMode) {
+        RenderSpec.SpecUiMode.LIGHT -> add("notnight")
+        RenderSpec.SpecUiMode.DARK -> add("night")
+        null -> {}
       }
       if (density > 0f) add("${(density * 160).toInt()}dpi")
     }
     if (qualifiers.isNotEmpty()) {
       org.robolectric.RuntimeEnvironment.setQualifiers("+${qualifiers.joinToString("-")}")
     }
+  }
+
+  /**
+   * Translates a BCP-47 locale tag (`en-US`, `fr`, `ja-JP`) to Robolectric's BCP-47 qualifier
+   * spelling (`b+en+US`, `b+fr`, `b+ja+JP`). Robolectric matches Android's resource framework: the
+   * `b+` prefix is mandatory for tags with non-empty regions or scripts; we use it unconditionally
+   * for simplicity — single-tag forms like `b+en` are accepted.
+   */
+  private fun localeTagToQualifier(tag: String): String {
+    val parts = tag.split('-', '_').filter { it.isNotBlank() }
+    if (parts.isEmpty()) return ""
+    return "b+${parts.joinToString("+")}"
   }
 
   companion object {
@@ -357,14 +394,40 @@ data class RenderSpec(
   val device: String? = null,
   /** Stem used for the output PNG filename (e.g. "preview-A" → "<outputDir>/preview-A.png"). */
   val outputBaseName: String = "${className.substringAfterLast('.')}-$functionName",
+  /**
+   * BCP-47 locale tag — overrides the default qualifier set when non-null. Threaded through the
+   * `+` qualifier prefix as `b+lang+region` (Robolectric grammar; see `applyPreviewQualifiers`).
+   */
+  val localeTag: String? = null,
+  /**
+   * Font scale multiplier. Null means "use whatever Robolectric defaults to" (1.0). Non-null
+   * routes through `RuntimeEnvironment.setFontScale` — same `Configuration` knob `RoborazziCompose
+   * FontScaleOption` uses.
+   */
+  val fontScale: Float? = null,
+  /** Light/dark mode override → `notnight` / `night` qualifier. */
+  val uiMode: SpecUiMode? = null,
+  /** Portrait/landscape override → `port` / `land` qualifier. Overrides the size-derived guess. */
+  val orientation: SpecOrientation? = null,
 ) {
+
+  enum class SpecUiMode {
+    LIGHT,
+    DARK,
+  }
+
+  enum class SpecOrientation {
+    PORTRAIT,
+    LANDSCAPE,
+  }
 
   companion object {
 
     /**
      * Parses [RenderRequest.Render.payload] — a `;`-delimited `key=value` string — into a
      * [RenderSpec]. Recognised keys: `className`, `functionName`, `widthPx`, `heightPx`, `density`,
-     * `showBackground`, `backgroundColor`, `device`, `outputBaseName`. `className` and
+     * `showBackground`, `backgroundColor`, `device`, `outputBaseName`, `localeTag`, `fontScale`,
+     * `uiMode` (`light`/`dark`), `orientation` (`portrait`/`landscape`). `className` and
      * `functionName` are required; everything else falls back to the defaults on this data class.
      * Returns `null` when the payload doesn't carry a `className=` token (the discriminator the
      * host uses to route legacy stub-payload requests through the classloader-identity path).
@@ -392,6 +455,20 @@ data class RenderSpec(
         backgroundColor = map["backgroundColor"]?.toLongOrNull() ?: defaults.backgroundColor,
         device = map["device"]?.takeIf { it.isNotBlank() } ?: defaults.device,
         outputBaseName = map["outputBaseName"] ?: defaults.outputBaseName,
+        localeTag = map["localeTag"]?.takeIf { it.isNotBlank() },
+        fontScale = map["fontScale"]?.toFloatOrNull(),
+        uiMode =
+          when (map["uiMode"]?.lowercase()) {
+            "light" -> SpecUiMode.LIGHT
+            "dark" -> SpecUiMode.DARK
+            else -> null
+          },
+        orientation =
+          when (map["orientation"]?.lowercase()) {
+            "portrait" -> SpecOrientation.PORTRAIT
+            "landscape" -> SpecOrientation.LANDSCAPE
+            else -> null
+          },
       )
     }
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -35,6 +35,8 @@ import ee.schimke.composeai.daemon.protocol.JsonRpcRequest
 import ee.schimke.composeai.daemon.protocol.JsonRpcResponse
 import ee.schimke.composeai.daemon.protocol.LeakDetectionMode
 import ee.schimke.composeai.daemon.protocol.Manifest
+import ee.schimke.composeai.daemon.protocol.Orientation
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.PruneReasonWire
 import ee.schimke.composeai.daemon.protocol.RejectedRender
 import ee.schimke.composeai.daemon.protocol.RenderFinishedParams
@@ -45,6 +47,7 @@ import ee.schimke.composeai.daemon.protocol.RenderStartedParams
 import ee.schimke.composeai.daemon.protocol.ServerCapabilities
 import ee.schimke.composeai.daemon.protocol.SetFocusParams
 import ee.schimke.composeai.daemon.protocol.SetVisibleParams
+import ee.schimke.composeai.daemon.protocol.UiMode
 import java.io.ByteArrayOutputStream
 import java.io.EOFException
 import java.io.IOException
@@ -290,6 +293,16 @@ class JsonRpcServer(
   private val lastFrameHashes = ConcurrentHashMap<String, String>()
 
   private val nextStreamIdCounter = java.util.concurrent.atomic.AtomicLong(1)
+
+  /**
+   * Preview ids currently in-flight for an override-bearing render. PROTOCOL.md § 5
+   * (`renderNow.overrides`) — when a second override-bearing `renderNow` arrives for a previewId
+   * already in this set, we reject with `coalesced` rather than queue it. This is the daemon-side
+   * half of "don't drown the queue when the user is dragging a slider"; the panel / MCP client is
+   * responsible for retrying on the next `renderFinished` if the latest override values still
+   * differ from what was rendered (see docs/daemon/INTERACTIVE.md § "Display overrides").
+   */
+  private val previewIdsWithOverridesInFlight = ConcurrentHashMap.newKeySet<String>()
 
   private val writerThread =
     Thread({ writerLoop() }, "compose-ai-daemon-writer").apply { isDaemon = false }
@@ -552,11 +565,26 @@ class JsonRpcServer(
     val queued = mutableListOf<String>()
     val rejected = mutableListOf<RejectedRender>()
     val now = System.currentTimeMillis()
+    val overrides = params.overrides
     for (previewId in params.previews) {
       // Stub policy for B1.5: accept any non-blank id. UnknownPreview (-32004)
       // requires a real discovery set, which lands with B2.2.
       if (previewId.isBlank()) {
         rejected.add(RejectedRender(id = previewId, reason = "blank preview id"))
+        continue
+      }
+      // Coalesce a slider-drag burst: if an override-bearing render is still in-flight for this
+      // previewId, drop the new one and let the client resubmit on `renderFinished`. Without this
+      // a fast drag fans out to N parallel sandbox renders that all serialise on the same slot.
+      // No coalescing on plain (no-overrides) `renderNow` so the existing save-debounce loop is
+      // unaffected.
+      if (overrides != null && !previewIdsWithOverridesInFlight.add(previewId)) {
+        rejected.add(
+          RejectedRender(
+            id = previewId,
+            reason = "coalesced: override-bearing render already in flight for this previewId",
+          )
+        )
         continue
       }
       val hostId = RenderHost.nextRequestId()
@@ -566,14 +594,14 @@ class JsonRpcServer(
       // Submit to host on a worker thread so we don't block the read loop.
       // submit() returns when the host returns a result; the watcher thread
       // demuxes the result back into renderFinished.
-      submitRenderAsync(hostId)
+      submitRenderAsync(hostId, overrides)
       queued.add(previewId)
     }
     val result = RenderNowResult(queued = queued, rejected = rejected)
     sendResponse(req.id, encode(RenderNowResult.serializer(), result))
   }
 
-  private fun submitRenderAsync(hostId: Long) {
+  private fun submitRenderAsync(hostId: Long, overrides: PreviewOverrides? = null) {
     // Fire-and-forget: the watcher thread polls the result and emits the
     // notification. We use a fresh thread (cheap; we expect O(visible) renders
     // queued at a time) rather than a pool to keep wiring trivial — B1.4 will
@@ -588,7 +616,7 @@ class JsonRpcServer(
     // the RenderRequest shape. B-desktop.1.4 will replace this with a typed
     // field; until then this is the documented workaround.
     val previewId = hostIdToPreviewId[hostId] ?: ""
-    val payload = if (previewId.isNotEmpty()) "previewId=$previewId" else ""
+    val payload = encodeRenderPayload(previewId, overrides)
     Thread(
         {
           try {
@@ -613,6 +641,67 @@ class JsonRpcServer(
       )
       .apply { isDaemon = true }
       .start()
+  }
+
+  /**
+   * Encodes the host-bound `RenderRequest.Render.payload` string. Today this carries:
+   *
+   * - `previewId=<id>` — the discovery-time identifier the per-backend `PreviewManifestRouter`
+   *   resolves into a [RenderSpec] before dispatch.
+   * - Optional `widthPx`, `heightPx`, `density`, `localeTag`, `fontScale`, `uiMode`, `orientation`
+   *   — the [PreviewOverrides] from this `renderNow` call. Routers preserve these when rewriting
+   *   the payload, and they win over the manifest entry's per-preview defaults.
+   *
+   * `;`-delimited so the existing `RenderSpec.parseFromPayload(OrNull)` parsers read each pair
+   * directly. See PROTOCOL.md § 5 (`renderNow.overrides`) for the wire-level shape.
+   */
+  private fun encodeRenderPayload(previewId: String, overrides: PreviewOverrides?): String {
+    return buildString {
+      if (previewId.isNotEmpty()) append("previewId=").append(previewId)
+      if (overrides == null) return@buildString
+      overrides.widthPx?.let {
+        if (isNotEmpty()) append(';')
+        append("widthPx=").append(it)
+      }
+      overrides.heightPx?.let {
+        if (isNotEmpty()) append(';')
+        append("heightPx=").append(it)
+      }
+      overrides.density?.let {
+        if (isNotEmpty()) append(';')
+        append("density=").append(it)
+      }
+      overrides.localeTag
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          if (isNotEmpty()) append(';')
+          append("localeTag=").append(it)
+        }
+      overrides.fontScale?.let {
+        if (isNotEmpty()) append(';')
+        append("fontScale=").append(it)
+      }
+      overrides.uiMode?.let {
+        if (isNotEmpty()) append(';')
+        append("uiMode=")
+        append(
+          when (it) {
+            UiMode.LIGHT -> "light"
+            UiMode.DARK -> "dark"
+          }
+        )
+      }
+      overrides.orientation?.let {
+        if (isNotEmpty()) append(';')
+        append("orientation=")
+        append(
+          when (it) {
+            Orientation.PORTRAIT -> "portrait"
+            Orientation.LANDSCAPE -> "landscape"
+          }
+        )
+      }
+    }
   }
 
   private val renderResultsQueue = LinkedBlockingQueue<Any>()
@@ -687,6 +776,7 @@ class JsonRpcServer(
       recordHistoryForRender(previewId = previewId, result = result, finished = finished)
     }
     inFlightRenders.remove(result.id)
+    previewIdsWithOverridesInFlight.remove(previewId)
     // Save-after-render invariant: a `fileChanged({kind:source})` queued discovery work that has
     // been waiting for this render to ship. The writer queue is FIFO and `renderFinished` is
     // already in it — kicking the discovery scan now guarantees its `discoveryUpdated`
@@ -1072,6 +1162,7 @@ class JsonRpcServer(
     val previewId = hostIdToPreviewId.remove(failure.hostId) ?: failure.hostId.toString()
     acceptedAtMs.remove(failure.hostId)
     inFlightRenders.remove(failure.hostId)
+    previewIdsWithOverridesInFlight.remove(previewId)
     // Minimal renderFailed; B1.4 widens this to the real RenderError shape.
     val payload = buildJsonObject {
       put("id", JsonPrimitive(previewId))

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -185,7 +185,50 @@ data class RenderNowParams(
   val previews: List<String>,
   val tier: RenderTier,
   val reason: String? = null,
+  /**
+   * Optional per-call display-property overrides. Applied to every preview in [previews] for this
+   * call only; a subsequent `renderNow` without `overrides` reverts to the discovery-time
+   * `RenderSpec` from `previews.json`. See PROTOCOL.md § 5 ("renderNow") and
+   * docs/daemon/INTERACTIVE.md § "Display overrides".
+   */
+  val overrides: PreviewOverrides? = null,
 )
+
+/**
+ * Per-render display-property overrides, threaded through to each backend's `RenderEngine`. Every
+ * field is optional — fields left null fall back to the discovery-time `RenderSpec`. Backends that
+ * don't model a particular field (e.g. desktop has no `uiMode` resource qualifier) ignore it. See
+ * PROTOCOL.md § 5 ("renderNow.overrides").
+ */
+@Serializable
+data class PreviewOverrides(
+  /** Sandbox width in pixels. Mirrors `@Preview(widthDp=…)` × density. */
+  val widthPx: Int? = null,
+  /** Sandbox height in pixels. */
+  val heightPx: Int? = null,
+  /** Display density (1.0 = mdpi/160dpi, 2.0 = xhdpi/320dpi, etc.). */
+  val density: Float? = null,
+  /** BCP-47 locale tag (e.g. `"en-US"`, `"fr"`, `"ja-JP"`). Android-only today. */
+  val localeTag: String? = null,
+  /** Font scale multiplier (1.0 = system default, 1.3 = "large", 2.0 = max accessibility). */
+  val fontScale: Float? = null,
+  /** Light/dark mode override. Android-only today. */
+  val uiMode: UiMode? = null,
+  /** Portrait/landscape override. Android-only today. */
+  val orientation: Orientation? = null,
+)
+
+@Serializable
+enum class UiMode {
+  @SerialName("light") LIGHT,
+  @SerialName("dark") DARK,
+}
+
+@Serializable
+enum class Orientation {
+  @SerialName("portrait") PORTRAIT,
+  @SerialName("landscape") LANDSCAPE,
+}
 
 @Serializable
 enum class RenderTier {

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/protocol/MessagesTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/protocol/MessagesTest.kt
@@ -40,6 +40,10 @@ class MessagesTest {
 
   @Test fun roundTripRenderNowParams() = roundTrip<RenderNowParams>("client-renderNow.json")
 
+  @Test
+  fun roundTripRenderNowParamsWithOverrides() =
+    roundTrip<RenderNowParams>("client-renderNow-overrides.json")
+
   @Test fun roundTripRenderNowResult() = roundTrip<RenderNowResult>("daemon-renderNowResult.json")
 
   @Test
@@ -126,6 +130,7 @@ class MessagesTest {
         "client-setFocus.json",
         "client-fileChanged.json",
         "client-renderNow.json",
+        "client-renderNow-overrides.json",
         "daemon-renderNowResult.json",
         "daemon-discoveryUpdated.json",
         "daemon-renderStarted.json",

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -49,7 +49,8 @@ class PreviewManifestRouter(
       "Use shutdown() to stop the host, not submit(Shutdown)."
     }
     val typed = request as RenderRequest.Render
-    val previewId = parsePreviewId(typed.payload)
+    val inbound = parseInboundPayload(typed.payload)
+    val previewId = inbound["previewId"]
     val entry =
       previewId?.let { byId[it] }
         ?: error(
@@ -64,9 +65,10 @@ class PreviewManifestRouter(
           buildString {
             append("className=").append(entry.className).append(';')
             append("functionName=").append(entry.functionName).append(';')
-            append("widthPx=").append(resolved.widthPx).append(';')
-            append("heightPx=").append(resolved.heightPx).append(';')
-            append("density=").append(resolved.density).append(';')
+            // Inbound override wins over the per-preview manifest default.
+            append("widthPx=").append(inbound["widthPx"] ?: resolved.widthPx).append(';')
+            append("heightPx=").append(inbound["heightPx"] ?: resolved.heightPx).append(';')
+            append("density=").append(inbound["density"] ?: resolved.density).append(';')
             append("showBackground=").append(resolved.showBackground).append(';')
             if (resolved.backgroundColor != 0L) {
               append("backgroundColor=").append(resolved.backgroundColor).append(';')
@@ -74,18 +76,32 @@ class PreviewManifestRouter(
             resolved.device
               ?.takeIf { it.isNotBlank() }
               ?.let { append("device=").append(it).append(';') }
+            // PROTOCOL.md § 5 (`renderNow.overrides`) — locale / fontScale / uiMode / orientation
+            // pass straight through. Desktop's `RenderEngine` ignores everything except size /
+            // density today (see RenderEngine.kt), but the fields ride along for parity with the
+            // android router so a single payload string drives both backends.
+            inbound["localeTag"]?.let { append("localeTag=").append(it).append(';') }
+            inbound["fontScale"]?.let { append("fontScale=").append(it).append(';') }
+            inbound["uiMode"]?.let { append("uiMode=").append(it).append(';') }
+            inbound["orientation"]?.let { append("orientation=").append(it).append(';') }
             append("outputBaseName=").append(resolved.outputBaseName)
           },
       )
     return super.submit(routed, timeoutMs)
   }
 
-  private fun parsePreviewId(payload: String): String? {
+  private fun parseInboundPayload(payload: String): Map<String, String> {
+    val map = mutableMapOf<String, String>()
     for (entry in payload.split(';')) {
       val trimmed = entry.trim()
-      if (trimmed.startsWith("previewId=")) return trimmed.substring("previewId=".length).trim()
+      if (trimmed.isEmpty()) continue
+      val eq = trimmed.indexOf('=')
+      if (eq <= 0) continue
+      val k = trimmed.substring(0, eq).trim()
+      val v = trimmed.substring(eq + 1).trim()
+      if (v.isNotEmpty()) map[k] = v
     }
-    return null
+    return map
   }
 
   companion object {

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -210,14 +210,41 @@ data class RenderSpec(
   val device: String? = null,
   /** Stem used for the output PNG filename (e.g. "preview-A" → "<outputDir>/preview-A.png"). */
   val outputBaseName: String = "${className.substringAfterLast('.')}-$functionName",
+  /**
+   * BCP-47 locale tag override. Carried on the wire for parity with `:daemon:android`'s
+   * `RenderSpec`; Compose Desktop has no Android-style resource qualifier system so this is a no-op
+   * on the desktop render path today. A future change can route it into `LocalConfiguration` /
+   * `androidx.compose.ui.text.intl.Locale.current` if a desktop consumer needs it.
+   */
+  val localeTag: String? = null,
+  /**
+   * Font scale multiplier override. No-op on desktop today (would route through `LocalDensity`'s
+   * `fontScale` field); carried for wire parity with `:daemon:android`.
+   */
+  val fontScale: Float? = null,
+  /** Light/dark mode override. No-op on desktop today; carried for wire parity. */
+  val uiMode: SpecUiMode? = null,
+  /** Portrait/landscape override. Desktop only honours derived size; carried for wire parity. */
+  val orientation: SpecOrientation? = null,
 ) {
+
+  enum class SpecUiMode {
+    LIGHT,
+    DARK,
+  }
+
+  enum class SpecOrientation {
+    PORTRAIT,
+    LANDSCAPE,
+  }
 
   companion object {
 
     /**
      * Parses [RenderRequest.Render.payload] — a `;`-delimited `key=value` string — into a
      * [RenderSpec]. Recognised keys: `className`, `functionName`, `widthPx`, `heightPx`, `density`,
-     * `showBackground`, `backgroundColor`, `device`, `outputBaseName`. `className` and
+     * `showBackground`, `backgroundColor`, `device`, `outputBaseName`, `localeTag`, `fontScale`,
+     * `uiMode` (`light`/`dark`), `orientation` (`portrait`/`landscape`). `className` and
      * `functionName` are required; everything else falls back to the defaults on this data class.
      *
      * Keeping this stringly-typed for v1 is deliberate (per the task brief). When `RenderRequest`
@@ -250,6 +277,20 @@ data class RenderSpec(
         backgroundColor = map["backgroundColor"]?.toLongOrNull() ?: defaults.backgroundColor,
         device = map["device"]?.takeIf { it.isNotBlank() } ?: defaults.device,
         outputBaseName = map["outputBaseName"] ?: defaults.outputBaseName,
+        localeTag = map["localeTag"]?.takeIf { it.isNotBlank() },
+        fontScale = map["fontScale"]?.toFloatOrNull(),
+        uiMode =
+          when (map["uiMode"]?.lowercase()) {
+            "light" -> SpecUiMode.LIGHT
+            "dark" -> SpecUiMode.DARK
+            else -> null
+          },
+        orientation =
+          when (map["orientation"]?.lowercase()) {
+            "portrait" -> SpecOrientation.PORTRAIT
+            "landscape" -> SpecOrientation.LANDSCAPE
+            else -> null
+          },
       )
     }
   }

--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -284,6 +284,49 @@ multiple concurrent streams coexist. The dispatch flow inside `JsonRpcServer`:
    to false during interactive frames and dispatches the pixel coords
    into the active `ImageComposeScene`.
 
+## 8a. Display overrides
+
+Per-render display properties — **size**, **density**, **locale**,
+**fontScale**, **uiMode** (light/dark), **orientation** — ride on the existing
+`renderNow` request via the optional `overrides` field documented in
+[PROTOCOL.md § 5](PROTOCOL.md#renderNow). They are not interactive-only: any
+caller (panel, MCP, future RPC) can attach overrides to a single `renderNow`
+to get a one-off render with a different qualifier set. A subsequent
+`renderNow` without `overrides` reverts to the discovery-time `RenderSpec` —
+overrides are call-scoped, not session-scoped.
+
+**Why not interactive-only.** Size/density/locale/fontScale/uiMode/orientation
+are all the same Robolectric qualifier knob (`setQualifiers` +
+`setFontScale`) under the hood. Splitting "size lives on `interactive/*`" vs
+"the rest live on `renderNow`" duplicates the plumbing for no payoff, and the
+MCP use case is overwhelmingly static ("render this at width=400, locale=fr,
+dark") so MCP needs them on the static path regardless. Interactive mode is
+just "auto-fire `renderNow` with the current overrides whenever the user
+moves a slider."
+
+**Coalescing.** When the user drags a width slider you don't want every
+intermediate value to queue a Robolectric render. The daemon coalesces:
+when an override-bearing `renderNow` arrives for a previewId that already
+has an override-bearing render in-flight, the new one is rejected with
+`reason = "coalesced: …"`. The panel / MCP client resubmits on the next
+`renderFinished` if the latest override values still differ from what was
+rendered. Plain (no-overrides) `renderNow` is unaffected — the save-debounce
+loop continues to coalesce upstream.
+
+**MCP surface.** The `render_preview` tool accepts the same `overrides`
+sub-object verbatim — see `mcp/src/main/kotlin/.../DaemonMcpServer.kt` (tool
+definition + `decodePreviewOverrides`). Agents asking "show me this preview
+in dark mode at width 400" route through the static path; no live-mode
+toggle required.
+
+**Backend fidelity.** The Android renderer applies all seven fields via
+`applyPreviewQualifiers` + `RuntimeEnvironment.setFontScale`. The desktop
+renderer applies size/density only; `uiMode` / `localeTag` / `fontScale` /
+`orientation` ride on the wire for parity but are no-ops on plain Skiko
+today (Compose Desktop has no Android-style resource qualifier system —
+they'd need to thread through `LocalConfiguration` /
+`androidx.compose.ui.text.intl.Locale.current`, which is a follow-up).
+
 ## 9. v2 — click dispatch into composition
 
 > **Status:** design only. v1 ships the wire shape; v2 makes

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -189,16 +189,32 @@ A `classpath` event triggers Tier-1 fingerprint recomputation; on mismatch the d
   previews: string[];                // preview IDs; empty = render all visible-and-stale
   tier: "fast" | "full";             // "fast" = single best-effort frame; "full" = full advanceTimeBy loop
   reason?: string;                   // free-form, surfaces in logs (e.g. "user clicked refresh")
+  overrides?: PreviewOverrides;      // optional per-call display-property overrides
+}
+
+// PreviewOverrides — every field optional; null falls back to the discovery-time RenderSpec.
+{
+  widthPx?: number;
+  heightPx?: number;
+  density?: number;                  // 1.0 = mdpi/160dpi, 2.0 = xhdpi/320dpi
+  localeTag?: string;                // BCP-47 (e.g. "en-US", "fr", "ja-JP"). Android-only today.
+  fontScale?: number;                // 1.0 = system default
+  uiMode?: "light" | "dark";         // Android-only today.
+  orientation?: "portrait" | "landscape";  // Android-only today.
 }
 
 // result
 {
   queued: string[];                  // IDs accepted into the render queue
-  rejected: { id: string; reason: string }[];   // unknown preview, etc.
+  rejected: { id: string; reason: string }[];   // unknown preview, coalesced, etc.
 }
 ```
 
 The result resolves as soon as the request is queued, **not** when rendering completes. Per-render progress arrives as `renderStarted` / `renderFinished` / `renderFailed` notifications keyed by ID.
+
+`overrides` are merged onto the discovery-time `RenderSpec` per-call. A subsequent `renderNow` for the same preview **without** `overrides` reverts to the discovery-time defaults — overrides are not sticky across calls. Backends that don't model a particular field ignore it (e.g. desktop has no Android resource qualifier system, so `uiMode` / `localeTag` / `orientation` are no-ops on the desktop render path today).
+
+**Coalescing.** When `overrides` is non-null and a prior override-bearing render is still in-flight for the same `previewId`, the new request is rejected with `reason = "coalesced: …"` rather than queued. The client (panel, MCP, etc.) is responsible for resubmitting on the next `renderFinished` if the latest override values still differ from what was rendered. Plain (no-overrides) `renderNow` is unaffected — the existing save-debounce loop continues to coalesce upstream.
 
 Errors:
 - `ClasspathDirty` (-32002) — daemon will not render until restarted.

--- a/docs/daemon/protocol-fixtures/README.md
+++ b/docs/daemon/protocol-fixtures/README.md
@@ -11,7 +11,7 @@ Fixture inventory (added in B1.2):
 - `client-initialize.json` — `initialize` request params (§ 3).
 - `daemon-initializeResult.json` — `initialize` response result (§ 3).
 - `client-setVisible.json`, `client-setFocus.json`, `client-fileChanged.json` — client → daemon notifications (§ 4).
-- `client-renderNow.json`, `daemon-renderNowResult.json` — `renderNow` request and response (§ 5).
+- `client-renderNow.json`, `client-renderNow-overrides.json`, `daemon-renderNowResult.json` — `renderNow` request (with and without `overrides`) and response (§ 5).
 - `daemon-discoveryUpdated.json`, `daemon-renderStarted.json`, `daemon-renderFinished.json`, `daemon-renderFailed.json`, `daemon-classpathDirty.json`, `daemon-sandboxRecycle.json`, `daemon-daemonWarming.json`, `daemon-daemonReady.json`, `daemon-log.json` — daemon → client notifications (§ 6).
 - `envelope-request.json`, `envelope-response.json`, `envelope-notification.json`, `envelope-errorResponse.json` — JSON-RPC envelope shapes (§ 2).
 

--- a/docs/daemon/protocol-fixtures/client-renderNow-overrides.json
+++ b/docs/daemon/protocol-fixtures/client-renderNow-overrides.json
@@ -1,0 +1,14 @@
+{
+  "previews": ["com.example.HomeKt#HomePreview"],
+  "tier": "fast",
+  "reason": "user dragged width slider",
+  "overrides": {
+    "widthPx": 600,
+    "heightPx": 800,
+    "density": 2.0,
+    "localeTag": "fr-FR",
+    "fontScale": 1.3,
+    "uiMode": "dark",
+    "orientation": "portrait"
+  }
+}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
@@ -20,6 +20,7 @@ import ee.schimke.composeai.daemon.protocol.InitializeResult
 import ee.schimke.composeai.daemon.protocol.JsonRpcNotification
 import ee.schimke.composeai.daemon.protocol.JsonRpcRequest
 import ee.schimke.composeai.daemon.protocol.Options
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RenderNowParams
 import ee.schimke.composeai.daemon.protocol.RenderNowResult
 import ee.schimke.composeai.daemon.protocol.RenderTier
@@ -148,10 +149,12 @@ class DaemonClient(
     previews: List<String>,
     tier: RenderTier = RenderTier.FULL,
     reason: String? = null,
+    overrides: PreviewOverrides? = null,
     timeout: Duration = 30.seconds,
   ): RenderNowResult {
     val id = nextId.getAndIncrement()
-    val params = RenderNowParams(previews = previews, tier = tier, reason = reason)
+    val params =
+      RenderNowParams(previews = previews, tier = tier, reason = reason, overrides = overrides)
     val request =
       JsonRpcRequest(
         id = id,

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -2,7 +2,10 @@ package ee.schimke.composeai.mcp
 
 import ee.schimke.composeai.daemon.protocol.ChangeType
 import ee.schimke.composeai.daemon.protocol.FileKind
+import ee.schimke.composeai.daemon.protocol.Orientation
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RenderTier
+import ee.schimke.composeai.daemon.protocol.UiMode
 import ee.schimke.composeai.mcp.protocol.CallToolResult
 import ee.schimke.composeai.mcp.protocol.ContentBlock
 import ee.schimke.composeai.mcp.protocol.Implementation
@@ -282,6 +285,7 @@ class DaemonMcpServer(
     uri: PreviewUri,
     session: McpSession? = null,
     progressToken: JsonElement? = null,
+    overrides: PreviewOverrides? = null,
   ): ByteArray {
     val daemon = supervisor.daemonFor(uri.workspaceId, uri.modulePath)
     val key = RenderKey(uri.workspaceId, uri.modulePath, uri.previewFqn)
@@ -302,7 +306,7 @@ class DaemonMcpServer(
     // single-daemon path.
     daemon
       .clientForRender(uri.previewFqn)
-      .renderNow(previews = listOf(uri.previewFqn), tier = RenderTier.FULL)
+      .renderNow(previews = listOf(uri.previewFqn), tier = RenderTier.FULL, overrides = overrides)
     // Optional `notifications/progress` beat: when the client opted in via
     // `_meta.progressToken`, fire periodic monotonic progress notifications so a UI can show a
     // spinner / progress bar while the slow render completes. Beat thread is daemon-flagged
@@ -375,14 +379,29 @@ class DaemonMcpServer(
       ToolDef(
         name = "render_preview",
         description =
-          "Force-render a preview by URI, bypassing any cache. Returns the rendered PNG inline.",
+          "Force-render a preview by URI, bypassing any cache. Returns the rendered PNG inline. " +
+            "Optional `overrides` apply per-call display-property overrides (size, density, " +
+            "locale, fontScale, uiMode, orientation) — see PROTOCOL.md § 5 (`renderNow.overrides`).",
         inputSchema =
           parseSchema(
             """
             {
               "type":"object",
               "properties":{
-                "uri":{"type":"string","description":"compose-preview://<workspace>/<module>/<fqn>?config=<qualifier>"}
+                "uri":{"type":"string","description":"compose-preview://<workspace>/<module>/<fqn>?config=<qualifier>"},
+                "overrides":{
+                  "type":"object",
+                  "description":"Per-call display overrides. Each field is optional; nulls fall back to the discovery-time RenderSpec. Backends that don't model a field (e.g. desktop has no Android resource qualifier system) ignore it.",
+                  "properties":{
+                    "widthPx":{"type":"integer","description":"Sandbox width in pixels."},
+                    "heightPx":{"type":"integer","description":"Sandbox height in pixels."},
+                    "density":{"type":"number","description":"Display density (1.0 = mdpi, 2.0 = xhdpi, etc.)."},
+                    "localeTag":{"type":"string","description":"BCP-47 locale tag (e.g. 'en-US', 'fr', 'ja-JP'). Android-only today."},
+                    "fontScale":{"type":"number","description":"Font scale multiplier (1.0 = system default)."},
+                    "uiMode":{"type":"string","enum":["light","dark"],"description":"Light/dark mode override. Android-only today."},
+                    "orientation":{"type":"string","enum":["portrait","landscape"],"description":"Portrait/landscape override. Android-only today."}
+                  }
+                }
               },
               "required":["uri"]
             }
@@ -713,11 +732,71 @@ class DaemonMcpServer(
       args["uri"]?.jsonPrimitive?.contentOrNull
         ?: return errorCallToolResult("render_preview: missing 'uri'")
     val uri = PreviewUri.parseOrNull(uriStr) ?: return errorCallToolResult("invalid uri: $uriStr")
+    val overrides =
+      args["overrides"]?.let {
+        runCatching { decodePreviewOverrides(it) }
+          .getOrElse { e ->
+            return errorCallToolResult("render_preview: invalid overrides: ${e.message}")
+          }
+      }
     return runCatching {
-        val bytes = renderAndReadBytes(uri)
+        val bytes = renderAndReadBytes(uri, overrides = overrides)
         pngCallToolResult(Base64.getEncoder().encodeToString(bytes))
       }
       .getOrElse { errorCallToolResult("render_preview failed: ${it.message}") }
+  }
+
+  /**
+   * Translates the MCP `render_preview.overrides` JSON sub-object into a typed [PreviewOverrides]
+   * for the daemon RPC. Only the fields PROTOCOL.md § 5 documents are accepted; unknown keys are
+   * ignored (forward-compatible with future fields). Throws on malformed primitives so the caller
+   * surfaces "invalid overrides: …" rather than rendering with surprising defaults.
+   */
+  private fun decodePreviewOverrides(elem: JsonElement): PreviewOverrides {
+    val obj = (elem as? JsonObject) ?: error("overrides must be an object")
+    fun int(name: String): Int? =
+      obj[name]
+        ?.takeUnless { it is kotlinx.serialization.json.JsonNull }
+        ?.jsonPrimitive
+        ?.content
+        ?.toInt()
+    fun float(name: String): Float? =
+      obj[name]
+        ?.takeUnless { it is kotlinx.serialization.json.JsonNull }
+        ?.jsonPrimitive
+        ?.content
+        ?.toFloat()
+    fun str(name: String): String? =
+      obj[name]
+        ?.takeUnless { it is kotlinx.serialization.json.JsonNull }
+        ?.jsonPrimitive
+        ?.contentOrNull
+        ?.takeIf { it.isNotBlank() }
+    val uiMode =
+      str("uiMode")?.let {
+        when (it.lowercase()) {
+          "light" -> UiMode.LIGHT
+          "dark" -> UiMode.DARK
+          else -> error("uiMode must be 'light' or 'dark', got '$it'")
+        }
+      }
+    val orientation =
+      str("orientation")?.let {
+        when (it.lowercase()) {
+          "portrait" -> Orientation.PORTRAIT
+          "landscape" -> Orientation.LANDSCAPE
+          else -> error("orientation must be 'portrait' or 'landscape', got '$it'")
+        }
+      }
+    return PreviewOverrides(
+      widthPx = int("widthPx"),
+      heightPx = int("heightPx"),
+      density = float("density"),
+      localeTag = str("localeTag"),
+      fontScale = float("fontScale"),
+      uiMode = uiMode,
+      orientation = orientation,
+    )
   }
 
   private fun toolWatch(session: McpSession, args: JsonObject): CallToolResult {

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -144,10 +144,26 @@ export interface FileChangedParams {
 
 export type RenderTier = 'fast' | 'full';
 
+/**
+ * Per-render display-property overrides — see PROTOCOL.md § 5 (`renderNow.overrides`).
+ * Backends that don't model a particular field (e.g. desktop has no `uiMode` resource qualifier)
+ * ignore it.
+ */
+export interface PreviewOverrides {
+    widthPx?: number;
+    heightPx?: number;
+    density?: number;
+    localeTag?: string;
+    fontScale?: number;
+    uiMode?: 'light' | 'dark';
+    orientation?: 'portrait' | 'landscape';
+}
+
 export interface RenderNowParams {
     previews: string[];
     tier: RenderTier;
     reason?: string;
+    overrides?: PreviewOverrides;
 }
 
 export interface RenderNowResult {

--- a/vscode-extension/src/test/daemonProtocol.test.ts
+++ b/vscode-extension/src/test/daemonProtocol.test.ts
@@ -97,6 +97,18 @@ describe('daemon protocol — golden fixtures', () => {
         assert.strictEqual(params.tier, 'fast');
         assert.ok(params.previews.length >= 1);
     });
+
+    it('parses client-renderNow-overrides.json with display-property overrides', () => {
+        // PROTOCOL.md § 5 — `renderNow.overrides` extends the request shape with optional
+        // per-call display overrides. The Kotlin counterpart round-trips the same fixture in
+        // MessagesTest, which is the cross-language source of truth for this feature.
+        const params = readFixture<RenderNowParams>('client-renderNow-overrides.json');
+        assert.strictEqual(params.tier, 'fast');
+        assert.ok(params.overrides);
+        assert.strictEqual(params.overrides!.widthPx, 600);
+        assert.strictEqual(params.overrides!.uiMode, 'dark');
+        assert.strictEqual(params.overrides!.localeTag, 'fr-FR');
+    });
 });
 
 describe('daemon launch descriptor', () => {


### PR DESCRIPTION
Adds an optional `overrides` field to `renderNow` (PROTOCOL.md § 5)
carrying widthPx / heightPx / density / localeTag / fontScale / uiMode /
orientation. Backends merge them onto the discovery-time RenderSpec for
that single call only — overrides are call-scoped, not session-scoped.

Android renderer applies all seven via `applyPreviewQualifiers` +
`RuntimeEnvironment.setFontScale`. Desktop renderer applies size /
density today; the rest ride on the wire for parity but are no-ops on
plain Skiko (Compose Desktop has no Android resource qualifier system).

`PreviewManifestRouter` (android+desktop) preserves inbound override
fields when rewriting the payload — overrides win over the per-preview
manifest defaults.

Coalescing rule in `JsonRpcServer.handleRenderNow`: when an
override-bearing renderNow arrives for a previewId that already has
an override-bearing render in flight, reject with `coalesced` rather
than queue. Prevents a slider drag from fanning out N parallel
sandbox renders. Plain (no-overrides) renderNow is unaffected.

`render_preview` MCP tool gains the same `overrides` sub-object so
agents can render statically at any qualifier set without a live-mode
toggle. INTERACTIVE.md § 8a explains the design — interactive mode is
just "auto-fire renderNow with current overrides on slider drag."

Includes a new shared protocol fixture
`client-renderNow-overrides.json` and round-trip tests on both the
Kotlin and TypeScript sides.