### PR TITLE
Implement fonts/used data product

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -265,6 +265,10 @@ fun main(args: Array<String>) {
             "compose-ai-tools daemon: I18nTranslationsDataProductRegistry active (dataRoot=$dataRoot)"
           )
           add(I18nTranslationsDataProductRegistry(rootDir = dataRoot))
+          System.err.println(
+            "compose-ai-tools daemon: FontsUsedDataProductRegistry active (dataRoot=$dataRoot)"
+          )
+          add(FontsUsedDataProductRegistry(rootDir = dataRoot))
           if (PerfettoTraceDataProducer.enabled()) {
             System.err.println(
               "compose-ai-tools daemon: PerfettoTraceDataProductRegistry active (dataRoot=$dataRoot)"

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -331,13 +331,15 @@ private fun previewIndexBackedSpecResolver(previewIndex: PreviewIndex): ((String
  * resource uiMode threaded through so a live Wear preview matches the one-shot render.
  */
 internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
-  val defaults = RenderSpec(className = info.className, functionName = info.methodName)
+  val defaults =
+    RenderSpec(previewId = info.id, className = info.className, functionName = info.methodName)
   val params = info.params ?: return defaults
   val density = params.density ?: defaults.density
   val widthPx = params.widthDp?.let { (it * density).toInt() } ?: defaults.widthPx
   val heightPx = params.heightDp?.let { (it * density).toInt() } ?: defaults.heightPx
   val uiMode = if (uiModeIsNight(params.uiMode)) RenderSpec.SpecUiMode.DARK else defaults.uiMode
   return RenderSpec(
+    previewId = info.id,
     className = info.className,
     functionName = info.methodName,
     widthPx = widthPx,

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/FontResolverRecorder.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/FontResolverRecorder.kt
@@ -1,0 +1,177 @@
+package ee.schimke.composeai.daemon
+
+import android.content.Context
+import android.util.TypedValue
+import androidx.compose.runtime.State
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontListFontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.font.GenericFontFamily
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Proxy
+import java.util.Collections
+
+class FontResolverRecorder(private val context: Context? = null) {
+  private val entries = Collections.synchronizedMap(linkedMapOf<String, FontUsedEntry>())
+
+  fun record(fontFamily: FontFamily?, fontWeight: FontWeight?, fontStyle: Any?, resolved: Any?) {
+    val weight = fontWeight?.weight ?: FontWeight.Normal.weight
+    val style = styleName(fontStyle)
+    val requestedFamily = requestedFamily(fontFamily)
+    val resolvedFamily = resolvedFamily(resolved)
+    val chain = fallbackCandidates(fontFamily).filterNot { it == resolvedFamily }.take(5)
+    val key = listOf(requestedFamily, resolvedFamily, weight.toString(), style).joinToString("|")
+    entries[key] =
+      FontUsedEntry(
+        requestedFamily = requestedFamily,
+        resolvedFamily = resolvedFamily,
+        weight = weight,
+        style = style,
+        sourceFile = sourceFile(fontFamily, fontWeight, fontStyle),
+        fellBackFrom = chain.takeIf { it.isNotEmpty() },
+        consumerNodeIds = emptyList(),
+      )
+  }
+
+  fun payload(): FontsUsedPayload =
+    FontsUsedPayload(
+      fonts =
+        synchronized(entries) {
+          entries.values.sortedWith(compareBy({ it.requestedFamily }, { it.weight }, { it.style }))
+        }
+    )
+
+  private fun sourceFile(
+    fontFamily: FontFamily?,
+    fontWeight: FontWeight?,
+    fontStyle: Any?,
+  ): String? {
+    val font = matchingFont(fontFamily, fontWeight, fontStyle) ?: return null
+    val resId = resourceId(font)
+    val ctx = context
+    if (resId != null && ctx != null) {
+      val value = TypedValue()
+      val path =
+        runCatching {
+            ctx.resources.getValue(resId, value, true)
+            value.string?.toString()
+          }
+          .getOrNull()
+      if (!path.isNullOrBlank()) return path
+    }
+    val label = fontLabel(font)
+    return label.takeIf { it.isNotBlank() && !it.startsWith("ResourceFont(") }
+  }
+}
+
+fun recordingFontFamilyResolver(
+  delegate: FontFamily.Resolver,
+  recorder: FontResolverRecorder,
+): FontFamily.Resolver {
+  val handler =
+    InvocationHandler { _, method, args ->
+      if (method.declaringClass == Any::class.java) {
+        return@InvocationHandler when (method.name) {
+          "toString" -> "RecordingFontFamilyResolver($delegate)"
+          "hashCode" -> System.identityHashCode(delegate)
+          "equals" -> delegate === args?.firstOrNull()
+          else -> method.invoke(delegate, *(args ?: emptyArray()))
+        }
+      }
+      val result =
+        try {
+          method.invoke(delegate, *(args ?: emptyArray()))
+        } catch (e: InvocationTargetException) {
+          throw e.targetException ?: e
+        }
+      if (method.name.startsWith("resolve")) {
+        @Suppress("UNCHECKED_CAST") val state = result as? State<Any>
+        recorder.record(
+          fontFamily = args?.getOrNull(0) as? FontFamily,
+          fontWeight = args?.getOrNull(1) as? FontWeight,
+          fontStyle = args?.getOrNull(2),
+          resolved = state?.value,
+        )
+      }
+      result
+    }
+  return Proxy.newProxyInstance(
+      FontFamily.Resolver::class.java.classLoader,
+      arrayOf(FontFamily.Resolver::class.java),
+      handler,
+    )
+    as FontFamily.Resolver
+}
+
+private fun requestedFamily(fontFamily: FontFamily?): String =
+  when (fontFamily) {
+    null -> "FontFamily.Default"
+    is GenericFontFamily -> fontFamily.name
+    is FontListFontFamily -> fallbackCandidates(fontFamily).firstOrNull() ?: fontFamily.toString()
+    else -> fontFamily.toString()
+  }
+
+private fun fallbackCandidates(fontFamily: FontFamily?): List<String> =
+  when (fontFamily) {
+    is FontListFontFamily -> fontFamily.fonts.map(::fontLabel).distinct()
+    null -> emptyList()
+    else -> emptyList()
+  }
+
+private fun matchingFont(fontFamily: FontFamily?, fontWeight: FontWeight?, fontStyle: Any?): Font? {
+  val list = fontFamily as? FontListFontFamily ?: return null
+  val weight = fontWeight?.weight ?: FontWeight.Normal.weight
+  val style = styleName(fontStyle)
+  return list.fonts.firstOrNull { it.weight.weight == weight && styleName(it.style) == style }
+    ?: list.fonts.firstOrNull { it.weight.weight == weight }
+    ?: list.fonts.firstOrNull()
+}
+
+private fun fontLabel(font: Font): String {
+  val identity =
+    runCatching {
+        val field = font.javaClass.getDeclaredField("identity")
+        field.isAccessible = true
+        field.get(font) as? String
+      }
+      .getOrNull()
+  if (!identity.isNullOrBlank()) return identity
+  val resId = resourceId(font)
+  if (resId != null) return "res/font/$resId"
+  return font.toString()
+}
+
+private fun resourceId(font: Font): Int? =
+  runCatching {
+      val field = font.javaClass.getDeclaredField("resId")
+      field.isAccessible = true
+      field.get(font) as? Int
+    }
+    .getOrNull()
+
+private fun resolvedFamily(resolved: Any?): String {
+  if (resolved == null) return "<unresolved>"
+  val reflected =
+    listOf("getFamilyName", "getFamily", "getName")
+      .firstNotNullOfOrNull { name ->
+        runCatching {
+            val value =
+              resolved.javaClass.methods
+                .firstOrNull { it.name == name && it.parameterCount == 0 }
+                ?.invoke(resolved)
+            value as? String
+          }
+          .getOrNull()
+      }
+  return reflected?.takeIf { it.isNotBlank() } ?: resolved.toString()
+}
+
+private fun styleName(style: Any?): String {
+  val raw = style?.toString()?.lowercase()
+  return when {
+    raw == "1" || raw?.contains("italic") == true -> "italic"
+    else -> "normal"
+  }
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/FontResolverRecorder.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/FontResolverRecorder.kt
@@ -71,12 +71,12 @@ fun recordingFontFamilyResolver(
   recorder: FontResolverRecorder,
 ): FontFamily.Resolver {
   val handler =
-    InvocationHandler { _, method, args ->
+    InvocationHandler { proxy, method, args ->
       if (method.declaringClass == Any::class.java) {
         return@InvocationHandler when (method.name) {
           "toString" -> "RecordingFontFamilyResolver($delegate)"
-          "hashCode" -> System.identityHashCode(delegate)
-          "equals" -> delegate === args?.firstOrNull()
+          "hashCode" -> System.identityHashCode(proxy)
+          "equals" -> proxy === args?.firstOrNull()
           else -> method.invoke(delegate, *(args ?: emptyArray()))
         }
       }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -159,6 +159,7 @@ class PreviewManifestRouter(
 private fun PreviewManifestEntry.renderSpec(): RenderSpec {
   val resolved = resolved()
   return RenderSpec(
+    previewId = id,
     className = className,
     functionName = functionName,
     widthPx = resolved.widthPx,

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalFontFamilyResolver
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewRootForTest
@@ -218,6 +219,7 @@ class RenderEngine(
             val bgArgb = resolveBackgroundColor(spec).toArgb()
             rule.runOnUiThread { rule.activity.window.decorView.setBackgroundColor(bgArgb) }
             val resourceRecorder = ResourcesUsedDataProducer.recorder(rule.activity)
+            val fontRecorder = FontResolverRecorder(rule.activity)
 
             trace.section("compose:setContent") {
               rule.setContent {
@@ -227,9 +229,12 @@ class RenderEngine(
                 // through rather than parking under the paused clock — same trade
                 // `RobolectricRenderTest.renderWithA11y` already pays.
                 val inspectionMode = if (runAccessibility) false else spec.inspectionMode ?: true
+                val baseFontResolver = LocalFontFamilyResolver.current
                 CompositionLocalProvider(
                   LocalInspectionMode provides inspectionMode,
                   LocalContext provides ResourcesUsedDataProducer.context(rule.activity, resourceRecorder),
+                  LocalFontFamilyResolver provides
+                    recordingFontFamilyResolver(baseFontResolver, fontRecorder),
                 ) {
                   Box(modifier = Modifier.fillMaxSize()) { InvokeComposable(composableMethod) }
                 }
@@ -259,6 +264,23 @@ class RenderEngine(
                   it.captureRoboImage(file = outputFile, roborazziOptions = roborazziOptions)
                 }
               }
+
+            if (dataDir != null) {
+              try {
+                trace.section("compose:fontsUsedDataProduct") {
+                  FontsUsedDataProducer.writeArtifacts(
+                    rootDir = dataDir,
+                    previewId = spec.previewId ?: spec.outputBaseName,
+                    payload = fontRecorder.payload(),
+                  )
+                }
+              } catch (t: Throwable) {
+                System.err.println(
+                  "RenderEngine: fonts/used data write failed for ${spec.outputBaseName}: " +
+                    "${t.javaClass.simpleName}: ${t.message}"
+                )
+              }
+            }
 
             if (dataDir != null) {
               try {
@@ -516,6 +538,7 @@ private fun InvokeComposable(composableMethod: ComposableMethod) {
  * cross-backend driver can drive both backends with the same payload string.
  */
 data class RenderSpec(
+  val previewId: String? = null,
   /** Fully-qualified name of the class containing the @Preview function. */
   val className: String,
   /** Method name of the @Preview function (parameterless overload). */
@@ -599,6 +622,7 @@ data class RenderSpec(
       val functionName = map["functionName"] ?: return null
       val defaults = RenderSpec(className = className, functionName = functionName)
       return RenderSpec(
+        previewId = map["previewId"]?.takeIf { it.isNotBlank() },
         className = className,
         functionName = functionName,
         widthPx = map["widthPx"]?.toIntOrNull() ?: defaults.widthPx,

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/FontResolverRecorderTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/FontResolverRecorderTest.kt
@@ -1,0 +1,35 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.ui.text.font.FontFamily
+import java.lang.reflect.Proxy
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FontResolverRecorderTest {
+
+  @Test
+  fun `recording resolver preserves reflexive equals`() {
+    val delegate = proxyResolver()
+    val resolver = recordingFontFamilyResolver(delegate, FontResolverRecorder())
+
+    assertTrue(resolver.equals(resolver))
+    assertFalse(resolver.equals(delegate))
+    assertEquals(System.identityHashCode(resolver), resolver.hashCode())
+  }
+
+  private fun proxyResolver(): FontFamily.Resolver =
+    Proxy.newProxyInstance(
+        FontFamily.Resolver::class.java.classLoader,
+        arrayOf(FontFamily.Resolver::class.java),
+      ) { proxy, method, args ->
+        when (method.name) {
+          "toString" -> "DelegateFontFamilyResolver"
+          "hashCode" -> System.identityHashCode(proxy)
+          "equals" -> proxy === args?.firstOrNull()
+          else -> error("Unexpected resolver method in equals test: ${method.name}")
+        }
+      }
+      as FontFamily.Resolver
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -108,6 +108,51 @@ class RenderEngineTest {
   }
 
   @Test
+  fun serifTextWritesFontsUsedDataProduct() {
+    val outputDir = tempFolder.newFolder("renders-fonts")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost()
+    host.start()
+    try {
+      val result =
+        host.submit(
+          RenderRequest.Render(
+            payload =
+              "previewId=serif-text;" +
+                "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+                "functionName=SerifTextPreview;" +
+                "widthPx=160;heightPx=48;density=1.0;" +
+                "showBackground=true;" +
+                "outputBaseName=serif-text"
+          ),
+          timeoutMs = 120_000,
+        )
+      assertNotNull(result.pngPath)
+
+      val fontsFile =
+        outputDir.parentFile!!
+          .resolve("data")
+          .resolve("serif-text")
+          .resolve(FontsUsedDataProducer.FILE)
+      assertTrue("fonts/used data product should be written: $fontsFile", fontsFile.exists())
+      val payload = Json.parseToJsonElement(fontsFile.readText()).jsonObject
+      val fonts = payload["fonts"]!!.jsonArray
+      assertTrue("expected at least one resolved font entry", fonts.isNotEmpty())
+      val serif =
+        fonts
+          .map { it.jsonObject }
+          .firstOrNull { it["requestedFamily"]?.jsonPrimitive?.content == "serif" }
+      assertNotNull("expected FontFamily.Serif request in $fonts", serif)
+      assertEquals("normal", serif!!["style"]!!.jsonPrimitive.content)
+      assertEquals("400", serif["weight"]!!.jsonPrimitive.content)
+      assertTrue(serif["resolvedFamily"]!!.jsonPrimitive.content.isNotBlank())
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
   fun fiveSequentialRendersExposeWarmRuntime() {
     val outputDir = tempFolder.newFolder("renders-warmup")
     System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
@@ -1,0 +1,38 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RenderSpecFromInfoTest {
+
+  @Test
+  fun `preview id is preserved without params`() {
+    val spec =
+      renderSpecFromInfo(
+        PreviewInfoDto(
+          id = "preview-id",
+          className = "com.example.FooKt",
+          methodName = "Foo",
+          params = null,
+        )
+      )
+
+    assertEquals("preview-id", spec.previewId)
+  }
+
+  @Test
+  fun `preview id is preserved with params`() {
+    val spec =
+      renderSpecFromInfo(
+        PreviewInfoDto(
+          id = "preview-id",
+          className = "com.example.FooKt",
+          methodName = "Foo",
+          params = PreviewParamsDto(widthDp = 200, density = 1.5f),
+        )
+      )
+
+    assertEquals("preview-id", spec.previewId)
+    assertEquals(300, spec.widthPx)
+  }
+}

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Composable
@@ -25,6 +26,8 @@ import androidx.compose.ui.input.rotary.onRotaryScrollEvent
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 
 /**
@@ -51,6 +54,11 @@ fun RedSquare() {
 @Composable
 fun BlueSquare() {
   Box(modifier = Modifier.fillMaxSize().background(Color(0xFF42A5F5)))
+}
+
+@Composable
+fun SerifTextPreview() {
+  BasicText("Serif text", style = TextStyle(fontFamily = FontFamily.Serif))
 }
 
 /**

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FontsUsedDataProduct.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/FontsUsedDataProduct.kt
@@ -1,0 +1,107 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import java.io.File
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+/** Path-backed producer for `fonts/used`, written by backend render loops in default mode. */
+class FontsUsedDataProductRegistry(private val rootDir: File) : DataProductRegistry {
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = FontsUsedDataProducer.KIND,
+        schemaVersion = FontsUsedDataProducer.SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+      )
+    )
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != FontsUsedDataProducer.KIND) return DataProductRegistry.Outcome.Unknown
+    val payload =
+      try {
+        readPayload(previewId)
+      } catch (t: Throwable) {
+        return DataProductRegistry.Outcome.FetchFailed(
+          message = "could not parse $kind for $previewId: ${t.message}"
+        )
+      } ?: return DataProductRegistry.Outcome.NotAvailable
+    return DataProductRegistry.Outcome.Ok(
+      DataFetchResult(
+        kind = FontsUsedDataProducer.KIND,
+        schemaVersion = FontsUsedDataProducer.SCHEMA_VERSION,
+        payload =
+          FontsUsedDataProducer.json.encodeToJsonElement(FontsUsedPayload.serializer(), payload),
+      )
+    )
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
+    if (FontsUsedDataProducer.KIND !in kinds) return emptyList()
+    val payload =
+      try {
+        readPayload(previewId)
+      } catch (_: Throwable) {
+        null
+      } ?: return emptyList()
+    return listOf(
+      DataProductAttachment(
+        kind = FontsUsedDataProducer.KIND,
+        schemaVersion = FontsUsedDataProducer.SCHEMA_VERSION,
+        payload =
+          FontsUsedDataProducer.json.encodeToJsonElement(FontsUsedPayload.serializer(), payload),
+      )
+    )
+  }
+
+  private fun readPayload(previewId: String): FontsUsedPayload? {
+    val file = rootDir.resolve(previewId).resolve(FontsUsedDataProducer.FILE)
+    if (!file.exists()) return null
+    return FontsUsedDataProducer.json.decodeFromString(
+      FontsUsedPayload.serializer(),
+      file.readText(),
+    )
+  }
+}
+
+object FontsUsedDataProducer {
+  const val KIND: String = "fonts/used"
+  const val SCHEMA_VERSION: Int = 1
+  const val FILE: String = "fonts-used.json"
+
+  val json: Json = Json {
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+    prettyPrint = false
+  }
+
+  fun writeArtifacts(rootDir: File, previewId: String, payload: FontsUsedPayload) {
+    val previewDir = rootDir.resolve(previewId).also { it.mkdirs() }
+    previewDir.resolve(FILE).writeText(json.encodeToString(FontsUsedPayload.serializer(), payload))
+  }
+}
+
+@Serializable data class FontsUsedPayload(val fonts: List<FontUsedEntry>)
+
+@Serializable
+data class FontUsedEntry(
+  val requestedFamily: String,
+  val resolvedFamily: String,
+  val weight: Int,
+  val style: String,
+  val sourceFile: String? = null,
+  val fellBackFrom: List<String>? = null,
+  val consumerNodeIds: List<String> = emptyList(),
+)

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/FontsUsedDataProductRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/FontsUsedDataProductRegistryTest.kt
@@ -1,0 +1,83 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class FontsUsedDataProductRegistryTest {
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun capabilities_advertise_fonts_used_as_default_inline_product() {
+    val registry = FontsUsedDataProductRegistry(tempFolder.root)
+    val cap = registry.capabilities.single()
+    assertEquals("fonts/used", cap.kind)
+    assertEquals(1, cap.schemaVersion)
+    assertEquals(DataProductTransport.INLINE, cap.transport)
+    assertTrue(cap.attachable)
+    assertTrue(cap.fetchable)
+    assertTrue(!cap.requiresRerender)
+  }
+
+  @Test
+  fun fetch_reads_payload_written_by_render_loop() {
+    val root = tempFolder.newFolder("data")
+    FontsUsedDataProducer.writeArtifacts(
+      rootDir = root,
+      previewId = "preview-1",
+      payload =
+        FontsUsedPayload(
+          fonts =
+            listOf(
+              FontUsedEntry(
+                requestedFamily = "serif",
+                resolvedFamily = "Serif",
+                weight = 400,
+                style = "normal",
+                sourceFile = null,
+                fellBackFrom = listOf("Poppins"),
+                consumerNodeIds = emptyList(),
+              )
+            )
+        ),
+    )
+
+    val outcome =
+      FontsUsedDataProductRegistry(root)
+        .fetch("preview-1", "fonts/used", params = null, inline = true)
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    val payload = (outcome as DataProductRegistry.Outcome.Ok).result.payload!!.jsonObject
+    val font = payload["fonts"]!!.jsonArray.single().jsonObject
+    assertEquals("serif", font["requestedFamily"]!!.jsonPrimitive.content)
+    assertEquals("Serif", font["resolvedFamily"]!!.jsonPrimitive.content)
+    assertEquals("400", font["weight"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun fetch_missing_payload_returns_not_available() {
+    val root = tempFolder.newFolder("data-missing")
+    val outcome = FontsUsedDataProductRegistry(root).fetch("missing", "fonts/used", null, true)
+    assertEquals(DataProductRegistry.Outcome.NotAvailable, outcome)
+  }
+
+  @Test
+  fun attachments_return_written_payload() {
+    val root = tempFolder.newFolder("data-attachments")
+    FontsUsedDataProducer.writeArtifacts(
+      rootDir = root,
+      previewId = "preview-1",
+      payload = FontsUsedPayload(fonts = emptyList()),
+    )
+
+    val attachments =
+      FontsUsedDataProductRegistry(root).attachmentsFor("preview-1", setOf("fonts/used"))
+    assertEquals(1, attachments.size)
+    assertEquals("fonts/used", attachments.single().kind)
+  }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -369,13 +369,15 @@ private fun previewIndexBackedSpecResolver(previewIndex: PreviewIndex): ((String
  * exercise the conversion without standing up a [PreviewIndex] + lambda.
  */
 internal fun renderSpecFromInfo(info: PreviewInfoDto): RenderSpec {
-  val defaults = RenderSpec(className = info.className, functionName = info.methodName)
+  val defaults =
+    RenderSpec(previewId = info.id, className = info.className, functionName = info.methodName)
   val params = info.params ?: return defaults
   val density = params.density ?: defaults.density
   val widthPx = params.widthDp?.let { (it * density).toInt() } ?: defaults.widthPx
   val heightPx = params.heightDp?.let { (it * density).toInt() } ?: defaults.heightPx
   val uiMode = if (uiModeIsNight(params.uiMode)) RenderSpec.SpecUiMode.DARK else defaults.uiMode
   return RenderSpec(
+    previewId = info.id,
     className = info.className,
     functionName = info.methodName,
     widthPx = widthPx,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -224,16 +224,6 @@ fun main(args: Array<String>) {
       buildList {
         add(DeviceClipDataProductRegistry(previewIndex = previewIndex))
         add(RenderTraceDataProductRegistry())
-        val renderOutputDir =
-          File(
-            System.getProperty(RenderEngine.OUTPUT_DIR_PROP)
-              ?: "${System.getProperty("user.dir")}/.compose-preview-history/daemon-renders"
-          )
-        val dataRoot = renderOutputDir.parentFile?.resolve("data") ?: renderOutputDir
-        System.err.println(
-          "compose-ai-tools desktop daemon: FontsUsedDataProductRegistry active (dataRoot=$dataRoot)"
-        )
-        add(FontsUsedDataProductRegistry(rootDir = dataRoot))
         add(themeRegistry)
         add(recompositionRegistry)
         if (PerfettoTraceDataProducer.enabled()) {

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -224,6 +224,16 @@ fun main(args: Array<String>) {
       buildList {
         add(DeviceClipDataProductRegistry(previewIndex = previewIndex))
         add(RenderTraceDataProductRegistry())
+        val renderOutputDir =
+          File(
+            System.getProperty(RenderEngine.OUTPUT_DIR_PROP)
+              ?: "${System.getProperty("user.dir")}/.compose-preview-history/daemon-renders"
+          )
+        val dataRoot = renderOutputDir.parentFile?.resolve("data") ?: renderOutputDir
+        System.err.println(
+          "compose-ai-tools desktop daemon: FontsUsedDataProductRegistry active (dataRoot=$dataRoot)"
+        )
+        add(FontsUsedDataProductRegistry(rootDir = dataRoot))
         add(themeRegistry)
         add(recompositionRegistry)
         if (PerfettoTraceDataProducer.enabled()) {

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -281,6 +281,20 @@ class RenderEngine(
 
     state.outputFile.parentFile?.mkdirs()
     trace.section("render:writePng") { state.outputFile.writeBytes(pngData.bytes) }
+    dataDir?.let { dataRoot ->
+      val previewId = state.spec.previewId ?: state.spec.outputBaseName
+      trace.section("compose:fontsUsedDataProduct") {
+        // Compose Desktop's paragraph builder casts LocalFontFamilyResolver to Compose's internal
+        // resolver implementation, so replacing it with a recording proxy crashes text layout.
+        // Keep the product available and path-backed on desktop, but leave resolver-level capture
+        // to the Android backend until desktop exposes a proxy-safe resolver seam.
+        FontsUsedDataProducer.writeArtifacts(
+          dataRoot,
+          previewId,
+          FontsUsedPayload(fonts = emptyList()),
+        )
+      }
+    }
 
     val tookMs = (System.nanoTime() - startNs) / 1_000_000L
     val metrics = SandboxMeasurement.collect(sandboxStats, tookMs = tookMs)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -281,20 +281,6 @@ class RenderEngine(
 
     state.outputFile.parentFile?.mkdirs()
     trace.section("render:writePng") { state.outputFile.writeBytes(pngData.bytes) }
-    dataDir?.let { dataRoot ->
-      val previewId = state.spec.previewId ?: state.spec.outputBaseName
-      trace.section("compose:fontsUsedDataProduct") {
-        // Compose Desktop's paragraph builder casts LocalFontFamilyResolver to Compose's internal
-        // resolver implementation, so replacing it with a recording proxy crashes text layout.
-        // Keep the product available and path-backed on desktop, but leave resolver-level capture
-        // to the Android backend until desktop exposes a proxy-safe resolver seam.
-        FontsUsedDataProducer.writeArtifacts(
-          dataRoot,
-          previewId,
-          FontsUsedPayload(fonts = emptyList()),
-        )
-      }
-    }
 
     val tookMs = (System.nanoTime() - startNs) / 1_000_000L
     val metrics = SandboxMeasurement.collect(sandboxStats, tookMs = tookMs)

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/RenderSpecFromInfoTest.kt
@@ -36,6 +36,7 @@ class RenderSpecFromInfoTest {
     assertNull(spec.localeTag)
     assertNull(spec.fontScale)
     assertNull(spec.device)
+    assertEquals("Foo", spec.previewId)
     assertEquals("com.example.FooKt", spec.className)
     assertEquals("Foo", spec.functionName)
   }


### PR DESCRIPTION
Closes #453

Summary:
- add the core fonts/used registry, schema v1 payload, and path-backed artifact reader/writer
- record Android font resolver calls through LocalFontFamilyResolver and emit requested/resolved family, weight, style, source file, and fallback candidates
- register the product on Android only; Desktop does not advertise fonts/used because Compose Desktop casts the resolver to an internal implementation during text layout, so callers see it as unavailable instead of receiving placeholder data

Tests:
- ./gradlew :daemon:desktop:ktfmtFormat :daemon:desktop:compileKotlin :daemon:core:test --tests ee.schimke.composeai.daemon.FontsUsedDataProductRegistryTest :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.RenderEngineTest.serifTextWritesFontsUsedDataProduct
- git diff --check