### PR TITLE
feat(mcp): bundle MCP server in the CLI launcher; document agent flows

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -38,6 +38,10 @@ dependencies {
   implementation("org.gradle:gradle-tooling-api:9.3.1")
   runtimeOnly("org.slf4j:slf4j-nop:2.0.16")
 
+  // Bundle the MCP server so `compose-preview mcp serve` can invoke it in-process —
+  // the consumer install story stays a single tarball + a single launcher.
+  implementation(project(":mcp"))
+
   testImplementation(kotlin("test"))
 }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Args.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Args.kt
@@ -12,3 +12,27 @@ internal fun List<String>.flagValue(flag: String): String? {
   val idx = indexOf(flag)
   return if (idx >= 0 && idx + 1 < size) this[idx + 1] else null
 }
+
+/**
+ * Repeatable flag values: every `--flag value` and every `--flag=value` form, in order. Empty list
+ * when the flag isn't present. Used by `mcp install --module :a --module :b` and similar.
+ */
+internal fun List<String>.flagValuesAll(flag: String): List<String> {
+  val out = mutableListOf<String>()
+  var i = 0
+  while (i < size) {
+    val arg = this[i]
+    when {
+      arg == flag && i + 1 < size -> {
+        out.add(this[i + 1])
+        i += 2
+      }
+      arg.startsWith("$flag=") -> {
+        out.add(arg.substringAfter("="))
+        i++
+      }
+      else -> i++
+    }
+  }
+  return out
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -43,6 +43,7 @@ fun main(args: Array<String>) {
       "doctor",
       "share-gist",
       "publish-images",
+      "mcp",
       "update",
       "version",
       "help",
@@ -86,6 +87,7 @@ fun main(args: Array<String>) {
     "doctor" -> DoctorCommand(allArgs).run()
     "share-gist" -> ShareGistCommand(allArgs).run()
     "publish-images" -> PublishImagesCommand(allArgs).run()
+    "mcp" -> McpCommand(allArgs).run()
     "update" -> UpdateCommand(allArgs).run()
     "version" -> println("compose-preview $BUNDLE_VERSION")
     "help" -> printUsage()
@@ -116,6 +118,7 @@ private fun printUsage() {
       doctor           Verify Java 17 + Compose/AGP environment before editing Gradle files
       share-gist       Create a gist from a markdown file plus image attachments
       publish-images   Push a directory of rendered PNGs to a shared branch (default compose-preview/pr)
+      mcp              MCP server lifecycle: serve | install | doctor (see `mcp help`)
       update           Re-run the bootstrap installer to pull the latest release
       version          Print the installed bundle version and exit
       help             Show this help message

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -1,0 +1,325 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.mcp.DaemonMcpMain
+import java.io.File
+import kotlin.system.exitProcess
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `compose-preview mcp <subcommand>`
+ *
+ * Three subcommands cover the full agent-attach lifecycle:
+ *
+ * - `serve` — start the MCP server on stdio. Writes nothing to stdout itself; the only stdout
+ *   traffic is the JSON-RPC frames the [DaemonMcpMain] reader/writer pair owns. Status / errors go
+ *   to stderr.
+ * - `install` — bootstrap descriptors for every module that applies the plugin, flip each
+ *   descriptor's `enabled` flag to `true` (`composePreview.experimental.daemon { enabled = true }`
+ *   isn't required up-front this way), run `discoverPreviews`, and print the `claude mcp add`
+ *   invocation an agent host needs.
+ * - `doctor` — report per-module descriptor state (present / missing / disabled / stale) without
+ *   making any changes.
+ *
+ * The CLI bundles `:mcp` so all three run in-process. No second tarball, no manual classpath.
+ */
+internal class McpCommand(args: List<String>) {
+
+  private val sub: String = args.firstOrNull { !it.startsWith("--") } ?: "help"
+  private val rest: List<String> = args.toMutableList().apply { remove(sub) }
+
+  fun run() {
+    when (sub) {
+      "serve" -> serve(rest)
+      "install" -> install(rest)
+      "doctor" -> doctor(rest)
+      "help",
+      "--help",
+      "-h" -> {
+        printUsage()
+      }
+      else -> {
+        System.err.println("Unknown mcp subcommand: $sub")
+        printUsage()
+        exitProcess(1)
+      }
+    }
+  }
+
+  private fun printUsage() {
+    println(
+      """
+      compose-preview mcp <subcommand>
+
+      Subcommands:
+        serve    Start the MCP server on stdio. Forwards remaining flags to DaemonMcpMain
+                 (--project <path>[:<rootName>], --replicas-per-daemon N).
+        install  Bootstrap daemon descriptors for every module with the plugin applied,
+                 flip each descriptor's enabled flag, and print a `claude mcp add` line.
+        doctor   Report per-module descriptor state (no mutations).
+
+      Common options (install/doctor):
+        --project <path>     Project root containing settings.gradle[.kts] (default: cwd)
+        --module <gradlePath> Limit to one or more module paths (repeatable)
+        --json               Emit a structured envelope on stdout (install, doctor)
+
+      See skills/compose-preview/design/MCP.md for the full agent flow.
+      """
+        .trimIndent()
+    )
+  }
+
+  // -- serve -------------------------------------------------------------------------------------
+
+  private fun serve(args: List<String>) {
+    // Pure delegation — the MCP server owns System.in / System.out for JSON-RPC framing. Anything
+    // we print to stdout would corrupt the wire protocol; status goes to stderr.
+    DaemonMcpMain.main(args.toTypedArray())
+  }
+
+  // -- install -----------------------------------------------------------------------------------
+
+  private fun install(args: List<String>) {
+    val emitJson = "--json" in args
+    val projectDir = resolveProjectDir(args)
+    val moduleFilter = args.flagValuesAll("--module").map { it.removePrefix(":") }.toSet()
+
+    val connection = GradleConnection(projectDir, verbose = "--verbose" in args || "-v" in args)
+    connection.use { gc ->
+      val allModules = gc.findPreviewModules()
+      val modules =
+        if (moduleFilter.isEmpty()) allModules
+        else allModules.filter { it.gradlePath in moduleFilter }
+
+      if (modules.isEmpty()) {
+        val msg =
+          if (moduleFilter.isEmpty()) "no modules apply the compose-preview plugin"
+          else "none of --module ${moduleFilter.joinToString(",")} apply the plugin"
+        System.err.println("compose-preview mcp install: $msg")
+        exitProcess(2)
+      }
+
+      // Two batched runs: bootstrap every descriptor, then re-run discovery so previews.json sits
+      // alongside. Single Gradle invocation per phase keeps configuration cache hits warm.
+      val daemonTasks = modules.map { ":${it.gradlePath}:composePreviewDaemonStart" }
+      val discoverTasks = modules.map { ":${it.gradlePath}:discoverPreviews" }
+
+      System.err.println(
+        "==> bootstrapping daemon descriptors for ${modules.size} module(s): " +
+          modules.joinToString(", ") { ":${it.gradlePath}" }
+      )
+      // No `-P` propagation here: DaemonExtension's `enabled` property is intentionally not wired
+      // to a Gradle property (see DaemonExtension.kt KDoc). We populate the descriptor by running
+      // the task and then patch the JSON ourselves below — same as the smoke script does.
+      val daemonOk = gc.runTasks(*daemonTasks.toTypedArray())
+      if (!daemonOk) {
+        System.err.println("composePreviewDaemonStart failed; aborting.")
+        exitProcess(1)
+      }
+
+      // Flip the on-disk `enabled` flag — DaemonExtension's gradle-property override is
+      // intentionally
+      // not propagated into the JSON (see DaemonExtension.kt KDoc), so we patch it here so the
+      // agent
+      // doesn't have to remember the build-script edit.
+      val descriptors = modules.mapNotNull { module ->
+        val descriptor = File(module.projectDir, "build/compose-previews/daemon-launch.json")
+        if (!descriptor.isFile) {
+          System.err.println(
+            "warning: descriptor missing for :${module.gradlePath} (${descriptor})"
+          )
+          null
+        } else {
+          enableDescriptor(descriptor)
+          DescriptorState(module.gradlePath, descriptor, enabled = true)
+        }
+      }
+
+      System.err.println("==> running discoverPreviews so previews.json is up to date")
+      val discoverOk = gc.runTasks(*discoverTasks.toTypedArray())
+      if (!discoverOk) {
+        System.err.println("discoverPreviews failed; descriptors are still in place.")
+        exitProcess(1)
+      }
+
+      // CLAUDE_CLOUD users need an absolute path because `~/.claude/skills/.../bin/compose-preview`
+      // is the canonical launcher; we don't know how `compose-preview` is on the consumer's PATH.
+      val launcher = locateOwnLauncher() ?: "compose-preview"
+      val claudeMcpAdd =
+        "claude mcp add compose-preview-mcp -- $launcher mcp serve --project=${projectDir.absolutePath}"
+
+      if (emitJson) {
+        val payload = buildJsonObject {
+          put("schema", JsonPrimitive("compose-preview-mcp-install/v1"))
+          put("projectRoot", JsonPrimitive(projectDir.absolutePath))
+          put("launcher", JsonPrimitive(launcher))
+          put("claudeMcpAdd", JsonPrimitive(claudeMcpAdd))
+          put(
+            "modules",
+            kotlinx.serialization.json.JsonArray(
+              descriptors.map {
+                buildJsonObject {
+                  put("gradlePath", JsonPrimitive(":${it.gradlePath}"))
+                  put("descriptor", JsonPrimitive(it.descriptor.absolutePath))
+                  put("enabled", JsonPrimitive(it.enabled))
+                }
+              }
+            ),
+          )
+        }
+        println(JSON.encodeToString(JsonObject.serializer(), payload))
+      } else {
+        System.err.println()
+        System.err.println("==> ready. Bootstrapped descriptors:")
+        descriptors.forEach { d ->
+          System.err.println("    :${d.gradlePath}  ${d.descriptor}  (enabled=true)")
+        }
+        System.err.println()
+        System.err.println("Attach an MCP-aware agent host with:")
+        println(claudeMcpAdd)
+      }
+    }
+  }
+
+  // -- doctor ------------------------------------------------------------------------------------
+
+  private fun doctor(args: List<String>) {
+    val emitJson = "--json" in args
+    val projectDir = resolveProjectDir(args)
+    val moduleFilter = args.flagValuesAll("--module").map { it.removePrefix(":") }.toSet()
+
+    val connection = GradleConnection(projectDir, verbose = false)
+    connection.use { gc ->
+      val allModules = gc.findPreviewModules()
+      val modules =
+        if (moduleFilter.isEmpty()) allModules
+        else allModules.filter { it.gradlePath in moduleFilter }
+
+      if (modules.isEmpty()) {
+        System.err.println("compose-preview mcp doctor: no matching modules apply the plugin")
+        exitProcess(2)
+      }
+
+      val states = modules.map { module ->
+        val descriptor = File(module.projectDir, "build/compose-previews/daemon-launch.json")
+        if (!descriptor.isFile) {
+          DoctorState(module.gradlePath, descriptor, status = "missing", enabled = false)
+        } else {
+          val obj = parseDescriptor(descriptor)
+          val enabled = obj?.get("enabled")?.jsonPrimitive?.boolean == true
+          DoctorState(
+            module.gradlePath,
+            descriptor,
+            status = if (enabled) "ok" else "disabled",
+            enabled = enabled,
+          )
+        }
+      }
+
+      if (emitJson) {
+        val payload = buildJsonObject {
+          put("schema", JsonPrimitive("compose-preview-mcp-doctor/v1"))
+          put("projectRoot", JsonPrimitive(projectDir.absolutePath))
+          put(
+            "modules",
+            kotlinx.serialization.json.JsonArray(
+              states.map {
+                buildJsonObject {
+                  put("gradlePath", JsonPrimitive(":${it.gradlePath}"))
+                  put("descriptor", JsonPrimitive(it.descriptor.absolutePath))
+                  put("status", JsonPrimitive(it.status))
+                  put("enabled", JsonPrimitive(it.enabled))
+                }
+              }
+            ),
+          )
+        }
+        println(JSON.encodeToString(JsonObject.serializer(), payload))
+      } else {
+        states.forEach { s ->
+          val marker =
+            when (s.status) {
+              "ok" -> "ok"
+              "disabled" -> "disabled (run `compose-preview mcp install` to flip enabled=true)"
+              "missing" -> "missing (run `compose-preview mcp install`)"
+              else -> s.status
+            }
+          println(":${s.gradlePath}  $marker  (${s.descriptor})")
+        }
+      }
+
+      val anyMissing = states.any { it.status != "ok" }
+      if (anyMissing) exitProcess(1)
+    }
+  }
+
+  // -- helpers -----------------------------------------------------------------------------------
+
+  private fun resolveProjectDir(args: List<String>): File {
+    val explicit = args.flagValue("--project")?.let(::File)
+    val cwd = explicit ?: File(".").canonicalFile
+    val resolved = findGradleRoot(cwd) ?: cwd
+    return resolved
+  }
+
+  private fun findGradleRoot(from: File): File? {
+    var dir: File? = from.canonicalFile
+    while (dir != null) {
+      if (
+        File(dir, "settings.gradle.kts").isFile ||
+          File(dir, "settings.gradle").isFile ||
+          File(dir, "gradlew").isFile
+      ) {
+        return dir
+      }
+      dir = dir.parentFile
+    }
+    return null
+  }
+
+  private fun enableDescriptor(file: File) {
+    val text = file.readText()
+    val updated = text.replace(Regex("\"enabled\"\\s*:\\s*false"), "\"enabled\": true")
+    if (updated != text) file.writeText(updated)
+  }
+
+  private fun parseDescriptor(file: File): JsonObject? =
+    try {
+      JSON.parseToJsonElement(file.readText()).jsonObject
+    } catch (_: Exception) {
+      null
+    }
+
+  /**
+   * Locate the `compose-preview` launcher from `app_home` exported by the Gradle distribution
+   * `application` plugin. Falls back to the `compose-preview` PATH entry when the env var isn't set
+   * (e.g. running directly via `java -jar`).
+   */
+  private fun locateOwnLauncher(): String? {
+    val appHome = System.getenv("APP_HOME") ?: return null
+    val candidate = File(appHome, "bin/compose-preview")
+    return if (candidate.isFile) candidate.absolutePath else null
+  }
+
+  private data class DescriptorState(
+    val gradlePath: String,
+    val descriptor: File,
+    val enabled: Boolean,
+  )
+
+  private data class DoctorState(
+    val gradlePath: String,
+    val descriptor: File,
+    val status: String,
+    val enabled: Boolean,
+  )
+
+  private companion object {
+    val JSON: Json = Json { prettyPrint = true }
+  }
+}

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -37,68 +37,71 @@ in [`docs/daemon/MCP-KOTLIN.md`](../docs/daemon/MCP-KOTLIN.md).
 
 ## Quick start
 
-The server is a standalone JVM. The `claude mcp add` invocation tells
-your MCP client (Claude Code, an SDK harness, …) how to spawn it.
+The CLI bundles `:mcp` so the consumer-facing path is two commands —
+`compose-preview mcp install` then `claude mcp add`. The standalone
+`:mcp:installDist` launcher is the alternative path for embedders that
+don't ship the CLI.
 
-### 1. Build the jar + dependencies
+### Path A: via the bundled CLI (recommended)
+
+```bash
+# Bootstrap descriptors + previews.json for every plugin-applied module
+# in your project. Idempotent — patches each daemon-launch.json's
+# `enabled` flag to true and runs discoverPreviews.
+compose-preview mcp install --project /abs/path/to/your-repo
+
+# Verify per-module state.
+compose-preview mcp doctor --project /abs/path/to/your-repo
+
+# `mcp install` printed the exact `claude mcp add` line; copy/paste it.
+claude mcp add compose-preview-mcp -- compose-preview mcp serve \
+  --project=/abs/path/to/your-repo
+```
+
+`compose-preview mcp serve` runs the MCP server in-process; status goes
+to stderr and stdout is reserved for JSON-RPC framing.
+
+The consumer-facing skill doc is
+[`skills/compose-preview/design/MCP.md`](../skills/compose-preview/design/MCP.md);
+the PR-review variant (two workspaces, base + head) is
+[`skills/compose-preview-review/design/MCP_REVIEW.md`](../skills/compose-preview-review/design/MCP_REVIEW.md).
+
+### Path B: standalone `:mcp:installDist`
+
+Useful when embedding the server outside the CLI launcher (a custom
+agent host, a downstream IDE plugin, etc.).
 
 ```bash
 ./gradlew :mcp:installDist
 ```
 
-This produces `mcp/build/install/mcp/` with a launcher script and all
-runtime dependencies. (Today the module doesn't actually wire the
-`application` plugin — see [issue tracker]; until then build the jars
-manually:)
+Produces `mcp/build/install/compose-preview-mcp/` with a launcher script
+(`bin/compose-preview-mcp`) and all runtime jars under `lib/`.
 
-```bash
-./gradlew :mcp:jar :daemon:core:jar
-```
-
-### 2. Bootstrap the daemon for the modules you want to expose
-
-For each Android module:
+Bootstrap descriptors per module the same way — either via
+`compose-preview mcp install` (still the easiest, even when you're not
+using its `serve` subcommand) or by hand:
 
 ```bash
 ./gradlew :samples:wear:composePreviewDaemonStart \
-  -PcomposePreview.experimental.daemon.enabled=true
+          :samples:wear:discoverPreviews
+sed -i 's/"enabled": false/"enabled": true/' \
+  samples/wear/build/compose-previews/daemon-launch.json
 ```
 
-For each Compose-Desktop module:
-
-```bash
-./gradlew :samples:cmp:composePreviewDaemonStart \
-  -PcomposePreview.experimental.daemon.enabled=true
-```
-
-The task writes
-`<module>/build/compose-previews/daemon-launch.json` — a JSON descriptor
-with the classpath, JVM args, and system properties the supervisor needs
-to launch the daemon JVM. The descriptor's `enabled: false` field is
-load-bearing — flip it to `true` either in the build script
+The descriptor's `enabled: false` field is load-bearing — flip it to
+`true` either in the build script
 (`composePreview { experimental { daemon { enabled = true } } }`) or by
 editing the JSON directly. (Direct `-P` propagation is intentionally not
 wired; see `DaemonExtension.kt` KDoc for rationale.)
 
-Also run `discoverPreviews` so `previews.json` exists alongside:
+Then attach:
 
 ```bash
-./gradlew :samples:wear:discoverPreviews :samples:cmp:discoverPreviews
+claude mcp add compose-preview-mcp \
+  -- /abs/path/to/mcp/build/install/compose-preview-mcp/bin/compose-preview-mcp \
+  --project=/abs/path/to/your-repo
 ```
-
-### 3. Register the MCP server with your client
-
-```bash
-# Claude Code:
-claude mcp add compose-preview \
-  -- java -cp "<classpath>" ee.schimke.composeai.mcp.DaemonMcpMain \
-  --project=/abs/path/to/your-repo:my-project
-```
-
-The classpath needs `mcp/build/libs/mcp-*.jar` plus
-`daemon/core/build/libs/core-*.jar` plus the kotlinx runtime jars. See
-[`scripts/real_e2e_smoke.py`](scripts/real_e2e_smoke.py) for a concrete
-classpath assembly.
 
 `--project=<path>[:<rootProjectName>]` pre-registers a workspace at
 startup; you can also call the `register_project` tool from the agent

--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -12,6 +12,7 @@
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
+  application
 }
 
 group = "ee.schimke.composeai"
@@ -24,6 +25,20 @@ version =
       val (major, minor, patch) = current.split(".").map { it.toInt() }
       "$major.$minor.${patch + 1}-SNAPSHOT"
     }
+
+base { archivesName.set("compose-preview-mcp") }
+
+application {
+  applicationName = "compose-preview-mcp"
+  mainClass.set("ee.schimke.composeai.mcp.DaemonMcpMain")
+}
+
+// Match `:cli` — `archiveExtension = "tar.gz"` keeps the in-archive root as
+// `compose-preview-mcp-<version>/` rather than leaking `.tar.gz` into the dir name.
+tasks.named<Tar>("distTar") {
+  archiveExtension.set("tar.gz")
+  compression = Compression.GZIP
+}
 
 dependencies {
   implementation(libs.kotlinx.coroutines.core)

--- a/skills/compose-preview-review/SKILL.md
+++ b/skills/compose-preview-review/SKILL.md
@@ -68,6 +68,7 @@ Pick the workflow that matches the task:
 |---|---|
 | [design/AGENT_PR.md](./design/AGENT_PR.md) | Full PR review + agent PR authoring guidance: comment structure, image hosting choices, things to flag, integration with `preview-comment` CI when present. |
 | [design/CI_PREVIEWS.md](./design/CI_PREVIEWS.md) | `compose-preview/main` baselines branch + PR-comment GitHub Actions: workflow YAML, action inputs, branch durability. |
+| [design/MCP_REVIEW.md](./design/MCP_REVIEW.md) | Driving a PR review through the MCP server (two-workspace base+head flow, push notifications, edit-on-top iteration). |
 
 ## Related
 

--- a/skills/compose-preview-review/design/MCP_REVIEW.md
+++ b/skills/compose-preview-review/design/MCP_REVIEW.md
@@ -1,0 +1,156 @@
+# Reviewing a PR via the MCP server
+
+The default PR-review flow in [AGENT_PR.md](./AGENT_PR.md#reviewing-a-pr-agent-workflow)
+shells out to the CLI inside two worktrees. That works without any setup, but
+it pays Gradle's cold-config cost twice and gives the agent no way to react to
+edits while the review is open. When the agent is already attached to the
+[MCP server](../../compose-preview/design/MCP.md), prefer the flow below: same
+two-worktree shape, but driven over MCP.
+
+## When this is worth it
+
+- The repo has more than a handful of `@Preview`s and you want **push
+  notifications** (`resources/updated`) instead of re-running `compose-preview
+  show` on every iteration.
+- You expect to **edit on top of the PR** during review (suggesting fixes,
+  trying alternative renders) and want the agent to react to file saves.
+- You're reviewing **multiple PRs in one session** — register them all as
+  workspaces, watch the relevant module on each, compare across.
+
+For a one-shot "render base, render head, post a comment, done" review,
+`compose-preview show --json` in two worktrees is still simpler.
+
+## Two-workspace flow
+
+1. **Worktree the base.** Same as the CLI flow — both classpaths must exist
+   on disk, MCP can't dodge that.
+
+   ```bash
+   BASE=$(gh pr view <N> --json baseRefName -q .baseRefName)
+   git worktree add ../_pr_base "origin/$BASE"
+   ```
+
+2. **Bootstrap descriptors on both sides.** `mcp install` is idempotent and
+   batched per Gradle invocation — running it on each worktree is a small
+   one-time cost that subsequent renders amortise.
+
+   ```bash
+   compose-preview mcp install --project /abs/path/to/your-repo
+   compose-preview mcp install --project /abs/path/to/your-repo/../_pr_base
+   ```
+
+3. **Register both workspaces.** From the agent, after `initialize`:
+
+   ```jsonc
+   { "method": "tools/call", "params": { "name": "register_project",
+     "arguments": { "path": "/abs/path/to/your-repo",
+                    "modules": [":app"] } } }
+   { "method": "tools/call", "params": { "name": "register_project",
+     "arguments": { "path": "/abs/path/to/your-repo/../_pr_base",
+                    "modules": [":app"] } } }
+   ```
+
+   Each call returns a `workspaceId`. They differ by construction —
+   `WorkspaceId.derive` hashes the canonical path, so two worktrees of the
+   same repo never collide.
+
+4. **Watch both.** This propagates as `setVisible` / `setFocus` to the
+   daemon, so the supervisor prioritises rendering the previews you're about
+   to read:
+
+   ```jsonc
+   { "method": "tools/call", "params": { "name": "watch",
+     "arguments": { "workspaceId": "<head-id>", "module": ":app" } } }
+   { "method": "tools/call", "params": { "name": "watch",
+     "arguments": { "workspaceId": "<base-id>", "module": ":app" } } }
+   ```
+
+   Wait for `notifications/resources/list_changed` on each — the daemon's
+   discovery completes asynchronously.
+
+5. **Read the PNGs by URI.** For every preview FQN the head workspace
+   advertises, read the same FQN from the base workspace too. The URI
+   suffix after `<workspaceId>/<encodedModulePath>/` is the stable preview
+   id; bucketing into `changed` / `new` / `removed` is identical to the
+   CLI flow.
+
+   ```jsonc
+   { "method": "resources/read",
+     "params": { "uri": "compose-preview://<head-id>/_app/com.example.HomeScreen_dark" } }
+   { "method": "resources/read",
+     "params": { "uri": "compose-preview://<base-id>/_app/com.example.HomeScreen_dark" } }
+   ```
+
+   `resources/read` returns the PNG inline (`BlobResourceContents`,
+   base64). Diff client-side; the bytes returned already include the
+   daemon's per-render `sha256` so you can short-circuit on equality
+   without decoding.
+
+6. **(Optional) iterate.** When you edit source on the PR head as part of
+   the review (proposing a fix), tell the daemon directly rather than
+   re-rendering the world:
+
+   ```jsonc
+   { "method": "tools/call", "params": { "name": "notify_file_changed",
+     "arguments": { "workspaceId": "<head-id>",
+                    "path": "/abs/path/.../HomeScreen.kt", "kind": "source" } } }
+   ```
+
+   The daemon's classloader-swap path picks up the bytecode change after
+   the agent runs `./gradlew :app:compileKotlin`. Subscribed URIs fire
+   `resources/updated`; the agent re-reads only those.
+
+7. **Tear down.** When the review is done:
+
+   ```bash
+   git worktree remove ../_pr_base
+   ```
+
+   Connected agents see `unregister_project` calls (or just disconnect —
+   the supervisor cleans up on stdin EOF).
+
+## Posting the review
+
+Same as the CLI flow — see
+[AGENT_PR.md § Default: show the human the diffs inline, post a text comment](./AGENT_PR.md#2-default-show-the-human-the-diffs-inline-post-a-text-comment).
+The MCP path saved you per-render Gradle re-bootstrap cost; it doesn't
+change what the human reading the comment sees.
+
+## Why two workspaces, not one with a branch flip
+
+The natural-sounding alternative — register one workspace, `git checkout
+base`, render, `git checkout head`, render — does not work:
+
+- The daemon's classloader is pinned to whichever bytecode was on disk when
+  it spawned. A branch flip on the same `build/` output produces stale
+  renders unless you also `compileKotlin` between flips and send
+  `notify_file_changed` for every touched file.
+- `classpathDirty` will eventually fire and respawn the daemon, but the
+  intermediate state is mixed-version PNGs.
+
+Two worktrees give each daemon its own pristine `build/` and remove the
+ordering problem entirely. Worktree creation is cheap (`git worktree add`
+hard-links the object database).
+
+## Caveats
+
+- **Cold-start cost is per workspace.** First read on each side pays the
+  daemon's spawn time (~600 ms desktop, ~5–10 s Robolectric). After that,
+  everything is sub-second.
+- **`@Preview` ids must match.** A renamed function counts as `removed`
+  on base + `new` on head. The CLI flow has the same blind spot; flag
+  rename suspicions in the review text rather than rubber-stamping.
+- **Per-call overrides** (`render_preview` with `overrides`) only affect
+  one render, not subsequent `resources/read` calls on the same URI. If
+  you want a lasting variant — say "head at `fontScale=1.3`" — pass the
+  override in the qualifier (`?config=fontScale_1.3`) so it's part of the
+  URI.
+
+## See also
+
+- [`compose-preview/design/MCP.md`](../../compose-preview/design/MCP.md) —
+  setup of the MCP server itself, `compose-preview mcp install/serve/doctor`.
+- [`AGENT_PR.md`](./AGENT_PR.md) — CLI-driven review, agent-authored PRs,
+  comment style, image hosting choices.
+- [`CI_PREVIEWS.md`](./CI_PREVIEWS.md) — `compose-preview/main` baselines
+  branch + PR-comment GitHub Actions for the no-agent path.

--- a/skills/compose-preview/SKILL.md
+++ b/skills/compose-preview/SKILL.md
@@ -174,6 +174,7 @@ Loaded on demand. Read only what the current task needs.
 | [design/CAPTURE_MODES.md](./design/CAPTURE_MODES.md) | Multi-preview annotations, paused-clock animation captures, scrolling captures. |
 | [design/A11Y.md](./design/A11Y.md) | ATF accessibility checks (`compose-preview a11y`). |
 | [design/DATA_PRODUCTS.md](./design/DATA_PRODUCTS.md) | Structured per-render data (a11y findings + hierarchy, layout tree, recomposition heat-map, …) via MCP tools and on-disk Gradle output. |
+| [design/MCP.md](./design/MCP.md) | Driving compose-preview from an MCP-aware agent host (push notifications, multi-workspace, in-process server bundled in the CLI). |
 | [design/CMP_SHARED.md](./design/CMP_SHARED.md) | Compose Multiplatform `:shared` modules (`commonMain` previews via Desktop pipeline). |
 | [design/RESOURCE_PREVIEWS.md](./design/RESOURCE_PREVIEWS.md) | Android XML resources (`<vector>`, `<animated-vector>`, `<adaptive-icon>`). |
 | [design/WEAR_UI.md](./design/WEAR_UI.md) | Wear OS Material 3 Expressive design. |

--- a/skills/compose-preview/design/MCP.md
+++ b/skills/compose-preview/design/MCP.md
@@ -1,0 +1,139 @@
+# MCP server (agent integration)
+
+Driving compose-preview from an MCP-aware agent host (Claude Code, the Agent
+SDK, custom hosts) instead of from a shell. Companion to the
+[contributor README](https://github.com/yschimke/compose-ai-tools/blob/main/mcp/README.md);
+this file covers what the consumer of the published skill bundle needs.
+
+## When to read this
+
+You want any of:
+
+- An agent that can re-render a `@Preview` on demand and **read the PNG inline**
+  without spawning Gradle per call.
+- **Push notifications** when a render finishes (no polling) — for a chat-style
+  loop where the user edits source and the agent reacts.
+- **Multi-workspace fan-out** — one MCP server serving previews from multiple
+  projects, or two worktrees of the same repo at once (the bread-and-butter of
+  PR review; see [`compose-preview-review/design/MCP_REVIEW.md`](../../compose-preview-review/design/MCP_REVIEW.md)).
+
+If you just want a one-shot render or a CI diff comment, the CLI
+(`compose-preview show --json`) is simpler and has the same render engine
+behind it. Reach for MCP when the loop is long-lived.
+
+## Setup in three commands
+
+The `compose-preview` CLI bundles the MCP server. There is no second
+download, no manual classpath, no `claude mcp add` argument to compose by
+hand.
+
+```bash
+# 1. Bootstrap descriptors + previews.json for every plugin-applied module
+#    in your project. Idempotent; safe to re-run.
+compose-preview mcp install --project /abs/path/to/your-repo
+
+# 2. Verify per-module state (descriptor present, enabled=true).
+compose-preview mcp doctor --project /abs/path/to/your-repo
+
+# 3. Wire it into your agent host. The exact command is what
+#    `mcp install` printed on stdout — copy/paste it.
+claude mcp add compose-preview-mcp -- compose-preview mcp serve \
+  --project=/abs/path/to/your-repo
+```
+
+`compose-preview mcp install` does three things behind the scenes:
+
+1. Runs `composePreviewDaemonStart` for every module that applies the plugin,
+   so each `<module>/build/compose-previews/daemon-launch.json` exists.
+2. Patches each descriptor's `enabled` flag to `true`. (The Gradle DSL knob
+   `composePreview.experimental.daemon { enabled = true }` is intentionally
+   not propagated via `-P`, so the on-disk patch is the canonical way to flip
+   it from outside the build script.)
+3. Runs `discoverPreviews` so `previews.json` sits alongside.
+
+`mcp doctor` reads the descriptors back without mutating, and exits non-zero
+if any module's descriptor is missing or has `enabled: false`. Use it from a
+SessionStart hook, CI, or a watchdog.
+
+## What an attached agent sees
+
+Once the host is wired, the agent gets a stable resource catalogue:
+
+- Each `@Preview` becomes one resource:
+  `compose-preview://<workspaceId>/<encodedModulePath>/<previewFqn>`.
+- `resources/list` enumerates every preview every supervised daemon knows.
+- `resources/read` triggers a render and returns the PNG inline (base64
+  `image/png`).
+- `resources/subscribe(uri)` pushes `notifications/resources/updated` whenever
+  that one preview re-renders.
+- `notifications/resources/list_changed` fires when the discovery set or the
+  workspace set mutates.
+
+Tool calls (12 today, see [`mcp/README.md` § Tool reference](https://github.com/yschimke/compose-ai-tools/blob/main/mcp/README.md#tool-reference)
+for the full table) cover the rest:
+
+- `register_project`, `unregister_project`, `list_projects` — manage
+  workspaces at runtime.
+- `watch(workspaceId, module?, fqnGlob?)` — area-of-interest registration.
+  The supervisor expands the watch into a URI set and forwards it to the
+  daemon as `setVisible` / `setFocus`, so render queue prioritisation
+  matches what the agent is looking at.
+- `notify_file_changed(workspaceId, path, kind?)` — tell the daemon that the
+  source on disk changed. Use after editing source files outside the host's
+  view (e.g. the agent invoked the Edit tool from a different process). The
+  daemon's classloader-swap fast path picks up bytecode changes without a
+  full reboot.
+- `render_preview(uri, overrides?)` — force-render bypassing cache. Use
+  `overrides` to flip device, locale, fontScale, uiMode, orientation, or
+  density per call without editing the `@Preview` annotation.
+- `history_list` / `history_diff` — proxy the daemon's history feature for
+  comparing rendered output across runs.
+- `list_data_products` / `get_preview_data` / `subscribe_preview_data` —
+  fetch structured per-render data (a11y findings, layout tree, recomposition
+  heat-map, …) alongside the PNG. See
+  [`design/DATA_PRODUCTS.md`](./DATA_PRODUCTS.md) for the kind catalogue.
+
+## Multi-workspace and worktrees
+
+`WorkspaceId.derive(rootProjectName, path)` is
+`<rootProjectName>-<8-hex-chars-of-sha256(canonical-path)>`. The hash is
+always present, so two worktrees of the same repo at different paths get
+distinct ids by construction — not just distinct names.
+
+Daemons are owned per `(workspaceId, modulePath)`. Two worktrees of the
+same module run two independent daemon JVMs against their own `build/`
+output. No PNG or cache cross-contamination.
+
+For PR-review-style flows (base + head worktrees, render both, diff client-side)
+see the dedicated [`compose-preview-review/design/MCP_REVIEW.md`](../../compose-preview-review/design/MCP_REVIEW.md).
+
+## Lifecycle and operational notes
+
+- **Cold start.** Robolectric daemon: ~5–10 s. Desktop daemon: ~600 ms.
+  `watch` spawns asynchronously; the host's reader thread doesn't block.
+- **One server, N clients.** A single MCP server JVM can serve N agents over
+  N stdio connections. Daemons are shared across sessions when they target
+  the same `(workspace, module)`, so two agents reading the same preview
+  both benefit from one warm sandbox.
+- **`classpathDirty`.** When a daemon's classpath fingerprint changes (e.g.
+  dependency bump), it emits `classpathDirty` and exits. The supervisor
+  drops the dying daemon and respawns; clients see
+  `notifications/resources/list_changed`.
+- **Disconnect.** On stdin EOF the server tears down every supervised daemon
+  cleanly (`shutdown` + `exit`, drain wait) before exiting itself.
+- **Cloud sandboxes.** The `install.sh` bootstrap covers the CLI; the MCP
+  server runs out of the same launcher with no extra steps. JVM toolchain
+  story is unchanged from the CLI — see
+  [`design/CLAUDE_CLOUD.md`](./CLAUDE_CLOUD.md).
+
+## See also
+
+- [`mcp/README.md`](https://github.com/yschimke/compose-ai-tools/blob/main/mcp/README.md)
+  — full tool reference, URI scheme details, end-to-end smoke script.
+- [`docs/daemon/MCP.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/daemon/MCP.md)
+  — protocol-level design (subscriptions, notifications, capability
+  negotiation).
+- [`docs/daemon/PROTOCOL.md`](https://github.com/yschimke/compose-ai-tools/blob/main/docs/daemon/PROTOCOL.md)
+  — daemon JSON-RPC wire format the MCP shim translates from.
+- [`compose-preview-review/design/MCP_REVIEW.md`](../../compose-preview-review/design/MCP_REVIEW.md)
+  — agent-driven PR review using two MCP workspaces (base + head).

--- a/skills/compose-preview/design/VSCODE.md
+++ b/skills/compose-preview/design/VSCODE.md
@@ -1,8 +1,9 @@
 # VS Code extension
 
 Aimed at humans working in the IDE; agents driving renders should use the
-CLI. With the `vscjava.vscode-gradle` extension installed, the Compose
-Preview extension provides:
+CLI or — for long-lived chat-style loops — the MCP server (see below).
+With the `vscjava.vscode-gradle` extension installed, the Compose Preview
+extension provides:
 
 - A **preview panel** (webview) listing rendered previews for the active module.
 - **CodeLens** and **hover** actions above every `@Preview` function in Kotlin
@@ -12,3 +13,38 @@ Preview extension provides:
   - `Compose Preview: Run for File` — render only previews in the active file.
 - Auto-refresh on editor save (debounced) and on active-editor switch to a
   Kotlin file.
+
+## VS Code + an MCP-attached agent
+
+When the human is editing in VS Code and chatting with an agent (Claude
+Code, the SDK, …) attached to `compose-preview-mcp` against the same
+project, both surfaces share the **same daemon JVM per `(workspace,
+module)`**. Useful properties:
+
+- VS Code's auto-refresh-on-save and the agent's `resources/read` race
+  against the same daemon. Whichever arrives second is a cache hit; PNGs
+  the agent reads are byte-equal to what VS Code displays.
+- `notify_file_changed` from either side invalidates the same in-memory
+  state. The agent doesn't have to re-discover the source set after VS
+  Code saves a file.
+- A11y findings, layout trees, recomposition heat-maps — all data
+  products the agent fetches via `get_preview_data` are computed against
+  the same render the human just looked at.
+
+Two gotchas worth knowing:
+
+- **Don't double-trigger.** If the agent has a `subscribe_preview_data` /
+  `watch` set up, it will receive `resources/updated` on every save. If
+  the agent then immediately calls `render_preview` to "be sure", it
+  forces a redundant render. Trust the notification — the daemon already
+  has fresh bytes.
+- **Cold-start belongs to whichever side connected first.** If the agent
+  is the first to spawn the desktop daemon, VS Code's first save sees a
+  warm sandbox. If VS Code spawned it via `Compose Preview: Render All`,
+  the agent's first `resources/read` is fast. Order doesn't matter for
+  correctness, only first-call latency.
+
+For the protocol-level agent flow see
+[`design/MCP.md`](./MCP.md). For PR review with two worktrees attached as
+two workspaces see
+[`compose-preview-review/design/MCP_REVIEW.md`](../../compose-preview-review/design/MCP_REVIEW.md).


### PR DESCRIPTION
## Goal

Two questions:

1. How does an agent reviewing a PR via the MCP server typically work?
2. Are the primary agent-using-MCP use cases documented, and are they feasible
   in terms of installs and API ergonomics? Either fix limitations or document
   them as part of existing reference instructions.

The four flows under consideration are: agent-authored PRs (with preview
images), agent-driven PR review, GitHub-workflow-driven preview comments, and
user-in-VS-Code chatting to an agent.

## Summary

The MCP server's wire protocol already supports every flow; the gap was install
ergonomics and the lack of consumer-facing documentation pointing at it. This
PR closes both.

**Build wiring**
- `mcp/build.gradle.kts`: add `application` plugin, `archivesName =
  compose-preview-mcp`, `mainClass = ee.schimke.composeai.mcp.DaemonMcpMain`,
  `distTar` config mirroring `:cli`. `:mcp:installDist` now produces a runnable
  launcher (`bin/compose-preview-mcp`) under `mcp/build/install/...`.
- `cli/build.gradle.kts`: add `implementation(project(":mcp"))` so the MCP server
  is bundled inside the CLI launcher. Single tarball, single launcher; no second
  install path for consumers.

**CLI subcommand**
- `cli/.../McpCommand.kt`: new `compose-preview mcp` group with `serve`,
  `install`, `doctor`.
  - `serve` delegates to `DaemonMcpMain.main`, leaving stdio for JSON-RPC.
  - `install` runs `composePreviewDaemonStart` + `discoverPreviews` for every
    plugin-applied module, patches each descriptor's `enabled` flag, and prints
    the ready-to-paste `claude mcp add` line.
  - `doctor` reports per-module descriptor state (missing / disabled / ok)
    without mutating, and exits non-zero when any module isn't ready.
- `cli/.../Args.kt`: `flagValuesAll` helper for repeatable `--module` flags.
- `cli/.../Main.kt`: register the `mcp` command and add it to `--help`.

**Docs (consumer-facing)**
- `skills/compose-preview/design/MCP.md` (new): when to reach for MCP, the
  three-command setup, what an attached agent sees (resources, subscriptions,
  tools), multi-workspace and worktree semantics, lifecycle.
- `skills/compose-preview-review/design/MCP_REVIEW.md` (new): two-workspace PR
  review (base + head worktrees registered as separate workspaces),
  edit-on-top iteration via `notify_file_changed`, why this beats one workspace
  with branch flips.
- `skills/compose-preview/design/VSCODE.md`: new "VS Code + an MCP-attached
  agent" section covering the shared-daemon semantics when both surfaces attach
  to the same `(workspace, module)`.
- `skills/compose-preview/SKILL.md` and
  `skills/compose-preview-review/SKILL.md`: teaser-link rows pointing at the new
  design files. No expansion of the main bodies, per project convention.

**Docs (contributor-facing)**
- `mcp/README.md`: refactor Quick Start to lead with
  `compose-preview mcp install`. Path B (`:mcp:installDist` standalone) stays
  documented for embedders that don't ship the CLI.

## Test plan

- [x] `./gradlew :mcp:installDist` → `bin/compose-preview-mcp` produced
- [x] `./gradlew :cli:installDist` → CLI launcher built
- [x] `compose-preview mcp install --module :samples:cmp` → bootstraps
      descriptor, patches `enabled: false` → `true`, runs `discoverPreviews`,
      prints `claude mcp add` line
- [x] `compose-preview mcp doctor --module :samples:cmp` → reports `ok`
- [x] `compose-preview mcp serve` + framed `initialize` request → returns
      protocol-version + capabilities response over stdio
- [x] `./gradlew ktfmtCheckAll` → up-to-date
- [x] `./gradlew :cli:test :mcp:test` → green

## Notes for review

- The first commit on the branch (`7d1b346`) has a `wip(mcp):` message; its
  contents are part of the final shape of the change but its body says docs
  were pending. Squash-merge or re-message on merge.
- No `-P` propagation was added to `composePreviewDaemonStart` from
  `mcp install` — `DaemonExtension`'s `enabled` property is intentionally not
  wired to a Gradle property (see `DaemonExtension.kt` KDoc). The on-disk JSON
  patch is what the smoke script does today and is what `mcp install` does too.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vr8LHGqmrv1xzcXinAfmLx)_