### PR TITLE
Make preview daemon stable by default

### DIFF
--- a/docs/daemon/CONFIG.md
+++ b/docs/daemon/CONFIG.md
@@ -1,23 +1,22 @@
 # Preview daemon — configuration
 
-> **Status:** v1, experimental. Defaults are conservative; only the master switch defaults to "off."
+> **Status:** stable editor path. Defaults are conservative; the master switch defaults to "on."
 
 The preview daemon's behaviour is configured through a nested DSL block in the consumer module's `build.gradle.kts`:
 
 ```kotlin
 composePreview {
-  experimental {
-    daemon {
-      enabled = true
-      maxHeapMb = 1024
-      maxRendersPerSandbox = 1000
-      warmSpare = true
-    }
+  daemon {
+    enabled = true
+    maxHeapMb = 1024
+    maxRendersPerSandbox = 1000
+    warmSpare = true
   }
 }
 ```
 
-The block lives under `experimental` because the entire daemon path is opt-in for the v1 release cycle — see [DESIGN.md § 1](DESIGN.md#1-goals--non-goals) on the "may eat your laundry" framing. The `experimental` namespace makes the experimental status visible at every call site.
+The block used to live under `experimental`; new builds should use the top-level
+`composePreview.daemon { ... }` block.
 
 ## Fields
 
@@ -25,9 +24,9 @@ The block lives under `experimental` because the entire daemon path is opt-in fo
 
 | | |
 |-|-|
-| **Default** | `false` |
+| **Default** | `true` |
 | **Range** | `true` / `false` |
-| **Effect** | Master switch. When `false`, `composePreviewDaemonStart` still runs and writes a descriptor with `"enabled": false` so VS Code can sniff that the consumer ran the task — but the extension MUST refuse to spawn the daemon JVM. When `true`, the descriptor's `"enabled": true` flag is set and the VS Code extension may launch the daemon per its own `composePreview.experimental.daemon` setting. |
+| **Effect** | Master switch. When `false`, `composePreviewDaemonStart` still runs and writes a descriptor with `"enabled": false` so VS Code can warn and use the Gradle render path temporarily. When `true`, the descriptor's `"enabled": true` flag is set and the VS Code extension launches the daemon per its own `composePreview.daemon.enabled` setting. |
 
 The flag does NOT control task registration: the task is always registered so the file-presence check on the VS Code side has a stable signal.
 
@@ -88,7 +87,7 @@ holder.
 
 ## Gradle properties
 
-There is intentionally NO `-PcomposePreview.experimental.daemon.enabled=...` property override in v1. Gradle property reads at config time key the configuration cache, and the daemon flag is one consumers will flip frequently from VS Code — a property override would force a ~5–10s reconfigure on every toggle. Flip via build script and rely on Gradle's incremental task graph, or use VS Code's own setting (which gates the spawn without re-running `composePreviewDaemonStart`).
+There is intentionally NO `-PcomposePreview.daemon.enabled=...` property override. Gradle property reads at config time key the configuration cache, and the daemon flag is one consumers may flip from VS Code — a property override would force a ~5–10s reconfigure on every toggle. Flip via build script and rely on Gradle's incremental task graph, or use VS Code's own setting (which gates the spawn without re-running `composePreviewDaemonStart`).
 
 ## Schema
 

--- a/docs/daemon/DESIGN.md
+++ b/docs/daemon/DESIGN.md
@@ -1,6 +1,6 @@
 # Persistent preview server — design
 
-> **Status:** v1 implemented and ships behind `composePreview.experimental.daemon=true`. Render loop, classloader split, classpath fingerprint, incremental discovery, history, and the renderer-agnostic surface have landed across `:daemon:core` / `:daemon:android` / `:daemon:desktop`. Sandbox recycle, warm spare, and active leak detection (§ 9 + § 10 below) remain designed-but-not-implemented — wire-format surface is reserved in PROTOCOL.md but the daemon does not yet emit those notifications. The Gradle `renderPreviews` task remains the always-available fallback and the CI-canonical render path.
+> **Status:** v1 implemented and enabled by default for editor integrations through `composePreview.daemon`. Render loop, classloader split, classpath fingerprint, incremental discovery, history, and the renderer-agnostic surface have landed across `:daemon:core` / `:daemon:android` / `:daemon:desktop`. Sandbox recycle, warm spare, and active leak detection (§ 9 + § 10 below) remain designed-but-not-implemented — wire-format surface is reserved in PROTOCOL.md but the daemon does not yet emit those notifications. The Gradle `renderPreviews` task remains the CI-canonical render path.
 
 ## 1. Goals & non-goals
 
@@ -133,7 +133,7 @@ daemon/desktop/             NEW — depends on renderer-desktop + core
 gradle-plugin/                       ADDITIVE ONLY (one helper extraction)
   src/main/kotlin/.../plugin/daemon/
     DaemonBootstrapTask.kt           Emits launch-descriptor JSON
-    DaemonExtension.kt               composePreview.experimental.daemon { … }
+    DaemonExtension.kt               composePreview.daemon { … }
     DaemonClasspathDescriptor.kt     Serialises the JVM launch spec
                                      (target-aware: picks android-daemon vs
                                      desktop-daemon classpath based on the
@@ -418,7 +418,7 @@ const renderer = daemonGate.isEnabled(config)
 await renderer.renderPreviews(module, tier);
 ```
 
-`daemonGate` checks `composePreview.experimental.daemon` and verifies daemon health. On daemon failure, falls back to `gradleService` automatically and surfaces a notification. Existing `gradleService.ts`, file watcher, and debouncer in `extension.ts` are untouched — the daemon client receives the same calls, plus visibility/focus signals from the webview.
+`daemonGate` checks `composePreview.daemon.enabled` and launches the daemon. On daemon failure while enabled, the extension surfaces an error instead of silently falling back to Gradle. Users can explicitly disable the daemon setting as a temporary Gradle escape hatch.
 
 ## 13. Latency budget
 

--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -1,8 +1,8 @@
 # Interactive mode (VS Code panel ↔ daemon)
 
 > **Status:** v1 — live-streaming surface plus `interactive/start` /
-> `interactive/stop` / `interactive/input` RPCs in the daemon, behind the
-> `composePreview.experimental.daemon.enabled` flag. Click coordinates are
+> `interactive/stop` / `interactive/input` RPCs in the daemon. The daemon is
+> enabled by default through `composePreview.daemon.enabled`. Click coordinates are
 > forwarded to the daemon as `interactive/input` notifications; today the
 > daemon treats each input as a render trigger (LocalInspectionMode is still
 > true, so the renderer doesn't yet dispatch the click into the composition —

--- a/docs/daemon/LAYERING.md
+++ b/docs/daemon/LAYERING.md
@@ -61,11 +61,10 @@ is forbidden.
 The Gradle `renderPreviews` task and CLI binary that exist today are
 the contract for "the simple way". Constraints:
 
-- **No new required configuration** in `composePreview { … }` to
-  reach the existing behaviour. The DSL block keeps working with the
-  fields it had before the daemon work started; new fields live in
-  the `experimental.daemon { … }` sub-block and default to the no-op
-  setting (`enabled = false`).
+- **No daemon requirement for CI.** `renderPreviews` remains the
+  existing behaviour and does not require a running daemon. Editor
+  integrations use the top-level `daemon { … }` DSL, which defaults to
+  enabled and can be disabled temporarily.
 - **No daemon code on the Layer 1 classpath.** `:gradle-plugin` does
   not depend on `:daemon:core`. The daemon-bootstrap task
   the plugin registers (`composePreviewDaemonStart`) emits a
@@ -79,14 +78,14 @@ the contract for "the simple way". Constraints:
   `renderPreviews` remains the canonical render path for golden-image
   baselines, regression tests, and release builds.
 
-What Layer 1 *may* gain (additively, behind opt-in):
+What Layer 1 gained for editor integrations:
 
-- A `composePreview.experimental.daemon { enabled = true ; … }` DSL
-  block that, when set, registers `composePreviewDaemonStart`. When
-  unset, that task is not registered and the descriptor file is not
-  written.
+- A `composePreview.daemon { enabled = true ; … }` DSL block that
+  emits the `composePreviewDaemonStart` launch descriptor. When
+  disabled, the descriptor is still written with `"enabled": false`
+  so editor clients can warn and use the Gradle path temporarily.
 - A new task `composePreviewDaemonStop` symmetric to `…Start`.
-  Optional; only makes sense when the user opts in.
+  Optional; only makes sense for editor-supervised daemon sessions.
 
 What Layer 1 must **not** gain:
 
@@ -182,7 +181,7 @@ not on this list is a layering violation.
 
 | Seam | Direction | Mechanism | Owner |
 |------|-----------|-----------|-------|
-| `composePreview.experimental.daemon { enabled }` DSL | user → L1 | Gradle DSL property | L1 |
+| `composePreview.daemon { enabled }` DSL | user → L1 | Gradle DSL property | L1 |
 | `composePreviewDaemonStart` task → launch descriptor JSON | L1 → L2 | file in `build/preview-daemon/launch.json` | L1 emits, L2 reads |
 | Daemon JSON-RPC over stdio | L2 ↔ extension/supervisor | `PROTOCOL.md` | L2 |
 | MCP wire format ↔ daemon JSON-RPC translation | L3 ↔ L2 | `:mcp` shim | L3 |
@@ -207,7 +206,7 @@ Each layer can be removed without breaking the layers below it.
 - Delete `:daemon:core`, `:daemon:android`,
   `:daemon:desktop`, `:daemon:harness`,
   `:mcp`.
-- Remove the `experimental.daemon` DSL block and the
+- Remove the `daemon` DSL block and the
   `composePreviewDaemonStart` task registration from `:gradle-plugin`.
 - The base `composePreview { … }` DSL and `renderPreviews` task work
   unchanged. CI still passes.
@@ -262,5 +261,5 @@ Concrete rules to keep the existing paths simple:
   Option A's recommendation as the layering-correct choice.
 - [MCP-KOTLIN.md](MCP-KOTLIN.md) — Layer 3 Kotlin/Ktor implementation.
 - [PROTOCOL.md](PROTOCOL.md) — the L2 ↔ L3 wire contract.
-- [CONFIG.md](CONFIG.md) — `experimental.daemon { … }` DSL reference,
+- [CONFIG.md](CONFIG.md) — `composePreview.daemon { … }` DSL reference,
   the user-visible Layer 1 ↔ Layer 2 seam.

--- a/docs/daemon/README.md
+++ b/docs/daemon/README.md
@@ -10,7 +10,7 @@ A persistent preview server that replaces the per-save Gradle invocation with a 
 - **`:daemon:harness`** — end-to-end harness driving real daemons over JSON-RPC; ten scenarios (S1–S10) covering lifecycle, drain, render-after-edit, visibility, failures, latency-record, classpath-dirty, history.
 - **`:mcp`** — top-level MCP server multiplexing per-(workspace, module) daemons behind one MCP surface; tools for project registration, watches, render, history; resource subscriptions for push.
 
-The daemon ships behind `composePreview.experimental.daemon { enabled = true }`. The Gradle `renderPreviews` task remains the always-available fallback and the CI-canonical render path.
+The daemon is configured with `composePreview.daemon { ... }` and defaults on for editor use. The Gradle `renderPreviews` task remains the CI-canonical render path.
 
 ## What's open
 
@@ -28,7 +28,7 @@ The daemon ships behind `composePreview.experimental.daemon { enabled = true }`.
 - **[DESIGN.md](DESIGN.md)** — daemon architecture: scope, module layout, staleness cascade, lifecycle, leak defense, validation strategy, decisions log.
 - **[LAYERING.md](LAYERING.md)** — the rule that keeps Gradle/CLI, daemon, and MCP additive. Module-boundary list, integration seams, removal procedures.
 - **[PROTOCOL.md](PROTOCOL.md)** — locked v1 wire format between client (VS Code, harness, MCP shim) and daemon.
-- **[CONFIG.md](CONFIG.md)** — `composePreview.experimental.daemon { … }` DSL reference.
+- **[CONFIG.md](CONFIG.md)** — `composePreview.daemon { … }` DSL reference.
 
 ### Subsystems
 

--- a/docs/daemon/TODO.md
+++ b/docs/daemon/TODO.md
@@ -89,7 +89,7 @@ New `DaemonBootstrapTask` that, given a variant, emits `build/compose-previews/d
 
 #### A1.2 — `DaemonExtension` DSL ✅
 
-Add `composePreview.experimental.daemon { … }` extension with `enabled`, `maxHeapMb`, `maxRendersPerSandbox`, `warmSpare` fields. No-op when disabled. Documented in `docs/daemon/CONFIG.md` (new).
+Add `composePreview.daemon { … }` extension with `enabled`, `maxHeapMb`, `maxRendersPerSandbox`, `warmSpare` fields. No-op when disabled. Documented in `docs/daemon/CONFIG.md` (new).
 
 - **Depends on:** A1.1
 - **DoD:** unit test on the extension's defaults (`DaemonExtensionTest`). README of daemon docs links to [CONFIG.md](CONFIG.md).
@@ -258,7 +258,7 @@ Stdio JSON-RPC over the spawned process. Methods mirror those used by `gradleSer
 
 #### C1.4 — `daemonGate.ts` router shim
 
-Read `composePreview.experimental.daemon` setting. If enabled and daemon healthy → use `daemonClient`; else fall back to `gradleService`. One call site in `extension.ts`. On daemon failure, log + notification + auto-fallback for the remainder of the session.
+Read `composePreview.daemon` setting. If enabled and daemon healthy → use `daemonClient`; explicit disable falls back to `gradleService`. One call site in `extension.ts`. On daemon failure while enabled, log + notification + no silent Gradle fallback.
 
 - **Depends on:** C1.3
 - **DoD:** manual smoke test in VS Code: enable flag, observe daemon spawn on first preview action, render works. Disable flag, observe normal Gradle path.
@@ -635,7 +635,7 @@ Adds dwell-hover, file-explorer-click, recently-focused-history reasons. Persist
 All CI gates from `DESIGN.md` § 15 green. Bench numbers meet the < 1s focused-preview target. Soak stable for one week of nightly runs.
 
 - **Depends on:** D2.2, D2.3
-- **DoD:** PR opened to flip the default of `composePreview.experimental.daemon` from `false` → still `false` but with "stable preview" label; or hold at experimental for another release cycle.
+- **DoD:** PR opened to flip the default of `composePreview.daemon` to `true` and remove the experimental gate from the primary DSL.
 
 ---
 
@@ -705,8 +705,8 @@ Tracking the daemon-side history phases from [HISTORY.md § "Phasing"](HISTORY.m
 - **H11+ — `GitRefHistorySource` WRITE modes, git-LFS, squash GC** — still open
 - H6+ (MCP / VS Code / cross-worktree merging) — see HISTORY.md table.
 
-H1+H2 + H3 + H10-read ship behind the existing `composePreview.experimental.daemon { enabled =
-true }` gate. The gradle plugin's daemon launch descriptor will gain `composeai.daemon.historyDir`
+H1+H2 + H3 + H10-read ship behind the existing `composePreview.daemon { enabled = true }` gate.
+The gradle plugin's daemon launch descriptor will gain `composeai.daemon.historyDir`
 + `composeai.daemon.gitRefHistory` emission in a follow-up (H10b); until then, agents and ad-hoc
 launches set the sysprops directly.
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1184,7 +1184,7 @@ internal object AndroidPreviewSupport {
 
     // Phase 1, Stream A — preview daemon bootstrap descriptor. Registered
     // unconditionally so the VS Code extension can sniff the output file
-    // even when `experimental.daemon.enabled = false` (it then refuses to
+    // even when `daemon.enabled = false` (it then refuses to
     // launch — see [DaemonClasspathDescriptor] KDoc). Inputs mirror the
     // renderPreviews task's so the spawned daemon JVM is byte-for-byte
     // equivalent. See `docs/daemon/DESIGN.md` § 4 / § 6.
@@ -1231,10 +1231,10 @@ internal object AndroidPreviewSupport {
 
       this.modulePath.set(project.path)
       this.variant.set(variantName)
-      this.daemonEnabled.set(extension.experimental.daemon.enabled)
-      this.maxHeapMb.set(extension.experimental.daemon.maxHeapMb)
-      this.maxRendersPerSandbox.set(extension.experimental.daemon.maxRendersPerSandbox)
-      this.warmSpare.set(extension.experimental.daemon.warmSpare)
+      this.daemonEnabled.set(extension.daemon.enabled)
+      this.maxHeapMb.set(extension.daemon.maxHeapMb)
+      this.maxRendersPerSandbox.set(extension.daemon.maxRendersPerSandbox)
+      this.warmSpare.set(extension.daemon.warmSpare)
       // Conventional entry-point name — `daemon/android` / Stream B
       // (task B1.1) will provide the implementation. Surfacing it as a
       // Property leaves room for future variants (foreground / debug) without
@@ -1278,7 +1278,7 @@ internal object AndroidPreviewSupport {
       // (e.g. `-ea` and JUnit-internal opens) and may collide with the
       // daemon's own runner. Stream B can opt back in if needed.
       this.jvmArgs.addAll(AndroidPreviewClasspath.buildJvmArgs())
-      this.jvmArgs.add(extension.experimental.daemon.maxHeapMb.map { "-Xmx${it}m" })
+      this.jvmArgs.add(extension.daemon.maxHeapMb.map { "-Xmx${it}m" })
       // Same path-bearing system properties the renderPreviews Test task uses, plus
       // daemon-specific keys for [DaemonExtension] config the daemon reads at startup.
       //
@@ -1302,15 +1302,15 @@ internal object AndroidPreviewSupport {
       this.systemProperties.put("composeai.daemon.idleTimeoutMs", "5000")
       this.systemProperties.put(
         "composeai.daemon.maxHeapMb",
-        extension.experimental.daemon.maxHeapMb.map { it.toString() },
+        extension.daemon.maxHeapMb.map { it.toString() },
       )
       this.systemProperties.put(
         "composeai.daemon.maxRendersPerSandbox",
-        extension.experimental.daemon.maxRendersPerSandbox.map { it.toString() },
+        extension.daemon.maxRendersPerSandbox.map { it.toString() },
       )
       this.systemProperties.put(
         "composeai.daemon.warmSpare",
-        extension.experimental.daemon.warmSpare.map { it.toString() },
+        extension.daemon.warmSpare.map { it.toString() },
       )
       // D2 — opt-out for the a11y data products (see `DaemonExtension.attachA11y`). When
       // `false`, `DaemonMain` constructs `DataProductRegistry.Empty` and the renderer skips
@@ -1319,7 +1319,7 @@ internal object AndroidPreviewSupport {
       // consumer side.
       this.systemProperties.put(
         "composeai.daemon.attachA11y",
-        extension.experimental.daemon.attachA11y.map { it.toString() },
+        extension.daemon.attachA11y.map { it.toString() },
       )
       this.systemProperties.put("composeai.daemon.modulePath", project.path)
       // B2.0 — `composeai.daemon.userClassDirs`. The closure captures only the

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -234,10 +234,10 @@ internal object ComposePreviewTasks {
       // `variant` field for debug/log purposes only — VS Code's `daemonProcess.ts` doesn't key
       // off it.
       variant.set("desktop")
-      daemonEnabled.set(extension.experimental.daemon.enabled)
-      maxHeapMb.set(extension.experimental.daemon.maxHeapMb)
-      maxRendersPerSandbox.set(extension.experimental.daemon.maxRendersPerSandbox)
-      warmSpare.set(extension.experimental.daemon.warmSpare)
+      daemonEnabled.set(extension.daemon.enabled)
+      maxHeapMb.set(extension.daemon.maxHeapMb)
+      maxRendersPerSandbox.set(extension.daemon.maxRendersPerSandbox)
+      warmSpare.set(extension.daemon.warmSpare)
       // `:daemon:desktop`'s `DaemonMain` and `:daemon:android`'s `DaemonMain` share the FQN
       // intentionally (see the kdoc on `daemon/desktop/.../DaemonMain.kt`). The desktop classes
       // jar is FIRST on the classpath below, so this loads the Compose-Multiplatform path.
@@ -256,7 +256,7 @@ internal object ComposePreviewTasks {
       // Desktop daemons don't run inside Robolectric, so the AGP-side `--add-opens` flags don't
       // apply here. `-Xmx` is the only essential JVM arg; B-desktop follow-ups can add Skia /
       // ImageComposeScene-specific opens if profiling shows a need.
-      jvmArgs.add(extension.experimental.daemon.maxHeapMb.map { "-Xmx${it}m" })
+      jvmArgs.add(extension.daemon.maxHeapMb.map { "-Xmx${it}m" })
 
       // Desktop sysprops are a strict subset of the Android side — no Robolectric / Roborazzi
       // keys. Per-key `put(...)` so each Provider chain captures only serialisable references
@@ -265,15 +265,15 @@ internal object ComposePreviewTasks {
       systemProperties.put("composeai.daemon.idleTimeoutMs", "5000")
       systemProperties.put(
         "composeai.daemon.maxHeapMb",
-        extension.experimental.daemon.maxHeapMb.map { it.toString() },
+        extension.daemon.maxHeapMb.map { it.toString() },
       )
       systemProperties.put(
         "composeai.daemon.maxRendersPerSandbox",
-        extension.experimental.daemon.maxRendersPerSandbox.map { it.toString() },
+        extension.daemon.maxRendersPerSandbox.map { it.toString() },
       )
       systemProperties.put(
         "composeai.daemon.warmSpare",
-        extension.experimental.daemon.warmSpare.map { it.toString() },
+        extension.daemon.warmSpare.map { it.toString() },
       )
       systemProperties.put("composeai.daemon.modulePath", project.path)
       systemProperties.put("composeai.fonts.cacheDir", daemonFontsCacheDir)

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewExtension.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.plugin
 
+import ee.schimke.composeai.plugin.daemon.DaemonExtension
 import ee.schimke.composeai.plugin.daemon.ExperimentalExtension
 import javax.inject.Inject
 import org.gradle.api.Action
@@ -112,11 +113,16 @@ abstract class PreviewExtension @Inject constructor(private val objects: ObjectF
     action.execute(resourcePreviews)
   }
 
+  /** Persistent preview daemon configuration. Enabled by default for the VS Code extension. */
+  val daemon: DaemonExtension = objects.newInstance(DaemonExtension::class.java)
+
+  fun daemon(action: Action<DaemonExtension>) {
+    action.execute(daemon)
+  }
+
   /**
-   * Namespace for in-progress / experimental features whose DSL shape may change. Today: just the
-   * preview-daemon block (`experimental.daemon { … }` — see `docs/daemon/CONFIG.md`). Kept as a
-   * nested block so consumers see "this is experimental" both in the build script and in IDE
-   * autocomplete.
+   * Namespace for in-progress / experimental features whose DSL shape may change. Kept for backward
+   * source compatibility; new daemon configuration belongs in [daemon].
    */
   val experimental: ExperimentalExtension = objects.newInstance(ExperimentalExtension::class.java)
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtension.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtension.kt
@@ -5,9 +5,8 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 
 /**
- * `composePreview.experimental.daemon { … }` block. See `docs/daemon/CONFIG.md` for field
- * semantics, defaults, and ranges, and `docs/daemon/DESIGN.md` § 9 for the lifecycle policy these
- * knobs feed into.
+ * `composePreview.daemon { … }` block. See `docs/daemon/CONFIG.md` for field semantics, defaults,
+ * and ranges, and `docs/daemon/DESIGN.md` § 9 for the lifecycle policy these knobs feed into.
  *
  * This block is read by [DaemonBootstrapTask] (Phase 1, Stream A) at config time and baked into
  * `daemon-launch.json`. The daemon JVM reads the same values back at startup; a value change
@@ -15,26 +14,25 @@ import org.gradle.api.provider.Property
  * `classpathDirty`-style restart, since heap size and recycle thresholds can't be changed
  * in-flight).
  *
- * Defaults are [DESIGN.md § 9]; intentionally conservative for v1 — the daemon is opt-in behind
- * [enabled] anyway.
+ * Defaults are [DESIGN.md § 9]. The daemon is on by default for editor integrations; consumers may
+ * disable it temporarily with [enabled].
  */
 abstract class DaemonExtension @Inject constructor(objects: ObjectFactory) {
   /**
-   * Master switch. Default: `false`.
+   * Master switch. Default: `true`.
    *
    * When `false`, `composePreviewDaemonStart` still runs and writes a descriptor with `enabled:
    * false` so the VS Code extension can sniff the file and learn the user explicitly opted out —
    * but the extension must NOT spawn the daemon JVM in that case.
    *
    * When `true`, the descriptor's `enabled: true` flag is set and the VS Code extension may launch
-   * the daemon per its `composePreview.experimental.daemon` setting.
+   * the daemon per its `composePreview.daemon.enabled` setting.
    *
-   * Flip via build script (`composePreview { experimental { daemon { enabled = true } } }`), or
-   * transiently via `-PcomposePreview.experimental.daemon.enabled=true`. The Gradle property
+   * Flip via build script (`composePreview { daemon { enabled = false } }`). The Gradle property
    * override is intentionally NOT wired here — it would key the config cache on a property that VS
    * Code flips frequently. See `CONFIG.md`.
    */
-  val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+  val enabled: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 
   /**
    * Maximum heap (post-GC) the daemon JVM may use, in MiB. Default: `1024`.
@@ -87,10 +85,9 @@ abstract class DaemonExtension @Inject constructor(objects: ObjectFactory) {
    * who don't care about a11y in the daemon path. Diagnostic squigglies still flow via the Gradle
    * sidecar reader as today — toggling this off only affects the daemon's data-product surface.
    *
-   * Flip via build script (`composePreview { experimental { daemon { attachA11y = false } } }`) to
-   * opt out at the producer side. Pairs with the VS Code-side `composePreview.a11y.alwaysSubscribe`
-   * setting (which controls whether the *consumer* side subscribes ambient or only on the
-   * focus-mode toggle).
+   * Flip via build script (`composePreview { daemon { attachA11y = false } }`) to opt out at the
+   * producer side. Pairs with the VS Code-side `composePreview.a11y.alwaysSubscribe` setting (which
+   * controls whether the *consumer* side subscribes ambient or only on the focus-mode toggle).
    */
   val attachA11y: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/ExperimentalExtension.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/ExperimentalExtension.kt
@@ -5,15 +5,11 @@ import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
 
 /**
- * `composePreview.experimental { … }` namespace. Holds in-progress / unstable features whose DSL
- * shape is not yet covered by the plugin's compatibility promise. Today: just [daemon] (Phase 1,
- * Stream A — `docs/daemon/`).
+ * `composePreview.experimental { … }` namespace. Kept for backward source compatibility while
+ * features graduate to stable top-level DSL blocks.
  *
- * Kept as its own type (rather than dumping `daemon` directly under
- * [ee.schimke.composeai.plugin.PreviewExtension]) so that consumers writing
- * `composePreview.experimental.daemon { … }` get a clear "this is experimental" signal both in the
- * build script and in IDE autocomplete. Future experimental features land here without polluting
- * the top-level namespace.
+ * The daemon configuration has moved to `composePreview.daemon { … }`; this legacy block is no
+ * longer read by the plugin.
  */
 abstract class ExperimentalExtension @Inject constructor(objects: ObjectFactory) {
   val daemon: DaemonExtension = objects.newInstance(DaemonExtension::class.java)

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtensionTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtensionTest.kt
@@ -1,11 +1,12 @@
 package ee.schimke.composeai.plugin.daemon
 
 import com.google.common.truth.Truth.assertThat
+import ee.schimke.composeai.plugin.PreviewExtension
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Test
 
 /**
- * Defaults guard for the `composePreview.experimental.daemon { … }` block. Locks in the v1 contract
+ * Defaults guard for the `composePreview.daemon { … }` block. Locks in the stable daemon contract
  * from `docs/daemon/CONFIG.md` — any change to a default needs a corresponding doc update and a
  * deliberate test edit.
  */
@@ -16,9 +17,9 @@ class DaemonExtensionTest {
     val project = ProjectBuilder.builder().build()
     val daemon = project.objects.newInstance(DaemonExtension::class.java)
 
-    // Master switch off by default — the feature is opt-in for the entire
-    // v1 release cycle (see DESIGN.md's "may eat your laundry" warning).
-    assertThat(daemon.enabled.get()).isFalse()
+    // Master switch on by default — editor integrations use the daemon path unless users
+    // explicitly opt out.
+    assertThat(daemon.enabled.get()).isTrue()
     // Heap ceiling: DESIGN.md § 9, recycle policy.
     assertThat(daemon.maxHeapMb.get()).isEqualTo(1024)
     // Belt-and-braces render-count cap.
@@ -42,7 +43,7 @@ class DaemonExtensionTest {
   }
 
   @Test
-  fun `daemon block is reachable via composePreview experimental namespace`() {
+  fun `daemon block is reachable via legacy experimental namespace`() {
     val project = ProjectBuilder.builder().build()
     val experimental = project.objects.newInstance(ExperimentalExtension::class.java)
 
@@ -51,5 +52,15 @@ class DaemonExtensionTest {
     experimental.daemon { enabled.set(true) }
 
     assertThat(experimental.daemon.enabled.get()).isTrue()
+  }
+
+  @Test
+  fun `daemon block is reachable via top-level composePreview namespace`() {
+    val project = ProjectBuilder.builder().build()
+    val extension = project.extensions.create("composePreview", PreviewExtension::class.java)
+
+    extension.daemon { enabled.set(false) }
+
+    assertThat(extension.daemon.enabled.get()).isFalse()
   }
 }

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -63,7 +63,7 @@
                     "type": "webview",
                     "id": "composePreview.historyPanel",
                     "name": "History",
-                    "when": "config.composePreview.experimental.daemon.enabled",
+                    "when": "config.composePreview.daemon.enabled",
                     "visibility": "collapsed"
                 }
             ]
@@ -139,15 +139,21 @@
                     "default": false,
                     "description": "Run ATF accessibility checks on every rendered preview. When on, the extension passes `-PcomposePreview.accessibilityChecks.enabled=true` to each Gradle task; findings surface as diagnostics in the Problems panel and on the `@Preview` line. Overrides the `accessibilityChecks { enabled = ... }` block in build.gradle.kts for this session only."
                 },
+                "composePreview.daemon.enabled": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Use the persistent preview daemon for refresh on saves to files the user has open, plus scroll-ahead speculative renders. When on, daemon failures are shown as errors instead of silently falling back to the Gradle `renderPreviews` task. Turning this off temporarily uses the Gradle path, but the daemon will become required by the extension in a future release."
+                },
                 "composePreview.experimental.daemon.enabled": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Use the persistent preview daemon for sub-second refresh on saves to files the user has open, plus scroll-ahead speculative renders. Requires `composePreview { experimental { daemon { enabled = true } } }` in the consumer's build.gradle.kts. When the daemon isn't healthy, the extension silently falls back to the Gradle `renderPreviews` task. See docs/daemon/DESIGN.md for caveats."
+                    "deprecationMessage": "Use composePreview.daemon.enabled instead.",
+                    "description": "Deprecated alias for composePreview.daemon.enabled."
                 },
                 "composePreview.a11y.alwaysSubscribe": {
                     "type": "boolean",
                     "default": false,
-                    "description": "When on, the panel auto-subscribes to a11y data products (`a11y/atf` for diagnostic squigglies, `a11y/hierarchy` for the local overlay) for every visible preview in daemon mode — diagnostics fire ambient without entering focus mode. Off (the default) keeps the focus-mode 'Show accessibility overlay' button as the only opt-in. The producer side must also be on (Gradle: `composePreview { experimental { daemon { attachA11y = true } } }`, the default); when the daemon advertises no a11y kinds this setting has no effect."
+                    "description": "When on, the panel auto-subscribes to a11y data products (`a11y/atf` for diagnostic squigglies, `a11y/hierarchy` for the local overlay) for every visible preview in daemon mode — diagnostics fire ambient without entering focus mode. Off (the default) keeps the focus-mode 'Show accessibility overlay' button as the only opt-in. The producer side must also be on (Gradle: `composePreview { daemon { attachA11y = true } }`, the default); when the daemon advertises no a11y kinds this setting has no effect."
                 },
                 "composePreview.logging.level": {
                     "type": "string",

--- a/vscode-extension/src/daemon/daemonGate.ts
+++ b/vscode-extension/src/daemon/daemonGate.ts
@@ -3,19 +3,18 @@ import { GradleService } from '../gradleService';
 import { LogFilter } from '../logFilter';
 import { DaemonClient, DaemonClientEvents, DaemonClientLogger } from './daemonClient';
 import { readLaunchDescriptor, spawnDaemon, SpawnedDaemon } from './daemonProcess';
+import { DaemonLaunchDescriptor } from './daemonProtocol';
 
-const SETTING_ENABLED = 'experimental.daemon.enabled';
+const SETTING_ENABLED = 'daemon.enabled';
+const LEGACY_SETTING_ENABLED = 'experimental.daemon.enabled';
 
 /**
  * Source-of-truth for "is the daemon path live for this user/workspace?"
  *
- * Controlled by the `composePreview.experimental.daemon.enabled` setting
- * (true by default). Even when enabled, the gate falls back to
- * `gradleService.renderPreviews` whenever the daemon isn't healthy:
- * descriptor missing, descriptor disabled by the build config, JVM died,
- * classpath dirty, or RPC failed. Failures are logged but never thrown to
- * the caller — the rest of the extension is unaware whether a render came
- * from the daemon or from Gradle.
+ * Controlled by the `composePreview.daemon.enabled` setting (true by default).
+ * When enabled, daemon startup/render failures are surfaced to the user rather
+ * than silently falling back to `renderPreviews`. Users can explicitly disable
+ * the daemon setting to use the Gradle path temporarily.
  *
  * One daemon per Gradle module (per `:samples:android`, etc.). Modules are
  * spawned lazily on first use and shut down on extension dispose.
@@ -23,6 +22,8 @@ const SETTING_ENABLED = 'experimental.daemon.enabled';
 export class DaemonGate {
     private readonly daemons = new Map<string, ManagedDaemon>();
     private disposed = false;
+    private warnedUserDisabled = false;
+    private readonly warnedBuildDisabled = new Set<string>();
 
     constructor(
         private readonly workspaceRoot: string,
@@ -33,20 +34,34 @@ export class DaemonGate {
 
     /** Reads the user setting freshly each time so toggles don't need a reload. */
     isEnabled(): boolean {
-        return vscode.workspace
-            .getConfiguration('composePreview')
-            .get<boolean>(SETTING_ENABLED, true);
+        const config = vscode.workspace.getConfiguration('composePreview');
+        const current = config.inspect<boolean>(SETTING_ENABLED);
+        const legacy = config.inspect<boolean>(LEGACY_SETTING_ENABLED);
+        const value =
+            current?.workspaceFolderValue ??
+            current?.workspaceValue ??
+            current?.globalValue ??
+            legacy?.workspaceFolderValue ??
+            legacy?.workspaceValue ??
+            legacy?.globalValue ??
+            true;
+        if (!value && !this.warnedUserDisabled) {
+            this.warnedUserDisabled = true;
+            this.logger.appendLine(
+                '[daemon] WARNING: composePreview.daemon.enabled is false; using the Gradle render path. ' +
+                'The daemon will become required by the VS Code extension in a future release.',
+            );
+        }
+        return value;
     }
 
     /**
-     * Returns a healthy daemon for [moduleId], spawning one if needed. Returns
-     * null when the daemon path isn't usable for this module — caller must
-     * fall back to [GradleService]. Reasons null is returned:
+     * Returns a healthy daemon for [moduleId], spawning one if needed. Returns null when the daemon
+     * path has been explicitly disabled by user or build config. Throws when the daemon is enabled
+     * but unavailable, so callers can surface the failure instead of silently rendering via Gradle.
+     * Reasons null is returned:
      *   - Setting disabled.
-     *   - `daemon-launch.json` missing (consumer hasn't run
-     *     `composePreviewDaemonStart` yet, or the plugin isn't applied).
      *   - Descriptor's `enabled: false` (user didn't opt in at the build level).
-     *   - Spawn failed.
      */
     async getOrSpawn(
         moduleId: string,
@@ -62,68 +77,88 @@ export class DaemonGate {
 
         const descriptor = readLaunchDescriptor(this.workspaceRoot, moduleId, this.logger);
         if (!descriptor) {
-            this.logger.appendLine(
+            const message =
                 `[daemon] no launch descriptor for ${moduleId}; ` +
-                `run :${moduleId.replace(/\//g, ':')}:composePreviewDaemonStart first`,
-            );
-            return null;
+                `run :${moduleId.replace(/\//g, ':')}:composePreviewDaemonStart first`;
+            this.logger.appendLine(message);
+            throw new Error(message);
         }
         if (!descriptor.enabled) {
-            this.logger.appendLine(
-                `[daemon] descriptor for ${moduleId} has enabled=false; ` +
-                'set composePreview.experimental.daemon.enabled = true in build.gradle.kts',
-            );
+            if (!this.warnedBuildDisabled.has(moduleId)) {
+                this.warnedBuildDisabled.add(moduleId);
+                this.logger.appendLine(
+                    `[daemon] WARNING: descriptor for ${moduleId} has enabled=false; ` +
+                    'using the Gradle render path for now. The daemon will become required by ' +
+                    'the VS Code extension in a future release. Configure composePreview { daemon { enabled = true } }.',
+                );
+            }
             return null;
         }
 
         try {
-            const composed = composeEvents(events, () => {
-                // On channel close drop the entry so the next caller spawns a
-                // fresh JVM. Avoid awaiting `exited` here — events fires as
-                // soon as the stream ends, exit code may lag by a tick.
-                this.daemons.delete(moduleId);
-            });
-            const spawned = await spawnDaemon({
-                workspaceRoot: this.workspaceRoot,
-                descriptor,
-                clientVersion: this.clientVersion,
-                events: composed,
-                logger: this.logger,
-                logFilter: this.logFilter,
-            });
-            this.daemons.set(moduleId, { spawned, client: spawned.client });
-            const readyLine =
-                `[daemon] ready for ${moduleId} ` +
-                `(daemonVersion=${spawned.initializeResult.daemonVersion}, ` +
-                `pid=${spawned.initializeResult.pid}, ` +
-                `previews=${spawned.initializeResult.manifest.previewCount})`;
-            if (this.logFilter.shouldEmitInformational(readyLine)) {
-                this.logger.appendLine(readyLine);
-            }
-            return spawned.client;
+            return await this.spawn(moduleId, descriptor, events);
         } catch (err) {
-            this.logger.appendLine(
-                `[daemon] spawn failed for ${moduleId}: ${(err as Error).message}`,
-            );
-            return null;
+            const message = `[daemon] spawn failed for ${moduleId}: ${(err as Error).message}`;
+            this.logger.appendLine(message);
+            throw new Error(message);
         }
+    }
+
+    isBuildDisabled(moduleId: string): boolean {
+        const descriptor = readLaunchDescriptor(this.workspaceRoot, moduleId, this.logger);
+        if (descriptor?.enabled === false) {
+            if (!this.warnedBuildDisabled.has(moduleId)) {
+                this.warnedBuildDisabled.add(moduleId);
+                this.logger.appendLine(
+                    `[daemon] WARNING: descriptor for ${moduleId} has enabled=false; ` +
+                    'using the Gradle render path for now. The daemon will become required by ' +
+                    'the VS Code extension in a future release. Configure composePreview { daemon { enabled = true } }.',
+                );
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private async spawn(
+        moduleId: string,
+        descriptor: DaemonLaunchDescriptor,
+        events: DaemonClientEvents,
+    ): Promise<DaemonClient> {
+        const composed = composeEvents(events, () => {
+            // On channel close drop the entry so the next caller spawns a
+            // fresh JVM. Avoid awaiting `exited` here — events fires as
+            // soon as the stream ends, exit code may lag by a tick.
+            this.daemons.delete(moduleId);
+        });
+        const spawned = await spawnDaemon({
+            workspaceRoot: this.workspaceRoot,
+            descriptor,
+            clientVersion: this.clientVersion,
+            events: composed,
+            logger: this.logger,
+            logFilter: this.logFilter,
+        });
+        this.daemons.set(moduleId, { spawned, client: spawned.client });
+        const readyLine =
+            `[daemon] ready for ${moduleId} ` +
+            `(daemonVersion=${spawned.initializeResult.daemonVersion}, ` +
+            `pid=${spawned.initializeResult.pid}, ` +
+            `previews=${spawned.initializeResult.manifest.previewCount})`;
+        if (this.logFilter.shouldEmitInformational(readyLine)) {
+            this.logger.appendLine(readyLine);
+        }
+        return spawned.client;
     }
 
     /**
      * Ensures the consumer's `daemon-launch.json` exists by running the
-     * Gradle bootstrap task once per module. Cheap and cacheable. Swallows
-     * failures — a missing descriptor on first launch just means we silently
-     * fall back to Gradle, which is the safe default.
+     * Gradle bootstrap task once per module. Cheap and cacheable. Propagates failures so callers
+     * can surface daemon-enabled bootstrap errors instead of falling back to Gradle.
      */
     async bootstrap(gradleService: GradleService, moduleId: string): Promise<void> {
         if (!this.isEnabled()) { return; }
-        try {
-            await gradleService.runDaemonBootstrap(moduleId);
-        } catch (err) {
-            this.logger.appendLine(
-                `[daemon] bootstrap task failed for ${moduleId}: ${(err as Error).message}`,
-            );
-        }
+        await gradleService.runDaemonBootstrap(moduleId);
     }
 
     /** True iff a healthy daemon is already up for this module — warm path

--- a/vscode-extension/src/daemon/daemonProcess.ts
+++ b/vscode-extension/src/daemon/daemonProcess.ts
@@ -70,8 +70,8 @@ export interface SpawnOptions {
  * `renderNow` requests.
  *
  * Throws when:
- *   - `descriptor.enabled === false` (the user hasn't opted in via
- *     `composePreview { experimental { daemon { enabled = true } } }`),
+ *   - `descriptor.enabled === false` (the user opted out via
+ *     `composePreview { daemon { enabled = false } }`),
  *   - the JVM exits before `initialize` completes,
  *   - `initialize` returns an error.
  */
@@ -81,9 +81,7 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
     const logFilter = opts.logFilter ?? new LogFilter(() => 'verbose');
 
     if (!descriptor.enabled) {
-        throw new Error(
-            'Daemon disabled in build config: set composePreview.experimental.daemon.enabled = true',
-        );
+        throw new Error('Daemon disabled in build config: set composePreview.daemon.enabled = true');
     }
 
     const javaPath = descriptor.javaLauncher ?? findJavaOnPath();

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -143,8 +143,8 @@ export class DaemonScheduler {
     /**
      * Bring up the daemon for a module if necessary and ensure subsequent
      * notifications go to the right client. Returns true iff a client is
-     * available (caller can use the daemon path); false means "fall back
-     * to Gradle for this module."
+     * available (caller can use the daemon path); false means the daemon was explicitly disabled.
+     * Enabled-but-broken daemon failures throw so callers do not silently fall back to Gradle.
      */
     async ensureModule(moduleId: string): Promise<boolean> {
         const client = await this.gate.getOrSpawn(moduleId, this.daemonEvents(moduleId));
@@ -161,9 +161,9 @@ export class DaemonScheduler {
      *
      * `progress` fires through `'bootstrapping'` while the Gradle task
      * runs, `'spawning'` while the JVM comes up, and `'ready'` once
-     * `initialize` is acknowledged. `'fallback'` fires on any failure —
-     * the next save will run Gradle as today. No-op when the gate is
-     * disabled.
+     * `initialize` is acknowledged. `'fallback'` fires only when the daemon is explicitly disabled.
+     * Enabled-but-broken daemon failures throw so the UI can surface the error. No-op when the gate
+     * is disabled.
      */
     async warmModule(
         gradleService: GradleService,
@@ -182,11 +182,18 @@ export class DaemonScheduler {
             this.logger.appendLine(
                 `[daemon] bootstrap task failed for ${moduleId}: ${(err as Error).message}`,
             );
-            progress?.('fallback');
-            return false;
+            throw err;
         }
         progress?.('spawning');
-        const ok = await this.ensureModule(moduleId);
+        let ok = false;
+        try {
+            ok = await this.ensureModule(moduleId);
+        } catch (err) {
+            this.logger.appendLine(
+                `[daemon] warm failed for ${moduleId}: ${(err as Error).message}`,
+            );
+            throw err;
+        }
         progress?.(ok ? 'ready' : 'fallback');
         return ok;
     }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -376,16 +376,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         return args;
     }, logFilter);
 
-    // Daemon path is controlled by composePreview.experimental.daemon.enabled
-    // (true by default). When disabled the gate's `isEnabled()` returns false
-    // and the scheduler is never asked to spawn anything — the Gradle path is
-    // the entire user-facing behaviour. When enabled, the scheduler runs
-    // *alongside* the existing refresh logic: saves and viewport changes push
-    // notifications to the daemon, the daemon emits renderFinished, and the
-    // extension forwards PNGs to the panel as they arrive (typically ahead
-    // of Gradle's `renderPreviews` on a hot sandbox). The Gradle path remains
-    // the safety net; if the daemon fails we silently fall back without any
-    // user-visible change.
+    // Daemon path is controlled by composePreview.daemon.enabled (true by default). When disabled
+    // the gate's `isEnabled()` returns false and the scheduler is never asked to spawn anything —
+    // the Gradle path is the temporary escape hatch. When enabled, daemon failures surface as
+    // errors instead of silently falling back to Gradle.
     daemonGate = new DaemonGate(workspaceRoot, '0.1.0', outputChannel, logFilter);
     daemonScheduler = new DaemonScheduler(daemonGate, {
         onPreviewImageReady: (_moduleId, previewId, imageBase64) => {
@@ -546,7 +540,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     );
 
     // Phase H7 — Preview History panel (HISTORY.md § "VS Code integration").
-    // Live when `composePreview.experimental.daemon.enabled` is true; falls
+    // Live when `composePreview.daemon.enabled` is true; falls
     // back to reading `<projectDir>/.compose-preview-history/index.jsonl` +
     // sidecars when the daemon isn't healthy. View shows up unconditionally
     // — the view container is contributed in package.json — but its content
@@ -1109,17 +1103,16 @@ async function applyDiscoveryDiff(moduleId: string, params: { added: unknown[]; 
 }
 
 /**
- * Side-channel save handler that pushes a `fileChanged` + focus-scoped
- * `renderNow` to the daemon when the daemon path is enabled and a daemon
- * exists for this file's module. Runs alongside the Gradle refresh, never
- * instead of it; the daemon's faster updateImage simply lands sooner. When
- * the daemon is disabled or unhealthy, this is a complete no-op — the
- * existing Gradle path is the entire user-facing behaviour.
+ * Side-channel save handler that pushes a `fileChanged` + focus-scoped `renderNow` to the daemon
+ * when the daemon path is enabled. Explicit daemon opt-out returns `'disabled'` so the caller can
+ * use the Gradle render path; daemon failures return `'failed'` and do not fall back.
  */
-async function notifyDaemonOfSave(filePath: string): Promise<boolean> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler || !gradleService) { return false; }
+type DaemonSaveResult = 'accepted' | 'disabled' | 'failed';
+
+async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
+    if (!daemonGate?.isEnabled() || !daemonScheduler || !gradleService) { return 'disabled'; }
     const module = gradleService.resolveModule(filePath);
-    if (!module) { return false; }
+    if (!module) { return 'failed'; }
 
     // Bootstrap (Gradle task + JVM spawn) happens once per module per
     // session. Normally it has already fired from the active-editor warm
@@ -1127,15 +1120,30 @@ async function notifyDaemonOfSave(filePath: string): Promise<boolean> {
     // external file save, another editor split) we cover ourselves here.
     if (!daemonBootstrappedModules.has(module)) {
         daemonBootstrappedModules.add(module);
-        await daemonScheduler.warmModule(
-            gradleService, module,
-            (state) => updateDaemonStatus(module, state),
-        );
+        try {
+            const warmed = await daemonScheduler.warmModule(
+                gradleService, module,
+                (state) => updateDaemonStatus(module, state),
+            );
+            if (!warmed) {
+                daemonBootstrappedModules.delete(module);
+                return daemonGate.isBuildDisabled(module) ? 'disabled' : 'failed';
+            }
+        } catch (err) {
+            daemonBootstrappedModules.delete(module);
+            logLine(`daemon: ${String((err as Error).message ?? err)}`);
+            return daemonGate.isBuildDisabled(module) ? 'disabled' : 'failed';
+        }
     }
 
-    const ok = await daemonScheduler.ensureModule(module);
-    if (!ok) { return false; }
-    await daemonScheduler.fileChanged(module, filePath);
+    try {
+        const ok = await daemonScheduler.ensureModule(module);
+        if (!ok) { return daemonGate.isBuildDisabled(module) ? 'disabled' : 'failed'; }
+        await daemonScheduler.fileChanged(module, filePath);
+    } catch (err) {
+        logLine(`daemon: ${String((err as Error).message ?? err)}`);
+        return daemonGate.isBuildDisabled(module) ? 'disabled' : 'failed';
+    }
 
     // Focus scope = the saved file's previews, derived from the most recent
     // manifest snapshot we got from Gradle's discoverPreviews. The daemon
@@ -1150,9 +1158,14 @@ async function notifyDaemonOfSave(filePath: string): Promise<boolean> {
     const filterFile = packageQualifiedSourcePath(filePath);
     const manifest = moduleManifestCache.get(module) ?? [];
     const ids = manifest.filter(p => p.sourceFile === filterFile).map(p => p.id);
-    if (ids.length === 0) { return true; }
-    await daemonScheduler.setFocus(module, ids);
-    return await daemonScheduler.renderNow(module, ids, 'fast', 'save');
+    if (ids.length === 0) { return 'accepted'; }
+    try {
+        await daemonScheduler.setFocus(module, ids);
+        return (await daemonScheduler.renderNow(module, ids, 'fast', 'save')) ? 'accepted' : 'failed';
+    } catch (err) {
+        logLine(`daemon: ${String((err as Error).message ?? err)}`);
+        return daemonGate.isBuildDisabled(module) ? 'disabled' : 'failed';
+    }
 }
 
 /**
@@ -1296,10 +1309,21 @@ async function warmDaemonForFile(filePath: string): Promise<void> {
     if (!module) { return; }
     if (daemonBootstrappedModules.has(module)) { return; }
     daemonBootstrappedModules.add(module);
-    await daemonScheduler.warmModule(
-        gradleService, module,
-        (state) => updateDaemonStatus(module, state),
-    );
+    try {
+        const warmed = await daemonScheduler.warmModule(
+            gradleService, module,
+            (state) => updateDaemonStatus(module, state),
+        );
+        if (!warmed) {
+            daemonBootstrappedModules.delete(module);
+        }
+    } catch (err) {
+        daemonBootstrappedModules.delete(module);
+        logLine(`daemon: warm failed for ${module}: ${String((err as Error).message ?? err)}`);
+        vscode.window.showErrorMessage(
+            'Compose Preview daemon is enabled but failed to start. Preview saves will not fall back to Gradle until the daemon is fixed or disabled.',
+        );
+    }
 }
 
 /**
@@ -1471,12 +1495,9 @@ function maybeFirePendingRefresh(): void {
  *  during the run, re-applying the debounce-elapsed check.
  *
  *  Picks daemon-vs-Gradle deliberately — never runs both for the same save.
- *  When the daemon is healthy for the file's module, the save uses the
- *  daemon's hot sandbox (sub-second updateImage via `renderFinished`); the
- *  refresh itself is `forceRender=false` so Gradle does a cheap cached
- *  discovery for the panel manifest only. When the daemon is disabled or
- *  unhealthy, the refresh is `forceRender=true` and Gradle does a full
- *  render as today.
+ *  When the daemon is enabled for the file's module, the save uses the daemon path. If the daemon
+ *  is unavailable while enabled, we surface an error instead of rendering via Gradle. Explicitly
+ *  disabling the daemon keeps the Gradle render path available for now.
  *
  *  **Recompile-before-notify invariant.** In the daemon path the compile
  *  step runs *first*, then the daemon is notified. The daemon's
@@ -1500,18 +1521,23 @@ async function runRefreshExclusive(filePath: string): Promise<void> {
         if (mode === 'daemon') {
             const compileOk = await runDaemonCompileOnly(filePath);
             if (!compileOk) {
-                logLine('daemon: skipped notify (compile failed or no module)');
+                vscode.window.showErrorMessage(
+                    'Compose Preview daemon refresh failed because compile failed. Fix the compile error and save again.',
+                );
                 return;
             }
-            const accepted = await notifyDaemonOfSave(filePath);
-            if (accepted) {
+            const result = await notifyDaemonOfSave(filePath);
+            if (result === 'accepted') {
                 return;
             }
-            // Daemon was healthy at decision time but the actual call
-            // failed — race with channel close, sandbox died mid-save,
-            // gate unexpectedly returned null. Deliberate switch: run the
-            // Gradle render so the user still sees fresh previews.
-            logLine('daemon: rejected the work — falling back to Gradle render');
+            if (result === 'disabled') {
+                await refresh(true, filePath, 'fast');
+                return;
+            }
+            vscode.window.showErrorMessage(
+                'Compose Preview daemon is enabled but unavailable. Restart the preview daemon after fixing the daemon issue.',
+            );
+            return;
         }
         await refresh(true, filePath, 'fast');
     } finally {
@@ -1572,7 +1598,6 @@ function pickRefreshMode(filePath: string): RefreshMode {
         filePath,
         daemonGate.isEnabled(),
         gradleService.resolveModule(filePath),
-        (m) => daemonGate!.isDaemonReady(m),
     );
 }
 

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -552,8 +552,7 @@ export class GradleService {
      * Runs `:<module>:composePreviewDaemonStart` so the daemon launch
      * descriptor (`build/compose-previews/daemon-launch.json`) is up to date.
      * Cheap and cacheable — emits a small JSON. Called only when the daemon
-     * path is enabled (`composePreview.experimental.daemon.enabled`); the
-     * caller (DaemonGate) handles errors by falling back to Gradle.
+     * path is enabled (`composePreview.daemon.enabled`); the caller (DaemonGate) handles errors.
      */
     async runDaemonBootstrap(module: string): Promise<void> {
         await this.runTask(`${gradleProjectPath(module)}:composePreviewDaemonStart`);

--- a/vscode-extension/src/refreshMode.ts
+++ b/vscode-extension/src/refreshMode.ts
@@ -10,28 +10,19 @@
 export type RefreshMode = 'daemon' | 'gradle';
 
 /**
- * - `'daemon'` — the daemon flag is on, the file resolves to a
- *   module, and the daemon for that module is up and the sandbox has
- *   finished bootstrapping (post-#327 `RobolectricHost.start` blocks
- *   until ready, so `isDaemonReady` is the right signal). The save
- *   path skips `renderPreviews` entirely.
- * - `'gradle'` — daemon disabled, file outside any module, daemon not
- *   yet warm, daemon spawn failed, or daemon exited (e.g. classpath
- *   dirty). Existing Gradle render path runs.
+ * - `'daemon'` — the daemon flag is on and the file resolves to a module. The save path skips
+ *   `renderPreviews` entirely; daemon failures are surfaced as errors instead of falling back.
+ * - `'gradle'` — daemon disabled or file outside any module. Existing Gradle render path runs.
  *
- * The decision is made fresh on each save — `isDaemonReady` reads the
- * live registry, so a daemon that crashed mid-session silently flips
- * back to the Gradle path on the next save without any extension state
- * to manage.
+ * The decision is made fresh on each save, so explicitly disabling the daemon still gives users a
+ * temporary Gradle escape hatch while the daemon path is being stabilised.
  */
 export function pickRefreshModeFor(
     _filePath: string,
     daemonEnabled: boolean,
     moduleId: string | null,
-    isDaemonReady: (moduleId: string) => boolean,
 ): RefreshMode {
     if (!daemonEnabled) { return 'gradle'; }
     if (!moduleId) { return 'gradle'; }
-    if (!isDaemonReady(moduleId)) { return 'gradle'; }
     return 'daemon';
 }

--- a/vscode-extension/src/test/daemonProcess.test.ts
+++ b/vscode-extension/src/test/daemonProcess.test.ts
@@ -85,7 +85,7 @@ describe('readLaunchDescriptor', () => {
     }));
 
     it('preserves an explicit enabled=false flag without mutating it', withTempWorkspace((dir) => {
-        // The build can opt out via composePreview.experimental.daemon.enabled = false
+        // The build can opt out via composePreview.daemon.enabled = false
         // even with the VS Code setting on. Reader must return the descriptor
         // honestly; the gate decides what to do with it.
         const descriptor = { ...validDescriptor(), enabled: false };

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -453,29 +453,26 @@ describe('DaemonScheduler', () => {
             assert.deepStrictEqual(gradle.bootstrapCalls, [], 'bootstrap should not run when daemon is ready');
         });
 
-        it('reports fallback when the bootstrap task throws', async () => {
+        it('throws when the bootstrap task fails while the daemon is enabled', async () => {
             const { scheduler } = build();
             const gradle = new FakeGradleService();
             gradle.bootstrapShouldThrow = new Error('Gradle config-cache rejected');
             const states: string[] = [];
-            const ok = await scheduler.warmModule(
-                gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
-                'mod',
-                (s) => states.push(s),
+            await assert.rejects(
+                scheduler.warmModule(
+                    gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
+                    'mod',
+                    (s) => states.push(s),
+                ),
+                /Gradle config-cache rejected/,
             );
-            assert.strictEqual(ok, false);
-            assert.deepStrictEqual(states, ['bootstrapping', 'fallback']);
+            assert.deepStrictEqual(states, ['bootstrapping']);
         });
 
-        it('reports fallback when the JVM spawn fails', async () => {
-            // Disabled gate makes ensureModule return false (caller falls
-            // back to Gradle); warmModule should mirror that as 'fallback'.
+        it('reports fallback only when the daemon is explicitly unavailable after bootstrap', async () => {
             const { gate, scheduler } = build();
             const gradle = new FakeGradleService();
             const states: string[] = [];
-            // After bootstrap the scheduler tries to spawn — flip the gate
-            // so spawn returns null on the second call only by clearing
-            // the client.
             gate.client = null;
             const ok = await scheduler.warmModule(
                 gradle as unknown as Parameters<typeof scheduler.warmModule>[0],

--- a/vscode-extension/src/test/refreshMode.test.ts
+++ b/vscode-extension/src/test/refreshMode.test.ts
@@ -8,47 +8,23 @@ import { pickRefreshModeFor } from '../refreshMode';
  * every branch without stubbing the VS Code API.
  */
 describe('pickRefreshModeFor', () => {
-    const ready = (id: string) => id === 'mod';
-    const notReady = () => false;
-
     it('returns gradle when the daemon flag is off', () => {
         assert.strictEqual(
-            pickRefreshModeFor('/x.kt', /* enabled */ false, 'mod', ready),
+            pickRefreshModeFor('/x.kt', /* enabled */ false, 'mod'),
             'gradle',
         );
     });
 
     it('returns gradle when the file resolves to no module', () => {
         assert.strictEqual(
-            pickRefreshModeFor('/outside.kt', true, null, ready),
+            pickRefreshModeFor('/outside.kt', true, null),
             'gradle',
         );
     });
 
-    it('returns gradle when the daemon for the module is not ready', () => {
+    it('returns daemon when enabled and the file resolves to a module', () => {
         assert.strictEqual(
-            pickRefreshModeFor('/x.kt', true, 'mod', notReady),
-            'gradle',
-        );
-    });
-
-    it('returns daemon only when all three preconditions hold', () => {
-        assert.strictEqual(
-            pickRefreshModeFor('/x.kt', true, 'mod', ready),
-            'daemon',
-        );
-    });
-
-    it('isDaemonReady is consulted per-module — a different module that\'s not warm stays on gradle', () => {
-        // Two modules in the same workspace; one daemon is up, the other
-        // isn't. The save picks the path keyed off the saved file's
-        // module, not the union of all daemon health.
-        assert.strictEqual(
-            pickRefreshModeFor('/x.kt', true, 'cold-module', ready),
-            'gradle',
-        );
-        assert.strictEqual(
-            pickRefreshModeFor('/x.kt', true, 'mod', ready),
+            pickRefreshModeFor('/x.kt', true, 'mod'),
             'daemon',
         );
     });


### PR DESCRIPTION
## Summary
- move daemon Gradle DSL to top-level composePreview.daemon and default it on
- keep explicit disable paths as temporary Gradle fallback with warnings
- make enabled daemon failures surface errors instead of falling back to Gradle render
- refresh daemon docs and VS Code settings/tests for the stable daemon path

## Verification
- npm --prefix vscode-extension test
- ./gradlew :gradle-plugin:ktfmtFormatMain :gradle-plugin:ktfmtFormatTest
- ./gradlew :gradle-plugin:test --tests "ee.schimke.composeai.plugin.daemon.DaemonExtensionTest" --tests "ee.schimke.composeai.plugin.ComposePreviewCompileTaskTest" --tests "ee.schimke.composeai.plugin.KmpAndroidDesktopRoutingTest"
- ./gradlew :samples:wear:composePreviewDaemonStart
- confirmed samples/wear/build/compose-previews/daemon-launch.json has enabled=true