### PR TITLE
docs: clarify agent git workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,5 @@ See [docs/AGENTS.md](docs/AGENTS.md) for project context, architecture, commands
 ## Git conventions (must follow)
 
 - **No `Co-Authored-By` trailers** in commit messages or PR bodies. Commits are attributed solely to the committer — do not add a Claude/AI co-author line, even by default.
+- **Use conventional commits for PR titles and commit subjects** (`fix:`, `feat:`, `docs:`, `test:`, etc.) so squash merges feed release-please correctly.
+- **Before adding commits to an existing PR branch, check whether the PR has already landed.** Fetch `origin` and inspect the PR state or compare against `origin/main` first. If the PR has merged, create a fresh branch from `origin/main` for follow-up work instead of stacking commits onto the merged branch.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -94,6 +94,8 @@ The CLI ([cli/](cli/src/main/kotlin/ee/schimke/composeai/cli/)) and VS Code exte
 ## Git conventions
 
 - **Do not add `Co-Authored-By` trailers** to git commit messages. Commits should be attributed solely to the committer.
+- **Use conventional commits for PR titles and commit subjects** (`fix:`, `feat:`, `docs:`, `test:`, etc.) so squash merges feed release-please correctly.
+- **Before adding commits to an existing PR branch, check whether the PR has already landed.** Fetch `origin` and inspect the PR state or compare `origin/main` first. If the PR is merged, start a fresh branch from `origin/main` for follow-up work instead of stacking new commits onto the merged branch.
 - **Run the formatter before committing.** CI's `format` job runs `./gradlew ktfmtCheckAll` and it's a hard gate — `ktfmtCheck` aborts on the first unformatted file. Before each commit that touches `*.kt`/`*.kts`, run `./gradlew ktfmtFormat` (or `./gradlew :<module>:ktfmtFormatMain :<module>:ktfmtFormatTest` for the touched modules) and stage the result. For VS Code extension TypeScript changes, run `npm --prefix vscode-extension run format`. Don't push without re-running these — the fix-up round-trip costs more than running the formatter locally.
 
 ## Important constraints


### PR DESCRIPTION
## Summary
- Tell agents to check whether an existing PR has already landed before adding commits to its branch
- Tell agents to use conventional commit format for PR titles and commit subjects
- Mirror the guidance in both CLAUDE.md and docs/AGENTS.md

## Test
- Not run; docs-only change