### PR TITLE
feat(daemon): coalesce interactive input bursts on in-flight render

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -304,6 +304,37 @@ class JsonRpcServer(
    */
   private val interactiveSessions = ConcurrentHashMap<String, InteractiveSession>()
 
+  /**
+   * v2 phase 3 — per-stream coalescing queue. Inputs arriving while a render is already in flight
+   * for the same stream get appended here; the render-finishing path drains the whole queue and
+   * dispatches it as a batch followed by a single render. See INTERACTIVE.md § 9.6.
+   *
+   * Caps the per-stream render rate at the renderer's natural cadence (typically 60 Hz on Skiko)
+   * without dropping events — important when we wire pointer-move bursts in v3, modest payoff for
+   * click-only v2 since clicks rarely arrive faster than renders complete. The coalescing path
+   * still exists for v2 so the implementation is exercised end-to-end before move/drag work starts
+   * asking it for more.
+   *
+   * Concurrent reads are safe because each stream's queue is only ever drained by the worker thread
+   * that owns the in-flight render slot for that stream.
+   */
+  private val pendingInteractiveInputs =
+    ConcurrentHashMap<
+      String,
+      java.util.concurrent.ConcurrentLinkedQueue<
+        ee.schimke.composeai.daemon.protocol.InteractiveInputParams
+      >,
+    >()
+
+  /**
+   * v2 phase 3 — claim flag for "this stream has an interactive render in flight". Inputs that find
+   * this flag already set queue themselves rather than spawning another worker; the worker that
+   * holds the flag drains the queue at the start of each render iteration. The flag is cleared in
+   * `finally` after the render finishes; if more inputs arrived in the meantime, the worker
+   * re-claims and re-iterates.
+   */
+  private val interactiveRenderInFlight = ConcurrentHashMap<String, Boolean>()
+
   private val lastFrameHashes = ConcurrentHashMap<String, String>()
 
   private val nextStreamIdCounter = java.util.concurrent.atomic.AtomicLong(1)
@@ -1498,10 +1529,17 @@ class JsonRpcServer(
     val session = interactiveSessions[params.frameStreamId]
     if (session != null) {
       // v2 dispatch path — feed the input into the held composition, render the next frame
-      // through the same session. The render-watcher thread picks the result up off
-      // [renderResultsQueue] and emits `renderFinished` (subject to the byte-identical dedup).
-      // Sequenced on a fire-and-forget worker so the read loop never blocks on a render body.
-      submitInteractiveRenderAsync(target.previewId, session, params)
+      // through the same session. Coalesce: if a render for this stream is already in flight,
+      // queue the input rather than spawning another render — the in-flight worker drains the
+      // queue and dispatches everything as a batch before its render. See § 9.6 of the design.
+      pendingInteractiveInputs
+        .computeIfAbsent(params.frameStreamId) { java.util.concurrent.ConcurrentLinkedQueue() }
+        .add(params)
+      // Try to claim the in-flight slot. Whoever wins owns the render thread; whoever loses
+      // already had their input queued and the winner will dispatch it.
+      if (interactiveRenderInFlight.putIfAbsent(params.frameStreamId, true) == null) {
+        submitInteractiveRenderAsync(params.frameStreamId, target.previewId, session)
+      }
       return
     }
     // v1 fallback: each input enqueues a fresh stateless render of the target preview. The
@@ -1516,19 +1554,21 @@ class JsonRpcServer(
   }
 
   /**
-   * v2 — dispatch one interactive input through a held [InteractiveSession] and enqueue the
-   * resulting render onto [renderResultsQueue] so the existing watcher pipeline emits
-   * `renderFinished` for it. Mirrors [submitRenderAsync] structurally — fresh worker thread per
-   * call, no read-loop blocking — but goes through the session instead of `host.submit` so
-   * `remember`'d state survives between inputs.
+   * v2 — drain pending interactive inputs for [streamId], dispatch the batch into [session], and
+   * render once. Owns the in-flight slot for [streamId] until the render completes; on completion,
+   * checks the queue and re-claims if more inputs arrived during the render. Mirrors
+   * [submitRenderAsync] structurally — fresh worker thread, no read-loop blocking, results onto
+   * [renderResultsQueue] for the existing watcher pipeline.
    *
-   * Failures during dispatch or render are routed onto the same queue as
-   * [RenderResultOrFailure.Failure]; the watcher demuxes that into a `renderFailed` notification.
+   * Failures during dispatch or render are routed onto the queue as [RenderResultOrFailure.Failure]
+   * for the watcher to demux into a `renderFailed` notification. The in-flight slot is always
+   * cleared in `finally` even on failure, and any inputs queued during the failed render still get
+   * a chance via the post-finally re-claim — a single bad render shouldn't strand subsequent ones.
    */
   private fun submitInteractiveRenderAsync(
+    streamId: String,
     previewId: String,
     session: InteractiveSession,
-    input: ee.schimke.composeai.daemon.protocol.InteractiveInputParams,
   ) {
     val hostId = RenderHost.nextRequestId()
     hostIdToPreviewId[hostId] = previewId
@@ -1537,7 +1577,14 @@ class JsonRpcServer(
     Thread(
         {
           try {
-            session.dispatch(input)
+            // Drain every input currently pending for this stream and dispatch them as a batch
+            // before rendering. Inputs that arrive *during* dispatch + render get queued for the
+            // next iteration via the post-finally re-claim below.
+            val queue = pendingInteractiveInputs[streamId]
+            while (queue != null) {
+              val next = queue.poll() ?: break
+              session.dispatch(next)
+            }
             val result = session.render(hostId)
             renderResultsQueue.put(result)
           } catch (e: Throwable) {
@@ -1545,6 +1592,31 @@ class JsonRpcServer(
               "compose-ai-daemon: interactive session render($hostId) failed: ${e.message}"
             )
             renderResultsQueue.put(RenderResultOrFailure.Failure(hostId, e))
+          } finally {
+            // Release the in-flight slot, then check if more inputs arrived during the render.
+            // If so, re-claim and recurse (on a new worker thread) so the next batch is dispatched
+            // and rendered. The recursion always converges because each iteration drains some
+            // inputs from the queue; without new arrivals the queue empties and the next claim
+            // skips re-spawning.
+            interactiveRenderInFlight.remove(streamId)
+            val pending = pendingInteractiveInputs[streamId]
+            if (
+              pending != null &&
+                pending.isNotEmpty() &&
+                interactiveRenderInFlight.putIfAbsent(streamId, true) == null
+            ) {
+              val curSession = interactiveSessions[streamId]
+              val curTarget = interactiveTargets[streamId]
+              if (curSession != null && curTarget != null) {
+                submitInteractiveRenderAsync(streamId, curTarget.previewId, curSession)
+              } else {
+                // Session was stopped while we were rendering; drop the queued inputs and clear
+                // the slot. Stale inputs against a stopped stream are dropped per the v1
+                // contract (handleInteractiveInput would also short-circuit on the next poll).
+                pendingInteractiveInputs.remove(streamId)
+                interactiveRenderInFlight.remove(streamId)
+              }
+            }
           }
         },
         "compose-ai-daemon-interactive-render-$hostId",
@@ -1875,6 +1947,11 @@ class JsonRpcServer(
   private fun closeAllInteractiveSessions() {
     val sessions = interactiveSessions.values.toList()
     interactiveSessions.clear()
+    // v2 phase 3 — drop any pending coalesced inputs and in-flight claims. The render workers
+    // they refer to may still be running; they observe the cleared sessions map on their post-
+    // finally re-claim and exit cleanly without re-spawning.
+    pendingInteractiveInputs.clear()
+    interactiveRenderInFlight.clear()
     for (session in sessions) {
       try {
         session.close()

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveCoalescingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveCoalescingTest.kt
@@ -1,0 +1,291 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
+import java.io.File
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.nio.file.Files
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Validates the v2 phase-3 coalescing path (INTERACTIVE.md § 9.6) — inputs arriving while a render
+ * is already in flight for the same stream queue up and dispatch as a batch when the in-flight
+ * render finishes, capping the per-stream render rate at the renderer's natural cadence without
+ * dropping events.
+ *
+ * Driven by [SlowFakeHost] — a session whose `render` blocks for a configurable wall-clock duration
+ * so the test can fire a burst of inputs faster than the renderer drains them. The load-bearing
+ * assertion is that the burst produces fewer renders than inputs (specifically: the daemon emitted
+ * at most 2 renderFinished notifications for 5 inputs — the first one and the batch-drain after).
+ */
+class InteractiveCoalescingTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+  private val resourcesToClose = mutableListOf<AutoCloseable>()
+
+  @After
+  fun teardown() {
+    resourcesToClose.reversed().forEach { runCatching { it.close() } }
+  }
+
+  @Test(timeout = 30_000)
+  fun burst_inputs_during_in_flight_render_coalesce_into_one_followup_render() {
+    val tmp = Files.createTempDirectory("interactive-coalescing").toFile()
+    val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
+    val host = SlowFakeHost(pngFile, renderDelayMs = 200)
+
+    val (_, serverThread, clientToServerOut, received, exitLatch) = bringUpServer(host)
+    resourcesToClose.add(AutoCloseable { runCatching { clientToServerOut.close() } })
+
+    handshake(clientToServerOut, received)
+
+    // Start an interactive session.
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","id":10,"method":"interactive/start","params":{"previewId":"preview-A"}}""",
+    )
+    val startResp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 10 }
+    val streamId =
+      startResp!!["result"]!!.jsonObject["frameStreamId"]!!.jsonPrimitive.contentOrNull!!
+    val session = host.lastSession()!!
+
+    // Fire 5 inputs back-to-back — faster than the 200ms render cadence. With coalescing, only
+    // the first input triggers a render; inputs 2-5 queue up while render 1 is in flight, then
+    // dispatch as a batch driving exactly one follow-up render. Without coalescing this burst
+    // would produce 5 renders (one per input), each waiting 200ms — taking >1 s total.
+    repeat(5) { i ->
+      writeFrame(
+        clientToServerOut,
+        """
+        {"jsonrpc":"2.0","method":"interactive/input","params":{
+          "frameStreamId":"$streamId","kind":"click","pixelX":$i,"pixelY":$i
+        }}
+        """
+          .trimIndent(),
+      )
+    }
+
+    // Collect every renderFinished notification within a generous window. With coalescing we
+    // expect ≤ 2 renders total (one for the first input, one for the batch-drain). 5 renders
+    // would fail this — that's the load-bearing assertion.
+    val finishedFrames = mutableListOf<JsonObject>()
+    val deadline = System.currentTimeMillis() + 2_500
+    while (System.currentTimeMillis() < deadline) {
+      val msg =
+        pollUntil(received, timeoutMs = (deadline - System.currentTimeMillis()).coerceAtLeast(50)) {
+          it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished"
+        }
+      if (msg == null) break
+      finishedFrames.add(msg)
+    }
+
+    assertTrue(
+      "expected at least one renderFinished after the burst; got ${finishedFrames.size}",
+      finishedFrames.isNotEmpty(),
+    )
+    assertTrue(
+      "expected ≤ 2 renderFinished notifications for 5 coalesced inputs (one per render-batch); " +
+        "got ${finishedFrames.size}",
+      finishedFrames.size <= 2,
+    )
+
+    // Render count should match the number of renderFinished frames — the session got driven
+    // through `render` once per emitted frame.
+    assertEquals(
+      "session.render should fire once per emitted frame",
+      finishedFrames.size,
+      session.renderCount.get(),
+    )
+    // All 5 inputs should have been dispatched (none dropped). Coalescing batches dispatch, it
+    // doesn't discard — that's the contract.
+    assertEquals(
+      "every input must have been dispatch()'d (none dropped during coalescing)",
+      5,
+      session.dispatchCount.get(),
+    )
+
+    teardownServer(clientToServerOut, received, serverThread, exitLatch)
+  }
+
+  // ----- harness scaffolding (mirrors InteractiveSessionPlumbingTest's; kept self-contained
+  // so this file doesn't depend on the other test's private helpers) -----
+
+  private data class ServerHarness(
+    val server: JsonRpcServer,
+    val thread: Thread,
+    val clientToServerOut: PipedOutputStream,
+    val received: LinkedBlockingQueue<JsonObject>,
+    val exitLatch: CountDownLatch,
+  )
+
+  private fun bringUpServer(host: RenderHost): ServerHarness {
+    val clientToServerOut = PipedOutputStream()
+    val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
+    val serverToClientOut = PipedOutputStream()
+    val serverToClientIn = PipedInputStream(serverToClientOut, 64 * 1024)
+    val exitLatch = CountDownLatch(1)
+    val server =
+      JsonRpcServer(
+        input = clientToServerIn,
+        output = serverToClientOut,
+        host = host,
+        daemonVersion = "test",
+        onExit = { _ -> exitLatch.countDown() },
+      )
+    val thread = Thread({ server.run() }, "interactive-coalescing-server").apply { isDaemon = true }
+    thread.start()
+    val reader = ContentLengthFramer(serverToClientIn)
+    val received = LinkedBlockingQueue<JsonObject>()
+    Thread(
+        {
+          try {
+            while (true) {
+              val frame = reader.readFrame() ?: break
+              val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+              received.put(obj)
+            }
+          } catch (_: Throwable) {}
+        },
+        "interactive-coalescing-reader",
+      )
+      .apply { isDaemon = true }
+      .start()
+    return ServerHarness(server, thread, clientToServerOut, received, exitLatch)
+  }
+
+  private fun handshake(out: PipedOutputStream, received: LinkedBlockingQueue<JsonObject>) {
+    writeFrame(
+      out,
+      """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+        "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+        "moduleId":":test","moduleProjectDir":"/tmp",
+        "capabilities":{"visibility":true,"metrics":false}}}""",
+    )
+    val init = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 1 }
+    assertNotNull(init)
+    writeFrame(out, """{"jsonrpc":"2.0","method":"initialized","params":{}}""")
+  }
+
+  private fun teardownServer(
+    out: PipedOutputStream,
+    received: LinkedBlockingQueue<JsonObject>,
+    thread: Thread,
+    exitLatch: CountDownLatch,
+  ) {
+    writeFrame(out, """{"jsonrpc":"2.0","id":99,"method":"shutdown"}""")
+    pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 99 }
+    writeFrame(out, """{"jsonrpc":"2.0","method":"exit"}""")
+    assertTrue("server should exit cleanly", exitLatch.await(5, TimeUnit.SECONDS))
+    thread.join(5_000)
+  }
+
+  private fun writeFrame(out: PipedOutputStream, json: String) {
+    val payload = json.toByteArray(Charsets.UTF_8)
+    out.write("Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII))
+    out.write(payload)
+    out.flush()
+  }
+
+  private fun pollUntil(
+    queue: LinkedBlockingQueue<JsonObject>,
+    timeoutMs: Long = 5_000,
+    matcher: (JsonObject) -> Boolean,
+  ): JsonObject? {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+      val remaining = (deadline - System.currentTimeMillis()).coerceAtLeast(0)
+      val msg = queue.poll(remaining, TimeUnit.MILLISECONDS) ?: return null
+      if (matcher(msg)) return msg
+    }
+    return null
+  }
+
+  private fun testPngBytes(seed: Int): ByteArray {
+    val sig = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10)
+    val payload = ByteArray(16) { i -> ((i + seed * 13) and 0xFF).toByte() }
+    return sig + payload
+  }
+}
+
+/**
+ * Test [RenderHost] whose [InteractiveSession] sleeps for [renderDelayMs] inside `render` so the
+ * coalescing test can fire inputs faster than the renderer drains them. Records dispatch and render
+ * counters so the test can assert on the coalescing arithmetic.
+ */
+private class SlowFakeHost(private val pngFile: File, private val renderDelayMs: Long) :
+  RenderHost {
+
+  private val sessions = ConcurrentHashMap<Long, SlowSession>()
+  private val nextSessionKey = java.util.concurrent.atomic.AtomicLong(1)
+
+  override fun start() {}
+
+  override fun submit(request: RenderRequest, timeoutMs: Long): RenderResult {
+    require(request is RenderRequest.Render)
+    return RenderResult(
+      id = request.id,
+      classLoaderHashCode = 0,
+      classLoaderName = "slow-fake",
+      pngPath = pngFile.absolutePath,
+      metrics = mapOf("tookMs" to renderDelayMs),
+    )
+  }
+
+  override fun shutdown(timeoutMs: Long) {}
+
+  override fun acquireInteractiveSession(
+    previewId: String,
+    classLoader: ClassLoader,
+  ): InteractiveSession {
+    val session = SlowSession(previewId, pngFile, renderDelayMs)
+    sessions[nextSessionKey.getAndIncrement()] = session
+    return session
+  }
+
+  fun lastSession(): SlowSession? = sessions.entries.maxByOrNull { it.key }?.value
+}
+
+private class SlowSession(
+  override val previewId: String,
+  private val pngFile: File,
+  private val renderDelayMs: Long,
+) : InteractiveSession {
+
+  val dispatchCount = AtomicInteger(0)
+  val renderCount = AtomicInteger(0)
+
+  override fun dispatch(input: InteractiveInputParams) {
+    require(input.kind == InteractiveInputKind.CLICK) // test only sends clicks
+    dispatchCount.incrementAndGet()
+  }
+
+  override fun render(requestId: Long): RenderResult {
+    Thread.sleep(renderDelayMs) // simulate a slow render so subsequent inputs queue up
+    renderCount.incrementAndGet()
+    return RenderResult(
+      id = requestId,
+      classLoaderHashCode = 0,
+      classLoaderName = "slow-session",
+      pngPath = pngFile.absolutePath,
+      metrics = mapOf("tookMs" to renderDelayMs),
+    )
+  }
+
+  override fun close() {}
+}


### PR DESCRIPTION
**PR 3 of 3** for the v2 click-into-composition rollout designed in #403, following PR 1 (#406, `RenderHost` surface) and PR 2 (#408, desktop session). Caps the per-stream render rate at the renderer's natural cadence without dropping events — the load-bearing optimisation when v3 wires pointer-move bursts that can fire hundreds of events per second from a drag.

Click-only v2 doesn't burst hard, so the immediate user-visible payoff is modest. The path is exercised end-to-end so v3's move/drag work plugs in without a follow-on coalescing PR.

## What this lands in `:daemon:core`

- **Per-stream coalescing state.** New `pendingInteractiveInputs: ConcurrentHashMap<String, ConcurrentLinkedQueue<InteractiveInputParams>>` and `interactiveRenderInFlight: ConcurrentHashMap<String, Boolean>` claim flag, both keyed by `frameStreamId` so concurrent streams coalesce independently.

- **`handleInteractiveInput` refactor.** Every input appends to the per-stream queue; whichever caller wins `putIfAbsent` on the in-flight flag spawns the render worker. Losers exit immediately — the winner will dispatch their queued input as part of its batch.

- **`submitInteractiveRenderAsync` refactor.** Drains every input currently pending for the stream and dispatches them as a batch BEFORE rendering. After the render finishes, releases the in-flight slot; if more inputs queued during the render, re-claims and recurses on a new worker. Recursion converges because each iteration drains at least one input.

- **`closeAllInteractiveSessions` clears coalescing state** so workers observing the cleared sessions map on their post-finally re-claim exit cleanly without re-spawning.

## Test

`InteractiveCoalescingTest` fires 5 inputs against a session whose `render()` blocks 200ms. Asserts:

- **≤ 2 renderFinished frames emitted** (one for the first input, one for the batch-drain after) — proves coalescing fired. Without coalescing this burst produces 5 renders.
- **`session.dispatch()` ran 5 times** — proves no inputs were dropped. The contract of coalescing is "batch dispatch, render once" not "discard".
- **`session.render()` count matches emitted frame count** — proves the render path didn't double-fire.

The assertion shape catches both regressions: "render fires per input" (too many frames) and "inputs are dropped to keep render count low" (dispatch < input count).

## Why this is in core, not desktop

The coalescing is a daemon-internal scheduling decision keyed on `frameStreamId` — independent of which renderer backend ultimately consumes the dispatched inputs. `RobolectricHost` (when v3 wires it) gets the same coalescing for free; programmatic clients building their own `RenderHost` implementation likewise. Putting it in `:daemon:core` keeps the per-stream rate-limit invariant uniform across backends.

## Wire compatibility

No protocol changes. Coalescing is a daemon-internal scheduling behaviour; the wire shape is identical to PR 1.

## Test plan

- [x] `LANG=C.UTF-8 LC_ALL=C.UTF-8 ./gradlew :daemon:core:test --tests "ee.schimke.composeai.daemon.InteractiveCoalescingTest"` — 1/1 pass
- [x] `LANG=C.UTF-8 LC_ALL=C.UTF-8 ./gradlew :daemon:core:test --tests "ee.schimke.composeai.daemon.InteractiveSessionPlumbingTest"` — pre-existing PR 1 plumbing tests still green
- [x] `LANG=C.UTF-8 LC_ALL=C.UTF-8 ./gradlew :daemon:core:test --tests "ee.schimke.composeai.daemon.InteractiveRpcIntegrationTest"` — pre-existing v1 RPC tests still green
- [x] `LANG=C.UTF-8 LC_ALL=C.UTF-8 ./gradlew :daemon:core:ktfmtFormatMain :daemon:core:ktfmtFormatTest` — clean

## Out of scope (deferred to v3)

The design doc § 9.11 also mentioned PR 3 might wire a status-bar hint for "interactive mode unsupported" (Android case) and a Shift+LIVE multi-stream UI affordance. Both belong to the VS Code extension, not the daemon — and they're nice-to-haves, not load-bearing. Splitting them out keeps this PR focused on the daemon-internal scheduling primitive.


---
_Generated by [Claude Code](https://claude.ai/code/session_017NDGZk17VhvctNNoSrVZsK)_