### PR TITLE
feat(daemon): advertise known device catalog via initialize capabilities

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -33,6 +33,7 @@ import ee.schimke.composeai.daemon.protocol.InitializeResult
 import ee.schimke.composeai.daemon.protocol.JsonRpcNotification
 import ee.schimke.composeai.daemon.protocol.JsonRpcRequest
 import ee.schimke.composeai.daemon.protocol.JsonRpcResponse
+import ee.schimke.composeai.daemon.protocol.KnownDevice
 import ee.schimke.composeai.daemon.protocol.LeakDetectionMode
 import ee.schimke.composeai.daemon.protocol.Manifest
 import ee.schimke.composeai.daemon.protocol.Orientation
@@ -584,6 +585,13 @@ class JsonRpcServer(
             // real held-scene session (DesktopHost). `false` for hosts that inherit the throwing
             // default (FakeHost, RobolectricHost today) — clients fall back to v1 dispatch.
             interactive = host.supportsInteractive,
+            // PROTOCOL.md § 3 — surface the daemon's `DeviceDimensions` catalog so clients can
+            // build a `renderNow.overrides.device` picker without re-bundling the list. The
+            // catalog itself lives in `:daemon:core/.../daemon/devices/DeviceDimensions.kt`;
+            // we project each entry into a wire-friendly shape (id + dp dims + density) so
+            // clients can render labels like "Pixel 5 — 393×851 dp @ 2.75x" without
+            // re-resolving.
+            knownDevices = buildKnownDevices(),
           ),
         // B2.1 — surface the authoritative SHA-256 to the client so VS Code can correlate later
         // `classpathDirty` notifications against the daemon's known-at-startup state. Empty
@@ -2313,6 +2321,18 @@ class JsonRpcServer(
     } catch (_: Throwable) {
       // Fallback for environments where ProcessHandle is unavailable.
       ManagementFactory.getRuntimeMXBean().name.substringBefore('@').toLongOrNull() ?: -1L
+    }
+
+  /**
+   * Project the daemon's `DeviceDimensions` catalog into the wire shape advertised on
+   * `InitializeResult.capabilities.knownDevices`. Sorted by id so the client sees a stable order
+   * across runs (the underlying map is insertion-ordered today, but spelling that out here keeps
+   * the contract independent of catalog-edit ordering).
+   */
+  private fun buildKnownDevices(): List<KnownDevice> =
+    ee.schimke.composeai.daemon.devices.DeviceDimensions.KNOWN_DEVICE_IDS.sorted().map { id ->
+      val spec = ee.schimke.composeai.daemon.devices.DeviceDimensions.resolve(id)
+      KnownDevice(id = id, widthDp = spec.widthDp, heightDp = spec.heightDp, density = spec.density)
     }
 
   /** Tagged failure carrier for the watcher loop. */

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -122,7 +122,24 @@ data class ServerCapabilities(
   // mutating state (v1 fallback). Defaulted for old daemons that pre-date the
   // capability — clients treat absent and `false` identically.
   val interactive: Boolean = false,
+  /**
+   * The `@Preview(device = ...)` ids the daemon's `DeviceDimensions` catalog recognises, paired
+   * with their resolved geometry. Lets clients build a "render this preview at..." picker without
+   * re-bundling the catalog. Empty list = pre-feature daemon (clients treat absent and `[]`
+   * identically). The `spec:width=…,height=…,dpi=…` grammar is not enumerable — clients pass it as
+   * a free-form `device` override and the daemon parses it at resolve-time. See
+   * `daemon/core/.../daemon/devices/DeviceDimensions.kt` for the source of truth.
+   */
+  val knownDevices: List<KnownDevice> = emptyList(),
 )
+
+/**
+ * One entry in `ServerCapabilities.knownDevices`. The id is the string a caller passes via
+ * `renderNow.overrides.device` (or `@Preview(device = ...)` at discovery time); the geometry fields
+ * let a UI label the device ("Pixel 5 — 393×851 dp @ 2.75x") without re-resolving.
+ */
+@Serializable
+data class KnownDevice(val id: String, val widthDp: Int, val heightDp: Int, val density: Float)
 
 /**
  * One advertised data-product kind. Mirrors `DataProductCapability` in

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -96,8 +96,8 @@ open class DesktopHost(
    * Without one, [acquireInteractiveSession] throws unconditionally; advertising `true` in that
    * shape would mislead the client into thinking it can dispatch into a held composition. The
    * production daemon-main path always passes a resolver, so the production wire is `true` for
-   * desktop daemons and stays `false` for in-process tests that don't wire one (which are the
-   * same tests that exercise the v1 fallback path).
+   * desktop daemons and stays `false` for in-process tests that don't wire one (which are the same
+   * tests that exercise the v1 fallback path).
    */
   override val supportsInteractive: Boolean
     get() = previewSpecResolver != null

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -118,7 +118,14 @@ Result:
     incrementalDiscovery: boolean;   // false in v1.0; true once Tier-2 lands
     sandboxRecycle: boolean;
     leakDetection: ("light" | "heavy")[];   // reserved; always [] today (TODO B2.4)
+    knownDevices?: KnownDevice[];    // catalog of @Preview(device=...) ids the daemon recognises
   };
+  // KnownDevice — one entry per id in DeviceDimensions.KNOWN_DEVICE_IDS, projected to wire shape.
+  // `id` is the string a caller passes via renderNow.overrides.device; widthDp/heightDp/density
+  // let a UI label the device ("Pixel 5 — 393×851 dp @ 2.75x") without re-resolving.
+  // Empty list = pre-feature daemon; treat absent and `[]` identically.
+  // The `spec:width=…,height=…,dpi=…` grammar is not enumerable — clients pass it as a
+  // free-form `device` override and the daemon parses it at resolve-time.
   classpathFingerprint: string;      // SHA-256 hex of the resolved test classpath
   manifest: {
     path: string;                    // absolute path to the daemon's working previews.json

--- a/docs/daemon/protocol-fixtures/daemon-initializeResult.json
+++ b/docs/daemon/protocol-fixtures/daemon-initializeResult.json
@@ -23,6 +23,10 @@
         "fetchable": true,
         "requiresRerender": false
       }
+    ],
+    "knownDevices": [
+      {"id": "id:pixel_5", "widthDp": 393, "heightDp": 851, "density": 2.75},
+      {"id": "id:wearos_small_round", "widthDp": 192, "heightDp": 192, "density": 2.0}
     ]
   },
   "classpathFingerprint": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -132,9 +132,30 @@ export interface InitializeResult {
          * Robolectric / Android backends.
          */
         interactive?: boolean;
+        /**
+         * The `@Preview(device = ...)` ids the daemon's catalog recognises, paired with
+         * resolved geometry. Lets clients build a "render this preview at..." picker without
+         * re-bundling the catalog. Empty list = pre-feature daemon (treat absent and `[]`
+         * identically). The `spec:width=…,height=…,dpi=…` grammar is not enumerable —
+         * clients pass it as a free-form `device` override and the daemon parses it at
+         * resolve-time.
+         */
+        knownDevices?: KnownDevice[];
     };
     classpathFingerprint: string;
     manifest: { path: string; previewCount: number };
+}
+
+/**
+ * One entry in `ServerCapabilities.knownDevices`. The `id` is the string a caller passes via
+ * `renderNow.overrides.device` (or `@Preview(device = ...)` at discovery time); the geometry
+ * fields let a UI label the device ("Pixel 5 — 393×851 dp @ 2.75x") without re-resolving.
+ */
+export interface KnownDevice {
+    id: string;
+    widthDp: number;
+    heightDp: number;
+    density: number;
 }
 
 // Client → daemon notifications (PROTOCOL.md § 4)

--- a/vscode-extension/src/test/daemonProtocol.test.ts
+++ b/vscode-extension/src/test/daemonProtocol.test.ts
@@ -61,6 +61,14 @@ describe('daemon protocol — golden fixtures', () => {
         assert.strictEqual(result.capabilities.sandboxRecycle, true);
         assert.strictEqual(result.classpathFingerprint.length, 64);
         assert.deepStrictEqual(result.capabilities.leakDetection, ['light', 'heavy']);
+        // PROTOCOL.md § 3 — `knownDevices` is the daemon's catalog of `@Preview(device = ...)`
+        // ids, projected to wire shape so panels can build a picker without re-bundling.
+        const known = result.capabilities.knownDevices ?? [];
+        assert.ok(known.length >= 1, 'fixture should advertise at least one known device');
+        const pixel5 = known.find(d => d.id === 'id:pixel_5');
+        assert.ok(pixel5, 'fixture should include id:pixel_5');
+        assert.strictEqual(pixel5!.widthDp, 393);
+        assert.strictEqual(pixel5!.density, 2.75);
     });
 
     it('parses client-fileChanged.json with all required fields', () => {


### PR DESCRIPTION
## Summary

Adds `ServerCapabilities.knownDevices: List<KnownDevice>` to `InitializeResult` so clients building a `renderNow.overrides.device` picker can read the catalog off the wire instead of re-bundling `DeviceDimensions`. First step on the "config negotiation" thread we discussed — **flips the device catalog from a duplicated-on-each-side hardcode into a daemon-advertised list**.

- **Wire shape** — Each entry carries `id` plus resolved `widthDp` / `heightDp` / `density` so a UI can label "Pixel 5 — 393×851 dp @ 2.75x" without re-resolving. Populated at `initialize`-handler time from `DeviceDimensions.KNOWN_DEVICE_IDS`, sorted alphabetically so the client sees a stable order across runs (catalog map is insertion-ordered today, but the contract should be independent of catalog-edit ordering).
- **`spec:width=…,height=…,dpi=…`** — not enumerable; documented as a free-form override the daemon still parses at resolve-time.
- **Backwards-compatible** — defaulted to `emptyList()`. Pre-feature daemons advertise nothing and clients treat absent and `[]` identically.
- **Mirrored on TypeScript** — `ServerCapabilities.knownDevices` plus the `KnownDevice` interface in `daemonProtocol.ts`.
- **Docs + fixtures** — `PROTOCOL.md § 3` updated; the shared `daemon-initializeResult.json` fixture now includes `id:pixel_5` + `id:wearos_small_round` so the round-trip tests on both sides exercise the new field.

## Test plan

- [x] `:daemon:core:test` — 27/27 `MessagesTest` (incl. updated fixture round-trip), 11/11 `JsonRpcServerIntegrationTest` (one flaky pre-existing test on the first run, clean on rerun — unrelated to this change which is `initialize`-only)
- [x] `:daemon:core:ktfmtCheck` — clean
- [x] `ktfmtCheckAll` — clean across the repo

## Notes

- Includes ktfmtFormatAll output for `DesktopHost.kt` (pre-existing unrelated format drift the global pre-commit hook required — same pattern as the previous two PRs in this thread).
- Natural follow-up: a small MCP `list_devices` tool that just returns this list. Out of scope here — wire shape lands first; tool wrapper after.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmHMG3rJrJowyM15hK2Bow)_