### PR TITLE
feat(daemon): live (non-scripted) recording driven by recording/input (P4)

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -2021,6 +2021,7 @@ class JsonRpcServer(
           fps = fps,
           scale = scale,
           overrides = params.overrides,
+          live = params.live,
         )
       } catch (e: UnsupportedOperationException) {
         sendErrorResponse(
@@ -2060,6 +2061,26 @@ class JsonRpcServer(
     } catch (t: Throwable) {
       System.err.println(
         "compose-ai-daemon: recording/script: postScript failed for " +
+          "recordingId='${params.recordingId}': ${t.javaClass.simpleName}: ${t.message}"
+      )
+    }
+  }
+
+  /**
+   * RECORDING.md § "live mode" — `recording/input` notification handler. Drops silently when the
+   * recording id is unknown (stale, never started, already stopped, or typo'd by the client) or
+   * when the session is scripted (mode mismatch surfaces as a `postInput` IllegalStateException
+   * which we log but don't propagate — notifications are fire-and-forget).
+   */
+  private fun handleRecordingInput(
+    params: ee.schimke.composeai.daemon.protocol.RecordingInputParams
+  ) {
+    val session = recordings[params.recordingId] ?: return
+    try {
+      session.postInput(params)
+    } catch (t: Throwable) {
+      System.err.println(
+        "compose-ai-daemon: recording/input: postInput failed for " +
           "recordingId='${params.recordingId}': ${t.javaClass.simpleName}: ${t.message}"
       )
     }
@@ -2214,6 +2235,10 @@ class JsonRpcServer(
       "recording/script" ->
         tryDecode(ee.schimke.composeai.daemon.protocol.RecordingScriptParams.serializer(), n) {
           handleRecordingScript(it)
+        }
+      "recording/input" ->
+        tryDecode(ee.schimke.composeai.daemon.protocol.RecordingInputParams.serializer(), n) {
+          handleRecordingInput(it)
         }
       else -> System.err.println("compose-ai-daemon: unknown notification method: ${n.method}")
     }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingInputParams
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
 
 /**
@@ -52,16 +53,44 @@ interface RecordingSession : AutoCloseable {
   val scale: Float
 
   /**
-   * Append a batch of events to the virtual timeline. May be called multiple times before [stop];
-   * each call merges and re-sorts by `tMs` so out-of-order client batches still play in order.
+   * `true` when this session captures real-time interactions instead of replaying a scripted
+   * timeline — see RECORDING.md § "live mode". Frozen at allocation. Implementations spin a
+   * background tick thread at [fps] cadence on construction; [postInput] feeds the queue that tick
+   * thread drains. [postScript] is rejected; [postInput] is the only legal append.
+   *
+   * `false` (the default) is the scripted path that's been live since v1: post a full timeline via
+   * [postScript], then [stop] plays it back at virtual frame time.
+   */
+  val live: Boolean
+
+  /**
+   * **Scripted mode only.** Append a batch of events to the virtual timeline. May be called
+   * multiple times before [stop]; each call merges and re-sorts by `tMs` so out-of-order client
+   * batches still play in order. Throws [IllegalStateException] when [live] is `true`.
    */
   fun postScript(events: List<RecordingScriptEvent>)
 
   /**
-   * Play the script back on the virtual clock, writing one PNG per virtual frame to disk. After
-   * [stop] returns, the held scene is closed and further [postScript] calls are illegal — but the
-   * PNGs remain on disk so [encode] can be invoked. Idempotent in the limited sense that a second
-   * call returns the same [RecordingResult] without re-rendering.
+   * **Live mode only.** Append one input event to the live tick loop's pending queue. The
+   * implementation stamps it with the current virtual `tMs` (= wall-clock elapsed since
+   * construction) and dispatches it on the next frame boundary. Throws [IllegalStateException] when
+   * [live] is `false` — scripted callers should use [postScript] instead.
+   *
+   * Fire-and-forget by design: the daemon's `recording/input` notification handler doesn't wait for
+   * the tick to consume the event. Inputs that arrive after [stop] are dropped silently.
+   */
+  fun postInput(input: RecordingInputParams)
+
+  /**
+   * Stop the recording and return its frame metadata. Behaviour differs by mode:
+   * - **Scripted** ([live] = `false`): plays the posted script back on the virtual clock, writing
+   *   one PNG per virtual frame to disk.
+   * - **Live** ([live] = `true`): joins the background tick thread, waits for any in-flight frame
+   *   write to finish, then returns metadata for the frames already on disk.
+   *
+   * After [stop] returns, the held scene is closed and further [postScript] / [postInput] calls are
+   * illegal — but the PNGs remain on disk so [encode] can be invoked. Idempotent in the limited
+   * sense that a second call returns the same [RecordingResult] without re-rendering.
    */
   fun stop(): RecordingResult
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -196,6 +196,12 @@ interface RenderHost {
    * @param overrides per-render display overrides applied to the held scene; same shape and
    *   semantics as `renderNow.overrides`. Lets a `Button`-sized component preview be recorded at
    *   its natural size with a custom background.
+   * @param live when `true`, the session runs in live (real-time) mode — a background tick thread
+   *   captures frames at [fps] cadence using a wall-clock-driven virtual nanoTime, and
+   *   `recording/input` notifications drive the held scene as they arrive. When `false` (the
+   *   default), the session is scripted: callers post a full timeline via
+   *   [RecordingSession.postScript] and [RecordingSession.stop] plays it back. See RECORDING.md §
+   *   "live mode".
    */
   fun acquireRecordingSession(
     previewId: String,
@@ -204,6 +210,7 @@ interface RenderHost {
     fps: Int,
     scale: Float,
     overrides: ee.schimke.composeai.daemon.protocol.PreviewOverrides?,
+    live: Boolean = false,
   ): RecordingSession =
     throw UnsupportedOperationException(
       "recording unsupported by ${this::class.simpleName ?: this::class.java.name}"

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -843,6 +843,12 @@ enum class PruneReasonWire {
  * @property overrides per-render display overrides applied to the held scene; mirrors
  *   `renderNow.overrides` exactly. Lets a `Button` preview be recorded at `widthPx: 240, heightPx:
  *   80, backgroundColor: 0xFFFFFFFF` (or whatever the agent prefers) without editing source.
+ * @property live when `true`, the recording captures real-time interactions instead of replaying a
+ *   scripted timeline. The daemon spins a background tick thread at [fps] cadence using a
+ *   wall-clock-driven virtual nanoTime; agents (or the panel) post `recording/input` notifications
+ *   that the tick loop drains and dispatches at the current virtual `tMs`. Mutually exclusive with
+ *   `recording/script` — once a session is allocated `live`, `recording/script` is rejected.
+ *   Defaults to `false` (scripted mode); see RECORDING.md § "live mode".
  */
 @Serializable
 data class RecordingStartParams(
@@ -850,6 +856,30 @@ data class RecordingStartParams(
   val fps: Int? = null,
   val scale: Float? = null,
   val overrides: PreviewOverrides? = null,
+  val live: Boolean = false,
+)
+
+/**
+ * `recording/input` notification — fire-and-forget input event for a `live = true` recording.
+ * Mirrors [InteractiveInputParams] modulo the routing key (recordingId vs frameStreamId).
+ *
+ * The daemon's tick loop drains pending events at every frame boundary and stamps them with the
+ * current virtual `tMs` (= wall-clock elapsed since `recording/start`); the `pixelX` / `pixelY` are
+ * dispatched through the held scene's pointer pipeline at the same virtual nanoTime as the
+ * surrounding frame's `scene.render(nanoTime = …)` call.
+ *
+ * Inputs against a `live = false` (scripted) recording are dropped silently on the daemon side —
+ * the analogous wire shape there is `recording/script`.
+ */
+@Serializable
+data class RecordingInputParams(
+  val recordingId: String,
+  val kind: InteractiveInputKind,
+  /** Image-natural pixel coordinates. Daemon translates to dp using the held scene's density. */
+  val pixelX: Int? = null,
+  val pixelY: Int? = null,
+  /** For `keyDown` / `keyUp` (reserved; v1 dispatch is a no-op). */
+  val keyCode: String? = null,
 )
 
 /**

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -325,6 +325,7 @@ open class DesktopHost(
     fps: Int,
     scale: Float,
     overrides: ee.schimke.composeai.daemon.protocol.PreviewOverrides?,
+    live: Boolean,
   ): RecordingSession {
     val resolver =
       previewSpecResolver
@@ -348,6 +349,7 @@ open class DesktopHost(
       recordingId = recordingId,
       fps = fps,
       scale = scale,
+      live = live,
       engine = engine,
       state = state,
       sandboxStats = sandboxStats,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -5,8 +5,10 @@ import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
+import ee.schimke.composeai.daemon.protocol.RecordingInputParams
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
 import java.io.File
+import java.util.concurrent.ConcurrentLinkedQueue
 import org.jetbrains.skia.EncodedImageFormat
 import org.jetbrains.skia.Image
 import org.jetbrains.skia.Rect
@@ -47,6 +49,7 @@ class DesktopRecordingSession(
   override val recordingId: String,
   override val fps: Int,
   override val scale: Float,
+  override val live: Boolean = false,
   private val engine: RenderEngine,
   private val state: RenderEngine.SceneState,
   private val sandboxStats: SandboxLifecycleStats,
@@ -56,9 +59,18 @@ class DesktopRecordingSession(
 
   private val timeline = mutableListOf<RecordingScriptEvent>()
 
+  // Live mode pending-input queue. Drained by the tick thread at every frame boundary.
+  // ConcurrentLinkedQueue so postInput callers (notification handler thread) and the tick
+  // thread don't contend on a lock — adds and polls are wait-free.
+  private val liveInputs = ConcurrentLinkedQueue<RecordingInputParams>()
+
   @Volatile private var stopped: Boolean = false
 
   @Volatile private var closed: Boolean = false
+
+  // Live mode signal: set true by stop() to make the tick thread exit cleanly. The thread polls
+  // this on every iteration; the join in stop() then guarantees no further tick after return.
+  @Volatile private var liveStopRequested: Boolean = false
 
   private var result: RecordingResult? = null
 
@@ -66,7 +78,26 @@ class DesktopRecordingSession(
 
   private val frameHeightPx: Int = (state.spec.heightPx * scale).toInt().coerceAtLeast(1)
 
+  // Live mode bookkeeping: wall-clock anchor + frame counter. Both written only by the tick
+  // thread (with frameCount also read by stop() after the join).
+  @Volatile private var liveStartNs: Long = 0L
+
+  @Volatile private var liveFrameCount: Int = 0
+
+  private val liveTickThread: Thread? =
+    if (live) {
+      framesDir.mkdirs()
+      Thread({ runLiveTickLoop() }, "compose-ai-daemon-recording-live-$recordingId").apply {
+        isDaemon = true
+        start()
+      }
+    } else null
+
   override fun postScript(events: List<RecordingScriptEvent>) {
+    check(!live) {
+      "DesktopRecordingSession.postScript called on a live recording (recordingId='$recordingId'); " +
+        "use postInput for live mode"
+    }
     check(!stopped) {
       "DesktopRecordingSession.postScript called after stop() for recordingId='$recordingId'"
     }
@@ -80,13 +111,35 @@ class DesktopRecordingSession(
     }
   }
 
+  override fun postInput(input: RecordingInputParams) {
+    check(live) {
+      "DesktopRecordingSession.postInput called on a scripted recording " +
+        "(recordingId='$recordingId'); use postScript for scripted mode"
+    }
+    if (stopped) return // Late inputs after stop() are dropped silently.
+    liveInputs.add(input)
+  }
+
   override fun stop(): RecordingResult {
     val cached = result
     if (cached != null) return cached
     if (stopped) error("DesktopRecordingSession.stop() called twice without a cached result")
     stopped = true
-    framesDir.mkdirs()
 
+    val r = if (live) stopLive() else stopScripted()
+    result = r
+    // The held scene is no longer needed; tear it down so subsequent close() is a no-op. The
+    // per-frame PNGs and any encoded video stay on disk for `recording/encode`.
+    engine.tearDown(state)
+    return r
+  }
+
+  /**
+   * Scripted-mode stop: play the timeline back at virtual frame time. Identical to the v1 scripted
+   * path; lifted into its own method now that [stop] dispatches by mode.
+   */
+  private fun stopScripted(): RecordingResult {
+    framesDir.mkdirs()
     val sortedEvents = synchronized(timeline) { timeline.toList() }
     val durationMs: Long = sortedEvents.maxOfOrNull { it.tMs } ?: 0L
     // Frames are paced as `frameIndex * 1000 / fps` (integer division on the ms side keeps the
@@ -102,12 +155,9 @@ class DesktopRecordingSession(
       val tNanos: Long = frameIndex.toLong() * 1_000_000_000L / fps.toLong()
       val tMs: Long = tNanos / 1_000_000L
 
-      // Drain every scripted event whose virtual tMs has elapsed by this frame's tMs and dispatch
-      // it through the held scene at the same nanoTime. CLICK splits into Press → tick → Release
-      // (see class KDoc); the intermediate `scene.render(nanoTime)` makes the gesture detector
-      // see the down event before the up event without writing a separate output frame.
       while (nextEventIdx < sortedEvents.size && sortedEvents[nextEventIdx].tMs <= tMs) {
-        dispatchAtVirtual(sortedEvents[nextEventIdx], tNanos, tMs)
+        val e = sortedEvents[nextEventIdx]
+        dispatchInput(e.kind, e.pixelX, e.pixelY, tNanos, tMs)
         nextEventIdx++
       }
 
@@ -116,24 +166,101 @@ class DesktopRecordingSession(
     }
     val tookMs = (System.nanoTime() - startNs) / 1_000_000L
     System.err.println(
-      "compose-ai-daemon: DesktopRecordingSession.stop($recordingId): " +
+      "compose-ai-daemon: DesktopRecordingSession.stop($recordingId, scripted): " +
         "rendered $totalFrames frame(s) covering ${durationMs}ms virtual time in ${tookMs}ms wall " +
         "(scale=$scale, fps=$fps, ${frameWidthPx}x${frameHeightPx}px)"
     )
+    return RecordingResult(
+      frameCount = totalFrames,
+      durationMs = durationMs,
+      framesDir = framesDir.absolutePath,
+      frameWidthPx = frameWidthPx,
+      frameHeightPx = frameHeightPx,
+    )
+  }
 
-    val r =
-      RecordingResult(
-        frameCount = totalFrames,
-        durationMs = durationMs,
-        framesDir = framesDir.absolutePath,
-        frameWidthPx = frameWidthPx,
-        frameHeightPx = frameHeightPx,
-      )
-    result = r
-    // The held scene is no longer needed; tear it down so subsequent close() is a no-op. The
-    // per-frame PNGs and any encoded video stay on disk for `recording/encode`.
-    engine.tearDown(state)
-    return r
+  /**
+   * Live-mode stop: signal the tick thread, join it, return metadata for what was written. Duration
+   * matches the wall-clock window between construction and stop, rounded to a frame boundary. Frame
+   * count is the number of ticks the loop completed before observing the signal.
+   */
+  private fun stopLive(): RecordingResult {
+    liveStopRequested = true
+    val thread = liveTickThread
+    if (thread != null) {
+      // Bound the join — the tick body itself is bounded by one render (typ. 5–30ms on desktop)
+      // plus one frame interval. 5s is generous; if it ever times out something is wrong with the
+      // tick body and we'd rather surface that than wait forever.
+      thread.join(5_000)
+      if (thread.isAlive) {
+        System.err.println(
+          "compose-ai-daemon: DesktopRecordingSession.stop($recordingId, live): " +
+            "tick thread did not exit within 5s after liveStopRequested; continuing anyway"
+        )
+      }
+    }
+    val frameCount = liveFrameCount
+    val durationMs: Long = if (frameCount == 0) 0L else (frameCount - 1).toLong() * 1000L / fps
+    System.err.println(
+      "compose-ai-daemon: DesktopRecordingSession.stop($recordingId, live): " +
+        "captured $frameCount frame(s) over ~${durationMs}ms wall time " +
+        "(scale=$scale, fps=$fps, ${frameWidthPx}x${frameHeightPx}px)"
+    )
+    return RecordingResult(
+      frameCount = frameCount,
+      durationMs = durationMs,
+      framesDir = framesDir.absolutePath,
+      frameWidthPx = frameWidthPx,
+      frameHeightPx = frameHeightPx,
+    )
+  }
+
+  /**
+   * Live tick loop body. Runs on the dedicated `compose-ai-daemon-recording-live-<id>` thread.
+   * Anchors the virtual clock at construction time (`liveStartNs`); each iteration:
+   *
+   * 1. Computes virtual `tNanos` from `System.nanoTime() - liveStartNs`.
+   * 2. Drains every pending input from [liveInputs] and dispatches it at `tNanos`.
+   * 3. Renders one frame at the same `tNanos` and writes it as `frame-NNNNN.png`.
+   * 4. Sleeps until the next frame boundary (`nextTickNs - now`), preserving fps cadence even when
+   *    the render body undershoots the budget.
+   *
+   * Exits cleanly when [liveStopRequested] is observed at the top of the loop. The dispatch pattern
+   * matches scripted mode (CLICK splits into Press → render-tick → Release at the same nanoTime) so
+   * `Modifier.clickable {}` and other tap-gesture-detecting modifiers see a clean down→up sequence.
+   */
+  private fun runLiveTickLoop() {
+    liveStartNs = System.nanoTime()
+    val frameIntervalNs: Long = 1_000_000_000L / fps.toLong()
+    while (!liveStopRequested) {
+      val tNanos = System.nanoTime() - liveStartNs
+      val tMs = tNanos / 1_000_000L
+
+      // Drain inputs accumulated since the last tick; dispatch each at the current virtual
+      // nanoTime. Inputs that arrive *during* the dispatch+render below are picked up next tick.
+      while (true) {
+        val next = liveInputs.poll() ?: break
+        dispatchInput(next.kind, next.pixelX, next.pixelY, tNanos, tMs)
+      }
+
+      val image = state.scene.render(nanoTime = tNanos)
+      writeFramePng(image, liveFrameCount)
+      liveFrameCount++
+
+      // Sleep until the next frame boundary. If the render body overran (unlikely on desktop;
+      // common on Android one day), `sleepFor` clamps to 0 — we just take the next frame
+      // immediately rather than chasing missed frames retrospectively.
+      val nextTickNs = liveStartNs + liveFrameCount.toLong() * frameIntervalNs
+      val sleepNs = (nextTickNs - System.nanoTime()).coerceAtLeast(0L)
+      if (sleepNs > 0) {
+        try {
+          Thread.sleep(sleepNs / 1_000_000L, (sleepNs % 1_000_000L).toInt())
+        } catch (_: InterruptedException) {
+          Thread.currentThread().interrupt()
+          return
+        }
+      }
+    }
   }
 
   override fun encode(format: RecordingFormat): EncodedRecording {
@@ -200,20 +327,45 @@ class DesktopRecordingSession(
     if (closed) return
     closed = true
     if (!stopped) {
-      // Auto-stop path: idle-timeout fired or daemon shutdown caught us mid-recording. Tear the
-      // held scene down without writing a final frame batch — partial frames already on disk stay
-      // there in case `recording/encode` arrives later. Result map left null so a subsequent
-      // encode call surfaces the "stop() must be called first" check.
+      // Auto-stop path: idle-timeout fired or daemon shutdown caught us mid-recording. For live
+      // recordings we still need to signal + join the tick thread so it doesn't keep rendering
+      // into a torn-down scene; the bounded join in [stopLive] handles that. For scripted, the
+      // playback loop never started, so tearing the scene down directly is enough.
+      if (live) {
+        liveStopRequested = true
+        liveTickThread?.let { thread ->
+          thread.join(5_000)
+          if (thread.isAlive) {
+            System.err.println(
+              "compose-ai-daemon: DesktopRecordingSession.close($recordingId, live): " +
+                "tick thread did not exit within 5s; tearing down anyway"
+            )
+          }
+        }
+      }
       engine.tearDown(state)
     }
     // When stopped is true, stop() already called engine.tearDown(state); a second call is safe
     // (RenderEngine.tearDown is idempotent) but unnecessary.
   }
 
-  private fun dispatchAtVirtual(event: RecordingScriptEvent, tNanos: Long, tMs: Long) {
-    val px = event.pixelX
-    val py = event.pixelY
-    when (event.kind) {
+  /**
+   * Common pointer-input dispatch shared by scripted ([stopScripted]) and live ([runLiveTickLoop])
+   * paths. Translates protocol [InteractiveInputKind] into Skiko `sendPointerEvent` calls at the
+   * supplied virtual `tNanos` / `tMs`. Same Press → render-tick → Release pattern for CLICK as
+   * [DesktopInteractiveSession] uses, so `Modifier.clickable {}` and other tap-gesture detectors
+   * see a clean down→up sequence regardless of mode.
+   */
+  private fun dispatchInput(
+    kind: InteractiveInputKind,
+    pixelX: Int?,
+    pixelY: Int?,
+    tNanos: Long,
+    tMs: Long,
+  ) {
+    val px = pixelX
+    val py = pixelY
+    when (kind) {
       InteractiveInputKind.CLICK -> {
         if (px == null || py == null) return
         val offset = sceneOffset(px, py)

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
@@ -374,6 +374,180 @@ class DesktopRecordingSessionTest {
     )
   }
 
+  @Test
+  fun live_mode_captures_frames_at_fps_cadence_and_dispatches_inputs() {
+    // P4 — live mode test. The session runs a background tick thread at fps cadence using
+    // wall-clock-driven virtual time. We:
+    //   1. Allocate a live session against TristateClickSquare (red → green → blue on click).
+    //   2. Sleep a short window (250 ms wall) so several frames accumulate (initial-state red).
+    //   3. Post a click via postInput.
+    //   4. Sleep another window so the post-click state (green) renders into more frames.
+    //   5. Stop, then assert:
+    //      - Frame count is in a tolerant range — we expect ~3..30 frames at 30 fps over ~500 ms;
+    //        wide bounds because CI machines vary in timing precision and the JIT may need a few
+    //        frames to warm up the render path.
+    //      - The first frame is red (pre-click state).
+    //      - The last frame is green (post-click state, dispatched at some virtual tMs > 0).
+    //
+    // Wall-clock-based timing assertions are tolerant (range, not exact count) to keep the test
+    // portable across slower CI runners. The state-flip assertion is the load-bearing one — it
+    // proves the live tick loop is actually draining inputs and the held scene is mutating.
+    val outputDir = tempFolder.newFolder("live-engine-renders")
+    val recordingsRoot = tempFolder.newFolder("live-recordings-root")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val engine = RenderEngine(outputDir = outputDir)
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == FIXTURE_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "TristateClickSquare",
+              widthPx = COMPONENT_WIDTH_PX,
+              heightPx = COMPONENT_HEIGHT_PX,
+              density = 1.0f,
+              outputBaseName = "tristate-click-square-live",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireRecordingSession(
+          previewId = FIXTURE_PREVIEW_ID,
+          recordingId = "test-rec-live",
+          classLoader =
+            DesktopRecordingSessionTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+          fps = FPS,
+          scale = 1.0f,
+          overrides = null,
+          live = true,
+        )
+      try {
+        // Pre-click window: let several initial-state frames render before we dispatch.
+        Thread.sleep(LIVE_PRE_CLICK_MS)
+
+        session.postInput(
+          ee.schimke.composeai.daemon.protocol.RecordingInputParams(
+            recordingId = "test-rec-live",
+            kind = ee.schimke.composeai.daemon.protocol.InteractiveInputKind.CLICK,
+            pixelX = COMPONENT_WIDTH_PX / 2,
+            pixelY = COMPONENT_HEIGHT_PX / 2,
+          )
+        )
+
+        // Post-click window: let a few more frames render so the post-click state (green) lands.
+        Thread.sleep(LIVE_POST_CLICK_MS)
+
+        val result = session.stop()
+        assertTrue(
+          "live recording should produce > 1 frame; got ${result.frameCount}",
+          result.frameCount > 1,
+        )
+        // Generous upper bound — slow CI runners might tick faster than fps in some configs.
+        assertTrue(
+          "live recording at 30 fps over ~500 ms should not exceed ${LIVE_MAX_FRAMES} frames; got ${result.frameCount}",
+          result.frameCount <= LIVE_MAX_FRAMES,
+        )
+
+        // First frame: pre-click state (red).
+        val frame0 = readPng(File(result.framesDir, "frame-00000.png"))
+        val redAt0 = pixelMatchPct(frame0, expectedRgb = 0xEF5350, perChannelTolerance = 8)
+        assertTrue(
+          "live frame 0 expected ≥ 95% red pixels (pre-click); got ${"%.2f".format(redAt0 * 100)}%",
+          redAt0 >= 0.95,
+        )
+
+        // Last frame: post-click state (green) — proves the tick loop drained the input and the
+        // held scene mutated. Without this assertion, a regression that broke postInput would
+        // still pass the frame-count check.
+        val lastFrameIdx = result.frameCount - 1
+        val frameLast = readPng(File(result.framesDir, "frame-${"%05d".format(lastFrameIdx)}.png"))
+        val greenAtLast = pixelMatchPct(frameLast, expectedRgb = 0x66BB6A, perChannelTolerance = 8)
+        assertTrue(
+          "live last frame ($lastFrameIdx) expected ≥ 95% green pixels (state=1 after live click); " +
+            "got ${"%.2f".format(greenAtLast * 100)}% — this is the load-bearing live-mode " +
+            "dispatch assertion",
+          greenAtLast >= 0.95,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun live_mode_postScript_throws() {
+    // Mode-mismatch guard: postScript on a live session is illegal. The wire-side handler
+    // catches the throw and logs it; we exercise the underlying contract here.
+    val outputDir = tempFolder.newFolder("live-mismatch-engine-renders")
+    val recordingsRoot = tempFolder.newFolder("live-mismatch-recordings-root")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val engine = RenderEngine(outputDir = outputDir)
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == FIXTURE_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "TristateClickSquare",
+              widthPx = COMPONENT_WIDTH_PX,
+              heightPx = COMPONENT_HEIGHT_PX,
+              density = 1.0f,
+              outputBaseName = "tristate-click-square-mismatch",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireRecordingSession(
+          previewId = FIXTURE_PREVIEW_ID,
+          recordingId = "test-rec-mismatch",
+          classLoader =
+            DesktopRecordingSessionTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+          fps = FPS,
+          scale = 1.0f,
+          overrides = null,
+          live = true,
+        )
+      try {
+        val thrown =
+          runCatching {
+              session.postScript(
+                listOf(
+                  RecordingScriptEvent(
+                    tMs = 0L,
+                    kind = ee.schimke.composeai.daemon.protocol.InteractiveInputKind.CLICK,
+                  )
+                )
+              )
+            }
+            .exceptionOrNull()
+        assertTrue(
+          "postScript on a live session must throw IllegalStateException; got ${thrown?.javaClass}",
+          thrown is IllegalStateException,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
   private fun readPng(file: File): java.awt.image.BufferedImage {
     assertTrue("rendered PNG must exist on disk: ${file.absolutePath}", file.exists())
     assertTrue("rendered PNG must be non-empty", file.length() > 0)
@@ -416,5 +590,12 @@ class DesktopRecordingSessionTest {
     private const val COMPONENT_WIDTH_PX = 120
     private const val COMPONENT_HEIGHT_PX = 60
     private const val FPS = 30
+
+    // Live-mode timing windows. Tuned so frames accumulate on either side of the click without
+    // making the test slow. ~250 ms × 2 = ~500 ms wall total; at 30 fps that's ~15 frames in the
+    // ideal case but we accept anywhere in the range below to absorb CI jitter.
+    private const val LIVE_PRE_CLICK_MS: Long = 250L
+    private const val LIVE_POST_CLICK_MS: Long = 250L
+    private const val LIVE_MAX_FRAMES: Int = 60
   }
 }


### PR DESCRIPTION
## Summary

Adds live (non-scripted) recording on top of the v1 scripted flow. Set
`recording/start.live = true` and the daemon spins a background tick
thread at fps cadence using a wall-clock-driven virtual nanoTime;
agents (or the panel) post `recording/input` notifications that the
tick loop drains and dispatches at the current virtual `tMs`.

This is the natural complement to scripted mode for the human-in-the-
loop / interactive use case: a user clicks around in the VS Code panel
(or an agent drives the preview reactively rather than from a pre-built
timeline) and the daemon captures everything at fps cadence in real
time. Encoding (APNG / mp4 / webm) goes through the same
`recording/encode` path that scripted mode already uses — the only
difference is how frames get written.

### Wire shape

```jsonc
// 1. Allocate a live session
{ "method": "recording/start",
  "params": { "previewId": "...", "fps": 30, "live": true } }
// → { "recordingId": "rec-1" }

// 2. Drive interactions over time (notification — no response)
{ "method": "recording/input",
  "params": { "recordingId": "rec-1", "kind": "click",
              "pixelX": 100, "pixelY": 50 } }
// ... more inputs ...

// 3. Stop and encode
{ "method": "recording/stop",   "params": { "recordingId": "rec-1" } }
// → { "frameCount": ..., "durationMs": ..., ... }
{ "method": "recording/encode", "params": { "recordingId": "rec-1",
                                            "format": "mp4" } }
// → { "videoPath": "...", "mimeType": "video/mp4", "sizeBytes": ... }
```

### Mode mutual exclusivity

Sessions are either scripted (default, v1) or live, frozen at allocation:
- `postScript` on a live session → `IllegalStateException`
- `postInput` on a scripted session → `IllegalStateException`

Wire-side handlers catch the throw and log it (notifications are fire-
and-forget; we don't propagate to the client).

### Implementation notes

- **Tick thread**: per-recording `compose-ai-daemon-recording-live-<id>`,
  daemon-flagged. Anchors `liveStartNs = System.nanoTime()` at construction
  time; each iteration computes `tNanos = nanoTime() - liveStartNs`,
  drains the input queue (`ConcurrentLinkedQueue`), dispatches at that
  nanoTime, renders one frame, sleeps until the next frame boundary.
- **Click dispatch**: same Press → render-tick → Release pattern as
  scripted mode and `DesktopInteractiveSession`, so `Modifier.clickable {}`
  and other tap-gesture detectors see a clean down→up sequence.
- **Stop/close**: 5s bounded join on the tick thread; if it doesn't exit
  cleanly we log and tear the scene down anyway.
- **Threading**: only the tick thread touches `state.scene`; `postInput`
  only adds to a wait-free queue. Skiko thread-safety is preserved.

### Test plan

- [x] `:daemon:core:compileKotlin`, `:daemon:desktop:compileKotlin`,
      `:daemon:desktop:compileTestKotlin` clean
- [x] `:daemon:core:test`, `:daemon:desktop:test`, `:mcp:test` all pass
- [x] `ktfmtCheck*` clean across touched modules
- [x] `live_mode_captures_frames_at_fps_cadence_and_dispatches_inputs`:
      pre-click sleep → `postInput` → post-click sleep → stop. Asserts
      frame count is in a tolerant range (>1, ≤60 — wide bounds to
      absorb CI jitter) and that the first frame is red (pre-click
      state) while the last is green (post-click state, proving the
      tick loop drained the input and the held scene mutated).
- [x] `live_mode_postScript_throws`: mode-mismatch contract.

### Out of scope

- MCP tool surface for live mode (a separate `start_recording` /
  `record_input` / `stop_recording` triple, or an extension to
  `record_preview`). Agents that want live mode today drive the daemon
  RPCs directly; the all-in-one `record_preview` tool stays scripted-
  only since live mode doesn't fit the "send everything in one call"
  shape. Easy follow-up if there's demand.
- Android (Robolectric) backend recording — still gated on the v3
  pointer-dispatch work documented in `INTERACTIVE-ANDROID.md`.