### PR TITLE
Publish accessibility connector artifact

### DIFF
--- a/data/a11y/connector/build.gradle.kts
+++ b/data/a11y/connector/build.gradle.kts
@@ -6,14 +6,16 @@ import tapmoc.configureKotlinCompatibility
 // daemon's data-product API: `AccessibilityDataProducer` writes the per-render JSON
 // artefacts, `AccessibilityDataProductRegistry` advertises kinds + serves
 // fetch / attach paths, and `AccessibilityImageProcessor` wires the overlay PNG into the
-// `ImageProcessor` seam. Daemon-only — not published; consumed by `:daemon:android` via a
-// project dependency.
+// `ImageProcessor` seam. Published only so `:daemon:android`'s external POM can resolve its
+// transitive daemon-side data-product implementation.
 //
 // See docs/daemon/DATA-PRODUCTS.md § "Module split (D2.2)" for the rationale.
 
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.kotlin.serialization)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
   alias(libs.plugins.tapmoc)
 }
 
@@ -62,4 +64,68 @@ dependencies {
 
   testImplementation(libs.junit)
   testImplementation(libs.kotlinx.serialization.json)
+}
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  configure(
+    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
+      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
+      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
+      variant = "release",
+    )
+  )
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+
+  coordinates("ee.schimke.composeai", "data-a11y-connector", version.toString())
+
+  pom {
+    name.set("Compose Preview — Accessibility Data Product (Connector)")
+    description.set(
+      "Daemon-side accessibility data-product connector: wires data-a11y-core into the " +
+        "compose-preview daemon's data/* JSON-RPC surface and overlay image processor."
+    )
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2026")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
 }

--- a/data/a11y/core/build.gradle.kts
+++ b/data/a11y/core/build.gradle.kts
@@ -15,7 +15,8 @@ import tapmoc.configureKotlinCompatibility
 // model classes (`AccessibilityFinding` / `AccessibilityNode` / `AccessibilityEntry`
 // / `AccessibilityReport`). Anything that depends only on AndroidX, Compose,
 // AndroidX-test or ATF lives here; daemon coupling lives in
-// `:data-a11y-connector` (which is unpublished).
+// `:data-a11y-connector`, which is published only to satisfy daemon-android's
+// external transitive dependency.
 //
 // Pairs with `:data-a11y-connector` — see docs/daemon/DATA-PRODUCTS.md §
 // "Module split (D2.2)".


### PR DESCRIPTION
## Summary
- make :data-a11y-connector publishable with the same Maven Central/GitHub Packages setup used by :data-a11y-core
- keep the module comment aligned with the current workflow/published POM graph

## Why
PR #574 added :data-a11y-connector publish tasks to the workflows, but the module still did not apply publishing plugins, so main fails before the artifact can be published. This artifact is required because :daemon:android exposes api(project(":data-a11y-connector")) in its generated POM.

## Validation
- PLUGIN_VERSION=0.1.0-SNAPSHOT ./gradlew :gradle-plugin:publishToMavenLocal :data-a11y-core:publishToMavenLocal :data-a11y-connector:publishToMavenLocal :renderer-android:publishToMavenLocal :daemon:core:publishToMavenLocal :daemon:desktop:publishToMavenLocal :daemon:android:publishToMavenLocal --stacktrace
- ./gradlew ktfmtCheck

Note: local Maven Central dry-run reached credential resolution for mavenCentralUsername/mavenCentralPassword, which is expected outside CI secrets.