### PR TITLE
Parse shape=round in spec device strings

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensions.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensions.kt
@@ -168,7 +168,8 @@ object DeviceDimensions {
             .split(",")
             .mapNotNull {
               val parts = it.split("=", limit = 2)
-              if (parts.size == 2) parts[0].trim() to parts[1].trim().removeSuffix("dp") else null
+              if (parts.size == 2) parts[0].trim().lowercase() to parts[1].trim().removeSuffix("dp")
+              else null
             }
             .toMap()
         val parsedWidth = params["width"]?.toIntOrNull() ?: DEFAULT.widthDp
@@ -176,7 +177,9 @@ object DeviceDimensions {
         val landscape = params["orientation"]?.equals("landscape", ignoreCase = true) == true
         val w = if (landscape) maxOf(parsedWidth, parsedHeight) else parsedWidth
         val h = if (landscape) minOf(parsedWidth, parsedHeight) else parsedHeight
-        val isRound = params["isRound"]?.toBooleanStrictOrNull() == true
+        val isRound =
+          params["isround"]?.equals("true", ignoreCase = true) == true ||
+            params["shape"]?.equals("round", ignoreCase = true) == true
         val density = params["dpi"]?.toIntOrNull()?.let { it / 160f } ?: DEFAULT_DENSITY
         return DeviceSpec(w, h, density, isRound = isRound)
       }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensionsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/devices/DeviceDimensionsTest.kt
@@ -70,6 +70,14 @@ class DeviceDimensionsTest {
   }
 
   @Test
+  fun specStringPreservesShapeRoundParameter() {
+    assertEquals(
+      DeviceDimensions.DeviceSpec(227, 227, 2.0f, isRound = true),
+      DeviceDimensions.resolve("spec:width=227dp,height=227dp,dpi=320,Shape=ROUND"),
+    )
+  }
+
+  @Test
   fun specStringWithoutDpiUsesDefaultDensity() {
     assertEquals(
       DeviceDimensions.DeviceSpec(400, 800, DeviceDimensions.DEFAULT_DENSITY),

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceDimensions.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DeviceDimensions.kt
@@ -171,7 +171,8 @@ object DeviceDimensions {
             .split(",")
             .mapNotNull {
               val parts = it.split("=", limit = 2)
-              if (parts.size == 2) parts[0].trim() to parts[1].trim().removeSuffix("dp") else null
+              if (parts.size == 2) parts[0].trim().lowercase() to parts[1].trim().removeSuffix("dp")
+              else null
             }
             .toMap()
         val parsedWidth = params["width"]?.toIntOrNull() ?: DEFAULT.widthDp
@@ -179,7 +180,9 @@ object DeviceDimensions {
         val landscape = params["orientation"]?.equals("landscape", ignoreCase = true) == true
         val w = if (landscape) maxOf(parsedWidth, parsedHeight) else parsedWidth
         val h = if (landscape) minOf(parsedWidth, parsedHeight) else parsedHeight
-        val isRound = params["isRound"]?.toBooleanStrictOrNull() == true
+        val isRound =
+          params["isround"]?.equals("true", ignoreCase = true) == true ||
+            params["shape"]?.equals("round", ignoreCase = true) == true
         // `dpi=` is part of Studio's spec: grammar (e.g. spec:width=411dp,height=914dp,dpi=420)
         // — honour it if present, otherwise fall back to the AS default. `cutout=` is accepted by
         // Studio's grammar but intentionally ignored here until a renderer consumes it.

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DeviceDimensionsTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/DeviceDimensionsTest.kt
@@ -87,6 +87,12 @@ class DeviceDimensionsTest {
   }
 
   @Test
+  fun `spec string preserves shape round parameter`() {
+    val spec = DeviceDimensions.resolve("spec:width=227dp,height=227dp,dpi=320,Shape=ROUND")
+    assertThat(spec.isRound).isTrue()
+  }
+
+  @Test
   fun `wear device returns wear defaults`() {
     val spec = DeviceDimensions.resolve("id:wearos_large_round")
     assertThat(spec.widthDp).isEqualTo(227)


### PR DESCRIPTION
## Summary
- parse `shape=round` as round display metadata in `spec:` device strings
- normalize `spec:` parameter keys in both daemon/core and gradle-plugin parser copies
- add regression coverage for case-insensitive `Shape=ROUND`

Fixes #525

## Verification
- `./gradlew :daemon:core:test --tests ee.schimke.composeai.daemon.devices.DeviceDimensionsTest --stacktrace`
- `./gradlew :gradle-plugin:test --tests ee.schimke.composeai.plugin.DeviceDimensionsTest --stacktrace`
- `./gradlew :daemon:core:ktfmtCheck :gradle-plugin:ktfmtCheck --stacktrace`
- `git diff --check`