### PR TITLE
feat(vscode): status-bar hint when interactive runs on v1-fallback host

### DIFF
--- a/vscode-extension/src/daemon/daemonGate.ts
+++ b/vscode-extension/src/daemon/daemonGate.ts
@@ -133,6 +133,27 @@ export class DaemonGate {
         return existing != null && !existing.client.isClosed();
     }
 
+    /**
+     * v2 interactive-mode support flag from the daemon's `initialize` response
+     * (INTERACTIVE.md § 9 / `InitializeResult.capabilities.interactive`).
+     * `true` means clicks dispatched via `interactive/input` actually mutate
+     * composition state (desktop with v2 wiring); `false` means the daemon
+     * accepts `interactive/start` but inputs trigger stateless re-renders (v1
+     * fallback — Robolectric/Android, or any host that doesn't override
+     * `acquireInteractiveSession`). Returns `false` when no daemon is up for
+     * the module — the caller can't drive interactive mode either way.
+     *
+     * Pre-#425 daemons omit the capability bit entirely; we treat absent as
+     * `false` (the safer default) so pre-v2 daemons surface the unsupported
+     * hint instead of silently leaving the user wondering why clicks don't
+     * mutate state.
+     */
+    isInteractiveSupported(moduleId: string): boolean {
+        const existing = this.daemons.get(moduleId);
+        if (existing == null || existing.client.isClosed()) { return false; }
+        return existing.spawned.initializeResult.capabilities.interactive === true;
+    }
+
     async dispose(): Promise<void> {
         this.disposed = true;
         const entries = [...this.daemons.values()];

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -121,6 +121,17 @@ export interface InitializeResult {
          * kinds in subscribe/fetch with `DataProductUnknown` (-32020).
          */
         dataProducts: DataProductCapability[];
+        /**
+         * INTERACTIVE.md § 9 — `true` when the daemon's host can dispatch
+         * `interactive/input` events into a held composition (v2 — clicks
+         * mutate `remember { mutableStateOf(...) }` state). `false` means
+         * `interactive/start` still succeeds but inputs trigger a stateless
+         * re-render (v1 fallback). Defaulted for pre-#425 daemons that
+         * predate the capability — clients treat absent and `false`
+         * identically. Today: `true` for desktop hosts, `false` for the
+         * Robolectric / Android backends.
+         */
+        interactive?: boolean;
     };
     classpathFingerprint: string;
     manifest: { path: string; previewCount: number };

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -59,6 +59,7 @@ let gradleService: GradleService | null = null;
 let daemonGate: DaemonGate | null = null;
 let daemonScheduler: DaemonScheduler | null = null;
 let daemonStatusItem: vscode.StatusBarItem | null = null;
+let interactiveStatusItem: vscode.StatusBarItem | null = null;
 let daemonStatusClearTimer: NodeJS.Timeout | null = null;
 let historyPanel: HistoryPanel | null = null;
 /** Owned by activate(); reused by both the History panel and the live
@@ -481,6 +482,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
             for (const previewId of stale) {
                 activeInteractiveStreams.delete(previewId);
             }
+            updateInteractiveStatus();
             if (stale.length > 0) {
                 logLine(
                     `[interactive] daemon channel closed for ${moduleId}; ` +
@@ -499,6 +501,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     );
     daemonStatusItem.command = 'workbench.action.output.toggleOutput';
     context.subscriptions.push(daemonStatusItem);
+
+    // INTERACTIVE.md § 9 / #425 — status-bar hint surfaced only when the user has LIVE active
+    // on a daemon backend that DOESN'T speak v2 (`InitializeResult.capabilities.interactive`
+    // is false or absent). Today that's any module on the Robolectric/Android backend; the
+    // panel's LIVE chip lights up regardless, but the user sees clicks not mutate state and
+    // would otherwise have no signal as to why. Hidden when v2 IS supported (the LIVE chip
+    // alone is sufficient feedback) and when no streams are active.
+    interactiveStatusItem = vscode.window.createStatusBarItem(
+        vscode.StatusBarAlignment.Left, 89,
+    );
+    interactiveStatusItem.command = 'workbench.action.output.toggleOutput';
+    context.subscriptions.push(interactiveStatusItem);
 
     panel = new PreviewPanel(context.extensionUri, handleWebviewMessage);
     if (isTestMode) {
@@ -915,6 +929,7 @@ async function flushInteractiveStreams(): Promise<void> {
     if (activeInteractiveStreams.size === 0) { return; }
     const entries = [...activeInteractiveStreams.entries()];
     activeInteractiveStreams.clear();
+    updateInteractiveStatus();
     if (!daemonGate?.isEnabled() || !daemonScheduler) { return; }
     await Promise.all(entries.map(async ([previewId, streamId]) => {
         try {
@@ -2728,6 +2743,7 @@ async function handleSetInteractive(previewId: string, enabled: boolean): Promis
         const stream = activeInteractiveStreams.get(previewId);
         if (stream) {
             activeInteractiveStreams.delete(previewId);
+            updateInteractiveStatus();
             const client = await daemonGate?.getOrSpawn(
                 moduleId, daemonScheduler.daemonEvents(moduleId),
             );
@@ -2752,9 +2768,11 @@ async function handleSetInteractive(previewId: string, enabled: boolean): Promis
     try {
         const result = await client.interactiveStart({ previewId });
         activeInteractiveStreams.set(previewId, result.frameStreamId);
+        updateInteractiveStatus();
         logLine(
             `[interactive] live mode on for ${previewId} (module=${moduleId}, ` +
-            `streamId=${result.frameStreamId})`,
+            `streamId=${result.frameStreamId}, ` +
+            `v2=${daemonGate?.isInteractiveSupported(moduleId) ?? false})`,
         );
     } catch (err) {
         // MethodNotFound on a daemon that predates the interactive RPC — fall through
@@ -2776,6 +2794,48 @@ async function handleSetInteractive(previewId: string, enabled: boolean): Promis
  * (MethodNotFound), or has already been stopped" — drop the click.
  */
 const activeInteractiveStreams = new Map<string, string>();
+
+/**
+ * Update the v1-fallback status-bar hint (#425). Visible only when at least one active
+ * interactive stream is on a daemon that doesn't advertise
+ * `InitializeResult.capabilities.interactive`. Hidden when v2 is supported on every
+ * stream's host (the panel's LIVE chip is sufficient feedback) and when no streams are
+ * active.
+ *
+ * Called from every site that mutates `activeInteractiveStreams` plus the channel-close
+ * cleanup, so the indicator reflects the current state without polling.
+ */
+function updateInteractiveStatus(): void {
+    if (!interactiveStatusItem) { return; }
+    if (!daemonGate || activeInteractiveStreams.size === 0) {
+        interactiveStatusItem.hide();
+        return;
+    }
+    const unsupportedModules = new Set<string>();
+    for (const previewId of activeInteractiveStreams.keys()) {
+        const moduleId = previewModuleMap.get(previewId);
+        if (!moduleId) { continue; }
+        if (!daemonGate.isInteractiveSupported(moduleId)) {
+            unsupportedModules.add(moduleId);
+        }
+    }
+    if (unsupportedModules.size === 0) {
+        interactiveStatusItem.hide();
+        return;
+    }
+    const moduleLabel = unsupportedModules.size === 1
+        ? [...unsupportedModules][0]
+        : `${unsupportedModules.size} modules`;
+    interactiveStatusItem.text = `$(warning) Live · v1 fallback`;
+    interactiveStatusItem.tooltip = (
+        `Live mode is active on ${moduleLabel}, but this daemon backend doesn't ` +
+        `support clicks-into-composition (v2). Inputs trigger a fresh render but ` +
+        `state from \`remember { mutableStateOf(...) }\` resets between clicks. ` +
+        `Switch to a desktop module for full interactive mode. ` +
+        `See docs/daemon/INTERACTIVE.md § 9.10.`
+    );
+    interactiveStatusItem.show();
+}
 
 /**
  * Forward a panel-side click on a live preview to the daemon's `interactive/input`


### PR DESCRIPTION
Consumes the new `InitializeResult.capabilities.interactive` bit shipped in #425. Surfaces a status-bar warning when the user has LIVE active on a daemon backend that doesn't speak v2 (Robolectric/Android today) so they can tell why clicks don't mutate composition state.

This was the third item from my VS Code follow-up list that #424 deferred — the daemon agent has now landed the wire signal we needed.

## What this lands

- **`daemonProtocol.ts` mirrors the new optional capability field** (`ServerCapabilities.interactive`). Treats absent as `false` so pre-#425 daemons surface the unsupported hint cleanly rather than silently looking like v2 to the panel.

- **`DaemonGate.isInteractiveSupported(moduleId)`** reads `spawned.initializeResult.capabilities.interactive` for a per-module view of v2 readiness. Returns `false` when no daemon is up — caller can't drive interactive mode either way.

- **New status bar item** (Left, priority 89, just below the existing daemon warm-state slot) shows `$(warning) Live · v1 fallback` iff at least one active interactive stream is on a v1-only host. Tooltip explains the behaviour:
  > Live mode is active on `<moduleId>`, but this daemon backend doesn't support clicks-into-composition (v2). Inputs trigger a fresh render but state from `remember { mutableStateOf(...) }` resets between clicks. Switch to a desktop module for full interactive mode. See `docs/daemon/INTERACTIVE.md § 9.10`.

  Hidden when v2 is supported on every active stream's host (the panel's LIVE chip is sufficient feedback) and when no streams are active.

- **`updateInteractiveStatus()` wired into every mutation site** for `activeInteractiveStreams`: `handleSetInteractive` enter/exit, `flushInteractiveStreams` (deactivate), `onChannelClosed` cleanup. No polling — the indicator reflects current state through the existing mutation paths.

- **`handleSetInteractive`'s "live mode on" log line** now includes the v2-supported flag so debugging "why don't my clicks mutate state?" is one log scroll instead of a code dive.

## Why the panel's LIVE chip stays unchanged

The chip's job is "this preview is the daemon's render priority" — true on both v1 and v2. The status-bar hint is the qualifier that lives at a different surface so users intentionally probing for it can find it without the chip's UX getting busier.

The webview can't easily probe per-module v2 support today (would need plumbing the capability into `setInteractiveAvailability`); for now the status-bar hint suffices, and the per-card "live but degraded" UI is a nice-to-have for v3 when it'd carry actual demonstrable behaviour.

## Wire compatibility

None — this PR is strictly consumer-side of #425. Pre-#425 daemons emit `interactive: undefined` (the field was just added to the wire); the TS treats `undefined` as `false` and surfaces the hint accordingly.

## Test plan

- [x] `cd vscode-extension && npm run compile` — clean
- [x] `cd vscode-extension && npm test` — 315/315 pass
- [ ] Manual on a desktop module: toggle LIVE → status-bar hint stays hidden (LIVE chip shows). Toggle off → still hidden.
- [ ] Manual on an Android module: toggle LIVE → status-bar hint shows "Live · v1 fallback" with the explanatory tooltip. Toggle off → hint hides.
- [ ] Manual mixed: open LIVE on a desktop module first (no hint), Shift+click LIVE on an Android module (hint appears). Shift+click Android off (hint hides). Toggle desktop off (still hidden).

## What's left in the rough-edges list

- `Modifier.clickable {}` reliability under `ImageComposeScene`'s manual clock — pure `:daemon:desktop` work for the daemon agent.
- Display dimensions threading through `previewSpecResolver` — needs `PreviewInfoDto` widening in `:daemon:core` + gradle plugin for the daemon agent.
- `RobolectricHost.acquireInteractiveSession` (Android v3) — the big one; needs its own design pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_017NDGZk17VhvctNNoSrVZsK)_