### PR TITLE
Fix follow-ups from today's PR reviews

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Args.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Args.kt
@@ -1,7 +1,7 @@
 package ee.schimke.composeai.cli
 
 /**
- * Returns the value of `flag` from a positional argv (e.g. `--module foo`), or `null` if the flag
+ * Returns the value of `flag` from argv (`--module foo` or `--module=foo`), or `null` if the flag
  * is missing or unaccompanied.
  *
  * Trivial parser shared by every command. If we ever grow more flag types (repeatable, comma-list,
@@ -9,6 +9,10 @@ package ee.schimke.composeai.cli
  * call-site.
  */
 internal fun List<String>.flagValue(flag: String): String? {
+  firstOrNull { it.startsWith("$flag=") }
+    ?.let {
+      return it.substringAfter("=")
+    }
   val idx = indexOf(flag)
   return if (idx >= 0 && idx + 1 < size) this[idx + 1] else null
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -30,8 +30,9 @@ import kotlinx.serialization.json.jsonPrimitive
  */
 internal class McpCommand(args: List<String>) {
 
-  private val sub: String = args.firstOrNull { !it.startsWith("--") } ?: "help"
-  private val rest: List<String> = args.toMutableList().apply { remove(sub) }
+  private val parsed = parseSubcommand(args)
+  private val sub: String = parsed.first
+  private val rest: List<String> = parsed.second
 
   fun run() {
     when (sub) {
@@ -321,5 +322,25 @@ internal class McpCommand(args: List<String>) {
 
   private companion object {
     val JSON: Json = Json { prettyPrint = true }
+
+    private val VALUE_FLAGS = setOf("--project", "--module", "--replicas-per-daemon")
+
+    private fun parseSubcommand(args: List<String>): Pair<String, List<String>> {
+      var i = 0
+      while (i < args.size) {
+        val arg = args[i]
+        when {
+          arg in VALUE_FLAGS -> i += 2
+          VALUE_FLAGS.any { arg.startsWith("$it=") } -> i++
+          arg.startsWith("--") -> i++
+          arg.startsWith("-") -> i++
+          else -> {
+            val rest = args.toMutableList().apply { removeAt(i) }
+            return arg to rest
+          }
+        }
+      }
+      return "help" to args
+    }
   }
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ArgsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ArgsTest.kt
@@ -1,0 +1,20 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ArgsTest {
+  @Test
+  fun `flagValue accepts space and equals forms`() {
+    assertEquals("/repo", listOf("--project", "/repo").flagValue("--project"))
+    assertEquals("/repo", listOf("--project=/repo").flagValue("--project"))
+  }
+
+  @Test
+  fun `flagValuesAll preserves repeated space and equals forms`() {
+    assertEquals(
+      listOf(":app", ":wear"),
+      listOf("--module", ":app", "--module=:wear").flagValuesAll("--module"),
+    )
+  }
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -91,7 +91,7 @@ class AndroidRecordingSession(
       framesDir.mkdirs()
       val sortedEvents = synchronized(timeline) { timeline.toList() }
       val durationMs: Long = sortedEvents.maxOfOrNull { it.tMs } ?: 0L
-      val totalFrames = (durationMs * fps / 1000).toInt() + 1
+      val totalFrames = ((durationMs * fps + 999L) / 1000L).toInt() + 1
 
       // Probe the natural frame size from the first interactive render so the per-frame copies +
       // optional scaling know the output dimensions without hard-coding the spec. Robolectric

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
@@ -18,14 +18,12 @@ import org.junit.rules.TemporaryFolder
 /**
  * P5 — end-to-end test for [AndroidRecordingSession] (the Robolectric-backed scripted screen-
  * recording surface). Boots a 2-sandbox `RobolectricHost`, allocates a recording session against
- * the [ClickToggleSquare] fixture (red → green on first click), posts a two-event script — a
- * click at `tMs = 66` and a `keyDown` at `tMs = 99` (a no-op event used purely to anchor the
- * recording's duration so we get 4 frames), runs `stop()`, and asserts:
+ * the [ClickToggleSquare] fixture (red → green on first click), posts a click at `tMs = 67`, runs
+ * `stop()`, and asserts:
  *
- * 1. Frame count = 4 (100 ms × 30 fps + 1, with frame `tMs`'s of 0, 33, 66, 99).
+ * 1. Frame count = 4 (ceil(67 ms × 30 fps / 1000) + 1, with frame `tMs`'s of 0, 33, 66, 100).
  * 2. Frame 0 paints red — pre-click state at tMs=0.
- * 3. Frame 3 paints green — click@66 was drained at frame 2 (tMs=66 ≥ 66), state flipped, frame
- *    3 reflects the post-click composition.
+ * 3. Frame 3 paints green — click@67 was drained at the first frame at or after 67 ms.
  * 4. APNG encode produces a non-empty file with the standard PNG header bytes.
  *
  * **Test cost.** This test pays the same ~2× cold-boot wall-clock as
@@ -73,30 +71,27 @@ class AndroidRecordingSessionTest {
           live = false,
         )
       try {
-        // Click at tMs=66 (drains exactly at frame 2 since tMs=66 ≥ 66) plus a KEY_DOWN at
-        // tMs=100 used purely to anchor the script's max-tMs to 100, so the totalFrames math
-        // (durationMs × fps / 1000 + 1) yields 4. KEY_* events are filtered out of the dispatch
-        // path (no-op on Android) so the anchor doesn't disturb the held composition.
+        // Click at tMs=67 lands just after the 66 ms frame boundary. The frame-count math must
+        // ceil the script duration so frame 3 (100 ms) exists and drains the event.
         session.postScript(
           listOf(
             RecordingScriptEvent(
-              tMs = 66L,
+              tMs = 67L,
               kind = InteractiveInputKind.CLICK,
               pixelX = INTERACTIVE_WIDTH_PX / 2,
               pixelY = INTERACTIVE_HEIGHT_PX / 2,
-            ),
-            RecordingScriptEvent(tMs = 100L, kind = InteractiveInputKind.KEY_DOWN),
+            )
           )
         )
         val result = session.stop()
 
-        // 1. Frame count: 100ms × 30fps + 1 = 4 frames (frame tMs's: 0, 33, 66, 99).
+        // 1. Frame count: ceil(67ms × 30fps / 1000) + 1 = 4 frames.
         assertEquals(
-          "expected 4 frames at 30 fps over 100 ms timeline; got ${result.frameCount}",
+          "expected 4 frames at 30 fps over 67 ms timeline; got ${result.frameCount}",
           4,
           result.frameCount,
         )
-        assertEquals("durationMs", 100L, result.durationMs)
+        assertEquals("durationMs", 67L, result.durationMs)
         for (i in 0 until result.frameCount) {
           val f = File(result.framesDir, "frame-${"%05d".format(i)}.png")
           assertTrue("frame $i missing on disk: ${f.absolutePath}", f.isFile)
@@ -111,7 +106,7 @@ class AndroidRecordingSessionTest {
           redAt0 >= 0.95,
         )
 
-        // 3. Frame 3 — click@66 was drained at frame 2; final frame reflects the post-click
+        // 3. Frame 3 — click@67 was drained at frame 3; final frame reflects the post-click
         //    composition. This is the load-bearing assertion: it proves the script event reached
         //    the held-rule loop, the state mutated, and the next render captured the new state.
         val frame3 = decode(File(result.framesDir, "frame-00003.png"))

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensionsCatalogDriftTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensionsCatalogDriftTest.kt
@@ -38,6 +38,27 @@ class DeviceDimensionsCatalogDriftTest {
     )
   }
 
+  @Test
+  fun readCatalogIgnoresCommentedEntries() {
+    val temp = Files.createTempFile("device-dimensions-catalog", ".kt")
+    try {
+      Files.writeString(
+        temp,
+        """
+        val KNOWN_DEVICES = mapOf(
+          // "commented" to DeviceSpec(1, 2, 3.0f),
+          "active" to DeviceSpec(4, 5, 6.0f),
+        )
+        """
+          .trimIndent(),
+      )
+
+      assertEquals(mapOf("active" to DeviceEntry(4, 5, 6.0f)), readCatalog(temp))
+    } finally {
+      Files.deleteIfExists(temp)
+    }
+  }
+
   private fun readCatalog(path: Path): Map<String, DeviceEntry> {
     val text = Files.readString(path)
     return entryRegex.findAll(text).associate { match ->
@@ -68,6 +89,6 @@ class DeviceDimensionsCatalogDriftTest {
 
   companion object {
     private val entryRegex =
-      Regex("\"([^\"]+)\"\\s+to\\s+DeviceSpec\\((\\d+),\\s*(\\d+),\\s*([0-9.]+)f\\)")
+      Regex("(?m)^\\s*\"([^\"]+)\"\\s+to\\s+DeviceSpec\\((\\d+),\\s*(\\d+),\\s*([0-9.]+)f\\)")
   }
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1452,8 +1452,14 @@ async function reconcilePreviewManifestAfterDaemonReady(
         });
         gradleService.invalidateCache(module);
         const manifest = await gradleService.discoverPreviews(module);
-        if (!manifest) { return false; }
-        if (currentScopeFile && currentScopeFile !== filePath) { return false; }
+        if (!manifest) {
+            panel.postMessage({ command: 'clearProgress' });
+            return false;
+        }
+        if (currentScopeFile && currentScopeFile !== filePath) {
+            panel.postMessage({ command: 'clearProgress' });
+            return false;
+        }
 
         const fresh = manifest.previews;
         const freshIds = new Set(fresh.map(p => p.id));
@@ -1481,8 +1487,8 @@ async function reconcilePreviewManifestAfterDaemonReady(
                         ? `No @Preview functions in this file (${fresh.length} in other files in this module).`
                         : 'No @Preview functions found in this module',
                 });
-                panel.postMessage({ command: 'clearProgress' });
             }
+            panel.postMessage({ command: 'clearProgress' });
             return false;
         }
 
@@ -1497,11 +1503,14 @@ async function reconcilePreviewManifestAfterDaemonReady(
             moduleDir: module,
             heavyStaleIds,
         });
+        panel.postMessage({ command: 'clearCompileErrors' });
+        compileGateActive = false;
         panel.postMessage({ command: 'markAllLoading' });
         hasPreviewsLoaded = true;
         return true;
     } catch (err) {
         logLine(`daemon: post-warm discover failed for ${module}: ${(err as Error).message}`);
+        panel.postMessage({ command: 'clearProgress' });
         return false;
     }
 }

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -1378,16 +1378,17 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             imgContainer.addEventListener('click', (evt) => {
                 const previewId = card.dataset.previewId;
                 if (!previewId) return;
+                // If we're already live for this preview, the per-image click
+                // handler routes to recordInteractiveInput. Check before the
+                // stale-card branch so interactive clicks do not also queue a
+                // heavyweight refresh for stale captures.
+                if (interactivePreviewIds.has(previewId)) return;
                 if (card.classList.contains('is-stale')) {
                     evt.preventDefault();
                     evt.stopPropagation();
                     requestHeavyRefresh(card);
                     return;
                 }
-                // If we're already live for this preview, the per-image click
-                // handler routes to recordInteractiveInput — let that fire
-                // instead of toggling off.
-                if (interactivePreviewIds.has(previewId)) return;
                 enterInteractiveOnCard(card, evt.shiftKey);
             });
 


### PR DESCRIPTION
## Summary
- fix remaining actionable Codex review follow-ups from today: stale LIVE clicks, daemon reconcile cleanup, Android recording frame count, MCP CLI arg parsing, and device-catalog drift parsing
- add regression coverage for CLI flag parsing, late Android recording events, and commented device entries
- confirmed non-Codex comments were generated preview-diff/status comments only

## Verification
- npm run compile (vscode-extension)
- ./gradlew :cli:test --tests ee.schimke.composeai.cli.ArgsTest :daemon:core:test --tests ee.schimke.composeai.daemon.devices.DeviceDimensionsCatalogDriftTest :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.AndroidRecordingSessionTest ktfmtCheck --stacktrace
- git diff --check