### PR TITLE
Fix recent Codex review followups

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/I18nTranslationsDataProduct.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/I18nTranslationsDataProduct.kt
@@ -234,6 +234,7 @@ internal data class AndroidStringCatalog(
   companion object {
     fun load(resDirs: List<File>, defaultLocale: String): AndroidStringCatalog {
       val entries = linkedMapOf<String, AndroidStringEntry>()
+      val nonTranslatable = linkedSetOf<String>()
       val locales = linkedSetOf(defaultLocale)
       resDirs.filter { it.isDirectory }.forEach { resDir ->
         resDir.listFiles()
@@ -244,7 +245,7 @@ internal data class AndroidStringCatalog(
             locales.add(locale)
             valuesDir.listFiles { file -> file.isFile && file.extension == "xml" }
               ?.sortedBy { it.name }
-              ?.forEach { xml -> parseStringsXml(xml, locale, defaultLocale, entries) }
+              ?.forEach { xml -> parseStringsXml(xml, locale, defaultLocale, entries, nonTranslatable) }
           }
       }
       return AndroidStringCatalog(
@@ -259,6 +260,7 @@ internal data class AndroidStringCatalog(
       locale: String,
       defaultLocale: String,
       entries: MutableMap<String, AndroidStringEntry>,
+      nonTranslatable: MutableSet<String>,
     ) {
       val doc =
         runCatching {
@@ -275,7 +277,12 @@ internal data class AndroidStringCatalog(
       for (i in 0 until nodes.length) {
         val element = nodes.item(i) as? Element ?: continue
         val name = element.getAttribute("name").takeIf { it.isNotBlank() } ?: continue
-        if (element.getAttribute("translatable") == "false" && locale != defaultLocale) continue
+        if (element.getAttribute("translatable") == "false") {
+          nonTranslatable.add(name)
+          entries.remove(name)
+          continue
+        }
+        if (name in nonTranslatable) continue
         val value = element.textContent?.trim()?.takeIf { it.isNotBlank() } ?: continue
         val entry = entries.getOrPut(name) { AndroidStringEntry(name = name) }
         if (locale == defaultLocale) {

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -632,12 +632,13 @@ open class RobolectricHost(
           "RobolectricHost.previewSpecResolver returned null for previewId='$previewId'; " +
             "interactive session not allocated"
         )
-    return acquireInteractiveSession(previewId = previewId, spec = spec)
+    return acquireInteractiveSession(previewId = previewId, spec = spec, inspectionMode = inspectionMode)
   }
 
   private fun acquireInteractiveSession(
     previewId: String,
     spec: RenderSpec,
+    inspectionMode: Boolean? = spec.inspectionMode,
   ): AndroidInteractiveSession {
     val streamId = "android-stream-${nextStreamCounter.getAndIncrement()}"
     if (!activeInteractiveStreamId.compareAndSet(null, streamId)) {

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/I18nTranslationsDataProductRegistryTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/I18nTranslationsDataProductRegistryTest.kt
@@ -118,6 +118,24 @@ class I18nTranslationsDataProductRegistryTest {
   }
 
   @Test
+  fun `catalog ignores non-translatable default strings`() {
+    val resDir = rootDir.resolve("res")
+    writeStrings(
+      resDir.resolve("values/strings.xml"),
+      """<resources><string name="build_id" translatable="false">debug</string><string name="title">Title</string></resources>""",
+    )
+    writeStrings(
+      resDir.resolve("values-de/strings.xml"),
+      """<resources><string name="build_id">debug</string><string name="title">Titel</string></resources>""",
+    )
+
+    val catalog = AndroidStringCatalog.load(resDirs = listOf(resDir), defaultLocale = "en")
+
+    assertNull(catalog.match("debug", renderedLocale = "en"))
+    assertEquals("R.string.title", catalog.match("Titel", renderedLocale = "de")?.resourceName)
+  }
+
+  @Test
   fun `attachmentsFor emits path only after render wrote translations file`() {
     val previewId = "com.example.I18nPreview"
     val registry = I18nTranslationsDataProductRegistry(rootDir)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PerfettoTraceDataProduct.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PerfettoTraceDataProduct.kt
@@ -185,7 +185,6 @@ class PerfettoTraceDataProductRegistry(private val rootDir: File) : DataProductR
         kind = PerfettoTraceDataProducer.KIND,
         schemaVersion = PerfettoTraceDataProducer.SCHEMA_VERSION,
         path = file.absolutePath,
-        payload = metadataPayload(file),
         extras = listOf(traceExtra(file)),
       )
     )

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PerfettoTraceDataProductRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/PerfettoTraceDataProductRegistryTest.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -75,6 +76,7 @@ class PerfettoTraceDataProductRegistryTest {
     assertEquals(1, attachments.size)
     assertEquals("render/composeAiTrace", attachments.single().kind)
     assertNotNull(attachments.single().path)
+    assertNull(attachments.single().payload)
     assertEquals("perfetto", attachments.single().extras?.single()?.name)
   }
 }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -64,7 +64,7 @@ class RenderEngine(
       System.getProperty(OUTPUT_DIR_PROP)
         ?: "${System.getProperty("user.dir")}/.compose-preview-history/daemon-renders"
     ),
-  private val dataDir: File? = outputDir.parentFile?.resolve("data"),
+  private val dataDir: File = (outputDir.parentFile ?: outputDir).resolve("data"),
   private val themeCapture: ThemeCapture? = null,
 ) {
 
@@ -106,7 +106,7 @@ class RenderEngine(
       }
     } finally {
       trace.section("compose:tearDown") { tearDown(state) }
-      dataDir?.let(trace::write)
+      trace.write(dataDir)
     }
   }
 
@@ -278,7 +278,7 @@ class RenderEngine(
 
     val tookMs = (System.nanoTime() - startNs) / 1_000_000L
     val metrics = SandboxMeasurement.collect(sandboxStats, tookMs = tookMs)
-    dataDir?.let(trace::write)
+    trace.write(dataDir)
     return RenderResult(
       id = requestId,
       classLoaderHashCode = System.identityHashCode(state.classLoader),

--- a/samples/wear/src/main/kotlin/com/example/samplewear/Previews.kt
+++ b/samples/wear/src/main/kotlin/com/example/samplewear/Previews.kt
@@ -45,7 +45,6 @@ import androidx.wear.compose.ui.tooling.preview.WearPreviewLargeRound
 import androidx.wear.compose.ui.tooling.preview.WearPreviewSmallRound
 import ee.schimke.composeai.preview.ScrollMode
 import ee.schimke.composeai.preview.ScrollingPreview
-import java.util.UUID
 
 
 private data class Item(val title: String, val subtitle: String)
@@ -61,8 +60,7 @@ private val sampleItems = listOf(
 
 @Composable
 private fun rememberCompositionId(): String = remember {
-    // TODO: Remove this live-preview diagnostic once interactive refreshes are stable.
-    UUID.randomUUID().toString().take(8)
+    "preview"
 }
 
 @Composable

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -342,7 +342,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     daemonScheduler = new DaemonScheduler(daemonGate, {
         onPreviewImageReady: (_moduleId, previewId, imageBase64) => {
             if (!panel) { return; }
-            if (activeInteractiveStreams.has(previewId)) {
+            if (activeInteractiveStreams.has(previewId) && logFilter.shouldEmitVerbose()) {
                 logLine(`[interactive] frame ${previewId} bytes=${imageBase64.length}`);
             }
             // Capture index 0 — the daemon's v1 renderFinished targets the
@@ -3180,14 +3180,14 @@ async function handleSetInteractive(previewId: string, enabled: boolean): Promis
     }
     try {
         const result = await client.interactiveStart({ previewId });
-        if (result.heldSession !== true) {
+        if (result.heldSession === false) {
             client.interactiveStop({ frameStreamId: result.frameStreamId });
             logLine(
                 `[interactive] live mode unavailable for ${previewId}: daemon returned ` +
                 `stateless stream ${result.frameStreamId}` +
                 (result.fallbackReason ? ` (${result.fallbackReason})` : ''),
             );
-            panel?.postMessage({ command: 'clearInteractive' });
+            panel?.postMessage({ command: 'clearInteractive', previewId });
             updateInteractiveStatus();
             return;
         }
@@ -3204,7 +3204,7 @@ async function handleSetInteractive(previewId: string, enabled: boolean): Promis
         logLine(
             `[interactive] live mode failed for ${previewId}: ${(err as Error).message}`,
         );
-        panel?.postMessage({ command: 'clearInteractive' });
+        panel?.postMessage({ command: 'clearInteractive', previewId });
         updateInteractiveStatus();
         return;
     }
@@ -3227,7 +3227,7 @@ function queueInteractiveMutation(previewId: string, enabled: boolean): void {
         .then(() => handleSetInteractive(previewId, enabled))
         .catch((err) => {
             logLine(`[interactive] setInteractive failed for ${previewId}: ${(err as Error).message}`);
-            panel?.postMessage({ command: 'clearInteractive' });
+            panel?.postMessage({ command: 'clearInteractive', previewId });
         });
 }
 

--- a/vscode-extension/src/logFilter.ts
+++ b/vscode-extension/src/logFilter.ts
@@ -235,6 +235,11 @@ export class LogFilter {
         return true;
     }
 
+    /** Returns true only when verbose logging is enabled. */
+    shouldEmitVerbose(): boolean {
+        return this.level() === 'verbose';
+    }
+
     /** Resets dedupe state — call at session boundaries (extension activation in tests). */
     reset(): void {
         this.warnedOnce.clear();

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -2648,7 +2648,11 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     // different editor). Drop our UI-side bookkeeping in lockstep — the
                     // extension already stopped the streams server-side, so we MUST NOT post
                     // setInteractive messages back; that would race the flush.
-                    if (interactivePreviewIds.size > 0) {
+                    if (msg.previewId) {
+                        interactivePreviewIds.delete(msg.previewId);
+                        applyLiveBadge();
+                        applyInteractiveButtonState();
+                    } else if (interactivePreviewIds.size > 0) {
                         interactivePreviewIds.clear();
                         applyLiveBadge();
                         applyInteractiveButtonState();

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -420,7 +420,7 @@ export type ExtensionToWebview =
      * without sending its own `setInteractive` messages back (those would
      * race the extension's flush). See INTERACTIVE.md § 3.
      */
-    | { command: 'clearInteractive' };
+    | { command: 'clearInteractive'; previewId?: string };
 
 /** Messages from webview to extension */
 export type WebviewToExtension =


### PR DESCRIPTION
## Summary
- make composeAiTrace attachments path-only while preserving fetch metadata
- keep desktop trace data under a valid data dir for relative output paths
- skip non-translatable Android strings, make Wear preview text deterministic, and preserve recording/interactive inspection mode plumbing
- make VS Code LIVE handling compatible with older held-session responses, clear only the failed preview, and log per-frame updates only at verbose level

## Tracking issues raised
- #558 desktop theme capture should observe preview-local MaterialTheme
- #559 daemon i18n scan should use AGP variant resource roots
- #560 Android LocalContext wrapping should preserve Activity identity

## Tests
- ./gradlew :daemon:core:test --tests ee.schimke.composeai.daemon.PerfettoTraceDataProductRegistryTest
- ./gradlew :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.I18nTranslationsDataProductRegistryTest
- ./gradlew :daemon:desktop:compileKotlin :samples:wear:compileDebugKotlin
- npm run compile (vscode-extension)
- ./gradlew :daemon:core:ktfmtFormat :daemon:android:ktfmtFormat :daemon:desktop:ktfmtFormat :samples:wear:ktfmtFormat
- git diff --check origin/main...HEAD