### PR TITLE
Add live preview input diagnostics

### DIFF
--- a/samples/wear/src/main/kotlin/com/example/samplewear/Previews.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/Previews.kt
@@ -45,6 +45,7 @@ import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
 import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
 import ee.schimke.composeai.preview.ScrollMode
 import ee.schimke.composeai.preview.ScrollingPreview
+import java.util.UUID
 
 
 private data class Item(val title: String, val subtitle: String)
@@ -57,6 +58,12 @@ private val sampleItems = listOf(
     Item("Calories", "412 kcal"),
     Item("Timer", "12:30 remaining"),
 )
+
+@Composable
+private fun rememberCompositionId(): String = remember {
+    // TODO: Remove this live-preview diagnostic once interactive refreshes are stable.
+    UUID.randomUUID().toString().take(8)
+}
 
 @Composable
 fun WearApp() {
@@ -142,6 +149,7 @@ fun ActivityListScreen() {
 @Composable
 private fun ButtonPreviewContent() {
     var taps by remember { mutableStateOf(0) }
+    val compositionId = rememberCompositionId()
     MaterialTheme {
         AppScaffold(
             timeText = { TimeText(timeSource = FixedPreviewTimeSource) },
@@ -155,7 +163,7 @@ private fun ButtonPreviewContent() {
                     contentAlignment = Alignment.Center,
                 ) {
                     Button(onClick = { taps += 1 }) {
-                        Text("Taps: $taps")
+                        Text("Taps: $taps\n$compositionId")
                     }
                 }
             }
@@ -165,6 +173,7 @@ private fun ButtonPreviewContent() {
 
 @Composable
 private fun CircularProgressPreviewContent() {
+    val compositionId = rememberCompositionId()
     MaterialTheme {
         AppScaffold(
             timeText = { TimeText(timeSource = FixedPreviewTimeSource) },
@@ -180,6 +189,7 @@ private fun CircularProgressPreviewContent() {
                     CircularProgressIndicator(
                         modifier = Modifier.fillMaxSize(),
                     )
+                    Text(compositionId)
                 }
             }
         }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -389,6 +389,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     daemonScheduler = new DaemonScheduler(daemonGate, {
         onPreviewImageReady: (_moduleId, previewId, imageBase64) => {
             if (!panel) { return; }
+            if (activeInteractiveStreams.has(previewId)) {
+                logLine(`[interactive] frame ${previewId} bytes=${imageBase64.length}`);
+            }
             // Capture index 0 — the daemon's v1 renderFinished targets the
             // representative capture only. Multi-capture (animated) renders
             // still come through the Gradle path; the daemon's predictive

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -610,6 +610,8 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             const turnOn = !wasLive;
             if (turnOn) {
                 interactivePreviewIds.add(previewId);
+                const img = card.querySelector('.image-container img');
+                if (img) ensureInteractiveInputHandlers(card, img);
             } else {
                 interactivePreviewIds.delete(previewId);
             }


### PR DESCRIPTION
## Summary
- bind interactive input handlers immediately when a card enters live mode
- log changed live frames received by the VS Code extension
- add temporary composition UUID diagnostics to Button and CircularProgress previews

## Testing
- npm run compile
- ./gradlew :samples:wear:composePreviewCompile