### PR TITLE
Apply render overrides (uiMode, fontScale) on desktop

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -9,7 +9,9 @@ import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.SystemTheme
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.Density
 import java.io.File
@@ -115,6 +117,7 @@ class RenderEngine(
    * inspection branch. Interactive sessions pass `false` so `pointerInput` modifiers fire and the
    * preview shows its real, click-aware behaviour.
    */
+  @OptIn(androidx.compose.ui.InternalComposeUiApi::class)
   fun setUp(
     spec: RenderSpec,
     classLoader: ClassLoader =
@@ -148,7 +151,22 @@ class RenderEngine(
     val previousContext = Thread.currentThread().contextClassLoader
     Thread.currentThread().contextClassLoader = classLoader
 
-    val density = Density(spec.density)
+    // PROTOCOL.md § 5 (`renderNow.overrides.localeTag`) — Compose Desktop has no `LocalLocale`
+    // CompositionLocal to override; the only JVM-wide lever is `Locale.setDefault(...)`, which is
+    // unsafe to mutate transiently because every other JVM thread (JSON-RPC reader, Skiko font /
+    // text-shaping workers, GC finalizers, anything that calls `String.format` or
+    // `SimpleDateFormat` with the default locale) sees the wrong value for the render's duration.
+    // Per-text `TextStyle(localeList = …)` is the only safe lever and can't be applied
+    // sweepingly without rewriting the user's composition. So `localeTag` stays a no-op on
+    // desktop. The Android backend honours it via `setQualifiers("b+lang+region")`.
+
+    // PROTOCOL.md § 5 (`renderNow.overrides.fontScale`) — Compose Desktop has no resource-qualifier
+    // system, but `LocalDensity` carries `fontScale` as part of `Density`, and `Text` / `TextStyle`
+    // honour it. Threading through `ImageComposeScene`'s constructor makes the override visible to
+    // layout (sp → px conversion) before the first measure pass. We re-provide the same `Density`
+    // as `LocalDensity` below since a few ui-text/text-foundation paths read it directly during
+    // composition rather than going through the scene density.
+    val density = Density(spec.density, spec.fontScale ?: 1.0f)
     val scene =
       try {
         ImageComposeScene(width = spec.widthPx, height = spec.heightPx, density = density)
@@ -161,7 +179,22 @@ class RenderEngine(
       }
     try {
       scene.setContent {
-        CompositionLocalProvider(LocalInspectionMode provides inspectionMode) {
+        // PROTOCOL.md § 5 (`renderNow.overrides.uiMode`) — Compose Desktop's
+        // `isSystemInDarkTheme()` reads `LocalSystemTheme.current` (foundation-desktop's
+        // `DarkTheme.skiko.kt`). Override it here so `uiMode = "dark"` actually flips dark-aware
+        // composables instead of falling through to the JVM's `org.jetbrains.skiko.SystemTheme`
+        // probe.
+        val systemTheme =
+          when (spec.uiMode) {
+            RenderSpec.SpecUiMode.DARK -> SystemTheme.Dark
+            RenderSpec.SpecUiMode.LIGHT -> SystemTheme.Light
+            null -> SystemTheme.Unknown
+          }
+        CompositionLocalProvider(
+          LocalInspectionMode provides inspectionMode,
+          androidx.compose.ui.LocalSystemTheme provides systemTheme,
+          LocalDensity provides density,
+        ) {
           val bgColor =
             when {
               spec.backgroundColor != 0L -> Color(spec.backgroundColor.toInt())
@@ -303,20 +336,29 @@ data class RenderSpec(
   /** Stem used for the output PNG filename (e.g. "preview-A" → "<outputDir>/preview-A.png"). */
   val outputBaseName: String = "${className.substringAfterLast('.')}-$functionName",
   /**
-   * BCP-47 locale tag override. Carried on the wire for parity with `:daemon:android`'s
-   * `RenderSpec`; Compose Desktop has no Android-style resource qualifier system so this is a no-op
-   * on the desktop render path today. A future change can route it into `LocalConfiguration` /
-   * `androidx.compose.ui.text.intl.Locale.current` if a desktop consumer needs it.
+   * BCP-47 locale tag override. **No-op on desktop** — Compose Desktop has no `LocalLocale`
+   * CompositionLocal, and `Locale.setDefault(...)` is unsafe to mutate transiently because it
+   * affects every JVM thread (Skiko font/text-shaping workers, default-locale formatters, etc.).
+   * The field is carried for wire parity with `:daemon:android`, which honours it via
+   * `setQualifiers("b+lang+region")`.
    */
   val localeTag: String? = null,
   /**
-   * Font scale multiplier override. No-op on desktop today (would route through `LocalDensity`'s
-   * `fontScale` field); carried for wire parity with `:daemon:android`.
+   * Font scale multiplier override. Threaded through `Density(density, fontScale)` — applied to
+   * `ImageComposeScene`'s constructor and re-provided as `LocalDensity` so any composition path
+   * that reads `LocalDensity` directly (rather than the scene's density) sees the same value.
    */
   val fontScale: Float? = null,
-  /** Light/dark mode override. No-op on desktop today; carried for wire parity. */
+  /**
+   * Light/dark mode override. Provided as `LocalSystemTheme` — Compose Desktop's
+   * `isSystemInDarkTheme()` reads that local rather than `Configuration.uiMode`.
+   */
   val uiMode: SpecUiMode? = null,
-  /** Portrait/landscape override. Desktop only honours derived size; carried for wire parity. */
+  /**
+   * Portrait/landscape override. **No-op on desktop** — there's no display rotation concept for an
+   * `ImageComposeScene`. The size override (`widthPx`/`heightPx`) is the natural lever; the field
+   * is carried so a single payload string drives both backends.
+   */
   val orientation: SpecOrientation? = null,
 ) {
 

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -1,0 +1,194 @@
+package ee.schimke.composeai.daemon
+
+import java.io.ByteArrayInputStream
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.math.abs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Desktop counterpart of `:daemon:android`'s `OverrideIntegrationTest`. Drives
+ * [PreviewManifestRouter] directly with override-bearing payloads to prove the desktop renderer
+ * actually applies `widthPx`, `uiMode`, and `fontScale` (PROTOCOL.md § 5, INTERACTIVE.md § 8a).
+ *
+ * `localeTag` is **not** tested here — it's documented as a no-op on desktop (Compose Desktop has
+ * no `LocalLocale` CompositionLocal, and `Locale.setDefault(...)` is unsafe to mutate transiently
+ * because every JVM thread sees it). `orientation` is also a no-op on desktop (`ImageComposeScene`
+ * has no rotation concept).
+ */
+class OverrideIntegrationTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun widthPxOverrideChangesRenderedDimensions() {
+    val outputDir = tempFolder.newFolder("renders-width")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "red-square",
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "RedSquare",
+              widthPx = 64,
+              heightPx = 64,
+              density = 1.0f,
+              outputBaseName = "red-square-default",
+            )
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    host.start()
+    try {
+      val small = renderAndDecode(host, "previewId=red-square", "small")
+      assertEquals("manifest default width should be honoured", 64, small.width)
+
+      val large = renderAndDecode(host, "previewId=red-square;widthPx=128;heightPx=128", "large")
+      assertEquals("widthPx override should reach the RenderSpec", 128, large.width)
+      assertEquals("heightPx override should reach the RenderSpec", 128, large.height)
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun uiModeOverrideFlipsDarkAwareComposable() {
+    val outputDir = tempFolder.newFolder("renders-uimode")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "dark-aware",
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "DarkAwareSquare",
+              widthPx = 32,
+              heightPx = 32,
+              density = 1.0f,
+              outputBaseName = "dark-aware",
+            )
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    host.start()
+    try {
+      val light = renderAndDecode(host, "previewId=dark-aware;uiMode=light", "uimode-light")
+      val dark = renderAndDecode(host, "previewId=dark-aware;uiMode=dark", "uimode-dark")
+
+      // `LocalSystemTheme provides SystemTheme.Light/Dark` is what flips
+      // `isSystemInDarkTheme()` on Compose Desktop. Without the override reaching the
+      // CompositionLocalProvider both renders would fall through to `SystemTheme.Unknown` and
+      // pick the same colour.
+      val lightWhitePct = pixelMatchPct(light, expectedRgb = 0xFFFFFF, perChannelTolerance = 8)
+      val darkBlackPct = pixelMatchPct(dark, expectedRgb = 0x000000, perChannelTolerance = 8)
+      assertTrue(
+        "light render should be mostly white; got ${"%.2f".format(lightWhitePct * 100)}%",
+        lightWhitePct >= 0.95,
+      )
+      assertTrue(
+        "dark render should be mostly black; got ${"%.2f".format(darkBlackPct * 100)}%",
+        darkBlackPct >= 0.95,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun fontScaleOverrideReachesLocalDensity() {
+    val outputDir = tempFolder.newFolder("renders-fontscale")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "font-scale",
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "FontScaleAwareSquare",
+              widthPx = 32,
+              heightPx = 32,
+              density = 1.0f,
+              outputBaseName = "font-scale",
+            )
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    host.start()
+    try {
+      val unscaled = renderAndDecode(host, "previewId=font-scale;fontScale=1.0", "fontscale-1")
+      val scaled = renderAndDecode(host, "previewId=font-scale;fontScale=2.0", "fontscale-2")
+
+      // FontScaleAwareSquare paints black at fontScale<1.5, white at fontScale>=1.5. The override
+      // reaches the composition iff `LocalDensity.current.fontScale` reflects the spec's value.
+      val unscaledBlackPct =
+        pixelMatchPct(unscaled, expectedRgb = 0x000000, perChannelTolerance = 8)
+      val scaledWhitePct = pixelMatchPct(scaled, expectedRgb = 0xFFFFFF, perChannelTolerance = 8)
+      assertTrue(
+        "fontScale=1.0 render should be mostly black; got ${"%.2f".format(unscaledBlackPct * 100)}%",
+        unscaledBlackPct >= 0.95,
+      )
+      assertTrue(
+        "fontScale=2.0 render should be mostly white; got ${"%.2f".format(scaledWhitePct * 100)}%",
+        scaledWhitePct >= 0.95,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  private fun renderAndDecode(
+    host: PreviewManifestRouter,
+    payload: String,
+    label: String,
+  ): java.awt.image.BufferedImage {
+    val request = RenderRequest.Render(payload = payload)
+    val result = host.submit(request, timeoutMs = 30_000)
+    assertNotNull("$label: pngPath must be populated", result.pngPath)
+    val pngFile = File(result.pngPath!!)
+    assertTrue("$label: rendered PNG must exist", pngFile.exists())
+    return ByteArrayInputStream(pngFile.readBytes()).use { ImageIO.read(it) }
+      ?: error("$label: PNG failed to decode")
+  }
+
+  /**
+   * Returns the fraction of pixels in [img] whose RGB channels are within [perChannelTolerance] of
+   * the expected `0xRRGGBB` colour. Inlined here rather than imported from the harness's
+   * `PixelDiff` to avoid the same circular dep that [RenderEngineTest]'s helper sidesteps.
+   */
+  private fun pixelMatchPct(
+    img: java.awt.image.BufferedImage,
+    expectedRgb: Int,
+    perChannelTolerance: Int,
+  ): Double {
+    val expR = (expectedRgb shr 16) and 0xFF
+    val expG = (expectedRgb shr 8) and 0xFF
+    val expB = expectedRgb and 0xFF
+    var matches = 0L
+    for (y in 0 until img.height) {
+      for (x in 0 until img.width) {
+        val rgb = img.getRGB(x, y)
+        val r = (rgb shr 16) and 0xFF
+        val g = (rgb shr 8) and 0xFF
+        val b = rgb and 0xFF
+        if (
+          abs(r - expR) <= perChannelTolerance &&
+            abs(g - expG) <= perChannelTolerance &&
+            abs(b - expB) <= perChannelTolerance
+        ) {
+          matches++
+        }
+      }
+    }
+    val total = img.width.toLong() * img.height.toLong()
+    return matches.toDouble() / total.toDouble()
+  }
+}

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -104,3 +104,28 @@ fun ClickToggleSquare() {
       }
   )
 }
+
+/**
+ * Reads `isSystemInDarkTheme()` and fills the box with white in light mode, black in dark mode.
+ * Used by `OverrideIntegrationTest` (desktop) to prove `renderNow.overrides.uiMode` reaches
+ * `LocalSystemTheme` — Compose Desktop's `isSystemInDarkTheme()` reads that local rather than the
+ * OS-level Skiko theme probe.
+ */
+@Composable
+fun DarkAwareSquare() {
+  val bg = if (androidx.compose.foundation.isSystemInDarkTheme()) Color.Black else Color.White
+  Box(modifier = Modifier.fillMaxSize().background(bg))
+}
+
+/**
+ * Reads `LocalDensity.current.fontScale` and renders a square whose colour encodes the scale —
+ * black at fontScale=1.0 (background), white at fontScale=2.0. A pure-pixel signal for proving the
+ * override reaches `LocalDensity` without needing `Text` rendering (which would entangle
+ * font-metrics across platforms).
+ */
+@Composable
+fun FontScaleAwareSquare() {
+  val fontScale = androidx.compose.ui.platform.LocalDensity.current.fontScale
+  val bg = if (fontScale >= 1.5f) Color.White else Color.Black
+  Box(modifier = Modifier.fillMaxSize().background(bg))
+}

--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -321,11 +321,21 @@ toggle required.
 
 **Backend fidelity.** The Android renderer applies all seven fields via
 `applyPreviewQualifiers` + `RuntimeEnvironment.setFontScale`. The desktop
-renderer applies size/density only; `uiMode` / `localeTag` / `fontScale` /
-`orientation` ride on the wire for parity but are no-ops on plain Skiko
-today (Compose Desktop has no Android-style resource qualifier system —
-they'd need to thread through `LocalConfiguration` /
-`androidx.compose.ui.text.intl.Locale.current`, which is a follow-up).
+renderer applies `widthPx` / `heightPx` / `density` (via
+`ImageComposeScene`'s constructor), `fontScale` (via `Density(density,
+fontScale)` re-provided as `LocalDensity`), and `uiMode` (via
+`LocalSystemTheme provides SystemTheme.Light/Dark`, which is what Compose
+Desktop's `isSystemInDarkTheme()` reads). `localeTag` and `orientation`
+remain no-ops on desktop:
+
+- **`localeTag`** — Compose Desktop has no `LocalLocale` CompositionLocal,
+  and `java.util.Locale.setDefault(...)` is unsafe to mutate transiently
+  because every other JVM thread (Skiko font / text-shaping workers,
+  default-locale formatters like `String.format` / `SimpleDateFormat`,
+  GC finalizers) sees the wrong value for the render's duration. The
+  Android backend honours it via `setQualifiers("b+lang+region")`.
+- **`orientation`** — `ImageComposeScene` has no display rotation
+  concept; size override (`widthPx` / `heightPx`) is the natural lever.
 
 ## 9. v2 — click dispatch into composition
 


### PR DESCRIPTION
## Summary
Implement support for `uiMode` and `fontScale` render overrides in the desktop renderer, bringing it to feature parity with the Android backend for these configuration options. Previously these overrides were carried on the wire for parity but were no-ops on desktop.

## Key Changes

- **`uiMode` override support**: Thread `RenderSpec.uiMode` through `LocalSystemTheme` CompositionLocal. Compose Desktop's `isSystemInDarkTheme()` reads this local rather than OS-level theme detection, allowing light/dark mode overrides to actually affect dark-aware composables.

- **`fontScale` override support**: Pass `fontScale` to the `Density` constructor (alongside `density`) and re-provide it as `LocalDensity` in the composition. This ensures both layout calculations (sp → px conversion) and any composition paths reading `LocalDensity` directly see the correct font scale.

- **Documentation updates**: Clarify in `RenderSpec` kdoc and `INTERACTIVE.md` which overrides are supported on each backend:
  - Desktop now supports: `widthPx`, `heightPx`, `density`, `fontScale`, `uiMode`
  - Desktop no-ops: `localeTag` (unsafe to mutate `Locale.setDefault()` transiently — every JVM thread including Skiko font/text-shaping workers and default-locale formatters would see the wrong value), `orientation` (no rotation concept in `ImageComposeScene`)
  - Android supports all seven fields

- **Integration tests**: Add `OverrideIntegrationTest` with three test cases:
  - `widthPxOverrideChangesRenderedDimensions` — verify size overrides reach the render spec
  - `uiModeOverrideFlipsDarkAwareComposable` — verify light/dark mode overrides affect `isSystemInDarkTheme()`
  - `fontScaleOverrideReachesLocalDensity` — verify font scale overrides affect `LocalDensity.current.fontScale`

- **Test fixtures**: Add `DarkAwareSquare` and `FontScaleAwareSquare` composables to `RedFixturePreviews.kt` for testing override behavior.

## Implementation Details

The `uiMode` and `fontScale` overrides are applied in `RenderEngine.setUp()` via `CompositionLocalProvider`, ensuring they're visible to the composition before the first measure pass. The `fontScale` is applied both to `ImageComposeScene`'s `Density` constructor and re-provided as `LocalDensity` to handle composition paths that read the local directly rather than the scene's density.

`@OptIn(InternalComposeUiApi::class)` on `setUp()` — `LocalSystemTheme` is marked unstable in compose-ui's public API, but it's the documented read-site for `isSystemInDarkTheme()` on desktop.

## Test plan
- [x] `:daemon:desktop:test` (full suite, 7 classes) — pass
- [x] `:daemon:desktop:ktfmtCheck` — clean
- [x] New `OverrideIntegrationTest`'s 3 cases pass against the rebased `setUp`/`renderOnce`/`tearDown` structure introduced by #408