### PR TITLE
Reuse cached daemon launch descriptors

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonBootstrapTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonBootstrapTask.kt
@@ -8,8 +8,8 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -40,9 +40,10 @@ import org.gradle.api.tasks.TaskAction
  * extension MUST refuse to launch.
  *
  * **Caching.** `@CacheableTask` because the only output is a small JSON derivable from declared
- * inputs — the entire body is deterministic. The classpath is `@Classpath` (not `@InputFiles`) so a
- * re-ordered but equivalent classpath doesn't bust the cache. The path-bearing system properties go
- * through `@Input` because their values are absolute paths the daemon needs verbatim.
+ * inputs — the entire body is deterministic. The descriptor serializes classpath paths, not class
+ * contents, so the classpath FileCollection itself is internal and [classpathPaths] is the declared
+ * input. Preview source edits can then reuse the launch descriptor while the daemon reloads changed
+ * classes through its own classloader path.
  */
 @CacheableTask
 abstract class DaemonBootstrapTask : DefaultTask() {
@@ -94,10 +95,14 @@ abstract class DaemonBootstrapTask : DefaultTask() {
   /**
    * The full daemon test-runtime classpath, in load order, derived from
    * [ee.schimke.composeai.plugin.AndroidPreviewClasspath.buildTestClasspath]
-   * + AGP unit-test additions. `@Classpath` so re-ordering of equivalent entries doesn't bust the
-   *   cache.
+   * + AGP unit-test additions. The descriptor only needs paths, so contents are intentionally not
+   *   part of the task fingerprint.
    */
-  @get:Classpath abstract val classpath: ConfigurableFileCollection
+  @get:Internal abstract val classpath: ConfigurableFileCollection
+
+  @get:Input
+  val classpathPaths: List<String>
+    get() = classpath.files.map { it.absolutePath }
 
   /** Static JVM open flags (`--add-opens=...`) plus the `-Xmx` derived from [maxHeapMb]. */
   @get:Input abstract val jvmArgs: org.gradle.api.provider.ListProperty<String>
@@ -122,6 +127,7 @@ abstract class DaemonBootstrapTask : DefaultTask() {
     group = "compose preview"
     description =
       "Emit build/compose-previews/daemon-launch.json so VS Code can spawn the preview daemon JVM"
+    dependsOn(classpath)
   }
 
   @TaskAction
@@ -139,7 +145,7 @@ abstract class DaemonBootstrapTask : DefaultTask() {
         // sources). Filter to existing files so dropouts (a `from(...)` that
         // resolves to a non-existent dir on this OS / variant) don't bake
         // missing paths into the descriptor.
-        classpath = classpath.files.map { it.absolutePath },
+        classpath = classpathPaths,
         jvmArgs = jvmArgs.get().toList(),
         // LinkedHashMap preserves the buildSystemProperties iteration order,
         // which matches the renderPreviews task's systemProperty(...) call

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/daemon/DaemonBootstrapTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/daemon/DaemonBootstrapTaskTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import java.io.File
 import kotlinx.serialization.json.Json
 import org.gradle.api.Project
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import org.junit.Test
@@ -23,6 +24,71 @@ class DaemonBootstrapTaskTest {
   private val json = Json { ignoreUnknownKeys = true }
 
   private fun newProject(): Project = ProjectBuilder.builder().withProjectDir(tempDir.root).build()
+
+  @Test
+  fun `bootstrap descriptor task is cacheable`() {
+    assertThat(DaemonBootstrapTask::class.java.isAnnotationPresent(CacheableTask::class.java))
+      .isTrue()
+  }
+
+  @Test
+  fun `classpath fingerprint tracks launch paths not class contents`() {
+    val project = newProject()
+    val outFile = File(tempDir.root, "build/compose-previews/daemon-launch.json")
+    val cpJar = File(tempDir.root, "fakelib.jar").apply { writeText("first") }
+
+    val task =
+      project.tasks.register("composePreviewDaemonStart", DaemonBootstrapTask::class.java) {
+        modulePath.set(":x")
+        variant.set("debug")
+        daemonEnabled.set(true)
+        maxHeapMb.set(512)
+        maxRendersPerSandbox.set(50)
+        warmSpare.set(true)
+        mainClass.set("ee.schimke.composeai.daemon.DaemonMain")
+        classpath.from(cpJar)
+        jvmArgs.set(emptyList())
+        systemProperties.set(emptyMap())
+        workingDirectory.set(tempDir.root.absolutePath)
+        manifestPath.set("/abs/previews.json")
+        outputFile.set(outFile)
+      }
+
+    val before = task.get().classpathPaths
+    cpJar.writeText("changed class bytes")
+    val after = task.get().classpathPaths
+
+    assertThat(after).isEqualTo(before)
+    assertThat(after).containsExactly(cpJar.absolutePath)
+  }
+
+  @Test
+  fun `classpath still contributes producer task dependencies`() {
+    val project = newProject()
+    val outFile = File(tempDir.root, "build/compose-previews/daemon-launch.json")
+    val cpJar = File(tempDir.root, "fakelib.jar")
+    val producer = project.tasks.register("producer")
+    val producedClasspath = project.files(cpJar).builtBy(producer)
+
+    val task =
+      project.tasks.register("composePreviewDaemonStart", DaemonBootstrapTask::class.java) {
+        modulePath.set(":x")
+        variant.set("debug")
+        daemonEnabled.set(true)
+        maxHeapMb.set(512)
+        maxRendersPerSandbox.set(50)
+        warmSpare.set(true)
+        mainClass.set("ee.schimke.composeai.daemon.DaemonMain")
+        classpath.from(producedClasspath)
+        jvmArgs.set(emptyList())
+        systemProperties.set(emptyMap())
+        workingDirectory.set(tempDir.root.absolutePath)
+        manifestPath.set("/abs/previews.json")
+        outputFile.set(outFile)
+      }
+
+    assertThat(task.get().taskDependencies.getDependencies(task.get())).contains(producer.get())
+  }
 
   @Test
   fun `descriptor JSON populates every documented field`() {

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -123,6 +123,7 @@ export class DaemonScheduler {
      *  Stops the per-render ENOENT spam when the daemon (B1.5) emits
      *  synthetic `daemon-stub-N.png` paths that don't exist on disk. */
     private warnedStubModules = new Set<string>();
+    private settledBootstrapTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
     constructor(
         private readonly gate: DaemonGate,
@@ -138,6 +139,7 @@ export class DaemonScheduler {
          * `vscode.workspace.getConfiguration('composePreview').get('a11y.alwaysSubscribe')`.
          */
         private readonly isA11yAlwaysSubscribed: () => boolean = () => false,
+        private readonly settledBootstrapDelayMs: number = 5_000,
     ) {}
 
     /**
@@ -152,16 +154,16 @@ export class DaemonScheduler {
     }
 
     /**
-     * Pre-warms a module: runs the Gradle bootstrap task (writes
-     * `daemon-launch.json`) and spawns the JVM if not already up. Intended
+     * Pre-warms a module: first tries the existing `daemon-launch.json`, then falls back to the
+     * Gradle bootstrap task when the cached descriptor is absent/stale/disabled. Intended
      * to be called when the user navigates to a Kotlin file in a
      * daemon-enabled module, so the daemon is alive by the time they hit
      * save — the first save then collapses to "kotlinc + render" instead
      * of "Gradle bootstrap + JVM spawn + sandbox init + render".
      *
-     * `progress` fires through `'bootstrapping'` while the Gradle task
-     * runs, `'spawning'` while the JVM comes up, and `'ready'` once
-     * `initialize` is acknowledged. `'fallback'` fires only when the daemon is explicitly disabled.
+     * `progress` fires through `'spawning'` while the JVM comes up, `'bootstrapping'` only when the
+     * cached descriptor could not be used, and `'ready'` once `initialize` is acknowledged.
+     * `'fallback'` fires only when the daemon is explicitly disabled.
      * Enabled-but-broken daemon failures throw so the UI can surface the error. No-op when the gate
      * is disabled.
      */
@@ -173,7 +175,22 @@ export class DaemonScheduler {
         if (!this.gate.isEnabled()) { return false; }
         if (this.gate.isDaemonReady(moduleId)) {
             progress?.('ready');
+            this.scheduleSettledBootstrap(gradleService, moduleId);
             return true;
+        }
+        progress?.('spawning');
+        try {
+            const ok = await this.ensureModule(moduleId);
+            if (ok) {
+                progress?.('ready');
+                this.scheduleSettledBootstrap(gradleService, moduleId);
+                return true;
+            }
+        } catch (err) {
+            this.logger.appendLine(
+                `[daemon] cached launch failed for ${moduleId}: ${(err as Error).message}; ` +
+                'running composePreviewDaemonStart',
+            );
         }
         try {
             progress?.('bootstrapping');
@@ -196,6 +213,29 @@ export class DaemonScheduler {
         }
         progress?.(ok ? 'ready' : 'fallback');
         return ok;
+    }
+
+    private scheduleSettledBootstrap(gradleService: GradleService, moduleId: string): void {
+        if (this.settledBootstrapDelayMs < 0) { return; }
+        const existing = this.settledBootstrapTimers.get(moduleId);
+        if (existing) { clearTimeout(existing); }
+        const refresh = async () => {
+            this.settledBootstrapTimers.delete(moduleId);
+            try {
+                await gradleService.runDaemonBootstrap(moduleId);
+            } catch (err) {
+                this.logger.appendLine(
+                    `[daemon] settled bootstrap refresh failed for ${moduleId}: ${(err as Error).message}`,
+                );
+            }
+        };
+        if (this.settledBootstrapDelayMs === 0) {
+            void refresh();
+            return;
+        }
+        const timer = setTimeout(() => void refresh(), this.settledBootstrapDelayMs);
+        timer.unref?.();
+        this.settledBootstrapTimers.set(moduleId, timer);
     }
 
     /**

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -164,6 +164,7 @@ let lastLoadedModules: string[] = [];
  * webview has focus (undefined) or resolve to an unrelated editor.
  */
 let currentScopeFile: string | null = null;
+let currentScopeModule: string | null = null;
 /**
  * True when the panel currently shows a compile-error banner the
  * extension posted (either from the LSP gate or from a kotlinc parse
@@ -1227,7 +1228,7 @@ async function preloadCachedPreviews(filePath: string): Promise<boolean> {
     hasPreviewsLoaded = true;
     lastLoadedModules = [module];
     moduleManifestCache.set(module, visiblePreviews);
-    currentScopeFile = filePath;
+    setCurrentScopeFile(filePath);
     return true;
 }
 
@@ -1327,6 +1328,10 @@ async function warmDaemonForFile(
  */
 function publishDaemonStartupProgress(module: string, state: WarmState): void {
     if (!panel) { return; }
+    if (!isDaemonStartupScopeActive(module)) {
+        stopDaemonStartupProgress(module);
+        return;
+    }
     switch (state) {
         case 'bootstrapping':
             if (!hasPreviewsLoaded) {
@@ -1360,6 +1365,7 @@ function publishDaemonStartupProgress(module: string, state: WarmState): void {
             break;
         case 'ready':
             stopDaemonStartupProgress(module);
+            if (!isDaemonStartupScopeActive(module)) { return; }
             if (!hasPreviewsLoaded) {
                 panel.postMessage({
                     command: 'showMessage',
@@ -1376,6 +1382,7 @@ function publishDaemonStartupProgress(module: string, state: WarmState): void {
             break;
         case 'fallback':
             stopDaemonStartupProgress(module);
+            if (!isDaemonStartupScopeActive(module)) { return; }
             if (!hasPreviewsLoaded) {
                 panel.postMessage({
                     command: 'showMessage',
@@ -1398,6 +1405,10 @@ function startDaemonStartupProgress(
     const startedAt = Date.now();
     const tick = () => {
         if (!panel) { return; }
+        if (!isDaemonStartupScopeActive(module)) {
+            stopDaemonStartupProgress(module);
+            return;
+        }
         const elapsed = Date.now() - startedAt;
         const ratio = Math.min(0.98, 1 - Math.exp(-elapsed / durationMs));
         panel.postMessage({
@@ -1410,6 +1421,15 @@ function startDaemonStartupProgress(
     };
     tick();
     daemonStartupProgressTimers.set(module, setInterval(tick, 250));
+}
+
+function isDaemonStartupScopeActive(module: string): boolean {
+    return currentScopeModule === module;
+}
+
+function setCurrentScopeFile(filePath: string | null, module?: string | null): void {
+    currentScopeFile = filePath;
+    currentScopeModule = module ?? (filePath && gradleService ? gradleService.resolveModule(filePath) : null);
 }
 
 function stopDaemonStartupProgress(module: string): void {
@@ -2032,7 +2052,7 @@ async function refresh(
         panel.postMessage({ command: 'showMessage', text: emptyStateMessage(activeFile) });
         lastLoadedModules = [];
         hasPreviewsLoaded = false;
-        currentScopeFile = null;
+        setCurrentScopeFile(null);
         clearHeavyRefreshOptIns();
         historyScopeRef.current = null;
         historyPanel?.setScope(null);
@@ -2078,7 +2098,7 @@ async function refresh(
         // from a prior in-flight refresh that was just cancelled by the
         // pendingRefresh.abort() at the top of this function.
         panel.postMessage({ command: 'clearProgress' });
-        currentScopeFile = activeFile;
+        setCurrentScopeFile(activeFile, module);
         compileGateActive = true;
         logLine(`gated — ${compileErrors.length} compile error(s) in ${path.basename(activeFile)}`);
         return 'gated';
@@ -2089,7 +2109,7 @@ async function refresh(
     panel.postMessage({ command: 'clearCompileErrors' });
     compileGateActive = false;
 
-    currentScopeFile = activeFile;
+    setCurrentScopeFile(activeFile, module);
     // Phase H7 — re-scope the History panel alongside the live panel.
     // `projectDir` is the consumer module's absolute path; we synthesize
     // it from workspaceRoot + module here because GradleService keeps

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -58,6 +58,8 @@ class FakeGate {
     public enabled = true;
     public client: FakeClient | null = new FakeClient();
     public ready = false;
+    public getOrSpawnCalls: string[] = [];
+    public getOrSpawnErrors: Error[] = [];
     public capturedEvents = new Map<string, {
         onRenderFinished?: (p: { id: string; pngPath: string; tookMs: number }) => void;
         onRenderFailed?: (p: { id: string; error: { message: string } }) => void;
@@ -69,6 +71,9 @@ class FakeGate {
     isEnabled(): boolean { return this.enabled; }
     isDaemonReady(_moduleId: string): boolean { return this.ready; }
     getOrSpawn(moduleId: string, events: unknown): Promise<FakeClient | null> {
+        this.getOrSpawnCalls.push(moduleId);
+        const err = this.getOrSpawnErrors.shift();
+        if (err) { return Promise.reject(err); }
         this.capturedEvents.set(moduleId, events as never);
         return Promise.resolve(this.client);
     }
@@ -93,6 +98,7 @@ interface CapturedImage {
 interface BuildOptions {
     /** D2 — drives `composePreview.a11y.alwaysSubscribe`. Defaults to false to mirror prod. */
     a11yAlwaysSubscribe?: () => boolean;
+    settledBootstrapDelayMs?: number;
 }
 
 function build(opts: BuildOptions = {}) {
@@ -137,6 +143,7 @@ function build(opts: BuildOptions = {}) {
         events,
         { appendLine: (s) => log.push(s) },
         opts.a11yAlwaysSubscribe ?? (() => false),
+        opts.settledBootstrapDelayMs ?? -1,
     );
     return { gate, scheduler, log, images, failures, dirty, discovery, dataProducts, channelClosed };
 }
@@ -424,8 +431,8 @@ describe('DaemonScheduler', () => {
     });
 
     describe('warmModule', () => {
-        it('drives progress through bootstrapping → spawning → ready on the cold path', async () => {
-            const { scheduler } = build();
+        it('uses an existing daemon descriptor before running bootstrap', async () => {
+            const { gate, scheduler } = build();
             const gradle = new FakeGradleService();
             const states: string[] = [];
             const ok = await scheduler.warmModule(
@@ -434,8 +441,41 @@ describe('DaemonScheduler', () => {
                 (s) => states.push(s),
             );
             assert.strictEqual(ok, true);
-            assert.deepStrictEqual(states, ['bootstrapping', 'spawning', 'ready']);
+            assert.deepStrictEqual(states, ['spawning', 'ready']);
+            assert.deepStrictEqual(gate.getOrSpawnCalls, ['mod']);
+            assert.deepStrictEqual(gradle.bootstrapCalls, [], 'cached descriptor should start without blocking on Gradle');
+        });
+
+        it('quietly refreshes the bootstrap descriptor after a cached warm succeeds', async () => {
+            const { scheduler } = build({ settledBootstrapDelayMs: 0 });
+            const gradle = new FakeGradleService();
+            const states: string[] = [];
+            const ok = await scheduler.warmModule(
+                gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
+                'mod',
+                (s) => states.push(s),
+            );
+            assert.strictEqual(ok, true);
+            assert.deepStrictEqual(states, ['spawning', 'ready']);
+            await Promise.resolve();
             assert.deepStrictEqual(gradle.bootstrapCalls, ['mod']);
+        });
+
+        it('drives progress through bootstrap fallback when the cached descriptor is missing', async () => {
+            const { gate, scheduler, log } = build();
+            gate.getOrSpawnErrors.push(new Error('[daemon] no launch descriptor for mod'));
+            const gradle = new FakeGradleService();
+            const states: string[] = [];
+            const ok = await scheduler.warmModule(
+                gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
+                'mod',
+                (s) => states.push(s),
+            );
+            assert.strictEqual(ok, true);
+            assert.deepStrictEqual(states, ['spawning', 'bootstrapping', 'spawning', 'ready']);
+            assert.deepStrictEqual(gate.getOrSpawnCalls, ['mod', 'mod']);
+            assert.deepStrictEqual(gradle.bootstrapCalls, ['mod']);
+            assert.ok(log.some(l => l.includes('cached launch failed')), `expected cached failure log, got: ${log.join(' / ')}`);
         });
 
         it('short-circuits to ready without re-bootstrapping when the daemon is already up', async () => {
@@ -453,8 +493,25 @@ describe('DaemonScheduler', () => {
             assert.deepStrictEqual(gradle.bootstrapCalls, [], 'bootstrap should not run when daemon is ready');
         });
 
+        it('quietly refreshes the bootstrap descriptor after an already-ready warm', async () => {
+            const { gate, scheduler } = build({ settledBootstrapDelayMs: 0 });
+            gate.ready = true;
+            const gradle = new FakeGradleService();
+            const states: string[] = [];
+            const ok = await scheduler.warmModule(
+                gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
+                'mod',
+                (s) => states.push(s),
+            );
+            assert.strictEqual(ok, true);
+            assert.deepStrictEqual(states, ['ready']);
+            await Promise.resolve();
+            assert.deepStrictEqual(gradle.bootstrapCalls, ['mod']);
+        });
+
         it('throws when the bootstrap task fails while the daemon is enabled', async () => {
-            const { scheduler } = build();
+            const { gate, scheduler } = build();
+            gate.getOrSpawnErrors.push(new Error('[daemon] no launch descriptor for mod'));
             const gradle = new FakeGradleService();
             gradle.bootstrapShouldThrow = new Error('Gradle config-cache rejected');
             const states: string[] = [];
@@ -466,13 +523,14 @@ describe('DaemonScheduler', () => {
                 ),
                 /Gradle config-cache rejected/,
             );
-            assert.deepStrictEqual(states, ['bootstrapping']);
+            assert.deepStrictEqual(states, ['spawning', 'bootstrapping']);
         });
 
         it('reports fallback only when the daemon is explicitly unavailable after bootstrap', async () => {
             const { gate, scheduler } = build();
             const gradle = new FakeGradleService();
             const states: string[] = [];
+            gate.getOrSpawnErrors.push(new Error('[daemon] no launch descriptor for mod'));
             gate.client = null;
             const ok = await scheduler.warmModule(
                 gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
@@ -480,7 +538,7 @@ describe('DaemonScheduler', () => {
                 (s) => states.push(s),
             );
             assert.strictEqual(ok, false);
-            assert.deepStrictEqual(states, ['bootstrapping', 'spawning', 'fallback']);
+            assert.deepStrictEqual(states, ['spawning', 'bootstrapping', 'spawning', 'fallback']);
         });
 
         it('returns false without progress events when the gate is disabled', async () => {


### PR DESCRIPTION
## Summary
- start the preview daemon from an existing daemon-launch.json before running Gradle bootstrap
- schedule a quiet settle-time composePreviewDaemonStart refresh after cached/ready warm-ups
- make DaemonBootstrapTask fingerprint classpath paths, not class contents, so source edits do not invalidate the launch descriptor
- scope daemon startup progress updates to the active module, addressing #527

## Tests
- npm test -- --runTestsByPath src/test/daemonScheduler.test.ts
- ./gradlew :gradle-plugin:test --tests ee.schimke.composeai.plugin.daemon.DaemonBootstrapTaskTest