### PR TITLE
Move history into focus data view

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -375,6 +375,178 @@ body {
     font-variant-numeric: tabular-nums;
 }
 
+.focus-inspector {
+    display: grid;
+    grid-template-columns: minmax(150px, 0.8fr) minmax(240px, 1.6fr) minmax(150px, 0.8fr);
+    gap: 8px;
+    padding: 0 8px 8px;
+}
+
+.focus-inspector[hidden] {
+    display: none;
+}
+
+.focus-panel {
+    border: 1px solid var(--card-border);
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--vscode-editor-background) 94%, var(--text-secondary));
+    min-width: 0;
+}
+
+.focus-panel-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--card-border);
+    color: var(--text-secondary);
+    font-size: calc(var(--vscode-font-size) - 2px);
+    font-weight: 600;
+    text-transform: uppercase;
+}
+
+.focus-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 8px;
+}
+
+.focus-action {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    min-height: var(--control-height);
+    padding: 2px 8px;
+    border: 1px solid var(--card-border);
+    border-radius: 3px;
+    background: transparent;
+    color: var(--text-primary);
+    font: inherit;
+    cursor: pointer;
+}
+
+.focus-action:hover:not(:disabled) {
+    background: var(--toolbar-hover);
+}
+
+.focus-action:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: -1px;
+}
+
+.focus-product-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 4px;
+    padding: 8px;
+}
+
+.focus-product-chip {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    padding: 5px 6px;
+    border: 1px solid color-mix(in srgb, var(--card-border) 70%, transparent);
+    border-radius: 3px;
+    background: color-mix(in srgb, var(--text-secondary) 6%, transparent);
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+}
+
+.focus-product-chip:hover,
+.focus-product-chip[aria-pressed="true"] {
+    background: var(--toolbar-hover);
+}
+
+.focus-product-chip:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: -1px;
+}
+
+.focus-product-chip[data-state="ok"] {
+    border-color: color-mix(in srgb, var(--vscode-charts-green, #89d185) 45%, var(--card-border));
+}
+
+.focus-product-chip[data-state="warn"] {
+    border-color: color-mix(in srgb, var(--vscode-editorWarning-foreground, #cca700) 55%, var(--card-border));
+}
+
+.focus-product-chip > .codicon {
+    flex: 0 0 auto;
+    color: var(--text-secondary);
+}
+
+.focus-product-chip[data-state="ok"] > .codicon {
+    color: var(--vscode-charts-green, #89d185);
+}
+
+.focus-product-chip[data-state="warn"] > .codicon {
+    color: var(--vscode-editorWarning-foreground, #cca700);
+}
+
+.focus-product-text {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+
+.focus-product-name,
+.focus-product-value {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.focus-product-name {
+    color: var(--text-primary);
+    font-size: calc(var(--vscode-font-size) - 1px);
+}
+
+.focus-product-value {
+    color: var(--text-secondary);
+    font-size: calc(var(--vscode-font-size) - 3px);
+    font-variant-numeric: tabular-nums;
+}
+
+.focus-placeholder-list {
+    grid-column: 1 / -1;
+}
+
+.focus-placeholder-list .focus-panel-header {
+    border-bottom: none;
+}
+
+.focus-placeholder {
+    border-top: 1px solid var(--card-border);
+}
+
+.focus-placeholder > summary {
+    padding: 6px 8px;
+    cursor: pointer;
+    color: var(--text-primary);
+}
+
+.focus-placeholder > summary:hover {
+    background: var(--toolbar-hover);
+}
+
+.focus-placeholder-body {
+    padding: 0 8px 8px 22px;
+    color: var(--text-secondary);
+    font-size: calc(var(--vscode-font-size) - 2px);
+}
+
+@media (max-width: 560px) {
+    .focus-inspector {
+        grid-template-columns: 1fr;
+    }
+}
+
 /* -- Preview card ----------------------------------------------------- */
 
 .preview-card {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -58,13 +58,6 @@
                     "id": "composePreview.panel",
                     "name": "Previews",
                     "visibility": "visible"
-                },
-                {
-                    "type": "webview",
-                    "id": "composePreview.historyPanel",
-                    "name": "History",
-                    "when": "config.composePreview.daemon.enabled",
-                    "visibility": "collapsed"
                 }
             ]
         },

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -27,7 +27,7 @@ import { captureLabel } from './captureLabels';
 import { DaemonGate } from './daemon/daemonGate';
 import { DataProductAttachment } from './daemon/daemonProtocol';
 import { A11Y_OVERLAY_KINDS, DaemonScheduler, WarmState } from './daemon/daemonScheduler';
-import { buildHistorySource, HistoryPanel, HistoryScope, HistorySource } from './historyPanel';
+import { buildHistorySource, HistoryScope, HistorySource } from './historyPanel';
 import { disposePreviewMainBatches, readPreviewMainPng } from './previewMainSource';
 import { watchPreviewMainRef } from './previewMainWatcher';
 import { LogFilter, parseLogLevel } from './logFilter';
@@ -64,13 +64,11 @@ let daemonScheduler: DaemonScheduler | null = null;
 let daemonStatusItem: vscode.StatusBarItem | null = null;
 let interactiveStatusItem: vscode.StatusBarItem | null = null;
 let daemonStatusClearTimer: NodeJS.Timeout | null = null;
-let historyPanel: HistoryPanel | null = null;
-/** Owned by activate(); reused by both the History panel and the live
- *  panel's diff handler. */
+/** Owned by activate(); reused by the live panel's focus-mode diff handler. */
 let historySource: HistorySource | null = null;
 /**
- * Mutable closure for the history panel's read/diff fall-back path.
- * `buildHistorySource` captures this object once at panel-construction time
+ * Mutable closure for history read/diff fallback paths.
+ * `buildHistorySource` captures this object once at construction time
  * and reads `.current` at call-time so we never need to re-instantiate the
  * source when the user navigates between modules.
  */
@@ -414,12 +412,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
             applyDiscoveryDiff(moduleId, params);
         },
         onHistoryAdded: (_moduleId, params) => {
-            // Phase H7 — daemon push: a fresh render landed and was
-            // archived. Forward to the History panel; the panel filters
-            // by `entry.module` against the currently-scoped module so an
-            // unrelated render in a background module doesn't pop the
-            // timeline.
-            historyPanel?.onHistoryAdded(params);
+            // Phase H7 — daemon push: a fresh render landed and was archived. History is
+            // now focus-view-only; the live panel resolves it on demand when the user
+            // asks for a diff from the focused preview.
+            void params;
         },
         onChannelClosed: (moduleId) => {
             clearDaemonShownPreviewWarmScopes(moduleId);
@@ -481,7 +477,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     panel = new PreviewPanel(
         context.extensionUri,
         handleWebviewMessage,
-        () => historyPanel?.isVisible() ?? false,
     );
     if (isTestMode) {
         // Tap into every outgoing webview message so the test API can assert
@@ -507,13 +502,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         }),
     );
 
-    // Phase H7 — Preview History panel (HISTORY.md § "VS Code integration").
-    // Live when `composePreview.daemon.enabled` is true; falls
-    // back to reading `<projectDir>/.compose-preview-history/index.jsonl` +
-    // sidecars when the daemon isn't healthy. View shows up unconditionally
-    // — the view container is contributed in package.json — but its content
-    // is empty when no Kotlin file is in scope. The setScope() driver is
-    // wired below into the active-editor change events.
+    // Phase H7 — preview history source. The standalone History view is not
+    // contributed; history is surfaced from the focus view alongside data products.
     historyScopeRef.current = null;
     historySource = buildHistorySource({
         isDaemonReady: (moduleId) => daemonGate?.isDaemonReady(moduleId) ?? false,
@@ -545,11 +535,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         getCurrentScope: () => historyScopeRef.current,
         logger: outputChannel,
     });
-    historyPanel = new HistoryPanel(context.extensionUri, historySource);
-    context.subscriptions.push(
-        vscode.window.registerWebviewViewProvider(HistoryPanel.viewId, historyPanel),
-    );
-
     context.subscriptions.push(
         vscode.commands.registerCommand('composePreview.refresh', () =>
             refresh(true, currentScopeFile ?? undefined)),
@@ -2011,7 +1996,6 @@ async function refresh(
         setCurrentScopeFile(null);
         clearHeavyRefreshOptIns();
         historyScopeRef.current = null;
-        historyPanel?.setScope(null);
         if (activeFile && isPreviewSourceFile(activeFile)) {
             maybeShowSetupPrompt(activeFile);
         }
@@ -2082,7 +2066,6 @@ async function refresh(
         ? { moduleId: module, projectDir, previewId: prior!.previewId, previewLabel: prior!.previewLabel }
         : { moduleId: module, projectDir };
     historyScopeRef.current = newScope;
-    historyPanel?.setScope(newScope);
     const modules = [module];
     // Package-qualified path (e.g. `com/example/samplewear/Previews.kt`) so
     // files with the same basename in different packages don't collide.
@@ -2499,7 +2482,6 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                 previewLabel: requestedLabel,
             };
             historyScopeRef.current = newScope;
-            historyPanel?.setScope(newScope);
             break;
         }
         case 'openCompileError':

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -137,6 +137,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         </button>
     </div>
     <div id="preview-grid" class="preview-grid" role="list" aria-label="Preview cards"></div>
+    <div id="focus-inspector" class="focus-inspector" hidden aria-label="Focused preview data"></div>
 
     <script nonce="${nonce}">
     (function() {
@@ -144,6 +145,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         const state = vscode.getState() || { filters: {} };
 
         const grid = document.getElementById('preview-grid');
+        const focusInspector = document.getElementById('focus-inspector');
         const message = document.getElementById('message');
         const filterFunction = document.getElementById('filter-function');
         const filterGroup = document.getElementById('filter-group');
@@ -165,6 +167,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         // user gesture. State is per-previewId because hopping between focused cards re-applies
         // the toggle to the new target.
         let a11yOverlayPreviewId = null;
+        const enabledFocusProducts = new Set();
         const focusPosition = document.getElementById('focus-position');
         const progressBar = document.getElementById('progress-bar');
         const progressFill = progressBar.querySelector('.progress-fill');
@@ -506,6 +509,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 enabled: turningOn,
             });
             applyA11yOverlayButtonState();
+            renderFocusInspector(card);
         }
 
         function applyLiveBadge() {
@@ -622,6 +626,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             });
             applyLiveBadge();
             applyInteractiveButtonState();
+            renderFocusInspector(card);
         }
 
         /**
@@ -902,6 +907,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 const visible = getVisibleCards();
                 if (visible.length === 0) {
                     focusPosition.textContent = '0 / 0';
+                    renderFocusInspector(null);
                     publishScopedPreview();
                     return;
                 }
@@ -920,11 +926,13 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 focusPosition.textContent = (focusIndex + 1) + ' / ' + visible.length;
                 btnPrev.disabled = focusIndex === 0;
                 btnNext.disabled = focusIndex === visible.length - 1;
+                renderFocusInspector(visible[focusIndex]);
             } else {
                 // Clear focus classes for other layouts
                 document.querySelectorAll('.preview-card').forEach(card => {
                     card.classList.remove('focused', 'hidden-by-focus');
                 });
+                renderFocusInspector(null);
             }
             document.querySelectorAll('.image-container').forEach(c => c.removeAttribute('title'));
             publishScopedPreview();
@@ -966,12 +974,10 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             applyA11yOverlayButtonState();
         }
 
-        // Compute the previewId the panel is currently narrowed to, if any:
-        //   - focus mode: the focused card
-        //   - non-focus: the sole visible card when filters narrowed to one
-        //   - otherwise: null (panel shows multiple previews — module-level history)
-        // Posts the current value to the extension only when it changes so
-        // the History panel re-lists at most once per user-driven narrowing.
+        // Compute the focus-mode previewId. History is intentionally focus-only:
+        // list/grid/filter layouts publish null even if only one card is visible.
+        // Posts only when it changes so the extension does not rebuild history scope
+        // on ordinary filter/layout churn.
         function publishScopedPreview() {
             const visible = getVisibleCards();
             let previewId = null;
@@ -979,8 +985,6 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 if (visible.length > 0 && focusIndex >= 0 && focusIndex < visible.length) {
                     previewId = visible[focusIndex].dataset.previewId || null;
                 }
-            } else if (visible.length === 1) {
-                previewId = visible[0].dataset.previewId || null;
             }
             if (previewId === lastScopedPreviewId) return;
             lastScopedPreviewId = previewId;
@@ -1021,6 +1025,179 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             state.layout = previousLayout;
             vscode.setState(state);
             applyLayout();
+        }
+
+        function renderFocusInspector(card) {
+            focusInspector.innerHTML = '';
+            focusInspector.hidden = !card;
+            if (!card) return;
+            const previewId = card.dataset.previewId;
+            const p = allPreviews.find(pp => pp.id === previewId);
+            if (!previewId || !p) return;
+
+            const history = document.createElement('section');
+            history.className = 'focus-panel focus-history-panel';
+            history.appendChild(sectionHeader('history', 'History'));
+            const historyActions = document.createElement('div');
+            historyActions.className = 'focus-actions';
+            historyActions.appendChild(actionButton('git-compare', 'HEAD', 'Diff vs last archived render', () => {
+                requestFocusedDiff('head');
+            }));
+            historyActions.appendChild(actionButton('source-control', 'main', 'Diff vs latest archived main render', () => {
+                requestFocusedDiff('main');
+            }));
+            history.appendChild(historyActions);
+
+            const data = document.createElement('section');
+            data.className = 'focus-panel focus-products-panel';
+            data.appendChild(sectionHeader('layers', 'Data Products'));
+            const products = document.createElement('div');
+            products.className = 'focus-product-grid';
+            const findings = cardA11yFindings.get(previewId) || p.a11yFindings || [];
+            const nodes = cardA11yNodes.get(previewId) || p.a11yNodes || [];
+            products.appendChild(productToggle('eye', 'Accessibility', findings.length > 0
+                ? findings.length + ' finding' + (findings.length === 1 ? '' : 's')
+                : 'Overlay', previewId === a11yOverlayPreviewId, findings.length > 0 ? 'warn' : 'idle',
+                () => toggleA11yOverlay()));
+            products.appendChild(productToggle('list-tree', 'Layout', nodes.length > 0
+                ? nodes.length + ' node' + (nodes.length === 1 ? '' : 's')
+                : 'Overlay', previewId === a11yOverlayPreviewId, nodes.length > 0 ? 'ok' : 'idle',
+                () => toggleA11yOverlay()));
+            products.appendChild(productToggle('symbol-string', 'Strings', 'Section',
+                enabledFocusProducts.has('strings'), 'idle', () => toggleFocusProduct('strings')));
+            products.appendChild(productToggle('file-code', 'Resources', 'Section',
+                enabledFocusProducts.has('resources'), 'idle', () => toggleFocusProduct('resources')));
+            products.appendChild(productToggle('text-size', 'Fonts', 'Section',
+                enabledFocusProducts.has('fonts'), 'idle', () => toggleFocusProduct('fonts')));
+            products.appendChild(productToggle('pulse', 'Render', 'Section',
+                enabledFocusProducts.has('render'), 'idle', () => toggleFocusProduct('render')));
+            products.appendChild(productToggle('symbol-color', 'Theme', 'Section',
+                enabledFocusProducts.has('theme'), 'idle', () => toggleFocusProduct('theme')));
+            products.appendChild(productToggle('sync', 'Recomposition', interactivePreviewIds.has(previewId) ? 'Live' : 'Section',
+                enabledFocusProducts.has('recomposition') || interactivePreviewIds.has(previewId),
+                interactivePreviewIds.has(previewId) ? 'ok' : 'idle',
+                () => toggleFocusProduct('recomposition')));
+            data.appendChild(products);
+
+            const controls = document.createElement('section');
+            controls.className = 'focus-panel focus-controls-panel';
+            controls.appendChild(sectionHeader('settings-gear', 'Tools'));
+            const toolActions = document.createElement('div');
+            toolActions.className = 'focus-actions';
+            toolActions.appendChild(actionButton('eye', 'A11y', 'Toggle accessibility overlay', () => {
+                toggleA11yOverlay();
+            }));
+            toolActions.appendChild(actionButton('device-mobile', 'Device', 'Launch on connected Android device', () => {
+                requestLaunchOnDevice();
+            }));
+            toolActions.appendChild(actionButton('circle-large-outline', 'Live', 'Toggle live preview', () => {
+                toggleInteractive(false);
+            }));
+            controls.appendChild(toolActions);
+
+            focusInspector.appendChild(history);
+            focusInspector.appendChild(data);
+            focusInspector.appendChild(controls);
+            const placeholders = buildFocusPlaceholders(p);
+            if (placeholders) focusInspector.appendChild(placeholders);
+        }
+
+        function sectionHeader(icon, label) {
+            const header = document.createElement('div');
+            header.className = 'focus-panel-header';
+            header.innerHTML = '<i class="codicon codicon-' + icon + '" aria-hidden="true"></i>';
+            const span = document.createElement('span');
+            span.textContent = label;
+            header.appendChild(span);
+            return header;
+        }
+
+        function actionButton(icon, label, title, onClick) {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'focus-action';
+            btn.title = title;
+            btn.innerHTML = '<i class="codicon codicon-' + icon + '" aria-hidden="true"></i>';
+            const span = document.createElement('span');
+            span.textContent = label;
+            btn.appendChild(span);
+            btn.addEventListener('click', onClick);
+            return btn;
+        }
+
+        function productToggle(icon, label, value, enabled, state, onClick) {
+            const chip = document.createElement('button');
+            chip.type = 'button';
+            chip.className = 'focus-product-chip';
+            chip.dataset.state = state || 'idle';
+            chip.setAttribute('aria-pressed', enabled ? 'true' : 'false');
+            chip.title = enabled ? 'Disable ' + label : 'Enable ' + label;
+            chip.innerHTML = '<i class="codicon codicon-' + icon + '" aria-hidden="true"></i>';
+            const text = document.createElement('div');
+            text.className = 'focus-product-text';
+            const name = document.createElement('span');
+            name.className = 'focus-product-name';
+            name.textContent = label;
+            const val = document.createElement('span');
+            val.className = 'focus-product-value';
+            val.textContent = value;
+            text.appendChild(name);
+            text.appendChild(val);
+            chip.appendChild(text);
+            chip.addEventListener('click', onClick);
+            return chip;
+        }
+
+        function toggleFocusProduct(id) {
+            if (enabledFocusProducts.has(id)) {
+                enabledFocusProducts.delete(id);
+            } else {
+                enabledFocusProducts.add(id);
+            }
+            const card = getVisibleCards()[focusIndex];
+            if (layoutMode.value === 'focus' && card) renderFocusInspector(card);
+        }
+
+        function buildFocusPlaceholders(p) {
+            const defs = [
+                ['strings', 'Strings', 'text/strings and i18n/translations'],
+                ['resources', 'Resources', 'resources/used'],
+                ['fonts', 'Fonts', 'fonts/used'],
+                ['render', 'Render', 'render/trace and render/composeAiTrace'],
+                ['theme', 'Theme', 'compose/theme'],
+                ['recomposition', 'Recomposition', 'compose/recomposition'],
+            ].filter(([id]) => enabledFocusProducts.has(id));
+            if (defs.length === 0) return null;
+            const wrapper = document.createElement('section');
+            wrapper.className = 'focus-panel focus-placeholder-list';
+            wrapper.appendChild(sectionHeader('panel', 'Enabled'));
+            defs.forEach(([id, label, kind]) => {
+                const details = document.createElement('details');
+                details.className = 'focus-placeholder';
+                details.dataset.product = id;
+                const summary = document.createElement('summary');
+                summary.textContent = label;
+                details.appendChild(summary);
+                const body = document.createElement('div');
+                body.className = 'focus-placeholder-body';
+                body.textContent = kind;
+                details.appendChild(body);
+                wrapper.appendChild(details);
+            });
+            return wrapper;
+        }
+
+        function renderSummary(p) {
+            const captures = p.captures ? p.captures.length : 0;
+            if (captures > 1) return captures + ' captures';
+            const c = p.captures && p.captures[0];
+            if (c && c.label) return c.label;
+            return 'Static';
+        }
+
+        function themeSummary(p) {
+            if (p.params.backgroundColor) return 'Background';
+            return p.params.showSystemUi ? 'System UI' : 'Preview';
         }
 
         // Live-panel diff: only meaningful when one preview is focused. Pulls
@@ -2271,6 +2448,10 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     const layer = card.querySelector('.a11y-hierarchy-overlay');
                     if (layer) layer.remove();
                 }
+            }
+            if (layoutMode.value === 'focus') {
+                const focused = getVisibleCards()[focusIndex];
+                if (focused === card) renderFocusInspector(card);
             }
         }
 


### PR DESCRIPTION
## Summary
- remove the standalone History webview from the list/sidebar view contribution
- surface history actions inside focus mode alongside the focused preview
- add collapsed placeholder sections for the other data products so their future focus-view home is clear

## Verification
- npm ci
- npm run compile
- git diff --check