### PR TITLE
Clarify CLI parity scope: on-disk only, no --emit flag

### DIFF
--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -54,10 +54,20 @@ kinds are silently ignored both ways.
 5. **No `protocolVersion` bump.** Adding a kind, adding a field to a
    payload, adding a new method in the `data/*` family — all additive
    per PROTOCOL.md § 7. Both sides ignore unknowns.
-6. CLI parity: `compose-preview --emit a11y/hierarchy` (and friends)
-   produce the same JSON the daemon would, so MCP-driven agents see
-   the same payloads as VS Code. Daemon and CLI share the renderer-side
-   producers.
+6. CLI parity, **on-disk only**. Daemon and CLI share the renderer-side
+   producers, so a Gradle-driven render of an a11y-enabled module writes
+   the same `build/compose-previews/data/<id>/<kind>.json` files the
+   daemon would attach to `renderFinished`. CLI consumers (CI scripts,
+   non-MCP agents) read those files directly — there is **no
+   `--emit kind` flag** and the CLI surface stays as "render to disk,
+   look in `build/`." Kinds are selected via the consumer's
+   `composePreview { ... }` Gradle config (the same channel that already
+   gates `accessibilityChecks.enabled`); duplicating that selection on
+   the CLI would just create two ways to express the same intent and
+   let them drift. The agent ergonomics that justify a programmatic
+   surface — `data/fetch` re-render, `data/subscribe` priming, kind
+   discovery — live in the daemon protocol and its MCP front-end, not
+   the CLI.
 
 **Non-goals**:
 


### PR DESCRIPTION
## Summary
Updated DATA-PRODUCTS.md to clarify the scope and design of CLI parity with the daemon. The CLI shares renderer-side producers with the daemon but operates on-disk only, without a programmatic `--emit` flag for selecting data kinds.

## Key Changes
- **Removed `--emit` flag concept**: Clarified that there is no `compose-preview --emit a11y/hierarchy` flag; the CLI surface remains "render to disk, look in `build/`"
- **Kind selection via Gradle config**: Data kinds are selected through the consumer's `composePreview { ... }` Gradle configuration block (the same mechanism that gates `accessibilityChecks.enabled`), avoiding duplication of intent expression
- **Daemon-only programmatic surface**: Emphasized that advanced agent ergonomics like `data/fetch` re-render, `data/subscribe` priming, and kind discovery are daemon protocol features (and MCP front-end), not CLI features
- **Clarified file-based contract**: Daemon and CLI both write the same `build/compose-previews/data/<id>/<kind>.json` files; CLI consumers (CI scripts, non-MCP agents) read those files directly

## Rationale
This change prevents creating two separate ways to express the same intent (CLI flag vs. Gradle config) that could drift over time. It establishes a clear boundary: the CLI is a build-time tool that writes files, while the daemon protocol provides the programmatic surface for agents that need dynamic kind selection and subscription capabilities.

https://claude.ai/code/session_019eCR7c9UaZzvkAf9TeVVc9