### PR TITLE
Drive live preview frames for interactive sessions

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -196,6 +196,7 @@ class JsonRpcServer(
   private val dataFetchRerenderBudgetMs: Long =
     System.getProperty(DATA_FETCH_RERENDER_BUDGET_PROP)?.toLongOrNull()
       ?: DEFAULT_DATA_FETCH_RERENDER_BUDGET_MS,
+  private val interactiveFrameIntervalMs: Long = INTERACTIVE_FRAME_INTERVAL_MS,
   private val onExit: (Int) -> Unit = { code -> System.exit(code) },
 ) {
 
@@ -371,6 +372,9 @@ class JsonRpcServer(
    * re-claims and re-iterates.
    */
   private val interactiveRenderInFlight = ConcurrentHashMap<String, Boolean>()
+
+  /** Per-held-session frame loops for live previews with time-based animations. */
+  private val interactiveFrameLoops = ConcurrentHashMap<String, Thread>()
 
   private val lastFrameHashes = ConcurrentHashMap<String, String>()
 
@@ -784,6 +788,7 @@ class JsonRpcServer(
             renderResultsQueue.put(raw)
           } catch (e: Throwable) {
             System.err.println("compose-ai-daemon: host.submit($hostId) failed: ${e.message}")
+            e.printStackTrace(System.err)
             renderResultsQueue.put(RenderResultOrFailure.Failure(hostId, e))
           }
         },
@@ -1806,13 +1811,16 @@ class JsonRpcServer(
       }
     interactiveTargets[streamId] =
       InteractiveTarget(previewId = params.previewId, frameStreamId = streamId)
-    if (session != null) interactiveSessions[streamId] = session
     // Wipe any cached hash for this preview so the first interactive frame always paints.
     // Without this a `start` after a previous identical render would suppress the bootstrap
     // frame and the client's LIVE chip would have nothing to paint until the user clicks.
     // Per-preview wipe (not per-stream): two streams targeting the same preview both want a
     // fresh first frame, and the dedup state is shared by design.
     lastFrameHashes.remove(params.previewId)
+    if (session != null) {
+      interactiveSessions[streamId] = session
+      startInteractiveFrameLoop(streamId, params.previewId, session)
+    }
     sendResponse(
       req.id,
       encode(
@@ -1828,6 +1836,7 @@ class JsonRpcServer(
     // Idempotent on stale or unknown stream ids per INTERACTIVE.md § 8 — `remove` is a no-op
     // when the key isn't present, which is exactly the contract we want.
     interactiveTargets.remove(params.frameStreamId)
+    stopInteractiveFrameLoop(params.frameStreamId)
     // Release any held v2 session. close() is idempotent; failures from a host's session
     // teardown shouldn't propagate to the wire (the stop notification is fire-and-forget).
     interactiveSessions.remove(params.frameStreamId)?.let { session ->
@@ -1839,6 +1848,52 @@ class JsonRpcServer(
             "(${t.javaClass.simpleName}: ${t.message}); continuing"
         )
       }
+    }
+  }
+
+  private fun startInteractiveFrameLoop(
+    streamId: String,
+    previewId: String,
+    session: InteractiveSession,
+  ) {
+    if (interactiveFrameIntervalMs <= 0L) return
+    stopInteractiveFrameLoop(streamId)
+    val thread =
+      Thread(
+        {
+          while (
+            running.get() &&
+              !shutdownRequested.get() &&
+              interactiveTargets.containsKey(streamId) &&
+              interactiveSessions[streamId] === session
+          ) {
+            requestInteractiveRender(streamId, previewId, session)
+            try {
+              Thread.sleep(interactiveFrameIntervalMs)
+            } catch (_: InterruptedException) {
+              Thread.currentThread().interrupt()
+              return@Thread
+            }
+          }
+        },
+        "compose-ai-daemon-interactive-live-$streamId",
+      )
+    thread.isDaemon = true
+    interactiveFrameLoops[streamId] = thread
+    thread.start()
+  }
+
+  private fun stopInteractiveFrameLoop(streamId: String) {
+    interactiveFrameLoops.remove(streamId)?.interrupt()
+  }
+
+  private fun requestInteractiveRender(
+    streamId: String,
+    previewId: String,
+    session: InteractiveSession,
+  ) {
+    if (interactiveRenderInFlight.putIfAbsent(streamId, true) == null) {
+      submitInteractiveRenderAsync(streamId, previewId, session)
     }
   }
 
@@ -1864,9 +1919,7 @@ class JsonRpcServer(
         .add(params)
       // Try to claim the in-flight slot. Whoever wins owns the render thread; whoever loses
       // already had their input queued and the winner will dispatch it.
-      if (interactiveRenderInFlight.putIfAbsent(params.frameStreamId, true) == null) {
-        submitInteractiveRenderAsync(params.frameStreamId, target.previewId, session)
-      }
+      requestInteractiveRender(params.frameStreamId, target.previewId, session)
       return
     }
     // v1 fallback: each input enqueues a fresh stateless render of the target preview. The
@@ -1918,6 +1971,7 @@ class JsonRpcServer(
             System.err.println(
               "compose-ai-daemon: interactive session render($hostId) failed: ${e.message}"
             )
+            e.printStackTrace(System.err)
             renderResultsQueue.put(RenderResultOrFailure.Failure(hostId, e))
           } finally {
             // Release the in-flight slot, then check if more inputs arrived during the render.
@@ -2535,6 +2589,9 @@ class JsonRpcServer(
   private fun closeAllInteractiveSessions() {
     val sessions = interactiveSessions.values.toList()
     interactiveSessions.clear()
+    val frameLoops = interactiveFrameLoops.values.toList()
+    interactiveFrameLoops.clear()
+    frameLoops.forEach { it.interrupt() }
     // v2 phase 3 — drop any pending coalesced inputs and in-flight claims. The render workers
     // they refer to may still be running; they observe the cleared sessions map on their post-
     // finally re-claim and exit cleanly without re-spawning.
@@ -2789,6 +2846,9 @@ class JsonRpcServer(
 
     /** RECORDING.md — default `recording/start.fps` when the caller doesn't specify one. */
     const val DEFAULT_RECORDING_FPS: Int = 30
+
+    /** Live interactive preview frame cadence. Conservative to avoid saturating Android renders. */
+    const val INTERACTIVE_FRAME_INTERVAL_MS: Long = 250L
 
     /** RECORDING.md — minimum legal `recording/start.fps`. */
     const val MIN_RECORDING_FPS: Int = 1

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveRpcIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveRpcIntegrationTest.kt
@@ -335,6 +335,7 @@ class InteractiveRpcIntegrationTest {
         output = serverToClientOut,
         host = host,
         daemonVersion = "test",
+        interactiveFrameIntervalMs = 0,
         onExit = { _ -> exitLatch.countDown() },
       )
     val thread = Thread({ server.run() }, "interactive-rpc-server").apply { isDaemon = true }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveSessionPlumbingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveSessionPlumbingTest.kt
@@ -153,6 +153,42 @@ class InteractiveSessionPlumbingTest {
   }
 
   @Test(timeout = 30_000)
+  fun start_with_live_frame_loop_renders_without_input() {
+    val tmp = Files.createTempDirectory("interactive-session-live-loop").toFile()
+    val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
+    val host = SessionAwareFakeHost(pngFile)
+
+    val (_, _, clientToServerOut, received, _) =
+      bringUpServer(host, interactiveFrameIntervalMs = 25)
+    resourcesToClose.add(AutoCloseable { runCatching { clientToServerOut.close() } })
+
+    handshake(clientToServerOut, received)
+
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","id":10,"method":"interactive/start","params":{"previewId":"preview-A"}}""",
+    )
+    val startResp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 10 }
+    assertNotNull(startResp)
+    val streamId =
+      startResp!!["result"]!!.jsonObject["frameStreamId"]!!.jsonPrimitive.contentOrNull!!
+
+    val finished =
+      pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
+    assertNotNull("live frame loop should render without waiting for input", finished)
+    assertEquals("preview-A", finished!!["params"]!!.jsonObject["id"]?.jsonPrimitive?.contentOrNull)
+    assertTrue(
+      "session.render should be driven by the live frame loop",
+      host.lastSession()!!.renderCount.get() >= 1,
+    )
+
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","method":"interactive/stop","params":{"frameStreamId":"$streamId"}}""",
+    )
+  }
+
+  @Test(timeout = 30_000)
   fun host_unsupported_falls_back_to_v1_dispatch_path() {
     // A host whose acquireInteractiveSession throws UnsupportedOperationException (the
     // RenderHost default body) means "no v2 session". The daemon still accepts interactive/start
@@ -244,7 +280,7 @@ class InteractiveSessionPlumbingTest {
     val exitLatch: CountDownLatch,
   )
 
-  private fun bringUpServer(host: RenderHost): ServerHarness {
+  private fun bringUpServer(host: RenderHost, interactiveFrameIntervalMs: Long = 0): ServerHarness {
     val clientToServerOut = PipedOutputStream()
     val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
     val serverToClientOut = PipedOutputStream()
@@ -256,6 +292,7 @@ class InteractiveSessionPlumbingTest {
         output = serverToClientOut,
         host = host,
         daemonVersion = "test",
+        interactiveFrameIntervalMs = interactiveFrameIntervalMs,
         onExit = { _ -> exitLatch.countDown() },
       )
     val thread =

--- a/samples/wear/src/main/kotlin/com/example/samplewear/Previews.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/Previews.kt
@@ -178,10 +178,8 @@ private fun CircularProgressPreviewContent() {
                     contentAlignment = Alignment.Center,
                 ) {
                     CircularProgressIndicator(
-                        progress = { 0.72f },
                         modifier = Modifier.fillMaxSize(),
                     )
-                    Text("72%")
                 }
             }
         }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -3164,9 +3164,9 @@ function lookupPreviewLabel(previewId: string): string | undefined {
  * forwarding via [activeInteractiveStreams]. Exit calls `interactive/stop`
  * (notification, drop-and-go) and clears the cached stream id.
  *
- * Always falls back to the original setFocus + renderNow path so cards
- * still receive a fresh first frame — `interactive/start` itself does
- * not trigger a render, it just pins the slot.
+ * On daemons with held interactive sessions, `interactive/start` drives
+ * the live frame loop itself. Older v1 fallback daemons still receive the
+ * original setFocus + renderNow request so cards get a fresh first frame.
  */
 async function handleSetInteractive(previewId: string, enabled: boolean): Promise<void> {
     if (!daemonGate?.isEnabled() || !daemonScheduler) { return; }
@@ -3207,11 +3207,16 @@ async function handleSetInteractive(previewId: string, enabled: boolean): Promis
         const result = await client.interactiveStart({ previewId });
         activeInteractiveStreams.set(previewId, result.frameStreamId);
         updateInteractiveStatus();
+        const interactiveSupported = daemonGate?.isInteractiveSupported(moduleId) ?? false;
         logLine(
             `[interactive] live mode on for ${previewId} (module=${moduleId}, ` +
             `streamId=${result.frameStreamId}, ` +
-            `v2=${daemonGate?.isInteractiveSupported(moduleId) ?? false})`,
+            `v2=${interactiveSupported})`,
         );
+        if (interactiveSupported) {
+            await daemonScheduler.setFocus(moduleId, [previewId]);
+            return;
+        }
     } catch (err) {
         // MethodNotFound on a daemon that predates the interactive RPC — fall through
         // to the focus + renderNow path so the card still gets a fresh first frame.


### PR DESCRIPTION
## Summary
- switch the Wear circular progress preview to the indeterminate indicator
- start a daemon-side frame loop for held interactive sessions so live previews repaint without input
- skip the redundant stateless renderNow bootstrap from VS Code when v2 interactive support is available
- add stack traces for daemon render submit failures and core coverage for live frames after interactive/start

## Verification
- npm run compile
- ./gradlew :daemon:core:test --tests ee.schimke.composeai.daemon.InteractiveSessionPlumbingTest --tests ee.schimke.composeai.daemon.InteractiveRpcIntegrationTest
- ./gradlew :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.AndroidInteractiveSessionTest
- ./gradlew :samples:wear:composePreviewCompile
- ./gradlew :samples:wear:renderAllPreviews
- Direct daemon repro: interactive/start for the Wear CircularProgressIndicator preview emitted repeated renderFinished frames without input