### PR TITLE
feat(daemon): wire v3 Android-interactive held-rule loop

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -1,0 +1,323 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.bridge.DaemonHostBridge
+import ee.schimke.composeai.daemon.bridge.InteractiveCommand
+import ee.schimke.composeai.daemon.bridge.SandboxSlot
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Android (Robolectric) [InteractiveSession]. Mirrors `:daemon:desktop`'s
+ * [DesktopInteractiveSession] at the protocol surface; the difference is all in cross-classloader
+ * marshalling — Compose pointer / Roborazzi capture types can't cross the sandbox boundary, so
+ * `dispatch` / `render` ride [InteractiveCommand] envelopes through the
+ * [bridge.DaemonHostBridge] and the actual `MotionEvent.dispatchTouchEvent` +
+ * `captureRoboImage` happens inside the sandbox-side [RobolectricHost.SandboxRunner.runHeldInteractiveSession]
+ * loop.
+ *
+ * **Sandbox pinning** (INTERACTIVE-ANDROID.md § 2). Each session pins exactly one sandbox slot for
+ * its lifetime. v3 ships with `INTERACTIVE_SLOT_INDEX = 1` so slot 0 stays the always-on
+ * normal-render slot — that's enforced host-side in [RobolectricHost.acquireInteractiveSession]
+ * (the constraint that `sandboxCount >= 2`). The session itself is slot-agnostic; it only carries
+ * a reference to the slot it was constructed against.
+ *
+ * **Threading.** Per the [InteractiveSession] contract, callers are serialised — `JsonRpcServer`
+ * dispatches one input per session at a time. Each public method enqueues an
+ * [InteractiveCommand] and blocks the caller's thread on the per-command reply latch (or, for
+ * [render], on the shared [DaemonHostBridge.results] queue). The sandbox-side held-rule statement
+ * is single-threaded by construction (one `evaluate()` call), so command ordering on the wire
+ * matches dispatch order in the composition.
+ *
+ * **Lifecycle** (INTERACTIVE-ANDROID.md § 7).
+ * - **Allocate** at `interactive/start`. The host enqueues [InteractiveCommand.Start] onto slot 1's
+ *   [SandboxSlot.interactiveCommands]; the sandbox's idle loop picks it up and enters
+ *   `runHeldInteractiveSession`, which constructs the rule + ActivityScenario + paused-clock
+ *   `setContent`, then counts down [InteractiveCommand.Start.replyLatch] before draining further
+ *   commands. The host blocks on that latch in [RobolectricHost.acquireInteractiveSession] so
+ *   `interactive/start` only returns after `setContent` has landed.
+ * - **Drive** at `interactive/input` and `renderNow` while held. [dispatch] enqueues
+ *   [InteractiveCommand.Dispatch] (synthesised `MotionEvent`); [render] enqueues
+ *   [InteractiveCommand.Render] and polls the global results map.
+ * - **Release** at `interactive/stop` or daemon shutdown. [close] enqueues
+ *   [InteractiveCommand.Close]; the held-rule statement returns from `evaluate()`, which causes
+ *   the rule's outer wrapper to close the `ActivityScenario` — the same disposal point a one-shot
+ *   render hits.
+ */
+class AndroidInteractiveSession
+internal constructor(
+  override val previewId: String,
+  /**
+   * Stream identifier echoed back on every [InteractiveCommand]. Generated host-side at
+   * [RobolectricHost.acquireInteractiveSession] so the host can detect a nested-start race (#3 of
+   * the held-loop's open questions) and route its reply correctly.
+   */
+  internal val streamId: String,
+  /**
+   * The sandbox slot this session was acquired against — almost always slot 1 in v3 (slot 0 is the
+   * always-on normal-render slot). Carried explicitly rather than re-derived because the host's
+   * routing code (`acquireInteractiveSession`) already chose it; passing it in keeps the session
+   * itself slot-policy-agnostic so v4 (multi-target Android) can reuse this class unchanged.
+   */
+  private val slot: SandboxSlot,
+  /**
+   * Cleared by [close] so [RobolectricHost.acquireInteractiveSession] can reuse the slot for the
+   * next interactive/start. Wrapped in [AtomicReference] so the host's CAS-on-acquire race-check
+   * sees the same instance the session writes to.
+   */
+  private val activeStreamRef: AtomicReference<String?>,
+  /**
+   * Idle lease — auto-close the session if no [dispatch] / [render] arrives for this many
+   * milliseconds. Defaults to [DEFAULT_IDLE_LEASE_MS] (1 minute) and is overridable via the
+   * `composeai.daemon.interactive.idleLeaseMs` sysprop so operators can tune for slow networks
+   * and tests can drive a sub-second lease without sleeping CI for a minute.
+   *
+   * Without this lease, a panel that crashes or a websocket that drops mid-session would leak a
+   * pinned sandbox slot for the rest of the daemon's lifetime — slot 1 stays held with no
+   * `interactive/stop` ever arriving. v3 supports one held session at a time per host, so a
+   * single zombie burns the whole interactive capacity. Symmetry with the desktop story comes
+   * via the panel's auto-stop on editor change/scroll (#427); the lease is the daemon-side
+   * belt-and-braces.
+   *
+   * Setting this to a non-positive value disables the watchdog entirely — useful for tests that
+   * verify the lease itself or for scenarios where an external lifecycle (e.g. a smoke test
+   * driver) owns the session's close path explicitly.
+   */
+  private val idleLeaseMs: Long =
+    System.getProperty(IDLE_LEASE_PROP)?.toLongOrNull() ?: DEFAULT_IDLE_LEASE_MS,
+) : InteractiveSession {
+
+  @Volatile private var closed: Boolean = false
+
+  /**
+   * Wall-clock millis at the most recent [dispatch] / [render] call (or session construction, the
+   * implicit "first use"). The watchdog reads this every [idleLeaseMs]/4 ticks and triggers
+   * auto-close when the gap exceeds [idleLeaseMs]. Updated **before** the bridge enqueue so
+   * a long-running render doesn't look idle from the watchdog's perspective.
+   */
+  private val lastUsedAtMs: AtomicLong = AtomicLong(System.currentTimeMillis())
+
+  /**
+   * Set to a non-null human-readable string when the watchdog auto-closes. Surfaced via
+   * [autoClosedReason] so PR C's panel-side handler can distinguish "host force-closed because
+   * idle" from "client hit interactive/stop".
+   */
+  @Volatile private var autoClosedReason: String? = null
+
+  /**
+   * Daemon-thread executor that runs the idle-lease check. Allocated lazily so a session
+   * constructed with `idleLeaseMs <= 0` doesn't pay the executor allocation. Cancelled by
+   * [close] — the executor is single-threaded so cancellation is bounded.
+   */
+  private val watchdog: ScheduledExecutorService? =
+    if (idleLeaseMs > 0L) {
+      Executors.newSingleThreadScheduledExecutor { runnable ->
+        Thread(runnable, "compose-ai-daemon-interactive-watchdog-$streamId").apply {
+          isDaemon = true
+        }
+      }
+    } else null
+
+  init {
+    // Schedule the lease check at idleLeaseMs/4 intervals so we close within at most 25% over
+    // the configured timeout. Doesn't run on `idleLeaseMs <= 0` (watchdog is null) — that's the
+    // explicit opt-out path for tests that own the session lifecycle directly.
+    watchdog?.scheduleWithFixedDelay(
+      ::checkIdleLease,
+      idleLeaseMs,
+      (idleLeaseMs / 4).coerceAtLeast(50L),
+      TimeUnit.MILLISECONDS,
+    )
+  }
+
+  /**
+   * `true` when the session has been closed (either via explicit [close] or the idle-lease
+   * watchdog). Subsequent [dispatch] returns silently; [render] throws. Exposed for PR C's
+   * panel-side handler that wants to redraw the v1 fallback hint when the daemon force-closes a
+   * stream out from under it.
+   */
+  val isClosed: Boolean
+    get() = closed
+
+  /**
+   * Non-null when the session was force-closed by the idle-lease watchdog (rather than by an
+   * explicit [close] call). Carries the lease config + idle duration for diagnostics. Stays
+   * `null` when the session was closed explicitly — PR C's wire handler checks this to decide
+   * whether to surface a status-bar hint or treat the close as routine.
+   */
+  fun autoClosedReason(): String? = autoClosedReason
+
+  private fun checkIdleLease() {
+    if (closed) return
+    val now = System.currentTimeMillis()
+    val idle = now - lastUsedAtMs.get()
+    if (idle >= idleLeaseMs) {
+      autoClosedReason =
+        "idle for ${idle}ms (lease ${idleLeaseMs}ms); auto-closing held session " +
+          "'$streamId' (previewId='$previewId')"
+      System.err.println("compose-ai-daemon: AndroidInteractiveSession: $autoClosedReason")
+      // close() handles activeStreamRef CAS + bridge Close enqueue + watchdog shutdown.
+      // Running it on this scheduled thread blocks the scheduler for at most CLOSE_TIMEOUT_SEC
+      // — bounded, no leak.
+      try {
+        close()
+      } catch (t: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: AndroidInteractiveSession watchdog close threw: " +
+            "${t.javaClass.simpleName}: ${t.message}"
+        )
+      }
+    }
+  }
+
+  override fun dispatch(input: InteractiveInputParams) {
+    if (closed) return
+    val px = input.pixelX
+    val py = input.pixelY
+    val kind =
+      when (input.kind) {
+        InteractiveInputKind.CLICK -> "click"
+        InteractiveInputKind.POINTER_DOWN -> "pointerDown"
+        InteractiveInputKind.POINTER_UP -> "pointerUp"
+        // Key events are no-op on Android v3 — same shape as desktop v2's silent drop. Wire shape
+        // accepts them so a forward-looking client doesn't get rejected; the dispatch lands in
+        // the sandbox loop and is intentionally ignored there.
+        InteractiveInputKind.KEY_DOWN,
+        InteractiveInputKind.KEY_UP -> return
+      }
+    if (px == null || py == null) return
+    lastUsedAtMs.set(System.currentTimeMillis())
+    val replyLatch = CountDownLatch(1)
+    val replyError = AtomicReference<Throwable?>(null)
+    slot.interactiveCommands.put(
+      InteractiveCommand.Dispatch(
+        streamId = streamId,
+        kind = kind,
+        pixelX = px,
+        pixelY = py,
+        replyLatch = replyLatch,
+        replyError = replyError,
+      )
+    )
+    if (!replyLatch.await(DISPATCH_TIMEOUT_SEC, TimeUnit.SECONDS)) {
+      error(
+        "AndroidInteractiveSession.dispatch timed out after ${DISPATCH_TIMEOUT_SEC}s for stream " +
+          "'$streamId' (kind=$kind, px=$px, py=$py). Held-rule loop may be stuck."
+      )
+    }
+    replyError.get()?.let { throw it }
+  }
+
+  override fun render(requestId: Long): RenderResult {
+    check(!closed) { "AndroidInteractiveSession.render() called after close()" }
+    lastUsedAtMs.set(System.currentTimeMillis())
+    slot.interactiveCommands.put(
+      InteractiveCommand.Render(streamId = streamId, requestId = requestId)
+    )
+    val resultQueue =
+      DaemonHostBridge.results.computeIfAbsent(requestId) { LinkedBlockingQueue() }
+    val raw =
+      resultQueue.poll(RENDER_TIMEOUT_SEC, TimeUnit.SECONDS)
+        ?: error(
+          "AndroidInteractiveSession.render timed out after ${RENDER_TIMEOUT_SEC}s for stream " +
+            "'$streamId', request $requestId"
+        )
+    DaemonHostBridge.results.remove(requestId)
+    if (raw is Throwable) throw raw
+    // Same cross-classloader copy `RobolectricHost.submit` uses — the sandbox-side `RenderResult`
+    // is loaded by Robolectric's `InstrumentingClassLoader`, the host-side caller expects the
+    // host-loader's class. Reflective copy collapses the two.
+    return raw as? RenderResult ?: copyResultAcrossClassloaders(raw)
+  }
+
+  override fun close() {
+    if (closed) return
+    closed = true
+    // Stop the watchdog **before** waiting on the close latch — we don't want the watchdog
+    // double-firing close() on this same session while the bridge round-trip is in flight.
+    //
+    // `shutdown()` (non-interrupting) rather than `shutdownNow()`: the watchdog tick that fired
+    // the auto-close is itself running on this executor's worker thread and is in the middle of
+    // calling us. `shutdownNow()` would interrupt that tick mid-flight; the interrupt status
+    // would propagate into our subsequent `replyLatch.await(...)` and throw
+    // `InterruptedException` before `activeStreamRef` gets cleared. `shutdown()` lets the
+    // current task finish naturally (we're past the scheduled work, the rest of close() runs to
+    // completion) and just prevents future ticks — exactly what we want.
+    watchdog?.shutdown()
+    val replyLatch = CountDownLatch(1)
+    slot.interactiveCommands.put(
+      InteractiveCommand.Close(streamId = streamId, replyLatch = replyLatch)
+    )
+    // Bounded wait — if the held-rule statement is wedged we don't want `interactive/stop` to
+    // hang the JsonRpcServer thread forever. After this returns we always clear the active-stream
+    // ref so the host doesn't think a session is still pinned.
+    replyLatch.await(CLOSE_TIMEOUT_SEC, TimeUnit.SECONDS)
+    // CAS-from-our-streamId so concurrent close() calls don't clobber a fresh session that the
+    // host has already started binding to the slot. Idempotent against a missing entry.
+    activeStreamRef.compareAndSet(streamId, null)
+  }
+
+  private fun copyResultAcrossClassloaders(raw: Any): RenderResult {
+    val cls = raw.javaClass
+    val id = cls.getMethod("getId").invoke(raw) as Long
+    val hash = cls.getMethod("getClassLoaderHashCode").invoke(raw) as Int
+    val name = cls.getMethod("getClassLoaderName").invoke(raw) as String
+    val pngPath = cls.getMethod("getPngPath").invoke(raw) as String?
+    @Suppress("UNCHECKED_CAST")
+    val metrics = cls.getMethod("getMetrics").invoke(raw) as Map<String, Long>?
+    return RenderResult(
+      id = id,
+      classLoaderHashCode = hash,
+      classLoaderName = name,
+      pngPath = pngPath,
+      metrics = metrics?.let { LinkedHashMap(it) },
+    )
+  }
+
+  companion object {
+    /**
+     * Upper bound on a single `interactive/input` round-trip — sandbox synthesises the
+     * MotionEvent, dispatches on the UI thread, advances `mainClock` by `POINTER_HOLD_MS`, signals
+     * back. 30 s is generous; in practice well under 100 ms post-cold-boot.
+     */
+    private const val DISPATCH_TIMEOUT_SEC: Long = 30L
+
+    /**
+     * Upper bound on a single capture — Roborazzi's `captureRoboImage` plus the disk write.
+     * Matches the v1 `RobolectricHost.submit` default (60s) so a slow first-render after the
+     * Roborazzi static init doesn't trip the timeout.
+     */
+    private const val RENDER_TIMEOUT_SEC: Long = 60L
+
+    /**
+     * Upper bound on session teardown. Closes the ActivityScenario via the rule's outer wrapper —
+     * fast (single Activity.onDestroy + Compose disposal pass). 10 s is the slack for a degenerate
+     * case where a `LaunchedEffect` cleanup blocks the dispatcher; if it ever times out, the
+     * activeStreamRef is still cleared so the next acquire isn't blocked.
+     */
+    private const val CLOSE_TIMEOUT_SEC: Long = 10L
+
+    /**
+     * Sysprop knob for the idle-lease timeout (millis). When unset, sessions auto-close after
+     * [DEFAULT_IDLE_LEASE_MS] of inactivity. Operators can tune this for slow networks; tests
+     * pass a non-default via the constructor parameter directly.
+     */
+    const val IDLE_LEASE_PROP: String = "composeai.daemon.interactive.idleLeaseMs"
+
+    /**
+     * Default idle-lease timeout — 1 minute. Long enough that a user thinking about their
+     * preview between clicks doesn't get yanked out from under, short enough that a panel crash
+     * or a websocket drop returns the pinned slot to normal-render duty within a minute. The
+     * panel's own auto-stop on editor change/scroll already handles the "user moved on" case;
+     * this lease catches the "client disappeared" case PR C will explicitly wire to
+     * `JsonRpcServer.onChannelClosed`.
+     */
+    const val DEFAULT_IDLE_LEASE_MS: Long = 60_000L
+  }
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1,8 +1,17 @@
 package ee.schimke.composeai.daemon
 
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.reflect.getDeclaredComposableMethod
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.test.onRoot
+import com.github.takahirom.roborazzi.captureRoboImage
 import ee.schimke.composeai.daemon.bridge.DaemonHostBridge
+import ee.schimke.composeai.daemon.bridge.InteractiveCommand
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import org.junit.Test
 import org.junit.runner.JUnitCore
 import org.junit.runner.RunWith
@@ -103,7 +112,62 @@ open class RobolectricHost(
    */
   val userClassloaderHolderFactory: ((sandboxClassLoader: ClassLoader) -> UserClassLoaderHolder)? =
     null,
+  /**
+   * v3 (INTERACTIVE-ANDROID.md § 7) — resolves a wire-side `previewId` to a concrete [RenderSpec]
+   * for the held interactive scene. Without a resolver, [acquireInteractiveSession] throws
+   * `UnsupportedOperationException` and `JsonRpcServer` falls back to the v1 stateless dispatch
+   * path; the panel surfaces the "v1 fallback" hint via the same #431 path the desktop side uses.
+   *
+   * `null` (the default) keeps every pre-v3 caller's behaviour — the host advertises no
+   * interactive support. Production wiring in [DaemonMain] passes a resolver backed by
+   * `PreviewIndex`, with the same shape `:daemon:desktop`'s `DesktopHost` already uses. The two
+   * resolvers can share an implementation when v3 lifecycle hardening (PR C) lands.
+   */
+  private val previewSpecResolver: ((String) -> RenderSpec?)? = null,
+  /**
+   * v3 zombie-session safeguard — auto-close a held interactive session when no input or render
+   * has arrived for this many milliseconds. Forwarded to [AndroidInteractiveSession]'s
+   * idle-lease watchdog. Defaults to [AndroidInteractiveSession.DEFAULT_IDLE_LEASE_MS] (1 minute);
+   * tests pass a smaller value (or zero to disable) when they want to drive the lease path
+   * without sleeping CI for a minute.
+   *
+   * Without this lease, a panel that crashes or a websocket that drops mid-session would hold
+   * slot 1 for the rest of the daemon's lifetime — interactive capacity is one held session at
+   * a time per host (INTERACTIVE-ANDROID.md § 2.1), so a single zombie burns the whole pool.
+   */
+  private val interactiveIdleLeaseMs: Long =
+    System.getProperty(AndroidInteractiveSession.IDLE_LEASE_PROP)?.toLongOrNull()
+      ?: AndroidInteractiveSession.DEFAULT_IDLE_LEASE_MS,
 ) : RenderHost {
+
+  /**
+   * INTERACTIVE-ANDROID.md § 2 — interactive sessions on Android need one pinned sandbox slot in
+   * addition to the always-on slot 0 that drains normal renders, so the capability bit reads
+   * `true` only when both `sandboxCount >= 2` and a [previewSpecResolver] is wired. With
+   * `sandboxCount == 1` the single sandbox can't be sacrificed without taking normal renders down,
+   * so [acquireInteractiveSession] throws `Unsupported` and `JsonRpcServer` falls back to v1.
+   *
+   * Daemon-level capability — surfaced once in `InitializeResult.capabilities.interactive`, not
+   * re-probed per call. The panel reads it at `initialize` and renders the v1-fallback hint when
+   * it's `false`.
+   */
+  override val supportsInteractive: Boolean
+    get() = sandboxCount >= 2 && previewSpecResolver != null
+
+  /**
+   * Identifier of the currently-held interactive session, or `null` when no session is active.
+   * v3 supports one held session at a time per host; concurrent acquire calls CAS through this
+   * ref so the second loses cleanly with `Unsupported` rather than racing the slot's bridge
+   * queue. Cleared by [AndroidInteractiveSession.close] via the same ref.
+   */
+  private val activeInteractiveStreamId: AtomicReference<String?> = AtomicReference(null)
+
+  /**
+   * Monotonic counter for `streamId`s the host hands out. Persisted as a host-level counter
+   * (rather than `RenderHost.nextRequestId`) because the wire-side `streamId` is purely a
+   * host-internal correlation key — it doesn't share number space with render ids.
+   */
+  private val nextStreamCounter: AtomicLong = AtomicLong(1)
 
   /**
    * PROTOCOL.md § 3 (`InitializeResult.capabilities.supportedOverrides`) — the Robolectric
@@ -420,6 +484,111 @@ open class RobolectricHost(
   }
 
   /**
+   * v3 (INTERACTIVE-ANDROID.md § 7) — allocate an [AndroidInteractiveSession] backed by a held
+   * `createAndroidComposeRule` on the interactive sandbox slot. Throws
+   * `UnsupportedOperationException` (which `JsonRpcServer` translates to `MethodNotFound (-32601)`
+   * on the wire) when:
+   *  * [sandboxCount] is < 2 — only one sandbox is configured and we can't sacrifice it without
+   *    taking normal renders down for the session's lifetime.
+   *  * [previewSpecResolver] wasn't wired at construction — production [DaemonMain] passes one;
+   *    in-process tests that don't pass one explicitly opt out of v3.
+   *  * The resolver returns `null` for the wire-side [previewId] — the manifest doesn't know
+   *    about this preview, so we can't hand the held composition the class+method+dimensions it
+   *    needs.
+   *  * Another session is already held — v3 supports one held session at a time per host.
+   *  * The held-rule statement fails to set up `setContent` within
+   *    [INTERACTIVE_START_TIMEOUT_MS] (e.g. the user composable's body throws). In that case
+   *    [InteractiveCommand.Start.replyError] carries the underlying cause through to the wire.
+   *
+   * The [classLoader] argument is forwarded into the bridge for parity with desktop, but the
+   * sandbox-side held-rule loop reads the slot's child classloader directly via the
+   * `DaemonHostBridge`'s slot-level `childLoaderRef` (the host already publishes it on
+   * [submit]). Carrying the explicit ClassLoader through the bridge would double-load it across
+   * the sandbox boundary; not worth it for a value already mirrored on the slot.
+   */
+  override fun acquireInteractiveSession(
+    previewId: String,
+    classLoader: ClassLoader,
+  ): InteractiveSession {
+    if (sandboxCount < 2) {
+      throw UnsupportedOperationException(
+        "RobolectricHost: interactive sessions require sandboxCount >= 2 " +
+          "(have $sandboxCount); v3 pins one sandbox slot per held session and slot 0 must stay " +
+          "available for normal renders. See docs/daemon/INTERACTIVE-ANDROID.md § 2."
+      )
+    }
+    val resolver =
+      previewSpecResolver
+        ?: throw UnsupportedOperationException(
+          "RobolectricHost has no previewSpecResolver; pass one at construction time to enable " +
+            "v3 interactive sessions"
+        )
+    val spec =
+      resolver(previewId)
+        ?: throw UnsupportedOperationException(
+          "RobolectricHost.previewSpecResolver returned null for previewId='$previewId'; " +
+            "interactive session not allocated"
+        )
+    val streamId = "android-stream-${nextStreamCounter.getAndIncrement()}"
+    if (!activeInteractiveStreamId.compareAndSet(null, streamId)) {
+      val held = activeInteractiveStreamId.get() ?: "<concurrent close>"
+      throw UnsupportedOperationException(
+        "RobolectricHost: interactive session already held for stream '$held'; " +
+          "v3 supports one held session at a time per host (INTERACTIVE-ANDROID.md § 2.1)"
+      )
+    }
+    // Publish the slot's child classloader before the sandbox-side held-rule loop reads it. The
+    // legacy normal-render path does this on every `submit`; we do it once here because the held
+    // session uses one classloader for its entire lifetime. A subsequent file-changed-driven
+    // [swapUserClassLoaders] won't be picked up mid-session (PR C wires that — at which point
+    // the host posts an InteractiveCommand.Close and the next acquire starts fresh).
+    publishChildLoaderForSlot(INTERACTIVE_SLOT_INDEX)
+    val slot = DaemonHostBridge.slot(INTERACTIVE_SLOT_INDEX)
+    val replyLatch = CountDownLatch(1)
+    val replyError = AtomicReference<Throwable?>(null)
+    slot.interactiveCommands.put(
+      InteractiveCommand.Start(
+        streamId = streamId,
+        previewClassName = spec.className,
+        previewFunctionName = spec.functionName,
+        widthPx = spec.widthPx,
+        heightPx = spec.heightPx,
+        density = spec.density,
+        backgroundColor = spec.backgroundColor,
+        showBackground = spec.showBackground,
+        device = spec.device,
+        outputBaseName = spec.outputBaseName,
+        replyLatch = replyLatch,
+        replyError = replyError,
+      )
+    )
+    if (!replyLatch.await(INTERACTIVE_START_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+      activeInteractiveStreamId.compareAndSet(streamId, null)
+      throw UnsupportedOperationException(
+        "RobolectricHost.acquireInteractiveSession timed out after " +
+          "${INTERACTIVE_START_TIMEOUT_MS}ms for previewId='$previewId' — the held-rule loop on " +
+          "slot $INTERACTIVE_SLOT_INDEX did not register setContent in time"
+      )
+    }
+    val startError = replyError.get()
+    if (startError != null) {
+      activeInteractiveStreamId.compareAndSet(streamId, null)
+      throw UnsupportedOperationException(
+        "RobolectricHost.acquireInteractiveSession failed for previewId='$previewId': " +
+          "${startError.javaClass.simpleName}: ${startError.message}",
+        startError,
+      )
+    }
+    return AndroidInteractiveSession(
+      previewId = previewId,
+      streamId = streamId,
+      slot = slot,
+      activeStreamRef = activeInteractiveStreamId,
+      idleLeaseMs = interactiveIdleLeaseMs,
+    )
+  }
+
+  /**
    * Sends the poison pill, waits up to [timeoutMs] for the worker thread to
    * exit. Idempotent.
    */
@@ -461,6 +630,23 @@ open class RobolectricHost(
      * same sandbox slot. Mirrors the prefix `PreviewManifestRouter.parsePreviewId` recognises.
      */
     private const val PREVIEW_ID_KEY: String = "previewId="
+
+    /**
+     * INTERACTIVE-ANDROID.md § 7 — slot index pinned to interactive sessions in v3. Slot 0 stays
+     * the always-on normal-render slot; the held-rule loop runs exclusively on slot 1. Any future
+     * multi-target (v4) lift would expand this to a slot range and gate per-session slot
+     * allocation through a free-list.
+     */
+    internal const val INTERACTIVE_SLOT_INDEX: Int = 1
+
+    /**
+     * Upper bound on `interactive/start` round-trip — sandbox bootstraps the held rule, the
+     * `setContent` lands, the start latch counts down. 30 s covers a cold sandbox 0→1 transition
+     * (ActivityScenario launch + first composition + first paint); warm starts on slot 1 already
+     * being free are well under a second. If this trips, the held-rule loop is wedged or the
+     * preview composable's body is genuinely stuck.
+     */
+    internal const val INTERACTIVE_START_TIMEOUT_MS: Long = 30_000L
   }
 
   override fun shutdown(timeoutMs: Long) {
@@ -558,6 +744,31 @@ open class RobolectricHost(
       val slot = DaemonHostBridge.slot(slotIndex)
 
       while (!DaemonHostBridge.shutdown.get()) {
+        // INTERACTIVE-ANDROID.md § 4 — interactive priority. Non-blocking poll on the slot's
+        // [InteractiveCommand] queue: a queued [InteractiveCommand.Start] pins the slot to a held
+        // interactive session before the next normal render lands; orphan Dispatch/Render/Close
+        // (a wire-level race where the host enqueued without an active session) is logged and
+        // dropped. Slot 0 never receives an interactive command in v3 — host-side acquire pins
+        // everything to slot 1 — but the poll happens on every slot for symmetry.
+        //
+        // Direct type matching is safe here (unlike the `RenderRequest` block below, which uses
+        // [Class.simpleName] because [RenderRequest] lives in the instrumented
+        // `ee.schimke.composeai.daemon.*` package): [InteractiveCommand] sits in the
+        // `bridge` package which is `doNotAcquirePackage` under [SandboxHoldingRunner], so the
+        // host-side and sandbox-side `Class` objects are identical and `is` works.
+        val interactive = slot.interactiveCommands.poll()
+        if (interactive != null) {
+          if (interactive is InteractiveCommand.Start) {
+            runHeldInteractiveSession(slot, interactive)
+            continue
+          }
+          System.err.println(
+            "compose-ai-daemon: orphan interactive command on slot $slotIndex: " +
+              "${interactive.javaClass.simpleName} streamId=${interactive.streamId} " +
+              "(no session held; dropping)"
+          )
+          continue
+        }
         val request = slot.requests.poll(100, TimeUnit.MILLISECONDS) ?: continue
         // Match by simple class name rather than `is` so a future
         // classloader-rule change reintroducing instrumentation of
@@ -762,5 +973,364 @@ open class RobolectricHost(
       }
       return current
     }
+
+    /**
+     * INTERACTIVE-ANDROID.md § 4 — held-rule loop. Pins this slot to a single interactive session
+     * for the duration of [start.streamId]: allocates `createAndroidComposeRule<ComponentActivity>`,
+     * runs `setContent` once with [androidx.compose.ui.platform.LocalInspectionMode] flipped off
+     * so `Modifier.pointerInput` / `Modifier.clickable` actually fire, then drains
+     * [InteractiveCommand.Dispatch] / [InteractiveCommand.Render] / [InteractiveCommand.Close]
+     * commands until [InteractiveCommand.Close] returns control to [holdSandboxOpen].
+     *
+     * **Held statement blocks the slot's queue-drain.** Constraint (1) from
+     * INTERACTIVE-ANDROID.md § 1: `rule.apply().evaluate()` is a synchronous call from this
+     * thread (the slot's worker thread). While the held statement runs, this slot serves no
+     * normal renders — that's why v3 requires `sandboxCount >= 2`, so slot 0 keeps draining
+     * while slot 1 is pinned (host-side acquire enforces the pinning to slot 1).
+     *
+     * **MotionEvent dispatch.** The probe in `RobolectricInteractiveProbeTest` empirically
+     * confirmed that `decorView.dispatchTouchEvent` inside `rule.runOnUiThread` reaches Compose's
+     * pointer-input pipeline under a paused `mainClock`, and that a subsequent `captureRoboImage`
+     * on the same composition reflects state mutated by the dispatch. We use the same recipe
+     * here verbatim.
+     *
+     * **Failure surfacing.** If anything before the start latch counts down throws (most likely
+     * the user composable's body in `setContent`), the outer try/catch sets [start.replyError]
+     * and counts the latch down so the host's `acquireInteractiveSession` sees the failure
+     * rather than a 30s timeout. After the latch counts down, exceptions on individual
+     * [Dispatch] / [Render] commands ride [InteractiveCommand.Dispatch.replyError] /
+     * [DaemonHostBridge.results] respectively.
+     */
+    private fun runHeldInteractiveSession(
+      slot: ee.schimke.composeai.daemon.bridge.SandboxSlot,
+      start: InteractiveCommand.Start,
+    ) {
+      // Mirror `roborazzi.test.record` defaulting from RenderEngine.render — the held capture
+      // path uses the same `captureRoboImage` and needs record mode enabled.
+      if (System.getProperty("roborazzi.test.record") == null) {
+        System.setProperty("roborazzi.test.record", "true")
+      }
+
+      val classLoader: ClassLoader =
+        DaemonHostBridge.currentChildLoader()
+          ?: Thread.currentThread().contextClassLoader
+          ?: RenderEngine::class.java.classLoader
+      val composableMethod =
+        try {
+          val clazz = Class.forName(start.previewClassName, true, classLoader)
+          clazz.getDeclaredComposableMethod(start.previewFunctionName)
+        } catch (t: Throwable) {
+          // Resolution failure (class missing / method missing / signature mismatch) — surface
+          // immediately on the start reply so the host doesn't wait out the 30s timeout.
+          start.replyError.set(unwrapInvocationTarget(t))
+          start.replyLatch.countDown()
+          return
+        }
+
+      // Activity registration — same idempotent shape RenderEngine.render uses. Robolectric
+      // 4.13+ requires `ComponentActivity` to be reachable through `ShadowPackageManager` before
+      // `createAndroidComposeRule` can launch it.
+      val appContext: android.app.Application =
+        androidx.test.core.app.ApplicationProvider.getApplicationContext()
+      org.robolectric.Shadows.shadowOf(appContext.packageManager)
+        .addActivityIfNotPresent(
+          android.content.ComponentName(
+            appContext.packageName,
+            androidx.activity.ComponentActivity::class.java.name,
+          )
+        )
+
+      // Minimal qualifier set — size + density + round-device. PR C threads through the rest of
+      // the v1 RenderSpec qualifiers (locale, fontScale, uiMode, orientation) once the held
+      // session needs them; for v3's first ship the basics keep parity with what the panel
+      // already shows in non-interactive mode.
+      val widthDp = pxToDp(start.widthPx, start.density)
+      val heightDp = pxToDp(start.heightPx, start.density)
+      val isRound = isRoundDevice(start.device)
+      val qualifiers = buildList {
+        if (widthDp > 0) add("w${widthDp}dp")
+        if (heightDp > 0) add("h${heightDp}dp")
+        if (isRound) add("round")
+        if (widthDp > 0 && heightDp > 0) add(if (widthDp > heightDp) "land" else "port")
+        if (start.density > 0f) add("${(start.density * 160).toInt()}dpi")
+      }
+      if (qualifiers.isNotEmpty()) {
+        org.robolectric.RuntimeEnvironment.setQualifiers("+${qualifiers.joinToString("-")}")
+      }
+
+      val outputDir =
+        java.io.File(
+          System.getProperty(RenderEngine.OUTPUT_DIR_PROP)
+            ?: "${System.getProperty("user.dir")}/.compose-preview-history/daemon-renders"
+        )
+      outputDir.mkdirs()
+      val outputFile = java.io.File(outputDir, "${start.outputBaseName}.png")
+      val roborazziOptions =
+        com.github.takahirom.roborazzi.RoborazziOptions(
+          recordOptions =
+            com.github.takahirom.roborazzi.RoborazziOptions.RecordOptions(applyDeviceCrop = isRound)
+        )
+
+      val backgroundArgb =
+        when {
+          start.backgroundColor != 0L ->
+            androidx.compose.ui.graphics.Color(start.backgroundColor.toInt())
+              .toArgb()
+          start.showBackground -> androidx.compose.ui.graphics.Color.White.toArgb()
+          else -> androidx.compose.ui.graphics.Color.Transparent.toArgb()
+        }
+
+      @Suppress("DEPRECATION")
+      val rule =
+        androidx.compose.ui.test.junit4.createAndroidComposeRule<
+          androidx.activity.ComponentActivity
+        >()
+      val description =
+        org.junit.runner.Description.createTestDescription(
+          SandboxRunner::class.java,
+          "interactive_${start.streamId}",
+        )
+
+      val statement =
+        object : org.junit.runners.model.Statement() {
+          @OptIn(com.github.takahirom.roborazzi.ExperimentalRoborazziApi::class)
+          override fun evaluate() {
+            rule.mainClock.autoAdvance = false
+            rule.runOnUiThread { rule.activity.window.decorView.setBackgroundColor(backgroundArgb) }
+            rule.setContent {
+              androidx.compose.runtime.CompositionLocalProvider(
+                androidx.compose.ui.platform.LocalInspectionMode provides false
+              ) {
+                androidx.compose.foundation.layout.Box(
+                  modifier = androidx.compose.ui.Modifier.fillMaxSize()
+                ) {
+                  InvokeHeldComposable(composableMethod)
+                }
+              }
+            }
+            // Two Choreographer ticks under the paused clock — same settle window
+            // RenderEngine.render uses before its single capture. Enough for the initial
+            // composition + first LaunchedEffect-equivalent pass to land.
+            rule.mainClock.advanceTimeBy(HELD_CAPTURE_ADVANCE_MS)
+            // Start succeeded — count the latch down before draining further commands so the host
+            // doesn't wait out the start timeout.
+            start.replyLatch.countDown()
+
+            // Per-session drain loop. Single-threaded (this is `evaluate()`, the rule's wrapper
+            // statement runs us synchronously); InteractiveCommand subtypes are matched directly
+            // because the bridge package is do-not-acquire so the Class objects are identical
+            // host-side and sandbox-side.
+            while (true) {
+              val cmd = slot.interactiveCommands.take()
+              when (cmd) {
+                is InteractiveCommand.Dispatch -> {
+                  try {
+                    dispatchHeldMotion(rule, cmd)
+                    rule.mainClock.advanceTimeBy(POINTER_HOLD_MS)
+                  } catch (t: Throwable) {
+                    cmd.replyError.set(t)
+                  } finally {
+                    cmd.replyLatch.countDown()
+                  }
+                }
+                is InteractiveCommand.Render -> {
+                  val resultOrError: Any =
+                    try {
+                      rule.mainClock.advanceTimeBy(HELD_CAPTURE_ADVANCE_MS)
+                      rule
+                        .onRoot()
+                        .captureRoboImage(file = outputFile, roborazziOptions = roborazziOptions)
+                      val cl = Thread.currentThread().contextClassLoader
+                      RenderResult(
+                        id = cmd.requestId,
+                        classLoaderHashCode = System.identityHashCode(cl),
+                        classLoaderName = cl?.javaClass?.name ?: "<null>",
+                        pngPath = outputFile.absolutePath,
+                        metrics =
+                          mapOf<String, Long>(
+                            "tookMs" to 0L,
+                            "interactive" to 1L,
+                          ),
+                      )
+                    } catch (t: Throwable) {
+                      t
+                    }
+                  DaemonHostBridge.results
+                    .computeIfAbsent(cmd.requestId) { LinkedBlockingQueue() }
+                    .put(resultOrError)
+                }
+                is InteractiveCommand.Close -> {
+                  cmd.replyLatch.countDown()
+                  return
+                }
+                is InteractiveCommand.Start -> {
+                  // Nested-start race — host-side acquire CAS should already have refused, but
+                  // belt-and-braces: if a Start lands while we're held, surface a fail back so
+                  // the requesting acquire path errors instead of hanging.
+                  cmd.replyError.set(
+                    IllegalStateException(
+                      "nested interactive/start for stream '${cmd.streamId}' while " +
+                        "stream '${start.streamId}' is still held"
+                    )
+                  )
+                  cmd.replyLatch.countDown()
+                }
+              }
+            }
+          }
+        }
+
+      // Install the child classloader as the contextClassLoader for the rule's whole lifetime —
+      // same discipline RenderEngine.render uses. Compose's reflection-driven helpers (e.g.
+      // PreviewParameter providers) consult the context classloader; without this install they
+      // would miss user classes that aren't on the parent (sandbox) classpath.
+      val previousContext = Thread.currentThread().contextClassLoader
+      Thread.currentThread().contextClassLoader = classLoader
+      try {
+        rule.apply(statement, description).evaluate()
+      } catch (t: Throwable) {
+        // Rule lifecycle failed (e.g. setContent threw; ActivityScenario couldn't launch). If
+        // we never counted the start latch down, surface the error there so the host's acquire
+        // sees it. Otherwise log and let the slot return to draining normal renders.
+        if (start.replyLatch.count > 0) {
+          start.replyError.set(unwrapInvocationTarget(t))
+          start.replyLatch.countDown()
+        } else {
+          System.err.println(
+            "compose-ai-daemon: held-rule for stream ${start.streamId} threw after " +
+              "interactive/start succeeded: ${t.javaClass.simpleName}: ${t.message}"
+          )
+        }
+      } finally {
+        Thread.currentThread().contextClassLoader = previousContext
+      }
+    }
+
+    /**
+     * INTERACTIVE-ANDROID.md § 5 (Option A) — synthesise + dispatch a [android.view.MotionEvent]
+     * on the rule's UI thread. The probe at `RobolectricInteractiveProbeTest` empirically
+     * confirmed this reaches `Modifier.pointerInput { awaitFirstDown() }` under a paused
+     * `mainClock` provided we advance the clock by [POINTER_HOLD_MS] after the dispatch.
+     *
+     * `click` synthesises ACTION_DOWN + ACTION_UP at the same coords; `pointerDown` /
+     * `pointerUp` send a single event each. Unknown kinds are silently dropped — the host-side
+     * [AndroidInteractiveSession.dispatch] already filters key events out, so we should never
+     * see them here.
+     */
+    private fun dispatchHeldMotion(
+      rule:
+        androidx.compose.ui.test.junit4.AndroidComposeTestRule<
+          *,
+          androidx.activity.ComponentActivity,
+        >,
+      cmd: InteractiveCommand.Dispatch,
+    ) {
+      rule.runOnUiThread {
+        val decor = rule.activity.window.decorView
+        val now = android.os.SystemClock.uptimeMillis()
+        val x = cmd.pixelX.toFloat()
+        val y = cmd.pixelY.toFloat()
+        when (cmd.kind) {
+          "click" -> {
+            val down =
+              android.view.MotionEvent.obtain(
+                now,
+                now,
+                android.view.MotionEvent.ACTION_DOWN,
+                x,
+                y,
+                /* metaState = */ 0,
+              )
+            try {
+              decor.dispatchTouchEvent(down)
+            } finally {
+              down.recycle()
+            }
+            val up =
+              android.view.MotionEvent.obtain(
+                now,
+                now + POINTER_HOLD_MS,
+                android.view.MotionEvent.ACTION_UP,
+                x,
+                y,
+                /* metaState = */ 0,
+              )
+            try {
+              decor.dispatchTouchEvent(up)
+            } finally {
+              up.recycle()
+            }
+          }
+          "pointerDown" -> {
+            val ev =
+              android.view.MotionEvent.obtain(
+                now,
+                now,
+                android.view.MotionEvent.ACTION_DOWN,
+                x,
+                y,
+                /* metaState = */ 0,
+              )
+            try {
+              decor.dispatchTouchEvent(ev)
+            } finally {
+              ev.recycle()
+            }
+          }
+          "pointerUp" -> {
+            val ev =
+              android.view.MotionEvent.obtain(
+                now,
+                now,
+                android.view.MotionEvent.ACTION_UP,
+                x,
+                y,
+                /* metaState = */ 0,
+              )
+            try {
+              decor.dispatchTouchEvent(ev)
+            } finally {
+              ev.recycle()
+            }
+          }
+        }
+      }
+    }
+
+    private fun pxToDp(px: Int, density: Float): Int {
+      if (density <= 0f) return px
+      return (px / density).toInt().coerceAtLeast(1)
+    }
+
+    companion object {
+      /**
+       * Virtual time to advance before each capture in the paused-`mainClock` path, in
+       * milliseconds. Mirrors `RenderEngine.CAPTURE_ADVANCE_MS` (private) — held captures use
+       * the same settle point so a frame from a held session matches a frame from the one-shot
+       * path.
+       */
+      private const val HELD_CAPTURE_ADVANCE_MS: Long = 32L
+
+      /**
+       * Hold time between an ACTION_DOWN and its ACTION_UP for `click`, and the post-dispatch
+       * `mainClock` advance for any kind. 100 ms is the same window
+       * `:daemon:desktop`'s `DesktopInteractiveSession.CLICK_HOLD_MS` uses — long enough for
+       * `detectTapGestures` to register an unambiguous tap, short enough that the click feels
+       * instant.
+       */
+      private const val POINTER_HOLD_MS: Long = 100L
+    }
   }
+}
+
+/**
+ * Tiny @Composable trampoline — same shape as `RenderEngine.kt`'s top-level private
+ * `InvokeComposable`, duplicated here because Kotlin top-level `private` is file-scoped and the
+ * held-rule loop in `SandboxRunner` lives in this file. Reflectively invokes a
+ * [androidx.compose.runtime.reflect.ComposableMethod] so the held composition can host any
+ * @Preview-shaped function the user resolves.
+ */
+@androidx.compose.runtime.Composable
+private fun InvokeHeldComposable(method: androidx.compose.runtime.reflect.ComposableMethod) {
+  method.invoke(androidx.compose.runtime.currentComposer, null)
 }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
@@ -1,0 +1,356 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
+import java.io.ByteArrayInputStream
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.math.abs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Integration coverage for the v3 Android-interactive held-rule loop (INTERACTIVE-ANDROID.md § 9).
+ * This is the substantive PR B test — it boots two Robolectric sandboxes (`sandboxCount = 2`),
+ * pins slot 1 to a held interactive session against the [ClickToggleSquare] testFixture, drives
+ * the click into the held composition via [AndroidInteractiveSession.dispatch], and verifies the
+ * second [AndroidInteractiveSession.render] reflects the flipped state.
+ *
+ * The empirical probe at `RobolectricInteractiveProbeTest` already confirmed the underlying
+ * recipe (held rule + paused mainClock + dispatchTouchEvent + recapture) works under Robolectric.
+ * This test adds the host plumbing on top: cross-classloader command marshalling through the
+ * bridge, host-side `acquireInteractiveSession` precondition checks, the slot-pinning policy,
+ * and the streamId / requestId correlation paths.
+ *
+ * **Sandbox cold-boot cost.** With `sandboxCount = 2` the test pays ~2× the cold-boot wall-clock
+ * of single-sandbox tests (each sandbox downloads + instruments `android-all` independently on a
+ * cold cache). On a warm cache it's ≤ 5 s extra. Acceptable for a single integration test; we
+ * don't multiply this across the harness — the broader S1-S8 coverage stays on the v1 stateless
+ * path.
+ *
+ * **No `assumeTrue` gate.** Unlike the standalone probe (`-Dcomposeai.probe.interactive=true`),
+ * this test runs on every `:daemon:android:test` invocation. The probe stays gated because it's
+ * an empirical experiment about Robolectric internals; this is the wired-up production path and
+ * must not regress silently.
+ *
+ * Pixel-match helper inlined for the same reason `RenderEngineTest` and the probe inline theirs
+ * — pulling `:daemon:harness`'s `PixelDiff` would invert the dependency graph.
+ */
+class AndroidInteractiveSessionTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun heldClickToggleSurvivesAcrossInputs() {
+    val outputDir = tempFolder.newFolder("interactive-renders")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+
+    val resolver = previewSpecResolver()
+    val host = RobolectricHost(sandboxCount = 2, previewSpecResolver = resolver)
+    host.start()
+    try {
+      assertTrue(
+        "supportsInteractive must be true with sandboxCount=2 + previewSpecResolver wired",
+        host.supportsInteractive,
+      )
+
+      val session =
+        host.acquireInteractiveSession(
+          previewId = INTERACTIVE_PREVIEW_ID,
+          classLoader = AndroidInteractiveSessionTest::class.java.classLoader!!,
+        )
+      try {
+        assertEquals(INTERACTIVE_PREVIEW_ID, session.previewId)
+
+        // First frame: held composition starts on red (initial state of `ClickToggleSquare`).
+        val firstResult = session.render(requestId = RenderHost.nextRequestId())
+        assertNotNull("first render must produce a PNG path", firstResult.pngPath)
+        val firstImg = decode(File(firstResult.pngPath!!))
+        val redBefore = pixelMatchPct(firstImg, RED_RGB, perChannelTolerance = 8)
+        assertTrue(
+          "expected initial held capture to be ≥95% red (got ${"%.2f".format(redBefore * 100)}%)",
+          redBefore >= 0.95,
+        )
+
+        // Dispatch a click in the centre of the box. ClickToggleSquare's pointerInput awaits the
+        // first ACTION_DOWN and flips its remember'd state to green; held composition keeps the
+        // mutated state across captures.
+        session.dispatch(
+          InteractiveInputParams(
+            frameStreamId = "irrelevant-on-host-side",
+            kind = InteractiveInputKind.CLICK,
+            pixelX = INTERACTIVE_WIDTH_PX / 2,
+            pixelY = INTERACTIVE_HEIGHT_PX / 2,
+          )
+        )
+
+        // Second frame: state should now be green.
+        val secondResult = session.render(requestId = RenderHost.nextRequestId())
+        val secondImg = decode(File(secondResult.pngPath!!))
+        val greenAfter = pixelMatchPct(secondImg, GREEN_RGB, perChannelTolerance = 8)
+        val redAfter = pixelMatchPct(secondImg, RED_RGB, perChannelTolerance = 8)
+        assertTrue(
+          "expected post-click held capture to be ≥95% green (got " +
+            "${"%.2f".format(greenAfter * 100)}%, redAfter=${"%.2f".format(redAfter * 100)}%) — " +
+            "either dispatchTouchEvent didn't reach pointerInput or recomposition didn't land " +
+            "before the second capture",
+          greenAfter >= 0.95,
+        )
+      } finally {
+        session.close()
+      }
+
+      // After close, normal renders must still work — slot 0 should have stayed live throughout
+      // the held session, and slot 1 should be back to draining its requests queue. Submit a
+      // standard render to confirm.
+      val followupId = RenderHost.nextRequestId()
+      val followupResult =
+        host.submit(
+          RenderRequest.Render(
+            id = followupId,
+            payload =
+              "previewId=red-square;" +
+                "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+                "functionName=RedSquare;" +
+                "widthPx=64;heightPx=64;density=1.0;" +
+                "showBackground=true;" +
+                "outputBaseName=post-interactive-red",
+          ),
+          timeoutMs = 60_000,
+        )
+      assertEquals(followupId, followupResult.id)
+      assertNotNull(
+        "post-interactive normal render must still produce a PNG (slot 0 stayed alive)",
+        followupResult.pngPath,
+      )
+      val followupImg = decode(File(followupResult.pngPath!!))
+      val followupRed = pixelMatchPct(followupImg, RED_RGB, perChannelTolerance = 8)
+      assertTrue(
+        "post-interactive RedSquare render should still be ≥95% red (got " +
+          "${"%.2f".format(followupRed * 100)}%)",
+        followupRed >= 0.95,
+      )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun acquireWithoutResolverThrowsUnsupported() {
+    val host = RobolectricHost(sandboxCount = 2)
+    assertFalse(
+      "supportsInteractive must be false without a previewSpecResolver, even with sandboxCount=2",
+      host.supportsInteractive,
+    )
+    host.start()
+    try {
+      try {
+        host.acquireInteractiveSession(
+          previewId = INTERACTIVE_PREVIEW_ID,
+          classLoader = javaClass.classLoader!!,
+        )
+        fail("expected UnsupportedOperationException for missing previewSpecResolver")
+      } catch (expected: UnsupportedOperationException) {
+        assertNotNull(expected.message)
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun acquireWithSandboxCountOneThrowsUnsupported() {
+    // sandboxCount = 1 should refuse interactive even when a resolver is wired — the single slot
+    // can't be sacrificed without taking normal renders down.
+    val host = RobolectricHost(sandboxCount = 1, previewSpecResolver = previewSpecResolver())
+    assertFalse(
+      "supportsInteractive must be false with sandboxCount=1 even when resolver is wired",
+      host.supportsInteractive,
+    )
+    host.start()
+    try {
+      try {
+        host.acquireInteractiveSession(
+          previewId = INTERACTIVE_PREVIEW_ID,
+          classLoader = javaClass.classLoader!!,
+        )
+        fail("expected UnsupportedOperationException for sandboxCount=1")
+      } catch (expected: UnsupportedOperationException) {
+        assertNotNull(expected.message)
+        assertTrue(
+          "error message should mention the sandboxCount constraint",
+          expected.message!!.contains("sandboxCount"),
+        )
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun idleLeaseAutoClosesAbandonedSession() {
+    // Drive the watchdog with a 500ms lease so we don't burn a minute of CI per run. The host's
+    // interactiveIdleLeaseMs forwards to every session it acquires.
+    System.setProperty(
+      RenderEngine.OUTPUT_DIR_PROP,
+      tempFolder.newFolder("zombie").absolutePath,
+    )
+    System.setProperty("roborazzi.test.record", "true")
+    val host =
+      RobolectricHost(
+        sandboxCount = 2,
+        previewSpecResolver = previewSpecResolver(),
+        interactiveIdleLeaseMs = 500L,
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireInteractiveSession(
+          previewId = INTERACTIVE_PREVIEW_ID,
+          classLoader = javaClass.classLoader!!,
+        )
+      val typed = session as AndroidInteractiveSession
+      assertFalse("session must be open immediately after acquire", typed.isClosed)
+      assertNull("autoClosedReason should be null on a fresh session", typed.autoClosedReason())
+
+      // Wait long enough for the watchdog to fire and complete its close round-trip. Lease is
+      // 500ms; watchdog ticks at 500ms/4 = 125ms; close round-trip is < 1s. Polling once a tick
+      // for up to 10s is generous against a slow CI but fast in normal cases.
+      val deadline = System.currentTimeMillis() + 10_000L
+      while (!typed.isClosed && System.currentTimeMillis() < deadline) {
+        Thread.sleep(100L)
+      }
+      assertTrue(
+        "watchdog should have auto-closed the idle session within 10s of acquire " +
+          "(idleLeaseMs=500)",
+        typed.isClosed,
+      )
+      val reason = typed.autoClosedReason()
+      assertNotNull("autoClosedReason should be populated by the watchdog path", reason)
+      assertTrue(
+        "autoClosedReason should mention the idle gap and the lease for diagnostics: '$reason'",
+        reason!!.contains("idle for") && reason.contains("lease"),
+      )
+
+      // After auto-close, a fresh acquire must succeed — the host's activeInteractiveStreamId
+      // should have been cleared by the watchdog's close() call.
+      val followup =
+        host.acquireInteractiveSession(
+          previewId = INTERACTIVE_PREVIEW_ID,
+          classLoader = javaClass.classLoader!!,
+        )
+      followup.close()
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun nestedAcquireRefusesUntilFirstSessionCloses() {
+    System.setProperty(
+      RenderEngine.OUTPUT_DIR_PROP,
+      tempFolder.newFolder("nested").absolutePath,
+    )
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost(sandboxCount = 2, previewSpecResolver = previewSpecResolver())
+    host.start()
+    try {
+      val first =
+        host.acquireInteractiveSession(
+          previewId = INTERACTIVE_PREVIEW_ID,
+          classLoader = javaClass.classLoader!!,
+        )
+      try {
+        try {
+          host.acquireInteractiveSession(
+            previewId = INTERACTIVE_PREVIEW_ID,
+            classLoader = javaClass.classLoader!!,
+          )
+          fail("nested acquire should have thrown")
+        } catch (expected: UnsupportedOperationException) {
+          assertTrue(
+            "nested-acquire error should mention 'already held'",
+            expected.message!!.contains("already held"),
+          )
+        }
+      } finally {
+        first.close()
+      }
+      // After close, a fresh acquire must succeed — the host should have cleared its
+      // activeInteractiveStreamId ref.
+      val second =
+        host.acquireInteractiveSession(
+          previewId = INTERACTIVE_PREVIEW_ID,
+          classLoader = javaClass.classLoader!!,
+        )
+      second.close()
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  private fun previewSpecResolver(): (String) -> RenderSpec? = { previewId ->
+    if (previewId == INTERACTIVE_PREVIEW_ID) {
+      RenderSpec(
+        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+        functionName = "ClickToggleSquare",
+        widthPx = INTERACTIVE_WIDTH_PX,
+        heightPx = INTERACTIVE_HEIGHT_PX,
+        density = 1.0f,
+        showBackground = true,
+        outputBaseName = "interactive-clicktoggle",
+      )
+    } else null
+  }
+
+  private fun decode(file: File): java.awt.image.BufferedImage {
+    require(file.exists()) { "expected capture at ${file.absolutePath}" }
+    val bytes = file.readBytes()
+    require(bytes.isNotEmpty()) { "capture is empty: ${file.absolutePath}" }
+    return ByteArrayInputStream(bytes).use { ImageIO.read(it) }
+      ?: error("ImageIO refused to decode capture: ${file.absolutePath}")
+  }
+
+  private fun pixelMatchPct(
+    img: java.awt.image.BufferedImage,
+    expectedRgb: Int,
+    perChannelTolerance: Int,
+  ): Double {
+    val expR = (expectedRgb shr 16) and 0xFF
+    val expG = (expectedRgb shr 8) and 0xFF
+    val expB = expectedRgb and 0xFF
+    var matches = 0L
+    for (y in 0 until img.height) {
+      for (x in 0 until img.width) {
+        val rgb = img.getRGB(x, y)
+        val r = (rgb shr 16) and 0xFF
+        val g = (rgb shr 8) and 0xFF
+        val b = rgb and 0xFF
+        if (
+          abs(r - expR) <= perChannelTolerance &&
+            abs(g - expG) <= perChannelTolerance &&
+            abs(b - expB) <= perChannelTolerance
+        ) {
+          matches++
+        }
+      }
+    }
+    return matches.toDouble() / (img.width.toLong() * img.height.toLong()).toDouble()
+  }
+
+  companion object {
+    private const val INTERACTIVE_PREVIEW_ID = "interactive-clicktoggle"
+    private const val INTERACTIVE_WIDTH_PX = 96
+    private const val INTERACTIVE_HEIGHT_PX = 96
+    private const val RED_RGB = 0xEF5350
+    private const val GREEN_RGB = 0x66BB6A
+  }
+}

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -1,11 +1,15 @@
 package ee.schimke.composeai.daemon
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 
 /**
  * Test fixtures for [RenderEngineTest] and the D-harness.v2 Android real-mode scenarios. Lives in
@@ -88,4 +92,33 @@ fun DarkAwareSquare() {
   val bg =
     if (androidx.compose.foundation.isSystemInDarkTheme()) Color.Black else Color.White
   Box(modifier = Modifier.fillMaxSize().background(bg))
+}
+
+/**
+ * Stateful fixture for the v3 Android-interactive test ([AndroidInteractiveSessionTest]). Paints
+ * red on first composition; flips to green when any pointer-down event lands. Same shape as the
+ * desktop `ClickToggleSquare` fixture in `daemon/desktop`'s testFixtures so the two backends'
+ * integration tests assert against an identical state-mutation contract ("first capture red;
+ * dispatch click; second capture green — `remember{}` state survived across captures").
+ *
+ * Uses `awaitFirstDown` rather than `Modifier.clickable` because `clickable` sits on top of
+ * `detectTapGestures`, whose coroutine timing under Compose's paused clock is non-trivial. The
+ * `RobolectricInteractiveProbeTest` empirical probe verified `awaitFirstDown` fires reliably for
+ * a synthesised `MotionEvent` dispatched through `decorView.dispatchTouchEvent` under the held
+ * rule — the simplest pointerInput shape gives the cleanest yes/no answer for the wire-level
+ * test and matches what the desktop counterpart already asserts on.
+ */
+@Composable
+fun ClickToggleSquare() {
+  var clicked by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+  val color = if (clicked) Color(0xFF66BB6A) else Color(0xFFEF5350)
+  Box(
+    modifier =
+      Modifier.fillMaxSize().background(color).pointerInput(Unit) {
+        awaitPointerEventScope {
+          awaitFirstDown()
+          clicked = true
+        }
+      }
+  )
 }


### PR DESCRIPTION
## Summary

PR B of [INTERACTIVE-ANDROID.md § 10](docs/daemon/INTERACTIVE-ANDROID.md). Stacked on PR A (#459) — held `createAndroidComposeRule` on a pinned sandbox slot keeps a Compose composition alive across `interactive/input` events so `remember { mutableStateOf(…) }` survives between clicks.

Builds on PR A's bridge primitives and the dispatch recipe empirically validated by `RobolectricInteractiveProbeTest` on the probe branch.

### Architecture (recap)

- **Slot 0** stays the always-on normal-render slot.
- **Slot 1** pins to one held interactive session at a time; v3 requires `sandboxCount >= 2`. With `sandboxCount == 1` the host advertises `interactive=false` and the panel falls back to v1.
- Per the design's § 2.1, single-target only on Android — concurrent acquires throw `Unsupported`. The wire-level multi-stream support stays intact; the cap is host capability, not protocol restriction.

### What's in this PR

**Host side**
- `AndroidInteractiveSession` — `dispatch` / `render` / `close` marshal across the sandbox boundary via `InteractiveCommand` envelopes through `DaemonHostBridge`.
- `RobolectricHost.acquireInteractiveSession` — enforces `sandboxCount >= 2` + wired `previewSpecResolver` + one-session-at-a-time CAS on `activeInteractiveStreamId`. Throws `UnsupportedOperationException` (which `JsonRpcServer` translates to `MethodNotFound (-32601)`) for any precondition miss; `JsonRpcServer` then falls back to v1 and the panel surfaces the existing fallback hint.
- `RobolectricHost.supportsInteractive` flips to `true` under those conditions so `ServerCapabilities.interactive` advertises v3 for clients to detect.

**Sandbox side**
- `SandboxRunner.runHeldInteractiveSession` — constructs the rule + ActivityScenario, runs `setContent` once with `LocalInspectionMode = false` (so `Modifier.pointerInput` / `clickable` actually fire), then drains `InteractiveCommand.{Dispatch,Render,Close}` until Close returns control to `holdSandboxOpen`. `MotionEvent` synthesis + `decorView.dispatchTouchEvent` mirrors the probe's recipe verbatim. Per-render clock-advance (`HELD_CAPTURE_ADVANCE_MS = 32 ms`) before `captureRoboImage`; per-dispatch advance (`POINTER_HOLD_MS = 100 ms`).
- `holdSandboxOpen` grows an interactive-priority poll: a queued `InteractiveCommand.Start` pins the slot before the next normal render lands; orphan Dispatch/Render/Close (a wire-level race) is logged and dropped.

**Zombie-session safeguard (1 minute idle lease)**
- Per your note — every session carries a watchdog that auto-closes after `composeai.daemon.interactive.idleLeaseMs` (default 60 s) of no `dispatch` / `render`. Catches panel crashes and websocket drops so a zombie can't pin slot 1 for the rest of the daemon's lifetime. Surfaced via `AndroidInteractiveSession.autoClosedReason()` so PR C's wire handler can distinguish "force-closed because idle" from "client hit interactive/stop". Symmetric with the panel's existing auto-stop on editor change/scroll (#427).

**Test fixture**
- `ClickToggleSquare` — red → green on `awaitFirstDown`, matching the desktop counterpart so the two backends' integration tests assert against an identical state-mutation contract.

**Tests** (`AndroidInteractiveSessionTest`, 5 cases)
- `heldClickToggleSurvivesAcrossInputs` — the substantive integration: held composition red, dispatch click at centre, capture green; then a normal `host.submit(RedSquare)` on slot 0 still produces a 95%+ red PNG. Proves slot 1 pinning doesn't strand slot 0.
- `acquireWithoutResolverThrowsUnsupported`
- `acquireWithSandboxCountOneThrowsUnsupported`
- `nestedAcquireRefusesUntilFirstSessionCloses`
- `idleLeaseAutoClosesAbandonedSession` — drives the watchdog with a 500 ms lease (constructor param) so CI doesn't sleep for a minute. Asserts `isClosed`, `autoClosedReason()`, and that a fresh acquire works after the auto-close.

### What's NOT in this PR (deferred to PR C, INTERACTIVE-ANDROID.md § 10.3)

- Classpath-dirty handling (`fileChanged` mid-session → host posts `Close` to active session; next `interactive/start` after recompile gets a fresh classloader).
- Sandbox-recycle interaction (B2.5) — recycler must skip the pinned slot while a session is held; reads `activeInteractiveStreamId`.
- Explicit `JsonRpcServer.onChannelClosed` handler so client disconnect auto-closes immediately rather than waiting for the lease.
- Threading `localeTag` / `fontScale` / `uiMode` / `orientation` through `InteractiveCommand.Start` (PR B carries the v1 size/density/round subset; PR C extends).

## Test plan

- [x] `:daemon:android:testDebugUnitTest` — full module suite green, including all 5 new `AndroidInteractiveSessionTest` cases (~30 s with two sandbox cold boots in the integration test)
- [x] `:daemon:android:ktfmtCheck` clean
- [x] `:daemon:harness:compileTestKotlin` + `:daemon:core:test` — downstream consumers unaffected
- [ ] After landing, smoke-test the held session by running `:daemon:bench` against a sample with `sandboxCount=2` to confirm interactive feels fluid


---
_Generated by [Claude Code](https://claude.ai/code/session_017NDGZk17VhvctNNoSrVZsK)_