### PR TITLE
Honor landscape orientation in device specs

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensions.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensions.kt
@@ -164,8 +164,11 @@ object DeviceDimensions {
               if (parts.size == 2) parts[0].trim() to parts[1].trim().removeSuffix("dp") else null
             }
             .toMap()
-        val w = params["width"]?.toIntOrNull() ?: DEFAULT.widthDp
-        val h = params["height"]?.toIntOrNull() ?: DEFAULT.heightDp
+        val parsedWidth = params["width"]?.toIntOrNull() ?: DEFAULT.widthDp
+        val parsedHeight = params["height"]?.toIntOrNull() ?: DEFAULT.heightDp
+        val landscape = params["orientation"]?.equals("landscape", ignoreCase = true) == true
+        val w = if (landscape) maxOf(parsedWidth, parsedHeight) else parsedWidth
+        val h = if (landscape) minOf(parsedWidth, parsedHeight) else parsedHeight
         val density = params["dpi"]?.toIntOrNull()?.let { it / 160f } ?: DEFAULT_DENSITY
         return DeviceSpec(w, h, density)
       }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensionsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensionsTest.kt
@@ -46,6 +46,14 @@ class DeviceDimensionsTest {
   }
 
   @Test
+  fun specStringLandscapeOrientationResolvesLandscapeGeometry() {
+    assertEquals(
+      DeviceDimensions.DeviceSpec(800, 400, DeviceDimensions.DEFAULT_DENSITY),
+      DeviceDimensions.resolve("spec:width=400dp,height=800dp,orientation=landscape"),
+    )
+  }
+
+  @Test
   fun specStringWithoutDpiUsesDefaultDensity() {
     assertEquals(
       DeviceDimensions.DeviceSpec(400, 800, DeviceDimensions.DEFAULT_DENSITY),

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceDimensions.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceDimensions.kt
@@ -169,8 +169,11 @@ object DeviceDimensions {
               if (parts.size == 2) parts[0].trim() to parts[1].trim().removeSuffix("dp") else null
             }
             .toMap()
-        val w = params["width"]?.toIntOrNull() ?: DEFAULT.widthDp
-        val h = params["height"]?.toIntOrNull() ?: DEFAULT.heightDp
+        val parsedWidth = params["width"]?.toIntOrNull() ?: DEFAULT.widthDp
+        val parsedHeight = params["height"]?.toIntOrNull() ?: DEFAULT.heightDp
+        val landscape = params["orientation"]?.equals("landscape", ignoreCase = true) == true
+        val w = if (landscape) maxOf(parsedWidth, parsedHeight) else parsedWidth
+        val h = if (landscape) minOf(parsedWidth, parsedHeight) else parsedHeight
         // `dpi=` is part of Studio's spec: grammar (e.g. spec:width=411dp,height=914dp,dpi=420)
         // — honour it if present, otherwise fall back to the AS default.
         val density = params["dpi"]?.toIntOrNull()?.let { it / 160f } ?: DEFAULT_DENSITY

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DeviceDimensionsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DeviceDimensionsTest.kt
@@ -66,6 +66,13 @@ class DeviceDimensionsTest {
   }
 
   @Test
+  fun `spec string landscape orientation resolves landscape geometry`() {
+    val spec = DeviceDimensions.resolve("spec:width=400dp,height=800dp,orientation=landscape")
+    assertThat(spec.widthDp).isEqualTo(800)
+    assertThat(spec.heightDp).isEqualTo(400)
+  }
+
+  @Test
   fun `wear device returns wear defaults`() {
     val spec = DeviceDimensions.resolve("id:wearos_large_round")
     assertThat(spec.widthDp).isEqualTo(227)


### PR DESCRIPTION
## Summary
- parse spec:...,orientation=landscape in both DeviceDimensions copies
- resolve landscape spec geometry by using the larger parsed side as width and the smaller side as height
- add matching gradle-plugin and daemon-core tests to keep the duplicated parser behavior aligned

Refs #462

## Tests
- ./gradlew ktfmtFormat :gradle-plugin:test --tests ee.schimke.composeai.plugin.DeviceDimensionsTest :daemon:core:test --tests ee.schimke.composeai.daemon.devices.DeviceDimensionsTest
- ./gradlew :gradle-plugin:test --tests ee.schimke.composeai.plugin.DeviceDimensionsTest :daemon:core:test --tests ee.schimke.composeai.daemon.devices.DeviceDimensionsTest
- git diff --check HEAD~1 HEAD

## Skipped
- isRound plumbing and cutout handling from #462 remain for a later pass because they touch the renderer/wire model rather than just the DeviceDimensions parser.
- Other open issues remain feature-sized or integration-test-sized, so this batch stays scoped to the small parser fix.