### PR TITLE
feat(mcp): validate render_preview overrides against daemon capabilities

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -121,9 +121,10 @@ fun main(args: Array<String>) {
           previewIndexBackedSpecResolver(previewIndex)?.takeIf { previewIndex.size > 0 },
         // D5 — see RecompositionDataProductRegistry KDoc. Producer learns about session
         // lifecycle here so it can install/dispose its CompositionObserver.
-        interactiveSessionListener = DesktopHost.InteractiveSessionListener {
-          previewId, scene -> recompositionRegistry.onSessionLifecycle(previewId, scene)
-        },
+        interactiveSessionListener =
+          DesktopHost.InteractiveSessionListener { previewId, scene ->
+            recompositionRegistry.onSessionLifecycle(previewId, scene)
+          },
       )
     }
   // B2.1 — wire Tier-1 classpath fingerprinting (DESIGN § 8). Cheap-signal file set comes from
@@ -209,7 +210,8 @@ fun main(args: Array<String>) {
       previewIndex = previewIndex,
       incrementalDiscovery = incrementalDiscovery,
       historyManager = historyManager,
-      // D5 — only the desktop daemon advertises `compose/recomposition` today. The PreviewManifestRouter
+      // D5 — only the desktop daemon advertises `compose/recomposition` today. The
+      // PreviewManifestRouter
       // path doesn't expose interactive sessions, so the producer's lookups will all return empty
       // for that host; a delta subscribe degrades to "advertise but useless" via the same code
       // path as a future Compose API rename. Wiring is intentionally global — kinds advertised

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -91,22 +91,23 @@ open class DesktopHost(
   private val previewSpecResolver: ((String) -> RenderSpec?)? = null,
   /**
    * D5 — interactive-session lifecycle listener for the `compose/recomposition` producer
-   * ([RecompositionDataProductRegistry]). Called with the held [androidx.compose.ui.ImageComposeScene]
-   * after [acquireInteractiveSession] succeeds, and with `null` when the session is closed
-   * (either via the returned session's `close()` or via daemon shutdown).
+   * ([RecompositionDataProductRegistry]). Called with the held
+   * [androidx.compose.ui.ImageComposeScene] after [acquireInteractiveSession] succeeds, and with
+   * `null` when the session is closed (either via the returned session's `close()` or via daemon
+   * shutdown).
    *
    * Decoupled from the registry interface itself because (a) the held-scene contract is desktop-
-   * only — no Android equivalent exists today — and (b) the renderer-agnostic
-   * [DataProductRegistry] surface intentionally doesn't expose
-   * [androidx.compose.ui.ImageComposeScene]. The listener seam stays in the desktop module.
+   * only — no Android equivalent exists today — and (b) the renderer-agnostic [DataProductRegistry]
+   * surface intentionally doesn't expose [androidx.compose.ui.ImageComposeScene]. The listener seam
+   * stays in the desktop module.
    */
   private val interactiveSessionListener: InteractiveSessionListener? = null,
 ) : RenderHost {
 
   /**
-   * D5 — session lifecycle hook. Fires on `acquireInteractiveSession` success (with the held
-   * scene) and on session `close()` (with `scene = null`). Implementations are expected to be
-   * cheap and side-effect-isolated — they run on whatever thread called `acquire` / `close`.
+   * D5 — session lifecycle hook. Fires on `acquireInteractiveSession` success (with the held scene)
+   * and on session `close()` (with `scene = null`). Implementations are expected to be cheap and
+   * side-effect-isolated — they run on whatever thread called `acquire` / `close`.
    */
   fun interface InteractiveSessionListener {
     fun onSessionLifecycle(previewId: String, scene: androidx.compose.ui.ImageComposeScene?)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
@@ -31,45 +31,44 @@ import kotlinx.serialization.json.contentOrNull
  * - Advertises a single kind, `compose/recomposition`, schemaVersion=1, transport=INLINE,
  *   attachable=true, fetchable=true, requiresRerender=true.
  * - On `data/subscribe` with `params: { frameStreamId, mode: "delta" }` against a live
- *   [DesktopInteractiveSession]: looks up the live scene via [liveScenes], reaches the held
- *   scene's [androidx.compose.runtime.Recomposer] reflectively, and installs a
- *   [CompositionObserver] that increments per-[RecomposeScope] counters on each `onScopeExit`.
- * - On each `interactive/input` cycle the daemon's render watcher emits `renderFinished` and
- *   calls [attachmentsFor]; we snapshot the current counter map, attach it as a
- *   [RecompositionPayload], then reset counters to zero so the next input's payload is the
- *   delta *since the previous input*.
- * - On `data/unsubscribe` (or `setVisible` dropping the preview): tear down the observer and
- *   drop counter state.
+ *   [DesktopInteractiveSession]: looks up the live scene via [liveScenes], reaches the held scene's
+ *   [androidx.compose.runtime.Recomposer] reflectively, and installs a [CompositionObserver] that
+ *   increments per-[RecomposeScope] counters on each `onScopeExit`.
+ * - On each `interactive/input` cycle the daemon's render watcher emits `renderFinished` and calls
+ *   [attachmentsFor]; we snapshot the current counter map, attach it as a [RecompositionPayload],
+ *   then reset counters to zero so the next input's payload is the delta *since the previous
+ *   input*.
+ * - On `data/unsubscribe` (or `setVisible` dropping the preview): tear down the observer and drop
+ *   counter state.
  *
- * **Producer-side observation, not a registry-level flush hook.** Per the D5 brief: the
- * dispatcher (`JsonRpcServer`) stays unchanged. The producer collects counts as Compose runs
- * its own recomposition cycles, and `attachmentsFor` is the seam the dispatcher already calls
- * after every render — so we get an automatic flush-on-input from the existing wire path.
+ * **Producer-side observation, not a registry-level flush hook.** Per the D5 brief: the dispatcher
+ * (`JsonRpcServer`) stays unchanged. The producer collects counts as Compose runs its own
+ * recomposition cycles, and `attachmentsFor` is the seam the dispatcher already calls after every
+ * render — so we get an automatic flush-on-input from the existing wire path.
  *
  * **Stable id caveat (v2 problem).** [RecompositionNode.nodeId] is
- * `System.identityHashCode(scope).toString(16)`, scoped within the per-(previewId,
- * frameStreamId) subscription. That's stable for the *duration of the session* — enough for
- * the heat-map UI's "what recomposed when I clicked here" question — but NOT stable across
- * sessions. Stable ids require slot-table line:column extraction; deferred to v2.
+ * `System.identityHashCode(scope).toString(16)`, scoped within the per-(previewId, frameStreamId)
+ * subscription. That's stable for the *duration of the session* — enough for the heat-map UI's
+ * "what recomposed when I clicked here" question — but NOT stable across sessions. Stable ids
+ * require slot-table line:column extraction; deferred to v2.
  *
  * FOLLOWUP (D5 v2): swap the identityHashCode-based id for a slot-table-derived
  * `(file:line:column)` key so heat-map state survives daemon restarts and sandbox recycles.
  *
  * **Safety net.** [androidx.compose.runtime.tooling.CompositionObserver] is
  * `@ExperimentalComposeRuntimeApi`. Compose may rename or restructure these surfaces between
- * runtime releases. Every observer-install path is wrapped in
- * `try/catch (LinkageError | NoSuchMethodError)` so a future API rename degrades the producer
- * to "advertise but useless" (subscriptions succeed, `nodes: []` ships) rather than crashing
- * the daemon JVM.
+ * runtime releases. Every observer-install path is wrapped in `try/catch (LinkageError |
+ * NoSuchMethodError)` so a future API rename degrades the producer to "advertise but useless"
+ * (subscriptions succeed, `nodes: []` ships) rather than crashing the daemon JVM.
  */
 open class RecompositionDataProductRegistry : DataProductRegistry {
 
   /**
-   * Per-previewId tracking of the currently-held [ImageComposeScene], populated by
-   * [DesktopHost]'s interactive-session lifecycle hook (see
-   * [DesktopHost.InteractiveSessionListener] — this class implements that interface via
-   * [onSessionLifecycle]). The producer uses this map both as its "is there a live session?"
-   * lookup at subscribe time and as the source of the scene whose recomposer it instruments.
+   * Per-previewId tracking of the currently-held [ImageComposeScene], populated by [DesktopHost]'s
+   * interactive-session lifecycle hook (see [DesktopHost.InteractiveSessionListener] — this class
+   * implements that interface via [onSessionLifecycle]). The producer uses this map both as its "is
+   * there a live session?" lookup at subscribe time and as the source of the scene whose recomposer
+   * it instruments.
    */
   private val liveScenes: ConcurrentHashMap<String, ImageComposeScene> = ConcurrentHashMap()
 
@@ -82,14 +81,14 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     @Volatile var observerHandle: CompositionObserverHandle? = null,
     /**
      * `true` when the observer install path threw a `LinkageError` / `NoSuchMethodError`. The
-     * subscription stays in [subscriptions] so `attachmentsFor` keeps shipping payloads — they
-     * just carry `nodes: []` until the panel re-subscribes against a working build.
+     * subscription stays in [subscriptions] so `attachmentsFor` keeps shipping payloads — they just
+     * carry `nodes: []` until the panel re-subscribes against a working build.
      */
     @Volatile var instrumentationUnavailable: Boolean = false,
     /**
-     * Map of identity-hashcode-of-RecomposeScope → its current delta-window count. Cleared on
-     * each [snapshotAndReset]. Concurrent because the observer fires from Compose's recomposer
-     * thread while [attachmentsFor] runs from JsonRpcServer's render watcher.
+     * Map of identity-hashcode-of-RecomposeScope → its current delta-window count. Cleared on each
+     * [snapshotAndReset]. Concurrent because the observer fires from Compose's recomposer thread
+     * while [attachmentsFor] runs from JsonRpcServer's render watcher.
      */
     val counters: ConcurrentHashMap<Int, Int> = ConcurrentHashMap(),
   )
@@ -169,10 +168,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     }
   }
 
-  override fun attachmentsFor(
-    previewId: String,
-    kinds: Set<String>,
-  ): List<DataProductAttachment> {
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
     if (KIND !in kinds) return emptyList()
     val state = subscriptions[previewId] ?: return emptyList()
     // Bump the input-seq counter once per attachment build — that's exactly one per
@@ -219,8 +215,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     // DataProductRegistry.onSubscribe contract: "Producers that need 'reset on re-subscribe'
     // semantics use that as the signal."
     subscriptions.remove(previewId)?.disposeObserver()
-    val state =
-      SubscriptionState(frameStreamId = frameStreamId, mode = effectiveMode)
+    val state = SubscriptionState(frameStreamId = frameStreamId, mode = effectiveMode)
     subscriptions[previewId] = state
     if (effectiveMode == MODE_DELTA) {
       val scene = liveScenes[previewId]
@@ -236,17 +231,17 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
   }
 
   /**
-   * [DesktopHost.InteractiveSessionListener] entry point — wires this producer into the held-
-   * scene lifecycle so the observer install path can fire on session-up *or* on a
+   * [DesktopHost.InteractiveSessionListener] entry point — wires this producer into the held- scene
+   * lifecycle so the observer install path can fire on session-up *or* on a
    * subscribe-while-snapshot promotion. Idempotent.
    *
    * - `scene != null` → session acquired. Track in [liveScenes]. If a delta-mode subscription
    *   already exists for [previewId], install the observer now. If a snapshot-mode subscription
-   *   exists, replace it with a fresh delta entry and install — the panel asked for delta but
-   *   the daemon couldn't honour it at subscribe time; promote on session-up.
-   * - `scene == null` → session released. Drop from [liveScenes] and dispose the observer
-   *   handle (subscription state itself stays so `attachmentsFor` keeps shipping empty
-   *   payloads until the client unsubscribes).
+   *   exists, replace it with a fresh delta entry and install — the panel asked for delta but the
+   *   daemon couldn't honour it at subscribe time; promote on session-up.
+   * - `scene == null` → session released. Drop from [liveScenes] and dispose the observer handle
+   *   (subscription state itself stays so `attachmentsFor` keeps shipping empty payloads until the
+   *   client unsubscribes).
    */
   fun onSessionLifecycle(previewId: String, scene: ImageComposeScene?) {
     if (scene == null) {
@@ -278,9 +273,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
             val key = System.identityHashCode(scope)
             state.counters.merge(key, 1, Int::plus)
           },
-          onScopeDisposed = { scope ->
-            state.counters.remove(System.identityHashCode(scope))
-          },
+          onScopeDisposed = { scope -> state.counters.remove(System.identityHashCode(scope)) },
         )
       } catch (t: Throwable) {
         // The brief mandates LinkageError / NoSuchMethodError specifically; we widen to any
@@ -300,16 +293,16 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
   }
 
   /**
-   * The actual observer install. Walks `ImageComposeScene.scene` (BaseComposeScene) →
-   * `recomposer` (ComposeSceneRecomposer) → `recomposer` (androidx.compose.runtime.Recomposer)
-   * via reflection on the private fields, then registers a [CompositionRegistrationObserver]
-   * which calls [ObservableComposition.setObserver] for each existing + future composition.
+   * The actual observer install. Walks `ImageComposeScene.scene` (BaseComposeScene) → `recomposer`
+   * (ComposeSceneRecomposer) → `recomposer` (androidx.compose.runtime.Recomposer) via reflection on
+   * the private fields, then registers a [CompositionRegistrationObserver] which calls
+   * [ObservableComposition.setObserver] for each existing + future composition.
    *
-   * The walk is reflective because Compose UI doesn't expose the held [Recomposer] publicly —
-   * see the discussion in [RecompositionDataProductRegistry] KDoc. The
+   * The walk is reflective because Compose UI doesn't expose the held [Recomposer] publicly — see
+   * the discussion in [RecompositionDataProductRegistry] KDoc. The
    * `addCompositionRegistrationObserver$runtime` path the public `Recomposer.observe` extension
-   * delegates to also reports every *currently registered* composition synchronously, so even
-   * a subscribe-after-render install picks up the live composition tree on the same call.
+   * delegates to also reports every *currently registered* composition synchronously, so even a
+   * subscribe-after-render install picks up the live composition tree on the same call.
    */
   @OptIn(ExperimentalComposeRuntimeApi::class)
   protected open fun installObserver(
@@ -321,9 +314,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     val perCompositionHandles = mutableListOf<CompositionObserverHandle>()
     val perCompositionObserver =
       object : CompositionObserver {
-        override fun onBeginComposition(
-          composition: ObservableComposition,
-        ) {
+        override fun onBeginComposition(composition: ObservableComposition) {
           // No-op — we count post-recomposition via onScopeExit. onBeginComposition fires once
           // per composition cycle (not per scope) so it doesn't carry the per-scope info.
         }
@@ -343,9 +334,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
           onScopeRecomposed(scope)
         }
 
-        override fun onEndComposition(
-          composition: ObservableComposition,
-        ) {
+        override fun onEndComposition(composition: ObservableComposition) {
           // No-op for v1. A future "settle frame" hook could batch counts here, but the
           // attachmentsFor seam already runs once per renderFinished so there's nothing to add.
         }
@@ -400,12 +389,12 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
    * Reflectively reach the [androidx.compose.runtime.Recomposer] that drives [scene]'s held
    * composition. The chain is:
    *
-   * `ImageComposeScene` (public) → field `scene: ComposeScene` (private) →
-   * concrete `BaseComposeScene` → field `recomposer: ComposeSceneRecomposer` (private) →
-   * field `recomposer: Recomposer` (private).
+   * `ImageComposeScene` (public) → field `scene: ComposeScene` (private) → concrete
+   * `BaseComposeScene` → field `recomposer: ComposeSceneRecomposer` (private) → field `recomposer:
+   * Recomposer` (private).
    *
-   * Throws on any link breaking — caller wraps in the LinkageError/NoSuchMethodError safety
-   * net so a future Compose-UI refactor degrades to "instrumentation unavailable".
+   * Throws on any link breaking — caller wraps in the LinkageError/NoSuchMethodError safety net so
+   * a future Compose-UI refactor degrades to "instrumentation unavailable".
    */
   private fun reflectRecomposer(scene: ImageComposeScene): androidx.compose.runtime.Recomposer {
     val sceneField = ImageComposeScene::class.java.getDeclaredField("scene")
@@ -421,8 +410,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     val recomposerField = findDeclaredField(sceneRecomposer.javaClass, "recomposer")
     recomposerField.isAccessible = true
     val recomposer =
-      recomposerField.get(sceneRecomposer)
-        ?: error("ComposeSceneRecomposer.recomposer was null")
+      recomposerField.get(sceneRecomposer) ?: error("ComposeSceneRecomposer.recomposer was null")
     return recomposer as androidx.compose.runtime.Recomposer
   }
 
@@ -494,16 +482,16 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
 
     /**
      * Render mode tag the dispatcher forwards to the renderer-agnostic seam when this producer
-     * returns [DataProductRegistry.Outcome.RequiresRerender]. Renderer-side wiring of this tag
-     * is a follow-up — the desktop renderer doesn't yet write a recomposition sidecar — so
-     * snapshot fetches today complete the budget timer without producing a payload.
+     * returns [DataProductRegistry.Outcome.RequiresRerender]. Renderer-side wiring of this tag is a
+     * follow-up — the desktop renderer doesn't yet write a recomposition sidecar — so snapshot
+     * fetches today complete the budget timer without producing a payload.
      */
     const val MODE_RECOMPOSITION_RENDER: String = "recomposition"
 
     /**
-     * `encodeDefaults = true` so empty `nodes: []` lists ride the wire instead of being
-     * dropped — clients that read `nodes.length` on every payload can rely on the field's
-     * presence regardless of whether instrumentation is unavailable or just no-op-this-frame.
+     * `encodeDefaults = true` so empty `nodes: []` lists ride the wire instead of being dropped —
+     * clients that read `nodes.length` on every payload can rely on the field's presence regardless
+     * of whether instrumentation is unavailable or just no-op-this-frame.
      */
     private val json = Json {
       encodeDefaults = true
@@ -513,14 +501,14 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
 }
 
 /**
- * Wire shape for `compose/recomposition` payloads (schemaVersion=1). Mirrors the JSON the
- * VS Code panel's heat-map overlay decodes. See
+ * Wire shape for `compose/recomposition` payloads (schemaVersion=1). Mirrors the JSON the VS Code
+ * panel's heat-map overlay decodes. See
  * [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md) §
  * "Recomposition + interactive mode".
  *
- * [sinceFrameStreamId] / [inputSeq] are populated only in delta mode — the snapshot mode is
- * a one-shot answer to "what recomposed during the initial composition" with no temporal
- * baseline to track.
+ * [sinceFrameStreamId] / [inputSeq] are populated only in delta mode — the snapshot mode is a
+ * one-shot answer to "what recomposed during the initial composition" with no temporal baseline to
+ * track.
  */
 @Serializable
 data class RecompositionPayload(
@@ -534,8 +522,8 @@ data class RecompositionPayload(
 data class RecompositionNode(
   /**
    * Identity-hashcode-of-RecomposeScope encoded as base-16 — stable for the duration of one
-   * interactive session. NOT stable across sessions. See [RecompositionDataProductRegistry]
-   * KDoc for the v2 followup (slot-table-derived `(file:line:column)` keys).
+   * interactive session. NOT stable across sessions. See [RecompositionDataProductRegistry] KDoc
+   * for the v2 followup (slot-table-derived `(file:line:column)` keys).
    */
   val nodeId: String,
   val count: Int,

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecompositionDataProductRegistryTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecompositionDataProductRegistryTest.kt
@@ -22,27 +22,26 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
 /**
- * D5 — pins the `compose/recomposition` producer's contract for the desktop interactive
- * surface. See [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md)
- * § "Recomposition + interactive mode".
+ * D5 — pins the `compose/recomposition` producer's contract for the desktop interactive surface.
+ * See [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md) §
+ * "Recomposition + interactive mode".
  *
  * Three scenarios:
  *
- * 1. **Capabilities + delta-mode happy path** — the producer advertises
- *    `compose/recomposition` with `requiresRerender=true`, then a stateful preview
- *    ([ClickRecomposingSquare]) attaches a non-empty counter payload after a click. The
- *    second post-click attachment carries strictly fewer counts than the first (the delta
- *    has been reset between flushes), proving the inputSeq increments and counters reset.
+ * 1. **Capabilities + delta-mode happy path** — the producer advertises `compose/recomposition`
+ *    with `requiresRerender=true`, then a stateful preview ([ClickRecomposingSquare]) attaches a
+ *    non-empty counter payload after a click. The second post-click attachment carries strictly
+ *    fewer counts than the first (the delta has been reset between flushes), proving the inputSeq
+ *    increments and counters reset.
  * 2. **`mode=delta` against a non-live preview** — the producer falls back to snapshot at
- *    `onSubscribe` (per the D5 brief), so attachments still ship but with an empty payload
- *    until a live session arrives.
+ *    `onSubscribe` (per the D5 brief), so attachments still ship but with an empty payload until a
+ *    live session arrives.
  * 3. **Safety net** — when observer install throws (simulated by closing the scene before
  *    onSubscribe so reflection sees a torn-down state), the subscription still succeeds and
  *    `attachmentsFor` ships an empty `nodes: []` payload. The daemon doesn't crash.
  *
  * Driven against a real [DesktopHost] + [DesktopInteractiveSession] so the end-to-end Compose
- * runtime path (Recomposer, CompositionObserver, Modifier.clickable, mutableStateOf) is
- * covered.
+ * runtime path (Recomposer, CompositionObserver, Modifier.clickable, mutableStateOf) is covered.
  */
 class RecompositionDataProductRegistryTest {
 
@@ -99,11 +98,10 @@ class RecompositionDataProductRegistryTest {
         // Subscribe with delta mode AFTER the session is live — the listener has already
         // populated liveScenes for FIXTURE_PREVIEW_ID, so onSubscribe installs the observer
         // immediately rather than going through the snapshot-promotion path.
-        val subscribeParams =
-          buildJsonObject {
-            put("frameStreamId", JsonPrimitive("test-stream-1"))
-            put("mode", JsonPrimitive("delta"))
-          }
+        val subscribeParams = buildJsonObject {
+          put("frameStreamId", JsonPrimitive("test-stream-1"))
+          put("mode", JsonPrimitive("delta"))
+        }
         registry.onSubscribe(FIXTURE_PREVIEW_ID, "compose/recomposition", subscribeParams)
 
         // 1. Bootstrap render — initial composition runs the ClickRecomposingSquare body once.
@@ -139,14 +137,8 @@ class RecompositionDataProductRegistryTest {
         assertNotNull("delta payload must travel inline", postClick.payload)
         assertNull("compose/recomposition is INLINE-only; path must be null", postClick.path)
         val payload = postClick.payload!!.jsonObject
-        assertEquals(
-          "delta",
-          payload["mode"]?.jsonPrimitive?.content,
-        )
-        assertEquals(
-          "test-stream-1",
-          payload["sinceFrameStreamId"]?.jsonPrimitive?.content,
-        )
+        assertEquals("delta", payload["mode"]?.jsonPrimitive?.content)
+        assertEquals("test-stream-1", payload["sinceFrameStreamId"]?.jsonPrimitive?.content)
         // Two flushes have happened by now (the bootstrap-only and the post-click one), so
         // inputSeq is 2.
         assertEquals(
@@ -195,11 +187,10 @@ class RecompositionDataProductRegistryTest {
     // the subscription as snapshot. attachmentsFor still ships a payload (the brief: "advertise
     // but useless") with mode=snapshot and empty nodes.
     val registry = RecompositionDataProductRegistry()
-    val params =
-      buildJsonObject {
-        put("frameStreamId", JsonPrimitive("non-live-stream"))
-        put("mode", JsonPrimitive("delta"))
-      }
+    val params = buildJsonObject {
+      put("frameStreamId", JsonPrimitive("non-live-stream"))
+      put("mode", JsonPrimitive("delta"))
+    }
     registry.onSubscribe("non-live-preview", "compose/recomposition", params)
     val attachments = registry.attachmentsFor("non-live-preview", setOf("compose/recomposition"))
     assertEquals(1, attachments.size)
@@ -209,22 +200,17 @@ class RecompositionDataProductRegistryTest {
       "snapshot",
       payload["mode"]?.jsonPrimitive?.content,
     )
-    assertEquals(
-      "no live observer → no nodes",
-      0,
-      payload["nodes"]?.jsonArray?.size,
-    )
+    assertEquals("no live observer → no nodes", 0, payload["nodes"]?.jsonArray?.size)
     registry.onUnsubscribe("non-live-preview", "compose/recomposition")
   }
 
   @Test
   fun fetch_delta_against_non_live_preview_returns_not_available() {
     val registry = RecompositionDataProductRegistry()
-    val params =
-      buildJsonObject {
-        put("frameStreamId", JsonPrimitive("nope"))
-        put("mode", JsonPrimitive("delta"))
-      }
+    val params = buildJsonObject {
+      put("frameStreamId", JsonPrimitive("nope"))
+      put("mode", JsonPrimitive("delta"))
+    }
     val outcome =
       registry.fetch(
         previewId = "no-such-preview",
@@ -249,10 +235,7 @@ class RecompositionDataProductRegistryTest {
       "snapshot fetch must require a re-render in mode=recomposition; got $outcome",
       outcome is DataProductRegistry.Outcome.RequiresRerender,
     )
-    assertEquals(
-      "recomposition",
-      (outcome as DataProductRegistry.Outcome.RequiresRerender).mode,
-    )
+    assertEquals("recomposition", (outcome as DataProductRegistry.Outcome.RequiresRerender).mode)
   }
 
   @Test
@@ -278,21 +261,16 @@ class RecompositionDataProductRegistryTest {
       }
     val previewId = "preview-with-broken-instrumentation"
     val scene =
-      ImageComposeScene(
-        width = 32,
-        height = 32,
-        density = androidx.compose.ui.unit.Density(1.0f),
-      ) {
+      ImageComposeScene(width = 32, height = 32, density = androidx.compose.ui.unit.Density(1.0f)) {
         // Empty content — we just need a real scene to feed onSessionLifecycle, the override
         // above is what intercepts and throws.
       }
     try {
       registry.onSessionLifecycle(previewId, scene)
-      val params =
-        buildJsonObject {
-          put("frameStreamId", JsonPrimitive("broken-stream"))
-          put("mode", JsonPrimitive("delta"))
-        }
+      val params = buildJsonObject {
+        put("frameStreamId", JsonPrimitive("broken-stream"))
+        put("mode", JsonPrimitive("delta"))
+      }
       // The subscribe call must NOT propagate the LinkageError — that's the load-bearing
       // assertion. If the safety net is missing, this line throws and the test fails before
       // reaching any of the assertions below.

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -106,16 +106,16 @@ fun ClickToggleSquare() {
 }
 
 /**
- * D5 fixture for `RecompositionDataProductRegistryTest`. Exposes a `clicks` mutableStateOf
- * that increments on every press; the inner [androidx.compose.runtime.key]-keyed scope reads
- * `clicks` so it recomposes once per click. The Compose runtime's
- * [androidx.compose.runtime.tooling.CompositionObserver] sees that recomposition as a
- * onScopeExit on the inner block, which the producer counts.
+ * D5 fixture for `RecompositionDataProductRegistryTest`. Exposes a `clicks` mutableStateOf that
+ * increments on every press; the inner [androidx.compose.runtime.key]-keyed scope reads `clicks` so
+ * it recomposes once per click. The Compose runtime's
+ * [androidx.compose.runtime.tooling.CompositionObserver] sees that recomposition as a onScopeExit
+ * on the inner block, which the producer counts.
  *
- * Whole-card pointerInput (matches `ClickToggleSquare`'s pattern) so click coords don't
- * matter — the test cares about "did exactly one click cause exactly one recomposition of a
- * recognisable scope?", not pixel routing. Background colour shifts subtly per click so a
- * future pixel-diff regression would flag if the click stopped reaching the composition.
+ * Whole-card pointerInput (matches `ClickToggleSquare`'s pattern) so click coords don't matter —
+ * the test cares about "did exactly one click cause exactly one recomposition of a recognisable
+ * scope?", not pixel routing. Background colour shifts subtly per click so a future pixel-diff
+ * regression would flag if the click stopped reaching the composition.
  */
 @Composable
 fun ClickRecomposingSquare() {

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -899,11 +899,73 @@ class DaemonMcpServer(
             return errorCallToolResult("render_preview: invalid overrides: ${e.message}")
           }
       }
+    if (overrides != null) {
+      val daemon = supervisor.daemonFor(uri.workspaceId, uri.modulePath)
+      val violations = validateOverrides(overrides, daemon)
+      if (violations.isNotEmpty()) {
+        return errorCallToolResult("render_preview: ${violations.joinToString("; ")}")
+      }
+    }
     return runCatching {
         val bytes = renderAndReadBytes(uri, overrides = overrides)
         pngCallToolResult(Base64.getEncoder().encodeToString(bytes))
       }
       .getOrElse { errorCallToolResult("render_preview failed: ${it.message}") }
+  }
+
+  /**
+   * Validates [overrides] against the daemon's advertised
+   * `InitializeResult.capabilities.supportedOverrides` and `knownDevices`. Returns a list of
+   * human-readable violations (empty if everything checks out).
+   *
+   * **Falls open on pre-feature daemons.** When the daemon's `supportedOverrides` is empty (e.g.,
+   * it predates PR #441), every set field is allowed — clients see exactly the silent- no-op
+   * behaviour they had before the wire surface landed. Same for `knownDeviceIds` (#433): an empty
+   * catalog means we can't tell which ids are valid, so we accept any. This is the safe-pre-feature
+   * contract documented on `ServerCapabilities` itself.
+   *
+   * `device` ids that start with `spec:` (the inline geometry grammar) bypass the catalog check —
+   * `KNOWN_DEVICE_IDS` deliberately doesn't enumerate `spec:` shapes per the `DeviceDimensions`
+   * kdoc; the daemon parses them at resolve-time.
+   */
+  private fun validateOverrides(
+    overrides: PreviewOverrides,
+    daemon: SupervisedDaemon,
+  ): List<String> {
+    val violations = mutableListOf<String>()
+    val supported = daemon.supportedOverrides
+    if (supported.isNotEmpty()) {
+      // Each set field must appear in the daemon's advertised supportedOverrides; otherwise
+      // the backend would silently ignore it. Phrasing "this backend ignores it" so the agent
+      // knows the recovery is "use a different daemon" or "drop the field", not "the value
+      // was invalid".
+      fun check(name: String, set: Boolean) {
+        if (set && name !in supported) {
+          violations += "this backend does not apply '$name' overrides (supported: $supported)"
+        }
+      }
+      check("widthPx", overrides.widthPx != null)
+      check("heightPx", overrides.heightPx != null)
+      check("density", overrides.density != null)
+      check("localeTag", overrides.localeTag != null)
+      check("fontScale", overrides.fontScale != null)
+      check("uiMode", overrides.uiMode != null)
+      check("orientation", overrides.orientation != null)
+      check("device", overrides.device != null)
+    }
+    val deviceOverride = overrides.device
+    val knownIds = daemon.knownDeviceIds
+    if (
+      deviceOverride != null &&
+        knownIds.isNotEmpty() &&
+        !deviceOverride.startsWith("spec:") &&
+        deviceOverride !in knownIds
+    ) {
+      violations +=
+        "device='$deviceOverride' is not in the daemon's catalog (call list_devices to see valid ids; " +
+          "or use 'spec:width=…,height=…,dpi=…' for ad-hoc geometry)"
+    }
+    return violations
   }
 
   /**

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -207,6 +207,14 @@ class DaemonSupervisor(
       // daemons; the field is also `emptyList()` by default in [ServerCapabilities] so absent
       // and `[]` collapse the same way client-side.
       supervised.dataProductCapabilities = result.capabilities.dataProducts
+      // PROTOCOL.md § 3 — cache the daemon's advertised supportedOverrides + knownDevice ids so
+      // `DaemonMcpServer.toolRenderPreview` can validate inbound `overrides` against what this
+      // backend will actually apply (instead of silently no-op'ing fields the backend ignores) and
+      // reject typo'd `device` ids before they fall back to the default. Pre-feature daemons
+      // advertise `[]` for both, in which case validation falls open — clients are exactly where
+      // they were before the capability landed.
+      supervised.supportedOverrides = result.capabilities.supportedOverrides.toSet()
+      supervised.knownDeviceIds = result.capabilities.knownDevices.map { it.id }.toSet()
       // The daemon only emits `discoveryUpdated` for *deltas* — the initial preview set comes
       // via `initialize.manifest.path` (a `previews.json` written by the gradle plugin's
       // `discoverPreviews` task). Synthesise an initial `discoveryUpdated` notification by
@@ -294,6 +302,29 @@ class SupervisedDaemon(val workspaceId: WorkspaceId, val modulePath: String) {
    */
   @Volatile
   var dataProductCapabilities: List<DataProductCapability> = emptyList()
+    internal set
+
+  /**
+   * PROTOCOL.md § 3 — `PreviewOverrides` field names this daemon's host actually applies (see
+   * `RenderHost.supportedOverrides`). Populated by [DaemonSupervisor.spawn] right after the
+   * initialize round-trip. Read by `DaemonMcpServer.toolRenderPreview` to reject inbound
+   * `overrides` fields the backend would silently ignore. Empty set on pre-feature daemons —
+   * validation falls open and the request goes through unchanged (no behaviour change for old
+   * daemons, the caller just doesn't get the new diagnostic).
+   */
+  @Volatile
+  var supportedOverrides: Set<String> = emptySet()
+    internal set
+
+  /**
+   * PROTOCOL.md § 3 — `device` ids the daemon's catalog recognises (see
+   * `ServerCapabilities.knownDevices`). Populated by [DaemonSupervisor.spawn] right after the
+   * initialize round-trip. Read by `DaemonMcpServer.toolRenderPreview` to reject typo'd `device`
+   * overrides before they silently fall back to the default. The free-form `spec:width=…` grammar
+   * is not enumerable and not stored here — the validator passes those through.
+   */
+  @Volatile
+  var knownDeviceIds: Set<String> = emptySet()
     internal set
 
   /**

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -646,6 +646,133 @@ class DaemonMcpServerTest {
   }
 
   @Test
+  fun `render_preview rejects overrides the daemon does not support`() {
+    // Daemon advertises supportedOverrides = ["widthPx", "uiMode"]; an agent passes localeTag
+    // (which the backend would silently ignore today). MCP rejects with a diagnostic instead
+    // of letting the wire round-trip succeed and the locale silently drop.
+    factory.daemonConfigurer = { d -> d.advertisedSupportedOverrides = listOf("widthPx", "uiMode") }
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "render_preview",
+        buildJsonObject {
+          put("uri", uri)
+          putJsonObject("overrides") {
+            put("widthPx", 600) // supported
+            put("localeTag", "fr-FR") // NOT supported on this fake's advertisement
+          }
+        },
+      )
+    assertThat(resp.isError()).isTrue()
+    val msg = resp.firstTextContent()
+    assertThat(msg).contains("does not apply 'localeTag'")
+    // No renderNow should have been issued — validation runs before the daemon dispatch.
+    assertThat(daemon.renderRequests).isEmpty()
+  }
+
+  @Test
+  fun `render_preview falls open when daemon advertises empty supportedOverrides`() {
+    // Pre-feature daemon: empty supportedOverrides means we can't tell which fields work.
+    // Validation must fall open — same behaviour as before #441 landed. The renderNow goes
+    // through unchanged.
+    factory.daemonConfigurer = { d ->
+      d.advertisedSupportedOverrides = emptyList()
+      d.autoRenderPngPath = { _ ->
+        java.io.File.createTempFile("preview", ".png").also { it.deleteOnExit() }.absolutePath
+      }
+    }
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    client.callTool(
+      "render_preview",
+      buildJsonObject {
+        put("uri", uri)
+        putJsonObject("overrides") { put("localeTag", "fr-FR") }
+      },
+      timeoutMs = 10_000,
+    )
+    // The daemon DID receive the renderNow with the overrides — validation fell open.
+    assertThat(daemon.renderOverrides).hasSize(1)
+    assertThat(daemon.renderOverrides[0]?.localeTag).isEqualTo("fr-FR")
+  }
+
+  @Test
+  fun `render_preview rejects unknown device id and accepts spec grammar`() {
+    // Daemon advertises a small known-devices catalog. Agent passes id:typo_phone — rejected.
+    // Then the same agent passes a spec: grammar — accepted (spec: is not enumerable, so
+    // validation passes through and the daemon parses it at resolve-time).
+    factory.daemonConfigurer = { d ->
+      d.advertisedSupportedOverrides = listOf("device", "widthPx", "heightPx", "density")
+      d.advertisedKnownDevices =
+        listOf(
+          ee.schimke.composeai.daemon.protocol.KnownDevice(
+            id = "id:pixel_5",
+            widthDp = 393,
+            heightDp = 851,
+            density = 2.75f,
+          )
+        )
+      d.autoRenderPngPath = { _ ->
+        java.io.File.createTempFile("preview", ".png").also { it.deleteOnExit() }.absolutePath
+      }
+    }
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+
+    // Unknown id rejected with a helpful pointer to list_devices + spec: escape hatch.
+    val rejectResp =
+      client.callTool(
+        "render_preview",
+        buildJsonObject {
+          put("uri", uri)
+          putJsonObject("overrides") { put("device", "id:typo_phone") }
+        },
+      )
+    assertThat(rejectResp.isError()).isTrue()
+    val rejectMsg = rejectResp.firstTextContent()
+    assertThat(rejectMsg).contains("device='id:typo_phone' is not in the daemon's catalog")
+    assertThat(rejectMsg).contains("list_devices")
+    assertThat(daemon.renderRequests).isEmpty()
+
+    // spec: grammar accepted — passes validation, reaches the daemon as-is.
+    client.callTool(
+      "render_preview",
+      buildJsonObject {
+        put("uri", uri)
+        putJsonObject("overrides") { put("device", "spec:width=400dp,height=800dp,dpi=320") }
+      },
+      timeoutMs = 10_000,
+    )
+    assertThat(daemon.renderOverrides).hasSize(1)
+    assertThat(daemon.renderOverrides[0]?.device).isEqualTo("spec:width=400dp,height=800dp,dpi=320")
+  }
+
+  @Test
   fun `concurrent different-overrides render_preview calls are serialized per previewId`() {
     // Regression for the wrong-bytes hazard PR #432's "known limitation" note documented (and
     // mis-described as a hang). Pre-fix: two concurrent override-bearing render_preview calls

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
@@ -71,6 +71,21 @@ class FakeDaemon : DaemonSpawn {
   @Volatile var advertisedDataProducts: List<DataProductCapability> = emptyList()
 
   /**
+   * `PreviewOverrides` field names the fake advertises in
+   * `initialize.capabilities.supportedOverrides`. Tests assign before the spawn calls `initialize`.
+   * Empty list (the default) keeps pre-feature behaviour — `DaemonMcpServer`'s validation falls
+   * open on an empty advertised set.
+   */
+  @Volatile var advertisedSupportedOverrides: List<String> = emptyList()
+
+  /**
+   * Devices the fake advertises in `initialize.capabilities.knownDevices`. Tests assign before the
+   * spawn calls `initialize`. Empty list keeps pre-feature behaviour.
+   */
+  @Volatile
+  var advertisedKnownDevices: List<ee.schimke.composeai.daemon.protocol.KnownDevice> = emptyList()
+
+  /**
    * D1 — fake handler for `data/fetch`. When set, the lambda receives `(previewId, kind, params,
    * inline)` and returns either the [DataFetchOutcome] the daemon should respond with. Default
    * returns [DataFetchOutcome.Unknown] so unconfigured tests see the wire-error path.
@@ -265,6 +280,8 @@ class FakeDaemon : DaemonSpawn {
                 sandboxRecycle = false,
                 leakDetection = emptyList(),
                 dataProducts = advertisedDataProducts,
+                knownDevices = advertisedKnownDevices,
+                supportedOverrides = advertisedSupportedOverrides,
               ),
             classpathFingerprint = "fake-fingerprint",
             manifest = Manifest(path = "", previewCount = 0),
@@ -276,7 +293,6 @@ class FakeDaemon : DaemonSpawn {
           (params?.get("previews") as? kotlinx.serialization.json.JsonArray)?.mapNotNull {
             it.jsonPrimitive.contentOrNull
           } ?: emptyList()
-        renderRequests.offer(previews)
         val overrides =
           params
             ?.get("overrides")
@@ -287,7 +303,12 @@ class FakeDaemon : DaemonSpawn {
                 it,
               )
             }
+        // Populate the overrides slot BEFORE offering on `renderRequests` — tests poll on
+        // `renderRequests` and immediately check `renderOverrides`; reverse order opens a race
+        // window between the offer (which wakes the polling thread) and the add to the
+        // overrides list.
         renderOverrides.add(overrides)
+        renderRequests.offer(previews)
         val result = RenderNowResult(queued = previews, rejected = emptyList())
         sendResponse(id, json.encodeToJsonElement(RenderNowResult.serializer(), result))
         // Auto-emit renderFinished for any preview whose path the test pre-registered. The


### PR DESCRIPTION
## Summary

Closes the loop on PR #441 (`supportedOverrides`) and PR #438 (`list_devices`) — wire surface lands first, then the agent-facing tool surface uses it.

Today an agent can pass `localeTag` to a desktop-only daemon (no `LocalLocale` CompositionLocal) or a typo'd `device: "id:pixel_55"` and the request silently no-ops or falls back to the default. The daemon already advertises which override fields it applies and which device ids it recognises; `render_preview` now consults both before dispatching and rejects with a diagnostic instead of letting the wire round-trip through to a silent miss.

- **Cache** — `DaemonSupervisor.spawn` populates `SupervisedDaemon.supportedOverrides` and `knownDeviceIds` right after the initialize round-trip, same pattern `dataProductCapabilities` already uses.
- **Validate** — `toolRenderPreview` runs `validateOverrides` after decoding and before dispatch:
  - Each set field must appear in the daemon's advertised supportedOverrides; otherwise → `errorCallToolResult("this backend does not apply 'X' overrides (supported: [...])")`.
  - `device` overrides that don't start with `spec:` are checked against `knownDeviceIds`; on miss → rejected with a pointer to `list_devices` + the `spec:` escape hatch.
- **Falls open** when the daemon's advertised set is empty (pre-feature daemons) — request goes through unchanged. Same contract `ServerCapabilities` documents.

## Test plan

- [x] Three new regression tests in `DaemonMcpServerTest`:
  - `render_preview rejects overrides the daemon does not support` — fake advertises `{widthPx, uiMode}`; agent passes `localeTag`; assert rejection + no `renderNow` on the wire.
  - `render_preview falls open when daemon advertises empty supportedOverrides` — fake advertises `[]`, agent passes `localeTag`, request succeeds (pre-feature behaviour preserved).
  - `render_preview rejects unknown device id and accepts spec grammar` — fake advertises one known device; `id:typo_phone` rejected with `list_devices` pointer; `spec:width=400dp,…` passes through.
- [x] `:mcp:test` — 44/44 pass (41 unchanged + 3 new).
- [x] `ktfmtCheckAll` — clean.

## Notes

- Also fixes a race in `FakeDaemon.renderNow` where `renderRequests.offer` ran before `renderOverrides.add` — tests that polled `renderRequests` then immediately checked `renderOverrides` could see a stale empty list. Reordered so the overrides slot is populated first; the offer publishes the wakeup. Surfaced now because the new test path stresses the same fake-side ordering as the existing concurrent serialization test.
- Includes ktfmtFormatAll output for pre-existing format drift in `:daemon:desktop` — same pre-commit-hook pattern as prior PRs in this thread.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmHMG3rJrJowyM15hK2Bow)_