### PR TITLE
Require held sessions for live preview

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1789,6 +1789,7 @@ class JsonRpcServer(
     // "interactive/start always succeeds and returns a streamId; inputs route through whatever
     // path the host supports". A v2-aware client gets the held-state semantics; a v1 client
     // doesn't notice the difference. See INTERACTIVE.md § 9 for the rollout rationale.
+    var fallbackReason: String? = null
     val session: InteractiveSession? =
       try {
         val classLoader =
@@ -1796,19 +1797,41 @@ class JsonRpcServer(
             ?: this::class.java.classLoader
             ?: ClassLoader.getSystemClassLoader()
         host.acquireInteractiveSession(params.previewId, classLoader)
-      } catch (_: UnsupportedOperationException) {
+      } catch (t: UnsupportedOperationException) {
+        fallbackReason = "${t.javaClass.simpleName}: ${t.message}"
         null
       } catch (t: Throwable) {
+        val reason = "${t.javaClass.simpleName}: ${t.message}"
+        if (host.supportsInteractive) {
+          sendErrorResponse(
+            id = req.id,
+            code = ERR_INTERNAL,
+            message =
+              "interactive/start: host advertises held sessions but failed to acquire one for " +
+                "previewId='${params.previewId}': $reason",
+          )
+          return
+        }
         // Host overrode the method but failed to allocate (e.g. preview class not found, scene
         // setup threw). Surface as a log notification — the wire-level start still succeeds with
         // the v1 fall-back path so the client gets a usable streamId.
         System.err.println(
           "compose-ai-daemon: interactive/start: acquireInteractiveSession failed for " +
-            "previewId='${params.previewId}': ${t.javaClass.simpleName}: ${t.message}; " +
-            "falling back to v1 dispatch"
+            "previewId='${params.previewId}': $reason; falling back to v1 dispatch"
         )
+        fallbackReason = reason
         null
       }
+    if (session == null && host.supportsInteractive) {
+      sendErrorResponse(
+        id = req.id,
+        code = ERR_INTERNAL,
+        message =
+          "interactive/start: host advertises held sessions but did not acquire one for " +
+            "previewId='${params.previewId}': ${fallbackReason ?: "unknown reason"}",
+      )
+      return
+    }
     interactiveTargets[streamId] =
       InteractiveTarget(previewId = params.previewId, frameStreamId = streamId)
     // Wipe any cached hash for this preview so the first interactive frame always paints.
@@ -1825,7 +1848,11 @@ class JsonRpcServer(
       req.id,
       encode(
         ee.schimke.composeai.daemon.protocol.InteractiveStartResult.serializer(),
-        ee.schimke.composeai.daemon.protocol.InteractiveStartResult(frameStreamId = streamId),
+        ee.schimke.composeai.daemon.protocol.InteractiveStartResult(
+          frameStreamId = streamId,
+          heldSession = session != null,
+          fallbackReason = fallbackReason,
+        ),
       ),
     )
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -717,7 +717,17 @@ data class HistoryReadResultDto(
  * subsequent `interactive/input` and `interactive/stop` so the daemon can route the input to the
  * right frame stream and drop stale ids cleanly.
  */
-@Serializable data class InteractiveStartResult(val frameStreamId: String)
+@Serializable
+data class InteractiveStartResult(
+  val frameStreamId: String,
+  /**
+   * True when the daemon acquired a held composition for this stream. False means the stream is
+   * using the backwards-compatible v1 path where inputs trigger stateless renders.
+   */
+  val heldSession: Boolean,
+  /** Human-readable reason for v1 fallback, when known. */
+  val fallbackReason: String? = null,
+)
 
 @Serializable data class InteractiveStopParams(val frameStreamId: String)
 

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveSessionPlumbingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveSessionPlumbingTest.kt
@@ -13,7 +13,9 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.int
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -71,6 +73,7 @@ class InteractiveSessionPlumbingTest {
     assertNotNull(startResp)
     val streamId =
       startResp!!["result"]!!.jsonObject["frameStreamId"]!!.jsonPrimitive.contentOrNull!!
+    assertEquals(true, startResp["result"]!!.jsonObject["heldSession"]!!.jsonPrimitive.boolean)
     assertEquals(
       "host.acquireInteractiveSession should fire exactly once per start",
       1,
@@ -172,6 +175,7 @@ class InteractiveSessionPlumbingTest {
     assertNotNull(startResp)
     val streamId =
       startResp!!["result"]!!.jsonObject["frameStreamId"]!!.jsonPrimitive.contentOrNull!!
+    assertEquals(true, startResp["result"]!!.jsonObject["heldSession"]!!.jsonPrimitive.boolean)
 
     val finished =
       pollUntil(received) { it["method"]?.jsonPrimitive?.contentOrNull == "renderFinished" }
@@ -186,6 +190,30 @@ class InteractiveSessionPlumbingTest {
       clientToServerOut,
       """{"jsonrpc":"2.0","method":"interactive/stop","params":{"frameStreamId":"$streamId"}}""",
     )
+  }
+
+  @Test(timeout = 30_000)
+  fun supported_host_acquire_failure_fails_noisily() {
+    val tmp = Files.createTempDirectory("interactive-session-failure").toFile()
+    val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
+    val host = FailingSessionHost(pngFile)
+
+    val (_, serverThread, clientToServerOut, received, exitLatch) = bringUpServer(host)
+    resourcesToClose.add(AutoCloseable { runCatching { clientToServerOut.close() } })
+
+    handshake(clientToServerOut, received)
+
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","id":10,"method":"interactive/start","params":{"previewId":"preview-A"}}""",
+    )
+    val startResp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 10 }
+    assertNotNull(startResp)
+    val error = startResp!!["error"]!!.jsonObject
+    assertEquals(-32603, error["code"]!!.jsonPrimitive.int)
+    assertTrue(error["message"]!!.jsonPrimitive.contentOrNull!!.contains("failed to acquire"))
+
+    teardownServer(clientToServerOut, received, serverThread, exitLatch)
   }
 
   @Test(timeout = 30_000)
@@ -213,6 +241,7 @@ class InteractiveSessionPlumbingTest {
     )
     val streamId =
       startResp!!["result"]!!.jsonObject["frameStreamId"]!!.jsonPrimitive.contentOrNull!!
+    assertEquals(false, startResp["result"]!!.jsonObject["heldSession"]!!.jsonPrimitive.boolean)
 
     writeFrame(
       clientToServerOut,
@@ -401,6 +430,9 @@ private class SessionAwareFakeHost(
 
   override fun shutdown(timeoutMs: Long) {}
 
+  override val supportsInteractive: Boolean
+    get() = true
+
   override fun acquireInteractiveSession(
     previewId: String,
     classLoader: ClassLoader,
@@ -474,4 +506,31 @@ private class NoSessionFakeHost(private val defaultPng: File) : RenderHost {
   }
 
   override fun shutdown(timeoutMs: Long) {}
+}
+
+private class FailingSessionHost(private val defaultPng: File) : RenderHost {
+  override val supportsInteractive: Boolean
+    get() = true
+
+  override fun start() {}
+
+  override fun submit(request: RenderRequest, timeoutMs: Long): RenderResult {
+    require(request is RenderRequest.Render)
+    return RenderResult(
+      id = request.id,
+      classLoaderHashCode = 0,
+      classLoaderName = "failing-session-fake",
+      pngPath = defaultPng.absolutePath,
+      metrics = mapOf("tookMs" to 0L),
+    )
+  }
+
+  override fun shutdown(timeoutMs: Long) {}
+
+  override fun acquireInteractiveSession(
+    previewId: String,
+    classLoader: ClassLoader,
+  ): InteractiveSession {
+    throw IllegalStateException("boom")
+  }
 }

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -512,6 +512,10 @@ export interface InteractiveStartResult {
      *  notification so the daemon can route inputs to the right warm
      *  sandbox even if the user toggles between previews. */
     frameStreamId: string;
+    /** True when this stream is backed by a held composition rather than stateless fallback. */
+    heldSession: boolean;
+    /** Human-readable reason for stateless fallback, when the daemon reports one. */
+    fallbackReason?: string;
 }
 
 export interface InteractiveStopParams { frameStreamId: string }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2545,7 +2545,7 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             }
             break;
         case 'setInteractive':
-            void handleSetInteractive(msg.previewId, msg.enabled);
+            queueInteractiveMutation(msg.previewId, msg.enabled);
             break;
         case 'recordInteractiveInput':
             logLine(
@@ -3167,9 +3167,9 @@ function lookupPreviewLabel(previewId: string): string | undefined {
  * forwarding via [activeInteractiveStreams]. Exit calls `interactive/stop`
  * (notification, drop-and-go) and clears the cached stream id.
  *
- * On daemons with held interactive sessions, `interactive/start` drives
- * the live frame loop itself. Older v1 fallback daemons still receive the
- * original setFocus + renderNow request so cards get a fresh first frame.
+ * `interactive/start` must return a held session before the panel is allowed to stay LIVE.
+ * Stateless fallback streams are stopped immediately; otherwise the UI would show a LIVE badge
+ * while every frame comes from a fresh composition.
  */
 async function handleSetInteractive(previewId: string, enabled: boolean): Promise<void> {
     if (!daemonGate?.isEnabled() || !daemonScheduler) { return; }
@@ -3208,28 +3208,34 @@ async function handleSetInteractive(previewId: string, enabled: boolean): Promis
     }
     try {
         const result = await client.interactiveStart({ previewId });
+        if (result.heldSession !== true) {
+            client.interactiveStop({ frameStreamId: result.frameStreamId });
+            logLine(
+                `[interactive] live mode unavailable for ${previewId}: daemon returned ` +
+                `stateless stream ${result.frameStreamId}` +
+                (result.fallbackReason ? ` (${result.fallbackReason})` : ''),
+            );
+            panel?.postMessage({ command: 'clearInteractive' });
+            updateInteractiveStatus();
+            return;
+        }
         activeInteractiveStreams.set(previewId, result.frameStreamId);
         updateInteractiveStatus();
-        const interactiveSupported = daemonGate?.isInteractiveSupported(moduleId) ?? false;
         logLine(
             `[interactive] live mode on for ${previewId} (module=${moduleId}, ` +
             `streamId=${result.frameStreamId}, ` +
-            `v2=${interactiveSupported})`,
+            `heldSession=${result.heldSession})`,
         );
-        if (interactiveSupported) {
-            await daemonScheduler.setFocus(moduleId, [previewId]);
-            return;
-        }
+        await daemonScheduler.setFocus(moduleId, [previewId]);
+        return;
     } catch (err) {
-        // MethodNotFound on a daemon that predates the interactive RPC — fall through
-        // to the focus + renderNow path so the card still gets a fresh first frame.
         logLine(
-            `[interactive] interactive/start unsupported for ${moduleId}: ` +
-            `${(err as Error).message}; falling back to setFocus + renderNow`,
+            `[interactive] live mode failed for ${previewId}: ${(err as Error).message}`,
         );
+        panel?.postMessage({ command: 'clearInteractive' });
+        updateInteractiveStatus();
+        return;
     }
-    await daemonScheduler.setFocus(moduleId, [previewId]);
-    await daemonScheduler.renderNow(moduleId, [previewId], 'fast', 'interactive-on');
 }
 
 /**
@@ -3240,6 +3246,18 @@ async function handleSetInteractive(previewId: string, enabled: boolean): Promis
  * (MethodNotFound), or has already been stopped" — drop the click.
  */
 const activeInteractiveStreams = new Map<string, string>();
+
+let interactiveMutationQueue: Promise<void> = Promise.resolve();
+
+function queueInteractiveMutation(previewId: string, enabled: boolean): void {
+    interactiveMutationQueue = interactiveMutationQueue
+        .catch(() => {})
+        .then(() => handleSetInteractive(previewId, enabled))
+        .catch((err) => {
+            logLine(`[interactive] setInteractive failed for ${previewId}: ${(err as Error).message}`);
+            panel?.postMessage({ command: 'clearInteractive' });
+        });
+}
 
 /**
  * Update the v1-fallback status-bar hint (#425). Visible only when at least one active


### PR DESCRIPTION
## Summary
- make interactive/start report whether it acquired a held composition
- fail interactive/start noisily when a host advertises held sessions but cannot acquire one
- keep VS Code out of LIVE mode for stateless fallback streams
- serialize LIVE start/stop mutations so a new start cannot race the previous stop

## Testing
- npm run compile
- ./gradlew :daemon:core:test --tests ee.schimke.composeai.daemon.InteractiveSessionPlumbingTest --tests ee.schimke.composeai.daemon.InteractiveRpcIntegrationTest
- ./gradlew :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.AndroidInteractiveSessionTest