### PR TITLE
fix(vscode): hide live preview title overlay

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -413,6 +413,10 @@ body {
     pointer-events: auto;
 }
 
+.preview-card.live .card-header {
+    display: none;
+}
+
 .card-title {
     font-weight: 600;
     font-size: calc(var(--vscode-font-size) - 1px);


### PR DESCRIPTION
## Summary
- hide the card header overlay while a preview is live
- keep the live preview image unobscured for pointer input and streamed frames

## Tests
- npm test