### PR TITLE
feat(vscode): channel-close stream cleanup + Shift+LIVE multi-stream UI

### DIFF
--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -638,15 +638,17 @@ Total: ~600 lines of Kotlin + ~100 lines of TypeScript across the three PRs. Eac
   `LocalInspectionMode = true` so the input doesn't reach the active
   composition. v2 flips the local and dispatches the pixel coords
   through `ImageComposeScene`'s pointer-input pipeline.
-- **Multi-preview simultaneous live mode in the panel UI.** The wire
-  protocol supports concurrent `interactive/start` streams (see § 8),
-  but the panel only renders a single `.live` card at a time. Lifting
-  the UI is purely a webview change — `interactivePreviewId` would
-  become a `Set<previewId>` and the LIVE chip / badge would attach per
-  card — but the affordance argument for surfacing multi-target to a
-  human is weak (the user can only meaningfully focus on one live
-  preview at a time). Programmatic clients are the load-bearing case
-  for multi-target on the wire today.
+- **Multi-preview simultaneous live mode in the panel UI.** Surfaced
+  behind the Shift modifier on the LIVE toggle: plain click is
+  single-target (preserves the v1 mental model — one card live at a
+  time, follow-focus on navigation), Shift+click adds or removes the
+  focused preview from the live set without disturbing existing
+  streams. The webview keeps `interactivePreviewIds: Set<string>` and
+  decorates each card in the set; the wire protocol's multi-target
+  capability (§ 8) is what makes this trivial. Programmatic clients
+  exercising concurrent streams remain the primary load-bearing case;
+  the human-affordance argument is "nice when you need it, not in the
+  way when you don't".
 - **Mouse-move / drag** events. Click is the smallest first surface; we
   reserve the wire shape but don't capture moves to keep the
   implementation honest.

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -59,6 +59,16 @@ export interface SchedulerEvents {
     /** Phase H2 — daemon archived a render. Forwarded to the History
      *  panel; optional because the panel may not exist in test mode. */
     onHistoryAdded?: (moduleId: string, params: HistoryAddedParams) => void;
+    /**
+     * The daemon's stdio channel closed (process exit, classpath dirty,
+     * spawn died). Subscribers use this to drop module-scoped state that
+     * doesn't survive a JVM restart — `extension.ts` clears
+     * `activeInteractiveStreams` here so a subsequent `interactive/input`
+     * doesn't get routed to a stream id the new daemon doesn't know.
+     * Optional because tests may not wire it. Fires at most once per
+     * daemon lifetime per module.
+     */
+    onChannelClosed?: (moduleId: string) => void;
 }
 
 const HEAVY_TIER_DEFAULT: RenderTier = 'fast';
@@ -383,6 +393,11 @@ export class DaemonScheduler {
                 for (const k of [...this.subscribedPairs]) {
                     if (k.startsWith(`${moduleId}::`)) { this.subscribedPairs.delete(k); }
                 }
+                // Forward to the extension so it can drop interactive-mode stream state for
+                // this module — frameStreamIds don't survive a daemon restart, and a stale
+                // entry in `activeInteractiveStreams` would route subsequent clicks to a
+                // stream id the fresh daemon never minted.
+                this.events.onChannelClosed?.(moduleId);
             },
         };
     }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -463,6 +463,31 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
             // timeline.
             historyPanel?.onHistoryAdded(params);
         },
+        onChannelClosed: (moduleId) => {
+            // Daemon's stdio channel closed (process exit, classpath dirty,
+            // spawn died). frameStreamIds don't survive a JVM restart, so
+            // drop every entry in `activeInteractiveStreams` whose previewId
+            // belongs to this module. Without this, a click landing after
+            // the daemon respawned would carry a stale streamId the new
+            // JVM never minted, and v2 dispatch would silently drop. The
+            // extension's `previewModuleMap` still resolves correctly post-
+            // respawn so the lookup uses today's mapping.
+            const stale: string[] = [];
+            for (const previewId of activeInteractiveStreams.keys()) {
+                if (previewModuleMap.get(previewId) === moduleId) {
+                    stale.push(previewId);
+                }
+            }
+            for (const previewId of stale) {
+                activeInteractiveStreams.delete(previewId);
+            }
+            if (stale.length > 0) {
+                logLine(
+                    `[interactive] daemon channel closed for ${moduleId}; ` +
+                    `dropped ${stale.length} stale stream(s): ${stale.join(', ')}`,
+                );
+            }
+        },
     }, outputChannel);
 
     // Status-bar slot for daemon lifecycle. Hidden when the daemon flag is

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -314,14 +314,20 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 
         // Interactive (live-stream) mode state. Declared up here — *before*
         // the first applyLayout() call below — because applyLayout reads
-        // interactivePreviewId via the early-exit-on-focus-change path.
+        // interactivePreviewIds via the early-exit-on-focus-change path.
         // moduleDaemonReady tracks per-module daemon readiness pushed by the
         // extension via setInteractiveAvailability; the button enables only
-        // when the focused card's owning module is ready. interactivePreviewId
-        // is the single live target — see INTERACTIVE.md § 8 (one card at
-        // a time).
+        // when the focused card's owning module is ready.
+        //
+        // interactivePreviewIds is a Set so Shift+click on the LIVE toggle
+        // can add/remove a preview without disturbing others (multi-stream
+        // UI). The wire and daemon already support concurrent streams
+        // (INTERACTIVE.md § 8); the panel just exposes it under a modifier
+        // key. Default un-modified click stays single-target — clearing the
+        // set before adding the new one — so casual users don't accidentally
+        // pile up live streams.
         const moduleDaemonReady = new Map();
-        let interactivePreviewId = null;
+        const interactivePreviewIds = new Set();
 
         // Restore layout preference
         if (state.layout && ['grid', 'flow', 'column', 'focus'].includes(state.layout)) {
@@ -351,11 +357,14 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         btnDiffMain.addEventListener('click', () => requestFocusedDiff('main'));
         btnLaunchDevice.addEventListener('click', () => requestLaunchOnDevice());
         btnA11yOverlay.addEventListener('click', () => toggleA11yOverlay());
-        btnInteractive.addEventListener('click', () => toggleInteractive());
+        // Shift modifier opts into the multi-stream path: keep the prior live targets, add or
+        // remove just this one. Plain click keeps the single-target single-card UX casual users
+        // expect.
+        btnInteractive.addEventListener('click', (e) => toggleInteractive(e.shiftKey));
         btnExitFocus.addEventListener('click', () => exitFocus());
 
         // ----- Interactive (live-stream) mode helpers -----
-        // State (moduleDaemonReady, interactivePreviewId) is declared
+        // State (moduleDaemonReady, interactivePreviewIds) is declared
         // earlier so the first applyLayout() can reach it. The function
         // declarations below are hoisted, so call sites above this block
         // resolve fine.
@@ -403,13 +412,19 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             }
             const previewId = card.dataset.previewId;
             const ready = isFocusedDaemonReady();
-            const live = previewId === interactivePreviewId && interactivePreviewId !== null;
+            const live = !!previewId && interactivePreviewIds.has(previewId);
+            const otherLiveCount = interactivePreviewIds.size - (live ? 1 : 0);
             btnInteractive.disabled = !ready && !live;
             btnInteractive.setAttribute('aria-pressed', live ? 'true' : 'false');
             btnInteractive.classList.toggle('live-on', live);
             btnInteractive.title = !ready
                 ? 'Daemon not ready — live mode unavailable'
-                : (live ? 'Live · click to exit' : 'Enter live mode (stream renders)');
+                : (live
+                    ? 'Live · click to exit · Shift+click to leave others on'
+                    : (otherLiveCount > 0
+                        ? otherLiveCount + ' other live · click to make this one live too · '
+                          + 'Shift+click to add without unsubscribing the rest'
+                        : 'Enter live mode (stream renders) · Shift+click to add to multi-stream'));
             btnInteractive.innerHTML = live
                 ? '<i class="codicon codicon-record" aria-hidden="true"></i>'
                 : '<i class="codicon codicon-circle-large-outline" aria-hidden="true"></i>';
@@ -462,18 +477,20 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         }
 
         function applyLiveBadge() {
-            // Tear down all prior live decorations first so a focus change
-            // doesn't leave a stale badge on an unfocused card.
+            // Tear down every prior live decoration first — a removal from interactivePreviewIds
+            // (Shift+click off, set-cleared on daemon-not-ready, etc.) needs the badge to come
+            // off the now-not-live card. Then re-stamp every still-live preview.
             document.querySelectorAll('.preview-card.live').forEach(c => {
                 c.classList.remove('live');
                 const badge = c.querySelector('.live-badge');
                 if (badge) badge.remove();
             });
-            if (!interactivePreviewId) return;
-            const card = document.getElementById('preview-' + sanitizeId(interactivePreviewId));
-            if (!card) return;
-            card.classList.add('live');
-            if (!card.querySelector('.live-badge')) {
+            if (interactivePreviewIds.size === 0) return;
+            interactivePreviewIds.forEach(previewId => {
+                const card = document.getElementById('preview-' + sanitizeId(previewId));
+                if (!card) return;
+                card.classList.add('live');
+                if (card.querySelector('.live-badge')) return;
                 const badge = document.createElement('div');
                 badge.className = 'live-badge';
                 badge.setAttribute('aria-hidden', 'true');
@@ -484,28 +501,39 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 text.textContent = 'LIVE';
                 badge.appendChild(text);
                 card.appendChild(badge);
-            }
+            });
         }
 
-        function toggleInteractive() {
+        function toggleInteractive(shift) {
             if (layoutMode.value !== 'focus') return;
             const visible = getVisibleCards();
             const card = visible[focusIndex];
             if (!card) return;
             const previewId = card.dataset.previewId;
             if (!previewId) return;
-            const turnOn = previewId !== interactivePreviewId;
-            // Exit any prior live target before announcing the new one — the
-            // extension/daemon contract is single-target (INTERACTIVE.md § 8),
-            // so we never want two cards reporting .live at once.
-            if (interactivePreviewId && interactivePreviewId !== previewId) {
-                vscode.postMessage({
-                    command: 'setInteractive',
-                    previewId: interactivePreviewId,
-                    enabled: false,
+            const wasLive = interactivePreviewIds.has(previewId);
+            // Plain click: single-target. Drop every prior live target before adding (or
+            // re-removing) this one — keeps the casual UX matching v1's "one card live at a
+            // time" mental model.
+            // Shift+click: multi-target. Toggle just this preview in/out of the live set without
+            // touching the others.
+            if (!shift) {
+                interactivePreviewIds.forEach(prior => {
+                    if (prior === previewId) return;
+                    vscode.postMessage({
+                        command: 'setInteractive',
+                        previewId: prior,
+                        enabled: false,
+                    });
                 });
+                interactivePreviewIds.clear();
             }
-            interactivePreviewId = turnOn ? previewId : null;
+            const turnOn = !wasLive;
+            if (turnOn) {
+                interactivePreviewIds.add(previewId);
+            } else {
+                interactivePreviewIds.delete(previewId);
+            }
             vscode.postMessage({
                 command: 'setInteractive',
                 previewId,
@@ -521,12 +549,13 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         // mode exits, so non-live cards never carry the handler.
         function ensureInteractiveClickHandler(card, img) {
             const previewId = card.dataset.previewId;
-            const shouldHandle = previewId === interactivePreviewId;
+            const shouldHandle = !!previewId && interactivePreviewIds.has(previewId);
             if (shouldHandle && img.dataset.interactiveBound !== '1') {
                 img.dataset.interactiveBound = '1';
                 img.addEventListener('click', (evt) => {
-                    if (card.dataset.previewId !== interactivePreviewId) return;
-                    recordInteractiveClick(previewId, img, evt);
+                    const id = card.dataset.previewId;
+                    if (!id || !interactivePreviewIds.has(id)) return;
+                    recordInteractiveClick(id, img, evt);
                 });
             } else if (!shouldHandle && img.dataset.interactiveBound === '1') {
                 // Listener leak isn't worth a clone+replace dance — set the
@@ -699,18 +728,22 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             const tooltip = mode === 'focus' ? 'Double-click to exit focus' : 'Double-click to focus';
             document.querySelectorAll('.image-container').forEach(c => c.title = tooltip);
             publishScopedPreview();
-            // If the user navigated focus off the live preview, drop the
-            // live state so the badge and the "is live" UI follow the user.
-            if (interactivePreviewId) {
+            // Single-target follow-focus: when there's exactly one live stream and the user
+            // navigates off it, drop the stream so the LIVE chip follows the focused card.
+            // Multi-target (size > 1) is treated as an explicit opt-in via Shift+click — those
+            // streams persist across focus navigation until the user explicitly toggles them off
+            // (or daemon dies, or the webview disposes).
+            if (interactivePreviewIds.size === 1) {
                 const visible = getVisibleCards();
                 const card = mode === 'focus' ? visible[focusIndex] : null;
-                if (!card || card.dataset.previewId !== interactivePreviewId) {
+                const lone = interactivePreviewIds.values().next().value;
+                if (!card || card.dataset.previewId !== lone) {
                     vscode.postMessage({
                         command: 'setInteractive',
-                        previewId: interactivePreviewId,
+                        previewId: lone,
                         enabled: false,
                     });
-                    interactivePreviewId = null;
+                    interactivePreviewIds.clear();
                     applyLiveBadge();
                 }
             }
@@ -1877,7 +1910,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             // In live mode the new bytes are a frame, not a card reload —
             // skip the fade-in so successive frames read as a stream rather
             // than a sequence of independent renders. See INTERACTIVE.md § 3.
-            const isLive = previewId === interactivePreviewId;
+            const isLive = interactivePreviewIds.has(previewId);
             img.className = isLive ? 'live-frame' : 'fade-in';
             ensureInteractiveClickHandler(card, img);
 
@@ -2143,12 +2176,14 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     applyLayout();
                     // setPreviews can rebuild the focused card from scratch;
                     // re-stamp the live badge so the LIVE chip reattaches to
-                    // the right card. If the previously-live preview is gone
-                    // from the new manifest, drop the live state outright.
-                    if (interactivePreviewId
-                        && !msg.previews.some(p => p.id === interactivePreviewId)) {
-                        interactivePreviewId = null;
-                    }
+                    // the right card(s). Drop any live previewIds that are
+                    // gone from the new manifest — silent cleanup; we don't
+                    // bother sending interactive/stop because the preview no
+                    // longer exists for the daemon to dispatch into anyway.
+                    const newIds = new Set(msg.previews.map(p => p.id));
+                    interactivePreviewIds.forEach(id => {
+                        if (!newIds.has(id)) interactivePreviewIds.delete(id);
+                    });
                     applyLiveBadge();
                     applyInteractiveButtonState();
                     break;
@@ -2324,9 +2359,13 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     moduleDaemonReady.set(msg.moduleId, !!msg.ready);
                     // Daemon went away while a card was live — drop the live
                     // state so the user doesn't keep seeing a LIVE badge on
-                    // a card whose stream has stopped.
-                    if (!msg.ready && interactivePreviewId) {
-                        interactivePreviewId = null;
+                    // a card whose stream has stopped. Today the panel is
+                    // single-module-scoped so any not-ready signal applies
+                    // to every live preview; if the panel ever shows multi-
+                    // module previews simultaneously, this needs scoping by
+                    // each preview's owning module.
+                    if (!msg.ready && interactivePreviewIds.size > 0) {
+                        interactivePreviewIds.clear();
                         applyLiveBadge();
                     }
                     applyInteractiveButtonState();

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -102,6 +102,7 @@ function build() {
         previewId: string;
         attachments: { kind: string; payload?: unknown; path?: string }[];
     }[] = [];
+    const channelClosed: string[] = [];
     const events = {
         onPreviewImageReady: (moduleId: string, previewId: string, base64: string, pngPath: string) => {
             images.push({ moduleId, previewId, base64, pngPath });
@@ -122,13 +123,16 @@ function build() {
         onDiscoveryUpdated: (moduleId: string, params: { added: unknown[]; removed: string[]; changed: unknown[]; totalPreviews: number }) => {
             discovery.push({ moduleId, params });
         },
+        onChannelClosed: (moduleId: string) => {
+            channelClosed.push(moduleId);
+        },
     };
     const scheduler = new DaemonScheduler(
         gate as unknown as ConstructorParameters<typeof DaemonScheduler>[0],
         events,
         { appendLine: (s) => log.push(s) },
     );
-    return { gate, scheduler, log, images, failures, dirty, discovery, dataProducts };
+    return { gate, scheduler, log, images, failures, dirty, discovery, dataProducts, channelClosed };
 }
 
 describe('DaemonScheduler', () => {
@@ -350,6 +354,19 @@ describe('DaemonScheduler', () => {
         await scheduler.setVisible('mod', ['v1'], ['p1', 'p2']);
         const renderCalls = fresh.calls.filter(c => c.method === 'renderNow');
         assert.strictEqual(renderCalls.length, 1, 'speculation cache survived channel close');
+    });
+
+    it('forwards onChannelClosed to the caller with the moduleId attached', async () => {
+        // The extension uses this hook to drop interactive-mode stream state for the dead
+        // daemon — frameStreamIds don't survive a JVM restart, so a stale entry would route
+        // future clicks to a stream id the new daemon never minted.
+        const { gate, scheduler, channelClosed } = build();
+        await scheduler.ensureModule('alpha');
+        await scheduler.ensureModule('beta');
+        gate.capturedEvents.get('alpha')!.onChannelClosed!();
+        assert.deepStrictEqual(channelClosed, ['alpha']);
+        gate.capturedEvents.get('beta')!.onChannelClosed!();
+        assert.deepStrictEqual(channelClosed, ['alpha', 'beta']);
     });
 
     it('routes classpathDirty to the caller and drops the module speculation cache', async () => {


### PR DESCRIPTION
Two interactive-mode follow-ups to the v2 rollout (#406, #408, #409). Both VS-Code-side; no daemon work needed.

## 1. Channel-close stream cleanup

`SchedulerEvents` grows an `onChannelClosed?: (moduleId) => void` callback; `DaemonScheduler` forwards the gate's existing channel-close event to the extension. `extension.ts` uses it to drop entries from `activeInteractiveStreams` whose `previewId` belongs to the dead daemon's module.

**Why this matters.** `frameStreamId`s are minted per-`interactive/start` and don't survive a JVM restart. Without this cleanup, a click landing after a daemon respawn (classpath-dirty + reboot, JVM crash, manual restart) would carry a stale stream id; the fresh daemon would silently drop it on the v2 dispatch path, and the user would see clicks stop working with no signal.

A log line fires when at least one stream is dropped so it's traceable in the output channel.

## 2. Shift+LIVE multi-stream UI

The webview's `interactivePreviewId: string | null` becomes `interactivePreviewIds: Set<string>`:

- **Plain click** on the LIVE toggle stays single-target — drops every prior live stream before adding (or removing) this one. Preserves the v1 mental model and the follow-focus-on-navigation behaviour casual users expect.
- **Shift+click** toggles just this preview in/out of the live set without disturbing the rest. Multi-stream mode persists across focus navigation; the user explicitly opted in.
- **LIVE button title** surfaces the multi-stream affordance dynamically:
  - "Enter live mode (stream renders) · Shift+click to add to multi-stream" — when nothing's live.
  - "2 other live · click to make this one live too · Shift+click to add without unsubscribing the rest" — when other previews are already live.
  - "Live · click to exit · Shift+click to leave others on" — when this card is live.
- `applyLiveBadge` walks the set so every live card carries the chip.
- `ensureInteractiveClickHandler` / `updateImage` / `setPreviews` check set membership instead of equality.
- Daemon-not-ready signal clears the entire set (panel-side conservatism — daemon's stream registry is already gone if it told us it's not ready).

The wire and daemon already supported concurrent streams via per-streamId routing (#406 / #409); this PR just exposes it under the Shift modifier. Programmatic clients exercising concurrent streams remain the primary load-bearing case for multi-target on the wire.

`INTERACTIVE.md § 9` updated to reflect "Shift+LIVE is now reachable", not "out of scope".

## Tests

- New `DaemonScheduler` test (`forwards onChannelClosed to the caller with the moduleId attached`) asserts the new event forwards correctly across modules. Existing channel-close test (`clears the speculation cache and visibility memo when the channel closes`) still passes — channel-close is now both internally-reactive AND outwardly-observable.
- Webview Set-based logic isn't unit-tested directly (lives inline in the HTML template, driven by DOM events the test harness can't simulate); the existing `WebviewToExtension` message tests exercise the protocol surface that connects them to `extension.ts`.

## Test plan

- [x] `cd vscode-extension && npm run compile` — clean
- [x] `cd vscode-extension && npm test` — 315/315 pass (was 314; one new)
- [ ] Manual: Plain click LIVE on preview A, navigate to B → A drops live (single-target follow-focus, unchanged).
- [ ] Manual: Plain click LIVE on A, Shift+click LIVE on B → both live, navigate to C, both still live (multi-stream persists).
- [ ] Manual: Two live, Shift+click LIVE on one of them → only that one stops, the other stays.
- [ ] Manual: Force daemon restart (classpath dirty) while LIVE is on → next click is silently dropped only if the cleanup didn't fire; with cleanup, the next user click would re-trigger an `interactive/start` against the new daemon. (TODO: this also wants the `setInteractive` re-issue path that PR 1's panel currently lacks — out of scope here.)

## Not addressed (still in the daemon agent's queue)

- "Daemon doesn't support v2" status-bar hint — needs a daemon-side signal first (capability bit on `InitializeResult` or on `InteractiveStartResult`). Once that lands, the panel renders the hint in a one-line follow-up.
- `Modifier.clickable {}` reliability under `ImageComposeScene`'s manual clock — pure `:daemon:desktop` work.
- Display dimensions threaded through `previewSpecResolver` — needs `PreviewInfoDto` widening in `:daemon:core` + gradle plugin.


---
_Generated by [Claude Code](https://claude.ai/code/session_017NDGZk17VhvctNNoSrVZsK)_