### PR TITLE
feat(daemon): data/fetch re-render-on-demand with per-request budget

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
@@ -72,6 +72,28 @@ interface DataProductRegistry {
 
     /** Re-render budget tripped → `DataProductBudgetExceeded` (-32023). */
     data object BudgetExceeded : Outcome
+
+    /**
+     * D3 — the latest pass didn't compute the kind and producing it requires a fresh render in the
+     * named [mode] (DATA-PRODUCTS.md § "Re-render semantics"). The dispatcher
+     * ([JsonRpcServer.handleDataFetch]) reacts by:
+     *
+     * 1. Queueing a re-render of just `previewId` in [mode], emitting a normal
+     *    `renderStarted`/`renderFinished` so the panel UI updates the PNG if it changed.
+     * 2. Bounding the wait by the per-request budget (`composeai.daemon.dataFetchRerenderBudgetMs`,
+     *    default 30000ms). On budget exceeded the dispatcher returns
+     *    [Outcome.BudgetExceeded]'s wire error (`-32023`) — but per the spec the render is *not*
+     *    cancelled, the fetch just gives up waiting for it.
+     * 3. Re-invoking [fetch] once the render lands so the registry can return [Ok] (or another
+     *    failure) against the now-current pass.
+     *
+     * `mode` is a renderer-side mode tag (e.g. `"a11y"`, `"recomposition"`); the dispatcher
+     * forwards it through the host payload's `mode=<mode>` key so the renderer-agnostic seam stays
+     * stringly-typed. Producers pick the smallest mode that produces the kind — different kinds
+     * MAY share a mode, in which case a follow-up D-step can opportunistically piggy-back fetches
+     * against an already-queued re-render.
+     */
+    data class RequiresRerender(val mode: String) : Outcome
   }
 
   companion object {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -180,6 +180,21 @@ class JsonRpcServer(
    * in `renderer-android`) is the first concrete implementation that gets wired in by `DaemonMain`.
    */
   private val dataProducts: DataProductRegistry = DataProductRegistry.Empty,
+  /**
+   * D3 — per-request budget for `data/fetch` re-render-on-demand (DATA-PRODUCTS.md §
+   * "Re-render semantics"). When the registry returns
+   * [DataProductRegistry.Outcome.RequiresRerender] the dispatcher queues a fresh render in the
+   * required mode and waits at most this many milliseconds for the payload to land. On timeout we
+   * return `DataProductBudgetExceeded` (-32023); the render itself is **not** cancelled —
+   * Robolectric mid-render cancellation is unsafe (PROTOCOL.md § 8) — the fetch just stops waiting
+   * and lets the regular `renderFinished` notification ship when the render eventually completes.
+   *
+   * Default 30000ms per the spec. Overridable via the
+   * [DATA_FETCH_RERENDER_BUDGET_PROP] sysprop or the constructor (tests pin it small).
+   */
+  private val dataFetchRerenderBudgetMs: Long =
+    System.getProperty(DATA_FETCH_RERENDER_BUDGET_PROP)?.toLongOrNull()
+      ?: DEFAULT_DATA_FETCH_RERENDER_BUDGET_MS,
   private val onExit: (Int) -> Unit = { code -> System.exit(code) },
 ) {
 
@@ -260,6 +275,18 @@ class JsonRpcServer(
    * subscribe / unsubscribe / attachment-build can race without locking.
    */
   private val subscriptions = ConcurrentHashMap<String, MutableSet<String>>()
+
+  /**
+   * D3 — per-render `data/fetch` waiters. When `data/fetch` triggers a re-render via
+   * [DataProductRegistry.Outcome.RequiresRerender], the dispatcher registers a future against the
+   * host-side render id; [emitRenderFinished] / [emitRenderFailed] complete it as soon as the
+   * watcher loop processes the result. The waiter then re-invokes `dataProducts.fetch` to get the
+   * payload. On budget timeout the waiter abandons the entry — but does NOT cancel the render
+   * (PROTOCOL.md § 8 — no mid-render cancellation), so a stale entry may linger; the watcher
+   * cleans it up when the render eventually finishes.
+   */
+  private val dataFetchWaiters =
+    ConcurrentHashMap<Long, java.util.concurrent.CompletableFuture<RerenderOutcome>>()
 
   // ----------------------------------------------------------------------
   // Interactive (live-stream) mode state — see docs/daemon/INTERACTIVE.md.
@@ -791,6 +818,11 @@ class JsonRpcServer(
     }
     inFlightRenders.remove(result.id)
     previewIdsWithOverridesInFlight.remove(previewId)
+    // D3 — wake any `data/fetch` waiter that queued this render. The waiter re-invokes
+    // `dataProducts.fetch` to materialise the payload. We complete the future regardless of
+    // dedup (`unchanged: true`): the producer's payload may have changed even when the bytes
+    // didn't (an a11y projection re-computed against the same view tree, etc.).
+    dataFetchWaiters.remove(result.id)?.complete(RerenderOutcome.Ok(previewId))
     // Save-after-render invariant: a `fileChanged({kind:source})` queued discovery work that has
     // been waiting for this render to ship. The writer queue is FIFO and `renderFinished` is
     // already in it — kicking the discovery scan now guarantees its `discoveryUpdated`
@@ -1177,6 +1209,13 @@ class JsonRpcServer(
     acceptedAtMs.remove(failure.hostId)
     inFlightRenders.remove(failure.hostId)
     previewIdsWithOverridesInFlight.remove(previewId)
+    // D3 — wake any data/fetch waiter that queued this render so it can return
+    // DataProductFetchFailed rather than ride out its budget.
+    dataFetchWaiters
+      .remove(failure.hostId)
+      ?.complete(
+        RerenderOutcome.Failed(failure.cause.message ?: failure.cause.javaClass.simpleName)
+      )
     // Minimal renderFailed; B1.4 widens this to the real RenderError shape.
     val payload = buildJsonObject {
       put("id", JsonPrimitive(previewId))
@@ -1298,9 +1337,169 @@ class JsonRpcServer(
         )
         return
       }
-    when (
-      val outcome = dataProducts.fetch(params.previewId, params.kind, params.params, params.inline)
-    ) {
+    val outcome = dataProducts.fetch(params.previewId, params.kind, params.params, params.inline)
+    if (outcome is DataProductRegistry.Outcome.RequiresRerender) {
+      // D3 — kick the re-render off the read loop so other notifications / requests aren't
+      // blocked while we wait out the budget. The worker thread submits the render, parks on a
+      // future the watcher loop completes, then re-asks the registry for the payload.
+      handleDataFetchWithRerender(req, params, outcome.mode)
+      return
+    }
+    sendDataFetchOutcome(req, params, outcome)
+  }
+
+  /**
+   * D3 — handler for the [DataProductRegistry.Outcome.RequiresRerender] branch. Spawns a worker
+   * thread (mirrors [submitRenderAsync]'s "fresh thread per call" model — we expect at most a few
+   * concurrent fetch-driven re-renders from a UI panel) that:
+   *
+   * 1. Submits a [RenderRequest.Render] keyed by a fresh host id, payload tagged with the required
+   *    `mode=<mode>`. The submit goes through the regular [host] path so the watcher loop emits
+   *    `renderStarted`/`renderFinished` exactly as for a `renderNow`-driven render — the panel UI
+   *    repaints if the PNG changed (DATA-PRODUCTS.md:291-293).
+   * 2. Parks on a [java.util.concurrent.CompletableFuture] keyed by that host id, with the
+   *    per-request budget ([dataFetchRerenderBudgetMs]) as the deadline. The future is completed
+   *    by [emitRenderFinished] / [emitRenderFailed] when the watcher processes the result.
+   * 3. On `Ok`, re-invokes `dataProducts.fetch(...)` and routes the resulting [Outcome] to the
+   *    wire via [sendDataFetchOutcome]. On `Failed`, returns `DataProductFetchFailed`. On budget
+   *    timeout, returns `DataProductBudgetExceeded`; the render itself keeps going and the
+   *    waiter entry is leaked into `dataFetchWaiters` until the watcher finally clears it
+   *    (PROTOCOL.md § 8 — no mid-render cancellation).
+   */
+  private fun handleDataFetchWithRerender(
+    req: JsonRpcRequest,
+    params: DataFetchParams,
+    mode: String,
+  ) {
+    val hostId = RenderHost.nextRequestId()
+    val previewId = params.previewId
+    val future = java.util.concurrent.CompletableFuture<RerenderOutcome>()
+    dataFetchWaiters[hostId] = future
+    hostIdToPreviewId[hostId] = previewId
+    acceptedAtMs[hostId] = System.currentTimeMillis()
+    inFlightRenders.add(hostId)
+    val payload = encodeRenderPayloadWithMode(previewId, mode)
+    Thread(
+        {
+          // Submit goes through the same render thread as renderNow but on a worker so the
+          // budget timer below is what bounds wall-clock — not the host's submit timeout.
+          submitRerenderForFetch(hostId, payload)
+          val budgetMs = dataFetchRerenderBudgetMs.coerceAtLeast(1L)
+          val outcome =
+            try {
+              future.get(budgetMs, TimeUnit.MILLISECONDS)
+            } catch (_: java.util.concurrent.TimeoutException) {
+              null
+            } catch (t: Throwable) {
+              RerenderOutcome.Failed(t.message ?: t.javaClass.simpleName)
+            }
+          when (outcome) {
+            null -> {
+              // Budget tripped. Don't cancel the render; just stop waiting. The watcher loop
+              // will still fire `renderFinished`/`renderFailed` when the host completes the
+              // render, and `dataFetchWaiters` is cleared at that point.
+              sendErrorResponse(
+                id = req.id,
+                code = ERR_DATA_PRODUCT_BUDGET_EXCEEDED,
+                message =
+                  "data/fetch: re-render budget (${budgetMs}ms) exceeded for kind " +
+                    "'${params.kind}'",
+              )
+            }
+            is RerenderOutcome.Failed -> {
+              sendErrorResponse(
+                id = req.id,
+                code = ERR_DATA_PRODUCT_FETCH_FAILED,
+                message =
+                  "data/fetch: re-render failed for kind '${params.kind}': ${outcome.message}",
+              )
+            }
+            is RerenderOutcome.Ok -> {
+              // Re-ask the registry. By this point the renderer has produced the artefact for
+              // the requested mode, so a real producer should return `Ok` (or `FetchFailed` if
+              // its projection step blew up). A second `RequiresRerender` is treated as a
+              // producer bug — we don't recurse, we surface a fetch-failed so callers see it.
+              val secondOutcome =
+                try {
+                  dataProducts.fetch(
+                    params.previewId,
+                    params.kind,
+                    params.params,
+                    params.inline,
+                  )
+                } catch (t: Throwable) {
+                  DataProductRegistry.Outcome.FetchFailed(
+                    "registry threw on post-rerender fetch: ${t.message ?: t.javaClass.simpleName}"
+                  )
+                }
+              if (secondOutcome is DataProductRegistry.Outcome.RequiresRerender) {
+                sendErrorResponse(
+                  id = req.id,
+                  code = ERR_DATA_PRODUCT_FETCH_FAILED,
+                  message =
+                    "data/fetch: producer requested a second re-render for kind " +
+                      "'${params.kind}' after one already landed (mode='${secondOutcome.mode}')",
+                )
+              } else {
+                sendDataFetchOutcome(req, params, secondOutcome)
+              }
+            }
+          }
+        },
+        "compose-ai-daemon-data-fetch-$hostId",
+      )
+      .apply { isDaemon = true }
+      .start()
+  }
+
+  /**
+   * Submits the fetch-driven re-render onto the host. Mirrors [submitRenderAsync] but takes a
+   * pre-encoded payload (with `mode=<mode>`) and routes failures into [renderResultsQueue] so the
+   * watcher loop's existing `renderFailed` path handles them — and so the [dataFetchWaiters]
+   * future is woken via [emitRenderFailed]'s completion call rather than by this thread.
+   */
+  private fun submitRerenderForFetch(hostId: Long, payload: String) {
+    Thread(
+        {
+          try {
+            val raw =
+              host.submit(RenderRequest.Render(id = hostId, payload = payload), timeoutMs = 5 * 60_000)
+            renderResultsQueue.put(raw)
+          } catch (e: Throwable) {
+            System.err.println(
+              "compose-ai-daemon: data/fetch host.submit($hostId) failed: ${e.message}"
+            )
+            renderResultsQueue.put(RenderResultOrFailure.Failure(hostId, e))
+          }
+        },
+        "compose-ai-daemon-data-fetch-submit-$hostId",
+      )
+      .apply { isDaemon = true }
+      .start()
+  }
+
+  /**
+   * D3 — encodes a [RenderRequest.Render.payload] with `previewId=<id>;mode=<mode>`. The `mode`
+   * key is consumed renderer-side (D2 / `renderer-android`) to pick the smallest render
+   * configuration that produces the requested kind — the daemon stays kind-agnostic and just
+   * forwards the producer-supplied tag. Fake-mode hosts (the test harness's `FakeHost`,
+   * `FakeRenderHost` in unit tests) ignore unknown payload keys, so this is forward-compatible.
+   */
+  private fun encodeRenderPayloadWithMode(previewId: String, mode: String): String =
+    buildString {
+      if (previewId.isNotEmpty()) append("previewId=").append(previewId)
+      if (mode.isNotEmpty()) {
+        if (isNotEmpty()) append(';')
+        append("mode=").append(mode)
+      }
+    }
+
+  private fun sendDataFetchOutcome(
+    req: JsonRpcRequest,
+    params: DataFetchParams,
+    outcome: DataProductRegistry.Outcome,
+  ) {
+    when (outcome) {
       is DataProductRegistry.Outcome.Ok ->
         sendResponse(req.id, encode(DataFetchResult.serializer(), outcome.result))
       DataProductRegistry.Outcome.Unknown ->
@@ -1326,6 +1525,16 @@ class JsonRpcServer(
           id = req.id,
           code = ERR_DATA_PRODUCT_BUDGET_EXCEEDED,
           message = "data/fetch: re-render budget exceeded for kind '${params.kind}'",
+        )
+      is DataProductRegistry.Outcome.RequiresRerender ->
+        // Should never reach here — the dispatch layer handles this branch upstream. Surface
+        // as fetch-failed if it does so the caller sees a clean error rather than a hang.
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_DATA_PRODUCT_FETCH_FAILED,
+          message =
+            "data/fetch: registry returned RequiresRerender(${outcome.mode}) outside the " +
+              "re-render dispatch path for kind '${params.kind}'",
         )
     }
   }
@@ -2027,6 +2236,18 @@ class JsonRpcServer(
     class Failure(val hostId: Long, val cause: Throwable) : RenderResultOrFailure
   }
 
+  /**
+   * D3 — completion signal for [dataFetchWaiters]. The watcher loop completes the future with
+   * [Ok] when the underlying render lands and with [Failed] when the host rejects it; the data-
+   * fetch worker thread reads which one it got and decides whether to re-call the registry, surface
+   * `DataProductFetchFailed`, or — on its own timeout path — surface `DataProductBudgetExceeded`.
+   */
+  private sealed interface RerenderOutcome {
+    data class Ok(val previewId: String) : RerenderOutcome
+
+    data class Failed(val message: String) : RerenderOutcome
+  }
+
   companion object {
     /** PROTOCOL.md § 7. */
     const val PROTOCOL_VERSION: Int = 1
@@ -2037,6 +2258,15 @@ class JsonRpcServer(
     /** PROTOCOL.md § 6 — `daemon.classpathDirtyGraceMs`, default 2000ms. */
     const val CLASSPATH_DIRTY_GRACE_PROP: String = "composeai.daemon.classpathDirtyGraceMs"
     const val DEFAULT_CLASSPATH_DIRTY_GRACE_MS: Long = 2_000L
+
+    /**
+     * DATA-PRODUCTS.md § "Re-render semantics" — `daemon.dataFetchRerenderBudgetMs`, default
+     * 30000ms. The per-request ceiling on a `data/fetch` that triggered a re-render. Sysprop
+     * override for tests; `JsonRpcServer` constructor param for in-process callers (the in-process
+     * integration tests pin it sub-second so the timeout branch is fast).
+     */
+    const val DATA_FETCH_RERENDER_BUDGET_PROP: String = "composeai.daemon.dataFetchRerenderBudgetMs"
+    const val DEFAULT_DATA_FETCH_RERENDER_BUDGET_MS: Long = 30_000L
 
     /**
      * Watchdog window between `fileChanged({kind:source})` and the (deferred) discovery scan. The

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DataFetchRerenderTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DataFetchRerenderTest.kt
@@ -1,0 +1,552 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * D3 — `data/fetch` re-render-on-demand behaviour. See
+ * [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md) §
+ * "Re-render semantics" + § "Wire surface > data/fetch".
+ *
+ * The tests drive the JSON-RPC surface end-to-end against a [FakeProducer] [DataProductRegistry]
+ * that swings between "needs a re-render" and "Ok with the payload" depending on whether a render
+ * has been observed for the requested preview. That lets us pin every documented branch
+ * (happy-path re-render -> payload, post-render-no-payload -> fetch-failed, budget-exceeded)
+ * without standing up a real renderer-side producer (D2 / `renderer-android` lands on a separate
+ * branch).
+ */
+class DataFetchRerenderTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  /**
+   * Happy path. Producer reports "needs a11y mode re-render" on the first fetch, the daemon kicks
+   * a re-render off the regular render-queue path, the watcher emits `renderStarted` /
+   * `renderFinished`, the producer returns `Ok` on re-call, and the `data/fetch` response
+   * resolves with the payload.
+   */
+  @Test(timeout = 30_000)
+  fun rerender_happy_path_emits_render_notifications_then_payload_response() {
+    val producer = FakeProducer(modeForKind = mapOf("a11y/hierarchy" to "a11y"))
+    runWithServer(producer = producer) { rpc ->
+      rpc.initialize()
+      rpc.send(
+        """
+        {"jsonrpc":"2.0","id":42,"method":"data/fetch","params":{
+          "previewId":"com.example.Foo_bar","kind":"a11y/hierarchy"
+        }}
+        """
+          .trimIndent()
+      )
+
+      // Renderer-side notifications fire as for a regular renderNow - UI panel updates the PNG.
+      val started =
+        rpc.pollUntil { it["method"]?.jsonPrimitive?.contentOrNull == "renderStarted" }
+      assertNotNull("renderStarted should fire for the fetch-driven re-render", started)
+      assertEquals(
+        "com.example.Foo_bar",
+        started!!["params"]!!.jsonObject["id"]?.jsonPrimitive?.contentOrNull,
+      )
+
+      val finished =
+        rpc.pollUntil { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+      assertNotNull("renderFinished should fire for the fetch-driven re-render", finished)
+      assertEquals(
+        "com.example.Foo_bar",
+        finished!!["params"]!!.jsonObject["id"]?.jsonPrimitive?.contentOrNull,
+      )
+
+      // Then the data/fetch response - payload from the post-rerender producer call.
+      val response = rpc.pollUntil { it["id"]?.jsonPrimitive?.intOrNull == 42 }
+      assertNotNull("data/fetch should resolve once the re-render produces the payload", response)
+      val result = response!!["result"]!!.jsonObject
+      assertEquals("a11y/hierarchy", result["kind"]?.jsonPrimitive?.contentOrNull)
+      assertEquals(1, result["schemaVersion"]?.jsonPrimitive?.intOrNull)
+      assertNotNull("payload must be present on Ok", result["payload"])
+
+      // The producer's render submit observed the propagated mode tag. Renderer-agnostic seam
+      // stays string-typed: payload carries `mode=a11y` so D2's renderer-side producer can pick
+      // the right pipeline.
+      val payload = producer.lastRenderPayload
+      assertNotNull("producer should observe the host payload", payload)
+      assertTrue(
+        "render payload should propagate `mode=a11y`, was: $payload",
+        payload!!.contains("mode=a11y"),
+      )
+      assertTrue(
+        "render payload should carry previewId, was: $payload",
+        payload.contains("previewId=com.example.Foo_bar"),
+      )
+    }
+  }
+
+  /**
+   * Budget exceeded. The producer never resolves its render (host blocks indefinitely), so the
+   * fetch worker hits its budget timer. Per spec: budget tripped -> `DataProductBudgetExceeded`
+   * (-32023); the render is not cancelled, the fetch just stops waiting.
+   */
+  @Test(timeout = 30_000)
+  fun rerender_budget_exceeded_returns_minus_32023_and_does_not_cancel_render() {
+    val producer = FakeProducer(modeForKind = mapOf("a11y/hierarchy" to "a11y"))
+    runWithServer(
+      producer = producer,
+      // Block forever - anything past the budget below trips the timeout branch.
+      blockHostSubmits = true,
+      // Pin tiny so the test takes ~75ms in the timeout branch rather than the default 30s.
+      dataFetchRerenderBudgetMs = 75,
+    ) { rpc ->
+      rpc.initialize()
+      rpc.send(
+        """
+        {"jsonrpc":"2.0","id":7,"method":"data/fetch","params":{
+          "previewId":"preview-X","kind":"a11y/hierarchy"
+        }}
+        """
+          .trimIndent()
+      )
+      val response = rpc.pollUntil { it["id"]?.jsonPrimitive?.intOrNull == 7 }
+      assertNotNull("data/fetch should resolve via the budget-timeout branch", response)
+      assertNull("budget-timeout response carries no result", response!!["result"])
+      val error = response["error"]?.jsonObject
+      assertNotNull("budget-timeout response must carry a JSON-RPC error", error)
+      assertEquals(
+        "must surface DataProductBudgetExceeded (-32023)",
+        -32023,
+        error!!["code"]?.jsonPrimitive?.intOrNull,
+      )
+      // No `renderFailed` notification - the render is blocked, not cancelled. This confirms
+      // we honour the no-mid-render-cancellation invariant from PROTOCOL.md section 8.
+      val sawRenderFailed =
+        rpc.history.toList().any { it["method"]?.jsonPrimitive?.contentOrNull == "renderFailed" }
+      assertFalse(
+        "budget timeout must not surface as a renderFailed notification - render is in-flight",
+        sawRenderFailed,
+      )
+    }
+  }
+
+  /**
+   * Producer raises `FetchFailed` *after* the re-render lands (e.g. its projection step blew up).
+   * Dispatcher must surface `DataProductFetchFailed` (-32022) to the client, not silently retry.
+   */
+  @Test(timeout = 30_000)
+  fun rerender_then_producer_failure_returns_minus_32022() {
+    val producer =
+      FakeProducer(
+        modeForKind = mapOf("a11y/hierarchy" to "a11y"),
+        postRerenderOutcome =
+          DataProductRegistry.Outcome.FetchFailed(
+            message = "projection blew up",
+            errorKind = "projection",
+          ),
+      )
+    runWithServer(producer = producer) { rpc ->
+      rpc.initialize()
+      rpc.send(
+        """
+        {"jsonrpc":"2.0","id":11,"method":"data/fetch","params":{
+          "previewId":"preview-Y","kind":"a11y/hierarchy"
+        }}
+        """
+          .trimIndent()
+      )
+      val response = rpc.pollUntil { it["id"]?.jsonPrimitive?.intOrNull == 11 }
+      assertNotNull(response)
+      val error = response!!["error"]?.jsonObject
+      assertNotNull("post-rerender producer failure must surface as JSON-RPC error", error)
+      assertEquals(
+        "must surface DataProductFetchFailed (-32022)",
+        -32022,
+        error!!["code"]?.jsonPrimitive?.intOrNull,
+      )
+    }
+  }
+
+  /**
+   * Producer returns `RequiresRerender` *again* after the re-render lands. The dispatcher must
+   * NOT recurse infinitely - surface a `DataProductFetchFailed` once and stop.
+   */
+  @Test(timeout = 30_000)
+  fun rerender_then_second_requires_rerender_does_not_loop() {
+    val producer =
+      FakeProducer(
+        modeForKind = mapOf("a11y/hierarchy" to "a11y"),
+        postRerenderOutcome = DataProductRegistry.Outcome.RequiresRerender("a11y"),
+      )
+    runWithServer(producer = producer) { rpc ->
+      rpc.initialize()
+      rpc.send(
+        """
+        {"jsonrpc":"2.0","id":31,"method":"data/fetch","params":{
+          "previewId":"preview-Z","kind":"a11y/hierarchy"
+        }}
+        """
+          .trimIndent()
+      )
+      val response = rpc.pollUntil { it["id"]?.jsonPrimitive?.intOrNull == 31 }
+      assertNotNull(response)
+      val error = response!!["error"]?.jsonObject
+      assertNotNull(error)
+      assertEquals(-32022, error!!["code"]?.jsonPrimitive?.intOrNull)
+    }
+  }
+
+  /**
+   * Pre-render-on-demand fast paths still work - `Outcome.Ok` returned directly skips the worker
+   * entirely. Pins that we haven't accidentally regressed the D1 "kind already produced" path
+   * by routing it through the new D3 worker.
+   */
+  @Test(timeout = 15_000)
+  fun ok_outcome_short_circuits_without_a_rerender() {
+    val producer =
+      FakeProducer(
+        // No re-render mode configured - first fetch returns Ok directly.
+        modeForKind = emptyMap(),
+        immediateOk =
+          DataFetchResult(
+            kind = "a11y/atf",
+            schemaVersion = 1,
+            payload = buildJsonObject { /* empty payload is fine for the test */ },
+          ),
+      )
+    runWithServer(producer = producer) { rpc ->
+      rpc.initialize()
+      rpc.send(
+        """
+        {"jsonrpc":"2.0","id":99,"method":"data/fetch","params":{
+          "previewId":"preview-Q","kind":"a11y/atf"
+        }}
+        """
+          .trimIndent()
+      )
+      val response = rpc.pollUntil { it["id"]?.jsonPrimitive?.intOrNull == 99 }
+      assertNotNull(response)
+      val result = response!!["result"]!!.jsonObject
+      assertEquals("a11y/atf", result["kind"]?.jsonPrimitive?.contentOrNull)
+
+      // Critically: no render notifications were emitted - D1 fast path bypasses the queue.
+      val sawRender =
+        rpc.history.toList().any {
+          val method = it["method"]?.jsonPrimitive?.contentOrNull
+          method == "renderStarted" || method == "renderFinished"
+        }
+      assertFalse(
+        "Ok-shortcut must not trigger a render - only RequiresRerender does",
+        sawRender,
+      )
+      assertEquals("Ok shortcut must not call the host", 0, producer.renderSubmits.get())
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Test infrastructure
+  // -------------------------------------------------------------------------
+
+  /**
+   * In-memory [DataProductRegistry] driven by per-test config:
+   * - [modeForKind] tells the first fetch for a given kind to return `RequiresRerender(<mode>)`.
+   * - After the dispatcher's re-render lands ([renderObserved] is set), subsequent fetches for
+   *   that kind return [postRerenderOutcome] (defaults to a synthetic `Ok` payload).
+   * - [immediateOk] lets a test inject "Ok on first call, no re-render needed" for the D1
+   *   fast-path regression coverage.
+   */
+  private class FakeProducer(
+    private val modeForKind: Map<String, String>,
+    private val postRerenderOutcome: DataProductRegistry.Outcome? = null,
+    private val immediateOk: DataFetchResult? = null,
+  ) : DataProductRegistry {
+
+    val renderSubmits = AtomicInteger(0)
+    @Volatile var lastRenderPayload: String? = null
+    @Volatile var renderObserved: Boolean = false
+
+    override val capabilities: List<DataProductCapability> =
+      modeForKind.keys
+        .map { kind ->
+          DataProductCapability(
+            kind = kind,
+            schemaVersion = 1,
+            transport = DataProductTransport.INLINE,
+            attachable = true,
+            fetchable = true,
+            requiresRerender = true,
+          )
+        }
+        .ifEmpty {
+          immediateOk?.let { ok ->
+            listOf(
+              DataProductCapability(
+                kind = ok.kind,
+                schemaVersion = ok.schemaVersion,
+                transport = DataProductTransport.INLINE,
+                attachable = false,
+                fetchable = true,
+                requiresRerender = false,
+              )
+            )
+          } ?: emptyList()
+        }
+
+    override fun fetch(
+      previewId: String,
+      kind: String,
+      params: JsonElement?,
+      inline: Boolean,
+    ): DataProductRegistry.Outcome {
+      if (immediateOk != null && kind == immediateOk.kind) {
+        return DataProductRegistry.Outcome.Ok(immediateOk)
+      }
+      val mode = modeForKind[kind] ?: return DataProductRegistry.Outcome.Unknown
+      if (!renderObserved) {
+        return DataProductRegistry.Outcome.RequiresRerender(mode)
+      }
+      return postRerenderOutcome
+        ?: DataProductRegistry.Outcome.Ok(
+          DataFetchResult(
+            kind = kind,
+            schemaVersion = 1,
+            payload = buildJsonObject { /* deterministic empty payload */ },
+          )
+        )
+    }
+
+    override fun attachmentsFor(
+      previewId: String,
+      kinds: Set<String>,
+    ) = emptyList<ee.schimke.composeai.daemon.protocol.DataProductAttachment>()
+
+    /** Called by [TestRenderHost] when the dispatcher submits a render. */
+    fun observeRenderSubmit(payload: String) {
+      renderSubmits.incrementAndGet()
+      lastRenderPayload = payload
+      renderObserved = true
+    }
+  }
+
+  /**
+   * [RenderHost] for the data-fetch tests. Either completes renders instantly (writing the payload
+   * back through the producer so the next `fetch` returns `Ok`) or blocks forever (driving the
+   * budget-timeout branch).
+   */
+  private class TestRenderHost(
+    private val producer: FakeProducer,
+    private val blockSubmits: Boolean,
+  ) : RenderHost {
+    private val queue = LinkedBlockingQueue<RenderRequest>()
+    private val results =
+      java.util.concurrent.ConcurrentHashMap<Long, LinkedBlockingQueue<RenderResult>>()
+    @Volatile private var stopped = false
+    val interruptCount = AtomicInteger(0)
+    private val worker =
+      Thread(
+          {
+            while (!stopped) {
+              val req =
+                try {
+                  queue.poll(50, TimeUnit.MILLISECONDS)
+                } catch (_: InterruptedException) {
+                  interruptCount.incrementAndGet()
+                  Thread.currentThread().interrupt()
+                  return@Thread
+                } ?: continue
+              when (req) {
+                is RenderRequest.Render -> {
+                  producer.observeRenderSubmit(req.payload)
+                  if (blockSubmits) {
+                    // Hold the render forever - the dispatcher's budget timer is what trips
+                    // the test's data/fetch response, and we want to confirm the render is
+                    // not cancelled out from under us.
+                    continue
+                  }
+                  val result =
+                    RenderResult(
+                      id = req.id,
+                      classLoaderHashCode = 0,
+                      classLoaderName = "test",
+                    )
+                  results.computeIfAbsent(req.id) { LinkedBlockingQueue() }.put(result)
+                }
+                RenderRequest.Shutdown -> return@Thread
+              }
+            }
+          },
+          "data-fetch-test-render-host",
+        )
+        .apply { isDaemon = true }
+
+    override fun start() {
+      worker.start()
+    }
+
+    override fun submit(request: RenderRequest, timeoutMs: Long): RenderResult {
+      require(request is RenderRequest.Render)
+      queue.put(request)
+      val q = results.computeIfAbsent(request.id) { LinkedBlockingQueue() }
+      val result = q.poll(timeoutMs, TimeUnit.MILLISECONDS)
+      return result ?: error("TestRenderHost.submit($request) timed out")
+    }
+
+    override fun shutdown(timeoutMs: Long) {
+      stopped = true
+      queue.put(RenderRequest.Shutdown)
+      worker.join(timeoutMs)
+    }
+  }
+
+  private fun runWithServer(
+    producer: FakeProducer,
+    blockHostSubmits: Boolean = false,
+    dataFetchRerenderBudgetMs: Long = JsonRpcServer.DEFAULT_DATA_FETCH_RERENDER_BUDGET_MS,
+    block: (RpcDriver) -> Unit,
+  ) {
+    val clientToServerOut = PipedOutputStream()
+    val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
+    val serverToClientOut = PipedOutputStream()
+    val serverToClientIn = PipedInputStream(serverToClientOut, 64 * 1024)
+
+    val host = TestRenderHost(producer, blockSubmits = blockHostSubmits)
+    val exitCode = AtomicInteger(-1)
+    val exitLatch = CountDownLatch(1)
+    val server =
+      JsonRpcServer(
+        input = clientToServerIn,
+        output = serverToClientOut,
+        host = host,
+        daemonVersion = "test",
+        idleTimeoutMs = 100L,
+        dataProducts = producer,
+        dataFetchRerenderBudgetMs = dataFetchRerenderBudgetMs,
+        onExit = { code ->
+          exitCode.set(code)
+          exitLatch.countDown()
+        },
+      )
+    val serverThread =
+      Thread({ server.run() }, "data-fetch-rerender-server").apply { isDaemon = true }
+    serverThread.start()
+
+    val received = LinkedBlockingQueue<JsonObject>()
+    val history = java.util.Collections.synchronizedList(mutableListOf<JsonObject>())
+    val readerThread =
+      Thread(
+          {
+            try {
+              val reader = ContentLengthFramer(serverToClientIn)
+              while (true) {
+                val frame = reader.readFrame() ?: break
+                val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+                history.add(obj)
+                received.put(obj)
+              }
+            } catch (_: Throwable) {}
+          },
+          "data-fetch-rerender-reader",
+        )
+        .apply { isDaemon = true }
+    readerThread.start()
+
+    val driver =
+      RpcDriver(
+        clientToServerOut = clientToServerOut,
+        received = received,
+        history = history,
+      )
+    try {
+      block(driver)
+      // Tear down - drop subscriptions / let renders drain. Skip shutdown for the
+      // budget-blocked test (the host worker would block forever); fall back to closing pipes.
+      if (!blockHostSubmits) {
+        driver.send("""{"jsonrpc":"2.0","id":9999,"method":"shutdown"}""")
+        driver.pollUntil { it["id"]?.jsonPrimitive?.intOrNull == 9999 }
+        driver.send("""{"jsonrpc":"2.0","method":"exit"}""")
+        assertTrue(
+          "server should exit cleanly within 10s",
+          exitLatch.await(10, TimeUnit.SECONDS),
+        )
+      }
+      // Render thread interrupt invariant - fetch-driven re-renders must not interrupt the host.
+      assertEquals(
+        "fetch-driven re-renders must not interrupt the render thread",
+        0,
+        host.interruptCount.get(),
+      )
+    } finally {
+      try {
+        clientToServerOut.close()
+      } catch (_: Throwable) {}
+      try {
+        serverToClientIn.close()
+      } catch (_: Throwable) {}
+      serverThread.join(5_000)
+    }
+  }
+
+  private class RpcDriver(
+    private val clientToServerOut: PipedOutputStream,
+    val received: LinkedBlockingQueue<JsonObject>,
+    /**
+     * Append-only snapshot of every message the reader has parsed. `pollUntil` drains [received]
+     * but [history] retains the full timeline for "did we ever see X" assertions.
+     */
+    val history: List<JsonObject>,
+  ) {
+    fun send(text: String) {
+      val payload = text.toByteArray(Charsets.UTF_8)
+      clientToServerOut.write(
+        "Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII)
+      )
+      clientToServerOut.write(payload)
+      clientToServerOut.flush()
+    }
+
+    fun initialize() {
+      send(
+        """
+        {"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+          "protocolVersion":1,
+          "clientVersion":"test",
+          "workspaceRoot":"/tmp",
+          "moduleId":":test",
+          "moduleProjectDir":"/tmp",
+          "capabilities":{"visibility":true,"metrics":false}
+        }}
+        """
+          .trimIndent()
+      )
+      pollUntil { it["id"]?.jsonPrimitive?.intOrNull == 1 }
+        ?: error("initialize response should arrive")
+      send("""{"jsonrpc":"2.0","method":"initialized","params":{}}""")
+    }
+
+    fun pollUntil(timeoutMs: Long = 10_000, matcher: (JsonObject) -> Boolean): JsonObject? {
+      val deadline = System.currentTimeMillis() + timeoutMs
+      while (System.currentTimeMillis() < deadline) {
+        val remaining = (deadline - System.currentTimeMillis()).coerceAtLeast(0)
+        val msg = received.poll(remaining, TimeUnit.MILLISECONDS) ?: return null
+        if (matcher(msg)) return msg
+      }
+      return null
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements D3 of [DATA-PRODUCTS.md](docs/daemon/DATA-PRODUCTS.md) — the `data/fetch` re-render-on-demand path with per-request budget. Outcome 3 from § "Wire surface > data/fetch" (lines 194-201) and § "Re-render semantics" (lines 277-298).

- New additive variant `DataProductRegistry.Outcome.RequiresRerender(mode: String)` — minimal seam, doesn't disturb the existing `Empty` registry or any caller. The pre-existing variants (`Ok` / `Unknown` / `NotAvailable` / `FetchFailed` / `BudgetExceeded`) cover *outcomes*; this one carries the "I want a re-render in mode X" intent.
- `JsonRpcServer.handleDataFetch` reacts to `RequiresRerender` by queueing a render through the same `submitRenderAsync` path `renderNow` uses, parking on a `CompletableFuture<RerenderOutcome>` keyed on host render id, then re-invoking `fetch` once the producer has the data.
- New constructor param + sysprop `dataFetchRerenderBudgetMs` (default `30_000` per spec). Budget timeout returns `-32023 DataProductBudgetExceeded` without cancelling the render — the watcher loop still cleans up the waiter when the render eventually finishes.
- Re-renders emit a regular `renderStarted` / `renderFinished` so the panel UI updates the PNG if it changed (DATA-PRODUCTS.md:291-293). The `data/fetch` response resolves when the payload is ready.

## Test plan

- [x] `:daemon:core:test --tests "ee.schimke.composeai.daemon.DataFetchRerenderTest"` — 5/5 green:
  - `rerender_happy_path_emits_render_notifications_then_payload_response` (149ms)
  - `ok_outcome_short_circuits_without_a_rerender` (5ms)
  - `rerender_budget_exceeded_returns_minus_32023_and_does_not_cancel_render` (~5s — bounded by pipe-close idle wait, not the 75ms test budget; budget itself trips fast)
  - `rerender_then_second_requires_rerender_does_not_loop` (8ms)
  - `rerender_then_producer_failure_returns_minus_32022` (8ms)
- [x] `:daemon:core:test` (full) — green when the pre-existing `JsonRpcServerIntegrationTest` notification-ordering flakes don't fire. Those flakes (`fileChanged_then_renderNow_emits_renderFinished_before_discoveryUpdated`, `classpath_fingerprint_dirty_emits_classpathDirty_and_exits`, `renderFinished_metrics_null_when_host_supplies_null`) reproduce on bare `origin/main` without any of these changes — orthogonal pre-existing issue.
- [ ] CI: rerun on real producer integration once D2 (#412) lands — see follow-ups.

## Follow-ups (not in this PR)

1. **Real producer integration test.** Wire the renderer-android a11y producer's `RequiresRerender("a11y")` path through the daemon-main glue and pin it with an `@AndroidIntegration` smoke test. Gated on D2 (#412) landing. Will likely live alongside `DaemonHostTest`.
2. **Mode composition / piggy-backing.** Spec § "Re-render semantics" point 1 calls out "modes compose: a single re-render covers as many of the requested kinds as the modes overlap." This dispatcher handles one kind per re-render; once D2 + (likely) D5's `compose/recomposition` land, add a coalescer so two concurrent `data/fetch` calls that both need `mode=a11y` ride one render rather than two. Needs a producer-side `modeForKind(kind)` method to pre-classify; not worth adding before D2.
3. **Stale-waiter cleanup on shutdown.** `dataFetchWaiters` entries that don't get woken (host hung, server shutting down) currently leak until JVM exit. Benign today — `cleanShutdown()` waits for `inFlightRenders` to drain — but a defensive `dataFetchWaiters.clear()` in `cleanShutdown` would short-circuit any waiters that observed an early budget-trip. Pure hygiene.
4. **Surface `dataFetchRerenderBudgetMs` on the wire.** Currently sysprop/constructor-only. PROTOCOL.md § 6 already lists `daemon.dataFetchRerenderBudgetMs` as a config knob — wire it through `initialize.options` once a client wants per-session control.
5. **Pre-existing `JsonRpcServerIntegrationTest` flakes.** Notification-ordering races in `pollUntil` consumers — orthogonal to D3 but probably the same fix wherever it lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYvTgEGDJxSu9gAGUTF9ub)_