### PR TITLE
feat(samples/wear): animate FixedPreviewTimeSource in previews

### DIFF
--- a/samples/wear/src/main/kotlin/com/example/samplewear/FixedPreviewTimeSource.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/FixedPreviewTimeSource.kt
@@ -1,0 +1,41 @@
+package com.example.samplewear
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
+import androidx.wear.compose.material3.TimeSource
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+private val timeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
+private const val nanosPerMinute = 60_000_000_000L
+private val previewStartTime: LocalTime = LocalTime.of(10, 10)
+
+object FixedPreviewTimeSource : TimeSource {
+    @Composable
+    override fun currentTime(): String {
+        var elapsedMinutes by remember { mutableLongStateOf(0L) }
+        LaunchedEffect(Unit) {
+            while (true) {
+                withFrameNanos { frameNanos ->
+                    elapsedMinutes = frameNanos / nanosPerMinute
+                }
+            }
+        }
+
+        val currentTimeText by remember {
+            derivedStateOf {
+                previewStartTime
+                    .plusMinutes(elapsedMinutes)
+                    .format(timeFormatter)
+            }
+        }
+        return currentTimeText
+    }
+}

--- a/samples/wear/src/main/kotlin/com/example/samplewear/FixedPreviewTimeSource.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/FixedPreviewTimeSource.kt
@@ -22,9 +22,13 @@ object FixedPreviewTimeSource : TimeSource {
     override fun currentTime(): String {
         var elapsedMinutes by remember { mutableLongStateOf(0L) }
         LaunchedEffect(Unit) {
+            var startFrameNanos = -1L
             while (true) {
                 withFrameNanos { frameNanos ->
-                    elapsedMinutes = frameNanos / nanosPerMinute
+                    if (startFrameNanos < 0L) {
+                        startFrameNanos = frameNanos
+                    }
+                    elapsedMinutes = (frameNanos - startFrameNanos) / nanosPerMinute
                 }
             }
         }

--- a/samples/wear/src/main/kotlin/com/example/samplewear/Previews.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/Previews.kt
@@ -29,7 +29,6 @@ import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.ScrollIndicator
 import androidx.wear.compose.material3.SurfaceTransformation
 import androidx.wear.compose.material3.Text
-import androidx.wear.compose.material3.TimeSource
 import androidx.wear.compose.material3.TimeText
 import androidx.wear.compose.material3.TitleCard
 import androidx.wear.compose.material3.lazy.rememberTransformationSpec
@@ -41,10 +40,6 @@ import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
 import ee.schimke.composeai.preview.ScrollMode
 import ee.schimke.composeai.preview.ScrollingPreview
 
-private object FixedTimeSource : TimeSource {
-    @Composable
-    override fun currentTime(): String = "10:10"
-}
 
 private data class Item(val title: String, val subtitle: String)
 
@@ -63,7 +58,7 @@ fun WearApp() {
         AppScaffold(
             // Real production app — let TimeText use the system clock.
             // Previews that want a deterministic time supply their own
-            // `AppScaffold` with a `FixedTimeSource` (see [ActivityListPreview]).
+            // `AppScaffold` with a `FixedPreviewTimeSource` (see [ActivityListPreview]).
             timeText = { TimeText() },
         ) {
             ActivityListScreen()
@@ -142,7 +137,7 @@ fun ActivityListScreen() {
 private fun ButtonPreviewContent() {
     MaterialTheme {
         AppScaffold(
-            timeText = { TimeText(timeSource = FixedTimeSource) },
+            timeText = { TimeText(timeSource = FixedPreviewTimeSource) },
         ) {
             ScreenScaffold { contentPadding ->
                 Box(
@@ -165,7 +160,7 @@ private fun ButtonPreviewContent() {
 @Composable
 fun ActivityListPreview() {
     MaterialTheme {
-        AppScaffold(timeText = { TimeText(timeSource = FixedTimeSource) }) {
+        AppScaffold(timeText = { TimeText(timeSource = FixedPreviewTimeSource) }) {
             ActivityListScreen()
         }
     }
@@ -175,7 +170,7 @@ fun ActivityListPreview() {
 @Composable
 fun ActivityListFontScalesPreview() {
     MaterialTheme {
-        AppScaffold(timeText = { TimeText(timeSource = FixedTimeSource) }) {
+        AppScaffold(timeText = { TimeText(timeSource = FixedPreviewTimeSource) }) {
             ActivityListScreen()
         }
     }
@@ -213,7 +208,7 @@ fun BadWearButtonPreview() {
  * `@ScrollingPreview(modes = [LONG])` capture doesn't pick up a fading
  * indicator at random opacities. The screen does NOT compose its own
  * `MaterialTheme` / `AppScaffold` — its caller (the preview, or production)
- * does, which keeps the preview free to swap in a [FixedTimeSource].
+ * does, which keeps the preview free to swap in a [FixedPreviewTimeSource].
  * `ScreenScaffold` reveals the `EdgeButton` only when the list is pinned to
  * the bottom, so "Start workout" appears once, at the final slice.
  */
@@ -295,7 +290,7 @@ fun LongActivityListScreen() {
 fun ActivityListLongPreview() {
     MaterialTheme {
         AppScaffold(
-            timeText = { TimeText(timeSource = FixedTimeSource) },
+            timeText = { TimeText(timeSource = FixedPreviewTimeSource) },
         ) {
             LongActivityListScreen()
         }
@@ -308,7 +303,7 @@ fun ActivityListLongPreview() {
 fun ActivityListGifPreview() {
     MaterialTheme {
         AppScaffold(
-            timeText = { TimeText(timeSource = FixedTimeSource) },
+            timeText = { TimeText(timeSource = FixedPreviewTimeSource) },
         ) {
             LongActivityListScreen()
         }


### PR DESCRIPTION
## Summary

- Extract `FixedTimeSource` out of `Previews.kt` into its own `FixedPreviewTimeSource.kt` so any Wear preview can pick it up.
- Drive the preview clock from `withFrameNanos` so scroll/GIF captures show a ticking time starting from a deterministic 10:10 instead of a frozen string.
- Update every existing preview (`ActivityList*`, `Button*`, `ActivityListLong*`, `ActivityListGif*`) and the surrounding doc comments to reference the renamed object.

## Test plan

- [ ] `./gradlew ktfmtCheckAll`
- [ ] Re-render the affected `@WearPreview*` / `@ScrollingPreview` previews and confirm the clock advances during scroll/GIF captures while still starting at 10:10.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LP42twACr6xcqNqk2BTupY)_