### PR TITLE
fix(vscode): keep daemon reconcile scoped

### DIFF
--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -406,6 +406,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
                 previewId,
                 captureIndex: 0,
                 message,
+                replaceExisting: false,
             });
         },
         onDataProductsAttached: (_moduleId, previewId, dataProducts) => {
@@ -1058,10 +1059,13 @@ async function applyDiscoveryDiff(moduleId: string, params: { added: unknown[]; 
         return;
     }
 
-    // Re-filter against `currentScopeFile` so the panel stays scoped to the
-    // file the user is editing — same shape as the gradle path's setPreviews.
-    if (!currentScopeFile) { return; }
-    await reconcilePreviewManifestForFile(moduleId, currentScopeFile);
+    // Always reconcile caches, even when no preview editor is visible. Only
+    // repaint the panel when its current scope still belongs to this module;
+    // daemon save/discovery events can also arrive for background files.
+    const repaintFile = currentScopeFile && gradleService.resolveModule(currentScopeFile) === moduleId
+        ? currentScopeFile
+        : undefined;
+    await reconcilePreviewManifest(moduleId, repaintFile);
 }
 
 /**
@@ -1122,7 +1126,11 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
     let filePreviews = manifest.filter(p => p.sourceFile === filterFile);
     if (await sourceMayHaveDroppedCachedPreviews(filePath, filePreviews)) {
         logLine(`daemon: preview declarations changed in ${path.basename(filePath)}; reconciling before render`);
-        filePreviews = await reconcilePreviewManifestForFile(module, filePath) ?? filePreviews;
+        const repaintFile = currentScopeFile && gradleService.resolveModule(currentScopeFile) === module
+            ? currentScopeFile
+            : undefined;
+        const fresh = await reconcilePreviewManifest(module, repaintFile);
+        filePreviews = fresh?.filter(p => p.sourceFile === filterFile) ?? filePreviews;
     }
     const ids = filePreviews.map(p => p.id);
     if (ids.length === 0) { return 'accepted'; }
@@ -1437,8 +1445,11 @@ function visiblePreviewCount(module: string, filePath: string): number {
     return previews.filter(p => p.sourceFile === filterFile).length;
 }
 
-async function reconcilePreviewManifestForFile(module: string, filePath: string): Promise<PreviewInfo[] | null> {
-    if (!gradleService || !panel) { return null; }
+async function reconcilePreviewManifest(
+    module: string,
+    repaintFilePath?: string,
+): Promise<PreviewInfo[] | null> {
+    if (!gradleService) { return null; }
     gradleService.invalidateCache(module);
     let manifest;
     try {
@@ -1462,7 +1473,9 @@ async function reconcilePreviewManifestForFile(module: string, filePath: string)
     moduleManifestCache.set(module, fresh);
     registry.replaceModule(module, fresh);
 
-    const filterFile = packageQualifiedSourcePath(filePath);
+    if (!panel || !repaintFilePath) { return fresh; }
+
+    const filterFile = packageQualifiedSourcePath(repaintFilePath);
     const visiblePreviews = fresh.filter(p => p.sourceFile === filterFile);
     const heavyStaleIds = fastTierModules.has(module)
         ? visiblePreviews
@@ -1475,7 +1488,7 @@ async function reconcilePreviewManifestForFile(module: string, filePath: string)
         moduleDir: module,
         heavyStaleIds,
     });
-    return visiblePreviews;
+    return fresh;
 }
 
 async function refreshAfterDaemonReady(filePath: string, reason: string): Promise<void> {
@@ -2337,6 +2350,7 @@ async function refresh(
                                 captureIndex: idx,
                                 message,
                                 renderError,
+                                replaceExisting: true,
                             });
                         }
                         // else: discover-only pass, PNG not produced yet. Leave

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -2507,6 +2507,16 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                         const captureIndex = msg.command === 'setImageError' ? (msg.captureIndex || 0) : 0;
                         const renderError = msg.command === 'setImageError' ? (msg.renderError || null) : null;
                         const caps = cardCaptures.get(msg.previewId);
+                        const replaceExisting = msg.command !== 'setImageError'
+                            || msg.replaceExisting !== false;
+                        const existingImageData = caps && caps[captureIndex]
+                            ? caps[captureIndex].imageData
+                            : null;
+                        const container = errCard.querySelector('.image-container');
+                        const existingImg = container.querySelector('img');
+                        if (!replaceExisting && (existingImageData || existingImg)) {
+                            break;
+                        }
                         if (caps && caps[captureIndex]) {
                             caps[captureIndex].errorMessage = msg.message;
                             caps[captureIndex].renderError = renderError;
@@ -2516,7 +2526,6 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                         if (caps && cur !== captureIndex) break;
 
                         errCard.classList.add('has-error');
-                        const container = errCard.querySelector('.image-container');
                         const previousErr = container.querySelector('.error-message');
                         if (previousErr) previousErr.remove();
                         // setImageError keeps any existing rendered <img>

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -332,6 +332,13 @@ export type ExtensionToWebview =
            * the panel falls back to the generic message.
            */
           renderError?: PreviewRenderError | null;
+          /**
+           * True when this error should replace an already-rendered image.
+           * Gradle render failures use this; daemon failures are async and
+           * may race behind a later valid frame, so they preserve last-good
+           * pixels when false.
+           */
+          replaceExisting?: boolean;
       }
     | { command: 'setLoading'; previewId?: string }
     | { command: 'markAllLoading' }


### PR DESCRIPTION
## Summary
- keep daemon manifest reconciliation cache-first, with panel repaint only when the current panel scope belongs to the reconciled module
- avoid repainting the panel to a saved background Kotlin file during save-time stale-ID reconciliation
- keep daemon render failures non-destructive when a card already has last-good pixels, so racing failures do not turn valid screenshots red

## Review notes addressed
- applyDiscoveryDiff now reconciles caches even when currentScopeFile is null
- save-time reconciliation repaints currentScopeFile, not the saved file, and skips repaint when the panel is scoped elsewhere

## Tests
- npm test