### PR TITLE
Fix daemon save-loop compile wiring

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/UserClassLoaderHolder.kt
@@ -285,6 +285,11 @@ class UserClassLoaderHolder(
      */
     fun classFileFingerprint(loader: ClassLoader, className: String): String? {
       val resourceName = className.replace('.', '/') + ".class"
+      if (loader is URLClassLoader) {
+        fingerprintFromUrls(loader.urLs, resourceName)?.let {
+          return it
+        }
+      }
       val url = loader.getResource(resourceName) ?: return null
       if (url.protocol != "file") return null
       val file =
@@ -296,6 +301,37 @@ class UserClassLoaderHolder(
       if (!file.exists()) return null
       val mtime = java.time.Instant.ofEpochMilli(file.lastModified()).toString()
       return "path=${file.absolutePath} mtime=$mtime size=${file.length()} sha=${sha256Short(file)}"
+    }
+
+    private fun fingerprintFromUrls(urls: Array<URL>, resourceName: String): String? {
+      for (url in urls) {
+        if (url.protocol != "file") continue
+        val root =
+          try {
+            java.io.File(url.toURI())
+          } catch (_: Throwable) {
+            continue
+          }
+        if (root.isDirectory) {
+          val file = root.resolve(resourceName)
+          if (file.exists()) {
+            val mtime = java.time.Instant.ofEpochMilli(file.lastModified()).toString()
+            return "path=${file.absolutePath} mtime=$mtime size=${file.length()} sha=${sha256Short(file)}"
+          }
+        } else if (root.isFile) {
+          val hasEntry =
+            try {
+              java.util.jar.JarFile(root).use { jar -> jar.getEntry(resourceName) != null }
+            } catch (_: Throwable) {
+              false
+            }
+          if (hasEntry) {
+            val mtime = java.time.Instant.ofEpochMilli(root.lastModified()).toString()
+            return "jar=${root.absolutePath}!/$resourceName mtime=$mtime size=${root.length()} sha=${sha256Short(root)}"
+          }
+        }
+      }
+      return null
     }
 
     private fun sha256Short(file: java.io.File): String {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1082,12 +1082,12 @@ internal object AndroidPreviewSupport {
         // `generate${Cap}UnitTestConfig` below, so the `processResources`
         // dep is just belt-and-suspenders; skip it when absent so library
         // modules configure cleanly. See issue #136.
-        listOf("process${capVariant}Resources", "generate${capVariant}UnitTestConfig").forEach {
-          taskName ->
-          if (project.tasks.findByName(taskName) != null) {
-            dependsOn(taskName)
+        dependsOn(
+          project.tasks.matching {
+            it.name in
+              listOf("process${capVariant}Resources", "generate${capVariant}UnitTestConfig")
           }
-        }
+        )
         if (compileShardsTask != null) {
           dependsOn(compileShardsTask)
         }
@@ -1143,12 +1143,12 @@ internal object AndroidPreviewSupport {
         if (useLocalRenderer) {
           dependsOn(":renderer-android:compile${capVariant}Kotlin")
         }
-        listOf("process${capVariant}Resources", "generate${capVariant}UnitTestConfig").forEach {
-          taskName ->
-          if (project.tasks.findByName(taskName) != null) {
-            dependsOn(taskName)
+        dependsOn(
+          project.tasks.matching {
+            it.name in
+              listOf("process${capVariant}Resources", "generate${capVariant}UnitTestConfig")
           }
-        }
+        )
       }
     }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -72,17 +72,11 @@ internal object ComposePreviewTasks {
         extension,
       ) {
         onlyIf { extension.enabled.get() }
-        // `compileAndroidMain` is the lifecycle task for the KMP-Android
-        // target's `main` compilation (which depends on the underlying
-        // `compileAndroidMainKotlin`-shaped Kotlin compile under the hood).
-        // Listed alongside the JVM/Desktop siblings so we wire up exactly
-        // one — whichever the consumer's applied plugins actually register.
-        for (name in DESKTOP_COMPILE_TASK_CANDIDATES) {
-          if (project.tasks.findByName(name) != null) {
-            dependsOn(name)
-            break
-          }
-        }
+        // `compileAndroidMain` is the lifecycle task for the KMP-Android target's `main`
+        // compilation (which depends on the underlying `compileAndroidMainKotlin`-shaped Kotlin
+        // compile under the hood). Use lazy matching so compile tasks registered after this plugin
+        // block are still wired into discovery.
+        dependsOn(project.tasks.matching { it.name in DESKTOP_COMPILE_TASK_CANDIDATES })
       }
     registerCompileOnlyTask(project, extension, DESKTOP_COMPILE_TASK_CANDIDATES)
 
@@ -416,25 +410,22 @@ internal object ComposePreviewTasks {
    * `IncrementalDiscovery` cascade and `discoveryUpdated` notification, so the editor save loop no
    * longer needs `:discoverPreviews` on every keystroke.
    *
-   * Caller passes the set of candidate compile task names; we wire the first that exists at
-   * configuration time. When none are found (consumer hasn't applied a Kotlin plugin) the task is
-   * still registered but is a no-op — same `onlyIf(false)` shape as the disabled-by-extension
-   * gating below.
+   * Caller passes the set of candidate compile task names; we wire every matching task lazily so
+   * Android variants registered after this plugin block still participate. When none are found
+   * (consumer hasn't applied a Kotlin plugin) the task is still registered but is a no-op — same
+   * `onlyIf(false)` shape as the disabled-by-extension gating below.
    */
   fun registerCompileOnlyTask(
     project: Project,
     extension: PreviewExtension,
     compileTaskNames: List<String>,
   ): TaskProvider<DefaultTask> {
-    val resolvedCompileTask = compileTaskNames.firstOrNull { project.tasks.findByName(it) != null }
     return project.tasks.register("composePreviewCompile", DefaultTask::class.java) {
       group = "compose preview"
       description =
         "Compile sources without running discoverPreviews — used by the VS Code daemon save path."
       onlyIf { extension.enabled.get() }
-      if (resolvedCompileTask != null) {
-        dependsOn(resolvedCompileTask)
-      }
+      dependsOn(project.tasks.matching { it.name in compileTaskNames })
     }
   }
 

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ComposePreviewCompileTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ComposePreviewCompileTaskTest.kt
@@ -1,0 +1,45 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.api.DefaultTask
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+
+class ComposePreviewCompileTaskTest {
+
+  @Test
+  fun `compile-only task picks up compile task registered later`() {
+    val project = ProjectBuilder.builder().build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+
+    val compileOnly =
+      ComposePreviewTasks.registerCompileOnlyTask(
+        project,
+        extension,
+        compileTaskNames = listOf("compileDebugKotlin"),
+      )
+    val compileTask = project.tasks.register("compileDebugKotlin", DefaultTask::class.java)
+
+    val deps = compileOnly.get().taskDependencies.getDependencies(compileOnly.get())
+
+    assertThat(deps).contains(compileTask.get())
+  }
+
+  @Test
+  fun `desktop discover task picks up compile task registered later`() {
+    val project = ProjectBuilder.builder().build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+    project.configurations.create("runtimeClasspath") {
+      isCanBeResolved = true
+      isCanBeConsumed = false
+    }
+
+    ComposePreviewTasks.registerDesktopTasks(project, extension)
+    val compileTask = project.tasks.register("compileKotlin", DefaultTask::class.java)
+
+    val discover = project.tasks.named("discoverPreviews").get()
+    val deps = discover.taskDependencies.getDependencies(discover)
+
+    assertThat(deps).contains(compileTask.get())
+  }
+}


### PR DESCRIPTION
## Summary
- Wire composePreviewCompile and desktop discover compile dependencies lazily so late-registered Android/CMP compile tasks are not skipped
- Wire optional Android resource setup task dependencies lazily for renderPreviews/resource renders
- Improve daemon class-file fingerprint diagnostics for child URLClassLoader renders
- Add regression coverage for late-registered compile tasks

## Tests
- ./gradlew :gradle-plugin:ktfmtFormatMain :gradle-plugin:ktfmtFormatTest
- ./gradlew :gradle-plugin:test --tests "ee.schimke.composeai.plugin.ComposePreviewCompileTaskTest" --tests "ee.schimke.composeai.plugin.KmpAndroidDesktopRoutingTest"
- ./gradlew :samples:wear:renderPreviews --dry-run
- ./gradlew :samples:cmp:discoverPreviews --dry-run
- ./gradlew :gradle-plugin:assemble :daemon:core:assemble :daemon:android:assemble :daemon:desktop:assemble :samples:wear:composePreviewDaemonStart