### PR TITLE
fix(diff-bot,cli): surface CLI stdout pollution + flush before every exit

### DIFF
--- a/.github/actions/lib/compare-previews.py
+++ b/.github/actions/lib/compare-previews.py
@@ -174,6 +174,34 @@ def _render_basename(png_path: str, preview_id: str) -> str:
     return f"{preview_id}.png"
 
 
+def _diagnose_cli_json(path: Path, raw_bytes: bytes, summary: str) -> str:
+    """Build the SystemExit message for unparseable ``compose-preview show --json``
+    output — adds a hex preview, a repr of the head, and the file's tail when
+    long enough, so the CI log carries enough breadcrumbs to root-cause without
+    re-running the workflow. See preview-comment/action.yml for the
+    artifact-upload step that hands the full file to the user as well.
+    """
+    size = len(raw_bytes)
+    head = raw_bytes[:200]
+    head_hex = head[:32].hex(" ")
+    head_repr = head.decode("utf-8", errors="replace")
+    lines = [
+        f"{path} {summary}.",
+        f"File size: {size} bytes.",
+        f"First {min(32, size)} bytes (hex): {head_hex}",
+        f"First {min(200, size)} chars (repr): {head_repr!r}",
+    ]
+    if size > 400:
+        tail = raw_bytes[-200:]
+        lines.append(f"Last 200 chars (repr): {tail.decode('utf-8', errors='replace')!r}")
+    lines.append(
+        "Check the upstream `compose-preview show --json` step's log for "
+        "non-JSON output bleeding into stdout. The full file is uploaded as "
+        "the `preview-cli-output` artifact for postmortem inspection."
+    )
+    return "\n".join(lines)
+
+
 def load_cli_output(cli_json_path: Path) -> dict[str, dict]:
     """Parse ``compose-preview show --json`` output into a keyed dict.
 
@@ -192,8 +220,8 @@ def load_cli_output(cli_json_path: Path) -> dict[str, dict]:
     Rows carry the render PNG basename (``_SCROLL_end.png`` etc.) and a
     ``captureLabel`` for downstream markdown / filename handling.
     """
-    text = cli_json_path.read_text()
-    if not text.strip():
+    raw_bytes = cli_json_path.read_bytes()
+    if not raw_bytes.strip():
         # `compose-preview show --json` always emits an envelope — even the
         # no-previews case prints `{"schema": …, "previews": []}`. An empty
         # file means the upstream "Render previews" step lost its stdout
@@ -204,13 +232,37 @@ def load_cli_output(cli_json_path: Path) -> dict[str, dict]:
             f"{cli_json_path} is empty — the upstream `compose-preview show "
             f"--json` step produced no output. Check that step's log."
         )
+    # Strip a UTF-8 BOM if the JVM emitted one. Python's json parser doesn't
+    # treat U+FEFF as whitespace and would die with "Expecting value: line 1
+    # col 1" on otherwise-valid output. Logged to stderr so the workaround
+    # stays visible in CI rather than silently masking a real CLI bug.
+    text_bytes = raw_bytes
+    if text_bytes.startswith(b"\xef\xbb\xbf"):
+        print(
+            f"warning: stripped UTF-8 BOM from {cli_json_path} "
+            f"(upstream `compose-preview show --json` emitted one)",
+            file=sys.stderr,
+        )
+        text_bytes = text_bytes[3:]
+    try:
+        text = text_bytes.decode("utf-8")
+    except UnicodeDecodeError as e:
+        raise SystemExit(
+            _diagnose_cli_json(
+                cli_json_path,
+                raw_bytes,
+                f"is not valid UTF-8 ({e.reason} at byte {e.start})",
+            )
+        ) from None
     try:
         raw = json.loads(text)
     except json.JSONDecodeError as e:
         raise SystemExit(
-            f"{cli_json_path} is not valid JSON ({e.msg} at line {e.lineno} "
-            f"col {e.colno}). Check the upstream `compose-preview show --json` "
-            f"step's log for non-JSON output bleeding into stdout."
+            _diagnose_cli_json(
+                cli_json_path,
+                raw_bytes,
+                f"is not valid JSON ({e.msg} at line {e.lineno} col {e.colno})",
+            )
         ) from None
     if isinstance(raw, dict) and "previews" in raw:
         entries = raw["previews"]

--- a/.github/actions/lib/test_compare_previews.py
+++ b/.github/actions/lib/test_compare_previews.py
@@ -124,6 +124,36 @@ class LoadCliOutputTest(unittest.TestCase):
             cp.load_cli_output(path)
         self.assertIn("not valid JSON", str(ctx.exception))
 
+    def test_malformed_json_message_includes_diagnostic_breadcrumbs(self):
+        # The CI failure that motivated this — `_previews.json is not valid
+        # JSON (Expecting value at line 1 col 1)` — used to give us nothing
+        # to act on without re-running. Make sure the message now carries
+        # size / hex / repr so the user can root-cause from the log alone.
+        path = self.tmp / "bad.json"
+        # Leading ESC (0x1b) — not whitespace per .strip(), not valid JSON,
+        # exactly the "Expecting value at line 1 col 1" pattern.
+        path.write_bytes(b"\x1b]9;4;1;0\x1b\\{}\n")
+        with self.assertRaises(SystemExit) as ctx:
+            cp.load_cli_output(path)
+        msg = str(ctx.exception)
+        self.assertIn("not valid JSON", msg)
+        self.assertIn("File size:", msg)
+        self.assertIn("hex):", msg)
+        self.assertIn("repr):", msg)
+        self.assertIn("preview-cli-output", msg)
+
+    def test_utf8_bom_is_stripped_transparently(self):
+        # JVM PrintStream on some locales has been observed to emit a UTF-8
+        # BOM (0xef 0xbb 0xbf) before otherwise-valid JSON, which Python's
+        # json parser doesn't treat as whitespace. Recover transparently
+        # rather than failing the workflow on an entirely-correct payload.
+        path = self.tmp / "bom.json"
+        body = json.dumps({"schema": "compose-preview-show/v1", "previews": []})
+        path.write_bytes(b"\xef\xbb\xbf" + body.encode("utf-8"))
+        # Should not raise — empty previews list parses cleanly.
+        out = cp.load_cli_output(path)
+        self.assertEqual(out, {})
+
     def test_null_pngPath_and_sha_normalize_to_empty_string(self):
         # The downstream baselines/copy-changed logic uses truthiness on
         # these fields — null must become "" so `if not info["sha256"]`

--- a/.github/actions/preview-comment/action.yml
+++ b/.github/actions/preview-comment/action.yml
@@ -234,6 +234,24 @@ runs:
           --baseline-renders _resource_baselines/renders \
           --output-dir _pr_resource_renders
 
+    # Hand the user the actual `_previews.json` / `_resources.json` bytes when
+    # the JSON parse fails (or any later step in this composite trips). The
+    # diagnostic in `compare-previews.py` already prints a hex/repr head into
+    # the log, but the full file is what unblocks postmortem on a stdout-
+    # pollution bug — without this artifact, reproducing means re-running the
+    # whole render. Files are tiny (a few KB each) so always-upload on
+    # failure is fine.
+    - name: Upload CLI JSON output on failure
+      if: failure()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: preview-cli-output
+        path: |
+          _previews.json
+          _resources.json
+        if-no-files-found: ignore
+        retention-days: 14
+
     - name: Push PR renders
       shell: bash
       env:

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -637,6 +637,7 @@ class ShowCommand(args: List<String>) : Command(args) {
       if (!runGradle(gradle, *tasks)) {
         reportRenderFailures(gradle)
         System.err.println("Render failed")
+        System.out.flush()
         exitProcess(2)
       }
 

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ResourceCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ResourceCommands.kt
@@ -175,6 +175,12 @@ class ShowResourcesCommand(args: List<String>) : Command(args) {
       if (modules.isEmpty()) {
         if (jsonOutput) println(encodeResourceResponse(emptyList(), emptyList()))
         else println("No Android modules with the resource preview pipeline found.")
+        // Mirror ShowCommand: flush before exitProcess because System.exit
+        // doesn't drain PrintStream buffers, and the redirected stdout in
+        // `compose-preview show-resources --json > _resources.json` would
+        // otherwise see an empty file and trip the downstream JSON parser
+        // (issue #292).
+        System.out.flush()
         exitProcess(0)
       }
 
@@ -182,6 +188,7 @@ class ShowResourcesCommand(args: List<String>) : Command(args) {
       if (!runGradle(gradle, *tasks)) {
         reportRenderFailures(gradle)
         System.err.println("Resource render failed")
+        System.out.flush()
         exitProcess(2)
       }
 
@@ -192,6 +199,7 @@ class ShowResourcesCommand(args: List<String>) : Command(args) {
         // Resources are an opt-out feature — exit 0 (not 3) so consumers
         // running `show-resources` against a workspace that legitimately
         // has no XML drawables don't get a non-zero exit on every CI run.
+        System.out.flush()
         exitProcess(0)
       }
 
@@ -202,6 +210,7 @@ class ShowResourcesCommand(args: List<String>) : Command(args) {
       if (filtered.isEmpty()) {
         if (jsonOutput) println(encodeResourceResponse(emptyList(), allReferences, all))
         else println("No resource previews matched.")
+        System.out.flush()
         exitProcess(3)
       }
 
@@ -217,8 +226,10 @@ class ShowResourcesCommand(args: List<String>) : Command(args) {
           "Resource render completed but produced no PNG for ${missing.size} of " +
             "${filtered.size} resource preview(s)."
         )
+        System.out.flush()
         exitProcess(2)
       }
+      System.out.flush()
     }
   }
 


### PR DESCRIPTION
## Summary

Confetti hit `_previews.json is not valid JSON (Expecting value at line 1 col 1)` on https://github.com/joreilly/Confetti/actions/runs/25247722376, and the existing error gave us nothing to act on — "check the upstream step's log" against a step that printed only `Found preview modules: androidApp, wearApp` to stderr.

**This is a diagnostics + defensive-correctness PR, not a confirmed root-cause fix.** We don't yet know what wrote non-JSON to byte 0 of `_previews.json` on that run. Released CLI 0.8.12 stays as-is; 0.8.13 is on hold until we can reproduce or until the new diagnostics fire on a real failure.

Three changes, all strictly additive:

- **`compare-previews.py`** — strips a UTF-8 BOM transparently (with a stderr breadcrumb) and, on any remaining parse failure, dumps file size + hex of the first 32 bytes + repr of the head/tail into the SystemExit message. Enough to tell apart OSC escapes / Java stack traces / partial writes / encoding bugs from the log alone.
- **`preview-comment/action.yml`** — `if: failure()` upload of `_previews.json` and `_resources.json` as the `preview-cli-output` artifact, so the actual offending bytes survive the run when any step in the composite trips.
- **CLI flushes** — `ShowCommand` had `System.out.flush()` before every `exitProcess` for issue #292 but the render-fail path was missed, and `ShowResourcesCommand` had none of them. Same bug shape, fix in kind. (Probably not Confetti's failure mode — that path doesn't write JSON before exiting — but it's the right shape regardless.)

New unit tests cover the BOM-stripping recovery and the diagnostic breadcrumbs. `ktfmtCheckAll` clean.

## Test plan

- [x] `python3 -m unittest test_compare_previews` — all 59 tests pass (57 prior + 2 new).
- [x] `./gradlew ktfmtCheckAll` — clean.
- [x] Manual repro of the failure mode: feed `compare-previews.py copy-changed` a file beginning with an OSC escape; the new error message identifies the bytes decisively (`First 32 bytes (hex): 1b 5d 39 …`).
- [ ] Real-world: next time the corruption recurs, the artifact + diagnostic should give us the smoking gun. Hold 0.8.13 until then.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcGi2Ccvt7DsXgEDGGp8kL)_