### PR TITLE
Add CLI devices command

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -41,6 +41,9 @@ dependencies {
   // Bundle the MCP server so `compose-preview mcp serve` can invoke it in-process —
   // the consumer install story stays a single tarball + a single launcher.
   implementation(project(":mcp"))
+  // Renderer-agnostic daemon core helpers that are safe to use as a local library from CLI
+  // commands. Keep renderer backends (`:daemon:android`, `:daemon:desktop`) out of this module.
+  implementation(project(":daemon:core"))
 
   testImplementation(kotlin("test"))
 }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DeviceCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DeviceCommands.kt
@@ -1,0 +1,79 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.daemon.devices.DeviceDimensions
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+internal const val DEVICES_SCHEMA = "compose-preview-devices/v1"
+
+private val devicesJson = Json {
+  prettyPrint = true
+  encodeDefaults = true
+}
+
+@Serializable
+data class DeviceCatalogResponse(
+  val schema: String = DEVICES_SCHEMA,
+  val devices: List<DeviceCatalogEntry>,
+)
+
+@Serializable
+data class DeviceCatalogEntry(
+  val id: String,
+  val widthDp: Int,
+  val heightDp: Int,
+  val density: Float,
+)
+
+class DevicesCommand(private val args: List<String>) {
+  private val jsonOutput = "--json" in args
+
+  fun run() {
+    if ("--help" in args || "-h" in args) {
+      printUsage()
+      return
+    }
+
+    val response = buildDeviceCatalogResponse()
+    if (jsonOutput) {
+      println(devicesJson.encodeToString(DeviceCatalogResponse.serializer(), response))
+      return
+    }
+
+    println("Known @Preview(device=...) ids:")
+    val idWidth = response.devices.maxOfOrNull { it.id.length } ?: 0
+    response.devices.forEach { device ->
+      println(
+        "${device.id.padEnd(idWidth)} ${device.widthDp.toString().padStart(4)}x" +
+          "${device.heightDp.toString().padEnd(4)} dp  density=${device.density}"
+      )
+    }
+  }
+
+  private fun printUsage() {
+    println(
+      """
+      compose-preview devices [--json]
+
+      Lists the known @Preview(device=...) ids and their resolved geometry.
+      This command reads the shared daemon core device catalog directly; it
+      does not run Gradle and does not start a daemon.
+      """
+        .trimIndent()
+    )
+  }
+}
+
+internal fun buildDeviceCatalogResponse(): DeviceCatalogResponse =
+  DeviceCatalogResponse(
+    devices =
+      DeviceDimensions.KNOWN_DEVICE_IDS.sorted().map { id ->
+        val spec = DeviceDimensions.resolve(id)
+        DeviceCatalogEntry(
+          id = id,
+          widthDp = spec.widthDp,
+          heightDp = spec.heightDp,
+          density = spec.density,
+        )
+      }
+  )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -41,6 +41,7 @@ fun main(args: Array<String>) {
       "render",
       "a11y",
       "doctor",
+      "devices",
       "share-gist",
       "publish-images",
       "mcp",
@@ -85,6 +86,7 @@ fun main(args: Array<String>) {
     "render" -> RenderCommand(allArgs).run()
     "a11y" -> A11yCommand(allArgs).run()
     "doctor" -> DoctorCommand(allArgs).run()
+    "devices" -> DevicesCommand(allArgs).run()
     "share-gist" -> ShareGistCommand(allArgs).run()
     "publish-images" -> PublishImagesCommand(allArgs).run()
     "mcp" -> McpCommand(allArgs).run()
@@ -116,6 +118,7 @@ private fun printUsage() {
       render           Render previews; with --output copies a single match to disk
       a11y             Render previews and print ATF accessibility findings
       doctor           Verify Java 17 + Compose/AGP environment before editing Gradle files
+      devices          List known @Preview(device=...) ids and resolved geometry
       share-gist       Create a gist from a markdown file plus image attachments
       publish-images   Push a directory of rendered PNGs to a shared branch (default compose-preview/pr)
       mcp              MCP server lifecycle: serve | install | doctor (see `mcp help`)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DeviceCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DeviceCommandTest.kt
@@ -1,0 +1,35 @@
+package ee.schimke.composeai.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+
+class DeviceCommandTest {
+  private val json = Json {
+    prettyPrint = false
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+  }
+
+  @Test
+  fun `device catalog response pins schema and includes known device geometry`() {
+    val response = buildDeviceCatalogResponse()
+    val encoded = json.encodeToString(DeviceCatalogResponse.serializer(), response)
+    val parsed = json.decodeFromString(DeviceCatalogResponse.serializer(), encoded)
+
+    assertEquals(DEVICES_SCHEMA, parsed.schema)
+    assertTrue(""""schema":"$DEVICES_SCHEMA"""" in encoded)
+
+    val pixel5 = parsed.devices.single { it.id == "id:pixel_5" }
+    assertEquals(393, pixel5.widthDp)
+    assertEquals(851, pixel5.heightDp)
+    assertEquals(2.75f, pixel5.density)
+  }
+
+  @Test
+  fun `device catalog is sorted for stable CLI output`() {
+    val ids = buildDeviceCatalogResponse().devices.map { it.id }
+    assertEquals(ids.sorted(), ids)
+  }
+}


### PR DESCRIPTION
## Summary
- add top-level `compose-preview devices` command
- add `compose-preview devices --json` with schema `compose-preview-devices/v1`
- read the shared daemon core `DeviceDimensions` catalog directly, without Gradle or a daemon process

Closes #567.
Related: #566 documents the broader CLI daemon-library boundary.

## Test
- ./gradlew :cli:test --tests ee.schimke.composeai.cli.DeviceCommandTest
- ./gradlew :cli:ktfmtCheck
- ./gradlew :cli:run --args='devices'
- ./gradlew :cli:run --args='devices --json'
- git diff --check