### PR TITLE
Add a11y touch target data product

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -259,6 +259,7 @@ class RenderEngine(
                   previewId = spec.outputBaseName,
                   findings = a11yResult.findings,
                   nodes = a11yResult.nodes,
+                  density = spec.density,
                   pngFile = outputFile,
                   isRound = isRound,
                   imageProcessors = imageProcessors,

--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
@@ -22,6 +22,8 @@ import kotlinx.serialization.json.JsonElement
  *   so the registry can distinguish "no findings on this render" from "a11y didn't run".
  * - `a11y-hierarchy.json` — `{ "nodes": AccessibilityNode[] }`. Path-transport kind
  *   (`a11y/hierarchy`) returns this file's absolute path; VS Code's webview reads it.
+ * - `a11y-touchTargets.json` — `{ "targets": TouchTarget[] }`. Inline-transport kind
+ *   (`a11y/touchTargets`) derives clickable target sizes + overlaps from the hierarchy.
  *
  * On-disk layout pinned by [docs/daemon/DATA-PRODUCTS.md](../../../../../../../docs/daemon/DATA-PRODUCTS.md)
  * § "On-disk layout".
@@ -42,6 +44,9 @@ object AccessibilityDataProducer {
   /** `a11y/hierarchy` — accessibility-relevant nodes with bounds + label + states. */
   const val KIND_HIERARCHY: String = "a11y/hierarchy"
 
+  /** `a11y/touchTargets` — clickable node sizes and overlap findings derived from hierarchy. */
+  const val KIND_TOUCH_TARGETS: String = "a11y/touchTargets"
+
   /**
    * D2.1 — `a11y/overlay`. Path-transport kind whose only content is the Paparazzi-style
    * annotated PNG produced by [AccessibilityImageProcessor]. Lets clients fetch the picture
@@ -53,11 +58,24 @@ object AccessibilityDataProducer {
   /** File names under `<rootDir>/<previewId>/`. */
   const val FILE_ATF: String = "a11y-atf.json"
   const val FILE_HIERARCHY: String = "a11y-hierarchy.json"
+  const val FILE_TOUCH_TARGETS: String = "a11y-touchTargets.json"
   const val FILE_OVERLAY: String = "a11y-overlay.png"
 
   @Serializable internal data class AtfPayload(val findings: List<AccessibilityFinding>)
 
   @Serializable internal data class HierarchyPayload(val nodes: List<AccessibilityNode>)
+
+  @Serializable internal data class TouchTargetsPayload(val targets: List<TouchTarget>)
+
+  @Serializable
+  internal data class TouchTarget(
+    val nodeId: String,
+    val boundsInScreen: String,
+    val widthDp: Float,
+    val heightDp: Float,
+    val findings: List<String>,
+    val overlappingNodeIds: List<String>? = null,
+  )
 
   /**
    * Writes both JSON files to `<rootDir>/<previewId>/` (creating the directory tree if needed).
@@ -74,6 +92,7 @@ object AccessibilityDataProducer {
     previewId: String,
     findings: List<AccessibilityFinding>,
     nodes: List<AccessibilityNode>,
+    density: Float = 1f,
     pngFile: File? = null,
     isRound: Boolean = false,
     imageProcessors: List<ImageProcessor> = emptyList(),
@@ -86,6 +105,14 @@ object AccessibilityDataProducer {
     previewDir
       .resolve(FILE_HIERARCHY)
       .writeText(json.encodeToString(HierarchyPayload.serializer(), HierarchyPayload(nodes)))
+    previewDir
+      .resolve(FILE_TOUCH_TARGETS)
+      .writeText(
+        json.encodeToString(
+          TouchTargetsPayload.serializer(),
+          TouchTargetsPayload(buildTouchTargets(nodes, density)),
+        )
+      )
     if (pngFile == null || imageProcessors.isEmpty()) return
     val input =
       ImageProcessorInput(
@@ -106,6 +133,80 @@ object AccessibilityDataProducer {
       }
     }
   }
+
+  private fun buildTouchTargets(nodes: List<AccessibilityNode>, density: Float): List<TouchTarget> {
+    val scale = density.takeIf { it > 0f } ?: 1f
+    val candidates =
+      nodes.mapIndexedNotNull { index, node ->
+        if (!node.states.any { it == "clickable" || it == "long-clickable" }) return@mapIndexedNotNull null
+        val rect = parseBounds(node.boundsInScreen) ?: return@mapIndexedNotNull null
+        Candidate(
+          nodeId = "node-$index",
+          boundsInScreen = node.boundsInScreen,
+          rect = rect,
+          widthDp = rect.widthPx / scale,
+          heightDp = rect.heightPx / scale,
+        )
+      }
+
+    for (i in candidates.indices) {
+      for (j in i + 1 until candidates.size) {
+        val a = candidates[i]
+        val b = candidates[j]
+        if (a.rect.overlaps(b.rect) && !a.rect.contains(b.rect) && !b.rect.contains(a.rect)) {
+          a.overlappingNodeIds += b.nodeId
+          b.overlappingNodeIds += a.nodeId
+        }
+      }
+    }
+
+    return candidates.map { candidate ->
+      val findings = mutableListOf<String>()
+      if (candidate.widthDp < MIN_TOUCH_TARGET_DP || candidate.heightDp < MIN_TOUCH_TARGET_DP) {
+        findings += FINDING_BELOW_MINIMUM
+      }
+      if (candidate.overlappingNodeIds.isNotEmpty()) findings += FINDING_OVERLAPPING
+      TouchTarget(
+        nodeId = candidate.nodeId,
+        boundsInScreen = candidate.boundsInScreen,
+        widthDp = candidate.widthDp,
+        heightDp = candidate.heightDp,
+        findings = findings,
+        overlappingNodeIds = candidate.overlappingNodeIds.takeIf { it.isNotEmpty() },
+      )
+    }
+  }
+
+  private data class Candidate(
+    val nodeId: String,
+    val boundsInScreen: String,
+    val rect: BoundsRect,
+    val widthDp: Float,
+    val heightDp: Float,
+    val overlappingNodeIds: MutableList<String> = mutableListOf(),
+  )
+
+  private data class BoundsRect(val left: Int, val top: Int, val right: Int, val bottom: Int) {
+    val widthPx: Int = (right - left).coerceAtLeast(0)
+    val heightPx: Int = (bottom - top).coerceAtLeast(0)
+
+    fun overlaps(other: BoundsRect): Boolean =
+      left < other.right && right > other.left && top < other.bottom && bottom > other.top
+
+    fun contains(other: BoundsRect): Boolean =
+      left <= other.left && top <= other.top && right >= other.right && bottom >= other.bottom
+  }
+
+  private fun parseBounds(bounds: String): BoundsRect? {
+    val parts = bounds.split(',')
+    if (parts.size != 4) return null
+    val values = parts.map { it.trim().toIntOrNull() ?: return null }
+    return BoundsRect(values[0], values[1], values[2], values[3])
+  }
+
+  private const val MIN_TOUCH_TARGET_DP = 48f
+  private const val FINDING_BELOW_MINIMUM = "belowMinimum"
+  private const val FINDING_OVERLAPPING = "overlapping"
 }
 
 /**
@@ -146,6 +247,14 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
         requiresRerender = false,
       ),
       DataProductCapability(
+        kind = AccessibilityDataProducer.KIND_TOUCH_TARGETS,
+        schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+      ),
+      DataProductCapability(
         kind = AccessibilityDataProducer.KIND_OVERLAY,
         schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
         transport = DataProductTransport.PATH,
@@ -168,6 +277,9 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
         AccessibilityDataProducer.KIND_HIERARCHY ->
           fileFor(previewId, AccessibilityDataProducer.FILE_HIERARCHY) to
             DataProductTransport.PATH
+        AccessibilityDataProducer.KIND_TOUCH_TARGETS ->
+          fileFor(previewId, AccessibilityDataProducer.FILE_TOUCH_TARGETS) to
+            DataProductTransport.INLINE
         AccessibilityDataProducer.KIND_OVERLAY ->
           fileFor(previewId, AccessibilityDataProducer.FILE_OVERLAY) to DataProductTransport.PATH
         else -> return DataProductRegistry.Outcome.Unknown
@@ -234,6 +346,7 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
       when (kind) {
         AccessibilityDataProducer.KIND_ATF,
         AccessibilityDataProducer.KIND_HIERARCHY,
+        AccessibilityDataProducer.KIND_TOUCH_TARGETS,
         AccessibilityDataProducer.KIND_OVERLAY -> true
         else -> false
       }
@@ -287,6 +400,27 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
               kind = kind,
               schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
               path = file.absolutePath,
+              extras = extras,
+            )
+          )
+        }
+        AccessibilityDataProducer.KIND_TOUCH_TARGETS -> {
+          val file = fileFor(previewId, AccessibilityDataProducer.FILE_TOUCH_TARGETS)
+          if (!file.exists()) continue
+          val parsed =
+            try {
+              json.parseToJsonElement(file.readText())
+            } catch (t: Throwable) {
+              System.err.println(
+                "AccessibilityDataProductRegistry: parse $kind failed for $previewId: ${t.message}"
+              )
+              continue
+            }
+          out.add(
+            DataProductAttachment(
+              kind = kind,
+              schemaVersion = AccessibilityDataProducer.SCHEMA_VERSION,
+              payload = parsed,
               extras = extras,
             )
           )

--- a/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProductRegistryTest.kt
+++ b/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProductRegistryTest.kt
@@ -5,6 +5,7 @@ import ee.schimke.composeai.renderer.AccessibilityFinding
 import ee.schimke.composeai.renderer.AccessibilityNode
 import java.io.File
 import java.nio.file.Files
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -37,12 +38,13 @@ class AccessibilityDataProductRegistryTest {
   }
 
   @Test
-  fun `capabilities advertise a11y atf hierarchy and overlay with the documented transports`() {
+  fun `capabilities advertise a11y atf hierarchy touch targets and overlay with the documented transports`() {
     val registry = AccessibilityDataProductRegistry(rootDir)
     val byKind = registry.capabilities.associateBy { it.kind }
-    assertEquals(setOf("a11y/atf", "a11y/hierarchy", "a11y/overlay"), byKind.keys)
+    assertEquals(setOf("a11y/atf", "a11y/hierarchy", "a11y/touchTargets", "a11y/overlay"), byKind.keys)
     assertEquals(DataProductTransport.INLINE, byKind.getValue("a11y/atf").transport)
     assertEquals(DataProductTransport.PATH, byKind.getValue("a11y/hierarchy").transport)
+    assertEquals(DataProductTransport.INLINE, byKind.getValue("a11y/touchTargets").transport)
     assertEquals(DataProductTransport.PATH, byKind.getValue("a11y/overlay").transport)
     for (cap in registry.capabilities) {
       assertTrue(cap.attachable)
@@ -104,13 +106,86 @@ class AccessibilityDataProductRegistryTest {
   }
 
   @Test
+  fun `touch targets derive clickable sizes and non-containment overlaps from hierarchy`() {
+    val registry = AccessibilityDataProductRegistry(rootDir)
+    val previewId = "com.example.TouchTargets"
+    AccessibilityDataProducer.writeArtifacts(
+      rootDir = rootDir,
+      previewId = previewId,
+      findings = emptyList(),
+      nodes =
+        listOf(
+          AccessibilityNode(
+            label = "Small",
+            role = "Button",
+            states = listOf("clickable"),
+            boundsInScreen = "0,0,80,80",
+          ),
+          AccessibilityNode(
+            label = "Neighbor",
+            role = "Button",
+            states = listOf("clickable"),
+            boundsInScreen = "60,60,180,180",
+          ),
+          AccessibilityNode(
+            label = "Containing card",
+            role = "Button",
+            states = listOf("clickable"),
+            boundsInScreen = "0,0,240,240",
+          ),
+          AccessibilityNode(label = "Static", boundsInScreen = "250,0,300,50"),
+        ),
+      density = 2f,
+    )
+
+    val touchFile = File(rootDir, "$previewId/${AccessibilityDataProducer.FILE_TOUCH_TARGETS}")
+    val payload =
+      Json.decodeFromString(
+        AccessibilityDataProducer.TouchTargetsPayload.serializer(),
+        touchFile.readText(),
+      )
+    assertEquals(3, payload.targets.size)
+
+    val small = payload.targets[0]
+    assertEquals("node-0", small.nodeId)
+    assertEquals(40f, small.widthDp)
+    assertEquals(40f, small.heightDp)
+    assertEquals(listOf("belowMinimum", "overlapping"), small.findings)
+    assertEquals(listOf("node-1"), small.overlappingNodeIds)
+
+    val neighbor = payload.targets[1]
+    assertEquals(60f, neighbor.widthDp)
+    assertEquals(60f, neighbor.heightDp)
+    assertEquals(listOf("overlapping"), neighbor.findings)
+    assertEquals(listOf("node-0"), neighbor.overlappingNodeIds)
+
+    val parent = payload.targets[2]
+    assertEquals(emptyList<String>(), parent.findings)
+    assertNull("parent-child containment should not be reported as overlap", parent.overlappingNodeIds)
+
+    val attachment =
+      registry
+        .attachmentsFor(previewId = previewId, kinds = setOf("a11y/touchTargets"))
+        .single()
+    assertNotNull("a11y/touchTargets should travel inline", attachment.payload)
+    assertNull("a11y/touchTargets must not also carry a path", attachment.path)
+
+    val outcome =
+      registry.fetch(previewId = previewId, kind = "a11y/touchTargets", params = null, inline = false)
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    val result = (outcome as DataProductRegistry.Outcome.Ok).result
+    assertNotNull(result.payload)
+    assertNull(result.path)
+  }
+
+  @Test
   fun `attachmentsFor skips kinds with no on-disk file rather than emitting an empty entry`() {
     val registry = AccessibilityDataProductRegistry(rootDir)
     // No producer has run for this preview yet — neither file exists.
     val attachments =
       registry.attachmentsFor(
         previewId = "com.example.NoRender",
-        kinds = setOf("a11y/atf", "a11y/hierarchy"),
+        kinds = setOf("a11y/atf", "a11y/hierarchy", "a11y/touchTargets"),
       )
     assertEquals(emptyList<Any>(), attachments)
   }
@@ -165,7 +240,7 @@ class AccessibilityDataProductRegistryTest {
   }
 
   @Test
-  fun `attachmentsFor surfaces overlay PNG as an extra under a11y atf and hierarchy when present`() {
+  fun `attachmentsFor surfaces overlay PNG as an extra under a11y JSON kinds when present`() {
     val registry = AccessibilityDataProductRegistry(rootDir)
     val previewId = "com.example.HomeKt#HomePreview"
     AccessibilityDataProducer.writeArtifacts(
@@ -184,7 +259,7 @@ class AccessibilityDataProductRegistryTest {
     val attachments =
       registry.attachmentsFor(
         previewId = previewId,
-        kinds = setOf("a11y/atf", "a11y/hierarchy", "a11y/overlay"),
+        kinds = setOf("a11y/atf", "a11y/hierarchy", "a11y/touchTargets", "a11y/overlay"),
       )
     val byKind = attachments.associateBy { it.kind }
     val atfExtras = byKind.getValue("a11y/atf").extras
@@ -193,6 +268,9 @@ class AccessibilityDataProductRegistryTest {
     assertEquals("overlay", atfExtras[0].name)
     assertEquals("image/png", atfExtras[0].mediaType)
     assertEquals(overlay.absolutePath, atfExtras[0].path)
+    val touchExtras = byKind.getValue("a11y/touchTargets").extras
+    assertNotNull("touch target extras must populate when overlay PNG is on disk", touchExtras)
+    assertEquals(overlay.absolutePath, touchExtras!![0].path)
 
     val overlayKind = byKind.getValue("a11y/overlay")
     assertNotNull(overlayKind.path)

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -182,7 +182,8 @@ build/compose-previews/
 ```
 
 So `a11y/hierarchy` for preview `com.example.Foo_bar` lands at
-`build/compose-previews/data/com.example.Foo_bar/a11y-hierarchy.json`.
+`build/compose-previews/data/com.example.Foo_bar/a11y-hierarchy.json`, and
+`a11y/touchTargets` lands beside it as `a11y-touchTargets.json`.
 The slash-to-dash substitution is mechanical (kind `a/b/c` → file
 `a-b-c.json`); kinds MUST NOT contain dashes themselves to keep the
 mapping reversible. The existing accessibility-per-preview directory
@@ -370,7 +371,7 @@ SHIPPED; everything else is "we know the shape, no code yet."
 | `a11y/atf`                 | a11y | low  | `AccessibilityFinding[]` from ATF. Drives diagnostic squigglies. Cheap enough for global attach. Carries the `overlay` PNG as an extra when one was generated. |
 | `a11y/hierarchy`           | a11y | low  | `AccessibilityNode[]` (label, role, states, bounds). Powers a local overlay in VS Code. **First implementation.** Carries the `overlay` PNG as an extra. |
 | `a11y/overlay`             | a11y | low  | Path to the Paparazzi-style annotated PNG produced by `AccessibilityImageProcessor`. Pure-image kind — `transport='path'`, no JSON payload. **D2.1 — image-processor surface.** |
-| `a11y/touchTargets`        | a11y | low  | Derived from hierarchy; 48dp + overlap detection. |
+| `a11y/touchTargets`        | a11y | low  | Derived from hierarchy; 48dp + overlap detection. **D2.2 — shipped inline payload.** Carries the `overlay` PNG as an extra. |
 | `layout/tree`              | default | low | View / Compose layout tree with bounds, paddings, source-line refs. Layout inspector. |
 | `compose/semantics`        | default | low | SemanticsNode projection — testTag, role, mergeMode. |
 | `compose/recomposition`    | instrumented | medium | `[{ nodeId, count, sinceFrameStreamId? }]`. Heat-map overlay. Static snapshot answers "what recomposed during initial composition"; the load-bearing case is **delta after a click** in interactive mode (see § Recomposition + interactive). Needs an instrumented re-render. |
@@ -493,8 +494,8 @@ Each data product is a **pair of modules** under `data/<product>/`:
   published — internal to the daemon process. For `a11y` this is
   `AccessibilityDataProducer` (writes per-render JSON sidecars +
   invokes registered image processors), `AccessibilityDataProductRegistry`
-  (advertises `a11y/atf`, `a11y/hierarchy`, `a11y/overlay` and serves
-  fetch / attach), and `AccessibilityImageProcessor`
+  (advertises `a11y/atf`, `a11y/hierarchy`, `a11y/touchTargets`,
+  `a11y/overlay` and serves fetch / attach), and `AccessibilityImageProcessor`
   (drives the overlay PNG into the data-product extras list).
 
 Why split: the core is reusable in non-daemon contexts (`:gradle-plugin`,

--- a/docs/daemon/protocol-fixtures/daemon-initializeResult.json
+++ b/docs/daemon/protocol-fixtures/daemon-initializeResult.json
@@ -22,6 +22,22 @@
         "attachable": true,
         "fetchable": true,
         "requiresRerender": false
+      },
+      {
+        "kind": "a11y/touchTargets",
+        "schemaVersion": 1,
+        "transport": "inline",
+        "attachable": true,
+        "fetchable": true,
+        "requiresRerender": false
+      },
+      {
+        "kind": "a11y/overlay",
+        "schemaVersion": 1,
+        "transport": "path",
+        "attachable": true,
+        "fetchable": true,
+        "requiresRerender": false
       }
     ],
     "knownDevices": [

--- a/docs/daemon/protocol-fixtures/daemon-renderFinished-withDataProducts.json
+++ b/docs/daemon/protocol-fixtures/daemon-renderFinished-withDataProducts.json
@@ -46,6 +46,29 @@
       ]
     },
     {
+      "kind": "a11y/touchTargets",
+      "schemaVersion": 1,
+      "payload": {
+        "targets": [
+          {
+            "nodeId": "node-0",
+            "boundsInScreen": "120,440,184,504",
+            "widthDp": 32.0,
+            "heightDp": 32.0,
+            "findings": ["belowMinimum"]
+          }
+        ]
+      },
+      "extras": [
+        {
+          "name": "overlay",
+          "path": "/home/dev/projects/my-app/samples/android/build/compose-previews/data/com.example.HomeKt-HomePreview/a11y-overlay.png",
+          "mediaType": "image/png",
+          "sizeBytes": 38912
+        }
+      ]
+    },
+    {
       "kind": "a11y/overlay",
       "schemaVersion": 1,
       "path": "/home/dev/projects/my-app/samples/android/build/compose-previews/data/com.example.HomeKt-HomePreview/a11y-overlay.png",


### PR DESCRIPTION
## Summary
- add the inline `a11y/touchTargets` data product derived from the existing a11y hierarchy
- write `a11y-touchTargets.json` during a11y renders with 48dp size findings and non-containment overlap findings
- advertise/fetch/attach the new kind and document it in daemon fixtures

Fixes #446

## Verification
- `./gradlew :data-a11y-connector:testDebugUnitTest --stacktrace`
- `./gradlew :data-a11y-connector:ktfmtCheck --stacktrace`
- `./gradlew :daemon:android:compileDebugKotlin --stacktrace`
- `git diff --check`