### PR TITLE
Use transparent preview image background

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -441,7 +441,7 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: var(--skeleton-bg);
+    background: transparent;
     /* Click on a preview enters live (interactive) mode in any layout — see
        INTERACTIVE.md § 3. Pointer cursor signals "this is clickable" without
        implying a specific affordance (the magnifier zoom-in/out cursor was


### PR DESCRIPTION
## Summary
- Remove the themed skeleton background from preview image containers
- Let transparent preview PNG corners show the card/editor background, so round Wear previews render as clean circles

## Test
- `git diff --check`