### PR TITLE
feat(mcp): list_devices tool surfaces the @Preview device catalog

### DIFF
--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -429,6 +429,20 @@ class DaemonMcpServer(
         inputSchema = parseSchema("""{"type":"object","properties":{}}"""),
       ),
       ToolDef(
+        name = "list_devices",
+        description =
+          "List the `@Preview(device = ...)` ids the daemon's catalog recognises, paired with " +
+            "resolved geometry (widthDp/heightDp/density). Use these as the `device` field of " +
+            "`render_preview.overrides` to flip a preview to any catalog device without editing " +
+            "annotations. The free-form `spec:width=…,height=…,dpi=…` grammar is not enumerable " +
+            "and is not returned here — pass it as a `device` override and the daemon parses it " +
+            "at resolve-time. Mirror of every daemon's " +
+            "`InitializeResult.capabilities.knownDevices`; read directly from the shared " +
+            "`DeviceDimensions` rather than going through a daemon, so it works before any " +
+            "daemon has spawned.",
+        inputSchema = parseSchema("""{"type":"object","properties":{}}"""),
+      ),
+      ToolDef(
         name = "render_preview",
         description =
           "Force-render a preview by URI, bypassing any cache. Returns the rendered PNG inline. " +
@@ -708,6 +722,7 @@ class DaemonMcpServer(
       "register_project" -> toolRegisterProject(args)
       "unregister_project" -> toolUnregisterProject(args)
       "list_projects" -> toolListProjects()
+      "list_devices" -> toolListDevices()
       "render_preview" -> toolRenderPreview(args)
       "watch" -> toolWatch(session, args)
       "unwatch" -> toolUnwatch(session, args)
@@ -772,6 +787,36 @@ class DaemonMcpServer(
                 }
               }
               put("branch", JsonPrimitive(detectBranch(project.path)))
+            }
+          )
+        }
+      }
+    }
+    return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+  }
+
+  /**
+   * `list_devices` MCP tool — returns the daemon's `DeviceDimensions` catalog projected to `{id,
+   * widthDp, heightDp, density}`. Reads directly from the shared `:daemon:core` `Device Dimensions`
+   * object rather than round-tripping through a daemon's `InitializeResult.
+   * capabilities.knownDevices`. Same data either way (the daemon's
+   * `JsonRpcServer.buildKnownDevices` pulls from the same source); reading directly avoids forcing
+   * a daemon spawn just to enumerate the catalog. If a future change makes the daemon-advertised
+   * catalog backend-specific, this tool will need to consult a specific daemon —
+   * `KNOWN_DEVICE_IDS`'s kdoc flags that.
+   */
+  private fun toolListDevices(): CallToolResult {
+    val payload = buildJsonObject {
+      putJsonArray("devices") {
+        ee.schimke.composeai.daemon.devices.DeviceDimensions.KNOWN_DEVICE_IDS.sorted().forEach { id
+          ->
+          val spec = ee.schimke.composeai.daemon.devices.DeviceDimensions.resolve(id)
+          add(
+            buildJsonObject {
+              put("id", id)
+              put("widthDp", spec.widthDp)
+              put("heightDp", spec.heightDp)
+              put("density", spec.density.toDouble())
             }
           )
         }

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -93,6 +93,7 @@ class DaemonMcpServerTest {
         "register_project",
         "unregister_project",
         "list_projects",
+        "list_devices",
         "render_preview",
         "watch",
         "unwatch",
@@ -126,6 +127,32 @@ class DaemonMcpServerTest {
     assertThat(payload["workspaceId"]?.jsonPrimitive?.contentOrNull).startsWith("test-project-")
     val n = client.expectNotification("notifications/resources/list_changed", 2_000)
     assertThat(n.method).isEqualTo("notifications/resources/list_changed")
+  }
+
+  @Test
+  fun `list_devices returns the daemon catalog projected to id widthDp heightDp density`() {
+    // No daemon needs to be spawned — list_devices reads directly from the shared
+    // :daemon:core DeviceDimensions catalog.
+    client.initialize()
+    val result = client.callTool("list_devices")
+    val payload = json.parseToJsonElement(result.firstTextContent()).jsonObject
+    val devices =
+      payload["devices"]?.jsonArray ?: error("list_devices payload must include 'devices' array")
+    // Spot-check a few well-known catalog entries — full enumeration would couple this test to
+    // the catalog membership, which is exactly the kind of hardcoded duplication the wire
+    // surface aims to remove. Pick one phone, one Wear, one TV; verify shape + a couple of
+    // dimensions to prove the mapping reaches the JSON.
+    val byId = devices.associateBy { it.jsonObject["id"]?.jsonPrimitive?.contentOrNull }
+    val pixel5 =
+      byId["id:pixel_5"]?.jsonObject ?: error("expected id:pixel_5 in list_devices output")
+    assertThat(pixel5["widthDp"]?.jsonPrimitive?.contentOrNull?.toInt()).isEqualTo(393)
+    assertThat(pixel5["heightDp"]?.jsonPrimitive?.contentOrNull?.toInt()).isEqualTo(851)
+    assertThat(pixel5["density"]?.jsonPrimitive?.contentOrNull?.toDouble()).isEqualTo(2.75)
+    assertThat(byId).containsKey("id:wearos_small_round")
+    assertThat(byId).containsKey("id:tv_1080p")
+    // Sorted alphabetically — same contract as InitializeResult.capabilities.knownDevices.
+    val ids = devices.map { it.jsonObject["id"]?.jsonPrimitive?.contentOrNull!! }
+    assertThat(ids).isInOrder()
   }
 
   @Test


### PR DESCRIPTION
## Summary

Closes the loop on PR #433 — exposes the daemon's `DeviceDimensions` catalog as a zero-arg MCP tool so an agent driving `render_preview` can discover valid `device` override ids without re-bundling the list. Returns a `devices` array of `{id, widthDp, heightDp, density}` sorted alphabetically — same shape and order as the `InitializeResult.capabilities.knownDevices` wire surface from #433.

- **Reads directly from `:daemon:core`'s shared `DeviceDimensions.KNOWN_DEVICE_IDS`** rather than round-tripping through a daemon's `InitializeResult`. Same data either way (the daemon's `buildKnownDevices` pulls from the same source); reading directly avoids forcing a daemon spawn just to enumerate the catalog. If a future change makes the daemon-advertised catalog backend-specific, the tool will need to consult a specific daemon — `KNOWN_DEVICE_IDS`'s kdoc already flags that.
- **`spec:width=…,height=…,dpi=…` not enumerable** — tool description spells this out so an agent doesn't ask the tool for spec resolution hints.

## Test plan

- [x] New `list_devices returns the daemon catalog projected to id widthDp heightDp density` regression test spot-checks id:pixel_5 (widthDp=393, density=2.75) and asserts a couple of category-anchor entries (Wear, TV) are present, plus alphabetical ordering matches the `knownDevices` contract from #433.
- [x] `tools/list` smoke test updated — `containsExactly` set now includes `list_devices`.
- [x] `:mcp:test` — 40/40 pass across `DaemonMcpServerTest` (28), `DaemonSupervisorReplicaTest` (5), `PreviewResourceTest` (6), `RealMcpEndToEndTest` (1).
- [x] `ktfmtCheckAll` — clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmHMG3rJrJowyM15hK2Bow)_