### PR TITLE
Avoid redundant preview refresh work

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -8,6 +8,7 @@ import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.Directory
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskProvider
 
 private val previewManifestJson = Json { ignoreUnknownKeys = true }
@@ -481,6 +482,7 @@ internal object ComposePreviewTasks {
     // check the failure surfaces only in downstream tools (CLI / VSCode).
     val manifestFile = previewOutputDir.map { it.file("previews.json") }
     val rendersDir = previewOutputDir.map { it.dir("renders") }
+    val validationMarker = previewOutputDir.map { it.file("renderAllPreviews.validated") }
     // Captured at config time so the `doLast` body doesn't reach for
     // `project` at execution (config-cache safe). Resolves at execution
     // to "fast" or "full"; "fast" tells the post-condition to tolerate
@@ -493,6 +495,12 @@ internal object ComposePreviewTasks {
     project.tasks.register("renderAllPreviews", DefaultTask::class.java) {
       group = "compose preview"
       dependsOn(renderTask)
+      inputs
+        .file(manifestFile)
+        .withPathSensitivity(PathSensitivity.NONE)
+        .withPropertyName("manifest")
+      inputs.property("tier", tierProvider)
+      outputs.file(validationMarker).withPropertyName("validationMarker")
       // `verifyAccessibility` runs AFTER rendering so PNGs always exist
       // even when the check fails. `finalizedBy` (instead of `dependsOn`)
       // lets the build still produce artefacts for CLI/VSCode to
@@ -588,6 +596,9 @@ internal object ComposePreviewTasks {
               "testClassesDirs. Run with --info to see the task outcome."
           )
         }
+        val marker = validationMarker.get().asFile
+        marker.parentFile?.mkdirs()
+        marker.writeText("validated\n")
       }
     }
   }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -41,6 +41,7 @@ import {
     resolveAdbPath,
     runAdb,
 } from './launchOnDevice';
+import { hasFreshRenderStamp, writeRenderFreshnessStamp } from './renderFreshness';
 
 const DEBOUNCE_MS = 1500;
 // Edits to the currently-scoped preview file (e.g. Claude Code's Edit tool
@@ -80,69 +81,21 @@ const historyScopeRef: { current: HistoryScope | null } = { current: null };
  *  scoped focus signals can map "active file → preview IDs" without an
  *  extension-side discovery round-trip. */
 /**
- * Returns the mtime (ms since epoch) of the oldest on-disk PNG referenced by
- * any rendered capture in [previews] across [modules], or null if none of the
- * paths exist. Cheap stat call per capture; results are not cached because
- * renders rewrite these files on every save.
- */
-async function oldestRenderMtime(
-    previews: PreviewInfo[],
-    modules: string[],
-): Promise<number | null> {
-    if (!gradleService) { return null; }
-    let oldest: number | null = null;
-    for (const preview of previews) {
-        for (const capture of preview.captures) {
-            if (!capture.renderOutput) { continue; }
-            // Match the path the readPreviewImage resolver builds.
-            const mod = modules.find(m => previewModuleMap.get(preview.id) === m) ?? modules[0];
-            const pngPath = path.join(
-                gradleService.workspaceRoot, mod,
-                'build', 'compose-previews', capture.renderOutput,
-            );
-            try {
-                const stat = await fs.promises.stat(pngPath);
-                const mtime = stat.mtimeMs;
-                if (oldest == null || mtime < oldest) { oldest = mtime; }
-            } catch {
-                // File missing — discover-only pass on a never-rendered preview.
-                // Don't count toward oldest; the banner reflects what the user
-                // is actually seeing on screen.
-            }
-        }
-    }
-    return oldest;
-}
-
-/** Stat the source file and return its mtime, or null on any error.
- *  Used to detect "user edited since the rendered PNGs were written". */
-async function sourceFileMtime(filePath: string): Promise<number | null> {
-    try {
-        const stat = await fs.promises.stat(filePath);
-        return stat.mtimeMs;
-    } catch {
-        return null;
-    }
-}
-
-/**
- * True when the active source file's mtime is newer than the oldest visible
- * preview's PNG. Cheap signal that the on-disk renders don't reflect the
- * current buffer — used both to suppress reading those stale bytes into the
- * webview and to schedule an automatic re-render. Conservative: any
- * unreadable file (missing PNG, source-stat failure) yields `false` so we
- * default to "use what's on disk" rather than spuriously trigger renders.
+ * True when the active source file has changed since a successful render
+ * stamped the current preview set. This deliberately does not compare source
+ * mtime against PNG mtimes: Gradle build-cache restores preserve derived
+ * artefacts whose filesystem mtimes can be older than source files even though
+ * the cache key proves they were rendered from those inputs.
  */
 async function isSourceNewerThanRenders(
     activeFile: string,
     previews: PreviewInfo[],
     modules: string[],
 ): Promise<boolean> {
-    const [sourceMtime, oldestMtime] = await Promise.all([
-        sourceFileMtime(activeFile),
-        oldestRenderMtime(previews, modules),
-    ]);
-    return sourceMtime != null && oldestMtime != null && sourceMtime > oldestMtime;
+    if (!gradleService) { return false; }
+    const module = modules[0];
+    if (!module) { return false; }
+    return !(await hasFreshRenderStamp(gradleService.workspaceRoot, module, activeFile, previews));
 }
 
 const moduleManifestCache = new Map<string, PreviewInfo[]>();
@@ -2196,9 +2149,25 @@ async function refresh(
         for (const mod of modules) {
             if (abort.signal.aborted) { return 'cancelled'; }
 
-            const manifest = forceRender
+            let manifest = !forceRender ? gradleService.readManifest(mod) : null;
+            if (manifest) {
+                const manifestVisiblePreviews = manifest.previews.filter(p => p.sourceFile === filterFile);
+                const fresh = manifestVisiblePreviews.length > 0
+                    && await hasFreshRenderStamp(
+                        gradleService.workspaceRoot,
+                        mod,
+                        activeFile,
+                        manifestVisiblePreviews,
+                    );
+                if (fresh) {
+                    logLine(`cache hit: ${path.basename(activeFile)} render stamp fresh — skipping Gradle`);
+                } else {
+                    manifest = null;
+                }
+            }
+            manifest = manifest ?? (forceRender
                 ? await gradleService.renderPreviews(mod, tier, taskOpts)
-                : await gradleService.discoverPreviews(mod, taskOpts);
+                : await gradleService.discoverPreviews(mod, taskOpts));
 
             // Track tier so the webview can mark heavy cards as stale after a
             // fast save. A successful full render clears the flag for this
@@ -2290,6 +2259,9 @@ async function refresh(
         });
         hasPreviewsLoaded = true;
         logLine(`rendered ${visiblePreviews.length} preview(s) for ${path.basename(activeFile)}`);
+        if (forceRender && gradleService) {
+            await writeRenderFreshnessStamp(gradleService.workspaceRoot, module, activeFile, visiblePreviews);
+        }
 
         // Gradle is done; the rest of the work (reading PNGs, base64-encoding,
         // pushing to webview) is extension-side. The tracker has already

--- a/vscode-extension/src/renderFreshness.ts
+++ b/vscode-extension/src/renderFreshness.ts
@@ -1,0 +1,96 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { PreviewInfo } from './types';
+
+const STAMP_SCHEMA_VERSION = 1;
+const MTIME_EPSILON_MS = 1;
+
+interface RenderFreshnessStamp {
+    schemaVersion: number;
+    module: string;
+    sourceFile: string;
+    sourceMtimeMs: number;
+    renderedAtMs: number;
+    previewIds: string[];
+}
+
+export async function sourceFileMtime(filePath: string): Promise<number | null> {
+    try {
+        const stat = await fs.promises.stat(filePath);
+        return stat.mtimeMs;
+    } catch {
+        return null;
+    }
+}
+
+export function renderFreshnessStampPath(
+    workspaceRoot: string,
+    module: string,
+    sourceFile: string,
+): string {
+    const encoded = Buffer.from(sourceFile).toString('base64url');
+    return path.join(
+        workspaceRoot,
+        module,
+        'build',
+        'compose-previews',
+        'render-freshness',
+        `${encoded}.json`,
+    );
+}
+
+export async function writeRenderFreshnessStamp(
+    workspaceRoot: string,
+    module: string,
+    sourceFile: string,
+    previews: PreviewInfo[],
+): Promise<void> {
+    const sourceMtime = await sourceFileMtime(sourceFile);
+    if (sourceMtime == null) { return; }
+
+    const stamp: RenderFreshnessStamp = {
+        schemaVersion: STAMP_SCHEMA_VERSION,
+        module,
+        sourceFile,
+        sourceMtimeMs: sourceMtime,
+        renderedAtMs: Date.now(),
+        previewIds: previews.map(p => p.id).sort(),
+    };
+    const stampPath = renderFreshnessStampPath(workspaceRoot, module, sourceFile);
+    await fs.promises.mkdir(path.dirname(stampPath), { recursive: true });
+    await fs.promises.writeFile(stampPath, JSON.stringify(stamp, null, 2));
+}
+
+export async function hasFreshRenderStamp(
+    workspaceRoot: string,
+    module: string,
+    sourceFile: string,
+    previews: PreviewInfo[],
+): Promise<boolean> {
+    const sourceMtime = await sourceFileMtime(sourceFile);
+    if (sourceMtime == null) { return false; }
+
+    try {
+        const raw = await fs.promises.readFile(
+            renderFreshnessStampPath(workspaceRoot, module, sourceFile),
+            'utf8',
+        );
+        const stamp = JSON.parse(raw) as Partial<RenderFreshnessStamp>;
+        if (
+            stamp.schemaVersion !== STAMP_SCHEMA_VERSION
+            || stamp.module !== module
+            || stamp.sourceFile !== sourceFile
+            || typeof stamp.sourceMtimeMs !== 'number'
+            || !Array.isArray(stamp.previewIds)
+        ) {
+            return false;
+        }
+        if (sourceMtime > stamp.sourceMtimeMs + MTIME_EPSILON_MS) {
+            return false;
+        }
+        const stampedIds = new Set(stamp.previewIds.filter((id): id is string => typeof id === 'string'));
+        return previews.every(p => stampedIds.has(p.id));
+    } catch {
+        return false;
+    }
+}

--- a/vscode-extension/src/test/renderFreshness.test.ts
+++ b/vscode-extension/src/test/renderFreshness.test.ts
@@ -1,0 +1,100 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    hasFreshRenderStamp,
+    renderFreshnessStampPath,
+    writeRenderFreshnessStamp,
+} from '../renderFreshness';
+import { PreviewInfo } from '../types';
+
+function preview(id: string): PreviewInfo {
+    return {
+        id,
+        functionName: 'Preview',
+        className: 'com.example.PreviewsKt',
+        sourceFile: 'com/example/Previews.kt',
+        params: {
+            name: null,
+            device: null,
+            widthDp: null,
+            heightDp: null,
+            fontScale: 1,
+            showSystemUi: false,
+            showBackground: false,
+            backgroundColor: 0,
+            uiMode: 0,
+            locale: null,
+            group: null,
+        },
+        captures: [{ advanceTimeMillis: null, scroll: null, renderOutput: `renders/${id}.png` }],
+    };
+}
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'compose-preview-freshness-'));
+    try {
+        await fn(dir);
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+}
+
+describe('renderFreshness', () => {
+    it('treats a stamped render as fresh even when PNG mtimes are older than the source', async () => {
+        await withTempDir(async dir => {
+            const module = 'app';
+            const source = path.join(dir, module, 'src/main/kotlin/com/example/Previews.kt');
+            const png = path.join(dir, module, 'build/compose-previews/renders/p1.png');
+            fs.mkdirSync(path.dirname(source), { recursive: true });
+            fs.mkdirSync(path.dirname(png), { recursive: true });
+            fs.writeFileSync(source, '@Preview fun P() {}');
+            fs.writeFileSync(png, 'png');
+
+            const old = new Date(Date.now() - 60_000);
+            fs.utimesSync(png, old, old);
+            await writeRenderFreshnessStamp(dir, module, source, [preview('p1')]);
+
+            assert.strictEqual(await hasFreshRenderStamp(dir, module, source, [preview('p1')]), true);
+        });
+    });
+
+    it('marks the render stale when the source changes after the stamp', async () => {
+        await withTempDir(async dir => {
+            const module = 'app';
+            const source = path.join(dir, module, 'src/main/kotlin/com/example/Previews.kt');
+            fs.mkdirSync(path.dirname(source), { recursive: true });
+            fs.writeFileSync(source, '@Preview fun P() {}');
+            await writeRenderFreshnessStamp(dir, module, source, [preview('p1')]);
+
+            const newer = new Date(Date.now() + 5_000);
+            fs.utimesSync(source, newer, newer);
+
+            assert.strictEqual(await hasFreshRenderStamp(dir, module, source, [preview('p1')]), false);
+        });
+    });
+
+    it('marks the render stale when the visible preview set is not covered by the stamp', async () => {
+        await withTempDir(async dir => {
+            const module = 'app';
+            const source = path.join(dir, module, 'src/main/kotlin/com/example/Previews.kt');
+            fs.mkdirSync(path.dirname(source), { recursive: true });
+            fs.writeFileSync(source, '@Preview fun P() {}');
+            await writeRenderFreshnessStamp(dir, module, source, [preview('p1')]);
+
+            assert.strictEqual(
+                await hasFreshRenderStamp(dir, module, source, [preview('p1'), preview('p2')]),
+                false,
+            );
+        });
+    });
+
+    it('stores source-specific stamps under the module build directory', async () => {
+        await withTempDir(async dir => {
+            const stampPath = renderFreshnessStampPath(dir, 'app', path.join(dir, 'app/src/Previews.kt'));
+            assert.ok(stampPath.startsWith(path.join(dir, 'app', 'build', 'compose-previews')));
+            assert.ok(stampPath.endsWith('.json'));
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- make renderAllPreviews declare a validation marker output so Gradle can skip the aggregate task when renders are already current
- replace PNG mtime freshness checks with extension-owned render freshness stamps keyed by source mtime and preview ids
- skip discover/render Gradle calls on focus refresh when the local manifest and render stamp are fresh

Fixes #548

## Validation
- npm test -- --grep renderFreshness
- ./gradlew :samples:wear:renderAllPreviews -PcomposePreview.tier=fast --console=plain