### PR TITLE
chore(vscode): collapse History view by default; mark Previews visible

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -56,13 +56,15 @@
                 {
                     "type": "webview",
                     "id": "composePreview.panel",
-                    "name": "Previews"
+                    "name": "Previews",
+                    "visibility": "visible"
                 },
                 {
                     "type": "webview",
                     "id": "composePreview.historyPanel",
                     "name": "History",
-                    "when": "config.composePreview.experimental.daemon.enabled"
+                    "when": "config.composePreview.experimental.daemon.enabled",
+                    "visibility": "collapsed"
                 }
             ]
         },


### PR DESCRIPTION
## Summary

- Set `"visibility": "collapsed"` on the History view so it no longer takes up half the activity-bar pane on first activation.
- Set `"visibility": "visible"` on the Previews view to make the expanded-by-default intent explicit.

Note: VS Code's `views` contribution has no per-view "non-collapsible" flag — every view in a multi-view container renders a chevron. `"visibility": "visible"` is the strongest declarative signal that Previews should start expanded. If we ever need Previews to be truly non-collapsible, the only path is moving History out of the `compose-preview` container so Previews is the sole view in it.

## Test plan

- [ ] Reload VS Code with the extension installed; verify the **Compose Preview** activity-bar container shows Previews expanded and History collapsed on first open.
- [ ] Click the History header chevron and confirm it expands/collapses normally.
- [ ] Disable `composePreview.experimental.daemon.enabled` and confirm the History view disappears (the `when` clause still gates it).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FS6tnxUbL9rLzYKCDTqrhh)_