### PR TITLE
feat(daemon): scripted screen-record surface with virtual frame clock (P1)

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -376,6 +376,22 @@ class JsonRpcServer(
 
   private val nextStreamIdCounter = java.util.concurrent.atomic.AtomicLong(1)
 
+  // ----------------------------------------------------------------------
+  // Recording (scripted screen-record) state — see docs/daemon/RECORDING.md.
+  //
+  // [recordings] is the set of allocated [RecordingSession]s keyed by `recordingId`. Each entry
+  // is a held-scene driver for one scripted timeline. Lifecycle: insert at `recording/start`,
+  // mutate via `recording/script`, drive via `recording/stop`, encode via `recording/encode`,
+  // remove on session close (which happens at daemon shutdown via [closeAllRecordingSessions] or
+  // explicit close — there's no per-session idle watchdog in v1; the daemon's overall idle-
+  // timeout exit closes everything when the agent disconnects). The map lookup is concurrent so
+  // a `recording/encode` can safely race a daemon-shutdown drain.
+  // ----------------------------------------------------------------------
+
+  private val recordings = ConcurrentHashMap<String, RecordingSession>()
+
+  private val nextRecordingIdCounter = java.util.concurrent.atomic.AtomicLong(1)
+
   /**
    * Preview ids currently in-flight for an override-bearing render. PROTOCOL.md § 5
    * (`renderNow.overrides`) — when a second override-bearing `renderNow` arrives for a previewId
@@ -532,6 +548,9 @@ class JsonRpcServer(
       "data/subscribe" -> handleDataSubscribe(req, subscribe = true)
       "data/unsubscribe" -> handleDataSubscribe(req, subscribe = false)
       "interactive/start" -> handleInteractiveStart(req)
+      "recording/start" -> handleRecordingStart(req)
+      "recording/stop" -> handleRecordingStop(req)
+      "recording/encode" -> handleRecordingEncode(req)
       else ->
         sendErrorResponse(
           id = req.id,
@@ -597,6 +616,10 @@ class JsonRpcServer(
             // real held-scene session (DesktopHost). `false` for hosts that inherit the throwing
             // default (FakeHost, RobolectricHost today) — clients fall back to v1 dispatch.
             interactive = host.supportsInteractive,
+            // RECORDING.md — `true` when the host's `acquireRecordingSession` returns a real
+            // held-scene recording driver (DesktopHost). `false` keeps `recording/start` behind a
+            // `MethodNotFound` reply so clients can grey out the toggle.
+            recording = host.supportsRecording,
             // PROTOCOL.md § 3 — surface the daemon's `DeviceDimensions` catalog so clients can
             // build a `renderNow.overrides.device` picker without re-bundling the list. The
             // catalog itself lives in `:daemon:core/.../daemon/devices/DeviceDimensions.kt`;
@@ -1893,6 +1916,237 @@ class JsonRpcServer(
       .start()
   }
 
+  // --------------------------------------------------------------------------
+  // Recording (scripted screen-record) — docs/daemon/RECORDING.md.
+  //
+  // `recording/start`  → request: allocate a held-scene RecordingSession; respond with recordingId.
+  // `recording/script` → notification: append timeline events; no response.
+  // `recording/stop`   → request: play the timeline back at virtual fps, write per-frame PNGs;
+  //                      respond with frame metadata. Runs on a worker thread because the playback
+  //                      can take seconds for longer scripts and we don't want to block the
+  //                      JSON-RPC read loop.
+  // `recording/encode` → request: wrap the on-disk frames into an APNG (v1; mp4/webm v2). Also
+  //                      runs on a worker thread.
+  //
+  // No per-session idle watchdog in v1: when the agent disconnects, the daemon's overall idle-
+  // timeout exit path closes every recording via [closeAllRecordingSessions]. The user who
+  // requested this surface confirmed that's the right reuse of the existing
+  // `composeai.daemon.idleTimeoutMs` knob.
+  // --------------------------------------------------------------------------
+
+  private fun handleRecordingStart(req: JsonRpcRequest) {
+    val params =
+      try {
+        decodeParams(
+          req.params,
+          ee.schimke.composeai.daemon.protocol.RecordingStartParams.serializer(),
+        )
+      } catch (e: Throwable) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INVALID_PARAMS,
+          message = "invalid recording/start params: ${e.message}",
+        )
+        return
+      }
+    if (params.previewId.isBlank()) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_INVALID_PARAMS,
+        message = "recording/start: previewId is blank",
+      )
+      return
+    }
+    val fps = params.fps ?: DEFAULT_RECORDING_FPS
+    if (fps !in MIN_RECORDING_FPS..MAX_RECORDING_FPS) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_INVALID_PARAMS,
+        message = "recording/start: fps=$fps out of range [$MIN_RECORDING_FPS, $MAX_RECORDING_FPS]",
+      )
+      return
+    }
+    val scale = params.scale ?: DEFAULT_RECORDING_SCALE
+    if (scale <= 0f || scale > MAX_RECORDING_SCALE) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_INVALID_PARAMS,
+        message = "recording/start: scale=$scale out of range (0, $MAX_RECORDING_SCALE]",
+      )
+      return
+    }
+    val recordingId = "rec-${nextRecordingIdCounter.getAndIncrement()}"
+    val classLoader =
+      host.userClassloaderHolder?.currentChildLoader()
+        ?: this::class.java.classLoader
+        ?: ClassLoader.getSystemClassLoader()
+    val session: RecordingSession =
+      try {
+        host.acquireRecordingSession(
+          previewId = params.previewId,
+          recordingId = recordingId,
+          classLoader = classLoader,
+          fps = fps,
+          scale = scale,
+          overrides = params.overrides,
+        )
+      } catch (e: UnsupportedOperationException) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_METHOD_NOT_FOUND,
+          message = "recording/start: ${e.message ?: "recording unsupported by this host"}",
+        )
+        return
+      } catch (t: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: recording/start: acquireRecordingSession failed for " +
+            "previewId='${params.previewId}': ${t.javaClass.simpleName}: ${t.message}"
+        )
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INTERNAL,
+          message = "recording/start: ${t.javaClass.simpleName}: ${t.message}",
+        )
+        return
+      }
+    recordings[recordingId] = session
+    sendResponse(
+      req.id,
+      encode(
+        ee.schimke.composeai.daemon.protocol.RecordingStartResult.serializer(),
+        ee.schimke.composeai.daemon.protocol.RecordingStartResult(recordingId = recordingId),
+      ),
+    )
+  }
+
+  private fun handleRecordingScript(
+    params: ee.schimke.composeai.daemon.protocol.RecordingScriptParams
+  ) {
+    val session = recordings[params.recordingId] ?: return // Stale id; drop silently.
+    try {
+      session.postScript(params.events)
+    } catch (t: Throwable) {
+      System.err.println(
+        "compose-ai-daemon: recording/script: postScript failed for " +
+          "recordingId='${params.recordingId}': ${t.javaClass.simpleName}: ${t.message}"
+      )
+    }
+  }
+
+  private fun handleRecordingStop(req: JsonRpcRequest) {
+    val params =
+      try {
+        decodeParams(
+          req.params,
+          ee.schimke.composeai.daemon.protocol.RecordingStopParams.serializer(),
+        )
+      } catch (e: Throwable) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INVALID_PARAMS,
+          message = "invalid recording/stop params: ${e.message}",
+        )
+        return
+      }
+    val session = recordings[params.recordingId]
+    if (session == null) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_INVALID_PARAMS,
+        message = "recording/stop: unknown recordingId='${params.recordingId}'",
+      )
+      return
+    }
+    Thread(
+        {
+          try {
+            val r = session.stop()
+            sendResponse(
+              req.id,
+              encode(
+                ee.schimke.composeai.daemon.protocol.RecordingStopResult.serializer(),
+                ee.schimke.composeai.daemon.protocol.RecordingStopResult(
+                  frameCount = r.frameCount,
+                  durationMs = r.durationMs,
+                  framesDir = r.framesDir,
+                  frameWidthPx = r.frameWidthPx,
+                  frameHeightPx = r.frameHeightPx,
+                ),
+              ),
+            )
+          } catch (t: Throwable) {
+            System.err.println(
+              "compose-ai-daemon: recording/stop($${params.recordingId}) failed: ${t.message}"
+            )
+            sendErrorResponse(
+              id = req.id,
+              code = ERR_INTERNAL,
+              message = "recording/stop: ${t.javaClass.simpleName}: ${t.message}",
+            )
+          }
+        },
+        "compose-ai-daemon-recording-stop-${params.recordingId}",
+      )
+      .apply { isDaemon = true }
+      .start()
+  }
+
+  private fun handleRecordingEncode(req: JsonRpcRequest) {
+    val params =
+      try {
+        decodeParams(
+          req.params,
+          ee.schimke.composeai.daemon.protocol.RecordingEncodeParams.serializer(),
+        )
+      } catch (e: Throwable) {
+        sendErrorResponse(
+          id = req.id,
+          code = ERR_INVALID_PARAMS,
+          message = "invalid recording/encode params: ${e.message}",
+        )
+        return
+      }
+    val session = recordings[params.recordingId]
+    if (session == null) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_INVALID_PARAMS,
+        message = "recording/encode: unknown recordingId='${params.recordingId}'",
+      )
+      return
+    }
+    Thread(
+        {
+          try {
+            val encoded = session.encode(params.format)
+            sendResponse(
+              req.id,
+              encode(
+                ee.schimke.composeai.daemon.protocol.RecordingEncodeResult.serializer(),
+                ee.schimke.composeai.daemon.protocol.RecordingEncodeResult(
+                  videoPath = encoded.videoPath,
+                  mimeType = encoded.mimeType,
+                  sizeBytes = encoded.sizeBytes,
+                ),
+              ),
+            )
+          } catch (t: Throwable) {
+            System.err.println(
+              "compose-ai-daemon: recording/encode($${params.recordingId}) failed: ${t.message}"
+            )
+            sendErrorResponse(
+              id = req.id,
+              code = ERR_INTERNAL,
+              message = "recording/encode: ${t.javaClass.simpleName}: ${t.message}",
+            )
+          }
+        },
+        "compose-ai-daemon-recording-encode-${params.recordingId}",
+      )
+      .apply { isDaemon = true }
+      .start()
+  }
+
   private fun handleShutdown(req: JsonRpcRequest) {
     shutdownRequested.set(true)
     // Drain in-flight renders before responding, per PROTOCOL.md § 3 and
@@ -1924,6 +2178,10 @@ class JsonRpcServer(
       "interactive/input" ->
         tryDecode(ee.schimke.composeai.daemon.protocol.InteractiveInputParams.serializer(), n) {
           handleInteractiveInput(it)
+        }
+      "recording/script" ->
+        tryDecode(ee.schimke.composeai.daemon.protocol.RecordingScriptParams.serializer(), n) {
+          handleRecordingScript(it)
         }
       else -> System.err.println("compose-ai-daemon: unknown notification method: ${n.method}")
     }
@@ -2198,6 +2456,7 @@ class JsonRpcServer(
     // is idempotent (clears the map), so the duplicate call inside cleanShutdown's body is a
     // safe no-op on this path.
     closeAllInteractiveSessions()
+    closeAllRecordingSessions()
     running.set(false)
     cleanShutdown()
     invokeExit(exitCode)
@@ -2226,6 +2485,26 @@ class JsonRpcServer(
       } catch (e: Throwable) {
         System.err.println(
           "compose-ai-daemon: closeAllInteractiveSessions: session.close() " +
+            "(${session.previewId}) threw ${e.javaClass.simpleName}: ${e.message}; continuing"
+        )
+      }
+    }
+  }
+
+  /**
+   * RECORDING.md — drains every held [RecordingSession] from [recordings], close()'s each one, and
+   * clears the map. Idempotent. Called from both [handleExit] and [cleanShutdown]; mirrors the
+   * [closeAllInteractiveSessions] pattern.
+   */
+  private fun closeAllRecordingSessions() {
+    val sessions = recordings.values.toList()
+    recordings.clear()
+    for (session in sessions) {
+      try {
+        session.close()
+      } catch (e: Throwable) {
+        System.err.println(
+          "compose-ai-daemon: closeAllRecordingSessions: session.close() " +
             "(${session.previewId}) threw ${e.javaClass.simpleName}: ${e.message}; continuing"
         )
       }
@@ -2332,6 +2611,7 @@ class JsonRpcServer(
       System.err.println("compose-ai-daemon: historyManager.stopAutoPrune failed: ${e.message}")
     }
     closeAllInteractiveSessions()
+    closeAllRecordingSessions()
     try {
       host.shutdown()
     } catch (e: Throwable) {
@@ -2439,6 +2719,21 @@ class JsonRpcServer(
      * single-render render body. Overridable per-session via `initialize.options.maxRenderMs`.
      */
     const val DEFAULT_RENDER_TIMEOUT_MS: Long = 5 * 60_000L
+
+    /** RECORDING.md — default `recording/start.fps` when the caller doesn't specify one. */
+    const val DEFAULT_RECORDING_FPS: Int = 30
+
+    /** RECORDING.md — minimum legal `recording/start.fps`. */
+    const val MIN_RECORDING_FPS: Int = 1
+
+    /** RECORDING.md — maximum legal `recording/start.fps`. Capped to keep frame budgets sane. */
+    const val MAX_RECORDING_FPS: Int = 120
+
+    /** RECORDING.md — default `recording/start.scale` when the caller doesn't specify one. */
+    const val DEFAULT_RECORDING_SCALE: Float = 1.0f
+
+    /** RECORDING.md — maximum legal `recording/start.scale` (output dimension multiplier). */
+    const val MAX_RECORDING_SCALE: Float = 8.0f
 
     private const val DEFAULT_DAEMON_VERSION: String = "0.0.0-dev"
     private const val DEFAULT_HISTORY_DIR: String = ".compose-preview-history"

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
@@ -1,0 +1,96 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+
+/**
+ * Held-scene recording session for one `recordingId` — see
+ * [RECORDING.md](../../../../../../docs/daemon/RECORDING.md) (planned) and
+ * [INTERACTIVE.md § 9](../../../../../../docs/daemon/INTERACTIVE.md#9-v2--click-dispatch-into-composition).
+ *
+ * Backends that support recording (today: `:daemon:desktop`'s `DesktopRecordingSession`) implement
+ * this interface to keep an `ImageComposeScene` (or per-host equivalent) warm for the duration of
+ * the recording. The session owns a **virtual frame clock** at a fixed `fps`: dispatched pointer
+ * events and scene render ticks all key off the same `nanoTime`, so a script of `(tMs=0, click) +
+ * (tMs=500, click)` always produces 500 ms of inter-click animation regardless of how long the
+ * agent took to assemble the script. Without virtual time the renderer would tick on wall-clock,
+ * stretching agent latency into the recorded video.
+ *
+ * Lifecycle owned by [JsonRpcServer]:
+ * - **Allocate** at `recording/start` via [RenderHost.acquireRecordingSession]. The session holds
+ *   one fresh scene; concurrent recordings allocate independent sessions.
+ * - **Append** events at `recording/script` — [postScript] sorts and merges into the timeline.
+ * - **Drive** at `recording/stop` — [stop] plays the timeline back in virtual time, writing one PNG
+ *   per virtual frame, and returns the frame metadata.
+ * - **Encode** at `recording/encode` — [encode] assembles the on-disk frames into a single video
+ *   file (APNG today; mp4 / webm later).
+ * - **Release** at [close] (or daemon shutdown) — frees the scene and any native resources. Frame
+ *   PNGs and any encoded video stay on disk so a subsequent `recording/encode` can re-encode
+ *   without holding the scene open.
+ *
+ * **Threading.** Implementations may assume calls are serialised per-instance. JsonRpcServer
+ * dispatches recording RPCs on a per-recording worker thread (similar to the per-input worker for
+ * interactive sessions) so concurrent recordings on different sessions are independent. Skiko isn't
+ * thread-safe so the contract matches the underlying constraint.
+ *
+ * **No-mid-render-cancellation invariant** ([DESIGN.md §
+ * 9](../../../../../../docs/daemon/DESIGN.md)). [close] must drain any in-flight render before
+ * tearing down the scene, the same way `RenderHost.shutdown` drains its queue.
+ */
+interface RecordingSession : AutoCloseable {
+
+  /** The preview id this session is recording. Frozen at allocation time. */
+  val previewId: String
+
+  /** Opaque session id assigned by [JsonRpcServer] at `recording/start`. Frozen at allocation. */
+  val recordingId: String
+
+  /** Frame rate of the virtual clock, in frames per second. Frozen at allocation. */
+  val fps: Int
+
+  /** Output-frame size multiplier (≥ 0). Frozen at allocation. */
+  val scale: Float
+
+  /**
+   * Append a batch of events to the virtual timeline. May be called multiple times before [stop];
+   * each call merges and re-sorts by `tMs` so out-of-order client batches still play in order.
+   */
+  fun postScript(events: List<RecordingScriptEvent>)
+
+  /**
+   * Play the script back on the virtual clock, writing one PNG per virtual frame to disk. After
+   * [stop] returns, the held scene is closed and further [postScript] calls are illegal — but the
+   * PNGs remain on disk so [encode] can be invoked. Idempotent in the limited sense that a second
+   * call returns the same [RecordingResult] without re-rendering.
+   */
+  fun stop(): RecordingResult
+
+  /**
+   * Encode the on-disk frames produced by [stop] into a single video file. Must be called after
+   * [stop] (the implementation throws otherwise). Idempotent: encoding the same format twice
+   * returns the same path; encoding different formats writes side-by-side files.
+   */
+  fun encode(format: RecordingFormat): EncodedRecording
+
+  /**
+   * Drains any in-flight playback, frees the held scene + native resources, and removes any
+   * filesystem state owned by the session that survives past final encoding (the per-frame PNGs and
+   * encoded video files stay — the agent may want to re-encode later). Idempotent.
+   */
+  override fun close()
+}
+
+/**
+ * Metadata returned by [RecordingSession.stop]. The on-disk PNGs at `<framesDir>/frame-NNNNN.png`
+ * outlive the session.
+ */
+data class RecordingResult(
+  val frameCount: Int,
+  val durationMs: Long,
+  val framesDir: String,
+  val frameWidthPx: Int,
+  val frameHeightPx: Int,
+)
+
+/** Metadata returned by [RecordingSession.encode]. */
+data class EncodedRecording(val videoPath: String, val mimeType: String, val sizeBytes: Long)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -151,6 +151,51 @@ interface RenderHost {
       "interactive mode unsupported by ${this::class.simpleName ?: this::class.java.name}"
     )
 
+  /**
+   * `true` when this host's [acquireRecordingSession] returns a real held-scene session that drives
+   * a virtual frame clock and writes per-frame PNGs. `false` (the default) when the host inherits
+   * the throwing default and `recording/start` is rejected with `MethodNotFound (-32601)`. Surfaced
+   * verbatim as `InitializeResult.capabilities.recording`.
+   *
+   * Implementations MUST keep this in sync with their [acquireRecordingSession] override.
+   */
+  val supportsRecording: Boolean
+    get() = false
+
+  /**
+   * Allocate a [RecordingSession] for [previewId] — the scripted screen-record surface. The session
+   * holds a warm `ImageComposeScene` (or per-host equivalent) for the duration of the recording so
+   * `remember`'d state and animation timing are continuous across the virtual timeline.
+   *
+   * Hosts that support recording (today: `:daemon:desktop`'s `DesktopHost`) override and return a
+   * concrete session. The default body throws [UnsupportedOperationException] which
+   * [JsonRpcServer.handleRecordingStart] translates to `MethodNotFound (-32601)` on the wire.
+   *
+   * @param recordingId opaque session id assigned by [JsonRpcServer]; passed back on every
+   *   `recording/script` / `recording/stop` / `recording/encode` so the daemon can route to the
+   *   right held session.
+   * @param classLoader the disposable child loader from [UserClassLoaderHolder.currentChildLoader]
+   *   (B2.0 — see [CLASSLOADER.md](../../../../../../docs/daemon/CLASSLOADER.md)).
+   * @param fps frames per second at the virtual clock. Caller-validated to be in `[1, 120]`.
+   * @param scale output-frame size multiplier. Caller-validated to be in `(0, 8]`. Coordinates stay
+   *   in image-natural pixel space — the host scales the captured surface at encode time, not at
+   *   composition time.
+   * @param overrides per-render display overrides applied to the held scene; same shape and
+   *   semantics as `renderNow.overrides`. Lets a `Button`-sized component preview be recorded at
+   *   its natural size with a custom background.
+   */
+  fun acquireRecordingSession(
+    previewId: String,
+    recordingId: String,
+    classLoader: ClassLoader,
+    fps: Int,
+    scale: Float,
+    overrides: ee.schimke.composeai.daemon.protocol.PreviewOverrides?,
+  ): RecordingSession =
+    throw UnsupportedOperationException(
+      "recording unsupported by ${this::class.simpleName ?: this::class.java.name}"
+    )
+
   companion object {
     /**
      * Monotonic id source shared across [JsonRpcServer] (which assigns ids to incoming render

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -131,6 +131,13 @@ data class ServerCapabilities(
   // capability — clients treat absent and `false` identically.
   val interactive: Boolean = false,
   /**
+   * `true` when the daemon's host can drive a virtual-frame-clock recording session (the scripted
+   * screen-record surface — see RECORDING.md). Defaulted to `false` for old daemons that pre-date
+   * the capability; clients treat absent and `false` identically and fall back to surfacing
+   * "recording unsupported by this backend" when the toggle is offered.
+   */
+  val recording: Boolean = false,
+  /**
    * The `@Preview(device = ...)` ids the daemon's `DeviceDimensions` catalog recognises, paired
    * with their resolved geometry. Lets clients build a "render this preview at..." picker without
    * re-bundling the catalog. Empty list = pre-feature daemon (clients treat absent and `[]`
@@ -798,3 +805,110 @@ enum class PruneReasonWire {
   @SerialName("auto") AUTO,
   @SerialName("manual") MANUAL,
 }
+
+// =====================================================================
+// 5c. Recording (scripted screen-record) mode — see docs/daemon/RECORDING.md.
+//
+// A recording session is a held [androidx.compose.ui.ImageComposeScene] driven by a virtual
+// frame clock at a fixed `fps`. The agent posts a script of `(tMs, kind, pixelX, pixelY)`
+// events; on `recording/stop` the daemon plays the timeline back in virtual time, encoding
+// one PNG per frame to `<framesDir>/frame-NNNNN.png`. `recording/encode` then assembles those
+// frames into a single video file (APNG in v1; mp4 / webm in v2).
+//
+// "Feels like normal user time" property: agents that send "click at t=0ms, click at t=500ms"
+// produce a video with a full 500 ms of inter-click animation regardless of how long the
+// agent took to compose the script. The virtual clock decouples wire latency from playback
+// pacing.
+// =====================================================================
+
+/**
+ * `recording/start` parameters.
+ *
+ * @property previewId the discovery-time preview id to record. Same shape and resolution path as
+ *   `interactive/start.previewId` and `renderNow.previews[i]`.
+ * @property fps frames per second at the virtual clock. Must be in `[1, 120]`. Defaults to 30.
+ * @property scale output-frame size multiplier. Must be in `(0, 8]`. Defaults to 1.0. Coordinates
+ *   on the wire stay in image-natural pixel space — the Skiko surface is scaled at encode time, not
+ *   at composition time, so the agent's `pixelX`/`pixelY` always refer to the scene's own
+ *   coordinates.
+ * @property overrides per-render display overrides applied to the held scene; mirrors
+ *   `renderNow.overrides` exactly. Lets a `Button` preview be recorded at `widthPx: 240, heightPx:
+ *   80, backgroundColor: 0xFFFFFFFF` (or whatever the agent prefers) without editing source.
+ */
+@Serializable
+data class RecordingStartParams(
+  val previewId: String,
+  val fps: Int? = null,
+  val scale: Float? = null,
+  val overrides: PreviewOverrides? = null,
+)
+
+/**
+ * Opaque correlation token returned by `recording/start`. The client passes it back on every
+ * subsequent `recording/script`, `recording/stop`, and `recording/encode` so the daemon can route
+ * to the right held session.
+ */
+@Serializable data class RecordingStartResult(val recordingId: String)
+
+/** One scripted input event on the virtual timeline. */
+@Serializable
+data class RecordingScriptEvent(
+  /** Virtual time offset from `recording/start`, in milliseconds. Must be ≥ 0. */
+  val tMs: Long,
+  val kind: InteractiveInputKind,
+  /** Image-natural pixel coordinates. Same coordinate system as `interactive/input`. */
+  val pixelX: Int? = null,
+  val pixelY: Int? = null,
+  /** For `keyDown` / `keyUp` (no-op in v1; reserved for v2 key dispatch). */
+  val keyCode: String? = null,
+)
+
+@Serializable
+data class RecordingScriptParams(val recordingId: String, val events: List<RecordingScriptEvent>)
+
+@Serializable data class RecordingStopParams(val recordingId: String)
+
+/**
+ * Result of `recording/stop`. The daemon has played the script back in virtual time, written one
+ * PNG per virtual frame to [framesDir], and freed the held scene.
+ */
+@Serializable
+data class RecordingStopResult(
+  /**
+   * Number of frames written. Equals `ceil(durationMs * fps / 1000) + 1` (inclusive of frame 0).
+   */
+  val frameCount: Int,
+  /** Virtual duration covered by the recording, in milliseconds — `max(scriptEvent.tMs)` or 0. */
+  val durationMs: Long,
+  /** Absolute path of the directory containing `frame-NNNNN.png` files. */
+  val framesDir: String,
+  /** Frame width in pixels, after `scale`. */
+  val frameWidthPx: Int,
+  /** Frame height in pixels, after `scale`. */
+  val frameHeightPx: Int,
+)
+
+/**
+ * v1 supports only animated PNG (pure JVM, no native deps, plays in every browser/webview). mp4 /
+ * webm via `ffmpeg` shell-out land in v2 — the enum is open so new values don't bump
+ * `protocolVersion` per PROTOCOL.md § 7.
+ */
+@Serializable
+enum class RecordingFormat {
+  @SerialName("apng") APNG
+}
+
+@Serializable
+data class RecordingEncodeParams(
+  val recordingId: String,
+  val format: RecordingFormat = RecordingFormat.APNG,
+)
+
+@Serializable
+data class RecordingEncodeResult(
+  /** Absolute path of the encoded video file. */
+  val videoPath: String,
+  /** MIME type — `image/apng` for APNG; `video/mp4` / `video/webm` once v2 lands those. */
+  val mimeType: String,
+  val sizeBytes: Long,
+)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/ApngEncoder.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/ApngEncoder.kt
@@ -1,0 +1,202 @@
+package ee.schimke.composeai.daemon
+
+import java.io.File
+import java.io.RandomAccessFile
+import java.nio.ByteBuffer
+import java.util.zip.CRC32
+
+/**
+ * Minimal pure-JVM Animated PNG encoder. Used by [DesktopRecordingSession.encode] to assemble the
+ * per-frame PNGs produced by the playback loop into a single APNG file the agent (or a webview /
+ * browser) can play back.
+ *
+ * **Wire shape.** APNG is the standard PNG container with two chunk types added per the
+ * [APNG spec](https://wiki.mozilla.org/APNG_Specification):
+ *
+ * - `acTL` (animation control): emitted once after the IHDR chunk; carries `numFrames` and
+ *   `numPlays` (loop count).
+ * - `fcTL` (frame control): one per animation frame, carries `width`, `height`, `xOffset`,
+ *   `yOffset`, `delayNum/delayDen`, `disposeOp`, `blendOp`. The first `fcTL` precedes the `IDAT`
+ *   chunk that carries the first frame's pixels; subsequent `fcTL`s precede the `fdAT` chunks for
+ *   later frames.
+ * - `fdAT` (frame data): same compressed pixel data as IDAT but with a leading 4-byte sequence
+ *   number. Chained one or more per frame (we emit one).
+ *
+ * **Frame source.** [encodeFromPngFrames] takes a list of PNG files (one per frame, all with
+ * identical width × height — enforced by [DesktopRecordingSession]'s scaled-or-natural frame
+ * writer) and:
+ *
+ * 1. Reads the first frame's `IHDR` to learn width/height/colour type — that becomes the APNG's own
+ *    IHDR.
+ * 2. Copies each frame's `IDAT` chunks into either an output IDAT (frame 0) or `fdAT` chunks
+ *    (frames 1..N-1), wrapping each frame in a fresh `fcTL`.
+ * 3. Writes a single `IEND` to close.
+ *
+ * **What this isn't.** Not a re-encoder — we don't decode pixels and re-deflate them. We rely on
+ * Skiko emitting per-frame PNGs with the same IHDR shape, then surgically copy IDAT bytes into fdAT
+ * chunks. This keeps the encoder small (~150 LOC) and fast (no zlib round-trip), at the cost of
+ * trusting the input frames to share an IHDR. [DesktopRecordingSession] guarantees this via the
+ * fixed `frameWidthPx × frameHeightPx` raster surface.
+ *
+ * **Loop count.** `0` means "infinite" per APNG spec — that's the default.
+ */
+object ApngEncoder {
+
+  private val PNG_SIGNATURE = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10) // 0x89 PNG\r\n SUB \n
+  private const val CHUNK_TYPE_IHDR = "IHDR"
+  private const val CHUNK_TYPE_IDAT = "IDAT"
+  private const val CHUNK_TYPE_IEND = "IEND"
+  private const val CHUNK_TYPE_ACTL = "acTL"
+  private const val CHUNK_TYPE_FCTL = "fcTL"
+  private const val CHUNK_TYPE_FDAT = "fdAT"
+
+  fun encodeFromPngFrames(
+    frames: List<File>,
+    delayNumerator: Short,
+    delayDenominator: Short,
+    loopCount: Int,
+    out: File,
+  ) {
+    require(frames.isNotEmpty()) { "ApngEncoder: at least one frame required" }
+    require(delayDenominator > 0) { "ApngEncoder: delayDenominator must be > 0" }
+    require(loopCount >= 0) { "ApngEncoder: loopCount must be ≥ 0 (0 = infinite)" }
+
+    out.parentFile?.mkdirs()
+    RandomAccessFile(out, "rw").use { raf ->
+      raf.setLength(0)
+      raf.write(PNG_SIGNATURE)
+
+      // Read the first frame's IHDR + IDATs to seed the output IHDR + frame 0 fcTL+IDAT.
+      val firstFrame = readPngChunks(frames[0])
+      val ihdr =
+        firstFrame.firstOrNull { it.type == CHUNK_TYPE_IHDR }
+          ?: error("ApngEncoder: ${frames[0]} has no IHDR chunk")
+      writeChunk(raf, CHUNK_TYPE_IHDR, ihdr.data)
+
+      val (frameWidth, frameHeight) = parseIhdrSize(ihdr.data)
+
+      // acTL — animation control. Goes between IHDR and the first IDAT.
+      val acTl = ByteBuffer.allocate(8).putInt(frames.size).putInt(loopCount).array()
+      writeChunk(raf, CHUNK_TYPE_ACTL, acTl)
+
+      var sequenceNumber = 0
+
+      // Frame 0 — fcTL with seq=0, then frame's IDAT chunks copied verbatim.
+      writeFcTl(
+        raf,
+        sequenceNumber = sequenceNumber++,
+        width = frameWidth,
+        height = frameHeight,
+        delayNum = delayNumerator,
+        delayDen = delayDenominator,
+      )
+      for (chunk in firstFrame.filter { it.type == CHUNK_TYPE_IDAT }) {
+        writeChunk(raf, CHUNK_TYPE_IDAT, chunk.data)
+      }
+
+      // Frames 1..N — fcTL + fdAT(seq, idatPayload) per frame.
+      for (frameIndex in 1 until frames.size) {
+        val frameChunks = readPngChunks(frames[frameIndex])
+        val frameIhdr =
+          frameChunks.firstOrNull { it.type == CHUNK_TYPE_IHDR }
+            ?: error("ApngEncoder: ${frames[frameIndex]} has no IHDR chunk")
+        val (w, h) = parseIhdrSize(frameIhdr.data)
+        require(w == frameWidth && h == frameHeight) {
+          "ApngEncoder: frame $frameIndex (${frames[frameIndex]}) size ${w}x$h does not match " +
+            "frame 0 size ${frameWidth}x$frameHeight — frames must share IHDR"
+        }
+        writeFcTl(
+          raf,
+          sequenceNumber = sequenceNumber++,
+          width = w,
+          height = h,
+          delayNum = delayNumerator,
+          delayDen = delayDenominator,
+        )
+        for (chunk in frameChunks.filter { it.type == CHUNK_TYPE_IDAT }) {
+          val fdAt = ByteBuffer.allocate(4 + chunk.data.size)
+          fdAt.putInt(sequenceNumber++)
+          fdAt.put(chunk.data)
+          writeChunk(raf, CHUNK_TYPE_FDAT, fdAt.array())
+        }
+      }
+
+      writeChunk(raf, CHUNK_TYPE_IEND, ByteArray(0))
+    }
+  }
+
+  private fun writeFcTl(
+    raf: RandomAccessFile,
+    sequenceNumber: Int,
+    width: Int,
+    height: Int,
+    delayNum: Short,
+    delayDen: Short,
+  ) {
+    // fcTL chunk: 26 bytes
+    //   seq (4) + width (4) + height (4) + xOffset (4) + yOffset (4)
+    //   + delayNum (2) + delayDen (2) + disposeOp (1) + blendOp (1)
+    // disposeOp = 0 (NONE — leave the framebuffer as is for the next frame).
+    // blendOp = 0 (SOURCE — overwrite the framebuffer with this frame's pixels).
+    val payload =
+      ByteBuffer.allocate(26)
+        .putInt(sequenceNumber)
+        .putInt(width)
+        .putInt(height)
+        .putInt(0)
+        .putInt(0)
+        .putShort(delayNum)
+        .putShort(delayDen)
+        .put(0.toByte())
+        .put(0.toByte())
+        .array()
+    writeChunk(raf, CHUNK_TYPE_FCTL, payload)
+  }
+
+  private fun writeChunk(raf: RandomAccessFile, type: String, data: ByteArray) {
+    require(type.length == 4) { "PNG chunk type must be 4 ASCII chars; got '$type'" }
+    val typeBytes = type.toByteArray(Charsets.US_ASCII)
+    val crc = CRC32()
+    crc.update(typeBytes)
+    crc.update(data)
+    raf.writeInt(data.size)
+    raf.write(typeBytes)
+    raf.write(data)
+    raf.writeInt(crc.value.toInt())
+  }
+
+  private data class PngChunk(val type: String, val data: ByteArray)
+
+  private fun readPngChunks(file: File): List<PngChunk> {
+    val bytes = file.readBytes()
+    require(bytes.size > PNG_SIGNATURE.size) {
+      "ApngEncoder: ${file.absolutePath} is too small to be a PNG"
+    }
+    for (i in PNG_SIGNATURE.indices) {
+      require(bytes[i] == PNG_SIGNATURE[i]) {
+        "ApngEncoder: ${file.absolutePath} is not a valid PNG (signature mismatch at byte $i)"
+      }
+    }
+    val chunks = mutableListOf<PngChunk>()
+    val buf = ByteBuffer.wrap(bytes)
+    buf.position(PNG_SIGNATURE.size)
+    while (buf.remaining() >= 12) {
+      val length = buf.int
+      val typeBytes = ByteArray(4).also { buf.get(it) }
+      val type = String(typeBytes, Charsets.US_ASCII)
+      val data = ByteArray(length).also { buf.get(it) }
+      buf.int // skip CRC; trust the source PNG was well-formed (Skiko)
+      chunks.add(PngChunk(type, data))
+      if (type == CHUNK_TYPE_IEND) break
+    }
+    return chunks
+  }
+
+  private fun parseIhdrSize(ihdrData: ByteArray): Pair<Int, Int> {
+    require(ihdrData.size >= 8) { "ApngEncoder: IHDR chunk too short (${ihdrData.size} bytes)" }
+    val buf = ByteBuffer.wrap(ihdrData)
+    val width = buf.int
+    val height = buf.int
+    return width to height
+  }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
@@ -122,6 +123,13 @@ open class DesktopHost(
    * tests that exercise the v1 fallback path).
    */
   override val supportsInteractive: Boolean
+    get() = previewSpecResolver != null
+
+  /**
+   * RECORDING.md — same gating as [supportsInteractive]. Recording rides the held-scene machinery,
+   * so a host without a resolver can't allocate a session either way.
+   */
+  override val supportsRecording: Boolean
     get() = previewSpecResolver != null
 
   /**
@@ -282,6 +290,125 @@ open class DesktopHost(
   }
 
   /**
+   * RECORDING.md — allocate a [DesktopRecordingSession] holding a long-lived
+   * [androidx.compose.ui.ImageComposeScene] for [previewId]. Resolves the preview spec via
+   * [previewSpecResolver] (same path as [acquireInteractiveSession]) and merges the inbound
+   * [overrides] over it before [RenderEngine.setUp]. Session frame PNGs land at
+   * `<recordingsRoot>/<recordingId>/frame-NNNNN.png`; encoded videos land at
+   * `<recordingsRoot>/encoded/<recordingId>.<ext>`.
+   *
+   * The held scene composes with `LocalInspectionMode = false` — same as the interactive path — so
+   * `Modifier.clickable {}` and pointer-input modifiers fire on dispatched events.
+   */
+  override fun acquireRecordingSession(
+    previewId: String,
+    recordingId: String,
+    classLoader: ClassLoader,
+    fps: Int,
+    scale: Float,
+    overrides: ee.schimke.composeai.daemon.protocol.PreviewOverrides?,
+  ): RecordingSession {
+    val resolver =
+      previewSpecResolver
+        ?: throw UnsupportedOperationException(
+          "DesktopHost has no previewSpecResolver; pass one at construction time to enable " +
+            "recording sessions"
+        )
+    val baseSpec =
+      resolver(previewId)
+        ?: throw UnsupportedOperationException(
+          "DesktopHost.previewSpecResolver returned null for previewId='$previewId'; " +
+            "recording session not allocated"
+        )
+    val effectiveSpec = applyOverrides(baseSpec, overrides, recordingId)
+    val state = engine.setUp(effectiveSpec, classLoader, inspectionMode = false)
+    val recordingsRoot = recordingsRootDir()
+    val framesDir = File(File(recordingsRoot, "frames"), recordingId)
+    val encodedDir = File(recordingsRoot, "encoded")
+    return DesktopRecordingSession(
+      previewId = previewId,
+      recordingId = recordingId,
+      fps = fps,
+      scale = scale,
+      engine = engine,
+      state = state,
+      sandboxStats = sandboxStats,
+      framesDir = framesDir,
+      encodedDir = encodedDir,
+    )
+  }
+
+  /**
+   * Resolve the directory recordings live under. Defers to `composeai.daemon.recordingsDir` when
+   * set (the gradle plugin's daemon launch descriptor will eventually populate this); falls back to
+   * a sibling of the engine's output dir so unit tests don't need to set the property.
+   */
+  private fun recordingsRootDir(): File {
+    val sysprop = System.getProperty(RECORDINGS_DIR_PROP)
+    if (sysprop != null && sysprop.isNotBlank()) return File(sysprop)
+    val engineOut = System.getProperty(RenderEngine.OUTPUT_DIR_PROP)
+    val parent =
+      if (engineOut != null && engineOut.isNotBlank()) File(engineOut).parentFile
+      else File("${System.getProperty("user.dir")}/.compose-preview-history")
+    return File(parent ?: File(System.getProperty("user.dir")), "daemon-recordings")
+  }
+
+  /**
+   * Merge [overrides] over [base], resolving `device` against [DeviceDimensions] when present.
+   * Mirrors the stringly-typed merge that `JsonRpcServer.encodeRenderPayload` +
+   * `RenderSpec.parseFromPayload` perform on the renderNow path — typed because recording doesn't
+   * go through the host's render-queue payload string.
+   *
+   * Explicit `widthPx` / `heightPx` / `density` overrides win over `device`-resolved values.
+   * `outputBaseName` is rewritten to `recording-<recordingId>` so a stray engine fast-path encode
+   * (only used by the one-shot `engine.render` wrapper, not by the recording flow) wouldn't collide
+   * with another preview's PNG. The recording flow itself never reads it.
+   */
+  private fun applyOverrides(
+    base: RenderSpec,
+    overrides: ee.schimke.composeai.daemon.protocol.PreviewOverrides?,
+    recordingId: String,
+  ): RenderSpec {
+    if (overrides == null) {
+      return base.copy(outputBaseName = "recording-$recordingId")
+    }
+    val deviceOverride = overrides.device?.takeIf { it.isNotBlank() }
+    val deviceSpec = deviceOverride?.let {
+      ee.schimke.composeai.daemon.devices.DeviceDimensions.resolve(it)
+    }
+    val baseDensity = overrides.density ?: deviceSpec?.density ?: base.density
+    val baseWidthPx =
+      overrides.widthPx ?: deviceSpec?.let { (it.widthDp * baseDensity).toInt() } ?: base.widthPx
+    val baseHeightPx =
+      overrides.heightPx ?: deviceSpec?.let { (it.heightDp * baseDensity).toInt() } ?: base.heightPx
+    val uiMode =
+      when (overrides.uiMode) {
+        ee.schimke.composeai.daemon.protocol.UiMode.LIGHT -> RenderSpec.SpecUiMode.LIGHT
+        ee.schimke.composeai.daemon.protocol.UiMode.DARK -> RenderSpec.SpecUiMode.DARK
+        null -> base.uiMode
+      }
+    val orientation =
+      when (overrides.orientation) {
+        ee.schimke.composeai.daemon.protocol.Orientation.PORTRAIT ->
+          RenderSpec.SpecOrientation.PORTRAIT
+        ee.schimke.composeai.daemon.protocol.Orientation.LANDSCAPE ->
+          RenderSpec.SpecOrientation.LANDSCAPE
+        null -> base.orientation
+      }
+    return base.copy(
+      widthPx = baseWidthPx,
+      heightPx = baseHeightPx,
+      density = baseDensity,
+      device = deviceOverride ?: base.device,
+      localeTag = overrides.localeTag?.takeIf { it.isNotBlank() } ?: base.localeTag,
+      fontScale = overrides.fontScale ?: base.fontScale,
+      uiMode = uiMode,
+      orientation = orientation,
+      outputBaseName = "recording-$recordingId",
+    )
+  }
+
+  /**
    * Sends the poison pill, drains the in-flight render (DESIGN § 9 invariant: never aborts a render
    * mid-flight), waits up to [timeoutMs] for the worker thread to exit. Idempotent.
    */
@@ -405,5 +532,14 @@ open class DesktopHost(
       current = current.targetException ?: return current
     }
     return current
+  }
+
+  companion object {
+    /**
+     * System property carrying the absolute path of the recordings directory. Set by the gradle
+     * plugin's daemon launch descriptor in production; left unset in tests, in which case
+     * [recordingsRootDir] falls back to a sibling of [RenderEngine.OUTPUT_DIR_PROP].
+     */
+    const val RECORDINGS_DIR_PROP: String = "composeai.daemon.recordingsDir"
   }
 }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -1,0 +1,281 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerButtons
+import androidx.compose.ui.input.pointer.PointerEventType
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import java.io.File
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.Rect
+import org.jetbrains.skia.SamplingMode
+import org.jetbrains.skia.Surface
+
+/**
+ * Desktop concrete [RecordingSession] driving a virtual frame clock against a held
+ * [androidx.compose.ui.ImageComposeScene]. See
+ * [INTERACTIVE.md § 9](../../../../../../docs/daemon/INTERACTIVE.md#9-v2--click-dispatch-into-composition)
+ * for the held-scene contract this builds on, and `RECORDING.md` for the v1 protocol.
+ *
+ * **Virtual frame clock.** Both the dispatched pointer events and `scene.render(nanoTime)` key off
+ * the same monotonically-advancing virtual nanoTime — `frameIndex * 1e9 / fps`. A script of
+ * `(tMs=0, click) + (tMs=500, click)` always produces 500 ms of inter-click animation in the output
+ * regardless of how long the agent took to assemble the script. `LaunchedEffect`, `withFrameNanos`,
+ * and `rememberInfiniteTransition` all read the scene's frame clock — so they advance with the
+ * recording's virtual time, not with wall-clock.
+ *
+ * **CLICK dispatch.** Each `CLICK` event splits into Press → render-tick → Release at the same
+ * virtual `tMs`, mirroring the [DesktopInteractiveSession] pattern. The intermediate render tick
+ * doesn't write a frame to disk; only the per-frame loop's `scene.render(nanoTime)` produces an
+ * output PNG. Press carries `button = PointerButton.Primary` so `Modifier.clickable {}` and other
+ * primary-button-filtered modifiers fire.
+ *
+ * **Scale.** When `scale != 1.0` the held scene still composes at the spec's natural pixel size;
+ * the captured `Image` is then drawn into a scaled raster surface before encoding. Pointer coords
+ * on the wire stay in image-natural pixels — agents writing scripts never need to know the scale
+ * multiplier. `scale = 1.0` short-circuits the surface allocation and encodes the held scene's
+ * Image directly.
+ *
+ * **Threading.** Per the [RecordingSession] contract, JsonRpcServer serialises calls per-instance.
+ * The playback loop in [stop] runs on whatever worker thread invoked it. Skiko isn't thread-safe;
+ * the contract matches the underlying constraint.
+ */
+class DesktopRecordingSession(
+  override val previewId: String,
+  override val recordingId: String,
+  override val fps: Int,
+  override val scale: Float,
+  private val engine: RenderEngine,
+  private val state: RenderEngine.SceneState,
+  private val sandboxStats: SandboxLifecycleStats,
+  private val framesDir: File,
+  private val encodedDir: File,
+) : RecordingSession {
+
+  private val timeline = mutableListOf<RecordingScriptEvent>()
+
+  @Volatile private var stopped: Boolean = false
+
+  @Volatile private var closed: Boolean = false
+
+  private var result: RecordingResult? = null
+
+  private val frameWidthPx: Int = (state.spec.widthPx * scale).toInt().coerceAtLeast(1)
+
+  private val frameHeightPx: Int = (state.spec.heightPx * scale).toInt().coerceAtLeast(1)
+
+  override fun postScript(events: List<RecordingScriptEvent>) {
+    check(!stopped) {
+      "DesktopRecordingSession.postScript called after stop() for recordingId='$recordingId'"
+    }
+    if (events.isEmpty()) return
+    synchronized(timeline) {
+      for (e in events) {
+        require(e.tMs >= 0) { "RecordingScriptEvent.tMs must be ≥ 0; got ${e.tMs}" }
+        timeline.add(e)
+      }
+      timeline.sortBy { it.tMs }
+    }
+  }
+
+  override fun stop(): RecordingResult {
+    val cached = result
+    if (cached != null) return cached
+    if (stopped) error("DesktopRecordingSession.stop() called twice without a cached result")
+    stopped = true
+    framesDir.mkdirs()
+
+    val sortedEvents = synchronized(timeline) { timeline.toList() }
+    val durationMs: Long = sortedEvents.maxOfOrNull { it.tMs } ?: 0L
+    // Frames are paced as `frameIndex * 1000 / fps` (integer division on the ms side keeps the
+    // virtual cadence stable across long timelines; nanoTime stays exact via the 1e9/fps split
+    // below). We always render frame 0 plus one frame per `frameStep` covering the timeline up
+    // to and including `durationMs`. So a 500ms timeline at 30fps produces frames 0..15 (16
+    // frames in total — t = 0, 33, 66, ..., 500ms).
+    val totalFrames = (durationMs * fps / 1000).toInt() + 1
+
+    val startNs = System.nanoTime()
+    var nextEventIdx = 0
+    for (frameIndex in 0 until totalFrames) {
+      val tNanos: Long = frameIndex.toLong() * 1_000_000_000L / fps.toLong()
+      val tMs: Long = tNanos / 1_000_000L
+
+      // Drain every scripted event whose virtual tMs has elapsed by this frame's tMs and dispatch
+      // it through the held scene at the same nanoTime. CLICK splits into Press → tick → Release
+      // (see class KDoc); the intermediate `scene.render(nanoTime)` makes the gesture detector
+      // see the down event before the up event without writing a separate output frame.
+      while (nextEventIdx < sortedEvents.size && sortedEvents[nextEventIdx].tMs <= tMs) {
+        dispatchAtVirtual(sortedEvents[nextEventIdx], tNanos, tMs)
+        nextEventIdx++
+      }
+
+      val image = state.scene.render(nanoTime = tNanos)
+      writeFramePng(image, frameIndex)
+    }
+    val tookMs = (System.nanoTime() - startNs) / 1_000_000L
+    System.err.println(
+      "compose-ai-daemon: DesktopRecordingSession.stop($recordingId): " +
+        "rendered $totalFrames frame(s) covering ${durationMs}ms virtual time in ${tookMs}ms wall " +
+        "(scale=$scale, fps=$fps, ${frameWidthPx}x${frameHeightPx}px)"
+    )
+
+    val r =
+      RecordingResult(
+        frameCount = totalFrames,
+        durationMs = durationMs,
+        framesDir = framesDir.absolutePath,
+        frameWidthPx = frameWidthPx,
+        frameHeightPx = frameHeightPx,
+      )
+    result = r
+    // The held scene is no longer needed; tear it down so subsequent close() is a no-op. The
+    // per-frame PNGs and any encoded video stay on disk for `recording/encode`.
+    engine.tearDown(state)
+    return r
+  }
+
+  override fun encode(format: RecordingFormat): EncodedRecording {
+    val r =
+      result
+        ?: error(
+          "DesktopRecordingSession.encode($format): stop() must be called before encode() " +
+            "(recordingId='$recordingId')"
+        )
+    encodedDir.mkdirs()
+    return when (format) {
+      RecordingFormat.APNG -> {
+        val target = File(encodedDir, "$recordingId.apng")
+        val frames =
+          (0 until r.frameCount).map { i ->
+            File(framesDir, "frame-${"%05d".format(i)}.png").also {
+              check(it.isFile) {
+                "DesktopRecordingSession.encode: missing frame PNG ${it.absolutePath}"
+              }
+            }
+          }
+        // Frame delay in millis = 1000/fps. APNG carries delay as a numerator/denominator fraction
+        // so we keep the exact rate by passing the fps as denominator and `1` as numerator.
+        ApngEncoder.encodeFromPngFrames(
+          frames = frames,
+          delayNumerator = 1,
+          delayDenominator = fps.toShort(),
+          loopCount = 0, // 0 = infinite
+          out = target,
+        )
+        EncodedRecording(
+          videoPath = target.absolutePath,
+          mimeType = "image/apng",
+          sizeBytes = target.length(),
+        )
+      }
+    }
+  }
+
+  override fun close() {
+    if (closed) return
+    closed = true
+    if (!stopped) {
+      // Auto-stop path: idle-timeout fired or daemon shutdown caught us mid-recording. Tear the
+      // held scene down without writing a final frame batch — partial frames already on disk stay
+      // there in case `recording/encode` arrives later. Result map left null so a subsequent
+      // encode call surfaces the "stop() must be called first" check.
+      engine.tearDown(state)
+    }
+    // When stopped is true, stop() already called engine.tearDown(state); a second call is safe
+    // (RenderEngine.tearDown is idempotent) but unnecessary.
+  }
+
+  private fun dispatchAtVirtual(event: RecordingScriptEvent, tNanos: Long, tMs: Long) {
+    val px = event.pixelX
+    val py = event.pixelY
+    when (event.kind) {
+      InteractiveInputKind.CLICK -> {
+        if (px == null || py == null) return
+        val offset = sceneOffset(px, py)
+        state.scene.sendPointerEvent(
+          eventType = PointerEventType.Press,
+          position = offset,
+          timeMillis = tMs,
+          button = PointerButton.Primary,
+          buttons = PointerButtons(isPrimaryPressed = true),
+        )
+        state.scene.render(nanoTime = tNanos)
+        state.scene.sendPointerEvent(
+          eventType = PointerEventType.Release,
+          position = offset,
+          timeMillis = tMs,
+          button = PointerButton.Primary,
+          buttons = PointerButtons(),
+        )
+      }
+      InteractiveInputKind.POINTER_DOWN -> {
+        if (px == null || py == null) return
+        state.scene.sendPointerEvent(
+          eventType = PointerEventType.Press,
+          position = sceneOffset(px, py),
+          timeMillis = tMs,
+          button = PointerButton.Primary,
+          buttons = PointerButtons(isPrimaryPressed = true),
+        )
+      }
+      InteractiveInputKind.POINTER_UP -> {
+        if (px == null || py == null) return
+        state.scene.sendPointerEvent(
+          eventType = PointerEventType.Release,
+          position = sceneOffset(px, py),
+          timeMillis = tMs,
+          button = PointerButton.Primary,
+          buttons = PointerButtons(),
+        )
+      }
+      InteractiveInputKind.KEY_DOWN,
+      InteractiveInputKind.KEY_UP -> {
+        // Reserved for v2 key dispatch; same no-op as DesktopInteractiveSession.
+      }
+    }
+  }
+
+  private fun writeFramePng(image: Image, frameIndex: Int) {
+    val outFile = File(framesDir, "frame-${"%05d".format(frameIndex)}.png")
+    val bytes =
+      if (scale == 1.0f && image.width == frameWidthPx && image.height == frameHeightPx) {
+        // Fast path: no scaling needed, encode the held scene's Image directly.
+        image.encodeToData(EncodedImageFormat.PNG)?.bytes
+          ?: error("encodeToData(PNG) returned null at frame $frameIndex")
+      } else {
+        // Scaled path: draw the natural-size Image onto a `frameWidthPx × frameHeightPx` raster
+        // surface and encode the snapshot. `LINEAR` sampling is the right default for both up- and
+        // down-scaling: cheaper than CATMULL_ROM, no aliasing for typical UI content, matches what
+        // browsers do for `<img>` rendering. We don't expose the sampling mode on the wire — if a
+        // caller wants pixel-perfect upscale they can pass `scale = 1.0` and resample client-side.
+        val surface = Surface.makeRasterN32Premul(frameWidthPx, frameHeightPx)
+        try {
+          surface.canvas.drawImageRect(
+            image = image,
+            src = Rect.makeWH(image.width.toFloat(), image.height.toFloat()),
+            dst = Rect.makeWH(frameWidthPx.toFloat(), frameHeightPx.toFloat()),
+            samplingMode = SamplingMode.LINEAR,
+            paint = null,
+            strict = true,
+          )
+          val snap = surface.makeImageSnapshot()
+          try {
+            snap.encodeToData(EncodedImageFormat.PNG)?.bytes
+              ?: error("encodeToData(PNG) returned null at frame $frameIndex (scaled)")
+          } finally {
+            snap.close()
+          }
+        } finally {
+          surface.close()
+        }
+      }
+    outFile.writeBytes(bytes)
+  }
+
+  private fun sceneOffset(px: Int, py: Int): androidx.compose.ui.geometry.Offset {
+    val d = state.density.density
+    return androidx.compose.ui.geometry.Offset(px.toFloat() / d, py.toFloat() / d)
+  }
+}

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
@@ -1,0 +1,307 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import java.io.ByteArrayInputStream
+import java.io.File
+import javax.imageio.ImageIO
+import kotlin.math.abs
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end test for the v1 scripted screen-record surface — see
+ * [RECORDING.md](../../../../../../docs/daemon/RECORDING.md).
+ *
+ * Drives the desktop host's [DesktopRecordingSession] against a small component-preview fixture
+ * ([TristateClickSquare], 120×60 tri-state square) with a scripted timeline of two clicks at
+ * virtual `tMs = 0` and `tMs = 500`. Verifies:
+ *
+ * 1. **Frame count** — at 30 fps over 500ms, the playback emits 16 frames (`frame-00000.png` ..
+ *    `frame-00015.png`).
+ * 2. **State at each click** — frame 0 paints green (state=1 after first click drains at tMs=0),
+ *    frame 15 paints blue (state=2 after second click drains at tMs=500).
+ * 3. **State holds between events** — frame 5 (between the two scripted clicks) still paints green.
+ *    This is the load-bearing "virtual time + held scene" assertion: without virtual time, the
+ *    inter-click frames would have nothing to render between the two events; without held state,
+ *    the second `setUp` would reset `mutableStateOf` and frame 15 would paint green again.
+ * 4. **Component-preview suitability** — the test runs against a 120×60 sandbox (not a phone- sized
+ *    preview) to prove the recording path doesn't bake in screen-sized assumptions.
+ * 5. **APNG encode** — `session.encode(APNG)` produces a non-empty file at the advertised path with
+ *    the advertised mime type.
+ *
+ * Pixel-match helper inlined to avoid a circular dep on the harness's `PixelDiff` (same reasoning
+ * as `DesktopInteractiveSessionTest`).
+ */
+class DesktopRecordingSessionTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  private var savedRecordingsDir: String? = null
+
+  @After
+  fun tearDown() {
+    val saved = savedRecordingsDir
+    if (saved == null) System.clearProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    else System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, saved)
+  }
+
+  @Test
+  fun scripted_clicks_at_virtual_time_produce_expected_frames_and_state_survives() {
+    val outputDir = tempFolder.newFolder("recording-engine-renders")
+    val recordingsRoot = tempFolder.newFolder("recordings-root")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val engine = RenderEngine(outputDir = outputDir)
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == FIXTURE_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "TristateClickSquare",
+              widthPx = COMPONENT_WIDTH_PX,
+              heightPx = COMPONENT_HEIGHT_PX,
+              density = 1.0f,
+              outputBaseName = "tristate-click-square",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireRecordingSession(
+          previewId = FIXTURE_PREVIEW_ID,
+          recordingId = "test-rec-1",
+          classLoader =
+            DesktopRecordingSessionTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+          fps = FPS,
+          scale = 1.0f,
+          overrides = null,
+        )
+      try {
+        session.postScript(
+          listOf(
+            RecordingScriptEvent(
+              tMs = 0L,
+              kind = InteractiveInputKind.CLICK,
+              pixelX = COMPONENT_WIDTH_PX / 2,
+              pixelY = COMPONENT_HEIGHT_PX / 2,
+            ),
+            RecordingScriptEvent(
+              tMs = 500L,
+              kind = InteractiveInputKind.CLICK,
+              pixelX = COMPONENT_WIDTH_PX / 2,
+              pixelY = COMPONENT_HEIGHT_PX / 2,
+            ),
+          )
+        )
+
+        val result = session.stop()
+
+        // 1. Frame count: at 30 fps over 500ms = 500 * 30 / 1000 + 1 = 16 frames.
+        assertEquals(
+          "frame count: expected 16 frames at 30 fps over 500ms; got ${result.frameCount}",
+          16,
+          result.frameCount,
+        )
+        assertEquals("durationMs", 500L, result.durationMs)
+        assertEquals(
+          "frameWidthPx (component preview at native size)",
+          COMPONENT_WIDTH_PX,
+          result.frameWidthPx,
+        )
+        assertEquals(
+          "frameHeightPx (component preview at native size)",
+          COMPONENT_HEIGHT_PX,
+          result.frameHeightPx,
+        )
+        // Frame files actually exist on disk.
+        for (i in 0 until result.frameCount) {
+          val f = File(result.framesDir, "frame-${"%05d".format(i)}.png")
+          assertTrue("frame $i missing on disk: ${f.absolutePath}", f.isFile)
+          assertTrue("frame $i must be non-empty PNG: ${f.absolutePath}", f.length() > 0)
+        }
+
+        // 2. Frame 0 — click@0 has been drained before frame 0's render → state=1 (green).
+        val frame0 = readPng(File(result.framesDir, "frame-00000.png"))
+        val greenAt0 = pixelMatchPct(frame0, expectedRgb = 0x66BB6A, perChannelTolerance = 8)
+        assertTrue(
+          "frame 0 expected ≥ 95% green pixels (state=1 after click@0); got ${"%.2f".format(greenAt0 * 100)}%",
+          greenAt0 >= 0.95,
+        )
+
+        // 3. Frame 5 — between the two clicks (tMs=166ms); state still 1 (green).
+        // This is the load-bearing assertion: without held-scene + virtual-time playback, the
+        // mutableStateOf would reset between renders and frame 5 would paint red.
+        val frame5 = readPng(File(result.framesDir, "frame-00005.png"))
+        val greenAt5 = pixelMatchPct(frame5, expectedRgb = 0x66BB6A, perChannelTolerance = 8)
+        assertTrue(
+          "frame 5 expected ≥ 95% green pixels (state=1 holds between scripted clicks); got " +
+            "${"%.2f".format(greenAt5 * 100)}% — this is the load-bearing remember{} survival assertion",
+          greenAt5 >= 0.95,
+        )
+
+        // 4. Frame 15 — click@500 has been drained → state=2 (blue).
+        val frame15 = readPng(File(result.framesDir, "frame-00015.png"))
+        val blueAt15 = pixelMatchPct(frame15, expectedRgb = 0x42A5F5, perChannelTolerance = 8)
+        assertTrue(
+          "frame 15 expected ≥ 95% blue pixels (state=2 after click@500); got ${"%.2f".format(blueAt15 * 100)}%",
+          blueAt15 >= 0.95,
+        )
+
+        // 5. APNG encode produces a non-empty file with the advertised mime type.
+        val encoded = session.encode(RecordingFormat.APNG)
+        assertEquals("image/apng", encoded.mimeType)
+        val apngFile = File(encoded.videoPath)
+        assertTrue("encoded APNG must exist on disk: ${apngFile.absolutePath}", apngFile.isFile)
+        assertTrue("encoded APNG must be non-empty", encoded.sizeBytes > 0)
+        // Quick PNG-signature sanity check — APNG carries the standard PNG header.
+        val firstEight = apngFile.readBytes().copyOf(8)
+        assertNotNull("APNG file must contain bytes", firstEight)
+        val expectedHeader = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10)
+        assertTrue(
+          "APNG header must match PNG signature; got ${firstEight.joinToString { "0x%02x".format(it) }}",
+          firstEight.contentEquals(expectedHeader),
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun scale_changes_output_frame_size_but_not_pointer_coords() {
+    val outputDir = tempFolder.newFolder("scale-engine-renders")
+    val recordingsRoot = tempFolder.newFolder("scale-recordings-root")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val engine = RenderEngine(outputDir = outputDir)
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == FIXTURE_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "TristateClickSquare",
+              widthPx = COMPONENT_WIDTH_PX,
+              heightPx = COMPONENT_HEIGHT_PX,
+              density = 1.0f,
+              outputBaseName = "tristate-click-square-scaled",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireRecordingSession(
+          previewId = FIXTURE_PREVIEW_ID,
+          recordingId = "test-rec-scale-2x",
+          classLoader =
+            DesktopRecordingSessionTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+          fps = FPS,
+          scale = 2.0f,
+          overrides = null,
+        )
+      try {
+        // Click coords stay in image-natural pixel space — same coords as in the unscaled test.
+        session.postScript(
+          listOf(
+            RecordingScriptEvent(
+              tMs = 0L,
+              kind = InteractiveInputKind.CLICK,
+              pixelX = COMPONENT_WIDTH_PX / 2,
+              pixelY = COMPONENT_HEIGHT_PX / 2,
+            )
+          )
+        )
+        val result = session.stop()
+        // Scale 2× → output frame is 240×120, not 120×60.
+        assertEquals(
+          "scale=2 output width: expected 240 (= 120 * 2); got ${result.frameWidthPx}",
+          COMPONENT_WIDTH_PX * 2,
+          result.frameWidthPx,
+        )
+        assertEquals(
+          "scale=2 output height: expected 120 (= 60 * 2); got ${result.frameHeightPx}",
+          COMPONENT_HEIGHT_PX * 2,
+          result.frameHeightPx,
+        )
+        // Click still routed correctly: frame 0 paints green even though the canvas is 2×.
+        val frame0 = readPng(File(result.framesDir, "frame-00000.png"))
+        assertEquals(COMPONENT_WIDTH_PX * 2, frame0.width)
+        assertEquals(COMPONENT_HEIGHT_PX * 2, frame0.height)
+        val greenMatch = pixelMatchPct(frame0, expectedRgb = 0x66BB6A, perChannelTolerance = 8)
+        assertTrue(
+          "frame 0 (scale=2) expected ≥ 95% green; got ${"%.2f".format(greenMatch * 100)}% — " +
+            "click coords must dispatch in natural pixel space, not scaled-canvas space",
+          greenMatch >= 0.95,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  private fun readPng(file: File): java.awt.image.BufferedImage {
+    assertTrue("rendered PNG must exist on disk: ${file.absolutePath}", file.exists())
+    assertTrue("rendered PNG must be non-empty", file.length() > 0)
+    val bytes = file.readBytes()
+    return ByteArrayInputStream(bytes).use { ImageIO.read(it) }
+      ?: error("PNG must decode via javax.imageio: ${file.absolutePath}")
+  }
+
+  private fun pixelMatchPct(
+    img: java.awt.image.BufferedImage,
+    expectedRgb: Int,
+    perChannelTolerance: Int,
+  ): Double {
+    val expR = (expectedRgb shr 16) and 0xFF
+    val expG = (expectedRgb shr 8) and 0xFF
+    val expB = expectedRgb and 0xFF
+    var matches = 0L
+    for (y in 0 until img.height) {
+      for (x in 0 until img.width) {
+        val rgb = img.getRGB(x, y)
+        val r = (rgb shr 16) and 0xFF
+        val g = (rgb shr 8) and 0xFF
+        val b = rgb and 0xFF
+        if (
+          abs(r - expR) <= perChannelTolerance &&
+            abs(g - expG) <= perChannelTolerance &&
+            abs(b - expB) <= perChannelTolerance
+        ) {
+          matches++
+        }
+      }
+    }
+    val total = img.width.toLong() * img.height.toLong()
+    return matches.toDouble() / total.toDouble()
+  }
+
+  companion object {
+    private const val FIXTURE_PREVIEW_ID = "tristate-click-square"
+    // Component-preview-sized sandbox — a button-ish 120x60 surface, deliberately NOT phone-sized.
+    private const val COMPONENT_WIDTH_PX = 120
+    private const val COMPONENT_HEIGHT_PX = 60
+    private const val FPS = 30
+  }
+}

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -141,6 +141,41 @@ fun ClickRecomposingSquare() {
 }
 
 /**
+ * v1 recording-mode component-preview fixture — a small (120×60-typical) tri-state square that
+ * cycles red → green → blue on successive clicks. Used by `DesktopRecordingSessionTest` to assert
+ * that a scripted timeline of `(tMs=0, click) + (tMs=500, click)` plays back as expected:
+ *
+ * - Frame 0 (after click@0 drains) paints green.
+ * - Frames 1..14 hold green — proving `remember`'d state survives between scripted events.
+ * - Frame 15 (at tMs=500, after click@500 drains) paints blue.
+ *
+ * Same `awaitFirstDown` loop pattern as [ClickRecomposingSquare] so the dispatch path doesn't
+ * depend on `Modifier.clickable`'s tap-gesture timing (which is awkward under
+ * [androidx.compose.ui.ImageComposeScene]'s manual clock).
+ */
+@Composable
+fun TristateClickSquare() {
+  var state by remember { mutableStateOf(0) }
+  val color =
+    when (state) {
+      0 -> Color(0xFFEF5350) // red
+      1 -> Color(0xFF66BB6A) // green
+      else -> Color(0xFF42A5F5) // blue
+    }
+  Box(
+    modifier =
+      Modifier.fillMaxSize().background(color).pointerInput(Unit) {
+        awaitPointerEventScope {
+          while (true) {
+            awaitFirstDown()
+            state += 1
+          }
+        }
+      }
+  )
+}
+
+/**
  * Reads `isSystemInDarkTheme()` and fills the box with white in light mode, black in dark mode.
  * Used by `OverrideIntegrationTest` (desktop) to prove `renderNow.overrides.uiMode` reaches
  * `LocalSystemTheme` — Compose Desktop's `isSystemInDarkTheme()` reads that local rather than the


### PR DESCRIPTION
## Summary

Adds `recording/start | script | stop | encode` RPCs to the daemon. A
recording session owns a held `ImageComposeScene` driven by a virtual
frame clock at fixed fps, so a scripted timeline of `(tMs=0, click) +
(tMs=500, click)` plays back with full inter-event animation regardless
of how long the agent took to assemble the script. Pointer events and
`scene.render` both key off the same virtual nanoTime; `LaunchedEffect`,
`withFrameNanos`, and `rememberInfiniteTransition` advance with virtual
time, not wall-clock.

This is P1 of the design — desktop only, scripted (not live), APNG only.
Live mode + mp4/webm encoding + Android backend are deferred.

### What landed

- **Protocol** (`Messages.kt`): `RecordingStartParams/Result`,
  `RecordingScriptParams`, `RecordingScriptEvent`,
  `RecordingStopParams/Result`, `RecordingEncodeParams/Result`,
  `RecordingFormat` (APNG today). `recording: Boolean` capability on
  `InitializeResult` mirrors the existing `interactive` flag.
- **`:daemon:core`**: `RecordingSession` interface + `RenderHost.acquireRecordingSession` (default throws → `MethodNotFound`).
  Four handlers in `JsonRpcServer` (start/stop/encode on worker threads;
  script as a fire-and-forget notification). `closeAllRecordingSessions`
  hooked alongside `closeAllInteractiveSessions` so the daemon's
  existing `composeai.daemon.idleTimeoutMs` closes recordings when the
  agent disconnects.
- **`:daemon:desktop`**: `DesktopRecordingSession` — held scene, virtual
  nanoTime drives `sendPointerEvent` + `scene.render(nanoTime)`, frames
  written as `frame-NNNNN.png`. `scale` knob applied at encode time via
  Skiko `Surface.makeRasterN32Premul` + `drawImageRect` so pointer
  coords stay in image-natural pixel space. `DesktopHost.acquireRecordingSession`
  resolves the preview spec via the existing `previewSpecResolver` and
  applies a typed `PreviewOverrides` merge so component previews can
  record at custom width/height/density/background.
- **`ApngEncoder`** — pure-JVM (~190 LOC), no native deps, copies IDAT
  bytes verbatim into `fdAT` chunks (no zlib round-trip). Plays in any
  browser/webview at MIME `image/apng`.
- **Test fixture** `TristateClickSquare` (120×60 red → green → blue) +
  `DesktopRecordingSessionTest`.

### Wire shape

```
recording/start   { previewId, fps?: 30, scale?: 1.0, overrides? }
                  → { recordingId }
recording/script  { recordingId, events: [{tMs, kind, pixelX, pixelY}, …] }
recording/stop    { recordingId }
                  → { frameCount, durationMs, framesDir, frameWidthPx, frameHeightPx }
recording/encode  { recordingId, format?: "apng" }
                  → { videoPath, mimeType, sizeBytes }
```

Component-preview ergonomics: `record_preview` agents can record a
button-sized preview at native size with a custom background, optionally
upscaled for legibility:

```jsonc
{
  "previewId": "...",
  "fps": 30,
  "scale": 4.0,
  "overrides": { "widthPx": 240, "heightPx": 80, "backgroundColor": 4294967295 },
  "events": [
    { "tMs": 100, "kind": "click", "pixelX": 120, "pixelY": 40 },
    { "tMs": 600, "kind": "click", "pixelX": 120, "pixelY": 40 }
  ]
}
```

### Test plan

- [x] `:daemon:core:compileKotlin` clean
- [x] `:daemon:desktop:compileKotlin` + `compileTestKotlin` clean
- [x] `:daemon:desktop:test` passes (existing tests + new ones)
- [x] `ktfmtCheckMain` / `ktfmtCheckTest` clean on both modules
- [x] New test `DesktopRecordingSessionTest` covers:
  - 30 fps × 500 ms script produces exactly 16 frames
  - Frame 0 paints green (state=1 after click@0 drains)
  - Frame 5 paints green (state-survives-between-events — load-bearing
    assertion that virtual time + held scene actually work)
  - Frame 15 paints blue (state=2 after click@500 drains)
  - APNG file exists, has correct header, advertised mime type
  - `scale=2` produces 240×120 frames with click coords still routed
    correctly in 120×60 natural-pixel space

### Out of scope (deferred to P2/P3)

- MCP tool (`record_preview`) — P2
- mp4 / webm via optional ffmpeg shell-out — P3
- Live (non-scripted) recording driven by `interactive/input` — P3
- Android (Robolectric) backend — P4 (gated on the v3 pointer-dispatch
  work documented in `INTERACTIVE-ANDROID.md`)


---
_Generated by [Claude Code](https://claude.ai/code/session_018GGtBuG7ZeRPpUP8AMz49E)_