### PR TITLE
Document ignored device cutouts

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensions.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensions.kt
@@ -145,7 +145,9 @@ object DeviceDimensions {
    * - Explicit `widthDp`+`heightDp` short-circuit to a [DeviceSpec] at [DEFAULT_DENSITY] (no device
    *   info, so we fall back to the Studio default).
    * - `id:pixel_5`-style ids hit [KNOWN_DEVICES]; unknown ids fall through to the default.
-   * - `spec:width=…,height=…,dpi=…` is parsed inline; the `dp` suffix on values is tolerated.
+   * - `spec:width=…,height=…,dpi=…,isRound=…` is parsed inline; the `dp` suffix on values is
+   *   tolerated. `cutout=…` is accepted by Studio's grammar but ignored here until a renderer
+   *   consumes it.
    * - Any device string containing `wear` (case-insensitive) returns [DEFAULT_WEAR].
    * - Otherwise [DEFAULT] (400×800 dp at xxhdpi).
    */

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensionsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensionsTest.kt
@@ -62,6 +62,14 @@ class DeviceDimensionsTest {
   }
 
   @Test
+  fun specStringToleratesIgnoredCutoutParameter() {
+    assertEquals(
+      DeviceDimensions.DeviceSpec(411, 914, DeviceDimensions.DEFAULT_DENSITY),
+      DeviceDimensions.resolve("spec:width=411dp,height=914dp,dpi=420,cutout=corner"),
+    )
+  }
+
+  @Test
   fun specStringWithoutDpiUsesDefaultDensity() {
     assertEquals(
       DeviceDimensions.DeviceSpec(400, 800, DeviceDimensions.DEFAULT_DENSITY),

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -130,8 +130,9 @@ Result:
   // let a UI label the device ("Pixel 5 — 393×851 dp @ 2.75x") without re-resolving. isRound marks
   // circular Wear-style displays.
   // Empty list = pre-feature daemon; treat absent and `[]` identically.
-  // The `spec:width=…,height=…,dpi=…` grammar is not enumerable — clients pass it as a
-  // free-form `device` override and the daemon parses it at resolve-time.
+  // The `spec:width=…,height=…,dpi=…,isRound=…` grammar is not enumerable — clients pass it as a
+  // free-form `device` override and the daemon parses it at resolve-time. `cutout=…` is tolerated
+  // but ignored until a renderer consumes it.
   //
   // supportedOverrides — the `PreviewOverrides` field names this daemon's host actually applies
   // (subset of {"widthPx","heightPx","density","localeTag","fontScale","uiMode","orientation",

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceDimensions.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceDimensions.kt
@@ -181,7 +181,8 @@ object DeviceDimensions {
         val h = if (landscape) minOf(parsedWidth, parsedHeight) else parsedHeight
         val isRound = params["isRound"]?.toBooleanStrictOrNull() == true
         // `dpi=` is part of Studio's spec: grammar (e.g. spec:width=411dp,height=914dp,dpi=420)
-        // — honour it if present, otherwise fall back to the AS default.
+        // — honour it if present, otherwise fall back to the AS default. `cutout=` is accepted by
+        // Studio's grammar but intentionally ignored here until a renderer consumes it.
         val density = params["dpi"]?.toIntOrNull()?.let { it / 160f } ?: DEFAULT_DENSITY
         return DeviceSpec(w, h, density, isRound = isRound)
       }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DeviceDimensionsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DeviceDimensionsTest.kt
@@ -79,6 +79,14 @@ class DeviceDimensionsTest {
   }
 
   @Test
+  fun `spec string tolerates ignored cutout parameter`() {
+    val spec = DeviceDimensions.resolve("spec:width=411dp,height=914dp,dpi=420,cutout=corner")
+    assertThat(spec.widthDp).isEqualTo(411)
+    assertThat(spec.heightDp).isEqualTo(914)
+    assertThat(spec.density).isEqualTo(DeviceDimensions.DEFAULT_DENSITY)
+  }
+
+  @Test
   fun `wear device returns wear defaults`() {
     val spec = DeviceDimensions.resolve("id:wearos_large_round")
     assertThat(spec.widthDp).isEqualTo(227)


### PR DESCRIPTION
## Summary
- document that spec cutout values are tolerated but ignored until a renderer consumes them
- add matching DeviceDimensions tests in the Gradle plugin and daemon copies
- update PROTOCOL.md to describe the current cutout behavior for free-form device overrides

Refs #462

## Tests
- ./gradlew ktfmtFormat :gradle-plugin:test --tests ee.schimke.composeai.plugin.DeviceDimensionsTest :daemon:core:test --tests ee.schimke.composeai.daemon.devices.DeviceDimensionsTest
- ./gradlew :gradle-plugin:test --tests ee.schimke.composeai.plugin.DeviceDimensionsTest :daemon:core:test --tests ee.schimke.composeai.daemon.devices.DeviceDimensionsTest
- git diff --check HEAD~1 HEAD

## Skipped
- No cutout rendering behavior was added; there is still no renderer or wire consumer for it.
- Remaining open issues are feature-sized or integration-test-sized, so this batch stays scoped to the parser contract.