### PR TITLE
feat(daemon): advertise renderer backend in initialize capabilities

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -124,6 +124,10 @@ open class RobolectricHost(
       "device",
     )
 
+  /** PROTOCOL.md § 3 — android backend identifier surfaced via `capabilities.backend`. */
+  override val backendKind: ee.schimke.composeai.daemon.protocol.BackendKind =
+    ee.schimke.composeai.daemon.protocol.BackendKind.ANDROID
+
   init {
     require(sandboxCount >= 1) { "sandboxCount must be >= 1, got $sandboxCount" }
     require(userClassloaderHolder == null || userClassloaderHolderFactory == null) {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -597,6 +597,11 @@ class JsonRpcServer(
             // set fields the backend would silently ignore. Sorted for stable wire ordering;
             // pre-feature hosts inherit `emptySet()` from the interface, projected to `[]`.
             supportedOverrides = host.supportedOverrides.sorted(),
+            // PROTOCOL.md § 3 — surface the renderer backend so clients can render
+            // backend-specific UI hints (e.g. "Wear preview unsupported on desktop") without
+            // per-call probing. Defaulted to `null` for hosts that don't classify themselves
+            // (FakeHost, in-test stubs); production hosts always populate.
+            backend = host.backendKind,
           ),
         // B2.1 — surface the authoritative SHA-256 to the client so VS Code can correlate later
         // `classpathDirty` notifications against the daemon's known-at-startup state. Empty

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -113,6 +113,17 @@ interface RenderHost {
     get() = emptySet()
 
   /**
+   * Identifier for the renderer backend this host implements. Surfaced verbatim as
+   * `InitializeResult.capabilities.backend` so clients can render backend-specific UI hints (e.g.
+   * "Wear preview unsupported on desktop") without per-call probing. `null` (the default) for hosts
+   * that haven't been classified — `FakeHost` in `:daemon:harness`, the in-test `FakeRenderHost`,
+   * etc. Real backends override: `RobolectricHost` returns `ANDROID`, `DesktopHost` returns
+   * `DESKTOP`.
+   */
+  val backendKind: ee.schimke.composeai.daemon.protocol.BackendKind?
+    get() = null
+
+  /**
    * Allocate an [InteractiveSession] for [previewId] — the v2 click-into-composition surface
    * documented in
    * [INTERACTIVE.md § 9](../../../../../../docs/daemon/INTERACTIVE.md#9-v2--click-dispatch-into-composition).

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -144,7 +144,27 @@ data class ServerCapabilities(
    * `orientation` (no rotation concept on `ImageComposeScene`).
    */
   val supportedOverrides: List<String> = emptyList(),
+  /**
+   * Identifier for the renderer backend behind this daemon. Lets clients render backend-specific UI
+   * hints (e.g. "Wear preview not supported on desktop", "round-device qualifier requires the
+   * Android backend") without per-call probing. Today: `"desktop"` for the Compose Desktop / Skiko
+   * backend (`DesktopHost`), `"android"` for the Robolectric backend (`RobolectricHost`). `null`
+   * (the default) on hosts that haven't been classified — e.g. `FakeHost` from the harness, or a
+   * future stub backend; clients should treat absent and `null` as "unknown".
+   */
+  val backend: BackendKind? = null,
 )
+
+/**
+ * Renderer backend identifier surfaced via `ServerCapabilities.backend`. Stable string spellings —
+ * these values appear in panel UI matching and MCP-side dispatch heuristics, so adding a new
+ * variant is a wire change.
+ */
+@Serializable
+enum class BackendKind {
+  @SerialName("desktop") DESKTOP,
+  @SerialName("android") ANDROID,
+}
 
 /**
  * One entry in `ServerCapabilities.knownDevices`. The id is the string a caller passes via

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -121,9 +121,10 @@ fun main(args: Array<String>) {
           previewIndexBackedSpecResolver(previewIndex)?.takeIf { previewIndex.size > 0 },
         // D5 — see RecompositionDataProductRegistry KDoc. Producer learns about session
         // lifecycle here so it can install/dispose its CompositionObserver.
-        interactiveSessionListener = DesktopHost.InteractiveSessionListener {
-          previewId, scene -> recompositionRegistry.onSessionLifecycle(previewId, scene)
-        },
+        interactiveSessionListener =
+          DesktopHost.InteractiveSessionListener { previewId, scene ->
+            recompositionRegistry.onSessionLifecycle(previewId, scene)
+          },
       )
     }
   // B2.1 — wire Tier-1 classpath fingerprinting (DESIGN § 8). Cheap-signal file set comes from
@@ -209,7 +210,8 @@ fun main(args: Array<String>) {
       previewIndex = previewIndex,
       incrementalDiscovery = incrementalDiscovery,
       historyManager = historyManager,
-      // D5 — only the desktop daemon advertises `compose/recomposition` today. The PreviewManifestRouter
+      // D5 — only the desktop daemon advertises `compose/recomposition` today. The
+      // PreviewManifestRouter
       // path doesn't expose interactive sessions, so the producer's lookups will all return empty
       // for that host; a delta subscribe degrades to "advertise but useless" via the same code
       // path as a future Compose API rename. Wiring is intentionally global — kinds advertised

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -91,22 +91,23 @@ open class DesktopHost(
   private val previewSpecResolver: ((String) -> RenderSpec?)? = null,
   /**
    * D5 — interactive-session lifecycle listener for the `compose/recomposition` producer
-   * ([RecompositionDataProductRegistry]). Called with the held [androidx.compose.ui.ImageComposeScene]
-   * after [acquireInteractiveSession] succeeds, and with `null` when the session is closed
-   * (either via the returned session's `close()` or via daemon shutdown).
+   * ([RecompositionDataProductRegistry]). Called with the held
+   * [androidx.compose.ui.ImageComposeScene] after [acquireInteractiveSession] succeeds, and with
+   * `null` when the session is closed (either via the returned session's `close()` or via daemon
+   * shutdown).
    *
    * Decoupled from the registry interface itself because (a) the held-scene contract is desktop-
-   * only — no Android equivalent exists today — and (b) the renderer-agnostic
-   * [DataProductRegistry] surface intentionally doesn't expose
-   * [androidx.compose.ui.ImageComposeScene]. The listener seam stays in the desktop module.
+   * only — no Android equivalent exists today — and (b) the renderer-agnostic [DataProductRegistry]
+   * surface intentionally doesn't expose [androidx.compose.ui.ImageComposeScene]. The listener seam
+   * stays in the desktop module.
    */
   private val interactiveSessionListener: InteractiveSessionListener? = null,
 ) : RenderHost {
 
   /**
-   * D5 — session lifecycle hook. Fires on `acquireInteractiveSession` success (with the held
-   * scene) and on session `close()` (with `scene = null`). Implementations are expected to be
-   * cheap and side-effect-isolated — they run on whatever thread called `acquire` / `close`.
+   * D5 — session lifecycle hook. Fires on `acquireInteractiveSession` success (with the held scene)
+   * and on session `close()` (with `scene = null`). Implementations are expected to be cheap and
+   * side-effect-isolated — they run on whatever thread called `acquire` / `close`.
    */
   fun interface InteractiveSessionListener {
     fun onSessionLifecycle(previewId: String, scene: androidx.compose.ui.ImageComposeScene?)
@@ -135,6 +136,10 @@ open class DesktopHost(
    */
   override val supportedOverrides: Set<String> =
     setOf("widthPx", "heightPx", "density", "fontScale", "uiMode", "device")
+
+  /** PROTOCOL.md § 3 — desktop backend identifier surfaced via `capabilities.backend`. */
+  override val backendKind: ee.schimke.composeai.daemon.protocol.BackendKind =
+    ee.schimke.composeai.daemon.protocol.BackendKind.DESKTOP
 
   private val requests: LinkedBlockingQueue<RenderRequest> = LinkedBlockingQueue()
   private val results: ConcurrentHashMap<Long, LinkedBlockingQueue<Any>> = ConcurrentHashMap()

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
@@ -31,45 +31,44 @@ import kotlinx.serialization.json.contentOrNull
  * - Advertises a single kind, `compose/recomposition`, schemaVersion=1, transport=INLINE,
  *   attachable=true, fetchable=true, requiresRerender=true.
  * - On `data/subscribe` with `params: { frameStreamId, mode: "delta" }` against a live
- *   [DesktopInteractiveSession]: looks up the live scene via [liveScenes], reaches the held
- *   scene's [androidx.compose.runtime.Recomposer] reflectively, and installs a
- *   [CompositionObserver] that increments per-[RecomposeScope] counters on each `onScopeExit`.
- * - On each `interactive/input` cycle the daemon's render watcher emits `renderFinished` and
- *   calls [attachmentsFor]; we snapshot the current counter map, attach it as a
- *   [RecompositionPayload], then reset counters to zero so the next input's payload is the
- *   delta *since the previous input*.
- * - On `data/unsubscribe` (or `setVisible` dropping the preview): tear down the observer and
- *   drop counter state.
+ *   [DesktopInteractiveSession]: looks up the live scene via [liveScenes], reaches the held scene's
+ *   [androidx.compose.runtime.Recomposer] reflectively, and installs a [CompositionObserver] that
+ *   increments per-[RecomposeScope] counters on each `onScopeExit`.
+ * - On each `interactive/input` cycle the daemon's render watcher emits `renderFinished` and calls
+ *   [attachmentsFor]; we snapshot the current counter map, attach it as a [RecompositionPayload],
+ *   then reset counters to zero so the next input's payload is the delta *since the previous
+ *   input*.
+ * - On `data/unsubscribe` (or `setVisible` dropping the preview): tear down the observer and drop
+ *   counter state.
  *
- * **Producer-side observation, not a registry-level flush hook.** Per the D5 brief: the
- * dispatcher (`JsonRpcServer`) stays unchanged. The producer collects counts as Compose runs
- * its own recomposition cycles, and `attachmentsFor` is the seam the dispatcher already calls
- * after every render — so we get an automatic flush-on-input from the existing wire path.
+ * **Producer-side observation, not a registry-level flush hook.** Per the D5 brief: the dispatcher
+ * (`JsonRpcServer`) stays unchanged. The producer collects counts as Compose runs its own
+ * recomposition cycles, and `attachmentsFor` is the seam the dispatcher already calls after every
+ * render — so we get an automatic flush-on-input from the existing wire path.
  *
  * **Stable id caveat (v2 problem).** [RecompositionNode.nodeId] is
- * `System.identityHashCode(scope).toString(16)`, scoped within the per-(previewId,
- * frameStreamId) subscription. That's stable for the *duration of the session* — enough for
- * the heat-map UI's "what recomposed when I clicked here" question — but NOT stable across
- * sessions. Stable ids require slot-table line:column extraction; deferred to v2.
+ * `System.identityHashCode(scope).toString(16)`, scoped within the per-(previewId, frameStreamId)
+ * subscription. That's stable for the *duration of the session* — enough for the heat-map UI's
+ * "what recomposed when I clicked here" question — but NOT stable across sessions. Stable ids
+ * require slot-table line:column extraction; deferred to v2.
  *
  * FOLLOWUP (D5 v2): swap the identityHashCode-based id for a slot-table-derived
  * `(file:line:column)` key so heat-map state survives daemon restarts and sandbox recycles.
  *
  * **Safety net.** [androidx.compose.runtime.tooling.CompositionObserver] is
  * `@ExperimentalComposeRuntimeApi`. Compose may rename or restructure these surfaces between
- * runtime releases. Every observer-install path is wrapped in
- * `try/catch (LinkageError | NoSuchMethodError)` so a future API rename degrades the producer
- * to "advertise but useless" (subscriptions succeed, `nodes: []` ships) rather than crashing
- * the daemon JVM.
+ * runtime releases. Every observer-install path is wrapped in `try/catch (LinkageError |
+ * NoSuchMethodError)` so a future API rename degrades the producer to "advertise but useless"
+ * (subscriptions succeed, `nodes: []` ships) rather than crashing the daemon JVM.
  */
 open class RecompositionDataProductRegistry : DataProductRegistry {
 
   /**
-   * Per-previewId tracking of the currently-held [ImageComposeScene], populated by
-   * [DesktopHost]'s interactive-session lifecycle hook (see
-   * [DesktopHost.InteractiveSessionListener] — this class implements that interface via
-   * [onSessionLifecycle]). The producer uses this map both as its "is there a live session?"
-   * lookup at subscribe time and as the source of the scene whose recomposer it instruments.
+   * Per-previewId tracking of the currently-held [ImageComposeScene], populated by [DesktopHost]'s
+   * interactive-session lifecycle hook (see [DesktopHost.InteractiveSessionListener] — this class
+   * implements that interface via [onSessionLifecycle]). The producer uses this map both as its "is
+   * there a live session?" lookup at subscribe time and as the source of the scene whose recomposer
+   * it instruments.
    */
   private val liveScenes: ConcurrentHashMap<String, ImageComposeScene> = ConcurrentHashMap()
 
@@ -82,14 +81,14 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     @Volatile var observerHandle: CompositionObserverHandle? = null,
     /**
      * `true` when the observer install path threw a `LinkageError` / `NoSuchMethodError`. The
-     * subscription stays in [subscriptions] so `attachmentsFor` keeps shipping payloads — they
-     * just carry `nodes: []` until the panel re-subscribes against a working build.
+     * subscription stays in [subscriptions] so `attachmentsFor` keeps shipping payloads — they just
+     * carry `nodes: []` until the panel re-subscribes against a working build.
      */
     @Volatile var instrumentationUnavailable: Boolean = false,
     /**
-     * Map of identity-hashcode-of-RecomposeScope → its current delta-window count. Cleared on
-     * each [snapshotAndReset]. Concurrent because the observer fires from Compose's recomposer
-     * thread while [attachmentsFor] runs from JsonRpcServer's render watcher.
+     * Map of identity-hashcode-of-RecomposeScope → its current delta-window count. Cleared on each
+     * [snapshotAndReset]. Concurrent because the observer fires from Compose's recomposer thread
+     * while [attachmentsFor] runs from JsonRpcServer's render watcher.
      */
     val counters: ConcurrentHashMap<Int, Int> = ConcurrentHashMap(),
   )
@@ -169,10 +168,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     }
   }
 
-  override fun attachmentsFor(
-    previewId: String,
-    kinds: Set<String>,
-  ): List<DataProductAttachment> {
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
     if (KIND !in kinds) return emptyList()
     val state = subscriptions[previewId] ?: return emptyList()
     // Bump the input-seq counter once per attachment build — that's exactly one per
@@ -219,8 +215,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     // DataProductRegistry.onSubscribe contract: "Producers that need 'reset on re-subscribe'
     // semantics use that as the signal."
     subscriptions.remove(previewId)?.disposeObserver()
-    val state =
-      SubscriptionState(frameStreamId = frameStreamId, mode = effectiveMode)
+    val state = SubscriptionState(frameStreamId = frameStreamId, mode = effectiveMode)
     subscriptions[previewId] = state
     if (effectiveMode == MODE_DELTA) {
       val scene = liveScenes[previewId]
@@ -236,17 +231,17 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
   }
 
   /**
-   * [DesktopHost.InteractiveSessionListener] entry point — wires this producer into the held-
-   * scene lifecycle so the observer install path can fire on session-up *or* on a
+   * [DesktopHost.InteractiveSessionListener] entry point — wires this producer into the held- scene
+   * lifecycle so the observer install path can fire on session-up *or* on a
    * subscribe-while-snapshot promotion. Idempotent.
    *
    * - `scene != null` → session acquired. Track in [liveScenes]. If a delta-mode subscription
    *   already exists for [previewId], install the observer now. If a snapshot-mode subscription
-   *   exists, replace it with a fresh delta entry and install — the panel asked for delta but
-   *   the daemon couldn't honour it at subscribe time; promote on session-up.
-   * - `scene == null` → session released. Drop from [liveScenes] and dispose the observer
-   *   handle (subscription state itself stays so `attachmentsFor` keeps shipping empty
-   *   payloads until the client unsubscribes).
+   *   exists, replace it with a fresh delta entry and install — the panel asked for delta but the
+   *   daemon couldn't honour it at subscribe time; promote on session-up.
+   * - `scene == null` → session released. Drop from [liveScenes] and dispose the observer handle
+   *   (subscription state itself stays so `attachmentsFor` keeps shipping empty payloads until the
+   *   client unsubscribes).
    */
   fun onSessionLifecycle(previewId: String, scene: ImageComposeScene?) {
     if (scene == null) {
@@ -278,9 +273,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
             val key = System.identityHashCode(scope)
             state.counters.merge(key, 1, Int::plus)
           },
-          onScopeDisposed = { scope ->
-            state.counters.remove(System.identityHashCode(scope))
-          },
+          onScopeDisposed = { scope -> state.counters.remove(System.identityHashCode(scope)) },
         )
       } catch (t: Throwable) {
         // The brief mandates LinkageError / NoSuchMethodError specifically; we widen to any
@@ -300,16 +293,16 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
   }
 
   /**
-   * The actual observer install. Walks `ImageComposeScene.scene` (BaseComposeScene) →
-   * `recomposer` (ComposeSceneRecomposer) → `recomposer` (androidx.compose.runtime.Recomposer)
-   * via reflection on the private fields, then registers a [CompositionRegistrationObserver]
-   * which calls [ObservableComposition.setObserver] for each existing + future composition.
+   * The actual observer install. Walks `ImageComposeScene.scene` (BaseComposeScene) → `recomposer`
+   * (ComposeSceneRecomposer) → `recomposer` (androidx.compose.runtime.Recomposer) via reflection on
+   * the private fields, then registers a [CompositionRegistrationObserver] which calls
+   * [ObservableComposition.setObserver] for each existing + future composition.
    *
-   * The walk is reflective because Compose UI doesn't expose the held [Recomposer] publicly —
-   * see the discussion in [RecompositionDataProductRegistry] KDoc. The
+   * The walk is reflective because Compose UI doesn't expose the held [Recomposer] publicly — see
+   * the discussion in [RecompositionDataProductRegistry] KDoc. The
    * `addCompositionRegistrationObserver$runtime` path the public `Recomposer.observe` extension
-   * delegates to also reports every *currently registered* composition synchronously, so even
-   * a subscribe-after-render install picks up the live composition tree on the same call.
+   * delegates to also reports every *currently registered* composition synchronously, so even a
+   * subscribe-after-render install picks up the live composition tree on the same call.
    */
   @OptIn(ExperimentalComposeRuntimeApi::class)
   protected open fun installObserver(
@@ -321,9 +314,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     val perCompositionHandles = mutableListOf<CompositionObserverHandle>()
     val perCompositionObserver =
       object : CompositionObserver {
-        override fun onBeginComposition(
-          composition: ObservableComposition,
-        ) {
+        override fun onBeginComposition(composition: ObservableComposition) {
           // No-op — we count post-recomposition via onScopeExit. onBeginComposition fires once
           // per composition cycle (not per scope) so it doesn't carry the per-scope info.
         }
@@ -343,9 +334,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
           onScopeRecomposed(scope)
         }
 
-        override fun onEndComposition(
-          composition: ObservableComposition,
-        ) {
+        override fun onEndComposition(composition: ObservableComposition) {
           // No-op for v1. A future "settle frame" hook could batch counts here, but the
           // attachmentsFor seam already runs once per renderFinished so there's nothing to add.
         }
@@ -400,12 +389,12 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
    * Reflectively reach the [androidx.compose.runtime.Recomposer] that drives [scene]'s held
    * composition. The chain is:
    *
-   * `ImageComposeScene` (public) → field `scene: ComposeScene` (private) →
-   * concrete `BaseComposeScene` → field `recomposer: ComposeSceneRecomposer` (private) →
-   * field `recomposer: Recomposer` (private).
+   * `ImageComposeScene` (public) → field `scene: ComposeScene` (private) → concrete
+   * `BaseComposeScene` → field `recomposer: ComposeSceneRecomposer` (private) → field `recomposer:
+   * Recomposer` (private).
    *
-   * Throws on any link breaking — caller wraps in the LinkageError/NoSuchMethodError safety
-   * net so a future Compose-UI refactor degrades to "instrumentation unavailable".
+   * Throws on any link breaking — caller wraps in the LinkageError/NoSuchMethodError safety net so
+   * a future Compose-UI refactor degrades to "instrumentation unavailable".
    */
   private fun reflectRecomposer(scene: ImageComposeScene): androidx.compose.runtime.Recomposer {
     val sceneField = ImageComposeScene::class.java.getDeclaredField("scene")
@@ -421,8 +410,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     val recomposerField = findDeclaredField(sceneRecomposer.javaClass, "recomposer")
     recomposerField.isAccessible = true
     val recomposer =
-      recomposerField.get(sceneRecomposer)
-        ?: error("ComposeSceneRecomposer.recomposer was null")
+      recomposerField.get(sceneRecomposer) ?: error("ComposeSceneRecomposer.recomposer was null")
     return recomposer as androidx.compose.runtime.Recomposer
   }
 
@@ -494,16 +482,16 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
 
     /**
      * Render mode tag the dispatcher forwards to the renderer-agnostic seam when this producer
-     * returns [DataProductRegistry.Outcome.RequiresRerender]. Renderer-side wiring of this tag
-     * is a follow-up — the desktop renderer doesn't yet write a recomposition sidecar — so
-     * snapshot fetches today complete the budget timer without producing a payload.
+     * returns [DataProductRegistry.Outcome.RequiresRerender]. Renderer-side wiring of this tag is a
+     * follow-up — the desktop renderer doesn't yet write a recomposition sidecar — so snapshot
+     * fetches today complete the budget timer without producing a payload.
      */
     const val MODE_RECOMPOSITION_RENDER: String = "recomposition"
 
     /**
-     * `encodeDefaults = true` so empty `nodes: []` lists ride the wire instead of being
-     * dropped — clients that read `nodes.length` on every payload can rely on the field's
-     * presence regardless of whether instrumentation is unavailable or just no-op-this-frame.
+     * `encodeDefaults = true` so empty `nodes: []` lists ride the wire instead of being dropped —
+     * clients that read `nodes.length` on every payload can rely on the field's presence regardless
+     * of whether instrumentation is unavailable or just no-op-this-frame.
      */
     private val json = Json {
       encodeDefaults = true
@@ -513,14 +501,14 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
 }
 
 /**
- * Wire shape for `compose/recomposition` payloads (schemaVersion=1). Mirrors the JSON the
- * VS Code panel's heat-map overlay decodes. See
+ * Wire shape for `compose/recomposition` payloads (schemaVersion=1). Mirrors the JSON the VS Code
+ * panel's heat-map overlay decodes. See
  * [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md) §
  * "Recomposition + interactive mode".
  *
- * [sinceFrameStreamId] / [inputSeq] are populated only in delta mode — the snapshot mode is
- * a one-shot answer to "what recomposed during the initial composition" with no temporal
- * baseline to track.
+ * [sinceFrameStreamId] / [inputSeq] are populated only in delta mode — the snapshot mode is a
+ * one-shot answer to "what recomposed during the initial composition" with no temporal baseline to
+ * track.
  */
 @Serializable
 data class RecompositionPayload(
@@ -534,8 +522,8 @@ data class RecompositionPayload(
 data class RecompositionNode(
   /**
    * Identity-hashcode-of-RecomposeScope encoded as base-16 — stable for the duration of one
-   * interactive session. NOT stable across sessions. See [RecompositionDataProductRegistry]
-   * KDoc for the v2 followup (slot-table-derived `(file:line:column)` keys).
+   * interactive session. NOT stable across sessions. See [RecompositionDataProductRegistry] KDoc
+   * for the v2 followup (slot-table-derived `(file:line:column)` keys).
    */
   val nodeId: String,
   val count: Int,

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecompositionDataProductRegistryTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecompositionDataProductRegistryTest.kt
@@ -22,27 +22,26 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
 /**
- * D5 — pins the `compose/recomposition` producer's contract for the desktop interactive
- * surface. See [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md)
- * § "Recomposition + interactive mode".
+ * D5 — pins the `compose/recomposition` producer's contract for the desktop interactive surface.
+ * See [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md) §
+ * "Recomposition + interactive mode".
  *
  * Three scenarios:
  *
- * 1. **Capabilities + delta-mode happy path** — the producer advertises
- *    `compose/recomposition` with `requiresRerender=true`, then a stateful preview
- *    ([ClickRecomposingSquare]) attaches a non-empty counter payload after a click. The
- *    second post-click attachment carries strictly fewer counts than the first (the delta
- *    has been reset between flushes), proving the inputSeq increments and counters reset.
+ * 1. **Capabilities + delta-mode happy path** — the producer advertises `compose/recomposition`
+ *    with `requiresRerender=true`, then a stateful preview ([ClickRecomposingSquare]) attaches a
+ *    non-empty counter payload after a click. The second post-click attachment carries strictly
+ *    fewer counts than the first (the delta has been reset between flushes), proving the inputSeq
+ *    increments and counters reset.
  * 2. **`mode=delta` against a non-live preview** — the producer falls back to snapshot at
- *    `onSubscribe` (per the D5 brief), so attachments still ship but with an empty payload
- *    until a live session arrives.
+ *    `onSubscribe` (per the D5 brief), so attachments still ship but with an empty payload until a
+ *    live session arrives.
  * 3. **Safety net** — when observer install throws (simulated by closing the scene before
  *    onSubscribe so reflection sees a torn-down state), the subscription still succeeds and
  *    `attachmentsFor` ships an empty `nodes: []` payload. The daemon doesn't crash.
  *
  * Driven against a real [DesktopHost] + [DesktopInteractiveSession] so the end-to-end Compose
- * runtime path (Recomposer, CompositionObserver, Modifier.clickable, mutableStateOf) is
- * covered.
+ * runtime path (Recomposer, CompositionObserver, Modifier.clickable, mutableStateOf) is covered.
  */
 class RecompositionDataProductRegistryTest {
 
@@ -99,11 +98,10 @@ class RecompositionDataProductRegistryTest {
         // Subscribe with delta mode AFTER the session is live — the listener has already
         // populated liveScenes for FIXTURE_PREVIEW_ID, so onSubscribe installs the observer
         // immediately rather than going through the snapshot-promotion path.
-        val subscribeParams =
-          buildJsonObject {
-            put("frameStreamId", JsonPrimitive("test-stream-1"))
-            put("mode", JsonPrimitive("delta"))
-          }
+        val subscribeParams = buildJsonObject {
+          put("frameStreamId", JsonPrimitive("test-stream-1"))
+          put("mode", JsonPrimitive("delta"))
+        }
         registry.onSubscribe(FIXTURE_PREVIEW_ID, "compose/recomposition", subscribeParams)
 
         // 1. Bootstrap render — initial composition runs the ClickRecomposingSquare body once.
@@ -139,14 +137,8 @@ class RecompositionDataProductRegistryTest {
         assertNotNull("delta payload must travel inline", postClick.payload)
         assertNull("compose/recomposition is INLINE-only; path must be null", postClick.path)
         val payload = postClick.payload!!.jsonObject
-        assertEquals(
-          "delta",
-          payload["mode"]?.jsonPrimitive?.content,
-        )
-        assertEquals(
-          "test-stream-1",
-          payload["sinceFrameStreamId"]?.jsonPrimitive?.content,
-        )
+        assertEquals("delta", payload["mode"]?.jsonPrimitive?.content)
+        assertEquals("test-stream-1", payload["sinceFrameStreamId"]?.jsonPrimitive?.content)
         // Two flushes have happened by now (the bootstrap-only and the post-click one), so
         // inputSeq is 2.
         assertEquals(
@@ -195,11 +187,10 @@ class RecompositionDataProductRegistryTest {
     // the subscription as snapshot. attachmentsFor still ships a payload (the brief: "advertise
     // but useless") with mode=snapshot and empty nodes.
     val registry = RecompositionDataProductRegistry()
-    val params =
-      buildJsonObject {
-        put("frameStreamId", JsonPrimitive("non-live-stream"))
-        put("mode", JsonPrimitive("delta"))
-      }
+    val params = buildJsonObject {
+      put("frameStreamId", JsonPrimitive("non-live-stream"))
+      put("mode", JsonPrimitive("delta"))
+    }
     registry.onSubscribe("non-live-preview", "compose/recomposition", params)
     val attachments = registry.attachmentsFor("non-live-preview", setOf("compose/recomposition"))
     assertEquals(1, attachments.size)
@@ -209,22 +200,17 @@ class RecompositionDataProductRegistryTest {
       "snapshot",
       payload["mode"]?.jsonPrimitive?.content,
     )
-    assertEquals(
-      "no live observer → no nodes",
-      0,
-      payload["nodes"]?.jsonArray?.size,
-    )
+    assertEquals("no live observer → no nodes", 0, payload["nodes"]?.jsonArray?.size)
     registry.onUnsubscribe("non-live-preview", "compose/recomposition")
   }
 
   @Test
   fun fetch_delta_against_non_live_preview_returns_not_available() {
     val registry = RecompositionDataProductRegistry()
-    val params =
-      buildJsonObject {
-        put("frameStreamId", JsonPrimitive("nope"))
-        put("mode", JsonPrimitive("delta"))
-      }
+    val params = buildJsonObject {
+      put("frameStreamId", JsonPrimitive("nope"))
+      put("mode", JsonPrimitive("delta"))
+    }
     val outcome =
       registry.fetch(
         previewId = "no-such-preview",
@@ -249,10 +235,7 @@ class RecompositionDataProductRegistryTest {
       "snapshot fetch must require a re-render in mode=recomposition; got $outcome",
       outcome is DataProductRegistry.Outcome.RequiresRerender,
     )
-    assertEquals(
-      "recomposition",
-      (outcome as DataProductRegistry.Outcome.RequiresRerender).mode,
-    )
+    assertEquals("recomposition", (outcome as DataProductRegistry.Outcome.RequiresRerender).mode)
   }
 
   @Test
@@ -278,21 +261,16 @@ class RecompositionDataProductRegistryTest {
       }
     val previewId = "preview-with-broken-instrumentation"
     val scene =
-      ImageComposeScene(
-        width = 32,
-        height = 32,
-        density = androidx.compose.ui.unit.Density(1.0f),
-      ) {
+      ImageComposeScene(width = 32, height = 32, density = androidx.compose.ui.unit.Density(1.0f)) {
         // Empty content — we just need a real scene to feed onSessionLifecycle, the override
         // above is what intercepts and throws.
       }
     try {
       registry.onSessionLifecycle(previewId, scene)
-      val params =
-        buildJsonObject {
-          put("frameStreamId", JsonPrimitive("broken-stream"))
-          put("mode", JsonPrimitive("delta"))
-        }
+      val params = buildJsonObject {
+        put("frameStreamId", JsonPrimitive("broken-stream"))
+        put("mode", JsonPrimitive("delta"))
+      }
       // The subscribe call must NOT propagate the LinkageError — that's the load-bearing
       // assertion. If the safety net is missing, this line throws and the test fails before
       // reaching any of the assertions below.

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -106,16 +106,16 @@ fun ClickToggleSquare() {
 }
 
 /**
- * D5 fixture for `RecompositionDataProductRegistryTest`. Exposes a `clicks` mutableStateOf
- * that increments on every press; the inner [androidx.compose.runtime.key]-keyed scope reads
- * `clicks` so it recomposes once per click. The Compose runtime's
- * [androidx.compose.runtime.tooling.CompositionObserver] sees that recomposition as a
- * onScopeExit on the inner block, which the producer counts.
+ * D5 fixture for `RecompositionDataProductRegistryTest`. Exposes a `clicks` mutableStateOf that
+ * increments on every press; the inner [androidx.compose.runtime.key]-keyed scope reads `clicks` so
+ * it recomposes once per click. The Compose runtime's
+ * [androidx.compose.runtime.tooling.CompositionObserver] sees that recomposition as a onScopeExit
+ * on the inner block, which the producer counts.
  *
- * Whole-card pointerInput (matches `ClickToggleSquare`'s pattern) so click coords don't
- * matter — the test cares about "did exactly one click cause exactly one recomposition of a
- * recognisable scope?", not pixel routing. Background colour shifts subtly per click so a
- * future pixel-diff regression would flag if the click stopped reaching the composition.
+ * Whole-card pointerInput (matches `ClickToggleSquare`'s pattern) so click coords don't matter —
+ * the test cares about "did exactly one click cause exactly one recomposition of a recognisable
+ * scope?", not pixel routing. Background colour shifts subtly per click so a future pixel-diff
+ * regression would flag if the click stopped reaching the composition.
  */
 @Composable
 fun ClickRecomposingSquare() {

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -120,6 +120,7 @@ Result:
     leakDetection: ("light" | "heavy")[];   // reserved; always [] today (TODO B2.4)
     knownDevices?: KnownDevice[];    // catalog of @Preview(device=...) ids the daemon recognises
     supportedOverrides?: string[];   // PreviewOverrides field names this host actually applies
+    backend?: "desktop" | "android"; // which renderer backend this daemon implements
   };
   // KnownDevice — one entry per id in DeviceDimensions.KNOWN_DEVICE_IDS, projected to wire shape.
   // `id` is the string a caller passes via renderNow.overrides.device; widthDp/heightDp/density

--- a/docs/daemon/protocol-fixtures/daemon-initializeResult.json
+++ b/docs/daemon/protocol-fixtures/daemon-initializeResult.json
@@ -28,7 +28,8 @@
       {"id": "id:pixel_5", "widthDp": 393, "heightDp": 851, "density": 2.75},
       {"id": "id:wearos_small_round", "widthDp": 192, "heightDp": 192, "density": 2.0}
     ],
-    "supportedOverrides": ["density", "device", "fontScale", "heightPx", "uiMode", "widthPx"]
+    "supportedOverrides": ["density", "device", "fontScale", "heightPx", "uiMode", "widthPx"],
+    "backend": "desktop"
   },
   "classpathFingerprint": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   "manifest": {

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -154,6 +154,14 @@ export interface InitializeResult {
          * `ImageComposeScene`).
          */
         supportedOverrides?: string[];
+        /**
+         * Identifier for the renderer backend behind this daemon. Lets clients render
+         * backend-specific UI hints (e.g. "Wear preview not supported on desktop") without
+         * per-call probing. Today: `'desktop'` for the Compose Desktop / Skiko backend,
+         * `'android'` for the Robolectric backend. Absent / `null` on hosts that haven't
+         * classified themselves (e.g. test fakes); clients should treat both as "unknown".
+         */
+        backend?: 'desktop' | 'android' | null;
     };
     classpathFingerprint: string;
     manifest: { path: string; previewCount: number };

--- a/vscode-extension/src/test/daemonProtocol.test.ts
+++ b/vscode-extension/src/test/daemonProtocol.test.ts
@@ -78,6 +78,8 @@ describe('daemon protocol — golden fixtures', () => {
         assert.ok(supported.includes('device'), 'desktop should advertise device');
         assert.ok(!supported.includes('localeTag'), 'desktop should NOT advertise localeTag');
         assert.ok(!supported.includes('orientation'), 'desktop should NOT advertise orientation');
+        // PROTOCOL.md § 3 — backend identifies the renderer; fixture mirrors a desktop daemon.
+        assert.strictEqual(result.capabilities.backend, 'desktop');
     });
 
     it('parses client-fileChanged.json with all required fields', () => {


### PR DESCRIPTION
## Summary

Adds `ServerCapabilities.backend: BackendKind?` (`"desktop"` | `"android"`, optional) to `InitializeResult`, surfaced verbatim from a new `RenderHost.backendKind` property. Lets clients render backend-specific UI hints (e.g. "Wear preview unsupported on desktop", "round-device qualifier requires the Android backend") without per-call probing.

Today the panel/MCP infers backend identity by looking at the spawn descriptor's main class — works but couples the client to launch-side plumbing. Advertising it on the initialize handshake is the same pattern #433 (knownDevices) and #441 (supportedOverrides) follow.

- `RobolectricHost.backendKind = ANDROID`
- `DesktopHost.backendKind = DESKTOP`
- `FakeHost`, in-test stubs, etc. inherit the `null` default. Clients should treat absent and `null` as "unknown".

Mirrored on TS (`ServerCapabilities.backend?: 'desktop' | 'android' | null`). Fixture mirrors a desktop daemon and now advertises `backend: "desktop"`; both round-trip tests assert the field.

## Test plan

- [x] `:daemon:core:test` — 151/151 pass (incl. `MessagesTest.roundTripInitializeResult` exercising the new field)
- [x] `:daemon:android:compileDebugKotlin` + `:daemon:desktop:compileKotlin` — clean (override compiles)
- [x] TS `daemonProtocol.test.ts` updated to assert `result.capabilities.backend === 'desktop'`
- [x] `ktfmtCheckAll` — clean

## Notes

- Default value `null` so pre-feature daemons don't break the schema; clients should treat absent and `null` identically (same convention as `dataProducts`, `knownDevices`, `supportedOverrides`).
- Includes ktfmtFormatAll output for pre-existing format drift in `:daemon:desktop` — same pre-commit-hook pattern as prior PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmHMG3rJrJowyM15hK2Bow)_