### PR TITLE
feat(mcp): cache attached data products + --attach-data-product flag

### DIFF
--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -11,7 +11,9 @@ import kotlinx.serialization.json.JsonObject
  * **CLI:**
  *
  * ```
- * compose-preview-mcp [--project <path>[:<rootProjectName>]]... [--replicas-per-daemon <N>]
+ * compose-preview-mcp [--project <path>[:<rootProjectName>]]...
+ *                     [--replicas-per-daemon <N>]
+ *                     [--attach-data-product <KIND>]...
  * ```
  *
  * Each `--project` flag pre-registers a workspace with the supervisor at startup so connecting
@@ -25,6 +27,14 @@ import kotlinx.serialization.json.JsonObject
  * [DaemonSupervisor.DEFAULT_REPLICAS_PER_DAEMON] (= 3, i.e. 4 sandboxes per daemon). Set `0` to opt
  * out and run a single sandbox per daemon.
  *
+ * `--attach-data-product KIND` (repeatable) configures ambient data-product kinds the supervisor
+ * passes through `initialize.options.attachDataProducts` to every spawned daemon. The daemon then
+ * attaches the kind's payload to every `renderFinished`, the supervisor caches it, and
+ * `get_preview_data` serves cache hits with no daemon round-trip. Reserved for "always on,
+ * everywhere" cases — e.g. `--attach-data-product a11y/atf` to keep accessibility findings ambient
+ * for every preview. Most agents leave this empty and use the per-call `subscribe_preview_data`
+ * tool instead. See `docs/daemon/DATA-PRODUCTS.md`.
+ *
  * On stdin EOF the server tears down every supervised daemon (sending `shutdown` + `exit` per
  * PROTOCOL.md § 3) and exits cleanly.
  */
@@ -33,11 +43,13 @@ object DaemonMcpMain {
   @JvmStatic
   fun main(args: Array<String>) {
     val replicasPerDaemon = parseReplicasPerDaemon(args)
+    val attachDataProducts = parseAttachDataProducts(args)
     val supervisor =
       DaemonSupervisor(
         descriptorProvider = DescriptorProvider.readingFromDisk(),
         clientFactory = SubprocessDaemonClientFactory(),
         replicasPerDaemon = replicasPerDaemon,
+        globalAttachDataProducts = attachDataProducts,
       )
     val server = DaemonMcpServer(supervisor)
 
@@ -88,6 +100,34 @@ object DaemonMcpMain {
     val idx = raw.lastIndexOf(':')
     return if (idx <= 0) raw to null
     else raw.substring(0, idx) to raw.substring(idx + 1).takeIf { it.isNotEmpty() }
+  }
+
+  /**
+   * Collects every `--attach-data-product KIND` (or `--attach-data-product=KIND`) occurrence into
+   * an ordered, de-duplicated list. Empty by default — most agents don't want ambient data products
+   * and use `subscribe_preview_data` per call. Wired through to every daemon's
+   * `initialize.options.attachDataProducts`.
+   */
+  private fun parseAttachDataProducts(args: Array<String>): List<String> {
+    val out = LinkedHashSet<String>()
+    var i = 0
+    while (i < args.size) {
+      val a = args[i]
+      when {
+        a == "--attach-data-product" && i + 1 < args.size -> {
+          val kind = args[i + 1]
+          if (kind.isNotBlank()) out.add(kind)
+          i += 2
+        }
+        a.startsWith("--attach-data-product=") -> {
+          val kind = a.removePrefix("--attach-data-product=")
+          if (kind.isNotBlank()) out.add(kind)
+          i++
+        }
+        else -> i++
+      }
+    }
+    return out.toList()
   }
 
   private fun parseReplicasPerDaemon(args: Array<String>): Int {

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -98,6 +98,23 @@ class DaemonMcpServer(
    */
   private val respawnAttempts = ConcurrentHashMap<DaemonAddr, Int>()
 
+  /**
+   * D1 — `(workspace, module, previewId, kind) → latest payload from
+   * `renderFinished.dataProducts``. Populated whenever a daemon ships attachments alongside a
+   * render (which it only does for kinds the MCP server has subscribed to via
+   * `subscribe_preview_data`, or that are in the global `attachDataProducts` set passed at
+   * `initialize` time).
+   *
+   * Lets `get_preview_data` short-circuit to the cache for kinds that are already fresh — agents
+   * that do `subscribe_preview_data` once and then `get_preview_data` repeatedly pay one wire
+   * round-trip total instead of one per fetch.
+   *
+   * Eviction: each new `renderFinished` REPLACES every cached attachment for that `(uri)` —
+   * anything the daemon didn't include this render is no longer fresh. Daemon-level wipes
+   * (classpathDirty, onClose) drop every cached entry for the affected `(workspace, module)`.
+   */
+  private val dataProductCache = ConcurrentHashMap<DataAttachKey, DataAttachmentEntry>()
+
   private val watchPropagator =
     WatchPropagator(
       subscriptions = subscriptions,
@@ -148,6 +165,7 @@ class DaemonMcpServer(
     router.on("historyAdded") { daemon, params -> onHistoryAdded(daemon, params) }
     router.onClose { daemon ->
       catalog.remove(DaemonAddr(daemon.workspaceId, daemon.modulePath))
+      evictDataProductsForDaemon(daemon.workspaceId, daemon.modulePath)
       watchPropagator.forget(daemon)
     }
   }
@@ -295,7 +313,7 @@ class DaemonMcpServer(
     progressToken: JsonElement? = null,
     overrides: PreviewOverrides? = null,
   ): ByteArray {
-    val outcome = awaitNextRender(uri, session, progressToken)
+    val outcome = awaitNextRender(uri, session, progressToken, overrides)
     val file = File(outcome.pngPath)
     check(file.isFile) { "renderAndReadBytes: pngPath does not exist: ${outcome.pngPath}" }
     return Files.readAllBytes(file.toPath())
@@ -307,11 +325,17 @@ class DaemonMcpServer(
    * `get_preview_data`'s auto-render fallback (which doesn't care about the bytes — it just needs
    * the daemon to have rendered SOMETHING so a follow-up `data/fetch` returns the kind instead of
    * `DataProductNotAvailable`).
+   *
+   * [overrides] forwards the per-call display-property overrides PROTOCOL.md § 5 documents on
+   * `renderNow`. Defaults to null (use discovery-time RenderSpec); the auto-render fallback in
+   * `get_preview_data` leaves it null on purpose since it just wants any render so the kind becomes
+   * available.
    */
   private fun awaitNextRender(
     uri: PreviewUri,
     session: McpSession? = null,
     progressToken: JsonElement? = null,
+    overrides: PreviewOverrides? = null,
   ): RenderOutcome.Finished {
     val daemon = supervisor.daemonFor(uri.workspaceId, uri.modulePath)
     val key = RenderKey(uri.workspaceId, uri.modulePath, uri.previewFqn)
@@ -609,7 +633,7 @@ class DaemonMcpServer(
       ToolDef(
         name = "get_preview_data",
         description =
-          "Fetch one data product (a11y findings, a11y hierarchy, layout tree, …) for a preview. The kind names a structured payload the daemon can produce alongside the PNG; call list_data_products first to see what each daemon advertises. Returns the JSON payload as a single text content block. Auto-renders the preview if it hasn't rendered yet (so the agent doesn't need to call render_preview first). When the daemon's latest render didn't compute the kind, the daemon may queue a re-render in the right mode; this is bounded by the daemon's per-request budget (DataProductBudgetExceeded if exceeded). `inline` defaults to true so the agent gets JSON back rather than a path it may not be able to read; flip to false on local-FS callers that prefer to read sibling files directly.",
+          "Fetch one data product (a11y findings, a11y hierarchy, layout tree, …) for a preview. The kind names a structured payload the daemon can produce alongside the PNG; call list_data_products first to see what each daemon advertises. Returns the JSON payload as a single text content block. Auto-renders the preview if it hasn't rendered yet (so the agent doesn't need to call render_preview first). Cache short-circuit: if the kind has been subscribed (subscribe_preview_data) or globally attached (--attach-data-product server flag), the latest renderFinished payload is served from an in-memory cache with zero daemon round-trip — the response carries `cached: true`. When the daemon's latest render didn't compute the kind and it's not cached, the daemon may queue a re-render in the right mode; this is bounded by the daemon's per-request budget (DataProductBudgetExceeded if exceeded). `inline` defaults to true so the agent gets JSON back rather than a path it may not be able to read; flip to false on local-FS callers that prefer to read sibling files directly.",
         inputSchema =
           parseSchema(
             """
@@ -1153,6 +1177,24 @@ class DaemonMcpServer(
         .getOrElse {
           return errorCallToolResult("get_preview_data: daemon spawn failed: ${it.message}")
         }
+    // Cache hit short-circuit: if a previous renderFinished attached this kind (because someone
+    // subscribed, or the kind is in the global attachDataProducts set), serve the cached payload
+    // and skip the wire round-trip entirely. The cache mirrors the latest render; a new render
+    // wipes stale entries via [refreshDataProductCache], so a hit is always fresh.
+    //
+    // Skip the cache when the caller asked for a path-shaped result (`inline = false`) but the
+    // cached entry is payload-shaped (or vice versa) — the daemon would have returned a different
+    // transport on a direct fetch, so falling through preserves the contract.
+    //
+    // Skip the cache when per-kind `params` are present — those select sub-views (e.g.
+    // `{ nodeId }` for `layout/tree`), and the cached entry is the no-params form.
+    if (perKindParams == null) {
+      val cached =
+        dataProductCache[DataAttachKey(uri.workspaceId, uri.modulePath, uri.previewFqn, kind)]
+      if (cached != null && transportMatches(cached, inline)) {
+        return renderCachedAttachment(kind, cached, inline)
+      }
+    }
     return runCatching {
         // Try the fetch directly first — works whenever the preview has rendered at least once.
         // On `DataProductNotAvailable` (-32021) the daemon is telling us the preview has never
@@ -1175,6 +1217,37 @@ class DaemonMcpServer(
           else -> errorCallToolResult("get_preview_data failed: ${e.message}")
         }
       }
+  }
+
+  /**
+   * `true` iff the cached entry can satisfy a request with the given [inline] flag without
+   * round-tripping the daemon. A `payload`-shaped cache entry serves any caller that asked for
+   * inline (the default); a `path`-shaped entry serves callers that explicitly passed `inline =
+   * false`. Mismatches fall through to a direct `data/fetch`, which lets the daemon pick the right
+   * transport.
+   */
+  private fun transportMatches(entry: DataAttachmentEntry, inline: Boolean): Boolean =
+    when {
+      inline && entry.payload != null -> true
+      !inline && entry.path != null -> true
+      else -> false
+    }
+
+  private fun renderCachedAttachment(
+    kind: String,
+    entry: DataAttachmentEntry,
+    inline: Boolean,
+  ): CallToolResult {
+    val payload = buildJsonObject {
+      put("kind", kind)
+      put("schemaVersion", entry.schemaVersion)
+      put("cached", true)
+      val attachedPayload = entry.payload
+      val attachedPath = entry.path
+      if (inline && attachedPayload != null) put("payload", attachedPayload)
+      if (!inline && attachedPath != null) put("path", JsonPrimitive(attachedPath))
+    }
+    return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
   }
 
   /**
@@ -1377,7 +1450,13 @@ class DaemonMcpServer(
     val key = RenderKey(daemon.workspaceId, daemon.modulePath, previewId)
     val toComplete = pendingRenders.remove(key)
     toComplete?.forEach { it.complete(RenderOutcome.Finished(pngPath)) }
-    // 2. Build the matching URI and notify subscribers + watchers.
+    // 2. Refresh the data-product attachment cache for this `(uri)`. Any kind the daemon attached
+    //    on this render is the new fresh payload; any kind it didn't attach is stale and gets
+    //    dropped (the daemon stops attaching kinds the MCP server unsubscribed from, so a missing
+    //    entry means "no longer requested" — caching the previous payload would serve stale data
+    //    to a future re-subscribe).
+    refreshDataProductCache(daemon, previewId, params["dataProducts"])
+    // 3. Build the matching URI and notify subscribers + watchers.
     val entry = catalog[DaemonAddr(daemon.workspaceId, daemon.modulePath)]?.get(previewId)
     val uri =
       PreviewUri(
@@ -1391,8 +1470,49 @@ class DaemonMcpServer(
     targets.addAll(subscriptions.sessionsSubscribedTo(uriStr))
     targets.addAll(subscriptions.sessionsWatching(uri))
     targets.forEach { it.notifyResourceUpdated(uriStr) }
-    // 3. Record history (no-op default).
+    // 4. Record history (no-op default).
     runCatching { historyStore.record(uri, pngPath, Instant.now()) }
+  }
+
+  /**
+   * Replaces the [dataProductCache] entries for `(daemon, previewId)` with whatever
+   * [attachmentsField] carried. Tolerant of missing / malformed entries: a single broken entry
+   * skips itself rather than poisoning the whole cache update. When [attachmentsField] is null or
+   * empty (the common case — no client subscribed), every previously-cached entry for this `(uri)`
+   * is evicted.
+   */
+  private fun refreshDataProductCache(
+    daemon: SupervisedDaemon,
+    previewId: String,
+    attachmentsField: JsonElement?,
+  ) {
+    // Drop everything the cache had for this preview — the daemon's latest render is the truth.
+    dataProductCache.keys.removeIf {
+      it.workspaceId == daemon.workspaceId &&
+        it.modulePath == daemon.modulePath &&
+        it.previewId == previewId
+    }
+    val arr = attachmentsField as? kotlinx.serialization.json.JsonArray ?: return
+    for (elem in arr) {
+      val obj = elem as? JsonObject ?: continue
+      val kind = obj["kind"]?.jsonPrimitive?.contentOrNull ?: continue
+      val schemaVersion =
+        obj["schemaVersion"]?.jsonPrimitive?.contentOrNull?.toIntOrNull() ?: continue
+      val payload = obj["payload"]
+      val path = obj["path"]?.jsonPrimitive?.contentOrNull
+      val key = DataAttachKey(daemon.workspaceId, daemon.modulePath, previewId, kind)
+      dataProductCache[key] = DataAttachmentEntry(schemaVersion, payload, path)
+    }
+  }
+
+  /**
+   * Drops every cached attachment for `(workspace, module)`. Called from `onClose` and the
+   * `classpathDirty` respawn path — after the daemon goes away, the cached payloads are tied to a
+   * renderer state that no longer exists, so a follow-up `get_preview_data` should round-trip the
+   * (possibly respawned) daemon rather than serving a possibly-stale payload.
+   */
+  private fun evictDataProductsForDaemon(workspaceId: WorkspaceId, modulePath: String) {
+    dataProductCache.keys.removeIf { it.workspaceId == workspaceId && it.modulePath == modulePath }
   }
 
   private fun onRenderFailed(daemon: SupervisedDaemon, params: JsonObject?) {
@@ -1492,6 +1612,7 @@ class DaemonMcpServer(
     // respawn-counter bump and the respawn schedule, avoiding double-spawn under the race.
     val firstClassedDirty = supervisor.forgetDaemon(workspaceId, modulePath)
     catalog.remove(DaemonAddr(workspaceId, modulePath))
+    evictDataProductsForDaemon(workspaceId, modulePath)
     watchPropagator.forget(daemon)
     sessions.forEach { it.notifyResourceListChanged() }
     if (!firstClassedDirty) return
@@ -1538,6 +1659,28 @@ class DaemonMcpServer(
     val workspaceId: WorkspaceId,
     val modulePath: String,
     val previewId: String,
+  )
+
+  /**
+   * Cache key for [dataProductCache]. `(workspace, module, previewId)` identifies the render-target
+   * preview; `kind` discriminates the data-product attachment within that render.
+   */
+  private data class DataAttachKey(
+    val workspaceId: WorkspaceId,
+    val modulePath: String,
+    val previewId: String,
+    val kind: String,
+  )
+
+  /**
+   * Cached `(payload | path)` from one `renderFinished.dataProducts[*]` entry. Mirrors the wire
+   * shape; carries `schemaVersion` so a cache hit reports the same version the agent would see on a
+   * direct `data/fetch`.
+   */
+  private data class DataAttachmentEntry(
+    val schemaVersion: Int,
+    val payload: JsonElement?,
+    val path: String?,
   )
 
   private sealed interface RenderOutcome {

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -47,6 +47,13 @@ class DaemonSupervisor(
    * (initialize, renderNow, fileChanged fan-out) is unchanged from the consumer's perspective.
    */
   private val replicasPerDaemon: Int = DEFAULT_REPLICAS_PER_DAEMON,
+  /**
+   * D1 — kinds the supervisor passes through `initialize.options.attachDataProducts` to every
+   * spawned daemon. Configures "always-on" data products (e.g. `a11y/atf` for ambient diagnostic
+   * squigglies). Empty list (the default) keeps the wire absent — no global attach. Wired from the
+   * `--attach-data-product KIND` flag on [DaemonMcpMain].
+   */
+  private val globalAttachDataProducts: List<String> = emptyList(),
 ) {
 
   init {
@@ -187,6 +194,7 @@ class DaemonSupervisor(
           workspaceRoot = project.path.absolutePath,
           moduleId = descriptor.modulePath,
           moduleProjectDir = descriptor.workingDirectory,
+          attachDataProducts = globalAttachDataProducts.takeIf { it.isNotEmpty() },
         )
       // D1 — surface the daemon's advertised data-product kinds so the MCP server's
       // `list_data_products` tool can answer without a wire round-trip. Empty list on pre-D2

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -967,6 +967,282 @@ class DaemonMcpServerTest {
     runCatching { session2.close() }
   }
 
+  @Test
+  fun `get_preview_data hits cache from renderFinished attachments without round-tripping`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    factory.daemonConfigurer = { daemon ->
+      daemon.advertisedDataProducts =
+        listOf(
+          ee.schimke.composeai.daemon.protocol.DataProductCapability(
+            kind = "a11y/atf",
+            schemaVersion = 1,
+            transport = ee.schimke.composeai.daemon.protocol.DataProductTransport.INLINE,
+            attachable = true,
+            fetchable = true,
+            requiresRerender = false,
+          )
+        )
+      // Configure dataFetch to fail loudly — the cache hit MUST serve without ever touching the
+      // wire. If our cache short-circuit is broken, the test will fall through to this branch
+      // and the assertion on payload contents will fail.
+      daemon.dataFetchHandler = { _, _, _, _ ->
+        FakeDaemon.DataFetchOutcome.FetchFailed("cache-miss-must-not-happen")
+      }
+    }
+    val previewId = "com.example.Red"
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    // Subscribe so the resources/updated notification is our sync point: the supervisor finished
+    // processing the renderFinished (including caching attachments) before we move on.
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    client.request("resources/subscribe", buildJsonObject { put("uri", uri) })
+
+    // Daemon ships an attached payload on a renderFinished — simulating the post-subscribe
+    // attach-on-render path. The supervisor caches it.
+    daemon.emitRenderFinishedWithDataProducts(
+      previewId,
+      "/tmp/red.png",
+      listOf(
+        buildJsonObject {
+          put("kind", "a11y/atf")
+          put("schemaVersion", 1)
+          putJsonObject("payload") {
+            putJsonArray("findings") { add(JsonPrimitive("missing-content-description")) }
+          }
+        }
+      ),
+    )
+    client.expectNotification("notifications/resources/updated", 2_000)
+
+    val resp =
+      client.callTool(
+        "get_preview_data",
+        buildJsonObject {
+          put("uri", uri)
+          put("kind", "a11y/atf")
+        },
+      )
+    val payload = json.parseToJsonElement(resp.firstTextContent()).jsonObject
+    assertThat(payload["cached"]?.jsonPrimitive?.contentOrNull).isEqualTo("true")
+    assertThat(payload["kind"]?.jsonPrimitive?.contentOrNull).isEqualTo("a11y/atf")
+    val findings = payload["payload"]?.jsonObject?.get("findings")?.jsonArray
+    assertThat(findings?.single()?.jsonPrimitive?.content).isEqualTo("missing-content-description")
+  }
+
+  @Test
+  fun `cache evicts stale kinds when next renderFinished omits them`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    factory.daemonConfigurer = { daemon ->
+      daemon.advertisedDataProducts =
+        listOf(
+          ee.schimke.composeai.daemon.protocol.DataProductCapability(
+            kind = "a11y/atf",
+            schemaVersion = 1,
+            transport = ee.schimke.composeai.daemon.protocol.DataProductTransport.INLINE,
+            attachable = true,
+            fetchable = true,
+            requiresRerender = false,
+          )
+        )
+      // After the cache evicts, dataFetch is the fallback path — return a distinguishable Ok so
+      // we can assert that the second call went through the wire (not the cache).
+      daemon.dataFetchHandler = { _, kind, _, _ ->
+        FakeDaemon.DataFetchOutcome.Ok(
+          kind = kind,
+          schemaVersion = 1,
+          payload = buildJsonObject { put("source", "wire") },
+        )
+      }
+    }
+    val previewId = "com.example.Red"
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    // Subscribe to the URI so we get a `resources/updated` notification per renderFinished —
+    // those notifications act as our synchronization point that the supervisor finished processing
+    // each render (and updating the cache) before we move on.
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    client.request("resources/subscribe", buildJsonObject { put("uri", uri) })
+
+    // First render: a11y/atf is attached. Cache is warm.
+    daemon.emitRenderFinishedWithDataProducts(
+      previewId,
+      "/tmp/red-1.png",
+      listOf(
+        buildJsonObject {
+          put("kind", "a11y/atf")
+          put("schemaVersion", 1)
+          putJsonObject("payload") { put("source", "cache") }
+        }
+      ),
+    )
+    client.expectNotification("notifications/resources/updated", 2_000)
+
+    // Second render: NO data products attached (e.g. session unsubscribed in between). Cache for
+    // a11y/atf must be evicted so a follow-up get_preview_data falls through to the wire.
+    daemon.emitRenderFinishedWithDataProducts(
+      previewId,
+      "/tmp/red-2.png",
+      attachments = emptyList(),
+    )
+    client.expectNotification("notifications/resources/updated", 2_000)
+
+    val resp =
+      client.callTool(
+        "get_preview_data",
+        buildJsonObject {
+          put("uri", uri)
+          put("kind", "a11y/atf")
+        },
+      )
+    val payload = json.parseToJsonElement(resp.firstTextContent()).jsonObject
+    // No `cached: true` field on a wire-served payload.
+    assertThat(payload["cached"]?.jsonPrimitive?.contentOrNull).isNull()
+    assertThat(payload["payload"]?.jsonObject?.get("source")?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("wire")
+  }
+
+  @Test
+  fun `cache miss when caller passes per-kind params skips the cache`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+
+    factory.daemonConfigurer = { daemon ->
+      daemon.advertisedDataProducts =
+        listOf(
+          ee.schimke.composeai.daemon.protocol.DataProductCapability(
+            kind = "layout/tree",
+            schemaVersion = 1,
+            transport = ee.schimke.composeai.daemon.protocol.DataProductTransport.INLINE,
+            attachable = true,
+            fetchable = true,
+            requiresRerender = false,
+          )
+        )
+      daemon.dataFetchHandler = { _, kind, perKindParams, _ ->
+        // The wire call must receive the params verbatim — that's how kinds with sub-views (e.g.
+        // layout/tree filtered by nodeId) work.
+        val nodeId = perKindParams?.get("nodeId")?.jsonPrimitive?.contentOrNull ?: "?"
+        FakeDaemon.DataFetchOutcome.Ok(
+          kind = kind,
+          schemaVersion = 1,
+          payload = buildJsonObject { put("nodeId", nodeId) },
+        )
+      }
+    }
+    val previewId = "com.example.Red"
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    client.request("resources/subscribe", buildJsonObject { put("uri", uri) })
+
+    // Warm the cache with the no-params variant.
+    daemon.emitRenderFinishedWithDataProducts(
+      previewId,
+      "/tmp/red.png",
+      listOf(
+        buildJsonObject {
+          put("kind", "layout/tree")
+          put("schemaVersion", 1)
+          putJsonObject("payload") { put("nodeId", "root") }
+        }
+      ),
+    )
+    client.expectNotification("notifications/resources/updated", 2_000)
+
+    val resp =
+      client.callTool(
+        "get_preview_data",
+        buildJsonObject {
+          put("uri", uri)
+          put("kind", "layout/tree")
+          putJsonObject("params") { put("nodeId", "node-42") }
+        },
+      )
+    val payload = json.parseToJsonElement(resp.firstTextContent()).jsonObject
+    // params present → skip cache → wire call → response carries the param-filtered nodeId, not
+    // the cached "root".
+    assertThat(payload["cached"]?.jsonPrimitive?.contentOrNull).isNull()
+    assertThat(payload["payload"]?.jsonObject?.get("nodeId")?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("node-42")
+  }
+
+  @Test
+  fun `globalAttachDataProducts forwards through initialize to the daemon`() {
+    // Build a separate supervisor + server with the global attach list set, so we can assert the
+    // exact parameters reach the daemon's initialize handler.
+    val factoryLocal = FakeDaemonClientFactory()
+    val capturedParams = java.util.concurrent.LinkedBlockingQueue<JsonObject>(/* capacity */ 4)
+    factoryLocal.daemonConfigurer = { daemon ->
+      daemon.onInitializeReceived = { params -> capturedParams.offer(params) }
+    }
+    val supervisorLocal =
+      DaemonSupervisor(
+        descriptorProvider = FakeDescriptorProvider(),
+        clientFactory = factoryLocal,
+        globalAttachDataProducts = listOf("a11y/atf", "layout/tree"),
+      )
+    try {
+      val projectDir = tmp.newFolder("workspace-attach")
+      tmp.newFolder("workspace-attach", "module")
+      val project = supervisorLocal.registerProject(projectDir, "demo-attach")
+      // Trigger spawn — this sends initialize with attachDataProducts under options.
+      supervisorLocal.daemonFor(project.workspaceId, ":module")
+
+      val params = capturedParams.poll(3_000, TimeUnit.MILLISECONDS)
+      assertThat(params).isNotNull()
+      val attached = params!!["options"]?.jsonObject?.get("attachDataProducts")?.jsonArray
+      assertThat(attached?.map { it.jsonPrimitive.content })
+        .containsExactly("a11y/atf", "layout/tree")
+        .inOrder()
+    } finally {
+      runCatching { supervisorLocal.shutdown() }
+    }
+  }
+
+  @Test
+  fun `empty globalAttachDataProducts omits the options field entirely`() {
+    val factoryLocal = FakeDaemonClientFactory()
+    val capturedParams = java.util.concurrent.LinkedBlockingQueue<JsonObject>(/* capacity */ 4)
+    factoryLocal.daemonConfigurer = { daemon ->
+      daemon.onInitializeReceived = { params -> capturedParams.offer(params) }
+    }
+    val supervisorLocal =
+      DaemonSupervisor(
+        descriptorProvider = FakeDescriptorProvider(),
+        clientFactory = factoryLocal,
+        // Empty list (the default) — supervisor must NOT send an options object with an empty
+        // attachDataProducts array (encodeDefaults = false on the wire keeps the field absent;
+        // an explicit empty array would be an unnecessary protocol diff).
+      )
+    try {
+      val projectDir = tmp.newFolder("workspace-no-attach")
+      tmp.newFolder("workspace-no-attach", "module")
+      val project = supervisorLocal.registerProject(projectDir, "demo-no-attach")
+      supervisorLocal.daemonFor(project.workspaceId, ":module")
+      val params = capturedParams.poll(3_000, TimeUnit.MILLISECONDS)
+      assertThat(params).isNotNull()
+      assertThat(params!!.containsKey("options")).isFalse()
+    } finally {
+      runCatching { supervisorLocal.shutdown() }
+    }
+  }
+
   // -------------------------------------------------------------------------
   // Helpers
   // -------------------------------------------------------------------------

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
@@ -81,6 +81,13 @@ class FakeDaemon : DaemonSpawn {
   val dataUnsubscribes = java.util.concurrent.LinkedBlockingQueue<Pair<String, String>>()
 
   /**
+   * Optional capture hook for the params object the fake received on `initialize`. Tests use this
+   * to assert what the supervisor passes through (e.g. `options.attachDataProducts`). Default is a
+   * no-op.
+   */
+  @Volatile var onInitializeReceived: (JsonObject) -> Unit = {}
+
+  /**
    * Outcome the fake's `data/fetch` handler returns. Mirrors the daemon's
    * [`DataProductRegistry.Outcome`] but deliberately decouples — the fake doesn't depend on the
    * registry interface.
@@ -191,6 +198,28 @@ class FakeDaemon : DaemonSpawn {
     return pngPath
   }
 
+  /**
+   * Pushes a `renderFinished` notification carrying the given [attachments] under the wire's
+   * `dataProducts` field. Each attachment is `(kind, schemaVersion, payload?, path?)` matching the
+   * D1 wire shape (DATA-PRODUCTS.md). Used by tests that exercise the supervisor's
+   * `dataProductCache` — the MCP server reads attachments off this notification, caches them, and
+   * `get_preview_data` cache-hits them.
+   */
+  fun emitRenderFinishedWithDataProducts(
+    previewId: String,
+    pngPath: String,
+    attachments: List<JsonObject>,
+  ): String {
+    val params = buildJsonObject {
+      put("id", previewId)
+      put("pngPath", pngPath)
+      put("tookMs", 50L)
+      putJsonArray("dataProducts") { attachments.forEach { add(it) } }
+    }
+    sendNotification("renderFinished", params)
+    return pngPath
+  }
+
   // -------------------------------------------------------------------------
   // Daemon-side reader: read framed JSON-RPC from the MCP shim, respond.
   // -------------------------------------------------------------------------
@@ -217,6 +246,7 @@ class FakeDaemon : DaemonSpawn {
   private fun handleRequest(id: Long, method: String, params: JsonObject?) {
     when (method) {
       "initialize" -> {
+        if (params != null) runCatching { onInitializeReceived(params) }
         val result =
           InitializeResult(
             protocolVersion = 1,


### PR DESCRIPTION
## Summary

Two composable additions to the data-product surface, plus a small compile-fix on a pre-existing main bug.

1. **Cache `renderFinished.dataProducts` in the supervisor.** When a session has subscribed (or a kind is globally attached), the daemon ships payloads on every render. Today MCP drops that field. This PR caches `(workspace, module, previewId, kind) → DataAttachmentEntry` and has `get_preview_data` consult the cache before issuing `data/fetch` — a subscribed agent now pays one wire round-trip total instead of one per fetch. Cache hits surface `cached: true` so callers can tell.

   Eviction is per-render: each `renderFinished` REPLACES every cached entry for that `(uri)`, so kinds the daemon stops attaching (after an unsubscribe) drop out automatically. Daemon teardown (`onClose`, `classpathDirty`) clears the cache for the affected `(workspace, module)`.

   The cache is bypassed when the caller passes per-kind `params` (sub-views like `{ nodeId }` for `layout/tree` — cached entry is the no-params form) or when the requested transport doesn't match the cached entry's shape (`inline=true` vs `path` and vice versa).

2. **`--attach-data-product KIND` flag on `DaemonMcpMain`** (repeatable). Plumbed through the supervisor as `globalAttachDataProducts`, passed to every spawned daemon via `initialize.options.attachDataProducts`. Reserved for "always on, everywhere" cases — e.g. `--attach-data-product a11y/atf` to keep accessibility findings ambient on every preview, where they cost nothing extra to compute and the cache makes follow-up `get_preview_data` calls instant. Empty list (the default) keeps the wire field absent.

3. **Drive-by fix:** `awaitNextRender` (extracted in #415) was referencing an `overrides` parameter that only existed on its caller (`renderAndReadBytes`, where #402 added it). The race between #402 and #415 merging meant main was uncompilable. Threads `overrides` through from `renderAndReadBytes` to `awaitNextRender`.

Together with #415, the agent loop is now:
- One `subscribe_preview_data(uri, kind)` (or `--attach-data-product KIND` once at server startup).
- Each render warms the cache automatically.
- `get_preview_data(uri, kind)` is a cache hit with no daemon round-trip.

## Test plan

- [x] `./gradlew :mcp:ktfmtCheckMain :mcp:ktfmtCheckTest` — clean
- [x] `./gradlew :mcp:test` — 26/26 pass, including 5 new cases:
  - `get_preview_data hits cache from renderFinished attachments without round-tripping`
  - `cache evicts stale kinds when next renderFinished omits them`
  - `cache miss when caller passes per-kind params skips the cache`
  - `globalAttachDataProducts forwards through initialize to the daemon`
  - `empty globalAttachDataProducts omits the options field entirely`


---
_Generated by [Claude Code](https://claude.ai/code/session_019eCR7c9UaZzvkAf9TeVVc9)_