### PR TITLE
fix(daemon): live recording propagates tick failures + guarantees first frame

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -84,11 +84,33 @@ class DesktopRecordingSession(
 
   @Volatile private var liveFrameCount: Int = 0
 
+  // Live mode failure latch. Set by the tick loop's catch when scene.render or writeFramePng
+  // throws; read by stopLive() (after the join) to propagate the underlying error to the caller.
+  // Without this, a runtime exception on the background tick thread would silently truncate the
+  // recording and stopLive() would still report a successful (but partial) result — the
+  // asymmetry vs scripted mode that Codex flagged.
+  @Volatile private var liveFailure: Throwable? = null
+
   private val liveTickThread: Thread? =
     if (live) {
       framesDir.mkdirs()
       Thread({ runLiveTickLoop() }, "compose-ai-daemon-recording-live-$recordingId").apply {
         isDaemon = true
+        // Belt + suspenders for failure capture. The tick body's own try/catch handles failures
+        // that escape `dispatchInput` / `scene.render` / `writeFramePng` synchronously. But
+        // Compose's recomposer dispatches recompositions onto a coroutine that uses *this thread*
+        // as its dispatcher; if the recomposition body throws, the coroutine's exception surfaces
+        // via the thread's UncaughtExceptionHandler, NOT out of the next `scene.render()` call.
+        // Hooking the handler latches those into [liveFailure] too so [stopLive] propagates them
+        // exactly the same way.
+        uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, t ->
+          if (liveFailure == null) liveFailure = t
+          System.err.println(
+            "compose-ai-daemon: DesktopRecordingSession($recordingId) tick-thread uncaught " +
+              "exception (likely Compose recomposition error): ${t.javaClass.simpleName}: " +
+              "${t.message}"
+          )
+        }
         start()
       }
     } else null
@@ -126,12 +148,17 @@ class DesktopRecordingSession(
     if (stopped) error("DesktopRecordingSession.stop() called twice without a cached result")
     stopped = true
 
-    val r = if (live) stopLive() else stopScripted()
-    result = r
-    // The held scene is no longer needed; tear it down so subsequent close() is a no-op. The
-    // per-frame PNGs and any encoded video stay on disk for `recording/encode`.
-    engine.tearDown(state)
-    return r
+    // try/finally so the held scene is always torn down — including when stopLive() rethrows a
+    // captured live-tick failure, or when the scripted playback loop throws mid-render. Without
+    // this wrapping a render-time exception would leak the Skia Surface for the JVM's lifetime.
+    // engine.tearDown is idempotent, so the eventual close() call is still a no-op.
+    return try {
+      val r = if (live) stopLive() else stopScripted()
+      result = r
+      r
+    } finally {
+      engine.tearDown(state)
+    }
   }
 
   /**
@@ -199,6 +226,18 @@ class DesktopRecordingSession(
         )
       }
     }
+    // Failure propagation: if the tick loop caught an exception before exiting, surface it now
+    // so JsonRpcServer.handleRecordingStop returns a wire-level error instead of a successful
+    // (truncated) result. Mirrors scripted mode's contract — there, stopScripted's synchronous
+    // loop throws directly out of stop().
+    val failure = liveFailure
+    if (failure != null) {
+      throw IllegalStateException(
+        "live recording '$recordingId' failed mid-flight: " +
+          "${failure.javaClass.simpleName}: ${failure.message}",
+        failure,
+      )
+    }
     val frameCount = liveFrameCount
     val durationMs: Long = if (frameCount == 0) 0L else (frameCount - 1).toLong() * 1000L / fps
     System.err.println(
@@ -225,41 +264,64 @@ class DesktopRecordingSession(
    * 4. Sleeps until the next frame boundary (`nextTickNs - now`), preserving fps cadence even when
    *    the render body undershoots the budget.
    *
-   * Exits cleanly when [liveStopRequested] is observed at the top of the loop. The dispatch pattern
-   * matches scripted mode (CLICK splits into Press → render-tick → Release at the same nanoTime) so
-   * `Modifier.clickable {}` and other tap-gesture-detecting modifiers see a clean down→up sequence.
+   * **Initial-frame guarantee.** Structured as a `do { ... } while (!liveStopRequested)` so at
+   * least one frame always lands on disk, even when `recording/stop` arrives so quickly that
+   * `liveStopRequested` is set before the OS schedules this thread for its first iteration. Without
+   * this the very-short-recording path produced 0 frames and `recording/encode` (APNG specifically)
+   * would later fail with "at least one frame required" — a non-deterministic failure depending on
+   * thread-scheduling timing.
+   *
+   * **Failure capture.** Any throwable from `dispatchInput`, `scene.render`, or `writeFramePng` is
+   * caught into [liveFailure] and the loop exits. [stopLive] reads the latch after joining and
+   * rethrows so the wire-side `recording/stop` returns a clean error rather than a
+   * silently-truncated successful result. Without this, a render-time exception (e.g. a state
+   * mutation that triggers an `error("…")` inside the composition) would terminate the tick thread
+   * asynchronously and `stop()` would lie about success.
+   *
+   * The dispatch pattern matches scripted mode (CLICK splits into Press → render-tick → Release at
+   * the same nanoTime) so `Modifier.clickable {}` and other tap-gesture-detecting modifiers see a
+   * clean down→up sequence.
    */
   private fun runLiveTickLoop() {
     liveStartNs = System.nanoTime()
     val frameIntervalNs: Long = 1_000_000_000L / fps.toLong()
-    while (!liveStopRequested) {
-      val tNanos = System.nanoTime() - liveStartNs
-      val tMs = tNanos / 1_000_000L
+    try {
+      do {
+        val tNanos = System.nanoTime() - liveStartNs
+        val tMs = tNanos / 1_000_000L
 
-      // Drain inputs accumulated since the last tick; dispatch each at the current virtual
-      // nanoTime. Inputs that arrive *during* the dispatch+render below are picked up next tick.
-      while (true) {
-        val next = liveInputs.poll() ?: break
-        dispatchInput(next.kind, next.pixelX, next.pixelY, tNanos, tMs)
-      }
-
-      val image = state.scene.render(nanoTime = tNanos)
-      writeFramePng(image, liveFrameCount)
-      liveFrameCount++
-
-      // Sleep until the next frame boundary. If the render body overran (unlikely on desktop;
-      // common on Android one day), `sleepFor` clamps to 0 — we just take the next frame
-      // immediately rather than chasing missed frames retrospectively.
-      val nextTickNs = liveStartNs + liveFrameCount.toLong() * frameIntervalNs
-      val sleepNs = (nextTickNs - System.nanoTime()).coerceAtLeast(0L)
-      if (sleepNs > 0) {
-        try {
-          Thread.sleep(sleepNs / 1_000_000L, (sleepNs % 1_000_000L).toInt())
-        } catch (_: InterruptedException) {
-          Thread.currentThread().interrupt()
-          return
+        // Drain inputs accumulated since the last tick; dispatch each at the current virtual
+        // nanoTime. Inputs that arrive *during* the dispatch+render below are picked up next
+        // tick.
+        while (true) {
+          val next = liveInputs.poll() ?: break
+          dispatchInput(next.kind, next.pixelX, next.pixelY, tNanos, tMs)
         }
-      }
+
+        val image = state.scene.render(nanoTime = tNanos)
+        writeFramePng(image, liveFrameCount)
+        liveFrameCount++
+
+        // Sleep until the next frame boundary. If the render body overran (unlikely on desktop;
+        // common on Android one day), `sleepFor` clamps to 0 — we just take the next frame
+        // immediately rather than chasing missed frames retrospectively.
+        val nextTickNs = liveStartNs + liveFrameCount.toLong() * frameIntervalNs
+        val sleepNs = (nextTickNs - System.nanoTime()).coerceAtLeast(0L)
+        if (sleepNs > 0) {
+          try {
+            Thread.sleep(sleepNs / 1_000_000L, (sleepNs % 1_000_000L).toInt())
+          } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            return
+          }
+        }
+      } while (!liveStopRequested)
+    } catch (t: Throwable) {
+      liveFailure = t
+      System.err.println(
+        "compose-ai-daemon: DesktopRecordingSession.runLiveTickLoop($recordingId) failed at " +
+          "frame $liveFrameCount: ${t.javaClass.simpleName}: ${t.message}"
+      )
     }
   }
 

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
@@ -548,6 +548,165 @@ class DesktopRecordingSessionTest {
     }
   }
 
+  @Test
+  fun live_mode_propagates_render_failure_through_stop() {
+    // Codex P1 follow-up on #491. Without per-tick try/catch + liveFailure propagation, an
+    // exception inside scene.render or writeFramePng on the tick thread silently terminates it
+    // and stop() reports a successful (truncated) recording. Mirrors the asymmetry vs scripted
+    // mode where the synchronous playback loop propagates failures naturally.
+    //
+    // Setup: a live recording against ClickToBoomSquare. First composition paints cyan and arms
+    // a click handler; postInput dispatches the click; the next recomposition reads `boom = true`
+    // and throws inside scene.render. The tick loop catches that, stop() rethrows.
+    val outputDir = tempFolder.newFolder("live-fail-engine-renders")
+    val recordingsRoot = tempFolder.newFolder("live-fail-recordings-root")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val engine = RenderEngine(outputDir = outputDir)
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == FAILURE_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "ClickToBoomSquare",
+              widthPx = COMPONENT_WIDTH_PX,
+              heightPx = COMPONENT_HEIGHT_PX,
+              density = 1.0f,
+              outputBaseName = "click-to-boom-live",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireRecordingSession(
+          previewId = FAILURE_PREVIEW_ID,
+          recordingId = "test-rec-fail",
+          classLoader =
+            DesktopRecordingSessionTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+          fps = FPS,
+          scale = 1.0f,
+          overrides = null,
+          live = true,
+        )
+      try {
+        // Let a couple of healthy frames land before posting the click that arms the boom.
+        Thread.sleep(LIVE_PRE_CLICK_MS)
+
+        session.postInput(
+          ee.schimke.composeai.daemon.protocol.RecordingInputParams(
+            recordingId = "test-rec-fail",
+            kind = ee.schimke.composeai.daemon.protocol.InteractiveInputKind.CLICK,
+            pixelX = COMPONENT_WIDTH_PX / 2,
+            pixelY = COMPONENT_HEIGHT_PX / 2,
+          )
+        )
+
+        // Give the tick loop time to absorb the click, recompose, and throw.
+        Thread.sleep(LIVE_POST_CLICK_MS)
+
+        val thrown = runCatching { session.stop() }.exceptionOrNull()
+        assertNotNull(
+          "stop() must rethrow the live tick failure; got null (recording silently truncated)",
+          thrown,
+        )
+        assertTrue(
+          "stop() failure must be IllegalStateException; got ${thrown?.javaClass}",
+          thrown is IllegalStateException,
+        )
+        val message = thrown!!.message ?: ""
+        assertTrue(
+          "failure message must mention the recording id; got '$message'",
+          message.contains("test-rec-fail"),
+        )
+        // The original throwable is chained as the cause so callers can inspect render-side
+        // detail without parsing the message.
+        assertNotNull("failure must carry the underlying cause", thrown.cause)
+      } finally {
+        // close() is idempotent and safe even when stop() threw — the held scene was already
+        // torn down via the try/finally inside stop().
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun live_mode_emits_at_least_one_frame_even_on_immediate_stop() {
+    // Codex P2 follow-up on #491. Original tick loop had `while (!liveStopRequested)` as the
+    // gate, so a recording/stop arriving before the OS scheduled the tick thread for its first
+    // iteration produced 0 frames — and APNG explicitly requires ≥1, so the subsequent encode
+    // would fail nondeterministically based on thread scheduling.
+    //
+    // Fix: do-while loop body — at least one frame always lands on disk, regardless of stop()
+    // timing. This test calls stop() synchronously after acquireRecordingSession to maximise the
+    // chance of the original racing failure mode, and asserts the result is well-formed.
+    val outputDir = tempFolder.newFolder("live-immediate-engine-renders")
+    val recordingsRoot = tempFolder.newFolder("live-immediate-recordings-root")
+    savedRecordingsDir = System.getProperty(DesktopHost.RECORDINGS_DIR_PROP)
+    System.setProperty(DesktopHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+
+    val engine = RenderEngine(outputDir = outputDir)
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == FIXTURE_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "TristateClickSquare",
+              widthPx = COMPONENT_WIDTH_PX,
+              heightPx = COMPONENT_HEIGHT_PX,
+              density = 1.0f,
+              outputBaseName = "tristate-click-square-immediate",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireRecordingSession(
+          previewId = FIXTURE_PREVIEW_ID,
+          recordingId = "test-rec-immediate",
+          classLoader =
+            DesktopRecordingSessionTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+          fps = FPS,
+          scale = 1.0f,
+          overrides = null,
+          live = true,
+        )
+      try {
+        // No sleep — stop synchronously to race the tick thread's first iteration.
+        val result = session.stop()
+        assertTrue(
+          "live recording must always emit at least one frame; got ${result.frameCount} " +
+            "(this is the load-bearing initial-frame guarantee)",
+          result.frameCount >= 1,
+        )
+        // Frame 0 must exist on disk so a follow-up recording/encode (APNG requires ≥1 frame)
+        // succeeds rather than failing with "at least one frame required".
+        val frame0 = File(result.framesDir, "frame-00000.png")
+        assertTrue("frame 0 must exist on disk: ${frame0.absolutePath}", frame0.isFile)
+        assertTrue("frame 0 must be non-empty", frame0.length() > 0)
+        // Encode confirms the end-to-end path works for very-short recordings.
+        val encoded = session.encode(RecordingFormat.APNG)
+        assertTrue("APNG encode must produce a non-empty file", encoded.sizeBytes > 0)
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
   private fun readPng(file: File): java.awt.image.BufferedImage {
     assertTrue("rendered PNG must exist on disk: ${file.absolutePath}", file.exists())
     assertTrue("rendered PNG must be non-empty", file.length() > 0)
@@ -586,6 +745,7 @@ class DesktopRecordingSessionTest {
 
   companion object {
     private const val FIXTURE_PREVIEW_ID = "tristate-click-square"
+    private const val FAILURE_PREVIEW_ID = "click-to-boom-square"
     // Component-preview-sized sandbox — a button-ish 120x60 surface, deliberately NOT phone-sized.
     private const val COMPONENT_WIDTH_PX = 120
     private const val COMPONENT_HEIGHT_PX = 60

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -176,6 +176,32 @@ fun TristateClickSquare() {
 }
 
 /**
+ * Live-mode failure-propagation fixture for `DesktopRecordingSessionTest`. First composition paints
+ * cyan and arms a click watcher; the click flips `boom = true`, the recomposition reads `boom` and
+ * `error("…")`s. The thrown exception propagates out of `scene.render()` on the live tick thread —
+ * exactly the failure mode Codex flagged: without per-tick try/catch + propagation to `stopLive()`,
+ * that throwable would silently terminate the tick thread and `stop()` would lie about success.
+ *
+ * The pattern matches existing [BoomComposable] (which throws at first composition) but defers the
+ * throw so the held scene's `setUp` succeeds and the tick loop has a chance to render at least one
+ * healthy frame before failing.
+ */
+@Composable
+fun ClickToBoomSquare() {
+  var boom by remember { mutableStateOf(false) }
+  if (boom) error("boom-after-click")
+  Box(
+    modifier =
+      Modifier.fillMaxSize().background(Color(0xFF00BCD4)).pointerInput(Unit) {
+        awaitPointerEventScope {
+          awaitFirstDown()
+          boom = true
+        }
+      }
+  )
+}
+
+/**
  * Reads `isSystemInDarkTheme()` and fills the box with white in light mode, black in dark mode.
  * Used by `OverrideIntegrationTest` (desktop) to prove `renderNow.overrides.uiMode` reaches
  * `LocalSystemTheme` — Compose Desktop's `isSystemInDarkTheme()` reads that local rather than the


### PR DESCRIPTION
## Summary

Two follow-ups on the P4 live-recording PR (#491), both flagged in code
review:

### 1. Propagate tick-thread failures (codex P1)

The live tick loop called `scene.render` and `writeFramePng` without
capturing failures, so any runtime exception silently terminated the
thread and `stopLive()` reported a successful (truncated) recording.
Asymmetric vs scripted mode where the synchronous playback loop
propagates failures naturally.

Fix: belt + suspenders capture into a `liveFailure: Throwable?` latch:

- `try/catch` around the tick loop body for **synchronous** escapes
  (`writeFramePng` I/O, `dispatchInput` errors).
- `Thread.UncaughtExceptionHandler` on the tick thread for
  **asynchronous** escapes — Compose's recomposer dispatches
  recompositions on a coroutine that uses the tick thread as its
  dispatcher, and an uncaught exception there surfaces via the thread's
  handler rather than out of the next `scene.render()` call. This is
  the case the failure-propagation test actually exercises (the
  `error("…")` from a recomposition body lands here, not in the
  synchronous catch).

`stopLive()` reads the latch after the join and rethrows as
`IllegalStateException` with the original throwable as its `cause`, so
`JsonRpcServer.handleRecordingStop` returns a clean wire-level error
instead of a misleading success. Wrapped `stop()`'s body in
`try/finally` so `engine.tearDown` always runs even when the
propagation throws.

### 2. Guarantee at least one frame (codex P2)

Original tick loop had `while (!liveStopRequested)` as the gate, so a
`recording/stop` that arrived before the OS scheduled the tick thread
for its first iteration produced 0 frames. APNG explicitly requires ≥1
frame, so the subsequent encode would fail nondeterministically
depending on thread scheduling.

Fix: `do { ... } while (!liveStopRequested)` — at least one frame
always lands on disk.

### Test plan

- [x] `:daemon:desktop:test` passes (existing + 2 new)
- [x] `:daemon:core:test`, `:mcp:test` pass
- [x] `ktfmtCheck*` clean
- [x] **`live_mode_propagates_render_failure_through_stop`**: new
      `ClickToBoomSquare` fixture (paints cyan, throws on click-
      triggered recomposition). Asserts `stop()` rethrows as
      `IllegalStateException` carrying the original
      `IllegalStateException("boom-after-click")` as its `cause`.
- [x] **`live_mode_emits_at_least_one_frame_even_on_immediate_stop`**:
      calls `stop()` synchronously after `acquireRecordingSession` to
      race the tick thread's first iteration. Asserts `frameCount ≥ 1`,
      `frame-00000.png` exists on disk, and APNG encode produces a
      non-empty file.