### PR TITLE
feat(daemon): harden v3 Android interactive lifecycle

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -91,6 +91,19 @@ internal constructor(
    */
   private val idleLeaseMs: Long =
     System.getProperty(IDLE_LEASE_PROP)?.toLongOrNull() ?: DEFAULT_IDLE_LEASE_MS,
+  /**
+   * Invoked from [close] (after the bridge round-trip and `activeStreamRef` clear) so the host
+   * can drop its own reference to this session — see
+   * [RobolectricHost.activeInteractiveSession]. PR C wired this so the host's lifecycle hooks
+   * ([RobolectricHost.swapUserClassLoaders] and [RobolectricHost.shutdown]) can force-close a
+   * held session without keeping a strong reference that would survive an explicit
+   * `interactive/stop`.
+   *
+   * Default is a no-op so tests and other callers that construct sessions directly don't have
+   * to wire a hook. Called exactly once per session — after the first [close]. Subsequent
+   * [close] calls (idempotent) skip the hook.
+   */
+  private val onCloseHook: () -> Unit = {},
 ) : InteractiveSession {
 
   @Volatile private var closed: Boolean = false
@@ -261,6 +274,17 @@ internal constructor(
     // CAS-from-our-streamId so concurrent close() calls don't clobber a fresh session that the
     // host has already started binding to the slot. Idempotent against a missing entry.
     activeStreamRef.compareAndSet(streamId, null)
+    // PR C — let the host drop its own reference to this session. Wrapped in try/catch because
+    // the hook runs on whatever thread called close() (could be the watchdog) and a
+    // mis-configured hook shouldn't take down the watchdog.
+    try {
+      onCloseHook()
+    } catch (t: Throwable) {
+      System.err.println(
+        "compose-ai-daemon: AndroidInteractiveSession.onCloseHook for stream " +
+          "'$streamId' threw: ${t.javaClass.simpleName}: ${t.message}"
+      )
+    }
   }
 
   private fun copyResultAcrossClassloaders(raw: Any): RenderResult {

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -163,6 +163,25 @@ open class RobolectricHost(
   private val activeInteractiveStreamId: AtomicReference<String?> = AtomicReference(null)
 
   /**
+   * Live reference to the held [AndroidInteractiveSession]. Used by the host's lifecycle hooks
+   * ([swapUserClassLoaders], [shutdown]) to force-close the session before performing operations
+   * that would otherwise strand the held composition with stale state.
+   *
+   * Wired in two places:
+   *  * [acquireInteractiveSession] sets this after a successful acquire.
+   *  * [AndroidInteractiveSession.close] clears it via the `onCloseHook` callback the host
+   *    passes at construction time, so an explicit `interactive/stop` doesn't leave a dangling
+   *    reference here.
+   *
+   * The host-side close path reads + atomically nulls this ref before invoking
+   * [AndroidInteractiveSession.close] so a concurrent explicit close doesn't double-fire (the
+   * session's own close is idempotent, but the AtomicReference guard makes the host-driven path
+   * single-shot too).
+   */
+  private val activeInteractiveSession: AtomicReference<AndroidInteractiveSession?> =
+    AtomicReference(null)
+
+  /**
    * Monotonic counter for `streamId`s the host hands out. Persisted as a host-level counter
    * (rather than `RenderHost.nextRequestId`) because the wire-side `streamId` is purely a
    * host-internal correlation key — it doesn't share number space with render ids.
@@ -376,8 +395,43 @@ open class RobolectricHost(
    * sees the recompiled bytecode. No-op when no holder is wired (default in-process tests).
    */
   override fun swapUserClassLoaders() {
+    // INTERACTIVE-ANDROID.md § 6 (Lifecycle-on-classpath-dirty) — when the user's source
+    // recompiles (`fileChanged{kind: "source"}`), the held composition's `Class.forName`
+    // references stale bytecode that the upcoming swap is about to invalidate. Tear the held
+    // session down BEFORE swapping so the next `interactive/start` after the save sees a fresh
+    // child loader and resolves the recompiled class. Without this, a held session would either
+    // serve stale paint until idle-lease expiry or crash on the next dispatch when the loader's
+    // backing JAR is gone.
+    forceCloseActiveInteractiveSession(reason = "user classloader swap (source recompile)")
     for (i in 0 until sandboxCount) {
       perSlotHolders.get(i)?.swap()
+    }
+  }
+
+  /**
+   * Force-closes any active interactive session. Idempotent — if no session is active, returns
+   * immediately. Used by the host's lifecycle hooks ([swapUserClassLoaders] and [shutdown])
+   * before performing operations that would strand the held composition with stale state.
+   *
+   * The session's own `close()` is the close path: it stops the watchdog, posts the bridge
+   * `Close` command, awaits the held loop's reply, clears `activeStreamRef`, and finally fires
+   * `onCloseHook` which nulls [activeInteractiveSession] here. We `compareAndSet` rather than
+   * `getAndSet` so a fresh acquire that races us doesn't get its ref clobbered.
+   */
+  private fun forceCloseActiveInteractiveSession(reason: String) {
+    val session = activeInteractiveSession.get() ?: return
+    if (!activeInteractiveSession.compareAndSet(session, null)) return
+    System.err.println(
+      "compose-ai-daemon: RobolectricHost: force-closing held session " +
+        "'${session.streamId}' (previewId='${session.previewId}'): $reason"
+    )
+    try {
+      session.close()
+    } catch (t: Throwable) {
+      System.err.println(
+        "compose-ai-daemon: RobolectricHost.forceCloseActiveInteractiveSession threw: " +
+          "${t.javaClass.simpleName}: ${t.message}"
+      )
     }
   }
 
@@ -560,6 +614,25 @@ open class RobolectricHost(
         outputBaseName = spec.outputBaseName,
         replyLatch = replyLatch,
         replyError = replyError,
+        // INTERACTIVE-ANDROID.md § 10.3 / PR C — thread the rest of the v1 RenderSpec qualifiers
+        // through Start so the held composition observes the same `Configuration` overrides a
+        // one-shot render would. Strings are bridge-package-compatible (java.lang.String); the
+        // SpecUiMode / SpecOrientation enums are in the instrumented daemon package and would
+        // re-load across the sandbox boundary if passed directly.
+        localeTag = spec.localeTag,
+        fontScale = spec.fontScale,
+        uiMode =
+          when (spec.uiMode) {
+            RenderSpec.SpecUiMode.LIGHT -> "light"
+            RenderSpec.SpecUiMode.DARK -> "dark"
+            null -> null
+          },
+        orientation =
+          when (spec.orientation) {
+            RenderSpec.SpecOrientation.PORTRAIT -> "portrait"
+            RenderSpec.SpecOrientation.LANDSCAPE -> "landscape"
+            null -> null
+          },
       )
     )
     if (!replyLatch.await(INTERACTIVE_START_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
@@ -579,13 +652,23 @@ open class RobolectricHost(
         startError,
       )
     }
-    return AndroidInteractiveSession(
-      previewId = previewId,
-      streamId = streamId,
-      slot = slot,
-      activeStreamRef = activeInteractiveStreamId,
-      idleLeaseMs = interactiveIdleLeaseMs,
-    )
+    // Hold the session in a one-element array so the onCloseHook lambda can reference it via
+    // closure-capture without a forward declaration. compareAndSet-from-self guards against a
+    // close racing a fresh acquire — without the CAS we could clobber the new session's ref
+    // when the prior session's close fires late (e.g. from the watchdog).
+    val sessionBox = arrayOfNulls<AndroidInteractiveSession>(1)
+    val session =
+      AndroidInteractiveSession(
+        previewId = previewId,
+        streamId = streamId,
+        slot = slot,
+        activeStreamRef = activeInteractiveStreamId,
+        idleLeaseMs = interactiveIdleLeaseMs,
+        onCloseHook = { activeInteractiveSession.compareAndSet(sessionBox[0], null) },
+      )
+    sessionBox[0] = session
+    activeInteractiveSession.set(session)
+    return session
   }
 
   /**
@@ -650,6 +733,15 @@ open class RobolectricHost(
   }
 
   override fun shutdown(timeoutMs: Long) {
+    // INTERACTIVE-ANDROID.md § 11.4 (Dispatch-on-shutdown) — close any held interactive session
+    // BEFORE setting the global shutdown flag and posting the slot poison pills. Without this,
+    // the slot-1 worker would be sitting inside the held-rule loop's `take()` on
+    // `interactiveCommands` and would never see the `RenderRequest.Shutdown` we enqueue on the
+    // `requests` queue — `shutdown()` would then time out joining the worker thread. The
+    // session's `close()` posts `InteractiveCommand.Close` to the same queue the held loop is
+    // blocked on, which lets the held loop return cleanly and the slot revert to draining
+    // `requests` (where the poison pill is waiting).
+    forceCloseActiveInteractiveSession(reason = "host shutdown")
     DaemonHostBridge.shutdown.set(true)
     // Belt-and-braces: also enqueue a Shutdown on every slot's queue so each worker wakes from
     // poll() promptly rather than waiting out the 100ms cycle.
@@ -1040,22 +1132,39 @@ open class RobolectricHost(
           )
         )
 
-      // Minimal qualifier set — size + density + round-device. PR C threads through the rest of
-      // the v1 RenderSpec qualifiers (locale, fontScale, uiMode, orientation) once the held
-      // session needs them; for v3's first ship the basics keep parity with what the panel
-      // already shows in non-interactive mode.
+      // INTERACTIVE-ANDROID.md § 10.3 / PR C — full v1 RenderSpec qualifier set. Mirrors
+      // RenderEngine.applyPreviewQualifiers's grammar verbatim (locale, width, height, round,
+      // orientation, uiMode, density) so a held-session capture matches a one-shot capture for
+      // the same RenderSpec bit-for-bit. fontScale rides RuntimeEnvironment.setFontScale rather
+      // than the qualifier string — same Configuration knob RoborazziCompose's FontScaleOption
+      // uses on the standalone JUnit path.
       val widthDp = pxToDp(start.widthPx, start.density)
       val heightDp = pxToDp(start.heightPx, start.density)
       val isRound = isRoundDevice(start.device)
+      val derivedOrientation =
+        when (start.orientation) {
+          "portrait" -> "port"
+          "landscape" -> "land"
+          else ->
+            if (widthDp > 0 && heightDp > 0) (if (widthDp > heightDp) "land" else "port") else null
+        }
       val qualifiers = buildList {
+        if (!start.localeTag.isNullOrBlank()) add(localeTagToQualifier(start.localeTag))
         if (widthDp > 0) add("w${widthDp}dp")
         if (heightDp > 0) add("h${heightDp}dp")
         if (isRound) add("round")
-        if (widthDp > 0 && heightDp > 0) add(if (widthDp > heightDp) "land" else "port")
+        if (derivedOrientation != null) add(derivedOrientation)
+        when (start.uiMode) {
+          "light" -> add("notnight")
+          "dark" -> add("night")
+        }
         if (start.density > 0f) add("${(start.density * 160).toInt()}dpi")
       }
       if (qualifiers.isNotEmpty()) {
         org.robolectric.RuntimeEnvironment.setQualifiers("+${qualifiers.joinToString("-")}")
+      }
+      if (start.fontScale != null && start.fontScale > 0f) {
+        org.robolectric.RuntimeEnvironment.setFontScale(start.fontScale)
       }
 
       val outputDir =
@@ -1300,6 +1409,20 @@ open class RobolectricHost(
     private fun pxToDp(px: Int, density: Float): Int {
       if (density <= 0f) return px
       return (px / density).toInt().coerceAtLeast(1)
+    }
+
+    /**
+     * Translates a BCP-47 locale tag (`en-US`, `fr`, `ja-JP`) to Robolectric's BCP-47 qualifier
+     * spelling (`b+en+US`, `b+fr`, `b+ja+JP`). Mirrors `RenderEngine.localeTagToQualifier`'s
+     * formula exactly so a held-session capture matches a one-shot capture for the same locale.
+     * The `b+` prefix is mandatory for tags with non-empty regions or scripts under Android's
+     * resource framework; we apply it unconditionally for simplicity (single-tag forms like
+     * `b+en` are accepted).
+     */
+    private fun localeTagToQualifier(tag: String): String {
+      val parts = tag.split('-', '_').filter { it.isNotBlank() }
+      if (parts.isEmpty()) return ""
+      return "b+${parts.joinToString("+")}"
     }
 
     companion object {

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -362,7 +362,16 @@ sealed interface InteractiveCommand {
    * Allocate the rule + ActivityScenario, run `setContent`, signal ready via [replyLatch]. The
    * preview reference travels as separate FQN + function-name strings (the sandbox resolves them
    * via `Class.forName` against the slot's child classloader), and dimension/qualifier fields
-   * mirror the v1 [`RenderSpec`] subset the held composition needs.
+   * mirror the v1 `RenderSpec` subset the held composition needs.
+   *
+   * **Qualifier fields are encoded as primitives + Strings** rather than the daemon-side
+   * [`RenderSpec.SpecUiMode`] / [`RenderSpec.SpecOrientation`] enums because those enums live in
+   * the instrumented `ee.schimke.composeai.daemon.*` package — passing them across the bridge
+   * would re-load the enum class inside the sandbox, breaking `==` equality. Strings cross the
+   * boundary as `java.lang.String` (do-not-acquire by default). PR C wired the extra qualifiers
+   * (`localeTag`, `fontScale`, `uiMode`, `orientation`) so the held composition reflects the
+   * same Configuration overrides a one-shot render would; PR B's Start carried only the v1
+   * size/density/round subset.
    *
    * @param replyError the sandbox sets this before counting down [replyLatch] when `setContent`
    *   throws; the host then surfaces a clean failure on the v2 `interactive/start` reply rather
@@ -383,6 +392,14 @@ sealed interface InteractiveCommand {
     val outputBaseName: String,
     val replyLatch: CountDownLatch,
     val replyError: AtomicReference<Throwable?>,
+    /** BCP-47 locale tag (e.g. `"en-US"`); `null` = no `b+lang+region` qualifier. */
+    val localeTag: String? = null,
+    /** Font scale multiplier; `null` = leave Robolectric's `RuntimeEnvironment.setFontScale` at 1.0. */
+    val fontScale: Float? = null,
+    /** `"light"` / `"dark"` / `null`; resolved sandbox-side to the `notnight` / `night` qualifier. */
+    val uiMode: String? = null,
+    /** `"portrait"` / `"landscape"` / `null`; overrides the size-derived guess. */
+    val orientation: String? = null,
   ) : InteractiveCommand
 
   /**

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
@@ -297,18 +297,157 @@ class AndroidInteractiveSessionTest {
     }
   }
 
-  private fun previewSpecResolver(): (String) -> RenderSpec? = { previewId ->
-    if (previewId == INTERACTIVE_PREVIEW_ID) {
-      RenderSpec(
-        className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
-        functionName = "ClickToggleSquare",
-        widthPx = INTERACTIVE_WIDTH_PX,
-        heightPx = INTERACTIVE_HEIGHT_PX,
-        density = 1.0f,
-        showBackground = true,
-        outputBaseName = "interactive-clicktoggle",
+  @Test
+  fun uiModeOverrideReachesHeldSession() {
+    System.setProperty(
+      RenderEngine.OUTPUT_DIR_PROP,
+      tempFolder.newFolder("dark-overrides").absolutePath,
+    )
+    System.setProperty("roborazzi.test.record", "true")
+    val host =
+      RobolectricHost(
+        sandboxCount = 2,
+        previewSpecResolver = previewSpecResolver(),
       )
-    } else null
+    host.start()
+    try {
+      val session =
+        host.acquireInteractiveSession(
+          previewId = DARK_PREVIEW_ID,
+          classLoader = javaClass.classLoader!!,
+        )
+      try {
+        val result = session.render(requestId = RenderHost.nextRequestId())
+        assertNotNull("dark-mode held render must produce a PNG", result.pngPath)
+        val img = decode(File(result.pngPath!!))
+        // DarkAwareSquare paints white in light, black in dark. The DARK uiMode override should
+        // route through `night` qualifier → `Configuration.UI_MODE_NIGHT_YES` → the composable's
+        // `isSystemInDarkTheme()` returns true → black.
+        val blackPct = pixelMatchPct(img, BLACK_RGB, perChannelTolerance = 8)
+        val whitePct = pixelMatchPct(img, WHITE_RGB, perChannelTolerance = 8)
+        assertTrue(
+          "uiMode=DARK should drive DarkAwareSquare to ≥95% black (got " +
+            "${"%.2f".format(blackPct * 100)}% black, ${"%.2f".format(whitePct * 100)}% white) " +
+            "— qualifier didn't reach the held composition's Configuration",
+          blackPct >= 0.95,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun swapUserClassLoadersForceClosesHeldSession() {
+    System.setProperty(
+      RenderEngine.OUTPUT_DIR_PROP,
+      tempFolder.newFolder("classpath-dirty").absolutePath,
+    )
+    System.setProperty("roborazzi.test.record", "true")
+    val host =
+      RobolectricHost(
+        sandboxCount = 2,
+        previewSpecResolver = previewSpecResolver(),
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireInteractiveSession(
+          previewId = INTERACTIVE_PREVIEW_ID,
+          classLoader = javaClass.classLoader!!,
+        ) as AndroidInteractiveSession
+      assertFalse("session must be open after acquire", session.isClosed)
+
+      // Simulate a `fileChanged{kind: "source"}` save while a session is held. The host's
+      // `swapUserClassLoaders` should tear the held composition down BEFORE swapping the
+      // per-slot child loaders so the next acquire sees fresh bytecode.
+      host.swapUserClassLoaders()
+
+      assertTrue(
+        "session must be closed after swapUserClassLoaders — held composition references stale " +
+          "bytecode that swap is about to invalidate",
+        session.isClosed,
+      )
+
+      // After the force-close, a fresh acquire must succeed — the host should have cleared its
+      // active-session state.
+      val followup =
+        host.acquireInteractiveSession(
+          previewId = INTERACTIVE_PREVIEW_ID,
+          classLoader = javaClass.classLoader!!,
+        )
+      followup.close()
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun shutdownClosesHeldSessionCleanly() {
+    System.setProperty(
+      RenderEngine.OUTPUT_DIR_PROP,
+      tempFolder.newFolder("shutdown-drain").absolutePath,
+    )
+    System.setProperty("roborazzi.test.record", "true")
+    val host =
+      RobolectricHost(
+        sandboxCount = 2,
+        previewSpecResolver = previewSpecResolver(),
+      )
+    host.start()
+    val session =
+      host.acquireInteractiveSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        classLoader = javaClass.classLoader!!,
+      ) as AndroidInteractiveSession
+
+    // host.shutdown() should drain the held session before posting slot poison pills. Without
+    // PR C's wiring, slot 1's worker would be stuck in `interactiveCommands.take()` and
+    // shutdown would time out joining the thread (see the IllegalStateException path in
+    // shutdown). We assert it returns within a generous budget AND the session is closed.
+    val startMs = System.currentTimeMillis()
+    host.shutdown(timeoutMs = 30_000L)
+    val elapsedMs = System.currentTimeMillis() - startMs
+
+    assertTrue(
+      "shutdown() must close the held session — without that drain, slot 1's worker sits in " +
+        "interactiveCommands.take() and shutdown times out",
+      session.isClosed,
+    )
+    assertTrue(
+      "shutdown() should complete well under the timeout (got ${elapsedMs}ms / 30000ms) when " +
+        "the held session is drained correctly",
+      elapsedMs < 25_000L,
+    )
+  }
+
+  private fun previewSpecResolver(): (String) -> RenderSpec? = { previewId ->
+    when (previewId) {
+      INTERACTIVE_PREVIEW_ID ->
+        RenderSpec(
+          className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+          functionName = "ClickToggleSquare",
+          widthPx = INTERACTIVE_WIDTH_PX,
+          heightPx = INTERACTIVE_HEIGHT_PX,
+          density = 1.0f,
+          showBackground = true,
+          outputBaseName = "interactive-clicktoggle",
+        )
+      DARK_PREVIEW_ID ->
+        RenderSpec(
+          className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+          functionName = "DarkAwareSquare",
+          widthPx = INTERACTIVE_WIDTH_PX,
+          heightPx = INTERACTIVE_HEIGHT_PX,
+          density = 1.0f,
+          showBackground = true,
+          outputBaseName = "interactive-darkaware",
+          uiMode = RenderSpec.SpecUiMode.DARK,
+        )
+      else -> null
+    }
   }
 
   private fun decode(file: File): java.awt.image.BufferedImage {
@@ -348,9 +487,12 @@ class AndroidInteractiveSessionTest {
 
   companion object {
     private const val INTERACTIVE_PREVIEW_ID = "interactive-clicktoggle"
+    private const val DARK_PREVIEW_ID = "interactive-darkaware"
     private const val INTERACTIVE_WIDTH_PX = 96
     private const val INTERACTIVE_HEIGHT_PX = 96
     private const val RED_RGB = 0xEF5350
     private const val GREEN_RGB = 0x66BB6A
+    private const val BLACK_RGB = 0x000000
+    private const val WHITE_RGB = 0xFFFFFF
   }
 }


### PR DESCRIPTION
## Summary

PR C of [INTERACTIVE-ANDROID.md § 10](docs/daemon/INTERACTIVE-ANDROID.md). Wires the lifecycle hooks the held-rule loop needs to interact correctly with the rest of the daemon: classpath-dirty teardown, daemon-shutdown drain, and the full v1 `RenderSpec` qualifier set on `Start`.

PR A (#459) and PR B (#467) landed the wire shape and the held-rule loop. Without this PR, a held session goes out of sync with the rest of the daemon under three conditions:

1. **User saves a source file mid-session** → `swapUserClassLoaders()` invalidates the loader the held composition is reflecting against; held session would serve stale paint until idle-lease expiry or crash on next dispatch.
2. **Daemon shuts down with a session held** → slot 1 worker is blocked on `interactiveCommands.take()` and never sees the `RenderRequest.Shutdown` poison pill; `shutdown()` times out joining the worker thread.
3. **Resolved RenderSpec carries `uiMode` / `localeTag` / `fontScale` / `orientation`** → PR B only wired size/density/round through `Start`, so a held capture with `uiMode=DARK` would silently render in light mode.

### Qualifier threading (§ 10.3 "dimensions" item)

- `InteractiveCommand.Start` grows `localeTag: String?`, `fontScale: Float?`, `uiMode: String?`, `orientation: String?`. Strings + primitives so the bridge boundary stays sandbox-safe — the `SpecUiMode` / `SpecOrientation` enums live in the instrumented daemon package and would re-load if passed directly.
- `runHeldInteractiveSession`'s qualifier-string assembly mirrors `RenderEngine.applyPreviewQualifiers` verbatim (locale, width, height, round, orientation, uiMode, density). `fontScale` rides `RuntimeEnvironment.setFontScale` (a Configuration knob, not a qualifier — same path the standalone JUnit + `RoborazziCompose.FontScaleOption` use). Held-session captures now match one-shot captures bit-for-bit when the spec is identical.
- Inlined `localeTagToQualifier` mirrors `RenderEngine.localeTagToQualifier` exactly (BCP-47 → `b+lang+region`).

### Classpath-dirty handling (§ 6 "Lifecycle-on-classpath-dirty")

- `RobolectricHost.swapUserClassLoaders` force-closes the active session **before** swapping per-slot child loaders.
- `forceCloseActiveInteractiveSession` helper centralises the host-driven close path; `compareAndSet`-clears `activeInteractiveSession` so a fresh acquire racing the close doesn't get its ref clobbered.

### Daemon-shutdown drain (§ 11.4 "Dispatch-on-shutdown")

- `RobolectricHost.shutdown` closes the held session **before** setting `DaemonHostBridge.shutdown` and posting slot poison pills. The session's `close()` posts `InteractiveCommand.Close` to the same queue the held loop is blocked on, which lets the loop return cleanly and the slot revert to draining `requests` (where the poison pill is waiting).

### Plumbing

- `AndroidInteractiveSession` gains an optional `onCloseHook: () -> Unit` callback that the host wires to clear its strong session reference when an explicit `close()` finishes (so an explicit `interactive/stop` doesn't leave a dangling reference for the lifecycle hooks to re-close).
- `RobolectricHost` tracks `activeInteractiveSession: AtomicReference<AndroidInteractiveSession?>` (the host's strong pointer to the live session). Set in `acquire`, cleared via the `onCloseHook` callback.

### Tests (3 new cases, 8 total on `AndroidInteractiveSessionTest`)

- `uiModeOverrideReachesHeldSession` — `uiMode = DARK` on the held composition drives `DarkAwareSquare` to ≥95% black; proves Configuration overrides actually reach the sandbox-side qualifier setup.
- `swapUserClassLoadersForceClosesHeldSession` — held session is `isClosed = true` after the swap; fresh acquire after the swap succeeds.
- `shutdownClosesHeldSessionCleanly` — `shutdown()` drains the held session within the timeout (~7 s in practice). Without the drain wiring, slot 1's worker is stuck on `interactiveCommands.take()` and `shutdown()` times out at 30 s.

## What's NOT in this PR (deferred)

- Sandbox-recycle interaction (B2.5) — the recycler isn't implemented yet, so PR C just leaves the comment trail noting that whoever wires it must skip the interactive slot when `activeInteractiveStreamId` is non-null.
- Explicit `JsonRpcServer.onChannelClosed` daemon-side hook (today the idle lease catches client disconnect within 60 s) — that's a cross-backend concern (desktop too) and warrants its own PR.

## Test plan

- [x] `:daemon:android:testDebugUnitTest` — full module green; all 8 `AndroidInteractiveSessionTest` cases pass (~50 s including two sandbox cold boots per integration test). One unrelated pre-existing flake (`SandboxPoolMemoryBench` heap-delta — passes on rerun, not touched by this PR).
- [x] `:daemon:android:ktfmtCheck` clean
- [x] `:daemon:harness:compileTestKotlin` — downstream consumer unaffected
- [ ] Optional: smoke-test against a sample with `sandboxCount=2` to confirm a save during interactive mode doesn't strand the panel

After this lands, INTERACTIVE-ANDROID.md § 10's three-PR rollout is complete; v3 Android interactive ships.


---
_Generated by [Claude Code](https://claude.ai/code/session_017NDGZk17VhvctNNoSrVZsK)_