### PR TITLE
ci: force-enable daemon integration block

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -324,7 +324,8 @@ jobs:
           set -euo pipefail
           # Append the stable composePreview.daemon block to the matrix module's build.gradle(.kts)
           # so composePreviewDaemonStart writes `enabled: true` into the launch descriptor.
-          # Idempotent — skip if a daemon block is already present.
+          # Idempotent for the CI-injected block, but still overrides a consumer block that
+          # explicitly sets enabled = false.
           python3 - <<'PY'
           from pathlib import Path
           import os
@@ -339,10 +340,10 @@ jobs:
               if not p.exists():
                   continue
               text = p.read_text()
-              if "composePreview" in text and "daemon {" in text:
-                  print(f"daemon block already present in {p}")
-                  break
               suffix = "\n\ncomposePreview {\n  daemon {\n    enabled = true\n  }\n}\n"
+              if suffix.strip() in text:
+                  print(f"daemon enable block already present in {p}")
+                  break
               p.write_text(text + suffix)
               print(f"appended daemon enable block to {p}")
               break


### PR DESCRIPTION
## Summary
- keep the integration workflow daemon patch idempotent for the injected block
- append the stable daemon enable block even when a consumer build already has daemon configured as disabled

Fixes review feedback from https://github.com/yschimke/compose-ai-tools/pull/572#discussion_r3177243334.

## Test
- git diff --check