### PR TITLE
feat(daemon): image-processor seam + extras on data products (D2.1)

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.daemon
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductExtra
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.renderer.AccessibilityFinding
 import ee.schimke.composeai.renderer.AccessibilityNode
@@ -41,24 +42,41 @@ object AccessibilityDataProducer {
   /** `a11y/hierarchy` — accessibility-relevant nodes with bounds + label + states. */
   const val KIND_HIERARCHY: String = "a11y/hierarchy"
 
+  /**
+   * D2.1 — `a11y/overlay`. Path-transport kind whose only content is the Paparazzi-style
+   * annotated PNG produced by [AccessibilityImageProcessor]. Lets clients fetch the picture
+   * directly without first asking for the JSON kinds. Also surfaces as an `overlay` extra on
+   * the JSON kinds, so a panel that subscribed to `a11y/atf` still has the PNG path handy.
+   */
+  const val KIND_OVERLAY: String = "a11y/overlay"
+
   /** File names under `<rootDir>/<previewId>/`. */
   const val FILE_ATF: String = "a11y-atf.json"
   const val FILE_HIERARCHY: String = "a11y-hierarchy.json"
+  const val FILE_OVERLAY: String = "a11y-overlay.png"
 
   @Serializable internal data class AtfPayload(val findings: List<AccessibilityFinding>)
 
   @Serializable internal data class HierarchyPayload(val nodes: List<AccessibilityNode>)
 
   /**
-   * Writes both files to `<rootDir>/<previewId>/` (creating the directory tree if needed).
-   * Idempotent — overwrites prior files. Called from [RenderEngine.render]'s a11y branch
-   * with the result of [ee.schimke.composeai.renderer.AccessibilityChecker.analyze].
+   * Writes both JSON files to `<rootDir>/<previewId>/` (creating the directory tree if needed).
+   * Idempotent — overwrites prior files. Called from [RenderEngine.render]'s a11y branch with
+   * the result of [ee.schimke.composeai.renderer.AccessibilityChecker.analyze].
+   *
+   * When [pngFile] is supplied (the captured screenshot), the configured [imageProcessors]
+   * also run — for the daemon's default wiring that means [AccessibilityImageProcessor]
+   * generates `a11y-overlay.png`. Each processor failure is logged + skipped so a single
+   * bad processor never strands the JSON the consumer already cares about.
    */
   fun writeArtifacts(
     rootDir: File,
     previewId: String,
     findings: List<AccessibilityFinding>,
     nodes: List<AccessibilityNode>,
+    pngFile: File? = null,
+    isRound: Boolean = false,
+    imageProcessors: List<ImageProcessor> = emptyList(),
   ) {
     val previewDir = rootDir.resolve(previewId)
     previewDir.mkdirs()
@@ -68,6 +86,26 @@ object AccessibilityDataProducer {
     previewDir
       .resolve(FILE_HIERARCHY)
       .writeText(json.encodeToString(HierarchyPayload.serializer(), HierarchyPayload(nodes)))
+    if (pngFile == null || imageProcessors.isEmpty()) return
+    val input =
+      ImageProcessorInput(
+        previewId = previewId,
+        pngFile = pngFile,
+        dataDir = rootDir,
+        isRound = isRound,
+        accessibility =
+          ImageProcessorInput.AccessibilityResult(findings = findings, nodes = nodes),
+      )
+    for (processor in imageProcessors) {
+      try {
+        processor.process(input)
+      } catch (t: Throwable) {
+        System.err.println(
+          "AccessibilityDataProducer: image processor '${processor.name}' failed " +
+            "for $previewId: ${t.javaClass.simpleName}: ${t.message}"
+        )
+      }
+    }
   }
 }
 
@@ -108,6 +146,14 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
         fetchable = true,
         requiresRerender = false,
       ),
+      DataProductCapability(
+        kind = AccessibilityDataProducer.KIND_OVERLAY,
+        schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
+        transport = DataProductTransport.PATH,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+      ),
     )
 
   override fun fetch(
@@ -123,9 +169,23 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
         AccessibilityDataProducer.KIND_HIERARCHY ->
           fileFor(previewId, AccessibilityDataProducer.FILE_HIERARCHY) to
             DataProductTransport.PATH
+        AccessibilityDataProducer.KIND_OVERLAY ->
+          fileFor(previewId, AccessibilityDataProducer.FILE_OVERLAY) to DataProductTransport.PATH
         else -> return DataProductRegistry.Outcome.Unknown
       }
     if (!file.exists()) return DataProductRegistry.Outcome.NotAvailable
+    val extras = extrasFor(previewId, kind)
+    // The overlay kind is binary (PNG); never parse it as JSON. Path-only.
+    if (kind == AccessibilityDataProducer.KIND_OVERLAY) {
+      return DataProductRegistry.Outcome.Ok(
+        DataFetchResult(
+          kind = kind,
+          schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
+          path = file.absolutePath,
+          extras = extras.takeIf { it.isNotEmpty() },
+        )
+      )
+    }
     val payloadElement: JsonElement? =
       try {
         json.parseToJsonElement(file.readText())
@@ -141,6 +201,7 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
             kind = kind,
             schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
             payload = payloadElement,
+            extras = extras.takeIf { it.isNotEmpty() },
           )
         transport == DataProductTransport.INLINE ->
           // Even when the caller didn't ask for inline, the `inline` transport kind has no
@@ -150,15 +211,44 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
             kind = kind,
             schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
             payload = payloadElement,
+            extras = extras.takeIf { it.isNotEmpty() },
           )
         else ->
           DataFetchResult(
             kind = kind,
             schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
             path = file.absolutePath,
+            extras = extras.takeIf { it.isNotEmpty() },
           )
       }
     return DataProductRegistry.Outcome.Ok(result)
+  }
+
+  /**
+   * Builds the [DataProductExtra] list for [kind] by scanning [previewId]'s data dir for
+   * known sibling outputs. Today the only extra is the a11y overlay PNG, attached to all
+   * three a11y kinds. Returns an empty list when no extras are available — the caller wraps
+   * the result in `takeIf { it.isNotEmpty() }` so the wire field stays absent in that case.
+   */
+  private fun extrasFor(previewId: String, kind: String): List<DataProductExtra> {
+    val attaches =
+      when (kind) {
+        AccessibilityDataProducer.KIND_ATF,
+        AccessibilityDataProducer.KIND_HIERARCHY,
+        AccessibilityDataProducer.KIND_OVERLAY -> true
+        else -> false
+      }
+    if (!attaches) return emptyList()
+    val overlay = fileFor(previewId, AccessibilityDataProducer.FILE_OVERLAY)
+    if (!overlay.exists()) return emptyList()
+    return listOf(
+      DataProductExtra(
+        name = AccessibilityImageProcessor.OVERLAY_NAME,
+        path = overlay.absolutePath,
+        mediaType = "image/png",
+        sizeBytes = overlay.length().takeIf { it > 0 },
+      )
+    )
   }
 
   override fun attachmentsFor(
@@ -167,6 +257,7 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
   ): List<DataProductAttachment> {
     val out = mutableListOf<DataProductAttachment>()
     for (kind in kinds) {
+      val extras = extrasFor(previewId, kind).takeIf { it.isNotEmpty() }
       when (kind) {
         AccessibilityDataProducer.KIND_ATF -> {
           val file = fileFor(previewId, AccessibilityDataProducer.FILE_ATF)
@@ -185,6 +276,7 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
               kind = kind,
               schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
               payload = parsed,
+              extras = extras,
             )
           )
         }
@@ -196,6 +288,19 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
               kind = kind,
               schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
               path = file.absolutePath,
+              extras = extras,
+            )
+          )
+        }
+        AccessibilityDataProducer.KIND_OVERLAY -> {
+          val file = fileFor(previewId, AccessibilityDataProducer.FILE_OVERLAY)
+          if (!file.exists()) continue
+          out.add(
+            DataProductAttachment(
+              kind = kind,
+              schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
+              path = file.absolutePath,
+              extras = extras,
             )
           )
         }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/ImageProcessor.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/ImageProcessor.kt
@@ -1,0 +1,116 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductExtra
+import ee.schimke.composeai.renderer.AccessibilityChecker
+import ee.schimke.composeai.renderer.AccessibilityFinding
+import ee.schimke.composeai.renderer.AccessibilityNode
+import ee.schimke.composeai.renderer.AccessibilityOverlay
+import java.io.File
+
+/**
+ * D2.1 — pluggable post-render hook for the daemon's render loop. An [ImageProcessor]
+ * receives the just-captured PNG and the renderer-side a11y artefacts (when a11y mode is on)
+ * and writes derived files — typically annotated PNGs like the Paparazzi-style accessibility
+ * overlay — under the data-product directory tree.
+ *
+ * Each output is reported back as a [DataProductExtra] tagged with the kind it should attach
+ * to (so `a11y/atf` rides with its overlay PNG even when the caller fetched the JSON inline)
+ * and a stable [DataProductExtra.name] the registry uses as the cache key. Processors stay
+ * pure-data — the registry decides whether the extras end up on the wire based on the
+ * client's subscription set.
+ *
+ * **Where this fits.** The Gradle / CLI path keeps using
+ * [AccessibilityChecker.writePerPreviewReport]'s built-in overlay bake (see
+ * `AccessibilityChecker.kt` § `writePerPreviewReport`); processors are the daemon-mode
+ * replacement that lets clients drive their own a11y panel UI without a second baked PNG.
+ * Same generator either way — see [AccessibilityOverlay] for the visual language.
+ *
+ * Implementations are stateless across renders and **must not** retain references to
+ * [ImageProcessorInput.pngFile] or any [java.io.File] handed to them — the daemon recycles
+ * `<dataDir>` between renders.
+ */
+interface ImageProcessor {
+  /** Producer-stable identifier for the processor. Surfaces in error logs. */
+  val name: String
+
+  /**
+   * Runs against the just-captured render. Returns the per-kind extras the processor wrote;
+   * the registry attaches them to matching `data/fetch` results and `renderFinished`
+   * attachments. An empty map means "this render didn't have anything to add" (e.g. an a11y
+   * processor on a render whose mode skipped a11y).
+   */
+  fun process(input: ImageProcessorInput): Map<String, List<DataProductExtra>>
+}
+
+/**
+ * Per-render inputs handed to every [ImageProcessor]. `pngFile` is the absolute path of the
+ * primary capture (already on disk); `dataDir` is the per-preview output root
+ * (`<rootDir>/<previewId>/`); `accessibility` carries the ATF + hierarchy result when a11y
+ * mode ran for this render, or `null` when it didn't.
+ */
+data class ImageProcessorInput(
+  val previewId: String,
+  val pngFile: File,
+  val dataDir: File,
+  val isRound: Boolean,
+  val accessibility: AccessibilityResult? = null,
+) {
+  /** Adapter onto [AccessibilityChecker.Result] kept here so processors don't depend on it. */
+  data class AccessibilityResult(
+    val findings: List<AccessibilityFinding>,
+    val nodes: List<AccessibilityNode>,
+  )
+}
+
+/**
+ * D2.1 — first concrete [ImageProcessor]. When the render ran in a11y mode and produced any
+ * findings or nodes, generates the Paparazzi-style annotated overlay via
+ * [AccessibilityOverlay.generate] and attaches it to `a11y/atf` and `a11y/hierarchy` as the
+ * `overlay` extra. Standalone consumers can also fetch the dedicated `a11y/overlay` kind that
+ * the registry advertises.
+ *
+ * Output path: `<dataDir>/<previewId>/a11y-overlay.png`. Same naming convention the JSON
+ * artefacts use (slash-to-dash on the kind), so the registry's reverse mapping stays
+ * mechanical.
+ */
+class AccessibilityImageProcessor : ImageProcessor {
+  override val name: String = "a11y-overlay"
+
+  override fun process(input: ImageProcessorInput): Map<String, List<DataProductExtra>> {
+    val a11y = input.accessibility ?: return emptyMap()
+    if (a11y.findings.isEmpty() && a11y.nodes.isEmpty()) return emptyMap()
+    val previewDir = input.dataDir.resolve(input.previewId).also { it.mkdirs() }
+    val dest = previewDir.resolve(OVERLAY_FILE)
+    val written =
+      AccessibilityOverlay.generate(
+        sourcePng = input.pngFile,
+        findings = a11y.findings,
+        nodes = a11y.nodes,
+        destPng = dest,
+        isRound = input.isRound,
+      ) ?: return emptyMap()
+    val extra =
+      DataProductExtra(
+        name = OVERLAY_NAME,
+        path = written.absolutePath,
+        mediaType = "image/png",
+        sizeBytes = written.length().takeIf { it > 0 },
+      )
+    // Same overlay attaches to both a11y kinds so a panel that only fetched one kind still
+    // gets the picture; the dedicated `a11y/overlay` kind is for clients that just want the
+    // PNG without the JSON.
+    return mapOf(
+      AccessibilityDataProducer.KIND_ATF to listOf(extra),
+      AccessibilityDataProducer.KIND_HIERARCHY to listOf(extra),
+      AccessibilityDataProducer.KIND_OVERLAY to listOf(extra),
+    )
+  }
+
+  companion object {
+    /** [DataProductExtra.name] used for the rendered overlay PNG. */
+    const val OVERLAY_NAME: String = "overlay"
+
+    /** Filename under `<dataDir>/<previewId>/`. Mirrors `a11y-{atf,hierarchy}.json`. */
+    const val OVERLAY_FILE: String = "a11y-overlay.png"
+  }
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -86,6 +86,14 @@ class RenderEngine(
    */
   private val dataDir: File? =
     (outputDir.parentFile ?: outputDir).resolve("data"),
+  /**
+   * D2.1 — image processors that run after the PNG + JSON artefacts are written. Defaults to
+   * a single [AccessibilityImageProcessor] so the Paparazzi-style overlay PNG lands under
+   * `<dataDir>/<previewId>/a11y-overlay.png` whenever a11y mode produced findings or nodes.
+   * Empty list disables — useful for the harness's fake-mode runs that don't exercise the
+   * processor surface.
+   */
+  private val imageProcessors: List<ImageProcessor> = listOf(AccessibilityImageProcessor()),
 ) {
 
   /**
@@ -249,6 +257,9 @@ class RenderEngine(
                   previewId = spec.outputBaseName,
                   findings = a11yResult.findings,
                   nodes = a11yResult.nodes,
+                  pngFile = outputFile,
+                  isRound = isRound,
+                  imageProcessors = imageProcessors,
                 )
               } catch (t: Throwable) {
                 System.err.println(

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProductRegistryTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProductRegistryTest.kt
@@ -37,12 +37,13 @@ class AccessibilityDataProductRegistryTest {
   }
 
   @Test
-  fun `capabilities advertise a11y atf and hierarchy with the documented transports`() {
+  fun `capabilities advertise a11y atf hierarchy and overlay with the documented transports`() {
     val registry = AccessibilityDataProductRegistry(rootDir)
     val byKind = registry.capabilities.associateBy { it.kind }
-    assertEquals(setOf("a11y/atf", "a11y/hierarchy"), byKind.keys)
+    assertEquals(setOf("a11y/atf", "a11y/hierarchy", "a11y/overlay"), byKind.keys)
     assertEquals(DataProductTransport.INLINE, byKind.getValue("a11y/atf").transport)
     assertEquals(DataProductTransport.PATH, byKind.getValue("a11y/hierarchy").transport)
+    assertEquals(DataProductTransport.PATH, byKind.getValue("a11y/overlay").transport)
     for (cap in registry.capabilities) {
       assertTrue(cap.attachable)
       assertTrue(cap.fetchable)
@@ -161,5 +162,84 @@ class AccessibilityDataProductRegistryTest {
     assertNotNull(result.path)
     assertNull(result.payload)
     assertTrue(File(result.path!!).exists())
+  }
+
+  @Test
+  fun `attachmentsFor surfaces overlay PNG as an extra under a11y atf and hierarchy when present`() {
+    val registry = AccessibilityDataProductRegistry(rootDir)
+    val previewId = "com.example.HomeKt#HomePreview"
+    AccessibilityDataProducer.writeArtifacts(
+      rootDir = rootDir,
+      previewId = previewId,
+      findings = emptyList(),
+      nodes = emptyList(),
+    )
+    // Simulate the AccessibilityImageProcessor having written the overlay PNG into the
+    // per-preview data dir alongside the JSON artefacts. The registry doesn't care how the
+    // bytes got there; it just surfaces the file as an extra.
+    val previewDir = File(rootDir, previewId).also { it.mkdirs() }
+    val overlay = File(previewDir, AccessibilityDataProducer.FILE_OVERLAY)
+    overlay.writeBytes(byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47))
+
+    val attachments =
+      registry.attachmentsFor(
+        previewId = previewId,
+        kinds = setOf("a11y/atf", "a11y/hierarchy", "a11y/overlay"),
+      )
+    val byKind = attachments.associateBy { it.kind }
+    val atfExtras = byKind.getValue("a11y/atf").extras
+    assertNotNull("extras must populate when overlay PNG is on disk", atfExtras)
+    assertEquals(1, atfExtras!!.size)
+    assertEquals("overlay", atfExtras[0].name)
+    assertEquals("image/png", atfExtras[0].mediaType)
+    assertEquals(overlay.absolutePath, atfExtras[0].path)
+
+    val overlayKind = byKind.getValue("a11y/overlay")
+    assertNotNull(overlayKind.path)
+    assertEquals(overlay.absolutePath, overlayKind.path)
+    assertNull(overlayKind.payload)
+  }
+
+  @Test
+  fun `fetch on a11y overlay returns the path and the same extra as the JSON kinds`() {
+    val registry = AccessibilityDataProductRegistry(rootDir)
+    val previewId = "com.example.X"
+    AccessibilityDataProducer.writeArtifacts(
+      rootDir = rootDir,
+      previewId = previewId,
+      findings = emptyList(),
+      nodes = emptyList(),
+    )
+    val previewDir = File(rootDir, previewId).also { it.mkdirs() }
+    val overlay = File(previewDir, AccessibilityDataProducer.FILE_OVERLAY)
+    overlay.writeBytes(byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47))
+
+    val outcome =
+      registry.fetch(previewId = previewId, kind = "a11y/overlay", params = null, inline = false)
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    val result = (outcome as DataProductRegistry.Outcome.Ok).result
+    assertEquals(overlay.absolutePath, result.path)
+    assertNull("a11y/overlay must not be parsed as JSON", result.payload)
+    val extras = result.extras
+    assertNotNull(extras)
+    assertEquals(1, extras!!.size)
+    assertEquals(overlay.absolutePath, extras[0].path)
+  }
+
+  @Test
+  fun `attachmentsFor omits extras when the overlay PNG never landed`() {
+    val registry = AccessibilityDataProductRegistry(rootDir)
+    val previewId = "com.example.NoOverlay"
+    AccessibilityDataProducer.writeArtifacts(
+      rootDir = rootDir,
+      previewId = previewId,
+      findings = emptyList(),
+      nodes = emptyList(),
+    )
+    val attachments =
+      registry.attachmentsFor(previewId = previewId, kinds = setOf("a11y/atf", "a11y/hierarchy"))
+    for (att in attachments) {
+      assertNull("extras must be absent when overlay PNG is missing", att.extras)
+    }
   }
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -332,6 +332,15 @@ data class DataFetchResult(
   // Reserved for non-local clients; populated only when caller passes
   // `inline: true` and the kind's transport is blob-shaped.
   val bytes: String? = null,
+  /**
+   * Additional non-JSON outputs the producer wrote alongside the primary payload — typically
+   * derived images such as the a11y overlay PNG. Each entry points at a sibling file under the
+   * preview's data dir; clients read the file directly. Always omitted (`null` on the wire) when no
+   * extras landed for this fetch — older clients ignore the field. See
+   * [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md) § "Image
+   * processors and extras".
+   */
+  val extras: List<DataProductExtra>? = null,
 )
 
 /**
@@ -402,6 +411,9 @@ data class RenderFinishedParams(
  * One data-product attachment riding on a `renderFinished`. `payload` is per-kind JSON when the
  * producer's transport is `inline`; `path` is an absolute path to a sibling file when the
  * producer's transport is `path`. Exactly one of the two is set per attachment.
+ *
+ * `extras` carries derived non-JSON outputs the producer wrote alongside (e.g. the a11y overlay
+ * PNG). Always omitted on the wire when empty so pre-feature clients ignore it.
  */
 @Serializable
 data class DataProductAttachment(
@@ -409,6 +421,31 @@ data class DataProductAttachment(
   val schemaVersion: Int,
   val payload: JsonElement? = null,
   val path: String? = null,
+  val extras: List<DataProductExtra>? = null,
+)
+
+/**
+ * One additional output a data-product producer wrote alongside its primary payload. Used for
+ * derived images (the Paparazzi-style a11y overlay PNG, layout-tree visualisations, recomposition
+ * heat maps) that the producer emits as a side effect of running. The wire format is intentionally
+ * minimal — pointer-only, no inlining — because the file is typically tens of KB and the daemon
+ * already lives on the client's filesystem.
+ *
+ * `name` is a producer-stable, human-readable identifier (`"overlay"`, `"diff"`); the registry uses
+ * it as the cache key for fetch-on-demand and also as the suggested file basename when the producer
+ * writes the extra to disk. `mediaType` is the IANA media type when known (`image/png`), left null
+ * when the producer doesn't classify the file. `sizeBytes` is the file size at write time; clients
+ * use it for "show this only when small enough to inline" UI heuristics.
+ *
+ * See [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md) § "Image
+ * processors and extras".
+ */
+@Serializable
+data class DataProductExtra(
+  val name: String,
+  val path: String,
+  val mediaType: String? = null,
+  val sizeBytes: Long? = null,
 )
 
 @Serializable

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -116,6 +116,39 @@ A producer picks one transport per kind, advertised in capabilities. A
 producer MAY support both `inline` and `path`; the caller picks via
 the `inline` flag on `data/fetch`.
 
+### Image processors and extras
+
+A kind's primary payload is JSON or a JSON-shaped path. Some producers
+also want to ship **derived images** alongside — the Paparazzi-style
+a11y overlay PNG is the load-bearing example. Two seams cover this:
+
+- **`extras` field** — additive on `DataProductAttachment` and
+  `DataFetchResult`. List of `{name, path, mediaType?, sizeBytes?}`
+  entries pointing at sibling files the producer wrote. Pointer-only
+  (no inlining) because the files are typically tens of KB and the
+  daemon already lives on the client's filesystem. Empty / absent
+  are interchangeable on the wire.
+- **`ImageProcessor` interface** (`daemon/android`) — pluggable
+  post-render hook the renderer's [`RenderEngine`] runs after the PNG
+  is captured. Each processor gets `(previewId, pngFile, dataDir,
+  isRound, accessibility?)` and returns a `Map<kind, List<extra>>` so
+  the registry can attach the same derived file to multiple kinds (the
+  a11y overlay rides under `a11y/atf`, `a11y/hierarchy`, AND the
+  dedicated `a11y/overlay` kind).
+
+The first concrete processor is `AccessibilityImageProcessor`, which
+adapts the existing renderer-side `AccessibilityOverlay.generate(...)`
+into the new contract. Output lands at
+`<dataDir>/<previewId>/a11y-overlay.png`; same directory the JSON
+artefacts live in. The Gradle / CLI path keeps its own overlay bake
+via `AccessibilityChecker.writePerPreviewReport` — same generator,
+different writer — so on-disk consumers are unchanged.
+
+For pure-image kinds (`a11y/overlay`), `transport='path'` and the
+fetch returns the PNG path directly. Clients that want both the JSON
+and the picture can subscribe once to `a11y/atf` and read the overlay
+out of the resulting attachment's `extras` list — no second round-trip.
+
 ### On-disk layout
 
 Today a11y-per-preview lives at
@@ -313,8 +346,9 @@ SHIPPED; everything else is "we know the shape, no code yet."
 
 | Kind                       | Mode | Cost | Notes |
 |----------------------------|------|------|-------|
-| `a11y/atf`                 | a11y | low  | `AccessibilityFinding[]` from ATF. Drives diagnostic squigglies. Cheap enough for global attach. |
-| `a11y/hierarchy`           | a11y | low  | `AccessibilityNode[]` (label, role, states, bounds). Powers a local overlay in VS Code. **First implementation.** |
+| `a11y/atf`                 | a11y | low  | `AccessibilityFinding[]` from ATF. Drives diagnostic squigglies. Cheap enough for global attach. Carries the `overlay` PNG as an extra when one was generated. |
+| `a11y/hierarchy`           | a11y | low  | `AccessibilityNode[]` (label, role, states, bounds). Powers a local overlay in VS Code. **First implementation.** Carries the `overlay` PNG as an extra. |
+| `a11y/overlay`             | a11y | low  | Path to the Paparazzi-style annotated PNG produced by `AccessibilityImageProcessor`. Pure-image kind — `transport='path'`, no JSON payload. **D2.1 — image-processor surface.** |
 | `a11y/touchTargets`        | a11y | low  | Derived from hierarchy; 48dp + overlap detection. |
 | `layout/tree`              | default | low | View / Compose layout tree with bounds, paddings, source-line refs. Layout inspector. |
 | `compose/semantics`        | default | low | SemanticsNode projection — testTag, role, mergeMode. |

--- a/docs/daemon/protocol-fixtures/daemon-dataFetchResult.json
+++ b/docs/daemon/protocol-fixtures/daemon-dataFetchResult.json
@@ -1,5 +1,13 @@
 {
   "kind": "a11y/hierarchy",
   "schemaVersion": 1,
-  "path": "/home/dev/projects/my-app/samples/android/build/compose-previews/data/com.example.HomeKt-HomePreview/a11y-hierarchy.json"
+  "path": "/home/dev/projects/my-app/samples/android/build/compose-previews/data/com.example.HomeKt-HomePreview/a11y-hierarchy.json",
+  "extras": [
+    {
+      "name": "overlay",
+      "path": "/home/dev/projects/my-app/samples/android/build/compose-previews/data/com.example.HomeKt-HomePreview/a11y-overlay.png",
+      "mediaType": "image/png",
+      "sizeBytes": 38912
+    }
+  ]
 }

--- a/docs/daemon/protocol-fixtures/daemon-renderFinished-withDataProducts.json
+++ b/docs/daemon/protocol-fixtures/daemon-renderFinished-withDataProducts.json
@@ -22,12 +22,41 @@
             "boundsInScreen": "120,440,184,504"
           }
         ]
-      }
+      },
+      "extras": [
+        {
+          "name": "overlay",
+          "path": "/home/dev/projects/my-app/samples/android/build/compose-previews/data/com.example.HomeKt-HomePreview/a11y-overlay.png",
+          "mediaType": "image/png",
+          "sizeBytes": 38912
+        }
+      ]
     },
     {
       "kind": "a11y/hierarchy",
       "schemaVersion": 1,
-      "path": "/home/dev/projects/my-app/samples/android/build/compose-previews/data/com.example.HomeKt-HomePreview/a11y-hierarchy.json"
+      "path": "/home/dev/projects/my-app/samples/android/build/compose-previews/data/com.example.HomeKt-HomePreview/a11y-hierarchy.json",
+      "extras": [
+        {
+          "name": "overlay",
+          "path": "/home/dev/projects/my-app/samples/android/build/compose-previews/data/com.example.HomeKt-HomePreview/a11y-overlay.png",
+          "mediaType": "image/png",
+          "sizeBytes": 38912
+        }
+      ]
+    },
+    {
+      "kind": "a11y/overlay",
+      "schemaVersion": 1,
+      "path": "/home/dev/projects/my-app/samples/android/build/compose-previews/data/com.example.HomeKt-HomePreview/a11y-overlay.png",
+      "extras": [
+        {
+          "name": "overlay",
+          "path": "/home/dev/projects/my-app/samples/android/build/compose-previews/data/com.example.HomeKt-HomePreview/a11y-overlay.png",
+          "mediaType": "image/png",
+          "sizeBytes": 38912
+        }
+      ]
     }
   ]
 }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -772,6 +772,74 @@ class DaemonMcpServer(
               .trimIndent()
           ),
       ),
+      ToolDef(
+        name = "render_preview_overlay",
+        description =
+          "Render a preview and return the annotated overlay PNG instead of (or alongside) the bare " +
+            "screenshot. Drives the daemon's image-processor surface — when `kind` is `a11y/overlay` " +
+            "(the default), the response carries a base64-encoded image with ATF findings and " +
+            "Paparazzi-style accessibility legend painted on top. " +
+            "Use this when you want a single tool call that (1) triggers a render in the right mode, " +
+            "(2) lets the producer compose its derived image, and (3) hands you back the bytes — no " +
+            "separate `render_preview` + `get_preview_data` round trip. The overlay PNG also lands on " +
+            "disk under `<dataDir>/<previewId>/a11y-overlay.png` so callers that prefer the path can " +
+            "set `inline=false`. " +
+            "Errors: DataProductUnknown when the daemon has no producer for `kind` (no a11y wiring or " +
+            "`composeai.daemon.attachA11y=false`).",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "uri":{"type":"string","description":"compose-preview://<workspace>/<module>/<fqn>?config=<qualifier>"},
+                "kind":{"type":"string","description":"Overlay kind. Default 'a11y/overlay'. Anything advertised by list_data_products with media-bearing extras can be used here.","default":"a11y/overlay"},
+                "inline":{"type":"boolean","description":"Default true. When true, returns the overlay bytes as a base64 image content block. When false, returns the on-disk path only."},
+                "overrides":{
+                  "type":"object",
+                  "description":"Per-call display overrides forwarded to render_preview. Same shape as render_preview.overrides.",
+                  "properties":{
+                    "widthPx":{"type":"integer"},
+                    "heightPx":{"type":"integer"},
+                    "density":{"type":"number"},
+                    "localeTag":{"type":"string"},
+                    "fontScale":{"type":"number"},
+                    "uiMode":{"type":"string","enum":["light","dark"]},
+                    "orientation":{"type":"string","enum":["portrait","landscape"]},
+                    "device":{"type":"string"}
+                  }
+                }
+              },
+              "required":["uri"]
+            }
+            """
+              .trimIndent()
+          ),
+      ),
+      ToolDef(
+        name = "get_preview_extras",
+        description =
+          "List the extra (non-JSON) outputs the producer wrote alongside a data product — typically " +
+            "PNGs like the a11y overlay. Returns one entry per extra: `{name, path, mediaType?, sizeBytes?}`. " +
+            "Hits the in-memory cache when the kind is subscribed/attached, otherwise round-trips a " +
+            "data/fetch with `inline=false` to pick up the path-shaped result and its `extras`. Use this " +
+            "when a panel UI wants to enumerate everything a producer made available without committing " +
+            "to one transport (e.g. show a thumbnail of `overlay` alongside the JSON viewer).",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "uri":{"type":"string"},
+                "kind":{"type":"string","description":"Data-product kind whose extras to enumerate. Use list_data_products to discover candidates."}
+              },
+              "required":["uri","kind"]
+            }
+            """
+              .trimIndent()
+          ),
+      ),
     )
 
   private fun handleCallTool(
@@ -796,6 +864,8 @@ class DaemonMcpServer(
       "history_diff" -> toolHistoryDiff(args)
       "list_data_products" -> toolListDataProducts(args)
       "get_preview_data" -> toolGetPreviewData(args)
+      "render_preview_overlay" -> toolRenderPreviewOverlay(args)
+      "get_preview_extras" -> toolGetPreviewExtras(args)
       "subscribe_preview_data" -> toolDataSubOrUnsub(session, args, subscribe = true)
       "unsubscribe_preview_data" -> toolDataSubOrUnsub(session, args, subscribe = false)
       else -> errorCallToolResult("unknown tool: $name")
@@ -1423,8 +1493,184 @@ class DaemonMcpServer(
       val attachedPath = entry.path
       if (inline && attachedPayload != null) put("payload", attachedPayload)
       if (!inline && attachedPath != null) put("path", JsonPrimitive(attachedPath))
+      val extras = entry.extras
+      if (extras != null) put("extras", extras)
     }
     return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+  }
+
+  /**
+   * D2.1 — `render_preview_overlay`. Triggers a render (so the producer's image processor runs) and
+   * returns the resulting overlay PNG. Default `kind` is `a11y/overlay`; callers can target any
+   * path-transport kind whose producer emits PNG-shaped extras.
+   *
+   * Flow: render → `data/fetch` for the overlay kind (cache short-circuited when possible) → read
+   * PNG bytes → return as base64 image content. With `inline=false` the response stays text-shaped
+   * and just carries the path the agent can read directly. Overrides forward to the underlying
+   * `renderNow` exactly the same way `render_preview` does.
+   */
+  private fun toolRenderPreviewOverlay(args: JsonObject): CallToolResult {
+    val uriStr =
+      args["uri"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("render_preview_overlay: missing 'uri'")
+    val uri =
+      PreviewUri.parseOrNull(uriStr)
+        ?: return errorCallToolResult("render_preview_overlay: invalid uri: $uriStr")
+    val kind =
+      args["kind"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() } ?: DEFAULT_OVERLAY_KIND
+    val inline = args["inline"]?.jsonPrimitive?.contentOrNull?.toBooleanStrictOrNull() ?: true
+    val overrides =
+      args["overrides"]?.let {
+        runCatching { decodePreviewOverrides(it) }
+          .getOrElse { e ->
+            return errorCallToolResult("render_preview_overlay: invalid overrides: ${e.message}")
+          }
+      }
+    if (supervisor.project(uri.workspaceId) == null) {
+      return errorCallToolResult(
+        "render_preview_overlay: workspace '${uri.workspaceId.value}' not registered"
+      )
+    }
+    val daemon =
+      runCatching { supervisor.daemonFor(uri.workspaceId, uri.modulePath) }
+        .getOrElse {
+          return errorCallToolResult("render_preview_overlay: daemon spawn failed: ${it.message}")
+        }
+    if (overrides != null) {
+      val violations = validateOverrides(overrides, daemon)
+      if (violations.isNotEmpty()) {
+        return errorCallToolResult("render_preview_overlay: ${violations.joinToString("; ")}")
+      }
+    }
+    if (daemon.dataProductCapabilities.none { it.kind == kind }) {
+      return errorCallToolResult(
+        "render_preview_overlay: DataProductUnknown: kind '$kind' not advertised by " +
+          "${uri.workspaceId.value}/${uri.modulePath}"
+      )
+    }
+    return runCatching {
+        // Force a fresh render so the image processor runs against the current source state;
+        // this is the "generate previews with an overlay" entry point that callers expect
+        // to be deterministic vs. cached PNGs.
+        awaitNextRender(uri, overrides = overrides)
+        val fetchResult =
+          daemon.client.dataFetch(uri.previewFqn, kind, params = null, inline = false)
+        val pngPath =
+          fetchResult.path
+            ?: return@runCatching errorCallToolResult(
+              "render_preview_overlay: producer for '$kind' returned no path; expected an " +
+                "image-bearing kind"
+            )
+        if (inline) {
+          val file = File(pngPath)
+          if (!file.isFile) {
+            return@runCatching errorCallToolResult(
+              "render_preview_overlay: overlay PNG missing at $pngPath"
+            )
+          }
+          pngCallToolResult(Base64.getEncoder().encodeToString(Files.readAllBytes(file.toPath())))
+        } else {
+          val payload = buildJsonObject {
+            put("kind", kind)
+            put("schemaVersion", fetchResult.schemaVersion)
+            put("path", pngPath)
+            val extras = fetchResult.extras
+            if (!extras.isNullOrEmpty()) {
+              putJsonArray("extras") {
+                for (extra in extras) {
+                  add(
+                    buildJsonObject {
+                      put("name", extra.name)
+                      put("path", extra.path)
+                      if (extra.mediaType != null) put("mediaType", extra.mediaType)
+                      if (extra.sizeBytes != null) put("sizeBytes", extra.sizeBytes)
+                    }
+                  )
+                }
+              }
+            }
+          }
+          textCallToolResult(payload.toString())
+        }
+      }
+      .getOrElse { e ->
+        when (e) {
+          is DataProductWireException ->
+            errorCallToolResult("render_preview_overlay: ${nameOf(e.code)}: ${e.wireMessage}")
+          else -> errorCallToolResult("render_preview_overlay failed: ${e.message}")
+        }
+      }
+  }
+
+  /**
+   * D2.1 — `get_preview_extras`. Enumerates the producer's extras for `(uri, kind)`. Same cache
+   * short-circuit as `get_preview_data`; on a miss we round-trip a `data/fetch` with `inline=false`
+   * to pick up the path-shaped result so the daemon hands back the extras list in one call instead
+   * of forcing a re-render path. Returns an `extras` array (possibly empty); callers iterate to
+   * find the `(name, path, mediaType?, sizeBytes?)` they want.
+   */
+  private fun toolGetPreviewExtras(args: JsonObject): CallToolResult {
+    val uriStr =
+      args["uri"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("get_preview_extras: missing 'uri'")
+    val uri =
+      PreviewUri.parseOrNull(uriStr)
+        ?: return errorCallToolResult("get_preview_extras: invalid uri: $uriStr")
+    val kind =
+      args["kind"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("get_preview_extras: missing 'kind'")
+    if (supervisor.project(uri.workspaceId) == null) {
+      return errorCallToolResult(
+        "get_preview_extras: workspace '${uri.workspaceId.value}' not registered"
+      )
+    }
+    val daemon =
+      runCatching { supervisor.daemonFor(uri.workspaceId, uri.modulePath) }
+        .getOrElse {
+          return errorCallToolResult("get_preview_extras: daemon spawn failed: ${it.message}")
+        }
+    val cached =
+      dataProductCache[DataAttachKey(uri.workspaceId, uri.modulePath, uri.previewFqn, kind)]
+    val cachedExtras = cached?.extras as? JsonArray
+    val payload = buildJsonObject {
+      put("kind", kind)
+      put("uri", uriStr)
+      if (cachedExtras != null) {
+        put("cached", true)
+        put("extras", cachedExtras)
+      } else {
+        val fetched =
+          runCatching {
+              try {
+                daemon.client.dataFetch(uri.previewFqn, kind, params = null, inline = false)
+              } catch (e: DataProductWireException) {
+                if (e.code != DataProductWireException.NOT_AVAILABLE) throw e
+                awaitNextRender(uri)
+                daemon.client.dataFetch(uri.previewFqn, kind, params = null, inline = false)
+              }
+            }
+            .getOrElse { e ->
+              return when (e) {
+                is DataProductWireException ->
+                  errorCallToolResult("get_preview_extras: ${nameOf(e.code)}: ${e.wireMessage}")
+                else -> errorCallToolResult("get_preview_extras failed: ${e.message}")
+              }
+            }
+        putJsonArray("extras") {
+          for (extra in fetched.extras.orEmpty()) {
+            add(
+              buildJsonObject {
+                put("name", extra.name)
+                put("path", extra.path)
+                if (extra.mediaType != null) put("mediaType", extra.mediaType)
+                if (extra.sizeBytes != null) put("sizeBytes", extra.sizeBytes)
+              }
+            )
+          }
+        }
+      }
+    }
+    return textCallToolResult(payload.toString())
   }
 
   /**
@@ -1451,12 +1697,27 @@ class DaemonMcpServer(
     val resultPayload = result.payload
     val resultPath = result.path
     val resultBytes = result.bytes
+    val resultExtras = result.extras
     val payload = buildJsonObject {
       put("kind", result.kind)
       put("schemaVersion", result.schemaVersion)
       if (resultPayload != null) put("payload", resultPayload)
       if (resultPath != null) put("path", JsonPrimitive(resultPath))
       if (resultBytes != null) put("bytes", JsonPrimitive(resultBytes))
+      if (!resultExtras.isNullOrEmpty()) {
+        putJsonArray("extras") {
+          for (extra in resultExtras) {
+            add(
+              buildJsonObject {
+                put("name", extra.name)
+                put("path", extra.path)
+                if (extra.mediaType != null) put("mediaType", extra.mediaType)
+                if (extra.sizeBytes != null) put("sizeBytes", extra.sizeBytes)
+              }
+            )
+          }
+        }
+      }
     }
     return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
   }
@@ -1677,8 +1938,9 @@ class DaemonMcpServer(
         obj["schemaVersion"]?.jsonPrimitive?.contentOrNull?.toIntOrNull() ?: continue
       val payload = obj["payload"]
       val path = obj["path"]?.jsonPrimitive?.contentOrNull
+      val extras = obj["extras"]
       val key = DataAttachKey(daemon.workspaceId, daemon.modulePath, previewId, kind)
-      dataProductCache[key] = DataAttachmentEntry(schemaVersion, payload, path)
+      dataProductCache[key] = DataAttachmentEntry(schemaVersion, payload, path, extras)
     }
   }
 
@@ -1884,12 +2146,14 @@ class DaemonMcpServer(
   /**
    * Cached `(payload | path)` from one `renderFinished.dataProducts[*]` entry. Mirrors the wire
    * shape; carries `schemaVersion` so a cache hit reports the same version the agent would see on a
-   * direct `data/fetch`.
+   * direct `data/fetch`. `extras` carries the producer's derived files (e.g. the a11y overlay PNG)
+   * so a cache hit on `get_preview_data` exposes the same paths the daemon would have returned.
    */
   private data class DataAttachmentEntry(
     val schemaVersion: Int,
     val payload: JsonElement?,
     val path: String?,
+    val extras: JsonElement? = null,
   )
 
   private sealed interface RenderOutcome {
@@ -1965,5 +2229,13 @@ class DaemonMcpServer(
      * replica-spawn pool cap.
      */
     private const val DAEMON_LIFECYCLE_THREADS: Int = 4
+
+    /**
+     * D2.1 — default `kind` for `render_preview_overlay` when the caller doesn't specify one.
+     * `a11y/overlay` is the only image-bearing kind in the catalogue today (it also serves as an
+     * extra under `a11y/atf` and `a11y/hierarchy`); future kinds with PNG-shaped extras become
+     * valid arguments without code changes here.
+     */
+    private const val DEFAULT_OVERLAY_KIND: String = "a11y/overlay"
   }
 }

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -107,6 +107,8 @@ class DaemonMcpServerTest {
         "get_preview_data",
         "subscribe_preview_data",
         "unsubscribe_preview_data",
+        "render_preview_overlay",
+        "get_preview_extras",
       )
   }
 

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityOverlay.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityOverlay.kt
@@ -30,7 +30,11 @@ import kotlin.math.min
  * match the per-child screenshot fills, so the legend stays short and the
  * parent/child grouping reads at a glance.
  */
-internal object AccessibilityOverlay {
+// D2.1 — promoted from `internal` so `:daemon:android`'s `AccessibilityImageProcessor` can
+// reuse the same overlay generator the standalone Gradle / CLI path drives. The renderer-side
+// home stays the single source of truth for the visual language; the daemon adapter writes the
+// output under the data-product extras directory rather than next to the primary PNG.
+object AccessibilityOverlay {
 
     /** Width of the legend panel beside the screenshot. */
     private const val LEGEND_WIDTH = 540
@@ -96,13 +100,32 @@ internal object AccessibilityOverlay {
     )
 
     /**
-     * Writes the annotated PNG next to [sourcePng]. No-op when [findings] and
-     * [nodes] are both empty. Returns the destination [File] when written.
+     * Writes the annotated PNG next to [sourcePng] (`<basename>.a11y.png`). No-op when
+     * [findings] and [nodes] are both empty. Returns the destination [File] when written.
      */
     fun generate(
         sourcePng: File,
         findings: List<AccessibilityFinding>,
         nodes: List<AccessibilityNode>,
+        isRound: Boolean = false,
+    ): File? = generate(
+        sourcePng = sourcePng,
+        findings = findings,
+        nodes = nodes,
+        destPng = File(sourcePng.parentFile, "${sourcePng.nameWithoutExtension}.a11y.png"),
+        isRound = isRound,
+    )
+
+    /**
+     * Writes the annotated PNG to [destPng] (creating parent directories as needed). Same
+     * generator as the no-arg overload — the daemon's data-product producer drops the file
+     * under `<dataDir>/<previewId>/a11y-overlay.png` rather than next to the primary PNG.
+     */
+    fun generate(
+        sourcePng: File,
+        findings: List<AccessibilityFinding>,
+        nodes: List<AccessibilityNode>,
+        destPng: File,
         isRound: Boolean = false,
     ): File? {
         if (findings.isEmpty() && nodes.isEmpty()) return null
@@ -116,7 +139,7 @@ internal object AccessibilityOverlay {
             return null
         }
         return try {
-            generateInternal(sourcePng, findings, nodes, isRound)
+            generateInternal(sourcePng, findings, nodes, destPng, isRound)
         } catch (t: Throwable) {
             // Without this catch, a Canvas / Bitmap.createBitmap blow-up
             // would propagate through writePerPreviewReport and skip the
@@ -135,6 +158,7 @@ internal object AccessibilityOverlay {
         sourcePng: File,
         findings: List<AccessibilityFinding>,
         nodes: List<AccessibilityNode>,
+        destPng: File,
         isRound: Boolean,
     ): File? {
         val source = BitmapFactory.decodeFile(sourcePng.absolutePath)
@@ -146,11 +170,11 @@ internal object AccessibilityOverlay {
             return null
         }
         val composite = compose(source, findings, nodes, isRound)
-        val dest = File(sourcePng.parentFile, "${sourcePng.nameWithoutExtension}.a11y.png")
-        dest.outputStream().use { composite.compress(Bitmap.CompressFormat.PNG, 100, it) }
+        destPng.parentFile?.mkdirs()
+        destPng.outputStream().use { composite.compress(Bitmap.CompressFormat.PNG, 100, it) }
         source.recycle()
         composite.recycle()
-        return dest
+        return destPng
     }
 
     /**

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -265,16 +265,32 @@ export interface RenderMetrics {
 }
 
 /**
+ * One additional non-JSON output a producer wrote alongside its primary
+ * payload — typically a derived image such as the Paparazzi-style a11y
+ * overlay PNG. Pointer-only on the wire; the client reads the file
+ * directly. See docs/daemon/DATA-PRODUCTS.md § "Image processors and
+ * extras".
+ */
+export interface DataProductExtra {
+    name: string;
+    path: string;
+    mediaType?: string;
+    sizeBytes?: number;
+}
+
+/**
  * One data-product attachment riding on a `renderFinished` notification.
  * `payload` is per-kind JSON when `transport='inline'`; `path` is an
  * absolute path to a sibling file when `transport='path'`. Exactly one of
- * the two is set per entry.
+ * the two is set per entry. `extras` is the producer's derived non-JSON
+ * outputs (PNGs etc.); absent / empty are interchangeable.
  */
 export interface DataProductAttachment {
     kind: string;
     schemaVersion: number;
     payload?: unknown;
     path?: string;
+    extras?: DataProductExtra[];
 }
 
 export interface RenderFinishedParams {
@@ -445,6 +461,9 @@ export interface DataFetchResult {
     /** Base64 — set only when caller passed `inline: true` and the kind's
      *  transport is blob-shaped. Reserved for non-local clients. */
     bytes?: string;
+    /** Derived non-JSON outputs the producer wrote alongside (e.g. a11y
+     *  overlay PNG). Absent / empty are interchangeable on the wire. */
+    extras?: DataProductExtra[];
 }
 
 export interface DataSubscribeParams {


### PR DESCRIPTION
Adds an optional image-processor surface to the daemon's data-product
API and wires the existing a11y overlay through it.

- DataProductAttachment / DataFetchResult gain an additive `extras`
  field — list of {name, path, mediaType?, sizeBytes?} pointers to
  derived non-JSON outputs (typically PNGs). Pre-feature daemons /
  clients keep round-tripping unchanged.
- ImageProcessor seam in :daemon:android lets RenderEngine run a
  post-capture hook that emits derived files keyed by kind.
  AccessibilityImageProcessor is the first concrete implementation,
  reusing the renderer-side AccessibilityOverlay (promoted from
  internal) to drop a Paparazzi-style annotated PNG under
  <dataDir>/<previewId>/a11y-overlay.png.
- AccessibilityDataProductRegistry advertises a new `a11y/overlay`
  kind (transport=path) and surfaces the overlay as an `overlay`
  extra under `a11y/atf` and `a11y/hierarchy` so a single subscribe
  carries both the JSON and the picture.
- Two new MCP tools cover the agent surface:
  - render_preview_overlay — render and return the overlay PNG in one
    call (base64 image content, or a path with `inline=false`).
  - get_preview_extras — enumerate a kind's extras without committing
    to a transport, with the same cache short-circuit as
    get_preview_data.
- DATA-PRODUCTS.md documents the new `extras` field, the image-
  processor contract, and `a11y/overlay`. Fixtures and the TS
  daemonProtocol are updated to match.