### PR TITLE
Flag KMP desktop siblings in doctor

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/tooling/CompatRules.kt
@@ -78,6 +78,7 @@ internal object CompatRules {
     checkComposeUiVsCore(mainV, testV, main)?.let(findings::add)
     checkComposeBom(main)?.let(findings::add)
     checkHamcrestSkew(test)?.let(findings::add)
+    checkKmpAndroidSiblingMismatch(test)?.let(findings::add)
     findings += checkOldDeps(mainV, testV, main, test)
     return findings
   }
@@ -137,6 +138,57 @@ internal object CompatRules {
           "}",
         ),
       docsUrl = DOCS_HAMCREST_SKEW,
+    )
+  }
+
+  /**
+   * KMP-published AndroidX / Compose Multiplatform modules ship platform siblings under separate
+   * coordinates (`foo-android`, `foo-desktop`, sometimes `foo-jvmstubs`). Kotlin's
+   * `org.jetbrains.kotlin.platform.type` compat rule normally steers Android test classpaths to the
+   * Android sibling, but consumers that build Kotlin through AGP alone may not have that rule
+   * registered. The renderer configuration substitutes these back to `-android`; this finding
+   * surfaces the same latent skew for consumer-owned unit-test tasks.
+   */
+  private fun checkKmpAndroidSiblingMismatch(test: Map<String, String>): ModuleFindingData? {
+    val mismatches =
+      test.keys
+        .filter { coordinate ->
+          val separator = coordinate.indexOf(':')
+          if (separator <= 0) return@filter false
+          val group = coordinate.substring(0, separator)
+          val name = coordinate.substring(separator + 1)
+          (group.startsWith("androidx.") || group.startsWith("org.jetbrains.compose.")) &&
+            (name.endsWith("-desktop") || name.endsWith("-jvmstubs"))
+        }
+        .sorted()
+    if (mismatches.isEmpty()) return null
+    val rendered = mismatches.joinToString(", ") { "$it:${test.getValue(it)}" }
+    return ModuleFindingData(
+      id = "kmp-android-sibling-mismatch",
+      severity = "error",
+      message = "desktop/JVM-stub KMP sibling resolved on the unit-test classpath ($rendered)",
+      detail =
+        "AndroidX and Compose Multiplatform KMP modules publish Android and desktop/JVM-stub " +
+          "siblings as separate coordinates. Android unit tests need the `-android` sibling so " +
+          "AGP-flavoured bytecode links against the expected class shapes. If the Kotlin Android " +
+          "plugin is absent, Gradle may resolve a desktop/JVM-stub sibling instead; the renderer " +
+          "configuration substitutes it back to `-android`, but consumer-owned unit-test tasks " +
+          "still see the mismatch.",
+      remediationSummary =
+        "Apply `org.jetbrains.kotlin.android`, or add a unit-test classpath substitution from `-desktop` / `-jvmstubs` to `-android`.",
+      remediationCommands =
+        listOf(
+          "configurations.matching { it.name.endsWith(\"UnitTestRuntimeClasspath\") }.configureEach {",
+          "  resolutionStrategy.eachDependency {",
+          "    if ((requested.group.startsWith(\"androidx.\") || requested.group.startsWith(\"org.jetbrains.compose.\")) &&",
+          "        (requested.name.endsWith(\"-desktop\") || requested.name.endsWith(\"-jvmstubs\"))) {",
+          "      val suffix = if (requested.name.endsWith(\"-desktop\")) \"-desktop\" else \"-jvmstubs\"",
+          "      useTarget(\"${'$'}{requested.group}:${'$'}{requested.name.removeSuffix(suffix)}-android:${'$'}{requested.version}\")",
+          "    }",
+          "  }",
+          "}",
+        ),
+      docsUrl = null,
     )
   }
 

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/tooling/CompatRulesTest.kt
@@ -243,6 +243,44 @@ class CompatRulesTest {
   }
 
   @Test
+  fun `kmp desktop sibling on test classpath fires error`() {
+    val test =
+      mainWithBom() +
+        ("androidx.compose.ui:ui-test-manifest" to "1.10.6") +
+        ("androidx.lifecycle:lifecycle-viewmodel-desktop" to "2.8.7") +
+        ("org.jetbrains.compose.ui:ui-desktop" to "1.10.0")
+    val findings = CompatRules.evaluate(mainWithBom(), test)
+    val f = findings.single { it.id == "kmp-android-sibling-mismatch" }
+    assertEquals("error", f.severity)
+    assertTrue("lifecycle-viewmodel-desktop:2.8.7" in f.message)
+    assertTrue("org.jetbrains.compose.ui:ui-desktop:1.10.0" in f.message)
+    assertTrue(f.remediationCommands.any { "removeSuffix" in it })
+  }
+
+  @Test
+  fun `kmp jvmstubs sibling on test classpath fires error`() {
+    val test =
+      mainWithBom() +
+        ("androidx.compose.ui:ui-test-manifest" to "1.10.6") +
+        ("androidx.savedstate:savedstate-jvmstubs" to "1.3.0")
+    val findings = CompatRules.evaluate(mainWithBom(), test)
+    val f = findings.single { it.id == "kmp-android-sibling-mismatch" }
+    assertEquals("error", f.severity)
+    assertTrue("androidx.savedstate:savedstate-jvmstubs:1.3.0" in f.message)
+  }
+
+  @Test
+  fun `kmp android sibling and unscoped desktop artifacts are quiet`() {
+    val test =
+      mainWithBom() +
+        ("androidx.compose.ui:ui-test-manifest" to "1.10.6") +
+        ("androidx.lifecycle:lifecycle-viewmodel-android" to "2.8.7") +
+        ("org.jetbrains.kotlinx:kotlinx-coroutines-swing-desktop" to "1.10.2")
+    val findings = CompatRules.evaluate(mainWithBom(), test)
+    assertNull(findings.firstOrNull { it.id == "kmp-android-sibling-mismatch" })
+  }
+
+  @Test
   fun `semver parses and compares`() {
     assertEquals(Semver(1, 16, 0), Semver.parseOrNull("1.16.0"))
     assertEquals(Semver(1, 16, 0), Semver.parseOrNull("1.16"))


### PR DESCRIPTION
## Summary
- add a CompatRules doctor finding for AndroidX / JetBrains Compose KMP desktop and JVM-stub siblings on the unit-test classpath
- explain that renderer classpath substitution protects compose-preview, while consumer-owned AGP unit-test tasks can still see the mismatch
- add focused tests for AndroidX desktop, AndroidX jvmstubs, JetBrains Compose desktop, Android sibling, and unscoped desktop-like artifacts

Refs #302

## Tests
- ./gradlew :gradle-plugin:ktfmtFormat :gradle-plugin:test --tests ee.schimke.composeai.plugin.tooling.CompatRulesTest
- ./gradlew :gradle-plugin:test --tests ee.schimke.composeai.plugin.tooling.CompatRulesTest
- git diff --check HEAD~1 HEAD

## Skipped
- The docs expansion requested in #302 is intentionally left for a separate documentation pass.
- Other open issues remain feature-sized or integration-test-sized, so this batch stays scoped to the pure doctor rule.