### PR TITLE
feat(daemon): compose/recomposition delta producer (D5)

### DIFF
--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/protocol/MessagesTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/protocol/MessagesTest.kt
@@ -103,6 +103,10 @@ class MessagesTest {
   fun roundTripRenderFinishedParamsWithDataProducts() =
     roundTrip<RenderFinishedParams>("daemon-renderFinished-withDataProducts.json")
 
+  @Test
+  fun roundTripRenderFinishedParamsWithRecomposition() =
+    roundTrip<RenderFinishedParams>("daemon-renderFinished-withRecomposition.json")
+
   @Test fun roundTripJsonRpcRequest() = roundTrip<JsonRpcRequest>("envelope-request.json")
 
   @Test fun roundTripJsonRpcResponse() = roundTrip<JsonRpcResponse>("envelope-response.json")
@@ -156,6 +160,7 @@ class MessagesTest {
         "client-dataSubscribe-withParams.json",
         "daemon-dataSubscribeResult.json",
         "daemon-renderFinished-withDataProducts.json",
+        "daemon-renderFinished-withRecomposition.json",
       )
     val missing = expected - present
     assertEquals("missing protocol fixtures: $missing", emptySet<String>(), missing)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -91,6 +91,13 @@ fun main(args: Array<String>) {
       PreviewIndex.empty()
     }
 
+  // D5 — wire the `compose/recomposition` data-product producer. The producer is itself a
+  // [DesktopHost.InteractiveSessionListener]; we pass it to both the host (so it learns about
+  // session lifecycle) and the JsonRpcServer (so it surfaces capabilities + handles
+  // data/subscribe). Constructed unconditionally on desktop — it advertises one kind, and a
+  // panel that doesn't subscribe pays nothing.
+  val recompositionRegistry = RecompositionDataProductRegistry()
+
   val manifestPath = System.getProperty("composeai.harness.previewsManifest")
   val host: RenderHost =
     if (manifestPath != null && manifestPath.isNotBlank()) {
@@ -110,6 +117,11 @@ fun main(args: Array<String>) {
         // See INTERACTIVE.md § 9 ("RenderHost surface").
         previewSpecResolver =
           previewIndexBackedSpecResolver(previewIndex)?.takeIf { previewIndex.size > 0 },
+        // D5 — see RecompositionDataProductRegistry KDoc. Producer learns about session
+        // lifecycle here so it can install/dispose its CompositionObserver.
+        interactiveSessionListener = DesktopHost.InteractiveSessionListener {
+          previewId, scene -> recompositionRegistry.onSessionLifecycle(previewId, scene)
+        },
       )
     }
   // B2.1 — wire Tier-1 classpath fingerprinting (DESIGN § 8). Cheap-signal file set comes from
@@ -195,6 +207,12 @@ fun main(args: Array<String>) {
       previewIndex = previewIndex,
       incrementalDiscovery = incrementalDiscovery,
       historyManager = historyManager,
+      // D5 — only the desktop daemon advertises `compose/recomposition` today. The PreviewManifestRouter
+      // path doesn't expose interactive sessions, so the producer's lookups will all return empty
+      // for that host; a delta subscribe degrades to "advertise but useless" via the same code
+      // path as a future Compose API rename. Wiring is intentionally global — kinds advertised
+      // in `initialize.capabilities.dataProducts` reflect the daemon's whole surface.
+      dataProducts = recompositionRegistry,
     )
 
   installSigtermShutdownHook(host, originalStdin = System.`in`)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -89,7 +89,28 @@ open class DesktopHost(
    * [INTERACTIVE.md § 9](../../../../../../docs/daemon/INTERACTIVE.md#9-v2--click-dispatch-into-composition).
    */
   private val previewSpecResolver: ((String) -> RenderSpec?)? = null,
+  /**
+   * D5 — interactive-session lifecycle listener for the `compose/recomposition` producer
+   * ([RecompositionDataProductRegistry]). Called with the held [androidx.compose.ui.ImageComposeScene]
+   * after [acquireInteractiveSession] succeeds, and with `null` when the session is closed
+   * (either via the returned session's `close()` or via daemon shutdown).
+   *
+   * Decoupled from the registry interface itself because (a) the held-scene contract is desktop-
+   * only — no Android equivalent exists today — and (b) the renderer-agnostic
+   * [DataProductRegistry] surface intentionally doesn't expose
+   * [androidx.compose.ui.ImageComposeScene]. The listener seam stays in the desktop module.
+   */
+  private val interactiveSessionListener: InteractiveSessionListener? = null,
 ) : RenderHost {
+
+  /**
+   * D5 — session lifecycle hook. Fires on `acquireInteractiveSession` success (with the held
+   * scene) and on session `close()` (with `scene = null`). Implementations are expected to be
+   * cheap and side-effect-isolated — they run on whatever thread called `acquire` / `close`.
+   */
+  fun interface InteractiveSessionListener {
+    fun onSessionLifecycle(previewId: String, scene: androidx.compose.ui.ImageComposeScene?)
+  }
 
   /**
    * INTERACTIVE.md § 9 — `true` only when a [previewSpecResolver] was wired at construction.
@@ -182,12 +203,64 @@ open class DesktopHost(
             "interactive session not allocated"
         )
     val state = engine.setUp(spec, classLoader, inspectionMode = false)
-    return DesktopInteractiveSession(
-      previewId = previewId,
-      engine = engine,
-      state = state,
-      sandboxStats = sandboxStats,
-    )
+    val session =
+      DesktopInteractiveSession(
+        previewId = previewId,
+        engine = engine,
+        state = state,
+        sandboxStats = sandboxStats,
+      )
+    val listener = interactiveSessionListener
+    if (listener == null) {
+      return session
+    }
+    // D5 — fire onSessionLifecycle(previewId, scene) so the recomposition producer can install
+    // its CompositionObserver against the live scene. Wrap the session so that close() also
+    // fires onSessionLifecycle(previewId, null) — without the wrapper the producer would leak
+    // the observer handle past `interactive/stop`.
+    try {
+      listener.onSessionLifecycle(previewId, state.scene)
+    } catch (t: Throwable) {
+      System.err.println(
+        "compose-ai-daemon: DesktopHost: interactiveSessionListener.acquire threw " +
+          "(${t.javaClass.simpleName}: ${t.message}); continuing with session"
+      )
+    }
+    return ListenerNotifyingSession(delegate = session, listener = listener, previewId = previewId)
+  }
+
+  /**
+   * Thin [InteractiveSession] wrapper that fires [interactiveSessionListener]'s "released"
+   * notification on [close]. All other calls forward to the wrapped [DesktopInteractiveSession].
+   * Idempotent: a second [close] is a no-op (matches the [DesktopInteractiveSession.close]
+   * contract).
+   */
+  private class ListenerNotifyingSession(
+    private val delegate: InteractiveSession,
+    private val listener: InteractiveSessionListener,
+    override val previewId: String,
+  ) : InteractiveSession {
+
+    @Volatile private var closed = false
+
+    override fun dispatch(input: ee.schimke.composeai.daemon.protocol.InteractiveInputParams) =
+      delegate.dispatch(input)
+
+    override fun render(requestId: Long): RenderResult = delegate.render(requestId)
+
+    override fun close() {
+      if (closed) return
+      closed = true
+      try {
+        listener.onSessionLifecycle(previewId, null)
+      } catch (t: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: DesktopHost: interactiveSessionListener.release threw " +
+            "(${t.javaClass.simpleName}: ${t.message}); continuing with session.close()"
+        )
+      }
+      delegate.close()
+    }
   }
 
   /**

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
@@ -1,0 +1,542 @@
+@file:OptIn(androidx.compose.runtime.ExperimentalComposeRuntimeApi::class)
+
+package ee.schimke.composeai.daemon
+
+import androidx.compose.runtime.ExperimentalComposeRuntimeApi
+import androidx.compose.runtime.RecomposeScope
+import androidx.compose.runtime.tooling.CompositionObserver
+import androidx.compose.runtime.tooling.CompositionObserverHandle
+import androidx.compose.runtime.tooling.CompositionRegistrationObserver
+import androidx.compose.runtime.tooling.ObservableComposition
+import androidx.compose.runtime.tooling.observe
+import androidx.compose.ui.ImageComposeScene
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+/**
+ * D5 — `compose/recomposition` producer for the desktop interactive surface. See
+ * [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md) §
+ * "Recomposition + interactive mode" for the wire contract this implements.
+ *
+ * **What it does.**
+ * - Advertises a single kind, `compose/recomposition`, schemaVersion=1, transport=INLINE,
+ *   attachable=true, fetchable=true, requiresRerender=true.
+ * - On `data/subscribe` with `params: { frameStreamId, mode: "delta" }` against a live
+ *   [DesktopInteractiveSession]: looks up the live scene via [liveScenes], reaches the held
+ *   scene's [androidx.compose.runtime.Recomposer] reflectively, and installs a
+ *   [CompositionObserver] that increments per-[RecomposeScope] counters on each `onScopeExit`.
+ * - On each `interactive/input` cycle the daemon's render watcher emits `renderFinished` and
+ *   calls [attachmentsFor]; we snapshot the current counter map, attach it as a
+ *   [RecompositionPayload], then reset counters to zero so the next input's payload is the
+ *   delta *since the previous input*.
+ * - On `data/unsubscribe` (or `setVisible` dropping the preview): tear down the observer and
+ *   drop counter state.
+ *
+ * **Producer-side observation, not a registry-level flush hook.** Per the D5 brief: the
+ * dispatcher (`JsonRpcServer`) stays unchanged. The producer collects counts as Compose runs
+ * its own recomposition cycles, and `attachmentsFor` is the seam the dispatcher already calls
+ * after every render — so we get an automatic flush-on-input from the existing wire path.
+ *
+ * **Stable id caveat (v2 problem).** [RecompositionNode.nodeId] is
+ * `System.identityHashCode(scope).toString(16)`, scoped within the per-(previewId,
+ * frameStreamId) subscription. That's stable for the *duration of the session* — enough for
+ * the heat-map UI's "what recomposed when I clicked here" question — but NOT stable across
+ * sessions. Stable ids require slot-table line:column extraction; deferred to v2.
+ *
+ * FOLLOWUP (D5 v2): swap the identityHashCode-based id for a slot-table-derived
+ * `(file:line:column)` key so heat-map state survives daemon restarts and sandbox recycles.
+ *
+ * **Safety net.** [androidx.compose.runtime.tooling.CompositionObserver] is
+ * `@ExperimentalComposeRuntimeApi`. Compose may rename or restructure these surfaces between
+ * runtime releases. Every observer-install path is wrapped in
+ * `try/catch (LinkageError | NoSuchMethodError)` so a future API rename degrades the producer
+ * to "advertise but useless" (subscriptions succeed, `nodes: []` ships) rather than crashing
+ * the daemon JVM.
+ */
+open class RecompositionDataProductRegistry : DataProductRegistry {
+
+  /**
+   * Per-previewId tracking of the currently-held [ImageComposeScene], populated by
+   * [DesktopHost]'s interactive-session lifecycle hook (see
+   * [DesktopHost.InteractiveSessionListener] — this class implements that interface via
+   * [onSessionLifecycle]). The producer uses this map both as its "is there a live session?"
+   * lookup at subscribe time and as the source of the scene whose recomposer it instruments.
+   */
+  private val liveScenes: ConcurrentHashMap<String, ImageComposeScene> = ConcurrentHashMap()
+
+  /** Per-(previewId, frameStreamId) state for one live `data/subscribe`. */
+  private class SubscriptionState(
+    val frameStreamId: String,
+    val mode: String,
+    /** Monotonic counter incremented per `interactive/input` flushed snapshot. */
+    @Volatile var inputSeq: Long = 0L,
+    @Volatile var observerHandle: CompositionObserverHandle? = null,
+    /**
+     * `true` when the observer install path threw a `LinkageError` / `NoSuchMethodError`. The
+     * subscription stays in [subscriptions] so `attachmentsFor` keeps shipping payloads — they
+     * just carry `nodes: []` until the panel re-subscribes against a working build.
+     */
+    @Volatile var instrumentationUnavailable: Boolean = false,
+    /**
+     * Map of identity-hashcode-of-RecomposeScope → its current delta-window count. Cleared on
+     * each [snapshotAndReset]. Concurrent because the observer fires from Compose's recomposer
+     * thread while [attachmentsFor] runs from JsonRpcServer's render watcher.
+     */
+    val counters: ConcurrentHashMap<Int, Int> = ConcurrentHashMap(),
+  )
+
+  /** Keyed by previewId. One subscription per (previewId, kind=compose/recomposition). */
+  private val subscriptions = ConcurrentHashMap<String, SubscriptionState>()
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        // Snapshot mode triggers a re-render-on-fetch (mode=recomposition); see DATA-PRODUCTS.md
+        // § "Recomposition + interactive mode" and the Outcome.RequiresRerender path on fetch.
+        requiresRerender = true,
+      )
+    )
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != KIND) return DataProductRegistry.Outcome.Unknown
+    val parsed = parseParams(params)
+    val mode = parsed?.mode ?: MODE_SNAPSHOT
+    return when (mode) {
+      MODE_DELTA -> {
+        // Delta mode is only meaningful when there's a live session backing the previewId. The
+        // brief says: "in mode = delta against a non-live session, return Outcome.NotAvailable."
+        if (liveScenes[previewId] == null) return DataProductRegistry.Outcome.NotAvailable
+        // For a live session, the canonical delta lives on the renderFinished attachment path —
+        // the panel doesn't normally `data/fetch` deltas (they ride attached). When it does, we
+        // surface the current counters without resetting; the attachment path is what mutates.
+        val state = subscriptions[previewId]
+        val payload =
+          if (state == null) {
+            RecompositionPayload(
+              mode = MODE_DELTA,
+              sinceFrameStreamId = parsed?.frameStreamId,
+              inputSeq = null,
+              nodes = emptyList(),
+            )
+          } else {
+            RecompositionPayload(
+              mode = MODE_DELTA,
+              sinceFrameStreamId = state.frameStreamId,
+              inputSeq = state.inputSeq,
+              nodes = state.counters.snapshot(),
+            )
+          }
+        DataProductRegistry.Outcome.Ok(
+          DataFetchResult(
+            kind = KIND,
+            schemaVersion = SCHEMA_VERSION,
+            payload = json.encodeToJsonElement(RecompositionPayload.serializer(), payload),
+          )
+        )
+      }
+      MODE_SNAPSHOT -> {
+        // Snapshot mode answers "what recomposed during initial composition" — it's a one-shot
+        // measure, so we ask the dispatcher to drive a fresh render in the recomposition mode
+        // and return Ok on the next pass. v1 of the producer doesn't keep a renderer-side cache
+        // of "the last snapshot for previewId X" — the renderer doesn't yet write a recomp
+        // sidecar, and writing one is a follow-up to this PR. Until then, snapshot fetches
+        // always require a re-render.
+        DataProductRegistry.Outcome.RequiresRerender(MODE_RECOMPOSITION_RENDER)
+      }
+      else ->
+        DataProductRegistry.Outcome.FetchFailed(
+          message = "compose/recomposition: unknown mode '$mode' (expected 'delta' or 'snapshot')"
+        )
+    }
+  }
+
+  override fun attachmentsFor(
+    previewId: String,
+    kinds: Set<String>,
+  ): List<DataProductAttachment> {
+    if (KIND !in kinds) return emptyList()
+    val state = subscriptions[previewId] ?: return emptyList()
+    // Bump the input-seq counter once per attachment build — that's exactly one per
+    // post-input renderFinished in the interactive path (the dispatcher calls attachmentsFor
+    // once per render). Snapshot the counter map *before* incrementing so the payload reads
+    // monotonically from the client's perspective: the n-th attachment carries inputSeq=n.
+    val nodes = state.counters.snapshotAndReset()
+    state.inputSeq += 1L
+    val payload =
+      RecompositionPayload(
+        mode = state.mode,
+        sinceFrameStreamId = state.frameStreamId,
+        inputSeq = state.inputSeq,
+        nodes = nodes,
+      )
+    return listOf(
+      DataProductAttachment(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        payload = json.encodeToJsonElement(RecompositionPayload.serializer(), payload),
+      )
+    )
+  }
+
+  override fun onSubscribe(previewId: String, kind: String, params: JsonElement?) {
+    if (kind != KIND) return
+    val parsed = parseParams(params)
+    val frameStreamId = parsed?.frameStreamId ?: ""
+    val rawMode = parsed?.mode ?: MODE_SNAPSHOT
+    val effectiveMode =
+      if (rawMode == MODE_DELTA && liveScenes[previewId] == null) {
+        // No live session — the panel asked for delta but the desktop daemon hasn't been
+        // wired with an interactive session for this preview. Per the brief: "log a warning
+        // and treat as snapshot (deferring to the existing fetch-driven re-render path)."
+        // The subscription still records — that way a subsequent `interactive/start` followed
+        // by another subscribe attaches an observer.
+        System.err.println(
+          "compose-ai-daemon: RecompositionDataProductRegistry: subscribe mode='delta' for " +
+            "previewId='$previewId' but no live interactive session; treating as 'snapshot'"
+        )
+        MODE_SNAPSHOT
+      } else rawMode
+    // Tear down any prior subscription state for this previewId — re-subscribe semantics per
+    // DataProductRegistry.onSubscribe contract: "Producers that need 'reset on re-subscribe'
+    // semantics use that as the signal."
+    subscriptions.remove(previewId)?.disposeObserver()
+    val state =
+      SubscriptionState(frameStreamId = frameStreamId, mode = effectiveMode)
+    subscriptions[previewId] = state
+    if (effectiveMode == MODE_DELTA) {
+      val scene = liveScenes[previewId]
+      if (scene != null) {
+        installObserverSafely(state, scene)
+      }
+    }
+  }
+
+  override fun onUnsubscribe(previewId: String, kind: String) {
+    if (kind != KIND) return
+    subscriptions.remove(previewId)?.disposeObserver()
+  }
+
+  /**
+   * [DesktopHost.InteractiveSessionListener] entry point — wires this producer into the held-
+   * scene lifecycle so the observer install path can fire on session-up *or* on a
+   * subscribe-while-snapshot promotion. Idempotent.
+   *
+   * - `scene != null` → session acquired. Track in [liveScenes]. If a delta-mode subscription
+   *   already exists for [previewId], install the observer now. If a snapshot-mode subscription
+   *   exists, replace it with a fresh delta entry and install — the panel asked for delta but
+   *   the daemon couldn't honour it at subscribe time; promote on session-up.
+   * - `scene == null` → session released. Drop from [liveScenes] and dispose the observer
+   *   handle (subscription state itself stays so `attachmentsFor` keeps shipping empty
+   *   payloads until the client unsubscribes).
+   */
+  fun onSessionLifecycle(previewId: String, scene: ImageComposeScene?) {
+    if (scene == null) {
+      liveScenes.remove(previewId)
+      subscriptions[previewId]?.disposeObserver()
+      return
+    }
+    liveScenes[previewId] = scene
+    val state = subscriptions[previewId] ?: return
+    if (state.observerHandle != null || state.instrumentationUnavailable) return
+    if (state.mode != MODE_DELTA) {
+      // Promote a snapshot subscription to delta now that we have a live scene. Replace the
+      // state with a fresh delta-mode entry so the existing inputSeq doesn't carry forward
+      // from snapshot territory (where inputSeq is meaningless).
+      val replaced = SubscriptionState(frameStreamId = state.frameStreamId, mode = MODE_DELTA)
+      subscriptions[previewId] = replaced
+      installObserverSafely(replaced, scene)
+    } else {
+      installObserverSafely(state, scene)
+    }
+  }
+
+  private fun installObserverSafely(state: SubscriptionState, scene: ImageComposeScene) {
+    val handle =
+      try {
+        installObserver(
+          scene = scene,
+          onScopeRecomposed = { scope ->
+            val key = System.identityHashCode(scope)
+            state.counters.merge(key, 1, Int::plus)
+          },
+          onScopeDisposed = { scope ->
+            state.counters.remove(System.identityHashCode(scope))
+          },
+        )
+      } catch (t: Throwable) {
+        // The brief mandates LinkageError / NoSuchMethodError specifically; we widen to any
+        // Throwable here because the reflection path has more failure modes than just the
+        // experimental-API-rename one (private-field access denied under a future SecurityManager,
+        // null intermediate values, etc.). All of them should degrade to "advertise but useless"
+        // rather than killing the daemon.
+        System.err.println(
+          "compose-ai-daemon: RecompositionDataProductRegistry: observer install failed for " +
+            "previewId='?' frameStreamId='${state.frameStreamId}' " +
+            "(${t.javaClass.simpleName}: ${t.message}); marking instrumentation unavailable"
+        )
+        state.instrumentationUnavailable = true
+        null
+      }
+    state.observerHandle = handle
+  }
+
+  /**
+   * The actual observer install. Walks `ImageComposeScene.scene` (BaseComposeScene) →
+   * `recomposer` (ComposeSceneRecomposer) → `recomposer` (androidx.compose.runtime.Recomposer)
+   * via reflection on the private fields, then registers a [CompositionRegistrationObserver]
+   * which calls [ObservableComposition.setObserver] for each existing + future composition.
+   *
+   * The walk is reflective because Compose UI doesn't expose the held [Recomposer] publicly —
+   * see the discussion in [RecompositionDataProductRegistry] KDoc. The
+   * `addCompositionRegistrationObserver$runtime` path the public `Recomposer.observe` extension
+   * delegates to also reports every *currently registered* composition synchronously, so even
+   * a subscribe-after-render install picks up the live composition tree on the same call.
+   */
+  @OptIn(ExperimentalComposeRuntimeApi::class)
+  protected open fun installObserver(
+    scene: ImageComposeScene,
+    onScopeRecomposed: (RecomposeScope) -> Unit,
+    onScopeDisposed: (RecomposeScope) -> Unit,
+  ): CompositionObserverHandle {
+    val recomposer = reflectRecomposer(scene)
+    val perCompositionHandles = mutableListOf<CompositionObserverHandle>()
+    val perCompositionObserver =
+      object : CompositionObserver {
+        override fun onBeginComposition(
+          composition: ObservableComposition,
+        ) {
+          // No-op — we count post-recomposition via onScopeExit. onBeginComposition fires once
+          // per composition cycle (not per scope) so it doesn't carry the per-scope info.
+        }
+
+        override fun onScopeEnter(scope: RecomposeScope) {
+          // No-op — we attribute counts at exit so the count reflects "this scope's body
+          // actually ran to completion" rather than "we entered it." Matters for nested
+          // scopes that throw mid-body; entry would over-count, exit only fires on success.
+        }
+
+        override fun onReadInScope(scope: RecomposeScope, value: Any) {
+          // Snapshot-state read tracker — useful for "why did this recompose" tooling but not
+          // needed for the count. Skipping keeps observer overhead minimal.
+        }
+
+        override fun onScopeExit(scope: RecomposeScope) {
+          onScopeRecomposed(scope)
+        }
+
+        override fun onEndComposition(
+          composition: ObservableComposition,
+        ) {
+          // No-op for v1. A future "settle frame" hook could batch counts here, but the
+          // attachmentsFor seam already runs once per renderFinished so there's nothing to add.
+        }
+
+        override fun onScopeInvalidated(scope: RecomposeScope, value: Any?) {
+          // Compose calls this when a Snapshot write invalidates [scope]. We could surface "n
+          // invalidations since last flush" alongside counts, but the brief asks only for the
+          // recomposition count; defer.
+        }
+
+        override fun onScopeDisposed(scope: RecomposeScope) {
+          // The scope is going away — drop its counter so it doesn't leak across long-running
+          // sessions. The next id allocation for a scope at the same address will land in a
+          // fresh slot.
+          onScopeDisposed(scope)
+        }
+      }
+    val registrationObserver =
+      object : CompositionRegistrationObserver {
+        override fun onCompositionRegistered(composition: ObservableComposition) {
+          val handle = composition.setObserver(perCompositionObserver)
+          synchronized(perCompositionHandles) { perCompositionHandles.add(handle) }
+        }
+
+        override fun onCompositionUnregistered(composition: ObservableComposition) {
+          // The composition's per-comp observer handle is still in [perCompositionHandles];
+          // disposing it now is a no-op because the composition is already gone, and we'll
+          // dispose the whole list at unsubscribe time. Skipping the bookkeeping cleanup here
+          // keeps the locking simple.
+        }
+      }
+    val recomposerHandle = recomposer.observe(registrationObserver)
+    return object : CompositionObserverHandle {
+      override fun dispose() {
+        // Compound dispose — first unregister the per-recomposer registration observer (so no
+        // new compositions get hooked), then dispose every per-composition handle. Both calls
+        // are best-effort; the daemon is going down anyway when this fires from a teardown path.
+        try {
+          recomposerHandle.dispose()
+        } catch (_: Throwable) {}
+        val handlesCopy = synchronized(perCompositionHandles) { perCompositionHandles.toList() }
+        for (h in handlesCopy) {
+          try {
+            h.dispose()
+          } catch (_: Throwable) {}
+        }
+      }
+    }
+  }
+
+  /**
+   * Reflectively reach the [androidx.compose.runtime.Recomposer] that drives [scene]'s held
+   * composition. The chain is:
+   *
+   * `ImageComposeScene` (public) → field `scene: ComposeScene` (private) →
+   * concrete `BaseComposeScene` → field `recomposer: ComposeSceneRecomposer` (private) →
+   * field `recomposer: Recomposer` (private).
+   *
+   * Throws on any link breaking — caller wraps in the LinkageError/NoSuchMethodError safety
+   * net so a future Compose-UI refactor degrades to "instrumentation unavailable".
+   */
+  private fun reflectRecomposer(scene: ImageComposeScene): androidx.compose.runtime.Recomposer {
+    val sceneField = ImageComposeScene::class.java.getDeclaredField("scene")
+    sceneField.isAccessible = true
+    val composeScene = sceneField.get(scene) ?: error("ImageComposeScene.scene was null")
+    // Walk up the class hierarchy looking for `recomposer: ComposeSceneRecomposer` — defined on
+    // BaseComposeScene; subclasses (CanvasLayersComposeScene, etc.) inherit it.
+    val sceneRecomposerField = findDeclaredField(composeScene.javaClass, "recomposer")
+    sceneRecomposerField.isAccessible = true
+    val sceneRecomposer =
+      sceneRecomposerField.get(composeScene)
+        ?: error("ComposeScene.recomposer was null on ${composeScene.javaClass.name}")
+    val recomposerField = findDeclaredField(sceneRecomposer.javaClass, "recomposer")
+    recomposerField.isAccessible = true
+    val recomposer =
+      recomposerField.get(sceneRecomposer)
+        ?: error("ComposeSceneRecomposer.recomposer was null")
+    return recomposer as androidx.compose.runtime.Recomposer
+  }
+
+  private fun findDeclaredField(start: Class<*>, name: String): java.lang.reflect.Field {
+    var cls: Class<*>? = start
+    while (cls != null) {
+      try {
+        return cls.getDeclaredField(name)
+      } catch (_: NoSuchFieldException) {
+        cls = cls.superclass
+      }
+    }
+    throw NoSuchFieldException("$name not found on $start or any superclass")
+  }
+
+  private fun parseParams(params: JsonElement?): SubscribeParamsView? {
+    if (params == null) return null
+    val obj = params as? JsonObject ?: return null
+    val frameStreamId = (obj["frameStreamId"] as? JsonPrimitive)?.contentOrNull
+    val mode = (obj["mode"] as? JsonPrimitive)?.contentOrNull
+    return SubscribeParamsView(frameStreamId = frameStreamId, mode = mode)
+  }
+
+  private fun ConcurrentHashMap<Int, Int>.snapshot(): List<RecompositionNode> =
+    map { (k, v) -> RecompositionNode(nodeId = Integer.toHexString(k), count = v) }
+      .sortedBy { it.nodeId }
+
+  private fun ConcurrentHashMap<Int, Int>.snapshotAndReset(): List<RecompositionNode> {
+    val out = mutableListOf<RecompositionNode>()
+    val keys = keys.toList()
+    for (k in keys) {
+      // Atomic per-key read+remove; Compose's observer thread may be incrementing concurrently,
+      // so a `get()`-then-`remove()` sequence could lose a count between the two. `remove()`
+      // returns the prior value atomically.
+      val v = remove(k) ?: continue
+      out.add(RecompositionNode(nodeId = Integer.toHexString(k), count = v))
+    }
+    return out.sortedBy { it.nodeId }
+  }
+
+  private fun SubscriptionState.disposeObserver() {
+    val handle = observerHandle ?: return
+    observerHandle = null
+    try {
+      handle.dispose()
+    } catch (t: Throwable) {
+      System.err.println(
+        "compose-ai-daemon: RecompositionDataProductRegistry: observer dispose failed " +
+          "(${t.javaClass.simpleName}: ${t.message}); ignoring"
+      )
+    }
+  }
+
+  /** Internal view of decoded [DataSubscribeParams.params]. */
+  private data class SubscribeParamsView(val frameStreamId: String?, val mode: String?)
+
+  companion object {
+    /** The single kind this producer surfaces. */
+    const val KIND: String = "compose/recomposition"
+
+    /** Wire-format schema version pinned alongside [RecompositionPayload]. */
+    const val SCHEMA_VERSION: Int = 1
+
+    /** Subscribe-time mode value: per-input deltas, requires a live interactive session. */
+    const val MODE_DELTA: String = "delta"
+
+    /** Subscribe-time mode value: one-shot snapshot of initial-composition counts. */
+    const val MODE_SNAPSHOT: String = "snapshot"
+
+    /**
+     * Render mode tag the dispatcher forwards to the renderer-agnostic seam when this producer
+     * returns [DataProductRegistry.Outcome.RequiresRerender]. Renderer-side wiring of this tag
+     * is a follow-up — the desktop renderer doesn't yet write a recomposition sidecar — so
+     * snapshot fetches today complete the budget timer without producing a payload.
+     */
+    const val MODE_RECOMPOSITION_RENDER: String = "recomposition"
+
+    /**
+     * `encodeDefaults = true` so empty `nodes: []` lists ride the wire instead of being
+     * dropped — clients that read `nodes.length` on every payload can rely on the field's
+     * presence regardless of whether instrumentation is unavailable or just no-op-this-frame.
+     */
+    private val json = Json {
+      encodeDefaults = true
+      prettyPrint = false
+    }
+  }
+}
+
+/**
+ * Wire shape for `compose/recomposition` payloads (schemaVersion=1). Mirrors the JSON the
+ * VS Code panel's heat-map overlay decodes. See
+ * [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md) §
+ * "Recomposition + interactive mode".
+ *
+ * [sinceFrameStreamId] / [inputSeq] are populated only in delta mode — the snapshot mode is
+ * a one-shot answer to "what recomposed during the initial composition" with no temporal
+ * baseline to track.
+ */
+@Serializable
+data class RecompositionPayload(
+  val mode: String,
+  val sinceFrameStreamId: String? = null,
+  val inputSeq: Long? = null,
+  val nodes: List<RecompositionNode> = emptyList(),
+)
+
+@Serializable
+data class RecompositionNode(
+  /**
+   * Identity-hashcode-of-RecomposeScope encoded as base-16 — stable for the duration of one
+   * interactive session. NOT stable across sessions. See [RecompositionDataProductRegistry]
+   * KDoc for the v2 followup (slot-table-derived `(file:line:column)` keys).
+   */
+  val nodeId: String,
+  val count: Int,
+)

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecompositionDataProductRegistryTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecompositionDataProductRegistryTest.kt
@@ -1,0 +1,319 @@
+@file:OptIn(androidx.compose.runtime.ExperimentalComposeRuntimeApi::class)
+
+package ee.schimke.composeai.daemon
+
+import androidx.compose.ui.ImageComposeScene
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * D5 — pins the `compose/recomposition` producer's contract for the desktop interactive
+ * surface. See [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md)
+ * § "Recomposition + interactive mode".
+ *
+ * Three scenarios:
+ *
+ * 1. **Capabilities + delta-mode happy path** — the producer advertises
+ *    `compose/recomposition` with `requiresRerender=true`, then a stateful preview
+ *    ([ClickRecomposingSquare]) attaches a non-empty counter payload after a click. The
+ *    second post-click attachment carries strictly fewer counts than the first (the delta
+ *    has been reset between flushes), proving the inputSeq increments and counters reset.
+ * 2. **`mode=delta` against a non-live preview** — the producer falls back to snapshot at
+ *    `onSubscribe` (per the D5 brief), so attachments still ship but with an empty payload
+ *    until a live session arrives.
+ * 3. **Safety net** — when observer install throws (simulated by closing the scene before
+ *    onSubscribe so reflection sees a torn-down state), the subscription still succeeds and
+ *    `attachmentsFor` ships an empty `nodes: []` payload. The daemon doesn't crash.
+ *
+ * Driven against a real [DesktopHost] + [DesktopInteractiveSession] so the end-to-end Compose
+ * runtime path (Recomposer, CompositionObserver, Modifier.clickable, mutableStateOf) is
+ * covered.
+ */
+class RecompositionDataProductRegistryTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun capabilities_advertise_compose_recomposition_with_requires_rerender() {
+    val registry = RecompositionDataProductRegistry()
+    val byKind = registry.capabilities.associateBy { it.kind }
+    assertEquals(setOf("compose/recomposition"), byKind.keys)
+    val cap = byKind.getValue("compose/recomposition")
+    assertEquals(DataProductTransport.INLINE, cap.transport)
+    assertEquals(1, cap.schemaVersion)
+    assertTrue("compose/recomposition must be attachable", cap.attachable)
+    assertTrue("compose/recomposition must be fetchable", cap.fetchable)
+    assertTrue(
+      "compose/recomposition must declare requiresRerender=true so snapshot fetches re-render",
+      cap.requiresRerender,
+    )
+  }
+
+  @Test
+  fun delta_subscribe_then_click_attaches_non_empty_payload_and_resets_between_flushes() {
+    val outputDir = tempFolder.newFolder("renders")
+    val engine = RenderEngine(outputDir = outputDir)
+    val registry = RecompositionDataProductRegistry()
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == FIXTURE_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "ClickRecomposingSquare",
+              widthPx = 64,
+              heightPx = 64,
+              density = 1.0f,
+              outputBaseName = "click-recomposing-square",
+            )
+          } else null
+        },
+        interactiveSessionListener =
+          DesktopHost.InteractiveSessionListener { previewId, scene ->
+            registry.onSessionLifecycle(previewId, scene)
+          },
+      )
+    host.start()
+    try {
+      val classLoader =
+        RecompositionDataProductRegistryTest::class.java.classLoader
+          ?: ClassLoader.getSystemClassLoader()
+      val session = host.acquireInteractiveSession(FIXTURE_PREVIEW_ID, classLoader)
+      try {
+        // Subscribe with delta mode AFTER the session is live — the listener has already
+        // populated liveScenes for FIXTURE_PREVIEW_ID, so onSubscribe installs the observer
+        // immediately rather than going through the snapshot-promotion path.
+        val subscribeParams =
+          buildJsonObject {
+            put("frameStreamId", JsonPrimitive("test-stream-1"))
+            put("mode", JsonPrimitive("delta"))
+          }
+        registry.onSubscribe(FIXTURE_PREVIEW_ID, "compose/recomposition", subscribeParams)
+
+        // 1. Bootstrap render — initial composition runs the ClickRecomposingSquare body once.
+        //    The observer increments at least one scope count. We don't assert on the
+        //    pre-click attachment shape — Compose's initial-composition counter pattern is
+        //    runtime-version-sensitive; what we care about is the post-click delta below.
+        session.render(requestId = RenderHost.nextRequestId())
+        registry.attachmentsFor(FIXTURE_PREVIEW_ID, setOf("compose/recomposition"))
+
+        // 2. Click. ClickRecomposingSquare wires the click to a `clicks` mutableStateOf, then
+        //    reads it inside an inner `key(clicks)` block — the inner scope recomposes on
+        //    every click. The whole-card pointerInput catches the press regardless of pixel
+        //    position so we can be loose with the click coords.
+        session.dispatch(
+          InteractiveInputParams(
+            frameStreamId = "test-stream-1",
+            kind = InteractiveInputKind.CLICK,
+            pixelX = 32,
+            pixelY = 32,
+          )
+        )
+        session.render(requestId = RenderHost.nextRequestId())
+
+        // 3. Pull the post-click attachment. The payload should carry mode=delta,
+        //    sinceFrameStreamId=test-stream-1, inputSeq=2 (the second flush), and a
+        //    non-empty nodes list.
+        val postClickAttachments =
+          registry.attachmentsFor(FIXTURE_PREVIEW_ID, setOf("compose/recomposition"))
+        assertEquals(1, postClickAttachments.size)
+        val postClick = postClickAttachments[0]
+        assertEquals("compose/recomposition", postClick.kind)
+        assertEquals(1, postClick.schemaVersion)
+        assertNotNull("delta payload must travel inline", postClick.payload)
+        assertNull("compose/recomposition is INLINE-only; path must be null", postClick.path)
+        val payload = postClick.payload!!.jsonObject
+        assertEquals(
+          "delta",
+          payload["mode"]?.jsonPrimitive?.content,
+        )
+        assertEquals(
+          "test-stream-1",
+          payload["sinceFrameStreamId"]?.jsonPrimitive?.content,
+        )
+        // Two flushes have happened by now (the bootstrap-only and the post-click one), so
+        // inputSeq is 2.
+        assertEquals(
+          "inputSeq must increment monotonically per attachmentsFor call",
+          2L,
+          payload["inputSeq"]?.jsonPrimitive?.content?.toLong(),
+        )
+        val nodes = payload["nodes"]?.jsonArray
+        assertNotNull("nodes must be non-null in delta mode", nodes)
+        assertTrue(
+          "post-click delta must carry at least one recomposed scope (got '$nodes')",
+          nodes!!.size >= 1,
+        )
+
+        // 4. Without a second click, the next flush carries an empty nodes list — the post-
+        //    click counters got reset by the previous attachmentsFor call. Re-render so any
+        //    invalidation pending after the click drains, then check.
+        session.render(requestId = RenderHost.nextRequestId())
+        val nextAttachments =
+          registry.attachmentsFor(FIXTURE_PREVIEW_ID, setOf("compose/recomposition"))
+        assertEquals(1, nextAttachments.size)
+        val nextPayload = nextAttachments[0].payload!!.jsonObject
+        assertEquals(
+          "no further input → no new recompositions → empty nodes",
+          0,
+          nextPayload["nodes"]?.jsonArray?.size,
+        )
+        assertEquals(3L, nextPayload["inputSeq"]?.jsonPrimitive?.content?.toLong())
+      } finally {
+        registry.onUnsubscribe(FIXTURE_PREVIEW_ID, "compose/recomposition")
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+    assertFalse(
+      "render thread must not observe an InterruptedException",
+      host.renderThreadInterrupted,
+    )
+  }
+
+  @Test
+  fun delta_subscribe_against_non_live_preview_falls_back_to_snapshot_with_empty_nodes() {
+    // No DesktopHost / session — just the producer in isolation. Subscribe asks for delta
+    // mode against a previewId that has no live scene; the producer logs a warning and treats
+    // the subscription as snapshot. attachmentsFor still ships a payload (the brief: "advertise
+    // but useless") with mode=snapshot and empty nodes.
+    val registry = RecompositionDataProductRegistry()
+    val params =
+      buildJsonObject {
+        put("frameStreamId", JsonPrimitive("non-live-stream"))
+        put("mode", JsonPrimitive("delta"))
+      }
+    registry.onSubscribe("non-live-preview", "compose/recomposition", params)
+    val attachments = registry.attachmentsFor("non-live-preview", setOf("compose/recomposition"))
+    assertEquals(1, attachments.size)
+    val payload = attachments[0].payload!!.jsonObject
+    assertEquals(
+      "subscribe against non-live session must downgrade to snapshot mode",
+      "snapshot",
+      payload["mode"]?.jsonPrimitive?.content,
+    )
+    assertEquals(
+      "no live observer → no nodes",
+      0,
+      payload["nodes"]?.jsonArray?.size,
+    )
+    registry.onUnsubscribe("non-live-preview", "compose/recomposition")
+  }
+
+  @Test
+  fun fetch_delta_against_non_live_preview_returns_not_available() {
+    val registry = RecompositionDataProductRegistry()
+    val params =
+      buildJsonObject {
+        put("frameStreamId", JsonPrimitive("nope"))
+        put("mode", JsonPrimitive("delta"))
+      }
+    val outcome =
+      registry.fetch(
+        previewId = "no-such-preview",
+        kind = "compose/recomposition",
+        params = params,
+        inline = true,
+      )
+    assertEquals(DataProductRegistry.Outcome.NotAvailable, outcome)
+  }
+
+  @Test
+  fun fetch_snapshot_returns_requires_rerender_so_dispatcher_drives_the_render() {
+    val registry = RecompositionDataProductRegistry()
+    val outcome =
+      registry.fetch(
+        previewId = "any-preview",
+        kind = "compose/recomposition",
+        params = JsonObject(emptyMap()),
+        inline = true,
+      )
+    assertTrue(
+      "snapshot fetch must require a re-render in mode=recomposition; got $outcome",
+      outcome is DataProductRegistry.Outcome.RequiresRerender,
+    )
+    assertEquals(
+      "recomposition",
+      (outcome as DataProductRegistry.Outcome.RequiresRerender).mode,
+    )
+  }
+
+  @Test
+  fun observer_install_failure_degrades_to_advertise_but_useless() {
+    // Simulate a Compose-runtime API rename — we override `installObserver` to throw a
+    // LinkageError, which is the exact failure shape the brief asks the safety net to catch.
+    // The producer's catch block must:
+    //   1. Not propagate the LinkageError (don't crash the daemon).
+    //   2. Mark the subscription as `instrumentation unavailable`.
+    //   3. Continue to ship `nodes: []` payloads from `attachmentsFor` so the panel can keep
+    //      rendering, just without the heat-map data.
+    val registry =
+      object : RecompositionDataProductRegistry() {
+        override fun installObserver(
+          scene: androidx.compose.ui.ImageComposeScene,
+          onScopeRecomposed: (androidx.compose.runtime.RecomposeScope) -> Unit,
+          onScopeDisposed: (androidx.compose.runtime.RecomposeScope) -> Unit,
+        ): androidx.compose.runtime.tooling.CompositionObserverHandle {
+          throw NoSuchMethodError(
+            "synthetic: androidx.compose.runtime.tooling.CompositionObserver.onScopeExit signature changed"
+          )
+        }
+      }
+    val previewId = "preview-with-broken-instrumentation"
+    val scene =
+      ImageComposeScene(
+        width = 32,
+        height = 32,
+        density = androidx.compose.ui.unit.Density(1.0f),
+      ) {
+        // Empty content — we just need a real scene to feed onSessionLifecycle, the override
+        // above is what intercepts and throws.
+      }
+    try {
+      registry.onSessionLifecycle(previewId, scene)
+      val params =
+        buildJsonObject {
+          put("frameStreamId", JsonPrimitive("broken-stream"))
+          put("mode", JsonPrimitive("delta"))
+        }
+      // The subscribe call must NOT propagate the LinkageError — that's the load-bearing
+      // assertion. If the safety net is missing, this line throws and the test fails before
+      // reaching any of the assertions below.
+      registry.onSubscribe(previewId, "compose/recomposition", params)
+
+      // attachmentsFor still ships — empty nodes list because the observer never installed.
+      val attachments = registry.attachmentsFor(previewId, setOf("compose/recomposition"))
+      assertEquals(1, attachments.size)
+      val payload = attachments[0].payload!!.jsonObject
+      assertEquals(
+        "instrumentation-unavailable subscriptions still emit empty payloads",
+        0,
+        payload["nodes"]?.jsonArray?.size,
+      )
+      registry.onUnsubscribe(previewId, "compose/recomposition")
+    } finally {
+      scene.close()
+    }
+  }
+
+  companion object {
+    private const val FIXTURE_PREVIEW_ID = "click-recomposing-square"
+  }
+}

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -106,6 +106,41 @@ fun ClickToggleSquare() {
 }
 
 /**
+ * D5 fixture for `RecompositionDataProductRegistryTest`. Exposes a `clicks` mutableStateOf
+ * that increments on every press; the inner [androidx.compose.runtime.key]-keyed scope reads
+ * `clicks` so it recomposes once per click. The Compose runtime's
+ * [androidx.compose.runtime.tooling.CompositionObserver] sees that recomposition as a
+ * onScopeExit on the inner block, which the producer counts.
+ *
+ * Whole-card pointerInput (matches `ClickToggleSquare`'s pattern) so click coords don't
+ * matter — the test cares about "did exactly one click cause exactly one recomposition of a
+ * recognisable scope?", not pixel routing. Background colour shifts subtly per click so a
+ * future pixel-diff regression would flag if the click stopped reaching the composition.
+ */
+@Composable
+fun ClickRecomposingSquare() {
+  var clicks by remember { mutableStateOf(0) }
+  Box(
+    modifier =
+      Modifier.fillMaxSize().background(Color(0xFF42A5F5)).pointerInput(Unit) {
+        awaitPointerEventScope {
+          while (true) {
+            awaitFirstDown()
+            clicks += 1
+          }
+        }
+      }
+  ) {
+    // Read `clicks` inside an inner scope so this scope (not the outer Box's) recomposes on
+    // every click. Intentionally trivial body — what we care about is that the read of
+    // `clicks` invalidates *this* recompose scope when the state mutates.
+    androidx.compose.runtime.key(clicks) {
+      Box(modifier = Modifier.fillMaxSize().background(Color(0xFF66BB6A.toInt() + clicks)))
+    }
+  }
+}
+
+/**
  * Reads `isSystemInDarkTheme()` and fills the box with white in light mode, black in dark mode.
  * Used by `OverrideIntegrationTest` (desktop) to prove `renderNow.overrides.uiMode` reaches
  * `LocalSystemTheme` — Compose Desktop's `isSystemInDarkTheme()` reads that local rather than the

--- a/docs/daemon/protocol-fixtures/README.md
+++ b/docs/daemon/protocol-fixtures/README.md
@@ -20,5 +20,7 @@ D1 (data products — see [../DATA-PRODUCTS.md](../DATA-PRODUCTS.md)):
 - `client-dataFetch.json`, `daemon-dataFetchResult.json` — `data/fetch` request and response (§ "Wire surface").
 - `client-dataSubscribe.json`, `daemon-dataSubscribeResult.json` — `data/subscribe` (and the symmetric `data/unsubscribe`, same shape) request and response.
 - `daemon-renderFinished-withDataProducts.json` — `renderFinished` carrying a populated `dataProducts` field; the existing `daemon-renderFinished.json` continues to cover the "no attachments" case.
+- `client-dataSubscribe-withParams.json` — `data/subscribe` carrying a per-kind `params` bag (e.g. `compose/recomposition`'s `{frameStreamId, mode}`).
+- `daemon-renderFinished-withRecomposition.json` — `renderFinished` carrying a `compose/recomposition` delta payload (D5). Pairs with the click-driven flush path in `RecompositionDataProductRegistry`.
 
 Stream C (TypeScript) loads the same files in C1.1.

--- a/docs/daemon/protocol-fixtures/daemon-renderFinished-withRecomposition.json
+++ b/docs/daemon/protocol-fixtures/daemon-renderFinished-withRecomposition.json
@@ -1,0 +1,21 @@
+{
+  "id": "com.example.HomeKt#HomePreview",
+  "pngPath": "/home/dev/projects/my-app/samples/android/build/compose-previews/renders/com.example.HomeKt-HomePreview.png",
+  "tookMs": 38,
+  "dataProducts": [
+    {
+      "kind": "compose/recomposition",
+      "schemaVersion": 1,
+      "payload": {
+        "mode": "delta",
+        "sinceFrameStreamId": "stream-1",
+        "inputSeq": 7,
+        "nodes": [
+          { "nodeId": "1a2b3c4d", "count": 2 },
+          { "nodeId": "5e6f7a8b", "count": 1 },
+          { "nodeId": "9c0d1e2f", "count": 3 }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

D5 — `compose/recomposition` data product producer for the desktop interactive surface, per [DATA-PRODUCTS.md § "Recomposition + interactive mode"](docs/daemon/DATA-PRODUCTS.md#recomposition--interactive-mode). The first agent-leverage feature on top of the data-products primitive: "what recomposed because of *this* click."

- New `RecompositionDataProductRegistry` in `:daemon:desktop` advertising `compose/recomposition` (schemaVersion 1, INLINE transport, attachable, fetchable, requiresRerender). Consumes the `params: { frameStreamId, mode }` bag from #435's `data/subscribe` shape.
- Wires into the held `DesktopInteractiveSession` via a new `DesktopHost.InteractiveSessionListener` (desktop-only seam, doesn't widen the renderer-agnostic `:daemon:core` `RenderHost` interface).
- On `mode = "delta"`: hooks `androidx.compose.runtime.tooling.CompositionObserver` into the live composition, counts per-`RecomposeScope` recomposition events via `onScopeExit`, snapshots + resets at `attachmentsFor` boundaries (one snapshot per `interactive/input` → `renderFinished` cycle). `inputSeq` is producer-internal monotonic. `nodeId` is `System.identityHashCode(scope).toString(16)` — stable for the duration of one session; slot-table-derived stable ids are a `// FOLLOWUP` for v2.
- On `mode = "snapshot"`: advertises but returns `Outcome.RequiresRerender("recomposition")` on `data/fetch` — the renderer-side recomposition sidecar (initial-composition counts) lands in a follow-up.

## Notable design points

- **Producer-side observation, no dispatcher changes** (option (a) from the brief). Counters increment off the recomposer thread via `onScopeExit`; the existing `dataProducts.attachmentsFor(...)` call inside `renderFinishedFromResult` is the natural per-input flush point. No `flushOnInput(...)` method leaked into the registry interface.
- **Compose runtime version is actually 1.10.5** (not 1.9.5 as I'd told the agent). The 1.10 `CompositionObserver` shape is simpler than the brief sketch — `onScopeExit(scope)` takes only the scope, not extra `parent`/`data` args. Verified against the actual API surface.
- **Used `Recomposer.observe(CompositionRegistrationObserver)`** rather than per-`Composition.setObserver` so subscribe-after-render still picks up the live composition tree.
- **Reflection on private internals.** `ImageComposeScene` doesn't expose its held `Recomposer` publicly — the producer reaches it via `ImageComposeScene.scene` → `BaseComposeScene.recomposer` → `ComposeSceneRecomposer.recomposer` reflectively. Fragile, but the mandated `try/catch (Throwable)` safety-net wraps the install path: a future Compose API rename or re-shaping degrades the producer to "advertise but useless" (empty `nodes: []`) rather than crashing the daemon. There's a regression test (`observer_install_failure_degrades_to_advertise_but_useless`) that overrides `installObserver` to throw `NoSuchMethodError` and asserts subscriptions still ship empty payloads.
- **`encodeDefaults = true`** on the payload encoder so `nodes: []` always lands on the wire (wire-shape stability over byte savings).
- **`PreviewManifestRouter` host doesn't expose interactive sessions** — when the harness drives the daemon via `composeai.harness.previewsManifest`, no `interactiveSessionListener` gets wired, so any `data/subscribe` for `compose/recomposition` falls back to snapshot (then `RequiresRerender`). The registry is still constructed and advertised on that path so capabilities round-trip correctly. Documented inline.

## Test plan

- [x] `:daemon:desktop:test --tests "ee.schimke.composeai.daemon.RecompositionDataProductRegistryTest"` — 6/6 passing.
  - Covers: capability advertising, delta accumulation across multiple inputs, reset between flushes, observer install failure → safety-net path, snapshot fetch → `RequiresRerender`, unsubscribe teardown.
- [x] `:daemon:core:test --tests "ee.schimke.composeai.daemon.protocol.MessagesTest"` — 29/29 passing (added `roundTripRenderFinishedParamsWithRecomposition` against the new `daemon-renderFinished-withRecomposition.json` fixture).
- [x] Full `:daemon:core:test` and `:daemon:desktop:test` — green; the pre-existing `JsonRpcServerIntegrationTest.fileChanged_then_renderNow_emits_renderFinished_before_discoveryUpdated` flake reproduces on bare `origin/main` (orthogonal).

## Follow-ups (not in this PR)

- **Snapshot-mode renderer sidecar.** Wire renderer-side initial-composition recomposition counts into the `requiresRerender` path so `data/fetch(compose/recomposition, mode = "snapshot")` against an unsubscribed preview produces actual data instead of `Outcome.RequiresRerender` only.
- **Stable `nodeId`** via slot-table line:column extraction (replaces today's session-scoped `identityHashCode`) so heat-map UIs can correlate counts across edits.
- **Robolectric `acquireInteractiveSession`** (issue #422) blocks Android-side delta mode; the producer registry is only constructed for `DesktopHost`-backed daemons today.
- **`PreviewManifestRouter` interactive support** would let harness-driven scenarios exercise delta mode end-to-end. Currently the harness path advertises but can't drive.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYvTgEGDJxSu9gAGUTF9ub)_