### PR TITLE
Use pointer-up release coordinates

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1459,7 +1459,10 @@ open class RobolectricHost(
           rule.onRoot().performTouchInput { moveTo(position) }
         }
         "pointerUp" -> {
-          rule.onRoot().performTouchInput { up() }
+          rule.onRoot().performTouchInput {
+            moveTo(position)
+            up()
+          }
         }
         "rotaryScroll" -> {
           val delta = cmd.scrollDeltaY ?: 0f

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
@@ -252,6 +252,68 @@ class AndroidInteractiveSessionTest {
   }
 
   @Test
+  fun pointerUpUsesReleaseCoordinates() {
+    System.setProperty(
+      RenderEngine.OUTPUT_DIR_PROP,
+      tempFolder.newFolder("interactive-release-position").absolutePath,
+    )
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost(sandboxCount = 2, previewSpecResolver = previewSpecResolver())
+    host.start()
+    try {
+      val session =
+        host.acquireInteractiveSession(
+          previewId = RELEASE_POSITION_PREVIEW_ID,
+          classLoader = javaClass.classLoader!!,
+        )
+      try {
+        val before = decode(File(session.render(RenderHost.nextRequestId()).pngPath!!))
+        assertTrue(
+          "release-position fixture should start red",
+          pixelMatchPct(before, RED_RGB, perChannelTolerance = 8) >= 0.95,
+        )
+
+        session.dispatch(
+          InteractiveInputParams(
+            frameStreamId = "irrelevant-on-host-side",
+            kind = InteractiveInputKind.POINTER_DOWN,
+            pixelX = INTERACTIVE_WIDTH_PX / 2,
+            pixelY = 82,
+          )
+        )
+        session.dispatch(
+          InteractiveInputParams(
+            frameStreamId = "irrelevant-on-host-side",
+            kind = InteractiveInputKind.POINTER_MOVE,
+            pixelX = INTERACTIVE_WIDTH_PX / 2,
+            pixelY = 70,
+          )
+        )
+        session.dispatch(
+          InteractiveInputParams(
+            frameStreamId = "irrelevant-on-host-side",
+            kind = InteractiveInputKind.POINTER_UP,
+            pixelX = INTERACTIVE_WIDTH_PX / 2,
+            pixelY = 8,
+          )
+        )
+
+        val after = decode(File(session.render(RenderHost.nextRequestId()).pngPath!!))
+        val greenAfter = pixelMatchPct(after, GREEN_RGB, perChannelTolerance = 8)
+        assertTrue(
+          "pointerUp should release at its command coordinates, not the last move; got " +
+            "${"%.2f".format(greenAfter * 100)}% green",
+          greenAfter >= 0.95,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
   fun rotaryScrollDispatchesAsRsbInput() {
     System.setProperty(
       RenderEngine.OUTPUT_DIR_PROP,
@@ -621,6 +683,16 @@ class AndroidInteractiveSessionTest {
           showBackground = true,
           outputBaseName = "interactive-scroll",
         )
+      RELEASE_POSITION_PREVIEW_ID ->
+        RenderSpec(
+          className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+          functionName = "ReleasePositionSquare",
+          widthPx = INTERACTIVE_WIDTH_PX,
+          heightPx = INTERACTIVE_HEIGHT_PX,
+          density = 1.0f,
+          showBackground = true,
+          outputBaseName = "interactive-release-position",
+        )
       ROTARY_PREVIEW_ID ->
         RenderSpec(
           className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
@@ -675,6 +747,7 @@ class AndroidInteractiveSessionTest {
     private const val DARK_PREVIEW_ID = "interactive-darkaware"
     private const val CLICKABLE_PREVIEW_ID = "interactive-clickable"
     private const val SCROLL_PREVIEW_ID = "interactive-scroll"
+    private const val RELEASE_POSITION_PREVIEW_ID = "interactive-release-position"
     private const val ROTARY_PREVIEW_ID = "interactive-rsb"
     private const val INTERACTIVE_WIDTH_PX = 96
     private const val INTERACTIVE_HEIGHT_PX = 96

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.rotary.onRotaryScrollEvent
 import androidx.compose.ui.unit.dp
@@ -154,6 +155,29 @@ fun DragScrollableSquare() {
     Box(modifier = Modifier.width(96.dp).height(96.dp).background(Color(0xFFEF5350)))
     Box(modifier = Modifier.width(96.dp).height(96.dp).background(Color(0xFF66BB6A)))
   }
+}
+
+@Composable
+fun ReleasePositionSquare() {
+  var releasedNearTop by androidx.compose.runtime.remember {
+    androidx.compose.runtime.mutableStateOf(false)
+  }
+  val color = if (releasedNearTop) Color(0xFF66BB6A) else Color(0xFFEF5350)
+  Box(
+    modifier =
+      Modifier.fillMaxSize().background(color).pointerInput(Unit) {
+        awaitPointerEventScope {
+          awaitFirstDown()
+          while (true) {
+            val change = awaitPointerEvent().changes.first()
+            if (change.changedToUp()) {
+              releasedNearTop = change.position.y < 24f
+              break
+            }
+          }
+        }
+      }
+  )
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- move the held touch pointer to the client-provided pointerUp coordinates before injecting up()
- add a daemon regression fixture/test where release coordinates differ from the last pointerMove

## Test
- ./gradlew :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.AndroidInteractiveSessionTest.pointerUpUsesReleaseCoordinates
- ./gradlew :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.AndroidInteractiveSessionTest