### PR TITLE
Support Android recording overrides

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -631,6 +631,13 @@ open class RobolectricHost(
           "RobolectricHost.previewSpecResolver returned null for previewId='$previewId'; " +
             "interactive session not allocated"
         )
+    return acquireInteractiveSession(previewId = previewId, spec = spec)
+  }
+
+  private fun acquireInteractiveSession(
+    previewId: String,
+    spec: RenderSpec,
+  ): AndroidInteractiveSession {
     val streamId = "android-stream-${nextStreamCounter.getAndIncrement()}"
     if (!activeInteractiveStreamId.compareAndSet(null, streamId)) {
       val held = activeInteractiveStreamId.get() ?: "<concurrent close>"
@@ -746,19 +753,27 @@ open class RobolectricHost(
           "scripted mode (recording/start with live=false). See RECORDING.md § \"Android backend\"."
       )
     }
-    if (overrides != null) {
-      // v1 accepts overrides on acquire only when they wouldn't conflict with the held-rule loop's
-      // start-up. The session is constructed off the resolver-provided RenderSpec; merging
-      // overrides through that path is its own follow-up because the held loop's Start command
-      // already takes the spec's qualifiers verbatim. Fail fast rather than silently dropping
-      // overrides — a future v2 wires them through Start.
+    if (sandboxCount < 2) {
       throw UnsupportedOperationException(
-        "RobolectricHost: per-call PreviewOverrides on recording/start are not supported on " +
-          "the Android backend in v1; use the discovery-time RenderSpec or override at the " +
-          "@Preview annotation. See RECORDING.md § \"Android backend\"."
+        "RobolectricHost: recording sessions require sandboxCount >= 2 " +
+          "(have $sandboxCount); Android recording pins one sandbox slot per held session and " +
+          "slot 0 must stay available for normal renders."
       )
     }
-    val interactive = acquireInteractiveSession(previewId, classLoader)
+    val resolver =
+      previewSpecResolver
+        ?: throw UnsupportedOperationException(
+          "RobolectricHost has no previewSpecResolver; pass one at construction time to enable " +
+            "recording sessions"
+        )
+    val baseSpec =
+      resolver(previewId)
+        ?: throw UnsupportedOperationException(
+          "RobolectricHost.previewSpecResolver returned null for previewId='$previewId'; " +
+            "recording session not allocated"
+        )
+    val effectiveSpec = applyRecordingOverrides(baseSpec, overrides, recordingId)
+    val interactive = acquireInteractiveSession(previewId = previewId, spec = effectiveSpec)
     val recordingsRoot = recordingsRootDir()
     val framesDir = File(File(recordingsRoot, "frames"), recordingId)
     val encodedDir = File(recordingsRoot, "encoded")
@@ -770,6 +785,67 @@ open class RobolectricHost(
       interactive = interactive,
       framesDir = framesDir,
       encodedDir = encodedDir,
+    )
+  }
+
+  private fun applyRecordingOverrides(
+    base: RenderSpec,
+    overrides: ee.schimke.composeai.daemon.protocol.PreviewOverrides?,
+    recordingId: String,
+  ): RenderSpec {
+    val merged =
+      mergePreviewOverrides(
+        base =
+          PreviewOverrideBaseSpec(
+            widthPx = base.widthPx,
+            heightPx = base.heightPx,
+            density = base.density,
+            device = base.device,
+            localeTag = base.localeTag,
+            fontScale = base.fontScale,
+            uiMode =
+              when (base.uiMode) {
+                RenderSpec.SpecUiMode.LIGHT ->
+                  ee.schimke.composeai.daemon.protocol.UiMode.LIGHT
+                RenderSpec.SpecUiMode.DARK ->
+                  ee.schimke.composeai.daemon.protocol.UiMode.DARK
+                null -> null
+              },
+            orientation =
+              when (base.orientation) {
+                RenderSpec.SpecOrientation.PORTRAIT ->
+                  ee.schimke.composeai.daemon.protocol.Orientation.PORTRAIT
+                RenderSpec.SpecOrientation.LANDSCAPE ->
+                  ee.schimke.composeai.daemon.protocol.Orientation.LANDSCAPE
+                null -> null
+              },
+            inspectionMode = base.inspectionMode,
+          ),
+        overrides = overrides,
+      )
+    return base.copy(
+      widthPx = merged.widthPx,
+      heightPx = merged.heightPx,
+      density = merged.density,
+      device = merged.device,
+      localeTag = merged.localeTag,
+      fontScale = merged.fontScale,
+      uiMode =
+        when (merged.uiMode) {
+          ee.schimke.composeai.daemon.protocol.UiMode.LIGHT -> RenderSpec.SpecUiMode.LIGHT
+          ee.schimke.composeai.daemon.protocol.UiMode.DARK -> RenderSpec.SpecUiMode.DARK
+          null -> null
+        },
+      orientation =
+        when (merged.orientation) {
+          ee.schimke.composeai.daemon.protocol.Orientation.PORTRAIT ->
+            RenderSpec.SpecOrientation.PORTRAIT
+          ee.schimke.composeai.daemon.protocol.Orientation.LANDSCAPE ->
+            RenderSpec.SpecOrientation.LANDSCAPE
+          null -> null
+        },
+      inspectionMode = merged.inspectionMode,
+      outputBaseName = "recording-$recordingId",
     )
   }
 

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
 import java.io.ByteArrayInputStream
@@ -162,6 +163,43 @@ class AndroidRecordingSessionTest {
           "error message should mention live recording is unsupported on Android",
           expected.message!!.contains("live recording", ignoreCase = true),
         )
+      }
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun acquireWithOverridesAppliesFrameSize() {
+    val outputDir = tempFolder.newFolder("recording-override-renders")
+    val recordingsRoot = tempFolder.newFolder("recording-override-root")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty(RobolectricHost.RECORDINGS_DIR_PROP, recordingsRoot.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+
+    val host = RobolectricHost(sandboxCount = 2, previewSpecResolver = previewSpecResolver())
+    host.start()
+    try {
+      val session =
+        host.acquireRecordingSession(
+          previewId = INTERACTIVE_PREVIEW_ID,
+          recordingId = "test-rec-android-overrides",
+          classLoader = AndroidRecordingSessionTest::class.java.classLoader!!,
+          fps = FPS,
+          scale = 1.0f,
+          overrides = PreviewOverrides(widthPx = 48, heightPx = 64, density = 1.0f),
+          live = false,
+        )
+      try {
+        val result = session.stop()
+        assertEquals(1, result.frameCount)
+        assertEquals(48, result.frameWidthPx)
+        assertEquals(64, result.frameHeightPx)
+        val frame0 = decode(File(result.framesDir, "frame-00000.png"))
+        assertEquals(48, frame0.width)
+        assertEquals(64, frame0.height)
+      } finally {
+        session.close()
       }
     } finally {
       host.shutdown()

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
@@ -1,0 +1,84 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.devices.DeviceDimensions
+import ee.schimke.composeai.daemon.protocol.Orientation
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.UiMode
+
+/**
+ * Backend-neutral subset of a render spec that [PreviewOverrides] can mutate.
+ *
+ * Concrete hosts keep backend-local `RenderSpec` types, but recording and render override semantics
+ * need to stay identical across hosts. This small DTO lets hosts adapt their local spec into a
+ * shared merge function, then copy the merged fields back into their local type.
+ */
+data class PreviewOverrideBaseSpec(
+  val widthPx: Int,
+  val heightPx: Int,
+  val density: Float,
+  val device: String?,
+  val localeTag: String?,
+  val fontScale: Float?,
+  val uiMode: UiMode?,
+  val orientation: Orientation?,
+  val inspectionMode: Boolean?,
+)
+
+data class MergedPreviewOverrides(
+  val widthPx: Int,
+  val heightPx: Int,
+  val density: Float,
+  val device: String?,
+  val localeTag: String?,
+  val fontScale: Float?,
+  val uiMode: UiMode?,
+  val orientation: Orientation?,
+  val inspectionMode: Boolean?,
+)
+
+/**
+ * Merge per-call [PreviewOverrides] over a discovery-time spec.
+ *
+ * Explicit `widthPx` / `heightPx` / `density` overrides win over `device`-resolved values. Device
+ * resolution matches `renderNow.overrides.device`: resolve the supplied device id/spec, derive
+ * pixels from its dp geometry at the effective density, then let explicit pixel dimensions replace
+ * either axis.
+ */
+fun mergePreviewOverrides(
+  base: PreviewOverrideBaseSpec,
+  overrides: PreviewOverrides?,
+): MergedPreviewOverrides {
+  if (overrides == null) {
+    return MergedPreviewOverrides(
+      widthPx = base.widthPx,
+      heightPx = base.heightPx,
+      density = base.density,
+      device = base.device,
+      localeTag = base.localeTag,
+      fontScale = base.fontScale,
+      uiMode = base.uiMode,
+      orientation = base.orientation,
+      inspectionMode = base.inspectionMode,
+    )
+  }
+  val deviceOverride = overrides.device?.takeIf { it.isNotBlank() }
+  val deviceSpec = deviceOverride?.let { DeviceDimensions.resolve(it) }
+  val effectiveDensity = overrides.density ?: deviceSpec?.density ?: base.density
+  val widthPx =
+    overrides.widthPx ?: deviceSpec?.let { (it.widthDp * effectiveDensity).toInt() } ?: base.widthPx
+  val heightPx =
+    overrides.heightPx
+      ?: deviceSpec?.let { (it.heightDp * effectiveDensity).toInt() }
+      ?: base.heightPx
+  return MergedPreviewOverrides(
+    widthPx = widthPx,
+    heightPx = heightPx,
+    density = effectiveDensity,
+    device = deviceOverride ?: base.device,
+    localeTag = overrides.localeTag?.takeIf { it.isNotBlank() } ?: base.localeTag,
+    fontScale = overrides.fontScale ?: base.fontScale,
+    uiMode = overrides.uiMode ?: base.uiMode,
+    orientation = overrides.orientation ?: base.orientation,
+    inspectionMode = overrides.inspectionMode ?: base.inspectionMode,
+  )
+}

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMergeTest.kt
@@ -1,0 +1,77 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.Orientation
+import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.daemon.protocol.UiMode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class PreviewOverrideMergeTest {
+  @Test
+  fun `null overrides preserve base spec`() {
+    val base =
+      PreviewOverrideBaseSpec(
+        widthPx = 100,
+        heightPx = 200,
+        density = 2.0f,
+        device = "id:pixel_5",
+        localeTag = "en-US",
+        fontScale = 1.2f,
+        uiMode = UiMode.DARK,
+        orientation = Orientation.PORTRAIT,
+        inspectionMode = false,
+      )
+
+    val merged = mergePreviewOverrides(base, null)
+
+    assertEquals(100, merged.widthPx)
+    assertEquals(200, merged.heightPx)
+    assertEquals(2.0f, merged.density)
+    assertEquals("id:pixel_5", merged.device)
+    assertEquals("en-US", merged.localeTag)
+    assertEquals(1.2f, merged.fontScale)
+    assertEquals(UiMode.DARK, merged.uiMode)
+    assertEquals(Orientation.PORTRAIT, merged.orientation)
+    assertEquals(false, merged.inspectionMode)
+  }
+
+  @Test
+  fun `device override resolves dimensions and explicit fields win`() {
+    val base =
+      PreviewOverrideBaseSpec(
+        widthPx = 100,
+        heightPx = 200,
+        density = 1.0f,
+        device = null,
+        localeTag = null,
+        fontScale = null,
+        uiMode = null,
+        orientation = null,
+        inspectionMode = null,
+      )
+
+    val merged =
+      mergePreviewOverrides(
+        base,
+        PreviewOverrides(
+          device = "spec:width=50dp,height=80dp,dpi=320",
+          widthPx = 123,
+          localeTag = "de",
+          fontScale = 1.5f,
+          uiMode = UiMode.LIGHT,
+          orientation = Orientation.LANDSCAPE,
+          inspectionMode = true,
+        ),
+      )
+
+    assertEquals(123, merged.widthPx)
+    assertEquals(160, merged.heightPx)
+    assertEquals(2.0f, merged.density)
+    assertEquals("spec:width=50dp,height=80dp,dpi=320", merged.device)
+    assertEquals("de", merged.localeTag)
+    assertEquals(1.5f, merged.fontScale)
+    assertEquals(UiMode.LIGHT, merged.uiMode)
+    assertEquals(Orientation.LANDSCAPE, merged.orientation)
+    assertEquals(true, merged.inspectionMode)
+  }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -395,42 +395,58 @@ open class DesktopHost(
     overrides: ee.schimke.composeai.daemon.protocol.PreviewOverrides?,
     recordingId: String,
   ): RenderSpec {
-    if (overrides == null) {
-      return base.copy(outputBaseName = "recording-$recordingId")
-    }
-    val deviceOverride = overrides.device?.takeIf { it.isNotBlank() }
-    val deviceSpec = deviceOverride?.let {
-      ee.schimke.composeai.daemon.devices.DeviceDimensions.resolve(it)
-    }
-    val baseDensity = overrides.density ?: deviceSpec?.density ?: base.density
-    val baseWidthPx =
-      overrides.widthPx ?: deviceSpec?.let { (it.widthDp * baseDensity).toInt() } ?: base.widthPx
-    val baseHeightPx =
-      overrides.heightPx ?: deviceSpec?.let { (it.heightDp * baseDensity).toInt() } ?: base.heightPx
+    val merged =
+      mergePreviewOverrides(
+        base =
+          PreviewOverrideBaseSpec(
+            widthPx = base.widthPx,
+            heightPx = base.heightPx,
+            density = base.density,
+            device = base.device,
+            localeTag = base.localeTag,
+            fontScale = base.fontScale,
+            uiMode =
+              when (base.uiMode) {
+                RenderSpec.SpecUiMode.LIGHT -> ee.schimke.composeai.daemon.protocol.UiMode.LIGHT
+                RenderSpec.SpecUiMode.DARK -> ee.schimke.composeai.daemon.protocol.UiMode.DARK
+                null -> null
+              },
+            orientation =
+              when (base.orientation) {
+                RenderSpec.SpecOrientation.PORTRAIT ->
+                  ee.schimke.composeai.daemon.protocol.Orientation.PORTRAIT
+                RenderSpec.SpecOrientation.LANDSCAPE ->
+                  ee.schimke.composeai.daemon.protocol.Orientation.LANDSCAPE
+                null -> null
+              },
+            inspectionMode = base.inspectionMode,
+          ),
+        overrides = overrides,
+      )
     val uiMode =
-      when (overrides.uiMode) {
+      when (merged.uiMode) {
         ee.schimke.composeai.daemon.protocol.UiMode.LIGHT -> RenderSpec.SpecUiMode.LIGHT
         ee.schimke.composeai.daemon.protocol.UiMode.DARK -> RenderSpec.SpecUiMode.DARK
-        null -> base.uiMode
+        null -> null
       }
     val orientation =
-      when (overrides.orientation) {
+      when (merged.orientation) {
         ee.schimke.composeai.daemon.protocol.Orientation.PORTRAIT ->
           RenderSpec.SpecOrientation.PORTRAIT
         ee.schimke.composeai.daemon.protocol.Orientation.LANDSCAPE ->
           RenderSpec.SpecOrientation.LANDSCAPE
-        null -> base.orientation
+        null -> null
       }
     return base.copy(
-      widthPx = baseWidthPx,
-      heightPx = baseHeightPx,
-      density = baseDensity,
-      device = deviceOverride ?: base.device,
-      localeTag = overrides.localeTag?.takeIf { it.isNotBlank() } ?: base.localeTag,
-      fontScale = overrides.fontScale ?: base.fontScale,
+      widthPx = merged.widthPx,
+      heightPx = merged.heightPx,
+      density = merged.density,
+      device = merged.device,
+      localeTag = merged.localeTag,
+      fontScale = merged.fontScale,
       uiMode = uiMode,
       orientation = orientation,
-      inspectionMode = overrides.inspectionMode ?: base.inspectionMode,
+      inspectionMode = merged.inspectionMode,
       outputBaseName = "recording-$recordingId",
     )
   }


### PR DESCRIPTION
## Summary
- add shared daemon-core PreviewOverrides merge helper for recording specs
- use the shared merge from desktop recording and Android recording acquisition
- allow Android scripted recording/start to honor per-call size/device/display overrides instead of rejecting them

Part of #504 (per-call PreviewOverrides on Android recording/start).

## Tests
- `./gradlew :daemon:core:test --tests 'ee.schimke.composeai.daemon.PreviewOverrideMergeTest' :daemon:android:testDebugUnitTest --tests 'ee.schimke.composeai.daemon.AndroidRecordingSessionTest.acquireWithOverridesAppliesFrameSize'`
- `./gradlew :daemon:desktop:test --tests 'ee.schimke.composeai.daemon.DesktopRecordingSessionTest'`