### PR TITLE
Keep opted-in heavy previews fresh

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -905,10 +905,11 @@ body {
 }
 
 /* Stale heavy capture: dim the rendered image so the user notices it isn't
-   fresh, and tint the warning icon. The badge button itself is the only
-   click target — clicking re-runs render at tier=full for this module. */
+   fresh. Clicking the faded image or warning icon opts this preview into
+   full-tier updates while the current source file remains focused. */
 .preview-card.is-stale .image-container img {
     opacity: 0.7;
+    cursor: pointer;
 }
 .card-stale-btn {
     color: var(--vscode-editorWarning-foreground, #cca700);

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -144,6 +144,11 @@ async function isSourceNewerThanRenders(
 }
 
 const moduleManifestCache = new Map<string, PreviewInfo[]>();
+/**
+ * Heavy previews the user explicitly asked to keep fresh for the current
+ * editor focus scope. Cleared when focus leaves the backing Kotlin file.
+ */
+const heavyRefreshOptIns = new Map<string, Set<string>>();
 let panel: PreviewPanel | null = null;
 let debounceTimer: NodeJS.Timeout | null = null;
 let selectedModule: string | null = null;
@@ -773,6 +778,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
                 // race this on the new file's manifest arrival.
                 void flushInteractiveStreams();
                 panel?.postMessage({ command: 'clearInteractive' });
+                clearHeavyRefreshOptIns();
                 refresh(false, filePath);
                 // Pre-warm the daemon for this file's module so the first
                 // save in the session collapses to "kotlinc + render"
@@ -793,6 +799,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
                 // rendering into an invisible panel.
                 void flushInteractiveStreams();
                 panel?.postMessage({ command: 'clearInteractive' });
+                clearHeavyRefreshOptIns();
                 refresh(false);
             }
         }),
@@ -805,6 +812,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     context.subscriptions.push(
         vscode.window.onDidChangeVisibleTextEditors(() => {
             if (currentScopeFile && !isFileVisibleInEditor(currentScopeFile)) {
+                clearHeavyRefreshOptIns();
                 refresh(false);
             }
         }),
@@ -1091,7 +1099,7 @@ async function applyDiscoveryDiff(moduleId: string, params: { added: unknown[]; 
     const moduleIsFastTier = fastTierModules.has(moduleId);
     const heavyStaleIds = moduleIsFastTier
         ? visiblePreviews
-            .filter(p => p.captures.some(c => (c.cost ?? 1) > HEAVY_COST_THRESHOLD))
+            .filter(hasHeavyCapture)
             .map(p => p.id)
         : [];
     panel.postMessage({
@@ -1161,7 +1169,20 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
     if (ids.length === 0) { return 'accepted'; }
     try {
         await daemonScheduler.setFocus(module, ids);
-        return (await daemonScheduler.renderNow(module, ids, 'fast', 'save')) ? 'accepted' : 'failed';
+        const fullIds = heavyOptInsFor(module, ids);
+        const fastIds = fullIds.length === 0
+            ? ids
+            : ids.filter(id => !fullIds.includes(id));
+
+        if (fastIds.length > 0) {
+            const ok = await daemonScheduler.renderNow(module, fastIds, 'fast', 'save');
+            if (!ok) { return 'failed'; }
+        }
+        if (fullIds.length > 0) {
+            const ok = await daemonScheduler.renderNow(module, fullIds, 'full', 'save-heavy-opt-in');
+            if (!ok) { return 'failed'; }
+        }
+        return 'accepted';
     } catch (err) {
         logLine(`daemon: ${String((err as Error).message ?? err)}`);
         return daemonGate.isBuildDisabled(module) ? 'disabled' : 'failed';
@@ -1615,6 +1636,26 @@ function sendModuleList() {
  */
 const fastTierModules = new Set<string>();
 
+function hasHeavyCapture(preview: PreviewInfo): boolean {
+    return preview.captures.some(c => (c.cost ?? 1) > HEAVY_COST_THRESHOLD);
+}
+
+function optInHeavyRefresh(moduleId: string, previewId: string): void {
+    const current = heavyRefreshOptIns.get(moduleId) ?? new Set<string>();
+    current.add(previewId);
+    heavyRefreshOptIns.set(moduleId, current);
+}
+
+function clearHeavyRefreshOptIns(): void {
+    heavyRefreshOptIns.clear();
+}
+
+function heavyOptInsFor(moduleId: string, previewIds: string[]): string[] {
+    const opted = heavyRefreshOptIns.get(moduleId);
+    if (!opted || opted.size === 0) { return []; }
+    return previewIds.filter(id => opted.has(id));
+}
+
 /**
  * Main refresh entry point.
  * @param forceRender  If true, runs renderAllPreviews (not just discover).
@@ -1679,12 +1720,16 @@ async function refresh(
         lastLoadedModules = [];
         hasPreviewsLoaded = false;
         currentScopeFile = null;
+        clearHeavyRefreshOptIns();
         historyScopeRef.current = null;
         historyPanel?.setScope(null);
         if (activeFile && isPreviewSourceFile(activeFile)) {
             maybeShowSetupPrompt(activeFile);
         }
         return 'no-module';
+    }
+    if (currentScopeFile && currentScopeFile !== activeFile) {
+        clearHeavyRefreshOptIns();
     }
     logLine(`start forceRender=${forceRender} file=${path.basename(activeFile)} (${scopeSource}) module=${module}`);
 
@@ -1894,7 +1939,7 @@ async function refresh(
         const moduleIsFastTier = modules.some(mod => fastTierModules.has(mod));
         const heavyStaleIds = moduleIsFastTier
             ? visiblePreviews
-                .filter(p => p.captures.some(c => (c.cost ?? 1) > HEAVY_COST_THRESHOLD))
+                .filter(hasHeavyCapture)
                 .map(p => p.id)
             : [];
 
@@ -2092,13 +2137,22 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             if (selectedModule) { refresh(false); }
             break;
         case 'refreshHeavy': {
-            // Click on the stale badge → full-tier render of the owning
-            // module. Once we have a `-PcomposePreview.previewIds=` filter
-            // we can scope this to just the requested capture; for now the
-            // user pays a full-module render for the freshness guarantee.
+            // Click on a faded heavy card opts it into full-tier renders for
+            // this editor focus scope. Future saves keep that preview fresh;
+            // changing focus clears the opt-in set.
             const mod = previewModuleMap.get(msg.previewId);
             if (mod) {
-                void refresh(true, currentScopeFile ?? undefined, 'full');
+                optInHeavyRefresh(mod, msg.previewId);
+                if (daemonGate?.isEnabled() && daemonScheduler) {
+                    void daemonScheduler.renderNow(
+                        mod,
+                        [msg.previewId],
+                        'full',
+                        'heavy-opt-in',
+                    );
+                } else {
+                    void refresh(true, currentScopeFile ?? undefined, 'full');
+                }
             }
             break;
         }

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -1265,6 +1265,12 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             imgContainer.addEventListener('click', (evt) => {
                 const previewId = card.dataset.previewId;
                 if (!previewId) return;
+                if (card.classList.contains('is-stale')) {
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    requestHeavyRefresh(card);
+                    return;
+                }
                 // If we're already live for this preview, the per-image click
                 // handler routes to recordInteractiveClick — let that fire
                 // instead of toggling off.
@@ -1771,6 +1777,15 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
          * editing source. Keeping it inside the title row puts it in the
          * same affordance band as the open-source buttons.
          */
+        function requestHeavyRefresh(card) {
+            const previewId = card.dataset.previewId;
+            if (!previewId) return;
+            vscode.postMessage({
+                command: 'refreshHeavy',
+                previewId,
+            });
+        }
+
         function applyStaleBadge(card, isStale) {
             const titleRow = card.querySelector('.card-title-row');
             if (!titleRow) return;
@@ -1778,14 +1793,13 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             if (isStale && !existing) {
                 const btn = document.createElement('button');
                 btn.className = 'icon-button card-stale-btn';
-                btn.title = 'Stale heavy capture — click to render at full tier';
-                btn.setAttribute('aria-label', 'Refresh stale capture');
+                btn.title = 'Stale heavy capture — click to keep fresh while focused';
+                btn.setAttribute('aria-label', 'Keep stale capture fresh');
                 btn.innerHTML = '<i class="codicon codicon-warning" aria-hidden="true"></i>';
-                btn.addEventListener('click', () => {
-                    vscode.postMessage({
-                        command: 'refreshHeavy',
-                        previewId: card.dataset.previewId,
-                    });
+                btn.addEventListener('click', (evt) => {
+                    evt.preventDefault();
+                    evt.stopPropagation();
+                    requestHeavyRefresh(card);
                 });
                 titleRow.appendChild(btn);
                 card.classList.add('is-stale');

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -412,10 +412,9 @@ export type WebviewToExtension =
     | { command: 'openFile'; className: string; functionName: string }
     | { command: 'selectModule'; value: string }
     /**
-     * User clicked the stale-badge refresh icon on a heavy card. Triggers a
-     * `tier='full'` render of the owning module so the heavy capture is
-     * re-rendered. (A future per-preview filter would scope this to the
-     * single previewId; today it falls back to a full-module render.)
+     * User clicked a faded heavy card. The extension opts that preview into
+     * full-tier refreshes until focus moves to another source scope, and
+     * triggers an immediate full-tier render for the selected preview.
      */
     | { command: 'refreshHeavy'; previewId: string }
     /**


### PR DESCRIPTION
## Summary
- make faded stale heavy preview images clickable, not just the warning badge
- opt clicked heavy previews into full-tier daemon refreshes for the current focus scope
- clear the heavy-preview opt-in state when focus moves to another source scope

## Tests
- npm test
- git diff --check