### PR TITLE
Add render trace data product

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -245,6 +245,8 @@ fun main(args: Array<String>) {
     buildList {
         System.err.println("compose-ai-tools daemon: DeviceClipDataProductRegistry active")
         add(DeviceClipDataProductRegistry(previewIndex = previewIndex))
+        System.err.println("compose-ai-tools daemon: RenderTraceDataProductRegistry active")
+        add(RenderTraceDataProductRegistry())
         if (historyManager != null) {
           System.err.println("compose-ai-tools daemon: HistoryDiffRegionsDataProductRegistry active")
           add(HistoryDiffRegionsDataProductRegistry(historyManager = historyManager))

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/CompositeDataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/CompositeDataProductRegistry.kt
@@ -33,6 +33,10 @@ class CompositeDataProductRegistry(private val registries: List<DataProductRegis
       else registry.attachmentsFor(previewId, supportedKinds)
     }
 
+  override fun onRender(previewId: String, result: RenderResult) {
+    registries.forEach { it.onRender(previewId, result) }
+  }
+
   override fun onSubscribe(previewId: String, kind: String, params: JsonElement?) {
     registries.firstOrNull { it.isKnown(kind) }?.onSubscribe(previewId, kind, params)
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
@@ -55,6 +55,13 @@ interface DataProductRegistry {
   fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment>
 
   /**
+   * Render lifecycle hook. Called after a host returns [result] and before `renderFinished`
+   * attachments are collected. Producers whose payload is derived from the latest render result can
+   * snapshot it here; stateless producers can ignore it.
+   */
+  fun onRender(previewId: String, result: RenderResult) {}
+
+  /**
    * Producer-side subscription lifecycle hook. Called by the dispatcher when a client issues a
    * successful `data/subscribe` for `(previewId, kind)`. [params] carries the per-kind subscription
    * option bag — `compose/recomposition` reads `{ frameStreamId, mode }` from it; stateless kinds

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -931,6 +931,14 @@ class JsonRpcServer(
     // `<previewId>.metrics.json` carries a `tookMs` entry) populate this; stub hosts return null
     // and we emit `tookMs = 0`. Other RenderMetrics fields (heap / native / sandbox-age) stay
     // null until B2.3 wires the cost-model collection path.
+    try {
+      dataProducts.onRender(previewId, result)
+    } catch (t: Throwable) {
+      System.err.println(
+        "compose-ai-daemon: data product onRender failed for $previewId " +
+          "(${t.javaClass.simpleName}: ${t.message})"
+      )
+    }
     val tookMs = result.metrics?.get("tookMs") ?: 0L
     val finished = renderFinishedFromResult(previewId, result, tookMs = tookMs)
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderTraceDataProduct.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderTraceDataProduct.kt
@@ -1,0 +1,93 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+
+/**
+ * `render/trace` v1 backed by the latest host render metrics.
+ *
+ * This establishes the data-product surface with a stable trace-shaped payload. Renderer-side
+ * nested `Trace.beginSection` capture can extend the `phases` tree later without changing the
+ * fetch/attach contract.
+ */
+class RenderTraceDataProductRegistry : DataProductRegistry {
+
+  private val latestPayloads = ConcurrentHashMap<String, JsonElement>()
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+      )
+    )
+
+  override fun onRender(previewId: String, result: RenderResult) {
+    val metrics = result.metrics
+    if (metrics == null) {
+      latestPayloads.remove(previewId)
+    } else {
+      latestPayloads[previewId] = payloadFrom(metrics)
+    }
+  }
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != KIND) return DataProductRegistry.Outcome.Unknown
+    val payload = latestPayloads[previewId] ?: return DataProductRegistry.Outcome.NotAvailable
+    return DataProductRegistry.Outcome.Ok(
+      DataFetchResult(kind = KIND, schemaVersion = SCHEMA_VERSION, payload = payload)
+    )
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
+    if (KIND !in kinds) return emptyList()
+    val payload = latestPayloads[previewId] ?: return emptyList()
+    return listOf(
+      DataProductAttachment(kind = KIND, schemaVersion = SCHEMA_VERSION, payload = payload)
+    )
+  }
+
+  private fun payloadFrom(metrics: Map<String, Long>): JsonElement {
+    val totalMs = metrics["tookMs"]?.coerceAtLeast(0L) ?: 0L
+    return buildJsonObject {
+      put("totalMs", totalMs)
+      put(
+        "phases",
+        buildJsonArray {
+          add(
+            buildJsonObject {
+              put("name", "render")
+              put("startMs", 0L)
+              put("durationMs", totalMs)
+            }
+          )
+        },
+      )
+      putJsonObject("metrics") {
+        metrics.toSortedMap().forEach { (name, value) -> put(name, value) }
+      }
+    }
+  }
+
+  companion object {
+    const val KIND: String = "render/trace"
+    const val SCHEMA_VERSION: Int = 1
+  }
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DataFetchRerenderTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/DataFetchRerenderTest.kt
@@ -97,6 +97,9 @@ class DataFetchRerenderTest {
         "render payload should carry previewId, was: $payload",
         payload.contains("previewId=com.example.Foo_bar"),
       )
+      assertEquals("producer should observe the completed render", 1, producer.onRenderCalls.get())
+      assertEquals("com.example.Foo_bar", producer.lastOnRenderPreviewId)
+      assertEquals(3L, producer.lastOnRenderMetrics?.get("tookMs"))
     }
   }
 
@@ -276,6 +279,9 @@ class DataFetchRerenderTest {
     val renderSubmits = AtomicInteger(0)
     @Volatile var lastRenderPayload: String? = null
     @Volatile var renderObserved: Boolean = false
+    val onRenderCalls = AtomicInteger(0)
+    @Volatile var lastOnRenderPreviewId: String? = null
+    @Volatile var lastOnRenderMetrics: Map<String, Long>? = null
 
     override val capabilities: List<DataProductCapability> =
       modeForKind.keys
@@ -330,6 +336,12 @@ class DataFetchRerenderTest {
     override fun attachmentsFor(previewId: String, kinds: Set<String>) =
       emptyList<ee.schimke.composeai.daemon.protocol.DataProductAttachment>()
 
+    override fun onRender(previewId: String, result: RenderResult) {
+      onRenderCalls.incrementAndGet()
+      lastOnRenderPreviewId = previewId
+      lastOnRenderMetrics = result.metrics
+    }
+
     /** Called by [TestRenderHost] when the dispatcher submits a render. */
     fun observeRenderSubmit(payload: String) {
       renderSubmits.incrementAndGet()
@@ -374,7 +386,12 @@ class DataFetchRerenderTest {
                     continue
                   }
                   val result =
-                    RenderResult(id = req.id, classLoaderHashCode = 0, classLoaderName = "test")
+                    RenderResult(
+                      id = req.id,
+                      classLoaderHashCode = 0,
+                      classLoaderName = "test",
+                      metrics = mapOf("tookMs" to 3L),
+                    )
                   results.computeIfAbsent(req.id) { LinkedBlockingQueue() }.put(result)
                 }
                 RenderRequest.Shutdown -> return@Thread

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RenderTraceDataProductRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RenderTraceDataProductRegistryTest.kt
@@ -1,0 +1,126 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RenderTraceDataProductRegistryTest {
+  @Test
+  fun `capability advertises inline fetchable attachable render trace`() {
+    val registry = RenderTraceDataProductRegistry()
+
+    val cap = registry.capabilities.single()
+    assertEquals(RenderTraceDataProductRegistry.KIND, cap.kind)
+    assertEquals(1, cap.schemaVersion)
+    assertEquals(DataProductTransport.INLINE, cap.transport)
+    assertTrue(cap.attachable)
+    assertTrue(cap.fetchable)
+    assertTrue(!cap.requiresRerender)
+  }
+
+  @Test
+  fun `fetch returns not available before a metric-bearing render lands`() {
+    val registry = RenderTraceDataProductRegistry()
+
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch(
+        previewId = "preview",
+        kind = RenderTraceDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      ),
+    )
+  }
+
+  @Test
+  fun `onRender stores latest metrics as trace-shaped payload`() {
+    val registry = RenderTraceDataProductRegistry()
+    registry.onRender(
+      previewId = "preview",
+      result =
+        RenderResult(
+          id = 1L,
+          classLoaderHashCode = 2,
+          classLoaderName = "test",
+          metrics = mapOf("tookMs" to 42L, "heapAfterGcMb" to 9L),
+        ),
+    )
+
+    val outcome =
+      registry.fetch(
+        previewId = "preview",
+        kind = RenderTraceDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      )
+
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    val payload = (outcome as DataProductRegistry.Outcome.Ok).result.payload!!.jsonObject
+    assertEquals("42", payload["totalMs"]!!.jsonPrimitive.content)
+    val phases = payload["phases"] as JsonArray
+    assertEquals(1, phases.size)
+    val renderPhase = phases.single().jsonObject
+    assertEquals("render", renderPhase["name"]!!.jsonPrimitive.content)
+    assertEquals("0", renderPhase["startMs"]!!.jsonPrimitive.content)
+    assertEquals("42", renderPhase["durationMs"]!!.jsonPrimitive.content)
+    assertEquals("9", payload["metrics"]!!.jsonObject["heapAfterGcMb"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `attachments mirror latest trace payload when subscribed`() {
+    val registry = RenderTraceDataProductRegistry()
+    registry.onRender(
+      previewId = "preview",
+      result =
+        RenderResult(
+          id = 1L,
+          classLoaderHashCode = 2,
+          classLoaderName = "test",
+          metrics = mapOf("tookMs" to 17L),
+        ),
+    )
+
+    val attachment =
+      registry.attachmentsFor("preview", setOf(RenderTraceDataProductRegistry.KIND)).single()
+
+    assertEquals(RenderTraceDataProductRegistry.KIND, attachment.kind)
+    assertEquals(1, attachment.schemaVersion)
+    assertNull(attachment.path)
+    assertEquals("17", attachment.payload!!.jsonObject["totalMs"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `metricless render clears stale trace`() {
+    val registry = RenderTraceDataProductRegistry()
+    registry.onRender(
+      previewId = "preview",
+      result =
+        RenderResult(
+          id = 1L,
+          classLoaderHashCode = 2,
+          classLoaderName = "test",
+          metrics = mapOf("tookMs" to 17L),
+        ),
+    )
+    registry.onRender(
+      previewId = "preview",
+      result = RenderResult(id = 2L, classLoaderHashCode = 2, classLoaderName = "test"),
+    )
+
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch(
+        previewId = "preview",
+        kind = RenderTraceDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      ),
+    )
+  }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -205,6 +205,7 @@ fun main(args: Array<String>) {
     CompositeDataProductRegistry(
       buildList {
         add(DeviceClipDataProductRegistry(previewIndex = previewIndex))
+        add(RenderTraceDataProductRegistry())
         add(recompositionRegistry)
         if (historyManager != null) {
           System.err.println(

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -378,7 +378,7 @@ SHIPPED; everything else is "we know the shape, no code yet."
 | `compose/theme`            | default | medium | Resolved `MaterialTheme.*` values + which nodes consumed which tokens. |
 | `resources/used`           | default | low | `R.*` references resolved during render. Jump-to-source. |
 | `text/strings`             | default | low | Text drawn on screen with locale, fontScale, bounds. |
-| `render/trace`             | default | low | Phase breakdown (compose / measure / layout / draw). Exposes existing `Trace.beginSection` markers. |
+| `render/trace`             | default | low | Phase breakdown. **Android + desktop daemon implementation:** v1 exposes the latest render as a trace-shaped payload from render metrics; nested `Trace.beginSection` markers are a follow-up. |
 | `fonts/used`               | default | low | Font families with weight/style fallback chain. |
 | `history/diff/regions`     | default | low | Per-pixel bbox of changed regions vs. another history entry. **D6 — shipped inline payload when daemon history is enabled.** |
 | `test/failure`             | failed render | low | Partial bitmap + last Snapshot state + pending `LaunchedEffect` queue. |


### PR DESCRIPTION
## Summary
- Claim and implement issue #452 with a first `render/trace` data product
- Add a render lifecycle hook so registries can snapshot data from the latest `RenderResult` before attachments are built
- Wire `render/trace` into Android and desktop daemon mains with inline fetch/attach support
- Emit schema v1 payloads with `totalMs`, a trace-shaped `render` phase, and the backing render metrics

## Notes
- This establishes the data-product surface from existing render metrics. Nested user/renderer `Trace.beginSection` capture is left as a follow-up once renderer-side trace buffering exists.

## Test
- `./gradlew :daemon:core:test --tests ee.schimke.composeai.daemon.RenderTraceDataProductRegistryTest --tests ee.schimke.composeai.daemon.DataFetchRerenderTest :daemon:desktop:compileKotlin :daemon:android:compileDebugKotlin`

Closes #452