### PR TITLE
fix(mcp): record_preview content-block shape + strict fps/scale

### DIFF
--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -1828,8 +1828,20 @@ class DaemonMcpServer(
         .getOrElse {
           return errorCallToolResult("record_preview: invalid events: ${it.message}")
         }
-    val fps = args["fps"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()
-    val scale = args["scale"]?.jsonPrimitive?.contentOrNull?.toFloatOrNull()
+    // Strict numeric validation — distinguish "absent" (use daemon default) from "malformed"
+    // (return a clean diagnostic). The previous lenient `toIntOrNull` / `toFloatOrNull` swallowed
+    // typos like `"fps": "fast"` into a silently-defaulted recording, which is hard to trust
+    // when a script's timing is wrong but no error surfaces.
+    val fps =
+      runCatching { decodeOptionalInt("fps", args["fps"]) }
+        .getOrElse {
+          return errorCallToolResult("record_preview: invalid fps: ${it.message}")
+        }
+    val scale =
+      runCatching { decodeOptionalFloat("scale", args["scale"]) }
+        .getOrElse {
+          return errorCallToolResult("record_preview: invalid scale: ${it.message}")
+        }
     val formatStr = args["format"]?.jsonPrimitive?.contentOrNull?.lowercase()
     val format =
       when (formatStr) {
@@ -1916,18 +1928,49 @@ class DaemonMcpServer(
           put("frameWidthPx", stopResult.frameWidthPx)
           put("frameHeightPx", stopResult.frameHeightPx)
         }
-        CallToolResult(
-          content =
-            listOf(
-              ContentBlock.Image(
-                data = Base64.getEncoder().encodeToString(videoBytes),
-                mimeType = encoded.mimeType,
-              ),
-              ContentBlock.Text(payload.toString()),
+        // Per the MCP 2025-06-18 spec, only `image/*` mimeTypes belong in `ContentBlock.Image`;
+        // strict clients reject mismatches. APNG (`image/apng`) round-trips as an image; mp4 /
+        // webm route through `EmbeddedResource` wrapping a `Blob` so a client that already
+        // understands `resources/read` reads them via the same code path.
+        val base64 = Base64.getEncoder().encodeToString(videoBytes)
+        val mediaBlock: ContentBlock =
+          if (encoded.mimeType.startsWith("image/")) {
+            ContentBlock.Image(data = base64, mimeType = encoded.mimeType)
+          } else {
+            ContentBlock.EmbeddedResource(
+              resource =
+                ResourceContents.Blob(
+                  uri = "compose-preview-recording://$recordingId",
+                  mimeType = encoded.mimeType,
+                  blob = base64,
+                )
             )
-        )
+          }
+        CallToolResult(content = listOf(mediaBlock, ContentBlock.Text(payload.toString())))
       }
       .getOrElse { errorCallToolResult("record_preview failed: ${it.message}") }
+  }
+
+  /**
+   * Decode an optional integer arg from [elem]. Returns `null` when [elem] is `null` or JSON null
+   * (caller falls back to the daemon's default); throws [IllegalStateException] when [elem] is
+   * present but not parseable as an integer (e.g. `"fps": "fast"`). The throw maps to a
+   * `record_preview: invalid <name>` tool-level error so an agent typo surfaces clearly instead of
+   * silently producing a default-paced recording.
+   */
+  private fun decodeOptionalInt(name: String, elem: JsonElement?): Int? {
+    if (elem == null || elem is kotlinx.serialization.json.JsonNull) return null
+    val raw =
+      elem.jsonPrimitive.contentOrNull ?: error("'$name' must be a number; got null primitive")
+    return raw.toIntOrNull() ?: error("'$name' must be an integer; got '$raw'")
+  }
+
+  /** As [decodeOptionalInt] but for a floating-point arg (`scale`). */
+  private fun decodeOptionalFloat(name: String, elem: JsonElement?): Float? {
+    if (elem == null || elem is kotlinx.serialization.json.JsonNull) return null
+    val raw =
+      elem.jsonPrimitive.contentOrNull ?: error("'$name' must be a number; got null primitive")
+    return raw.toFloatOrNull() ?: error("'$name' must be a number; got '$raw'")
   }
 
   /**

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/protocol/McpMessages.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/protocol/McpMessages.kt
@@ -114,6 +114,21 @@ sealed interface ContentBlock {
   @Serializable
   @SerialName("image")
   data class Image(val data: String, val mimeType: String) : ContentBlock
+
+  /**
+   * MCP 2025-06-18 spec — `EmbeddedResource` content block. Wraps a [ResourceContents] (text or
+   * blob) so a tool can return non-image binary payloads (audio, video, arbitrary `application`
+   * mime types) without misusing the `image` block — strict clients reject mismatched mimeTypes on
+   * `image`.
+   *
+   * Use this for `record_preview` mp4/webm responses (mimeType `video/mp4` / `video/webm`) and any
+   * other tool that needs to inline non-image bytes. The wrapped [ResourceContents.Blob] carries
+   * the same `{uri, mimeType, blob}` shape `resources/read` uses, so a client that already knows
+   * how to render resources reads the same code path.
+   */
+  @Serializable
+  @SerialName("resource")
+  data class EmbeddedResource(val resource: ResourceContents) : ContentBlock
 }
 
 // =====================================================================

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -1027,6 +1027,73 @@ class DaemonMcpServerTest {
     assertThat(encodeCall).isNotNull()
     assertThat(encodeCall!!.format)
       .isEqualTo(ee.schimke.composeai.daemon.protocol.RecordingFormat.MP4)
+
+    // Per the MCP 2025-06-18 spec, `video/mp4` belongs in an `EmbeddedResource` content block,
+    // not a `ContentBlock.Image` (strict clients reject mismatched mimeTypes on `image`). The
+    // sibling Text block still carries the metadata for callers that prefer the path.
+    val (blob, mime, blobUri) = resp.firstEmbeddedResourceBlob()
+    assertThat(mime).isEqualTo("video/mp4")
+    assertThat(blobUri).startsWith("compose-preview-recording://")
+    val decoded = Base64.getDecoder().decode(blob)
+    assertThat(decoded.size).isEqualTo(8) // matches the canned 8-byte payload above
+  }
+
+  @Test
+  fun `record_preview rejects malformed fps without spawning a session`() {
+    // Regression for Codex P2 — `args["fps"]?.toIntOrNull()` silently dropped typo'd values like
+    // "fast" into null and the daemon defaulted to 30 fps. We now distinguish absent (use default)
+    // from present-but-unparseable (error). Same shape for `scale`.
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "record_preview",
+        buildJsonObject {
+          put("uri", uri)
+          put("fps", "fast") // string, not parseable as integer
+          putJsonArray("events") {}
+        },
+      )
+    assertThat(resp.isError()).isTrue()
+    val msg = resp.firstTextContent()
+    assertThat(msg).contains("invalid fps")
+    assertThat(msg).contains("fast")
+    // No daemon-side recording session was allocated when validation failed.
+    assertThat(daemon.recordingStarts).isEmpty()
+  }
+
+  @Test
+  fun `record_preview rejects malformed scale without spawning a session`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "record_preview",
+        buildJsonObject {
+          put("uri", uri)
+          put("scale", "2x") // string suffix, not parseable as float
+          putJsonArray("events") {}
+        },
+      )
+    assertThat(resp.isError()).isTrue()
+    assertThat(resp.firstTextContent()).contains("invalid scale")
+    assertThat(daemon.recordingStarts).isEmpty()
   }
 
   @Test
@@ -2045,6 +2112,25 @@ class McpToolResult(val raw: JsonObject) {
   fun textContents(): List<String> {
     val content = raw["content"]?.jsonArray ?: return emptyList()
     return content.mapNotNull { it.jsonObject["text"]?.jsonPrimitive?.contentOrNull }
+  }
+
+  /**
+   * First `EmbeddedResource` content block (MCP `type: "resource"`); returns `(blobBase64,
+   * mimeType, uri)`. Used for non-image binary payloads (mp4 / webm) where `ContentBlock.Image`
+   * would be the wrong shape.
+   */
+  fun firstEmbeddedResourceBlob(): Triple<String, String, String> {
+    val content = raw["content"]?.jsonArray ?: error("tool result has no content array")
+    val block =
+      content.firstOrNull { it.jsonObject["type"]?.jsonPrimitive?.contentOrNull == "resource" }
+        ?: error("tool result has no resource content block (content=$content)")
+    val resource =
+      block.jsonObject["resource"]?.jsonObject
+        ?: error("embedded-resource block has no 'resource' object")
+    val blob = resource["blob"]?.jsonPrimitive?.content ?: error("resource has no 'blob'")
+    val mime = resource["mimeType"]?.jsonPrimitive?.content ?: error("resource has no 'mimeType'")
+    val uri = resource["uri"]?.jsonPrimitive?.content ?: error("resource has no 'uri'")
+    return Triple(blob, mime, uri)
   }
 
   fun isError(): Boolean = raw["isError"]?.jsonPrimitive?.contentOrNull == "true"


### PR DESCRIPTION
## Summary

Two follow-ups on the `record_preview` tool from #487, both flagged in
code review on the original PR:

### 1. Return mp4/webm via `EmbeddedResource`, not `Image` (codex P1)

The MCP 2025-06-18 spec says `ContentBlock.Image` is for `image/*`
mimeTypes only — strict clients reject mismatched mimeTypes, which made
the v3 mp4/webm responses effectively broken.

Fix: introduce `ContentBlock.EmbeddedResource` (MCP `type: "resource"`)
wrapping a `ResourceContents.Blob`. Dispatch in `toolRecordPreview`:

- `image/*` mimeTypes → `ContentBlock.Image` (APNG keeps working).
- everything else → `ContentBlock.EmbeddedResource` carrying
  `{uri: "compose-preview-recording://<recordingId>", mimeType, blob}`.

A client that already understands `resources/read` reads the same code
path; the sibling `Text` metadata block (recordingId, videoPath,
sizeBytes, frameCount, durationMs) still rides along.

### 2. Reject malformed fps/scale up front (codex P2)

Previous code parsed via `toIntOrNull` / `toFloatOrNull`, so typos like
`"fps": "fast"` or `"scale": "2x"` silently became `null` and the
daemon defaulted to 30 fps / 1.0 scale. Tool returned success, agent
got an unintended-paced recording.

Fix: distinguish "absent" (use daemon default) from "present but
unparseable" (return `record_preview: invalid fps: …`). New
`decodeOptionalInt` / `decodeOptionalFloat` helpers centralise the
pattern.

### Test plan

- [x] `:mcp:compileKotlin` + `compileTestKotlin` clean
- [x] `:mcp:test` passes (existing + new)
- [x] `:mcp:ktfmtCheckMain` / `:mcp:ktfmtCheckTest` clean
- [x] Strengthened `record_preview accepts mp4 when the daemon
      advertises it`: now asserts the response carries an
      `EmbeddedResource` block with `video/mp4` mimeType and a
      `compose-preview-recording://` uri, plus the canned 8-byte
      payload decodes correctly.
- [x] New `record_preview rejects malformed fps`: `"fps": "fast"`
      returns `invalid fps … 'fast'` and no daemon-side recording
      session is allocated.
- [x] New `record_preview rejects malformed scale`: same shape for
      `"scale": "2x"`.

### Notes

- Hit a self-inflicted bug while drafting the docstring for the new
  content-block variant: `application/*` in a KDoc block contains
  `*/` which closes the comment. Reworded to `application` mime types
  to dodge the parse-time hazard. Worth knowing for future docstrings
  that talk about MIME globs.


---
_Generated by [Claude Code](https://claude.ai/code/session_018GGtBuG7ZeRPpUP8AMz49E)_