### PR TITLE
revert(mcp): drop speculative --attach-data-product CLI flag

### DIFF
--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -13,7 +13,6 @@ import kotlinx.serialization.json.JsonObject
  * ```
  * compose-preview-mcp [--project <path>[:<rootProjectName>]]...
  *                     [--replicas-per-daemon <N>]
- *                     [--attach-data-product <KIND>]...
  * ```
  *
  * Each `--project` flag pre-registers a workspace with the supervisor at startup so connecting
@@ -27,14 +26,6 @@ import kotlinx.serialization.json.JsonObject
  * [DaemonSupervisor.DEFAULT_REPLICAS_PER_DAEMON] (= 3, i.e. 4 sandboxes per daemon). Set `0` to opt
  * out and run a single sandbox per daemon.
  *
- * `--attach-data-product KIND` (repeatable) configures ambient data-product kinds the supervisor
- * passes through `initialize.options.attachDataProducts` to every spawned daemon. The daemon then
- * attaches the kind's payload to every `renderFinished`, the supervisor caches it, and
- * `get_preview_data` serves cache hits with no daemon round-trip. Reserved for "always on,
- * everywhere" cases — e.g. `--attach-data-product a11y/atf` to keep accessibility findings ambient
- * for every preview. Most agents leave this empty and use the per-call `subscribe_preview_data`
- * tool instead. See `docs/daemon/DATA-PRODUCTS.md`.
- *
  * On stdin EOF the server tears down every supervised daemon (sending `shutdown` + `exit` per
  * PROTOCOL.md § 3) and exits cleanly.
  */
@@ -43,13 +34,11 @@ object DaemonMcpMain {
   @JvmStatic
   fun main(args: Array<String>) {
     val replicasPerDaemon = parseReplicasPerDaemon(args)
-    val attachDataProducts = parseAttachDataProducts(args)
     val supervisor =
       DaemonSupervisor(
         descriptorProvider = DescriptorProvider.readingFromDisk(),
         clientFactory = SubprocessDaemonClientFactory(),
         replicasPerDaemon = replicasPerDaemon,
-        globalAttachDataProducts = attachDataProducts,
       )
     val server = DaemonMcpServer(supervisor)
 
@@ -100,34 +89,6 @@ object DaemonMcpMain {
     val idx = raw.lastIndexOf(':')
     return if (idx <= 0) raw to null
     else raw.substring(0, idx) to raw.substring(idx + 1).takeIf { it.isNotEmpty() }
-  }
-
-  /**
-   * Collects every `--attach-data-product KIND` (or `--attach-data-product=KIND`) occurrence into
-   * an ordered, de-duplicated list. Empty by default — most agents don't want ambient data products
-   * and use `subscribe_preview_data` per call. Wired through to every daemon's
-   * `initialize.options.attachDataProducts`.
-   */
-  private fun parseAttachDataProducts(args: Array<String>): List<String> {
-    val out = LinkedHashSet<String>()
-    var i = 0
-    while (i < args.size) {
-      val a = args[i]
-      when {
-        a == "--attach-data-product" && i + 1 < args.size -> {
-          val kind = args[i + 1]
-          if (kind.isNotBlank()) out.add(kind)
-          i += 2
-        }
-        a.startsWith("--attach-data-product=") -> {
-          val kind = a.removePrefix("--attach-data-product=")
-          if (kind.isNotBlank()) out.add(kind)
-          i++
-        }
-        else -> i++
-      }
-    }
-    return out.toList()
   }
 
   private fun parseReplicasPerDaemon(args: Array<String>): Int {

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -50,8 +50,14 @@ class DaemonSupervisor(
   /**
    * D1 — kinds the supervisor passes through `initialize.options.attachDataProducts` to every
    * spawned daemon. Configures "always-on" data products (e.g. `a11y/atf` for ambient diagnostic
-   * squigglies). Empty list (the default) keeps the wire absent — no global attach. Wired from the
-   * `--attach-data-product KIND` flag on [DaemonMcpMain].
+   * squigglies). Empty list (the default) keeps the wire absent — no global attach.
+   *
+   * No production entry point sets this today: [DaemonMcpMain] used to expose a
+   * `--attach-data-product KIND` CLI flag, but it was deemed speculative (the design doc reserves
+   * `attachDataProducts` for "always-on everywhere" cases that no real operator deployment needs
+   * yet) and dropped. The parameter stays so a future agent-driven negotiation tool — or embedding
+   * consumer that wires a non-default config — can populate it without re-plumbing the supervisor →
+   * `initialize` path. Tests use it directly (see `DaemonMcpServerTest`).
    */
   private val globalAttachDataProducts: List<String> = emptyList(),
 ) {


### PR DESCRIPTION
## Summary

PR #430 added `--attach-data-product KIND` on `DaemonMcpMain` to configure ambient data-product attachment at server startup. On reflection it's speculative: D2 just landed, `a11y/atf` is the only attachable kind today, and no actual operator deployment is using it. Per DATA-PRODUCTS.md goal #2 ("Default is nothing"), the wire's `attachDataProducts` is meant to ride only when explicitly asked.

Drop the CLI surface. Everything else stays:

- The wire field (`initialize.options.attachDataProducts`).
- `DaemonClient.initialize`'s `attachDataProducts` parameter.
- `DaemonSupervisor.globalAttachDataProducts` constructor parameter (with a refreshed KDoc explaining why no production entry point sets it today).
- The spawn-time passthrough.

So a future agent-driven negotiation tool (or an embedding consumer that wires non-default config) can populate it without re-plumbing anything. Tests that exercise the supervisor parameter directly stay green.

**Re-adding paths:**
- If the operator-policy use case ever materialises: 30-line patch reverting this commit.
- If the agent-driven use case materialises: new MCP tool that synthesises "global attach" via fan-out per-preview subscribes — different mechanism, same end effect.

## Test plan

- [x] `./gradlew :mcp:ktfmtCheckMain :mcp:ktfmtCheckTest` — clean
- [x] `./gradlew :mcp:test` — 27/27 pass; the `globalAttachDataProducts forwards through initialize` and `empty globalAttachDataProducts omits the options field` tests still cover the supervisor parameter via direct construction.


---
_Generated by [Claude Code](https://claude.ai/code/session_019eCR7c9UaZzvkAf9TeVVc9)_