### PR TITLE
feat(vscode): one-click LIVE on any preview, auto-stop on focus/scroll

### DIFF
--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -52,35 +52,48 @@ settings, the toggle vanishes on the next focus change.
 
 ## 3. UI surface
 
-Lives inside `focus-controls` next to the existing diff / launch-on-device
-buttons. Visible only when:
+Two equivalent affordances reach interactive mode:
 
-- `layout-mode === 'focus'`
-- The currently focused preview's module has a healthy daemon (extension
-  pushes a `setInteractiveAvailability` message on daemon up/down).
+1. **Click the preview image** in any layout (focus, grid, flow, column).
+   Single-click on a non-live card enters LIVE for that preview;
+   subsequent clicks while LIVE forward as pointer events to the
+   daemon. Plain click is single-target (drops every prior live
+   stream); Shift+click adds the preview to the live set without
+   disturbing others (multi-stream).
+2. **The LIVE button** in the focus-mode toolbar — same plain/Shift
+   semantics. Redundant for focus-mode users but useful for keyboard
+   navigation and as a visible exit.
 
-```
-[ ◄ ] 1/3 [ ► ]  [ ⟂HEAD ] [ ⟂main ] [ 🌐 device ]  [ 🔴 LIVE ] [ × ]
-                                                       ──new──
-```
+A small **focus button** sits in each card's title row
+(`codicon-screen-full`) so users can jump into focus mode without
+relying on a hidden double-click affordance — single-click on the
+image is reserved for entering LIVE.
 
-Toggle states:
+When LIVE for a card, that card carries:
 
-| State        | Icon                                 | Tooltip                                    |
-|--------------|--------------------------------------|--------------------------------------------|
-| Disabled     | `circle-large-outline` (codicon)     | "Daemon not ready — live mode unavailable" |
-| Off (ready)  | `circle-large-outline`               | "Enter live mode (stream renders)"         |
-| On           | `record` (red)                       | "Live · click to exit"                     |
-
-When ON, the focused card carries:
-
-- `.preview-card.live` class (CSS adds a 1-pixel red border and a
-  bottom-right pulsing **LIVE** chip).
+- `.preview-card.live` class (CSS draws a 2px red border + soft red
+  glow so the live state reads from across the panel, not just on
+  close inspection).
+- A solid red **LIVE** chip pinned top-right with a blinking dot.
 - `<img>` swaps clear `.fade-in`, so the next paint reads as a frame
   update, not a card reload.
-- Click on the image is handled by `recordInteractiveClick(card, event)`
-  which dispatches a `recordInteractiveClick` webview→extension message
-  with image-pixel coordinates (see § 6).
+- Crosshair cursor signalling "click here to dispatch into the live
+  preview".
+- Image click handler routes to `recordInteractiveClick(card, event)`
+  which posts a `recordInteractiveClick` webview→extension message
+  with image-natural pixel coordinates (see § 7).
+
+LIVE is **sticky for edits** — saves trigger fresh `renderFinished`
+notifications that the live card consumes. LIVE **auto-stops** when:
+
+- The user moves focus to a different editor (extension flushes via
+  `interactive/stop`, posts `clearInteractive` to the panel — both
+  sides reach the off state in lockstep without race).
+- A live card scrolls out of viewport (panel-side, hooked into the
+  existing IntersectionObserver). Re-entering view doesn't auto-
+  resume; the user re-clicks if they want it back.
+- The daemon's `interactive` capability flips to false (status-bar
+  hint surfaces in this case — see #431).
 
 ## 4. Lifecycle
 

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -438,11 +438,11 @@ body {
     align-items: center;
     justify-content: center;
     background: var(--skeleton-bg);
-    cursor: zoom-in;
-}
-
-.preview-grid.layout-focus .preview-card.focused .image-container {
-    cursor: zoom-out;
+    /* Click on a preview enters live (interactive) mode in any layout — see
+       INTERACTIVE.md § 3. Pointer cursor signals "this is clickable" without
+       implying a specific affordance (the magnifier zoom-in/out cursor was
+       misleading; we don't zoom). */
+    cursor: pointer;
 }
 
 .image-container img {
@@ -496,36 +496,46 @@ body {
    visual language as recording indicators in screen-share apps so the
    meaning lands without a tooltip. */
 .preview-card.live {
-    border-color: color-mix(in srgb, var(--vscode-errorForeground, #f55) 60%, transparent);
+    /* 2px ringed border + a soft outer glow so the live state reads from across
+       the panel, not just on close inspection. The glow uses box-shadow so it
+       doesn't reflow neighbours; the border-color carries the same tint as the
+       LIVE badge dot for visual coherence. */
+    border-color: var(--vscode-errorForeground, #f55);
+    border-width: 2px;
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--vscode-errorForeground, #f55) 30%, transparent),
+                0 0 12px color-mix(in srgb, var(--vscode-errorForeground, #f55) 25%, transparent);
 }
 .preview-card.live .image-container {
-    cursor: crosshair; /* hint at the future click-input surface */
+    cursor: crosshair; /* signals "click here to dispatch into the live preview" */
 }
 .live-badge {
     position: absolute;
-    bottom: 6px;
+    top: 6px;
     right: 6px;
     z-index: 4;
     display: inline-flex;
     align-items: center;
-    gap: 4px;
-    padding: 2px 6px;
-    border-radius: 3px;
-    background: color-mix(in srgb, var(--vscode-editor-background) 70%, transparent);
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
-    color: var(--vscode-errorForeground, #f55);
-    font-size: calc(var(--vscode-font-size) - 2px);
-    font-weight: 600;
+    gap: 5px;
+    padding: 3px 8px;
+    border-radius: 4px;
+    /* Solid red chip — the previous transparent-with-blur version blended into
+       the underlying preview when the preview happened to be red/orange. Solid
+       background guarantees the LIVE state is unambiguous. */
+    background: var(--vscode-errorForeground, #f55);
+    color: var(--vscode-editor-background);
+    font-size: calc(var(--vscode-font-size) - 1px);
+    font-weight: 700;
     letter-spacing: 0.5px;
+    text-transform: uppercase;
     pointer-events: none;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
 }
 .live-badge-dot {
-    width: 7px;
-    height: 7px;
+    width: 8px;
+    height: 8px;
     border-radius: 50%;
-    background: var(--vscode-errorForeground, #f55);
-    animation: liveBlink 1.2s ease-in-out infinite;
+    background: var(--vscode-editor-background);
+    animation: liveBlink 1s ease-in-out infinite;
 }
 @keyframes liveBlink {
     0%, 100% { opacity: 1; }
@@ -983,6 +993,36 @@ body {
     padding: 0;
     font: inherit;
     font-weight: 600;
+}
+
+/* Focus icon next to the title — clicking enters focus mode for that card.
+   Replaces the previous "double-click on the image" affordance, which collided
+   with the new single-click-to-LIVE behaviour. Subtle until hovered so the
+   title row stays uncluttered when the user isn't reaching for the affordance. */
+.card-focus-btn {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 2px;
+    border-radius: 3px;
+    display: inline-flex;
+    align-items: center;
+    opacity: 0.7;
+    transition: opacity 0.15s, background 0.15s;
+}
+.card-focus-btn:hover {
+    opacity: 1;
+    background: var(--toolbar-hover);
+}
+.card-focus-btn:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: 1px;
+}
+/* In focus mode the icon flips to "exit focus" — same hot zone, opposite verb. */
+.preview-grid.layout-focus .preview-card.focused .card-focus-btn {
+    color: var(--vscode-foreground);
+    opacity: 1;
 }
 
 /* --- Accessibility (ATF) findings --- */

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -772,6 +772,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
                 // just cancels any in-flight render, flashes spinners, and
                 // burns a Gradle invocation — all for a no-op.
                 if (filePath === currentScopeFile) { return; }
+                // INTERACTIVE.md § 3 — drop active interactive streams when
+                // the user moves focus to a different file. Daemon-side
+                // streams flushed here, panel cleared via clearInteractive
+                // below; the panel's own setPreviews flow would otherwise
+                // race this on the new file's manifest arrival.
+                void flushInteractiveStreams();
+                panel?.postMessage({ command: 'clearInteractive' });
                 refresh(false, filePath);
                 // Pre-warm the daemon for this file's module so the first
                 // save in the session collapses to "kotlinc + render"
@@ -786,6 +793,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
             // sticky got covered/closed and we need to re-resolve (which may
             // blank the panel) — issue #145.
             if (currentScopeFile && !isFileVisibleInEditor(currentScopeFile)) {
+                // The sticky scope file is no longer on screen — same UX flush as the
+                // different-Kotlin-file branch above. The user can't see the source code
+                // backing the live preview; stop the stream so the daemon doesn't keep
+                // rendering into an invisible panel.
+                void flushInteractiveStreams();
+                panel?.postMessage({ command: 'clearInteractive' });
                 refresh(false);
             }
         }),

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -505,18 +505,27 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         }
 
         function toggleInteractive(shift) {
+            // Drives the LIVE button in the focus-mode toolbar — operates on the currently
+            // focused card. Body factored into setInteractiveForCard so the in-card click handler
+            // (any layout) can reuse the same plain-vs-Shift logic.
             if (layoutMode.value !== 'focus') return;
             const visible = getVisibleCards();
             const card = visible[focusIndex];
             if (!card) return;
+            setInteractiveForCard(card, shift);
+        }
+
+        /**
+         * Toggle interactive mode for [card] honouring plain/Shift semantics:
+         *  - Plain: single-target. Drop every prior live target before adding (or re-removing)
+         *    this one — keeps the casual UX matching v1's "one card live at a time" mental model.
+         *  - Shift: multi-target. Toggle just this preview in/out of the live set without
+         *    touching the others.
+         */
+        function setInteractiveForCard(card, shift) {
             const previewId = card.dataset.previewId;
             if (!previewId) return;
             const wasLive = interactivePreviewIds.has(previewId);
-            // Plain click: single-target. Drop every prior live target before adding (or
-            // re-removing) this one — keeps the casual UX matching v1's "one card live at a
-            // time" mental model.
-            // Shift+click: multi-target. Toggle just this preview in/out of the live set without
-            // touching the others.
             if (!shift) {
                 interactivePreviewIds.forEach(prior => {
                     if (prior === previewId) return;
@@ -541,6 +550,18 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             });
             applyLiveBadge();
             applyInteractiveButtonState();
+        }
+
+        /**
+         * Single-click-to-LIVE entry point from the in-card image click handler. Ensures
+         * image clicks land here in any layout (focus, grid, flow, column) — the focus-mode
+         * LIVE button is a redundant affordance for the focus-mode user, this lets every layout
+         * reach interactive mode in one click. Subsequent clicks while LIVE forward to the
+         * daemon via the per-image handler in updateImage; that is a separate code path and
+         * the click here short-circuits.
+         */
+        function enterInteractiveOnCard(card, shift) {
+            setInteractiveForCard(card, shift);
         }
 
         // Idempotent attach. Adds a click listener to the live card's image
@@ -1194,6 +1215,27 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 titleRow.appendChild(icon);
             }
 
+            // Per-card focus icon. Replaces the previous "double-click image"
+            // affordance — single-click on the image is now reserved for
+            // entering LIVE (interactive) mode, so we need an explicit handle
+            // for "view this card by itself". Same hot zone toggles between
+            // enter-focus (other layouts) and exit-focus (focus layout).
+            const focusBtn = document.createElement('button');
+            focusBtn.type = 'button';
+            focusBtn.className = 'card-focus-btn';
+            focusBtn.innerHTML = '<i class="codicon codicon-screen-full" aria-hidden="true"></i>';
+            focusBtn.title = 'Focus this preview';
+            focusBtn.setAttribute('aria-label', 'Focus this preview');
+            focusBtn.addEventListener('click', (evt) => {
+                evt.stopPropagation();
+                if (layoutMode.value === 'focus') {
+                    exitFocus();
+                } else {
+                    focusOnCard(card);
+                }
+            });
+            titleRow.appendChild(focusBtn);
+
             // Stale-tier refresh button — only attached up front for cards
             // already known to be stale at setPreviews time. updateStaleBadges
             // also adds/removes it on subsequent renders. Placed before the
@@ -1205,24 +1247,29 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 
             const imgContainer = document.createElement('div');
             imgContainer.className = 'image-container';
-            imgContainer.title = 'Double-click to focus';
+            imgContainer.title = 'Click to enter live mode';
             const skeleton = document.createElement('div');
             skeleton.className = 'skeleton';
             skeleton.setAttribute('aria-label', 'Loading preview');
             imgContainer.appendChild(skeleton);
             card.appendChild(imgContainer);
 
-            // Double-click the image to jump straight to focus mode on this
-            // preview, or back out of it. The dblclick handler stays on the
-            // image so single-clicks remain free for future selection
-            // affordances and don't interfere with the existing title /
-            // stale-badge / carousel buttons.
-            imgContainer.addEventListener('dblclick', () => {
-                if (layoutMode.value === 'focus') {
-                    exitFocus();
-                } else {
-                    focusOnCard(card);
-                }
+            // Single-click on the image enters LIVE for this preview (in any
+            // layout — focus, grid, flow, column). The first click toggles
+            // interactive on; subsequent clicks while LIVE forward as pointer
+            // events to the daemon (handled by ensureInteractiveClickHandler
+            // attached via updateImage). The handler is on the container, not
+            // the <img>, so clicks land before the image renders too. Modifier-
+            // aware: Shift+click follows the multi-stream semantics from
+            // toggleInteractive().
+            imgContainer.addEventListener('click', (evt) => {
+                const previewId = card.dataset.previewId;
+                if (!previewId) return;
+                // If we're already live for this preview, the per-image click
+                // handler routes to recordInteractiveClick — let that fire
+                // instead of toggling off.
+                if (interactivePreviewIds.has(previewId)) return;
+                enterInteractiveOnCard(card, evt.shiftKey);
             });
 
             // ATF legend + overlay layer — rendered in the webview (not
@@ -2070,8 +2117,25 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 for (const entry of entries) {
                     const id = entry.target.dataset.previewId;
                     if (!id) continue;
-                    if (entry.isIntersecting) intersecting.add(id);
-                    else intersecting.delete(id);
+                    if (entry.isIntersecting) {
+                        intersecting.add(id);
+                    } else {
+                        intersecting.delete(id);
+                        // Auto-stop interactive mode when a live preview scrolls out of view —
+                        // keeps the daemon from accumulating warm scenes the user can't see and
+                        // matches the "follow what the user is looking at" UX. Re-entering view
+                        // doesn't auto-resume; the user re-clicks if they want it back.
+                        if (interactivePreviewIds.has(id)) {
+                            interactivePreviewIds.delete(id);
+                            vscode.postMessage({
+                                command: 'setInteractive',
+                                previewId: id,
+                                enabled: false,
+                            });
+                            applyLiveBadge();
+                            applyInteractiveButtonState();
+                        }
+                    }
                 }
                 scheduleViewportPublish();
             }, { root: null, rootMargin: '0px', threshold: 0.1 })
@@ -2369,6 +2433,18 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                         applyLiveBadge();
                     }
                     applyInteractiveButtonState();
+                    break;
+                }
+                case 'clearInteractive': {
+                    // Extension flushed daemon-side streams (e.g. user moved focus to a
+                    // different editor). Drop our UI-side bookkeeping in lockstep — the
+                    // extension already stopped the streams server-side, so we MUST NOT post
+                    // setInteractive messages back; that would race the flush.
+                    if (interactivePreviewIds.size > 0) {
+                        interactivePreviewIds.clear();
+                        applyLiveBadge();
+                        applyInteractiveButtonState();
+                    }
                     break;
                 }
                 case 'previewMainRefChanged': {

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -395,7 +395,17 @@ export type ExtensionToWebview =
      * focus-mode "LIVE" toggle for any focused preview owned by the
      * module. See docs/daemon/INTERACTIVE.md § 3 for the UI surface.
      */
-    | { command: 'setInteractiveAvailability'; moduleId: string; ready: boolean };
+    | { command: 'setInteractiveAvailability'; moduleId: string; ready: boolean }
+    /**
+     * Drop every active interactive (live-stream) UI state on the panel side.
+     * Posted by the extension when the user moves focus away from the panel's
+     * scope file (active editor change to a different file) — the daemon-side
+     * streams are flushed in parallel via `interactive/stop`. The panel
+     * clears the LIVE badge / .live class / `interactivePreviewIds` set
+     * without sending its own `setInteractive` messages back (those would
+     * race the extension's flush). See INTERACTIVE.md § 3.
+     */
+    | { command: 'clearInteractive' };
 
 /** Messages from webview to extension */
 export type WebviewToExtension =


### PR DESCRIPTION
Smooths out the v2 interactive-mode UX based on real-use feedback. Five user-observable changes, each small, all shipped together because they share the panel's interactive surface.

## What changes

### 1. Single-click any preview enters LIVE

Click on a card image in any layout (focus, grid, flow, column) and that preview enters LIVE. No more "double-click to focus, then find the LIVE button" two-step. Subsequent clicks while LIVE forward to the daemon as before. Plain click is single-target (drops every prior live stream); Shift+click adds without disturbing other live streams (multi-stream from #424).

The focus-mode LIVE button stays — it's a redundant affordance now, but useful for keyboard navigation and as a visible exit.

### 2. Per-card focus icon

A small `codicon-screen-full` button in each card's title row enters focus mode for that card. Replaces the implicit double-click-on-image affordance, which collided with the new single-click-to-LIVE behaviour. Subtle until hovered so the title row stays uncluttered; flips to "exit focus" appearance when the card is focused.

### 3. Drop the magnifier (zoom) cursor

`.image-container` no longer carries `cursor: zoom-in/zoom-out`. The zoom cursor was misleading — we don't zoom. Replaced with `cursor: pointer` (and `cursor: crosshair` when LIVE, signalling "click here to dispatch into the live preview").

### 4. Much more obvious LIVE state

- 2px solid red border on the card (was 1px tinted).
- Soft outer red glow via `box-shadow` so the LIVE state reads from across the panel, not just on close inspection.
- LIVE badge moved bottom-right → top-right.
- Solid red background on the badge (previous transparent-with-blur version blended into red/orange previews).
- Larger blinking dot, slightly brighter pulse animation.

### 5. Auto-stop on focus change / viewport-out

LIVE is **sticky for edits** — saves trigger fresh `renderFinished` notifications that the live card consumes. LIVE **auto-stops** when:

- **Active editor changes** to a different file. The extension flushes streams server-side via `interactive/stop` and posts a new `clearInteractive` message to the panel so both sides reach the off state in lockstep without race. Webview/output focus does NOT trigger this (active editor stays the same).
- **Live card scrolls out of viewport** (panel-side, hooked into the existing IntersectionObserver). Daemon stops rendering into an invisible card. Re-entering view doesn't auto-resume; the user re-clicks if they want it back.

## Wire/protocol

New `ExtensionToWebview` message `clearInteractive` to coordinate extension-side flush with panel-side UI cleanup. No daemon-protocol change.

## Tests

318 pass. The panel-level UX logic (dom event wiring inside the HTML template) isn't directly unit-testable; the existing tests exercise the protocol surface that connects them to `extension.ts`. Worth a manual walkthrough:

## Test plan

- [x] `cd vscode-extension && npm run compile` — clean
- [x] `cd vscode-extension && npm test` — 318/318 pass
- [ ] Manual: in grid layout, click any preview image → LIVE chip appears, daemon receives `interactive/start`. Click again → daemon receives `interactive/input`.
- [ ] Manual: with LIVE on a preview, save the source file → preview re-renders, LIVE stays on (sticky for edits).
- [ ] Manual: with LIVE on a preview, click into a different .kt file → LIVE chip disappears, daemon receives `interactive/stop`.
- [ ] Manual: with LIVE on a preview, scroll the panel until the card is off-screen → LIVE chip disappears, daemon receives `interactive/stop`. Scroll back into view → LIVE stays off (no auto-resume).
- [ ] Manual: per-card focus icon (top-right of title row, visible on hover) → enters focus mode for that card. Same icon in focus mode → exits focus.
- [ ] Manual: Shift+click a second preview while one is already LIVE → both go LIVE simultaneously.

## INTERACTIVE.md § 3 rewritten

Reflects the new affordances. Old "Toggle states" table replaced with a description of the two equivalent entry paths plus the auto-stop conditions.

## What's still in the daemon agent's queue (unchanged)

- `Modifier.clickable {}` reliability — pure `:daemon:desktop`.
- `PreviewInfoDto` widening for display dims.
- Robolectric/Android v3.


---
_Generated by [Claude Code](https://claude.ai/code/session_017NDGZk17VhvctNNoSrVZsK)_