### PR TITLE
Tweak interactive preview controls

### DIFF
--- a/samples/wear/src/main/kotlin/com/example/samplewear/Previews.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/Previews.kt
@@ -8,6 +8,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalScrollCaptureInProgress
@@ -135,6 +139,7 @@ fun ActivityListScreen() {
 
 @Composable
 private fun ButtonPreviewContent() {
+    var taps by remember { mutableStateOf(0) }
     MaterialTheme {
         AppScaffold(
             timeText = { TimeText(timeSource = FixedPreviewTimeSource) },
@@ -147,8 +152,8 @@ private fun ButtonPreviewContent() {
                         .padding(horizontal = 16.dp),
                     contentAlignment = Alignment.Center,
                 ) {
-                    Button(onClick = {}) {
-                        Text("Tap me!")
+                    Button(onClick = { taps += 1 }) {
+                        Text("Taps: $taps")
                     }
                 }
             }

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -491,58 +491,19 @@ body {
     animation: none;
 }
 
-/* Subtle red border telegraphs that the focused card is the current
-   live target. Bottom-right pill shows LIVE + a pulsing dot — the same
-   visual language as recording indicators in screen-share apps so the
-   meaning lands without a tooltip. */
+/* Subtle red border telegraphs that the card is an interactive target.
+   Keep the indicator outside the preview pixels: the toolbar stop button
+   carries the explicit control, while the image stays unobscured. */
 .preview-card.live {
-    /* 2px ringed border + a soft outer glow so the live state reads from across
-       the panel, not just on close inspection. The glow uses box-shadow so it
-       doesn't reflow neighbours; the border-color carries the same tint as the
-       LIVE badge dot for visual coherence. */
     border-color: var(--vscode-errorForeground, #f55);
-    border-width: 2px;
     box-shadow: 0 0 0 1px color-mix(in srgb, var(--vscode-errorForeground, #f55) 30%, transparent),
                 0 0 12px color-mix(in srgb, var(--vscode-errorForeground, #f55) 25%, transparent);
 }
 .preview-card.live .image-container {
     cursor: crosshair; /* signals "click here to dispatch into the live preview" */
 }
-.live-badge {
-    position: absolute;
-    top: 6px;
-    right: 6px;
-    z-index: 4;
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    padding: 3px 8px;
-    border-radius: 4px;
-    /* Solid red chip — the previous transparent-with-blur version blended into
-       the underlying preview when the preview happened to be red/orange. Solid
-       background guarantees the LIVE state is unambiguous. */
-    background: var(--vscode-errorForeground, #f55);
-    color: var(--vscode-editor-background);
-    font-size: calc(var(--vscode-font-size) - 1px);
-    font-weight: 700;
-    letter-spacing: 0.5px;
-    text-transform: uppercase;
-    pointer-events: none;
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
-}
-.live-badge-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: var(--vscode-editor-background);
-    animation: liveBlink 1s ease-in-out infinite;
-}
-@keyframes liveBlink {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.35; }
-}
 
-/* Toggle button "live-on" state: red glyph echoing the badge. */
+/* Toggle button "live-on" state: red glyph matching the live card outline. */
 .icon-button.live-on {
     color: var(--vscode-errorForeground, #f55);
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -514,7 +514,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     interactiveStatusItem.command = 'workbench.action.output.toggleOutput';
     context.subscriptions.push(interactiveStatusItem);
 
-    panel = new PreviewPanel(context.extensionUri, handleWebviewMessage);
+    panel = new PreviewPanel(
+        context.extensionUri,
+        handleWebviewMessage,
+        () => historyPanel?.isVisible() ?? false,
+    );
     if (isTestMode) {
         // Tap into every outgoing webview message so the test API can assert
         // on the message stream. The wrapper preserves the original

--- a/vscode-extension/src/historyPanel.ts
+++ b/vscode-extension/src/historyPanel.ts
@@ -78,6 +78,10 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
         this.view.webview.postMessage({ command: 'entryAdded', entry: params.entry });
     }
 
+    isVisible(): boolean {
+        return this.view?.visible ?? false;
+    }
+
     /** Force a re-list against the current scope. */
     async refresh(): Promise<void> {
         if (!this.view || !this.currentScope) {

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -7,10 +7,16 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
     private view?: vscode.WebviewView;
     private extensionUri: vscode.Uri;
     private onMessage: (msg: WebviewToExtension) => void;
+    private shouldRestoreVisibility: () => boolean;
 
-    constructor(extensionUri: vscode.Uri, onMessage: (msg: WebviewToExtension) => void) {
+    constructor(
+        extensionUri: vscode.Uri,
+        onMessage: (msg: WebviewToExtension) => void,
+        shouldRestoreVisibility: () => boolean = () => false,
+    ) {
         this.extensionUri = extensionUri;
         this.onMessage = onMessage;
+        this.shouldRestoreVisibility = shouldRestoreVisibility;
     }
 
     resolveWebviewView(
@@ -26,6 +32,10 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         webviewView.webview.html = this.getHtml(webviewView.webview);
         webviewView.webview.onDidReceiveMessage((msg: WebviewToExtension) => {
             this.onMessage(msg);
+        });
+        webviewView.onDidChangeVisibility(() => {
+            if (webviewView.visible || !this.shouldRestoreVisibility()) { return; }
+            void vscode.commands.executeCommand(`${PreviewPanel.viewId}.focus`);
         });
     }
 
@@ -90,6 +100,10 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             </select>
             <i class="codicon codicon-chevron-down select-chevron" aria-hidden="true"></i>
         </div>
+        <button class="icon-button" id="btn-stop-interactive-global" title="Stop live preview"
+                aria-label="Stop live preview" hidden>
+            <i class="codicon codicon-debug-stop" aria-hidden="true"></i>
+        </button>
     </div>
 
     <div id="message" class="message" role="status" aria-live="polite"></div>
@@ -118,6 +132,10 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 aria-label="Toggle live (interactive) mode" aria-pressed="false" disabled hidden>
             <i class="codicon codicon-circle-large-outline" aria-hidden="true"></i>
         </button>
+        <button class="icon-button" id="btn-stop-interactive" title="Stop live preview"
+                aria-label="Stop live preview" hidden>
+            <i class="codicon codicon-debug-stop" aria-hidden="true"></i>
+        </button>
         <button class="icon-button" id="btn-exit-focus" title="Exit focus mode" aria-label="Exit focus mode">
             <i class="codicon codicon-close" aria-hidden="true"></i>
         </button>
@@ -142,6 +160,8 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         const btnLaunchDevice = document.getElementById('btn-launch-device');
         const btnA11yOverlay = document.getElementById('btn-a11y-overlay');
         const btnInteractive = document.getElementById('btn-interactive');
+        const btnStopInteractiveGlobal = document.getElementById('btn-stop-interactive-global');
+        const btnStopInteractive = document.getElementById('btn-stop-interactive');
         const btnExitFocus = document.getElementById('btn-exit-focus');
         // D2 — focus-mode a11y overlay toggle. Off by default; turning it on subscribes the
         // focused preview to a11y/atf + a11y/hierarchy via the extension, off unsubscribes.
@@ -361,6 +381,8 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         // remove just this one. Plain click keeps the single-target single-card UX casual users
         // expect.
         btnInteractive.addEventListener('click', (e) => toggleInteractive(e.shiftKey));
+        btnStopInteractiveGlobal.addEventListener('click', () => stopAllInteractive());
+        btnStopInteractive.addEventListener('click', () => stopAllInteractive());
         btnExitFocus.addEventListener('click', () => exitFocus());
 
         // ----- Interactive (live-stream) mode helpers -----
@@ -389,6 +411,11 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             // hides itself, but this keeps aria-pressed correct for tests
             // that snapshot the button in either layout.
             btnInteractive.hidden = !inFocus;
+            const hasLive = interactivePreviewIds.size > 0;
+            btnStopInteractiveGlobal.hidden = !hasLive;
+            btnStopInteractiveGlobal.disabled = !hasLive;
+            btnStopInteractive.hidden = !inFocus || !hasLive;
+            btnStopInteractive.disabled = !hasLive;
             if (!inFocus) {
                 // Cheap fast-path: applyLayout fires this on every layout
                 // change (filter tweaks, focus nav, every setPreviews). In
@@ -482,26 +509,28 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             // off the now-not-live card. Then re-stamp every still-live preview.
             document.querySelectorAll('.preview-card.live').forEach(c => {
                 c.classList.remove('live');
-                const badge = c.querySelector('.live-badge');
-                if (badge) badge.remove();
             });
             if (interactivePreviewIds.size === 0) return;
             interactivePreviewIds.forEach(previewId => {
                 const card = document.getElementById('preview-' + sanitizeId(previewId));
                 if (!card) return;
                 card.classList.add('live');
-                if (card.querySelector('.live-badge')) return;
-                const badge = document.createElement('div');
-                badge.className = 'live-badge';
-                badge.setAttribute('aria-hidden', 'true');
-                const dot = document.createElement('span');
-                dot.className = 'live-badge-dot';
-                badge.appendChild(dot);
-                const text = document.createElement('span');
-                text.textContent = 'LIVE';
-                badge.appendChild(text);
-                card.appendChild(badge);
             });
+        }
+
+        function stopAllInteractive() {
+            if (interactivePreviewIds.size === 0) return;
+            const ids = Array.from(interactivePreviewIds);
+            interactivePreviewIds.clear();
+            ids.forEach(previewId => {
+                vscode.postMessage({
+                    command: 'setInteractive',
+                    previewId,
+                    enabled: false,
+                });
+            });
+            applyLiveBadge();
+            applyInteractiveButtonState();
         }
 
         function toggleInteractive(shift) {
@@ -746,8 +775,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     card.classList.remove('focused', 'hidden-by-focus');
                 });
             }
-            const tooltip = mode === 'focus' ? 'Double-click to exit focus' : 'Double-click to focus';
-            document.querySelectorAll('.image-container').forEach(c => c.title = tooltip);
+            document.querySelectorAll('.image-container').forEach(c => c.removeAttribute('title'));
             publishScopedPreview();
             // Single-target follow-focus: when there's exactly one live stream and the user
             // navigates off it, drop the stream so the LIVE chip follows the focused card.
@@ -1247,7 +1275,6 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 
             const imgContainer = document.createElement('div');
             imgContainer.className = 'image-container';
-            imgContainer.title = 'Click to enter live mode';
             const skeleton = document.createElement('div');
             skeleton.className = 'skeleton';
             skeleton.setAttribute('aria-label', 'Loading preview');


### PR DESCRIPTION
## Summary
- add explicit stop controls for interactive preview mode
- keep live indicators out of preview pixels and remove preview hover tooltips
- keep the Previews view restored while History remains the collapsible view
- update the Wear button sample to show a click counter

## Verification
- npm run compile
- ./gradlew :samples:wear:compileDebugKotlin
- git diff --check