### PR TITLE
Implement desktop compose/theme data product

### DIFF
--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
   implementation(compose.runtime)
   implementation(compose.foundation)
   implementation(compose.ui)
+  implementation(compose.material3)
   implementation(compose.components.uiToolingPreview)
 
   // `compose.desktop.currentOs` bakes the *build host's* Skiko platform into

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -97,6 +97,19 @@ fun main(args: Array<String>) {
   // data/subscribe). Constructed unconditionally on desktop — it advertises one kind, and a
   // panel that doesn't subscribe pays nothing.
   val recompositionRegistry = RecompositionDataProductRegistry()
+  val themeRegistry = ThemeDataProductRegistry()
+  val renderEngine =
+    RenderEngine(
+      themeCapture =
+        object : RenderEngine.ThemeCapture {
+          override fun shouldCapture(previewId: String?, renderMode: String?): Boolean =
+            themeRegistry.shouldCapture(previewId, renderMode)
+
+          override fun capture(previewId: String?, payload: ThemePayload) {
+            themeRegistry.capture(previewId, payload)
+          }
+        }
+    )
 
   val manifestPath = System.getProperty("composeai.harness.previewsManifest")
   val host: RenderHost =
@@ -106,9 +119,14 @@ fun main(args: Array<String>) {
         "compose-ai-tools desktop daemon: PreviewManifestRouter active " +
           "(manifest=$manifestPath, previews=${manifest.previews.map { it.id }})"
       )
-      PreviewManifestRouter(manifest = manifest, userClassloaderHolder = userClassloaderHolder)
+      PreviewManifestRouter(
+        manifest = manifest,
+        engine = renderEngine,
+        userClassloaderHolder = userClassloaderHolder,
+      )
     } else {
       DesktopHost(
+        engine = renderEngine,
         userClassloaderHolder = userClassloaderHolder,
         // v2 — resolve `previewId` via PreviewIndex for the interactive session path. Issue #420
         // wired the `params` block on `PreviewInfoDto`, so when the discovery JSON carries
@@ -206,6 +224,7 @@ fun main(args: Array<String>) {
       buildList {
         add(DeviceClipDataProductRegistry(previewIndex = previewIndex))
         add(RenderTraceDataProductRegistry())
+        add(themeRegistry)
         add(recompositionRegistry)
         if (PerfettoTraceDataProducer.enabled()) {
           System.getProperty(RenderEngine.OUTPUT_DIR_PROP)?.let { renderOutputDir ->

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -513,21 +513,65 @@ open class DesktopHost(
    */
   private fun dispatchRender(request: RenderRequest.Render): RenderResult {
     val parseable = request.payload.contains("className=")
-    return if (!parseable) {
-      renderStubFallback(request.id)
-    } else {
-      val spec = RenderSpec.parseFromPayload(request.payload)
-      // B2.0 — resolve preview classes via the disposable child loader when the holder is wired
-      // (production path; the Gradle plugin's daemon launch descriptor sets
-      // `composeai.daemon.userClassDirs` and DaemonMain mounts the holder). Falls back to the
-      // engine's default classloader when the holder is null (the in-process unit-test path,
-      // where testFixtures live on `java.class.path`).
-      val classLoader: ClassLoader =
-        userClassloaderHolder?.currentChildLoader()
-          ?: RenderEngine::class.java.classLoader
-          ?: ClassLoader.getSystemClassLoader()
-      engine.render(spec, request.id, classLoader, sandboxStats = sandboxStats)
+    val spec =
+      if (parseable) {
+        RenderSpec.parseFromPayload(request.payload)
+      } else {
+        specFromPreviewIdPayload(request.payload) ?: return renderStubFallback(request.id)
+      }
+    // B2.0 — resolve preview classes via the disposable child loader when the holder is wired
+    // (production path; the Gradle plugin's daemon launch descriptor sets
+    // `composeai.daemon.userClassDirs` and DaemonMain mounts the holder). Falls back to the
+    // engine's default classloader when the holder is null (the in-process unit-test path,
+    // where testFixtures live on `java.class.path`).
+    val classLoader: ClassLoader =
+      userClassloaderHolder?.currentChildLoader()
+        ?: RenderEngine::class.java.classLoader
+        ?: ClassLoader.getSystemClassLoader()
+    return engine.render(spec, request.id, classLoader, sandboxStats = sandboxStats)
+  }
+
+  private fun specFromPreviewIdPayload(payload: String): RenderSpec? {
+    val map = parsePayloadMap(payload)
+    val previewId = map["previewId"]?.takeIf { it.isNotBlank() } ?: return null
+    val resolver = previewSpecResolver ?: return null
+    val base = resolver(previewId) ?: return null
+    return base.copy(
+      previewId = previewId,
+      renderMode = map["mode"]?.takeIf { it.isNotBlank() },
+      widthPx = map["widthPx"]?.toIntOrNull() ?: base.widthPx,
+      heightPx = map["heightPx"]?.toIntOrNull() ?: base.heightPx,
+      density = map["density"]?.toFloatOrNull() ?: base.density,
+      localeTag = map["localeTag"]?.takeIf { it.isNotBlank() } ?: base.localeTag,
+      fontScale = map["fontScale"]?.toFloatOrNull() ?: base.fontScale,
+      uiMode =
+        when (map["uiMode"]?.lowercase()) {
+          "light" -> RenderSpec.SpecUiMode.LIGHT
+          "dark" -> RenderSpec.SpecUiMode.DARK
+          else -> base.uiMode
+        },
+      orientation =
+        when (map["orientation"]?.lowercase()) {
+          "portrait" -> RenderSpec.SpecOrientation.PORTRAIT
+          "landscape" -> RenderSpec.SpecOrientation.LANDSCAPE
+          else -> base.orientation
+        },
+      inspectionMode = map["inspectionMode"]?.toBooleanStrictOrNull() ?: base.inspectionMode,
+    )
+  }
+
+  private fun parsePayloadMap(payload: String): Map<String, String> {
+    val map = mutableMapOf<String, String>()
+    for (entry in payload.split(';')) {
+      val trimmed = entry.trim()
+      if (trimmed.isEmpty()) continue
+      val eq = trimmed.indexOf('=')
+      if (eq <= 0) continue
+      val key = trimmed.substring(0, eq).trim()
+      val value = trimmed.substring(eq + 1).trim()
+      if (value.isNotEmpty()) map[key] = value
     }
+    return map
   }
 
   /**

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -76,6 +76,8 @@ class PreviewManifestRouter(
         id = typed.id,
         payload =
           buildString {
+            append("previewId=").append(entry.id).append(';')
+            inbound["mode"]?.let { append("mode=").append(it).append(';') }
             append("className=").append(entry.className).append(';')
             append("functionName=").append(entry.functionName).append(';')
             // Inbound explicit override wins over both the device-derived value and the

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -3,7 +3,9 @@ package ee.schimke.composeai.daemon
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
@@ -63,6 +65,7 @@ class RenderEngine(
         ?: "${System.getProperty("user.dir")}/.compose-preview-history/daemon-renders"
     ),
   private val dataDir: File? = outputDir.parentFile?.resolve("data"),
+  private val themeCapture: ThemeCapture? = null,
 ) {
 
   /**
@@ -206,6 +209,9 @@ class RenderEngine(
             androidx.compose.ui.LocalSystemTheme provides systemTheme,
             LocalDensity provides density,
           ) {
+            if (themeCapture?.shouldCapture(spec.previewId, spec.renderMode) == true) {
+              CaptureMaterialTheme { payload -> themeCapture.capture(spec.previewId, payload) }
+            }
             val bgColor =
               when {
                 spec.backgroundColor != 0L -> Color(spec.backgroundColor.toInt())
@@ -315,6 +321,12 @@ class RenderEngine(
     internal val previousContext: ClassLoader?,
   )
 
+  interface ThemeCapture {
+    fun shouldCapture(previewId: String?, renderMode: String?): Boolean
+
+    fun capture(previewId: String?, payload: ThemePayload)
+  }
+
   companion object {
     /**
      * System property carrying the absolute path of the renders directory. Same name the Android
@@ -334,6 +346,8 @@ class RenderEngine(
  * `:daemon:core`.
  */
 data class RenderSpec(
+  val previewId: String? = null,
+  val renderMode: String? = null,
   /** Fully-qualified name of the class containing the @Preview function. */
   val className: String,
   /** Method name of the @Preview function (parameterless overload). */
@@ -401,8 +415,8 @@ data class RenderSpec(
      * [RenderSpec]. Recognised keys: `className`, `functionName`, `widthPx`, `heightPx`, `density`,
      * `showBackground`, `backgroundColor`, `device`, `outputBaseName`, `localeTag`, `fontScale`,
      * `uiMode` (`light`/`dark`), `orientation` (`portrait`/`landscape`), `inspectionMode`
-     * (`true`/`false`). `className` and `functionName` are required; everything else falls back to
-     * the defaults on this data class.
+     * (`true`/`false`), and data-product routing keys `previewId` / `mode`. `className` and
+     * `functionName` are required; everything else falls back to the defaults on this data class.
      *
      * Keeping this stringly-typed for v1 is deliberate (per the task brief). When `RenderRequest`
      * grows a typed `previewId: String?` field, [DesktopHost] will look the spec up in
@@ -425,6 +439,8 @@ data class RenderSpec(
           ?: error("RenderSpec.parseFromPayload: missing 'functionName' in '$payload'")
       val defaults = RenderSpec(className = className, functionName = functionName)
       return RenderSpec(
+        previewId = map["previewId"]?.takeIf { it.isNotBlank() },
+        renderMode = map["mode"]?.takeIf { it.isNotBlank() },
         className = className,
         functionName = functionName,
         widthPx = map["widthPx"]?.toIntOrNull() ?: defaults.widthPx,
@@ -462,4 +478,12 @@ data class RenderSpec(
 @androidx.compose.runtime.Composable
 private fun InvokeComposable(composableMethod: ComposableMethod) {
   composableMethod.invoke(currentComposer, null)
+}
+
+@androidx.compose.runtime.Composable
+private fun CaptureMaterialTheme(onCaptured: (ThemePayload) -> Unit) {
+  val colorScheme = MaterialTheme.colorScheme
+  val typography = MaterialTheme.typography
+  val shapes = MaterialTheme.shapes
+  SideEffect { onCaptured(themePayloadFromMaterialTheme(colorScheme, typography, shapes)) }
 }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
@@ -1,0 +1,222 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.Shapes
+import androidx.compose.material3.Typography
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.isSpecified
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Desktop v1 producer for `compose/theme`.
+ *
+ * It snapshots the resolved Material 3 theme tokens when a render runs in `mode=theme` (or when a
+ * subscribed preview renders). Per issue #449, node-level consumer tracking needs intrusive Compose
+ * runtime/compiler instrumentation; v1 keeps the schema shape and returns `consumers: []`.
+ */
+class ThemeDataProductRegistry : DataProductRegistry {
+  private val latestPayloads = ConcurrentHashMap<String, ThemePayload>()
+  private val capturedThisRender = ConcurrentHashMap.newKeySet<String>()
+  private val subscribed = ConcurrentHashMap.newKeySet<String>()
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = true,
+      )
+    )
+
+  fun shouldCapture(previewId: String?, renderMode: String?): Boolean =
+    renderMode == RENDER_MODE || (previewId != null && previewId in subscribed)
+
+  fun capture(previewId: String?, payload: ThemePayload) {
+    if (previewId == null) return
+    latestPayloads[previewId] = payload
+    capturedThisRender.add(previewId)
+  }
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != KIND) return DataProductRegistry.Outcome.Unknown
+    val payload = latestPayloads[previewId]
+    return if (payload == null) {
+      DataProductRegistry.Outcome.RequiresRerender(RENDER_MODE)
+    } else {
+      DataProductRegistry.Outcome.Ok(
+        DataFetchResult(
+          kind = KIND,
+          schemaVersion = SCHEMA_VERSION,
+          payload = json.encodeToJsonElement(ThemePayload.serializer(), payload),
+        )
+      )
+    }
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
+    if (KIND !in kinds) return emptyList()
+    val payload = latestPayloads[previewId] ?: return emptyList()
+    return listOf(
+      DataProductAttachment(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        payload = json.encodeToJsonElement(ThemePayload.serializer(), payload),
+      )
+    )
+  }
+
+  override fun onRender(previewId: String, result: RenderResult) {
+    if (!capturedThisRender.remove(previewId)) {
+      latestPayloads.remove(previewId)
+    }
+  }
+
+  override fun onSubscribe(previewId: String, kind: String, params: JsonElement?) {
+    if (kind == KIND) subscribed.add(previewId)
+  }
+
+  override fun onUnsubscribe(previewId: String, kind: String) {
+    if (kind == KIND) subscribed.remove(previewId)
+  }
+
+  companion object {
+    const val KIND = "compose/theme"
+    const val SCHEMA_VERSION = 1
+    const val RENDER_MODE = "theme"
+
+    private val json = Json {
+      encodeDefaults = true
+      prettyPrint = false
+    }
+  }
+}
+
+@Serializable
+data class ThemePayload(
+  val resolvedTokens: ResolvedThemeTokens,
+  val consumers: List<ThemeConsumer> = emptyList(),
+)
+
+@Serializable
+data class ResolvedThemeTokens(
+  val colorScheme: Map<String, String>,
+  val typography: Map<String, TypographyToken>,
+  val shapes: Map<String, String>,
+)
+
+@Serializable data class ThemeConsumer(val nodeId: String, val tokens: List<String>)
+
+@Serializable
+data class TypographyToken(
+  val fontFamily: String? = null,
+  val fontSize: Float? = null,
+  val fontSizeUnit: String? = null,
+  val fontWeight: String? = null,
+  val fontStyle: String? = null,
+  val lineHeight: Float? = null,
+  val lineHeightUnit: String? = null,
+  val letterSpacing: Float? = null,
+  val letterSpacingUnit: String? = null,
+)
+
+fun themePayloadFromMaterialTheme(
+  colorScheme: ColorScheme,
+  typography: Typography,
+  shapes: Shapes,
+): ThemePayload =
+  ThemePayload(
+    resolvedTokens =
+      ResolvedThemeTokens(
+        colorScheme =
+          linkedMapOf(
+            "primary" to colorScheme.primary.hexArgb(),
+            "onPrimary" to colorScheme.onPrimary.hexArgb(),
+            "primaryContainer" to colorScheme.primaryContainer.hexArgb(),
+            "onPrimaryContainer" to colorScheme.onPrimaryContainer.hexArgb(),
+            "inversePrimary" to colorScheme.inversePrimary.hexArgb(),
+            "secondary" to colorScheme.secondary.hexArgb(),
+            "onSecondary" to colorScheme.onSecondary.hexArgb(),
+            "secondaryContainer" to colorScheme.secondaryContainer.hexArgb(),
+            "onSecondaryContainer" to colorScheme.onSecondaryContainer.hexArgb(),
+            "tertiary" to colorScheme.tertiary.hexArgb(),
+            "onTertiary" to colorScheme.onTertiary.hexArgb(),
+            "tertiaryContainer" to colorScheme.tertiaryContainer.hexArgb(),
+            "onTertiaryContainer" to colorScheme.onTertiaryContainer.hexArgb(),
+            "background" to colorScheme.background.hexArgb(),
+            "onBackground" to colorScheme.onBackground.hexArgb(),
+            "surface" to colorScheme.surface.hexArgb(),
+            "onSurface" to colorScheme.onSurface.hexArgb(),
+            "surfaceVariant" to colorScheme.surfaceVariant.hexArgb(),
+            "onSurfaceVariant" to colorScheme.onSurfaceVariant.hexArgb(),
+            "surfaceTint" to colorScheme.surfaceTint.hexArgb(),
+            "inverseSurface" to colorScheme.inverseSurface.hexArgb(),
+            "inverseOnSurface" to colorScheme.inverseOnSurface.hexArgb(),
+            "error" to colorScheme.error.hexArgb(),
+            "onError" to colorScheme.onError.hexArgb(),
+            "errorContainer" to colorScheme.errorContainer.hexArgb(),
+            "onErrorContainer" to colorScheme.onErrorContainer.hexArgb(),
+            "outline" to colorScheme.outline.hexArgb(),
+            "outlineVariant" to colorScheme.outlineVariant.hexArgb(),
+            "scrim" to colorScheme.scrim.hexArgb(),
+          ),
+        typography =
+          linkedMapOf(
+            "displayLarge" to typography.displayLarge.token(),
+            "displayMedium" to typography.displayMedium.token(),
+            "displaySmall" to typography.displaySmall.token(),
+            "headlineLarge" to typography.headlineLarge.token(),
+            "headlineMedium" to typography.headlineMedium.token(),
+            "headlineSmall" to typography.headlineSmall.token(),
+            "titleLarge" to typography.titleLarge.token(),
+            "titleMedium" to typography.titleMedium.token(),
+            "titleSmall" to typography.titleSmall.token(),
+            "bodyLarge" to typography.bodyLarge.token(),
+            "bodyMedium" to typography.bodyMedium.token(),
+            "bodySmall" to typography.bodySmall.token(),
+            "labelLarge" to typography.labelLarge.token(),
+            "labelMedium" to typography.labelMedium.token(),
+            "labelSmall" to typography.labelSmall.token(),
+          ),
+        shapes =
+          linkedMapOf(
+            "extraSmall" to shapes.extraSmall.toString(),
+            "small" to shapes.small.toString(),
+            "medium" to shapes.medium.toString(),
+            "large" to shapes.large.toString(),
+            "extraLarge" to shapes.extraLarge.toString(),
+          ),
+      ),
+    consumers = emptyList(),
+  )
+
+private fun Color.hexArgb(): String = "#%08X".format(toArgb())
+
+private fun TextStyle.token(): TypographyToken =
+  TypographyToken(
+    fontFamily = fontFamily?.toString(),
+    fontSize = fontSize.takeIf { it.isSpecified }?.value,
+    fontSizeUnit = fontSize.takeIf { it.isSpecified }?.type?.toString(),
+    fontWeight = fontWeight?.toString(),
+    fontStyle = fontStyle?.toString(),
+    lineHeight = lineHeight.takeIf { it.isSpecified }?.value,
+    lineHeightUnit = lineHeight.takeIf { it.isSpecified }?.type?.toString(),
+    letterSpacing = letterSpacing.takeIf { it.isSpecified }?.value,
+    letterSpacingUnit = letterSpacing.takeIf { it.isSpecified }?.type?.toString(),
+  )

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/ThemeDataProductRegistryTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/ThemeDataProductRegistryTest.kt
@@ -1,0 +1,213 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class ThemeDataProductRegistryTest {
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun capabilities_advertise_compose_theme_as_medium_cost_inline_product() {
+    val registry = ThemeDataProductRegistry()
+    val cap = registry.capabilities.single()
+    assertEquals("compose/theme", cap.kind)
+    assertEquals(1, cap.schemaVersion)
+    assertEquals(DataProductTransport.INLINE, cap.transport)
+    assertTrue(cap.attachable)
+    assertTrue(cap.fetchable)
+    assertTrue(cap.requiresRerender)
+  }
+
+  @Test
+  fun fetch_without_captured_payload_requires_theme_rerender() {
+    val registry = ThemeDataProductRegistry()
+    val outcome = registry.fetch("preview-1", "compose/theme", params = null, inline = true)
+    assertTrue(outcome is DataProductRegistry.Outcome.RequiresRerender)
+    assertEquals("theme", (outcome as DataProductRegistry.Outcome.RequiresRerender).mode)
+  }
+
+  @Test
+  fun theme_mode_render_captures_material_tokens_for_fetch_and_attachments() {
+    val outputDir = tempFolder.newFolder("renders")
+    val registry = ThemeDataProductRegistry()
+    val engine =
+      RenderEngine(
+        outputDir = outputDir,
+        themeCapture =
+          object : RenderEngine.ThemeCapture {
+            override fun shouldCapture(previewId: String?, renderMode: String?): Boolean =
+              registry.shouldCapture(previewId, renderMode)
+
+            override fun capture(previewId: String?, payload: ThemePayload) {
+              registry.capture(previewId, payload)
+            }
+          },
+      )
+
+    engine.render(
+      spec =
+        RenderSpec(
+          previewId = "preview-1",
+          renderMode = "theme",
+          className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+          functionName = "RedSquare",
+          widthPx = 32,
+          heightPx = 32,
+          density = 1.0f,
+          outputBaseName = "theme-red-square",
+        ),
+      requestId = RenderHost.nextRequestId(),
+    )
+
+    val fetch =
+      registry.fetch("preview-1", "compose/theme", params = null, inline = true)
+        as DataProductRegistry.Outcome.Ok
+    assertEquals("compose/theme", fetch.result.kind)
+    val payload = fetch.result.payload!!.jsonObject
+    val tokens = payload["resolvedTokens"]!!.jsonObject
+    val colorScheme = tokens["colorScheme"]!!.jsonObject
+    assertTrue(colorScheme["primary"]!!.jsonPrimitive.content.matches(Regex("#[0-9A-F]{8}")))
+    assertNotNull(tokens["typography"]!!.jsonObject["titleMedium"])
+    assertNotNull(tokens["shapes"]!!.jsonObject["medium"])
+    assertEquals(0, payload["consumers"]!!.jsonArray.size)
+
+    val attachments = registry.attachmentsFor("preview-1", setOf("compose/theme"))
+    assertEquals(1, attachments.size)
+    assertEquals("compose/theme", attachments.single().kind)
+    assertEquals(
+      colorScheme["primary"],
+      attachments
+        .single()
+        .payload!!
+        .jsonObject["resolvedTokens"]!!
+        .jsonObject["colorScheme"]!!
+        .jsonObject["primary"],
+    )
+  }
+
+  @Test
+  fun subscribed_preview_captures_on_default_render() {
+    val outputDir = tempFolder.newFolder("renders")
+    val registry = ThemeDataProductRegistry()
+    registry.onSubscribe("preview-2", "compose/theme", JsonPrimitive("ignored"))
+    val engine =
+      RenderEngine(
+        outputDir = outputDir,
+        themeCapture =
+          object : RenderEngine.ThemeCapture {
+            override fun shouldCapture(previewId: String?, renderMode: String?): Boolean =
+              registry.shouldCapture(previewId, renderMode)
+
+            override fun capture(previewId: String?, payload: ThemePayload) {
+              registry.capture(previewId, payload)
+            }
+          },
+      )
+
+    engine.render(
+      spec =
+        RenderSpec(
+          previewId = "preview-2",
+          className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+          functionName = "RedSquare",
+          widthPx = 32,
+          heightPx = 32,
+          density = 1.0f,
+          outputBaseName = "subscribed-theme-red-square",
+        ),
+      requestId = RenderHost.nextRequestId(),
+    )
+
+    val outcome = registry.fetch("preview-2", "compose/theme", params = null, inline = true)
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+  }
+
+  @Test
+  fun desktop_host_resolves_preview_id_payload_and_theme_mode() {
+    val outputDir = tempFolder.newFolder("renders")
+    val registry = ThemeDataProductRegistry()
+    val engine =
+      RenderEngine(
+        outputDir = outputDir,
+        themeCapture =
+          object : RenderEngine.ThemeCapture {
+            override fun shouldCapture(previewId: String?, renderMode: String?): Boolean =
+              registry.shouldCapture(previewId, renderMode)
+
+            override fun capture(previewId: String?, payload: ThemePayload) {
+              registry.capture(previewId, payload)
+            }
+          },
+      )
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == "preview-3") {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "RedSquare",
+              widthPx = 32,
+              heightPx = 32,
+              density = 1.0f,
+              outputBaseName = "host-theme-red-square",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val result =
+        host.submit(
+          RenderRequest.Render(
+            id = RenderHost.nextRequestId(),
+            payload = "previewId=preview-3;mode=theme",
+          )
+        )
+      registry.onRender("preview-3", result)
+      val outcome = registry.fetch("preview-3", "compose/theme", params = null, inline = true)
+      assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun non_theme_render_clears_stale_payload_for_preview() {
+    val registry = ThemeDataProductRegistry()
+    registry.capture(
+      "preview-3",
+      ThemePayload(
+        resolvedTokens =
+          ResolvedThemeTokens(
+            colorScheme = emptyMap(),
+            typography = emptyMap(),
+            shapes = emptyMap(),
+          )
+      ),
+    )
+
+    registry.onRender(
+      "preview-3",
+      RenderResult(id = 1, classLoaderHashCode = 1, classLoaderName = "test"),
+    )
+    val freshFetch = registry.fetch("preview-3", "compose/theme", params = null, inline = true)
+    assertTrue(freshFetch is DataProductRegistry.Outcome.Ok)
+
+    registry.onRender(
+      "preview-3",
+      RenderResult(id = 2, classLoaderHashCode = 1, classLoaderName = "test"),
+    )
+    val staleFetch = registry.fetch("preview-3", "compose/theme", params = null, inline = true)
+    assertTrue(staleFetch is DataProductRegistry.Outcome.RequiresRerender)
+  }
+}


### PR DESCRIPTION
## Summary
- add a desktop compose/theme data-product registry that advertises inline schema v1 payloads
- capture resolved Material 3 color, typography, and shape tokens during theme-mode or subscribed renders
- route previewId+mode desktop renders through the preview resolver so fetch-driven theme rerenders render real previews

## Notes
- v1 returns an empty consumers array; per #449, per-node token-consumer tracking needs deeper Compose instrumentation.

## Tests
- ./gradlew :daemon:desktop:compileKotlin
- ./gradlew :daemon:desktop:test --tests ee.schimke.composeai.daemon.ThemeDataProductRegistryTest
- ./gradlew :daemon:desktop:test --tests ee.schimke.composeai.daemon.DesktopHostTest --tests ee.schimke.composeai.daemon.RenderEngineTest --tests ee.schimke.composeai.daemon.JsonRpcDesktopIntegrationTest

Closes #449