### PR TITLE
feat(daemon): add v3 Android-interactive bridge primitives

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -263,6 +263,11 @@ object DaemonHostBridge {
     // top-level field. Slot 0's other refs alias the top-level AtomicReferences directly so they
     // were already cleared by the lines above.
     slot0Eager.sandboxReadyLatchRef.set(sandboxReadyLatch)
+    // INTERACTIVE-ANDROID.md § 3 — drain any queued interactive commands so a previous host
+    // lifecycle's leftover Start/Dispatch/Close don't leak into the next start. Slot 0's queue is
+    // an instance field on [SandboxSlot] (not aliased to a top-level @JvmField like [requests]),
+    // so the explicit clear is necessary even on the single-slot path.
+    slot0Eager.interactiveCommands.clear()
     // Drop any extended slots back to the canonical single-slot list. Multi-slot configuration is
     // re-applied by the next [configureSlotCount] call (typically from `RobolectricHost.start`).
     // Render IDs (RenderHost.nextRequestId) deliberately stay monotonic across host restarts
@@ -299,6 +304,17 @@ internal constructor(
    * reference held by callers.
    */
   @JvmField val sandboxReadyLatchRef: AtomicReference<CountDownLatch>,
+  /**
+   * Inbound interactive-mode command queue (INTERACTIVE-ANDROID.md § 3 — v3 Android interactive).
+   * The held-rule loop in `SandboxRunner.holdSandboxOpen` (lands in PR B) drains this queue when
+   * the slot is in interactive-mode; until PR B lands, the queue exists as part of the bridge
+   * surface but no sandbox-side code reads from it (callers can enqueue, nothing happens).
+   *
+   * Separate from [requests] because the held-rule loop's lifecycle is different: it's allocated
+   * on `Start`, drained until `Close`, then the slot returns to draining [requests]. A single
+   * mixed queue would force the sandbox-side loop to discriminate per-poll.
+   */
+  @JvmField val interactiveCommands: LinkedBlockingQueue<InteractiveCommand> = LinkedBlockingQueue(),
 ) {
   /** Convenience: blocks until this slot's sandbox is ready. */
   fun awaitSandboxReady(timeoutMs: Long): Boolean =
@@ -316,4 +332,89 @@ internal constructor(
         sandboxReadyLatchRef = AtomicReference(CountDownLatch(1)),
       )
   }
+}
+
+/**
+ * Cross-classloader command for the v3 Android-interactive held-rule loop (INTERACTIVE-ANDROID.md
+ * § 3). The sandbox-side `SandboxRunner` reads from [SandboxSlot.interactiveCommands] when its
+ * slot is pinned to an interactive session; commands are routed to the held rule's main thread.
+ *
+ * **Bridge-package-only.** This sealed interface and every member must use only `java.*` types or
+ * other types in this `bridge` package — see the file KDoc on [DaemonHostBridge] for the
+ * Robolectric do-not-acquire boundary the package relies on. Specifically: no Compose pointer
+ * types, no Roborazzi capture types, no `ee.schimke.composeai.daemon.*` imports outside this
+ * package. Pixel coordinates ride as primitives; the sandbox synthesises the `MotionEvent` itself.
+ *
+ * **Wire-only in PR A.** The host enqueues nothing yet; no sandbox-side loop drains the queue.
+ * PR B (INTERACTIVE-ANDROID.md § 4 + § 7) wires both ends and ships
+ * `RobolectricHost.acquireInteractiveSession`. Lands here first so PR B doesn't have to widen
+ * the bridge surface mid-rollout.
+ */
+sealed interface InteractiveCommand {
+  /**
+   * Stream identifier echoed back to the host so a single slot can reject nested-start races
+   * (INTERACTIVE-ANDROID.md § 4: "A nested Start while a session is held is an error"). Opaque to
+   * the bridge — the host generates it, the sandbox carries it back unchanged.
+   */
+  val streamId: String
+
+  /**
+   * Allocate the rule + ActivityScenario, run `setContent`, signal ready via [replyLatch]. The
+   * preview reference travels as separate FQN + function-name strings (the sandbox resolves them
+   * via `Class.forName` against the slot's child classloader), and dimension/qualifier fields
+   * mirror the v1 [`RenderSpec`] subset the held composition needs.
+   *
+   * @param replyError the sandbox sets this before counting down [replyLatch] when `setContent`
+   *   throws; the host then surfaces a clean failure on the v2 `interactive/start` reply rather
+   *   than a wire-level timeout. Wrapping in [AtomicReference] keeps the field assignable from
+   *   the sandbox classloader without requiring Throwable types to cross the boundary as
+   *   anything other than the standard `java.lang.Throwable`.
+   */
+  data class Start(
+    override val streamId: String,
+    val previewClassName: String,
+    val previewFunctionName: String,
+    val widthPx: Int,
+    val heightPx: Int,
+    val density: Float,
+    val backgroundColor: Long,
+    val showBackground: Boolean,
+    val device: String?,
+    val outputBaseName: String,
+    val replyLatch: CountDownLatch,
+    val replyError: AtomicReference<Throwable?>,
+  ) : InteractiveCommand
+
+  /**
+   * Synthesise + dispatch a [android.view.MotionEvent] on the rule's main thread. [kind] mirrors
+   * the v2 wire `interactive/input` `kind` field — `"click"` / `"pointerDown"` / `"pointerUp"`
+   * for v3; key events fall through to a no-op until v4. Pixel coordinates are in the held
+   * composition's own pixel space — the host has already scaled from any `pixelDensity` ratio.
+   */
+  data class Dispatch(
+    override val streamId: String,
+    val kind: String,
+    val pixelX: Int,
+    val pixelY: Int,
+    val replyLatch: CountDownLatch,
+    val replyError: AtomicReference<Throwable?>,
+  ) : InteractiveCommand
+
+  /**
+   * Capture current pixels via the same `captureRoboImage` path the one-shot `RenderEngine` uses,
+   * and emit a `RenderResult` on [DaemonHostBridge.results] keyed by [requestId]. The host's
+   * `AndroidInteractiveSession.render()` polls that map exactly like the v1
+   * `RobolectricHost.submit` does today — no new result channel needed because render ids are
+   * already globally monotonic.
+   */
+  data class Render(override val streamId: String, val requestId: Long) : InteractiveCommand
+
+  /**
+   * Tear down the rule + ActivityScenario; the held statement returns and the slot reverts to
+   * draining normal renders from [SandboxSlot.requests]. [replyLatch] counts down before the
+   * statement exits so the host knows the ActivityScenario has actually closed before the next
+   * `interactive/start` would race against the same slot.
+   */
+  data class Close(override val streamId: String, val replyLatch: CountDownLatch) :
+    InteractiveCommand
 }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/InteractiveCommandTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/InteractiveCommandTest.kt
@@ -1,0 +1,150 @@
+package ee.schimke.composeai.daemon.bridge
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Wire-shape coverage for the v3 Android-interactive bridge primitives (INTERACTIVE-ANDROID.md
+ * § 3, PR A scope). The held-rule loop and host-side `AndroidInteractiveSession` land in PR B —
+ * here we only verify that the cross-classloader handoff surface itself is wired correctly:
+ *
+ *  * [InteractiveCommand] is a sealed family carrying only `java.*` types and bridge-package
+ *    types, so it crosses the Robolectric do-not-acquire boundary unchanged.
+ *  * [SandboxSlot.interactiveCommands] enqueues and dequeues each variant in FIFO order.
+ *  * [DaemonHostBridge.reset] drains every slot's interactive queue and re-points slot 0 at a
+ *    fresh `LinkedBlockingQueue`-equivalent (i.e. a leftover command from a previous host lifecycle
+ *    cannot leak into the next `start`).
+ *  * [DaemonHostBridge.configureSlotCount] allocates `interactiveCommands` for every standalone
+ *    slot, so a v3-capable `sandboxCount=2` configuration has a queue on slot 1.
+ *
+ * Plain JUnit (no `@RunWith(SandboxHoldingRunner::class)`) — the bridge is host-side state, not
+ * sandboxed; the do-not-acquire rule only applies inside Robolectric's `InstrumentingClassLoader`.
+ */
+class InteractiveCommandTest {
+
+  @After
+  fun tearDown() {
+    // Subsequent tests in the suite (e.g. `RobolectricHostTest`) start from
+    // `DaemonHostBridge.reset()` themselves, but resetting here too keeps the per-test isolation
+    // explicit and makes `slotsRef` shrink back to slot 0 between cases in this file.
+    DaemonHostBridge.reset()
+  }
+
+  @Test
+  fun queueRoundTripsEveryVariantInFifoOrder() {
+    DaemonHostBridge.reset()
+    val slot = DaemonHostBridge.slot(0)
+    val startLatch = CountDownLatch(1)
+    val startError = AtomicReference<Throwable?>(null)
+    val dispatchLatch = CountDownLatch(1)
+    val dispatchError = AtomicReference<Throwable?>(null)
+    val closeLatch = CountDownLatch(1)
+
+    val start =
+      InteractiveCommand.Start(
+        streamId = "stream-A",
+        previewClassName = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        previewFunctionName = "RedSquare",
+        widthPx = 320,
+        heightPx = 320,
+        density = 2.0f,
+        backgroundColor = 0L,
+        showBackground = true,
+        device = null,
+        outputBaseName = "stream-A-frame",
+        replyLatch = startLatch,
+        replyError = startError,
+      )
+    val dispatch =
+      InteractiveCommand.Dispatch(
+        streamId = "stream-A",
+        kind = "click",
+        pixelX = 160,
+        pixelY = 160,
+        replyLatch = dispatchLatch,
+        replyError = dispatchError,
+      )
+    val render = InteractiveCommand.Render(streamId = "stream-A", requestId = 42L)
+    val close = InteractiveCommand.Close(streamId = "stream-A", replyLatch = closeLatch)
+
+    slot.interactiveCommands.put(start)
+    slot.interactiveCommands.put(dispatch)
+    slot.interactiveCommands.put(render)
+    slot.interactiveCommands.put(close)
+
+    val drained = mutableListOf<InteractiveCommand>()
+    while (true) {
+      val next = slot.interactiveCommands.poll(1, TimeUnit.SECONDS) ?: break
+      drained.add(next)
+      if (drained.size == 4) break
+    }
+
+    assertEquals(listOf<InteractiveCommand>(start, dispatch, render, close), drained)
+    assertTrue(
+      "queue should be empty after draining all four commands",
+      slot.interactiveCommands.isEmpty(),
+    )
+    // Reply scaffolding round-trips — i.e. the same latch / AtomicReference instances we put in
+    // come back out by reference, not via copy. PR B's session class relies on this for the
+    // host-side await semantics.
+    val drainedStart = drained[0] as InteractiveCommand.Start
+    assertSame(startLatch, drainedStart.replyLatch)
+    assertSame(startError, drainedStart.replyError)
+    assertNull("replyError defaults to null", drainedStart.replyError.get())
+  }
+
+  @Test
+  fun resetClearsLeftoverInteractiveCommands() {
+    DaemonHostBridge.reset()
+    val slot = DaemonHostBridge.slot(0)
+    slot.interactiveCommands.put(
+      InteractiveCommand.Render(streamId = "stream-leftover", requestId = 1L)
+    )
+    assertEquals(1, slot.interactiveCommands.size)
+
+    DaemonHostBridge.reset()
+
+    val slotAfterReset = DaemonHostBridge.slot(0)
+    assertSame(
+      "slot 0's instance is stable across reset (legacy aliasing contract)",
+      slot,
+      slotAfterReset,
+    )
+    assertTrue(
+      "reset must drain leftover interactive commands so a previous host lifecycle does not " +
+        "leak Start/Dispatch/Close into the next session",
+      slotAfterReset.interactiveCommands.isEmpty(),
+    )
+  }
+
+  @Test
+  fun configureSlotCountAllocatesInteractiveQueuePerSlot() {
+    DaemonHostBridge.reset()
+
+    DaemonHostBridge.configureSlotCount(2)
+    val slot0 = DaemonHostBridge.slot(0)
+    val slot1 = DaemonHostBridge.slot(1)
+
+    assertNotSame(
+      "standalone slot 1 must have its own interactive queue distinct from slot 0's",
+      slot0.interactiveCommands,
+      slot1.interactiveCommands,
+    )
+    val cmd =
+      InteractiveCommand.Render(streamId = "stream-pinned-to-slot-1", requestId = 99L)
+    slot1.interactiveCommands.put(cmd)
+    assertTrue(
+      "enqueue on slot 1 must not appear on slot 0 — sandbox-pool isolation",
+      slot0.interactiveCommands.isEmpty(),
+    )
+    assertEquals(cmd, slot1.interactiveCommands.poll(1, TimeUnit.SECONDS))
+  }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -121,9 +121,10 @@ fun main(args: Array<String>) {
           previewIndexBackedSpecResolver(previewIndex)?.takeIf { previewIndex.size > 0 },
         // D5 — see RecompositionDataProductRegistry KDoc. Producer learns about session
         // lifecycle here so it can install/dispose its CompositionObserver.
-        interactiveSessionListener = DesktopHost.InteractiveSessionListener {
-          previewId, scene -> recompositionRegistry.onSessionLifecycle(previewId, scene)
-        },
+        interactiveSessionListener =
+          DesktopHost.InteractiveSessionListener { previewId, scene ->
+            recompositionRegistry.onSessionLifecycle(previewId, scene)
+          },
       )
     }
   // B2.1 — wire Tier-1 classpath fingerprinting (DESIGN § 8). Cheap-signal file set comes from
@@ -209,7 +210,8 @@ fun main(args: Array<String>) {
       previewIndex = previewIndex,
       incrementalDiscovery = incrementalDiscovery,
       historyManager = historyManager,
-      // D5 — only the desktop daemon advertises `compose/recomposition` today. The PreviewManifestRouter
+      // D5 — only the desktop daemon advertises `compose/recomposition` today. The
+      // PreviewManifestRouter
       // path doesn't expose interactive sessions, so the producer's lookups will all return empty
       // for that host; a delta subscribe degrades to "advertise but useless" via the same code
       // path as a future Compose API rename. Wiring is intentionally global — kinds advertised

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -91,22 +91,23 @@ open class DesktopHost(
   private val previewSpecResolver: ((String) -> RenderSpec?)? = null,
   /**
    * D5 — interactive-session lifecycle listener for the `compose/recomposition` producer
-   * ([RecompositionDataProductRegistry]). Called with the held [androidx.compose.ui.ImageComposeScene]
-   * after [acquireInteractiveSession] succeeds, and with `null` when the session is closed
-   * (either via the returned session's `close()` or via daemon shutdown).
+   * ([RecompositionDataProductRegistry]). Called with the held
+   * [androidx.compose.ui.ImageComposeScene] after [acquireInteractiveSession] succeeds, and with
+   * `null` when the session is closed (either via the returned session's `close()` or via daemon
+   * shutdown).
    *
    * Decoupled from the registry interface itself because (a) the held-scene contract is desktop-
-   * only — no Android equivalent exists today — and (b) the renderer-agnostic
-   * [DataProductRegistry] surface intentionally doesn't expose
-   * [androidx.compose.ui.ImageComposeScene]. The listener seam stays in the desktop module.
+   * only — no Android equivalent exists today — and (b) the renderer-agnostic [DataProductRegistry]
+   * surface intentionally doesn't expose [androidx.compose.ui.ImageComposeScene]. The listener seam
+   * stays in the desktop module.
    */
   private val interactiveSessionListener: InteractiveSessionListener? = null,
 ) : RenderHost {
 
   /**
-   * D5 — session lifecycle hook. Fires on `acquireInteractiveSession` success (with the held
-   * scene) and on session `close()` (with `scene = null`). Implementations are expected to be
-   * cheap and side-effect-isolated — they run on whatever thread called `acquire` / `close`.
+   * D5 — session lifecycle hook. Fires on `acquireInteractiveSession` success (with the held scene)
+   * and on session `close()` (with `scene = null`). Implementations are expected to be cheap and
+   * side-effect-isolated — they run on whatever thread called `acquire` / `close`.
    */
   fun interface InteractiveSessionListener {
     fun onSessionLifecycle(previewId: String, scene: androidx.compose.ui.ImageComposeScene?)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
@@ -31,45 +31,44 @@ import kotlinx.serialization.json.contentOrNull
  * - Advertises a single kind, `compose/recomposition`, schemaVersion=1, transport=INLINE,
  *   attachable=true, fetchable=true, requiresRerender=true.
  * - On `data/subscribe` with `params: { frameStreamId, mode: "delta" }` against a live
- *   [DesktopInteractiveSession]: looks up the live scene via [liveScenes], reaches the held
- *   scene's [androidx.compose.runtime.Recomposer] reflectively, and installs a
- *   [CompositionObserver] that increments per-[RecomposeScope] counters on each `onScopeExit`.
- * - On each `interactive/input` cycle the daemon's render watcher emits `renderFinished` and
- *   calls [attachmentsFor]; we snapshot the current counter map, attach it as a
- *   [RecompositionPayload], then reset counters to zero so the next input's payload is the
- *   delta *since the previous input*.
- * - On `data/unsubscribe` (or `setVisible` dropping the preview): tear down the observer and
- *   drop counter state.
+ *   [DesktopInteractiveSession]: looks up the live scene via [liveScenes], reaches the held scene's
+ *   [androidx.compose.runtime.Recomposer] reflectively, and installs a [CompositionObserver] that
+ *   increments per-[RecomposeScope] counters on each `onScopeExit`.
+ * - On each `interactive/input` cycle the daemon's render watcher emits `renderFinished` and calls
+ *   [attachmentsFor]; we snapshot the current counter map, attach it as a [RecompositionPayload],
+ *   then reset counters to zero so the next input's payload is the delta *since the previous
+ *   input*.
+ * - On `data/unsubscribe` (or `setVisible` dropping the preview): tear down the observer and drop
+ *   counter state.
  *
- * **Producer-side observation, not a registry-level flush hook.** Per the D5 brief: the
- * dispatcher (`JsonRpcServer`) stays unchanged. The producer collects counts as Compose runs
- * its own recomposition cycles, and `attachmentsFor` is the seam the dispatcher already calls
- * after every render — so we get an automatic flush-on-input from the existing wire path.
+ * **Producer-side observation, not a registry-level flush hook.** Per the D5 brief: the dispatcher
+ * (`JsonRpcServer`) stays unchanged. The producer collects counts as Compose runs its own
+ * recomposition cycles, and `attachmentsFor` is the seam the dispatcher already calls after every
+ * render — so we get an automatic flush-on-input from the existing wire path.
  *
  * **Stable id caveat (v2 problem).** [RecompositionNode.nodeId] is
- * `System.identityHashCode(scope).toString(16)`, scoped within the per-(previewId,
- * frameStreamId) subscription. That's stable for the *duration of the session* — enough for
- * the heat-map UI's "what recomposed when I clicked here" question — but NOT stable across
- * sessions. Stable ids require slot-table line:column extraction; deferred to v2.
+ * `System.identityHashCode(scope).toString(16)`, scoped within the per-(previewId, frameStreamId)
+ * subscription. That's stable for the *duration of the session* — enough for the heat-map UI's
+ * "what recomposed when I clicked here" question — but NOT stable across sessions. Stable ids
+ * require slot-table line:column extraction; deferred to v2.
  *
  * FOLLOWUP (D5 v2): swap the identityHashCode-based id for a slot-table-derived
  * `(file:line:column)` key so heat-map state survives daemon restarts and sandbox recycles.
  *
  * **Safety net.** [androidx.compose.runtime.tooling.CompositionObserver] is
  * `@ExperimentalComposeRuntimeApi`. Compose may rename or restructure these surfaces between
- * runtime releases. Every observer-install path is wrapped in
- * `try/catch (LinkageError | NoSuchMethodError)` so a future API rename degrades the producer
- * to "advertise but useless" (subscriptions succeed, `nodes: []` ships) rather than crashing
- * the daemon JVM.
+ * runtime releases. Every observer-install path is wrapped in `try/catch (LinkageError |
+ * NoSuchMethodError)` so a future API rename degrades the producer to "advertise but useless"
+ * (subscriptions succeed, `nodes: []` ships) rather than crashing the daemon JVM.
  */
 open class RecompositionDataProductRegistry : DataProductRegistry {
 
   /**
-   * Per-previewId tracking of the currently-held [ImageComposeScene], populated by
-   * [DesktopHost]'s interactive-session lifecycle hook (see
-   * [DesktopHost.InteractiveSessionListener] — this class implements that interface via
-   * [onSessionLifecycle]). The producer uses this map both as its "is there a live session?"
-   * lookup at subscribe time and as the source of the scene whose recomposer it instruments.
+   * Per-previewId tracking of the currently-held [ImageComposeScene], populated by [DesktopHost]'s
+   * interactive-session lifecycle hook (see [DesktopHost.InteractiveSessionListener] — this class
+   * implements that interface via [onSessionLifecycle]). The producer uses this map both as its "is
+   * there a live session?" lookup at subscribe time and as the source of the scene whose recomposer
+   * it instruments.
    */
   private val liveScenes: ConcurrentHashMap<String, ImageComposeScene> = ConcurrentHashMap()
 
@@ -82,14 +81,14 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     @Volatile var observerHandle: CompositionObserverHandle? = null,
     /**
      * `true` when the observer install path threw a `LinkageError` / `NoSuchMethodError`. The
-     * subscription stays in [subscriptions] so `attachmentsFor` keeps shipping payloads — they
-     * just carry `nodes: []` until the panel re-subscribes against a working build.
+     * subscription stays in [subscriptions] so `attachmentsFor` keeps shipping payloads — they just
+     * carry `nodes: []` until the panel re-subscribes against a working build.
      */
     @Volatile var instrumentationUnavailable: Boolean = false,
     /**
-     * Map of identity-hashcode-of-RecomposeScope → its current delta-window count. Cleared on
-     * each [snapshotAndReset]. Concurrent because the observer fires from Compose's recomposer
-     * thread while [attachmentsFor] runs from JsonRpcServer's render watcher.
+     * Map of identity-hashcode-of-RecomposeScope → its current delta-window count. Cleared on each
+     * [snapshotAndReset]. Concurrent because the observer fires from Compose's recomposer thread
+     * while [attachmentsFor] runs from JsonRpcServer's render watcher.
      */
     val counters: ConcurrentHashMap<Int, Int> = ConcurrentHashMap(),
   )
@@ -169,10 +168,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     }
   }
 
-  override fun attachmentsFor(
-    previewId: String,
-    kinds: Set<String>,
-  ): List<DataProductAttachment> {
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
     if (KIND !in kinds) return emptyList()
     val state = subscriptions[previewId] ?: return emptyList()
     // Bump the input-seq counter once per attachment build — that's exactly one per
@@ -219,8 +215,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     // DataProductRegistry.onSubscribe contract: "Producers that need 'reset on re-subscribe'
     // semantics use that as the signal."
     subscriptions.remove(previewId)?.disposeObserver()
-    val state =
-      SubscriptionState(frameStreamId = frameStreamId, mode = effectiveMode)
+    val state = SubscriptionState(frameStreamId = frameStreamId, mode = effectiveMode)
     subscriptions[previewId] = state
     if (effectiveMode == MODE_DELTA) {
       val scene = liveScenes[previewId]
@@ -236,17 +231,17 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
   }
 
   /**
-   * [DesktopHost.InteractiveSessionListener] entry point — wires this producer into the held-
-   * scene lifecycle so the observer install path can fire on session-up *or* on a
+   * [DesktopHost.InteractiveSessionListener] entry point — wires this producer into the held- scene
+   * lifecycle so the observer install path can fire on session-up *or* on a
    * subscribe-while-snapshot promotion. Idempotent.
    *
    * - `scene != null` → session acquired. Track in [liveScenes]. If a delta-mode subscription
    *   already exists for [previewId], install the observer now. If a snapshot-mode subscription
-   *   exists, replace it with a fresh delta entry and install — the panel asked for delta but
-   *   the daemon couldn't honour it at subscribe time; promote on session-up.
-   * - `scene == null` → session released. Drop from [liveScenes] and dispose the observer
-   *   handle (subscription state itself stays so `attachmentsFor` keeps shipping empty
-   *   payloads until the client unsubscribes).
+   *   exists, replace it with a fresh delta entry and install — the panel asked for delta but the
+   *   daemon couldn't honour it at subscribe time; promote on session-up.
+   * - `scene == null` → session released. Drop from [liveScenes] and dispose the observer handle
+   *   (subscription state itself stays so `attachmentsFor` keeps shipping empty payloads until the
+   *   client unsubscribes).
    */
   fun onSessionLifecycle(previewId: String, scene: ImageComposeScene?) {
     if (scene == null) {
@@ -278,9 +273,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
             val key = System.identityHashCode(scope)
             state.counters.merge(key, 1, Int::plus)
           },
-          onScopeDisposed = { scope ->
-            state.counters.remove(System.identityHashCode(scope))
-          },
+          onScopeDisposed = { scope -> state.counters.remove(System.identityHashCode(scope)) },
         )
       } catch (t: Throwable) {
         // The brief mandates LinkageError / NoSuchMethodError specifically; we widen to any
@@ -300,16 +293,16 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
   }
 
   /**
-   * The actual observer install. Walks `ImageComposeScene.scene` (BaseComposeScene) →
-   * `recomposer` (ComposeSceneRecomposer) → `recomposer` (androidx.compose.runtime.Recomposer)
-   * via reflection on the private fields, then registers a [CompositionRegistrationObserver]
-   * which calls [ObservableComposition.setObserver] for each existing + future composition.
+   * The actual observer install. Walks `ImageComposeScene.scene` (BaseComposeScene) → `recomposer`
+   * (ComposeSceneRecomposer) → `recomposer` (androidx.compose.runtime.Recomposer) via reflection on
+   * the private fields, then registers a [CompositionRegistrationObserver] which calls
+   * [ObservableComposition.setObserver] for each existing + future composition.
    *
-   * The walk is reflective because Compose UI doesn't expose the held [Recomposer] publicly —
-   * see the discussion in [RecompositionDataProductRegistry] KDoc. The
+   * The walk is reflective because Compose UI doesn't expose the held [Recomposer] publicly — see
+   * the discussion in [RecompositionDataProductRegistry] KDoc. The
    * `addCompositionRegistrationObserver$runtime` path the public `Recomposer.observe` extension
-   * delegates to also reports every *currently registered* composition synchronously, so even
-   * a subscribe-after-render install picks up the live composition tree on the same call.
+   * delegates to also reports every *currently registered* composition synchronously, so even a
+   * subscribe-after-render install picks up the live composition tree on the same call.
    */
   @OptIn(ExperimentalComposeRuntimeApi::class)
   protected open fun installObserver(
@@ -321,9 +314,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     val perCompositionHandles = mutableListOf<CompositionObserverHandle>()
     val perCompositionObserver =
       object : CompositionObserver {
-        override fun onBeginComposition(
-          composition: ObservableComposition,
-        ) {
+        override fun onBeginComposition(composition: ObservableComposition) {
           // No-op — we count post-recomposition via onScopeExit. onBeginComposition fires once
           // per composition cycle (not per scope) so it doesn't carry the per-scope info.
         }
@@ -343,9 +334,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
           onScopeRecomposed(scope)
         }
 
-        override fun onEndComposition(
-          composition: ObservableComposition,
-        ) {
+        override fun onEndComposition(composition: ObservableComposition) {
           // No-op for v1. A future "settle frame" hook could batch counts here, but the
           // attachmentsFor seam already runs once per renderFinished so there's nothing to add.
         }
@@ -400,12 +389,12 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
    * Reflectively reach the [androidx.compose.runtime.Recomposer] that drives [scene]'s held
    * composition. The chain is:
    *
-   * `ImageComposeScene` (public) → field `scene: ComposeScene` (private) →
-   * concrete `BaseComposeScene` → field `recomposer: ComposeSceneRecomposer` (private) →
-   * field `recomposer: Recomposer` (private).
+   * `ImageComposeScene` (public) → field `scene: ComposeScene` (private) → concrete
+   * `BaseComposeScene` → field `recomposer: ComposeSceneRecomposer` (private) → field `recomposer:
+   * Recomposer` (private).
    *
-   * Throws on any link breaking — caller wraps in the LinkageError/NoSuchMethodError safety
-   * net so a future Compose-UI refactor degrades to "instrumentation unavailable".
+   * Throws on any link breaking — caller wraps in the LinkageError/NoSuchMethodError safety net so
+   * a future Compose-UI refactor degrades to "instrumentation unavailable".
    */
   private fun reflectRecomposer(scene: ImageComposeScene): androidx.compose.runtime.Recomposer {
     val sceneField = ImageComposeScene::class.java.getDeclaredField("scene")
@@ -421,8 +410,7 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
     val recomposerField = findDeclaredField(sceneRecomposer.javaClass, "recomposer")
     recomposerField.isAccessible = true
     val recomposer =
-      recomposerField.get(sceneRecomposer)
-        ?: error("ComposeSceneRecomposer.recomposer was null")
+      recomposerField.get(sceneRecomposer) ?: error("ComposeSceneRecomposer.recomposer was null")
     return recomposer as androidx.compose.runtime.Recomposer
   }
 
@@ -494,16 +482,16 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
 
     /**
      * Render mode tag the dispatcher forwards to the renderer-agnostic seam when this producer
-     * returns [DataProductRegistry.Outcome.RequiresRerender]. Renderer-side wiring of this tag
-     * is a follow-up — the desktop renderer doesn't yet write a recomposition sidecar — so
-     * snapshot fetches today complete the budget timer without producing a payload.
+     * returns [DataProductRegistry.Outcome.RequiresRerender]. Renderer-side wiring of this tag is a
+     * follow-up — the desktop renderer doesn't yet write a recomposition sidecar — so snapshot
+     * fetches today complete the budget timer without producing a payload.
      */
     const val MODE_RECOMPOSITION_RENDER: String = "recomposition"
 
     /**
-     * `encodeDefaults = true` so empty `nodes: []` lists ride the wire instead of being
-     * dropped — clients that read `nodes.length` on every payload can rely on the field's
-     * presence regardless of whether instrumentation is unavailable or just no-op-this-frame.
+     * `encodeDefaults = true` so empty `nodes: []` lists ride the wire instead of being dropped —
+     * clients that read `nodes.length` on every payload can rely on the field's presence regardless
+     * of whether instrumentation is unavailable or just no-op-this-frame.
      */
     private val json = Json {
       encodeDefaults = true
@@ -513,14 +501,14 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
 }
 
 /**
- * Wire shape for `compose/recomposition` payloads (schemaVersion=1). Mirrors the JSON the
- * VS Code panel's heat-map overlay decodes. See
+ * Wire shape for `compose/recomposition` payloads (schemaVersion=1). Mirrors the JSON the VS Code
+ * panel's heat-map overlay decodes. See
  * [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md) §
  * "Recomposition + interactive mode".
  *
- * [sinceFrameStreamId] / [inputSeq] are populated only in delta mode — the snapshot mode is
- * a one-shot answer to "what recomposed during the initial composition" with no temporal
- * baseline to track.
+ * [sinceFrameStreamId] / [inputSeq] are populated only in delta mode — the snapshot mode is a
+ * one-shot answer to "what recomposed during the initial composition" with no temporal baseline to
+ * track.
  */
 @Serializable
 data class RecompositionPayload(
@@ -534,8 +522,8 @@ data class RecompositionPayload(
 data class RecompositionNode(
   /**
    * Identity-hashcode-of-RecomposeScope encoded as base-16 — stable for the duration of one
-   * interactive session. NOT stable across sessions. See [RecompositionDataProductRegistry]
-   * KDoc for the v2 followup (slot-table-derived `(file:line:column)` keys).
+   * interactive session. NOT stable across sessions. See [RecompositionDataProductRegistry] KDoc
+   * for the v2 followup (slot-table-derived `(file:line:column)` keys).
    */
   val nodeId: String,
   val count: Int,

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecompositionDataProductRegistryTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RecompositionDataProductRegistryTest.kt
@@ -22,27 +22,26 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 
 /**
- * D5 — pins the `compose/recomposition` producer's contract for the desktop interactive
- * surface. See [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md)
- * § "Recomposition + interactive mode".
+ * D5 — pins the `compose/recomposition` producer's contract for the desktop interactive surface.
+ * See [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md) §
+ * "Recomposition + interactive mode".
  *
  * Three scenarios:
  *
- * 1. **Capabilities + delta-mode happy path** — the producer advertises
- *    `compose/recomposition` with `requiresRerender=true`, then a stateful preview
- *    ([ClickRecomposingSquare]) attaches a non-empty counter payload after a click. The
- *    second post-click attachment carries strictly fewer counts than the first (the delta
- *    has been reset between flushes), proving the inputSeq increments and counters reset.
+ * 1. **Capabilities + delta-mode happy path** — the producer advertises `compose/recomposition`
+ *    with `requiresRerender=true`, then a stateful preview ([ClickRecomposingSquare]) attaches a
+ *    non-empty counter payload after a click. The second post-click attachment carries strictly
+ *    fewer counts than the first (the delta has been reset between flushes), proving the inputSeq
+ *    increments and counters reset.
  * 2. **`mode=delta` against a non-live preview** — the producer falls back to snapshot at
- *    `onSubscribe` (per the D5 brief), so attachments still ship but with an empty payload
- *    until a live session arrives.
+ *    `onSubscribe` (per the D5 brief), so attachments still ship but with an empty payload until a
+ *    live session arrives.
  * 3. **Safety net** — when observer install throws (simulated by closing the scene before
  *    onSubscribe so reflection sees a torn-down state), the subscription still succeeds and
  *    `attachmentsFor` ships an empty `nodes: []` payload. The daemon doesn't crash.
  *
  * Driven against a real [DesktopHost] + [DesktopInteractiveSession] so the end-to-end Compose
- * runtime path (Recomposer, CompositionObserver, Modifier.clickable, mutableStateOf) is
- * covered.
+ * runtime path (Recomposer, CompositionObserver, Modifier.clickable, mutableStateOf) is covered.
  */
 class RecompositionDataProductRegistryTest {
 
@@ -99,11 +98,10 @@ class RecompositionDataProductRegistryTest {
         // Subscribe with delta mode AFTER the session is live — the listener has already
         // populated liveScenes for FIXTURE_PREVIEW_ID, so onSubscribe installs the observer
         // immediately rather than going through the snapshot-promotion path.
-        val subscribeParams =
-          buildJsonObject {
-            put("frameStreamId", JsonPrimitive("test-stream-1"))
-            put("mode", JsonPrimitive("delta"))
-          }
+        val subscribeParams = buildJsonObject {
+          put("frameStreamId", JsonPrimitive("test-stream-1"))
+          put("mode", JsonPrimitive("delta"))
+        }
         registry.onSubscribe(FIXTURE_PREVIEW_ID, "compose/recomposition", subscribeParams)
 
         // 1. Bootstrap render — initial composition runs the ClickRecomposingSquare body once.
@@ -139,14 +137,8 @@ class RecompositionDataProductRegistryTest {
         assertNotNull("delta payload must travel inline", postClick.payload)
         assertNull("compose/recomposition is INLINE-only; path must be null", postClick.path)
         val payload = postClick.payload!!.jsonObject
-        assertEquals(
-          "delta",
-          payload["mode"]?.jsonPrimitive?.content,
-        )
-        assertEquals(
-          "test-stream-1",
-          payload["sinceFrameStreamId"]?.jsonPrimitive?.content,
-        )
+        assertEquals("delta", payload["mode"]?.jsonPrimitive?.content)
+        assertEquals("test-stream-1", payload["sinceFrameStreamId"]?.jsonPrimitive?.content)
         // Two flushes have happened by now (the bootstrap-only and the post-click one), so
         // inputSeq is 2.
         assertEquals(
@@ -195,11 +187,10 @@ class RecompositionDataProductRegistryTest {
     // the subscription as snapshot. attachmentsFor still ships a payload (the brief: "advertise
     // but useless") with mode=snapshot and empty nodes.
     val registry = RecompositionDataProductRegistry()
-    val params =
-      buildJsonObject {
-        put("frameStreamId", JsonPrimitive("non-live-stream"))
-        put("mode", JsonPrimitive("delta"))
-      }
+    val params = buildJsonObject {
+      put("frameStreamId", JsonPrimitive("non-live-stream"))
+      put("mode", JsonPrimitive("delta"))
+    }
     registry.onSubscribe("non-live-preview", "compose/recomposition", params)
     val attachments = registry.attachmentsFor("non-live-preview", setOf("compose/recomposition"))
     assertEquals(1, attachments.size)
@@ -209,22 +200,17 @@ class RecompositionDataProductRegistryTest {
       "snapshot",
       payload["mode"]?.jsonPrimitive?.content,
     )
-    assertEquals(
-      "no live observer → no nodes",
-      0,
-      payload["nodes"]?.jsonArray?.size,
-    )
+    assertEquals("no live observer → no nodes", 0, payload["nodes"]?.jsonArray?.size)
     registry.onUnsubscribe("non-live-preview", "compose/recomposition")
   }
 
   @Test
   fun fetch_delta_against_non_live_preview_returns_not_available() {
     val registry = RecompositionDataProductRegistry()
-    val params =
-      buildJsonObject {
-        put("frameStreamId", JsonPrimitive("nope"))
-        put("mode", JsonPrimitive("delta"))
-      }
+    val params = buildJsonObject {
+      put("frameStreamId", JsonPrimitive("nope"))
+      put("mode", JsonPrimitive("delta"))
+    }
     val outcome =
       registry.fetch(
         previewId = "no-such-preview",
@@ -249,10 +235,7 @@ class RecompositionDataProductRegistryTest {
       "snapshot fetch must require a re-render in mode=recomposition; got $outcome",
       outcome is DataProductRegistry.Outcome.RequiresRerender,
     )
-    assertEquals(
-      "recomposition",
-      (outcome as DataProductRegistry.Outcome.RequiresRerender).mode,
-    )
+    assertEquals("recomposition", (outcome as DataProductRegistry.Outcome.RequiresRerender).mode)
   }
 
   @Test
@@ -278,21 +261,16 @@ class RecompositionDataProductRegistryTest {
       }
     val previewId = "preview-with-broken-instrumentation"
     val scene =
-      ImageComposeScene(
-        width = 32,
-        height = 32,
-        density = androidx.compose.ui.unit.Density(1.0f),
-      ) {
+      ImageComposeScene(width = 32, height = 32, density = androidx.compose.ui.unit.Density(1.0f)) {
         // Empty content — we just need a real scene to feed onSessionLifecycle, the override
         // above is what intercepts and throws.
       }
     try {
       registry.onSessionLifecycle(previewId, scene)
-      val params =
-        buildJsonObject {
-          put("frameStreamId", JsonPrimitive("broken-stream"))
-          put("mode", JsonPrimitive("delta"))
-        }
+      val params = buildJsonObject {
+        put("frameStreamId", JsonPrimitive("broken-stream"))
+        put("mode", JsonPrimitive("delta"))
+      }
       // The subscribe call must NOT propagate the LinkageError — that's the load-bearing
       // assertion. If the safety net is missing, this line throws and the test fails before
       // reaching any of the assertions below.

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -106,16 +106,16 @@ fun ClickToggleSquare() {
 }
 
 /**
- * D5 fixture for `RecompositionDataProductRegistryTest`. Exposes a `clicks` mutableStateOf
- * that increments on every press; the inner [androidx.compose.runtime.key]-keyed scope reads
- * `clicks` so it recomposes once per click. The Compose runtime's
- * [androidx.compose.runtime.tooling.CompositionObserver] sees that recomposition as a
- * onScopeExit on the inner block, which the producer counts.
+ * D5 fixture for `RecompositionDataProductRegistryTest`. Exposes a `clicks` mutableStateOf that
+ * increments on every press; the inner [androidx.compose.runtime.key]-keyed scope reads `clicks` so
+ * it recomposes once per click. The Compose runtime's
+ * [androidx.compose.runtime.tooling.CompositionObserver] sees that recomposition as a onScopeExit
+ * on the inner block, which the producer counts.
  *
- * Whole-card pointerInput (matches `ClickToggleSquare`'s pattern) so click coords don't
- * matter — the test cares about "did exactly one click cause exactly one recomposition of a
- * recognisable scope?", not pixel routing. Background colour shifts subtly per click so a
- * future pixel-diff regression would flag if the click stopped reaching the composition.
+ * Whole-card pointerInput (matches `ClickToggleSquare`'s pattern) so click coords don't matter —
+ * the test cares about "did exactly one click cause exactly one recomposition of a recognisable
+ * scope?", not pixel routing. Background colour shifts subtly per click so a future pixel-diff
+ * regression would flag if the click stopped reaching the composition.
  */
 @Composable
 fun ClickRecomposingSquare() {


### PR DESCRIPTION
## Summary

PR A of [INTERACTIVE-ANDROID.md § 10](docs/daemon/INTERACTIVE-ANDROID.md). Lands the cross-classloader wire shape so PR B (held-rule loop + `AndroidInteractiveSession`) doesn't have to widen the bridge surface mid-rollout.

The empirical probe on `agent/interactive-android-probe` already confirmed the open question from § 11.1 — held `createAndroidComposeRule` + paused `mainClock` + `decorView.dispatchTouchEvent` + `captureRoboImage` recapture works (first frame 100% red, second frame 100% green after dispatched click). v3 sandbox-pinning is empirically sound; this PR is the safe wire-only landing.

### What's in `feat`

In the `bridge` package (do-not-acquire under `SandboxHoldingRunner`):

- `InteractiveCommand` sealed interface — `Start` / `Dispatch` / `Render` / `Close`. Carries only `java.*` and bridge-package types so it crosses the sandbox boundary unchanged. Pixel coords are primitives; the sandbox synthesises the `MotionEvent` itself in PR B.
- `SandboxSlot.interactiveCommands: LinkedBlockingQueue<InteractiveCommand>` — allocated per slot (slot 0 eager, every standalone slot from `configureSlotCount`).
- `DaemonHostBridge.reset()` drains slot 0's interactive queue so a previous host lifecycle's leftover commands don't leak forward.

`InteractiveCommandTest` (3 tests, plain JUnit) covers:
1. FIFO round-trip across all four variants, with `replyLatch` / `replyError` reference identity preserved.
2. `reset()` empties leftover commands.
3. `configureSlotCount(2)` allocates an isolated queue per standalone slot.

### What's not yet wired

- No host-side enqueue path — PR B adds `AndroidInteractiveSession` and the `acquireInteractiveSession` override.
- No sandbox-side drain — `SandboxRunner.holdSandboxOpen` keeps its current request-only loop. PR B grows the interactive branch.
- `supportsInteractive` stays at the inherited `false`, `acquireInteractiveSession` still throws `Unsupported`. The capability bit flips when PR B's drain ships.

### `chore` commit (separable)

`chore(daemon): apply ktfmt to desktop sources` — pre-existing ktfmt drift on main was blocking `ktfmtCheckAll` (the repo's pre-commit hook scans the whole repo, not just changed files). Pure formatting churn on five `:daemon:desktop` files; no behaviour change. Happy to land it as its own PR first if you'd prefer the `feat` PR to stand alone.

## Test plan

- [x] `:daemon:android:testDebugUnitTest` — full module suite green, including the 3 new `InteractiveCommandTest` cases
- [x] `:daemon:android:ktfmtCheck` clean
- [x] `:daemon:harness:compileTestKotlin` + `:daemon:core:test` — downstream consumers unaffected (all bridge changes are purely additive: new sealed interface, new field with default value)
- [ ] Optional: rebase PR B on top of this once landed and re-run the probe + integration tests


---
_Generated by [Claude Code](https://claude.ai/code/session_017NDGZk17VhvctNNoSrVZsK)_