### PR TITLE
Allow inspection mode for interactive sessions

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -611,6 +611,7 @@ open class RobolectricHost(
   override fun acquireInteractiveSession(
     previewId: String,
     classLoader: ClassLoader,
+    inspectionMode: Boolean?,
   ): InteractiveSession {
     if (sandboxCount < 2) {
       throw UnsupportedOperationException(
@@ -681,6 +682,7 @@ open class RobolectricHost(
             RenderSpec.SpecOrientation.LANDSCAPE -> "landscape"
             null -> null
           },
+        inspectionMode = inspectionMode,
       )
     )
     if (!replyLatch.await(INTERACTIVE_START_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
@@ -1342,16 +1344,17 @@ open class RobolectricHost(
               PerfettoTraceDataProducer.recorder(start.outputBaseName, backend = "android-live")
             setupTrace.section("compose:setContent") {
               rule.setContent {
-              androidx.compose.runtime.CompositionLocalProvider(
-                androidx.compose.ui.platform.LocalInspectionMode provides false
-              ) {
-                androidx.compose.foundation.layout.Box(
-                  modifier = androidx.compose.ui.Modifier.fillMaxSize()
+                androidx.compose.runtime.CompositionLocalProvider(
+                  androidx.compose.ui.platform.LocalInspectionMode provides
+                    (start.inspectionMode ?: false)
                 ) {
-                  InvokeHeldComposable(composableMethod)
+                  androidx.compose.foundation.layout.Box(
+                    modifier = androidx.compose.ui.Modifier.fillMaxSize()
+                  ) {
+                    InvokeHeldComposable(composableMethod)
+                  }
                 }
               }
-            }
             }
             // Two Choreographer ticks under the paused clock — same settle window
             // RenderEngine.render uses before its single capture. Enough for the initial

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -400,6 +400,8 @@ sealed interface InteractiveCommand {
     val uiMode: String? = null,
     /** `"portrait"` / `"landscape"` / `null`; overrides the size-derived guess. */
     val orientation: String? = null,
+    /** Held-session `LocalInspectionMode`; `null` preserves the runtime-like default (`false`). */
+    val inspectionMode: Boolean? = null,
   ) : InteractiveCommand
 
   /**

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1813,7 +1813,7 @@ class JsonRpcServer(
           host.userClassloaderHolder?.currentChildLoader()
             ?: this::class.java.classLoader
             ?: ClassLoader.getSystemClassLoader()
-        host.acquireInteractiveSession(params.previewId, classLoader)
+        host.acquireInteractiveSession(params.previewId, classLoader, params.inspectionMode)
       } catch (t: UnsupportedOperationException) {
         fallbackReason = "${t.javaClass.simpleName}: ${t.message}"
         null

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -155,7 +155,11 @@ interface RenderHost {
    *   doesn't drag stale bytecode into the held scene — the next `interactive/start` after a save
    *   gets a fresh loader.
    */
-  fun acquireInteractiveSession(previewId: String, classLoader: ClassLoader): InteractiveSession =
+  fun acquireInteractiveSession(
+    previewId: String,
+    classLoader: ClassLoader,
+    inspectionMode: Boolean? = null,
+  ): InteractiveSession =
     throw UnsupportedOperationException(
       "interactive mode unsupported by ${this::class.simpleName ?: this::class.java.name}"
     )

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -717,7 +717,16 @@ data class HistoryReadResultDto(
 // emitting a fresh `renderFinished` for the target preview.
 // =====================================================================
 
-@Serializable data class InteractiveStartParams(val previewId: String)
+@Serializable
+data class InteractiveStartParams(
+  val previewId: String,
+  /**
+   * Optional `LocalInspectionMode` override for held interactive sessions. Null preserves the
+   * current runtime-like interactive default (`false`); set `true` for previews that need their
+   * preview/stub-data branch while still using a held session.
+   */
+  val inspectionMode: Boolean? = null,
+)
 
 /**
  * Opaque correlation token returned by `interactive/start`. The client passes it back on every

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveCoalescingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveCoalescingTest.kt
@@ -252,6 +252,7 @@ private class SlowFakeHost(private val pngFile: File, private val renderDelayMs:
   override fun acquireInteractiveSession(
     previewId: String,
     classLoader: ClassLoader,
+    inspectionMode: Boolean?,
   ): InteractiveSession {
     val session = SlowSession(previewId, pngFile, renderDelayMs)
     sessions[nextSessionKey.getAndIncrement()] = session

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveSessionPlumbingTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InteractiveSessionPlumbingTest.kt
@@ -193,6 +193,27 @@ class InteractiveSessionPlumbingTest {
   }
 
   @Test(timeout = 30_000)
+  fun start_threads_inspection_mode_to_held_session_acquire() {
+    val tmp = Files.createTempDirectory("interactive-session-inspection-mode").toFile()
+    val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
+    val host = SessionAwareFakeHost(pngFile)
+
+    val (_, _, clientToServerOut, received, _) = bringUpServer(host)
+    resourcesToClose.add(AutoCloseable { runCatching { clientToServerOut.close() } })
+
+    handshake(clientToServerOut, received)
+
+    writeFrame(
+      clientToServerOut,
+      """{"jsonrpc":"2.0","id":10,"method":"interactive/start","params":{"previewId":"preview-A","inspectionMode":true}}""",
+    )
+
+    val startResp = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 10 }
+    assertNotNull(startResp)
+    assertEquals(true, host.lastInspectionMode)
+  }
+
+  @Test(timeout = 30_000)
   fun supported_host_acquire_failure_fails_noisily() {
     val tmp = Files.createTempDirectory("interactive-session-failure").toFile()
     val pngFile = File(tmp, "preview-A.png").apply { writeBytes(testPngBytes(seed = 0)) }
@@ -412,6 +433,7 @@ private class SessionAwareFakeHost(
 ) : RenderHost {
 
   val acquireCalls = AtomicInteger(0)
+  @Volatile var lastInspectionMode: Boolean? = null
   private val sessions = ConcurrentHashMap<Long, RecordingSession>()
   private val nextSessionKey = AtomicLong(1)
 
@@ -436,8 +458,10 @@ private class SessionAwareFakeHost(
   override fun acquireInteractiveSession(
     previewId: String,
     classLoader: ClassLoader,
+    inspectionMode: Boolean?,
   ): InteractiveSession {
     acquireCalls.incrementAndGet()
+    lastInspectionMode = inspectionMode
     val pngFile = perPreview[previewId] ?: defaultPng
     val session = RecordingSession(previewId = previewId, pngFile = pngFile)
     sessions[nextSessionKey.getAndIncrement()] = session
@@ -530,6 +554,7 @@ private class FailingSessionHost(private val defaultPng: File) : RenderHost {
   override fun acquireInteractiveSession(
     previewId: String,
     classLoader: ClassLoader,
+    inspectionMode: Boolean?,
   ): InteractiveSession {
     throw IllegalStateException("boom")
   }

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
@@ -1392,6 +1392,7 @@ private class DisconnectFakeHost : RenderHost {
   override fun acquireInteractiveSession(
     previewId: String,
     classLoader: ClassLoader,
+    inspectionMode: Boolean?,
   ): InteractiveSession {
     acquireCount.incrementAndGet()
     val session = RecordingDisconnectSession(previewId)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -228,12 +228,15 @@ open class DesktopHost(
    * [UnsupportedOperationException] which `JsonRpcServer` catches and falls back to the v1
    * stateless dispatch path.
    *
-   * The held scene composes with `LocalInspectionMode = false` so `Modifier.clickable {}` and other
-   * pointer-input modifiers fire on `interactive/input` notifications — the v2 payoff.
+   * The held scene composes with `LocalInspectionMode = false` by default so `Modifier.clickable
+   * {}` and other pointer-input modifiers fire on `interactive/input` notifications — the v2
+   * payoff. `interactive/start.inspectionMode=true` opts previews back into the preview/stub-data
+   * branch when they need it.
    */
   override fun acquireInteractiveSession(
     previewId: String,
     classLoader: ClassLoader,
+    inspectionMode: Boolean?,
   ): InteractiveSession {
     val resolver =
       previewSpecResolver
@@ -247,7 +250,7 @@ open class DesktopHost(
           "DesktopHost.previewSpecResolver returned null for previewId='$previewId'; " +
             "interactive session not allocated"
         )
-    val state = engine.setUp(spec, classLoader, inspectionMode = false)
+    val state = engine.setUp(spec, classLoader, inspectionMode = inspectionMode ?: false)
     val session =
       DesktopInteractiveSession(
         previewId = previewId,

--- a/docs/daemon/INTERACTIVE-ANDROID.md
+++ b/docs/daemon/INTERACTIVE-ANDROID.md
@@ -287,8 +287,10 @@ Key invariants:
 - `setContent` is called **exactly once** per session, before the
   drain loop. Compose's "no second setContent on the same Activity"
   constraint is satisfied.
-- `LocalInspectionMode = false` for the duration of the session, so
-  `Modifier.clickable` / `pointerInput` modifiers actually fire.
+- `LocalInspectionMode = false` by default for the duration of the
+  session, so `Modifier.clickable` / `pointerInput` modifiers actually
+  fire. `interactive/start.inspectionMode=true` opts previews back into
+  their preview/stub-data branch when needed.
 - Compose's `mainClock` is paused; we advance it manually after each
   dispatch + before each render so the gesture-detection pipeline
   observes time progression. Same `CAPTURE_ADVANCE_MS` constant the

--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -389,10 +389,11 @@ together force a real refactor:
 2. **Pointer dispatch.** The pixel coords carried in
    `interactive/input` need to reach the held scene via
    `ImageComposeScene.sendPointerEvent`.
-3. **Inspection-mode flip.** `LocalInspectionMode = false` for the
-   duration of the interactive session so previews that branch on
-   `isInspectionMode` show their non-inspection ("real") behaviour and
-   pointer-input modifiers actually fire.
+3. **Inspection-mode flip.** `LocalInspectionMode = false` by default
+   for the duration of the interactive session so previews that branch
+   on `isInspectionMode` show their non-inspection ("real") behaviour
+   and pointer-input modifiers actually fire. Callers may opt a held
+   session back into `true` with `interactive/start.inspectionMode`.
 
 ### 9.2 InteractiveSession — held scene per stream
 
@@ -505,10 +506,12 @@ data won't run that bypass. For v1 the trade-off was "pin
 inspection-mode-aware previews to a deterministic stub", which is why
 we set it to true everywhere.
 
-For v2 the call inverts: an interactive session is the user *wanting*
-real behaviour. `InteractiveSession.setUp` provides
-`LocalInspectionMode = false`; non-interactive renders (the existing
-save → discoveryUpdated → renderFinished flow) keep
+For v2 the default call inverts: an interactive session is the user
+*wanting* real behaviour. `interactive/start` therefore provides
+`LocalInspectionMode = false` unless the caller passes
+`inspectionMode: true` for previews that need their preview/stub-data
+branch while still using a held session. Non-interactive renders (the
+existing save → discoveryUpdated → renderFinished flow) keep
 `LocalInspectionMode = true`.
 
 The split is per-render, not per-engine: the same `RenderEngine`

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -510,7 +510,7 @@ export interface DataSubscribeResult {
 // lockstep with the daemon work. Adding these methods is additive per
 // PROTOCOL.md § 7 — no `protocolVersion` bump required.
 
-export interface InteractiveStartParams { previewId: string }
+export interface InteractiveStartParams { previewId: string; inspectionMode?: boolean }
 export interface InteractiveStartResult {
     /** Opaque correlation id; the client passes it back on every input
      *  notification so the daemon can route inputs to the right warm


### PR DESCRIPTION
## Summary
- add optional interactive/start.inspectionMode
- thread the override through RenderHost into desktop and Android held sessions
- keep the existing interactive default as LocalInspectionMode=false
- document the opt-in and cover JSON-RPC plumbing with a focused test

Fixes #421

## Verification
- ./gradlew :daemon:core:test --tests ee.schimke.composeai.daemon.InteractiveSessionPlumbingTest.start_threads_inspection_mode_to_held_session_acquire
- ./gradlew :daemon:desktop:compileKotlin :daemon:android:compileDebugKotlin :daemon:core:ktfmtCheck :daemon:desktop:ktfmtCheck :daemon:android:ktfmtCheck
- npm run compile (vscode-extension)