### PR TITLE
Add per-render inspectionMode override

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -126,6 +126,7 @@ class PreviewManifestRouter(
       inbound["captureAdvanceMs"]?.let {
         append("captureAdvanceMs=").append(it).append(';')
       }
+      inbound["inspectionMode"]?.let { append("inspectionMode=").append(it).append(';') }
       append("outputBaseName=").append(resolved.outputBaseName)
     }
   }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -221,7 +221,8 @@ class RenderEngine(
               // hierarchy walk to consume after capture. Tradeoff: infinite animations tick
               // through rather than parking under the paused clock — same trade
               // `RobolectricRenderTest.renderWithA11y` already pays.
-              CompositionLocalProvider(LocalInspectionMode provides !runAccessibility) {
+              val inspectionMode = if (runAccessibility) false else spec.inspectionMode ?: true
+              CompositionLocalProvider(LocalInspectionMode provides inspectionMode) {
                 Box(modifier = Modifier.fillMaxSize()) { InvokeComposable(composableMethod) }
               }
             }
@@ -511,6 +512,11 @@ data class RenderSpec(
    * settle window without editing the render body.
    */
   val captureAdvanceMs: Long? = null,
+  /**
+   * Per-render `LocalInspectionMode` override for one-shot renders. Null preserves preview
+   * semantics (`true`); a11y mode still forces `false` so accessibility semantics are populated.
+   */
+  val inspectionMode: Boolean? = null,
 ) {
 
   enum class SpecUiMode {
@@ -529,8 +535,9 @@ data class RenderSpec(
      * Parses [RenderRequest.Render.payload] — a `;`-delimited `key=value` string — into a
      * [RenderSpec]. Recognised keys: `className`, `functionName`, `widthPx`, `heightPx`, `density`,
      * `showBackground`, `backgroundColor`, `device`, `outputBaseName`, `localeTag`, `fontScale`,
-     * `uiMode` (`light`/`dark`), `orientation` (`portrait`/`landscape`). `className` and
-     * `functionName` are required; everything else falls back to the defaults on this data class.
+     * `uiMode` (`light`/`dark`), `orientation` (`portrait`/`landscape`), `inspectionMode`
+     * (`true`/`false`). `className` and `functionName` are required; everything else falls back to
+     * the defaults on this data class.
      * Returns `null` when the payload doesn't carry a `className=` token (the discriminator the
      * host uses to route legacy stub-payload requests through the classloader-identity path).
      */
@@ -572,6 +579,7 @@ data class RenderSpec(
             else -> null
           },
         captureAdvanceMs = map["captureAdvanceMs"]?.toLongOrNull()?.takeIf { it > 0L },
+        inspectionMode = map["inspectionMode"]?.toBooleanStrictOrNull(),
       )
     }
   }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -222,10 +222,11 @@ open class RobolectricHost(
 
   /**
    * PROTOCOL.md § 3 (`InitializeResult.capabilities.supportedOverrides`) — the Robolectric
-   * renderer applies all eight `PreviewOverrides` fields. Size / density / locale / uiMode /
+   * renderer applies all `PreviewOverrides` fields. Size / density / locale / uiMode /
    * orientation / device flow into `RuntimeEnvironment.setQualifiers`; `fontScale` flows into
-   * `RuntimeEnvironment.setFontScale` (a Configuration knob, not a qualifier — see
-   * `daemon/android/.../RenderEngine.kt` for the call site).
+   * `RuntimeEnvironment.setFontScale` (a Configuration knob, not a qualifier); `captureAdvanceMs`
+   * controls the paused-clock settle point; `inspectionMode` flows into `LocalInspectionMode`.
+   * See `daemon/android/.../RenderEngine.kt` for the call sites.
    */
   override val supportedOverrides: Set<String> =
     setOf(
@@ -238,6 +239,7 @@ open class RobolectricHost(
       "orientation",
       "device",
       "captureAdvanceMs",
+      "inspectionMode",
     )
 
   /** PROTOCOL.md § 3 — android backend identifier surfaced via `capabilities.backend`. */

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -803,9 +803,9 @@ class JsonRpcServer(
    *
    * - `previewId=<id>` — the discovery-time identifier the per-backend `PreviewManifestRouter`
    *   resolves into a [RenderSpec] before dispatch.
-   * - Optional `widthPx`, `heightPx`, `density`, `localeTag`, `fontScale`, `uiMode`, `orientation`
-   *   — the [PreviewOverrides] from this `renderNow` call. Routers preserve these when rewriting
-   *   the payload, and they win over the manifest entry's per-preview defaults.
+   * - Optional `widthPx`, `heightPx`, `density`, `localeTag`, `fontScale`, `uiMode`, `orientation`,
+   *   `inspectionMode` — the [PreviewOverrides] from this `renderNow` call. Routers preserve these
+   *   when rewriting the payload, and they win over the manifest entry's per-preview defaults.
    *
    * **`device` resolution.** When `overrides.device` is set we resolve it against
    * [ee.schimke.composeai.daemon.devices.DeviceDimensions] and emit the derived `widthPx` /
@@ -883,6 +883,10 @@ class JsonRpcServer(
           if (isNotEmpty()) append(';')
           append("captureAdvanceMs=").append(it)
         }
+      overrides.inspectionMode?.let {
+        if (isNotEmpty()) append(';')
+        append("inspectionMode=").append(it)
+      }
     }
   }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -99,9 +99,10 @@ interface RenderHost {
   /**
    * Field names from `PreviewOverrides` (see PROTOCOL.md § 5 `renderNow.overrides`) that this host
    * actually applies during a render. Names match the JSON spelling on the wire: `widthPx`,
-   * `heightPx`, `density`, `localeTag`, `fontScale`, `uiMode`, `orientation`, `device`. Surfaced
-   * verbatim as `InitializeResult.capabilities.supportedOverrides` so clients can grey out
-   * unsupported sliders and MCP can warn agents who set fields the backend would silently ignore.
+   * `heightPx`, `density`, `localeTag`, `fontScale`, `uiMode`, `orientation`, `device`,
+   * `captureAdvanceMs`, `inspectionMode`. Surfaced verbatim as
+   * `InitializeResult.capabilities.supportedOverrides` so clients can grey out unsupported sliders
+   * and MCP can warn agents who set fields the backend would silently ignore.
    *
    * The default empty set is the safe pre-feature value — clients treat absent and `[]` identically
    * and assume any field they pass might be ignored. Real backends override: `RobolectricHost`

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -158,14 +158,15 @@ data class ServerCapabilities(
   /**
    * The `PreviewOverrides` field names this daemon's host actually applies (see PROTOCOL.md § 5
    * `renderNow.overrides`). Names match the JSON spelling on the wire: `widthPx`, `heightPx`,
-   * `density`, `localeTag`, `fontScale`, `uiMode`, `orientation`, `device`. Lets clients grey out
-   * unsupported sliders and lets MCP warn agents who set fields the backend would silently ignore.
-   * Empty list = pre-feature daemon (clients treat absent and `[]` identically and assume any field
-   * they pass might be ignored).
+   * `density`, `localeTag`, `fontScale`, `uiMode`, `orientation`, `device`, `captureAdvanceMs`,
+   * `inspectionMode`. Lets clients grey out unsupported sliders and lets MCP warn agents who set
+   * fields the backend would silently ignore. Empty list = pre-feature daemon (clients treat absent
+   * and `[]` identically and assume any field they pass might be ignored).
    *
-   * Today: `RobolectricHost` advertises all eight; `DesktopHost` omits `localeTag` (Compose Desktop
-   * has no `LocalLocale` CompositionLocal + `Locale.setDefault(...)` is JVM-thread- unsafe) and
-   * `orientation` (no rotation concept on `ImageComposeScene`).
+   * Today: `RobolectricHost` advertises every field; `DesktopHost` omits `localeTag` (Compose
+   * Desktop has no `LocalLocale` CompositionLocal + `Locale.setDefault(...)` is JVM-thread-
+   * unsafe), `orientation` (no rotation concept on `ImageComposeScene`), and Android-only timing
+   * knobs.
    */
   val supportedOverrides: List<String> = emptyList(),
   /**
@@ -328,6 +329,12 @@ data class PreviewOverrides(
    * it (no paused-clock concept).
    */
   val captureAdvanceMs: Long? = null,
+  /**
+   * Per-render `LocalInspectionMode` value for one-shot renders. Null preserves the backend's
+   * default preview behaviour (`true` for renderNow). Set `false` to render as runtime-like content
+   * without allocating a held interactive session.
+   */
+  val inspectionMode: Boolean? = null,
 )
 
 @Serializable

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DeviceOverrideEncodingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DeviceOverrideEncodingTest.kt
@@ -89,6 +89,13 @@ class DeviceOverrideEncodingTest {
     assertContainsToken("uiMode=dark", captured)
   }
 
+  @Test(timeout = 30_000)
+  fun inspectionModeOverrideThreadsThroughPayload() {
+    val captured = renderAndCapturePayload(overrides = """{"inspectionMode":false}""")
+
+    assertContainsToken("inspectionMode=false", captured)
+  }
+
   private fun assertContainsToken(token: String, payload: String) {
     val tokens = payload.split(';')
     assertTrue(

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -158,10 +158,11 @@ open class DesktopHost(
    * Desktop has no `LocalLocale` CompositionLocal and `Locale.setDefault(...)` is JVM-thread-
    * unsafe (every other thread would see the override during the render). `orientation` is no-op
    * because `ImageComposeScene` has no rotation concept — see `daemon/desktop/.../RenderEngine.kt`
-   * for the docstring.
+   * for the docstring. `inspectionMode` flows into `LocalInspectionMode` on the one-shot render
+   * path; interactive and recording sessions keep their runtime-like `false` default.
    */
   override val supportedOverrides: Set<String> =
-    setOf("widthPx", "heightPx", "density", "fontScale", "uiMode", "device")
+    setOf("widthPx", "heightPx", "density", "fontScale", "uiMode", "device", "inspectionMode")
 
   /** PROTOCOL.md § 3 — desktop backend identifier surfaced via `capabilities.backend`. */
   override val backendKind: ee.schimke.composeai.daemon.protocol.BackendKind =
@@ -340,7 +341,12 @@ open class DesktopHost(
             "recording session not allocated"
         )
     val effectiveSpec = applyOverrides(baseSpec, overrides, recordingId)
-    val state = engine.setUp(effectiveSpec, classLoader, inspectionMode = false)
+    val state =
+      engine.setUp(
+        effectiveSpec,
+        classLoader,
+        inspectionMode = effectiveSpec.inspectionMode ?: false,
+      )
     val recordingsRoot = recordingsRootDir()
     val framesDir = File(File(recordingsRoot, "frames"), recordingId)
     val encodedDir = File(recordingsRoot, "encoded")
@@ -424,6 +430,7 @@ open class DesktopHost(
       fontScale = overrides.fontScale ?: base.fontScale,
       uiMode = uiMode,
       orientation = orientation,
+      inspectionMode = overrides.inspectionMode ?: base.inspectionMode,
       outputBaseName = "recording-$recordingId",
     )
   }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -99,6 +99,7 @@ class PreviewManifestRouter(
             inbound["uiMode"]?.let { append("uiMode=").append(it).append(';') }
             inbound["orientation"]?.let { append("orientation=").append(it).append(';') }
             inbound["captureAdvanceMs"]?.let { append("captureAdvanceMs=").append(it).append(';') }
+            inbound["inspectionMode"]?.let { append("inspectionMode=").append(it).append(';') }
             append("outputBaseName=").append(resolved.outputBaseName)
           },
       )

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -91,7 +91,7 @@ class RenderEngine(
      */
     sandboxStats: SandboxLifecycleStats = SandboxLifecycleStats(),
   ): RenderResult {
-    val state = setUp(spec, classLoader, inspectionMode = true)
+    val state = setUp(spec, classLoader, inspectionMode = spec.inspectionMode ?: true)
     try {
       return renderOnce(state, requestId, sandboxStats = sandboxStats)
     } finally {
@@ -360,6 +360,11 @@ data class RenderSpec(
    * is carried so a single payload string drives both backends.
    */
   val orientation: SpecOrientation? = null,
+  /**
+   * Per-render `LocalInspectionMode` override for one-shot renders. Null preserves preview
+   * semantics (`true`); held interactive/recording sessions pass their own runtime-like `false`.
+   */
+  val inspectionMode: Boolean? = null,
 ) {
 
   enum class SpecUiMode {
@@ -378,8 +383,9 @@ data class RenderSpec(
      * Parses [RenderRequest.Render.payload] — a `;`-delimited `key=value` string — into a
      * [RenderSpec]. Recognised keys: `className`, `functionName`, `widthPx`, `heightPx`, `density`,
      * `showBackground`, `backgroundColor`, `device`, `outputBaseName`, `localeTag`, `fontScale`,
-     * `uiMode` (`light`/`dark`), `orientation` (`portrait`/`landscape`). `className` and
-     * `functionName` are required; everything else falls back to the defaults on this data class.
+     * `uiMode` (`light`/`dark`), `orientation` (`portrait`/`landscape`), `inspectionMode`
+     * (`true`/`false`). `className` and `functionName` are required; everything else falls back to
+     * the defaults on this data class.
      *
      * Keeping this stringly-typed for v1 is deliberate (per the task brief). When `RenderRequest`
      * grows a typed `previewId: String?` field, [DesktopHost] will look the spec up in
@@ -425,6 +431,7 @@ data class RenderSpec(
             "landscape" -> SpecOrientation.LANDSCAPE
             else -> null
           },
+        inspectionMode = map["inspectionMode"]?.toBooleanStrictOrNull(),
       )
     }
   }

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -136,11 +136,12 @@ Result:
   //
   // supportedOverrides — the `PreviewOverrides` field names this daemon's host actually applies
   // (subset of {"widthPx","heightPx","density","localeTag","fontScale","uiMode","orientation",
-  // "device"}). Lets clients grey out unsupported sliders. Empty list = pre-feature daemon;
+  // "device","captureAdvanceMs","inspectionMode"}). Lets clients grey out unsupported sliders.
+  // Empty list = pre-feature daemon;
   // treat absent and `[]` identically and assume any field might be ignored.
-  // Today: Robolectric advertises all eight; Desktop omits "localeTag" (no `LocalLocale`
-  // CompositionLocal + `Locale.setDefault(...)` is JVM-thread-unsafe) and "orientation"
-  // (no rotation concept on `ImageComposeScene`).
+  // Today: Robolectric advertises every field; Desktop omits "localeTag" (no `LocalLocale`
+  // CompositionLocal + `Locale.setDefault(...)` is JVM-thread-unsafe), "orientation"
+  // (no rotation concept on `ImageComposeScene`), and Android-only timing knobs.
   //
   // androidSdk — fixed Android SDK level the backend renders against. Populated by the
   // Robolectric backend from its pinned @Config(sdk = ...) value; absent/null on Desktop and
@@ -232,6 +233,8 @@ A `classpath` event triggers Tier-1 fingerprint recomputation; on mismatch the d
                                      // explicit widthPx/heightPx/density above take precedence.
   captureAdvanceMs?: number;         // Paused-clock advance (ms) before capture. Android-only;
                                      // default ≈ 32ms. Bump for animation-heavy previews.
+  inspectionMode?: boolean;          // Override LocalInspectionMode for this one-shot render.
+                                     // Null/absent keeps normal preview semantics.
 }
 
 // result
@@ -243,7 +246,7 @@ A `classpath` event triggers Tier-1 fingerprint recomputation; on mismatch the d
 
 The result resolves as soon as the request is queued, **not** when rendering completes. Per-render progress arrives as `renderStarted` / `renderFinished` / `renderFailed` notifications keyed by ID.
 
-`overrides` are merged onto the discovery-time `RenderSpec` per-call. A subsequent `renderNow` for the same preview **without** `overrides` reverts to the discovery-time defaults — overrides are not sticky across calls. Backends that don't model a particular field ignore it (e.g. desktop has no Android resource qualifier system, so `uiMode` / `localeTag` / `orientation` are no-ops on the desktop render path today).
+`overrides` are merged onto the discovery-time `RenderSpec` per-call. A subsequent `renderNow` for the same preview **without** `overrides` reverts to the discovery-time defaults — overrides are not sticky across calls. Backends that don't model a particular field ignore it (e.g. desktop has no Android resource qualifier system, so `localeTag` / `orientation` are no-ops on the desktop render path today). `inspectionMode` controls the `LocalInspectionMode` value for this one-shot render; absent/null preserves preview behaviour (`true`).
 
 **Coalescing.** When `overrides` is non-null and a prior override-bearing render is still in-flight for the same `previewId`, the new request is rejected with `reason = "coalesced: …"` rather than queued. The client (panel, MCP, etc.) is responsible for resubmitting on the next `renderFinished` if the latest override values still differ from what was rendered. Plain (no-overrides) `renderNow` is unaffected — the existing save-debounce loop continues to coalesce upstream.
 

--- a/docs/daemon/protocol-fixtures/client-renderNow-overrides.json
+++ b/docs/daemon/protocol-fixtures/client-renderNow-overrides.json
@@ -11,6 +11,7 @@
     "uiMode": "dark",
     "orientation": "portrait",
     "device": "id:pixel_5",
-    "captureAdvanceMs": 250
+    "captureAdvanceMs": 250,
+    "inspectionMode": false
   }
 }

--- a/docs/daemon/protocol-fixtures/daemon-initializeResult.json
+++ b/docs/daemon/protocol-fixtures/daemon-initializeResult.json
@@ -44,7 +44,15 @@
       {"id": "id:pixel_5", "widthDp": 393, "heightDp": 851, "density": 2.75},
       {"id": "id:wearos_small_round", "widthDp": 192, "heightDp": 192, "density": 2.0, "isRound": true}
     ],
-    "supportedOverrides": ["density", "device", "fontScale", "heightPx", "uiMode", "widthPx"],
+    "supportedOverrides": [
+      "density",
+      "device",
+      "fontScale",
+      "heightPx",
+      "inspectionMode",
+      "uiMode",
+      "widthPx"
+    ],
     "backend": "desktop"
   },
   "classpathFingerprint": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -512,7 +512,8 @@ class DaemonMcpServer(
         description =
           "Force-render a preview by URI, bypassing any cache. Returns the rendered PNG inline. " +
             "Optional `overrides` apply per-call display-property overrides (size, density, " +
-            "locale, fontScale, uiMode, orientation) — see PROTOCOL.md § 5 (`renderNow.overrides`).",
+            "locale, fontScale, uiMode, orientation, device, inspectionMode) — see PROTOCOL.md " +
+            "§ 5 (`renderNow.overrides`).",
         inputSchema =
           parseSchema(
             """
@@ -531,7 +532,9 @@ class DaemonMcpServer(
                     "fontScale":{"type":"number","description":"Font scale multiplier (1.0 = system default)."},
                     "uiMode":{"type":"string","enum":["light","dark"],"description":"Light/dark mode override. Android-only today."},
                     "orientation":{"type":"string","enum":["portrait","landscape"],"description":"Portrait/landscape override. Android-only today."},
-                    "device":{"type":"string","description":"@Preview(device=...) string — 'id:pixel_5', 'id:wearos_small_round', 'id:tv_1080p', or full 'spec:width=400dp,height=800dp,dpi=320'. Resolved by the daemon's catalog into widthPx/heightPx/density; explicit width/height/density overrides on this same object take precedence."}
+                    "device":{"type":"string","description":"@Preview(device=...) string — 'id:pixel_5', 'id:wearos_small_round', 'id:tv_1080p', or full 'spec:width=400dp,height=800dp,dpi=320'. Resolved by the daemon's catalog into widthPx/heightPx/density; explicit width/height/density overrides on this same object take precedence."},
+                    "captureAdvanceMs":{"type":"integer","description":"Paused-clock advance before capture. Android-only today."},
+                    "inspectionMode":{"type":"boolean","description":"Override LocalInspectionMode for this one-shot render. Null/default keeps preview semantics."}
                   }
                 }
               },
@@ -809,7 +812,9 @@ class DaemonMcpServer(
                     "fontScale":{"type":"number"},
                     "uiMode":{"type":"string","enum":["light","dark"]},
                     "orientation":{"type":"string","enum":["portrait","landscape"]},
-                    "device":{"type":"string"}
+                    "device":{"type":"string"},
+                    "captureAdvanceMs":{"type":"integer"},
+                    "inspectionMode":{"type":"boolean"}
                   }
                 }
               },
@@ -901,7 +906,9 @@ class DaemonMcpServer(
                     "fontScale":{"type":"number"},
                     "uiMode":{"type":"string","enum":["light","dark"]},
                     "orientation":{"type":"string","enum":["portrait","landscape"]},
-                    "device":{"type":"string"}
+                    "device":{"type":"string"},
+                    "captureAdvanceMs":{"type":"integer"},
+                    "inspectionMode":{"type":"boolean"}
                   }
                 }
               },
@@ -1094,6 +1101,8 @@ class DaemonMcpServer(
       check("uiMode", overrides.uiMode != null)
       check("orientation", overrides.orientation != null)
       check("device", overrides.device != null)
+      check("captureAdvanceMs", overrides.captureAdvanceMs != null)
+      check("inspectionMode", overrides.inspectionMode != null)
     }
     val deviceOverride = overrides.device
     val knownIds = daemon.knownDeviceIds
@@ -1136,6 +1145,12 @@ class DaemonMcpServer(
         ?.jsonPrimitive
         ?.contentOrNull
         ?.takeIf { it.isNotBlank() }
+    fun bool(name: String): Boolean? =
+      obj[name]
+        ?.takeUnless { it is kotlinx.serialization.json.JsonNull }
+        ?.jsonPrimitive
+        ?.contentOrNull
+        ?.let { it.toBooleanStrictOrNull() ?: error("$name must be true or false, got '$it'") }
     val uiMode =
       str("uiMode")?.let {
         when (it.lowercase()) {
@@ -1161,6 +1176,8 @@ class DaemonMcpServer(
       uiMode = uiMode,
       orientation = orientation,
       device = str("device"),
+      captureAdvanceMs = int("captureAdvanceMs")?.toLong(),
+      inspectionMode = bool("inspectionMode"),
     )
   }
 

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -623,6 +623,8 @@ class DaemonMcpServerTest {
             put("heightPx", 800)
             put("uiMode", "dark")
             put("device", "id:pixel_5")
+            put("captureAdvanceMs", 250)
+            put("inspectionMode", false)
           },
         )
       },
@@ -639,6 +641,8 @@ class DaemonMcpServerTest {
     assertThat(firstOverrides.heightPx).isEqualTo(800)
     assertThat(firstOverrides.uiMode).isEqualTo(ee.schimke.composeai.daemon.protocol.UiMode.DARK)
     assertThat(firstOverrides.device).isEqualTo("id:pixel_5")
+    assertThat(firstOverrides.captureAdvanceMs).isEqualTo(250L)
+    assertThat(firstOverrides.inspectionMode).isFalse()
 
     // A second render_preview call WITHOUT overrides now uses a different RenderKey and triggers
     // a fresh renderNow rather than dedup'ing onto the first. Pre-fix, the now-stale shared key

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -238,6 +238,10 @@ export interface PreviewOverrides {
      * Values ≤ 0 fall back to the default. Desktop ignores it.
      */
     captureAdvanceMs?: number;
+    /**
+     * Per-render LocalInspectionMode override. Undefined preserves normal preview behaviour.
+     */
+    inspectionMode?: boolean;
 }
 
 export interface RenderNowParams {

--- a/vscode-extension/src/test/daemonProtocol.test.ts
+++ b/vscode-extension/src/test/daemonProtocol.test.ts
@@ -79,6 +79,7 @@ describe('daemon protocol — golden fixtures', () => {
         assert.ok(supported.includes('widthPx'), 'desktop should advertise widthPx');
         assert.ok(supported.includes('uiMode'), 'desktop should advertise uiMode');
         assert.ok(supported.includes('device'), 'desktop should advertise device');
+        assert.ok(supported.includes('inspectionMode'), 'desktop should advertise inspectionMode');
         assert.ok(!supported.includes('localeTag'), 'desktop should NOT advertise localeTag');
         assert.ok(!supported.includes('orientation'), 'desktop should NOT advertise orientation');
         // PROTOCOL.md § 3 — backend identifies the renderer; fixture mirrors a desktop daemon.
@@ -130,6 +131,7 @@ describe('daemon protocol — golden fixtures', () => {
         assert.strictEqual(params.overrides!.widthPx, 600);
         assert.strictEqual(params.overrides!.uiMode, 'dark');
         assert.strictEqual(params.overrides!.localeTag, 'fr-FR');
+        assert.strictEqual(params.overrides!.inspectionMode, false);
     });
 });
 


### PR DESCRIPTION
## Summary
- add `inspectionMode` to `PreviewOverrides` and protocol fixtures
- thread it through JSON-RPC payload encoding, manifest routers, and Android/Desktop `RenderSpec` parsing
- advertise support in backend capabilities and MCP override validation/tool schemas

Closes #469.

## Tests
- `./gradlew ktfmtFormat :daemon:core:test --tests ee.schimke.composeai.daemon.protocol.MessagesTest --tests ee.schimke.composeai.daemon.DeviceOverrideEncodingTest :mcp:test --tests ee.schimke.composeai.mcp.DaemonMcpServerTest :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.OverrideIntegrationTest :daemon:desktop:test --tests ee.schimke.composeai.daemon.OverrideIntegrationTest`
- `npm test -- --runTestsByPath src/test/daemonProtocol.test.ts`
