### PR TITLE
feat(daemon): per-render captureAdvanceMs override + bumpable maxRenderMs

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -107,6 +107,9 @@ class PreviewManifestRouter(
             inbound["fontScale"]?.let { append("fontScale=").append(it).append(';') }
             inbound["uiMode"]?.let { append("uiMode=").append(it).append(';') }
             inbound["orientation"]?.let { append("orientation=").append(it).append(';') }
+            inbound["captureAdvanceMs"]?.let {
+              append("captureAdvanceMs=").append(it).append(';')
+            }
             append("outputBaseName=").append(resolved.outputBaseName)
           },
       )

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -221,7 +221,9 @@ class RenderEngine(
             // CAPTURE_ADVANCE_MS is the same paused-clock advance `RobolectricRenderTest` uses —
             // ≈ 2 Choreographer frames. Enough to settle initial composition + one
             // `LaunchedEffect` pass; deterministic snapshot point for any infinite animation.
-            rule.mainClock.advanceTimeBy(CAPTURE_ADVANCE_MS)
+            // PROTOCOL.md § 5 (`renderNow.overrides.captureAdvanceMs`) — animation-heavy
+            // previews can override.
+            rule.mainClock.advanceTimeBy(spec.captureAdvanceMs ?: CAPTURE_ADVANCE_MS)
 
             outputFile.parentFile?.mkdirs()
             // `applyDeviceCrop = true` is what produces the circular alpha mask Roborazzi paints
@@ -273,7 +275,7 @@ class RenderEngine(
             // to disposal. Wrapped in try/catch so a thrown render body doesn't strand the next
             // render at a bad clock state.
             try {
-              rule.mainClock.advanceTimeBy(CAPTURE_ADVANCE_MS)
+              rule.mainClock.advanceTimeBy(spec.captureAdvanceMs ?: CAPTURE_ADVANCE_MS)
             } catch (t: Throwable) {
               System.err.println(
                 "RenderEngine: post-capture mainClock advance failed for ${spec.className}.${spec.functionName}: ${t.message}"
@@ -472,6 +474,13 @@ data class RenderSpec(
   val uiMode: SpecUiMode? = null,
   /** Portrait/landscape override → `port` / `land` qualifier. Overrides the size-derived guess. */
   val orientation: SpecOrientation? = null,
+  /**
+   * Paused-clock advance (ms) before capture. Null defaults to [CAPTURE_ADVANCE_MS]; values
+   * `<= 0` are treated as null (default). Routes per-render via PROTOCOL.md § 5
+   * (`renderNow.overrides.captureAdvanceMs`); animation-heavy previews can request a longer
+   * settle window without editing the render body.
+   */
+  val captureAdvanceMs: Long? = null,
 ) {
 
   enum class SpecUiMode {
@@ -532,6 +541,7 @@ data class RenderSpec(
             "landscape" -> SpecOrientation.LANDSCAPE
             else -> null
           },
+        captureAdvanceMs = map["captureAdvanceMs"]?.toLongOrNull()?.takeIf { it > 0L },
       )
     }
   }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -122,6 +122,7 @@ open class RobolectricHost(
       "uiMode",
       "orientation",
       "device",
+      "captureAdvanceMs",
     )
 
   /** PROTOCOL.md § 3 — android backend identifier surfaced via `capabilities.backend`. */

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -167,6 +167,43 @@ class OverrideIntegrationTest {
     }
   }
 
+  @Test
+  fun captureAdvanceMsOverrideThreadsThroughTheRenderPath() {
+    // PROTOCOL.md § 5 (`renderNow.overrides.captureAdvanceMs`) — the override should reach the
+    // Android RenderEngine's `mainClock.advanceTimeBy(...)` call site without breaking the
+    // render. Smoke test only — verifying the actual paused-clock effect needs a fixture with a
+    // `LaunchedEffect`-driven state flip and per-frame mainClock alignment, which is fragile in
+    // a single-pass integration test. The wire round-trip + parser are covered by MessagesTest.
+    val outputDir = tempFolder.newFolder("renders-advance")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = "red-square",
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "RedSquare",
+              widthPx = 32,
+              heightPx = 32,
+              density = 1.0f,
+              outputBaseName = "red-advance",
+            )
+          )
+      )
+    val host = PreviewManifestRouter(manifest = manifest)
+    host.start()
+    try {
+      val img =
+        renderAndDecode(host, "previewId=red-square;captureAdvanceMs=200", "advance-200")
+      assertEquals(32, img.width)
+      assertEquals(32, img.height)
+    } finally {
+      host.shutdown()
+    }
+  }
+
   /**
    * Asserts [actual] is within ±4px of [expected]. The Android backend's qualifier path round-trips
    * px → dp (via integer division) → px again inside `applyPreviewQualifiers`, so a request for

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -270,6 +270,15 @@ class JsonRpcServer(
   @Volatile private var globalAttachKinds: Set<String> = emptySet()
 
   /**
+   * Per-render timeout (ms) the daemon enforces on `host.submit(...)`. Defaults to
+   * [DEFAULT_RENDER_TIMEOUT_MS] (5 minutes — generous enough for Robolectric cold-sandbox bootstrap
+   * plus a heavy render). Overridden at handshake time by `initialize.options.maxRenderMs` if
+   * positive; values ≤ 0 are ignored and the default applies. See PROTOCOL.md § 3
+   * (`initialize.options.maxRenderMs`).
+   */
+  @Volatile private var renderTimeoutMs: Long = DEFAULT_RENDER_TIMEOUT_MS
+
+  /**
    * D1 — sticky `(previewId, kind)` subscriptions installed by `data/subscribe`. The map is keyed
    * by previewId so [setVisible] can drop entries for previews that are no longer on screen — see
    * [pruneSubscriptionsToVisible]. Inner sets are wrapped via [ConcurrentHashMap.newKeySet] so
@@ -565,6 +574,9 @@ class JsonRpcServer(
     val attachableKinds = dataProducts.capabilities.filter { it.attachable }.map { it.kind }.toSet()
     globalAttachKinds =
       (params.options?.attachDataProducts ?: emptyList()).toSet().intersect(attachableKinds)
+    // PROTOCOL.md § 3 — per-render timeout override. Positive values win; null / ≤ 0 keeps the
+    // 5-minute default. Survives across renders for this client's session lifetime.
+    params.options?.maxRenderMs?.takeIf { it > 0 }?.let { renderTimeoutMs = it }
     val result =
       InitializeResult(
         protocolVersion = PROTOCOL_VERSION,
@@ -723,7 +735,7 @@ class JsonRpcServer(
             val raw =
               host.submit(
                 RenderRequest.Render(id = hostId, payload = payload),
-                timeoutMs = 5 * 60_000,
+                timeoutMs = renderTimeoutMs,
               )
             renderResultsQueue.put(raw)
           } catch (e: Throwable) {
@@ -800,6 +812,12 @@ class JsonRpcServer(
         ?.let {
           if (isNotEmpty()) append(';')
           append("device=").append(it)
+        }
+      overrides.captureAdvanceMs
+        ?.takeIf { it > 0L }
+        ?.let {
+          if (isNotEmpty()) append(';')
+          append("captureAdvanceMs=").append(it)
         }
     }
   }
@@ -1519,7 +1537,7 @@ class JsonRpcServer(
             val raw =
               host.submit(
                 RenderRequest.Render(id = hostId, payload = payload),
-                timeoutMs = 5 * 60_000,
+                timeoutMs = renderTimeoutMs,
               )
             renderResultsQueue.put(raw)
           } catch (e: Throwable) {
@@ -2414,6 +2432,13 @@ class JsonRpcServer(
      * but the shutdown response will be sent.
      */
     private const val DRAIN_TIMEOUT_MS: Long = 60_000L
+
+    /**
+     * Default per-render `host.submit(...)` timeout — 5 minutes. Generous enough for the first
+     * render in a daemon's life (Robolectric cold sandbox bootstrap, ~5–15s) plus a heavy
+     * single-render render body. Overridable per-session via `initialize.options.maxRenderMs`.
+     */
+    const val DEFAULT_RENDER_TIMEOUT_MS: Long = 5 * 60_000L
 
     private const val DEFAULT_DAEMON_VERSION: String = "0.0.0-dev"
     private const val DEFAULT_HISTORY_DIR: String = ".compose-preview-history"

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -87,6 +87,14 @@ data class Options(
   // docs/daemon/DATA-PRODUCTS.md § "Wire surface". Most clients leave this
   // null/empty and use `data/subscribe` for sticky-while-visible attachment.
   val attachDataProducts: List<String>? = null,
+  /**
+   * Per-render timeout (in milliseconds) the daemon enforces on every `host.submit(...)` call for
+   * this client's session. Defaults to 5 minutes (`5 * 60_000`) — generous enough for Robolectric
+   * cold-sandbox bootstrap (5–15s) plus any single render. Bump for CI-style runs that render many
+   * heavy previews and want headroom; lower for interactive sessions that prefer a fast failure
+   * over a long hang. Values ≤ 0 fall back to the default.
+   */
+  val maxRenderMs: Long? = null,
 )
 
 @Serializable
@@ -282,6 +290,16 @@ data class PreviewOverrides(
    * Unknown device ids fall back to the default (400×800 dp at xxhdpi).
    */
   val device: String? = null,
+  /**
+   * Paused-clock advance (in milliseconds) before the renderer captures the PNG. Android-only today
+   * — the Robolectric backend uses `mainClock.advanceTimeBy(...)` to tick a deterministic snapshot
+   * point past initial composition + any `LaunchedEffect` settle. Default (~32ms ≈ 2 Choreographer
+   * frames) is enough for static previews and one `LaunchedEffect` pass; bump for animation-heavy
+   * previews that need longer to settle (e.g. staged enter animations, `rememberInfiniteTransition`
+   * chains where you want a specific phase). Values ≤ 0 fall back to the default. Desktop ignores
+   * it (no paused-clock concept).
+   */
+  val captureAdvanceMs: Long? = null,
 )
 
 @Serializable

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -98,6 +98,7 @@ class PreviewManifestRouter(
             inbound["fontScale"]?.let { append("fontScale=").append(it).append(';') }
             inbound["uiMode"]?.let { append("uiMode=").append(it).append(';') }
             inbound["orientation"]?.let { append("orientation=").append(it).append(';') }
+            inbound["captureAdvanceMs"]?.let { append("captureAdvanceMs=").append(it).append(';') }
             append("outputBaseName=").append(resolved.outputBaseName)
           },
       )

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -103,6 +103,8 @@ Params:
     warmSpare?: boolean;
     detectLeaks?: "off" | "light" | "heavy";
     foreground?: boolean;            // true when launched via `--foreground`
+    maxRenderMs?: number;            // per-render host.submit timeout. Default 5*60_000;
+                                     // values ≤ 0 are ignored.
   };
 }
 ```
@@ -221,6 +223,8 @@ A `classpath` event triggers Tier-1 fingerprint recomputation; on mismatch the d
   device?: string;                   // "id:pixel_5", "id:wearos_small_round", "spec:width=400dp,height=800dp,dpi=320".
                                      // Resolved by the daemon's catalog into widthPx/heightPx/density;
                                      // explicit widthPx/heightPx/density above take precedence.
+  captureAdvanceMs?: number;         // Paused-clock advance (ms) before capture. Android-only;
+                                     // default ≈ 32ms. Bump for animation-heavy previews.
 }
 
 // result

--- a/docs/daemon/protocol-fixtures/client-initialize.json
+++ b/docs/daemon/protocol-fixtures/client-initialize.json
@@ -12,6 +12,7 @@
     "maxHeapMb": 1024,
     "warmSpare": true,
     "detectLeaks": "light",
-    "foreground": false
+    "foreground": false,
+    "maxRenderMs": 600000
   }
 }

--- a/docs/daemon/protocol-fixtures/client-renderNow-overrides.json
+++ b/docs/daemon/protocol-fixtures/client-renderNow-overrides.json
@@ -10,6 +10,7 @@
     "fontScale": 1.3,
     "uiMode": "dark",
     "orientation": "portrait",
-    "device": "id:pixel_5"
+    "device": "id:pixel_5",
+    "captureAdvanceMs": 250
   }
 }

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -80,6 +80,14 @@ export interface InitializeParams {
          * See `docs/daemon/DATA-PRODUCTS.md` § "Wire surface".
          */
         attachDataProducts?: string[];
+        /**
+         * Per-render `host.submit(...)` timeout (ms) the daemon enforces for this client's
+         * session. Defaults to 5 minutes (`5 * 60_000`) — generous enough for Robolectric
+         * cold-sandbox bootstrap plus any single render. Bump for CI-style runs that render
+         * many heavy previews and want headroom; lower for interactive sessions that prefer
+         * a fast failure over a long hang. Values ≤ 0 fall back to the default.
+         */
+        maxRenderMs?: number;
     };
 }
 
@@ -217,6 +225,12 @@ export interface PreviewOverrides {
      * on this same object take precedence.
      */
     device?: string;
+    /**
+     * Paused-clock advance (ms) before capture — Android-only today. Default ≈ 32ms (≈ 2
+     * Choreographer frames); bump for animation-heavy previews that need longer to settle.
+     * Values ≤ 0 fall back to the default. Desktop ignores it.
+     */
+    captureAdvanceMs?: number;
 }
 
 export interface RenderNowParams {


### PR DESCRIPTION
## Summary

Two related timing knobs that used to be hardcoded constants. Surfaces both on the wire so callers can tune them per render or per session without editing daemon code.

### `PreviewOverrides.captureAdvanceMs` (per-render, Android-only)

The paused-clock advance Android's `RenderEngine` uses before capturing the PNG. Default ~32ms (≈ 2 Choreographer frames) is fine for static previews + one `LaunchedEffect` pass; bump for animation-heavy previews that need a longer settle window (staged enter animations, `rememberInfiniteTransition` chains where you want a specific phase).

- Threaded through `JsonRpcServer.encodeRenderPayload`, both `PreviewManifestRouter`s (Android + Desktop), and `RenderSpec.parseFromPayloadOrNull`.
- Both `mainClock.advanceTimeBy(...)` sites in Android's render body (pre-capture + post-capture cleanup) honour the override.
- Desktop ignores it (no paused-clock concept). `RobolectricHost.supportedOverrides` advertises it; `DesktopHost`'s set doesn't change.

### `Options.maxRenderMs` (per-session)

Overrides the daemon's `host.submit(...)` timeout, today hardcoded at 5 minutes in two places (`submitRenderAsync` + `submitRerenderForFetch`). CI-style runs that render many heavy previews can bump for headroom; interactive sessions that prefer a fast failure over a long hang can lower. Read at initialize time and stored in `JsonRpcServer.renderTimeoutMs`. Values ≤ 0 fall back to the new `DEFAULT_RENDER_TIMEOUT_MS` constant (5*60_000 ms).

## Test plan

- [x] `:daemon:core:test` — 155/155 pass (incl. `MessagesTest` round-trip on the updated `client-renderNow-overrides.json` and `client-initialize.json` fixtures)
- [x] `:daemon:desktop:test`, `:mcp:test` — 232 JVM tests total pass
- [x] `:daemon:android:testDebugUnitTest --tests OverrideIntegrationTest` — 4/4 pass including new `captureAdvanceMsOverrideThreadsThroughTheRenderPath` smoke case
- [x] `ktfmtCheckAll` — clean

## Notes

- The captureAdvanceMs integration test is a smoke case (verifies the override threads through end-to-end without breaking the render). The pixel-level behavioural effect needs a fixture with `LaunchedEffect`-driven state flips and per-frame `mainClock` alignment, which is fragile in a single-pass test. The wire shape and parser are covered by `MessagesTest`'s round-trip on the updated fixture.
- TS protocol mirrors land in lockstep with the Kotlin types (same fixtures drive both).
- Defaulted nullable fields so pre-feature daemons + clients keep working unchanged — same convention as every other PR in this thread.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmHMG3rJrJowyM15hK2Bow)_