### PR TITLE
docs(daemon): clarify CLI parity is on-disk, not a --emit flag

### DIFF
--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -54,10 +54,20 @@ kinds are silently ignored both ways.
 5. **No `protocolVersion` bump.** Adding a kind, adding a field to a
    payload, adding a new method in the `data/*` family — all additive
    per PROTOCOL.md § 7. Both sides ignore unknowns.
-6. CLI parity: `compose-preview --emit a11y/hierarchy` (and friends)
-   produce the same JSON the daemon would, so MCP-driven agents see
-   the same payloads as VS Code. Daemon and CLI share the renderer-side
-   producers.
+6. CLI parity, **on-disk only**. Daemon and CLI share the renderer-side
+   producers, so a Gradle-driven render of an a11y-enabled module writes
+   the same `build/compose-previews/data/<id>/<kind>.json` files the
+   daemon would attach to `renderFinished`. CLI consumers (CI scripts,
+   non-MCP agents) read those files directly — there is **no
+   `--emit kind` flag** and the CLI surface stays as "render to disk,
+   look in `build/`." Kinds are selected via the consumer's
+   `composePreview { ... }` Gradle config (the same channel that already
+   gates `accessibilityChecks.enabled`); duplicating that selection on
+   the CLI would just create two ways to express the same intent and
+   let them drift. The agent ergonomics that justify a programmatic
+   surface — `data/fetch` re-render, `data/subscribe` priming, kind
+   discovery — live in the daemon protocol and its MCP front-end, not
+   the CLI.
 
 **Non-goals**:
 


### PR DESCRIPTION
## Summary

Goal #6 in `docs/daemon/DATA-PRODUCTS.md` previously read as if a hypothetical `compose-preview --emit a11y/hierarchy` CLI flag was on the roadmap. It isn't — and adding one would shadow the existing `composePreview { ... }` Gradle config for kind selection, with the two channels free to drift.

Reword to make explicit that:

- The CLI surface for data products is `build/compose-previews/data/<id>/<kind>.json` written by the renderer-side producers daemon and CLI share.
- Kind selection is Gradle config, not a CLI flag.
- The agent ergonomics that need a programmatic surface (auto-render on `data/fetch`, subscribe-while-visible, kind discovery) belong in the daemon protocol + MCP front-end — not the CLI.

Pure docs, no code change.

## Test plan

- [x] N/A — markdown only.


---
_Generated by [Claude Code](https://claude.ai/code/session_019eCR7c9UaZzvkAf9TeVVc9)_