### PR TITLE
Address small daemon capability issues

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -140,7 +140,6 @@ open class RobolectricHost(
     System.getProperty(AndroidInteractiveSession.IDLE_LEASE_PROP)?.toLongOrNull()
       ?: AndroidInteractiveSession.DEFAULT_IDLE_LEASE_MS,
 ) : RenderHost {
-
   /**
    * INTERACTIVE-ANDROID.md § 2 — interactive sessions on Android need one pinned sandbox slot in
    * addition to the always-on slot 0 that drains normal renders, so the capability bit reads
@@ -238,6 +237,8 @@ open class RobolectricHost(
   /** PROTOCOL.md § 3 — android backend identifier surfaced via `capabilities.backend`. */
   override val backendKind: ee.schimke.composeai.daemon.protocol.BackendKind =
     ee.schimke.composeai.daemon.protocol.BackendKind.ANDROID
+
+  override val androidSdk: Int = ANDROID_SDK
 
   init {
     require(sandboxCount >= 1) { "sandboxCount must be >= 1, got $sandboxCount" }
@@ -775,6 +776,8 @@ open class RobolectricHost(
    * exit. Idempotent.
    */
   companion object {
+    const val ANDROID_SDK: Int = 35
+
     /** Same sysprop the desktop side uses; honoured on Android too. */
     const val RECORDINGS_DIR_PROP: String = "composeai.daemon.recordingsDir"
 
@@ -884,7 +887,7 @@ open class RobolectricHost(
    * once `@RunWith` triggers sandbox bootstrap. Its single `@Test` method
    * holds the sandbox open until it returns.
    *
-   * `@Config(sdk = [35])` matches the SDK pinned in renderer-android's
+   * `@Config(sdk = [ANDROID_SDK])` matches the SDK pinned in renderer-android's
    * generated `robolectric.properties`. We declare it here directly because
    * the daemon module doesn't generate that file (the consumer module does
    * for the existing JUnit path).
@@ -895,7 +898,7 @@ open class RobolectricHost(
    * didn't need it but the annotation is harmless when the body is a stub.
    */
   @RunWith(SandboxHoldingRunner::class)
-  @Config(sdk = [35])
+  @Config(sdk = [ANDROID_SDK])
   @GraphicsMode(GraphicsMode.Mode.NATIVE)
   class SandboxRunner {
 

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/DaemonHostTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/DaemonHostTest.kt
@@ -19,6 +19,11 @@ import org.junit.Test
 class RobolectricHostTest {
 
   @Test
+  fun advertisesPinnedAndroidSdk() {
+    assertEquals(35, RobolectricHost().androidSdk)
+  }
+
+  @Test
   fun tenRendersShareOneSandboxClassloader() {
     val host = RobolectricHost()
     host.start()

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -654,6 +654,10 @@ class JsonRpcServer(
             // per-call probing. Defaulted to `null` for hosts that don't classify themselves
             // (FakeHost, in-test stubs); production hosts always populate.
             backend = host.backendKind,
+            // PROTOCOL.md § 3 — Android/Robolectric hosts advertise their fixed SDK level so
+            // clients can reason about backend compatibility without scraping logs. Desktop and
+            // test fakes inherit null.
+            androidSdk = host.androidSdk,
           ),
         // B2.1 — surface the authoritative SHA-256 to the client so VS Code can correlate later
         // `classpathDirty` notifications against the daemon's known-at-startup state. Empty

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -124,6 +124,14 @@ interface RenderHost {
     get() = null
 
   /**
+   * Fixed Android SDK level this host renders against. Android/Robolectric backends expose the
+   * `@Config(sdk = ...)` value so clients can reason about backend compatibility without scraping
+   * daemon logs. Non-Android backends return `null`.
+   */
+  val androidSdk: Int?
+    get() = null
+
+  /**
    * Allocate an [InteractiveSession] for [previewId] — the v2 click-into-composition surface
    * documented in
    * [INTERACTIVE.md § 9](../../../../../../docs/daemon/INTERACTIVE.md#9-v2--click-dispatch-into-composition).

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -177,6 +177,11 @@ data class ServerCapabilities(
    * future stub backend; clients should treat absent and `null` as "unknown".
    */
   val backend: BackendKind? = null,
+  /**
+   * Fixed Android SDK level the backend renders against. Populated by the Robolectric backend from
+   * its pinned `@Config(sdk = ...)` value; `null` on Desktop and other non-Android backends.
+   */
+  val androidSdk: Int? = null,
 )
 
 /**

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
@@ -65,7 +65,7 @@ class JsonRpcServerIntegrationTest {
     val serverToClientOut = PipedOutputStream()
     val serverToClientIn = PipedInputStream(serverToClientOut, 64 * 1024)
 
-    val host = FakeRenderHost()
+    val host = FakeRenderHost(androidSdkToAdvertise = 35)
     val exitCode = AtomicInteger(-1)
     val exitLatch = CountDownLatch(1)
     val server =
@@ -124,6 +124,10 @@ class JsonRpcServerIntegrationTest {
       assertEquals(1, initResult["protocolVersion"]?.jsonPrimitive?.intOrNull)
       assertEquals("test", initResult["daemonVersion"]?.jsonPrimitive?.contentOrNull)
       assertNotNull("pid should be present", initResult["pid"])
+      assertEquals(
+        35,
+        initResult["capabilities"]?.jsonObject?.get("androidSdk")?.jsonPrimitive?.intOrNull,
+      )
 
       // 2. initialized notification
       writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"initialized","params":{}}""")
@@ -1293,8 +1297,12 @@ private class FakeRenderHost(
    * by the B2.3 integration tests to drive `JsonRpcServer.renderFinishedFromResult` through its
    * happy / partial / null branches.
    */
-  private val metricsToReturn: Map<String, Long>? = null
+  private val metricsToReturn: Map<String, Long>? = null,
+  private val androidSdkToAdvertise: Int? = null,
 ) : RenderHost {
+
+  override val androidSdk: Int?
+    get() = androidSdkToAdvertise
 
   val interruptCount = java.util.concurrent.atomic.AtomicInteger(0)
   private val queue = LinkedBlockingQueue<RenderRequest>()

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensionsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensionsTest.kt
@@ -1,0 +1,80 @@
+package ee.schimke.composeai.daemon.devices
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeviceDimensionsTest {
+
+  @Test
+  fun knownDeviceIdsResolveRepresentativeCatalogEntries() {
+    assertEquals(
+      DeviceDimensions.DeviceSpec(393, 851, 2.75f),
+      DeviceDimensions.resolve("id:pixel_5"),
+    )
+    assertEquals(
+      DeviceDimensions.DeviceSpec(841, 701, 2.625f),
+      DeviceDimensions.resolve("id:pixel_fold"),
+    )
+    assertEquals(
+      DeviceDimensions.DeviceSpec(192, 192, 2.0f),
+      DeviceDimensions.resolve("id:wearos_small_round"),
+    )
+    assertEquals(
+      DeviceDimensions.DeviceSpec(960, 540, 2.0f),
+      DeviceDimensions.resolve("id:tv_1080p"),
+    )
+  }
+
+  @Test
+  fun unknownDeviceIdFallsThroughToDefault() {
+    assertEquals(DeviceDimensions.DEFAULT, DeviceDimensions.resolve("id:typo_phone"))
+  }
+
+  @Test
+  fun nullDeviceReturnsDefault() {
+    assertEquals(DeviceDimensions.DEFAULT, DeviceDimensions.resolve(null))
+  }
+
+  @Test
+  fun specStringParsesDimensionsAndDpi() {
+    assertEquals(
+      DeviceDimensions.DeviceSpec(400, 800, 2.0f),
+      DeviceDimensions.resolve("spec:width=400dp,height=800dp,dpi=320"),
+    )
+  }
+
+  @Test
+  fun specStringWithoutDpiUsesDefaultDensity() {
+    assertEquals(
+      DeviceDimensions.DeviceSpec(400, 800, DeviceDimensions.DEFAULT_DENSITY),
+      DeviceDimensions.resolve("spec:width=400,height=800"),
+    )
+  }
+
+  @Test
+  fun unknownWearDeviceUsesWearDefault() {
+    assertEquals(DeviceDimensions.DEFAULT_WEAR, DeviceDimensions.resolve("foo_wear_bar"))
+  }
+
+  @Test
+  fun explicitDimensionsShortCircuitDeviceString() {
+    assertEquals(
+      DeviceDimensions.DeviceSpec(200, 400, DeviceDimensions.DEFAULT_DENSITY),
+      DeviceDimensions.resolve("id:pixel_5", widthDp = 200, heightDp = 400),
+    )
+  }
+
+  @Test
+  fun knownDeviceIdsContainRepresentativeCategories() {
+    val ids = DeviceDimensions.KNOWN_DEVICE_IDS
+
+    assertFalse(ids.isEmpty())
+    assertTrue(ids.contains("id:pixel_5"))
+    assertTrue(ids.contains("id:wearos_small_round"))
+    assertTrue(ids.contains("id:tv_1080p"))
+    assertTrue(ids.contains("id:automotive_portrait"))
+    assertTrue(ids.contains("id:xr_headset_device"))
+  }
+}

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.daemon
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -18,6 +19,11 @@ import org.junit.Test
  * runtime per request, this test would catch it.
  */
 class DesktopHostTest {
+
+  @Test
+  fun desktopDoesNotAdvertiseAndroidSdk() {
+    assertNull(DesktopHost().androidSdk)
+  }
 
   @Test
   fun tenRendersShareOneRenderThreadClassloader() {

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -123,6 +123,7 @@ Result:
     knownDevices?: KnownDevice[];    // catalog of @Preview(device=...) ids the daemon recognises
     supportedOverrides?: string[];   // PreviewOverrides field names this host actually applies
     backend?: "desktop" | "android"; // which renderer backend this daemon implements
+    androidSdk?: number | null;      // fixed Robolectric SDK, absent/null on non-Android backends
   };
   // KnownDevice — one entry per id in DeviceDimensions.KNOWN_DEVICE_IDS, projected to wire shape.
   // `id` is the string a caller passes via renderNow.overrides.device; widthDp/heightDp/density
@@ -138,6 +139,10 @@ Result:
   // Today: Robolectric advertises all eight; Desktop omits "localeTag" (no `LocalLocale`
   // CompositionLocal + `Locale.setDefault(...)` is JVM-thread-unsafe) and "orientation"
   // (no rotation concept on `ImageComposeScene`).
+  //
+  // androidSdk — fixed Android SDK level the backend renders against. Populated by the
+  // Robolectric backend from its pinned @Config(sdk = ...) value; absent/null on Desktop and
+  // other non-Android backends.
   classpathFingerprint: string;      // SHA-256 hex of the resolved test classpath
   manifest: {
     path: string;                    // absolute path to the daemon's working previews.json

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -170,6 +170,11 @@ export interface InitializeResult {
          * classified themselves (e.g. test fakes); clients should treat both as "unknown".
          */
         backend?: 'desktop' | 'android' | null;
+        /**
+         * Fixed Android SDK level this daemon renders against. Present on Robolectric /
+         * Android backends, absent or null on Desktop and other non-Android backends.
+         */
+        androidSdk?: number | null;
     };
     classpathFingerprint: string;
     manifest: { path: string; previewCount: number };


### PR DESCRIPTION
## Summary
- add daemon-core DeviceDimensions unit coverage for catalog ids, spec parsing, defaults, and representative categories
- advertise the fixed Android/Robolectric SDK through ServerCapabilities.androidSdk while leaving non-Android backends null
- update protocol docs and VS Code daemon protocol typing for androidSdk

Fixes #461
Fixes #463

## Skipped for now
- #462: parser/runtime semantics change, not a trivial batch fix
- #481: runtime module-opening failure, needs separate investigation

## Tests
- ./gradlew :daemon:core:test --tests ee.schimke.composeai.daemon.devices.DeviceDimensionsTest --tests ee.schimke.composeai.daemon.JsonRpcServerIntegrationTest.full_lifecycle_renders_one_preview_and_emits_finished_notification :daemon:desktop:test --tests ee.schimke.composeai.daemon.DesktopHostTest.desktopDoesNotAdvertiseAndroidSdk :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.RobolectricHostTest.advertisesPinnedAndroidSdk
- ./gradlew :daemon:core:ktfmtCheck :daemon:android:ktfmtCheck :daemon:desktop:ktfmtCheck
- npm test -- --grep "daemon protocol"
- git diff --check