### PR TITLE
feat(mcp): auto-render in get_preview_data + refcount data subscriptions

### DIFF
--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
@@ -267,8 +267,8 @@ class DaemonClient(
           ),
       )
     val response = sendAndAwait(id, request, timeout)
-    val errorElem = response["error"]
-    if (errorElem != null) error("data/fetch failed: $errorElem")
+    val errorElem = response["error"] as? JsonObject
+    if (errorElem != null) throw DataProductWireException.from(errorElem)
     val resultElem = response["result"] ?: error("data/fetch: no result — full=$response")
     return json.decodeFromJsonElement(DataFetchResult.serializer(), resultElem)
   }
@@ -433,5 +433,29 @@ class DaemonClient(
       }
       buf.write(b)
     }
+  }
+}
+
+/**
+ * Typed wire-error from `data/fetch`. The daemon error codes are reserved by DATA-PRODUCTS.md:
+ * `-32020` DataProductUnknown, `-32021` DataProductNotAvailable, `-32022` DataProductFetchFailed,
+ * `-32023` DataProductBudgetExceeded. Callers (notably `DaemonMcpServer.toolGetPreviewData`) use
+ * [code] to decide whether to retry — `DataProductNotAvailable` is the auto-render trigger.
+ */
+class DataProductWireException(val code: Int, val wireMessage: String, val data: JsonObject?) :
+  RuntimeException("data/fetch wire error $code: $wireMessage") {
+  companion object {
+    const val UNKNOWN = -32020
+    const val NOT_AVAILABLE = -32021
+    const val FETCH_FAILED = -32022
+    const val BUDGET_EXCEEDED = -32023
+
+    /** Extracts the JSON-RPC error payload into a [DataProductWireException]. */
+    fun from(errorElem: JsonObject): DataProductWireException =
+      DataProductWireException(
+        code = errorElem["code"]?.jsonPrimitive?.long?.toInt() ?: 0,
+        wireMessage = errorElem["message"]?.jsonPrimitive?.contentOrNull ?: errorElem.toString(),
+        data = errorElem["data"] as? JsonObject,
+      )
   }
 }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -189,6 +189,14 @@ class DaemonMcpServer(
         }
 
         override fun onClose(session: McpSession) {
+          // Release the session's data-product subscriptions and tell the daemon to unsubscribe
+          // the keys whose last reference just dropped — otherwise daemon-side subscriptions
+          // would leak until `setVisible` churn drops them, and an interactive UI that wants to
+          // re-attach later would see stale state. We forward unsubscribes best-effort: a daemon
+          // that's already gone (classpathDirty respawn) or rejects the kind doesn't block
+          // session teardown.
+          val released = subscriptions.forgetDataSubscriptions(session)
+          released.forEach { key -> dispatchDataUnsubscribe(key) }
           subscriptions.forget(session)
           sessions.unregister(session)
         }
@@ -283,6 +291,24 @@ class DaemonMcpServer(
     session: McpSession? = null,
     progressToken: JsonElement? = null,
   ): ByteArray {
+    val outcome = awaitNextRender(uri, session, progressToken)
+    val file = File(outcome.pngPath)
+    check(file.isFile) { "renderAndReadBytes: pngPath does not exist: ${outcome.pngPath}" }
+    return Files.readAllBytes(file.toPath())
+  }
+
+  /**
+   * Submits a `renderNow` for [uri] and blocks until the matching `renderFinished` lands. Throws on
+   * render failure or timeout. Used by [renderAndReadBytes] (which then reads the PNG) and by
+   * `get_preview_data`'s auto-render fallback (which doesn't care about the bytes — it just needs
+   * the daemon to have rendered SOMETHING so a follow-up `data/fetch` returns the kind instead of
+   * `DataProductNotAvailable`).
+   */
+  private fun awaitNextRender(
+    uri: PreviewUri,
+    session: McpSession? = null,
+    progressToken: JsonElement? = null,
+  ): RenderOutcome.Finished {
     val daemon = supervisor.daemonFor(uri.workspaceId, uri.modulePath)
     val key = RenderKey(uri.workspaceId, uri.modulePath, uri.previewFqn)
     // Multi-waiter dedup: each call adds its own CompletableFuture to the per-key list, so
@@ -315,18 +341,14 @@ class DaemonMcpServer(
         // Best-effort cleanup so a stuck daemon doesn't leak futures forever.
         pendingRenders.computeIfPresent(key) { _, list -> list.also { it.remove(future) } }
         progressBeat?.cancel(true)
-        error("renderAndReadBytes: timed out after ${renderTimeoutMs}ms for $uri")
+        error("awaitNextRender: timed out after ${renderTimeoutMs}ms for $uri")
       } finally {
         progressBeat?.cancel(false)
       }
-    when (outcome) {
+    return when (outcome) {
       is RenderOutcome.Failed ->
-        error("renderAndReadBytes failed for $uri: ${outcome.kind} ${outcome.message}")
-      is RenderOutcome.Finished -> {
-        val file = File(outcome.pngPath)
-        check(file.isFile) { "renderAndReadBytes: pngPath does not exist: ${outcome.pngPath}" }
-        return Files.readAllBytes(file.toPath())
-      }
+        error("awaitNextRender failed for $uri: ${outcome.kind} ${outcome.message}")
+      is RenderOutcome.Finished -> outcome
     }
   }
 
@@ -568,7 +590,7 @@ class DaemonMcpServer(
       ToolDef(
         name = "get_preview_data",
         description =
-          "Fetch one data product (a11y findings, a11y hierarchy, layout tree, …) for a preview. The kind names a structured payload the daemon can produce alongside the PNG; call list_data_products first to see what each daemon advertises. Returns the JSON payload as a single text content block. Requires that the preview has rendered at least once (otherwise: DataProductNotAvailable — call render_preview / resources/read first). When the daemon's latest render didn't compute the kind, the daemon may queue a re-render in the right mode; this is bounded by the daemon's per-request budget (DataProductBudgetExceeded if exceeded). `inline` defaults to true so the agent gets JSON back rather than a path it may not be able to read; flip to false on local-FS callers that prefer to read sibling files directly.",
+          "Fetch one data product (a11y findings, a11y hierarchy, layout tree, …) for a preview. The kind names a structured payload the daemon can produce alongside the PNG; call list_data_products first to see what each daemon advertises. Returns the JSON payload as a single text content block. Auto-renders the preview if it hasn't rendered yet (so the agent doesn't need to call render_preview first). When the daemon's latest render didn't compute the kind, the daemon may queue a re-render in the right mode; this is bounded by the daemon's per-request budget (DataProductBudgetExceeded if exceeded). `inline` defaults to true so the agent gets JSON back rather than a path it may not be able to read; flip to false on local-FS callers that prefer to read sibling files directly.",
         inputSchema =
           parseSchema(
             """
@@ -647,8 +669,8 @@ class DaemonMcpServer(
       "history_diff" -> toolHistoryDiff(args)
       "list_data_products" -> toolListDataProducts(args)
       "get_preview_data" -> toolGetPreviewData(args)
-      "subscribe_preview_data" -> toolDataSubOrUnsub(args, subscribe = true)
-      "unsubscribe_preview_data" -> toolDataSubOrUnsub(args, subscribe = false)
+      "subscribe_preview_data" -> toolDataSubOrUnsub(session, args, subscribe = true)
+      "unsubscribe_preview_data" -> toolDataSubOrUnsub(session, args, subscribe = false)
       else -> errorCallToolResult("unknown tool: $name")
     }
   }
@@ -1053,23 +1075,77 @@ class DaemonMcpServer(
           return errorCallToolResult("get_preview_data: daemon spawn failed: ${it.message}")
         }
     return runCatching {
-        val result = daemon.client.dataFetch(uri.previewFqn, kind, perKindParams, inline)
-        val resultPayload = result.payload
-        val resultPath = result.path
-        val resultBytes = result.bytes
-        val payload = buildJsonObject {
-          put("kind", result.kind)
-          put("schemaVersion", result.schemaVersion)
-          if (resultPayload != null) put("payload", resultPayload)
-          if (resultPath != null) put("path", JsonPrimitive(resultPath))
-          if (resultBytes != null) put("bytes", JsonPrimitive(resultBytes))
-        }
-        CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+        // Try the fetch directly first — works whenever the preview has rendered at least once.
+        // On `DataProductNotAvailable` (-32021) the daemon is telling us the preview has never
+        // rendered; trigger a single render and retry. Folds the two-call agent dance ("render
+        // first, then ask for data") into one tool call. Other wire errors propagate.
+        val result =
+          try {
+            daemon.client.dataFetch(uri.previewFqn, kind, perKindParams, inline)
+          } catch (e: DataProductWireException) {
+            if (e.code != DataProductWireException.NOT_AVAILABLE) throw e
+            awaitNextRender(uri)
+            daemon.client.dataFetch(uri.previewFqn, kind, perKindParams, inline)
+          }
+        renderDataFetchResult(result)
       }
-      .getOrElse { errorCallToolResult("get_preview_data failed: ${it.message}") }
+      .getOrElse { e ->
+        when (e) {
+          is DataProductWireException ->
+            errorCallToolResult("get_preview_data: ${nameOf(e.code)}: ${e.wireMessage}")
+          else -> errorCallToolResult("get_preview_data failed: ${e.message}")
+        }
+      }
   }
 
-  private fun toolDataSubOrUnsub(args: JsonObject, subscribe: Boolean): CallToolResult {
+  /**
+   * Forwards `data/unsubscribe` for a refcount-released `(uri, kind)` to the matching daemon.
+   * Best-effort — failures are logged to stderr but never propagated, since this runs on session
+   * teardown where we can't surface errors to the (already-gone) client. Returns silently when the
+   * URI doesn't parse, the workspace was unregistered, or the daemon already exited.
+   */
+  private fun dispatchDataUnsubscribe(key: DataSubKey) {
+    val uri = PreviewUri.parseOrNull(key.uri) ?: return
+    val project = supervisor.project(uri.workspaceId) ?: return
+    val daemon = project.daemons[uri.modulePath] ?: return
+    runCatching { daemon.client.dataUnsubscribe(uri.previewFqn, key.kind) }
+      .onFailure {
+        System.err.println(
+          "DaemonMcpServer: data/unsubscribe for ${key.uri} ($key.kind) failed: ${it.message}"
+        )
+      }
+  }
+
+  private fun renderDataFetchResult(
+    result: ee.schimke.composeai.daemon.protocol.DataFetchResult
+  ): CallToolResult {
+    val resultPayload = result.payload
+    val resultPath = result.path
+    val resultBytes = result.bytes
+    val payload = buildJsonObject {
+      put("kind", result.kind)
+      put("schemaVersion", result.schemaVersion)
+      if (resultPayload != null) put("payload", resultPayload)
+      if (resultPath != null) put("path", JsonPrimitive(resultPath))
+      if (resultBytes != null) put("bytes", JsonPrimitive(resultBytes))
+    }
+    return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+  }
+
+  private fun nameOf(code: Int): String =
+    when (code) {
+      DataProductWireException.UNKNOWN -> "DataProductUnknown"
+      DataProductWireException.NOT_AVAILABLE -> "DataProductNotAvailable"
+      DataProductWireException.FETCH_FAILED -> "DataProductFetchFailed"
+      DataProductWireException.BUDGET_EXCEEDED -> "DataProductBudgetExceeded"
+      else -> "wire-error-$code"
+    }
+
+  private fun toolDataSubOrUnsub(
+    session: McpSession,
+    args: JsonObject,
+    subscribe: Boolean,
+  ): CallToolResult {
     val toolName = if (subscribe) "subscribe_preview_data" else "unsubscribe_preview_data"
     val uriStr =
       args["uri"]?.jsonPrimitive?.contentOrNull
@@ -1088,10 +1164,26 @@ class DaemonMcpServer(
         .getOrElse {
           return errorCallToolResult("$toolName: daemon spawn failed: ${it.message}")
         }
+    // Refcount across MCP sessions so multiple agents subscribed to the same (uri, kind) only
+    // pay one wire-level `data/subscribe`. The daemon doesn't multiplex per-session; one
+    // subscribe is enough for as many MCP sessions as want it. Wire forwards happen only on
+    // first-ref / last-ref transitions.
     return runCatching {
-        if (subscribe) daemon.client.dataSubscribe(uri.previewFqn, kind)
-        else daemon.client.dataUnsubscribe(uri.previewFqn, kind)
-        textCallToolResult("$toolName: ok ($kind for ${uri.previewFqn})")
+        if (subscribe) {
+          val firstRef = subscriptions.subscribeData(uriStr, kind, session)
+          if (firstRef) daemon.client.dataSubscribe(uri.previewFqn, kind)
+          textCallToolResult(
+            "$toolName: ok ($kind for ${uri.previewFqn}, " +
+              if (firstRef) "first session)" else "shared with N≥2 sessions)"
+          )
+        } else {
+          val lastRef = subscriptions.unsubscribeData(uriStr, kind, session)
+          if (lastRef) daemon.client.dataUnsubscribe(uri.previewFqn, kind)
+          textCallToolResult(
+            "$toolName: ok ($kind for ${uri.previewFqn}, " +
+              if (lastRef) "released)" else "still shared with other sessions)"
+          )
+        }
       }
       .getOrElse { errorCallToolResult("$toolName failed: ${it.message}") }
   }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/Subscriptions.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/Subscriptions.kt
@@ -26,6 +26,16 @@ class Subscriptions {
   /** Session ref → its watch sets. */
   private val watches = ConcurrentHashMap<Session, MutableList<WatchEntry>>()
 
+  /**
+   * D1 — `(uri, kind)` → set of sessions subscribed to that data-product attachment via
+   * `subscribe_preview_data`. Refcounted across sessions: the supervisor only forwards
+   * `data/subscribe` to the daemon on first reference and `data/unsubscribe` on last release. This
+   * matches the resource-subscription model — multiple MCP sessions can hold the same logical
+   * subscription without redundant wire traffic to the daemon — and prevents leaked daemon-side
+   * subscriptions when a session disconnects without explicitly unsubscribing.
+   */
+  private val byDataKey = ConcurrentHashMap<DataSubKey, MutableSet<Session>>()
+
   fun subscribe(uri: String, session: Session) {
     val set = byUri.computeIfAbsent(uri) { ConcurrentHashMap.newKeySet() }
     set.add(session)
@@ -33,6 +43,61 @@ class Subscriptions {
 
   fun unsubscribe(uri: String, session: Session) {
     byUri[uri]?.remove(session)
+  }
+
+  /**
+   * Adds a `(uri, kind)` data-product subscription for [session]. Returns `true` iff this is the
+   * first session interested in the pair — the supervisor uses that signal to decide whether to
+   * forward `data/subscribe` to the daemon (idempotent on repeat).
+   */
+  fun subscribeData(uri: String, kind: String, session: Session): Boolean {
+    val key = DataSubKey(uri, kind)
+    var firstRef = false
+    byDataKey.compute(key) { _, existing ->
+      val set = existing ?: ConcurrentHashMap.newKeySet<Session>().also { firstRef = true }
+      // Re-subscribing the same session is idempotent (set semantics) — but we still surface
+      // `firstRef = true` only when the set was empty before this call.
+      set.add(session)
+      set
+    }
+    return firstRef
+  }
+
+  /**
+   * Removes [session] from the `(uri, kind)` subscription. Returns `true` iff this was the last
+   * session — the supervisor uses that signal to decide whether to forward `data/unsubscribe` to
+   * the daemon.
+   */
+  fun unsubscribeData(uri: String, kind: String, session: Session): Boolean {
+    val key = DataSubKey(uri, kind)
+    var lastRef = false
+    byDataKey.computeIfPresent(key) { _, set ->
+      set.remove(session)
+      if (set.isEmpty()) {
+        lastRef = true
+        null
+      } else set
+    }
+    return lastRef
+  }
+
+  /**
+   * Returns the `(uri, kind)` pairs [session] held the last reference to, removing them from the
+   * registry. The supervisor calls this on session disconnect and forwards `data/unsubscribe` to
+   * the matching daemon for each pair so the daemon doesn't leak subscriptions for previews the
+   * client will never look at again.
+   */
+  fun forgetDataSubscriptions(session: Session): List<DataSubKey> {
+    val released = mutableListOf<DataSubKey>()
+    val iter = byDataKey.entries.iterator()
+    while (iter.hasNext()) {
+      val (key, set) = iter.next()
+      if (set.remove(session) && set.isEmpty()) {
+        released.add(key)
+        iter.remove()
+      }
+    }
+    return released
   }
 
   /** Registers a watch entry for [session]. Returns the entry so the tool can echo it back. */
@@ -52,7 +117,13 @@ class Subscriptions {
     }
   }
 
-  /** Drops all subscriptions and watches owned by [session]. Called on session disconnect. */
+  /**
+   * Drops resource subscriptions and watches owned by [session]. Data-product subscriptions are NOT
+   * dropped here — call [forgetDataSubscriptions] separately and forward `data/unsubscribe` to the
+   * matching daemons for each released `(uri, kind)`. Splitting the two lets the caller see which
+   * keys lost their last reference (so it knows which wire calls to make) without this method
+   * needing to know about the supervisor.
+   */
   fun forget(session: Session) {
     byUri.values.forEach { it.remove(session) }
     watches.remove(session)
@@ -109,6 +180,13 @@ class Subscriptions {
     return out
   }
 }
+
+/**
+ * Refcount key for `subscribe_preview_data` bookkeeping. Modelled as a value type so the `(uri,
+ * kind)` pair stays opaque to callers — they get back the released keys on disconnect and forward
+ * unsubscribes without reaching into individual fields.
+ */
+data class DataSubKey(val uri: String, val kind: String)
 
 /**
  * One area-of-interest registration. The matching dimensions:

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -763,6 +763,210 @@ class DaemonMcpServerTest {
     assertThat(unsub).isEqualTo("com.example.Red" to "a11y/hierarchy")
   }
 
+  @Test
+  fun `get_preview_data auto-renders on DataProductNotAvailable and retries`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    val previewId = "com.example.Red"
+    val pngFile = tmp.newFile("auto-render.png")
+    Files.write(pngFile.toPath(), byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47))
+    val fetchAttempts = java.util.concurrent.atomic.AtomicInteger(0)
+
+    factory.daemonConfigurer = { daemon ->
+      daemon.advertisedDataProducts =
+        listOf(
+          ee.schimke.composeai.daemon.protocol.DataProductCapability(
+            kind = "a11y/hierarchy",
+            schemaVersion = 1,
+            transport = ee.schimke.composeai.daemon.protocol.DataProductTransport.INLINE,
+            attachable = true,
+            fetchable = true,
+            requiresRerender = false,
+          )
+        )
+      // First call → NotAvailable (preview hasn't rendered). Second call → Ok. The MCP server's
+      // auto-render path between the two issues a renderNow whose renderFinished completes
+      // `awaitNextRender`, after which the retry hits the Ok branch.
+      daemon.dataFetchHandler = { _, kind, _, _ ->
+        if (fetchAttempts.incrementAndGet() == 1) FakeDaemon.DataFetchOutcome.NotAvailable
+        else
+          FakeDaemon.DataFetchOutcome.Ok(
+            kind = kind,
+            schemaVersion = 1,
+            payload = buildJsonObject { put("nodes", JsonPrimitive("auto-rendered")) },
+          )
+      }
+      // Wire renderNow → renderFinished so awaitNextRender unblocks promptly.
+      daemon.autoRenderPngPath = { id -> if (id == previewId) pngFile.absolutePath else null }
+    }
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "get_preview_data",
+        buildJsonObject {
+          put("uri", uri)
+          put("kind", "a11y/hierarchy")
+        },
+        timeoutMs = 10_000,
+      )
+    val payload = json.parseToJsonElement(resp.firstTextContent()).jsonObject
+    assertThat(payload["payload"]?.jsonObject?.get("nodes")?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("auto-rendered")
+    assertThat(fetchAttempts.get()).isEqualTo(2)
+    // The auto-render path issued exactly one renderNow.
+    val renderRequest = daemon.renderRequests.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(renderRequest).isEqualTo(listOf(previewId))
+  }
+
+  @Test
+  fun `get_preview_data does not auto-render on DataProductUnknown`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    daemon.emitDiscovery("com.example.Red")
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", "com.example.Red").toUri()
+    val resp =
+      client.callTool(
+        "get_preview_data",
+        buildJsonObject {
+          put("uri", uri)
+          put("kind", "a11y/hierarchy")
+        },
+      )
+    assertThat(resp.isError()).isTrue()
+    assertThat(resp.firstTextContent()).contains("DataProductUnknown")
+    // No render was queued — auto-render is reserved for NotAvailable.
+    assertThat(daemon.renderRequests.poll(500, TimeUnit.MILLISECONDS)).isNull()
+  }
+
+  @Test
+  fun `subscribe_preview_data refcounts across two sessions and only forwards on first ref`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    factory.daemonConfigurer = { daemon ->
+      daemon.advertisedDataProducts =
+        listOf(
+          ee.schimke.composeai.daemon.protocol.DataProductCapability(
+            kind = "a11y/hierarchy",
+            schemaVersion = 1,
+            transport = ee.schimke.composeai.daemon.protocol.DataProductTransport.INLINE,
+            attachable = true,
+            fetchable = true,
+            requiresRerender = false,
+          )
+        )
+    }
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    daemon.emitDiscovery("com.example.Red")
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", "com.example.Red").toUri()
+    val args = buildJsonObject {
+      put("uri", uri)
+      put("kind", "a11y/hierarchy")
+    }
+
+    // Session A subscribes — first ref, forwards data/subscribe to daemon.
+    client.callTool("subscribe_preview_data", args)
+    val subA = daemon.dataSubscribes.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(subA).isEqualTo("com.example.Red" to "a11y/hierarchy")
+
+    // Session B opens, also subscribes — refcount goes to 2, no new wire call.
+    val (cToS2, sFromC2) = pipedPair()
+    val (sToC2, cFromS2) = pipedPair()
+    val session2 = server.newSession(input = sFromC2, output = sToC2).also { it.start() }
+    val client2 = McpTestClient(input = cFromS2, output = cToS2)
+    try {
+      client2.initialize()
+      client2.callTool("subscribe_preview_data", args)
+      // The fake's queue must stay quiet — no second daemon-side subscribe.
+      val subB = daemon.dataSubscribes.poll(500, TimeUnit.MILLISECONDS)
+      assertThat(subB).isNull()
+
+      // Session A unsubscribes — refcount drops to 1, still no wire unsubscribe.
+      client.callTool("unsubscribe_preview_data", args)
+      val unsubA = daemon.dataUnsubscribes.poll(500, TimeUnit.MILLISECONDS)
+      assertThat(unsubA).isNull()
+
+      // Session B unsubscribes — last ref, daemon gets the data/unsubscribe.
+      client2.callTool("unsubscribe_preview_data", args)
+      val unsubB = daemon.dataUnsubscribes.poll(2_000, TimeUnit.MILLISECONDS)
+      assertThat(unsubB).isEqualTo("com.example.Red" to "a11y/hierarchy")
+    } finally {
+      runCatching { client2.close() }
+      runCatching { session2.close() }
+    }
+  }
+
+  @Test
+  fun `session disconnect releases data subscriptions and forwards data slash unsubscribe`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    factory.daemonConfigurer = { daemon ->
+      daemon.advertisedDataProducts =
+        listOf(
+          ee.schimke.composeai.daemon.protocol.DataProductCapability(
+            kind = "a11y/hierarchy",
+            schemaVersion = 1,
+            transport = ee.schimke.composeai.daemon.protocol.DataProductTransport.INLINE,
+            attachable = true,
+            fetchable = true,
+            requiresRerender = false,
+          )
+        )
+    }
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    daemon.emitDiscovery("com.example.Red")
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    // Open a second session, subscribe, then disconnect it without unsubscribing. The supervisor's
+    // onClose path must drop the daemon-side subscription so the daemon doesn't leak it.
+    val (cToS2, sFromC2) = pipedPair()
+    val (sToC2, cFromS2) = pipedPair()
+    val session2 = server.newSession(input = sFromC2, output = sToC2).also { it.start() }
+    val client2 = McpTestClient(input = cFromS2, output = cToS2)
+    client2.initialize()
+
+    val uri = PreviewUri(workspaceId, ":module", "com.example.Red").toUri()
+    client2.callTool(
+      "subscribe_preview_data",
+      buildJsonObject {
+        put("uri", uri)
+        put("kind", "a11y/hierarchy")
+      },
+    )
+    val sub = daemon.dataSubscribes.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(sub).isEqualTo("com.example.Red" to "a11y/hierarchy")
+
+    // Hard close on the client side simulates the agent process going away. The McpSession's
+    // reader hits EOF, fires onClose, and the supervisor's hook calls forgetDataSubscriptions
+    // which forwards data/unsubscribe to the daemon. The poll-with-timeout below is what we use
+    // to wait for that asynchronous chain to complete.
+    client2.close()
+
+    val unsub = daemon.dataUnsubscribes.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(unsub).isEqualTo("com.example.Red" to "a11y/hierarchy")
+    runCatching { session2.close() }
+  }
+
   // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two follow-ups on top of the data-products tool surface that landed in #404/#405:

1. **Auto-render in `get_preview_data` on `DataProductNotAvailable`.** Previously an agent calling `get_preview_data` on a preview that hadn't rendered yet got a wire-error and had to figure out it should call `render_preview` first. Now the supervisor catches `-32021`, triggers a `renderNow`, awaits `renderFinished`, and retries the fetch — folds the two-call dance into one tool call.

   `dataFetch` upgraded to throw a typed `DataProductWireException` carrying the wire-error code so callers can pattern-match without parsing error strings. Other wire errors (`DataProductUnknown`, `DataProductBudgetExceeded`, `DataProductFetchFailed`) propagate as tool errors with the canonical name + message.

2. **Refcount data-product subscriptions across MCP sessions.** Previously `subscribe_preview_data` directly forwarded `data/subscribe` to the daemon and didn't track the requesting session, so a session disconnecting without unsubscribing leaked the daemon-side subscription until `setVisible` churn dropped it. Multiple sessions subscribing the same `(uri, kind)` also paid redundant wire calls.

   `Subscriptions` now tracks `(uri, kind) → set of sessions` keyed by `DataSubKey`. Supervisor forwards `data/subscribe` only on first reference and `data/unsubscribe` only on last release. Session disconnect calls `forgetDataSubscriptions(session)`, which returns keys that just lost their last reference; supervisor forwards `data/unsubscribe` to each affected daemon best-effort.

3. **Refactor:** extracted `awaitNextRender(uri)` from `renderAndReadBytes` so both the read path and the auto-render path share the render-and-wait machinery.

## Test plan

- [x] `./gradlew :mcp:ktfmtCheckMain :mcp:ktfmtCheckTest` — clean
- [x] `./gradlew :mcp:test` — 21/21 pass, including 4 new cases:
  - `get_preview_data auto-renders on DataProductNotAvailable and retries`
  - `get_preview_data does not auto-render on DataProductUnknown`
  - `subscribe_preview_data refcounts across two sessions and only forwards on first ref`
  - `session disconnect releases data subscriptions and forwards data/unsubscribe`


---
_Generated by [Claude Code](https://claude.ai/code/session_019eCR7c9UaZzvkAf9TeVVc9)_