### PR TITLE
feat(daemon): advertise InitializeResult.capabilities.interactive

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -580,6 +580,10 @@ class JsonRpcServer(
             leakDetection = emptyList<LeakDetectionMode>(),
             // D1 — advertised kinds. Empty when no producer was wired (pre-D2 default).
             dataProducts = dataProducts.capabilities,
+            // INTERACTIVE.md § 9 — `true` when the host's `acquireInteractiveSession` returns a
+            // real held-scene session (DesktopHost). `false` for hosts that inherit the throwing
+            // default (FakeHost, RobolectricHost today) — clients fall back to v1 dispatch.
+            interactive = host.supportsInteractive,
           ),
         // B2.1 — surface the authoritative SHA-256 to the client so VS Code can correlate later
         // `classpathDirty` notifications against the daemon's known-at-startup state. Empty

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -83,13 +83,28 @@ interface RenderHost {
   }
 
   /**
+   * `true` when this host's [acquireInteractiveSession] returns a real held-scene session that
+   * dispatches `interactive/input` into the composition (v2). `false` (the default) when the host
+   * inherits the throwing default and `interactive/input` falls back to v1 (re-render trigger,
+   * input does not reach the composition). Surfaced verbatim as
+   * `InitializeResult.capabilities.interactive` so clients can render an "unsupported host" hint
+   * without a per-call probe.
+   *
+   * Implementations MUST keep this in sync with their [acquireInteractiveSession] override —
+   * advertising `true` while throwing is a contract violation.
+   */
+  val supportsInteractive: Boolean
+    get() = false
+
+  /**
    * Allocate an [InteractiveSession] for [previewId] — the v2 click-into-composition surface
    * documented in
    * [INTERACTIVE.md § 9](../../../../../../docs/daemon/INTERACTIVE.md#9-v2--click-dispatch-into-composition).
    *
-   * Hosts that support interactive mode (today: `:daemon:desktop`'s `DesktopHost` once PR 2 lands)
-   * override and return a session holding a warm `ImageComposeScene` (or per-host equivalent) so
-   * `remember`'d state survives across `interactive/input` notifications.
+   * Hosts that support interactive mode (today: `:daemon:desktop`'s `DesktopHost`) override and
+   * return a session holding a warm `ImageComposeScene` (or per-host equivalent) so `remember`'d
+   * state survives across `interactive/input` notifications. Such hosts MUST also override
+   * [supportsInteractive] to return `true`.
    *
    * The default body throws [UnsupportedOperationException] — which
    * [JsonRpcServer.handleInteractiveStart] translates to `MethodNotFound (-32601)` on the wire. v1

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -116,6 +116,12 @@ data class ServerCapabilities(
   // client side treats absent and `[]` identically). See
   // docs/daemon/DATA-PRODUCTS.md § "Wire surface".
   val dataProducts: List<DataProductCapability> = emptyList(),
+  // INTERACTIVE.md § 9 — `true` when the daemon's host can dispatch
+  // `interactive/input` events into a held composition (v2). `false` means
+  // `interactive/start` still works but inputs trigger a re-render rather than
+  // mutating state (v1 fallback). Defaulted for old daemons that pre-date the
+  // capability — clients treat absent and `false` identically.
+  val interactive: Boolean = false,
 )
 
 /**

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -91,6 +91,17 @@ open class DesktopHost(
   private val previewSpecResolver: ((String) -> RenderSpec?)? = null,
 ) : RenderHost {
 
+  /**
+   * INTERACTIVE.md § 9 — `true` only when a [previewSpecResolver] was wired at construction.
+   * Without one, [acquireInteractiveSession] throws unconditionally; advertising `true` in that
+   * shape would mislead the client into thinking it can dispatch into a held composition. The
+   * production daemon-main path always passes a resolver, so the production wire is `true` for
+   * desktop daemons and stays `false` for in-process tests that don't wire one (which are the
+   * same tests that exercise the v1 fallback path).
+   */
+  override val supportsInteractive: Boolean
+    get() = previewSpecResolver != null
+
   private val requests: LinkedBlockingQueue<RenderRequest> = LinkedBlockingQueue()
   private val results: ConcurrentHashMap<Long, LinkedBlockingQueue<Any>> = ConcurrentHashMap()
 

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.daemon
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -56,6 +57,28 @@ class DesktopHostTest {
     assertFalse(
       "render thread observed an InterruptedException — DESIGN § 9 invariant violated",
       host.renderThreadInterrupted,
+    )
+  }
+
+  /**
+   * Capability-bit contract — `supportsInteractive` reflects whether a `previewSpecResolver` was
+   * wired at construction. Clients consume this verbatim as
+   * `InitializeResult.capabilities.interactive`; advertising `true` while
+   * `acquireInteractiveSession` would throw is a contract violation that misleads the panel into
+   * showing a v2 affordance the daemon can't honour.
+   */
+  @Test
+  fun supportsInteractiveReflectsResolverPresence() {
+    val withoutResolver = DesktopHost()
+    assertFalse(
+      "DesktopHost without a previewSpecResolver must advertise interactive=false",
+      withoutResolver.supportsInteractive,
+    )
+
+    val withResolver = DesktopHost(previewSpecResolver = { null })
+    assertTrue(
+      "DesktopHost with a previewSpecResolver must advertise interactive=true",
+      withResolver.supportsInteractive,
     )
   }
 }


### PR DESCRIPTION
## Summary

Follow-up #5 from the Interactive v2 review — add a capability bit so clients can render an "unsupported host" hint without a per-call probe of `interactive/start`.

- New `RenderHost.supportsInteractive: Boolean` property; defaults to `false`. Hosts that override `acquireInteractiveSession` to return a real held-scene session MUST also override this so the throw-vs-handle contract stays honest.
- `DesktopHost.supportsInteractive` reflects whether a `previewSpecResolver` was wired at construction. Without one, `acquireInteractiveSession` throws unconditionally; advertising `true` in that shape would mislead clients into showing a v2 affordance the daemon can't honour.
- New additive `interactive: Boolean = false` field on `ServerCapabilities`. Defaulted so old daemons that pre-date the capability serialise identically and pre-PR clients treat absent and `false` as the same. No `protocolVersion` bump per [PROTOCOL.md § 7](docs/daemon/PROTOCOL.md#7-versioning).
- `JsonRpcServer.handleInitialize` populates `capabilities.interactive = host.supportsInteractive` verbatim — no per-host knowledge in the dispatcher.

## Test plan

- [x] `:daemon:desktop:test --tests DesktopHostTest` — green; the new `supportsInteractiveReflectsResolverPresence` asserts both directions of the resolver contract.
- [x] `:daemon:core:test --tests "ee.schimke.composeai.daemon.protocol.MessagesTest"` — green; `daemon-initializeResult.json` round-trip stays clean because `encodeDefaults = false` skips the new defaulted field.
- [x] Full `:daemon:core:test` and `:daemon:desktop:test` — green except for the pre-existing `JsonRpcServerIntegrationTest.fileChanged_then_renderNow_emits_renderFinished_before_discoveryUpdated` flake (passes on rerun, reproduces on bare main, orthogonal to this PR).

## Follow-ups (not in this PR)

- Bump `daemon-initializeResult.json` to set `interactive: true` so the canonical fixture documents a production-shaped daemon (its `dataProducts` block already advertises both a11y kinds, so it's already representing the "everything wired" shape). Cosmetic; not load-bearing for any test.
- VS Code status-bar hint that surfaces "interactive mode unsupported by Android backend" can now consume `capabilities.interactive` directly. Tracked in #422 alongside the v3 Robolectric design pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYvTgEGDJxSu9gAGUTF9ub)_