### PR TITLE
Add Android resources/used data product

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -257,6 +257,10 @@ fun main(args: Array<String>) {
             "compose-ai-tools daemon: ComposeSemanticsDataProductRegistry active (dataRoot=$dataRoot)"
           )
           add(ComposeSemanticsDataProductRegistry(rootDir = dataRoot))
+          System.err.println(
+            "compose-ai-tools daemon: ResourcesUsedDataProductRegistry active (dataRoot=$dataRoot)"
+          )
+          add(ResourcesUsedDataProductRegistry(rootDir = dataRoot))
           if (PerfettoTraceDataProducer.enabled()) {
             System.err.println(
               "compose-ai-tools daemon: PerfettoTraceDataProductRegistry active (dataRoot=$dataRoot)"

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewRootForTest
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
@@ -216,6 +217,7 @@ class RenderEngine(
 
             val bgArgb = resolveBackgroundColor(spec).toArgb()
             rule.runOnUiThread { rule.activity.window.decorView.setBackgroundColor(bgArgb) }
+            val resourceRecorder = ResourcesUsedDataProducer.recorder(rule.activity)
 
             trace.section("compose:setContent") {
               rule.setContent {
@@ -225,7 +227,10 @@ class RenderEngine(
                 // through rather than parking under the paused clock — same trade
                 // `RobolectricRenderTest.renderWithA11y` already pays.
                 val inspectionMode = if (runAccessibility) false else spec.inspectionMode ?: true
-                CompositionLocalProvider(LocalInspectionMode provides inspectionMode) {
+                CompositionLocalProvider(
+                  LocalInspectionMode provides inspectionMode,
+                  LocalContext provides ResourcesUsedDataProducer.context(rule.activity, resourceRecorder),
+                ) {
                   Box(modifier = Modifier.fillMaxSize()) { InvokeComposable(composableMethod) }
                 }
               }
@@ -254,6 +259,23 @@ class RenderEngine(
                   it.captureRoboImage(file = outputFile, roborazziOptions = roborazziOptions)
                 }
               }
+
+            if (dataDir != null) {
+              try {
+                trace.section("android:resourcesUsedDataProduct") {
+                  ResourcesUsedDataProducer.writeArtifacts(
+                    rootDir = dataDir,
+                    previewId = spec.outputBaseName,
+                    recorder = resourceRecorder,
+                  )
+                }
+              } catch (t: Throwable) {
+                System.err.println(
+                  "RenderEngine: resources/used data write failed for ${spec.outputBaseName}: " +
+                    "${t.javaClass.simpleName}: ${t.message}"
+                )
+              }
+            }
 
             // compose/semantics data product. This is default-mode data, independent of the
             // accessibility checker: clients get a compact SemanticsNode projection for inspector

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/ResourcesUsedDataProduct.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/ResourcesUsedDataProduct.kt
@@ -1,0 +1,362 @@
+package ee.schimke.composeai.daemon
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.res.AssetManager
+import android.content.res.ColorStateList
+import android.content.res.Resources
+import android.content.res.TypedArray
+import android.content.res.XmlResourceParser
+import android.graphics.drawable.Drawable
+import android.util.TypedValue
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import java.io.File
+import java.nio.file.Files
+import java.util.Collections
+import kotlin.io.path.name
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/** Producer for `resources/used`, the Android resources resolved while rendering a preview. */
+object ResourcesUsedDataProducer {
+  const val KIND: String = "resources/used"
+  const val SCHEMA_VERSION: Int = 1
+  const val FILE: String = "resources-used.json"
+
+  private val json = Json {
+    encodeDefaults = false
+    prettyPrint = false
+  }
+
+  fun recorder(base: Context): RecordingResources {
+    val resources = base.resources
+    return RecordingResources(
+      base = resources,
+      assets = resources.assets,
+      displayMetrics = resources.displayMetrics,
+      configuration = resources.configuration,
+    )
+  }
+
+  fun context(base: Context, resources: RecordingResources): Context =
+    object : ContextWrapper(base) {
+      override fun getResources(): Resources = resources
+
+      override fun getAssets(): AssetManager = resources.assets
+    }
+
+  fun writeArtifacts(rootDir: File, previewId: String, recorder: RecordingResources) {
+    val previewDir = rootDir.resolve(previewId).also { it.mkdirs() }
+    val payload = ResourcesUsedPayload(references = recorder.references())
+    previewDir.resolve(FILE).writeText(
+      json.encodeToString(ResourcesUsedPayload.serializer(), payload)
+    )
+  }
+}
+
+@Serializable
+data class ResourcesUsedPayload(val references: List<ResourceUsedReference>)
+
+@Serializable
+data class ResourceUsedReference(
+  val resourceType: String,
+  val resourceName: String,
+  val packageName: String,
+  val resolvedValue: String? = null,
+  val resolvedFile: String? = null,
+  val consumers: List<ResourceUsedConsumer>,
+)
+
+@Serializable data class ResourceUsedConsumer(val nodeId: String)
+
+class RecordingResources(
+  private val base: Resources,
+  assets: AssetManager,
+  displayMetrics: android.util.DisplayMetrics,
+  configuration: android.content.res.Configuration,
+) : Resources(assets, displayMetrics, configuration) {
+  private val references =
+    Collections.synchronizedMap(linkedMapOf<String, ResourceUsedReference>())
+
+  fun references(): List<ResourceUsedReference> =
+    synchronized(references) { references.values.toList().sortedWith(compareBy({ it.resourceType }, { it.resourceName })) }
+
+  override fun getText(id: Int): CharSequence =
+    base.getText(id).also { record(id, "string", it.toString()) }
+
+  override fun getString(id: Int): String =
+    base.getString(id).also { record(id, "string", it) }
+
+  override fun getString(id: Int, vararg formatArgs: Any?): String =
+    base.getString(id, *formatArgs).also { record(id, "string", it) }
+
+  override fun getQuantityText(id: Int, quantity: Int): CharSequence =
+    base.getQuantityText(id, quantity).also { record(id, "plurals", it.toString()) }
+
+  override fun getQuantityString(id: Int, quantity: Int): String =
+    base.getQuantityString(id, quantity).also { record(id, "plurals", it) }
+
+  override fun getQuantityString(id: Int, quantity: Int, vararg formatArgs: Any?): String =
+    base.getQuantityString(id, quantity, *formatArgs).also { record(id, "plurals", it) }
+
+  override fun getTextArray(id: Int): Array<CharSequence> =
+    base.getTextArray(id).also { record(id, "array", it.joinToString()) }
+
+  override fun getStringArray(id: Int): Array<String> =
+    base.getStringArray(id).also { record(id, "array", it.joinToString()) }
+
+  override fun obtainTypedArray(id: Int): TypedArray =
+    base.obtainTypedArray(id).also { record(id, "array", null) }
+
+  override fun getDimension(id: Int): Float =
+    base.getDimension(id).also { record(id, "dimen", dimensionValue(id)) }
+
+  override fun getDimensionPixelOffset(id: Int): Int =
+    base.getDimensionPixelOffset(id).also { record(id, "dimen", dimensionValue(id)) }
+
+  override fun getDimensionPixelSize(id: Int): Int =
+    base.getDimensionPixelSize(id).also { record(id, "dimen", dimensionValue(id)) }
+
+  override fun getDrawable(id: Int): Drawable =
+    base.getDrawable(id).also { record(id, "drawable", fileValue(id)) }
+
+  override fun getDrawable(id: Int, theme: Theme?): Drawable =
+    base.getDrawable(id, theme).also { record(id, "drawable", fileValue(id)) }
+
+  override fun getDrawableForDensity(id: Int, density: Int): Drawable =
+    base.getDrawableForDensity(id, density)!!.also { record(id, "drawable", fileValue(id)) }
+
+  override fun getDrawableForDensity(id: Int, density: Int, theme: Theme?): Drawable =
+    base.getDrawableForDensity(id, density, theme)!!.also { record(id, "drawable", fileValue(id)) }
+
+  override fun getColor(id: Int): Int =
+    base.getColor(id).also { record(id, "color", "#%08X".format(it)) }
+
+  override fun getColor(id: Int, theme: Theme?): Int =
+    base.getColor(id, theme).also { record(id, "color", "#%08X".format(it)) }
+
+  override fun getColorStateList(id: Int): ColorStateList =
+    base.getColorStateList(id).also { record(id, "color", colorStateListValue(it)) }
+
+  override fun getColorStateList(id: Int, theme: Theme?): ColorStateList =
+    base.getColorStateList(id, theme).also { record(id, "color", colorStateListValue(it)) }
+
+  override fun getLayout(id: Int): XmlResourceParser =
+    base.getLayout(id).also { record(id, "layout", fileValue(id)) }
+
+  private fun record(id: Int, fallbackType: String, resolvedValue: String?) {
+    val type = runCatching { base.getResourceTypeName(id) }.getOrNull() ?: fallbackType
+    if (type !in SUPPORTED_TYPES) return
+    val name = runCatching { base.getResourceEntryName(id) }.getOrNull() ?: return
+    val packageName = runCatching { base.getResourcePackageName(id) }.getOrNull() ?: ""
+    val file = resolvedFile(id) ?: ResourceSourceIndex.find(type = type, name = name)
+    references["$packageName:$type/$name"] =
+      ResourceUsedReference(
+        resourceType = type,
+        resourceName = name,
+        packageName = packageName,
+        resolvedValue = resolvedValue?.takeIf { it.isNotBlank() },
+        resolvedFile = file,
+        consumers = emptyList(),
+      )
+  }
+
+  private fun resolvedFile(id: Int): String? {
+    return fileValue(id)?.let(::normaliseResourcePath)
+  }
+
+  private fun fileValue(id: Int): String? {
+    val value = TypedValue()
+    return runCatching {
+        base.getValue(id, value, true)
+        value.string?.toString()
+      }
+      .getOrNull()
+  }
+
+  private fun dimensionValue(id: Int): String? {
+    val value = TypedValue()
+    return runCatching {
+        base.getValue(id, value, true)
+        value.coerceToString()?.toString()
+      }
+      .getOrNull()
+  }
+
+  private fun colorStateListValue(value: ColorStateList): String =
+    "#%08X".format(value.defaultColor)
+
+  private fun normaliseResourcePath(path: String): String? {
+    val trimmed = path.trim().takeIf { it.isNotBlank() } ?: return null
+    val resIndex = trimmed.indexOf("res/")
+    val candidate = if (resIndex >= 0) trimmed.substring(resIndex) else trimmed
+    if (!candidate.startsWith("res/") && !File(candidate).isAbsolute) return null
+    if (File(candidate).isAbsolute) return candidate
+    return ResourceSourceIndex.findRelative(candidate)
+      ?: File(System.getProperty("user.dir"), candidate).absolutePath
+  }
+
+  private companion object {
+    val SUPPORTED_TYPES = setOf("string", "drawable", "color", "dimen", "layout", "plurals", "array")
+  }
+}
+
+private object ResourceSourceIndex {
+  private val valuesEntry =
+    Regex("""<\s*(string|color|dimen|plurals|string-array|integer-array|array)\b[^>]*\bname\s*=\s*["']([^"']+)["']""")
+
+  private val indexed: Map<String, String> by lazy { buildIndex() }
+  private val relativeFiles: Map<String, String> by lazy { buildRelativeIndex() }
+
+  fun find(type: String, name: String): String? = indexed["$type/$name"]
+
+  fun findRelative(relativePath: String): String? = relativeFiles[relativePath]
+
+  private fun buildIndex(): Map<String, String> {
+    val out = linkedMapOf<String, String>()
+    for (resDir in resDirs()) {
+      Files.walk(resDir.toPath()).use { paths ->
+        paths
+          .filter { Files.isRegularFile(it) }
+          .forEach { path ->
+            val parent = path.parent?.name ?: return@forEach
+            val baseType = parent.substringBefore('-')
+            val file = path.toFile()
+            if (baseType == "values" && file.extension == "xml") {
+              indexValuesFile(file, out)
+            } else if (baseType in FILE_RESOURCE_TYPES) {
+              out.putIfAbsent("$baseType/${file.nameWithoutExtension}", file.absolutePath)
+            }
+          }
+      }
+    }
+    return out
+  }
+
+  private fun buildRelativeIndex(): Map<String, String> {
+    val out = linkedMapOf<String, String>()
+    for (resDir in resDirs()) {
+      Files.walk(resDir.toPath()).use { paths ->
+        paths
+          .filter { Files.isRegularFile(it) }
+          .forEach { path ->
+            val relative = resDir.toPath().relativize(path).joinToString("/")
+            out.putIfAbsent("res/$relative", path.toFile().absolutePath)
+          }
+      }
+    }
+    return out
+  }
+
+  private fun indexValuesFile(file: File, out: MutableMap<String, String>) {
+    val text = runCatching { file.readText() }.getOrNull() ?: return
+    valuesEntry.findAll(text).forEach { match ->
+      val type =
+        when (match.groupValues[1]) {
+          "string-array", "integer-array" -> "array"
+          else -> match.groupValues[1]
+        }
+      val name = match.groupValues[2]
+      out.putIfAbsent("$type/$name", file.absolutePath)
+    }
+  }
+
+  private fun resDirs(): List<File> {
+    val roots =
+      listOfNotNull(
+        System.getProperty("composeai.daemon.moduleProjectDir"),
+        System.getProperty("composeai.daemon.workspaceRoot"),
+        System.getProperty("user.dir"),
+      ).distinct()
+    return roots.flatMap { root ->
+      val rootFile = File(root)
+      val src = rootFile.resolve("src")
+      if (src.isDirectory) {
+        src.listFiles()
+          ?.map { it.resolve("res") }
+          ?.filter { it.isDirectory }
+          .orEmpty()
+      } else {
+        emptyList()
+      }
+    }
+  }
+
+  private fun java.nio.file.Path.joinToString(separator: String): String =
+    iterator().asSequence().joinToString(separator) { it.name }
+
+  private val FILE_RESOURCE_TYPES = setOf("drawable", "layout")
+}
+
+/** Registry side for `resources/used`; reads the latest JSON artefact from disk. */
+class ResourcesUsedDataProductRegistry(private val rootDir: File) : DataProductRegistry {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = ResourcesUsedDataProducer.KIND,
+        schemaVersion = ResourcesUsedDataProducer.SCHEMA_VERSION,
+        transport = DataProductTransport.PATH,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+      )
+    )
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != ResourcesUsedDataProducer.KIND) return DataProductRegistry.Outcome.Unknown
+    val file = fileFor(previewId)
+    if (!file.exists()) return DataProductRegistry.Outcome.NotAvailable
+    if (!inline) {
+      return DataProductRegistry.Outcome.Ok(
+        DataFetchResult(
+          kind = kind,
+          schemaVersion = ResourcesUsedDataProducer.SCHEMA_VERSION,
+          path = file.absolutePath,
+        )
+      )
+    }
+    val payload: JsonObject =
+      try {
+        json.parseToJsonElement(file.readText()) as JsonObject
+      } catch (t: Throwable) {
+        return DataProductRegistry.Outcome.FetchFailed(
+          message = "could not parse $kind for $previewId: ${t.message}"
+        )
+      }
+    return DataProductRegistry.Outcome.Ok(
+      DataFetchResult(
+        kind = kind,
+        schemaVersion = ResourcesUsedDataProducer.SCHEMA_VERSION,
+        payload = payload,
+      )
+    )
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
+    if (ResourcesUsedDataProducer.KIND !in kinds) return emptyList()
+    val file = fileFor(previewId)
+    if (!file.exists()) return emptyList()
+    return listOf(
+      DataProductAttachment(
+        kind = ResourcesUsedDataProducer.KIND,
+        schemaVersion = ResourcesUsedDataProducer.SCHEMA_VERSION,
+        path = file.absolutePath,
+      )
+    )
+  }
+
+  private fun fileFor(previewId: String): File =
+    rootDir.resolve(previewId).resolve(ResourcesUsedDataProducer.FILE)
+}

--- a/daemon/android/src/main/res/values/resources_used.xml
+++ b/daemon/android/src/main/res/values/resources_used.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="compose_ai_resource_used_label">Resource label</string>
+    <color name="compose_ai_resource_used_color">#ff336699</color>
+    <dimen name="compose_ai_resource_used_size">32dp</dimen>
+</resources>

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -5,6 +5,7 @@ import java.io.File
 import javax.imageio.ImageIO
 import kotlin.math.abs
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
@@ -141,6 +142,59 @@ class RenderEngineTest {
         "RenderEngineTest 5-render warm-up: total=${totalMs}ms first=${firstMs}ms " +
           "warm-median=${warmMedianMs}ms per-render=$perRenderMs"
       )
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun resourceReadsWriteResourcesUsedDataProduct() {
+    val outputDir = tempFolder.newFolder("renders-resources")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("composeai.daemon.moduleProjectDir", File("daemon/android").absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost()
+    host.start()
+    try {
+      val request =
+        RenderRequest.Render(
+          payload =
+            "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+              "functionName=ResourceReadingPreview;" +
+              "widthPx=64;heightPx=64;density=1.0;" +
+              "showBackground=true;" +
+              "outputBaseName=resource-reading"
+        )
+      host.submit(request, timeoutMs = 120_000)
+
+      val resourcesFile =
+        outputDir.parentFile!!
+          .resolve("data")
+          .resolve("resource-reading")
+          .resolve(ResourcesUsedDataProducer.FILE)
+      assertTrue(
+        "resources/used data product should be written next to render data: $resourcesFile",
+        resourcesFile.exists(),
+      )
+      val references =
+        Json.parseToJsonElement(resourcesFile.readText())
+          .jsonObject["references"]!!
+          .jsonArray
+          .map { it.jsonObject }
+      val byName = references.associateBy { it["resourceName"]!!.jsonPrimitive.content }
+      assertEquals("string", byName["compose_ai_resource_used_label"]!!["resourceType"]!!.jsonPrimitive.content)
+      assertEquals(
+        "Resource label",
+        byName["compose_ai_resource_used_label"]!!["resolvedValue"]!!.jsonPrimitive.content,
+      )
+      assertTrue(
+        byName["compose_ai_resource_used_label"]!!["resolvedFile"]!!
+          .jsonPrimitive
+          .content
+          .endsWith("src/main/res/values/resources_used.xml")
+      )
+      assertEquals("color", byName["compose_ai_resource_used_color"]!!["resourceType"]!!.jsonPrimitive.content)
+      assertEquals("dimen", byName["compose_ai_resource_used_size"]!!["resourceType"]!!.jsonPrimitive.content)
     } finally {
       host.shutdown()
     }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/ResourcesUsedDataProductRegistryTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/ResourcesUsedDataProductRegistryTest.kt
@@ -1,0 +1,97 @@
+package ee.schimke.composeai.daemon
+
+import java.io.File
+import java.nio.file.Files
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ResourcesUsedDataProductRegistryTest {
+  private lateinit var rootDir: File
+
+  @Before
+  fun setUp() {
+    rootDir = Files.createTempDirectory("resources-used-product-test").toFile()
+  }
+
+  @After
+  fun tearDown() {
+    rootDir.deleteRecursively()
+  }
+
+  @Test
+  fun `capability advertises resources used as path transport`() {
+    val registry = ResourcesUsedDataProductRegistry(rootDir)
+    val cap = registry.capabilities.single()
+    assertEquals("resources/used", cap.kind)
+    assertEquals(1, cap.schemaVersion)
+    assertTrue(cap.attachable)
+    assertTrue(cap.fetchable)
+    assertTrue(!cap.requiresRerender)
+  }
+
+  @Test
+  fun `fetch returns path by default and payload when inline requested`() {
+    val previewId = "com.example.ResourcePreview"
+    val file =
+      rootDir
+        .resolve(previewId)
+        .also { it.mkdirs() }
+        .resolve(ResourcesUsedDataProducer.FILE)
+    file.writeText(
+      """{"references":[{"resourceType":"string","resourceName":"app_name","packageName":"com.example","resolvedValue":"Demo","consumers":[]}]}"""
+    )
+    val registry = ResourcesUsedDataProductRegistry(rootDir)
+
+    val pathOutcome =
+      registry.fetch(previewId = previewId, kind = "resources/used", params = null, inline = false)
+    assertTrue(pathOutcome is DataProductRegistry.Outcome.Ok)
+    val pathResult = (pathOutcome as DataProductRegistry.Outcome.Ok).result
+    assertEquals(file.absolutePath, pathResult.path)
+    assertNull(pathResult.payload)
+
+    val inlineOutcome =
+      registry.fetch(previewId = previewId, kind = "resources/used", params = null, inline = true)
+    assertTrue(inlineOutcome is DataProductRegistry.Outcome.Ok)
+    val inlineResult = (inlineOutcome as DataProductRegistry.Outcome.Ok).result
+    assertNull(inlineResult.path)
+    assertNotNull(inlineResult.payload)
+    assertEquals(
+      "app_name",
+      inlineResult
+        .payload!!
+        .jsonObject["references"]!!
+        .jsonArray
+        .single()
+        .jsonObject["resourceName"]!!
+        .jsonPrimitive
+        .content,
+    )
+  }
+
+  @Test
+  fun `attachmentsFor emits path only after render wrote resources file`() {
+    val previewId = "com.example.ResourcePreview"
+    val registry = ResourcesUsedDataProductRegistry(rootDir)
+    assertEquals(emptyList<Any>(), registry.attachmentsFor(previewId, setOf("resources/used")))
+
+    val file =
+      rootDir
+        .resolve(previewId)
+        .also { it.mkdirs() }
+        .resolve(ResourcesUsedDataProducer.FILE)
+    file.writeText("""{"references":[]}""")
+
+    val attachment = registry.attachmentsFor(previewId, setOf("resources/used")).single()
+    assertEquals("resources/used", attachment.kind)
+    assertEquals(file.absolutePath, attachment.path)
+    assertNull(attachment.payload)
+  }
+}

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -22,6 +22,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.rotary.onRotaryScrollEvent
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 
 /**
@@ -105,6 +108,20 @@ fun DarkAwareSquare() {
   val bg =
     if (androidx.compose.foundation.isSystemInDarkTheme()) Color.Black else Color.White
   Box(modifier = Modifier.fillMaxSize().background(bg))
+}
+
+@Composable
+fun ResourceReadingPreview() {
+  val label = stringResource(R.string.compose_ai_resource_used_label)
+  val color = colorResource(R.color.compose_ai_resource_used_color)
+  val size = dimensionResource(R.dimen.compose_ai_resource_used_size)
+  Box(
+    modifier =
+      Modifier
+        .width(size)
+        .height(size)
+        .background(if (label.isNotBlank()) color else Color.Transparent)
+  )
 }
 
 /**

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1351,6 +1351,10 @@ internal object AndroidPreviewSupport {
         resolveComposeAiTraceEnabled(project, extension).map { it.toString() },
       )
       this.systemProperties.put("composeai.daemon.modulePath", project.path)
+      this.systemProperties.put(
+        "composeai.daemon.moduleProjectDir",
+        project.layout.projectDirectory.asFile.absolutePath,
+      )
       // B2.0 — `composeai.daemon.userClassDirs`. The closure captures only the
       // `daemonUserClassMarkers` List<String> (a configuration-time constant);
       // `classpath.elements` is a Provider<Set<FileSystemLocation>> wired via the task's

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -277,6 +277,10 @@ internal object ComposePreviewTasks {
         extension.daemon.warmSpare.map { it.toString() },
       )
       systemProperties.put("composeai.daemon.modulePath", project.path)
+      systemProperties.put(
+        "composeai.daemon.moduleProjectDir",
+        project.layout.projectDirectory.asFile.absolutePath,
+      )
       systemProperties.put("composeai.render.outputDir", rendersDirProvider)
       systemProperties.put("composeai.fonts.cacheDir", daemonFontsCacheDir)
       systemProperties.put("composeai.fonts.offline", daemonFontsOffline)


### PR DESCRIPTION
## Summary
- add Android resources/used data product producer and registry
- record Compose resource reads via a recording Resources/LocalContext during render
- resolve resource source XML paths from module res directories and attach resources-used.json
- add focused registry and render coverage

Fixes #450

## Verification
- ./gradlew :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.ResourcesUsedDataProductRegistryTest --tests ee.schimke.composeai.daemon.RenderEngineTest.resourceReadsWriteResourcesUsedDataProduct
- ./gradlew :daemon:android:ktfmtCheck
- ./gradlew :gradle-plugin:ktfmtCheck