### PR TITLE
Add interactive drag and rotary scroll input

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -197,7 +197,9 @@ internal constructor(
       when (input.kind) {
         InteractiveInputKind.CLICK -> "click"
         InteractiveInputKind.POINTER_DOWN -> "pointerDown"
+        InteractiveInputKind.POINTER_MOVE -> "pointerMove"
         InteractiveInputKind.POINTER_UP -> "pointerUp"
+        InteractiveInputKind.ROTARY_SCROLL -> "rotaryScroll"
         // Key events are no-op on Android v3 — same shape as desktop v2's silent drop. Wire shape
         // accepts them so a forward-looking client doesn't get rejected; the dispatch lands in
         // the sandbox loop and is intentionally ignored there.
@@ -214,6 +216,7 @@ internal constructor(
         kind = kind,
         pixelX = px,
         pixelY = py,
+        scrollDeltaY = input.scrollDeltaY,
         replyLatch = replyLatch,
         replyError = replyError,
       )

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -805,6 +805,8 @@ open class RobolectricHost(
      */
     private val engine: RenderEngine by lazy { RenderEngine() }
 
+    private var heldPointerDownTimeMs: Long = 0L
+
     /**
      * B2.3 — per-sandbox lifecycle counters, instantiated inside the sandbox so `sandboxAgeMs`
      * is wall-clock since `holdSandboxOpen` started (i.e. since the sandbox booted, not since
@@ -1322,7 +1324,9 @@ open class RobolectricHost(
      * `mainClock` provided we advance the clock by [POINTER_HOLD_MS] after the dispatch.
      *
      * `click` synthesises ACTION_DOWN + ACTION_UP at the same coords; `pointerDown` /
-     * `pointerUp` send a single event each. Unknown kinds are silently dropped — the host-side
+     * `pointerMove` / `pointerUp` send a single event each. `rotaryScroll` dispatches a generic
+     * SOURCE_ROTARY_ENCODER ACTION_SCROLL so Wear Compose receives it like an RSB turn. Unknown kinds
+     * are silently dropped — the host-side
      * [AndroidInteractiveSession.dispatch] already filters key events out, so we should never
      * see them here.
      */
@@ -1371,9 +1375,10 @@ open class RobolectricHost(
             }
           }
           "pointerDown" -> {
+            heldPointerDownTimeMs = now
             val ev =
               android.view.MotionEvent.obtain(
-                now,
+                heldPointerDownTimeMs,
                 now,
                 android.view.MotionEvent.ACTION_DOWN,
                 x,
@@ -1386,10 +1391,28 @@ open class RobolectricHost(
               ev.recycle()
             }
           }
-          "pointerUp" -> {
+          "pointerMove" -> {
+            val downTime = if (heldPointerDownTimeMs != 0L) heldPointerDownTimeMs else now
             val ev =
               android.view.MotionEvent.obtain(
+                downTime,
                 now,
+                android.view.MotionEvent.ACTION_MOVE,
+                x,
+                y,
+                /* metaState = */ 0,
+              )
+            try {
+              decor.dispatchTouchEvent(ev)
+            } finally {
+              ev.recycle()
+            }
+          }
+          "pointerUp" -> {
+            val downTime = if (heldPointerDownTimeMs != 0L) heldPointerDownTimeMs else now
+            val ev =
+              android.view.MotionEvent.obtain(
+                downTime,
                 now,
                 android.view.MotionEvent.ACTION_UP,
                 x,
@@ -1400,6 +1423,52 @@ open class RobolectricHost(
               decor.dispatchTouchEvent(ev)
             } finally {
               ev.recycle()
+              heldPointerDownTimeMs = 0L
+            }
+          }
+          "rotaryScroll" -> {
+            val delta = cmd.scrollDeltaY ?: 0f
+            if (delta != 0f) {
+              val props =
+                arrayOf(
+                  android.view.MotionEvent.PointerProperties().apply {
+                    id = 0
+                    toolType = android.view.MotionEvent.TOOL_TYPE_UNKNOWN
+                  }
+                )
+              val coords =
+                arrayOf(
+                  android.view.MotionEvent.PointerCoords().apply {
+                    this.x = x
+                    this.y = y
+                    setAxisValue(
+                      android.view.MotionEvent.AXIS_SCROLL,
+                      if (delta > 0f) -1f else 1f,
+                    )
+                  }
+                )
+              val ev =
+                android.view.MotionEvent.obtain(
+                  now,
+                  now,
+                  android.view.MotionEvent.ACTION_SCROLL,
+                  1,
+                  props,
+                  coords,
+                  /* metaState = */ 0,
+                  /* buttonState = */ 0,
+                  /* xPrecision = */ 1f,
+                  /* yPrecision = */ 1f,
+                  /* deviceId = */ 0,
+                  /* edgeFlags = */ 0,
+                  android.view.InputDevice.SOURCE_ROTARY_ENCODER,
+                  /* flags = */ 0,
+                )
+              try {
+                decor.dispatchGenericMotionEvent(ev)
+              } finally {
+                ev.recycle()
+              }
             }
           }
         }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -404,8 +404,8 @@ sealed interface InteractiveCommand {
 
   /**
    * Synthesise + dispatch a [android.view.MotionEvent] on the rule's main thread. [kind] mirrors
-   * the v2 wire `interactive/input` `kind` field — `"click"` / `"pointerDown"` / `"pointerUp"`
-   * for v3; key events fall through to a no-op until v4. Pixel coordinates are in the held
+   * the v2 wire `interactive/input` `kind` field — pointer events plus `"rotaryScroll"` for Wear
+   * previews; key events fall through to a no-op until v4. Pixel coordinates are in the held
    * composition's own pixel space — the host has already scaled from any `pixelDensity` ratio.
    */
   data class Dispatch(
@@ -413,6 +413,7 @@ sealed interface InteractiveCommand {
     val kind: String,
     val pixelX: Int,
     val pixelY: Int,
+    val scrollDeltaY: Float? = null,
     val replyLatch: CountDownLatch,
     val replyError: AtomicReference<Throwable?>,
   ) : InteractiveCommand

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -716,6 +716,8 @@ data class InteractiveInputParams(
   /** Image-natural pixel coordinates. Daemon translates to dp using the last render's density. */
   val pixelX: Int? = null,
   val pixelY: Int? = null,
+  /** Browser wheel delta for `rotaryScroll`; positive means wheel-down. */
+  val scrollDeltaY: Float? = null,
   /** For `keyDown` / `keyUp`. */
   val keyCode: String? = null,
 )
@@ -724,7 +726,9 @@ data class InteractiveInputParams(
 enum class InteractiveInputKind {
   @SerialName("click") CLICK,
   @SerialName("pointerDown") POINTER_DOWN,
+  @SerialName("pointerMove") POINTER_MOVE,
   @SerialName("pointerUp") POINTER_UP,
+  @SerialName("rotaryScroll") ROTARY_SCROLL,
   @SerialName("keyDown") KEY_DOWN,
   @SerialName("keyUp") KEY_UP,
 }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
@@ -84,6 +84,15 @@ class DesktopInteractiveSession(
           buttons = PointerButtons(isPrimaryPressed = true),
         )
       }
+      InteractiveInputKind.POINTER_MOVE -> {
+        if (px == null || py == null) return
+        state.scene.sendPointerEvent(
+          eventType = PointerEventType.Move,
+          position = sceneOffset(px, py),
+          button = PointerButton.Primary,
+          buttons = PointerButtons(isPrimaryPressed = true),
+        )
+      }
       InteractiveInputKind.POINTER_UP -> {
         if (px == null || py == null) return
         state.scene.sendPointerEvent(
@@ -93,6 +102,7 @@ class DesktopInteractiveSession(
           buttons = PointerButtons(),
         )
       }
+      InteractiveInputKind.ROTARY_SCROLL,
       InteractiveInputKind.KEY_DOWN,
       InteractiveInputKind.KEY_UP -> {
         // No-op for v2 — see class KDoc. Wire shape accepts the input so the daemon doesn't reject

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -395,6 +395,16 @@ class DesktopRecordingSession(
           buttons = PointerButtons(isPrimaryPressed = true),
         )
       }
+      InteractiveInputKind.POINTER_MOVE -> {
+        if (px == null || py == null) return
+        state.scene.sendPointerEvent(
+          eventType = PointerEventType.Move,
+          position = sceneOffset(px, py),
+          timeMillis = tMs,
+          button = PointerButton.Primary,
+          buttons = PointerButtons(isPrimaryPressed = true),
+        )
+      }
       InteractiveInputKind.POINTER_UP -> {
         if (px == null || py == null) return
         state.scene.sendPointerEvent(
@@ -405,6 +415,7 @@ class DesktopRecordingSession(
           buttons = PointerButtons(),
         )
       }
+      InteractiveInputKind.ROTARY_SCROLL,
       InteractiveInputKind.KEY_DOWN,
       InteractiveInputKind.KEY_UP -> {
         // Reserved for v2 key dispatch; same no-op as DesktopInteractiveSession.

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -489,6 +489,7 @@ body {
 .image-container img.live-frame {
     /* No animation: the next frame replaces the current one with no fade. */
     animation: none;
+    touch-action: none;
 }
 
 /* Subtle red border telegraphs that the focused card is the current

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -512,7 +512,9 @@ export interface InteractiveStopParams { frameStreamId: string }
 export type InteractiveInputKind =
     | 'click'
     | 'pointerDown'
+    | 'pointerMove'
     | 'pointerUp'
+    | 'rotaryScroll'
     | 'keyDown'
     | 'keyUp';
 
@@ -523,6 +525,8 @@ export interface InteractiveInputParams {
      *  last-render density. Omit for keyboard events. */
     pixelX?: number;
     pixelY?: number;
+    /** Browser wheel delta for `rotaryScroll`; positive means wheel-down. */
+    scrollDeltaY?: number;
     /** For `keyDown` / `keyUp`. */
     keyCode?: string;
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2153,12 +2153,13 @@ function handleWebviewMessage(msg: WebviewToExtension) {
         case 'setInteractive':
             void handleSetInteractive(msg.previewId, msg.enabled);
             break;
-        case 'recordInteractiveClick':
+        case 'recordInteractiveInput':
             logLine(
-                `[interactive] click ${msg.previewId} px=${msg.pixelX},${msg.pixelY} `
-                + `image=${msg.imageWidth}x${msg.imageHeight}`,
+                `[interactive] ${msg.kind} ${msg.previewId} px=${msg.pixelX},${msg.pixelY} `
+                + `image=${msg.imageWidth}x${msg.imageHeight}`
+                + (msg.scrollDeltaY != null ? ` deltaY=${msg.scrollDeltaY}` : ''),
             );
-            void forwardInteractiveClick(msg.previewId, msg.pixelX, msg.pixelY);
+            void forwardInteractiveInput(msg);
             break;
         case 'setA11yOverlay':
             void handleSetA11yOverlay(msg.previewId, msg.enabled);
@@ -2882,16 +2883,15 @@ function updateInteractiveStatus(): void {
 }
 
 /**
- * Forward a panel-side click on a live preview to the daemon's `interactive/input`
+ * Forward panel-side input on a live preview to the daemon's `interactive/input`
  * notification. Drops silently when the previewId isn't currently in interactive mode
  * — callers don't need to coordinate with the start/stop dance.
  */
-async function forwardInteractiveClick(
-    previewId: string,
-    pixelX: number,
-    pixelY: number,
+async function forwardInteractiveInput(
+    input: Extract<WebviewToExtension, { command: 'recordInteractiveInput' }>,
 ): Promise<void> {
     if (!daemonGate?.isEnabled() || !daemonScheduler) { return; }
+    const previewId = input.previewId;
     const streamId = activeInteractiveStreams.get(previewId);
     if (!streamId) { return; }
     const moduleId = previewModuleMap.get(previewId);
@@ -2902,9 +2902,10 @@ async function forwardInteractiveClick(
     if (!client) { return; }
     client.interactiveInput({
         frameStreamId: streamId,
-        kind: 'click',
-        pixelX,
-        pixelY,
+        kind: input.kind,
+        pixelX: input.pixelX,
+        pixelY: input.pixelY,
+        scrollDeltaY: input.scrollDeltaY,
     });
 }
 

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -564,30 +564,101 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             setInteractiveForCard(card, shift);
         }
 
-        // Idempotent attach. Adds a click listener to the live card's image
+        // Idempotent attach. Adds pointer + wheel listeners to the live card's image
         // exactly once; flagged via dataset so a second updateImage on the
         // same element doesn't stack listeners. Detached the moment live
         // mode exits, so non-live cards never carry the handler.
-        function ensureInteractiveClickHandler(card, img) {
+        function ensureInteractiveInputHandlers(card, img) {
             const previewId = card.dataset.previewId;
             const shouldHandle = !!previewId && interactivePreviewIds.has(previewId);
             if (shouldHandle && img.dataset.interactiveBound !== '1') {
                 img.dataset.interactiveBound = '1';
-                img.addEventListener('click', (evt) => {
+                const state = {
+                    pointerId: null,
+                    start: null,
+                    last: null,
+                    dragging: false,
+                    sentDown: false,
+                };
+                img.addEventListener('pointerdown', (evt) => {
                     const id = card.dataset.previewId;
                     if (!id || !interactivePreviewIds.has(id)) return;
-                    recordInteractiveClick(id, img, evt);
+                    if (evt.button !== 0) return;
+                    state.pointerId = evt.pointerId;
+                    state.start = imagePoint(img, evt);
+                    state.last = state.start;
+                    state.dragging = false;
+                    state.sentDown = false;
+                    img.setPointerCapture?.(evt.pointerId);
+                    evt.preventDefault();
+                    evt.stopPropagation();
                 });
-            } else if (!shouldHandle && img.dataset.interactiveBound === '1') {
-                // Listener leak isn't worth a clone+replace dance — set the
-                // flag so the early-return inside the listener short-circuits
-                // future clicks, and let the element's lifetime clean things
-                // up. Re-entering live mode rebinds via the bound check above.
-                delete img.dataset.interactiveBound;
+                img.addEventListener('pointermove', (evt) => {
+                    const id = card.dataset.previewId;
+                    if (!id || !interactivePreviewIds.has(id)) return;
+                    if (state.pointerId !== evt.pointerId || !state.start) return;
+                    const next = imagePoint(img, evt);
+                    if (!next) return;
+                    const dx = next.clientX - state.start.clientX;
+                    const dy = next.clientY - state.start.clientY;
+                    if (!state.dragging && Math.hypot(dx, dy) >= 4) {
+                        state.dragging = true;
+                    }
+                    if (state.dragging) {
+                        if (!state.sentDown) {
+                            postInteractiveInput(id, img, 'pointerDown', state.start);
+                            state.sentDown = true;
+                        }
+                        postInteractiveInput(id, img, 'pointerMove', next);
+                        state.last = next;
+                        evt.preventDefault();
+                        evt.stopPropagation();
+                    }
+                });
+                img.addEventListener('pointerup', (evt) => {
+                    const id = card.dataset.previewId;
+                    if (!id || !interactivePreviewIds.has(id)) return;
+                    if (state.pointerId !== evt.pointerId || !state.start) return;
+                    const point = imagePoint(img, evt) || state.last || state.start;
+                    if (state.dragging) {
+                        if (!state.sentDown) {
+                            postInteractiveInput(id, img, 'pointerDown', state.start);
+                        }
+                        postInteractiveInput(id, img, 'pointerUp', point);
+                    } else {
+                        postInteractiveInput(id, img, 'click', point);
+                    }
+                    img.releasePointerCapture?.(evt.pointerId);
+                    state.pointerId = null;
+                    state.start = null;
+                    state.last = null;
+                    state.dragging = false;
+                    state.sentDown = false;
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                });
+                img.addEventListener('pointercancel', (evt) => {
+                    if (state.pointerId !== evt.pointerId) return;
+                    img.releasePointerCapture?.(evt.pointerId);
+                    state.pointerId = null;
+                    state.start = null;
+                    state.last = null;
+                    state.dragging = false;
+                    state.sentDown = false;
+                });
+                img.addEventListener('wheel', (evt) => {
+                    const id = card.dataset.previewId;
+                    if (!id || !interactivePreviewIds.has(id) || card.dataset.wearPreview !== '1') return;
+                    const point = imagePoint(img, evt);
+                    if (!point) return;
+                    postInteractiveInput(id, img, 'rotaryScroll', point, evt.deltaY);
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                }, { passive: false });
             }
         }
 
-        function recordInteractiveClick(previewId, img, evt) {
+        function imagePoint(img, evt) {
             // Image-natural pixel coords — same space the daemon's renderer
             // works in. The webview's offsetX/Y is in CSS pixels of the
             // displayed image; scale by the displayed/natural ratio to
@@ -595,18 +666,32 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             const natW = img.naturalWidth || 0;
             const natH = img.naturalHeight || 0;
             const rect = img.getBoundingClientRect();
-            if (!natW || !natH || rect.width === 0 || rect.height === 0) return;
+            if (!natW || !natH || rect.width === 0 || rect.height === 0) return null;
             const clientX = evt.clientX - rect.left;
             const clientY = evt.clientY - rect.top;
             const pixelX = Math.round(clientX * (natW / rect.width));
             const pixelY = Math.round(clientY * (natH / rect.height));
+            return {
+                clientX,
+                clientY,
+                pixelX: Math.max(0, Math.min(natW - 1, pixelX)),
+                pixelY: Math.max(0, Math.min(natH - 1, pixelY)),
+            };
+        }
+
+        function postInteractiveInput(previewId, img, kind, point, scrollDeltaY) {
+            const natW = img.naturalWidth || 0;
+            const natH = img.naturalHeight || 0;
+            if (!point || !natW || !natH) return;
             vscode.postMessage({
-                command: 'recordInteractiveClick',
+                command: 'recordInteractiveInput',
                 previewId,
-                pixelX,
-                pixelY,
+                kind,
+                pixelX: point.pixelX,
+                pixelY: point.pixelY,
                 imageWidth: natW,
                 imageHeight: natH,
+                scrollDeltaY,
             });
         }
 
@@ -1176,6 +1261,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             card.dataset.group = p.params.group || '';
             card.dataset.previewId = p.id;
             card.dataset.className = p.className;
+            card.dataset.wearPreview = isWearPreview(p) ? '1' : '0';
             card.dataset.currentIndex = '0';
             cardCaptures.set(p.id, captures.map(c => ({
                 label: c.label || '',
@@ -1257,7 +1343,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             // Single-click on the image enters LIVE for this preview (in any
             // layout — focus, grid, flow, column). The first click toggles
             // interactive on; subsequent clicks while LIVE forward as pointer
-            // events to the daemon (handled by ensureInteractiveClickHandler
+            // events to the daemon (handled by ensureInteractiveInputHandlers
             // attached via updateImage). The handler is on the container, not
             // the <img>, so clicks land before the image renders too. Modifier-
             // aware: Shift+click follows the multi-stream semantics from
@@ -1266,7 +1352,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 const previewId = card.dataset.previewId;
                 if (!previewId) return;
                 // If we're already live for this preview, the per-image click
-                // handler routes to recordInteractiveClick — let that fire
+                // handler routes to recordInteractiveInput — let that fire
                 // instead of toggling off.
                 if (interactivePreviewIds.has(previewId)) return;
                 enterInteractiveOnCard(card, evt.shiftKey);
@@ -1450,6 +1536,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 }
                 img.src = 'data:' + mimeFor(capture.renderOutput) + ';base64,' + capture.imageData;
                 img.className = 'fade-in';
+                ensureInteractiveInputHandlers(card, img);
             } else if (capture.errorMessage || capture.renderError) {
                 const existingErr = container.querySelector('.error-message');
                 if (existingErr) existingErr.remove();
@@ -1489,6 +1576,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         function updateCardMetadata(card, p) {
             card.dataset.function = p.functionName;
             card.dataset.group = p.params.group || '';
+            card.dataset.wearPreview = isWearPreview(p) ? '1' : '0';
             const title = card.querySelector('.card-title');
             if (title) {
                 title.textContent = p.functionName + (p.params.name ? ' — ' + p.params.name : '');
@@ -1630,6 +1718,14 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         function shortDevice(d) {
             if (!d) return '';
             return d.replace(/^id:/, '').replace(/_/g, ' ');
+        }
+
+        function isWearPreview(p) {
+            const device = (p.params.device || '').toLowerCase();
+            if (device.includes('wear')) return true;
+            const w = p.params.widthDp || 0;
+            const h = p.params.heightDp || 0;
+            return w > 0 && h > 0 && w === h && w <= 260;
         }
 
         function buildTooltip(p) {
@@ -1959,7 +2055,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             // than a sequence of independent renders. See INTERACTIVE.md § 3.
             const isLive = interactivePreviewIds.has(previewId);
             img.className = isLive ? 'live-frame' : 'fade-in';
-            ensureInteractiveClickHandler(card, img);
+            ensureInteractiveInputHandlers(card, img);
 
             if (caps) updateFrameIndicator(card);
 

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -487,20 +487,19 @@ export type WebviewToExtension =
      */
     | { command: 'setInteractive'; previewId: string; enabled: boolean }
     /**
-     * Click on the focused image while interactive mode is on. v0 logs
-     * the coordinates to the output channel (no daemon call yet); the
-     * payload shape matches the future `interactive/input` RPC so the
-     * panel side won't change when the daemon implementation lands.
+     * Pointer/rotary input on the focused image while interactive mode is on.
      * Coordinates are in IMAGE-NATURAL pixel space — the same coordinate
      * system the renderer thinks in. See docs/daemon/INTERACTIVE.md § 6/§ 7.
      */
     | {
-          command: 'recordInteractiveClick';
+          command: 'recordInteractiveInput';
           previewId: string;
+          kind: 'click' | 'pointerDown' | 'pointerMove' | 'pointerUp' | 'rotaryScroll';
           pixelX: number;
           pixelY: number;
           imageWidth: number;
           imageHeight: number;
+          scrollDeltaY?: number;
       }
     /**
      * D2 — focus-mode toggle for the local a11y overlay. When `enabled`, the


### PR DESCRIPTION
## Summary
- add pointer drag input for live VS Code previews, preserving simple click behavior
- extend the interactive daemon protocol with pointerMove and rotaryScroll events
- map Wear preview mouse wheel input to Android rotary encoder scroll events

## Verification
- npm test (vscode-extension)
- ./gradlew :daemon:core:compileKotlin :daemon:desktop:compileKotlin :daemon:android:compileDebugKotlin
- ./gradlew :daemon:android:compileDebugKotlin