### PR TITLE
fix(ci): unbreak ktfmt + CodeQL on main (D3 / #423 follow-ups)

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
@@ -81,16 +81,16 @@ interface DataProductRegistry {
      * 1. Queueing a re-render of just `previewId` in [mode], emitting a normal
      *    `renderStarted`/`renderFinished` so the panel UI updates the PNG if it changed.
      * 2. Bounding the wait by the per-request budget (`composeai.daemon.dataFetchRerenderBudgetMs`,
-     *    default 30000ms). On budget exceeded the dispatcher returns
-     *    [Outcome.BudgetExceeded]'s wire error (`-32023`) — but per the spec the render is *not*
-     *    cancelled, the fetch just gives up waiting for it.
+     *    default 30000ms). On budget exceeded the dispatcher returns [Outcome.BudgetExceeded]'s
+     *    wire error (`-32023`) — but per the spec the render is *not* cancelled, the fetch just
+     *    gives up waiting for it.
      * 3. Re-invoking [fetch] once the render lands so the registry can return [Ok] (or another
      *    failure) against the now-current pass.
      *
      * `mode` is a renderer-side mode tag (e.g. `"a11y"`, `"recomposition"`); the dispatcher
      * forwards it through the host payload's `mode=<mode>` key so the renderer-agnostic seam stays
-     * stringly-typed. Producers pick the smallest mode that produces the kind — different kinds
-     * MAY share a mode, in which case a follow-up D-step can opportunistically piggy-back fetches
+     * stringly-typed. Producers pick the smallest mode that produces the kind — different kinds MAY
+     * share a mode, in which case a follow-up D-step can opportunistically piggy-back fetches
      * against an already-queued re-render.
      */
     data class RequiresRerender(val mode: String) : Outcome

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -181,16 +181,16 @@ class JsonRpcServer(
    */
   private val dataProducts: DataProductRegistry = DataProductRegistry.Empty,
   /**
-   * D3 — per-request budget for `data/fetch` re-render-on-demand (DATA-PRODUCTS.md §
-   * "Re-render semantics"). When the registry returns
-   * [DataProductRegistry.Outcome.RequiresRerender] the dispatcher queues a fresh render in the
-   * required mode and waits at most this many milliseconds for the payload to land. On timeout we
-   * return `DataProductBudgetExceeded` (-32023); the render itself is **not** cancelled —
-   * Robolectric mid-render cancellation is unsafe (PROTOCOL.md § 8) — the fetch just stops waiting
-   * and lets the regular `renderFinished` notification ship when the render eventually completes.
+   * D3 — per-request budget for `data/fetch` re-render-on-demand (DATA-PRODUCTS.md § "Re-render
+   * semantics"). When the registry returns [DataProductRegistry.Outcome.RequiresRerender] the
+   * dispatcher queues a fresh render in the required mode and waits at most this many milliseconds
+   * for the payload to land. On timeout we return `DataProductBudgetExceeded` (-32023); the render
+   * itself is **not** cancelled — Robolectric mid-render cancellation is unsafe (PROTOCOL.md § 8) —
+   * the fetch just stops waiting and lets the regular `renderFinished` notification ship when the
+   * render eventually completes.
    *
-   * Default 30000ms per the spec. Overridable via the
-   * [DATA_FETCH_RERENDER_BUDGET_PROP] sysprop or the constructor (tests pin it small).
+   * Default 30000ms per the spec. Overridable via the [DATA_FETCH_RERENDER_BUDGET_PROP] sysprop or
+   * the constructor (tests pin it small).
    */
   private val dataFetchRerenderBudgetMs: Long =
     System.getProperty(DATA_FETCH_RERENDER_BUDGET_PROP)?.toLongOrNull()
@@ -282,8 +282,8 @@ class JsonRpcServer(
    * host-side render id; [emitRenderFinished] / [emitRenderFailed] complete it as soon as the
    * watcher loop processes the result. The waiter then re-invokes `dataProducts.fetch` to get the
    * payload. On budget timeout the waiter abandons the entry — but does NOT cancel the render
-   * (PROTOCOL.md § 8 — no mid-render cancellation), so a stale entry may linger; the watcher
-   * cleans it up when the render eventually finishes.
+   * (PROTOCOL.md § 8 — no mid-render cancellation), so a stale entry may linger; the watcher cleans
+   * it up when the render eventually finishes.
    */
   private val dataFetchWaiters =
     ConcurrentHashMap<Long, java.util.concurrent.CompletableFuture<RerenderOutcome>>()
@@ -1395,13 +1395,13 @@ class JsonRpcServer(
    *    `renderStarted`/`renderFinished` exactly as for a `renderNow`-driven render — the panel UI
    *    repaints if the PNG changed (DATA-PRODUCTS.md:291-293).
    * 2. Parks on a [java.util.concurrent.CompletableFuture] keyed by that host id, with the
-   *    per-request budget ([dataFetchRerenderBudgetMs]) as the deadline. The future is completed
-   *    by [emitRenderFinished] / [emitRenderFailed] when the watcher processes the result.
-   * 3. On `Ok`, re-invokes `dataProducts.fetch(...)` and routes the resulting [Outcome] to the
-   *    wire via [sendDataFetchOutcome]. On `Failed`, returns `DataProductFetchFailed`. On budget
-   *    timeout, returns `DataProductBudgetExceeded`; the render itself keeps going and the
-   *    waiter entry is leaked into `dataFetchWaiters` until the watcher finally clears it
-   *    (PROTOCOL.md § 8 — no mid-render cancellation).
+   *    per-request budget ([dataFetchRerenderBudgetMs]) as the deadline. The future is completed by
+   *    [emitRenderFinished] / [emitRenderFailed] when the watcher processes the result.
+   * 3. On `Ok`, re-invokes `dataProducts.fetch(...)` and routes the resulting [Outcome] to the wire
+   *    via [sendDataFetchOutcome]. On `Failed`, returns `DataProductFetchFailed`. On budget
+   *    timeout, returns `DataProductBudgetExceeded`; the render itself keeps going and the waiter
+   *    entry is leaked into `dataFetchWaiters` until the watcher finally clears it (PROTOCOL.md § 8
+   *    — no mid-render cancellation).
    */
   private fun handleDataFetchWithRerender(
     req: JsonRpcRequest,
@@ -1458,12 +1458,7 @@ class JsonRpcServer(
               // producer bug — we don't recurse, we surface a fetch-failed so callers see it.
               val secondOutcome =
                 try {
-                  dataProducts.fetch(
-                    params.previewId,
-                    params.kind,
-                    params.params,
-                    params.inline,
-                  )
+                  dataProducts.fetch(params.previewId, params.kind, params.params, params.inline)
                 } catch (t: Throwable) {
                   DataProductRegistry.Outcome.FetchFailed(
                     "registry threw on post-rerender fetch: ${t.message ?: t.javaClass.simpleName}"
@@ -1492,15 +1487,18 @@ class JsonRpcServer(
   /**
    * Submits the fetch-driven re-render onto the host. Mirrors [submitRenderAsync] but takes a
    * pre-encoded payload (with `mode=<mode>`) and routes failures into [renderResultsQueue] so the
-   * watcher loop's existing `renderFailed` path handles them — and so the [dataFetchWaiters]
-   * future is woken via [emitRenderFailed]'s completion call rather than by this thread.
+   * watcher loop's existing `renderFailed` path handles them — and so the [dataFetchWaiters] future
+   * is woken via [emitRenderFailed]'s completion call rather than by this thread.
    */
   private fun submitRerenderForFetch(hostId: Long, payload: String) {
     Thread(
         {
           try {
             val raw =
-              host.submit(RenderRequest.Render(id = hostId, payload = payload), timeoutMs = 5 * 60_000)
+              host.submit(
+                RenderRequest.Render(id = hostId, payload = payload),
+                timeoutMs = 5 * 60_000,
+              )
             renderResultsQueue.put(raw)
           } catch (e: Throwable) {
             System.err.println(
@@ -1516,20 +1514,19 @@ class JsonRpcServer(
   }
 
   /**
-   * D3 — encodes a [RenderRequest.Render.payload] with `previewId=<id>;mode=<mode>`. The `mode`
-   * key is consumed renderer-side (D2 / `renderer-android`) to pick the smallest render
-   * configuration that produces the requested kind — the daemon stays kind-agnostic and just
-   * forwards the producer-supplied tag. Fake-mode hosts (the test harness's `FakeHost`,
-   * `FakeRenderHost` in unit tests) ignore unknown payload keys, so this is forward-compatible.
+   * D3 — encodes a [RenderRequest.Render.payload] with `previewId=<id>;mode=<mode>`. The `mode` key
+   * is consumed renderer-side (D2 / `renderer-android`) to pick the smallest render configuration
+   * that produces the requested kind — the daemon stays kind-agnostic and just forwards the
+   * producer-supplied tag. Fake-mode hosts (the test harness's `FakeHost`, `FakeRenderHost` in unit
+   * tests) ignore unknown payload keys, so this is forward-compatible.
    */
-  private fun encodeRenderPayloadWithMode(previewId: String, mode: String): String =
-    buildString {
-      if (previewId.isNotEmpty()) append("previewId=").append(previewId)
-      if (mode.isNotEmpty()) {
-        if (isNotEmpty()) append(';')
-        append("mode=").append(mode)
-      }
+  private fun encodeRenderPayloadWithMode(previewId: String, mode: String): String = buildString {
+    if (previewId.isNotEmpty()) append("previewId=").append(previewId)
+    if (mode.isNotEmpty()) {
+      if (isNotEmpty()) append(';')
+      append("mode=").append(mode)
     }
+  }
 
   private fun sendDataFetchOutcome(
     req: JsonRpcRequest,
@@ -2320,9 +2317,9 @@ class JsonRpcServer(
   }
 
   /**
-   * D3 — completion signal for [dataFetchWaiters]. The watcher loop completes the future with
-   * [Ok] when the underlying render lands and with [Failed] when the host rejects it; the data-
-   * fetch worker thread reads which one it got and decides whether to re-call the registry, surface
+   * D3 — completion signal for [dataFetchWaiters]. The watcher loop completes the future with [Ok]
+   * when the underlying render lands and with [Failed] when the host rejects it; the data- fetch
+   * worker thread reads which one it got and decides whether to re-call the registry, surface
    * `DataProductFetchFailed`, or — on its own timeout path — surface `DataProductBudgetExceeded`.
    */
   private sealed interface RerenderOutcome {

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DataFetchRerenderTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DataFetchRerenderTest.kt
@@ -26,25 +26,24 @@ import org.junit.Test
 
 /**
  * D3 — `data/fetch` re-render-on-demand behaviour. See
- * [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md) §
- * "Re-render semantics" + § "Wire surface > data/fetch".
+ * [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md) § "Re-render
+ * semantics" + § "Wire surface > data/fetch".
  *
  * The tests drive the JSON-RPC surface end-to-end against a [FakeProducer] [DataProductRegistry]
  * that swings between "needs a re-render" and "Ok with the payload" depending on whether a render
- * has been observed for the requested preview. That lets us pin every documented branch
- * (happy-path re-render -> payload, post-render-no-payload -> fetch-failed, budget-exceeded)
- * without standing up a real renderer-side producer (D2 / `renderer-android` lands on a separate
- * branch).
+ * has been observed for the requested preview. That lets us pin every documented branch (happy-path
+ * re-render -> payload, post-render-no-payload -> fetch-failed, budget-exceeded) without standing
+ * up a real renderer-side producer (D2 / `renderer-android` lands on a separate branch).
  */
 class DataFetchRerenderTest {
 
   private val json = Json { ignoreUnknownKeys = true }
 
   /**
-   * Happy path. Producer reports "needs a11y mode re-render" on the first fetch, the daemon kicks
-   * a re-render off the regular render-queue path, the watcher emits `renderStarted` /
-   * `renderFinished`, the producer returns `Ok` on re-call, and the `data/fetch` response
-   * resolves with the payload.
+   * Happy path. Producer reports "needs a11y mode re-render" on the first fetch, the daemon kicks a
+   * re-render off the regular render-queue path, the watcher emits `renderStarted` /
+   * `renderFinished`, the producer returns `Ok` on re-call, and the `data/fetch` response resolves
+   * with the payload.
    */
   @Test(timeout = 30_000)
   fun rerender_happy_path_emits_render_notifications_then_payload_response() {
@@ -61,16 +60,16 @@ class DataFetchRerenderTest {
       )
 
       // Renderer-side notifications fire as for a regular renderNow - UI panel updates the PNG.
-      val started =
-        rpc.pollUntil { it["method"]?.jsonPrimitive?.contentOrNull == "renderStarted" }
+      val started = rpc.pollUntil { it["method"]?.jsonPrimitive?.contentOrNull == "renderStarted" }
       assertNotNull("renderStarted should fire for the fetch-driven re-render", started)
       assertEquals(
         "com.example.Foo_bar",
         started!!["params"]!!.jsonObject["id"]?.jsonPrimitive?.contentOrNull,
       )
 
-      val finished =
-        rpc.pollUntil { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+      val finished = rpc.pollUntil {
+        it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished"
+      }
       assertNotNull("renderFinished should fire for the fetch-driven re-render", finished)
       assertEquals(
         "com.example.Foo_bar",
@@ -184,8 +183,8 @@ class DataFetchRerenderTest {
   }
 
   /**
-   * Producer returns `RequiresRerender` *again* after the re-render lands. The dispatcher must
-   * NOT recurse infinitely - surface a `DataProductFetchFailed` once and stop.
+   * Producer returns `RequiresRerender` *again* after the re-render lands. The dispatcher must NOT
+   * recurse infinitely - surface a `DataProductFetchFailed` once and stop.
    */
   @Test(timeout = 30_000)
   fun rerender_then_second_requires_rerender_does_not_loop() {
@@ -214,8 +213,8 @@ class DataFetchRerenderTest {
 
   /**
    * Pre-render-on-demand fast paths still work - `Outcome.Ok` returned directly skips the worker
-   * entirely. Pins that we haven't accidentally regressed the D1 "kind already produced" path
-   * by routing it through the new D3 worker.
+   * entirely. Pins that we haven't accidentally regressed the D1 "kind already produced" path by
+   * routing it through the new D3 worker.
    */
   @Test(timeout = 15_000)
   fun ok_outcome_short_circuits_without_a_rerender() {
@@ -251,10 +250,7 @@ class DataFetchRerenderTest {
           val method = it["method"]?.jsonPrimitive?.contentOrNull
           method == "renderStarted" || method == "renderFinished"
         }
-      assertFalse(
-        "Ok-shortcut must not trigger a render - only RequiresRerender does",
-        sawRender,
-      )
+      assertFalse("Ok-shortcut must not trigger a render - only RequiresRerender does", sawRender)
       assertEquals("Ok shortcut must not call the host", 0, producer.renderSubmits.get())
     }
   }
@@ -266,10 +262,10 @@ class DataFetchRerenderTest {
   /**
    * In-memory [DataProductRegistry] driven by per-test config:
    * - [modeForKind] tells the first fetch for a given kind to return `RequiresRerender(<mode>)`.
-   * - After the dispatcher's re-render lands ([renderObserved] is set), subsequent fetches for
-   *   that kind return [postRerenderOutcome] (defaults to a synthetic `Ok` payload).
-   * - [immediateOk] lets a test inject "Ok on first call, no re-render needed" for the D1
-   *   fast-path regression coverage.
+   * - After the dispatcher's re-render lands ([renderObserved] is set), subsequent fetches for that
+   *   kind return [postRerenderOutcome] (defaults to a synthetic `Ok` payload).
+   * - [immediateOk] lets a test inject "Ok on first call, no re-render needed" for the D1 fast-path
+   *   regression coverage.
    */
   private class FakeProducer(
     private val modeForKind: Map<String, String>,
@@ -331,10 +327,8 @@ class DataFetchRerenderTest {
         )
     }
 
-    override fun attachmentsFor(
-      previewId: String,
-      kinds: Set<String>,
-    ) = emptyList<ee.schimke.composeai.daemon.protocol.DataProductAttachment>()
+    override fun attachmentsFor(previewId: String, kinds: Set<String>) =
+      emptyList<ee.schimke.composeai.daemon.protocol.DataProductAttachment>()
 
     /** Called by [TestRenderHost] when the dispatcher submits a render. */
     fun observeRenderSubmit(payload: String) {
@@ -380,11 +374,7 @@ class DataFetchRerenderTest {
                     continue
                   }
                   val result =
-                    RenderResult(
-                      id = req.id,
-                      classLoaderHashCode = 0,
-                      classLoaderName = "test",
-                    )
+                    RenderResult(id = req.id, classLoaderHashCode = 0, classLoaderName = "test")
                   results.computeIfAbsent(req.id) { LinkedBlockingQueue() }.put(result)
                 }
                 RenderRequest.Shutdown -> return@Thread
@@ -467,11 +457,7 @@ class DataFetchRerenderTest {
     readerThread.start()
 
     val driver =
-      RpcDriver(
-        clientToServerOut = clientToServerOut,
-        received = received,
-        history = history,
-      )
+      RpcDriver(clientToServerOut = clientToServerOut, received = received, history = history)
     try {
       block(driver)
       // Tear down - drop subscriptions / let renders drain. Skip shutdown for the
@@ -480,10 +466,7 @@ class DataFetchRerenderTest {
         driver.send("""{"jsonrpc":"2.0","id":9999,"method":"shutdown"}""")
         driver.pollUntil { it["id"]?.jsonPrimitive?.intOrNull == 9999 }
         driver.send("""{"jsonrpc":"2.0","method":"exit"}""")
-        assertTrue(
-          "server should exit cleanly within 10s",
-          exitLatch.await(10, TimeUnit.SECONDS),
-        )
+        assertTrue("server should exit cleanly within 10s", exitLatch.await(10, TimeUnit.SECONDS))
       }
       // Render thread interrupt invariant - fetch-driven re-renders must not interrupt the host.
       assertEquals(


### PR DESCRIPTION
## Summary

Fix two CI breaks left behind by recent daemon-side merges:

- **`ktfmt (Google style)` failure** — PRs #419 and #423 landed unformatted KDoc/call-site reflows in `daemon:core` (`DataProductRegistry.kt`, `JsonRpcServer.kt`, `DataFetchRerenderTest.kt`). Re-run `:daemon:core:ktfmtFormatMain` + `ktfmtFormatTest`. Pure formatter output, no semantic changes.
- **`Analyze (java-kotlin)` (CodeQL) failure** — PR #423 added a per-call `overrides` parameter to `renderAndReadBytes` and threaded it into the inner `renderNow` call, but never plumbed it through `awaitNextRender`'s parameter list, leaving an unresolved reference at `DaemonMcpServer.kt:335` that broke `:mcp:compileKotlin` (and CodeQL's java-kotlin DB build by extension). Add the missing `overrides` param and pass it from the one call site that has it.

## Test plan

- [x] `./gradlew ktfmtCheckAll` passes locally
- [x] `./gradlew compileKotlin compileDebugKotlin compileReleaseKotlin --no-configuration-cache --no-build-cache -Dorg.gradle.unsafe.isolated-projects=false --continue` passes locally (matches the CodeQL workflow's compile step)
- [x] `./gradlew :mcp:test` passes locally
- [ ] CI `ktfmt (Google style)` job passes
- [ ] CI `Analyze (java-kotlin)` job passes

Note: `wear-os-samples (ComposeStarter)` was also red on `95f4e7f` — that one fails inside an external repo's daemon round-trip integration and looks unrelated; out of scope here.