### PR TITLE
Extend KMP sibling substitution to Compose artifacts

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -54,6 +54,19 @@ internal object AndroidPreviewSupport {
       "org.jetbrains.compose.ui" to "ui-tooling-preview",
     )
 
+  internal fun kmpAndroidSiblingName(group: String, name: String): String? {
+    if (!group.startsWith("androidx.") && !group.startsWith("org.jetbrains.compose.")) {
+      return null
+    }
+    val replacementSuffix =
+      when {
+        name.endsWith("-desktop") -> "-desktop"
+        name.endsWith("-jvmstubs") -> "-jvmstubs"
+        else -> return null
+      }
+    return name.removeSuffix(replacementSuffix) + "-android"
+  }
+
   fun configure(project: Project, extension: PreviewExtension) {
     val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
 
@@ -616,9 +629,9 @@ internal object AndroidPreviewSupport {
           copyAttributes(attributes, testConfig.attributes)
           extendsFrom(testConfig)
         }
-        // Force AndroidX KMP-published modules (lifecycle 2.8+, savedstate
-        // 1.3+, activity 1.10+ ship `-android` / `-desktop` / `-jvmstubs`
-        // siblings of the same coordinate) to their Android sibling on the
+        // Force AndroidX / Compose Multiplatform KMP-published modules
+        // (`-android` / `-desktop` / `-jvmstubs` siblings of the same
+        // coordinate) to their Android sibling on the
         // renderer test JVM. Kotlin's `org.jetbrains.kotlin.platform.type`
         // attribute (`androidJvm` vs `jvm`) is the official disambiguator,
         // but its compatibility/disambiguation rules are only registered when
@@ -648,38 +661,24 @@ internal object AndroidPreviewSupport {
         // `-android` sibling, so this rule doesn't pin AndroidX to a stale
         // floor.
         //
-        // Scoped to `androidx.*` because every AndroidX KMP module that
-        // publishes a `-desktop` or `-jvmstubs` sibling also publishes an
-        // `-android` sibling at the same version — the convention is enforced
-        // upstream. Non-AndroidX `-jvm` artifacts (kotlinx-coroutines, okio,
-        // kotlin-stdlib) are genuinely JVM-only at the published name and
-        // must not be rewritten.
+        // Scoped to `androidx.*` and `org.jetbrains.compose.*` because those
+        // KMP module families publish matching `-android` siblings for their
+        // `-desktop` / `-jvmstubs` artifacts. Other JVM artifacts
+        // (kotlinx-coroutines, okio, kotlin-stdlib) are genuinely JVM-only at
+        // the published name and must not be rewritten.
         resolutionStrategy.eachDependency {
           val req = requested
-          if (req.group.startsWith("androidx.")) {
-            val replacementSuffix =
-              when {
-                req.name.endsWith("-desktop") -> "-desktop"
-                req.name.endsWith("-jvmstubs") -> "-jvmstubs"
-                else -> null
-              }
-            if (replacementSuffix != null) {
-              useTarget(
-                mapOf(
-                  "group" to req.group,
-                  "name" to req.name.removeSuffix(replacementSuffix) + "-android",
-                  "version" to req.version,
-                )
-              )
-              because(
-                "Gradle resolved the `$replacementSuffix` KMP sibling on a config without the " +
-                  "Kotlin-plugin platform-type compat rule. Force the Android sibling so the " +
-                  "renderer's bytecode links against the AGP-flavoured class shapes (e.g. the " +
-                  "legacy `ViewModelProvider(ViewModelStoreOwner, Factory)` constructor that " +
-                  "lifecycle-viewmodel-savedstate-android still calls but the desktop variant " +
-                  "removed in the KMP rewrite)."
-              )
-            }
+          val targetName = kmpAndroidSiblingName(req.group, req.name)
+          if (targetName != null) {
+            useTarget(mapOf("group" to req.group, "name" to targetName, "version" to req.version))
+            because(
+              "Gradle resolved a desktop/JVM-stub KMP sibling on a config without the " +
+                "Kotlin-plugin platform-type compat rule. Force the Android sibling so the " +
+                "renderer's bytecode links against the AGP-flavoured class shapes (e.g. the " +
+                "legacy `ViewModelProvider(ViewModelStoreOwner, Factory)` constructor that " +
+                "lifecycle-viewmodel-savedstate-android still calls but the desktop variant " +
+                "removed in the KMP rewrite)."
+            )
           }
         }
         // Espresso (transitively pulled by `androidx.compose.ui:ui-test-junit4`) was

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/KmpAndroidSiblingTargetTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/KmpAndroidSiblingTargetTest.kt
@@ -1,0 +1,55 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class KmpAndroidSiblingTargetTest {
+  @Test
+  fun `androidx desktop sibling maps to android sibling`() {
+    assertThat(
+        AndroidPreviewSupport.kmpAndroidSiblingName(
+          "androidx.lifecycle",
+          "lifecycle-viewmodel-desktop",
+        )
+      )
+      .isEqualTo("lifecycle-viewmodel-android")
+  }
+
+  @Test
+  fun `androidx jvmstubs sibling maps to android sibling`() {
+    assertThat(
+        AndroidPreviewSupport.kmpAndroidSiblingName("androidx.savedstate", "savedstate-jvmstubs")
+      )
+      .isEqualTo("savedstate-android")
+  }
+
+  @Test
+  fun `jetbrains compose desktop sibling maps to android sibling`() {
+    assertThat(
+        AndroidPreviewSupport.kmpAndroidSiblingName("org.jetbrains.compose.ui", "ui-desktop")
+      )
+      .isEqualTo("ui-android")
+  }
+
+  @Test
+  fun `unscoped desktop artifact is not rewritten`() {
+    assertThat(
+        AndroidPreviewSupport.kmpAndroidSiblingName(
+          "org.jetbrains.kotlinx",
+          "kotlinx-coroutines-swing-desktop",
+        )
+      )
+      .isNull()
+  }
+
+  @Test
+  fun `non sibling artifact is not rewritten`() {
+    assertThat(
+        AndroidPreviewSupport.kmpAndroidSiblingName(
+          "org.jetbrains.compose.ui",
+          "ui-tooling-preview",
+        )
+      )
+      .isNull()
+  }
+}


### PR DESCRIPTION
## Summary
- extend the Android renderer KMP sibling substitution to cover org.jetbrains.compose.* artifacts, not only androidx.*
- keep the rewrite scoped to -desktop and -jvmstubs siblings and preserve the requested version through Gradle's existing map target form
- add focused unit coverage for accepted AndroidX / JetBrains Compose coordinates and rejected non-scoped artifacts

Refs #302

## Tests
- ./gradlew :gradle-plugin:ktfmtFormat :gradle-plugin:test --tests ee.schimke.composeai.plugin.KmpAndroidSiblingTargetTest
- ./gradlew :gradle-plugin:test --tests ee.schimke.composeai.plugin.KmpAndroidSiblingTargetTest
- git diff --check HEAD~1 HEAD

## Skipped
- The doctor finding and renderer compatibility docs from #302 are intentionally left for a larger follow-up.
- Other open issues looked feature-sized or integration-test-sized, so this batch stays to the small substitution fix.