### PR TITLE
Preserve Android interactive mode through manifest router

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -124,12 +124,16 @@ fun main(args: Array<String>) {
         "compose-ai-tools daemon: PreviewManifestRouter active " +
           "(manifest=$manifestPath, previews=${manifest.previews.map { it.id }})"
       )
-      // The harness's PreviewManifestRouter wraps a single RobolectricHost; sandbox pooling is
-      // an optimisation for the production daemon path, not the harness mode (which exists to
-      // exercise the wire protocol against in-process fakes). Stay at sandboxCount=1 here and
-      // use the legacy single-instance holder (PreviewManifestRouter still takes that form).
+      // The Gradle plugin also sets the historical "harness" manifest sysprop for production
+      // Android daemons so previewId renderNow calls still route through the manifest. In that
+      // production shape we must preserve the warm-spare pool and per-slot user classloaders;
+      // otherwise the router silently downgrades the daemon to v1 interactive mode and scroll/click
+      // inputs only trigger stateless re-renders. Standalone harness launchers have no preview
+      // index/user class dirs, so they keep the old single-sandbox route.
+      val productionManifestRoute = previewIndex.size > 0 || hasUserClasses
+      val routerSandboxCount = if (productionManifestRoute) sandboxCount else 1
       val singletonHolder: UserClassLoaderHolder? =
-        userClassloaderHolderFactory?.let { factory ->
+        if (routerSandboxCount == 1) userClassloaderHolderFactory?.let { factory ->
           UserClassLoaderHolder(
             urls = userClassUrls,
             parentSupplier = {
@@ -141,8 +145,19 @@ fun main(args: Array<String>) {
                 )
             },
           )
-        }
-      PreviewManifestRouter(manifest = manifest, userClassloaderHolder = singletonHolder)
+        } else null
+      if (routerSandboxCount > 1) {
+        System.err.println(
+          "compose-ai-tools daemon: sandbox pool active (sandboxCount=$routerSandboxCount)"
+        )
+      }
+      PreviewManifestRouter(
+        manifest = manifest,
+        userClassloaderHolder = singletonHolder,
+        sandboxCount = routerSandboxCount,
+        userClassloaderHolderFactory =
+          if (routerSandboxCount > 1) userClassloaderHolderFactory else null,
+      )
     } else {
       if (sandboxCount > 1) {
         System.err.println(

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -46,7 +46,17 @@ import kotlinx.serialization.json.Json
 class PreviewManifestRouter(
   private val manifest: PreviewManifest,
   userClassloaderHolder: UserClassLoaderHolder? = null,
-) : RobolectricHost(userClassloaderHolder = userClassloaderHolder) {
+  sandboxCount: Int = 1,
+  userClassloaderHolderFactory: ((sandboxClassLoader: ClassLoader) -> UserClassLoaderHolder)? =
+    null,
+) : RobolectricHost(
+  userClassloaderHolder = userClassloaderHolder,
+  sandboxCount = sandboxCount,
+  userClassloaderHolderFactory = userClassloaderHolderFactory,
+  previewSpecResolver = { previewId ->
+    manifest.previews.firstOrNull { it.id == previewId }?.renderSpec()
+  },
+) {
 
   private val byId: Map<String, PreviewManifestEntry> = manifest.previews.associateBy { it.id }
 
@@ -139,6 +149,21 @@ class PreviewManifestRouter(
       return json.decodeFromString(PreviewManifest.serializer(), file.readText())
     }
   }
+}
+
+private fun PreviewManifestEntry.renderSpec(): RenderSpec {
+  val resolved = resolved()
+  return RenderSpec(
+    className = className,
+    functionName = functionName,
+    widthPx = resolved.widthPx,
+    heightPx = resolved.heightPx,
+    density = resolved.density,
+    showBackground = resolved.showBackground,
+    backgroundColor = resolved.backgroundColor,
+    device = resolved.device,
+    outputBaseName = resolved.outputBaseName,
+  )
 }
 
 @Serializable data class PreviewManifest(val previews: List<PreviewManifestEntry>)

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
@@ -384,6 +384,33 @@ class AndroidInteractiveSessionTest {
   }
 
   @Test
+  fun previewManifestRouterPreservesInteractiveCapabilityWhenPooled() {
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = INTERACTIVE_PREVIEW_ID,
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "ClickToggleSquare",
+              widthPx = INTERACTIVE_WIDTH_PX,
+              heightPx = INTERACTIVE_HEIGHT_PX,
+              density = 1.0f,
+            )
+          )
+      )
+
+    assertFalse(
+      "single-sandbox router must keep the v1 fallback capability",
+      PreviewManifestRouter(manifest = manifest, sandboxCount = 1).supportsInteractive,
+    )
+    assertTrue(
+      "pooled production router must advertise held interactive sessions",
+      PreviewManifestRouter(manifest = manifest, sandboxCount = 2).supportsInteractive,
+    )
+  }
+
+  @Test
   fun acquireWithSandboxCountOneThrowsUnsupported() {
     // sandboxCount = 1 should refuse interactive even when a resolver is wired — the single slot
     // can't be sacrificed without taking normal renders down.


### PR DESCRIPTION
## Summary
- preserve the production Android daemon sandbox pool when the manifest router is active
- wire PreviewManifestRouter as the Android interactive preview resolver so initialize advertises held interactive support instead of v1 fallback
- add regression coverage for the router's interactive capability bit

## Why
The VS Code logs showed live mode starting with v2=false. That means the daemon was accepting interactive input but falling back to stateless re-renders, so clicks/scroll/RSB could render without any visible state change. The Gradle plugin sets the historical composeai.harness.previewsManifest property in production, and DaemonMain was treating that route as single-sandbox harness mode.

This is not an InspectionMode issue for the held Android path: runHeldInteractiveSession composes with LocalInspectionMode=false. The problem was that production was being downgraded before reaching that held-session path.

## Verification
- ./gradlew :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.AndroidInteractiveSessionTest.previewManifestRouterPreservesInteractiveCapabilityWhenPooled
- ./gradlew :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.AndroidInteractiveSessionTest