### PR TITLE
feat(daemon): device override on renderNow

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -64,6 +64,23 @@ class PreviewManifestRouter(
             "(payload='${typed.payload}'). Manifest knows: ${byId.keys}"
         )
     val resolved = entry.resolved()
+    // PROTOCOL.md § 5 (`renderNow.overrides.device`) — when the inbound carries a `device=` token
+    // we resolve it against the catalog and use its widthPx/heightPx/density as the BASE for this
+    // render, replacing the manifest's per-preview defaults. Explicit `widthPx` / `heightPx` /
+    // `density` overrides on the same call still win over the device-derived values, so a caller
+    // can say `device=id:pixel_5;widthPx=600` to force a wider window on the Pixel's density.
+    // The override device string is also written through to the output payload so the Android
+    // renderer's `isRoundDevice(spec.device)` round-detection sees it (Wear devices applied via
+    // override should still get the circular crop).
+    val deviceOverride = inbound["device"]?.takeIf { it.isNotBlank() }
+    val deviceSpec =
+      deviceOverride?.let {
+        ee.schimke.composeai.daemon.devices.DeviceDimensions.resolve(it)
+      }
+    val baseWidthPx = deviceSpec?.let { (it.widthDp * it.density).toInt() } ?: resolved.widthPx
+    val baseHeightPx = deviceSpec?.let { (it.heightDp * it.density).toInt() } ?: resolved.heightPx
+    val baseDensity = deviceSpec?.density ?: resolved.density
+    val effectiveDevice = deviceOverride ?: resolved.device
     val routed =
       RenderRequest.Render(
         id = typed.id,
@@ -71,15 +88,16 @@ class PreviewManifestRouter(
           buildString {
             append("className=").append(entry.className).append(';')
             append("functionName=").append(entry.functionName).append(';')
-            // Inbound override wins over the per-preview manifest default.
-            append("widthPx=").append(inbound["widthPx"] ?: resolved.widthPx).append(';')
-            append("heightPx=").append(inbound["heightPx"] ?: resolved.heightPx).append(';')
-            append("density=").append(inbound["density"] ?: resolved.density).append(';')
+            // Inbound explicit override wins over both the device-derived value and the
+            // per-preview manifest default.
+            append("widthPx=").append(inbound["widthPx"] ?: baseWidthPx).append(';')
+            append("heightPx=").append(inbound["heightPx"] ?: baseHeightPx).append(';')
+            append("density=").append(inbound["density"] ?: baseDensity).append(';')
             append("showBackground=").append(resolved.showBackground).append(';')
             if (resolved.backgroundColor != 0L) {
               append("backgroundColor=").append(resolved.backgroundColor).append(';')
             }
-            resolved.device?.takeIf { it.isNotBlank() }?.let {
+            effectiveDevice?.takeIf { it.isNotBlank() }?.let {
               append("device=").append(it).append(';')
             }
             // PROTOCOL.md § 5 (`renderNow.overrides`) — locale / fontScale / uiMode / orientation

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -117,6 +117,69 @@ class OverrideIntegrationTest {
     }
   }
 
+  @Test
+  fun deviceOverrideResolvesCatalogDimensions() {
+    // PROTOCOL.md § 5 (`renderNow.overrides.device`) — `device=id:pixel_5` should resolve via
+    // `DeviceDimensions.resolve` to widthDp=393, heightDp=851, density=2.75, giving widthPx=1080
+    // (393 × 2.75) and heightPx=2340 (851 × 2.75). The manifest's per-preview defaults are
+    // small (64×64) so the PNG dimension change is the visible signal.
+    val outputDir = tempFolder.newFolder("renders-device")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "red-square",
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "RedSquare",
+              widthPx = 64,
+              heightPx = 64,
+              density = 1.0f,
+              outputBaseName = "red-square-device",
+            )
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    host.start()
+    try {
+      val pixel5 = renderAndDecode(host, "previewId=red-square;device=id:pixel_5", "pixel_5")
+      // 393dp × 2.75 density = 1080px nominal, 851dp × 2.75 = 2340px nominal. Robolectric's
+      // qualifier round-trip is lossy by a couple of px (px → dp via integer division → px again),
+      // so we assert "near nominal" rather than equality. The point is that the device override
+      // routed through the catalog and produced ~Pixel 5 dimensions, not the manifest's 64×64.
+      assertNearPx("device=id:pixel_5 width should be ~1080px", expected = 1080, pixel5.width)
+      assertNearPx("device=id:pixel_5 height should be ~2340px", expected = 2340, pixel5.height)
+
+      // Explicit widthPx still wins over the device-derived value — `device=id:pixel_5;widthPx=600`
+      // takes the Pixel 5's density (2.75) but forces a custom width.
+      val custom =
+        renderAndDecode(host, "previewId=red-square;device=id:pixel_5;widthPx=600", "custom")
+      assertNearPx("explicit widthPx should override device dims", expected = 600, custom.width)
+      assertNearPx(
+        "heightPx still flows from the device when not overridden",
+        expected = 2340,
+        custom.height,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  /**
+   * Asserts [actual] is within ±4px of [expected]. The Android backend's qualifier path round-trips
+   * px → dp (via integer division) → px again inside `applyPreviewQualifiers`, so a request for
+   * 1080px can come back as 1078px etc. The exact-px assertion isn't what this test is proving —
+   * we're proving the device override reached the spec at all.
+   */
+  private fun assertNearPx(message: String, expected: Int, actual: Int) {
+    assertTrue(
+      "$message — expected ~$expected, got $actual (drift > 4px)",
+      kotlin.math.abs(expected - actual) <= 4,
+    )
+  }
+
   private fun renderAndDecode(
     host: PreviewManifestRouter,
     payload: String,

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -746,6 +746,12 @@ class JsonRpcServer(
           }
         )
       }
+      overrides.device
+        ?.takeIf { it.isNotBlank() }
+        ?.let {
+          if (isNotEmpty()) append(';')
+          append("device=").append(it)
+        }
     }
   }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensions.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensions.kt
@@ -1,0 +1,178 @@
+package ee.schimke.composeai.daemon.devices
+
+/**
+ * Per-`@Preview(device = ...)` geometry catalog and parser.
+ *
+ * **Duplicated from `:gradle-plugin`'s
+ * [DeviceDimensions][ee.schimke.composeai.plugin.DeviceDimensions].** Per
+ * [DESIGN.md § 7](../../../../../../docs/daemon/DESIGN.md#7-sharing-strategy--what-crosses-the-boundary)
+ * the catalog lives in two places — the standalone Gradle plugin (which uses it during discovery to
+ * populate `PreviewParams.widthDp/heightDp/density`) and the daemon (which uses it at the override
+ * layer to resolve `renderNow.overrides.device` to dimensions). The two builds are separate
+ * (`includeBuild("gradle-plugin")`) so there's no clean way to share without a publish-and-consume
+ * cycle on every catalog change.
+ *
+ * **Drift policy.** The KNOWN_DEVICES map is the load-bearing data. When you add a device here, add
+ * it to the gradle-plugin copy too (and vice versa). The `spec:width=…,height=…,dpi=…` parser is
+ * also duplicated; the rules are intentionally identical so a single payload string drives both
+ * code paths.
+ *
+ * **Daemon-only constants.** Unlike the gradle-plugin counterpart, this object only ships the
+ * `resolve(device, widthDp?, heightDp?)` entrypoint — `resolveForRender` (which makes the
+ * fixed-vs-wrap decision per axis) is plugin-only because it consumes `showSystemUi`, an annotation
+ * field that doesn't appear in the daemon's override surface. Callers who already have
+ * widthPx/heightPx/density (e.g. the `PreviewManifestRouter` after merging an inbound override) can
+ * skip [resolve] entirely.
+ *
+ * @see ee.schimke.composeai.plugin.DeviceDimensions
+ */
+object DeviceDimensions {
+  /**
+   * Per-device geometry resolved from a `@Preview(device = ...)` string.
+   *
+   * `density` is the Compose density factor (= densityDpi / 160). The daemon multiplies dp by
+   * density to populate `RenderSpec.widthPx`/`heightPx`; the Android backend then re-derives the
+   * Robolectric `<n>dpi` qualifier from it.
+   */
+  data class DeviceSpec(val widthDp: Int, val heightDp: Int, val density: Float = DEFAULT_DENSITY)
+
+  /**
+   * The density Android Studio uses when no device is specified — xxhdpi-ish (420dpi → 2.625x),
+   * matching its default phone-class preview.
+   */
+  const val DEFAULT_DENSITY: Float = 2.625f
+
+  // Source-of-truth for the dp values and densities below: sergio-sastre/ComposablePreviewScanner
+  // (Phone.kt / Tablet.kt / Wear.kt / GenericDevices.kt / Desktop.kt / Television.kt /
+  // Automotive.kt / XR.kt under android/.../device/types/), with dp = px / (densityDpi / 160)
+  // and density = densityDpi / 160. KEEP IN SYNC with `:gradle-plugin`'s `DeviceDimensions`.
+  private val KNOWN_DEVICES =
+    mapOf(
+      // --- Pixel phones ---
+      "id:pixel" to DeviceSpec(411, 731, 2.625f),
+      "id:pixel_xl" to DeviceSpec(411, 731, 3.5f),
+      "id:pixel_2" to DeviceSpec(411, 731, 2.625f),
+      "id:pixel_2_xl" to DeviceSpec(411, 823, 3.5f),
+      "id:pixel_3" to DeviceSpec(393, 786, 2.75f),
+      "id:pixel_3_xl" to DeviceSpec(411, 846, 3.5f),
+      "id:pixel_3a" to DeviceSpec(393, 808, 2.75f),
+      "id:pixel_3a_xl" to DeviceSpec(411, 823, 2.625f),
+      "id:pixel_4" to DeviceSpec(393, 829, 2.75f),
+      "id:pixel_4_xl" to DeviceSpec(411, 869, 3.5f),
+      "id:pixel_4a" to DeviceSpec(393, 851, 2.75f),
+      "id:pixel_5" to DeviceSpec(393, 851, 2.75f),
+      "id:pixel_6" to DeviceSpec(411, 914, 2.625f),
+      "id:pixel_6a" to DeviceSpec(411, 914, 2.625f),
+      "id:pixel_6_pro" to DeviceSpec(411, 891, 3.5f),
+      "id:pixel_7" to DeviceSpec(411, 914, 2.625f),
+      "id:pixel_7a" to DeviceSpec(411, 914, 2.625f),
+      "id:pixel_7_pro" to DeviceSpec(411, 891, 3.5f),
+      "id:pixel_8" to DeviceSpec(411, 914, 2.625f),
+      "id:pixel_8a" to DeviceSpec(411, 914, 2.625f),
+      "id:pixel_8_pro" to DeviceSpec(448, 997, 3.0f),
+      "id:pixel_9" to DeviceSpec(411, 923, 2.625f),
+      "id:pixel_9a" to DeviceSpec(411, 923, 2.625f),
+      "id:pixel_9_pro" to DeviceSpec(426, 952, 3.0f),
+      "id:pixel_9_pro_xl" to DeviceSpec(438, 997, 3.0f),
+      // Foldables — natural orientation per upstream
+      "id:pixel_fold" to DeviceSpec(841, 701, 2.625f),
+      "id:pixel_9_pro_fold" to DeviceSpec(791, 819, 2.625f),
+
+      // --- Pixel tablets ---
+      "id:pixel_c" to DeviceSpec(1280, 900, 2.0f),
+      "id:pixel_tablet" to DeviceSpec(1280, 800, 2.0f),
+
+      // --- Generic Android Studio device IDs ---
+      "id:small_phone" to DeviceSpec(360, 640, 2.0f),
+      "id:medium_phone" to DeviceSpec(411, 914, 2.625f),
+      "id:medium_tablet" to DeviceSpec(1280, 800, 2.0f),
+      "id:resizable" to DeviceSpec(411, 914, 2.625f),
+
+      // --- Wear OS ---
+      "id:wearos_small_round" to DeviceSpec(192, 192, 2.0f),
+      "id:wearos_large_round" to DeviceSpec(227, 227, 2.0f),
+      "id:wearos_xl_round" to DeviceSpec(240, 240, 2.0f),
+      "id:wearos_square" to DeviceSpec(180, 180, 2.0f),
+      "id:wearos_rect" to DeviceSpec(201, 238, 2.0f),
+      "id:wearos_rectangular" to DeviceSpec(201, 238, 2.0f),
+
+      // --- Desktop ---
+      "id:desktop_small" to DeviceSpec(1366, 768, 1.0f),
+      "id:desktop_medium" to DeviceSpec(1920, 1080, 2.0f),
+      "id:desktop_large" to DeviceSpec(1920, 1080, 1.0f),
+
+      // --- Television (Android TV) ---
+      "id:tv_720p" to DeviceSpec(931, 524, 1.375f),
+      "id:tv_1080p" to DeviceSpec(960, 540, 2.0f),
+      "id:tv_4k" to DeviceSpec(960, 540, 4.0f),
+
+      // --- Automotive (Android Auto / AAOS) ---
+      "id:automotive_1024p_landscape" to DeviceSpec(1024, 768, 1.0f),
+      "id:automotive_1080p_landscape" to DeviceSpec(1440, 800, 0.75f),
+      "id:automotive_1408p_landscape_with_google_apis" to DeviceSpec(1408, 792, 1.0f),
+      "id:automotive_1408p_landscape_with_play" to DeviceSpec(1408, 792, 1.0f),
+      "id:automotive_distant_display" to DeviceSpec(1440, 800, 0.75f),
+      "id:automotive_distant_display_with_play" to DeviceSpec(1440, 800, 0.75f),
+      "id:automotive_portrait" to DeviceSpec(1067, 1707, 0.75f),
+      "id:automotive_large_portrait" to DeviceSpec(1280, 1606, 1.0f),
+      "id:automotive_ultrawide" to DeviceSpec(2603, 880, 1.5f),
+
+      // --- XR ---
+      "id:xr_headset_device" to DeviceSpec(1280, 1279, 2.0f),
+      "id:xr_device" to DeviceSpec(1280, 1279, 2.0f),
+    )
+
+  val DEFAULT = DeviceSpec(400, 800, DEFAULT_DENSITY)
+  val DEFAULT_WEAR = DeviceSpec(227, 227, 2.0f)
+
+  /**
+   * The set of device-id strings the catalog recognises (every key in [KNOWN_DEVICES]). Useful for
+   * building a `list_devices` MCP tool surface or validating user input before issuing a
+   * `renderNow`. The `spec:...` and `name:...` grammars are not enumerable; they're parsed at
+   * resolve-time.
+   */
+  val KNOWN_DEVICE_IDS: Set<String> = KNOWN_DEVICES.keys
+
+  /**
+   * Resolves a `@Preview(device = ...)` string to a [DeviceSpec]. Mirrors the gradle-plugin's
+   * resolution rules byte-for-byte:
+   *
+   * - Explicit `widthDp`+`heightDp` short-circuit to a [DeviceSpec] at [DEFAULT_DENSITY] (no device
+   *   info, so we fall back to the Studio default).
+   * - `id:pixel_5`-style ids hit [KNOWN_DEVICES]; unknown ids fall through to the default.
+   * - `spec:width=…,height=…,dpi=…` is parsed inline; the `dp` suffix on values is tolerated.
+   * - Any device string containing `wear` (case-insensitive) returns [DEFAULT_WEAR].
+   * - Otherwise [DEFAULT] (400×800 dp at xxhdpi).
+   */
+  fun resolve(device: String?, widthDp: Int? = null, heightDp: Int? = null): DeviceSpec {
+    if (widthDp != null && widthDp > 0 && heightDp != null && heightDp > 0) {
+      return DeviceSpec(widthDp, heightDp, DEFAULT_DENSITY)
+    }
+
+    if (device != null) {
+      KNOWN_DEVICES[device]?.let {
+        return it
+      }
+
+      if (device.startsWith("spec:")) {
+        val params =
+          device
+            .removePrefix("spec:")
+            .split(",")
+            .mapNotNull {
+              val parts = it.split("=", limit = 2)
+              if (parts.size == 2) parts[0].trim() to parts[1].trim().removeSuffix("dp") else null
+            }
+            .toMap()
+        val w = params["width"]?.toIntOrNull() ?: DEFAULT.widthDp
+        val h = params["height"]?.toIntOrNull() ?: DEFAULT.heightDp
+        val density = params["dpi"]?.toIntOrNull()?.let { it / 160f } ?: DEFAULT_DENSITY
+        return DeviceSpec(w, h, density)
+      }
+
+      if (device.contains("wear", ignoreCase = true)) return DEFAULT_WEAR
+    }
+
+    return DEFAULT
+  }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -216,6 +216,16 @@ data class PreviewOverrides(
   val uiMode: UiMode? = null,
   /** Portrait/landscape override. Android-only today. */
   val orientation: Orientation? = null,
+  /**
+   * `@Preview(device = ...)` string — `id:pixel_5`, `id:wearos_small_round`, `id:tv_1080p`, or a
+   * full `spec:width=400dp,height=800dp,dpi=320,isRound=true` grammar. The daemon resolves the
+   * string against its built-in catalog (`ee.schimke.composeai.daemon.devices.DeviceDimensions`)
+   * and merges the resulting `widthPx` / `heightPx` / `density` into the render spec. Explicit
+   * `widthPx` / `heightPx` / `density` overrides on this same object take precedence — so a caller
+   * can say `device: "id:pixel_5", widthPx: 600` to force a wider window on the Pixel 5's density.
+   * Unknown device ids fall back to the default (400×800 dp at xxhdpi).
+   */
+  val device: String? = null,
 )
 
 @Serializable

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -58,6 +58,19 @@ class PreviewManifestRouter(
             "(payload='${typed.payload}'). Manifest knows: ${byId.keys}"
         )
     val resolved = entry.resolved()
+    // PROTOCOL.md § 5 (`renderNow.overrides.device`) — when the inbound carries a `device=` token
+    // we resolve it against the catalog and use its widthPx/heightPx/density as the BASE for this
+    // render, replacing the manifest's per-preview defaults. Explicit `widthPx` / `heightPx` /
+    // `density` overrides on the same call still win over the device-derived values, so a caller
+    // can say `device=id:pixel_5;widthPx=600` to force a wider window on the Pixel's density.
+    val deviceOverride = inbound["device"]?.takeIf { it.isNotBlank() }
+    val deviceSpec = deviceOverride?.let {
+      ee.schimke.composeai.daemon.devices.DeviceDimensions.resolve(it)
+    }
+    val baseWidthPx = deviceSpec?.let { (it.widthDp * it.density).toInt() } ?: resolved.widthPx
+    val baseHeightPx = deviceSpec?.let { (it.heightDp * it.density).toInt() } ?: resolved.heightPx
+    val baseDensity = deviceSpec?.density ?: resolved.density
+    val effectiveDevice = deviceOverride ?: resolved.device
     val routed =
       RenderRequest.Render(
         id = typed.id,
@@ -65,15 +78,16 @@ class PreviewManifestRouter(
           buildString {
             append("className=").append(entry.className).append(';')
             append("functionName=").append(entry.functionName).append(';')
-            // Inbound override wins over the per-preview manifest default.
-            append("widthPx=").append(inbound["widthPx"] ?: resolved.widthPx).append(';')
-            append("heightPx=").append(inbound["heightPx"] ?: resolved.heightPx).append(';')
-            append("density=").append(inbound["density"] ?: resolved.density).append(';')
+            // Inbound explicit override wins over both the device-derived value and the
+            // per-preview manifest default.
+            append("widthPx=").append(inbound["widthPx"] ?: baseWidthPx).append(';')
+            append("heightPx=").append(inbound["heightPx"] ?: baseHeightPx).append(';')
+            append("density=").append(inbound["density"] ?: baseDensity).append(';')
             append("showBackground=").append(resolved.showBackground).append(';')
             if (resolved.backgroundColor != 0L) {
               append("backgroundColor=").append(resolved.backgroundColor).append(';')
             }
-            resolved.device
+            effectiveDevice
               ?.takeIf { it.isNotBlank() }
               ?.let { append("device=").append(it).append(';') }
             // PROTOCOL.md § 5 (`renderNow.overrides`) — locale / fontScale / uiMode / orientation

--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -287,13 +287,25 @@ multiple concurrent streams coexist. The dispatch flow inside `JsonRpcServer`:
 ## 8a. Display overrides
 
 Per-render display properties — **size**, **density**, **locale**,
-**fontScale**, **uiMode** (light/dark), **orientation** — ride on the existing
-`renderNow` request via the optional `overrides` field documented in
-[PROTOCOL.md § 5](PROTOCOL.md#renderNow). They are not interactive-only: any
-caller (panel, MCP, future RPC) can attach overrides to a single `renderNow`
-to get a one-off render with a different qualifier set. A subsequent
-`renderNow` without `overrides` reverts to the discovery-time `RenderSpec` —
-overrides are call-scoped, not session-scoped.
+**fontScale**, **uiMode** (light/dark), **orientation**, **device** — ride
+on the existing `renderNow` request via the optional `overrides` field
+documented in [PROTOCOL.md § 5](PROTOCOL.md#renderNow). They are not
+interactive-only: any caller (panel, MCP, future RPC) can attach overrides
+to a single `renderNow` to get a one-off render with a different qualifier
+set. A subsequent `renderNow` without `overrides` reverts to the
+discovery-time `RenderSpec` — overrides are call-scoped, not
+session-scoped.
+
+**Device override.** `device: "id:pixel_5"` (or any other catalog id /
+`spec:` grammar that `@Preview(device = …)` accepts) is resolved by the
+daemon's built-in `DeviceDimensions` catalog into `widthPx` / `heightPx` /
+`density`. Explicit `widthPx` / `heightPx` / `density` overrides on the
+same call take precedence — so a caller can say `device: "id:pixel_5",
+widthPx: 600` to force a wider window on the Pixel 5's density, or
+`device: "id:wearos_small_round"` to flip a phone preview to a Wear round
+device frame (the Android backend's `isRoundDevice` round-detection picks
+up the override). Unknown ids fall back to the daemon's default
+(400×800dp at xxhdpi).
 
 **Why not interactive-only.** Size/density/locale/fontScale/uiMode/orientation
 are all the same Robolectric qualifier knob (`setQualifiers` +

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -201,6 +201,9 @@ A `classpath` event triggers Tier-1 fingerprint recomputation; on mismatch the d
   fontScale?: number;                // 1.0 = system default
   uiMode?: "light" | "dark";         // Android-only today.
   orientation?: "portrait" | "landscape";  // Android-only today.
+  device?: string;                   // "id:pixel_5", "id:wearos_small_round", "spec:width=400dp,height=800dp,dpi=320".
+                                     // Resolved by the daemon's catalog into widthPx/heightPx/density;
+                                     // explicit widthPx/heightPx/density above take precedence.
 }
 
 // result

--- a/docs/daemon/protocol-fixtures/client-renderNow-overrides.json
+++ b/docs/daemon/protocol-fixtures/client-renderNow-overrides.json
@@ -9,6 +9,7 @@
     "localeTag": "fr-FR",
     "fontScale": 1.3,
     "uiMode": "dark",
-    "orientation": "portrait"
+    "orientation": "portrait",
+    "device": "id:pixel_5"
   }
 }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -399,7 +399,8 @@ class DaemonMcpServer(
                     "localeTag":{"type":"string","description":"BCP-47 locale tag (e.g. 'en-US', 'fr', 'ja-JP'). Android-only today."},
                     "fontScale":{"type":"number","description":"Font scale multiplier (1.0 = system default)."},
                     "uiMode":{"type":"string","enum":["light","dark"],"description":"Light/dark mode override. Android-only today."},
-                    "orientation":{"type":"string","enum":["portrait","landscape"],"description":"Portrait/landscape override. Android-only today."}
+                    "orientation":{"type":"string","enum":["portrait","landscape"],"description":"Portrait/landscape override. Android-only today."},
+                    "device":{"type":"string","description":"@Preview(device=...) string — 'id:pixel_5', 'id:wearos_small_round', 'id:tv_1080p', or full 'spec:width=400dp,height=800dp,dpi=320'. Resolved by the daemon's catalog into widthPx/heightPx/density; explicit width/height/density overrides on this same object take precedence."}
                   }
                 }
               },
@@ -796,6 +797,7 @@ class DaemonMcpServer(
       fontScale = float("fontScale"),
       uiMode = uiMode,
       orientation = orientation,
+      device = str("device"),
     )
   }
 

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -157,6 +157,13 @@ export interface PreviewOverrides {
     fontScale?: number;
     uiMode?: 'light' | 'dark';
     orientation?: 'portrait' | 'landscape';
+    /**
+     * `@Preview(device = ...)` string — `id:pixel_5`, `id:wearos_small_round`, `id:tv_1080p`,
+     * or a full `spec:width=400dp,height=800dp,dpi=320` grammar. Resolved by the daemon's
+     * built-in catalog into widthPx/heightPx/density; explicit width/height/density overrides
+     * on this same object take precedence.
+     */
+    device?: string;
 }
 
 export interface RenderNowParams {


### PR DESCRIPTION
## Summary

Adds `device: String?` to `PreviewOverrides` so a single preview can be flipped to any catalog device — `id:pixel_5`, `id:wearos_small_round`, `id:tv_1080p`, or a full `spec:width=400dp,height=800dp,dpi=320` grammar — without adding temporary `@Preview(device=…)` annotations.

- **Resolution** — Both `PreviewManifestRouter`s (Android + Desktop) resolve `device=` via a daemon-side `DeviceDimensions` catalog into `widthPx` / `heightPx` / `density` as the **base** for the render. Explicit `widthPx` / `heightPx` / `density` overrides on the same call still win, so callers can do `device: "id:pixel_5", widthPx: 600` to force a wider window on the Pixel 5's density.
- **Round detection** — The override device string is also threaded through to the rebuilt payload, so the Android renderer's `isRoundDevice(spec.device)` round-detection picks up overrides — flipping a phone preview to `id:wearos_small_round` gets the circular crop, not just the dims.
- **Catalog placement** — Daemon-side `DeviceDimensions` is **duplicated** from the Gradle plugin's copy and lives at `:daemon:core/.../daemon/devices/DeviceDimensions.kt`. The two builds are separate (`includeBuild("gradle-plugin")`) so direct sharing would require a publish-and-consume cycle on every catalog edit. Per DESIGN.md § 7 this is the same pattern `RenderEngine` already uses; drift policy is documented in the file kdoc.
- **MCP** — `render_preview` tool gains the same `device` sub-object field so agents can sweep a single preview across devices without annotation churn.
- **Docs** — PROTOCOL.md § 5 and INTERACTIVE.md § 8a updated. Shared `client-renderNow-overrides.json` fixture refreshed; round-trip tests on Kotlin + TS sides still pass.

## Test plan

- [x] `:daemon:core:test --tests MessagesTest` — 22/22 pass (protocol round-trip + new fixture)
- [x] `:daemon:android:testDebugUnitTest --tests OverrideIntegrationTest` — 3/3 pass including new `deviceOverrideResolvesCatalogDimensions` (proves catalog routing + the explicit-on-top precedence rule; ±4px tolerance for the Android qualifier path's px → dp → px round-trip)
- [x] `:daemon:core:ktfmtCheck`, `:daemon:android:ktfmtCheck`, `:daemon:desktop:ktfmtCheck`, `:mcp:ktfmtCheck` — clean
- [x] `:daemon:core:compileKotlin`, `:daemon:android:compileDebugKotlin`, `:daemon:desktop:compileKotlin`, `:mcp:compileKotlin` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmHMG3rJrJowyM15hK2Bow)_