### PR TITLE
Add Android compose semantics data product

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -1,0 +1,154 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/** Producer for `compose/semantics`, a compact SemanticsNode projection for inspector clients. */
+object ComposeSemanticsDataProducer {
+  const val KIND: String = "compose/semantics"
+  const val SCHEMA_VERSION: Int = 1
+  const val FILE: String = "compose-semantics.json"
+
+  private val json = Json {
+    encodeDefaults = false
+    prettyPrint = false
+  }
+
+  fun writeArtifacts(rootDir: File, previewId: String, root: SemanticsNode) {
+    val previewDir = rootDir.resolve(previewId).also { it.mkdirs() }
+    val payload = ComposeSemanticsPayload(root = root.toWireNode())
+    previewDir.resolve(FILE).writeText(
+      json.encodeToString(ComposeSemanticsPayload.serializer(), payload)
+    )
+  }
+
+  private fun SemanticsNode.toWireNode(): ComposeSemanticsNode {
+    val cfg = config
+    return ComposeSemanticsNode(
+      nodeId = id.toString(),
+      boundsInRoot = boundsInRoot.toWireBounds(),
+      label = cfg.label(),
+      role = cfg.getOrNull(SemanticsProperties.Role)?.toString(),
+      testTag = cfg.getOrNull(SemanticsProperties.TestTag),
+      mergeMode =
+        when {
+          cfg.isClearingSemantics -> "clearAndSet"
+          cfg.isMergingSemanticsOfDescendants -> "mergeDescendants"
+          else -> null
+        },
+      clickable = cfg.getOrNull(SemanticsActions.OnClick) != null,
+      children = children.map { it.toWireNode() },
+    )
+  }
+
+  private fun SemanticsConfiguration.label(): String? {
+    getOrNull(SemanticsProperties.ContentDescription)
+      ?.joinToString(" ")
+      ?.takeIf { it.isNotBlank() }
+      ?.let { return it }
+    return getOrNull(SemanticsProperties.Text)
+      ?.joinToString(" ") { it.text }
+      ?.takeIf { it.isNotBlank() }
+  }
+
+  private fun androidx.compose.ui.geometry.Rect.toWireBounds(): String =
+    "${left.toInt()},${top.toInt()},${right.toInt()},${bottom.toInt()}"
+}
+
+@Serializable
+data class ComposeSemanticsPayload(val root: ComposeSemanticsNode)
+
+@Serializable
+data class ComposeSemanticsNode(
+  val nodeId: String,
+  val boundsInRoot: String,
+  val label: String? = null,
+  val role: String? = null,
+  val testTag: String? = null,
+  val mergeMode: String? = null,
+  val clickable: Boolean = false,
+  val children: List<ComposeSemanticsNode> = emptyList(),
+)
+
+/** Registry side for `compose/semantics`; reads the latest JSON artefact from disk. */
+class ComposeSemanticsDataProductRegistry(private val rootDir: File) : DataProductRegistry {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = ComposeSemanticsDataProducer.KIND,
+        schemaVersion = ComposeSemanticsDataProducer.SCHEMA_VERSION,
+        transport = DataProductTransport.PATH,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+      )
+    )
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != ComposeSemanticsDataProducer.KIND) return DataProductRegistry.Outcome.Unknown
+    val file = fileFor(previewId)
+    if (!file.exists()) return DataProductRegistry.Outcome.NotAvailable
+    if (!inline) {
+      return DataProductRegistry.Outcome.Ok(
+        DataFetchResult(
+          kind = kind,
+          schemaVersion = ComposeSemanticsDataProducer.SCHEMA_VERSION,
+          path = file.absolutePath,
+        )
+      )
+    }
+    val payload: JsonObject =
+      try {
+        json.parseToJsonElement(file.readText()) as JsonObject
+      } catch (t: Throwable) {
+        return DataProductRegistry.Outcome.FetchFailed(
+          message = "could not parse $kind for $previewId: ${t.message}"
+        )
+      }
+    return DataProductRegistry.Outcome.Ok(
+      DataFetchResult(
+        kind = kind,
+        schemaVersion = ComposeSemanticsDataProducer.SCHEMA_VERSION,
+        payload = payload,
+      )
+    )
+  }
+
+  override fun attachmentsFor(
+    previewId: String,
+    kinds: Set<String>,
+  ): List<DataProductAttachment> {
+    if (ComposeSemanticsDataProducer.KIND !in kinds) return emptyList()
+    val file = fileFor(previewId)
+    if (!file.exists()) return emptyList()
+    return listOf(
+      DataProductAttachment(
+        kind = ComposeSemanticsDataProducer.KIND,
+        schemaVersion = ComposeSemanticsDataProducer.SCHEMA_VERSION,
+        path = file.absolutePath,
+      )
+    )
+  }
+
+  private fun fileFor(previewId: String): File =
+    rootDir.resolve(previewId).resolve(ComposeSemanticsDataProducer.FILE)
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -236,28 +236,33 @@ fun main(args: Array<String>) {
       )
     }
 
-  // D2 — wire the accessibility data-product registry. The `composeai.daemon.attachA11y`
-  // sysprop (driven by `DaemonExtension.attachA11y`, default true) is the producer-side
-  // opt-out: when `false` we never construct the registry, no a11y kinds get advertised,
-  // and the renderer skips a11y mode for the per-render saving (see `RenderEngine.render`).
-  // The renders dir must also be resolvable, since `AccessibilityDataProductRegistry`
-  // reads its JSON sidecars relative to it; pre-D2 callers without the sysprop wired
-  // (harness fake-mode) keep the no-op `DataProductRegistry.Empty`.
+  // D2 — wire data-product registries. `compose/semantics` is default-mode data emitted by the
+  // Android render loop whenever a render output dir exists. The a11y registry remains gated by
+  // `composeai.daemon.attachA11y` because it flips LocalInspectionMode and runs ATF.
   val renderOutputDir = System.getProperty(RenderEngine.OUTPUT_DIR_PROP)
   val attachA11y = System.getProperty(RenderEngine.ATTACH_A11Y_PROP) == "true"
   val dataProducts: DataProductRegistry =
-    if (renderOutputDir != null && attachA11y) {
+    if (renderOutputDir != null) {
       val dataRoot = File(renderOutputDir).parentFile?.resolve("data") ?: File(renderOutputDir)
-      System.err.println(
-        "compose-ai-tools daemon: AccessibilityDataProductRegistry active (dataRoot=$dataRoot)"
-      )
-      AccessibilityDataProductRegistry(rootDir = dataRoot)
+      val registries =
+        buildList {
+          System.err.println(
+            "compose-ai-tools daemon: ComposeSemanticsDataProductRegistry active (dataRoot=$dataRoot)"
+          )
+          add(ComposeSemanticsDataProductRegistry(rootDir = dataRoot))
+          if (attachA11y) {
+            System.err.println(
+              "compose-ai-tools daemon: AccessibilityDataProductRegistry active (dataRoot=$dataRoot)"
+            )
+            add(AccessibilityDataProductRegistry(rootDir = dataRoot))
+          } else {
+            System.err.println(
+              "compose-ai-tools daemon: a11y data products disabled via composeai.daemon.attachA11y=false"
+            )
+          }
+        }
+      CompositeDataProductRegistry(registries)
     } else {
-      if (renderOutputDir != null && !attachA11y) {
-        System.err.println(
-          "compose-ai-tools daemon: a11y data products disabled via composeai.daemon.attachA11y=false"
-        )
-      }
       DataProductRegistry.Empty
     }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -244,6 +244,24 @@ class RenderEngine(
               .onRoot()
               .captureRoboImage(file = outputFile, roborazziOptions = roborazziOptions)
 
+            // compose/semantics data product. This is default-mode data, independent of the
+            // accessibility checker: clients get a compact SemanticsNode projection for inspector
+            // overlays without paying ATF costs.
+            if (dataDir != null) {
+              try {
+                ComposeSemanticsDataProducer.writeArtifacts(
+                  rootDir = dataDir,
+                  previewId = spec.outputBaseName,
+                  root = rule.onRoot(useUnmergedTree = true).fetchSemanticsNode(),
+                )
+              } catch (t: Throwable) {
+                System.err.println(
+                  "RenderEngine: compose semantics data write failed for ${spec.outputBaseName}: " +
+                    "${t.javaClass.simpleName}: ${t.message}"
+                )
+              }
+            }
+
             // D2 — a11y data products. Walk the same `ViewRootForTest` ATF can populate, dump
             // `a11y-atf.json` (findings) and `a11y-hierarchy.json` (nodes) next to the PNG. The
             // dispatcher reads these on `data/fetch` / `data/subscribe` attachment via

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProductRegistryTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProductRegistryTest.kt
@@ -1,0 +1,88 @@
+package ee.schimke.composeai.daemon
+
+import java.io.File
+import java.nio.file.Files
+import kotlinx.serialization.json.jsonObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ComposeSemanticsDataProductRegistryTest {
+  private lateinit var rootDir: File
+
+  @Before
+  fun setUp() {
+    rootDir = Files.createTempDirectory("compose-semantics-product-test").toFile()
+  }
+
+  @After
+  fun tearDown() {
+    rootDir.deleteRecursively()
+  }
+
+  @Test
+  fun `capability advertises compose semantics as path transport`() {
+    val registry = ComposeSemanticsDataProductRegistry(rootDir)
+    val cap = registry.capabilities.single()
+    assertEquals("compose/semantics", cap.kind)
+    assertEquals(1, cap.schemaVersion)
+    assertTrue(cap.attachable)
+    assertTrue(cap.fetchable)
+    assertTrue(!cap.requiresRerender)
+  }
+
+  @Test
+  fun `fetch returns path by default and payload when inline requested`() {
+    val previewId = "com.example.SemanticsPreview"
+    val file =
+      rootDir
+        .resolve(previewId)
+        .also { it.mkdirs() }
+        .resolve(ComposeSemanticsDataProducer.FILE)
+    file.writeText(
+      """{"root":{"nodeId":"1","boundsInRoot":"0,0,64,64","label":"Submit","role":"Button","clickable":true}}"""
+    )
+    val registry = ComposeSemanticsDataProductRegistry(rootDir)
+
+    val pathOutcome =
+      registry.fetch(previewId = previewId, kind = "compose/semantics", params = null, inline = false)
+    assertTrue(pathOutcome is DataProductRegistry.Outcome.Ok)
+    val pathResult = (pathOutcome as DataProductRegistry.Outcome.Ok).result
+    assertEquals(file.absolutePath, pathResult.path)
+    assertNull(pathResult.payload)
+
+    val inlineOutcome =
+      registry.fetch(previewId = previewId, kind = "compose/semantics", params = null, inline = true)
+    assertTrue(inlineOutcome is DataProductRegistry.Outcome.Ok)
+    val inlineResult = (inlineOutcome as DataProductRegistry.Outcome.Ok).result
+    assertNull(inlineResult.path)
+    assertNotNull(inlineResult.payload)
+    assertEquals(
+      "Submit",
+      inlineResult.payload!!.jsonObject["root"]!!.jsonObject["label"].toString().trim('"'),
+    )
+  }
+
+  @Test
+  fun `attachmentsFor emits path only after render wrote semantics file`() {
+    val previewId = "com.example.SemanticsPreview"
+    val registry = ComposeSemanticsDataProductRegistry(rootDir)
+    assertEquals(emptyList<Any>(), registry.attachmentsFor(previewId, setOf("compose/semantics")))
+
+    val file =
+      rootDir
+        .resolve(previewId)
+        .also { it.mkdirs() }
+        .resolve(ComposeSemanticsDataProducer.FILE)
+    file.writeText("""{"root":{"nodeId":"1","boundsInRoot":"0,0,1,1"}}""")
+
+    val attachment = registry.attachmentsFor(previewId, setOf("compose/semantics")).single()
+    assertEquals("compose/semantics", attachment.kind)
+    assertEquals(file.absolutePath, attachment.path)
+    assertNull(attachment.payload)
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -4,6 +4,9 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import javax.imageio.ImageIO
 import kotlin.math.abs
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -82,6 +85,21 @@ class RenderEngineTest {
       assertTrue(
         "expected >= 95% of pixels close to #EF5350; got ${"%.2f".format(matchPct * 100)}%",
         matchPct >= 0.95,
+      )
+
+      val semanticsFile =
+        outputDir.parentFile!!
+          .resolve("data")
+          .resolve("red-square")
+          .resolve(ComposeSemanticsDataProducer.FILE)
+      assertTrue(
+        "compose/semantics data product should be written next to render data: $semanticsFile",
+        semanticsFile.exists(),
+      )
+      val semanticsJson = Json.parseToJsonElement(semanticsFile.readText()).jsonObject
+      assertEquals(
+        "0,0,64,64",
+        semanticsJson["root"]!!.jsonObject["boundsInRoot"]!!.jsonPrimitive.content,
       )
     } finally {
       host.shutdown()

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/CompositeDataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/CompositeDataProductRegistry.kt
@@ -1,0 +1,43 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Small fan-out registry for daemon builds that wire multiple independent data-product producers.
+ * Capabilities are concatenated in constructor order; kind routing uses the first registry that
+ * advertises the kind.
+ */
+class CompositeDataProductRegistry(private val registries: List<DataProductRegistry>) :
+  DataProductRegistry {
+
+  override val capabilities = registries.flatMap { it.capabilities }
+
+  override fun isKnown(kind: String): Boolean = registries.any { it.isKnown(kind) }
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    val registry =
+      registries.firstOrNull { it.isKnown(kind) } ?: return DataProductRegistry.Outcome.Unknown
+    return registry.fetch(previewId, kind, params, inline)
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> =
+    registries.flatMap { registry ->
+      val supportedKinds = kinds.filterTo(mutableSetOf()) { registry.isKnown(it) }
+      if (supportedKinds.isEmpty()) emptyList()
+      else registry.attachmentsFor(previewId, supportedKinds)
+    }
+
+  override fun onSubscribe(previewId: String, kind: String, params: JsonElement?) {
+    registries.firstOrNull { it.isKnown(kind) }?.onSubscribe(previewId, kind, params)
+  }
+
+  override fun onUnsubscribe(previewId: String, kind: String) {
+    registries.firstOrNull { it.isKnown(kind) }?.onUnsubscribe(previewId, kind)
+  }
+}

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -372,7 +372,7 @@ SHIPPED; everything else is "we know the shape, no code yet."
 | `a11y/overlay`             | a11y | low  | Path to the Paparazzi-style annotated PNG produced by `AccessibilityImageProcessor`. Pure-image kind — `transport='path'`, no JSON payload. **D2.1 — image-processor surface.** |
 | `a11y/touchTargets`        | a11y | low  | Derived from hierarchy; 48dp + overlap detection. |
 | `layout/tree`              | default | low | View / Compose layout tree with bounds, paddings, source-line refs. Layout inspector. |
-| `compose/semantics`        | default | low | SemanticsNode projection — testTag, role, mergeMode. |
+| `compose/semantics`        | default | low | SemanticsNode projection — testTag, role, mergeMode, bounds. **Android daemon implementation.** |
 | `compose/recomposition`    | instrumented | medium | `[{ nodeId, count, sinceFrameStreamId? }]`. Heat-map overlay. Static snapshot answers "what recomposed during initial composition"; the load-bearing case is **delta after a click** in interactive mode (see § Recomposition + interactive). Needs an instrumented re-render. |
 | `compose/theme`            | default | medium | Resolved `MaterialTheme.*` values + which nodes consumed which tokens. |
 | `resources/used`           | default | low | `R.*` references resolved during render. Jump-to-source. |


### PR DESCRIPTION
## Summary
- add an Android daemon compose/semantics data product backed by SemanticsNode data
- emit compose-semantics.json during normal renders and expose it via fetch/attachments
- add a composite data-product registry so compose semantics can coexist with optional a11y products

## Verification
- ./gradlew ktfmtFormatAll
- ./gradlew :daemon:android:testDebugUnitTest