### PR TITLE
feat(daemon,vscode): D2 a11y data products end-to-end + focus-mode toggle

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
@@ -1,0 +1,212 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.renderer.AccessibilityFinding
+import ee.schimke.composeai.renderer.AccessibilityNode
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * D2 — writes the per-render a11y artefacts the data-product registry surfaces.
+ *
+ * One pair of files per render under `<rootDir>/<previewId>/`:
+ *
+ * - `a11y-atf.json` — `{ "findings": AccessibilityFinding[] }`. Inline-transport kind
+ *   (`a11y/atf`) parses this into `payload`. Always written, even when `findings` is empty,
+ *   so the registry can distinguish "no findings on this render" from "a11y didn't run".
+ * - `a11y-hierarchy.json` — `{ "nodes": AccessibilityNode[] }`. Path-transport kind
+ *   (`a11y/hierarchy`) returns this file's absolute path; VS Code's webview reads it.
+ *
+ * On-disk layout pinned by [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md)
+ * § "On-disk layout".
+ */
+object AccessibilityDataProducer {
+
+  private val json = Json {
+    encodeDefaults = false
+    prettyPrint = false
+  }
+
+  /** Schema version pinned alongside the on-disk shape. Bumped when the shape changes. */
+  const val SCHEMA_VERSION: Int = 1
+
+  /** `a11y/atf` — findings array. */
+  const val KIND_ATF: String = "a11y/atf"
+
+  /** `a11y/hierarchy` — accessibility-relevant nodes with bounds + label + states. */
+  const val KIND_HIERARCHY: String = "a11y/hierarchy"
+
+  /** File names under `<rootDir>/<previewId>/`. */
+  const val FILE_ATF: String = "a11y-atf.json"
+  const val FILE_HIERARCHY: String = "a11y-hierarchy.json"
+
+  @Serializable internal data class AtfPayload(val findings: List<AccessibilityFinding>)
+
+  @Serializable internal data class HierarchyPayload(val nodes: List<AccessibilityNode>)
+
+  /**
+   * Writes both files to `<rootDir>/<previewId>/` (creating the directory tree if needed).
+   * Idempotent — overwrites prior files. Called from [RenderEngine.render]'s a11y branch
+   * with the result of [ee.schimke.composeai.renderer.AccessibilityChecker.analyze].
+   */
+  fun writeArtifacts(
+    rootDir: File,
+    previewId: String,
+    findings: List<AccessibilityFinding>,
+    nodes: List<AccessibilityNode>,
+  ) {
+    val previewDir = rootDir.resolve(previewId)
+    previewDir.mkdirs()
+    previewDir
+      .resolve(FILE_ATF)
+      .writeText(json.encodeToString(AtfPayload.serializer(), AtfPayload(findings)))
+    previewDir
+      .resolve(FILE_HIERARCHY)
+      .writeText(json.encodeToString(HierarchyPayload.serializer(), HierarchyPayload(nodes)))
+  }
+}
+
+/**
+ * D2 — [DataProductRegistry] implementation that surfaces `a11y/atf` (inline) and
+ * `a11y/hierarchy` (path) by reading the JSON files [AccessibilityDataProducer] writes during
+ * each render. The renderer-side producer always writes when daemon-mode a11y is active; this
+ * registry decides whether the data ends up on the wire based on the dispatcher's subscription
+ * bookkeeping.
+ *
+ * `attachable: true` for both kinds — they ride `renderFinished.dataProducts` when the client
+ * has subscribed. `fetchable: true` for both — pull-on-demand reads from the same files. Neither
+ * kind triggers a re-render: the producer always runs in daemon a11y mode, so the JSON is on
+ * disk for any preview that has rendered at least once.
+ *
+ * `rootDir` mirrors `RenderEngine`'s `dataDir` (defaults to `<outputDir.parent>/data`). Wired by
+ * [DaemonMain].
+ */
+class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductRegistry {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = AccessibilityDataProducer.KIND_ATF,
+        schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+      ),
+      DataProductCapability(
+        kind = AccessibilityDataProducer.KIND_HIERARCHY,
+        schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
+        transport = DataProductTransport.PATH,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+      ),
+    )
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    val (file, transport) =
+      when (kind) {
+        AccessibilityDataProducer.KIND_ATF ->
+          fileFor(previewId, AccessibilityDataProducer.FILE_ATF) to DataProductTransport.INLINE
+        AccessibilityDataProducer.KIND_HIERARCHY ->
+          fileFor(previewId, AccessibilityDataProducer.FILE_HIERARCHY) to
+            DataProductTransport.PATH
+        else -> return DataProductRegistry.Outcome.Unknown
+      }
+    if (!file.exists()) return DataProductRegistry.Outcome.NotAvailable
+    val payloadElement: JsonElement? =
+      try {
+        json.parseToJsonElement(file.readText())
+      } catch (t: Throwable) {
+        return DataProductRegistry.Outcome.FetchFailed(
+          message = "could not parse $kind for $previewId: ${t.message}"
+        )
+      }
+    val result =
+      when {
+        inline ->
+          DataFetchResult(
+            kind = kind,
+            schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
+            payload = payloadElement,
+          )
+        transport == DataProductTransport.INLINE ->
+          // Even when the caller didn't ask for inline, the `inline` transport kind has no
+          // separate `path` representation. Returning the parsed payload keeps the API
+          // self-consistent: `transport='inline'` ⇒ payload always set.
+          DataFetchResult(
+            kind = kind,
+            schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
+            payload = payloadElement,
+          )
+        else ->
+          DataFetchResult(
+            kind = kind,
+            schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
+            path = file.absolutePath,
+          )
+      }
+    return DataProductRegistry.Outcome.Ok(result)
+  }
+
+  override fun attachmentsFor(
+    previewId: String,
+    kinds: Set<String>,
+  ): List<DataProductAttachment> {
+    val out = mutableListOf<DataProductAttachment>()
+    for (kind in kinds) {
+      when (kind) {
+        AccessibilityDataProducer.KIND_ATF -> {
+          val file = fileFor(previewId, AccessibilityDataProducer.FILE_ATF)
+          if (!file.exists()) continue
+          val parsed =
+            try {
+              json.parseToJsonElement(file.readText())
+            } catch (t: Throwable) {
+              System.err.println(
+                "AccessibilityDataProductRegistry: parse $kind failed for $previewId: ${t.message}"
+              )
+              continue
+            }
+          out.add(
+            DataProductAttachment(
+              kind = kind,
+              schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
+              payload = parsed,
+            )
+          )
+        }
+        AccessibilityDataProducer.KIND_HIERARCHY -> {
+          val file = fileFor(previewId, AccessibilityDataProducer.FILE_HIERARCHY)
+          if (!file.exists()) continue
+          out.add(
+            DataProductAttachment(
+              kind = kind,
+              schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
+              path = file.absolutePath,
+            )
+          )
+        }
+      // Unknown kinds drop out silently — the dispatcher already filtered against
+      // `capabilities` before calling this; an unrecognised kind here means the
+      // dispatcher's filtering drifted and we'd rather skip than emit garbage.
+      }
+    }
+    return out
+  }
+
+  private fun fileFor(previewId: String, fileName: String): File =
+    rootDir.resolve(previewId).resolve(fileName)
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -209,6 +209,24 @@ fun main(args: Array<String>) {
       )
     }
 
+  // D2 — wire the accessibility data-product registry. Always-on when the renders dir is
+  // resolvable: the registry advertises `a11y/atf` + `a11y/hierarchy` and reads the JSON files
+  // RenderEngine writes under `<outputDir.parent>/data/<id>/`. The registry never blocks
+  // rendering; missing files surface as "no attachment for this kind on this render". Setting
+  // [RenderEngine.ATTACH_A11Y_PROP] flips the renderer into a11y mode so the JSON ever lands.
+  val renderOutputDir = System.getProperty(RenderEngine.OUTPUT_DIR_PROP)
+  val dataProducts: DataProductRegistry =
+    if (renderOutputDir != null) {
+      val dataRoot = File(renderOutputDir).parentFile?.resolve("data") ?: File(renderOutputDir)
+      System.setProperty(RenderEngine.ATTACH_A11Y_PROP, "true")
+      System.err.println(
+        "compose-ai-tools daemon: AccessibilityDataProductRegistry active (dataRoot=$dataRoot)"
+      )
+      AccessibilityDataProductRegistry(rootDir = dataRoot)
+    } else {
+      DataProductRegistry.Empty
+    }
+
   val server =
     JsonRpcServer(
       input = System.`in`,
@@ -218,6 +236,7 @@ fun main(args: Array<String>) {
       previewIndex = previewIndex,
       incrementalDiscovery = incrementalDiscovery,
       historyManager = historyManager,
+      dataProducts = dataProducts,
     )
   server.run()
 }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -13,11 +13,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.ViewRootForTest
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.captureRoboImage
+import ee.schimke.composeai.renderer.AccessibilityChecker
 import java.io.File
 
 /**
@@ -72,7 +74,18 @@ class RenderEngine(
     File(
       System.getProperty(OUTPUT_DIR_PROP)
         ?: "${System.getProperty("user.dir")}/.compose-preview-history/daemon-renders"
-    )
+    ),
+  /**
+   * D2 — root of the per-preview data-product output tree
+   * (`<dataDir>/<previewId>/a11y-{atf,hierarchy}.json`). Defaults to `${outputDir.parent}/data` so
+   * the layout sits next to the renders dir, matching the design doc's
+   * `build/compose-previews/data/<id>/<kind>.json` convention. Unit tests override to a temp dir.
+   *
+   * `null` disables the a11y-on-render path entirely — useful for the harness fake-mode runs that
+   * don't exercise the producer.
+   */
+  private val dataDir: File? =
+    (outputDir.parentFile ?: outputDir).resolve("data"),
 ) {
 
   /**
@@ -98,6 +111,19 @@ class RenderEngine(
      * with a sandbox-age that resets per test render.
      */
     sandboxStats: SandboxLifecycleStats = SandboxLifecycleStats(),
+    /**
+     * D2 — when true, render in a11y mode (`LocalInspectionMode = false`) and dump
+     * `a11y-atf.json` + `a11y-hierarchy.json` under [dataDir] so the daemon's data-product
+     * registry can surface them as `a11y/atf` + `a11y/hierarchy`. Mirrors the design doc's
+     * "produce always, gate emission on subscriptions" approach — the cost is a few ms per
+     * render, traded for simpler implementation than per-render kind threading.
+     *
+     * Defaults to the [ATTACH_A11Y_PROP] system property — `composeai.daemon.attachA11y=true` set
+     * by [DaemonMain] when the a11y data-product registry is wired. False (the default) keeps the
+     * pre-D2 paused-clock + `LocalInspectionMode = true` fast path used by the harness's fake-mode
+     * tests.
+     */
+    runAccessibility: Boolean = System.getProperty(ATTACH_A11Y_PROP) == "true",
   ): RenderResult {
     // Roborazzi defaults to "compare" mode — `captureRoboImage` reads the existing baseline at
     // the target path and *doesn't* write a new PNG. The daemon writes baselines, never compares,
@@ -179,7 +205,12 @@ class RenderEngine(
             rule.runOnUiThread { rule.activity.window.decorView.setBackgroundColor(bgArgb) }
 
             rule.setContent {
-              CompositionLocalProvider(LocalInspectionMode provides true) {
+              // D2 — a11y mode flips LocalInspectionMode off so Compose populates real
+              // accessibility semantics (mergeMode, contentDescription, role) for ATF + the
+              // hierarchy walk to consume after capture. Tradeoff: infinite animations tick
+              // through rather than parking under the paused clock — same trade
+              // `RobolectricRenderTest.renderWithA11y` already pays.
+              CompositionLocalProvider(LocalInspectionMode provides !runAccessibility) {
                 Box(modifier = Modifier.fillMaxSize()) { InvokeComposable(composableMethod) }
               }
             }
@@ -199,6 +230,30 @@ class RenderEngine(
             rule
               .onRoot()
               .captureRoboImage(file = outputFile, roborazziOptions = roborazziOptions)
+
+            // D2 — a11y data products. Walk the same `ViewRootForTest` ATF can populate, dump
+            // `a11y-atf.json` (findings) and `a11y-hierarchy.json` (nodes) next to the PNG. The
+            // dispatcher reads these on `data/fetch` / `data/subscribe` attachment via
+            // `AccessibilityDataProductRegistry`. Wrapped in try/catch so an a11y failure does
+            // not strand the PNG the user already cares about — the registry sees a missing
+            // file as "no attachment for this kind on this render".
+            if (runAccessibility && dataDir != null) {
+              try {
+                val view = (rule.onRoot().fetchSemanticsNode().root as ViewRootForTest).view
+                val a11yResult = AccessibilityChecker.analyze(spec.outputBaseName, view)
+                AccessibilityDataProducer.writeArtifacts(
+                  rootDir = dataDir,
+                  previewId = spec.outputBaseName,
+                  findings = a11yResult.findings,
+                  nodes = a11yResult.nodes,
+                )
+              } catch (t: Throwable) {
+                System.err.println(
+                  "RenderEngine: a11y data write failed for ${spec.outputBaseName}: " +
+                    "${t.javaClass.simpleName}: ${t.message}"
+                )
+              }
+            }
           } finally {
             // DESIGN § 9 + § 10 cleanup epilogue. The Compose test rule does not allow a second
             // `setContent` on the same `ComponentActivity`, so we can't drive the
@@ -288,6 +343,14 @@ class RenderEngine(
      * side uses; the gradle plugin's daemon launch descriptor sets it once at JVM start.
      */
     const val OUTPUT_DIR_PROP: String = "composeai.render.outputDir"
+
+    /**
+     * D2 — when set to `"true"` (by [DaemonMain] after wiring the a11y data-product registry)
+     * each render runs in a11y mode and writes `a11y-{atf,hierarchy}.json` artefacts under
+     * `<outputDir.parent>/data/<previewId>/`. Tests / pre-D2 callers leave it unset and the
+     * fast path stays unchanged.
+     */
+    const val ATTACH_A11Y_PROP: String = "composeai.daemon.attachA11y"
 
     /**
      * Virtual time to advance before capture in the paused-`mainClock` path, in milliseconds.

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProductRegistryTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProductRegistryTest.kt
@@ -1,0 +1,165 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.renderer.AccessibilityFinding
+import ee.schimke.composeai.renderer.AccessibilityNode
+import java.io.File
+import java.nio.file.Files
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * D2 — pins the producer/registry contract for the daemon's a11y data products. Producer
+ * writes to `<rootDir>/<previewId>/a11y-{atf,hierarchy}.json`; registry reads back what's
+ * there and surfaces it as inline (`a11y/atf`) or path (`a11y/hierarchy`). Unknown kinds
+ * route to `Outcome.Unknown`; missing files route to `Outcome.NotAvailable`.
+ */
+class AccessibilityDataProductRegistryTest {
+
+  private lateinit var rootDir: File
+
+  @Before
+  fun setUp() {
+    rootDir = Files.createTempDirectory("a11y-data-product-test").toFile()
+  }
+
+  @After
+  fun tearDown() {
+    rootDir.deleteRecursively()
+  }
+
+  @Test
+  fun `capabilities advertise a11y atf and hierarchy with the documented transports`() {
+    val registry = AccessibilityDataProductRegistry(rootDir)
+    val byKind = registry.capabilities.associateBy { it.kind }
+    assertEquals(setOf("a11y/atf", "a11y/hierarchy"), byKind.keys)
+    assertEquals(DataProductTransport.INLINE, byKind.getValue("a11y/atf").transport)
+    assertEquals(DataProductTransport.PATH, byKind.getValue("a11y/hierarchy").transport)
+    for (cap in registry.capabilities) {
+      assertTrue(cap.attachable)
+      assertTrue(cap.fetchable)
+      // The producer always runs in daemon a11y mode — no per-fetch re-render.
+      assertTrue(!cap.requiresRerender)
+    }
+  }
+
+  @Test
+  fun `attachmentsFor returns inline a11y atf payload and path-only a11y hierarchy entry`() {
+    val registry = AccessibilityDataProductRegistry(rootDir)
+    val finding =
+      AccessibilityFinding(
+        level = "WARNING",
+        type = "TouchTargetSizeCheck",
+        message = "below 48dp",
+        viewDescription = "Button",
+        boundsInScreen = "0,0,32,32",
+      )
+    val node =
+      AccessibilityNode(
+        label = "Submit",
+        role = "Button",
+        states = listOf("clickable"),
+        merged = true,
+        boundsInScreen = "10,20,200,80",
+      )
+    AccessibilityDataProducer.writeArtifacts(
+      rootDir = rootDir,
+      previewId = "com.example.HomeKt#HomePreview",
+      findings = listOf(finding),
+      nodes = listOf(node),
+    )
+
+    val attachments =
+      registry.attachmentsFor(
+        previewId = "com.example.HomeKt#HomePreview",
+        kinds = setOf("a11y/atf", "a11y/hierarchy"),
+      )
+    assertEquals(2, attachments.size)
+    val byKind = attachments.associateBy { it.kind }
+
+    val atf = byKind.getValue("a11y/atf")
+    assertNotNull("a11y/atf should travel inline", atf.payload)
+    assertNull("a11y/atf must not also carry a path", atf.path)
+    val findings = (atf.payload as JsonObject)["findings"]?.jsonArray
+    assertNotNull(findings)
+    assertEquals(1, findings!!.size)
+    assertEquals(
+      "TouchTargetSizeCheck",
+      findings[0].jsonObject["type"]!!.toString().trim('"'),
+    )
+
+    val hierarchy = byKind.getValue("a11y/hierarchy")
+    assertNull("a11y/hierarchy travels by path, not inline", hierarchy.payload)
+    assertNotNull("a11y/hierarchy must point at the JSON file", hierarchy.path)
+    assertTrue(File(hierarchy.path!!).exists())
+  }
+
+  @Test
+  fun `attachmentsFor skips kinds with no on-disk file rather than emitting an empty entry`() {
+    val registry = AccessibilityDataProductRegistry(rootDir)
+    // No producer has run for this preview yet — neither file exists.
+    val attachments =
+      registry.attachmentsFor(
+        previewId = "com.example.NoRender",
+        kinds = setOf("a11y/atf", "a11y/hierarchy"),
+      )
+    assertEquals(emptyList<Any>(), attachments)
+  }
+
+  @Test
+  fun `fetch returns NotAvailable when the preview never rendered`() {
+    val registry = AccessibilityDataProductRegistry(rootDir)
+    val outcome =
+      registry.fetch(
+        previewId = "com.example.NoRender",
+        kind = "a11y/hierarchy",
+        params = null,
+        inline = false,
+      )
+    assertEquals(DataProductRegistry.Outcome.NotAvailable, outcome)
+  }
+
+  @Test
+  fun `fetch returns Unknown for a kind the registry does not advertise`() {
+    val registry = AccessibilityDataProductRegistry(rootDir)
+    val outcome =
+      registry.fetch(
+        previewId = "com.example.HomeKt#HomePreview",
+        kind = "compose/recomposition",
+        params = null,
+        inline = false,
+      )
+    assertEquals(DataProductRegistry.Outcome.Unknown, outcome)
+  }
+
+  @Test
+  fun `fetch on a11y hierarchy returns the absolute path when caller did not request inline`() {
+    val registry = AccessibilityDataProductRegistry(rootDir)
+    AccessibilityDataProducer.writeArtifacts(
+      rootDir = rootDir,
+      previewId = "com.example.X",
+      findings = emptyList(),
+      nodes = emptyList(),
+    )
+    val outcome =
+      registry.fetch(
+        previewId = "com.example.X",
+        kind = "a11y/hierarchy",
+        params = null,
+        inline = false,
+      )
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    val result = (outcome as DataProductRegistry.Outcome.Ok).result
+    assertNotNull(result.path)
+    assertNull(result.payload)
+    assertTrue(File(result.path!!).exists())
+  }
+}

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityChecker.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityChecker.kt
@@ -28,7 +28,12 @@ import org.robolectric.shadows.ShadowBuild
  * directly against the view we snapshot through [LocalView] avoids paying the
  * `createComposeRule()` tax on every render.
  */
-internal object AccessibilityChecker {
+// D2 — promoted from `internal` so `:daemon:android`'s RenderEngine can run the
+// same ATF + hierarchy walk this object performs and drive the daemon's
+// `a11y/atf` + `a11y/hierarchy` data products. The `:cli` and Gradle paths
+// continue to use it via `RobolectricRenderTest`. See
+// docs/daemon/DATA-PRODUCTS.md § "Worked example: a11y/hierarchy".
+object AccessibilityChecker {
 
     private val json = Json { prettyPrint = true; encodeDefaults = true }
 

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -991,6 +991,37 @@ body {
     pointer-events: none;
     z-index: 2;
 }
+/* D2 — daemon-attached `a11y/hierarchy` overlay. Sits BELOW the finding overlay so
+ * findings stay legible (numbered badges + coloured borders win); shows every
+ * accessibility-relevant node with a thin dotted border + translucent fill so the
+ * full TalkBack-visible tree is laid out without obscuring the design. Pointer-events
+ * are auto on the boxes so the `title` tooltip fires on hover. */
+.a11y-hierarchy-overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 1;
+}
+.a11y-hierarchy-box {
+    position: absolute;
+    border: 1px dashed rgba(80, 160, 255, 0.7);
+    background: rgba(80, 160, 255, 0.06);
+    border-radius: 1px;
+    pointer-events: auto;
+    transition: background 120ms ease;
+}
+.a11y-hierarchy-box:hover {
+    background: rgba(80, 160, 255, 0.18);
+    border-color: rgba(80, 160, 255, 1);
+}
+/* Nodes sitting under a focusable ancestor that already carries its own
+ * contentDescription — TalkBack reads only the ancestor. Shown with a lighter
+ * border so reviewers can see the structure without confusing it for "two
+ * separate stops". */
+.a11y-hierarchy-box.a11y-hierarchy-unmerged {
+    border-style: dotted;
+    border-color: rgba(160, 200, 255, 0.5);
+}
 .a11y-box {
     position: absolute;
     border: 2px solid var(--a11y-color, #d32f2f);

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -537,6 +537,12 @@ body {
     color: var(--vscode-errorForeground, #f55);
 }
 
+/* D2 — a11y-overlay toggle pressed state. Blue glyph echoes the hierarchy
+ * overlay's box border colour so the toolbar tells you which layer is on. */
+.icon-button.a11y-overlay-on {
+    color: rgba(80, 160, 255, 1);
+}
+
 /* Diff overlay — covers the focused image with a side-by-side comparison
    when the user clicks Diff vs HEAD / vs main. Lives inside the
    .image-container so it inherits the card's bounds and exits cleanly via

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -64,12 +64,11 @@ export interface SchedulerEvents {
 const HEAVY_TIER_DEFAULT: RenderTier = 'fast';
 
 /**
- * D2 — kinds the panel implicitly subscribes to whenever a preview becomes visible. Pinned to the
- * a11y producer for now so the diagnostic squigglies + the local hierarchy overlay both fire
- * without a user gesture. A future "show a11y" toggle moves this from a hardcoded constant to
- * panel-driven state.
+ * D2 — kinds the focus-mode "Show a11y overlay" button toggles. Pinned to the a11y producer
+ * so the local finding + hierarchy overlays light up together; a future panel that wants to
+ * subscribe to other kinds (`compose/recomposition`, `layout/tree`) will export its own list.
  */
-const DEFAULT_SUBSCRIBED_KINDS: readonly string[] = ['a11y/atf', 'a11y/hierarchy'];
+export const A11Y_OVERLAY_KINDS: readonly string[] = ['a11y/atf', 'a11y/hierarchy'];
 /**
  * Cards we'll pre-render ahead of the visible viewport on each scroll-ahead
  * push from the webview. Bounded so a fast scroll past 50 cards doesn't
@@ -222,15 +221,12 @@ export class DaemonScheduler {
         if (!client) { return; }
         client.setVisible({ ids: visible });
 
-        // D2 — subscribe to a11y data products for newly-visible previews. The daemon attaches
-        // matching kinds to subsequent `renderFinished` events, and prunes subscriptions itself
-        // when a preview leaves `setVisible`. We only track which (moduleId, previewId, kind)
-        // triples we've already asked about so we don't spam `data/subscribe`. dataSubscribe
-        // rejects gracefully (DataProductUnknown) on pre-D2 daemons; those reject promises are
-        // ignored so the panel keeps working unchanged.
+        // D2 — drop bookkeeping for previews that fell out of view. The daemon already
+        // pruned its side on the same `setVisible`, so this just keeps our local dedup
+        // set in sync. Subscriptions themselves are now opt-in per focused preview via
+        // [setDataProductSubscription]; the panel calls in when the user toggles the
+        // a11y overlay in focus mode.
         const visibleSetForSub = new Set(visible);
-        // Drop bookkeeping for previews that fell out of view — daemon already pruned its side.
-        // Key format is `${moduleId}::${id}::${kind}`; we parse to compare just the id.
         const modulePrefix = `${moduleId}::`;
         for (const key of [...this.subscribedPairs]) {
             if (!key.startsWith(modulePrefix)) { continue; }
@@ -238,23 +234,6 @@ export class DaemonScheduler {
             const sep = rest.indexOf('::');
             const id = sep < 0 ? rest : rest.slice(0, sep);
             if (!visibleSetForSub.has(id)) { this.subscribedPairs.delete(key); }
-        }
-        for (const id of visible) {
-            for (const kind of DEFAULT_SUBSCRIBED_KINDS) {
-                const subKey = `${moduleId}::${id}::${kind}`;
-                if (this.subscribedPairs.has(subKey)) { continue; }
-                this.subscribedPairs.add(subKey);
-                client.dataSubscribe({ previewId: id, kind }).catch((err) => {
-                    // Pre-D2 daemons reject with DataProductUnknown for every kind; that's
-                    // expected, not noise. Log at debug level via the channel so the user
-                    // doesn't see it unless they're poking at the protocol surface.
-                    const msg = (err as Error)?.message ?? String(err);
-                    this.logger.appendLine(
-                        `[daemon] dataSubscribe(${id}, ${kind}) failed (pre-D2 daemon?): ${msg}`,
-                    );
-                    this.subscribedPairs.delete(subKey);
-                });
-            }
         }
 
         if (predicted.length === 0) { return; }
@@ -278,6 +257,54 @@ export class DaemonScheduler {
             this.logger.appendLine(
                 `[daemon] scroll-ahead renderNow failed for ${moduleId}: ${(err as Error).message}`,
             );
+        }
+    }
+
+    /**
+     * D2 — explicit per-`(previewId, kind)` subscription toggle. Wired to the focus-mode a11y
+     * overlay button: enabling subscribes to `a11y/atf` + `a11y/hierarchy` (or whatever the
+     * caller passes) so the next render attaches the payload; disabling unsubscribes. Idempotent
+     * on both sides.
+     *
+     * We deliberately keep the auto-subscribe out of `setVisible` so the wire stays quiet for
+     * unfocused previews — the design doc's "Default = nothing attached" stance with a per-panel
+     * opt-in.
+     */
+    async setDataProductSubscription(
+        moduleId: string,
+        previewId: string,
+        kinds: readonly string[],
+        enabled: boolean,
+    ): Promise<void> {
+        const client = await this.gate.getOrSpawn(moduleId, this.daemonEvents(moduleId));
+        if (!client) { return; }
+        for (const kind of kinds) {
+            const subKey = `${moduleId}::${previewId}::${kind}`;
+            const already = this.subscribedPairs.has(subKey);
+            if (enabled === already) { continue; }
+            if (enabled) {
+                this.subscribedPairs.add(subKey);
+                client.dataSubscribe({ previewId, kind }).catch((err) => {
+                    // Pre-D2 daemons reject with DataProductUnknown for every kind; that's
+                    // expected, not noise — log to the daemon channel and roll back the
+                    // bookkeeping so a later daemon spawn re-issues.
+                    const msg = (err as Error)?.message ?? String(err);
+                    this.logger.appendLine(
+                        `[daemon] dataSubscribe(${previewId}, ${kind}) failed: ${msg}`,
+                    );
+                    this.subscribedPairs.delete(subKey);
+                });
+            } else {
+                this.subscribedPairs.delete(subKey);
+                client.dataUnsubscribe({ previewId, kind }).catch((err) => {
+                    // Unsubscribe rejection is purely informational — the daemon already
+                    // cleaned up on its side, our bookkeeping is gone, no rollback needed.
+                    const msg = (err as Error)?.message ?? String(err);
+                    this.logger.appendLine(
+                        `[daemon] dataUnsubscribe(${previewId}, ${kind}) failed: ${msg}`,
+                    );
+                });
+            }
         }
     }
 

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import { GradleService } from '../gradleService';
 import { DaemonGate } from './daemonGate';
 import {
+    DataProductAttachment,
     DiscoveryUpdatedParams,
     FileChangeType,
     FileKind,
@@ -26,6 +27,20 @@ export interface SchedulerEvents {
         imageBase64: string,
         pngPath: string,
     ) => void;
+    /**
+     * D2 — `renderFinished` arrived with `dataProducts: [{kind, payload? | path?}]`.
+     * Fires once per render, after the PNG has been read; consumers route each kind
+     * into the registry / webview / diagnostics surface.
+     *
+     * Optional because tests may not wire it. Only fires when the daemon attaches
+     * data products (i.e. the client subscribed via `dataSubscribe` for one of the
+     * `(previewId, kind)` pairs, or attached one globally at `initialize`).
+     */
+    onDataProductsAttached?: (
+        moduleId: string,
+        previewId: string,
+        dataProducts: DataProductAttachment[],
+    ) => void;
     onRenderFailed: (moduleId: string, previewId: string, message: string) => void;
     /**
      * Daemon told us the classpath drifted (e.g. `libs.versions.toml`
@@ -47,6 +62,14 @@ export interface SchedulerEvents {
 }
 
 const HEAVY_TIER_DEFAULT: RenderTier = 'fast';
+
+/**
+ * D2 — kinds the panel implicitly subscribes to whenever a preview becomes visible. Pinned to the
+ * a11y producer for now so the diagnostic squigglies + the local hierarchy overlay both fire
+ * without a user gesture. A future "show a11y" toggle moves this from a hardcoded constant to
+ * panel-driven state.
+ */
+const DEFAULT_SUBSCRIBED_KINDS: readonly string[] = ['a11y/atf', 'a11y/hierarchy'];
 /**
  * Cards we'll pre-render ahead of the visible viewport on each scroll-ahead
  * push from the webview. Bounded so a fast scroll past 50 cards doesn't
@@ -77,6 +100,13 @@ export class DaemonScheduler {
     private lastVisible = new Map<string, string[]>();
     /** Last `setFocus` per module so editor refocus on the same file is a no-op. */
     private lastFocus = new Map<string, string[]>();
+    /**
+     * D2 — `(moduleId, previewId)` pairs we've already issued `data/subscribe` for. Subscribed kinds
+     * are pinned at [DEFAULT_SUBSCRIBED_KINDS] today; per-kind tracking moves here when the panel
+     * grows a runtime "show a11y" toggle. Daemon prunes its side automatically when a previewId
+     * leaves `setVisible`, so we only need to dedup re-subscribes.
+     */
+    private readonly subscribedPairs = new Set<string>();
     /** Cards we've already speculatively requested so scrolling back over
      *  them doesn't re-queue identical work. Keyed by `${moduleId}::${id}`. */
     private speculated = new Set<string>();
@@ -192,6 +222,41 @@ export class DaemonScheduler {
         if (!client) { return; }
         client.setVisible({ ids: visible });
 
+        // D2 — subscribe to a11y data products for newly-visible previews. The daemon attaches
+        // matching kinds to subsequent `renderFinished` events, and prunes subscriptions itself
+        // when a preview leaves `setVisible`. We only track which (moduleId, previewId, kind)
+        // triples we've already asked about so we don't spam `data/subscribe`. dataSubscribe
+        // rejects gracefully (DataProductUnknown) on pre-D2 daemons; those reject promises are
+        // ignored so the panel keeps working unchanged.
+        const visibleSetForSub = new Set(visible);
+        // Drop bookkeeping for previews that fell out of view — daemon already pruned its side.
+        // Key format is `${moduleId}::${id}::${kind}`; we parse to compare just the id.
+        const modulePrefix = `${moduleId}::`;
+        for (const key of [...this.subscribedPairs]) {
+            if (!key.startsWith(modulePrefix)) { continue; }
+            const rest = key.slice(modulePrefix.length);
+            const sep = rest.indexOf('::');
+            const id = sep < 0 ? rest : rest.slice(0, sep);
+            if (!visibleSetForSub.has(id)) { this.subscribedPairs.delete(key); }
+        }
+        for (const id of visible) {
+            for (const kind of DEFAULT_SUBSCRIBED_KINDS) {
+                const subKey = `${moduleId}::${id}::${kind}`;
+                if (this.subscribedPairs.has(subKey)) { continue; }
+                this.subscribedPairs.add(subKey);
+                client.dataSubscribe({ previewId: id, kind }).catch((err) => {
+                    // Pre-D2 daemons reject with DataProductUnknown for every kind; that's
+                    // expected, not noise. Log at debug level via the channel so the user
+                    // doesn't see it unless they're poking at the protocol surface.
+                    const msg = (err as Error)?.message ?? String(err);
+                    this.logger.appendLine(
+                        `[daemon] dataSubscribe(${id}, ${kind}) failed (pre-D2 daemon?): ${msg}`,
+                    );
+                    this.subscribedPairs.delete(subKey);
+                });
+            }
+        }
+
         if (predicted.length === 0) { return; }
         // Bound the speculative request so a flick-scroll past 50 cards
         // doesn't queue 50 renders. Visible IDs trump predicted ones —
@@ -285,6 +350,12 @@ export class DaemonScheduler {
                 for (const k of [...this.speculated]) {
                     if (k.startsWith(`${moduleId}::`)) { this.speculated.delete(k); }
                 }
+                // D2 — wipe data-product subscription state so the next daemon spawn re-issues
+                // `data/subscribe` against the fresh JVM. Subscriptions don't survive daemon
+                // restarts (PROTOCOL.md / DATA-PRODUCTS.md § "Wire surface").
+                for (const k of [...this.subscribedPairs]) {
+                    if (k.startsWith(`${moduleId}::`)) { this.subscribedPairs.delete(k); }
+                }
             },
         };
     }
@@ -325,6 +396,13 @@ export class DaemonScheduler {
                 buf.toString('base64'),
                 params.pngPath,
             );
+            // D2 — forward attached data products. The dispatcher already filtered to the
+            // `(previewId, kind)` pairs the client subscribed to, so any non-empty list is a
+            // payload the panel asked for. Empty / absent → nothing to do; we DON'T fire the
+            // event in that case to keep the consumer-side dispatch trivial.
+            if (params.dataProducts && params.dataProducts.length > 0) {
+                this.events.onDataProductsAttached?.(moduleId, params.id, params.dataProducts);
+            }
         } catch (err) {
             this.logger.appendLine(
                 `[daemon] failed to read ${params.pngPath} for ${params.id}: ${(err as Error).message}`,

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -15,10 +15,17 @@ import { AndroidManifestCodeLensProvider } from './androidManifestCodeLensProvid
 import { PreviewA11yDiagnostics } from './previewA11yDiagnostics';
 import { PreviewDoctorDiagnostics } from './previewDoctorDiagnostics';
 import { packageQualifiedSourcePath } from './sourcePath';
-import { HEAVY_COST_THRESHOLD, PreviewInfo, WebviewToExtension } from './types';
+import {
+    AccessibilityFinding,
+    AccessibilityNode,
+    HEAVY_COST_THRESHOLD,
+    PreviewInfo,
+    WebviewToExtension,
+} from './types';
 import { formatRenderErrorMessage } from './renderError';
 import { captureLabel } from './captureLabels';
 import { DaemonGate } from './daemon/daemonGate';
+import { DataProductAttachment } from './daemon/daemonProtocol';
 import { DaemonScheduler, WarmState } from './daemon/daemonScheduler';
 import { buildHistorySource, HistoryPanel, HistoryScope, HistorySource } from './historyPanel';
 import { disposePreviewMainBatches, readPreviewMainPng } from './previewMainSource';
@@ -251,6 +258,62 @@ export interface ComposePreviewTestApi {
  *  populated when running under `COMPOSE_PREVIEW_TEST_MODE=1`. */
 const postedMessageLog: unknown[] = [];
 
+/**
+ * D2 — routes daemon-attached `a11y/atf` + `a11y/hierarchy` data products into the
+ * [PreviewRegistry]. Inline payloads are decoded directly; path-transport kinds are
+ * read off disk (the daemon writes them under `<outputDir.parent>/data/<previewId>/`).
+ *
+ * Failure mode: malformed JSON or a missing path file logs to the daemon channel and
+ * leaves the registry untouched — the previous render's a11y state stays valid until
+ * the next attachment arrives.
+ *
+ * Exported for unit-testability; the module-scoped scheduler wiring above is the
+ * production caller.
+ */
+export function applyDataProductsToRegistry(
+    registry: PreviewRegistry,
+    previewId: string,
+    dataProducts: DataProductAttachment[],
+    log: { appendLine(value: string): void },
+): { findings?: AccessibilityFinding[]; nodes?: AccessibilityNode[] } | null {
+    let findings: AccessibilityFinding[] | undefined;
+    let nodes: AccessibilityNode[] | undefined;
+    for (const dp of dataProducts) {
+        try {
+            if (dp.kind === 'a11y/atf') {
+                const payload = (dp.payload ?? readJsonPath(dp.path, log)) as
+                    | { findings?: AccessibilityFinding[] }
+                    | undefined;
+                if (payload?.findings) { findings = payload.findings; }
+            } else if (dp.kind === 'a11y/hierarchy') {
+                const payload = (dp.payload ?? readJsonPath(dp.path, log)) as
+                    | { nodes?: AccessibilityNode[] }
+                    | undefined;
+                if (payload?.nodes) { nodes = payload.nodes; }
+            }
+        } catch (err) {
+            log.appendLine(
+                `[daemon] data product ${dp.kind} for ${previewId} failed: ${(err as Error).message}`,
+            );
+        }
+    }
+    if (findings !== undefined || nodes !== undefined) {
+        registry.setA11y(previewId, { findings, nodes });
+        return { findings, nodes };
+    }
+    return null;
+}
+
+function readJsonPath(p: string | undefined, log: { appendLine(value: string): void }): unknown {
+    if (!p) { return undefined; }
+    try {
+        return JSON.parse(fs.readFileSync(p, 'utf-8'));
+    } catch (err) {
+        log.appendLine(`[daemon] could not read data-product JSON at ${p}: ${(err as Error).message}`);
+        return undefined;
+    }
+}
+
 export async function activate(context: vscode.ExtensionContext): Promise<ComposePreviewTestApi | void> {
     const workspaceFolders = vscode.workspace.workspaceFolders;
     if (!workspaceFolders || workspaceFolders.length === 0) { return; }
@@ -345,6 +408,28 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
                 captureIndex: 0,
                 message,
             });
+        },
+        onDataProductsAttached: (_moduleId, previewId, dataProducts) => {
+            // D2 — route the data products attached to this render. For path-transport kinds
+            // (`a11y/hierarchy`) we read the JSON off disk; inline kinds (`a11y/atf`) carry
+            // their payload in `dp.payload`. The registry update fires `onDidChange`, which
+            // the diagnostics provider already listens to. The panel receives a targeted
+            // `updateA11y` post so its cached overlays repaint without re-emitting the entire
+            // preview list.
+            const decoded = applyDataProductsToRegistry(
+                registry,
+                previewId,
+                dataProducts,
+                outputChannel,
+            );
+            if (decoded && panel) {
+                panel.postMessage({
+                    command: 'updateA11y',
+                    previewId,
+                    findings: decoded.findings ?? undefined,
+                    nodes: decoded.nodes ?? undefined,
+                });
+            }
         },
         onClasspathDirty: (moduleId, detail) => {
             outputChannel.appendLine(

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -26,7 +26,7 @@ import { formatRenderErrorMessage } from './renderError';
 import { captureLabel } from './captureLabels';
 import { DaemonGate } from './daemon/daemonGate';
 import { DataProductAttachment } from './daemon/daemonProtocol';
-import { DaemonScheduler, WarmState } from './daemon/daemonScheduler';
+import { A11Y_OVERLAY_KINDS, DaemonScheduler, WarmState } from './daemon/daemonScheduler';
 import { buildHistorySource, HistoryPanel, HistoryScope, HistorySource } from './historyPanel';
 import { disposePreviewMainBatches, readPreviewMainPng } from './previewMainSource';
 import { watchPreviewMainRef } from './previewMainWatcher';
@@ -2041,6 +2041,41 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                 + `image=${msg.imageWidth}x${msg.imageHeight}`,
             );
             break;
+        case 'setA11yOverlay':
+            void handleSetA11yOverlay(msg.previewId, msg.enabled);
+            break;
+    }
+}
+
+/**
+ * D2 — focus-mode a11y-overlay toggle. Resolves the focused preview's owning module, then
+ * subscribes to `a11y/atf` + `a11y/hierarchy` (or unsubscribes) via the scheduler. When
+ * disabling, also clears the cached payloads in the panel so the existing overlay tears down
+ * even if the next render takes a beat. No-op when the preview's module isn't known yet
+ * (panel rebuild race) or when the daemon scheduler isn't wired (Gradle-only mode).
+ */
+async function handleSetA11yOverlay(previewId: string, enabled: boolean): Promise<void> {
+    if (!daemonScheduler) { return; }
+    const moduleId = previewModuleMap.get(previewId);
+    if (!moduleId) { return; }
+    await daemonScheduler.setDataProductSubscription(
+        moduleId,
+        previewId,
+        A11Y_OVERLAY_KINDS,
+        enabled,
+    );
+    if (!enabled) {
+        // Tear down the panel-side overlay caches immediately so the visual layer clears
+        // without waiting on the next render. Deliberately does NOT touch the registry —
+        // diagnostic squigglies sourced from the Gradle sidecar are independent of the
+        // daemon overlay subscription and shouldn't disappear when the user hides the
+        // visual overlay.
+        panel?.postMessage({
+            command: 'updateA11y',
+            previewId,
+            findings: [],
+            nodes: [],
+        });
     }
 }
 

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -1821,8 +1821,12 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             // check both. Findings are stashed at setPreviews time via the
             // renderPreviews pipeline.
             const findings = cardA11yFindings.get(previewId);
-            if (findings && findings.length > 0) {
-                const apply = () => buildA11yOverlay(card, findings, img);
+            const nodes = cardA11yNodes.get(previewId);
+            if ((findings && findings.length > 0) || (nodes && nodes.length > 0)) {
+                const apply = () => {
+                    if (findings && findings.length > 0) buildA11yOverlay(card, findings, img);
+                    if (nodes && nodes.length > 0) applyHierarchyOverlay(card, nodes, img);
+                };
                 if (img.complete && img.naturalWidth > 0) {
                     apply();
                 } else {
@@ -1835,6 +1839,102 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         // re-read the list on every image (re)load without re-querying the
         // DOM for data attributes.
         const cardA11yFindings = new Map();
+
+        // D2 — previewId -> nodes for the daemon-attached a11y/hierarchy payload. Drives
+        // the local hierarchy overlay (translucent rectangles + label/role/states tooltip
+        // on hover) drawn on top of the existing finding overlay. Populated by
+        // applyA11yUpdate and re-read on each image (re)load via applyHierarchyOverlay.
+        const cardA11yNodes = new Map();
+
+        // D2 — handles updateA11y from the extension (daemon-attached a11y data products).
+        // Updates the per-preview caches and re-applies whichever overlays are now relevant
+        // without rebuilding the whole card. Findings -> legend + finding overlay; nodes ->
+        // hierarchy overlay. Either argument may be omitted to leave that side untouched.
+        function applyA11yUpdate(previewId, findings, nodes) {
+            const card = document.getElementById('preview-' + sanitizeId(previewId));
+            if (!card) return;
+            const container = card.querySelector('.image-container');
+            const img = container && container.querySelector('img');
+            if (findings !== undefined) {
+                if (findings && findings.length > 0) {
+                    cardA11yFindings.set(previewId, findings);
+                    if (container && !container.querySelector('.a11y-overlay')) {
+                        const overlay = document.createElement('div');
+                        overlay.className = 'a11y-overlay';
+                        overlay.setAttribute('aria-hidden', 'true');
+                        container.appendChild(overlay);
+                    }
+                    const existingLegend = card.querySelector('.a11y-legend');
+                    if (existingLegend) existingLegend.remove();
+                    const p = allPreviews.find(pp => pp.id === previewId);
+                    if (p) {
+                        p.a11yFindings = findings;
+                        card.appendChild(buildA11yLegend(p));
+                    }
+                    if (img && img.complete && img.naturalWidth > 0) {
+                        buildA11yOverlay(card, findings, img);
+                    }
+                } else {
+                    cardA11yFindings.delete(previewId);
+                    const overlay = card.querySelector('.a11y-overlay');
+                    if (overlay) overlay.remove();
+                    const legend = card.querySelector('.a11y-legend');
+                    if (legend) legend.remove();
+                }
+            }
+            if (nodes !== undefined) {
+                if (nodes && nodes.length > 0) {
+                    cardA11yNodes.set(previewId, nodes);
+                    ensureHierarchyOverlay(container);
+                    if (img && img.complete && img.naturalWidth > 0) {
+                        applyHierarchyOverlay(card, nodes, img);
+                    }
+                } else {
+                    cardA11yNodes.delete(previewId);
+                    const layer = card.querySelector('.a11y-hierarchy-overlay');
+                    if (layer) layer.remove();
+                }
+            }
+        }
+
+        function ensureHierarchyOverlay(container) {
+            if (!container) return;
+            if (container.querySelector('.a11y-hierarchy-overlay')) return;
+            const layer = document.createElement('div');
+            layer.className = 'a11y-hierarchy-overlay';
+            layer.setAttribute('aria-hidden', 'true');
+            container.appendChild(layer);
+        }
+
+        // D2 — draws one translucent rectangle per accessibility-relevant node. Uses the
+        // same boundsInScreen parsing as the finding overlay so the math stays trivial.
+        // Each box gets a title attribute summarising label / role / states so a hover
+        // yields the same data TalkBack would announce, without baking any of it into
+        // the PNG.
+        function applyHierarchyOverlay(card, nodes, img) {
+            const overlay = card.querySelector('.a11y-hierarchy-overlay');
+            if (!overlay) return;
+            overlay.innerHTML = '';
+            const natW = img.naturalWidth;
+            const natH = img.naturalHeight;
+            if (!natW || !natH) return;
+            nodes.forEach((n) => {
+                const bounds = parseBounds(n.boundsInScreen);
+                if (!bounds) return;
+                const box = document.createElement('div');
+                box.className = 'a11y-hierarchy-box' + (n.merged ? '' : ' a11y-hierarchy-unmerged');
+                box.style.left = (bounds.left / natW * 100) + '%';
+                box.style.top = (bounds.top / natH * 100) + '%';
+                box.style.width = ((bounds.right - bounds.left) / natW * 100) + '%';
+                box.style.height = ((bounds.bottom - bounds.top) / natH * 100) + '%';
+                const tooltipParts = [];
+                if (n.label) tooltipParts.push(n.label);
+                if (n.role) tooltipParts.push(n.role);
+                if (n.states && n.states.length) tooltipParts.push(n.states.join(', '));
+                if (tooltipParts.length) box.title = tooltipParts.join(' · ');
+                overlay.appendChild(box);
+            });
+        }
 
         // ----- Viewport tracking (daemon scroll-ahead, PREDICTIVE.md § 7) -----
         // Webview owns the geometry. Extension's daemon scheduler consumes
@@ -1993,6 +2093,13 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 
                 case 'updateImage':
                     updateImage(msg.previewId, msg.captureIndex || 0, msg.imageData);
+                    break;
+
+                case 'updateA11y':
+                    // D2 — daemon-attached a11y data products landed for one preview. Refresh
+                    // the per-card caches and re-apply the overlays in place; no full re-render
+                    // of the grid. findings/nodes left undefined means leave that side alone.
+                    applyA11yUpdate(msg.previewId, msg.findings, msg.nodes);
                     break;
 
                 case 'setModules':

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -110,6 +110,10 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         <button class="icon-button" id="btn-launch-device" title="Launch on connected Android device" aria-label="Launch on device">
             <i class="codicon codicon-device-mobile" aria-hidden="true"></i>
         </button>
+        <button class="icon-button" id="btn-a11y-overlay" title="Show accessibility overlay"
+                aria-label="Toggle accessibility overlay" aria-pressed="false">
+            <i class="codicon codicon-eye" aria-hidden="true"></i>
+        </button>
         <button class="icon-button" id="btn-interactive" title="Daemon not ready — live mode unavailable"
                 aria-label="Toggle live (interactive) mode" aria-pressed="false" disabled hidden>
             <i class="codicon codicon-circle-large-outline" aria-hidden="true"></i>
@@ -136,8 +140,16 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         const btnDiffHead = document.getElementById('btn-diff-head');
         const btnDiffMain = document.getElementById('btn-diff-main');
         const btnLaunchDevice = document.getElementById('btn-launch-device');
+        const btnA11yOverlay = document.getElementById('btn-a11y-overlay');
         const btnInteractive = document.getElementById('btn-interactive');
         const btnExitFocus = document.getElementById('btn-exit-focus');
+        // D2 — focus-mode a11y overlay toggle. Off by default; turning it on subscribes the
+        // focused preview to a11y/atf + a11y/hierarchy via the extension, off unsubscribes.
+        // Also gates the panel-side hierarchy overlay so the existing finding overlay (which
+        // can also arrive via the Gradle sidecar path) doesn't appear without an explicit
+        // user gesture. State is per-previewId because hopping between focused cards re-applies
+        // the toggle to the new target.
+        let a11yOverlayPreviewId = null;
         const focusPosition = document.getElementById('focus-position');
         const progressBar = document.getElementById('progress-bar');
         const progressFill = progressBar.querySelector('.progress-fill');
@@ -338,6 +350,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         btnDiffHead.addEventListener('click', () => requestFocusedDiff('head'));
         btnDiffMain.addEventListener('click', () => requestFocusedDiff('main'));
         btnLaunchDevice.addEventListener('click', () => requestLaunchOnDevice());
+        btnA11yOverlay.addEventListener('click', () => toggleA11yOverlay());
         btnInteractive.addEventListener('click', () => toggleInteractive());
         btnExitFocus.addEventListener('click', () => exitFocus());
 
@@ -389,6 +402,52 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             btnInteractive.innerHTML = live
                 ? '<i class="codicon codicon-record" aria-hidden="true"></i>'
                 : '<i class="codicon codicon-circle-large-outline" aria-hidden="true"></i>';
+        }
+
+        // D2 — keep the a11y-overlay toggle in lockstep with focus-mode + the focused card
+        // identity. Outside focus mode the button hides; inside focus mode aria-pressed
+        // tracks whether the currently focused preview has the overlay subscription on.
+        function applyA11yOverlayButtonState() {
+            const inFocus = layoutMode.value === 'focus';
+            btnA11yOverlay.hidden = !inFocus;
+            if (!inFocus) {
+                btnA11yOverlay.setAttribute('aria-pressed', 'false');
+                return;
+            }
+            const card = getVisibleCards()[focusIndex];
+            const previewId = card ? card.dataset.previewId : null;
+            const on = previewId !== null && previewId === a11yOverlayPreviewId;
+            btnA11yOverlay.setAttribute('aria-pressed', on ? 'true' : 'false');
+            btnA11yOverlay.title = on
+                ? 'Hide accessibility overlay'
+                : 'Show accessibility overlay';
+            btnA11yOverlay.classList.toggle('a11y-overlay-on', on);
+        }
+
+        // D2 — clicking the a11y toggle subscribes/unsubscribes via the extension. When
+        // turning OFF, the extension also pushes an empty updateA11y so the cached overlay
+        // tears down immediately rather than waiting for a next render. When turning ON for a
+        // different preview, first turn the previous one off so the wire stays clean.
+        function toggleA11yOverlay() {
+            if (layoutMode.value !== 'focus') return;
+            const card = getVisibleCards()[focusIndex];
+            const previewId = card ? card.dataset.previewId : null;
+            if (!previewId) return;
+            const turningOn = previewId !== a11yOverlayPreviewId;
+            if (a11yOverlayPreviewId && a11yOverlayPreviewId !== previewId) {
+                vscode.postMessage({
+                    command: 'setA11yOverlay',
+                    previewId: a11yOverlayPreviewId,
+                    enabled: false,
+                });
+            }
+            a11yOverlayPreviewId = turningOn ? previewId : null;
+            vscode.postMessage({
+                command: 'setA11yOverlay',
+                previewId,
+                enabled: turningOn,
+            });
+            applyA11yOverlayButtonState();
         }
 
         function applyLiveBadge() {
@@ -644,7 +703,23 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     applyLiveBadge();
                 }
             }
+            // D2 — same teardown for the a11y overlay: navigating off the previewed card
+            // (or exiting focus mode) unsubscribes so the wire stays quiet for cards the
+            // user isn't looking at.
+            if (a11yOverlayPreviewId) {
+                const visible = getVisibleCards();
+                const card = mode === 'focus' ? visible[focusIndex] : null;
+                if (!card || card.dataset.previewId !== a11yOverlayPreviewId) {
+                    vscode.postMessage({
+                        command: 'setA11yOverlay',
+                        previewId: a11yOverlayPreviewId,
+                        enabled: false,
+                    });
+                    a11yOverlayPreviewId = null;
+                }
+            }
             applyInteractiveButtonState();
+            applyA11yOverlayButtonState();
         }
 
         // Compute the previewId the panel is currently narrowed to, if any:

--- a/vscode-extension/src/previewRegistry.ts
+++ b/vscode-extension/src/previewRegistry.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { packageQualifiedSourcePath } from './sourcePath';
-import { PreviewInfo } from './types';
+import { AccessibilityFinding, AccessibilityNode, PreviewInfo } from './types';
 
 export interface RegistryEntry {
     preview: PreviewInfo;
@@ -43,6 +43,22 @@ export class PreviewRegistry {
         const entry = this.byId.get(previewId);
         if (!entry) { return; }
         entry.imageBase64 = imageBase64;
+        this._onDidChange.fire();
+    }
+
+    /**
+     * D2 — daemon-attached `a11y/atf` payload routed in by the scheduler. Replaces what the
+     * Gradle sidecar path used to populate via [GradleService.readA11yById]. Either argument may
+     * be omitted to leave the existing field untouched.
+     */
+    setA11y(
+        previewId: string,
+        opts: { findings?: AccessibilityFinding[]; nodes?: AccessibilityNode[] },
+    ): void {
+        const entry = this.byId.get(previewId);
+        if (!entry) { return; }
+        if (opts.findings !== undefined) { entry.preview.a11yFindings = opts.findings; }
+        if (opts.nodes !== undefined) { entry.preview.a11yNodes = opts.nodes; }
         this._onDidChange.fire();
     }
 

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -510,44 +510,72 @@ describe('DaemonScheduler', () => {
     });
 
     /**
-     * D2 — data-product surface. setVisible auto-subscribes the panel to a11y/atf +
-     * a11y/hierarchy for newly-visible previews; renderFinished forwards the attachments.
+     * D2 — data-product surface. Subscriptions are explicit per focused preview (the panel's
+     * focus-mode "Show a11y overlay" toggle drives them) — `setVisible` itself does NOT
+     * subscribe, only prunes stale bookkeeping. `renderFinished` forwards attachments.
      */
     describe('data products', () => {
-        it('issues data/subscribe for each newly-visible preview, twice per (atf + hierarchy)', async () => {
+        it('does not auto-subscribe on setVisible — subscriptions are explicit', async () => {
             const { gate, scheduler } = build();
             await scheduler.setVisible('mod', ['a', 'b'], []);
             const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
-            assert.strictEqual(subs.length, 4);
-            const kinds = subs.map(c => (c.args as { kind: string }).kind).sort();
-            assert.deepStrictEqual(
-                kinds,
-                ['a11y/atf', 'a11y/atf', 'a11y/hierarchy', 'a11y/hierarchy'],
+            assert.strictEqual(subs.length, 0);
+        });
+
+        it('setDataProductSubscription(true) issues data/subscribe per kind', async () => {
+            const { gate, scheduler } = build();
+            await scheduler.setDataProductSubscription(
+                'mod',
+                'a',
+                ['a11y/atf', 'a11y/hierarchy'],
+                true,
             );
-            const ids = subs.map(c => (c.args as { previewId: string }).previewId).sort();
-            assert.deepStrictEqual(ids, ['a', 'a', 'b', 'b']);
+            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            assert.strictEqual(subs.length, 2);
+            const kinds = subs.map(c => (c.args as { kind: string }).kind).sort();
+            assert.deepStrictEqual(kinds, ['a11y/atf', 'a11y/hierarchy']);
         });
 
-        it('does not re-subscribe a (previewId, kind) pair on a repeated setVisible', async () => {
+        it('setDataProductSubscription(true) twice is idempotent', async () => {
             const { gate, scheduler } = build();
-            await scheduler.setVisible('mod', ['a'], []);
-            await scheduler.setVisible('mod', ['a', 'b'], []); // 'a' is already subscribed
+            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
+            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
             const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
-            // 'a': 2 kinds + 'b' newly visible: 2 kinds = 4 total. 'a' is NOT re-subscribed.
-            assert.strictEqual(subs.length, 4);
+            assert.strictEqual(subs.length, 1);
         });
 
-        it('drops bookkeeping when a preview leaves visible — daemon already pruned its side', async () => {
+        it('setDataProductSubscription(false) issues data/unsubscribe and forgets the pair', async () => {
+            const { gate, scheduler } = build();
+            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
+            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], false);
+            const unsubs = gate.client!.calls.filter(c => c.method === 'dataUnsubscribe');
+            assert.strictEqual(unsubs.length, 1);
+            // Re-enabling re-issues subscribe (bookkeeping was cleared).
+            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
+            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            assert.strictEqual(subs.length, 2);
+        });
+
+        it('setDataProductSubscription(false) on an unknown pair is a no-op', async () => {
+            const { gate, scheduler } = build();
+            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], false);
+            const calls = gate.client!.calls.filter(
+                c => c.method === 'dataSubscribe' || c.method === 'dataUnsubscribe',
+            );
+            assert.strictEqual(calls.length, 0);
+        });
+
+        it('setVisible drops bookkeeping for previews that left view', async () => {
             const { gate, scheduler } = build();
             await scheduler.setVisible('mod', ['a', 'b'], []);
-            await scheduler.setVisible('mod', ['a'], []); // 'b' fell out
-            // No new subscribe. 'a' was already subscribed.
-            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
-            assert.strictEqual(subs.length, 4);
-            // Bring 'b' back — it should re-subscribe (bookkeeping was dropped).
+            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
+            await scheduler.setVisible('mod', ['b'], []); // 'a' fell out
+            // Re-subscribing 'a' should issue another subscribe (bookkeeping was cleared by
+            // the visibility prune even though the daemon never received our explicit call).
             await scheduler.setVisible('mod', ['a', 'b'], []);
-            const subsAfter = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
-            assert.strictEqual(subsAfter.length, 6);
+            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
+            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            assert.strictEqual(subs.length, 2);
         });
 
         it('forwards renderFinished.dataProducts via onDataProductsAttached', async () => {
@@ -595,15 +623,21 @@ describe('DaemonScheduler', () => {
         it('survives a pre-D2 daemon that rejects dataSubscribe with DataProductUnknown', async () => {
             const { gate, scheduler, log } = build();
             gate.client!.dataSubscribeRejects = true;
-            await scheduler.setVisible('mod', ['a'], []);
-            // Wait one microtask cycle so the rejected promises settle.
+            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
+            // Wait one microtask cycle so the rejected promise settles.
             await Promise.resolve();
             await Promise.resolve();
-            // The setVisible itself still fires; subscribe failures are absorbed and logged.
-            const visibleCalls = gate.client!.calls.filter(c => c.method === 'setVisible');
-            assert.strictEqual(visibleCalls.length, 1);
+            // Subscribe was attempted; the rejection is absorbed and the bookkeeping rolls
+            // back so a future re-attempt re-issues.
+            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            assert.strictEqual(subs.length, 1);
             const subFailures = log.filter(l => l.includes('dataSubscribe'));
             assert.ok(subFailures.length >= 1, 'expected log entry for failed dataSubscribe');
+            // Retry succeeds (the rollback dropped the bookkeeping).
+            gate.client!.dataSubscribeRejects = false;
+            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
+            const subsAfter = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            assert.strictEqual(subsAfter.length, 2);
         });
     });
 });

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -5,7 +5,13 @@ import * as path from 'path';
 import { DaemonScheduler } from '../daemon/daemonScheduler';
 
 interface RecordedCall {
-    method: 'fileChanged' | 'setFocus' | 'setVisible' | 'renderNow';
+    method:
+        | 'fileChanged'
+        | 'setFocus'
+        | 'setVisible'
+        | 'renderNow'
+        | 'dataSubscribe'
+        | 'dataUnsubscribe';
     args: unknown;
 }
 
@@ -14,6 +20,11 @@ class FakeClient {
     public closed = false;
     public renderNowResult: { queued: string[]; rejected: { id: string; reason: string }[] } =
         { queued: ['x'], rejected: [] };
+    /**
+     * D2 — when true, `dataSubscribe` rejects with `DataProductUnknown`-shaped error,
+     * mimicking a pre-D2 daemon. Tests that don't set this get a successful resolution.
+     */
+    public dataSubscribeRejects = false;
 
     fileChanged(args: unknown): void { this.calls.push({ method: 'fileChanged', args }); }
     setFocus(args: unknown): void { this.calls.push({ method: 'setFocus', args }); }
@@ -21,6 +32,17 @@ class FakeClient {
     renderNow(args: unknown): Promise<unknown> {
         this.calls.push({ method: 'renderNow', args });
         return Promise.resolve(this.renderNowResult);
+    }
+    dataSubscribe(args: unknown): Promise<unknown> {
+        this.calls.push({ method: 'dataSubscribe', args });
+        if (this.dataSubscribeRejects) {
+            return Promise.reject(new Error('-32020 DataProductUnknown'));
+        }
+        return Promise.resolve({ ok: true });
+    }
+    dataUnsubscribe(args: unknown): Promise<unknown> {
+        this.calls.push({ method: 'dataUnsubscribe', args });
+        return Promise.resolve({ ok: true });
     }
     isClosed(): boolean { return this.closed; }
 }
@@ -75,9 +97,21 @@ function build() {
     const failures: { moduleId: string; previewId: string; message: string }[] = [];
     const dirty: { moduleId: string; detail: string }[] = [];
     const discovery: { moduleId: string; params: { added: unknown[]; removed: string[]; changed: unknown[]; totalPreviews: number } }[] = [];
+    const dataProducts: {
+        moduleId: string;
+        previewId: string;
+        attachments: { kind: string; payload?: unknown; path?: string }[];
+    }[] = [];
     const events = {
         onPreviewImageReady: (moduleId: string, previewId: string, base64: string, pngPath: string) => {
             images.push({ moduleId, previewId, base64, pngPath });
+        },
+        onDataProductsAttached: (
+            moduleId: string,
+            previewId: string,
+            attachments: { kind: string; payload?: unknown; path?: string }[],
+        ) => {
+            dataProducts.push({ moduleId, previewId, attachments });
         },
         onRenderFailed: (moduleId: string, previewId: string, message: string) => {
             failures.push({ moduleId, previewId, message });
@@ -94,7 +128,7 @@ function build() {
         events,
         { appendLine: (s) => log.push(s) },
     );
-    return { gate, scheduler, log, images, failures, dirty, discovery };
+    return { gate, scheduler, log, images, failures, dirty, discovery, dataProducts };
 }
 
 describe('DaemonScheduler', () => {
@@ -472,6 +506,104 @@ describe('DaemonScheduler', () => {
             };
             // Doesn't throw.
             evts.onHistoryAdded!({ entry: { id: 'abc' } });
+        });
+    });
+
+    /**
+     * D2 — data-product surface. setVisible auto-subscribes the panel to a11y/atf +
+     * a11y/hierarchy for newly-visible previews; renderFinished forwards the attachments.
+     */
+    describe('data products', () => {
+        it('issues data/subscribe for each newly-visible preview, twice per (atf + hierarchy)', async () => {
+            const { gate, scheduler } = build();
+            await scheduler.setVisible('mod', ['a', 'b'], []);
+            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            assert.strictEqual(subs.length, 4);
+            const kinds = subs.map(c => (c.args as { kind: string }).kind).sort();
+            assert.deepStrictEqual(
+                kinds,
+                ['a11y/atf', 'a11y/atf', 'a11y/hierarchy', 'a11y/hierarchy'],
+            );
+            const ids = subs.map(c => (c.args as { previewId: string }).previewId).sort();
+            assert.deepStrictEqual(ids, ['a', 'a', 'b', 'b']);
+        });
+
+        it('does not re-subscribe a (previewId, kind) pair on a repeated setVisible', async () => {
+            const { gate, scheduler } = build();
+            await scheduler.setVisible('mod', ['a'], []);
+            await scheduler.setVisible('mod', ['a', 'b'], []); // 'a' is already subscribed
+            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            // 'a': 2 kinds + 'b' newly visible: 2 kinds = 4 total. 'a' is NOT re-subscribed.
+            assert.strictEqual(subs.length, 4);
+        });
+
+        it('drops bookkeeping when a preview leaves visible — daemon already pruned its side', async () => {
+            const { gate, scheduler } = build();
+            await scheduler.setVisible('mod', ['a', 'b'], []);
+            await scheduler.setVisible('mod', ['a'], []); // 'b' fell out
+            // No new subscribe. 'a' was already subscribed.
+            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            assert.strictEqual(subs.length, 4);
+            // Bring 'b' back — it should re-subscribe (bookkeeping was dropped).
+            await scheduler.setVisible('mod', ['a', 'b'], []);
+            const subsAfter = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            assert.strictEqual(subsAfter.length, 6);
+        });
+
+        it('forwards renderFinished.dataProducts via onDataProductsAttached', async () => {
+            const { gate, scheduler, dataProducts } = build();
+            await scheduler.ensureModule('mod');
+            const evts = gate.capturedEvents.get('mod')! as unknown as {
+                onRenderFinished: (p: {
+                    id: string;
+                    pngPath: string;
+                    tookMs: number;
+                    dataProducts?: { kind: string; payload?: unknown; path?: string }[];
+                }) => void;
+            };
+            // Stage a real PNG so the scheduler doesn't bail on ENOENT.
+            const tmp = path.join(os.tmpdir(), `data-products-${Date.now()}.png`);
+            fs.writeFileSync(tmp, Buffer.from('\x89PNG\r\n\x1a\n', 'binary'));
+            evts.onRenderFinished({
+                id: 'a',
+                pngPath: tmp,
+                tookMs: 10,
+                dataProducts: [
+                    { kind: 'a11y/atf', payload: { findings: [] } },
+                    { kind: 'a11y/hierarchy', path: '/abs/a11y-hierarchy.json' },
+                ],
+            });
+            assert.strictEqual(dataProducts.length, 1);
+            assert.strictEqual(dataProducts[0].previewId, 'a');
+            assert.strictEqual(dataProducts[0].attachments.length, 2);
+            fs.unlinkSync(tmp);
+        });
+
+        it('does not fire onDataProductsAttached when renderFinished carries no products', async () => {
+            const { gate, scheduler, dataProducts } = build();
+            await scheduler.ensureModule('mod');
+            const evts = gate.capturedEvents.get('mod')! as unknown as {
+                onRenderFinished: (p: { id: string; pngPath: string; tookMs: number }) => void;
+            };
+            const tmp = path.join(os.tmpdir(), `data-products-empty-${Date.now()}.png`);
+            fs.writeFileSync(tmp, Buffer.from('\x89PNG\r\n\x1a\n', 'binary'));
+            evts.onRenderFinished({ id: 'a', pngPath: tmp, tookMs: 10 });
+            assert.strictEqual(dataProducts.length, 0);
+            fs.unlinkSync(tmp);
+        });
+
+        it('survives a pre-D2 daemon that rejects dataSubscribe with DataProductUnknown', async () => {
+            const { gate, scheduler, log } = build();
+            gate.client!.dataSubscribeRejects = true;
+            await scheduler.setVisible('mod', ['a'], []);
+            // Wait one microtask cycle so the rejected promises settle.
+            await Promise.resolve();
+            await Promise.resolve();
+            // The setVisible itself still fires; subscribe failures are absorbed and logged.
+            const visibleCalls = gate.client!.calls.filter(c => c.method === 'setVisible');
+            assert.strictEqual(visibleCalls.length, 1);
+            const subFailures = log.filter(l => l.includes('dataSubscribe'));
+            assert.ok(subFailures.length >= 1, 'expected log entry for failed dataSubscribe');
         });
     });
 });

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -91,6 +91,27 @@ export interface PreviewInfo {
     a11yFindings?: AccessibilityFinding[] | null;
     /** Absolute path to the annotated screenshot (clean PNG + overlay legend), when findings exist. */
     a11yAnnotatedPath?: string | null;
+    /**
+     * D2 — accessibility-relevant nodes from the rendered tree (label, role,
+     * states, bounds). Daemon-attached via the `a11y/hierarchy` data product;
+     * VS Code draws a local overlay from this rather than reading the
+     * baked-into-PNG annotated screenshot. See
+     * `docs/daemon/DATA-PRODUCTS.md` § "Worked example".
+     */
+    a11yNodes?: AccessibilityNode[] | null;
+}
+
+/**
+ * Per-node entry in the `a11y/hierarchy` data product. Mirrors the renderer-side
+ * `AccessibilityNode` (in `renderer-android/.../RenderManifest.kt`).
+ */
+export interface AccessibilityNode {
+    label: string;
+    role?: string | null;
+    states: string[];
+    merged: boolean;
+    /** `left,top,right,bottom` in source-bitmap pixels. */
+    boundsInScreen: string;
 }
 
 export interface PreviewManifest {
@@ -285,6 +306,18 @@ export type ExtensionToWebview =
     /** `captureIndex` addresses which capture within an animated preview the
      *  image belongs to. Static previews have a single capture at index 0. */
     | { command: 'updateImage'; previewId: string; captureIndex: number; imageData: string }
+    /**
+     * D2 — daemon-attached `a11y/atf` (findings) and/or `a11y/hierarchy` (nodes) for one
+     * preview. The webview updates its in-memory caches and re-applies the existing finding
+     * overlay; the hierarchy overlay draws translucent bounds for every accessibility-relevant
+     * node when present. Either field may be undefined to leave the current state untouched.
+     */
+    | {
+          command: 'updateA11y';
+          previewId: string;
+          findings?: AccessibilityFinding[] | null;
+          nodes?: AccessibilityNode[] | null;
+      }
     | {
           command: 'setImageError';
           previewId: string;

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -491,4 +491,13 @@ export type WebviewToExtension =
           pixelY: number;
           imageWidth: number;
           imageHeight: number;
-      };
+      }
+    /**
+     * D2 — focus-mode toggle for the local a11y overlay. When `enabled`, the
+     * extension `data/subscribe`s to `a11y/atf` + `a11y/hierarchy` for
+     * [previewId]; subsequent renders attach the payload and the panel paints
+     * the overlay locally. When `enabled = false`, the extension unsubscribes
+     * and tells the webview to drop the cached nodes/findings. Idempotent on
+     * both sides.
+     */
+    | { command: 'setA11yOverlay'; previewId: string; enabled: boolean };


### PR DESCRIPTION
## Summary

Lands the first concrete data-product pair on the D1 wire surface and exposes it through a focus-mode opt-in in the panel.

- **Daemon side (`daemon-android`).** `RenderEngine.runAccessibility` flips `LocalInspectionMode = false` and dumps `a11y-atf.json` + `a11y-hierarchy.json` under `<outputDir.parent>/data/<previewId>/` after capture. `AccessibilityDataProducer` owns the on-disk shape; `AccessibilityDataProductRegistry` plugs into the D1 `DataProductRegistry` seam — advertises `a11y/atf` (inline) + `a11y/hierarchy` (path), attaches them to subscribed renders, serves `data/fetch` from the same files. `DaemonMain` constructs the registry whenever the renders dir is resolvable and sets `composeai.daemon.attachA11y=true` so the renderer-side dump fires. Pre-D2 callers (harness fake-mode) keep the no-op `DataProductRegistry.Empty`. `AccessibilityChecker` promoted from `internal` to public so the daemon module reuses it instead of duplicating ATF logic.
- **VS Code side (initial wire).** `renderFinished.dataProducts` flow through `onDataProductsAttached` → `applyDataProductsToRegistry` → `PreviewRegistry.setA11y` + targeted `updateA11y` post to the panel. New `cardA11yNodes` cache + hierarchy overlay layer (translucent dashed boxes per accessibility node, hover tooltip with label / role / states) drawn locally over the clean PNG. Existing finding overlay continues to work, now sourced from the wire when daemon mode is active.
- **Focus-mode opt-in (follow-up commit).** Auto-subscribing every visible card was too eager. New "Show accessibility overlay" eye-icon button in the focus-mode toolbar (aria-pressed). Click → `data/subscribe` for the focused preview; click again → `data/unsubscribe` and clears the cached overlay. Stepping focus to another card or exiting focus mode auto-disables the toggle so wire stays quiet for cards outside the spotlight. `DaemonScheduler.setVisible` no longer auto-subscribes; new `setDataProductSubscription(moduleId, previewId, kinds, enabled)` is the explicit toggle the panel drives via a `setA11yOverlay` webview message + `handleSetA11yOverlay` on the extension side. Diagnostic squigglies (Gradle-sidecar-fed) remain independent of the daemon overlay subscription.

## Test plan

- [x] `:daemon:android:testDebugUnitTest --tests "*AccessibilityDataProductRegistryTest*"` — 6 tests pinning advertise / attach / fetch outcomes including `Unknown`, `NotAvailable`, path-vs-inline transports.
- [x] `vscode-extension/` `npm test` — 312 tests pass, including 6 new `DaemonScheduler` tests for explicit subscribe/unsubscribe, idempotency, visibility-prune cleanup, pre-D2 daemon rejection roll-back, and `onDataProductsAttached` forwarding.
- [x] `./gradlew ktfmtFormatAll` clean.
- [x] TypeScript compile clean (`npm run compile`).
- [ ] Manual smoke (consumer side): start daemon-mode panel, focus a preview, click the eye-icon button — overlay paints; click again — overlay clears; navigate next/prev — overlay tears down; exit focus — overlay tears down.

Spec: [`docs/daemon/DATA-PRODUCTS.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/daemon/DATA-PRODUCTS.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVoxnr38t4n1LEatFc1yGe)_