### PR TITLE
Remove deprecated glob type stub

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -9,7 +9,6 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "devDependencies": {
-                "@types/glob": "^9.0.0",
                 "@types/mocha": "^10.0.0",
                 "@types/node": "^24.0.0",
                 "@types/vscode": "^1.85.0",
@@ -563,17 +562,6 @@
             "license": "MIT",
             "dependencies": {
                 "@textlint/ast-node-types": "15.5.4"
-            }
-        },
-        "node_modules/@types/glob": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-9.0.0.tgz",
-            "integrity": "sha512-00UxlRaIUvYm4R4W9WYkN8/J+kV8fmOQ7okeH6YFtGWFMt3odD45tpG5yA5wnL7HE6lLgjaTW5n14ju2hl2NNA==",
-            "deprecated": "This is a stub types definition. glob provides its own type definitions, so you do not need this installed.",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "glob": "*"
             }
         },
         "node_modules/@types/mocha": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -168,7 +168,6 @@
         "package": "npm run compile && vsce package --no-dependencies"
     },
     "devDependencies": {
-        "@types/glob": "^9.0.0",
         "@types/mocha": "^10.0.0",
         "@types/node": "^24.0.0",
         "@types/vscode": "^1.85.0",


### PR DESCRIPTION
## Summary
- remove the deprecated @types/glob stub package from the VS Code extension dev dependencies
- update package-lock.json accordingly; glob already ships its own TypeScript definitions

Refs #195

## Tests
- npm test (from vscode-extension)
- git diff --check HEAD~1 HEAD

## Skipped
- Larger/open-ended issues such as #481 and #464 were left for a later batch because they need behavior-level investigation beyond a trivial dependency cleanup.