### PR TITLE
feat: settings to gate a11y data products on producer + consumer sides

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -209,21 +209,28 @@ fun main(args: Array<String>) {
       )
     }
 
-  // D2 — wire the accessibility data-product registry. Always-on when the renders dir is
-  // resolvable: the registry advertises `a11y/atf` + `a11y/hierarchy` and reads the JSON files
-  // RenderEngine writes under `<outputDir.parent>/data/<id>/`. The registry never blocks
-  // rendering; missing files surface as "no attachment for this kind on this render". Setting
-  // [RenderEngine.ATTACH_A11Y_PROP] flips the renderer into a11y mode so the JSON ever lands.
+  // D2 — wire the accessibility data-product registry. The `composeai.daemon.attachA11y`
+  // sysprop (driven by `DaemonExtension.attachA11y`, default true) is the producer-side
+  // opt-out: when `false` we never construct the registry, no a11y kinds get advertised,
+  // and the renderer skips a11y mode for the per-render saving (see `RenderEngine.render`).
+  // The renders dir must also be resolvable, since `AccessibilityDataProductRegistry`
+  // reads its JSON sidecars relative to it; pre-D2 callers without the sysprop wired
+  // (harness fake-mode) keep the no-op `DataProductRegistry.Empty`.
   val renderOutputDir = System.getProperty(RenderEngine.OUTPUT_DIR_PROP)
+  val attachA11y = System.getProperty(RenderEngine.ATTACH_A11Y_PROP) == "true"
   val dataProducts: DataProductRegistry =
-    if (renderOutputDir != null) {
+    if (renderOutputDir != null && attachA11y) {
       val dataRoot = File(renderOutputDir).parentFile?.resolve("data") ?: File(renderOutputDir)
-      System.setProperty(RenderEngine.ATTACH_A11Y_PROP, "true")
       System.err.println(
         "compose-ai-tools daemon: AccessibilityDataProductRegistry active (dataRoot=$dataRoot)"
       )
       AccessibilityDataProductRegistry(rootDir = dataRoot)
     } else {
+      if (renderOutputDir != null && !attachA11y) {
+        System.err.println(
+          "compose-ai-tools daemon: a11y data products disabled via composeai.daemon.attachA11y=false"
+        )
+      }
       DataProductRegistry.Empty
     }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1314,6 +1314,15 @@ internal object AndroidPreviewSupport {
         "composeai.daemon.warmSpare",
         extension.experimental.daemon.warmSpare.map { it.toString() },
       )
+      // D2 — opt-out for the a11y data products (see `DaemonExtension.attachA11y`). When
+      // `false`, `DaemonMain` constructs `DataProductRegistry.Empty` and the renderer skips
+      // a11y mode, which saves the per-render ATF cost for users who don't consume the
+      // overlay. Pairs with the VS Code `composePreview.a11y.alwaysSubscribe` setting on the
+      // consumer side.
+      this.systemProperties.put(
+        "composeai.daemon.attachA11y",
+        extension.experimental.daemon.attachA11y.map { it.toString() },
+      )
       this.systemProperties.put("composeai.daemon.modulePath", project.path)
       // B2.0 — `composeai.daemon.userClassDirs`. The closure captures only the
       // `daemonUserClassMarkers` List<String> (a configuration-time constant);

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtension.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtension.kt
@@ -69,4 +69,28 @@ abstract class DaemonExtension @Inject constructor(objects: ObjectFactory) {
    * inline and emit a `daemonWarming` notification while the new sandbox builds.
    */
   val warmSpare: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
+
+  /**
+   * D2 — whether the daemon advertises and produces the `a11y/atf` + `a11y/hierarchy` data
+   * products. Default: `true`.
+   *
+   * When `true`, every render runs in a11y mode (`LocalInspectionMode = false`) so ATF can walk the
+   * semantics tree and the `AccessibilityDataProductRegistry` can surface findings + the hierarchy
+   * via `data/fetch` / `data/subscribe`. Cost is a few ms per render plus the usual a11y-mode side
+   * effect (animations don't park under the paused clock — see
+   * `RobolectricRenderTest.renderWithA11y`'s docstring).
+   *
+   * When `false`, the daemon advertises no a11y kinds at handshake time. Clients see an empty
+   * `capabilities.dataProducts` and the focus-mode "Show accessibility overlay" toggle in the VS
+   * Code panel becomes a no-op (its `data/subscribe` rejects with `DataProductUnknown`). The
+   * daemon's internal renderer skips the a11y branch entirely, which is the cheapest mode for users
+   * who don't care about a11y in the daemon path. Diagnostic squigglies still flow via the Gradle
+   * sidecar reader as today — toggling this off only affects the daemon's data-product surface.
+   *
+   * Flip via build script (`composePreview { experimental { daemon { attachA11y = false } } }`) to
+   * opt out at the producer side. Pairs with the VS Code-side `composePreview.a11y.alwaysSubscribe`
+   * setting (which controls whether the *consumer* side subscribes ambient or only on the
+   * focus-mode toggle).
+   */
+  val attachA11y: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtensionTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtensionTest.kt
@@ -26,6 +26,19 @@ class DaemonExtensionTest {
     // Warm spare on by default — pays double idle memory for zero
     // user-visible recycle pause. Off-by-default would be a regression.
     assertThat(daemon.warmSpare.get()).isTrue()
+    // D2 — attachA11y on by default so the data-product surface advertises a11y kinds.
+    // Flipping this to false would silently break the focus-mode overlay and the
+    // VS Code `composePreview.a11y.alwaysSubscribe` setting; defaults are pinned here
+    // so a regression is loud.
+    assertThat(daemon.attachA11y.get()).isTrue()
+  }
+
+  @Test
+  fun `attachA11y is settable per consumer`() {
+    val project = ProjectBuilder.builder().build()
+    val daemon = project.objects.newInstance(DaemonExtension::class.java)
+    daemon.attachA11y.set(false)
+    assertThat(daemon.attachA11y.get()).isFalse()
   }
 
   @Test

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -144,6 +144,11 @@
                     "default": true,
                     "description": "Use the persistent preview daemon for sub-second refresh on saves to files the user has open, plus scroll-ahead speculative renders. Requires `composePreview { experimental { daemon { enabled = true } } }` in the consumer's build.gradle.kts. When the daemon isn't healthy, the extension silently falls back to the Gradle `renderPreviews` task. See docs/daemon/DESIGN.md for caveats."
                 },
+                "composePreview.a11y.alwaysSubscribe": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When on, the panel auto-subscribes to a11y data products (`a11y/atf` for diagnostic squigglies, `a11y/hierarchy` for the local overlay) for every visible preview in daemon mode — diagnostics fire ambient without entering focus mode. Off (the default) keeps the focus-mode 'Show accessibility overlay' button as the only opt-in. The producer side must also be on (Gradle: `composePreview { experimental { daemon { attachA11y = true } } }`, the default); when the daemon advertises no a11y kinds this setting has no effect."
+                },
                 "composePreview.logging.level": {
                     "type": "string",
                     "enum": ["quiet", "normal", "verbose"],

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -128,6 +128,16 @@ export class DaemonScheduler {
         private readonly gate: DaemonGate,
         private readonly events: SchedulerEvents,
         private readonly logger: { appendLine(s: string): void } = { appendLine() {} },
+        /**
+         * D2 — read freshly per `setVisible` so toggling the user setting
+         * `composePreview.a11y.alwaysSubscribe` doesn't need a reload. When `true`,
+         * newly-visible previews are auto-subscribed to a11y data products
+         * ([A11Y_OVERLAY_KINDS] + the ambient atf kind); when `false` (the default),
+         * the focus-mode toggle is the only path — no wire traffic for unfocused
+         * cards. Tests pass a constant lambda; production wires
+         * `vscode.workspace.getConfiguration('composePreview').get('a11y.alwaysSubscribe')`.
+         */
+        private readonly isA11yAlwaysSubscribed: () => boolean = () => false,
     ) {}
 
     /**
@@ -233,7 +243,7 @@ export class DaemonScheduler {
 
         // D2 — drop bookkeeping for previews that fell out of view. The daemon already
         // pruned its side on the same `setVisible`, so this just keeps our local dedup
-        // set in sync. Subscriptions themselves are now opt-in per focused preview via
+        // set in sync. Subscriptions themselves are opt-in per focused preview via
         // [setDataProductSubscription]; the panel calls in when the user toggles the
         // a11y overlay in focus mode.
         const visibleSetForSub = new Set(visible);
@@ -244,6 +254,29 @@ export class DaemonScheduler {
             const sep = rest.indexOf('::');
             const id = sep < 0 ? rest : rest.slice(0, sep);
             if (!visibleSetForSub.has(id)) { this.subscribedPairs.delete(key); }
+        }
+
+        // D2 — when the user opted into ambient a11y via
+        // `composePreview.a11y.alwaysSubscribe`, subscribe every newly-visible preview to
+        // [A11Y_OVERLAY_KINDS] so diagnostics + the hierarchy overlay fire without entering
+        // focus mode. dataSubscribe rejects gracefully (DataProductUnknown) when the daemon
+        // wasn't built with `attachA11y = true` on the producer side; that path absorbs the
+        // rejection and rolls back the bookkeeping (matching `setDataProductSubscription`).
+        if (this.isA11yAlwaysSubscribed()) {
+            for (const id of visible) {
+                for (const kind of A11Y_OVERLAY_KINDS) {
+                    const subKey = `${moduleId}::${id}::${kind}`;
+                    if (this.subscribedPairs.has(subKey)) { continue; }
+                    this.subscribedPairs.add(subKey);
+                    client.dataSubscribe({ previewId: id, kind }).catch((err) => {
+                        const msg = (err as Error)?.message ?? String(err);
+                        this.logger.appendLine(
+                            `[daemon] alwaysSubscribe dataSubscribe(${id}, ${kind}) failed: ${msg}`,
+                        );
+                        this.subscribedPairs.delete(subKey);
+                    });
+                }
+            }
         }
 
         if (predicted.length === 0) { return; }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -490,7 +490,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
                 );
             }
         },
-    }, outputChannel);
+    }, outputChannel,
+        // D2 — read the user setting freshly on each `setVisible` so toggling
+        // `composePreview.a11y.alwaysSubscribe` doesn't need a window reload.
+        () =>
+            vscode.workspace
+                .getConfiguration('composePreview')
+                .get<boolean>('a11y.alwaysSubscribe', false));
 
     // Status-bar slot for daemon lifecycle. Hidden when the daemon flag is
     // off or no module is currently warming. Surfacing the cold-bootstrap

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -90,7 +90,12 @@ interface CapturedImage {
     pngPath: string;
 }
 
-function build() {
+interface BuildOptions {
+    /** D2 — drives `composePreview.a11y.alwaysSubscribe`. Defaults to false to mirror prod. */
+    a11yAlwaysSubscribe?: () => boolean;
+}
+
+function build(opts: BuildOptions = {}) {
     const gate = new FakeGate();
     const log: string[] = [];
     const images: CapturedImage[] = [];
@@ -131,6 +136,7 @@ function build() {
         gate as unknown as ConstructorParameters<typeof DaemonScheduler>[0],
         events,
         { appendLine: (s) => log.push(s) },
+        opts.a11yAlwaysSubscribe ?? (() => false),
     );
     return { gate, scheduler, log, images, failures, dirty, discovery, dataProducts, channelClosed };
 }
@@ -550,11 +556,48 @@ describe('DaemonScheduler', () => {
      * subscribe, only prunes stale bookkeeping. `renderFinished` forwards attachments.
      */
     describe('data products', () => {
-        it('does not auto-subscribe on setVisible — subscriptions are explicit', async () => {
+        it('does not auto-subscribe on setVisible by default — subscriptions are explicit', async () => {
             const { gate, scheduler } = build();
             await scheduler.setVisible('mod', ['a', 'b'], []);
             const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
             assert.strictEqual(subs.length, 0);
+        });
+
+        it('auto-subscribes both a11y kinds for newly-visible previews when alwaysSubscribe is on', async () => {
+            const { gate, scheduler } = build({ a11yAlwaysSubscribe: () => true });
+            await scheduler.setVisible('mod', ['a', 'b'], []);
+            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            // 2 kinds × 2 previews = 4 subscribes.
+            assert.strictEqual(subs.length, 4);
+            const kinds = new Set(subs.map(c => (c.args as { kind: string }).kind));
+            assert.deepStrictEqual([...kinds].sort(), ['a11y/atf', 'a11y/hierarchy']);
+            const ids = new Set(subs.map(c => (c.args as { previewId: string }).previewId));
+            assert.deepStrictEqual([...ids].sort(), ['a', 'b']);
+        });
+
+        it('alwaysSubscribe re-reads on every setVisible — flipping the setting takes effect immediately', async () => {
+            let alwaysOn = false;
+            const { gate, scheduler } = build({ a11yAlwaysSubscribe: () => alwaysOn });
+            await scheduler.setVisible('mod', ['a'], []);
+            const initial = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            assert.strictEqual(initial.length, 0);
+            // User flips the setting on between setVisible calls.
+            alwaysOn = true;
+            await scheduler.setVisible('mod', ['a', 'b'], []);
+            // 'a' was previously visible but skipped under the off setting; 'b' is new.
+            // With alwaysOn now true, both get subscribed (we haven't seen them yet under
+            // the on setting, so subscribedPairs is empty for them).
+            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            assert.strictEqual(subs.length, 4);
+        });
+
+        it('alwaysSubscribe does not re-subscribe (previewId, kind) pairs already in flight', async () => {
+            const { gate, scheduler } = build({ a11yAlwaysSubscribe: () => true });
+            await scheduler.setVisible('mod', ['a'], []);
+            await scheduler.setVisible('mod', ['a', 'b'], []); // 'a' already subscribed
+            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            // 'a': 2 kinds (round 1) + 'b': 2 kinds (round 2) = 4. 'a' is NOT re-subscribed.
+            assert.strictEqual(subs.length, 4);
         });
 
         it('setDataProductSubscription(true) issues data/subscribe per kind', async () => {


### PR DESCRIPTION
## Summary

Two coordinated knobs so the cost of running a11y in the daemon path is opt-out at the producer (Gradle) and opt-in at the consumer (VS Code).

- **Gradle plugin** — `composePreview { experimental { daemon { attachA11y } } }` (default `true`). When false, `DaemonMain` constructs `DataProductRegistry.Empty` instead of the a11y registry; the renderer skips a11y mode entirely so renders keep `LocalInspectionMode = true` and animations park under the paused clock as in the pre-D2 fast path. Plumbed through `DaemonBootstrapTask` as the existing `composeai.daemon.attachA11y` sysprop (now sourced from the DSL rather than hardcoded in `DaemonMain`).
- **VS Code** — `composePreview.a11y.alwaysSubscribe` (default `false`). When on, `DaemonScheduler.setVisible` auto-subscribes both a11y kinds for every newly-visible preview so diagnostic squigglies fire ambient and the hierarchy overlay paints without entering focus mode. Off keeps the focus-mode "Show accessibility overlay" toggle as the only opt-in. Read freshly per `setVisible` so toggling in `settings.json` takes effect immediately, no reload.

Combined matrix:

| Gradle `attachA11y` | VS Code `alwaysSubscribe` | Behaviour |
|---|---|---|
| `false` | _(any)_ | No a11y anywhere — cheapest mode for users who don't consume it. |
| `true` | `false` (default) | Capability advertised; opt-in via the focus-mode "Show accessibility overlay" toggle. |
| `true` | `true` | Ambient diagnostics + ambient hierarchy overlay on every visible preview. |

Also picks up unrelated ktfmt drift in three `daemon/core` files that had landed on main without formatting — the pre-commit hook (`ktfmtCheck`) blocked the commit otherwise. Diff is whitespace-only for those three.

## Test plan

- [x] `:gradle-plugin:test --tests "*DaemonExtensionTest*"` — defaults guard updated to pin `attachA11y = true` plus a per-consumer settable test.
- [x] `vscode-extension/` `npm test` — 317 tests; scheduler suite gains 4 new tests (no auto-sub by default, both kinds when on, fresh read between `setVisible` calls, dedup of already-subscribed pairs).
- [x] `./gradlew ktfmtFormatAll` clean.
- [x] `./gradlew :daemon:android:compileDebugKotlin` clean.
- [ ] Manual smoke (consumer side):
  - Default daemon (attachA11y on, alwaysSubscribe off) — toggle behaves as today.
  - Flip alwaysSubscribe on — overlay appears on every visible card; diagnostics fire without focus mode.
  - Flip Gradle attachA11y off, restart daemon — toggle becomes a no-op (subscribe rejects with `DataProductUnknown`); diagnostics still flow via the Gradle sidecar reader.

Spec context: `docs/daemon/DATA-PRODUCTS.md` § "Default = nothing attached".

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVoxnr38t4n1LEatFc1yGe)_