### PR TITLE
feat(vscode): auto-subscribe a11y/atf for diagnostics in daemon mode

### DIFF
--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -64,11 +64,20 @@ export interface SchedulerEvents {
 const HEAVY_TIER_DEFAULT: RenderTier = 'fast';
 
 /**
- * D2 — kinds the focus-mode "Show a11y overlay" button toggles. Pinned to the a11y producer
- * so the local finding + hierarchy overlays light up together; a future panel that wants to
- * subscribe to other kinds (`compose/recomposition`, `layout/tree`) will export its own list.
+ * D2 — kinds the focus-mode "Show accessibility overlay" toggle adds on top of the ambient
+ * subscriptions. `a11y/atf` is ambient (see [AMBIENT_A11Y_KINDS]) so the diagnostic squigglies
+ * stay live without a user gesture; the toggle layers `a11y/hierarchy` for the visual overlay.
  */
-export const A11Y_OVERLAY_KINDS: readonly string[] = ['a11y/atf', 'a11y/hierarchy'];
+export const A11Y_OVERLAY_KINDS: readonly string[] = ['a11y/hierarchy'];
+
+/**
+ * D2 — kinds auto-subscribed per visible preview. Pinned to `a11y/atf` because (a) it's the
+ * cheap-always-on kind the design doc reserves for ambient attach and (b) the diagnostic
+ * squigglies in the Problems panel read straight off it via [PreviewA11yDiagnostics] →
+ * [PreviewRegistry] → wire. The hierarchy overlay (heavier visual layer) stays toggle-gated
+ * via [A11Y_OVERLAY_KINDS] so the wire stays quiet for cards the user isn't actively examining.
+ */
+const AMBIENT_A11Y_KINDS: readonly string[] = ['a11y/atf'];
 /**
  * Cards we'll pre-render ahead of the visible viewport on each scroll-ahead
  * push from the webview. Bounded so a fast scroll past 50 cards doesn't
@@ -223,9 +232,7 @@ export class DaemonScheduler {
 
         // D2 — drop bookkeeping for previews that fell out of view. The daemon already
         // pruned its side on the same `setVisible`, so this just keeps our local dedup
-        // set in sync. Subscriptions themselves are now opt-in per focused preview via
-        // [setDataProductSubscription]; the panel calls in when the user toggles the
-        // a11y overlay in focus mode.
+        // set in sync.
         const visibleSetForSub = new Set(visible);
         const modulePrefix = `${moduleId}::`;
         for (const key of [...this.subscribedPairs]) {
@@ -234,6 +241,27 @@ export class DaemonScheduler {
             const sep = rest.indexOf('::');
             const id = sep < 0 ? rest : rest.slice(0, sep);
             if (!visibleSetForSub.has(id)) { this.subscribedPairs.delete(key); }
+        }
+
+        // D2 — auto-subscribe ambient kinds (currently `a11y/atf`) for newly-visible previews.
+        // Drives diagnostic squigglies (PreviewA11yDiagnostics reads off the registry, registry
+        // is fed by `onDataProductsAttached`) without the user having to enter focus mode.
+        // Heavier kinds (`a11y/hierarchy`, future `compose/recomposition`) stay toggle-gated.
+        // dataSubscribe rejects gracefully (DataProductUnknown) on pre-D2 daemons; absorbed
+        // and logged so the panel keeps working unchanged.
+        for (const id of visible) {
+            for (const kind of AMBIENT_A11Y_KINDS) {
+                const subKey = `${moduleId}::${id}::${kind}`;
+                if (this.subscribedPairs.has(subKey)) { continue; }
+                this.subscribedPairs.add(subKey);
+                client.dataSubscribe({ previewId: id, kind }).catch((err) => {
+                    const msg = (err as Error)?.message ?? String(err);
+                    this.logger.appendLine(
+                        `[daemon] dataSubscribe(${id}, ${kind}) failed (pre-D2 daemon?): ${msg}`,
+                    );
+                    this.subscribedPairs.delete(subKey);
+                });
+            }
         }
 
         if (predicted.length === 0) { return; }

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -528,16 +528,50 @@ describe('DaemonScheduler', () => {
     });
 
     /**
-     * D2 — data-product surface. Subscriptions are explicit per focused preview (the panel's
-     * focus-mode "Show a11y overlay" toggle drives them) — `setVisible` itself does NOT
-     * subscribe, only prunes stale bookkeeping. `renderFinished` forwards attachments.
+     * D2 — data-product surface. `setVisible` auto-subscribes the ambient kinds (`a11y/atf`,
+     * cheap, drives diagnostic squigglies). Heavier kinds (`a11y/hierarchy`, the visual
+     * overlay) are explicit per focused preview via [setDataProductSubscription], which
+     * the panel's focus-mode toggle drives. `renderFinished` forwards attachments.
      */
     describe('data products', () => {
-        it('does not auto-subscribe on setVisible — subscriptions are explicit', async () => {
+        it('auto-subscribes a11y/atf for each newly-visible preview', async () => {
             const { gate, scheduler } = build();
             await scheduler.setVisible('mod', ['a', 'b'], []);
             const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
-            assert.strictEqual(subs.length, 0);
+            // One ambient kind per previewId — `a11y/atf` only.
+            assert.strictEqual(subs.length, 2);
+            const kinds = subs.map(c => (c.args as { kind: string }).kind);
+            assert.deepStrictEqual([...new Set(kinds)], ['a11y/atf']);
+            const ids = subs.map(c => (c.args as { previewId: string }).previewId).sort();
+            assert.deepStrictEqual(ids, ['a', 'b']);
+        });
+
+        it('does not auto-subscribe a11y/hierarchy on setVisible — that stays toggle-gated', async () => {
+            const { gate, scheduler } = build();
+            await scheduler.setVisible('mod', ['a'], []);
+            const hierarchySubs = gate.client!.calls
+                .filter(c => c.method === 'dataSubscribe')
+                .filter(c => (c.args as { kind: string }).kind === 'a11y/hierarchy');
+            assert.strictEqual(hierarchySubs.length, 0);
+        });
+
+        it('does not re-subscribe a (previewId, kind) pair on a repeated setVisible', async () => {
+            const { gate, scheduler } = build();
+            await scheduler.setVisible('mod', ['a'], []);
+            await scheduler.setVisible('mod', ['a', 'b'], []); // 'a' is already subscribed
+            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            // 'a' atf (1) + 'b' atf (1) = 2 — 'a' is NOT re-subscribed.
+            assert.strictEqual(subs.length, 2);
+        });
+
+        it('drops bookkeeping when a preview leaves visible — re-visible re-subscribes', async () => {
+            const { gate, scheduler } = build();
+            await scheduler.setVisible('mod', ['a', 'b'], []);
+            await scheduler.setVisible('mod', ['a'], []); // 'b' fell out
+            await scheduler.setVisible('mod', ['a', 'b'], []); // 'b' back
+            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            // Initial 2 + 'b' re-subscribed once = 3.
+            assert.strictEqual(subs.length, 3);
         });
 
         it('setDataProductSubscription(true) issues data/subscribe per kind', async () => {
@@ -584,16 +618,17 @@ describe('DaemonScheduler', () => {
         });
 
         it('setVisible drops bookkeeping for previews that left view', async () => {
+            // Drive this through the toggle-only `a11y/hierarchy` kind so the ambient
+            // `a11y/atf` auto-subscribe doesn't muddy the count. Intent: when 'a' leaves
+            // visible, local bookkeeping clears so a future explicit re-subscribe re-issues.
             const { gate, scheduler } = build();
-            await scheduler.setVisible('mod', ['a', 'b'], []);
-            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
+            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/hierarchy'], true);
             await scheduler.setVisible('mod', ['b'], []); // 'a' fell out
-            // Re-subscribing 'a' should issue another subscribe (bookkeeping was cleared by
-            // the visibility prune even though the daemon never received our explicit call).
-            await scheduler.setVisible('mod', ['a', 'b'], []);
-            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
-            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
-            assert.strictEqual(subs.length, 2);
+            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/hierarchy'], true);
+            const hierarchySubs = gate.client!.calls
+                .filter(c => c.method === 'dataSubscribe')
+                .filter(c => (c.args as { kind: string }).kind === 'a11y/hierarchy');
+            assert.strictEqual(hierarchySubs.length, 2);
         });
 
         it('forwards renderFinished.dataProducts via onDataProductsAttached', async () => {


### PR DESCRIPTION
## Summary

Splits the D2 a11y kinds along the design doc's "ambient vs. opt-in" axis so `PreviewA11yDiagnostics` works in daemon mode without requiring the user to enter focus mode and toggle the overlay on.

- `a11y/atf` is the cheap-always-on kind. Auto-subscribe per visible preview (driven by `setVisible`) so findings flow into the `PreviewRegistry` ambient — the diagnostic squigglies in the Problems panel read straight off it.
- `a11y/hierarchy` stays toggle-gated via the focus-mode "Show accessibility overlay" button. It's the heavier visual layer; no point firing it for cards outside the spotlight.

`PreviewA11yDiagnostics` itself doesn't change — it already reads `entry.preview.a11yFindings` from the registry and listens to `registry.onDidChange`. The migration is making sure the daemon path feeds the registry ambient, matching what the Gradle sidecar reader already does at manifest-load time. Both paths now converge on the same registry; diagnostics is source-agnostic.

## Test plan

- [x] `vscode-extension/` `npm test` — 317 tests pass; scheduler tests updated to assert the split (setVisible auto-subscribes atf only; hierarchy absent until the toggle drives it).
- [x] TypeScript compile clean (`npm run compile`).
- [ ] Manual smoke (consumer side): start daemon-mode panel without focus, verify ATF-derived squigglies appear on `@Preview` annotations whose composables fail an ATF check; enter focus + click eye toggle, verify hierarchy overlay also paints.

Spec: [`docs/daemon/DATA-PRODUCTS.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/daemon/DATA-PRODUCTS.md) § "Catalogue" — `a11y/atf` is flagged as low-cost / candidate for global attach; this PR realises that.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVoxnr38t4n1LEatFc1yGe)_