### PR TITLE
Drive live preview frames with wall clock time

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSession.kt
@@ -58,19 +58,20 @@ class DesktopInteractiveSession(
         // Press carries `button = PointerButton.Primary` + matching `buttons` because
         // `Modifier.clickable` filters on the primary mouse button (or first finger on touch);
         // omitting these makes the detector treat the event as ambiguous and ignore it.
-        val now = System.currentTimeMillis()
+        val nowNs = engine.currentFrameNanoTime()
+        val nowMs = nowNs / 1_000_000L
         state.scene.sendPointerEvent(
           eventType = PointerEventType.Press,
           position = offset,
-          timeMillis = now,
+          timeMillis = nowMs,
           button = PointerButton.Primary,
           buttons = PointerButtons(isPrimaryPressed = true),
         )
-        state.scene.render(nanoTime = now * 1_000_000L)
+        state.scene.render(nanoTime = nowNs)
         state.scene.sendPointerEvent(
           eventType = PointerEventType.Release,
           position = offset,
-          timeMillis = now + CLICK_HOLD_MS,
+          timeMillis = nowMs + CLICK_HOLD_MS,
           button = PointerButton.Primary,
           buttons = PointerButtons(),
         )
@@ -114,7 +115,12 @@ class DesktopInteractiveSession(
 
   override fun render(requestId: Long): RenderResult {
     check(!closed) { "DesktopInteractiveSession.render() called after close()" }
-    return engine.renderOnce(state, requestId, sandboxStats = sandboxStats)
+    return engine.renderOnce(
+      state,
+      requestId,
+      sandboxStats = sandboxStats,
+      useWallClockFrameTime = true,
+    )
   }
 
   override fun close() {

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -66,6 +66,7 @@ class RenderEngine(
     ),
   private val dataDir: File? = outputDir.parentFile?.resolve("data"),
   private val themeCapture: ThemeCapture? = null,
+  private val frameNanoTime: () -> Long = System::nanoTime,
 ) {
 
   /**
@@ -246,10 +247,17 @@ class RenderEngine(
     )
   }
 
+  internal fun currentFrameNanoTime(): Long = frameNanoTime()
+
   /**
    * v2 phase 2 — drive the held scene through enough frames to settle (two `scene.render()` calls,
    * same heuristic as the one-shot path) and encode the latest pixels to PNG. Reusable across
    * inputs in the interactive path; called exactly once by the [render] wrapper.
+   *
+   * [ImageComposeScene.render] defaults `nanoTime` to zero, and that timestamp is the frame clock
+   * seen by `withFrameNanos` / Compose animations. The one-shot preview path keeps that old
+   * deterministic frame-zero behavior, while live interactive preview passes monotonic wall-clock
+   * timestamps so animations advance at real elapsed time instead of repainting a frozen timeline.
    */
   fun renderOnce(
     state: SceneState,
@@ -257,13 +265,14 @@ class RenderEngine(
     sandboxStats: SandboxLifecycleStats = SandboxLifecycleStats(),
     trace: PerfettoTraceDataProducer.Recorder =
       PerfettoTraceDataProducer.recorder(state.spec.outputBaseName, backend = "desktop"),
+    useWallClockFrameTime: Boolean = false,
   ): RenderResult {
     val startNs = System.nanoTime()
 
     // Render two frames so any LaunchedEffect / animations have a tick to settle. Same reasoning
     // as `:renderer-desktop`'s renderPreview.
-    trace.section("compose:frame") { state.scene.render() }
-    val image = trace.section("compose:captureFrame") { state.scene.render() }
+    trace.section("compose:frame") { renderFrame(state, useWallClockFrameTime) }
+    val image = trace.section("compose:captureFrame") { renderFrame(state, useWallClockFrameTime) }
 
     val pngData =
       trace.section("render:encodePng") {
@@ -287,6 +296,13 @@ class RenderEngine(
       metrics = metrics,
     )
   }
+
+  private fun renderFrame(state: SceneState, useWallClockFrameTime: Boolean) =
+    if (useWallClockFrameTime) {
+      state.scene.render(nanoTime = currentFrameNanoTime())
+    } else {
+      state.scene.render()
+    }
 
   /**
    * v2 phase 3 — close the held scene (frees the Skia [org.jetbrains.skia.Surface]) and restore the

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopInteractiveSessionTest.kt
@@ -115,6 +115,63 @@ class DesktopInteractiveSessionTest {
   }
 
   @Test
+  fun live_render_advances_frame_clock_with_monotonic_wall_time() {
+    val outputDir = tempFolder.newFolder("interactive-frame-clock-renders")
+    val frameTimes =
+      java.util.ArrayDeque(listOf(1_000_000_000L, 1_000_000_000L, 1_300_000_000L, 1_300_000_000L))
+    val engine = RenderEngine(outputDir = outputDir, frameNanoTime = { frameTimes.removeFirst() })
+    val host =
+      DesktopHost(
+        engine = engine,
+        previewSpecResolver = { previewId ->
+          if (previewId == FRAME_CLOCK_PREVIEW_ID) {
+            RenderSpec(
+              className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+              functionName = "FrameClockSquare",
+              widthPx = 64,
+              heightPx = 64,
+              density = 1.0f,
+              outputBaseName = "frame-clock-square",
+            )
+          } else null
+        },
+      )
+    host.start()
+    try {
+      val session =
+        host.acquireInteractiveSession(
+          previewId = FRAME_CLOCK_PREVIEW_ID,
+          classLoader =
+            DesktopInteractiveSessionTest::class.java.classLoader
+              ?: ClassLoader.getSystemClassLoader(),
+        )
+      try {
+        val first = session.render(requestId = RenderHost.nextRequestId())
+        val firstImage = readPng(File(first.pngPath!!))
+        val redMatch = pixelMatchPct(firstImage, expectedRgb = 0xEF5350, perChannelTolerance = 8)
+        assertTrue(
+          "expected frame-clock fixture to start red; got ${"%.2f".format(redMatch * 100)}%",
+          redMatch >= 0.95,
+        )
+
+        val second = session.render(requestId = RenderHost.nextRequestId())
+        val secondImage = readPng(File(second.pngPath!!))
+        val greenMatch = pixelMatchPct(secondImage, expectedRgb = 0x66BB6A, perChannelTolerance = 8)
+        assertTrue(
+          "expected frame-clock fixture to turn green after 300ms of render time; got " +
+            "${"%.2f".format(greenMatch * 100)}%",
+          greenMatch >= 0.95,
+        )
+      } finally {
+        session.close()
+      }
+    } finally {
+      host.shutdown()
+    }
+    assertTrue("all injected frame times should be consumed", frameTimes.isEmpty())
+  }
+
+  @Test
   fun acquire_throws_unsupported_when_resolver_unwired() {
     // No previewSpecResolver passed — host advertises no v2 support and throws
     // UnsupportedOperationException, which `JsonRpcServer.handleInteractiveStart` translates into
@@ -209,5 +266,6 @@ class DesktopInteractiveSessionTest {
 
   companion object {
     private const val FIXTURE_PREVIEW_ID = "click-toggle-square"
+    private const val FRAME_CLOCK_PREVIEW_ID = "frame-clock-square"
   }
 }

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
@@ -103,6 +105,28 @@ fun ClickToggleSquare() {
         }
       }
   )
+}
+
+/**
+ * Live interactive fixture that exposes Compose's frame clock as pixels. It starts red and turns
+ * green after at least 250 ms of frame-clock time has elapsed. If [ImageComposeScene.render] is
+ * called without an explicit timestamp, every frame is rendered at `nanoTime = 0` and this preview
+ * never advances.
+ */
+@Composable
+fun FrameClockSquare() {
+  var firstFrameNs by remember { mutableStateOf<Long?>(null) }
+  var elapsedNs by remember { mutableStateOf(0L) }
+  LaunchedEffect(Unit) {
+    while (true) {
+      withFrameNanos { frameNs ->
+        val first = firstFrameNs ?: frameNs.also { firstFrameNs = it }
+        elapsedNs = frameNs - first
+      }
+    }
+  }
+  val color = if (elapsedNs >= 250_000_000L) Color(0xFF66BB6A) else Color(0xFFEF5350)
+  Box(modifier = Modifier.fillMaxSize().background(color))
 }
 
 /**


### PR DESCRIPTION
## Summary
- pass real monotonic frame timestamps to held desktop interactive/live sessions
- keep one-shot desktop renders on the existing deterministic frame-zero path
- add a frame-clock fixture/test proving live renders advance Compose animation time

## Tests
- ./gradlew :daemon:desktop:test --tests ee.schimke.composeai.daemon.DesktopInteractiveSessionTest
- ./gradlew :daemon:desktop:ktfmtCheck