### PR TITLE
Preserve round device specs

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -2717,7 +2717,13 @@ class JsonRpcServer(
   private fun buildKnownDevices(): List<KnownDevice> =
     ee.schimke.composeai.daemon.devices.DeviceDimensions.KNOWN_DEVICE_IDS.sorted().map { id ->
       val spec = ee.schimke.composeai.daemon.devices.DeviceDimensions.resolve(id)
-      KnownDevice(id = id, widthDp = spec.widthDp, heightDp = spec.heightDp, density = spec.density)
+      KnownDevice(
+        id = id,
+        widthDp = spec.widthDp,
+        heightDp = spec.heightDp,
+        density = spec.density,
+        isRound = spec.isRound,
+      )
     }
 
   /** Tagged failure carrier for the watcher loop. */

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensions.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensions.kt
@@ -34,7 +34,12 @@ object DeviceDimensions {
    * density to populate `RenderSpec.widthPx`/`heightPx`; the Android backend then re-derives the
    * Robolectric `<n>dpi` qualifier from it.
    */
-  data class DeviceSpec(val widthDp: Int, val heightDp: Int, val density: Float = DEFAULT_DENSITY)
+  data class DeviceSpec(
+    val widthDp: Int,
+    val heightDp: Int,
+    val density: Float = DEFAULT_DENSITY,
+    val isRound: Boolean = false,
+  )
 
   /**
    * The density Android Studio uses when no device is specified — xxhdpi-ish (420dpi → 2.625x),
@@ -123,7 +128,7 @@ object DeviceDimensions {
     )
 
   val DEFAULT = DeviceSpec(400, 800, DEFAULT_DENSITY)
-  val DEFAULT_WEAR = DeviceSpec(227, 227, 2.0f)
+  val DEFAULT_WEAR = DeviceSpec(227, 227, 2.0f, isRound = true)
 
   /**
    * The set of device-id strings the catalog recognises (every key in [KNOWN_DEVICES]). Useful for
@@ -151,7 +156,7 @@ object DeviceDimensions {
 
     if (device != null) {
       KNOWN_DEVICES[device]?.let {
-        return it
+        return it.copy(isRound = isRoundDeviceString(device))
       }
 
       if (device.startsWith("spec:")) {
@@ -169,13 +174,21 @@ object DeviceDimensions {
         val landscape = params["orientation"]?.equals("landscape", ignoreCase = true) == true
         val w = if (landscape) maxOf(parsedWidth, parsedHeight) else parsedWidth
         val h = if (landscape) minOf(parsedWidth, parsedHeight) else parsedHeight
+        val isRound = params["isRound"]?.toBooleanStrictOrNull() == true
         val density = params["dpi"]?.toIntOrNull()?.let { it / 160f } ?: DEFAULT_DENSITY
-        return DeviceSpec(w, h, density)
+        return DeviceSpec(w, h, density, isRound = isRound)
       }
 
       if (device.contains("wear", ignoreCase = true)) return DEFAULT_WEAR
     }
 
     return DEFAULT
+  }
+
+  private fun isRoundDeviceString(device: String): Boolean {
+    val lower = device.lowercase()
+    return lower.contains("_round") ||
+      lower.contains("isround=true") ||
+      lower.contains("shape=round")
   }
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -198,10 +198,17 @@ enum class BackendKind {
 /**
  * One entry in `ServerCapabilities.knownDevices`. The id is the string a caller passes via
  * `renderNow.overrides.device` (or `@Preview(device = ...)` at discovery time); the geometry fields
- * let a UI label the device ("Pixel 5 — 393×851 dp @ 2.75x") without re-resolving.
+ * let a UI label the device ("Pixel 5 — 393×851 dp @ 2.75x") without re-resolving. [isRound]
+ * identifies circular Wear-style displays.
  */
 @Serializable
-data class KnownDevice(val id: String, val widthDp: Int, val heightDp: Int, val density: Float)
+data class KnownDevice(
+  val id: String,
+  val widthDp: Int,
+  val heightDp: Int,
+  val density: Float,
+  val isRound: Boolean = false,
+)
 
 /**
  * One advertised data-product kind. Mirrors `DataProductCapability` in

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensionsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensionsTest.kt
@@ -18,7 +18,7 @@ class DeviceDimensionsTest {
       DeviceDimensions.resolve("id:pixel_fold"),
     )
     assertEquals(
-      DeviceDimensions.DeviceSpec(192, 192, 2.0f),
+      DeviceDimensions.DeviceSpec(192, 192, 2.0f, isRound = true),
       DeviceDimensions.resolve("id:wearos_small_round"),
     )
     assertEquals(
@@ -50,6 +50,14 @@ class DeviceDimensionsTest {
     assertEquals(
       DeviceDimensions.DeviceSpec(800, 400, DeviceDimensions.DEFAULT_DENSITY),
       DeviceDimensions.resolve("spec:width=400dp,height=800dp,orientation=landscape"),
+    )
+  }
+
+  @Test
+  fun specStringPreservesIsRoundParameter() {
+    assertEquals(
+      DeviceDimensions.DeviceSpec(227, 227, 2.0f, isRound = true),
+      DeviceDimensions.resolve("spec:width=227dp,height=227dp,dpi=320,isRound=true"),
     )
   }
 

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -127,7 +127,8 @@ Result:
   };
   // KnownDevice — one entry per id in DeviceDimensions.KNOWN_DEVICE_IDS, projected to wire shape.
   // `id` is the string a caller passes via renderNow.overrides.device; widthDp/heightDp/density
-  // let a UI label the device ("Pixel 5 — 393×851 dp @ 2.75x") without re-resolving.
+  // let a UI label the device ("Pixel 5 — 393×851 dp @ 2.75x") without re-resolving. isRound marks
+  // circular Wear-style displays.
   // Empty list = pre-feature daemon; treat absent and `[]` identically.
   // The `spec:width=…,height=…,dpi=…` grammar is not enumerable — clients pass it as a
   // free-form `device` override and the daemon parses it at resolve-time.

--- a/docs/daemon/protocol-fixtures/daemon-initializeResult.json
+++ b/docs/daemon/protocol-fixtures/daemon-initializeResult.json
@@ -26,7 +26,7 @@
     ],
     "knownDevices": [
       {"id": "id:pixel_5", "widthDp": 393, "heightDp": 851, "density": 2.75},
-      {"id": "id:wearos_small_round", "widthDp": 192, "heightDp": 192, "density": 2.0}
+      {"id": "id:wearos_small_round", "widthDp": 192, "heightDp": 192, "density": 2.0, "isRound": true}
     ],
     "supportedOverrides": ["density", "device", "fontScale", "heightPx", "uiMode", "widthPx"],
     "backend": "desktop"

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceDimensions.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceDimensions.kt
@@ -9,7 +9,12 @@ object DeviceDimensions {
    * Compose's `Density(...)` constructor) so output PNGs match what Android Studio's preview
    * renders for the same `@Preview`.
    */
-  data class DeviceSpec(val widthDp: Int, val heightDp: Int, val density: Float = DEFAULT_DENSITY)
+  data class DeviceSpec(
+    val widthDp: Int,
+    val heightDp: Int,
+    val density: Float = DEFAULT_DENSITY,
+    val isRound: Boolean = false,
+  )
 
   /**
    * The density Android Studio uses when no device is specified — xxhdpi-ish (420dpi → 2.625x),
@@ -144,7 +149,7 @@ object DeviceDimensions {
     )
 
   val DEFAULT = DeviceSpec(400, 800, DEFAULT_DENSITY)
-  val DEFAULT_WEAR = DeviceSpec(227, 227, 2.0f)
+  val DEFAULT_WEAR = DeviceSpec(227, 227, 2.0f, isRound = true)
 
   fun resolve(device: String?, widthDp: Int? = null, heightDp: Int? = null): DeviceSpec {
     // Explicit widthDp/heightDp on the @Preview annotation — no device info,
@@ -156,7 +161,7 @@ object DeviceDimensions {
 
     if (device != null) {
       KNOWN_DEVICES[device]?.let {
-        return it
+        return it.copy(isRound = isRoundDeviceString(device))
       }
 
       if (device.startsWith("spec:")) {
@@ -174,16 +179,24 @@ object DeviceDimensions {
         val landscape = params["orientation"]?.equals("landscape", ignoreCase = true) == true
         val w = if (landscape) maxOf(parsedWidth, parsedHeight) else parsedWidth
         val h = if (landscape) minOf(parsedWidth, parsedHeight) else parsedHeight
+        val isRound = params["isRound"]?.toBooleanStrictOrNull() == true
         // `dpi=` is part of Studio's spec: grammar (e.g. spec:width=411dp,height=914dp,dpi=420)
         // — honour it if present, otherwise fall back to the AS default.
         val density = params["dpi"]?.toIntOrNull()?.let { it / 160f } ?: DEFAULT_DENSITY
-        return DeviceSpec(w, h, density)
+        return DeviceSpec(w, h, density, isRound = isRound)
       }
 
       if (device.contains("wear", ignoreCase = true)) return DEFAULT_WEAR
     }
 
     return DEFAULT
+  }
+
+  private fun isRoundDeviceString(device: String): Boolean {
+    val lower = device.lowercase()
+    return lower.contains("_round") ||
+      lower.contains("isround=true") ||
+      lower.contains("shape=round")
   }
 
   /**

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DeviceDimensionsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DeviceDimensionsTest.kt
@@ -73,10 +73,17 @@ class DeviceDimensionsTest {
   }
 
   @Test
+  fun `spec string preserves isRound parameter`() {
+    val spec = DeviceDimensions.resolve("spec:width=227dp,height=227dp,dpi=320,isRound=true")
+    assertThat(spec.isRound).isTrue()
+  }
+
+  @Test
   fun `wear device returns wear defaults`() {
     val spec = DeviceDimensions.resolve("id:wearos_large_round")
     assertThat(spec.widthDp).isEqualTo(227)
     assertThat(spec.heightDp).isEqualTo(227)
+    assertThat(spec.isRound).isTrue()
   }
 
   @Test

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -184,12 +184,14 @@ export interface InitializeResult {
  * One entry in `ServerCapabilities.knownDevices`. The `id` is the string a caller passes via
  * `renderNow.overrides.device` (or `@Preview(device = ...)` at discovery time); the geometry
  * fields let a UI label the device ("Pixel 5 — 393×851 dp @ 2.75x") without re-resolving.
+ * `isRound` marks circular Wear-style displays.
  */
 export interface KnownDevice {
     id: string;
     widthDp: number;
     heightDp: number;
     density: number;
+    isRound?: boolean;
 }
 
 // Client → daemon notifications (PROTOCOL.md § 4)

--- a/vscode-extension/src/test/daemonProtocol.test.ts
+++ b/vscode-extension/src/test/daemonProtocol.test.ts
@@ -69,6 +69,9 @@ describe('daemon protocol — golden fixtures', () => {
         assert.ok(pixel5, 'fixture should include id:pixel_5');
         assert.strictEqual(pixel5!.widthDp, 393);
         assert.strictEqual(pixel5!.density, 2.75);
+        const wear = known.find(d => d.id === 'id:wearos_small_round');
+        assert.ok(wear, 'fixture should include id:wearos_small_round');
+        assert.strictEqual(wear!.isRound, true);
         // PROTOCOL.md § 3 — supportedOverrides advertises which `PreviewOverrides` fields
         // this host actually applies. Desktop omits `localeTag` and `orientation`; the
         // fixture mirrors a desktop daemon so those should be absent.


### PR DESCRIPTION
## Summary
- preserve isRound=true when resolving spec device strings in both DeviceDimensions copies
- derive round metadata for known round Wear ids without changing the catalog table geometry
- surface KnownDevice.isRound in daemon capabilities and update Kotlin/TypeScript protocol fixtures

Refs #462

## Tests
- ./gradlew ktfmtFormat :gradle-plugin:test --tests ee.schimke.composeai.plugin.DeviceDimensionsTest :daemon:core:test --tests ee.schimke.composeai.daemon.devices.DeviceDimensionsTest --tests ee.schimke.composeai.daemon.protocol.MessagesTest
- ./gradlew :daemon:core:test --tests ee.schimke.composeai.daemon.devices.DeviceDimensionsCatalogDriftTest
- ./gradlew :gradle-plugin:test --tests ee.schimke.composeai.plugin.DeviceDimensionsTest :daemon:core:test --tests ee.schimke.composeai.daemon.devices.DeviceDimensionsTest --tests ee.schimke.composeai.daemon.devices.DeviceDimensionsCatalogDriftTest --tests ee.schimke.composeai.daemon.protocol.MessagesTest
- npm test -- --grep "daemon protocol" (from vscode-extension)
- git diff --check HEAD~1 HEAD

## Skipped
- cutout handling from #462 remains for later because no renderer or wire consumer reads it yet.
- Other open issues are feature-sized or integration-test-sized, so this batch stays scoped to round device metadata.