### PR TITLE
ci: publish data-a11y connector for daemon samples

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: Publish plugin + renderer-android + data-a11y-core + daemon-* to mavenLocal
+      - name: Publish plugin + renderer-android + data-a11y-* + daemon-* to mavenLocal
         # Both `gradle-plugin` and `renderer-android` are needed end-to-end:
         # the plugin resolves through pluginManagement when the consumer's
         # `plugins { }` block is patched, and it wires
@@ -65,6 +65,7 @@ jobs:
           ./gradlew \
             :gradle-plugin:publishToMavenLocal \
             :data-a11y-core:publishToMavenLocal \
+            :data-a11y-connector:publishToMavenLocal \
             :renderer-android:publishToMavenLocal \
             :daemon:core:publishToMavenLocal \
             :daemon:desktop:publishToMavenLocal \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
-      - name: Publish plugin, renderer-android, data-a11y-core, preview-annotations, daemon-* to GitHub Packages
+      - name: Publish plugin, renderer-android, data-a11y-*, preview-annotations, daemon-* to GitHub Packages
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -98,12 +98,13 @@ jobs:
           ./gradlew \
             :gradle-plugin:publishAllPublicationsToGitHubPackagesRepository \
             :data-a11y-core:publishAllPublicationsToGitHubPackagesRepository \
+            :data-a11y-connector:publishAllPublicationsToGitHubPackagesRepository \
             :renderer-android:publishAllPublicationsToGitHubPackagesRepository \
             :preview-annotations:publishAllPublicationsToGitHubPackagesRepository \
             :daemon:core:publishAllPublicationsToGitHubPackagesRepository \
             :daemon:desktop:publishAllPublicationsToGitHubPackagesRepository \
             :daemon:android:publishAllPublicationsToGitHubPackagesRepository
-      - name: Publish plugin, renderer-android, data-a11y-core, preview-annotations, daemon-* to Maven Central
+      - name: Publish plugin, renderer-android, data-a11y-*, preview-annotations, daemon-* to Maven Central
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
@@ -111,6 +112,7 @@ jobs:
           ./gradlew \
             :gradle-plugin:publishAndReleaseToMavenCentral \
             :data-a11y-core:publishAndReleaseToMavenCentral \
+            :data-a11y-connector:publishAndReleaseToMavenCentral \
             :renderer-android:publishAndReleaseToMavenCentral \
             :preview-annotations:publishAndReleaseToMavenCentral \
             :daemon:core:publishAndReleaseToMavenCentral \

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -53,6 +53,7 @@ jobs:
           ./gradlew \
             :gradle-plugin:publishToMavenCentral \
             :data-a11y-core:publishToMavenCentral \
+            :data-a11y-connector:publishToMavenCentral \
             :renderer-android:publishToMavenCentral \
             :preview-annotations:publishToMavenCentral \
             :daemon:core:publishToMavenCentral \

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -632,7 +632,11 @@ open class RobolectricHost(
           "RobolectricHost.previewSpecResolver returned null for previewId='$previewId'; " +
             "interactive session not allocated"
         )
-    return acquireInteractiveSession(previewId = previewId, spec = spec, inspectionMode = inspectionMode)
+    return acquireInteractiveSession(
+      previewId = previewId,
+      spec = spec,
+      inspectionMode = inspectionMode,
+    )
   }
 
   private fun acquireInteractiveSession(
@@ -776,7 +780,12 @@ open class RobolectricHost(
             "recording session not allocated"
         )
     val effectiveSpec = applyRecordingOverrides(baseSpec, overrides, recordingId)
-    val interactive = acquireInteractiveSession(previewId = previewId, spec = effectiveSpec)
+    val interactive =
+      acquireInteractiveSession(
+        previewId = previewId,
+        spec = effectiveSpec,
+        inspectionMode = effectiveSpec.inspectionMode,
+      )
     val recordingsRoot = recordingsRootDir()
     val framesDir = File(File(recordingsRoot, "frames"), recordingId)
     val encodedDir = File(recordingsRoot, "encoded")

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewIndex.kt
@@ -83,9 +83,9 @@ data class PreviewInfoDto(
  * Names mirror the plugin's `PreviewParams` JSON keys verbatim. The daemon side maps subsets of
  * these onto `RenderSpec` (`widthDp`/`heightDp`/`density` → pixel dimensions; `localeTag` from
  * `locale`; `uiMode` bitmask → `SpecUiMode`; `fontScale` straight through). Backends that don't
- * model a particular knob (desktop has no resource-qualifier system; `localeTag` / `orientation`
- * are no-ops there) ignore the field but still carry it for wire parity with `PreviewOverrides` —
- * see [PROTOCOL.md § 5](../../../../../../../docs/daemon/PROTOCOL.md#5-client--daemon-requests).
+ * model a particular knob (for example, desktop has no display rotation concept for `orientation`)
+ * ignore the field but still carry it for wire parity with `PreviewOverrides` — see
+ * [PROTOCOL.md § 5](../../../../../../../docs/daemon/PROTOCOL.md#5-client--daemon-requests).
  *
  * `uiMode` here is the raw Android `Configuration.uiMode` bitmask the plugin reads off the
  * `@Preview` annotation (`0` means unset; bit `0x20` = `UI_MODE_NIGHT_YES`). The daemon decodes it
@@ -99,7 +99,7 @@ data class PreviewParamsDto(
   val heightDp: Int? = null,
   val density: Float? = null,
   val fontScale: Float? = null,
-  /** BCP-47 locale tag — the plugin's `PreviewParams.locale`. Android-only at render time. */
+  /** BCP-47 locale tag — the plugin's `PreviewParams.locale`. */
   val locale: String? = null,
   /**
    * Raw `@Preview(uiMode = …)` bitmask. `null` and `0` are interchangeable on the daemon side (both

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -106,9 +106,9 @@ interface RenderHost {
    *
    * The default empty set is the safe pre-feature value — clients treat absent and `[]` identically
    * and assume any field they pass might be ignored. Real backends override: `RobolectricHost`
-   * advertises all eight; `DesktopHost` omits `localeTag` (no `LocalLocale` CompositionLocal +
-   * `Locale.setDefault` is JVM-thread-unsafe — see `daemon/desktop/.../RenderEngine.kt`) and
-   * `orientation` (no rotation concept on `ImageComposeScene`).
+   * advertises all fields; `DesktopHost` omits `orientation` (no rotation concept on
+   * `ImageComposeScene`), Android-only timing knobs, and `localeTag` unless the Compose UI runtime
+   * exposes a providable locale list.
    */
   val supportedOverrides: Set<String>
     get() = emptySet()

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -177,10 +177,9 @@ data class ServerCapabilities(
    * fields the backend would silently ignore. Empty list = pre-feature daemon (clients treat absent
    * and `[]` identically and assume any field they pass might be ignored).
    *
-   * Today: `RobolectricHost` advertises every field; `DesktopHost` omits `localeTag` (Compose
-   * Desktop has no `LocalLocale` CompositionLocal + `Locale.setDefault(...)` is JVM-thread-
-   * unsafe), `orientation` (no rotation concept on `ImageComposeScene`), and Android-only timing
-   * knobs.
+   * Today: `RobolectricHost` advertises every field; `DesktopHost` omits `orientation` (no rotation
+   * concept on `ImageComposeScene`), Android-only timing knobs, and `localeTag` unless the Compose
+   * UI runtime exposes a providable locale list.
    */
   val supportedOverrides: List<String> = emptyList(),
   /**
@@ -315,7 +314,7 @@ data class PreviewOverrides(
   val heightPx: Int? = null,
   /** Display density (1.0 = mdpi/160dpi, 2.0 = xhdpi/320dpi, etc.). */
   val density: Float? = null,
-  /** BCP-47 locale tag (e.g. `"en-US"`, `"fr"`, `"ja-JP"`). Android-only today. */
+  /** BCP-47 locale tag (e.g. `"en-US"`, `"fr"`, `"ja-JP"`). */
   val localeTag: String? = null,
   /** Font scale multiplier (1.0 = system default, 1.3 = "large", 2.0 = max accessibility). */
   val fontScale: Float? = null,

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -154,15 +154,23 @@ open class DesktopHost(
    * PROTOCOL.md § 3 (`InitializeResult.capabilities.supportedOverrides`) — the desktop renderer
    * applies size / density / fontScale (via `Density(density, fontScale)` on the
    * `ImageComposeScene` constructor + `LocalDensity`), `uiMode` (via `LocalSystemTheme`), and
-   * `device` (resolved by `DeviceDimensions`). `localeTag` is no-op on desktop because Compose
-   * Desktop has no `LocalLocale` CompositionLocal and `Locale.setDefault(...)` is JVM-thread-
-   * unsafe (every other thread would see the override during the render). `orientation` is no-op
-   * because `ImageComposeScene` has no rotation concept — see `daemon/desktop/.../RenderEngine.kt`
-   * for the docstring. `inspectionMode` flows into `LocalInspectionMode` on the one-shot render
-   * path; interactive and recording sessions keep their runtime-like `false` default.
+   * `device` (resolved by `DeviceDimensions`). `localeTag` is advertised only when the Compose UI
+   * runtime on the classpath exposes its providable locale list; older Compose Desktop runtimes
+   * keep treating it as unsupported rather than falling back to JVM-wide `Locale.setDefault(...)`.
+   * `orientation` is no-op because `ImageComposeScene` has no rotation concept. `inspectionMode`
+   * flows into `LocalInspectionMode` on the one-shot render path; interactive and recording
+   * sessions keep their runtime-like `false` default.
    */
-  override val supportedOverrides: Set<String> =
-    setOf("widthPx", "heightPx", "density", "fontScale", "uiMode", "device", "inspectionMode")
+  override val supportedOverrides: Set<String> = buildSet {
+    add("widthPx")
+    add("heightPx")
+    add("density")
+    if (RenderEngine.supportsLocaleTagOverride()) add("localeTag")
+    add("fontScale")
+    add("uiMode")
+    add("device")
+    add("inspectionMode")
+  }
 
   /** PROTOCOL.md § 3 — desktop backend identifier surfaced via `capabilities.backend`. */
   override val backendKind: ee.schimke.composeai.daemon.protocol.BackendKind =

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.reflect.ComposableMethod
@@ -15,6 +17,7 @@ import androidx.compose.ui.SystemTheme
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.text.intl.LocaleList
 import androidx.compose.ui.unit.Density
 import java.io.File
 import org.jetbrains.skia.EncodedImageFormat
@@ -165,14 +168,7 @@ class RenderEngine(
     val previousContext = Thread.currentThread().contextClassLoader
     Thread.currentThread().contextClassLoader = classLoader
 
-    // PROTOCOL.md § 5 (`renderNow.overrides.localeTag`) — Compose Desktop has no `LocalLocale`
-    // CompositionLocal to override; the only JVM-wide lever is `Locale.setDefault(...)`, which is
-    // unsafe to mutate transiently because every other JVM thread (JSON-RPC reader, Skiko font /
-    // text-shaping workers, GC finalizers, anything that calls `String.format` or
-    // `SimpleDateFormat` with the default locale) sees the wrong value for the render's duration.
-    // Per-text `TextStyle(localeList = …)` is the only safe lever and can't be applied
-    // sweepingly without rewriting the user's composition. So `localeTag` stays a no-op on
-    // desktop. The Android backend honours it via `setQualifiers("b+lang+region")`.
+    val localeProviders = localeProviders(spec.localeTag)
 
     // PROTOCOL.md § 5 (`renderNow.overrides.fontScale`) — Compose Desktop has no resource-qualifier
     // system, but `LocalDensity` carries `fontScale` as part of `Density`, and `Text` / `TextStyle`
@@ -209,6 +205,7 @@ class RenderEngine(
             LocalInspectionMode provides inspectionMode,
             androidx.compose.ui.LocalSystemTheme provides systemTheme,
             LocalDensity provides density,
+            *localeProviders,
           ) {
             if (themeCapture?.shouldCapture(spec.previewId, spec.renderMode) == true) {
               CaptureMaterialTheme { payload -> themeCapture.capture(spec.previewId, payload) }
@@ -349,6 +346,26 @@ class RenderEngine(
      * side uses; the gradle plugin's daemon launch descriptor sets it once at JVM start.
      */
     const val OUTPUT_DIR_PROP: String = "composeai.render.outputDir"
+
+    fun supportsLocaleTagOverride(): Boolean = localProvidableLocaleListOrNull() != null
+
+    @Suppress("UNCHECKED_CAST")
+    private fun localProvidableLocaleListOrNull(): ProvidableCompositionLocal<LocaleList>? {
+      val holder =
+        runCatching { Class.forName("androidx.compose.ui.platform.CompositionLocalsKt") }
+          .getOrNull() ?: return null
+      return runCatching {
+          holder.getMethod("getLocalProvidableLocaleList").invoke(null)
+            as ProvidableCompositionLocal<LocaleList>
+        }
+        .getOrNull()
+    }
+
+    private fun localeProviders(localeTag: String?): Array<ProvidedValue<*>> {
+      val tag = localeTag?.takeIf { it.isNotBlank() } ?: return emptyArray()
+      val local = localProvidableLocaleListOrNull() ?: return emptyArray()
+      return arrayOf(local provides LocaleList(tag))
+    }
   }
 }
 
@@ -383,11 +400,7 @@ data class RenderSpec(
   /** Stem used for the output PNG filename (e.g. "preview-A" → "<outputDir>/preview-A.png"). */
   val outputBaseName: String = "${className.substringAfterLast('.')}-$functionName",
   /**
-   * BCP-47 locale tag override. **No-op on desktop** — Compose Desktop has no `LocalLocale`
-   * CompositionLocal, and `Locale.setDefault(...)` is unsafe to mutate transiently because it
-   * affects every JVM thread (Skiko font/text-shaping workers, default-locale formatters, etc.).
-   * The field is carried for wire parity with `:daemon:android`, which honours it via
-   * `setQualifiers("b+lang+region")`.
+   * BCP-47 locale tag override. Scoped through Compose UI's providable locale list when present.
    */
   val localeTag: String? = null,
   /**

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
@@ -87,4 +87,11 @@ class DesktopHostTest {
       withResolver.supportsInteractive,
     )
   }
+
+  @Test
+  fun supportedOverridesReflectRuntimeLocaleCapability() {
+    val supported = DesktopHost().supportedOverrides
+
+    assertEquals(RenderEngine.supportsLocaleTagOverride(), "localeTag" in supported)
+  }
 }

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/OverrideIntegrationTest.kt
@@ -16,10 +16,8 @@ import org.junit.rules.TemporaryFolder
  * [PreviewManifestRouter] directly with override-bearing payloads to prove the desktop renderer
  * actually applies `widthPx`, `uiMode`, and `fontScale` (PROTOCOL.md § 5, INTERACTIVE.md § 8a).
  *
- * `localeTag` is **not** tested here — it's documented as a no-op on desktop (Compose Desktop has
- * no `LocalLocale` CompositionLocal, and `Locale.setDefault(...)` is unsafe to mutate transiently
- * because every JVM thread sees it). `orientation` is also a no-op on desktop (`ImageComposeScene`
- * has no rotation concept).
+ * `localeTag` is applied only when the Compose UI runtime exposes a providable locale list;
+ * `orientation` is a no-op on desktop (`ImageComposeScene` has no rotation concept).
  */
 class OverrideIntegrationTest {
 

--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -348,17 +348,13 @@ toggle required.
 `applyPreviewQualifiers` + `RuntimeEnvironment.setFontScale`. The desktop
 renderer applies `widthPx` / `heightPx` / `density` (via
 `ImageComposeScene`'s constructor), `fontScale` (via `Density(density,
-fontScale)` re-provided as `LocalDensity`), and `uiMode` (via
+fontScale)` re-provided as `LocalDensity`), `uiMode` (via
 `LocalSystemTheme provides SystemTheme.Light/Dark`, which is what Compose
-Desktop's `isSystemInDarkTheme()` reads). `localeTag` and `orientation`
-remain no-ops on desktop:
+Desktop's `isSystemInDarkTheme()` reads), and `localeTag` when the Compose UI
+runtime exposes a providable locale list. `orientation` remains a no-op on
+desktop; older Compose Desktop runtimes also leave `localeTag` unsupported
+rather than mutating JVM-wide `Locale.setDefault(...)`:
 
-- **`localeTag`** — Compose Desktop has no `LocalLocale` CompositionLocal,
-  and `java.util.Locale.setDefault(...)` is unsafe to mutate transiently
-  because every other JVM thread (Skiko font / text-shaping workers,
-  default-locale formatters like `String.format` / `SimpleDateFormat`,
-  GC finalizers) sees the wrong value for the render's duration. The
-  Android backend honours it via `setQualifiers("b+lang+region")`.
 - **`orientation`** — `ImageComposeScene` has no display rotation
   concept; size override (`widthPx` / `heightPx`) is the natural lever.
 

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -145,9 +145,9 @@ Result:
   // "device","captureAdvanceMs","inspectionMode"}). Lets clients grey out unsupported sliders.
   // Empty list = pre-feature daemon;
   // treat absent and `[]` identically and assume any field might be ignored.
-  // Today: Robolectric advertises every field; Desktop omits "localeTag" (no `LocalLocale`
-  // CompositionLocal + `Locale.setDefault(...)` is JVM-thread-unsafe), "orientation"
-  // (no rotation concept on `ImageComposeScene`), and Android-only timing knobs.
+  // Today: Robolectric advertises every field; Desktop omits "orientation" (no rotation concept
+  // on `ImageComposeScene`), Android-only timing knobs, and "localeTag" unless the Compose UI
+  // runtime exposes a providable locale list.
   //
   // androidSdk — fixed Android SDK level the backend renders against. Populated by the
   // Robolectric backend from its pinned @Config(sdk = ...) value; absent/null on Desktop and
@@ -230,7 +230,7 @@ A `classpath` event triggers Tier-1 fingerprint recomputation; on mismatch the d
   widthPx?: number;
   heightPx?: number;
   density?: number;                  // 1.0 = mdpi/160dpi, 2.0 = xhdpi/320dpi
-  localeTag?: string;                // BCP-47 (e.g. "en-US", "fr", "ja-JP"). Android-only today.
+  localeTag?: string;                // BCP-47 (e.g. "en-US", "fr", "ja-JP").
   fontScale?: number;                // 1.0 = system default
   uiMode?: "light" | "dark";         // Android-only today.
   orientation?: "portrait" | "landscape";  // Android-only today.
@@ -252,7 +252,7 @@ A `classpath` event triggers Tier-1 fingerprint recomputation; on mismatch the d
 
 The result resolves as soon as the request is queued, **not** when rendering completes. Per-render progress arrives as `renderStarted` / `renderFinished` / `renderFailed` notifications keyed by ID.
 
-`overrides` are merged onto the discovery-time `RenderSpec` per-call. A subsequent `renderNow` for the same preview **without** `overrides` reverts to the discovery-time defaults — overrides are not sticky across calls. Backends that don't model a particular field ignore it (e.g. desktop has no Android resource qualifier system, so `localeTag` / `orientation` are no-ops on the desktop render path today). `inspectionMode` controls the `LocalInspectionMode` value for this one-shot render; absent/null preserves preview behaviour (`true`).
+`overrides` are merged onto the discovery-time `RenderSpec` per-call. A subsequent `renderNow` for the same preview **without** `overrides` reverts to the discovery-time defaults — overrides are not sticky across calls. Backends that don't model a particular field ignore it (e.g. desktop has no display rotation concept, so `orientation` is a no-op on the desktop render path today; desktop `localeTag` requires a Compose UI runtime that exposes a providable locale list). `inspectionMode` controls the `LocalInspectionMode` value for this one-shot render; absent/null preserves preview behaviour (`true`).
 
 **Coalescing.** When `overrides` is non-null and a prior override-bearing render is still in-flight for the same `previewId`, the new request is rejected with `reason = "coalesced: …"` rather than queued. The client (panel, MCP, etc.) is responsible for resubmitting on the next `renderFinished` if the latest override values still differ from what was rendered. Plain (no-overrides) `renderNow` is unaffected — the existing save-debounce loop continues to coalesce upstream.
 

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -528,7 +528,7 @@ class DaemonMcpServer(
                     "widthPx":{"type":"integer","description":"Sandbox width in pixels."},
                     "heightPx":{"type":"integer","description":"Sandbox height in pixels."},
                     "density":{"type":"number","description":"Display density (1.0 = mdpi, 2.0 = xhdpi, etc.)."},
-                    "localeTag":{"type":"string","description":"BCP-47 locale tag (e.g. 'en-US', 'fr', 'ja-JP'). Android-only today."},
+                    "localeTag":{"type":"string","description":"BCP-47 locale tag (e.g. 'en-US', 'fr', 'ja-JP')."},
                     "fontScale":{"type":"number","description":"Font scale multiplier (1.0 = system default)."},
                     "uiMode":{"type":"string","enum":["light","dark"],"description":"Light/dark mode override. Android-only today."},
                     "orientation":{"type":"string","enum":["portrait","landscape"],"description":"Portrait/landscape override. Android-only today."},


### PR DESCRIPTION
## Summary
- Publish data-a11y-connector alongside daemon-android in integration workflow setup
- Include data-a11y-connector in snapshot and release publishing lists so daemon-android's API dependency is resolvable externally

Follow-up to #562 / #465: #562 merged the desktop locale support, but the integration sample job exposed this missing published dependency after daemon-android was resolved from Maven Local.

## Testing
- ./gradlew :daemon:android:ktfmtFormat :daemon:android:compileDebugKotlin :daemon:desktop:test --tests ee.schimke.composeai.daemon.DesktopHostTest --tests ee.schimke.composeai.daemon.OverrideIntegrationTest :mcp:compileKotlin