### PR TITLE
feat: expose history prune initialize options

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -22,6 +22,7 @@ import ee.schimke.composeai.daemon.protocol.HistoryDiffParams
 import ee.schimke.composeai.daemon.protocol.HistoryDiffResult
 import ee.schimke.composeai.daemon.protocol.HistoryListParams
 import ee.schimke.composeai.daemon.protocol.HistoryListResult
+import ee.schimke.composeai.daemon.protocol.HistoryPruneOptions
 import ee.schimke.composeai.daemon.protocol.HistoryPruneParams
 import ee.schimke.composeai.daemon.protocol.HistoryPruneResult
 import ee.schimke.composeai.daemon.protocol.HistoryPruneSourceResult
@@ -427,10 +428,8 @@ class JsonRpcServer(
     StartupTimings.mark("JsonRpcServer.run() entered")
     host.start()
     StartupTimings.mark("host.start() returned (sandbox ready)")
-    // H4 — kick off the auto-prune scheduler now that the sandbox is up. The first pass fires
-    // after `autoPruneInitialDelayMs` (5s default; small in tests). All-off configs short-circuit
-    // inside `startAutoPrune` so we don't spin a thread for nothing.
-    historyManager?.startAutoPrune(initialDelayMs = autoPruneInitialDelayMs)
+    // H4 — auto-prune starts after initialize so `initialize.options.historyPrune` can override
+    // sysprop/default config before the scheduler captures its interval.
     writerThread.start()
     renderWatcherThread.start()
     StartupTimings.mark("read loop entering")
@@ -615,6 +614,13 @@ class JsonRpcServer(
     // PROTOCOL.md § 3 — per-render timeout override. Positive values win; null / ≤ 0 keeps the
     // 5-minute default. Survives across renders for this client's session lifetime.
     params.options?.maxRenderMs?.takeIf { it > 0 }?.let { renderTimeoutMs = it }
+    params.options?.historyPrune?.let { options ->
+      historyManager?.configurePruneConfig(historyManager.pruneConfig.withOptions(options))
+    }
+    // H4 — kick off the auto-prune scheduler after initialize-time options have landed. The first
+    // pass fires after `autoPruneInitialDelayMs` (5s default; small in tests). All-off configs
+    // short-circuit inside `startAutoPrune` so we don't spin a thread for nothing.
+    historyManager?.startAutoPrune(initialDelayMs = autoPruneInitialDelayMs)
     val result =
       InitializeResult(
         protocolVersion = PROTOCOL_VERSION,
@@ -685,6 +691,14 @@ class JsonRpcServer(
     sendResponse(req.id, encode(InitializeResult.serializer(), result))
     StartupTimings.mark("initialize responded")
   }
+
+  private fun HistoryPruneConfig.withOptions(options: HistoryPruneOptions): HistoryPruneConfig =
+    HistoryPruneConfig(
+      maxEntriesPerPreview = options.maxEntriesPerPreview ?: maxEntriesPerPreview,
+      maxAgeDays = options.maxAgeDays ?: maxAgeDays,
+      maxTotalSizeBytes = options.maxTotalSizeBytes ?: maxTotalSizeBytes,
+      autoPruneIntervalMs = options.autoIntervalMs ?: autoPruneIntervalMs,
+    )
 
   private fun handleRenderNow(req: JsonRpcRequest) {
     if (firstRenderNowSeen.compareAndSet(false, true)) {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/history/HistoryManager.kt
@@ -46,8 +46,20 @@ class HistoryManager(
    * tests pass an explicit instance. The auto-prune scheduler reads this at construction time;
    * manual `history/prune` RPC calls override individual fields per-call.
    */
-  val pruneConfig: HistoryPruneConfig = HistoryPruneConfig(),
+  pruneConfig: HistoryPruneConfig = HistoryPruneConfig(),
 ) {
+  private val pruneConfigRef: AtomicReference<HistoryPruneConfig> = AtomicReference(pruneConfig)
+
+  val pruneConfig: HistoryPruneConfig
+    get() = pruneConfigRef.get()
+
+  /**
+   * Initialize-time override path for clients that cannot set daemon JVM sysprops directly. Must be
+   * called before [startAutoPrune] to affect the scheduler interval for this daemon session.
+   */
+  fun configurePruneConfig(config: HistoryPruneConfig) {
+    pruneConfigRef.set(config)
+  }
 
   /**
    * True when at least one writable source is configured — i.e. when `recordRender` is meaningful.
@@ -342,8 +354,9 @@ class HistoryManager(
    * scheduler thread is daemonised so the JVM can exit even if [stopAutoPrune] isn't called.
    */
   fun startAutoPrune(initialDelayMs: Long = DEFAULT_INITIAL_DELAY_MS) {
-    if (pruneConfig.isAllOff) return
-    if (pruneConfig.autoPruneIntervalMs <= 0L) return
+    val config = pruneConfig
+    if (config.isAllOff) return
+    if (config.autoPruneIntervalMs <= 0L) return
     if (!isEnabled) return
     if (autoPruneStopped.get()) return
     val existing = scheduler.get()
@@ -360,7 +373,7 @@ class HistoryManager(
       exec.scheduleWithFixedDelay(
         {
           try {
-            pruneNow(config = pruneConfig, dryRun = false, reason = PruneReason.AUTO)
+            pruneNow(config = config, dryRun = false, reason = PruneReason.AUTO)
           } catch (t: Throwable) {
             System.err.println(
               "compose-ai-daemon: HistoryManager auto-prune pass failed " +
@@ -369,7 +382,7 @@ class HistoryManager(
           }
         },
         initialDelayMs.coerceAtLeast(0L),
-        pruneConfig.autoPruneIntervalMs,
+        config.autoPruneIntervalMs,
         TimeUnit.MILLISECONDS,
       )
     autoPruneFuture.set(future)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -95,6 +95,20 @@ data class Options(
    * over a long hang. Values ≤ 0 fall back to the default.
    */
   val maxRenderMs: Long? = null,
+  /**
+   * Initialize-time override for the daemon's default history pruning policy. Each present value
+   * wins over the matching JVM sysprop/default; null fields preserve the daemon-configured value.
+   * Values ≤ 0 keep the existing pruning semantics for that knob: disabled.
+   */
+  val historyPrune: HistoryPruneOptions? = null,
+)
+
+@Serializable
+data class HistoryPruneOptions(
+  val maxEntriesPerPreview: Int? = null,
+  val maxAgeDays: Int? = null,
+  val maxTotalSizeBytes: Long? = null,
+  val autoIntervalMs: Long? = null,
 )
 
 @Serializable

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/history/JsonRpcServerHistoryIntegrationTest.kt
@@ -328,6 +328,98 @@ class JsonRpcServerHistoryIntegrationTest {
     }
   }
 
+  @Test(timeout = 30_000)
+  fun initialize_history_prune_options_override_manager_defaults() {
+    val host = RealPngHost(rendersDir)
+    val historyManager =
+      HistoryManager.forLocalFs(
+        historyDir = historyDir,
+        module = ":t",
+        gitProvenance = null,
+        pruneConfig =
+          HistoryPruneConfig(
+            maxEntriesPerPreview = 10,
+            maxAgeDays = 11,
+            maxTotalSizeBytes = 12L,
+            autoPruneIntervalMs = 13L,
+          ),
+      )
+
+    val clientToServerOut = PipedOutputStream()
+    val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
+    val serverToClientOut = PipedOutputStream()
+    val serverToClientIn = PipedInputStream(serverToClientOut, 64 * 1024)
+    val exitLatch = CountDownLatch(1)
+    val server =
+      JsonRpcServer(
+        input = clientToServerIn,
+        output = serverToClientOut,
+        host = host,
+        daemonVersion = "test",
+        idleTimeoutMs = 100L,
+        historyManager = historyManager,
+        onExit = { _ -> exitLatch.countDown() },
+      )
+    val serverThread =
+      Thread({ server.run() }, "json-rpc-server-history-prune-options-test").apply {
+        isDaemon = true
+      }
+    serverThread.start()
+
+    val received = LinkedBlockingQueue<JsonObject>()
+    val reader = ContentLengthFramer(serverToClientIn)
+    Thread(
+        {
+          try {
+            while (true) {
+              val frame = reader.readFrame() ?: break
+              val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+              received.put(obj)
+            }
+          } catch (_: Throwable) {}
+        },
+        "json-rpc-server-history-prune-options-reader",
+      )
+      .apply { isDaemon = true }
+      .start()
+
+    try {
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "moduleId":":test","moduleProjectDir":"/tmp",
+              "capabilities":{"visibility":true,"metrics":false},
+              "options":{"historyPrune":{
+                "maxEntriesPerPreview":0,
+                "maxAgeDays":1,
+                "maxTotalSizeBytes":2,
+                "autoIntervalMs":3
+              }}}}""",
+      )
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 1 })
+
+      assertEquals(
+        HistoryPruneConfig(
+          maxEntriesPerPreview = 0,
+          maxAgeDays = 1,
+          maxTotalSizeBytes = 2L,
+          autoPruneIntervalMs = 3L,
+        ),
+        historyManager.pruneConfig,
+      )
+    } finally {
+      try {
+        clientToServerOut.close()
+      } catch (_: Throwable) {}
+      try {
+        serverToClientIn.close()
+      } catch (_: Throwable) {}
+      assertTrue("server should exit after input closes", exitLatch.await(5, TimeUnit.SECONDS))
+      serverThread.join(5_000)
+    }
+  }
+
   /**
    * Test [RenderHost] that writes a deterministic PNG-shaped byte sequence to disk and returns its
    * path. We don't need a real PNG decoder — H1's history pipeline only sha256s the bytes, so any

--- a/docs/daemon/HISTORY.md
+++ b/docs/daemon/HISTORY.md
@@ -688,9 +688,25 @@ result: {
 ```
 
 Manual prune trigger. Auto-prune runs on a configurable interval
-(default 1h) using the same logic with the daemon's defaults. The
-dry-run mode lets a consumer ask "what would auto-prune do?" without
-mutating the archive.
+(default 1h) using the daemon's prune defaults. The dry-run mode lets a
+consumer ask "what would auto-prune do?" without mutating the archive.
+Clients can override the daemon defaults for the session during
+`initialize`:
+
+```ts
+options: {
+  historyPrune?: {
+    maxEntriesPerPreview?: number;
+    maxAgeDays?: number;
+    maxTotalSizeBytes?: number;
+    autoIntervalMs?: number;
+  }
+}
+```
+
+Each present value overrides the matching sysprop/default. Null or absent
+fields preserve current daemon behaviour; values `0` or negative disable
+that knob.
 
 `sourceResults` is keyed by `HistorySource.id`. Only WRITABLE sources
 participate — read-only `GitRefHistorySource` / HTTP backends are

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -105,6 +105,12 @@ Params:
     foreground?: boolean;            // true when launched via `--foreground`
     maxRenderMs?: number;            // per-render host.submit timeout. Default 5*60_000;
                                      // values ≤ 0 are ignored.
+    historyPrune?: {                 // session defaults for auto/manual history pruning;
+      maxEntriesPerPreview?: number; // null → daemon sysprop/default; 0 / negative → disabled
+      maxAgeDays?: number;
+      maxTotalSizeBytes?: number;
+      autoIntervalMs?: number;       // auto-prune scheduler interval; 0 / negative disables it
+    };
   };
 }
 ```

--- a/docs/daemon/protocol-fixtures/client-initialize.json
+++ b/docs/daemon/protocol-fixtures/client-initialize.json
@@ -13,6 +13,12 @@
     "warmSpare": true,
     "detectLeaks": "light",
     "foreground": false,
-    "maxRenderMs": 600000
+    "maxRenderMs": 600000,
+    "historyPrune": {
+      "maxEntriesPerPreview": 100,
+      "maxAgeDays": 30,
+      "maxTotalSizeBytes": 1000000000,
+      "autoIntervalMs": 3600000
+    }
   }
 }

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -88,6 +88,17 @@ export interface InitializeParams {
          * a fast failure over a long hang. Values ≤ 0 fall back to the default.
          */
         maxRenderMs?: number;
+        /**
+         * Optional history pruning defaults for this daemon session. Present values override the
+         * matching daemon JVM sysprop/default at initialize time; absent/null values preserve the
+         * daemon-configured value. Values ≤ 0 disable that pruning knob.
+         */
+        historyPrune?: {
+            maxEntriesPerPreview?: number;
+            maxAgeDays?: number;
+            maxTotalSizeBytes?: number;
+            autoIntervalMs?: number;
+        };
     };
 }
 


### PR DESCRIPTION
## Summary
- add initialize.options.historyPrune to the daemon protocol
- apply history prune option overrides before starting the auto-prune scheduler
- document the new wire shape and update protocol fixtures/types

## Test
- ./gradlew :daemon:core:test --tests ee.schimke.composeai.daemon.protocol.MessagesTest --tests ee.schimke.composeai.daemon.history.JsonRpcServerHistoryIntegrationTest --tests ee.schimke.composeai.daemon.history.HistoryManagerAutoPruneTest
- ./gradlew :daemon:core:ktfmtFormat
- git diff --check

Closes #464