### PR TITLE
Keep manifest-routed renders off held interactive slot

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -65,13 +65,22 @@ class PreviewManifestRouter(
       "Use shutdown() to stop the host, not submit(Shutdown)."
     }
     val typed = request as RenderRequest.Render
-    val inbound = parseInboundPayload(typed.payload)
+    val routed =
+      RenderRequest.Render(
+        id = typed.id,
+        payload = routePayload(typed.payload),
+      )
+    return super.submit(routed, timeoutMs)
+  }
+
+  internal fun routePayload(payload: String): String {
+    val inbound = parseInboundPayload(payload)
     val previewId = inbound["previewId"]
     val entry =
       previewId?.let { byId[it] }
         ?: error(
           "PreviewManifestRouter: no manifest entry for previewId='${previewId ?: "<missing>"}' " +
-            "(payload='${typed.payload}'). Manifest knows: ${byId.keys}"
+            "(payload='$payload'). Manifest knows: ${byId.keys}"
         )
     val resolved = entry.resolved()
     // PROTOCOL.md § 5 (`renderNow.overrides.device`) — when the inbound carries a `device=` token
@@ -91,39 +100,34 @@ class PreviewManifestRouter(
     val baseHeightPx = deviceSpec?.let { (it.heightDp * it.density).toInt() } ?: resolved.heightPx
     val baseDensity = deviceSpec?.density ?: resolved.density
     val effectiveDevice = deviceOverride ?: resolved.device
-    val routed =
-      RenderRequest.Render(
-        id = typed.id,
-        payload =
-          buildString {
-            append("className=").append(entry.className).append(';')
-            append("functionName=").append(entry.functionName).append(';')
-            // Inbound explicit override wins over both the device-derived value and the
-            // per-preview manifest default.
-            append("widthPx=").append(inbound["widthPx"] ?: baseWidthPx).append(';')
-            append("heightPx=").append(inbound["heightPx"] ?: baseHeightPx).append(';')
-            append("density=").append(inbound["density"] ?: baseDensity).append(';')
-            append("showBackground=").append(resolved.showBackground).append(';')
-            if (resolved.backgroundColor != 0L) {
-              append("backgroundColor=").append(resolved.backgroundColor).append(';')
-            }
-            effectiveDevice?.takeIf { it.isNotBlank() }?.let {
-              append("device=").append(it).append(';')
-            }
-            // PROTOCOL.md § 5 (`renderNow.overrides`) — locale / fontScale / uiMode / orientation
-            // pass straight through to the qualifier builder in `RenderEngine`. Wire-format twin
-            // of the desktop router; keep both in lockstep so a single payload drives both.
-            inbound["localeTag"]?.let { append("localeTag=").append(it).append(';') }
-            inbound["fontScale"]?.let { append("fontScale=").append(it).append(';') }
-            inbound["uiMode"]?.let { append("uiMode=").append(it).append(';') }
-            inbound["orientation"]?.let { append("orientation=").append(it).append(';') }
-            inbound["captureAdvanceMs"]?.let {
-              append("captureAdvanceMs=").append(it).append(';')
-            }
-            append("outputBaseName=").append(resolved.outputBaseName)
-          },
-      )
-    return super.submit(routed, timeoutMs)
+    return buildString {
+      append("previewId=").append(previewId).append(';')
+      append("className=").append(entry.className).append(';')
+      append("functionName=").append(entry.functionName).append(';')
+      // Inbound explicit override wins over both the device-derived value and the
+      // per-preview manifest default.
+      append("widthPx=").append(inbound["widthPx"] ?: baseWidthPx).append(';')
+      append("heightPx=").append(inbound["heightPx"] ?: baseHeightPx).append(';')
+      append("density=").append(inbound["density"] ?: baseDensity).append(';')
+      append("showBackground=").append(resolved.showBackground).append(';')
+      if (resolved.backgroundColor != 0L) {
+        append("backgroundColor=").append(resolved.backgroundColor).append(';')
+      }
+      effectiveDevice?.takeIf { it.isNotBlank() }?.let {
+        append("device=").append(it).append(';')
+      }
+      // PROTOCOL.md § 5 (`renderNow.overrides`) — locale / fontScale / uiMode / orientation
+      // pass straight through to the qualifier builder in `RenderEngine`. Wire-format twin
+      // of the desktop router; keep both in lockstep so a single payload drives both.
+      inbound["localeTag"]?.let { append("localeTag=").append(it).append(';') }
+      inbound["fontScale"]?.let { append("fontScale=").append(it).append(';') }
+      inbound["uiMode"]?.let { append("uiMode=").append(it).append(';') }
+      inbound["orientation"]?.let { append("orientation=").append(it).append(';') }
+      inbound["captureAdvanceMs"]?.let {
+        append("captureAdvanceMs=").append(it).append(';')
+      }
+      append("outputBaseName=").append(resolved.outputBaseName)
+    }
   }
 
   private fun parseInboundPayload(payload: String): Map<String, String> {

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -523,11 +523,23 @@ open class RobolectricHost(
    * `Math.floorMod` keeps the slot index non-negative for any hash. With `sandboxCount = 1` both
    * paths collapse to slot 0 — bit-identical with the pre-pool single-sandbox dispatch.
    */
-  private fun chooseSlotIndex(render: RenderRequest.Render): Int {
+  internal fun chooseSlotIndexForTest(
+    payload: String,
+    id: Long,
+    interactiveSlotPinned: Boolean = false,
+  ): Int = chooseSlotIndex(RenderRequest.Render(id = id, payload = payload), interactiveSlotPinned)
+
+  private fun chooseSlotIndex(
+    render: RenderRequest.Render,
+    interactiveSlotPinned: Boolean = activeInteractiveStreamId.get() != null,
+  ): Int {
     if (sandboxCount == 1) return 0
     val previewId = parsePreviewIdFromPayload(render.payload)
     val key: Int = previewId?.hashCode() ?: render.id.hashCode()
-    return Math.floorMod(key, sandboxCount)
+    if (!interactiveSlotPinned) return Math.floorMod(key, sandboxCount)
+    val normalSlotCount = sandboxCount - 1
+    val normalSlot = Math.floorMod(key, normalSlotCount)
+    return if (normalSlot < INTERACTIVE_SLOT_INDEX) normalSlot else normalSlot + 1
   }
 
   /**

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSessionTest.kt
@@ -411,6 +411,35 @@ class AndroidInteractiveSessionTest {
   }
 
   @Test
+  fun previewManifestRouterKeepsPreviewIdInRoutedPayloadForSlotAffinity() {
+    val manifest =
+      PreviewManifest(
+        previews =
+          listOf(
+            PreviewManifestEntry(
+              id = SCROLL_PREVIEW_ID,
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "DragScrollableSquare",
+              widthPx = INTERACTIVE_WIDTH_PX,
+              heightPx = INTERACTIVE_HEIGHT_PX,
+              density = 1.0f,
+            )
+          )
+      )
+    val router = PreviewManifestRouter(manifest = manifest, sandboxCount = 2)
+
+    val routed = router.routePayload("previewId=$SCROLL_PREVIEW_ID;widthPx=128")
+
+    assertTrue(
+      "routed payload must retain previewId so RobolectricHost can keep renderNow off the " +
+        "held interactive slot by preview affinity",
+      routed.split(';').contains("previewId=$SCROLL_PREVIEW_ID"),
+    )
+    assertTrue("routed payload should still carry resolved class", routed.contains("className="))
+    assertTrue("inbound overrides must survive routing", routed.contains("widthPx=128"))
+  }
+
+  @Test
   fun acquireWithSandboxCountOneThrowsUnsupported() {
     // sandboxCount = 1 should refuse interactive even when a resolver is wired — the single slot
     // can't be sacrificed without taking normal renders down.

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RobolectricHostPoolTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RobolectricHostPoolTest.kt
@@ -140,6 +140,40 @@ class RobolectricHostPoolTest {
   }
 
   @Test
+  fun normalRendersAvoidInteractiveSlotWhenHeldSessionIsPinned() {
+    val host = RobolectricHost(sandboxCount = 2)
+    val slotOnePayload =
+      (0 until 64)
+        .map { i -> "previewId=com.example.preview.HashesToInteractiveSlot$i" }
+        .first { payload ->
+          host.chooseSlotIndexForTest(
+            payload = payload,
+            id = 100L,
+            interactiveSlotPinned = false,
+          ) == RobolectricHost.INTERACTIVE_SLOT_INDEX
+        }
+
+    assertEquals(
+      "test setup should pick a payload that normally hashes to the interactive slot",
+      RobolectricHost.INTERACTIVE_SLOT_INDEX,
+      host.chooseSlotIndexForTest(
+        payload = slotOnePayload,
+        id = 100L,
+        interactiveSlotPinned = false,
+      ),
+    )
+    assertEquals(
+      "when slot 1 is held by live interactive mode, normal renderNow dispatch must stay on slot 0",
+      0,
+      host.chooseSlotIndexForTest(
+        payload = slotOnePayload,
+        id = 100L,
+        interactiveSlotPinned = true,
+      ),
+    )
+  }
+
+  @Test
   fun rejectsLegacyHolderPlusFactory() {
     // SANDBOX-POOL-FOLLOWUPS.md (#1) — the two constructor paths are mutually exclusive. Pre-#1
     // the constraint was "no holder when sandboxCount > 1"; now the constraint is "use either


### PR DESCRIPTION
## Summary
- retain previewId in PreviewManifestRouter's rewritten RenderSpec payload so pooled Robolectric dispatch can still use preview affinity
- make RobolectricHost avoid the pinned interactive slot for normal render dispatch while a held Android interactive session is active
- add regressions for routed previewId retention and slot selection with the interactive slot pinned

## Why
The previous manifest-router fix let production Android daemons advertise held interactive support, but normal renderNow traffic could still be sent to slot 1. When live mode holds slot 1 inside runHeldInteractiveSession, those normal renders would block until timeout. This keeps manifest-routed renders on normal-render slots during live mode.

## Verification
- ./gradlew :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.RobolectricHostPoolTest.normalRendersAvoidInteractiveSlotWhenHeldSessionIsPinned --tests ee.schimke.composeai.daemon.AndroidInteractiveSessionTest.previewManifestRouterKeepsPreviewIdInRoutedPayloadForSlotAffinity
- ./gradlew :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.AndroidInteractiveSessionTest --tests ee.schimke.composeai.daemon.RobolectricHostPoolTest