### PR TITLE
Add history diff regions data product

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -245,6 +245,10 @@ fun main(args: Array<String>) {
     buildList {
         System.err.println("compose-ai-tools daemon: DeviceClipDataProductRegistry active")
         add(DeviceClipDataProductRegistry(previewIndex = previewIndex))
+        if (historyManager != null) {
+          System.err.println("compose-ai-tools daemon: HistoryDiffRegionsDataProductRegistry active")
+          add(HistoryDiffRegionsDataProductRegistry(historyManager = historyManager))
+        }
         if (renderOutputDir != null) {
           val dataRoot = File(renderOutputDir).parentFile?.resolve("data") ?: File(renderOutputDir)
           System.err.println(

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/HistoryDiffRegionsDataProduct.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/HistoryDiffRegionsDataProduct.kt
@@ -1,0 +1,253 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.history.HistoryFilter
+import ee.schimke.composeai.daemon.history.HistoryManager
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import javax.imageio.ImageIO
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * `history/diff/regions` — compares the latest render for a preview against an explicit history
+ * baseline and returns connected changed-pixel regions.
+ */
+class HistoryDiffRegionsDataProductRegistry(private val historyManager: HistoryManager) :
+  DataProductRegistry {
+
+  private val json = Json { encodeDefaults = false }
+  private val subscriptions = ConcurrentHashMap<String, DiffParams>()
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+      )
+    )
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != KIND) return DataProductRegistry.Outcome.Unknown
+    val diffParams =
+      parseParams(params)
+        ?: return DataProductRegistry.Outcome.FetchFailed(
+          "history/diff/regions requires params.baselineHistoryId"
+        )
+    return fetchDiff(previewId, diffParams)
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
+    if (KIND !in kinds) return emptyList()
+    val params = subscriptions[previewId] ?: return emptyList()
+    val outcome = fetchDiff(previewId, params)
+    if (outcome !is DataProductRegistry.Outcome.Ok) return emptyList()
+    return listOf(
+      DataProductAttachment(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        payload = outcome.result.payload,
+      )
+    )
+  }
+
+  override fun onSubscribe(previewId: String, kind: String, params: JsonElement?) {
+    if (kind != KIND) return
+    val parsed = parseParams(params) ?: return
+    subscriptions[previewId] = parsed
+  }
+
+  override fun onUnsubscribe(previewId: String, kind: String) {
+    if (kind == KIND) subscriptions.remove(previewId)
+  }
+
+  private fun fetchDiff(previewId: String, params: DiffParams): DataProductRegistry.Outcome {
+    val latestEntry =
+      historyManager.list(HistoryFilter(previewId = previewId, limit = 1)).entries.firstOrNull()
+        ?: return DataProductRegistry.Outcome.NotAvailable
+    val latest =
+      historyManager.read(latestEntry.id, includeBytes = false)
+        ?: return DataProductRegistry.Outcome.NotAvailable
+    val baseline =
+      historyManager.read(params.baselineHistoryId, includeBytes = false)
+        ?: return DataProductRegistry.Outcome.FetchFailed(
+          "baseline history entry ${params.baselineHistoryId} was not found"
+        )
+    if (baseline.entry.previewId != previewId) {
+      return DataProductRegistry.Outcome.FetchFailed(
+        "baseline history entry ${params.baselineHistoryId} belongs to ${baseline.entry.previewId}, not $previewId"
+      )
+    }
+    val latestImage =
+      ImageIO.read(File(latest.pngPath))
+        ?: return DataProductRegistry.Outcome.FetchFailed(
+          "could not decode latest PNG ${latest.pngPath}"
+        )
+    val baselineImage =
+      ImageIO.read(File(baseline.pngPath))
+        ?: return DataProductRegistry.Outcome.FetchFailed(
+          "could not decode baseline PNG ${baseline.pngPath}"
+        )
+    if (latestImage.width != baselineImage.width || latestImage.height != baselineImage.height) {
+      return DataProductRegistry.Outcome.FetchFailed(
+        "latest and baseline PNG dimensions differ: ${latestImage.width}x${latestImage.height} vs " +
+          "${baselineImage.width}x${baselineImage.height}"
+      )
+    }
+    val payload = diff(params.baselineHistoryId, latestImage, baselineImage, params.threshold)
+    return DataProductRegistry.Outcome.Ok(
+      DataFetchResult(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        payload = json.encodeToJsonElement(DiffPayload.serializer(), payload),
+      )
+    )
+  }
+
+  private fun diff(
+    baselineHistoryId: String,
+    latest: java.awt.image.BufferedImage,
+    baseline: java.awt.image.BufferedImage,
+    threshold: Int,
+  ): DiffPayload {
+    val width = latest.width
+    val height = latest.height
+    val changed = BooleanArray(width * height)
+    var totalChanged = 0L
+    for (y in 0 until height) {
+      for (x in 0 until width) {
+        val latestArgb = latest.getRGB(x, y)
+        val baselineArgb = baseline.getRGB(x, y)
+        if (pixelChanged(latestArgb, baselineArgb, threshold)) {
+          changed[y * width + x] = true
+          totalChanged++
+        }
+      }
+    }
+    val regions = mutableListOf<MutableRegion>()
+    val stack = IntArray(width * height)
+    for (start in changed.indices) {
+      if (!changed[start]) continue
+      var stackSize = 0
+      stack[stackSize++] = start
+      changed[start] = false
+      val region = MutableRegion(width)
+      while (stackSize > 0) {
+        val idx = stack[--stackSize]
+        val x = idx % width
+        val y = idx / width
+        region.add(x, y, latest.getRGB(x, y), baseline.getRGB(x, y))
+        fun push(next: Int) {
+          if (changed[next]) {
+            changed[next] = false
+            stack[stackSize++] = next
+          }
+        }
+        if (x > 0) push(idx - 1)
+        if (x + 1 < width) push(idx + 1)
+        if (y > 0) push(idx - width)
+        if (y + 1 < height) push(idx + width)
+      }
+      regions += region
+    }
+    val totalPixels = width.toLong() * height.toLong()
+    return DiffPayload(
+      baselineHistoryId = baselineHistoryId,
+      totalPixelsChanged = totalChanged,
+      changedFraction = if (totalPixels == 0L) 0.0 else totalChanged.toDouble() / totalPixels,
+      regions = regions.sortedByDescending { it.pixelCount }.take(MAX_REGIONS).map { it.toRegion() },
+    )
+  }
+
+  private class MutableRegion(private val imageWidth: Int) {
+    var minX: Int = imageWidth
+    var minY: Int = Int.MAX_VALUE
+    var maxX: Int = -1
+    var maxY: Int = -1
+    var pixelCount: Long = 0
+    private var sumR: Long = 0
+    private var sumG: Long = 0
+    private var sumB: Long = 0
+    private var sumA: Long = 0
+
+    fun add(x: Int, y: Int, latestArgb: Int, baselineArgb: Int) {
+      minX = minOf(minX, x)
+      minY = minOf(minY, y)
+      maxX = maxOf(maxX, x)
+      maxY = maxOf(maxY, y)
+      pixelCount++
+      sumA += channel(latestArgb, 24) - channel(baselineArgb, 24)
+      sumR += channel(latestArgb, 16) - channel(baselineArgb, 16)
+      sumG += channel(latestArgb, 8) - channel(baselineArgb, 8)
+      sumB += channel(latestArgb, 0) - channel(baselineArgb, 0)
+    }
+
+    fun toRegion(): DiffRegion =
+      DiffRegion(
+        bounds = "$minX,$minY,${maxX + 1},${maxY + 1}",
+        pixelCount = pixelCount,
+        avgDelta =
+          AverageDelta(
+            r = sumR.toDouble() / pixelCount,
+            g = sumG.toDouble() / pixelCount,
+            b = sumB.toDouble() / pixelCount,
+            a = sumA.toDouble() / pixelCount,
+          ),
+      )
+  }
+
+  private fun parseParams(params: JsonElement?): DiffParams? {
+    val obj = params as? JsonObject ?: return null
+    val baselineHistoryId =
+      obj["baselineHistoryId"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() } ?: return null
+    val threshold =
+      obj["thresholdAlphaDelta"]?.jsonPrimitive?.content?.toIntOrNull()?.coerceIn(0, 255)
+        ?: DEFAULT_THRESHOLD
+    return DiffParams(baselineHistoryId = baselineHistoryId, threshold = threshold)
+  }
+
+  private data class DiffParams(val baselineHistoryId: String, val threshold: Int)
+
+  @Serializable
+  data class DiffPayload(
+    val baselineHistoryId: String,
+    val totalPixelsChanged: Long,
+    val changedFraction: Double,
+    val regions: List<DiffRegion>,
+  )
+
+  @Serializable
+  data class DiffRegion(val bounds: String, val pixelCount: Long, val avgDelta: AverageDelta)
+
+  @Serializable data class AverageDelta(val r: Double, val g: Double, val b: Double, val a: Double)
+
+  companion object {
+    const val KIND: String = "history/diff/regions"
+    const val SCHEMA_VERSION: Int = 1
+    private const val DEFAULT_THRESHOLD = 4
+    private const val MAX_REGIONS = 50
+
+    private fun pixelChanged(latestArgb: Int, baselineArgb: Int, threshold: Int): Boolean =
+      kotlin.math.abs(channel(latestArgb, 24) - channel(baselineArgb, 24)) > threshold ||
+        kotlin.math.abs(channel(latestArgb, 16) - channel(baselineArgb, 16)) > threshold ||
+        kotlin.math.abs(channel(latestArgb, 8) - channel(baselineArgb, 8)) > threshold ||
+        kotlin.math.abs(channel(latestArgb, 0) - channel(baselineArgb, 0)) > threshold
+
+    private fun channel(argb: Int, shift: Int): Int = (argb ushr shift) and 0xff
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/HistoryDiffRegionsDataProductRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/HistoryDiffRegionsDataProductRegistryTest.kt
@@ -1,0 +1,177 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.history.HistoryManager
+import ee.schimke.composeai.daemon.history.LocalFsHistorySource
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+import java.time.Instant
+import javax.imageio.ImageIO
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class HistoryDiffRegionsDataProductRegistryTest {
+
+  private lateinit var rootDir: java.io.File
+  private lateinit var historyManager: HistoryManager
+
+  @Before
+  fun setUp() {
+    rootDir = Files.createTempDirectory("history-diff-data-product-test").toFile()
+    historyManager =
+      HistoryManager(
+        sources = listOf(LocalFsHistorySource(rootDir.toPath())),
+        module = ":test",
+        gitProvenance = null,
+      )
+  }
+
+  @After
+  fun tearDown() {
+    rootDir.deleteRecursively()
+  }
+
+  @Test
+  fun `capabilities advertise inline history diff regions`() {
+    val registry = HistoryDiffRegionsDataProductRegistry(historyManager)
+    val cap = registry.capabilities.single()
+
+    assertEquals(HistoryDiffRegionsDataProductRegistry.KIND, cap.kind)
+    assertEquals(1, cap.schemaVersion)
+    assertEquals(DataProductTransport.INLINE, cap.transport)
+    assertTrue(cap.attachable)
+    assertTrue(cap.fetchable)
+    assertTrue(!cap.requiresRerender)
+  }
+
+  @Test
+  fun `fetch returns changed regions against explicit baseline`() {
+    val baseline =
+      historyManager.recordRender(
+        previewId = "com.example.Preview",
+        pngBytes = png(6, 6) { _, _ -> argb(255, 0, 0, 0) },
+        trigger = "test",
+        renderTookMs = 1,
+        timestamp = Instant.parse("2026-05-02T10:00:00Z"),
+      )!!
+    historyManager.recordRender(
+      previewId = "com.example.Preview",
+      pngBytes =
+        png(6, 6) { x, y ->
+          when {
+            x in 1..2 && y in 1..2 -> argb(255, 255, 0, 0)
+            x == 5 && y == 5 -> argb(255, 0, 0, 255)
+            else -> argb(255, 0, 0, 0)
+          }
+        },
+      trigger = "test",
+      renderTookMs = 1,
+      timestamp = Instant.parse("2026-05-02T10:00:01Z"),
+    )
+
+    val outcome =
+      HistoryDiffRegionsDataProductRegistry(historyManager)
+        .fetch(
+          previewId = "com.example.Preview",
+          kind = HistoryDiffRegionsDataProductRegistry.KIND,
+          params = params(baseline.id),
+          inline = false,
+        )
+
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    val result = (outcome as DataProductRegistry.Outcome.Ok).result
+    assertNotNull(result.payload)
+    assertNull(result.path)
+    val payload =
+      Json.decodeFromJsonElement(
+        HistoryDiffRegionsDataProductRegistry.DiffPayload.serializer(),
+        result.payload!!,
+      )
+
+    assertEquals(baseline.id, payload.baselineHistoryId)
+    assertEquals(5, payload.totalPixelsChanged)
+    assertEquals(5.0 / 36.0, payload.changedFraction, 0.0001)
+    assertEquals(listOf("1,1,3,3", "5,5,6,6"), payload.regions.map { it.bounds })
+    assertEquals(4, payload.regions[0].pixelCount)
+    assertEquals(255.0, payload.regions[0].avgDelta.r, 0.0001)
+    assertEquals(1, payload.regions[1].pixelCount)
+    assertEquals(255.0, payload.regions[1].avgDelta.b, 0.0001)
+  }
+
+  @Test
+  fun `attachments use subscribed baseline params`() {
+    val baseline =
+      historyManager.recordRender(
+        previewId = "preview",
+        pngBytes = png(2, 2) { _, _ -> argb(255, 0, 0, 0) },
+        trigger = "test",
+        renderTookMs = 1,
+        timestamp = Instant.parse("2026-05-02T10:00:00Z"),
+      )!!
+    historyManager.recordRender(
+      previewId = "preview",
+      pngBytes = png(2, 2) { x, _ -> if (x == 0) argb(255, 9, 0, 0) else argb(255, 0, 0, 0) },
+      trigger = "test",
+      renderTookMs = 1,
+      timestamp = Instant.parse("2026-05-02T10:00:01Z"),
+    )
+    val registry = HistoryDiffRegionsDataProductRegistry(historyManager)
+
+    registry.onSubscribe("preview", HistoryDiffRegionsDataProductRegistry.KIND, params(baseline.id))
+    val attachments =
+      registry.attachmentsFor("preview", setOf(HistoryDiffRegionsDataProductRegistry.KIND))
+
+    assertEquals(1, attachments.size)
+    assertEquals(HistoryDiffRegionsDataProductRegistry.KIND, attachments.single().kind)
+    assertNotNull(attachments.single().payload)
+  }
+
+  @Test
+  fun `fetch returns failed when baseline is missing`() {
+    val registry = HistoryDiffRegionsDataProductRegistry(historyManager)
+    historyManager.recordRender(
+      previewId = "preview",
+      pngBytes = png(1, 1) { _, _ -> argb(255, 0, 0, 0) },
+      trigger = "test",
+      renderTookMs = 1,
+    )
+
+    val outcome =
+      registry.fetch(
+        previewId = "preview",
+        kind = HistoryDiffRegionsDataProductRegistry.KIND,
+        params = params("missing"),
+        inline = false,
+      )
+
+    assertTrue(outcome is DataProductRegistry.Outcome.FetchFailed)
+  }
+
+  private fun params(baselineHistoryId: String) = buildJsonObject {
+    put("baselineHistoryId", baselineHistoryId)
+    put("thresholdAlphaDelta", 4)
+  }
+
+  private fun png(width: Int, height: Int, colorAt: (Int, Int) -> Int): ByteArray {
+    val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+    for (y in 0 until height) {
+      for (x in 0 until width) {
+        image.setRGB(x, y, colorAt(x, y))
+      }
+    }
+    val out = ByteArrayOutputStream()
+    ImageIO.write(image, "png", out)
+    return out.toByteArray()
+  }
+
+  private fun argb(a: Int, r: Int, g: Int, b: Int): Int = (a shl 24) or (r shl 16) or (g shl 8) or b
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -97,10 +97,6 @@ fun main(args: Array<String>) {
   // data/subscribe). Constructed unconditionally on desktop — it advertises one kind, and a
   // panel that doesn't subscribe pays nothing.
   val recompositionRegistry = RecompositionDataProductRegistry()
-  val dataProducts =
-    CompositeDataProductRegistry(
-      listOf(DeviceClipDataProductRegistry(previewIndex = previewIndex), recompositionRegistry)
-    )
 
   val manifestPath = System.getProperty("composeai.harness.previewsManifest")
   val host: RenderHost =
@@ -204,6 +200,20 @@ fun main(args: Array<String>) {
       pruneConfig = pruneConfig,
     )
   }
+
+  val dataProducts =
+    CompositeDataProductRegistry(
+      buildList {
+        add(DeviceClipDataProductRegistry(previewIndex = previewIndex))
+        add(recompositionRegistry)
+        if (historyManager != null) {
+          System.err.println(
+            "compose-ai-tools desktop daemon: HistoryDiffRegionsDataProductRegistry active"
+          )
+          add(HistoryDiffRegionsDataProductRegistry(historyManager = historyManager))
+        }
+      }
+    )
 
   val server =
     JsonRpcServer(

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -380,7 +380,7 @@ SHIPPED; everything else is "we know the shape, no code yet."
 | `text/strings`             | default | low | Text drawn on screen with locale, fontScale, bounds. |
 | `render/trace`             | default | low | Phase breakdown (compose / measure / layout / draw). Exposes existing `Trace.beginSection` markers. |
 | `fonts/used`               | default | low | Font families with weight/style fallback chain. |
-| `history/diff/regions`     | default | low | Per-pixel bbox of changed regions vs. another history entry. |
+| `history/diff/regions`     | default | low | Per-pixel bbox of changed regions vs. another history entry. **D6 — shipped inline payload when daemon history is enabled.** |
 | `test/failure`             | failed render | low | Partial bitmap + last Snapshot state + pending `LaunchedEffect` queue. |
 
 "Mode" picks which render configuration produces the data; "cost" is
@@ -541,6 +541,37 @@ for rectangular/default devices, or:
 
 for round Wear-style devices. It does not require a render pass and is
 available on both Android and desktop daemons.
+
+`history/diff/regions` is a cheap, inline, fetchable and attachable data product
+derived from the daemon history archive. It is advertised only when
+`HistoryManager` is active. Fetch and subscribe calls must pass an explicit
+baseline:
+
+```json
+{
+  "baselineHistoryId": "20260502-100000-1234abcd",
+  "thresholdAlphaDelta": 4
+}
+```
+
+The producer reads the latest history entry for the requested `previewId`,
+compares its PNG against the baseline entry, and returns connected changed-pixel
+regions capped to the largest 50:
+
+```json
+{
+  "baselineHistoryId": "20260502-100000-1234abcd",
+  "totalPixelsChanged": 42,
+  "changedFraction": 0.0012,
+  "regions": [
+    {
+      "bounds": "10,20,40,32",
+      "pixelCount": 360,
+      "avgDelta": { "r": 12.0, "g": -4.0, "b": 0.0, "a": 0.0 }
+    }
+  ]
+}
+```
 
 ## Phase plan
 


### PR DESCRIPTION
## Summary
- add the inline `history/diff/regions` data product backed by daemon history PNGs
- compare latest preview history against an explicit `baselineHistoryId`, with thresholded connected changed regions capped to 50
- wire the registry into Android and desktop daemons when history is enabled
- document the payload and add focused core coverage

Fixes #454

## Verification
- `./gradlew :daemon:core:test --tests ee.schimke.composeai.daemon.HistoryDiffRegionsDataProductRegistryTest --stacktrace`
- `./gradlew :daemon:core:ktfmtCheck --stacktrace`
- `./gradlew :daemon:android:compileDebugKotlin :daemon:desktop:compileKotlin --stacktrace`
- `git diff --check`