### PR TITLE
feat(mcp): expose data products via list/get/subscribe tools

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -143,6 +143,45 @@ later.
 | `notify_file_changed` | `workspaceId, path, kind?, changeType?` | Forward `fileChanged` to the daemon + re-issue `renderNow` for any watched / subscribed URIs in that workspace. Use after editing source files outside the MCP server's view. |
 | `history_list` | `workspaceId, module, previewId?, since?, until?, limit?, branch?, …` | Proxy daemon `history/list`. Each result entry is decorated with its `compose-preview-history://` URI. |
 | `history_diff` | `workspaceId, module, from, to` | Proxy daemon `history/diff` (METADATA mode). Cross-source: `from` may live on FS, `to` on a `preview/<branch>` ref. |
+| `list_data_products` | `workspaceId?, module?` | List the structured data kinds (a11y findings, a11y hierarchy, layout tree, recomposition heat-map, …) each spawned daemon advertises alongside its PNGs. See [`docs/daemon/DATA-PRODUCTS.md`](../docs/daemon/DATA-PRODUCTS.md) for the catalogue and per-kind schemas. |
+| `get_preview_data` | `uri, kind, params?, inline?` | Fetch one data product (e.g. `kind: "a11y/hierarchy"`) for a preview. Returns the per-kind JSON payload. Defaults `inline: true` so the agent gets the JSON inline rather than a sibling-file path. Re-render-on-demand kinds may pay a render cost; bounded by the daemon's per-request budget. |
+| `subscribe_preview_data` | `uri, kind` | Prime the daemon to compute `kind` on every render of `uri` (sticky-while-visible). Cuts subsequent `get_preview_data` latency. |
+| `unsubscribe_preview_data` | `uri, kind` | Drop a subscription. |
+
+## Data products
+
+Beyond the PNG, the daemon can produce structured data alongside each render —
+ATF accessibility findings, the a11y semantic hierarchy, the layout tree, a
+recomposition heat-map, theme resolution, and so on. Each is identified by a
+namespaced *kind* string (`a11y/hierarchy`, `compose/recomposition`, …).
+
+The agent flow is two calls:
+
+```jsonc
+// 1. Discover what kinds the daemon advertises (empty list = pre-D2 daemon
+//    with no producer wired yet).
+{ "method": "tools/call", "params": { "name": "list_data_products",
+  "arguments": { "workspaceId": "your-repo-a1b2c3d4" } } }
+
+// 2. Fetch one kind for one preview. The preview must have rendered at least
+//    once — otherwise the call returns DataProductNotAvailable and you should
+//    `resources/read` (or `render_preview`) first.
+{ "method": "tools/call", "params": { "name": "get_preview_data",
+  "arguments": {
+    "uri": "compose-preview://your-repo-a1b2c3d4/_samples_cmp/com.example.RedSquare",
+    "kind": "a11y/hierarchy"
+  } } }
+```
+
+For long-running flows where the agent expects to ask about the same preview
+repeatedly, call `subscribe_preview_data` first — the daemon then computes the
+kind on every render of that preview, so the next `get_preview_data` resolves
+without paying the re-render cost. Subscriptions auto-drop when the preview
+leaves the daemon's `setVisible` set, so re-subscribe when it comes back into
+view (or use `set_visible` to keep it warm).
+
+The full kind catalogue, per-kind payload schemas, and re-render semantics are
+in [`docs/daemon/DATA-PRODUCTS.md`](../docs/daemon/DATA-PRODUCTS.md).
 
 ## URI schemes
 

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
@@ -2,6 +2,10 @@ package ee.schimke.composeai.mcp
 
 import ee.schimke.composeai.daemon.protocol.ChangeType
 import ee.schimke.composeai.daemon.protocol.ClientCapabilities
+import ee.schimke.composeai.daemon.protocol.DataFetchParams
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataSubscribeParams
+import ee.schimke.composeai.daemon.protocol.DataSubscribeResult
 import ee.schimke.composeai.daemon.protocol.FileChangedParams
 import ee.schimke.composeai.daemon.protocol.FileKind
 import ee.schimke.composeai.daemon.protocol.HistoryDiffMode
@@ -15,6 +19,7 @@ import ee.schimke.composeai.daemon.protocol.InitializeParams
 import ee.schimke.composeai.daemon.protocol.InitializeResult
 import ee.schimke.composeai.daemon.protocol.JsonRpcNotification
 import ee.schimke.composeai.daemon.protocol.JsonRpcRequest
+import ee.schimke.composeai.daemon.protocol.Options
 import ee.schimke.composeai.daemon.protocol.RenderNowParams
 import ee.schimke.composeai.daemon.protocol.RenderNowResult
 import ee.schimke.composeai.daemon.protocol.RenderTier
@@ -78,6 +83,7 @@ class DaemonClient(
     moduleId: String,
     moduleProjectDir: String,
     capabilities: ClientCapabilities = ClientCapabilities(visibility = true, metrics = true),
+    attachDataProducts: List<String>? = null,
     timeout: Duration = 30.seconds,
   ): InitializeResult {
     val id = nextId.getAndIncrement()
@@ -89,6 +95,13 @@ class DaemonClient(
         moduleId = moduleId,
         moduleProjectDir = moduleProjectDir,
         capabilities = capabilities,
+        // D1 — only attach the option when the caller actually asked for ambient kinds; pre-D2
+        // daemons advertise nothing, so the daemon-side filter would silently drop these anyway,
+        // but keeping the field absent on `null` matches the `encodeDefaults = false` shape the
+        // rest of the protocol fixtures use.
+        options =
+          if (attachDataProducts.isNullOrEmpty()) null
+          else Options(attachDataProducts = attachDataProducts),
       )
     val request =
       JsonRpcRequest(
@@ -217,6 +230,89 @@ class DaemonClient(
       response["result"]
         ?: error("history/diff: no result — error=${response["error"]}, full=$response")
     return json.decodeFromJsonElement(HistoryDiffResult.serializer(), resultElem)
+  }
+
+  // ---------------------------------------------------------------------------
+  // D1 — data products. See docs/daemon/DATA-PRODUCTS.md § "Wire surface".
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Drives `data/fetch` for one `(previewId, kind)` pair against the latest render. The daemon
+   * resolves to one of:
+   *
+   * - already-computed payload from the last render (cheap),
+   * - a re-projection against the cached state (bounded cost),
+   * - a re-render in the right mode then the payload (subject to the daemon's per-request budget).
+   *
+   * Errors are surfaced as exceptions rather than swallowed: the MCP-side caller wraps them into
+   * the tool result so the agent sees the exact wire-error name (`DataProductUnknown`,
+   * `DataProductNotAvailable`, `DataProductFetchFailed`, `DataProductBudgetExceeded`).
+   */
+  fun dataFetch(
+    previewId: String,
+    kind: String,
+    params: kotlinx.serialization.json.JsonElement? = null,
+    inline: Boolean = false,
+    timeout: Duration = 30.seconds,
+  ): DataFetchResult {
+    val id = nextId.getAndIncrement()
+    val request =
+      JsonRpcRequest(
+        id = id,
+        method = "data/fetch",
+        params =
+          json.encodeToJsonElement(
+            DataFetchParams.serializer(),
+            DataFetchParams(previewId = previewId, kind = kind, params = params, inline = inline),
+          ),
+      )
+    val response = sendAndAwait(id, request, timeout)
+    val errorElem = response["error"]
+    if (errorElem != null) error("data/fetch failed: $errorElem")
+    val resultElem = response["result"] ?: error("data/fetch: no result — full=$response")
+    return json.decodeFromJsonElement(DataFetchResult.serializer(), resultElem)
+  }
+
+  /**
+   * Drives `data/subscribe`. Idempotent on the daemon side; subscriptions are sticky-while-visible
+   * — the daemon drops them automatically when the preview leaves the most recent `setVisible` set
+   * (see DATA-PRODUCTS.md). Re-subscribe when the preview returns to view.
+   */
+  fun dataSubscribe(
+    previewId: String,
+    kind: String,
+    timeout: Duration = 15.seconds,
+  ): DataSubscribeResult = dataSubOrUnsub("data/subscribe", previewId, kind, timeout)
+
+  /** Drives `data/unsubscribe`. See [dataSubscribe]. */
+  fun dataUnsubscribe(
+    previewId: String,
+    kind: String,
+    timeout: Duration = 15.seconds,
+  ): DataSubscribeResult = dataSubOrUnsub("data/unsubscribe", previewId, kind, timeout)
+
+  private fun dataSubOrUnsub(
+    method: String,
+    previewId: String,
+    kind: String,
+    timeout: Duration,
+  ): DataSubscribeResult {
+    val id = nextId.getAndIncrement()
+    val request =
+      JsonRpcRequest(
+        id = id,
+        method = method,
+        params =
+          json.encodeToJsonElement(
+            DataSubscribeParams.serializer(),
+            DataSubscribeParams(previewId = previewId, kind = kind),
+          ),
+      )
+    val response = sendAndAwait(id, request, timeout)
+    val errorElem = response["error"]
+    if (errorElem != null) error("$method failed: $errorElem")
+    val resultElem = response["result"] ?: error("$method: no result — full=$response")
+    return json.decodeFromJsonElement(DataSubscribeResult.serializer(), resultElem)
   }
 
   /**

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -547,6 +547,83 @@ class DaemonMcpServer(
               .trimIndent()
           ),
       ),
+      ToolDef(
+        name = "list_data_products",
+        description =
+          "Discover the data-product kinds (a11y findings, a11y hierarchy, layout tree, recomposition heat-map, theme resolution, …) the daemon can produce alongside each PNG. Returns one entry per (workspace, module) with the kinds the daemon advertised at initialize-time. Each entry carries `kind`, `schemaVersion`, `transport` (inline|path|both), and three flags: `attachable` (rides renderFinished when subscribed), `fetchable` (callable via get_preview_data), `requiresRerender` (true → fetching may pay a render cost). With no args, lists every spawned daemon; pass `workspaceId` and/or `module` to scope the answer. Empty list = pre-D2 daemon (no producers wired yet) — get_preview_data on such a daemon returns DataProductUnknown. See docs/daemon/DATA-PRODUCTS.md for the kind catalogue.",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "workspaceId":{"type":"string","description":"Optional. Restrict the answer to one workspace."},
+                "module":{"type":"string","description":"Optional Gradle module path; requires workspaceId."}
+              }
+            }
+            """
+              .trimIndent()
+          ),
+      ),
+      ToolDef(
+        name = "get_preview_data",
+        description =
+          "Fetch one data product (a11y findings, a11y hierarchy, layout tree, …) for a preview. The kind names a structured payload the daemon can produce alongside the PNG; call list_data_products first to see what each daemon advertises. Returns the JSON payload as a single text content block. Requires that the preview has rendered at least once (otherwise: DataProductNotAvailable — call render_preview / resources/read first). When the daemon's latest render didn't compute the kind, the daemon may queue a re-render in the right mode; this is bounded by the daemon's per-request budget (DataProductBudgetExceeded if exceeded). `inline` defaults to true so the agent gets JSON back rather than a path it may not be able to read; flip to false on local-FS callers that prefer to read sibling files directly.",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "uri":{"type":"string","description":"compose-preview://<workspace>/<module>/<fqn>?config=<qualifier>"},
+                "kind":{"type":"string","description":"Data-product kind, e.g. a11y/hierarchy, a11y/atf, layout/tree, compose/semantics."},
+                "params":{"type":"object","description":"Optional per-kind parameters (e.g. {nodeId} for layout/tree). Forwarded verbatim to the daemon's data/fetch."},
+                "inline":{"type":"boolean","description":"Default true. When false, the daemon returns a `path` to a sibling JSON file instead of inlining the payload."}
+              },
+              "required":["uri","kind"]
+            }
+            """
+              .trimIndent()
+          ),
+      ),
+      ToolDef(
+        name = "subscribe_preview_data",
+        description =
+          "Subscribe to a data-product kind for one preview. While subscribed, every renderFinished for the preview produces the kind alongside the PNG (subject to the daemon's producer wiring). Useful when the agent expects to ask repeatedly about the same preview — pre-computing on render avoids the get_preview_data re-render cost. Subscriptions are sticky-while-visible: the daemon drops them automatically when the preview leaves the most recent set_visible set, so re-subscribe when the preview returns to view. Idempotent. Errors: DataProductUnknown if the kind isn't advertised or isn't attachable. NOTE: today, MCP doesn't push the attached payload to clients automatically — agents still call get_preview_data to read it; the subscribe just primes the daemon-side cache.",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "uri":{"type":"string","description":"compose-preview://<workspace>/<module>/<fqn>"},
+                "kind":{"type":"string"}
+              },
+              "required":["uri","kind"]
+            }
+            """
+              .trimIndent()
+          ),
+      ),
+      ToolDef(
+        name = "unsubscribe_preview_data",
+        description =
+          "Drop a subscription installed by subscribe_preview_data. Idempotent — unsubscribing a kind that was never subscribed returns ok.",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "uri":{"type":"string"},
+                "kind":{"type":"string"}
+              },
+              "required":["uri","kind"]
+            }
+            """
+              .trimIndent()
+          ),
+      ),
     )
 
   private fun handleCallTool(
@@ -568,6 +645,10 @@ class DaemonMcpServer(
       "set_focus" -> toolSetFocus(args)
       "history_list" -> toolHistoryList(args)
       "history_diff" -> toolHistoryDiff(args)
+      "list_data_products" -> toolListDataProducts(args)
+      "get_preview_data" -> toolGetPreviewData(args)
+      "subscribe_preview_data" -> toolDataSubOrUnsub(args, subscribe = true)
+      "unsubscribe_preview_data" -> toolDataSubOrUnsub(args, subscribe = false)
       else -> errorCallToolResult("unknown tool: $name")
     }
   }
@@ -893,6 +974,126 @@ class DaemonMcpServer(
       if (result.diffPngPath != null) put("diffPngPath", JsonPrimitive(result.diffPngPath))
     }
     return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+  }
+
+  // -------------------------------------------------------------------------
+  // D1 — data product tools. See docs/daemon/DATA-PRODUCTS.md.
+  //
+  // The MCP surface is tool-shaped rather than resource-shaped because data
+  // products are keyed on (previewId, kind) — a 2D space — and `resources/read`
+  // can only return one content block per URI. Tools fit the shape exactly:
+  // arguments → JSON return.
+  // -------------------------------------------------------------------------
+
+  private fun toolListDataProducts(args: JsonObject): CallToolResult {
+    val ws = args["workspaceId"]?.jsonPrimitive?.contentOrNull
+    val module = args["module"]?.jsonPrimitive?.contentOrNull
+    if (module != null && ws == null) {
+      return errorCallToolResult("list_data_products: 'module' requires 'workspaceId'")
+    }
+    val workspaceFilter = ws?.let(::WorkspaceId)
+    if (workspaceFilter != null && supervisor.project(workspaceFilter) == null) {
+      return errorCallToolResult("list_data_products: workspace '$ws' not registered")
+    }
+    val payload = buildJsonObject {
+      putJsonArray("daemons") {
+        for (project in supervisor.listProjects()) {
+          if (workspaceFilter != null && project.workspaceId != workspaceFilter) continue
+          for ((mp, daemon) in project.daemons) {
+            if (module != null && mp != module) continue
+            add(
+              buildJsonObject {
+                put("workspaceId", project.workspaceId.value)
+                put("module", mp)
+                putJsonArray("kinds") {
+                  daemon.dataProductCapabilities.forEach { cap ->
+                    add(
+                      buildJsonObject {
+                        put("kind", cap.kind)
+                        put("schemaVersion", cap.schemaVersion)
+                        put("transport", cap.transport.name.lowercase())
+                        put("attachable", cap.attachable)
+                        put("fetchable", cap.fetchable)
+                        put("requiresRerender", cap.requiresRerender)
+                      }
+                    )
+                  }
+                }
+              }
+            )
+          }
+        }
+      }
+    }
+    return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+  }
+
+  private fun toolGetPreviewData(args: JsonObject): CallToolResult {
+    val uriStr =
+      args["uri"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("get_preview_data: missing 'uri'")
+    val uri =
+      PreviewUri.parseOrNull(uriStr)
+        ?: return errorCallToolResult("get_preview_data: invalid uri: $uriStr")
+    val kind =
+      args["kind"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("get_preview_data: missing 'kind'")
+    // Default to inline=true so agents get JSON back rather than a sibling-file path they may not
+    // be able to read. Local callers that prefer disk reads pass `inline: false` explicitly.
+    val inline = args["inline"]?.jsonPrimitive?.contentOrNull?.toBooleanStrictOrNull() ?: true
+    val perKindParams = args["params"] as? JsonObject
+    if (supervisor.project(uri.workspaceId) == null) {
+      return errorCallToolResult(
+        "get_preview_data: workspace '${uri.workspaceId.value}' not registered"
+      )
+    }
+    val daemon =
+      runCatching { supervisor.daemonFor(uri.workspaceId, uri.modulePath) }
+        .getOrElse {
+          return errorCallToolResult("get_preview_data: daemon spawn failed: ${it.message}")
+        }
+    return runCatching {
+        val result = daemon.client.dataFetch(uri.previewFqn, kind, perKindParams, inline)
+        val resultPayload = result.payload
+        val resultPath = result.path
+        val resultBytes = result.bytes
+        val payload = buildJsonObject {
+          put("kind", result.kind)
+          put("schemaVersion", result.schemaVersion)
+          if (resultPayload != null) put("payload", resultPayload)
+          if (resultPath != null) put("path", JsonPrimitive(resultPath))
+          if (resultBytes != null) put("bytes", JsonPrimitive(resultBytes))
+        }
+        CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+      }
+      .getOrElse { errorCallToolResult("get_preview_data failed: ${it.message}") }
+  }
+
+  private fun toolDataSubOrUnsub(args: JsonObject, subscribe: Boolean): CallToolResult {
+    val toolName = if (subscribe) "subscribe_preview_data" else "unsubscribe_preview_data"
+    val uriStr =
+      args["uri"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("$toolName: missing 'uri'")
+    val uri =
+      PreviewUri.parseOrNull(uriStr)
+        ?: return errorCallToolResult("$toolName: invalid uri: $uriStr")
+    val kind =
+      args["kind"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("$toolName: missing 'kind'")
+    if (supervisor.project(uri.workspaceId) == null) {
+      return errorCallToolResult("$toolName: workspace '${uri.workspaceId.value}' not registered")
+    }
+    val daemon =
+      runCatching { supervisor.daemonFor(uri.workspaceId, uri.modulePath) }
+        .getOrElse {
+          return errorCallToolResult("$toolName: daemon spawn failed: ${it.message}")
+        }
+    return runCatching {
+        if (subscribe) daemon.client.dataSubscribe(uri.previewFqn, kind)
+        else daemon.client.dataUnsubscribe(uri.previewFqn, kind)
+        textCallToolResult("$toolName: ok ($kind for ${uri.previewFqn})")
+      }
+      .getOrElse { errorCallToolResult("$toolName failed: ${it.message}") }
   }
 
   private fun toolNotifyFileChanged(args: JsonObject): CallToolResult {

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.mcp
 
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.Serializable
@@ -187,6 +188,11 @@ class DaemonSupervisor(
           moduleId = descriptor.modulePath,
           moduleProjectDir = descriptor.workingDirectory,
         )
+      // D1 — surface the daemon's advertised data-product kinds so the MCP server's
+      // `list_data_products` tool can answer without a wire round-trip. Empty list on pre-D2
+      // daemons; the field is also `emptyList()` by default in [ServerCapabilities] so absent
+      // and `[]` collapse the same way client-side.
+      supervised.dataProductCapabilities = result.capabilities.dataProducts
       // The daemon only emits `discoveryUpdated` for *deltas* — the initial preview set comes
       // via `initialize.manifest.path` (a `previews.json` written by the gradle plugin's
       // `discoverPreviews` task). Synthesise an initial `discoveryUpdated` notification by
@@ -265,6 +271,16 @@ class SupervisedDaemon(val workspaceId: WorkspaceId, val modulePath: String) {
    * caller thread reads this through [client] / [allClients] without external synchronisation.
    */
   @Volatile private var spawn: DaemonSpawn? = null
+
+  /**
+   * D1 — kinds the daemon advertised via `initialize.capabilities.dataProducts`. Populated by
+   * [DaemonSupervisor.spawn] right after the initialize round-trip, before [attachSpawn] returns to
+   * the caller. Empty list pre-D2 (no producers wired) — matches the daemon's default. Read by
+   * `DaemonMcpServer.toolListDataProducts` to answer without a wire round-trip.
+   */
+  @Volatile
+  var dataProductCapabilities: List<DataProductCapability> = emptyList()
+    internal set
 
   /**
    * The single [DaemonClient]. Used for everything — control-plane operations (`initialize`,

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -102,6 +102,10 @@ class DaemonMcpServerTest {
         "set_focus",
         "history_list",
         "history_diff",
+        "list_data_products",
+        "get_preview_data",
+        "subscribe_preview_data",
+        "unsubscribe_preview_data",
       )
   }
 
@@ -579,6 +583,184 @@ class DaemonMcpServerTest {
     val decoded = Base64.getDecoder().decode(blob.blob)
     assertThat(decoded).isEqualTo(pngBytes)
     assertThat(blob.mimeType).isEqualTo("image/png")
+  }
+
+  // -------------------------------------------------------------------------
+  // D1 — data product tools
+  // -------------------------------------------------------------------------
+
+  @Test
+  fun `list_data_products surfaces kinds advertised by each daemon's initialize`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    factory.daemonConfigurer = { daemon ->
+      daemon.advertisedDataProducts =
+        listOf(
+          ee.schimke.composeai.daemon.protocol.DataProductCapability(
+            kind = "a11y/hierarchy",
+            schemaVersion = 1,
+            transport = ee.schimke.composeai.daemon.protocol.DataProductTransport.INLINE,
+            attachable = true,
+            fetchable = true,
+            requiresRerender = false,
+          ),
+          ee.schimke.composeai.daemon.protocol.DataProductCapability(
+            kind = "a11y/atf",
+            schemaVersion = 1,
+            transport = ee.schimke.composeai.daemon.protocol.DataProductTransport.INLINE,
+            attachable = true,
+            fetchable = true,
+            requiresRerender = false,
+          ),
+        )
+    }
+    warmDaemonFor(workspaceId, ":module")
+
+    val resp = client.callTool("list_data_products", buildJsonObject {})
+    val payload = json.parseToJsonElement(resp.firstTextContent()).jsonObject
+    val daemons = payload["daemons"]!!.jsonArray
+    assertThat(daemons).hasSize(1)
+    val entry = daemons.single().jsonObject
+    assertThat(entry["workspaceId"]?.jsonPrimitive?.contentOrNull).isEqualTo(workspaceId.value)
+    assertThat(entry["module"]?.jsonPrimitive?.contentOrNull).isEqualTo(":module")
+    val kinds = entry["kinds"]!!.jsonArray.map { it.jsonObject["kind"]!!.jsonPrimitive.content }
+    assertThat(kinds).containsExactly("a11y/hierarchy", "a11y/atf")
+  }
+
+  @Test
+  fun `get_preview_data forwards data slash fetch and returns the payload`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    factory.daemonConfigurer = { daemon ->
+      daemon.advertisedDataProducts =
+        listOf(
+          ee.schimke.composeai.daemon.protocol.DataProductCapability(
+            kind = "a11y/hierarchy",
+            schemaVersion = 1,
+            transport = ee.schimke.composeai.daemon.protocol.DataProductTransport.INLINE,
+            attachable = true,
+            fetchable = true,
+            requiresRerender = false,
+          )
+        )
+      daemon.dataFetchHandler = { previewId, kind, _, _ ->
+        FakeDaemon.DataFetchOutcome.Ok(
+          kind = kind,
+          schemaVersion = 1,
+          payload =
+            buildJsonObject {
+              putJsonArray("nodes") {
+                add(
+                  buildJsonObject {
+                    put("label", "Hello $previewId")
+                    put("role", "Button")
+                  }
+                )
+              }
+            },
+        )
+      }
+    }
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "get_preview_data",
+        buildJsonObject {
+          put("uri", uri)
+          put("kind", "a11y/hierarchy")
+        },
+      )
+    val payload = json.parseToJsonElement(resp.firstTextContent()).jsonObject
+    assertThat(payload["kind"]?.jsonPrimitive?.contentOrNull).isEqualTo("a11y/hierarchy")
+    assertThat(payload["schemaVersion"]?.jsonPrimitive?.contentOrNull).isEqualTo("1")
+    val nodes = payload["payload"]!!.jsonObject["nodes"]!!.jsonArray
+    assertThat(nodes.single().jsonObject["label"]!!.jsonPrimitive.content)
+      .isEqualTo("Hello $previewId")
+  }
+
+  @Test
+  fun `get_preview_data surfaces DataProductUnknown when kind is not advertised`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    // Default daemon advertises nothing — every fetch returns DataProductUnknown.
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    daemon.emitDiscovery("com.example.Red")
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", "com.example.Red").toUri()
+    val resp =
+      client.callTool(
+        "get_preview_data",
+        buildJsonObject {
+          put("uri", uri)
+          put("kind", "a11y/hierarchy")
+        },
+      )
+    assertThat(resp.isError()).isTrue()
+    assertThat(resp.firstTextContent()).contains("DataProductUnknown")
+  }
+
+  @Test
+  fun `subscribe_preview_data and unsubscribe_preview_data forward to the daemon`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    factory.daemonConfigurer = { daemon ->
+      daemon.advertisedDataProducts =
+        listOf(
+          ee.schimke.composeai.daemon.protocol.DataProductCapability(
+            kind = "a11y/hierarchy",
+            schemaVersion = 1,
+            transport = ee.schimke.composeai.daemon.protocol.DataProductTransport.INLINE,
+            attachable = true,
+            fetchable = true,
+            requiresRerender = false,
+          )
+        )
+    }
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    daemon.emitDiscovery("com.example.Red")
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", "com.example.Red").toUri()
+    val subResp =
+      client.callTool(
+        "subscribe_preview_data",
+        buildJsonObject {
+          put("uri", uri)
+          put("kind", "a11y/hierarchy")
+        },
+      )
+    assertThat(subResp.firstTextContent()).contains("subscribe_preview_data: ok")
+    val sub = daemon.dataSubscribes.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(sub).isEqualTo("com.example.Red" to "a11y/hierarchy")
+
+    val unsubResp =
+      client.callTool(
+        "unsubscribe_preview_data",
+        buildJsonObject {
+          put("uri", uri)
+          put("kind", "a11y/hierarchy")
+        },
+      )
+    assertThat(unsubResp.firstTextContent()).contains("unsubscribe_preview_data: ok")
+    val unsub = daemon.dataUnsubscribes.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(unsub).isEqualTo("com.example.Red" to "a11y/hierarchy")
   }
 
   // -------------------------------------------------------------------------

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.mcp
 
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.InitializeResult
 import ee.schimke.composeai.daemon.protocol.Manifest
 import ee.schimke.composeai.daemon.protocol.RenderNowResult
@@ -54,6 +55,58 @@ class FakeDaemon : DaemonSpawn {
   val focusSets = java.util.concurrent.LinkedBlockingQueue<List<String>>()
   /** `renderNow` invocations the fake observed. */
   val renderRequests = java.util.concurrent.LinkedBlockingQueue<List<String>>()
+
+  /**
+   * D1 — kinds the fake advertises in `initialize.capabilities.dataProducts`. Tests assign before
+   * the spawn calls `initialize` (synchronous in [DaemonSupervisor.spawn], so assign-then-spawn is
+   * the natural order).
+   */
+  @Volatile var advertisedDataProducts: List<DataProductCapability> = emptyList()
+
+  /**
+   * D1 — fake handler for `data/fetch`. When set, the lambda receives `(previewId, kind, params,
+   * inline)` and returns either the [DataFetchOutcome] the daemon should respond with. Default
+   * returns [DataFetchOutcome.Unknown] so unconfigured tests see the wire-error path.
+   */
+  @Volatile
+  var dataFetchHandler:
+    (previewId: String, kind: String, params: JsonObject?, inline: Boolean) -> DataFetchOutcome =
+    { _, _, _, _ ->
+      DataFetchOutcome.Unknown
+    }
+
+  /** Recorded `data/subscribe` calls — list of (previewId, kind) tuples. */
+  val dataSubscribes = java.util.concurrent.LinkedBlockingQueue<Pair<String, String>>()
+  /** Recorded `data/unsubscribe` calls — same shape. */
+  val dataUnsubscribes = java.util.concurrent.LinkedBlockingQueue<Pair<String, String>>()
+
+  /**
+   * Outcome the fake's `data/fetch` handler returns. Mirrors the daemon's
+   * [`DataProductRegistry.Outcome`] but deliberately decouples — the fake doesn't depend on the
+   * registry interface.
+   */
+  sealed interface DataFetchOutcome {
+    /** Wire-success: the fake returns a `DataFetchResult` with the given fields. */
+    data class Ok(
+      val kind: String,
+      val schemaVersion: Int,
+      val payload: JsonElement? = null,
+      val path: String? = null,
+      val bytes: String? = null,
+    ) : DataFetchOutcome
+
+    /** -32020 DataProductUnknown. */
+    data object Unknown : DataFetchOutcome
+
+    /** -32021 DataProductNotAvailable. */
+    data object NotAvailable : DataFetchOutcome
+
+    /** -32022 DataProductFetchFailed. */
+    data class FetchFailed(val message: String) : DataFetchOutcome
+
+    /** -32023 DataProductBudgetExceeded. */
+    data object BudgetExceeded : DataFetchOutcome
+  }
 
   /**
    * When set, the fake auto-emits a `renderFinished` notification for every preview id in an
@@ -174,6 +227,7 @@ class FakeDaemon : DaemonSpawn {
                 incrementalDiscovery = true,
                 sandboxRecycle = false,
                 leakDetection = emptyList(),
+                dataProducts = advertisedDataProducts,
               ),
             classpathFingerprint = "fake-fingerprint",
             manifest = Manifest(path = "", previewCount = 0),
@@ -251,6 +305,58 @@ class FakeDaemon : DaemonSpawn {
             put("toMetadata", toEntry)
           }
           sendResponse(id, payload)
+        }
+      }
+      "data/fetch" -> {
+        val previewId = params?.get("previewId")?.jsonPrimitive?.contentOrNull ?: ""
+        val kind = params?.get("kind")?.jsonPrimitive?.contentOrNull ?: ""
+        val perKindParams = params?.get("params") as? JsonObject
+        // The wire shape encodes booleans as actual JSON booleans, but kotlinx serialises a
+        // `Boolean` as a primitive that prints as "true" / "false"; tolerate both forms.
+        val inline =
+          when (val raw = params?.get("inline")?.jsonPrimitive?.contentOrNull) {
+            null -> false
+            else -> raw == "true"
+          }
+        when (val outcome = dataFetchHandler(previewId, kind, perKindParams, inline)) {
+          is DataFetchOutcome.Ok -> {
+            val payload = buildJsonObject {
+              put("kind", outcome.kind)
+              put("schemaVersion", outcome.schemaVersion)
+              if (outcome.payload != null) put("payload", outcome.payload)
+              if (outcome.path != null) put("path", outcome.path)
+              if (outcome.bytes != null) put("bytes", outcome.bytes)
+            }
+            sendResponse(id, payload)
+          }
+          DataFetchOutcome.Unknown ->
+            sendError(id, -32020, "DataProductUnknown: kind not advertised: $kind")
+          DataFetchOutcome.NotAvailable ->
+            sendError(id, -32021, "DataProductNotAvailable: $previewId has no render available")
+          is DataFetchOutcome.FetchFailed -> sendError(id, -32022, outcome.message)
+          DataFetchOutcome.BudgetExceeded ->
+            sendError(id, -32023, "DataProductBudgetExceeded for kind $kind")
+        }
+      }
+      "data/subscribe",
+      "data/unsubscribe" -> {
+        val previewId = params?.get("previewId")?.jsonPrimitive?.contentOrNull ?: ""
+        val kind = params?.get("kind")?.jsonPrimitive?.contentOrNull ?: ""
+        // Validate the kind is in `advertisedDataProducts` and `attachable` — the daemon's real
+        // handler does this. Tests that need the failure path can advertise a non-attachable
+        // kind; tests that need success advertise an attachable one.
+        val capability = advertisedDataProducts.firstOrNull { it.kind == kind }
+        if (capability == null || !capability.attachable) {
+          sendError(
+            id,
+            -32020,
+            if (capability == null) "DataProductUnknown: kind not advertised: $kind"
+            else "DataProductUnknown: kind '$kind' is not attachable",
+          )
+        } else {
+          if (method == "data/subscribe") dataSubscribes.offer(previewId to kind)
+          else dataUnsubscribes.offer(previewId to kind)
+          sendResponse(id, buildJsonObject { put("ok", true) })
         }
       }
       else -> {
@@ -409,8 +515,17 @@ class FakeDaemonClientFactory : DaemonClientFactory {
   val spawnDescriptors: MutableList<DaemonLaunchDescriptor> =
     java.util.concurrent.CopyOnWriteArrayList()
 
+  /**
+   * Optional pre-`initialize` hook. Invoked synchronously inside [spawn], after the [FakeDaemon] is
+   * constructed but before the supervisor wires the client and sends `initialize`. Tests use this
+   * to configure per-spawn state (e.g. advertised data-product kinds) that needs to be in place
+   * before the initialize round-trip reaches the daemon's reader thread.
+   */
+  @Volatile var daemonConfigurer: (FakeDaemon) -> Unit = {}
+
   override fun spawn(project: RegisteredProject, descriptor: DaemonLaunchDescriptor): DaemonSpawn {
     val daemon = FakeDaemon()
+    runCatching { daemonConfigurer(daemon) }
     synchronized(this) {
       daemons[project.workspaceId to descriptor.modulePath] = daemon
       spawnHistory.add(daemon)


### PR DESCRIPTION
Wires the D1 data-product surface (PROTOCOL.md `data/fetch`,
`data/subscribe`, `data/unsubscribe`, capability advertising on
`initialize`) through the MCP server so agents can fetch a11y findings,
the a11y hierarchy, layout trees, and future structured payloads
alongside each PNG.

Tool surface:
- `list_data_products(workspaceId?, module?)` — advertises each daemon's
  kinds (kind, schemaVersion, transport, attachable, fetchable,
  requiresRerender). Empty list = pre-D2 daemon with no producer wired.
- `get_preview_data(uri, kind, params?, inline?)` — the workhorse.
  Defaults `inline: true` so agents get JSON inline rather than a
  sibling-file path. Forwards per-kind params verbatim.
- `subscribe_preview_data(uri, kind)` / `unsubscribe_preview_data` —
  maps to data/subscribe / data/unsubscribe. Sticky-while-visible.

Modelled as tools rather than resources because data products are keyed
on `(previewId, kind)` — a 2D space — and `resources/read` only returns
one content block per URI.

Underneath: `DaemonClient` got `dataFetch` / `dataSubscribe` /
`dataUnsubscribe` methods plus an `attachDataProducts` initialize
parameter; `SupervisedDaemon` caches the daemon's advertised
`dataProductCapabilities` from `initialize` so `list_data_products`
answers without a wire round-trip.

`FakeDaemon` grew matching handlers and a `daemonConfigurer` factory
hook so tests can configure the fake before the supervisor's
synchronous initialize round-trip. Four new test cases cover discovery,
fetch, the DataProductUnknown error path, and subscribe/unsubscribe.