### PR TITLE
Rename layout tree data product

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
@@ -37,7 +37,7 @@ interface DataProductRegistry {
    * catches the four documented failure shapes via [Outcome] and translates each to its wire-error
    * code.
    *
-   * `params` carries per-kind options (e.g. `nodeId` for `layout/tree`); `inline` mirrors the
+   * `params` carries per-kind options (e.g. `nodeId` for `layout/inspector`); `inline` mirrors the
    * `data/fetch.inline` flag — `true` asks the registry to inline the payload (or `bytes` for blob
    * kinds), `false` lets it return a `path` for cheap local-client read-from-disk.
    */

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -357,7 +357,7 @@ data class RenderNowResult(val queued: List<String>, val rejected: List<Rejected
 // D1 — data products (see docs/daemon/DATA-PRODUCTS.md).
 //
 // `params` is per-kind options carried as JsonElement so the dispatch surface
-// stays kind-agnostic — kinds that take params (e.g. `layout/tree` keyed by
+// stays kind-agnostic — kinds that take params (e.g. `layout/inspector` keyed by
 // nodeId) decode against their own serializer at producer time.
 // ---------------------------------------------------------------------------
 

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -234,7 +234,7 @@ asking for an unadvertised kind gets `DataProductUnknown` (-32020).
 {
   previewId: string;
   kind: string;
-  params?: Record<string, unknown>;  // per-kind options (e.g. { nodeId } for layout/tree)
+  params?: Record<string, unknown>;  // per-kind options (e.g. { nodeId } for layout/inspector)
   inline?: boolean;                  // true → daemon inlines payload (or bytes for blobs)
 }
 
@@ -372,7 +372,7 @@ SHIPPED; everything else is "we know the shape, no code yet."
 | `a11y/hierarchy`           | a11y | low  | `AccessibilityNode[]` (label, role, states, bounds). Powers a local overlay in VS Code. **First implementation.** Carries the `overlay` PNG as an extra. |
 | `a11y/overlay`             | a11y | low  | Path to the Paparazzi-style annotated PNG produced by `AccessibilityImageProcessor`. Pure-image kind — `transport='path'`, no JSON payload. **D2.1 — image-processor surface.** |
 | `a11y/touchTargets`        | a11y | low  | Derived from hierarchy; 48dp + overlap detection. **D2.2 — shipped inline payload.** Carries the `overlay` PNG as an extra. |
-| `layout/tree`              | default | low | View / Compose layout tree with bounds, paddings, source-line refs. Layout inspector. |
+| `layout/inspector`         | default | low | View / Compose hierarchy for layout-inspector style inspection: component tree, bounds, paddings, source-line refs. |
 | `compose/semantics`        | default | low | SemanticsNode projection — testTag, role, mergeMode, bounds. **Android daemon implementation.** |
 | `compose/recomposition`    | instrumented | medium | `[{ nodeId, count, sinceFrameStreamId? }]`. Heat-map overlay. Static snapshot answers "what recomposed during initial composition"; the load-bearing case is **delta after a click** in interactive mode (see § Recomposition + interactive). Needs an instrumented re-render. |
 | `compose/theme`            | default | medium | Resolved `MaterialTheme.*` values + which nodes consumed which tokens. |
@@ -505,7 +505,7 @@ The two also have different dependency profiles: the core only needs ATF +
 AndroidX, while the connector adds `:daemon:core` (protocol types) and
 exposes `ImageProcessor` to `RenderEngine`.
 
-The pattern generalises — when `layout/tree` or `compose/recomposition` get
+The pattern generalises — when `layout/inspector` or `compose/recomposition` get
 their own modules, they follow the same `:data-<product>-core` (published) +
 `:data-<product>-connector` (private) split. The `core` is optional: a
 data product whose entire surface is daemon-glue (no general-purpose Android
@@ -590,7 +590,7 @@ regions capped to the largest 50:
   re-render path for kinds the latest pass didn't compute. First
   consumer: agent-driven MCP calls that ask for `a11y/hierarchy`
   without first subscribing.
-- **D4 — `layout/tree`.** Layout inspector. Shares the View walk with
+- **D4 — `layout/inspector`.** Layout inspector. Shares the View walk with
   a11y; cheap enough for the same overlay panel surface.
 - **D5+** — pick from the catalogue based on demand. `compose/recomposition`
   in `mode: "delta"` is the highest-value next step for VS Code parity

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -727,8 +727,8 @@ class DaemonMcpServer(
               "type":"object",
               "properties":{
                 "uri":{"type":"string","description":"compose-preview://<workspace>/<module>/<fqn>?config=<qualifier>"},
-                "kind":{"type":"string","description":"Data-product kind, e.g. a11y/hierarchy, a11y/atf, layout/tree, compose/semantics."},
-                "params":{"type":"object","description":"Optional per-kind parameters (e.g. {nodeId} for layout/tree). Forwarded verbatim to the daemon's data/fetch."},
+                "kind":{"type":"string","description":"Data-product kind, e.g. a11y/hierarchy, a11y/atf, layout/inspector, compose/semantics."},
+                "params":{"type":"object","description":"Optional per-kind parameters (e.g. {nodeId} for layout/inspector). Forwarded verbatim to the daemon's data/fetch."},
                 "inline":{"type":"boolean","description":"Default true. When false, the daemon returns a `path` to a sibling JSON file instead of inlining the payload."}
               },
               "required":["uri","kind"]
@@ -1506,7 +1506,7 @@ class DaemonMcpServer(
     // transport on a direct fetch, so falling through preserves the contract.
     //
     // Skip the cache when per-kind `params` are present — those select sub-views (e.g.
-    // `{ nodeId }` for `layout/tree`), and the cached entry is the no-params form.
+    // `{ nodeId }` for `layout/inspector`), and the cached entry is the no-params form.
     if (perKindParams == null) {
       val cached =
         dataProductCache[DataAttachKey(uri.workspaceId, uri.modulePath, uri.previewFqn, kind)]

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -1761,7 +1761,7 @@ class DaemonMcpServerTest {
       daemon.advertisedDataProducts =
         listOf(
           ee.schimke.composeai.daemon.protocol.DataProductCapability(
-            kind = "layout/tree",
+            kind = "layout/inspector",
             schemaVersion = 1,
             transport = ee.schimke.composeai.daemon.protocol.DataProductTransport.INLINE,
             attachable = true,
@@ -1771,7 +1771,7 @@ class DaemonMcpServerTest {
         )
       daemon.dataFetchHandler = { _, kind, perKindParams, _ ->
         // The wire call must receive the params verbatim — that's how kinds with sub-views (e.g.
-        // layout/tree filtered by nodeId) work.
+        // layout/inspector filtered by nodeId) work.
         val nodeId = perKindParams?.get("nodeId")?.jsonPrimitive?.contentOrNull ?: "?"
         FakeDaemon.DataFetchOutcome.Ok(
           kind = kind,
@@ -1794,7 +1794,7 @@ class DaemonMcpServerTest {
       "/tmp/red.png",
       listOf(
         buildJsonObject {
-          put("kind", "layout/tree")
+          put("kind", "layout/inspector")
           put("schemaVersion", 1)
           putJsonObject("payload") { put("nodeId", "root") }
         }
@@ -1807,7 +1807,7 @@ class DaemonMcpServerTest {
         "get_preview_data",
         buildJsonObject {
           put("uri", uri)
-          put("kind", "layout/tree")
+          put("kind", "layout/inspector")
           putJsonObject("params") { put("nodeId", "node-42") }
         },
       )
@@ -1832,7 +1832,7 @@ class DaemonMcpServerTest {
       DaemonSupervisor(
         descriptorProvider = FakeDescriptorProvider(),
         clientFactory = factoryLocal,
-        globalAttachDataProducts = listOf("a11y/atf", "layout/tree"),
+        globalAttachDataProducts = listOf("a11y/atf", "layout/inspector"),
       )
     try {
       val projectDir = tmp.newFolder("workspace-attach")
@@ -1845,7 +1845,7 @@ class DaemonMcpServerTest {
       assertThat(params).isNotNull()
       val attached = params!!["options"]?.jsonObject?.get("attachDataProducts")?.jsonArray
       assertThat(attached?.map { it.jsonPrimitive.content })
-        .containsExactly("a11y/atf", "layout/tree")
+        .containsExactly("a11y/atf", "layout/inspector")
         .inOrder()
     } finally {
       runCatching { supervisorLocal.shutdown() }

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -76,7 +76,7 @@ const HEAVY_TIER_DEFAULT: RenderTier = 'fast';
 /**
  * D2 — kinds the focus-mode "Show a11y overlay" button toggles. Pinned to the a11y producer
  * so the local finding + hierarchy overlays light up together; a future panel that wants to
- * subscribe to other kinds (`compose/recomposition`, `layout/tree`) will export its own list.
+ * subscribe to other kinds (`compose/recomposition`, `layout/inspector`) will export its own list.
  */
 export const A11Y_OVERLAY_KINDS: readonly string[] = ['a11y/atf', 'a11y/hierarchy'];
 /**


### PR DESCRIPTION
## Summary
- Rename the planned data-product kind from `layout/tree` to `layout/inspector`
- Update docs, MCP schema text, and tests to use the inspector-oriented name
- Keep the product description aligned with Android Studio-style Layout Inspector semantics

## Test
- `./gradlew :mcp:test --tests ee.schimke.composeai.mcp.DaemonMcpServerTest`