### PR TITLE
Remove stale experimental daemon references

### DIFF
--- a/.github/ci/daemon-roundtrip.py
+++ b/.github/ci/daemon-roundtrip.py
@@ -358,7 +358,7 @@ def main() -> int:
     if not descriptor.get("enabled"):
         print(
             "[daemon-roundtrip] descriptor.enabled=false — set "
-            "composePreview.experimental.daemon.enabled=true. Skipping.",
+            "composePreview { daemon { enabled = true } }. Skipping.",
             file=sys.stderr,
         )
         return 2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -316,14 +316,14 @@ jobs:
           echo "Rendered ${#pngs[@]} PNG file(s):"
           printf '  %s\n' "${pngs[@]}"
 
-      - name: Enable experimental daemon in consumer build
+      - name: Configure daemon in consumer build
         if: matrix.daemon
         working-directory: external/${{ matrix.workdir }}
         run: |
           set -euo pipefail
-          # Append the composePreview { experimental { daemon { enabled = true } } } block
-          # to the matrix module's build.gradle(.kts) so composePreviewDaemonStart writes
-          # `enabled: true` into the launch descriptor. Idempotent — skip if already there.
+          # Append the stable composePreview.daemon block to the matrix module's build.gradle(.kts)
+          # so composePreviewDaemonStart writes `enabled: true` into the launch descriptor.
+          # Idempotent — skip if a daemon block is already present.
           python3 - <<'PY'
           from pathlib import Path
           import os
@@ -338,10 +338,10 @@ jobs:
               if not p.exists():
                   continue
               text = p.read_text()
-              if "experimental.daemon" in text or "experimental {" in text and "daemon {" in text:
+              if "composePreview" in text and "daemon {" in text:
                   print(f"daemon block already present in {p}")
                   break
-              suffix = "\n\ncomposePreview {\n  experimental {\n    daemon {\n      enabled = true\n    }\n  }\n}\n"
+              suffix = "\n\ncomposePreview {\n  daemon {\n    enabled = true\n  }\n}\n"
               p.write_text(text + suffix)
               print(f"appended daemon enable block to {p}")
               break

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -20,9 +20,9 @@ import kotlinx.serialization.json.jsonPrimitive
  *   traffic is the JSON-RPC frames the [DaemonMcpMain] reader/writer pair owns. Status / errors go
  *   to stderr.
  * - `install` — bootstrap descriptors for every module that applies the plugin, flip each
- *   descriptor's `enabled` flag to `true` (`composePreview.experimental.daemon { enabled = true }`
- *   isn't required up-front this way), run `discoverPreviews`, and print the `claude mcp add`
- *   invocation an agent host needs.
+ *   descriptor's `enabled` flag to `true` (`composePreview.daemon { enabled = true }` isn't
+ *   required up-front this way), run `discoverPreviews`, and print the `claude mcp add` invocation
+ *   an agent host needs.
  * - `doctor` — report per-module descriptor state (present / missing / disabled / stale) without
  *   making any changes.
  *

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -91,7 +91,7 @@ sed -i 's/"enabled": false/"enabled": true/' \
 
 The descriptor's `enabled: false` field is load-bearing — flip it to
 `true` either in the build script
-(`composePreview { experimental { daemon { enabled = true } } }`) or by
+(`composePreview { daemon { enabled = true } }`) or by
 editing the JSON directly. (Direct `-P` propagation is intentionally not
 wired; see `DaemonExtension.kt` KDoc for rationale.)
 
@@ -262,10 +262,10 @@ equivalent that integrates with `:mcp:test`.
 ## Operational notes
 
 - **Daemon enabled flag.** `composePreviewDaemonStart` always runs and
-  writes a descriptor; `enabled: false` is the default and the
+  writes a descriptor; `enabled: false` means the daemon was explicitly disabled, and the
   supervisor's `SubprocessDaemonClientFactory` refuses to spawn a
   daemon unless the descriptor reports `enabled: true`. Flip via
-  `composePreview.experimental.daemon { enabled = true }` in the
+  `composePreview.daemon { enabled = true }` in the
   consumer's build script.
 - **Multi-session.** A single MCP server process can serve N agents
   over N stdio connections (HTTP transport later may multiplex).

--- a/mcp/scripts/README.md
+++ b/mcp/scripts/README.md
@@ -24,12 +24,10 @@ Asserts `before == revert` (byte-equal) and `before != after`.
 # 1. Bootstrap descriptors and previews.json for the cmp sample.
 ./gradlew \
   :samples:cmp:composePreviewDaemonStart \
-  :samples:cmp:discoverPreviews \
-  -PcomposePreview.experimental.daemon.enabled=true
+  :samples:cmp:discoverPreviews
 
-# 2. Flip the descriptor's `enabled` flag (the gradle property override is
-#    intentionally not propagated into the descriptor JSON; see
-#    DaemonExtension.kt's KDoc + issue #314 follow-up).
+# 2. If your build sets composePreview.daemon.enabled=false, either change the build script
+#    or flip the descriptor's `enabled` flag for this local smoke run.
 sed -i 's/"enabled": false/"enabled": true/' \
   samples/cmp/build/compose-previews/daemon-launch.json
 

--- a/mcp/scripts/real_e2e_smoke.py
+++ b/mcp/scripts/real_e2e_smoke.py
@@ -19,10 +19,11 @@ re-render → revert flow:
 
 Prerequisites (all live on the host):
 
-- ``./gradlew :samples:cmp:composePreviewDaemonStart -PcomposePreview.experimental.daemon.enabled=true``
+- ``./gradlew :samples:cmp:composePreviewDaemonStart``
   has been run.
-- The descriptor's ``enabled`` flag must be ``true`` (use ``sed`` to flip it
-  if your build hasn't wired the gradle property; see issue #314 follow-up).
+- The descriptor's ``enabled`` flag must be ``true`` (set
+  ``composePreview { daemon { enabled = true } }`` in the build script, or use
+  ``sed`` to flip it for this local smoke run).
 - ``./gradlew :samples:cmp:discoverPreviews`` has been run so
   ``previews.json`` exists.
 - ``./gradlew :mcp:jar :daemon:core:jar`` has been built.

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -128,7 +128,7 @@ object DaemonMcpMain {
 class SubprocessDaemonClientFactory : DaemonClientFactory {
   override fun spawn(project: RegisteredProject, descriptor: DaemonLaunchDescriptor): DaemonSpawn {
     require(descriptor.enabled) {
-      "daemon disabled for ${descriptor.modulePath} — set composePreview.experimental.daemon.enabled = true"
+      "daemon disabled for ${descriptor.modulePath} — set composePreview { daemon { enabled = true } }"
     }
     val javaBin =
       descriptor.javaLauncher ?: File(System.getProperty("java.home"), "bin/java").absolutePath

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/RealMcpEndToEndTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/RealMcpEndToEndTest.kt
@@ -69,9 +69,9 @@ class RealMcpEndToEndTest {
     )
     Assume.assumeTrue(
       "Skipping RealMcpEndToEndTest — '$descriptorJson' missing. Run " +
-        "`./gradlew :samples:cmp:composePreviewDaemonStart -PcomposePreview.experimental.daemon.enabled=true` " +
-        "first; if the descriptor reports `enabled: false`, also enable the experimental flag in " +
-        "the sample's build.gradle.kts (see DaemonExtension.kt KDoc).",
+        "`./gradlew :samples:cmp:composePreviewDaemonStart` first; if the descriptor reports " +
+        "`enabled: false`, set `composePreview { daemon { enabled = true } }` in the sample's " +
+        "build.gradle.kts.",
       descriptorJson.isFile && descriptorJson.readText().contains("\"enabled\": true"),
     )
     Assume.assumeTrue(


### PR DESCRIPTION
## Summary
- replace stale experimental daemon DSL references with the stable composePreview.daemon block
- update daemon CI injection to append the stable daemon block
- refresh MCP smoke/test guidance and daemon disabled error text

## Tests
- ./gradlew :mcp:test :gradle-plugin:test
- ./gradlew ktfmtFormatAll