### PR TITLE
ci: publish data-a11y connector for daemon samples

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: Publish plugin + renderer-android + data-a11y-core + daemon-* to mavenLocal
+      - name: Publish plugin + renderer-android + data-a11y-* + daemon-* to mavenLocal
         # Both `gradle-plugin` and `renderer-android` are needed end-to-end:
         # the plugin resolves through pluginManagement when the consumer's
         # `plugins { }` block is patched, and it wires
@@ -65,6 +65,7 @@ jobs:
           ./gradlew \
             :gradle-plugin:publishToMavenLocal \
             :data-a11y-core:publishToMavenLocal \
+            :data-a11y-connector:publishToMavenLocal \
             :renderer-android:publishToMavenLocal \
             :daemon:core:publishToMavenLocal \
             :daemon:desktop:publishToMavenLocal \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
-      - name: Publish plugin, renderer-android, data-a11y-core, preview-annotations, daemon-* to GitHub Packages
+      - name: Publish plugin, renderer-android, data-a11y-*, preview-annotations, daemon-* to GitHub Packages
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -98,12 +98,13 @@ jobs:
           ./gradlew \
             :gradle-plugin:publishAllPublicationsToGitHubPackagesRepository \
             :data-a11y-core:publishAllPublicationsToGitHubPackagesRepository \
+            :data-a11y-connector:publishAllPublicationsToGitHubPackagesRepository \
             :renderer-android:publishAllPublicationsToGitHubPackagesRepository \
             :preview-annotations:publishAllPublicationsToGitHubPackagesRepository \
             :daemon:core:publishAllPublicationsToGitHubPackagesRepository \
             :daemon:desktop:publishAllPublicationsToGitHubPackagesRepository \
             :daemon:android:publishAllPublicationsToGitHubPackagesRepository
-      - name: Publish plugin, renderer-android, data-a11y-core, preview-annotations, daemon-* to Maven Central
+      - name: Publish plugin, renderer-android, data-a11y-*, preview-annotations, daemon-* to Maven Central
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
@@ -111,6 +112,7 @@ jobs:
           ./gradlew \
             :gradle-plugin:publishAndReleaseToMavenCentral \
             :data-a11y-core:publishAndReleaseToMavenCentral \
+            :data-a11y-connector:publishAndReleaseToMavenCentral \
             :renderer-android:publishAndReleaseToMavenCentral \
             :preview-annotations:publishAndReleaseToMavenCentral \
             :daemon:core:publishAndReleaseToMavenCentral \

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -53,6 +53,7 @@ jobs:
           ./gradlew \
             :gradle-plugin:publishToMavenCentral \
             :data-a11y-core:publishToMavenCentral \
+            :data-a11y-connector:publishToMavenCentral \
             :renderer-android:publishToMavenCentral \
             :preview-annotations:publishToMavenCentral \
             :daemon:core:publishToMavenCentral \


### PR DESCRIPTION
## Summary
- Publish data-a11y-connector alongside daemon-android in integration workflow setup
- Include data-a11y-connector in snapshot and release publishing lists so daemon-android's API dependency is resolvable externally

Follow-up to #562 / #465: #562 merged the desktop locale support, but the integration sample job exposed this missing published dependency after daemon-android was resolved from Maven Local.

Supersedes #573.

## Testing
- ./gradlew :daemon:android:ktfmtFormat :daemon:android:compileDebugKotlin :daemon:desktop:test --tests ee.schimke.composeai.daemon.DesktopHostTest --tests ee.schimke.composeai.daemon.OverrideIntegrationTest :mcp:compileKotlin