### PR TITLE
Fix a11y core publishing in workflows

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: Publish plugin + renderer-android + daemon-* to mavenLocal
+      - name: Publish plugin + renderer-android + data-a11y-core + daemon-* to mavenLocal
         # Both `gradle-plugin` and `renderer-android` are needed end-to-end:
         # the plugin resolves through pluginManagement when the consumer's
         # `plugins { }` block is patched, and it wires
@@ -64,6 +64,7 @@ jobs:
         run: |
           ./gradlew \
             :gradle-plugin:publishToMavenLocal \
+            :data-a11y-core:publishToMavenLocal \
             :renderer-android:publishToMavenLocal \
             :daemon:core:publishToMavenLocal \
             :daemon:desktop:publishToMavenLocal \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
-      - name: Publish plugin, renderer-android, preview-annotations, daemon-* to GitHub Packages
+      - name: Publish plugin, renderer-android, data-a11y-core, preview-annotations, daemon-* to GitHub Packages
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -97,18 +97,20 @@ jobs:
         run: |
           ./gradlew \
             :gradle-plugin:publishAllPublicationsToGitHubPackagesRepository \
+            :data-a11y-core:publishAllPublicationsToGitHubPackagesRepository \
             :renderer-android:publishAllPublicationsToGitHubPackagesRepository \
             :preview-annotations:publishAllPublicationsToGitHubPackagesRepository \
             :daemon:core:publishAllPublicationsToGitHubPackagesRepository \
             :daemon:desktop:publishAllPublicationsToGitHubPackagesRepository \
             :daemon:android:publishAllPublicationsToGitHubPackagesRepository
-      - name: Publish plugin, renderer-android, preview-annotations, daemon-* to Maven Central
+      - name: Publish plugin, renderer-android, data-a11y-core, preview-annotations, daemon-* to Maven Central
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         run: |
           ./gradlew \
             :gradle-plugin:publishAndReleaseToMavenCentral \
+            :data-a11y-core:publishAndReleaseToMavenCentral \
             :renderer-android:publishAndReleaseToMavenCentral \
             :preview-annotations:publishAndReleaseToMavenCentral \
             :daemon:core:publishAndReleaseToMavenCentral \

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -52,6 +52,7 @@ jobs:
         run: |
           ./gradlew \
             :gradle-plugin:publishToMavenCentral \
+            :data-a11y-core:publishToMavenCentral \
             :renderer-android:publishToMavenCentral \
             :preview-annotations:publishToMavenCentral \
             :daemon:core:publishToMavenCentral \


### PR DESCRIPTION
## Summary
- publish data-a11y-core to mavenLocal before renderer-android in Integration
- include data-a11y-core in snapshot and release publish workflows alongside renderer-android

## Root cause
Latest main Integration failed in wear-os-samples render jobs because renderer-android now declares ee.schimke.composeai:data-a11y-core as a transitive dependency, but the workflow only published renderer-android to Maven Local. External consumer renders then failed resolving data-a11y-core:0.1.0-SNAPSHOT.

## Verification
- ./gradlew :data-a11y-core:publishToMavenLocal :renderer-android:publishToMavenLocal --stacktrace
- ./gradlew :gradle-plugin:publishToMavenLocal :data-a11y-core:publishToMavenLocal :renderer-android:publishToMavenLocal :daemon:core:publishToMavenLocal :daemon:desktop:publishToMavenLocal :daemon:android:publishToMavenLocal --stacktrace
- git diff --check