### PR TITLE
feat(daemon): held compose scene for interactive sessions (v2 PR-2)

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -78,6 +78,24 @@ open class DesktopHost(
   override val userClassloaderHolder: UserClassLoaderHolder? = null,
 ) : RenderHost {
 
+  /**
+   * v2 — interactive session sharing per `previewId`, ref-counted by the number of subscribed
+   * streams (INTERACTIVE.md § 9.7 — "shared session per previewId, ref-counted by streamId").
+   * Two `interactive/start` calls for the same preview share one held [HeldScene] and one
+   * underlying [DesktopInteractiveSession]; the session lives until the last subscribed stream
+   * stops. Inputs from any stream drive the same composition state.
+   *
+   * Keyed by previewId. Each acquire returns a fresh per-stream proxy [InteractiveSession] whose
+   * [InteractiveSession.close] decrements the refcount; the inner shared session is torn down
+   * once the count hits zero.
+   */
+  private val sharedInteractiveSessions = ConcurrentHashMap<String, SharedInteractiveSession>()
+
+  private data class SharedInteractiveSession(
+    val inner: DesktopInteractiveSession,
+    val refCount: java.util.concurrent.atomic.AtomicInteger,
+  )
+
   private val requests: LinkedBlockingQueue<RenderRequest> = LinkedBlockingQueue()
   private val results: ConcurrentHashMap<Long, LinkedBlockingQueue<Any>> = ConcurrentHashMap()
 
@@ -254,5 +272,130 @@ open class DesktopHost(
       current = current.targetException ?: return current
     }
     return current
+  }
+
+  /**
+   * v2 (INTERACTIVE.md § 9) — resolve [previewId] to the [RenderSpec] the held scene should be
+   * built from. Default returns `null`, which causes [acquireInteractiveSession] to throw
+   * [UnsupportedOperationException]; that signals to [JsonRpcServer.handleInteractiveStart] that
+   * this host doesn't know how to serve interactive sessions for this preview, and the v1
+   * fallback path stays in force.
+   *
+   * Production wiring: [PreviewManifestRouter] overrides this to look the previewId up in its
+   * `previews.json` manifest. The base [DesktopHost] doesn't carry a manifest of its own — the
+   * renderer-agnostic surface in `:daemon:core` only forwards `previewId` strings, not specs — so
+   * the no-manifest case is "no interactive support". Tests can subclass and pin a fixture spec
+   * directly without going through the manifest.
+   */
+  protected open fun resolveInteractiveSpec(previewId: String): RenderSpec? = null
+
+  /**
+   * v2 — acquire a held [InteractiveSession] for [previewId]. Resolves the [RenderSpec] via
+   * [resolveInteractiveSpec], sets up an [HeldScene] with `LocalInspectionMode = false`
+   * (INTERACTIVE.md § 9.5), and returns a [DesktopInteractiveSession] backed by it.
+   *
+   * **Shared session per previewId** (INTERACTIVE.md § 9.7). Two streams targeting the same
+   * preview share one held scene so the second stream's input drives the same composition state
+   * as the first. The shared session lives until the last subscribed stream stops; that's
+   * tracked here via [SharedInteractiveSession.refCount]. Each call returns a fresh per-stream
+   * proxy whose [InteractiveSession.close] decrements the refcount and tears the held scene
+   * down once the count hits zero.
+   *
+   * **Inspection-mode flip.** v1 non-interactive renders pin `LocalInspectionMode = true`;
+   * interactive sessions explicitly want real behaviour (pointer-input modifiers fire, app code
+   * that branches on `isInspectionMode` runs the production path) — INTERACTIVE.md § 9.5.
+   */
+  override fun acquireInteractiveSession(
+    previewId: String,
+    classLoader: ClassLoader,
+  ): InteractiveSession {
+    val spec =
+      resolveInteractiveSpec(previewId)
+        ?: throw UnsupportedOperationException(
+          "DesktopHost: no manifest entry for previewId='$previewId'; " +
+            "interactive mode requires resolveInteractiveSpec to return a RenderSpec"
+        )
+    val shared =
+      sharedInteractiveSessions.compute(previewId) { _, existing ->
+        if (existing != null) {
+          existing.refCount.incrementAndGet()
+          existing
+        } else {
+          val held =
+            engine.setUp(
+              spec = spec,
+              classLoader = classLoader,
+              sandboxStats = sandboxStats,
+              runInspectionMode = false,
+            )
+          // Bootstrap render so the scene has done layout once before any pointer dispatch
+          // arrives — without it Compose's hit-testing has no measured tree to walk and pointer
+          // events miss every clickable. INTERACTIVE.md § 9.2 calls this out: "Pre-renders one
+          // bootstrap frame so the panel has something to paint immediately." We don't ship the
+          // pixels anywhere; the load-bearing side effect is layout.
+          held.scene.render()
+          val inner =
+            DesktopInteractiveSession(previewId = previewId, engine = engine, held = held)
+          SharedInteractiveSession(
+            inner = inner,
+            refCount = java.util.concurrent.atomic.AtomicInteger(1),
+          )
+        }
+      }!!
+    return RefCountedInteractiveSession(previewId, shared, this)
+  }
+
+  /**
+   * Decrement [previewId]'s refcount by one; close the underlying shared session and drop the map
+   * entry when it hits zero. Idempotent on a previewId that's already been fully released (the
+   * `compute` no-ops on a missing entry).
+   */
+  internal fun releaseInteractiveSession(previewId: String) {
+    sharedInteractiveSessions.compute(previewId) { _, existing ->
+      if (existing == null) return@compute null
+      val remaining = existing.refCount.decrementAndGet()
+      if (remaining > 0) {
+        existing
+      } else {
+        try {
+          existing.inner.close()
+        } catch (t: Throwable) {
+          System.err.println(
+            "compose-ai-daemon: DesktopHost.releaseInteractiveSession($previewId) " +
+              "inner close threw: ${t.javaClass.simpleName}: ${t.message}"
+          )
+        }
+        null
+      }
+    }
+  }
+
+  /**
+   * Per-stream proxy returned to [JsonRpcServer] from [acquireInteractiveSession]. Delegates
+   * dispatch + render to the shared inner session; [close] decrements the refcount and only
+   * tears the held scene down when the last subscribed stream stops.
+   */
+  private class RefCountedInteractiveSession(
+    override val previewId: String,
+    private val shared: SharedInteractiveSession,
+    private val host: DesktopHost,
+  ) : InteractiveSession {
+
+    private val closed = java.util.concurrent.atomic.AtomicBoolean(false)
+
+    override fun dispatch(input: ee.schimke.composeai.daemon.protocol.InteractiveInputParams) {
+      check(!closed.get()) { "RefCountedInteractiveSession($previewId) is closed" }
+      shared.inner.dispatch(input)
+    }
+
+    override fun render(requestId: Long): RenderResult {
+      check(!closed.get()) { "RefCountedInteractiveSession($previewId) is closed" }
+      return shared.inner.render(requestId)
+    }
+
+    override fun close() {
+      if (!closed.compareAndSet(false, true)) return
+      host.releaseInteractiveSession(previewId)
+    }
   }
 }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
@@ -1,0 +1,204 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEventType
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Compose-Desktop concrete [InteractiveSession] — the v2 click-into-composition body documented in
+ * [INTERACTIVE.md § 9](../../../../../../docs/daemon/INTERACTIVE.md#9-v2--click-dispatch-into-composition).
+ *
+ * Owns one [HeldScene] across the session's lifetime so `remember { mutableStateOf(...) }`
+ * survives between [dispatch] calls. The scene was set up with `LocalInspectionMode = false`
+ * (INTERACTIVE.md § 9.5) so previews that branch on `isInspectionMode` show their non-inspection
+ * ("real") behaviour and `pointerInput` modifiers actually fire.
+ *
+ * **Threading.** The hosting [JsonRpcServer] dispatches inputs serially per session — see the
+ * threading note on [InteractiveSession]. We don't lock internally; concurrent inputs to the same
+ * session are a contract violation, not a correctness concern. Each [dispatch] / [render] call
+ * installs the user [HeldScene.classLoader] as the calling thread's context classloader (and
+ * restores on the way out) so pointer/key dispatch on a per-input worker thread still resolves
+ * user classes the same way `setUp` did.
+ *
+ * **Ref-counting.** The desktop host shares one `DesktopInteractiveSession` per `previewId` —
+ * INTERACTIVE.md § 9.7's "shared session per previewId, ref-counted by streamId". The session
+ * itself doesn't track refcounts; that's [DesktopHost]'s job. [close] is the
+ * "last-stream-stopped-on-this-preview" notification — the session closes its [HeldScene] and any
+ * follow-up [dispatch] is a contract violation.
+ */
+class DesktopInteractiveSession(
+  override val previewId: String,
+  private val engine: RenderEngine,
+  private val held: HeldScene,
+) : InteractiveSession {
+
+  private val closed = AtomicBoolean(false)
+
+  override fun dispatch(input: InteractiveInputParams) {
+    check(!closed.get()) { "DesktopInteractiveSession($previewId) is closed" }
+    withUserContextClassLoader {
+      when (input.kind) {
+        InteractiveInputKind.CLICK -> {
+          val pos = sceneOffset(input)
+          // Compose's `Modifier.clickable` consumes Press / Release through the same
+          // pointer-input pipeline; for the gesture to register as a click the framework needs
+          // a chance to dispatch the Press event into the composition before we send Release.
+          // Render once between the two so the input handler flushes the Press; otherwise both
+          // events arrive together and `clickable`'s detector treats them as cancelled.
+          //
+          // PointerButton.Primary is required: `clickable` only fires for primary-button
+          // clicks (the desktop equivalent of touch-tap). Without it the events still
+          // dispatch but the modifier's detector ignores them.
+          held.scene.sendPointerEvent(
+            eventType = PointerEventType.Press,
+            position = pos,
+            button = PointerButton.Primary,
+          )
+          held.scene.render()
+          held.scene.sendPointerEvent(
+            eventType = PointerEventType.Release,
+            position = pos,
+            button = PointerButton.Primary,
+          )
+        }
+        InteractiveInputKind.POINTER_DOWN -> {
+          held.scene.sendPointerEvent(
+            eventType = PointerEventType.Press,
+            position = sceneOffset(input),
+            button = PointerButton.Primary,
+          )
+        }
+        InteractiveInputKind.POINTER_UP -> {
+          held.scene.sendPointerEvent(
+            eventType = PointerEventType.Release,
+            position = sceneOffset(input),
+            button = PointerButton.Primary,
+          )
+        }
+        InteractiveInputKind.KEY_DOWN -> dispatchKey(input, awtPressed = true)
+        InteractiveInputKind.KEY_UP -> dispatchKey(input, awtPressed = false)
+      }
+    }
+  }
+
+  /**
+   * Convert the wire's image-natural pixel coordinates to a Compose [Offset] in scene-px. Compose's
+   * `Offset` lives in scene-px which equals natural pixels at density 1.0; for non-default
+   * densities the wire coords are divided by the spec's density (INTERACTIVE.md § 9.4).
+   */
+  private fun sceneOffset(input: InteractiveInputParams): Offset {
+    val density = held.spec.density.takeIf { it > 0f } ?: 1f
+    val px = (input.pixelX ?: 0).toFloat()
+    val py = (input.pixelY ?: 0).toFloat()
+    return Offset(px / density, py / density)
+  }
+
+  private fun dispatchKey(input: InteractiveInputParams, awtPressed: Boolean) {
+    val keyCode = input.keyCode ?: return
+    val awtCode = parseAwtKeyCode(keyCode) ?: return
+    val component = dummyAwtComponent ?: return
+    // ImageComposeScene.sendKeyEvent takes a androidx.compose.ui.input.key.KeyEvent wrapping a
+    // native AWT KeyEvent on Desktop. The v2 wire shape only carries a string keycode, so we
+    // fall back to the smallest viable mapping (a-z / 0-9 / a few named keys). Richer key
+    // dispatch can land in a follow-up; for v2 click-only the path is exercised structurally
+    // but pointer events are the common case.
+    held.scene.sendKeyEvent(
+      androidx.compose.ui.input.key.KeyEvent(
+        nativeKeyEvent =
+          java.awt.event.KeyEvent(
+            component,
+            if (awtPressed) java.awt.event.KeyEvent.KEY_PRESSED
+            else java.awt.event.KeyEvent.KEY_RELEASED,
+            System.currentTimeMillis(),
+            0,
+            awtCode,
+            keyCode.firstOrNull() ?: java.awt.event.KeyEvent.CHAR_UNDEFINED,
+          )
+      )
+    )
+  }
+
+  override fun render(requestId: Long): RenderResult {
+    check(!closed.get()) { "DesktopInteractiveSession($previewId) is closed" }
+    // Two render() calls — same heuristic as RenderEngine.render's one-shot path: gives any
+    // LaunchedEffect / recomposition triggered by the just-dispatched input a tick to settle
+    // before we encode the PNG (INTERACTIVE.md § 9.2 sketch). renderOnce already calls
+    // scene.render() twice; the dispatch() path additionally settled the post-input frame on
+    // the way in.
+    return withUserContextClassLoader { engine.renderOnce(held, requestId) }
+  }
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    engine.tearDown(held)
+  }
+
+  /**
+   * Run [block] with the user classloader installed as the calling thread's context classloader,
+   * restoring the previous value on exit. The session lives across multiple [JsonRpcServer]
+   * worker threads (a fresh thread spins up per `interactive/input`), so we can't rely on a
+   * single setUp/tearDown to cover the install — every dispatch / render does its own.
+   */
+  private inline fun <R> withUserContextClassLoader(block: () -> R): R {
+    val previous = Thread.currentThread().contextClassLoader
+    Thread.currentThread().contextClassLoader = held.classLoader
+    return try {
+      block()
+    } finally {
+      Thread.currentThread().contextClassLoader = previous
+    }
+  }
+
+  private companion object {
+    /**
+     * Stand-in AWT component for the synthesized key events — only used as the event source.
+     * Lazy because constructing an AWT [java.awt.Label] in a headless JVM throws
+     * [java.awt.HeadlessException]; key dispatch is best-effort anyway and the click-only path
+     * doesn't touch this. We resolve the component at first use and tolerate the headless
+     * case by silently dropping key events.
+     */
+    private val dummyAwtComponent: java.awt.Component? by lazy {
+      try {
+        java.awt.Canvas()
+      } catch (_: Throwable) {
+        null
+      }
+    }
+
+    /**
+     * Best-effort string → AWT virtual-keycode mapping. Recognises single ASCII letters/digits and
+     * a small pinned set of named keys; returns `null` for anything we don't recognise so the
+     * caller drops the key event silently rather than synthesising a wrong dispatch. We go straight
+     * to AWT virtual codes rather than through `androidx.compose.ui.input.key.Key` so we don't
+     * couple to Key's (target-specific, Long-typed) constructor surface.
+     */
+    private fun parseAwtKeyCode(code: String): Int? {
+      val trimmed = code.trim()
+      if (trimmed.isEmpty()) return null
+      if (trimmed.length == 1) {
+        val ch = trimmed.first().uppercaseChar()
+        return when {
+          ch in 'A'..'Z' -> java.awt.event.KeyEvent.VK_A + (ch - 'A')
+          ch in '0'..'9' -> java.awt.event.KeyEvent.VK_0 + (ch - '0')
+          else -> null
+        }
+      }
+      return when (trimmed.lowercase()) {
+        "enter", "return" -> java.awt.event.KeyEvent.VK_ENTER
+        "tab" -> java.awt.event.KeyEvent.VK_TAB
+        "space" -> java.awt.event.KeyEvent.VK_SPACE
+        "escape", "esc" -> java.awt.event.KeyEvent.VK_ESCAPE
+        "backspace" -> java.awt.event.KeyEvent.VK_BACK_SPACE
+        "delete", "del" -> java.awt.event.KeyEvent.VK_DELETE
+        "arrowup", "up" -> java.awt.event.KeyEvent.VK_UP
+        "arrowdown", "down" -> java.awt.event.KeyEvent.VK_DOWN
+        "arrowleft", "left" -> java.awt.event.KeyEvent.VK_LEFT
+        "arrowright", "right" -> java.awt.event.KeyEvent.VK_RIGHT
+        else -> null
+      }
+    }
+  }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -44,6 +44,28 @@ class PreviewManifestRouter(
 
   private val byId: Map<String, PreviewManifestEntry> = manifest.previews.associateBy { it.id }
 
+  /**
+   * v2 (INTERACTIVE.md § 9) — resolve [previewId] to the [RenderSpec] the held interactive scene
+   * should be built from, by looking it up in this router's manifest. Returns null when the
+   * previewId is unknown, which causes [DesktopHost.acquireInteractiveSession] to throw
+   * [UnsupportedOperationException] and the daemon falls back to the v1 dispatch path.
+   */
+  override fun resolveInteractiveSpec(previewId: String): RenderSpec? {
+    val entry = byId[previewId] ?: return null
+    val resolved = entry.resolved()
+    return RenderSpec(
+      className = entry.className,
+      functionName = entry.functionName,
+      widthPx = resolved.widthPx,
+      heightPx = resolved.heightPx,
+      density = resolved.density,
+      showBackground = resolved.showBackground,
+      backgroundColor = resolved.backgroundColor,
+      device = resolved.device,
+      outputBaseName = "${resolved.outputBaseName}-interactive",
+    )
+  }
+
   override fun submit(request: RenderRequest, timeoutMs: Long): RenderResult {
     require(request !is RenderRequest.Shutdown) {
       "Use shutdown() to stop the host, not submit(Shutdown)."

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -89,6 +89,62 @@ class RenderEngine(
      */
     sandboxStats: SandboxLifecycleStats = SandboxLifecycleStats(),
   ): RenderResult {
+    // Install the user classloader as the thread's context classloader for the duration of the
+    // one-shot render so Compose's reflection paths (PreviewParameter providers — see
+    // CLASSLOADER.md § Risks 2) resolve user classes correctly. Restored in `finally`. v2's
+    // [setUp] / [renderOnce] / [tearDown] split owns its own per-call install on the calling
+    // thread (each interactive dispatch may run on a different thread than [setUp]).
+    val previousContext = Thread.currentThread().contextClassLoader
+    Thread.currentThread().contextClassLoader = classLoader
+    val held =
+      try {
+        setUp(spec, classLoader, sandboxStats)
+      } catch (t: Throwable) {
+        Thread.currentThread().contextClassLoader = previousContext
+        throw t
+      }
+    try {
+      return renderOnce(held, requestId)
+    } finally {
+      try {
+        tearDown(held)
+      } finally {
+        Thread.currentThread().contextClassLoader = previousContext
+      }
+    }
+  }
+
+  /**
+   * v2 (INTERACTIVE.md § 9.3) — first stage of the split render pipeline. Resolves [spec]'s class
+   * via reflection, allocates the [ImageComposeScene], and calls `scene.setContent`. **Does NOT
+   * call `scene.render()`** — that's [renderOnce]'s job. Pair every [setUp] with a [tearDown] in a
+   * `try/finally` so the scene is always closed, even if the caller throws between calls.
+   *
+   * Splitting [render] into [setUp] / [renderOnce] / [tearDown] is the load-bearing refactor for
+   * v2's held-scene interactive sessions (see
+   * [INTERACTIVE.md § 9](../../../../../../docs/daemon/INTERACTIVE.md#9-v2--click-dispatch-into-composition)).
+   * The one-shot [render] wrapper above keeps the existing behaviour for non-interactive callers;
+   * [DesktopInteractiveSession] keeps a [HeldScene] alive across [InteractiveSession.dispatch]
+   * calls so `remember`'d composition state survives between inputs.
+   *
+   * @param runInspectionMode controls the `LocalInspectionMode` provided to the composition. v1
+   *   non-interactive renders pin this to `true` (so previews that branch on `isInspectionMode`
+   *   show their inspection-mode stub data); interactive sessions pass `false` so pointer-input
+   *   modifiers actually fire and the user sees real behaviour. INTERACTIVE.md § 9.5.
+   *
+   * The caller is responsible for installing [classLoader] as the thread's context classloader
+   * for the duration of the operation that consumes this [HeldScene]. The one-shot [render]
+   * wrapper above does it once around setUp+renderOnce+tearDown; interactive sessions install it
+   * per-dispatch / per-render so dispatches running on a different thread than this [setUp]
+   * still resolve user classes correctly.
+   */
+  fun setUp(
+    spec: RenderSpec,
+    classLoader: ClassLoader =
+      RenderEngine::class.java.classLoader ?: ClassLoader.getSystemClassLoader(),
+    sandboxStats: SandboxLifecycleStats = SandboxLifecycleStats(),
+    runInspectionMode: Boolean = true,
+  ): HeldScene {
     outputDir.mkdirs()
     val outputFile = File(outputDir, "${spec.outputBaseName}.png")
     val startNs = System.nanoTime()
@@ -96,25 +152,14 @@ class RenderEngine(
     val clazz = Class.forName(spec.className, true, classLoader)
     val composableMethod: ComposableMethod = clazz.getDeclaredComposableMethod(spec.functionName)
 
-    // Self-diagnostic — surfaces in the VS Code extension's output channel as `[daemon stderr] …`.
-    // Pairs with `[classloader] swap requested` / `allocate child loader` lines from
-    // [UserClassLoaderHolder]. If `classFile` doesn't advance across saves the daemon is
-    // re-rendering against bytecode that wasn't actually recompiled.
     val fingerprint =
       UserClassLoaderHolder.classFileFingerprint(classLoader, spec.className)
         ?: "fingerprint unavailable (class not on a file: URL)"
     System.err.println(
       "compose-ai-daemon: [render] ${spec.className}#${spec.functionName} " +
-        "loaderId=${System.identityHashCode(classLoader).toString(16)} classFile=$fingerprint"
+        "loaderId=${System.identityHashCode(classLoader).toString(16)} classFile=$fingerprint " +
+        "inspectionMode=$runInspectionMode"
     )
-
-    // Install the child classloader as the context classloader for the duration of the render
-    // dispatch. Compose's reflection paths (notably PreviewParameter providers — see
-    // CLASSLOADER.md § Risks 2) consult the context classloader; without this install they would
-    // miss user classes that aren't on the parent's classpath. Restored in `finally` so the host
-    // render-thread invariants outside the render are unaffected.
-    val previousContext = Thread.currentThread().contextClassLoader
-    Thread.currentThread().contextClassLoader = classLoader
 
     val scene =
       ImageComposeScene(
@@ -124,7 +169,7 @@ class RenderEngine(
       )
     try {
       scene.setContent {
-        CompositionLocalProvider(LocalInspectionMode provides true) {
+        CompositionLocalProvider(LocalInspectionMode provides runInspectionMode) {
           val bgColor =
             when {
               spec.backgroundColor != 0L -> Color(spec.backgroundColor.toInt())
@@ -138,39 +183,72 @@ class RenderEngine(
           }
         }
       }
-
-      // Render two frames so any LaunchedEffect / animations have a tick to settle. Same reasoning
-      // as `:renderer-desktop`'s renderPreview.
-      scene.render()
-      val image = scene.render()
-
-      val pngData =
-        image.encodeToData(EncodedImageFormat.PNG)
-          ?: error("Failed to encode image to PNG for ${spec.className}.${spec.functionName}")
-
-      outputFile.parentFile?.mkdirs()
-      outputFile.writeBytes(pngData.bytes)
-    } finally {
-      // DESIGN § 9: always close the scene, even on render-body exceptions. Without this, a thrown
-      // render leaks one Skia `Surface` per submission until JVM exit. The desktop counterpart of
-      // Android's bitmap.recycle() discipline.
-      try {
-        scene.close()
-      } finally {
-        // Restore the pre-render context classloader regardless of how the body completed.
-        Thread.currentThread().contextClassLoader = previousContext
-      }
+    } catch (t: Throwable) {
+      // setContent threw — close the scene we just allocated before re-raising so the caller
+      // doesn't have to call tearDown on a broken HeldScene.
+      runCatching { scene.close() }
+      throw t
     }
 
+    return HeldScene(
+      scene = scene,
+      classLoader = classLoader,
+      spec = spec,
+      sandboxStats = sandboxStats,
+      outputFile = outputFile,
+      setUpStartNs = startNs,
+    )
+  }
+
+  /**
+   * v2 — second stage. Renders the [held] composition twice (so any `LaunchedEffect` /
+   * recomposition settles — same heuristic as the one-shot path) and writes the resulting PNG to
+   * disk. **Does NOT close the scene** — the caller is responsible for [tearDown] (one-shot
+   * [render]) or for keeping the scene alive across inputs ([DesktopInteractiveSession]).
+   *
+   * Safe to call repeatedly on the same [HeldScene] — each call writes the current pixel state
+   * to the same output path. Interactive sessions exploit this: dispatch a pointer event, then
+   * [renderOnce] re-paints the scene reflecting the new composition state.
+   */
+  fun renderOnce(held: HeldScene, requestId: Long): RenderResult {
+    val startNs = System.nanoTime()
+    // Render two frames so any LaunchedEffect / animations have a tick to settle. Same reasoning
+    // as `:renderer-desktop`'s renderPreview.
+    held.scene.render()
+    val image = held.scene.render()
+
+    val pngData =
+      image.encodeToData(EncodedImageFormat.PNG)
+        ?: error(
+          "Failed to encode image to PNG for ${held.spec.className}.${held.spec.functionName}"
+        )
+
+    held.outputFile.parentFile?.mkdirs()
+    held.outputFile.writeBytes(pngData.bytes)
+
     val tookMs = (System.nanoTime() - startNs) / 1_000_000L
-    val metrics = SandboxMeasurement.collect(sandboxStats, tookMs = tookMs)
+    val metrics = SandboxMeasurement.collect(held.sandboxStats, tookMs = tookMs)
     return RenderResult(
       id = requestId,
-      classLoaderHashCode = System.identityHashCode(classLoader),
-      classLoaderName = classLoader.javaClass.name,
-      pngPath = outputFile.absolutePath,
+      classLoaderHashCode = System.identityHashCode(held.classLoader),
+      classLoaderName = held.classLoader.javaClass.name,
+      pngPath = held.outputFile.absolutePath,
       metrics = metrics,
     )
+  }
+
+  /**
+   * v2 — third stage. Closes the scene's underlying Skia `Surface`. Restoration of any
+   * pre-render context classloader is the caller's responsibility (one-shot [render] manages that
+   * around setUp+renderOnce+tearDown; interactive sessions install + restore per
+   * dispatch/render call).
+   *
+   * DESIGN § 9: always invoked from a `try/finally` so the underlying Skia `Surface` always
+   * releases, even when the render body throws. Without this, a thrown render leaks one Skia
+   * `Surface` per submission until JVM exit.
+   */
+  fun tearDown(held: HeldScene) {
+    held.scene.close()
   }
 
   companion object {
@@ -181,6 +259,37 @@ class RenderEngine(
     const val OUTPUT_DIR_PROP: String = "composeai.render.outputDir"
   }
 }
+
+/**
+ * Held render state returned by [RenderEngine.setUp] and consumed by [RenderEngine.renderOnce] /
+ * [RenderEngine.tearDown]. Owns the live [ImageComposeScene] plus the bookkeeping needed to encode
+ * the next frame ([outputFile], [spec]).
+ *
+ * Outside [RenderEngine] this is the handle [DesktopInteractiveSession] keeps warm across
+ * `interactive/input` notifications so `remember`'d composition state survives between clicks
+ * (INTERACTIVE.md § 9.2). Public so the desktop interactive session — which lives next to
+ * [RenderEngine] in the same module — can read [scene] for `sendPointerEvent` dispatch without
+ * widening [RenderEngine]'s surface area further.
+ */
+class HeldScene
+internal constructor(
+  /**
+   * The live Compose scene. [DesktopInteractiveSession.dispatch] calls `scene.sendPointerEvent`
+   * on this instance; [RenderEngine.renderOnce] drives `scene.render()` twice and encodes the
+   * pixels.
+   */
+  val scene: androidx.compose.ui.ImageComposeScene,
+  /** User classloader the scene's content was resolved against (for diagnostics + result fields). */
+  val classLoader: ClassLoader,
+  /** The spec the scene was set up against. Carried so [RenderEngine.renderOnce] can name the PNG. */
+  val spec: RenderSpec,
+  /** Per-host measurement context. Bumped once per [RenderEngine.renderOnce] call. */
+  internal val sandboxStats: SandboxLifecycleStats,
+  /** Where the next [RenderEngine.renderOnce] will write its PNG. */
+  internal val outputFile: File,
+  /** `System.nanoTime()` snapshot captured at [RenderEngine.setUp]; for future cold-start metrics. */
+  internal val setUpStartNs: Long,
+)
 
 /**
  * What [RenderEngine.render] needs to produce a single PNG. Decoupled from the protocol's

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSessionTest.kt
@@ -1,0 +1,117 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
+import java.io.ByteArrayInputStream
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.math.abs
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Unit-level coverage for the v2 click-into-composition path: builds a [DesktopInteractiveSession]
+ * directly from a [RenderEngine] (without going through [JsonRpcServer]) and asserts that a single
+ * `dispatch(CLICK) → render` flips [ClickToGreenSquare]'s `remember`'d state from red to green.
+ *
+ * The companion [InteractiveDesktopRpcIntegrationTest] exercises the same flow through the full
+ * JSON-RPC + DesktopHost stack; this one isolates the engine + session pieces so a failure here
+ * tells us "the held scene + click dispatch are broken" rather than "something in the JSON-RPC
+ * routing is wrong".
+ */
+class DesktopInteractiveSessionTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test(timeout = 60_000)
+  fun click_flips_remembered_state_from_red_to_green() {
+    val outputDir = tempFolder.newFolder("renders")
+    val engine = RenderEngine(outputDir = outputDir)
+    val spec =
+      RenderSpec(
+        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        functionName = "ClickToGreenSquare",
+        widthPx = 64,
+        heightPx = 64,
+        density = 1.0f,
+        showBackground = true,
+        outputBaseName = "click-to-green-unit",
+      )
+    val held = engine.setUp(spec = spec, runInspectionMode = false)
+    // Bootstrap render (mirrors DesktopHost.acquireInteractiveSession) so the scene has done one
+    // layout pass before the pointer event arrives — without it Compose's hit-testing has no
+    // measured tree to walk.
+    held.scene.render()
+    val session =
+      DesktopInteractiveSession(previewId = "click-to-green", engine = engine, held = held)
+    try {
+      // Pre-click frame must be red.
+      val baseline = engine.renderOnce(held, requestId = 1L)
+      val baselineFile = File(baseline.pngPath!!)
+      assertMostlyColor(baselineFile, "baseline (pre-click)", expectedRgb = 0xEF5350)
+
+      session.dispatch(
+        InteractiveInputParams(
+          frameStreamId = "stream-1",
+          kind = InteractiveInputKind.CLICK,
+          pixelX = 32,
+          pixelY = 32,
+        )
+      )
+      val postClick = session.render(requestId = 2L)
+      val postClickFile = File(postClick.pngPath!!)
+      assertMostlyColor(postClickFile, "post-click", expectedRgb = 0x66BB6A)
+    } finally {
+      session.close()
+    }
+  }
+
+  private fun assertMostlyColor(pngFile: File, label: String, expectedRgb: Int) {
+    val bytes = pngFile.readBytes()
+    val img = ByteArrayInputStream(bytes).use { ImageIO.read(it) }
+    assertNotNull("$label PNG must decode via javax.imageio", img)
+    // Tolerance 32: ImageComposeScene renders against a transparent backing surface, so the
+    // tinted material colours come back several LSB darker than the literal hex (e.g. #66BB6A
+    // observed as #5BA85F here) once Skia has composited and the AWT decoder has gone through
+    // ARGB → RGB unpremultiply. Wide tolerance to keep the assertion robust against rendering
+    // pipeline drift; the load-bearing claim is "this is the green fixture, not the red one",
+    // which a single-channel-of-32 tolerance still differentiates trivially.
+    val matchPct = pixelMatchPct(img!!, expectedRgb, perChannelTolerance = 32)
+    assertTrue(
+      "$label: expected ≥ 90% of pixels close to #${expectedRgb.toString(16).padStart(6, '0')}; " +
+        "got ${"%.2f".format(matchPct * 100)}%",
+      matchPct >= 0.90,
+    )
+  }
+
+  private fun pixelMatchPct(
+    img: java.awt.image.BufferedImage,
+    expectedRgb: Int,
+    perChannelTolerance: Int,
+  ): Double {
+    val expR = (expectedRgb shr 16) and 0xFF
+    val expG = (expectedRgb shr 8) and 0xFF
+    val expB = expectedRgb and 0xFF
+    var matches = 0L
+    for (y in 0 until img.height) {
+      for (x in 0 until img.width) {
+        val rgb = img.getRGB(x, y)
+        val r = (rgb shr 16) and 0xFF
+        val g = (rgb shr 8) and 0xFF
+        val b = rgb and 0xFF
+        if (
+          abs(r - expR) <= perChannelTolerance &&
+            abs(g - expG) <= perChannelTolerance &&
+            abs(b - expB) <= perChannelTolerance
+        ) {
+          matches++
+        }
+      }
+    }
+    val total = img.width.toLong() * img.height.toLong()
+    return matches.toDouble() / total.toDouble()
+  }
+}

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveDesktopRpcIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveDesktopRpcIntegrationTest.kt
@@ -1,0 +1,394 @@
+package ee.schimke.composeai.daemon
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.IOException
+import java.io.InputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import javax.imageio.ImageIO
+import kotlin.math.abs
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * v2 PR-2 desktop integration test — the honest "click reaches composition" assertion documented
+ * in [INTERACTIVE.md § 9.9.2](../../../../../../docs/daemon/INTERACTIVE.md).
+ *
+ * Drives a stateful composable ([ClickToGreenSquare]) through the full JSON-RPC interactive
+ * lifecycle:
+ * 1. `initialize` + `initialized`
+ * 2. `interactive/start` for the click-to-green preview — host allocates a [DesktopInteractiveSession]
+ *    holding a warm scene with `LocalInspectionMode = false`.
+ * 3. Pre-render via `renderNow` so we have a baseline PNG to compare against; assert the rendered
+ *    surface is mostly red.
+ * 4. `interactive/input` (kind: click) at coordinates inside the surface — the session dispatches
+ *    `Press` + `Release` through `ImageComposeScene.sendPointerEvent`, the click flips the
+ *    `remember`'d `mutableStateOf`, the re-render encodes a fresh PNG.
+ * 5. Assert the new PNG is mostly green — proving the input round-tripped end-to-end and the
+ *    held composition retained the state mutation across the input.
+ * 6. `interactive/stop` releases the session.
+ *
+ * **Why a held scene matters.** A v1 one-shot render path (which composes from scratch on each
+ * input) would reset the `remember { mutableStateOf(false) }` to `false` on every render and the
+ * test would forever see red. The fact that the post-click render observes green is the
+ * load-bearing proof of v2: the scene survives, the state mutation sticks, and the encoded PNG
+ * reflects the new composition.
+ *
+ * **Why `LocalInspectionMode = false` matters.** `Modifier.clickable` no-ops when inspection mode
+ * is true (Compose's inspection-mode contract). v2's [DesktopInteractiveSession] sets up its
+ * scene with `runInspectionMode = false` precisely so click handlers fire. Flipping that to
+ * `true` here would silently fail the assertion — the click would arrive but the modifier
+ * wouldn't dispatch.
+ *
+ * The harness scaffolding (piped streams + Content-Length frame reader) mirrors
+ * [JsonRpcDesktopIntegrationTest] and the FakeHost-driven plumbing test in `:daemon:core`'s
+ * [ee.schimke.composeai.daemon.InteractiveSessionPlumbingTest].
+ */
+class InteractiveDesktopRpcIntegrationTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Test(timeout = 120_000)
+  fun click_reaches_composition_red_becomes_green() {
+    val outputDir = tempFolder.newFolder("renders")
+    val engine = RenderEngine(outputDir = outputDir)
+    val host = ClickToGreenRoutingHost(engine = engine)
+
+    val clientToServerOut = PipedOutputStream()
+    val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
+    val serverToClientOut = PipedOutputStream()
+    val serverToClientIn = PipedInputStream(serverToClientOut, 64 * 1024)
+
+    val exitLatch = CountDownLatch(1)
+    val server =
+      JsonRpcServer(
+        input = clientToServerIn,
+        output = serverToClientOut,
+        host = host,
+        daemonVersion = "test-desktop-interactive",
+        onExit = { _ -> exitLatch.countDown() },
+      )
+    val serverThread =
+      Thread({ server.run() }, "json-rpc-desktop-interactive-test").apply { isDaemon = true }
+    serverThread.start()
+
+    val received = LinkedBlockingQueue<JsonObject>()
+    val readerThread =
+      Thread(
+          {
+            try {
+              while (true) {
+                val frame = readContentLengthFrame(serverToClientIn) ?: break
+                val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+                received.put(obj)
+              }
+            } catch (_: Throwable) {
+              // EOF / pipe close — fine, test asserts on what we got.
+            }
+          },
+          "json-rpc-desktop-interactive-test-reader",
+        )
+        .apply { isDaemon = true }
+    readerThread.start()
+
+    try {
+      // 1. initialize + initialized.
+      writeFrame(
+        clientToServerOut,
+        """
+        {"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+                  "protocolVersion":1,
+                  "clientVersion":"test",
+                  "workspaceRoot":"/tmp",
+                  "moduleId":":test",
+                  "moduleProjectDir":"/tmp",
+                  "capabilities":{"visibility":true,"metrics":false}
+                }}
+        """
+          .trimIndent(),
+      )
+      val initResponse = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 1 }
+      assertNotNull("initialize response should arrive", initResponse)
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"initialized","params":{}}""")
+
+      // 2. interactive/start. Host allocates a held DesktopInteractiveSession with
+      //    LocalInspectionMode = false — Modifier.clickable inside the fixture only fires when
+      //    inspection mode is off.
+      writeFrame(
+        clientToServerOut,
+        """
+        {"jsonrpc":"2.0","id":2,"method":"interactive/start","params":{
+                  "previewId":"click-to-green"
+                }}
+        """
+          .trimIndent(),
+      )
+      val startResponse = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 2 }
+      assertNotNull("interactive/start response should arrive", startResponse)
+      val streamId =
+        startResponse!!["result"]!!.jsonObject["frameStreamId"]!!.jsonPrimitive.contentOrNull!!
+
+      // 3. Pre-render via renderNow so we have a baseline PNG. The host's submit() override re-
+      //    routes the JsonRpcServer's `previewId=click-to-green` payload into a parseable spec
+      //    pointing at the same fixture; the renderFinished bytes encode the current composition
+      //    — red, since the click hasn't fired yet.
+      writeFrame(
+        clientToServerOut,
+        """
+        {"jsonrpc":"2.0","id":3,"method":"renderNow","params":{
+                  "previews":["click-to-green"],"tier":"fast"
+                }}
+        """
+          .trimIndent(),
+      )
+      pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 3 }
+      val baselineFinished =
+        pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+      assertNotNull("baseline renderFinished must arrive", baselineFinished)
+      val baselinePngPath =
+        baselineFinished!!["params"]!!
+          .jsonObject["pngPath"]
+          ?.jsonPrimitive
+          ?.contentOrNull!!
+      val baselineFile = File(baselinePngPath)
+      assertTrue("baseline PNG must exist on disk: $baselinePngPath", baselineFile.exists())
+      assertMostlyColor(baselineFile, "baseline (pre-click)", expectedRgb = 0xEF5350)
+
+      // 4. interactive/input — click roughly in the centre of the 64x64 surface. Density on the
+      //    fixture is 1.0 so image-natural pixels equal scene px directly. The session dispatches
+      //    Press + Release back-to-back at the same position (CLICK semantics).
+      writeFrame(
+        clientToServerOut,
+        """
+        {"jsonrpc":"2.0","method":"interactive/input","params":{
+                  "frameStreamId":"$streamId","kind":"click",
+                  "pixelX":32,"pixelY":32
+                }}
+        """
+          .trimIndent(),
+      )
+      val postClickFinished =
+        pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+      assertNotNull("post-click renderFinished must arrive", postClickFinished)
+      val postClickPngPath =
+        postClickFinished!!["params"]!!
+          .jsonObject["pngPath"]
+          ?.jsonPrimitive
+          ?.contentOrNull!!
+      val postClickFile = File(postClickPngPath)
+      assertTrue(
+        "post-click PNG must exist on disk: $postClickPngPath",
+        postClickFile.exists(),
+      )
+      // The load-bearing assertion: the click flipped the remember'd state and the held scene
+      // re-rendered green.
+      assertMostlyColor(postClickFile, "post-click", expectedRgb = 0x66BB6A)
+
+      // 5. interactive/stop releases the held session.
+      writeFrame(
+        clientToServerOut,
+        """
+        {"jsonrpc":"2.0","method":"interactive/stop","params":{
+                  "frameStreamId":"$streamId"
+                }}
+        """
+          .trimIndent(),
+      )
+      // No response expected (notification); give the daemon a tick to release the session.
+      Thread.sleep(50)
+
+      // 6. shutdown + exit.
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","id":99,"method":"shutdown"}""")
+      pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 99 }
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"exit"}""")
+      assertTrue(
+        "server should invoke onExit() within 30s of exit notification",
+        exitLatch.await(30, TimeUnit.SECONDS),
+      )
+    } finally {
+      try {
+        clientToServerOut.close()
+      } catch (_: Throwable) {}
+      try {
+        serverToClientIn.close()
+      } catch (_: Throwable) {}
+      serverThread.join(15_000)
+    }
+  }
+
+  // ----- assertion helpers -----
+
+  private fun assertMostlyColor(pngFile: File, label: String, expectedRgb: Int) {
+    val bytes = pngFile.readBytes()
+    val img = ByteArrayInputStream(bytes).use { ImageIO.read(it) }
+    assertNotNull("$label PNG must decode via javax.imageio", img)
+    // Tolerance 32: ImageComposeScene renders against a transparent backing surface, so the
+    // tinted material colours come back several LSB darker than the literal hex (e.g. #66BB6A
+    // observed as #5BA85F) once Skia has composited and the AWT decoder has gone through
+    // ARGB → RGB unpremultiply. Wide tolerance to keep the assertion robust against rendering
+    // pipeline drift; the load-bearing claim is "this is the green fixture, not the red one",
+    // which a single-channel-of-32 tolerance still differentiates trivially.
+    val matchPct = pixelMatchPct(img!!, expectedRgb, perChannelTolerance = 32)
+    assertTrue(
+      "$label: expected ≥ 90% of pixels close to #${expectedRgb.toString(16).padStart(6, '0')}; " +
+        "got ${"%.2f".format(matchPct * 100)}%",
+      matchPct >= 0.90,
+    )
+  }
+
+  private fun pixelMatchPct(
+    img: java.awt.image.BufferedImage,
+    expectedRgb: Int,
+    perChannelTolerance: Int,
+  ): Double {
+    val expR = (expectedRgb shr 16) and 0xFF
+    val expG = (expectedRgb shr 8) and 0xFF
+    val expB = expectedRgb and 0xFF
+    var matches = 0L
+    for (y in 0 until img.height) {
+      for (x in 0 until img.width) {
+        val rgb = img.getRGB(x, y)
+        val r = (rgb shr 16) and 0xFF
+        val g = (rgb shr 8) and 0xFF
+        val b = rgb and 0xFF
+        if (
+          abs(r - expR) <= perChannelTolerance &&
+            abs(g - expG) <= perChannelTolerance &&
+            abs(b - expB) <= perChannelTolerance
+        ) {
+          matches++
+        }
+      }
+    }
+    val total = img.width.toLong() * img.height.toLong()
+    return matches.toDouble() / total.toDouble()
+  }
+
+  // ----- piped-stream + framer scaffolding (mirrors JsonRpcDesktopIntegrationTest) -----
+
+  private fun writeFrame(out: PipedOutputStream, json: String) {
+    val payload = json.toByteArray(Charsets.UTF_8)
+    out.write("Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII))
+    out.write(payload)
+    out.flush()
+  }
+
+  private fun readContentLengthFrame(input: InputStream): ByteArray? {
+    var contentLength = -1
+    var sawAny = false
+    while (true) {
+      val line =
+        readHeaderLine(input) ?: return if (sawAny) throw IOException("EOF in headers") else null
+      sawAny = true
+      if (line.isEmpty()) break
+      val colon = line.indexOf(':')
+      if (colon <= 0) throw IOException("malformed header: '$line'")
+      val name = line.substring(0, colon).trim()
+      val value = line.substring(colon + 1).trim()
+      if (name.equals("Content-Length", ignoreCase = true)) {
+        contentLength = value.toIntOrNull() ?: throw IOException("non-int Content-Length: '$value'")
+      }
+    }
+    if (contentLength < 0) throw IOException("missing Content-Length")
+    val payload = ByteArray(contentLength)
+    var off = 0
+    while (off < contentLength) {
+      val n = input.read(payload, off, contentLength - off)
+      if (n < 0) throw IOException("EOF mid-payload")
+      off += n
+    }
+    return payload
+  }
+
+  private fun readHeaderLine(input: InputStream): String? {
+    val buf = ByteArrayOutputStream(64)
+    while (true) {
+      val b = input.read()
+      if (b < 0) return if (buf.size() == 0) null else buf.toString(Charsets.US_ASCII.name())
+      if (b == '\n'.code) {
+        val bytes = buf.toByteArray()
+        val end =
+          if (bytes.isNotEmpty() && bytes.last() == '\r'.code.toByte()) bytes.size - 1
+          else bytes.size
+        return String(bytes, 0, end, Charsets.US_ASCII)
+      }
+      buf.write(b)
+    }
+  }
+
+  private fun pollUntil(
+    queue: LinkedBlockingQueue<JsonObject>,
+    timeoutMs: Long = 60_000,
+    matcher: (JsonObject) -> Boolean,
+  ): JsonObject? {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (System.currentTimeMillis() < deadline) {
+      val remaining = (deadline - System.currentTimeMillis()).coerceAtLeast(0)
+      val msg = queue.poll(remaining, TimeUnit.MILLISECONDS) ?: return null
+      if (matcher(msg)) return msg
+    }
+    return null
+  }
+}
+
+/**
+ * Test [DesktopHost] subclass that:
+ * - resolves the previewId `click-to-green` to a [RenderSpec] for [ClickToGreenSquare] via the v2
+ *   [DesktopHost.resolveInteractiveSpec] hook so `interactive/start` allocates a real held scene,
+ * - rewrites the inbound non-interactive `submit()` payload (which `JsonRpcServer.handleRenderNow`
+ *   ships as `previewId=click-to-green` only — see the file KDoc on [JsonRpcDesktopIntegrationTest])
+ *   to a parseable spec so the baseline `renderNow` produces a real PNG.
+ *
+ * Mirrors the `SpecRoutingHost` pattern from [JsonRpcDesktopIntegrationTest]; the resolveInteractiveSpec
+ * override is the v2 addition. Both routes (interactive + non-interactive renderNow) target the same
+ * fixture composable so the baseline-vs-post-click PNG comparison is apples-to-apples.
+ */
+private class ClickToGreenRoutingHost(engine: RenderEngine) : DesktopHost(engine = engine) {
+
+  override fun submit(request: RenderRequest, timeoutMs: Long): RenderResult {
+    require(request !is RenderRequest.Shutdown) {
+      "Use shutdown() to stop the host, not submit(Shutdown)."
+    }
+    val typed = request as RenderRequest.Render
+    val routed =
+      RenderRequest.Render(
+        id = typed.id,
+        payload =
+          "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+            "functionName=ClickToGreenSquare;" +
+            "widthPx=64;heightPx=64;density=1.0;" +
+            "showBackground=true;" +
+            "outputBaseName=click-to-green-${typed.id}",
+      )
+    return super.submit(routed, timeoutMs)
+  }
+
+  override fun resolveInteractiveSpec(previewId: String): RenderSpec? =
+    if (previewId == "click-to-green") {
+      RenderSpec(
+        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        functionName = "ClickToGreenSquare",
+        widthPx = 64,
+        heightPx = 64,
+        density = 1.0f,
+        showBackground = true,
+        outputBaseName = "click-to-green-interactive",
+      )
+    } else null
+}

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -1,9 +1,14 @@
 package ee.schimke.composeai.daemon
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 
@@ -64,4 +69,27 @@ fun GreenSquare() {
 @Composable
 fun BoomComposable() {
   error("boom")
+}
+
+/**
+ * Fixture for the v2 PR-2 desktop interactive integration test (INTERACTIVE.md § 9.9.2). Paints
+ * red on first composition; flips a `remember`'d `mutableStateOf` to green on the first
+ * click anywhere in the surface, so the test can assert "click reaches the composition" by
+ * comparing pre-click and post-click PNG bytes.
+ *
+ * The state lives in a `remember { mutableStateOf(...) }` — the load-bearing assertion of v2's
+ * "held composition" promise: a one-shot render path would reset this state on every render and
+ * the flip would never become visible. The interactive session keeps the scene warm across
+ * inputs, so the recomposition sticks and the second render observes green.
+ *
+ * `Modifier.clickable` requires `LocalInspectionMode = false` (otherwise the modifier no-ops, per
+ * Compose's inspection-mode contract). v2's [DesktopInteractiveSession] sets up its scene with
+ * `runInspectionMode = false`, so the click reaches us; v1's one-shot render would still pass
+ * inspection-mode = true and the click would be silently dropped.
+ */
+@Composable
+fun ClickToGreenSquare() {
+  var clicked by remember { mutableStateOf(false) }
+  val color = if (clicked) Color(0xFF66BB6A) else Color(0xFFEF5350)
+  Box(modifier = Modifier.fillMaxSize().background(color).clickable { clicked = true })
 }


### PR DESCRIPTION
## Summary

PR-2 of the Interactive v2 rollout — desktop-side held scene so `interactive/input` actually mutates the composition. Implements [INTERACTIVE.md § 9](docs/daemon/INTERACTIVE.md#9-v2--click-dispatch-into-composition).

- `RenderEngine.render` is split into `setUp` / `renderOnce` / `tearDown`; the existing one-shot `render` becomes a thin wrapper. Held scenes are the new `HeldScene` data class.
- New `DesktopInteractiveSession` implements the `:daemon:core` `InteractiveSession` interface — `dispatch(input)` routes pixel coords through `ImageComposeScene.sendPointerEvent` (with `LocalInspectionMode = false` so `pointerInput` modifiers fire), `render()` re-encodes a PNG, `close()` tears down.
- `DesktopHost.acquireInteractiveSession` returns a per-stream proxy over a ref-counted shared `DesktopInteractiveSession`; two `interactive/start` calls on the same `previewId` share one composition state per § 9.7.
- Android keeps the default `UnsupportedOperationException` — `JsonRpcServer.handleInteractiveStart` translates that to v1 fallback.

## Notable deviations from the spec

1. **Inter-event render between Press and Release.** `Modifier.clickable`'s gesture detector cancels events that arrive in the same dispatch tick — `dispatch(CLICK)` does `sendPointerEvent(Press) → scene.render() → sendPointerEvent(Release)`. The post-input `render()` then settles the post-Release frame normally. Wire shape unchanged.
2. **`PointerButton.Primary` on every Press/Release.** § 9.4's sketch elides the `button` parameter; `Modifier.clickable` only fires for primary clicks, so the session sets it explicitly.
3. **Bootstrap render in `acquireInteractiveSession`.** Compose's hit-testing has no measured tree until the first render — bootstrap pixels aren't shipped, only the layout pass matters.
4. **`resolveInteractiveSpec` hook on `DesktopHost`.** § 9.8's interface only carries `previewId` + `classLoader`; production needs a way to map previewId → `RenderSpec`. Added a `protected open fun resolveInteractiveSpec(previewId): RenderSpec?`. Default returns `null` (→ `UnsupportedOperationException` → v1 fallback). `PreviewManifestRouter` overrides it; tests subclass to pin a fixture.
5. **Per-call context-classloader install.** The original one-shot installed once around the whole render. The split moves install responsibility outward — `dispatch` and `render` install on whatever thread the JsonRpcServer worker uses.
6. **Headless AWT.** Key dispatch needs an AWT `Component` as event source — switched from `Label` (which throws `HeadlessException`) to a lazy `Canvas()` wrapped in try/catch. Click events don't touch this path.
7. **Pixel tolerance 32 (vs `RenderEngineTest`'s 8)** in the new integration test — `ImageComposeScene` renders against transparent and unpremultiply drift is several LSB. Still trivially distinguishes red ↔ green.

## Test plan

- [x] `:daemon:desktop:test` — 18 tests green, including 2 new:
  - `DesktopInteractiveSessionTest` — unit-level dispatch/render/close coverage.
  - `InteractiveDesktopRpcIntegrationTest` — full JSON-RPC round trip against a stateful `ClickToGreenSquare` fixture (red on first frame, green after one click).
- [x] `:daemon:core:test` — all green, including the existing `InteractiveSessionPlumbingTest` and `InteractiveRpcIntegrationTest`.
- [ ] Manual: drive an interactive session via the panel (post-merge) once a v2-supporting host advertises capability.

## Follow-ups (not in this PR)

- Wire a `interactive: Boolean` capability bit on `InitializeResult.capabilities` so clients can render an "unsupported host" hint cleanly. Small follow-up PR.
- Widen `PreviewInfoDto` in `:daemon:core` with `widthDp` / `heightDp` / `density` from the gradle plugin's discovery output so interactive scenes match `@Preview(widthDp=…)` exactly. Today the `resolveInteractiveSpec` hook gives subclasses a place to thread this; the wire/discovery widening is a separate PR.
- `LocalInspectionMode` opt-in story (currently hardcoded `false` for v2 sessions). Some previews assume `true`; design call pending.
- Robolectric `acquireInteractiveSession` (Android v3) — INTERACTIVE.md § 9.10 already calls this out as its own design pass.
- Pin `LANG=C.UTF-8 LC_ALL=C.UTF-8` in `gradle.properties` — the Kotlin compile daemon defaults to ASCII for `sun.jnu.encoding` and chokes on em-dashes in `@Test` names (pre-existing repo-wide; only affects fresh checkouts that don't inherit the user's locale).
- `RenderEngine.setUp` could opt the scene into an opaque background when `showBackground=true` to avoid the unpremultiply drift that forced tolerance 32 on the new tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYvTgEGDJxSu9gAGUTF9ub)_