### PR TITLE
Route a11y through data plugin selection

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -237,10 +237,11 @@ fun main(args: Array<String>) {
     }
 
   // D2 — wire data-product registries. `compose/semantics` is default-mode data emitted by the
-  // Android render loop whenever a render output dir exists. The a11y registry remains gated by
-  // `composeai.daemon.attachA11y` because it flips LocalInspectionMode and runs ATF.
+  // Android render loop whenever a render output dir exists. A11y is selected through the generic
+  // data-plugin property emitted by Gradle, not a daemon-specific feature flag.
   val renderOutputDir = System.getProperty(RenderEngine.OUTPUT_DIR_PROP)
-  val attachA11y = System.getProperty(RenderEngine.ATTACH_A11Y_PROP) == "true"
+  val a11yDataPluginEnabled =
+    System.getProperty(RenderEngine.A11Y_DATA_PLUGIN_ENABLED_PROP) == "true"
   val dataProducts: DataProductRegistry =
     buildList {
         System.err.println("compose-ai-tools daemon: DeviceClipDataProductRegistry active")
@@ -279,14 +280,14 @@ fun main(args: Array<String>) {
             "compose-ai-tools daemon: TextStringsDataProductRegistry active (dataRoot=$dataRoot)"
           )
           add(TextStringsDataProductRegistry(rootDir = dataRoot, previewIndex = previewIndex))
-          if (attachA11y) {
+          if (a11yDataPluginEnabled) {
             System.err.println(
               "compose-ai-tools daemon: AccessibilityDataProductRegistry active (dataRoot=$dataRoot)"
             )
             add(AccessibilityDataProductRegistry(rootDir = dataRoot))
           } else {
             System.err.println(
-              "compose-ai-tools daemon: a11y data products disabled via composeai.daemon.attachA11y=false"
+              "compose-ai-tools daemon: a11y data product plugin disabled"
             )
           }
         }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -128,12 +128,11 @@ class RenderEngine(
      * "produce always, gate emission on subscriptions" approach — the cost is a few ms per
      * render, traded for simpler implementation than per-render kind threading.
      *
-     * Defaults to the [ATTACH_A11Y_PROP] system property — `composeai.daemon.attachA11y=true` set
-     * by [DaemonMain] when the a11y data-product registry is wired. False (the default) keeps the
-     * pre-D2 paused-clock + `LocalInspectionMode = true` fast path used by the harness's fake-mode
-     * tests.
+     * Defaults to the [A11Y_DATA_PLUGIN_ENABLED_PROP] system property set by the Gradle data-plugin
+     * selector. False (the default) keeps the pre-D2 paused-clock + `LocalInspectionMode = true`
+     * fast path used by the harness's fake-mode tests.
      */
-    runAccessibility: Boolean = System.getProperty(ATTACH_A11Y_PROP) == "true",
+    runAccessibility: Boolean = System.getProperty(A11Y_DATA_PLUGIN_ENABLED_PROP) == "true",
   ): RenderResult {
     // Roborazzi defaults to "compare" mode — `captureRoboImage` reads the existing baseline at
     // the target path and *doesn't* write a new PNG. The daemon writes baselines, never compares,
@@ -481,12 +480,12 @@ class RenderEngine(
     const val OUTPUT_DIR_PROP: String = "composeai.render.outputDir"
 
     /**
-     * D2 — when set to `"true"` (by [DaemonMain] after wiring the a11y data-product registry)
-     * each render runs in a11y mode and writes `a11y-{atf,hierarchy}.json` artefacts under
-     * `<outputDir.parent>/data/<previewId>/`. Tests / pre-D2 callers leave it unset and the
-     * fast path stays unchanged.
+     * Data-plugin selector for the a11y producer. When set to `"true"`, each render runs in a11y
+     * mode and writes `a11y-{atf,hierarchy}.json` artefacts under
+     * `<outputDir.parent>/data/<previewId>/`. Tests and callers that do not enable the plugin leave
+     * it unset and the fast path stays unchanged.
      */
-    const val ATTACH_A11Y_PROP: String = "composeai.daemon.attachA11y"
+    const val A11Y_DATA_PLUGIN_ENABLED_PROP: String = "composeai.dataPlugins.a11y.enabled"
 
     /**
      * Virtual time to advance before capture in the paused-`mainClock` path, in milliseconds.

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/AndroidPreviewSupport.kt
@@ -1344,14 +1344,11 @@ internal object AndroidPreviewSupport {
         "composeai.daemon.warmSpare",
         extension.daemon.warmSpare.map { it.toString() },
       )
-      // D2 — opt-out for the a11y data products (see `DaemonExtension.attachA11y`). When
-      // `false`, `DaemonMain` constructs `DataProductRegistry.Empty` and the renderer skips
-      // a11y mode, which saves the per-render ATF cost for users who don't consume the
-      // overlay. Pairs with the VS Code `composePreview.a11y.alwaysSubscribe` setting on the
-      // consumer side.
+      // Data-product plugin selection. The daemon consumes the same a11y selector as
+      // `renderPreviews`; there is no daemon-specific a11y feature flag.
       this.systemProperties.put(
-        "composeai.daemon.attachA11y",
-        extension.daemon.attachA11y.map { it.toString() },
+        "composeai.dataPlugins.a11y.enabled",
+        resolveA11yEnabled(project, extension).map { it.toString() },
       )
       this.systemProperties.put(
         "composeai.daemon.perfettoTrace",
@@ -1430,8 +1427,7 @@ internal object AndroidPreviewSupport {
    * Returns a lazy `Provider<Boolean>` for the effective a11y data-product selection. The
    * `-PcomposePreview.dataPlugins.a11y.enableAllChecks=<true|false>` Gradle property enables every
    * a11y check; `-PcomposePreview.dataPlugins.a11y.checks=atf,hierarchy` enables only named a11y
-   * checks. The legacy `-PcomposePreview.accessibilityChecks.enabled=<true|false>` property remains
-   * as a fallback for one release so older editor integrations keep working.
+   * checks.
    *
    * **Deliberately returns a Provider, not a Boolean.** Reading `.get()` at configuration time keys
    * the configuration cache on the current property value, which means every VSCode toggle would
@@ -1456,11 +1452,6 @@ internal object AndroidPreviewSupport {
       project.providers
         .gradleProperty("composePreview.dataPlugins.a11y.enableAllChecks")
         .map { it.toBooleanStrictOrNull() ?: false }
-        .orElse(
-          project.providers.gradleProperty("composePreview.accessibilityChecks.enabled").map {
-            it.toBooleanStrictOrNull() ?: false
-          }
-        )
         .orElse(configuredAllChecks)
     val selectedChecks =
       project.providers
@@ -1482,11 +1473,6 @@ internal object AndroidPreviewSupport {
     project.providers
       .gradleProperty("composePreview.dataPlugins.a11y.annotateScreenshots")
       .map { it.toBooleanStrictOrNull() ?: true }
-      .orElse(
-        project.providers
-          .gradleProperty("composePreview.accessibilityChecks.annotateScreenshots")
-          .map { it.toBooleanStrictOrNull() ?: true }
-      )
       .orElse(a11yExtension(extension).annotateScreenshots)
 
   private fun a11yExtension(extension: PreviewExtension): A11yDataPluginExtension =

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtension.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtension.kt
@@ -67,27 +67,4 @@ abstract class DaemonExtension @Inject constructor(objects: ObjectFactory) {
    * inline and emit a `daemonWarming` notification while the new sandbox builds.
    */
   val warmSpare: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
-
-  /**
-   * D2 — whether the daemon advertises and produces the `a11y/atf` + `a11y/hierarchy` data
-   * products. Default: `true`.
-   *
-   * When `true`, every render runs in a11y mode (`LocalInspectionMode = false`) so ATF can walk the
-   * semantics tree and the `AccessibilityDataProductRegistry` can surface findings + the hierarchy
-   * via `data/fetch` / `data/subscribe`. Cost is a few ms per render plus the usual a11y-mode side
-   * effect (animations don't park under the paused clock — see
-   * `RobolectricRenderTest.renderWithA11y`'s docstring).
-   *
-   * When `false`, the daemon advertises no a11y kinds at handshake time. Clients see an empty
-   * `capabilities.dataProducts` and the focus-mode "Show accessibility overlay" toggle in the VS
-   * Code panel becomes a no-op (its `data/subscribe` rejects with `DataProductUnknown`). The
-   * daemon's internal renderer skips the a11y branch entirely, which is the cheapest mode for users
-   * who don't care about a11y in the daemon path. Diagnostic squigglies still flow via the Gradle
-   * sidecar reader as today — toggling this off only affects the daemon's data-product surface.
-   *
-   * Flip via build script (`composePreview { daemon { attachA11y = false } }`) to opt out at the
-   * producer side. Pairs with the VS Code-side `composePreview.a11y.alwaysSubscribe` setting (which
-   * controls whether the *consumer* side subscribes ambient or only on the focus-mode toggle).
-   */
-  val attachA11y: Property<Boolean> = objects.property(Boolean::class.java).convention(true)
 }

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtensionTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/daemon/DaemonExtensionTest.kt
@@ -27,19 +27,6 @@ class DaemonExtensionTest {
     // Warm spare on by default — pays double idle memory for zero
     // user-visible recycle pause. Off-by-default would be a regression.
     assertThat(daemon.warmSpare.get()).isTrue()
-    // D2 — attachA11y on by default so the data-product surface advertises a11y kinds.
-    // Flipping this to false would silently break the focus-mode overlay and the
-    // VS Code `composePreview.a11y.alwaysSubscribe` setting; defaults are pinned here
-    // so a regression is loud.
-    assertThat(daemon.attachA11y.get()).isTrue()
-  }
-
-  @Test
-  fun `attachA11y is settable per consumer`() {
-    val project = ProjectBuilder.builder().build()
-    val daemon = project.objects.newInstance(DaemonExtension::class.java)
-    daemon.attachA11y.set(false)
-    assertThat(daemon.attachA11y.get()).isFalse()
   }
 
   @Test

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -790,8 +790,8 @@ class DaemonMcpServer(
             "separate `render_preview` + `get_preview_data` round trip. The overlay PNG also lands on " +
             "disk under `<dataDir>/<previewId>/a11y-overlay.png` so callers that prefer the path can " +
             "set `inline=false`. " +
-            "Errors: DataProductUnknown when the daemon has no producer for `kind` (no a11y wiring or " +
-            "`composeai.daemon.attachA11y=false`).",
+            "Errors: DataProductUnknown when the daemon has no producer for `kind` (for example, " +
+            "the a11y data plugin is not enabled).",
         inputSchema =
           parseSchema(
             """

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -143,7 +143,7 @@
                 "composePreview.a11y.alwaysSubscribe": {
                     "type": "boolean",
                     "default": false,
-                    "description": "When on, the panel auto-subscribes to a11y data products (`a11y/atf` for diagnostic squigglies, `a11y/hierarchy` for the local overlay) for every visible preview in daemon mode — diagnostics fire ambient without entering focus mode. Off (the default) keeps the focus-mode 'Show accessibility overlay' button as the only opt-in. The producer side must also be on (Gradle: `composePreview { daemon { attachA11y = true } }`, the default); when the daemon advertises no a11y kinds this setting has no effect."
+                    "description": "When on, the panel auto-subscribes to a11y data products (`a11y/atf` for diagnostic squigglies, `a11y/hierarchy` for the local overlay) for every visible preview in daemon mode — diagnostics fire ambient without entering focus mode. Off (the default) keeps the focus-mode 'Show accessibility overlay' button as the only opt-in. The producer side must also be enabled with the Gradle data plugin (`composePreview { dataPlugins { a11y { enableAllChecks() } } }` or the matching `-PcomposePreview.dataPlugins.a11y.*` properties); when the daemon advertises no a11y kinds this setting has no effect."
                 },
                 "composePreview.logging.level": {
                     "type": "string",

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -307,7 +307,7 @@ export class DaemonScheduler {
         // `composePreview.a11y.alwaysSubscribe`, subscribe every newly-visible preview to
         // [A11Y_OVERLAY_KINDS] so diagnostics + the hierarchy overlay fire without entering
         // focus mode. dataSubscribe rejects gracefully (DataProductUnknown) when the daemon
-        // wasn't built with `attachA11y = true` on the producer side; that path absorbs the
+        // was not built with the a11y data plugin enabled; that path absorbs the
         // rejection and rolls back the bookkeeping (matching `setDataProductSubscription`).
         if (this.isA11yAlwaysSubscribed()) {
             for (const id of visible) {


### PR DESCRIPTION
## Summary
- remove the daemon-specific attachA11y DSL/property
- pass the a11y data-plugin selection into daemon launch descriptors as composeai.dataPlugins.a11y.enabled
- have the Android daemon and render engine use that data-plugin property for a11y registry/render-mode wiring
- remove legacy composePreview.accessibilityChecks property aliases and update user-facing text

## Tests
- ./gradlew :gradle-plugin:test --tests ee.schimke.composeai.plugin.daemon.DaemonExtensionTest --tests ee.schimke.composeai.plugin.DataPluginsExtensionTest
- ./gradlew :daemon:android:compileDebugKotlin :mcp:compileKotlin
- ./gradlew :samples:android:composePreviewDaemonStart -PcomposePreview.dataPlugins.a11y.enableAllChecks=true
- git diff --check

Note: npm run compile could not start because local node_modules is missing @types/mocha and @types/node.