### PR TITLE
Capture preview-local MaterialTheme tokens

### DIFF
--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -112,6 +112,7 @@ dependencies {
   "testFixturesImplementation"(compose.runtime)
   "testFixturesImplementation"(compose.foundation)
   "testFixturesImplementation"(compose.ui)
+  "testFixturesImplementation"(compose.material3)
 }
 
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -3,14 +3,22 @@ package ee.schimke.composeai.daemon
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Shapes
+import androidx.compose.material3.Typography
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
+import androidx.compose.runtime.tooling.CompositionData
+import androidx.compose.runtime.tooling.CompositionGroup
+import androidx.compose.runtime.tooling.LocalInspectionTables
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.SystemTheme
@@ -20,6 +28,8 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.intl.LocaleList
 import androidx.compose.ui.unit.Density
 import java.io.File
+import java.util.Collections
+import java.util.WeakHashMap
 import org.jetbrains.skia.EncodedImageFormat
 
 /**
@@ -169,6 +179,12 @@ class RenderEngine(
     Thread.currentThread().contextClassLoader = classLoader
 
     val localeProviders = localeProviders(spec.localeTag)
+    val themeSlotTableCapture =
+      if (themeCapture?.shouldCapture(spec.previewId, spec.renderMode) == true) {
+        ThemeSlotTableCapture()
+      } else {
+        null
+      }
 
     // PROTOCOL.md § 5 (`renderNow.overrides.fontScale`) — Compose Desktop has no resource-qualifier
     // system, but `LocalDensity` carries `fontScale` as part of `Density`, and `Text` / `TextStyle`
@@ -208,18 +224,28 @@ class RenderEngine(
             *localeProviders,
           ) {
             if (themeCapture?.shouldCapture(spec.previewId, spec.renderMode) == true) {
-              CaptureMaterialTheme { payload -> themeCapture.capture(spec.previewId, payload) }
-            }
-            val bgColor =
-              when {
-                spec.backgroundColor != 0L -> Color(spec.backgroundColor.toInt())
-                spec.showBackground -> Color.White
-                else -> Color.Transparent
+              CaptureMaterialTheme { _, typography, shapes, payload ->
+                themeSlotTableCapture?.captureFallbackValues(typography, shapes)
+                themeCapture.capture(spec.previewId, payload)
               }
-            Box(modifier = Modifier.fillMaxSize().background(bgColor)) {
-              // Trampoline through a @Composable so the reflective invocation lands inside the
-              // running composition. Mirrors `:renderer-desktop`'s InvokeComposable.
-              InvokeComposable(composableMethod)
+            }
+            val content: @Composable () -> Unit = {
+              val bgColor =
+                when {
+                  spec.backgroundColor != 0L -> Color(spec.backgroundColor.toInt())
+                  spec.showBackground -> Color.White
+                  else -> Color.Transparent
+                }
+              Box(modifier = Modifier.fillMaxSize().background(bgColor)) {
+                // Trampoline through a @Composable so the reflective invocation lands inside the
+                // running composition. Mirrors `:renderer-desktop`'s InvokeComposable.
+                InvokeComposable(composableMethod)
+              }
+            }
+            if (themeSlotTableCapture != null) {
+              InspectableThemeContent(themeSlotTableCapture, content)
+            } else {
+              content()
             }
           }
         }
@@ -241,6 +267,7 @@ class RenderEngine(
       density = density,
       outputFile = outputFile,
       previousContext = previousContext,
+      themeSlotTableCapture = themeSlotTableCapture,
     )
   }
 
@@ -270,6 +297,9 @@ class RenderEngine(
     // as `:renderer-desktop`'s renderPreview.
     trace.section("compose:frame") { renderFrame(state, useWallClockFrameTime) }
     val image = trace.section("compose:captureFrame") { renderFrame(state, useWallClockFrameTime) }
+    state.themeSlotTableCapture?.themePayloadFromMaterialThemeCall()?.let { payload ->
+      themeCapture?.capture(state.spec.previewId, payload)
+    }
 
     val pngData =
       trace.section("render:encodePng") {
@@ -325,13 +355,15 @@ class RenderEngine(
    * because [DesktopInteractiveSession] holds one across `interactive/input` notifications;
    * one-shot [render] callers don't need to look at it.
    */
-  class SceneState(
+  class SceneState
+  internal constructor(
     val spec: RenderSpec,
     val classLoader: ClassLoader,
     val scene: ImageComposeScene,
     val density: Density,
     val outputFile: File,
     internal val previousContext: ClassLoader?,
+    internal val themeSlotTableCapture: ThemeSlotTableCapture?,
   )
 
   interface ThemeCapture {
@@ -509,10 +541,66 @@ private fun InvokeComposable(composableMethod: ComposableMethod) {
   composableMethod.invoke(currentComposer, null)
 }
 
-@androidx.compose.runtime.Composable
-private fun CaptureMaterialTheme(onCaptured: (ThemePayload) -> Unit) {
+@Composable
+private fun CaptureMaterialTheme(
+  onCaptured: (ColorScheme, Typography, Shapes, ThemePayload) -> Unit
+) {
   val colorScheme = MaterialTheme.colorScheme
   val typography = MaterialTheme.typography
   val shapes = MaterialTheme.shapes
-  SideEffect { onCaptured(themePayloadFromMaterialTheme(colorScheme, typography, shapes)) }
+  SideEffect {
+    onCaptured(
+      colorScheme,
+      typography,
+      shapes,
+      themePayloadFromMaterialTheme(colorScheme, typography, shapes),
+    )
+  }
 }
+
+internal class ThemeSlotTableCapture {
+  val store: MutableSet<CompositionData> = Collections.newSetFromMap(WeakHashMap())
+  private var fallbackTypography: Typography? = null
+  private var fallbackShapes: Shapes? = null
+
+  fun themePayloadFromMaterialThemeCall(): ThemePayload? {
+    val materialThemeCalls =
+      store
+        .flatMap { data -> data.compositionGroups.flatMap { it.flattenGroups() } }
+        .filter { group -> group.sourceInfo?.startsWith("C(MaterialTheme)") == true }
+
+    for (group in materialThemeCalls.asReversed()) {
+      val values = group.data.toList()
+      val colorSource = values.lastOrNull { colorTokens(it).isNotEmpty() } ?: continue
+      val typographySource = values.lastOrNull { typographyTokens(it).isNotEmpty() }
+      val shapesSource = values.lastOrNull { shapeTokens(it).isNotEmpty() }
+      return themePayloadFromThemeObjects(
+        colorSource = colorSource,
+        typographySource = typographySource,
+        shapesSource = shapesSource,
+        fallbackTypography = fallbackTypography,
+        fallbackShapes = fallbackShapes,
+      )
+    }
+    return null
+  }
+
+  fun captureFallbackValues(typography: Typography, shapes: Shapes) {
+    fallbackTypography = typography
+    fallbackShapes = shapes
+  }
+}
+
+@OptIn(InternalComposeApi::class)
+@androidx.compose.runtime.Composable
+private fun InspectableThemeContent(
+  capture: ThemeSlotTableCapture,
+  content: @androidx.compose.runtime.Composable () -> Unit,
+) {
+  currentComposer.collectParameterInformation()
+  capture.store.add(currentComposer.compositionData)
+  CompositionLocalProvider(LocalInspectionTables provides capture.store, content = content)
+}
+
+private fun CompositionGroup.flattenGroups(): List<CompositionGroup> =
+  listOf(this) + compositionGroups.flatMap { it.flattenGroups() }

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/ThemeDataProductRegistryTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/ThemeDataProductRegistryTest.kt
@@ -95,6 +95,47 @@ class ThemeDataProductRegistryTest {
   }
 
   @Test
+  fun theme_mode_prefers_preview_local_material_theme_tokens() {
+    val outputDir = tempFolder.newFolder("renders-local-theme")
+    val registry = ThemeDataProductRegistry()
+    val engine =
+      RenderEngine(
+        outputDir = outputDir,
+        themeCapture =
+          object : RenderEngine.ThemeCapture {
+            override fun shouldCapture(previewId: String?, renderMode: String?): Boolean =
+              registry.shouldCapture(previewId, renderMode)
+
+            override fun capture(previewId: String?, payload: ThemePayload) {
+              registry.capture(previewId, payload)
+            }
+          },
+      )
+
+    engine.render(
+      spec =
+        RenderSpec(
+          previewId = "preview-local-theme",
+          renderMode = "theme",
+          className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+          functionName = "ThemedPrimarySquare",
+          widthPx = 32,
+          heightPx = 32,
+          density = 1.0f,
+          outputBaseName = "theme-local-square",
+        ),
+      requestId = RenderHost.nextRequestId(),
+    )
+
+    val fetch =
+      registry.fetch("preview-local-theme", "compose/theme", params = null, inline = true)
+        as DataProductRegistry.Outcome.Ok
+    val colorScheme =
+      fetch.result.payload!!.jsonObject["resolvedTokens"]!!.jsonObject["colorScheme"]!!.jsonObject
+    assertEquals("#FF123456", colorScheme["primary"]!!.jsonPrimitive.content)
+  }
+
+  @Test
   fun subscribed_preview_captures_on_default_render() {
     val outputDir = tempFolder.newFolder("renders")
     val registry = ThemeDataProductRegistry()

--- a/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/desktop/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -31,6 +33,13 @@ fun RedSquare() {
 @Composable
 fun BlueSquare() {
   Box(modifier = Modifier.fillMaxSize().background(Color(0xFF42A5F5)))
+}
+
+@Composable
+fun ThemedPrimarySquare() {
+  MaterialTheme(colorScheme = lightColorScheme(primary = Color(0xFF123456))) {
+    Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.primary))
+  }
 }
 
 /**

--- a/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
+++ b/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
@@ -11,6 +11,7 @@ import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import java.lang.reflect.Method
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -144,69 +145,158 @@ fun themePayloadFromMaterialTheme(
   ThemePayload(
     resolvedTokens =
       ResolvedThemeTokens(
-        colorScheme =
-          linkedMapOf(
-            "primary" to colorScheme.primary.hexArgb(),
-            "onPrimary" to colorScheme.onPrimary.hexArgb(),
-            "primaryContainer" to colorScheme.primaryContainer.hexArgb(),
-            "onPrimaryContainer" to colorScheme.onPrimaryContainer.hexArgb(),
-            "inversePrimary" to colorScheme.inversePrimary.hexArgb(),
-            "secondary" to colorScheme.secondary.hexArgb(),
-            "onSecondary" to colorScheme.onSecondary.hexArgb(),
-            "secondaryContainer" to colorScheme.secondaryContainer.hexArgb(),
-            "onSecondaryContainer" to colorScheme.onSecondaryContainer.hexArgb(),
-            "tertiary" to colorScheme.tertiary.hexArgb(),
-            "onTertiary" to colorScheme.onTertiary.hexArgb(),
-            "tertiaryContainer" to colorScheme.tertiaryContainer.hexArgb(),
-            "onTertiaryContainer" to colorScheme.onTertiaryContainer.hexArgb(),
-            "background" to colorScheme.background.hexArgb(),
-            "onBackground" to colorScheme.onBackground.hexArgb(),
-            "surface" to colorScheme.surface.hexArgb(),
-            "onSurface" to colorScheme.onSurface.hexArgb(),
-            "surfaceVariant" to colorScheme.surfaceVariant.hexArgb(),
-            "onSurfaceVariant" to colorScheme.onSurfaceVariant.hexArgb(),
-            "surfaceTint" to colorScheme.surfaceTint.hexArgb(),
-            "inverseSurface" to colorScheme.inverseSurface.hexArgb(),
-            "inverseOnSurface" to colorScheme.inverseOnSurface.hexArgb(),
-            "error" to colorScheme.error.hexArgb(),
-            "onError" to colorScheme.onError.hexArgb(),
-            "errorContainer" to colorScheme.errorContainer.hexArgb(),
-            "onErrorContainer" to colorScheme.onErrorContainer.hexArgb(),
-            "outline" to colorScheme.outline.hexArgb(),
-            "outlineVariant" to colorScheme.outlineVariant.hexArgb(),
-            "scrim" to colorScheme.scrim.hexArgb(),
-          ),
-        typography =
-          linkedMapOf(
-            "displayLarge" to typography.displayLarge.token(),
-            "displayMedium" to typography.displayMedium.token(),
-            "displaySmall" to typography.displaySmall.token(),
-            "headlineLarge" to typography.headlineLarge.token(),
-            "headlineMedium" to typography.headlineMedium.token(),
-            "headlineSmall" to typography.headlineSmall.token(),
-            "titleLarge" to typography.titleLarge.token(),
-            "titleMedium" to typography.titleMedium.token(),
-            "titleSmall" to typography.titleSmall.token(),
-            "bodyLarge" to typography.bodyLarge.token(),
-            "bodyMedium" to typography.bodyMedium.token(),
-            "bodySmall" to typography.bodySmall.token(),
-            "labelLarge" to typography.labelLarge.token(),
-            "labelMedium" to typography.labelMedium.token(),
-            "labelSmall" to typography.labelSmall.token(),
-          ),
-        shapes =
-          linkedMapOf(
-            "extraSmall" to shapes.extraSmall.toString(),
-            "small" to shapes.small.toString(),
-            "medium" to shapes.medium.toString(),
-            "large" to shapes.large.toString(),
-            "extraLarge" to shapes.extraLarge.toString(),
-          ),
+        colorScheme = colorTokens(colorScheme),
+        typography = typographyTokens(typography),
+        shapes = shapeTokens(shapes),
       ),
     consumers = emptyList(),
   )
 
-private fun Color.hexArgb(): String = "#%08X".format(toArgb())
+fun themePayloadFromThemeObjects(
+  colorSource: Any,
+  typographySource: Any?,
+  shapesSource: Any?,
+  fallbackTypography: Typography?,
+  fallbackShapes: Shapes?,
+): ThemePayload? {
+  val colorScheme = colorTokens(colorSource).takeIf { it.isNotEmpty() } ?: return null
+  val typography =
+    typographyTokens(typographySource).takeIf { it.isNotEmpty() }
+      ?: fallbackTypography?.let(::typographyTokens)
+      ?: emptyMap()
+  val shapes =
+    shapeTokens(shapesSource).takeIf { it.isNotEmpty() }
+      ?: fallbackShapes?.let(::shapeTokens)
+      ?: emptyMap()
+  return ThemePayload(
+    resolvedTokens =
+      ResolvedThemeTokens(colorScheme = colorScheme, typography = typography, shapes = shapes),
+    consumers = emptyList(),
+  )
+}
+
+fun colorTokens(source: Any?): Map<String, String> =
+  when (source) {
+    null -> emptyMap()
+    is ColorScheme ->
+      linkedMapOf(
+        "primary" to source.primary.hexArgb(),
+        "onPrimary" to source.onPrimary.hexArgb(),
+        "primaryContainer" to source.primaryContainer.hexArgb(),
+        "onPrimaryContainer" to source.onPrimaryContainer.hexArgb(),
+        "inversePrimary" to source.inversePrimary.hexArgb(),
+        "secondary" to source.secondary.hexArgb(),
+        "onSecondary" to source.onSecondary.hexArgb(),
+        "secondaryContainer" to source.secondaryContainer.hexArgb(),
+        "onSecondaryContainer" to source.onSecondaryContainer.hexArgb(),
+        "tertiary" to source.tertiary.hexArgb(),
+        "onTertiary" to source.onTertiary.hexArgb(),
+        "tertiaryContainer" to source.tertiaryContainer.hexArgb(),
+        "onTertiaryContainer" to source.onTertiaryContainer.hexArgb(),
+        "background" to source.background.hexArgb(),
+        "onBackground" to source.onBackground.hexArgb(),
+        "surface" to source.surface.hexArgb(),
+        "onSurface" to source.onSurface.hexArgb(),
+        "surfaceVariant" to source.surfaceVariant.hexArgb(),
+        "onSurfaceVariant" to source.onSurfaceVariant.hexArgb(),
+        "surfaceTint" to source.surfaceTint.hexArgb(),
+        "inverseSurface" to source.inverseSurface.hexArgb(),
+        "inverseOnSurface" to source.inverseOnSurface.hexArgb(),
+        "error" to source.error.hexArgb(),
+        "onError" to source.onError.hexArgb(),
+        "errorContainer" to source.errorContainer.hexArgb(),
+        "onErrorContainer" to source.onErrorContainer.hexArgb(),
+        "outline" to source.outline.hexArgb(),
+        "outlineVariant" to source.outlineVariant.hexArgb(),
+        "scrim" to source.scrim.hexArgb(),
+      )
+    else -> reflectedColorTokens(source)
+  }
+
+fun typographyTokens(source: Any?): Map<String, TypographyToken> =
+  when (source) {
+    null -> emptyMap()
+    is Typography ->
+      linkedMapOf(
+        "displayLarge" to source.displayLarge.token(),
+        "displayMedium" to source.displayMedium.token(),
+        "displaySmall" to source.displaySmall.token(),
+        "headlineLarge" to source.headlineLarge.token(),
+        "headlineMedium" to source.headlineMedium.token(),
+        "headlineSmall" to source.headlineSmall.token(),
+        "titleLarge" to source.titleLarge.token(),
+        "titleMedium" to source.titleMedium.token(),
+        "titleSmall" to source.titleSmall.token(),
+        "bodyLarge" to source.bodyLarge.token(),
+        "bodyMedium" to source.bodyMedium.token(),
+        "bodySmall" to source.bodySmall.token(),
+        "labelLarge" to source.labelLarge.token(),
+        "labelMedium" to source.labelMedium.token(),
+        "labelSmall" to source.labelSmall.token(),
+      )
+    else ->
+      linkedMapOf<String, TypographyToken>().also { tokens ->
+        for (method in source.javaClass.readableNoArgMethods()) {
+          val value = method.invokeOrNull(source)
+          if (value is TextStyle) tokens[method.propertyName()] = value.token()
+        }
+      }
+  }
+
+fun shapeTokens(source: Any?): Map<String, String> =
+  when (source) {
+    null -> emptyMap()
+    is Shapes ->
+      linkedMapOf(
+        "extraSmall" to source.extraSmall.toString(),
+        "small" to source.small.toString(),
+        "medium" to source.medium.toString(),
+        "large" to source.large.toString(),
+        "extraLarge" to source.extraLarge.toString(),
+      )
+    else ->
+      linkedMapOf<String, String>().also { tokens ->
+        for (method in source.javaClass.readableNoArgMethods()) {
+          val value = method.invokeOrNull(source) ?: continue
+          if (value.javaClass.name.contains("Shape", ignoreCase = true)) {
+            tokens[method.propertyName()] = value.toString()
+          }
+        }
+      }
+  }
+
+private fun reflectedColorTokens(source: Any): Map<String, String> =
+  linkedMapOf<String, String>().also { tokens ->
+    for (method in source.javaClass.readableNoArgMethods()) {
+      val name = method.propertyName()
+      val value = method.invokeOrNull(source)
+      when (value) {
+        is Color -> tokens[name] = value.hexArgb()
+        is Long ->
+          if (method.returnType == java.lang.Long.TYPE)
+            tokens[name] = Color(value.toULong()).hexArgb()
+      }
+    }
+  }
+
+private fun Class<*>.readableNoArgMethods(): List<Method> = methods.filter { method ->
+  method.parameterCount == 0 &&
+    method.name.startsWith("get") &&
+    method.name != "getClass" &&
+    method.returnType != java.lang.Void.TYPE
+}
+
+private fun Method.invokeOrNull(receiver: Any): Any? =
+  runCatching {
+      isAccessible = true
+      invoke(receiver)
+    }
+    .getOrNull()
+
+private fun Method.propertyName(): String =
+  name.removePrefix("get").substringBefore("-").replaceFirstChar { it.lowercase() }
+
+fun Color.hexArgb(): String = "#%08X".format(toArgb())
 
 private fun TextStyle.token(): TypographyToken =
   TypographyToken(


### PR DESCRIPTION
## Summary
- capture desktop compose/theme data from the slot table so preview-local MaterialTheme values win over daemon defaults
- add reflective token extraction for Material theme objects, including newer value structures
- add a regression preview/test for custom Material3 primary color capture

## Tests
- ./gradlew :daemon:desktop:test --tests ee.schimke.composeai.daemon.ThemeDataProductRegistryTest

Refs #558