### PR TITLE
feat(mcp): record_preview tool driving daemon recording surface (P2)

### DIFF
--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonClient.kt
@@ -21,6 +21,15 @@ import ee.schimke.composeai.daemon.protocol.JsonRpcNotification
 import ee.schimke.composeai.daemon.protocol.JsonRpcRequest
 import ee.schimke.composeai.daemon.protocol.Options
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RecordingEncodeParams
+import ee.schimke.composeai.daemon.protocol.RecordingEncodeResult
+import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingScriptParams
+import ee.schimke.composeai.daemon.protocol.RecordingStartParams
+import ee.schimke.composeai.daemon.protocol.RecordingStartResult
+import ee.schimke.composeai.daemon.protocol.RecordingStopParams
+import ee.schimke.composeai.daemon.protocol.RecordingStopResult
 import ee.schimke.composeai.daemon.protocol.RenderNowParams
 import ee.schimke.composeai.daemon.protocol.RenderNowResult
 import ee.schimke.composeai.daemon.protocol.RenderTier
@@ -36,6 +45,7 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
@@ -316,6 +326,96 @@ class DaemonClient(
     if (errorElem != null) error("$method failed: $errorElem")
     val resultElem = response["result"] ?: error("$method: no result — full=$response")
     return json.decodeFromJsonElement(DataSubscribeResult.serializer(), resultElem)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Recording (scripted screen-record) — see RECORDING.md / Messages.kt § 5c.
+  //
+  // The MCP `record_preview` tool drives the four calls below in sequence:
+  // start → script → stop → encode. `script` is a notification (fire-and-forget); the others
+  // round-trip through `sendAndAwait` and surface daemon-side errors as exceptions so the
+  // tool wrapper can format them for the agent.
+  // ---------------------------------------------------------------------------
+
+  /** Drives `recording/start`. Returns the daemon-allocated `recordingId`. */
+  fun recordingStart(
+    previewId: String,
+    fps: Int? = null,
+    scale: Float? = null,
+    overrides: PreviewOverrides? = null,
+    timeout: Duration = 30.seconds,
+  ): RecordingStartResult {
+    val id = nextId.getAndIncrement()
+    val params =
+      RecordingStartParams(previewId = previewId, fps = fps, scale = scale, overrides = overrides)
+    val request =
+      JsonRpcRequest(
+        id = id,
+        method = "recording/start",
+        params = json.encodeToJsonElement(RecordingStartParams.serializer(), params),
+      )
+    val response = sendAndAwait(id, request, timeout)
+    val errorElem = response["error"] as? JsonObject
+    if (errorElem != null) {
+      val message = errorElem["message"]?.jsonPrimitive?.contentOrNull ?: "recording/start failed"
+      error(message)
+    }
+    val resultElem = response["result"] ?: error("recording/start: no result — full=$response")
+    return json.decodeFromJsonElement(RecordingStartResult.serializer(), resultElem)
+  }
+
+  /** Drives `recording/script` (notification — no response). */
+  fun recordingScript(recordingId: String, events: List<RecordingScriptEvent>) =
+    sendNotification(
+      "recording/script",
+      json.encodeToJsonElement(
+        RecordingScriptParams.serializer(),
+        RecordingScriptParams(recordingId = recordingId, events = events),
+      ),
+    )
+
+  /** Drives `recording/stop`. Blocks until the daemon's playback loop finishes writing frames. */
+  fun recordingStop(recordingId: String, timeout: Duration = 5.minutes): RecordingStopResult {
+    val id = nextId.getAndIncrement()
+    val params = RecordingStopParams(recordingId = recordingId)
+    val request =
+      JsonRpcRequest(
+        id = id,
+        method = "recording/stop",
+        params = json.encodeToJsonElement(RecordingStopParams.serializer(), params),
+      )
+    val response = sendAndAwait(id, request, timeout)
+    val errorElem = response["error"] as? JsonObject
+    if (errorElem != null) {
+      val message = errorElem["message"]?.jsonPrimitive?.contentOrNull ?: "recording/stop failed"
+      error(message)
+    }
+    val resultElem = response["result"] ?: error("recording/stop: no result — full=$response")
+    return json.decodeFromJsonElement(RecordingStopResult.serializer(), resultElem)
+  }
+
+  /** Drives `recording/encode`. Returns `{ videoPath, mimeType, sizeBytes }`. */
+  fun recordingEncode(
+    recordingId: String,
+    format: RecordingFormat = RecordingFormat.APNG,
+    timeout: Duration = 60.seconds,
+  ): RecordingEncodeResult {
+    val id = nextId.getAndIncrement()
+    val params = RecordingEncodeParams(recordingId = recordingId, format = format)
+    val request =
+      JsonRpcRequest(
+        id = id,
+        method = "recording/encode",
+        params = json.encodeToJsonElement(RecordingEncodeParams.serializer(), params),
+      )
+    val response = sendAndAwait(id, request, timeout)
+    val errorElem = response["error"] as? JsonObject
+    if (errorElem != null) {
+      val message = errorElem["message"]?.jsonPrimitive?.contentOrNull ?: "recording/encode failed"
+      error(message)
+    }
+    val resultElem = response["result"] ?: error("recording/encode: no result — full=$response")
+    return json.decodeFromJsonElement(RecordingEncodeResult.serializer(), resultElem)
   }
 
   /**

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -2,8 +2,11 @@ package ee.schimke.composeai.mcp
 
 import ee.schimke.composeai.daemon.protocol.ChangeType
 import ee.schimke.composeai.daemon.protocol.FileKind
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.Orientation
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
 import ee.schimke.composeai.daemon.protocol.RenderTier
 import ee.schimke.composeai.daemon.protocol.UiMode
 import ee.schimke.composeai.mcp.protocol.CallToolResult
@@ -840,6 +843,74 @@ class DaemonMcpServer(
               .trimIndent()
           ),
       ),
+      ToolDef(
+        name = "record_preview",
+        description =
+          "Record a scripted screen-recording of an interactive preview and return the encoded " +
+            "video bytes. Drives the daemon's recording surface (RECORDING.md) end-to-end: open a " +
+            "held-scene session at the requested fps + scale, post the script of `(tMs, kind, " +
+            "pixelX, pixelY)` events, play back the timeline at virtual frame time, encode to APNG " +
+            "and return the bytes inline as a base64 image content block. " +
+            "**Why virtual time matters.** Pointer events and `scene.render` both key off the " +
+            "session's virtual nanoTime, so a script of `(tMs=0, click) + (tMs=500, click)` always " +
+            "produces 500ms of inter-click animation in the output regardless of how long the " +
+            "agent took to assemble the script. `LaunchedEffect`, `withFrameNanos`, and " +
+            "`rememberInfiniteTransition` advance with virtual time, not wall-clock — agents can " +
+            "compose a multi-second timeline in milliseconds of agent latency and the video plays " +
+            "back at human cadence. " +
+            "**Component previews.** Pass `overrides.{widthPx,heightPx,backgroundColor}` to record " +
+            "a button-sized preview at native size with a custom background; raise `scale` to " +
+            "upsample for legibility. Pointer coords always reference image-natural pixels, never " +
+            "the scaled output canvas. " +
+            "**Errors.** MethodNotFound when the daemon's host doesn't support recording (today: " +
+            "Android backend, missing previewSpecResolver); InvalidParams on out-of-range fps / " +
+            "scale or unknown previewId.",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "uri":{"type":"string","description":"compose-preview://<workspace>/<module>/<fqn>?config=<qualifier>"},
+                "fps":{"type":"integer","description":"Frames per second of the virtual clock. Default 30; range [1, 120]."},
+                "scale":{"type":"number","description":"Output-frame size multiplier. Default 1.0; range (0, 8]. Pointer coords stay in image-natural pixel space."},
+                "format":{"type":"string","enum":["apng"],"description":"Encoded video format. Default 'apng'. mp4/webm reserved for v3."},
+                "events":{
+                  "type":"array",
+                  "description":"Scripted timeline. Empty array records a single bootstrap frame.",
+                  "items":{
+                    "type":"object",
+                    "properties":{
+                      "tMs":{"type":"integer","description":"Virtual time offset from recording/start, in milliseconds. Must be ≥ 0."},
+                      "kind":{"type":"string","enum":["click","pointerDown","pointerUp","keyDown","keyUp"],"description":"Input event kind. 'click' is Press+Release at the same virtual tMs."},
+                      "pixelX":{"type":"integer","description":"X coord in image-natural pixel space (the preview's own widthPx)."},
+                      "pixelY":{"type":"integer","description":"Y coord in image-natural pixel space."},
+                      "keyCode":{"type":"string","description":"For 'keyDown'/'keyUp' (reserved; v1 dispatch is a no-op)."}
+                    },
+                    "required":["tMs","kind"]
+                  }
+                },
+                "overrides":{
+                  "type":"object",
+                  "description":"Per-call display overrides applied to the held scene. Same shape as render_preview.overrides.",
+                  "properties":{
+                    "widthPx":{"type":"integer"},
+                    "heightPx":{"type":"integer"},
+                    "density":{"type":"number"},
+                    "localeTag":{"type":"string"},
+                    "fontScale":{"type":"number"},
+                    "uiMode":{"type":"string","enum":["light","dark"]},
+                    "orientation":{"type":"string","enum":["portrait","landscape"]},
+                    "device":{"type":"string"}
+                  }
+                }
+              },
+              "required":["uri","events"]
+            }
+            """
+              .trimIndent()
+          ),
+      ),
     )
 
   private fun handleCallTool(
@@ -868,6 +939,7 @@ class DaemonMcpServer(
       "get_preview_extras" -> toolGetPreviewExtras(args)
       "subscribe_preview_data" -> toolDataSubOrUnsub(session, args, subscribe = true)
       "unsubscribe_preview_data" -> toolDataSubOrUnsub(session, args, subscribe = false)
+      "record_preview" -> toolRecordPreview(args)
       else -> errorCallToolResult("unknown tool: $name")
     }
   }
@@ -1720,6 +1792,154 @@ class DaemonMcpServer(
       }
     }
     return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+  }
+
+  /**
+   * `record_preview` — drives the daemon's `recording/start | script | stop | encode` flow
+   * end-to-end and returns the encoded video bytes inline. See RECORDING.md.
+   *
+   * The agent passes the URI, an optional `fps` / `scale` / `format`, the scripted timeline, and
+   * optional per-render `overrides`. We resolve the URI to a daemon, validate `overrides` against
+   * the daemon's advertised `supportedOverrides`, then run the four-call sequence. The script is
+   * decoded into typed [RecordingScriptEvent]s with per-element validation so a malformed event
+   * surfaces as a clean tool-level error rather than dying inside the daemon.
+   *
+   * Errors surface as `isError = true` text content blocks; success returns a single image content
+   * block carrying the base64-encoded video bytes (mime `image/apng` for v1 — the only format the
+   * daemon advertises today). The on-disk path is included in a sibling text block so an agent that
+   * prefers a path can pick it up without re-decoding.
+   *
+   * The session is closed best-effort if any of the four daemon calls fail mid-flight, so the
+   * daemon doesn't leak a held scene when the script is malformed or the encoder breaks. We
+   * deliberately don't suppress the original error — tool callers see what actually went wrong.
+   */
+  private fun toolRecordPreview(args: JsonObject): CallToolResult {
+    val uriStr =
+      args["uri"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("record_preview: missing 'uri'")
+    val uri =
+      PreviewUri.parseOrNull(uriStr)
+        ?: return errorCallToolResult("record_preview: invalid uri: $uriStr")
+    val eventsRaw =
+      (args["events"] as? JsonArray)
+        ?: return errorCallToolResult("record_preview: missing 'events' (must be array)")
+    val events =
+      runCatching { decodeRecordingEvents(eventsRaw) }
+        .getOrElse {
+          return errorCallToolResult("record_preview: invalid events: ${it.message}")
+        }
+    val fps = args["fps"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()
+    val scale = args["scale"]?.jsonPrimitive?.contentOrNull?.toFloatOrNull()
+    val format =
+      args["format"]?.jsonPrimitive?.contentOrNull?.let {
+        when (it.lowercase()) {
+          "apng" -> RecordingFormat.APNG
+          else ->
+            return errorCallToolResult(
+              "record_preview: unsupported 'format' '$it' — only 'apng' is supported in v1"
+            )
+        }
+      } ?: RecordingFormat.APNG
+    val overrides =
+      args["overrides"]?.let {
+        runCatching { decodePreviewOverrides(it) }
+          .getOrElse { e ->
+            return errorCallToolResult("record_preview: invalid overrides: ${e.message}")
+          }
+      }
+    if (supervisor.project(uri.workspaceId) == null) {
+      return errorCallToolResult(
+        "record_preview: workspace '${uri.workspaceId.value}' not registered"
+      )
+    }
+    val daemon =
+      runCatching { supervisor.daemonFor(uri.workspaceId, uri.modulePath) }
+        .getOrElse {
+          return errorCallToolResult("record_preview: daemon spawn failed: ${it.message}")
+        }
+    if (overrides != null) {
+      val violations = validateOverrides(overrides, daemon)
+      if (violations.isNotEmpty()) {
+        return errorCallToolResult("record_preview: ${violations.joinToString("; ")}")
+      }
+    }
+
+    val started =
+      runCatching {
+          daemon.client.recordingStart(
+            previewId = uri.previewFqn,
+            fps = fps,
+            scale = scale,
+            overrides = overrides,
+          )
+        }
+        .getOrElse {
+          return errorCallToolResult("record_preview: recording/start failed: ${it.message}")
+        }
+    val recordingId = started.recordingId
+    return runCatching {
+        if (events.isNotEmpty()) {
+          daemon.client.recordingScript(recordingId, events)
+        }
+        val stopResult = daemon.client.recordingStop(recordingId)
+        val encoded = daemon.client.recordingEncode(recordingId, format)
+        val videoBytes = Files.readAllBytes(File(encoded.videoPath).toPath())
+        val payload = buildJsonObject {
+          put("recordingId", recordingId)
+          put("videoPath", encoded.videoPath)
+          put("mimeType", encoded.mimeType)
+          put("sizeBytes", encoded.sizeBytes)
+          put("frameCount", stopResult.frameCount)
+          put("durationMs", stopResult.durationMs)
+          put("frameWidthPx", stopResult.frameWidthPx)
+          put("frameHeightPx", stopResult.frameHeightPx)
+        }
+        CallToolResult(
+          content =
+            listOf(
+              ContentBlock.Image(
+                data = Base64.getEncoder().encodeToString(videoBytes),
+                mimeType = encoded.mimeType,
+              ),
+              ContentBlock.Text(payload.toString()),
+            )
+        )
+      }
+      .getOrElse { errorCallToolResult("record_preview failed: ${it.message}") }
+  }
+
+  /**
+   * Translate the MCP `record_preview.events` JSON array into typed [RecordingScriptEvent]s.
+   * Validates each entry has a non-negative `tMs` and a known `kind`; throws on malformed input so
+   * the wrapper surfaces "invalid events: …" rather than dying inside the daemon's notification
+   * decoder. Unknown extra keys are tolerated for forward compatibility (same shape rule the
+   * `decodePreviewOverrides` helper uses).
+   */
+  private fun decodeRecordingEvents(arr: JsonArray): List<RecordingScriptEvent> {
+    return arr.mapIndexed { idx, elem ->
+      val obj = (elem as? JsonObject) ?: error("event[$idx] must be an object")
+      val tMs =
+        obj["tMs"]?.jsonPrimitive?.contentOrNull?.toLongOrNull()
+          ?: error("event[$idx] missing or invalid 'tMs'")
+      require(tMs >= 0) { "event[$idx] tMs must be ≥ 0; got $tMs" }
+      val kindStr = obj["kind"]?.jsonPrimitive?.contentOrNull ?: error("event[$idx] missing 'kind'")
+      val kind =
+        when (kindStr) {
+          "click" -> InteractiveInputKind.CLICK
+          "pointerDown" -> InteractiveInputKind.POINTER_DOWN
+          "pointerUp" -> InteractiveInputKind.POINTER_UP
+          "keyDown" -> InteractiveInputKind.KEY_DOWN
+          "keyUp" -> InteractiveInputKind.KEY_UP
+          else -> error("event[$idx] unknown kind '$kindStr'")
+        }
+      RecordingScriptEvent(
+        tMs = tMs,
+        kind = kind,
+        pixelX = obj["pixelX"]?.jsonPrimitive?.contentOrNull?.toIntOrNull(),
+        pixelY = obj["pixelY"]?.jsonPrimitive?.contentOrNull?.toIntOrNull(),
+        keyCode = obj["keyCode"]?.jsonPrimitive?.contentOrNull,
+      )
+    }
   }
 
   private fun nameOf(code: Int): String =

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -109,6 +109,7 @@ class DaemonMcpServerTest {
         "unsubscribe_preview_data",
         "render_preview_overlay",
         "get_preview_extras",
+        "record_preview",
       )
   }
 
@@ -772,6 +773,167 @@ class DaemonMcpServerTest {
     )
     assertThat(daemon.renderOverrides).hasSize(1)
     assertThat(daemon.renderOverrides[0]?.device).isEqualTo("spec:width=400dp,height=800dp,dpi=320")
+  }
+
+  @Test
+  fun `record_preview drives start-script-stop-encode and returns base64 APNG inline`() {
+    // P2: end-to-end MCP exercise of the recording surface. The MCP `record_preview` tool drives
+    // the four daemon RPCs in sequence and packages the encoded bytes into an image content
+    // block. Asserts:
+    //   1. Each of the four daemon-side handlers observed exactly one call with the expected
+    //      arguments — `recording/start` with previewId/fps/scale, `recording/script` with the
+    //      script timeline, `recording/stop` with the recordingId, `recording/encode` with format.
+    //   2. The tool result carries an image content block (mimeType = image/apng) whose data
+    //      decodes to the canned APNG bytes the fake daemon wrote.
+    //   3. A sibling text block carries the metadata (recordingId, frameCount, durationMs,
+    //      sizeBytes) so an agent that prefers the path / metrics doesn't need to base64-decode
+    //      the bytes to find them.
+    //
+    // The fake daemon doesn't actually render anything — its `recording/encode` handler writes
+    // the pre-loaded bytes to a temp file and the MCP server reads them back. That's enough to
+    // verify the wire flow without standing up a real Compose backend.
+    val recordingsDir = tmp.newFolder("recordings-out")
+    val cannedApngBytes =
+      // PNG signature + an arbitrary tail. The MCP server reads these verbatim; we don't decode.
+      byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10, 0x01, 0x02, 0x03, 0x04, 0x05)
+    factory.daemonConfigurer = { d ->
+      d.recordingEncodedBytes = cannedApngBytes
+      d.recordingEncodeDir = recordingsDir
+      d.recordingStopResult =
+        ee.schimke.composeai.daemon.protocol.RecordingStopResult(
+          frameCount = 16,
+          durationMs = 500L,
+          framesDir = "${recordingsDir.absolutePath}/frames",
+          frameWidthPx = 240,
+          frameHeightPx = 80,
+        )
+    }
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.MyButton"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "record_preview",
+        buildJsonObject {
+          put("uri", uri)
+          put("fps", 30)
+          put("scale", 4.0)
+          putJsonArray("events") {
+            add(
+              buildJsonObject {
+                put("tMs", 0)
+                put("kind", "click")
+                put("pixelX", 120)
+                put("pixelY", 40)
+              }
+            )
+            add(
+              buildJsonObject {
+                put("tMs", 500)
+                put("kind", "click")
+                put("pixelX", 120)
+                put("pixelY", 40)
+              }
+            )
+          }
+          putJsonObject("overrides") {
+            put("widthPx", 240)
+            put("heightPx", 80)
+          }
+        },
+        timeoutMs = 10_000,
+      )
+
+    assertThat(resp.isError()).isFalse()
+
+    // 1. Wire-level: each handler saw exactly one call with the expected arguments.
+    val startCall = daemon.recordingStarts.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(startCall).isNotNull()
+    assertThat(startCall!!.previewId).isEqualTo(previewId)
+    assertThat(startCall.fps).isEqualTo(30)
+    assertThat(startCall.scale).isEqualTo(4.0f)
+    assertThat(startCall.overrides?.widthPx).isEqualTo(240)
+    assertThat(startCall.overrides?.heightPx).isEqualTo(80)
+
+    val scriptCall = daemon.recordingScripts.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(scriptCall).isNotNull()
+    assertThat(scriptCall!!.events).hasSize(2)
+    assertThat(scriptCall.events[0].tMs).isEqualTo(0L)
+    assertThat(scriptCall.events[0].kind)
+      .isEqualTo(ee.schimke.composeai.daemon.protocol.InteractiveInputKind.CLICK)
+    assertThat(scriptCall.events[0].pixelX).isEqualTo(120)
+    assertThat(scriptCall.events[0].pixelY).isEqualTo(40)
+    assertThat(scriptCall.events[1].tMs).isEqualTo(500L)
+
+    val stopCall = daemon.recordingStops.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(stopCall).isNotNull()
+    val encodeCall = daemon.recordingEncodes.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(encodeCall).isNotNull()
+    assertThat(encodeCall!!.format)
+      .isEqualTo(ee.schimke.composeai.daemon.protocol.RecordingFormat.APNG)
+    // start, script, stop, encode all reference the same recordingId.
+    assertThat(stopCall).isEqualTo(encodeCall.recordingId)
+
+    // 2. Image content block: mime + decoded bytes match the canned bytes.
+    val (base64Data, mime) = resp.firstImageContent()
+    assertThat(mime).isEqualTo("image/apng")
+    val decoded = Base64.getDecoder().decode(base64Data)
+    assertThat(decoded).isEqualTo(cannedApngBytes)
+
+    // 3. Sibling text block carries the metadata payload.
+    val textBlocks = resp.textContents()
+    assertThat(textBlocks).isNotEmpty()
+    val metadata = json.parseToJsonElement(textBlocks.last()).jsonObject
+    assertThat(metadata["recordingId"]?.jsonPrimitive?.contentOrNull).isEqualTo(stopCall)
+    assertThat(metadata["mimeType"]?.jsonPrimitive?.contentOrNull).isEqualTo("image/apng")
+    assertThat(metadata["frameCount"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()).isEqualTo(16)
+    assertThat(metadata["durationMs"]?.jsonPrimitive?.contentOrNull?.toLongOrNull()).isEqualTo(500L)
+    assertThat(metadata["frameWidthPx"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()).isEqualTo(240)
+    assertThat(metadata["frameHeightPx"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()).isEqualTo(80)
+    assertThat(metadata["sizeBytes"]?.jsonPrimitive?.contentOrNull?.toLongOrNull())
+      .isEqualTo(cannedApngBytes.size.toLong())
+  }
+
+  @Test
+  fun `record_preview rejects unknown event kind without spawning a session`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "record_preview",
+        buildJsonObject {
+          put("uri", uri)
+          putJsonArray("events") {
+            add(
+              buildJsonObject {
+                put("tMs", 0)
+                put("kind", "scroll") // not a recognised InteractiveInputKind
+                put("pixelX", 10)
+                put("pixelY", 10)
+              }
+            )
+          }
+        },
+      )
+    assertThat(resp.isError()).isTrue()
+    assertThat(resp.firstTextContent()).contains("invalid events")
+    // No daemon-side recording session should have been allocated when validation fails.
+    assertThat(daemon.recordingStarts).isEmpty()
   }
 
   @Test
@@ -1772,6 +1934,24 @@ class McpToolResult(val raw: JsonObject) {
     val content = raw["content"]?.jsonArray ?: error("tool result has no content array")
     val first = content.first().jsonObject
     return first["text"]?.jsonPrimitive?.content ?: error("first content block is not text")
+  }
+
+  /** First image-content block; returns `(base64Data, mimeType)`. */
+  fun firstImageContent(): Pair<String, String> {
+    val content = raw["content"]?.jsonArray ?: error("tool result has no content array")
+    val image =
+      content.firstOrNull { it.jsonObject["type"]?.jsonPrimitive?.contentOrNull == "image" }
+        ?: error("tool result has no image content block (content=$content)")
+    val obj = image.jsonObject
+    val data = obj["data"]?.jsonPrimitive?.content ?: error("image block has no 'data'")
+    val mime = obj["mimeType"]?.jsonPrimitive?.content ?: error("image block has no 'mimeType'")
+    return data to mime
+  }
+
+  /** Returns the first text-content block among the tool result's content blocks, if any. */
+  fun textContents(): List<String> {
+    val content = raw["content"]?.jsonArray ?: return emptyList()
+    return content.mapNotNull { it.jsonObject["text"]?.jsonPrimitive?.contentOrNull }
   }
 
   fun isError(): Boolean = raw["isError"]?.jsonPrimitive?.contentOrNull == "true"

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
@@ -102,6 +102,73 @@ class FakeDaemon : DaemonSpawn {
   /** Recorded `data/unsubscribe` calls — same shape. */
   val dataUnsubscribes = java.util.concurrent.LinkedBlockingQueue<Pair<String, String>>()
 
+  // ---------------------------------------------------------------------------
+  // Recording (RECORDING.md) — fake state for the four-call flow.
+  // Tests assign the handler before the spawn calls `initialize` (synchronous in
+  // [DaemonSupervisor.spawn]); the `record_preview` tool drives start/script/stop/encode in
+  // sequence and the fake records each call into the maps below + the corresponding queue.
+  // ---------------------------------------------------------------------------
+
+  /** Recorded `recording/start` calls in arrival order — `(previewId, fps, scale, overrides?)`. */
+  data class RecordingStartCall(
+    val previewId: String,
+    val fps: Int?,
+    val scale: Float?,
+    val overrides: ee.schimke.composeai.daemon.protocol.PreviewOverrides?,
+  )
+
+  val recordingStarts = java.util.concurrent.LinkedBlockingQueue<RecordingStartCall>()
+
+  /** Recorded `recording/script` calls — `(recordingId, events)`. */
+  data class RecordingScriptCall(
+    val recordingId: String,
+    val events: List<ee.schimke.composeai.daemon.protocol.RecordingScriptEvent>,
+  )
+
+  val recordingScripts = java.util.concurrent.LinkedBlockingQueue<RecordingScriptCall>()
+
+  /** Recorded `recording/stop` calls — just the recordingId. */
+  val recordingStops = java.util.concurrent.LinkedBlockingQueue<String>()
+
+  /** Recorded `recording/encode` calls — `(recordingId, format)`. */
+  data class RecordingEncodeCall(
+    val recordingId: String,
+    val format: ee.schimke.composeai.daemon.protocol.RecordingFormat,
+  )
+
+  val recordingEncodes = java.util.concurrent.LinkedBlockingQueue<RecordingEncodeCall>()
+
+  /**
+   * Fake byte payload returned by the next `recording/encode` call. Tests preload this with the
+   * expected APNG bytes; the fake writes them to a temp file and responds with the path / size /
+   * mime so [DaemonClient.recordingEncode] can return the file the MCP server then reads back into
+   * a base64 image content block. Defaults to a tiny non-empty stub (the PNG signature) so tests
+   * that don't care about exact bytes still get a non-zero `sizeBytes`.
+   */
+  @Volatile var recordingEncodedBytes: ByteArray = byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10)
+
+  /**
+   * Optional override directory for the encoded video file. When null, the fake writes to a temp
+   * file under `java.io.tmpdir`. Tests pass an explicit folder when they want predictable paths.
+   */
+  @Volatile var recordingEncodeDir: java.io.File? = null
+
+  /**
+   * Pre-canned response shape for `recording/stop`. Tests override per scenario; defaults match
+   * "30fps × 500ms script" — 16 frames at 120×60.
+   */
+  @Volatile
+  var recordingStopResult: ee.schimke.composeai.daemon.protocol.RecordingStopResult =
+    ee.schimke.composeai.daemon.protocol.RecordingStopResult(
+      frameCount = 16,
+      durationMs = 500L,
+      framesDir = "/tmp/fake-frames",
+      frameWidthPx = 120,
+      frameHeightPx = 60,
+    )
+
+  private val nextRecordingId = java.util.concurrent.atomic.AtomicLong(1)
+
   /**
    * Optional capture hook for the params object the fake received on `initialize`. Tests use this
    * to assert what the supervisor passes through (e.g. `options.attachDataProducts`). Default is a
@@ -428,6 +495,69 @@ class FakeDaemon : DaemonSpawn {
           sendResponse(id, buildJsonObject { put("ok", true) })
         }
       }
+      "recording/start" -> {
+        val previewId = params?.get("previewId")?.jsonPrimitive?.contentOrNull ?: ""
+        val fps = params?.get("fps")?.jsonPrimitive?.contentOrNull?.toIntOrNull()
+        val scale = params?.get("scale")?.jsonPrimitive?.contentOrNull?.toFloatOrNull()
+        val overrides =
+          params
+            ?.get("overrides")
+            ?.takeUnless { it is kotlinx.serialization.json.JsonNull }
+            ?.let {
+              json.decodeFromJsonElement(
+                ee.schimke.composeai.daemon.protocol.PreviewOverrides.serializer(),
+                it,
+              )
+            }
+        recordingStarts.offer(
+          RecordingStartCall(previewId = previewId, fps = fps, scale = scale, overrides = overrides)
+        )
+        val recordingId = "fake-rec-${nextRecordingId.getAndIncrement()}"
+        sendResponse(
+          id,
+          json.encodeToJsonElement(
+            ee.schimke.composeai.daemon.protocol.RecordingStartResult.serializer(),
+            ee.schimke.composeai.daemon.protocol.RecordingStartResult(recordingId = recordingId),
+          ),
+        )
+      }
+      "recording/stop" -> {
+        val recordingId = params?.get("recordingId")?.jsonPrimitive?.contentOrNull ?: ""
+        recordingStops.offer(recordingId)
+        sendResponse(
+          id,
+          json.encodeToJsonElement(
+            ee.schimke.composeai.daemon.protocol.RecordingStopResult.serializer(),
+            recordingStopResult,
+          ),
+        )
+      }
+      "recording/encode" -> {
+        val recordingId = params?.get("recordingId")?.jsonPrimitive?.contentOrNull ?: ""
+        val format =
+          when (params?.get("format")?.jsonPrimitive?.contentOrNull) {
+            null,
+            "apng" -> ee.schimke.composeai.daemon.protocol.RecordingFormat.APNG
+            else -> ee.schimke.composeai.daemon.protocol.RecordingFormat.APNG
+          }
+        recordingEncodes.offer(RecordingEncodeCall(recordingId, format))
+        // Materialise the canned bytes onto disk so DaemonMcpServer's `Files.readAllBytes` works.
+        val dir = recordingEncodeDir ?: java.io.File(System.getProperty("java.io.tmpdir"))
+        dir.mkdirs()
+        val out = java.io.File(dir, "$recordingId.apng")
+        out.writeBytes(recordingEncodedBytes)
+        sendResponse(
+          id,
+          json.encodeToJsonElement(
+            ee.schimke.composeai.daemon.protocol.RecordingEncodeResult.serializer(),
+            ee.schimke.composeai.daemon.protocol.RecordingEncodeResult(
+              videoPath = out.absolutePath,
+              mimeType = "image/apng",
+              sizeBytes = out.length(),
+            ),
+          ),
+        )
+      }
       else -> {
         // Unknown methods: error response so the client doesn't hang.
         sendError(id, -32601, "method not found: $method")
@@ -471,6 +601,18 @@ class FakeDaemon : DaemonSpawn {
             it.jsonPrimitive.contentOrNull
           } ?: emptyList()
         focusSets.offer(ids)
+      }
+      "recording/script" -> {
+        val recordingId = params?.get("recordingId")?.jsonPrimitive?.contentOrNull ?: ""
+        val eventsArr = params?.get("events") as? kotlinx.serialization.json.JsonArray
+        val events =
+          eventsArr?.map {
+            json.decodeFromJsonElement(
+              ee.schimke.composeai.daemon.protocol.RecordingScriptEvent.serializer(),
+              it,
+            )
+          } ?: emptyList()
+        recordingScripts.offer(RecordingScriptCall(recordingId, events))
       }
       "exit" -> running.set(false)
       else -> {}


### PR DESCRIPTION
## Summary

Adds the `record_preview` MCP tool on top of the daemon recording surface
that landed in #478. Agents call it with a URI, scripted event timeline,
and optional `fps` / `scale` / `overrides`; the tool drives the daemon's
`recording/start | script | stop | encode` flow end-to-end and returns the
encoded video bytes inline as an `image/apng` content block (with a sibling
text block carrying `recordingId`, `frameCount`, `durationMs`, `sizeBytes`).

The "feels like normal user time" property comes from the daemon's
virtual frame clock (P1): an agent's `[(tMs=0, click), (tMs=500, click)]`
script always produces 500 ms of inter-click animation in the output
regardless of how long the agent took to send the script.

### Wire shape

```jsonc
{
  "name": "record_preview",
  "arguments": {
    "uri": "compose-preview://<workspace>/<module>/<fqn>",
    "fps": 30,
    "scale": 4.0,
    "format": "apng",
    "overrides": { "widthPx": 240, "heightPx": 80 },
    "events": [
      { "tMs": 0,   "kind": "click", "pixelX": 120, "pixelY": 40 },
      { "tMs": 500, "kind": "click", "pixelX": 120, "pixelY": 40 }
    ]
  }
}
```

Returns a `CallToolResult` with two content blocks:

- `Image { mimeType: "image/apng", data: <base64> }` — the encoded video
- `Text { ... }` — JSON metadata (recordingId, videoPath, mimeType,
  sizeBytes, frameCount, durationMs, frameWidthPx, frameHeightPx)

### What landed

- `DaemonClient.recordingStart / Script / Stop / Encode` helpers
  mirroring the existing `renderNow` / `data/*` shapes.
- `record_preview` tool definition + handler in `DaemonMcpServer`. Up-
  front script validation (non-negative `tMs`, known kind) so malformed
  input surfaces as a clean tool-level error rather than dying inside
  the daemon's notification decoder. Override validation reuses
  `validateOverrides` so the tool inherits the same
  `supportedOverrides` + `knownDevices` checks `render_preview` enforces.
- `FakeDaemon` handlers for the four recording RPCs + canned encoded-
  bytes plumbing for tests.

### Component-preview ergonomics

A button-sized preview can be recorded at native size with custom
background and upsampled for legibility. Pointer coords always
reference image-natural pixels — agents writing scripts never need to
know the scale multiplier.

### Test plan

- [x] `:mcp:compileKotlin` clean
- [x] `:mcp:compileTestKotlin` clean
- [x] `:mcp:test` passes (existing tests + new ones)
- [x] `:mcp:ktfmtCheckMain` / `:mcp:ktfmtCheckTest` clean
- [x] `record_preview drives start-script-stop-encode and returns base64
      APNG inline` — asserts each daemon-side handler observed exactly
      one call with expected args (previewId, fps, scale, overrides,
      script events, format), the response carries an image content
      block whose decoded bytes match the canned APNG, and a sibling
      text block carries the right metadata.
- [x] `record_preview rejects unknown event kind without spawning a
      session` — validation runs before dispatch; daemon never sees a
      `recording/start`.

### Out of scope

- mp4/webm via optional ffmpeg shell-out — P3
- Live (non-scripted) recording driven by `interactive/input` — P3
- Android backend — P4
- `compose-preview-recording://` resource URI scheme for large
  recordings (avoid base64 inflation) — deferred; the inline path is
  sufficient for typical clip sizes (~tens of KB) and the on-disk path
  is always available via the metadata block for callers that prefer it.


---
_Generated by [Claude Code](https://claude.ai/code/session_018GGtBuG7ZeRPpUP8AMz49E)_