### PR TITLE
Add device clip data product

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -242,10 +242,11 @@ fun main(args: Array<String>) {
   val renderOutputDir = System.getProperty(RenderEngine.OUTPUT_DIR_PROP)
   val attachA11y = System.getProperty(RenderEngine.ATTACH_A11Y_PROP) == "true"
   val dataProducts: DataProductRegistry =
-    if (renderOutputDir != null) {
-      val dataRoot = File(renderOutputDir).parentFile?.resolve("data") ?: File(renderOutputDir)
-      val registries =
-        buildList {
+    buildList {
+        System.err.println("compose-ai-tools daemon: DeviceClipDataProductRegistry active")
+        add(DeviceClipDataProductRegistry(previewIndex = previewIndex))
+        if (renderOutputDir != null) {
+          val dataRoot = File(renderOutputDir).parentFile?.resolve("data") ?: File(renderOutputDir)
           System.err.println(
             "compose-ai-tools daemon: ComposeSemanticsDataProductRegistry active (dataRoot=$dataRoot)"
           )
@@ -261,10 +262,8 @@ fun main(args: Array<String>) {
             )
           }
         }
-      CompositeDataProductRegistry(registries)
-    } else {
-      DataProductRegistry.Empty
-    }
+      }
+      .let(::CompositeDataProductRegistry)
 
   val server =
     JsonRpcServer(

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProduct.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProduct.kt
@@ -1,0 +1,78 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.devices.DeviceDimensions
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Stateless metadata product describing the device-frame clip implied by `@Preview(device = ...)`.
+ */
+class DeviceClipDataProductRegistry(private val previewIndex: PreviewIndex) : DataProductRegistry {
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+      )
+    )
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != KIND) return DataProductRegistry.Outcome.Unknown
+    val payload = payloadFor(previewId) ?: return DataProductRegistry.Outcome.NotAvailable
+    return DataProductRegistry.Outcome.Ok(
+      DataFetchResult(kind = KIND, schemaVersion = SCHEMA_VERSION, payload = payload)
+    )
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
+    if (KIND !in kinds) return emptyList()
+    val payload = payloadFor(previewId) ?: return emptyList()
+    return listOf(
+      DataProductAttachment(kind = KIND, schemaVersion = SCHEMA_VERSION, payload = payload)
+    )
+  }
+
+  private fun payloadFor(previewId: String): JsonElement? {
+    val preview = previewIndex.byId(previewId) ?: return null
+    val params = preview.params
+    val device = params?.device?.takeIf { it.isNotBlank() }
+    val deviceSpec = device?.let(DeviceDimensions::resolve)
+    val isRound = deviceSpec?.isRound == true
+    val widthDp = params?.widthDp ?: deviceSpec?.widthDp
+    val heightDp = params?.heightDp ?: deviceSpec?.heightDp
+    val clip =
+      if (isRound && widthDp != null && heightDp != null) {
+        val diameter = minOf(widthDp, heightDp)
+        val radius = diameter / 2.0
+        buildJsonObject {
+          put("shape", "circle")
+          put("centerXDp", widthDp / 2.0)
+          put("centerYDp", heightDp / 2.0)
+          put("radiusDp", radius)
+        }
+      } else {
+        JsonNull
+      }
+    return buildJsonObject { put("clip", clip) }
+  }
+
+  companion object {
+    const val KIND: String = "render/deviceClip"
+    const val SCHEMA_VERSION: Int = 1
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProductRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProductRegistryTest.kt
@@ -1,0 +1,174 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeviceClipDataProductRegistryTest {
+  @Test
+  fun `capability advertises inline fetchable attachable device clip`() {
+    val registry = DeviceClipDataProductRegistry(PreviewIndex.empty())
+
+    val cap = registry.capabilities.single()
+    assertEquals(DeviceClipDataProductRegistry.KIND, cap.kind)
+    assertEquals(1, cap.schemaVersion)
+    assertEquals(DataProductTransport.INLINE, cap.transport)
+    assertTrue(cap.attachable)
+    assertTrue(cap.fetchable)
+    assertTrue(!cap.requiresRerender)
+  }
+
+  @Test
+  fun `fetch returns circle for round wear device`() {
+    val registry =
+      DeviceClipDataProductRegistry(
+        PreviewIndex.fromMap(
+          path = null,
+          byId =
+            mapOf(
+              "wear" to
+                PreviewInfoDto(
+                  id = "wear",
+                  className = "com.example.WearKt",
+                  methodName = "Wear",
+                  params = PreviewParamsDto(device = "id:wearos_large_round"),
+                )
+            ),
+        )
+      )
+
+    val outcome =
+      registry.fetch(
+        previewId = "wear",
+        kind = DeviceClipDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      )
+
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    val payload = (outcome as DataProductRegistry.Outcome.Ok).result.payload!!.jsonObject
+    val clip = payload["clip"]!!.jsonObject
+    assertEquals("circle", clip["shape"]!!.jsonPrimitive.content)
+    assertEquals("113.5", clip["centerXDp"]!!.jsonPrimitive.content)
+    assertEquals("113.5", clip["centerYDp"]!!.jsonPrimitive.content)
+    assertEquals("113.5", clip["radiusDp"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `fetch returns null clip for rectangular device`() {
+    val registry =
+      DeviceClipDataProductRegistry(
+        PreviewIndex.fromMap(
+          path = null,
+          byId =
+            mapOf(
+              "phone" to
+                PreviewInfoDto(
+                  id = "phone",
+                  className = "com.example.PhoneKt",
+                  methodName = "Phone",
+                  params = PreviewParamsDto(device = "id:pixel_5"),
+                )
+            ),
+        )
+      )
+
+    val outcome =
+      registry.fetch(
+        previewId = "phone",
+        kind = DeviceClipDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      )
+
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    val payload = (outcome as DataProductRegistry.Outcome.Ok).result.payload!!.jsonObject
+    assertEquals(JsonNull, payload["clip"])
+  }
+
+  @Test
+  fun `fetch returns null clip for indexed preview with no params`() {
+    val registry =
+      DeviceClipDataProductRegistry(
+        PreviewIndex.fromMap(
+          path = null,
+          byId =
+            mapOf(
+              "plain" to
+                PreviewInfoDto(
+                  id = "plain",
+                  className = "com.example.PlainKt",
+                  methodName = "Plain",
+                )
+            ),
+        )
+      )
+
+    val outcome =
+      registry.fetch(
+        previewId = "plain",
+        kind = DeviceClipDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      )
+
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    val payload = (outcome as DataProductRegistry.Outcome.Ok).result.payload!!.jsonObject
+    assertEquals(JsonNull, payload["clip"])
+  }
+
+  @Test
+  fun `attachments mirror fetch payload when subscribed`() {
+    val registry =
+      DeviceClipDataProductRegistry(
+        PreviewIndex.fromMap(
+          path = null,
+          byId =
+            mapOf(
+              "round-spec" to
+                PreviewInfoDto(
+                  id = "round-spec",
+                  className = "com.example.RoundKt",
+                  methodName = "Round",
+                  params =
+                    PreviewParamsDto(device = "spec:width=300dp,height=300dp,dpi=320,isRound=true"),
+                )
+            ),
+        )
+      )
+
+    val attachment =
+      registry.attachmentsFor("round-spec", setOf(DeviceClipDataProductRegistry.KIND)).single()
+
+    assertEquals(DeviceClipDataProductRegistry.KIND, attachment.kind)
+    assertEquals(1, attachment.schemaVersion)
+    assertNull(attachment.path)
+    assertEquals(
+      "circle",
+      attachment.payload!!.jsonObject["clip"]!!.jsonObject["shape"]!!.jsonPrimitive.content,
+    )
+  }
+
+  @Test
+  fun `unknown preview is not available`() {
+    val registry = DeviceClipDataProductRegistry(PreviewIndex.empty())
+
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch(
+        previewId = "missing",
+        kind = DeviceClipDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      ),
+    )
+    assertTrue(
+      registry.attachmentsFor("missing", setOf(DeviceClipDataProductRegistry.KIND)).isEmpty()
+    )
+  }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -97,6 +97,10 @@ fun main(args: Array<String>) {
   // data/subscribe). Constructed unconditionally on desktop — it advertises one kind, and a
   // panel that doesn't subscribe pays nothing.
   val recompositionRegistry = RecompositionDataProductRegistry()
+  val dataProducts =
+    CompositeDataProductRegistry(
+      listOf(DeviceClipDataProductRegistry(previewIndex = previewIndex), recompositionRegistry)
+    )
 
   val manifestPath = System.getProperty("composeai.harness.previewsManifest")
   val host: RenderHost =
@@ -216,7 +220,7 @@ fun main(args: Array<String>) {
       // for that host; a delta subscribe degrades to "advertise but useless" via the same code
       // path as a future Compose API rename. Wiring is intentionally global — kinds advertised
       // in `initialize.capabilities.dataProducts` reflect the daemon's whole surface.
-      dataProducts = recompositionRegistry,
+      dataProducts = dataProducts,
     )
 
   installSigtermShutdownHook(host, originalStdin = System.`in`)

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -517,6 +517,31 @@ generic `ImageProcessorInput.context: Any?` field carries connector-specific
 typed payloads (e.g. `AccessibilityImageContext` for the a11y connector)
 that the matching processor downcasts at runtime.
 
+## Built-in render metadata products
+
+`render/deviceClip` is a cheap, inline, fetchable and attachable data product
+derived from the daemon's `PreviewIndex` plus `DeviceDimensions`. Its payload is:
+
+```json
+{ "clip": null }
+```
+
+for rectangular/default devices, or:
+
+```json
+{
+  "clip": {
+    "shape": "circle",
+    "centerXDp": 113.5,
+    "centerYDp": 113.5,
+    "radiusDp": 113.5
+  }
+}
+```
+
+for round Wear-style devices. It does not require a render pass and is
+available on both Android and desktop daemons.
+
 ## Phase plan
 
 - **D1 — primitive on the wire.** `initialize.capabilities.dataProducts`,


### PR DESCRIPTION
## Summary
- add render/deviceClip as an inline fetchable and attachable data product backed by PreviewIndex device metadata
- return a circle clip for round Wear-style devices and { clip: null } for rectangular/default previews
- wire the product into Android and desktop daemons and document the payload shape

## Tests
- ./gradlew ktfmtFormat :daemon:core:test --tests ee.schimke.composeai.daemon.DeviceClipDataProductRegistryTest :daemon:android:compileDebugKotlin :daemon:desktop:compileKotlin