### PR TITLE
docs(mcp,skill): document list_devices + cached fetch + data-products skill

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -134,7 +134,8 @@ later.
 | `register_project` | `path, rootProjectName?, modules?` | Register a workspace by absolute path. Returns the assigned `workspaceId`. Idempotent. |
 | `unregister_project` | `workspaceId` | Tear down all daemons for that workspace. |
 | `list_projects` | — | List registered workspaces with paths + branches. |
-| `render_preview` | `uri` | Force-render bypassing cache. Returns PNG inline. |
+| `list_devices` | — | List the `@Preview(device = ...)` ids the daemon's catalog recognises with resolved geometry (`widthDp`, `heightDp`, `density`). Use these as the `device` field of `render_preview.overrides` to flip a preview to a catalog device without editing annotations. |
+| `render_preview` | `uri, overrides?` | Force-render bypassing cache. Returns PNG inline. `overrides` applies per-call display-property overrides (size, density, locale, fontScale, uiMode, orientation, device) — see PROTOCOL.md § 5. |
 | `watch` | `workspaceId, module?, fqnGlob?` | Register an "area of interest" — propagates to daemon's `setVisible`/`setFocus`, fires `resources/updated` per render. Eagerly spawns matching daemons. |
 | `unwatch` | `workspaceId?, module?, fqnGlob?` | Remove watches matching the predicate (no args = remove all from this session). |
 | `list_watches` | — | This session's registered watches. |
@@ -144,7 +145,7 @@ later.
 | `history_list` | `workspaceId, module, previewId?, since?, until?, limit?, branch?, …` | Proxy daemon `history/list`. Each result entry is decorated with its `compose-preview-history://` URI. |
 | `history_diff` | `workspaceId, module, from, to` | Proxy daemon `history/diff` (METADATA mode). Cross-source: `from` may live on FS, `to` on a `preview/<branch>` ref. |
 | `list_data_products` | `workspaceId?, module?` | List the structured data kinds (a11y findings, a11y hierarchy, layout tree, recomposition heat-map, …) each spawned daemon advertises alongside its PNGs. See [`docs/daemon/DATA-PRODUCTS.md`](../docs/daemon/DATA-PRODUCTS.md) for the catalogue and per-kind schemas. |
-| `get_preview_data` | `uri, kind, params?, inline?` | Fetch one data product (e.g. `kind: "a11y/hierarchy"`) for a preview. Returns the per-kind JSON payload. Defaults `inline: true` so the agent gets the JSON inline rather than a sibling-file path. Re-render-on-demand kinds may pay a render cost; bounded by the daemon's per-request budget. |
+| `get_preview_data` | `uri, kind, params?, inline?` | Fetch one data product (e.g. `kind: "a11y/hierarchy"`) for a preview. Returns the per-kind JSON payload. Defaults `inline: true` so the agent gets the JSON inline rather than a sibling-file path. **Cache short-circuit:** when the kind has been subscribed (`subscribe_preview_data`), the latest `renderFinished` payload is served from the supervisor's in-memory cache with zero daemon round-trip — the response carries `cached: true`. Auto-renders the preview if it hasn't rendered yet (no need to call `render_preview` first). Re-render-on-demand kinds may pay a render cost; bounded by the daemon's per-request budget. |
 | `subscribe_preview_data` | `uri, kind` | Prime the daemon to compute `kind` on every render of `uri` (sticky-while-visible). Cuts subsequent `get_preview_data` latency. |
 | `unsubscribe_preview_data` | `uri, kind` | Drop a subscription. |
 

--- a/skills/compose-preview/SKILL.md
+++ b/skills/compose-preview/SKILL.md
@@ -173,6 +173,7 @@ Loaded on demand. Read only what the current task needs.
 | [design/STATE_HOISTING.md](./design/STATE_HOISTING.md) | Full state-hoisting pattern with code examples. |
 | [design/CAPTURE_MODES.md](./design/CAPTURE_MODES.md) | Multi-preview annotations, paused-clock animation captures, scrolling captures. |
 | [design/A11Y.md](./design/A11Y.md) | ATF accessibility checks (`compose-preview a11y`). |
+| [design/DATA_PRODUCTS.md](./design/DATA_PRODUCTS.md) | Structured per-render data (a11y findings + hierarchy, layout tree, recomposition heat-map, …) via MCP tools and on-disk Gradle output. |
 | [design/CMP_SHARED.md](./design/CMP_SHARED.md) | Compose Multiplatform `:shared` modules (`commonMain` previews via Desktop pipeline). |
 | [design/RESOURCE_PREVIEWS.md](./design/RESOURCE_PREVIEWS.md) | Android XML resources (`<vector>`, `<animated-vector>`, `<adaptive-icon>`). |
 | [design/WEAR_UI.md](./design/WEAR_UI.md) | Wear OS Material 3 Expressive design. |

--- a/skills/compose-preview/design/DATA_PRODUCTS.md
+++ b/skills/compose-preview/design/DATA_PRODUCTS.md
@@ -1,0 +1,114 @@
+# Data products
+
+The renderer can produce structured data alongside each PNG — accessibility
+findings, the a11y semantic hierarchy, layout trees, theme resolution,
+recomposition heat-maps, and so on. Each is identified by a namespaced
+*kind* string (`a11y/atf`, `a11y/hierarchy`, `compose/recomposition`, …)
+with its own JSON schema.
+
+Two surfaces:
+
+- **MCP** — `list_data_products` / `get_preview_data` /
+  `subscribe_preview_data` tools on the [`compose-preview-mcp`](../../../mcp/README.md)
+  server. The right path for any agent that's already driving previews
+  through MCP.
+- **CLI / Gradle** — when a kind is enabled in the consumer's
+  `composePreview { ... }` config, the renderer writes the same payload
+  to `build/compose-previews/data/<previewId>/<kind>.json` after every
+  render. CLI / CI consumers read those files directly. **No `--emit`
+  flag** — kind selection is Gradle config, not CLI surface (see
+  [`docs/daemon/DATA-PRODUCTS.md`](../../../docs/daemon/DATA-PRODUCTS.md)
+  goal #6).
+
+The full kind catalogue, per-kind schemas, transports, and re-render
+cost notes live in
+[`docs/daemon/DATA-PRODUCTS.md`](../../../docs/daemon/DATA-PRODUCTS.md).
+
+## Enabling a kind
+
+Kinds are produced only when the consumer's Gradle config asks for them.
+For accessibility:
+
+```kotlin
+composePreview {
+    accessibilityChecks {
+        enabled = true
+    }
+}
+```
+
+That switches on `a11y/atf` (findings) and `a11y/hierarchy` (semantic
+tree). Other kinds will gain their own toggles as they ship — see
+[A11Y.md](./A11Y.md) for the a11y-specific knobs.
+
+A daemon advertises only the kinds whose producers it has wired. An
+agent calling a kind that isn't advertised gets `DataProductUnknown`.
+
+## MCP workflow (the agent path)
+
+Three calls, one of which is optional but pays for itself on repeat use:
+
+```jsonc
+// 1. Discover what kinds the daemon advertises. Empty list = pre-D2
+//    daemon or producers not wired (e.g. accessibility not enabled in
+//    the consumer's build script).
+{ "method": "tools/call", "params": { "name": "list_data_products",
+  "arguments": { "workspaceId": "<id>" } } }
+
+// 2. (Optional but recommended for repeat use.) Subscribe so the
+//    daemon attaches the kind on every renderFinished. The MCP server
+//    caches the latest payload per (uri, kind).
+{ "method": "tools/call", "params": { "name": "subscribe_preview_data",
+  "arguments": { "uri": "compose-preview://<id>/_module/com.example.Foo",
+                 "kind": "a11y/hierarchy" } } }
+
+// 3. Fetch. With a subscription in place, the response carries
+//    `cached: true` and pays no daemon round-trip. Without a
+//    subscription, this falls through to data/fetch (and auto-renders
+//    the preview if it hasn't rendered yet).
+{ "method": "tools/call", "params": { "name": "get_preview_data",
+  "arguments": { "uri": "compose-preview://<id>/_module/com.example.Foo",
+                 "kind": "a11y/hierarchy" } } }
+```
+
+`subscribe_preview_data` is sticky-while-visible: when the preview
+leaves the daemon's `setVisible` set the subscription auto-drops, and
+the agent re-subscribes when it comes back into view. Refcounted across
+MCP sessions — a subscribed kind stays subscribed on the daemon as long
+as any session holds an interest, and is released cleanly on the last
+unsubscribe / disconnect.
+
+## When to subscribe vs just fetch
+
+- **One-shot question** ("does this preview have a11y issues?") — skip
+  subscribe, call `get_preview_data` directly. It auto-renders if
+  needed and returns one payload. ~one render's latency.
+- **Repeated questions about the same preview** ("for each preview in
+  this module, give me a11y findings") — subscribe first, then fetch.
+  The first fetch warms the daemon; subsequent fetches are cache hits.
+- **Always-on for a workspace** — currently no operator knob (the
+  speculative `--attach-data-product` CLI flag was removed; the
+  agent-side equivalent isn't built yet). Use per-preview
+  `subscribe_preview_data` calls for now.
+
+## Failure modes
+
+| Wire error | Code | Meaning |
+|---|---|---|
+| `DataProductUnknown` | -32020 | Kind isn't advertised. Call `list_data_products` to see what's available, and check the consumer's Gradle config enabled the producer. |
+| `DataProductNotAvailable` | -32021 | Preview has never rendered. `get_preview_data` already retries automatically; only surfaces if the auto-render itself failed. |
+| `DataProductFetchFailed` | -32022 | Producer-side failure (bug in the renderer or a malformed preview). Details in `data`. |
+| `DataProductBudgetExceeded` | -32023 | The daemon needed to re-render to compute the kind and the per-request budget tripped. Bump `daemon.dataFetchRerenderBudgetMs` if your previews are slow, or subscribe instead so the kind rides on every render. |
+
+## CLI / Gradle consumers
+
+When a kind's producer is enabled in `composePreview { ... }`, the
+renderer writes its payload to
+`build/compose-previews/data/<previewId>/<kind>.json` on every render
+of `<previewId>`. CLI agents read those files directly — no MCP, no
+tool calls. Same JSON shape either way (daemon and CLI share the
+renderer-side producers).
+
+For accessibility specifically the older
+`build/compose-previews/accessibility-per-preview/<id>.json` location
+stays for one release as a back-compat alias, then retires.


### PR DESCRIPTION
## Summary

Three small docs updates following the recently-shipped MCP work. Pure docs, no code change.

- **`mcp/README.md`** tool reference:
  - Add `list_devices` row (the tool itself shipped in #438; the README hadn't caught up).
  - Document `overrides` on `render_preview` (added in #402).
  - Call out the `cached: true` short-circuit on `get_preview_data` that #430 wired.

- **`skills/compose-preview/design/DATA_PRODUCTS.md`** (new): consumer-facing how-to for the data-products surface — discover → subscribe → fetch loop via MCP, when to subscribe vs not, failure modes by wire-error code, and the Gradle/CLI on-disk output (`build/compose-previews/data/<id>/<kind>.json`) that shares the same producers. Explicitly notes there's no `--emit` CLI flag (matches the design doc clarification in #416 / #434).

- **`skills/compose-preview/SKILL.md`**: one new row in the reference table next to `A11Y`, pointing at the new design doc. Top-level skill file grew by exactly one line.

## Test plan

- [x] N/A — markdown only.
- [x] Cross-checked links: `DATA_PRODUCTS.md` references `../../../mcp/README.md` and `../../../docs/daemon/DATA-PRODUCTS.md` (relative paths from `skills/compose-preview/design/`); both resolve.


---
_Generated by [Claude Code](https://claude.ai/code/session_019eCR7c9UaZzvkAf9TeVVc9)_