### PR TITLE
fix(daemon-harness): pull skiko native bundle via testFixtures classpath

### DIFF
--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -94,6 +94,16 @@ dependencies {
   // module to apply Compose plugins. The Compose runtime/ui deps below mirror the test
   // declarations above; only the foundation + runtime + ui surface area the fixtures actually
   // touch is needed here.
+  //
+  // `compose.desktop.currentOs` is added so the harness (which consumes
+  // `testFixtures(project(":daemon:desktop"))`) inherits the per-OS Skiko native bundle
+  // transitively. Without it the spawned daemon JVM dies in `ImageComposeScene.<init>` with
+  // `LibraryLoadException: Cannot find libskiko-linux-x64.so.sha256` — the production
+  // `compileOnly(compose.desktop.currentOs)` above keeps the bundle off the published POM, so
+  // nothing else on the harness's classpath would otherwise pull it. testFixtures variants are
+  // skipped from the publishable component (see the `afterEvaluate` block below), so this stays
+  // out of `daemon-desktop`'s POM too.
+  "testFixturesImplementation"(compose.desktop.currentOs)
   "testFixturesImplementation"(compose.runtime)
   "testFixturesImplementation"(compose.foundation)
   "testFixturesImplementation"(compose.ui)

--- a/daemon/harness/build.gradle.kts
+++ b/daemon/harness/build.gradle.kts
@@ -63,10 +63,11 @@ dependencies {
   // test source set is on this module's test runtime classpath.
   testImplementation(project(":daemon:desktop"))
   testImplementation(testFixtures(project(":daemon:desktop")))
-  // Skiko native bundle. Compose runtime/foundation/ui propagate transitively via
-  // `:daemon:desktop` (its own runtime classpath), so we don't re-declare them here.
-  // `:renderer-desktop` already brings `compose.desktop.currentOs` for the production renderer,
-  // so the harness's test classpath inherits the per-OS Skiko bundle automatically.
+  // Compose runtime/foundation/ui + the per-OS Skiko native bundle propagate transitively via
+  // `testFixtures(project(":daemon:desktop"))` above — see that module's
+  // `testFixturesImplementation(compose.desktop.currentOs)` for why the testFixtures variant is
+  // the seam (production `compileOnly(compose.desktop.currentOs)` keeps the Skiko bundle off the
+  // published POM, so nothing else on the harness's classpath would otherwise pull it).
 
   // D-harness.v2 — Android target (`-Ptarget=android`). Strategy diverges from desktop:
   //


### PR DESCRIPTION
## Summary

Fix the `Daemon Harness (desktop, real renderer)` CI job, which has been red since PR #373.

**Root cause.** PR #373 (`feat(daemon): publish daemon-core, daemon-desktop, daemon-android to Maven Central`) made two related changes to `:daemon:desktop` to keep the build host's Skiko native classifier (`org.jetbrains.skiko:skiko-awt-runtime-linux-x64`, etc.) out of the published `daemon-desktop` POM:

1. Flipped `implementation(compose.desktop.currentOs)` → `compileOnly(compose.desktop.currentOs)`.
2. Dropped `implementation(project(":renderer-desktop"))`, which had been pulling the per-OS Skiko bundle in transitively for the daemon's own tests.

After both changes nothing on `:daemon:harness`'s test classpath transitively pulls `compose.desktop.currentOs`. The harness already declares `testImplementation(testFixtures(project(":daemon:desktop")))` for the `RedSquare` / `BlueSquare` / etc. fixtures, but `:daemon:desktop`'s testFixtures source set only declared the Compose runtime/foundation/ui platform-agnostic surfaces — not the per-OS native bundle.

**Symptom.** `RealDesktopHarnessLauncher.spawn` builds the daemon JVM's `-cp` from `System.getProperty("java.class.path")` (the harness's own test classpath), so the spawned daemon dies inside `ImageComposeScene.<init>` with:

```
java.lang.ExceptionInInitializerError
  at androidx.compose.ui.ImageComposeScene.<init>(ImageComposeScene.skiko.kt:151)
  at ee.schimke.composeai.daemon.RenderEngine.setUp(RenderEngine.kt:172)
  ...
Caused by: org.jetbrains.skiko.LibraryLoadException: Cannot find
  libskiko-linux-x64.so.sha256, proper native dependency missing.
```

The render thread posts the throwable onto the per-id result queue, the watcher loop never emits `renderStarted`, and the test times out at 30 s with `pollNotification(renderStarted) timed out`. All 9 `*RealModeTest` scenarios (S1 through S8) fail the same way.

**Fix.** Add `compose.desktop.currentOs` to `:daemon:desktop`'s `testFixturesImplementation`. The harness inherits the per-OS Skiko bundle transitively via the testFixtures consumption it already does, so neither side needs new wiring. The `afterEvaluate` block in `:daemon:desktop`'s `build.gradle.kts` already skips testFixtures variants from the publishable Java component, so the published `daemon-desktop` POM stays unaffected.

Also fixes the now-stale comment in `:daemon:harness`/build.gradle.kts that pointed at `:renderer-desktop` as the (no-longer-existent) Skiko seam.

## Test plan

- [x] `./gradlew :daemon:harness:test -Pharness.host=real` — full real-mode suite green locally (was 9/9 failing before the fix)
- [x] `./gradlew :daemon:harness:test` — fake-mode suite still green
- [x] `./gradlew ktfmtCheckAll` — green
- [ ] CI `Daemon Harness (desktop, real renderer)` job passes
- [ ] CI `Daemon Harness (android, real renderer)` job stays green (unaffected — android has its own classpath descriptor seam)
- [ ] CI `Daemon Harness (desktop, fake host)` job stays green

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgkkN21Sps5oZkkTA3ZBrb)_