### PR TITLE
feat(daemon,mcp): mp4 / webm recording via optional ffmpeg (P3)

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -632,6 +632,11 @@ class JsonRpcServer(
             // held-scene recording driver (DesktopHost). `false` keeps `recording/start` behind a
             // `MethodNotFound` reply so clients can grey out the toggle.
             recording = host.supportsRecording,
+            // RECORDING.md § "encoded formats" — list of wire format spellings the host can
+            // produce (`"apng"`, `"mp4"`, `"webm"`). APNG is always present when recording is
+            // enabled; MP4 / WEBM appear only when an `ffmpeg` binary was detected at host
+            // construction time. Sorted for stable wire ordering.
+            recordingFormats = host.supportedRecordingFormats.sorted(),
             // PROTOCOL.md § 3 — surface the daemon's `DeviceDimensions` catalog so clients can
             // build a `renderNow.overrides.device` picker without re-bundling the list. The
             // catalog itself lives in `:daemon:core/.../daemon/devices/DeviceDimensions.kt`;

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -163,6 +163,19 @@ interface RenderHost {
     get() = false
 
   /**
+   * Encoded video formats this host can produce — surfaced verbatim as
+   * `InitializeResult.capabilities.recordingFormats` (wire spellings from
+   * [ee.schimke.composeai.daemon.protocol.RecordingFormat]). Implementations that override
+   * [supportsRecording] to `true` MUST include `"apng"` (pure-JVM, always available); MP4 / WEBM
+   * appear only when the host has detected an `ffmpeg` binary at construction time.
+   *
+   * Default empty list keeps pre-feature hosts (FakeHost, RobolectricHost today) consistent with
+   * `supportsRecording = false` — clients see "no formats" and don't offer the toggle.
+   */
+  val supportedRecordingFormats: List<String>
+    get() = emptyList()
+
+  /**
    * Allocate a [RecordingSession] for [previewId] — the scripted screen-record surface. The session
    * holds a warm `ImageComposeScene` (or per-host equivalent) for the duration of the recording so
    * `remember`'d state and animation timing are continuous across the virtual timeline.

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -138,6 +138,15 @@ data class ServerCapabilities(
    */
   val recording: Boolean = false,
   /**
+   * Encoded video formats the daemon's host can produce — names match the wire spelling on
+   * [RecordingFormat]. APNG is always present when [recording] is true (pure-JVM encoder, no native
+   * deps). MP4 / WEBM appear only when an `ffmpeg` binary is available on the daemon process's
+   * `PATH`; clients that ask for an unadvertised format should expect a clean rejection from
+   * `record_preview` rather than a daemon-side runtime error. Empty list = pre-feature daemon
+   * (clients treat absent and `[]` identically and fall back to APNG).
+   */
+  val recordingFormats: List<String> = emptyList(),
+  /**
    * The `@Preview(device = ...)` ids the daemon's `DeviceDimensions` catalog recognises, paired
    * with their resolved geometry. Lets clients build a "render this preview at..." picker without
    * re-bundling the catalog. Empty list = pre-feature daemon (clients treat absent and `[]`
@@ -893,9 +902,18 @@ data class RecordingStopResult(
  * webm via `ffmpeg` shell-out land in v2 — the enum is open so new values don't bump
  * `protocolVersion` per PROTOCOL.md § 7.
  */
+/**
+ * v1 ships APNG (pure-JVM, no native deps); v2 adds [MP4] and [WEBM] via optional `ffmpeg`
+ * shell-out. Daemons advertise the formats they actually support via
+ * `ServerCapabilities.recordingFormats` so clients can grey out unavailable options without
+ * round-tripping a request that would only fail. The enum stays open per PROTOCOL.md § 7 — adding a
+ * new variant is additive and does not bump `protocolVersion`.
+ */
 @Serializable
 enum class RecordingFormat {
-  @SerialName("apng") APNG
+  @SerialName("apng") APNG,
+  @SerialName("mp4") MP4,
+  @SerialName("webm") WEBM,
 }
 
 @Serializable

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -133,6 +133,24 @@ open class DesktopHost(
     get() = previewSpecResolver != null
 
   /**
+   * RECORDING.md § "encoded formats" — `apng` is always available (pure-JVM [ApngEncoder]); `mp4`
+   * and `webm` are added when [FfmpegEncoder.available] succeeds at the host's first probe. Empty
+   * list when [supportsRecording] is `false` so clients consistently see "no formats" rather than
+   * the misleading "apng available" + "but recording itself disabled" combination.
+   */
+  override val supportedRecordingFormats: List<String>
+    get() =
+      if (!supportsRecording) emptyList()
+      else
+        buildList {
+          add("apng")
+          if (FfmpegEncoder.available()) {
+            add("mp4")
+            add("webm")
+          }
+        }
+
+  /**
    * PROTOCOL.md § 3 (`InitializeResult.capabilities.supportedOverrides`) — the desktop renderer
    * applies size / density / fontScale (via `Density(density, fontScale)` on the
    * `ImageComposeScene` constructor + `LocalDensity`), `uiMode` (via `LocalSystemTheme`), and

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -170,7 +170,30 @@ class DesktopRecordingSession(
           sizeBytes = target.length(),
         )
       }
+      RecordingFormat.MP4 ->
+        encodeViaFfmpeg(FfmpegEncoder.RecordingFormatChoice.MP4, "mp4", "video/mp4")
+      RecordingFormat.WEBM ->
+        encodeViaFfmpeg(FfmpegEncoder.RecordingFormatChoice.WEBM, "webm", "video/webm")
     }
+  }
+
+  private fun encodeViaFfmpeg(
+    choice: FfmpegEncoder.RecordingFormatChoice,
+    extension: String,
+    mimeType: String,
+  ): EncodedRecording {
+    val target = File(encodedDir, "$recordingId.$extension")
+    FfmpegEncoder.encodeFromPngFrames(
+      framesDir = framesDir,
+      fps = fps,
+      format = choice,
+      out = target,
+    )
+    return EncodedRecording(
+      videoPath = target.absolutePath,
+      mimeType = mimeType,
+      sizeBytes = target.length(),
+    )
   }
 
   override fun close() {

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/FfmpegEncoder.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/FfmpegEncoder.kt
@@ -1,0 +1,202 @@
+package ee.schimke.composeai.daemon
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Optional `ffmpeg`-backed encoder for [RecordingFormat.MP4] and [RecordingFormat.WEBM] — see
+ * RECORDING.md § "encoded formats".
+ *
+ * **Detection.** [available] runs `ffmpeg -version` once at JVM start (lazily, on first call) and
+ * caches the result for the daemon's lifetime. A subsequent uninstall during the daemon's life
+ * isn't observed; that's fine — daemons are short-lived per workspace and the path is set at spawn
+ * time. When detection fails, [DesktopHost.supportedRecordingFormats] omits `mp4` / `webm` from the
+ * advertised set so the MCP layer's `validateRecordingFormat` rejects requests with a clean
+ * diagnostic instead of a `record_preview` runtime error.
+ *
+ * **Encoder shape.** Both formats use the standard `ffmpeg -framerate <fps> -i frame-%05d.png ...`
+ * pipeline against the per-frame PNGs [DesktopRecordingSession] writes:
+ *
+ * - **MP4**: H.264 via libx264 + yuv420p pixel format (the universal-compatibility default — plays
+ *   in QuickTime, every browser, mobile players). `-pix_fmt yuv420p` is load-bearing for Android /
+ *   iOS players that reject yuv444 and friends.
+ * - **WEBM**: VP9 via libvpx-vp9. Smaller files for the same quality at the cost of slower encode;
+ *   reasonable trade-off for short recordings (typical agent clips are <10 s).
+ *
+ * **Why not pure-Java mp4.** JCodec / Humble exist but pull in megabytes of native bindings or
+ * pure-Java H.264 implementations that are 5–10× slower than libx264. Since this is an opt-in
+ * surface (APNG is the always-available default), shelling out to `ffmpeg` is the right pragmatic
+ * answer — most developer machines and CI agents already have it installed.
+ *
+ * **Threading / process lifetime.** `ffmpeg` is run as a `ProcessBuilder` subprocess with a bounded
+ * wait. A 60 s budget covers typical clips (a few hundred frames) with margin; longer recordings
+ * should still complete within minutes. The subprocess is `destroyForcibly()`'d on timeout to
+ * prevent zombies; tests rely on this to keep the JVM clean across encode failures.
+ */
+object FfmpegEncoder {
+
+  /**
+   * Encoder timeout in milliseconds. 60 s is generous enough for ~5 s of 30 fps content (libx264
+   * encodes ~100 fps on a modern laptop) and covers libvpx-vp9's slower path. Longer recordings
+   * should still complete; if not, surfacing the timeout to the caller as an exception is
+   * preferable to leaving a half-written file on disk.
+   */
+  const val ENCODE_TIMEOUT_MS: Long = 60_000L
+
+  @Volatile private var detected: Boolean? = null
+
+  /**
+   * Cached probe of `ffmpeg -version`. Returns `true` if `ffmpeg` is on `PATH` and exits 0; cache
+   * is computed once per JVM. Tests can flip the cache via [resetDetectionForTesting] when they
+   * need to exercise the "ffmpeg unavailable" path on a machine where it's installed.
+   */
+  fun available(): Boolean {
+    val cached = detected
+    if (cached != null) return cached
+    val result =
+      try {
+        val process = ProcessBuilder("ffmpeg", "-version").redirectErrorStream(true).start()
+        process.inputStream.use { it.readBytes() } // drain so the subprocess exits cleanly
+        if (!process.waitFor(5, TimeUnit.SECONDS)) {
+          process.destroyForcibly()
+          false
+        } else {
+          process.exitValue() == 0
+        }
+      } catch (_: Throwable) {
+        false
+      }
+    detected = result
+    return result
+  }
+
+  /** Test hook — clears the detection cache so the next [available] call re-probes. */
+  internal fun resetDetectionForTesting() {
+    detected = null
+  }
+
+  /**
+   * Encode the per-frame PNGs in [framesDir] (named `frame-NNNNN.png`, contiguous starting at 0) to
+   * [out] using [format] at [fps] frames per second. Throws on any non-zero exit, missing binary
+   * (when [available] reports false at call time), or timeout — callers map these to a tool-level
+   * error so the agent sees the real failure instead of an empty file on disk.
+   */
+  fun encodeFromPngFrames(framesDir: File, fps: Int, format: RecordingFormatChoice, out: File) {
+    require(fps in 1..120) { "FfmpegEncoder: fps=$fps out of range [1, 120]" }
+    require(framesDir.isDirectory) {
+      "FfmpegEncoder: framesDir does not exist or is not a directory: ${framesDir.absolutePath}"
+    }
+    if (!available()) {
+      error("FfmpegEncoder: ffmpeg not found on PATH; install ffmpeg or use RecordingFormat.APNG")
+    }
+
+    out.parentFile?.mkdirs()
+    if (out.exists()) out.delete()
+
+    val args = mutableListOf("ffmpeg", "-y", "-framerate", fps.toString())
+    args.add("-i")
+    args.add(File(framesDir, "frame-%05d.png").absolutePath)
+    when (format) {
+      RecordingFormatChoice.MP4 -> {
+        // H.264 + yuv420p for universal player compatibility (mobile + QuickTime require yuv420p
+        // even though libx264's default profile would otherwise pick yuv444). `-movflags
+        // +faststart` shifts the moov atom to the start of the file so streaming players can
+        // begin playback before downloading the trailer; cheap on small clips, useful when the
+        // file is served via HTTP from the daemon's history dir.
+        args.addAll(
+          listOf(
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-preset",
+            "veryfast",
+            "-movflags",
+            "+faststart",
+          )
+        )
+      }
+      RecordingFormatChoice.WEBM -> {
+        // VP9 with the row-multithread + tile-columns combo most modern guides recommend for
+        // sub-720p content. `-deadline good -cpu-used 4` is the speed/quality middle ground —
+        // matching libx264's `veryfast`. Default WebM container.
+        args.addAll(
+          listOf(
+            "-c:v",
+            "libvpx-vp9",
+            "-pix_fmt",
+            "yuv420p",
+            "-deadline",
+            "good",
+            "-cpu-used",
+            "4",
+            "-row-mt",
+            "1",
+          )
+        )
+      }
+    }
+    args.add(out.absolutePath)
+
+    val pb = ProcessBuilder(args).redirectErrorStream(true)
+    val proc = pb.start()
+    // Drain stdout/stderr in a background thread so the subprocess doesn't block on a full pipe
+    // buffer mid-encode. ffmpeg writes a fair amount of progress info to stderr (which we've
+    // merged into stdout via `redirectErrorStream`); not draining causes the encoder to stall on
+    // a small clip after a few hundred KB of output.
+    val log = StringBuilder()
+    val drainThread =
+      Thread {
+          try {
+            proc.inputStream.bufferedReader().useLines { lines ->
+              lines.forEach { line ->
+                synchronized(log) {
+                  log.appendLine(line)
+                  if (log.length > MAX_LOG_BYTES) {
+                    log.delete(0, log.length - MAX_LOG_BYTES)
+                  }
+                }
+              }
+            }
+          } catch (_: Throwable) {
+            // Process exited; drain done.
+          }
+        }
+        .apply {
+          isDaemon = true
+          start()
+        }
+
+    val finished = proc.waitFor(ENCODE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+    if (!finished) {
+      proc.destroyForcibly()
+      runCatching { drainThread.join(2_000) }
+      error(
+        "FfmpegEncoder: ffmpeg ${format.name.lowercase()} encode timed out after ${ENCODE_TIMEOUT_MS}ms"
+      )
+    }
+    runCatching { drainThread.join(2_000) }
+    val exit = proc.exitValue()
+    if (exit != 0) {
+      val tail = synchronized(log) { log.toString().takeLast(2_000) }
+      error("FfmpegEncoder: ffmpeg ${format.name.lowercase()} exited with $exit; tail: $tail")
+    }
+    if (!out.isFile || out.length() == 0L) {
+      error(
+        "FfmpegEncoder: ffmpeg ${format.name.lowercase()} produced no output at ${out.absolutePath}"
+      )
+    }
+  }
+
+  /**
+   * The subset of [ee.schimke.composeai.daemon.protocol.RecordingFormat] this encoder handles. Kept
+   * distinct so the encoder body never has to consider the APNG path (handled by [ApngEncoder]
+   * inline in [DesktopRecordingSession.encode]).
+   */
+  enum class RecordingFormatChoice {
+    MP4,
+    WEBM,
+  }
+
+  private const val MAX_LOG_BYTES: Int = 16 * 1024
+}

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
@@ -11,6 +11,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -259,6 +260,118 @@ class DesktopRecordingSessionTest {
     } finally {
       host.shutdown()
     }
+  }
+
+  @Test
+  fun mp4_format_round_trips_through_ffmpeg_encoder() {
+    // Same shape as the APNG happy path, but encodes via ffmpeg's mp4 path. Skipped on machines
+    // without ffmpeg on PATH so the test is portable; runs anywhere `FfmpegEncoder.available()` is
+    // true. We're testing the dispatch in `DesktopRecordingSession.encode` here (APNG → ApngEncoder
+    // vs MP4 → FfmpegEncoder), not the ffmpeg encoder itself — `FfmpegEncoderTest` covers the
+    // signature-bytes side of that.
+    assumeTrue("ffmpeg not on PATH; skipping mp4 round-trip", FfmpegEncoder.available())
+    val outputDir = tempFolder.newFolder("mp4-engine-renders")
+    val recordingsRoot = tempFolder.newFolder("mp4-recordings-root")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val engine = RenderEngine(outputDir = outputDir)
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == FIXTURE_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "TristateClickSquare",
+              widthPx = COMPONENT_WIDTH_PX,
+              heightPx = COMPONENT_HEIGHT_PX,
+              density = 1.0f,
+              outputBaseName = "tristate-click-square-mp4",
+            )
+          } else null
+        },
+      )
+    // Capability advertisement should include mp4 (and webm) when ffmpeg is available.
+    assertTrue(
+      "DesktopHost should advertise mp4 when ffmpeg is on PATH; got ${host.supportedRecordingFormats}",
+      "mp4" in host.supportedRecordingFormats,
+    )
+    host.start()
+    try {
+      val session =
+        host.acquireRecordingSession(
+          previewId = FIXTURE_PREVIEW_ID,
+          recordingId = "test-rec-mp4",
+          classLoader =
+            DesktopRecordingSessionTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+          fps = FPS,
+          scale = 1.0f,
+          overrides = null,
+        )
+      try {
+        session.postScript(
+          listOf(
+            RecordingScriptEvent(
+              tMs = 0L,
+              kind = InteractiveInputKind.CLICK,
+              pixelX = COMPONENT_WIDTH_PX / 2,
+              pixelY = COMPONENT_HEIGHT_PX / 2,
+            ),
+            RecordingScriptEvent(
+              tMs = 200L,
+              kind = InteractiveInputKind.CLICK,
+              pixelX = COMPONENT_WIDTH_PX / 2,
+              pixelY = COMPONENT_HEIGHT_PX / 2,
+            ),
+          )
+        )
+        val stop = session.stop()
+        assertTrue("frame count must be > 1 for a 200ms timeline at 30fps", stop.frameCount > 1)
+        val encoded = session.encode(RecordingFormat.MP4)
+        assertEquals("video/mp4", encoded.mimeType)
+        val out = File(encoded.videoPath)
+        assertTrue("mp4 file must exist on disk: ${out.absolutePath}", out.isFile)
+        assertTrue("mp4 file must be non-empty", encoded.sizeBytes > 0)
+        // Same `ftyp`-at-byte-4 sanity check `FfmpegEncoderTest` uses.
+        val head = out.readBytes().copyOf(12)
+        assertTrue(
+          "mp4 should carry 'ftyp' at bytes 4..7; got ${head.joinToString { "0x%02x".format(it) }}",
+          head[4] == 'f'.code.toByte() &&
+            head[5] == 't'.code.toByte() &&
+            head[6] == 'y'.code.toByte() &&
+            head[7] == 'p'.code.toByte(),
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun supported_recording_formats_includes_apng_when_resolver_wired() {
+    // No ffmpeg dependence — APNG is always advertised when the host has a previewSpecResolver.
+    val host =
+      DesktopHost(
+        engine = RenderEngine(outputDir = tempFolder.newFolder("ignored")),
+        previewSpecResolver = { _ -> null },
+      )
+    assertTrue("apng must be advertised", "apng" in host.supportedRecordingFormats)
+  }
+
+  @Test
+  fun supported_recording_formats_empty_when_resolver_unwired() {
+    // Without a previewSpecResolver, recording isn't supported — the formats list is empty so
+    // clients consistently see "no formats" rather than a misleading "apng available + recording
+    // off" combination.
+    val host = DesktopHost(engine = RenderEngine(outputDir = tempFolder.newFolder("ignored")))
+    assertTrue(
+      "supportedRecordingFormats must be empty without resolver; got ${host.supportedRecordingFormats}",
+      host.supportedRecordingFormats.isEmpty(),
+    )
   }
 
   private fun readPng(file: File): java.awt.image.BufferedImage {

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/FfmpegEncoderTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/FfmpegEncoderTest.kt
@@ -1,0 +1,130 @@
+package ee.schimke.composeai.daemon
+
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * Smoke test for [FfmpegEncoder] — gated on `ffmpeg` being available on the test environment's
+ * `PATH`. Tests synthesise a tiny PNG sequence (4 frames of solid colour, 32×32 px), shell out
+ * through [FfmpegEncoder.encodeFromPngFrames] for both [FfmpegEncoder.RecordingFormatChoice.MP4]
+ * and `WEBM`, and assert:
+ *
+ * 1. The encoder produces a non-empty file at the requested path.
+ * 2. The file's leading bytes match the format's container magic — mp4 carries `ftyp` at byte 4,
+ *    webm starts with the EBML `1A 45 DF A3` header. Cheap signature check; we deliberately don't
+ *    decode the streams (that would couple the test to mp4/webm parsers we don't ship).
+ *
+ * The `assumeTrue(FfmpegEncoder.available())` skips the test cleanly on machines without ffmpeg —
+ * no failure in CI environments that haven't installed it; full coverage on developer laptops and
+ * the bench. The companion `DesktopRecordingSessionTest.mp4_format_round_trips_through_encoder`
+ * does the same `assume` so the higher-level path stays portable.
+ */
+class FfmpegEncoderTest {
+
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun mp4_encode_produces_valid_container() {
+    assumeTrue("ffmpeg not on PATH; skipping mp4 smoke test", FfmpegEncoder.available())
+    val framesDir = tempFolder.newFolder("frames-mp4")
+    writeSolidColourFrames(framesDir, count = 4, side = 32)
+    val out = tempFolder.newFile("out.mp4")
+
+    FfmpegEncoder.encodeFromPngFrames(
+      framesDir = framesDir,
+      fps = 30,
+      format = FfmpegEncoder.RecordingFormatChoice.MP4,
+      out = out,
+    )
+
+    assertTrue("mp4 output must exist: ${out.absolutePath}", out.isFile)
+    assertTrue("mp4 output must be non-empty", out.length() > 0)
+    // `ftyp` box at bytes 4..7 — the standard mp4 container marker. We don't check the brand
+    // (`isom` / `mp42` / `avc1` etc.); ffmpeg's `libx264` defaults to `isom` and we don't pin
+    // that here.
+    val head = out.readBytes().copyOf(12)
+    assertTrue(
+      "mp4 should carry 'ftyp' at bytes 4..7; got ${head.joinToString { "0x%02x".format(it) }}",
+      head[4] == 'f'.code.toByte() &&
+        head[5] == 't'.code.toByte() &&
+        head[6] == 'y'.code.toByte() &&
+        head[7] == 'p'.code.toByte(),
+    )
+  }
+
+  @Test
+  fun webm_encode_produces_valid_ebml_header() {
+    assumeTrue("ffmpeg not on PATH; skipping webm smoke test", FfmpegEncoder.available())
+    val framesDir = tempFolder.newFolder("frames-webm")
+    writeSolidColourFrames(framesDir, count = 4, side = 32)
+    val out = tempFolder.newFile("out.webm")
+
+    FfmpegEncoder.encodeFromPngFrames(
+      framesDir = framesDir,
+      fps = 30,
+      format = FfmpegEncoder.RecordingFormatChoice.WEBM,
+      out = out,
+    )
+
+    assertTrue("webm output must exist: ${out.absolutePath}", out.isFile)
+    assertTrue("webm output must be non-empty", out.length() > 0)
+    // EBML magic — `1A 45 DF A3`. WebM and Matroska share this header.
+    val head = out.readBytes().copyOf(4)
+    val expected = byteArrayOf(0x1A, 0x45.toByte(), 0xDF.toByte(), 0xA3.toByte())
+    assertTrue(
+      "webm should start with EBML magic 1A 45 DF A3; got ${head.joinToString { "0x%02x".format(it) }}",
+      head.contentEquals(expected),
+    )
+  }
+
+  @Test
+  fun missing_frames_dir_throws() {
+    assumeTrue("ffmpeg not on PATH; skipping", FfmpegEncoder.available())
+    val nonExistent = File(tempFolder.root, "does-not-exist")
+    val out = tempFolder.newFile("out.mp4")
+    val thrown =
+      runCatching {
+          FfmpegEncoder.encodeFromPngFrames(
+            framesDir = nonExistent,
+            fps = 30,
+            format = FfmpegEncoder.RecordingFormatChoice.MP4,
+            out = out,
+          )
+        }
+        .exceptionOrNull()
+    assertTrue(
+      "expected IllegalArgumentException for missing framesDir; got ${thrown?.javaClass}",
+      thrown is IllegalArgumentException,
+    )
+  }
+
+  /**
+   * Write `count` PNG frames of solid colour into [framesDir], named `frame-NNNNN.png` matching the
+   * `frame-%05d.png` pattern [FfmpegEncoder] hands ffmpeg. Cycles through R/G/B/Y so adjacent
+   * frames differ — without that, libx264's CRF mode might encode the whole clip as a single
+   * keyframe and ffmpeg would emit a very small file that some checkers reject as suspicious.
+   */
+  private fun writeSolidColourFrames(framesDir: File, count: Int, side: Int) {
+    framesDir.mkdirs()
+    val palette = listOf(Color.RED, Color.GREEN, Color.BLUE, Color.YELLOW)
+    for (i in 0 until count) {
+      val img = BufferedImage(side, side, BufferedImage.TYPE_INT_ARGB)
+      val g = img.createGraphics()
+      try {
+        g.color = palette[i % palette.size]
+        g.fillRect(0, 0, side, side)
+      } finally {
+        g.dispose()
+      }
+      val out = File(framesDir, "frame-${"%05d".format(i)}.png")
+      ImageIO.write(img, "png", out)
+    }
+  }
+}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -874,7 +874,7 @@ class DaemonMcpServer(
                 "uri":{"type":"string","description":"compose-preview://<workspace>/<module>/<fqn>?config=<qualifier>"},
                 "fps":{"type":"integer","description":"Frames per second of the virtual clock. Default 30; range [1, 120]."},
                 "scale":{"type":"number","description":"Output-frame size multiplier. Default 1.0; range (0, 8]. Pointer coords stay in image-natural pixel space."},
-                "format":{"type":"string","enum":["apng"],"description":"Encoded video format. Default 'apng'. mp4/webm reserved for v3."},
+                "format":{"type":"string","enum":["apng","mp4","webm"],"description":"Encoded video format. Default 'apng' (always available, pure-JVM). 'mp4' and 'webm' require an ffmpeg binary on the daemon's PATH; check ServerCapabilities.recordingFormats first or expect a clean rejection if unavailable."},
                 "events":{
                   "type":"array",
                   "description":"Scripted timeline. Empty array records a single bootstrap frame.",
@@ -1830,16 +1830,18 @@ class DaemonMcpServer(
         }
     val fps = args["fps"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()
     val scale = args["scale"]?.jsonPrimitive?.contentOrNull?.toFloatOrNull()
+    val formatStr = args["format"]?.jsonPrimitive?.contentOrNull?.lowercase()
     val format =
-      args["format"]?.jsonPrimitive?.contentOrNull?.let {
-        when (it.lowercase()) {
-          "apng" -> RecordingFormat.APNG
-          else ->
-            return errorCallToolResult(
-              "record_preview: unsupported 'format' '$it' — only 'apng' is supported in v1"
-            )
-        }
-      } ?: RecordingFormat.APNG
+      when (formatStr) {
+        null,
+        "apng" -> RecordingFormat.APNG
+        "mp4" -> RecordingFormat.MP4
+        "webm" -> RecordingFormat.WEBM
+        else ->
+          return errorCallToolResult(
+            "record_preview: unsupported 'format' '$formatStr' — supported: apng, mp4, webm"
+          )
+      }
     val overrides =
       args["overrides"]?.let {
         runCatching { decodePreviewOverrides(it) }
@@ -1862,6 +1864,26 @@ class DaemonMcpServer(
       if (violations.isNotEmpty()) {
         return errorCallToolResult("record_preview: ${violations.joinToString("; ")}")
       }
+    }
+    // RECORDING.md § "encoded formats" — when the daemon advertises a non-empty `recordingFormats`
+    // capability, reject formats outside the advertised set up front so the agent sees a clean
+    // diagnostic instead of waiting on a `recording/encode` round-trip that would only fail.
+    // Pre-feature daemons advertise an empty set; fall open so the request goes through and the
+    // underlying error (whatever it is) surfaces naturally — same pattern `validateOverrides`
+    // uses.
+    val advertisedFormats = daemon.recordingFormats
+    val formatWire =
+      when (format) {
+        RecordingFormat.APNG -> "apng"
+        RecordingFormat.MP4 -> "mp4"
+        RecordingFormat.WEBM -> "webm"
+      }
+    if (advertisedFormats.isNotEmpty() && formatWire !in advertisedFormats) {
+      return errorCallToolResult(
+        "record_preview: format '$formatWire' not advertised by this daemon " +
+          "(supported: ${advertisedFormats.sorted()}). " +
+          "mp4/webm require an ffmpeg binary on the daemon's PATH."
+      )
     }
 
     val started =

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -215,6 +215,9 @@ class DaemonSupervisor(
       // they were before the capability landed.
       supervised.supportedOverrides = result.capabilities.supportedOverrides.toSet()
       supervised.knownDeviceIds = result.capabilities.knownDevices.map { it.id }.toSet()
+      // RECORDING.md § "encoded formats" — same pattern. Empty list pre-feature; validation falls
+      // open and `record_preview` calls round-trip without the diagnostic.
+      supervised.recordingFormats = result.capabilities.recordingFormats.toSet()
       // The daemon only emits `discoveryUpdated` for *deltas* — the initial preview set comes
       // via `initialize.manifest.path` (a `previews.json` written by the gradle plugin's
       // `discoverPreviews` task). Synthesise an initial `discoveryUpdated` notification by
@@ -325,6 +328,18 @@ class SupervisedDaemon(val workspaceId: WorkspaceId, val modulePath: String) {
    */
   @Volatile
   var knownDeviceIds: Set<String> = emptySet()
+    internal set
+
+  /**
+   * RECORDING.md § "encoded formats" — wire format spellings the daemon's host can produce
+   * (`"apng"`, `"mp4"`, `"webm"`). Populated by [DaemonSupervisor.spawn] right after the initialize
+   * round-trip. Read by `DaemonMcpServer.toolRecordPreview` to reject formats the daemon doesn't
+   * advertise before `record_preview` round-trips a request that would only fail. Empty set on
+   * pre-feature daemons — validation falls open (assume any format might work; caller sees the
+   * underlying error if it doesn't), matching the same pattern `supportedOverrides` uses.
+   */
+  @Volatile
+  var recordingFormats: Set<String> = emptySet()
     internal set
 
   /**

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -937,6 +937,99 @@ class DaemonMcpServerTest {
   }
 
   @Test
+  fun `record_preview rejects format the daemon does not advertise`() {
+    // Daemon advertises only APNG (no ffmpeg on its PATH); agent asks for mp4. MCP rejects up
+    // front with a clean diagnostic naming the supported formats — no `recording/start` round-
+    // trip, no time wasted spinning up a session that would only fail at encode time.
+    factory.daemonConfigurer = { d -> d.advertisedRecordingFormats = listOf("apng") }
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "record_preview",
+        buildJsonObject {
+          put("uri", uri)
+          put("format", "mp4")
+          putJsonArray("events") {}
+        },
+      )
+    assertThat(resp.isError()).isTrue()
+    val msg = resp.firstTextContent()
+    assertThat(msg).contains("format 'mp4' not advertised")
+    assertThat(msg).contains("[apng]")
+    assertThat(msg).contains("ffmpeg")
+    // No recording session was allocated — validation runs before any wire dispatch.
+    assertThat(daemon.recordingStarts).isEmpty()
+  }
+
+  @Test
+  fun `record_preview accepts mp4 when the daemon advertises it`() {
+    // Capability advertises mp4 (i.e. the daemon's host detected ffmpeg at startup). MCP validates
+    // and forwards the request; the fake daemon's `recording/encode` handler echoes the format
+    // back. Asserts the format reaches the daemon as `RecordingFormat.MP4` (not silently coerced
+    // to APNG).
+    val recordingsDir = tmp.newFolder("mp4-recordings-out")
+    factory.daemonConfigurer = { d ->
+      d.advertisedRecordingFormats = listOf("apng", "mp4", "webm")
+      d.recordingEncodeDir = recordingsDir
+      // Tiny canned payload — content doesn't matter for the wire-shape assertion.
+      d.recordingEncodedBytes =
+        byteArrayOf(
+          0x00,
+          0x00,
+          0x00,
+          0x18,
+          'f'.code.toByte(),
+          't'.code.toByte(),
+          'y'.code.toByte(),
+          'p'.code.toByte(),
+        )
+    }
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "record_preview",
+        buildJsonObject {
+          put("uri", uri)
+          put("format", "mp4")
+          putJsonArray("events") {
+            add(
+              buildJsonObject {
+                put("tMs", 0)
+                put("kind", "click")
+                put("pixelX", 10)
+                put("pixelY", 10)
+              }
+            )
+          }
+        },
+        timeoutMs = 10_000,
+      )
+    assertThat(resp.isError()).isFalse()
+    val encodeCall = daemon.recordingEncodes.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(encodeCall).isNotNull()
+    assertThat(encodeCall!!.format)
+      .isEqualTo(ee.schimke.composeai.daemon.protocol.RecordingFormat.MP4)
+  }
+
+  @Test
   fun `concurrent different-overrides render_preview calls are serialized per previewId`() {
     // Regression for the wrong-bytes hazard PR #432's "known limitation" note documented (and
     // mis-described as a hang). Pre-fix: two concurrent override-bearing render_preview calls

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
@@ -86,6 +86,13 @@ class FakeDaemon : DaemonSpawn {
   var advertisedKnownDevices: List<ee.schimke.composeai.daemon.protocol.KnownDevice> = emptyList()
 
   /**
+   * Recording formats the fake advertises in `initialize.capabilities.recordingFormats`. Tests
+   * assign before the spawn calls `initialize`. Empty list keeps pre-feature behaviour — the MCP
+   * `record_preview` format-validation falls open and the request goes through.
+   */
+  @Volatile var advertisedRecordingFormats: List<String> = emptyList()
+
+  /**
    * D1 — fake handler for `data/fetch`. When set, the lambda receives `(previewId, kind, params,
    * inline)` and returns either the [DataFetchOutcome] the daemon should respond with. Default
    * returns [DataFetchOutcome.Unknown] so unconfigured tests see the wire-error path.
@@ -349,6 +356,7 @@ class FakeDaemon : DaemonSpawn {
                 dataProducts = advertisedDataProducts,
                 knownDevices = advertisedKnownDevices,
                 supportedOverrides = advertisedSupportedOverrides,
+                recordingFormats = advertisedRecordingFormats,
               ),
             classpathFingerprint = "fake-fingerprint",
             manifest = Manifest(path = "", previewCount = 0),
@@ -536,15 +544,23 @@ class FakeDaemon : DaemonSpawn {
         val recordingId = params?.get("recordingId")?.jsonPrimitive?.contentOrNull ?: ""
         val format =
           when (params?.get("format")?.jsonPrimitive?.contentOrNull) {
+            "mp4" -> ee.schimke.composeai.daemon.protocol.RecordingFormat.MP4
+            "webm" -> ee.schimke.composeai.daemon.protocol.RecordingFormat.WEBM
             null,
             "apng" -> ee.schimke.composeai.daemon.protocol.RecordingFormat.APNG
             else -> ee.schimke.composeai.daemon.protocol.RecordingFormat.APNG
           }
         recordingEncodes.offer(RecordingEncodeCall(recordingId, format))
+        val (extension, mime) =
+          when (format) {
+            ee.schimke.composeai.daemon.protocol.RecordingFormat.APNG -> "apng" to "image/apng"
+            ee.schimke.composeai.daemon.protocol.RecordingFormat.MP4 -> "mp4" to "video/mp4"
+            ee.schimke.composeai.daemon.protocol.RecordingFormat.WEBM -> "webm" to "video/webm"
+          }
         // Materialise the canned bytes onto disk so DaemonMcpServer's `Files.readAllBytes` works.
         val dir = recordingEncodeDir ?: java.io.File(System.getProperty("java.io.tmpdir"))
         dir.mkdirs()
-        val out = java.io.File(dir, "$recordingId.apng")
+        val out = java.io.File(dir, "$recordingId.$extension")
         out.writeBytes(recordingEncodedBytes)
         sendResponse(
           id,
@@ -552,7 +568,7 @@ class FakeDaemon : DaemonSpawn {
             ee.schimke.composeai.daemon.protocol.RecordingEncodeResult.serializer(),
             ee.schimke.composeai.daemon.protocol.RecordingEncodeResult(
               videoPath = out.absolutePath,
-              mimeType = "image/apng",
+              mimeType = mime,
               sizeBytes = out.length(),
             ),
           ),


### PR DESCRIPTION
## Summary

Adds `RecordingFormat.MP4` and `WEBM` on top of the v1 APNG path that
landed in #478 / #484. Both go through a new `FfmpegEncoder` that shells
out to `ffmpeg` against the per-frame PNGs `DesktopRecordingSession`
already writes — H.264 + yuv420p for mp4 (universal player
compatibility), VP9 for webm. APNG stays the always-available default;
mp4/webm are opt-in and require an `ffmpeg` binary on the daemon's
PATH.

Capability-gated end-to-end so clients don't fail late:

- `ServerCapabilities.recordingFormats: List<String>` advertises what
  the host can actually produce.
- `RenderHost.supportedRecordingFormats` (default empty).
- `DesktopHost` returns `["apng"]` when a recording resolver is wired,
  plus `"mp4"` / `"webm"` when `FfmpegEncoder.available()` succeeds at
  the host's first probe.
- MCP `record_preview` validates `format` against the daemon's
  advertised set up front, rejecting unavailable formats with a clean
  diagnostic instead of round-tripping a request that would only fail
  at encode time.

### Wire shape

```jsonc
{
  "name": "record_preview",
  "arguments": {
    "uri": "compose-preview://...",
    "format": "mp4",          // or "webm" or "apng"
    "events": [...]
  }
}
```

When the daemon advertises `recordingFormats: ["apng"]` and the agent
asks for `mp4`:

```
record_preview: format 'mp4' not advertised by this daemon (supported: [apng]).
mp4/webm require an ffmpeg binary on the daemon's PATH.
```

### Encoder choices

- **MP4**: `libx264`, `pix_fmt yuv420p`, `preset veryfast`,
  `movflags +faststart`. yuv420p is load-bearing for Android/iOS players
  that reject yuv444; faststart shifts the moov atom to the start so
  HTTP-served files stream without buffering the trailer.
- **WEBM**: `libvpx-vp9`, `pix_fmt yuv420p`, `deadline good`,
  `cpu-used 4`, `row-mt 1`. Speed/quality middle ground matching
  libx264's `veryfast`.

Why not pure-Java mp4 (JCodec/Humble)? Megabytes of native bindings or
5–10× slower pure-Java H.264. Since this is opt-in (APNG is always
available), shelling out to `ffmpeg` is the pragmatic answer — most
developer machines and CI agents already have it installed.

### Test plan

- [x] `:daemon:core:compileKotlin` clean
- [x] `:daemon:desktop:compileKotlin` + `compileTestKotlin` clean
- [x] `:mcp:compileKotlin` + `compileTestKotlin` clean
- [x] `:daemon:desktop:test` passes (existing + new)
- [x] `:mcp:test` passes (existing + new)
- [x] `ktfmtCheck*` clean across all touched modules
- [x] `FfmpegEncoderTest` (gated via `Assume.assumeTrue(available())`):
  encodes 4 solid-colour frames to mp4 and webm, asserts container
  magic bytes (mp4 `ftyp` at byte 4, webm EBML `1A 45 DF A3`).
- [x] `DesktopRecordingSessionTest.mp4_format_round_trips_through_ffmpeg_encoder`:
  end-to-end held-scene → ffmpeg dispatch (skipped on machines without
  ffmpeg).
- [x] `DesktopRecordingSessionTest.supported_recording_formats_*`:
  resolver-wired host advertises `apng`; resolver-unwired host
  advertises an empty list.
- [x] `DaemonMcpServerTest.record_preview rejects format the daemon
  does not advertise`: validation runs before any wire dispatch.
- [x] `DaemonMcpServerTest.record_preview accepts mp4 when the daemon
  advertises it`: format reaches the daemon as `RecordingFormat.MP4`.

Tests gate on `Assume.assumeTrue(FfmpegEncoder.available())` so
machines without ffmpeg skip the encode-path tests cleanly rather than
failing.

### Out of scope (deferred to P4)

- Live (non-scripted) recording driven by `interactive/input` while a
  recording is active — separate state-machine work.
- Android (Robolectric) backend recording — gated on the v3 pointer-
  dispatch work documented in `INTERACTIVE-ANDROID.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_018GGtBuG7ZeRPpUP8AMz49E)_