### PR TITLE
Introduce PreviewContext for slot-table data products

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewContext.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewContext.kt
@@ -1,0 +1,109 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.BackendKind
+
+/**
+ * Per-render context passed from a renderer backend to data products.
+ *
+ * The core module deliberately keeps renderer objects opaque. Compose-backed renderers may attach
+ * slot-table roots (currently `androidx.compose.runtime.tooling.CompositionData`) through
+ * [inspection]; data products that understand that runtime can cast and inspect them, while the
+ * daemon protocol and non-Compose producers stay decoupled from Compose internals.
+ */
+data class PreviewContext(
+  val previewId: String?,
+  val backend: BackendKind?,
+  val renderMode: String?,
+  val outputBaseName: String?,
+  val frameTime: PreviewFrameTime = PreviewFrameTime(),
+  val inspection: PreviewInspectionContext = PreviewInspectionContext(),
+  val animation: PreviewAnimationContext? = null,
+) {
+  class Builder(
+    private val previewId: String?,
+    private val backend: BackendKind?,
+    private val renderMode: String?,
+    private val outputBaseName: String?,
+  ) {
+    private var frameTime: PreviewFrameTime = PreviewFrameTime()
+    private var animation: PreviewAnimationContext? = null
+    private val slotTables = mutableListOf<Any>()
+    private var parameterInformationCollected: Boolean = false
+
+    fun frameTime(frameTime: PreviewFrameTime): Builder = apply { this.frameTime = frameTime }
+
+    fun animation(animation: PreviewAnimationContext?): Builder = apply {
+      this.animation = animation
+    }
+
+    fun addSlotTables(tables: Iterable<Any>): Builder = apply { slotTables.addAll(tables) }
+
+    fun parameterInformationCollected(): Builder = apply { parameterInformationCollected = true }
+
+    fun build(): PreviewContext =
+      PreviewContext(
+        previewId = previewId,
+        backend = backend,
+        renderMode = renderMode,
+        outputBaseName = outputBaseName,
+        frameTime = frameTime,
+        inspection =
+          PreviewInspectionContext(
+            slotTables = slotTables.toList(),
+            parameterInformationCollected = parameterInformationCollected,
+          ),
+        animation = animation,
+      )
+  }
+}
+
+/**
+ * Frame-clock semantics for the data represented by a [PreviewContext].
+ *
+ * Static one-shot products normally read [Mode.INITIAL_SETTLED_FRAME]. Animated products that
+ * sample every frame should publish one context per sampled frame, or attach a
+ * [PreviewAnimationContext] describing the sampled window.
+ */
+data class PreviewFrameTime(
+  val mode: Mode = Mode.INITIAL_SETTLED_FRAME,
+  val virtualTimeMs: Long? = null,
+  val frameIndex: Int? = null,
+) {
+  enum class Mode {
+    /** One-shot render after the backend has allowed effects/measure to settle. */
+    INITIAL_SETTLED_FRAME,
+    /** Deterministic animation or recording frame driven by virtual time. */
+    VIRTUAL_ANIMATION_FRAME,
+    /** Held live scene driven by wall-clock frame time. */
+    WALL_CLOCK_FRAME,
+  }
+}
+
+/**
+ * Inspection capability captured during composition.
+ *
+ * [slotTables] is intentionally `Any`: on Compose backends each entry is a `CompositionData`, but
+ * core must not expose a Compose dependency. The capture wrapper must call Compose's parameter-info
+ * collection before composing content when consumers need call-site values from the slot table.
+ */
+data class PreviewInspectionContext(
+  val slotTables: List<Any> = emptyList(),
+  val parameterInformationCollected: Boolean = false,
+)
+
+/**
+ * Animation sampling contract for data products.
+ *
+ * Structural products, such as theme extraction, should treat slot-table values as the initial
+ * settled composition unless they explicitly opt into frame-sampled contexts. Curve/animation
+ * products own the clock drive: they attach to the captured slot tables, seek their inspection
+ * clock to each [sampleTimesMs] entry, and publish sampled values without independently advancing
+ * the render clock.
+ */
+data class PreviewAnimationContext(
+  val showCurves: Boolean,
+  val requestedDurationMs: Int,
+  val effectiveDurationMs: Int?,
+  val frameIntervalMs: Int,
+  val sampleTimesMs: List<Long> = emptyList(),
+)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 import androidx.compose.runtime.tooling.CompositionData
-import androidx.compose.runtime.tooling.CompositionGroup
 import androidx.compose.runtime.tooling.LocalInspectionTables
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
@@ -27,6 +26,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.intl.LocaleList
 import androidx.compose.ui.unit.Density
+import ee.schimke.composeai.daemon.protocol.BackendKind
 import java.io.File
 import java.util.Collections
 import java.util.WeakHashMap
@@ -179,9 +179,15 @@ class RenderEngine(
     Thread.currentThread().contextClassLoader = classLoader
 
     val localeProviders = localeProviders(spec.localeTag)
-    val themeSlotTableCapture =
+    val themeFallbackCapture =
       if (themeCapture?.shouldCapture(spec.previewId, spec.renderMode) == true) {
-        ThemeSlotTableCapture()
+        MaterialThemeFallbackCapture()
+      } else {
+        null
+      }
+    val slotTableCapture =
+      if (themeCapture?.shouldCapture(spec.previewId, spec.renderMode) == true) {
+        PreviewSlotTableCapture()
       } else {
         null
       }
@@ -225,7 +231,7 @@ class RenderEngine(
           ) {
             if (themeCapture?.shouldCapture(spec.previewId, spec.renderMode) == true) {
               CaptureMaterialTheme { _, typography, shapes, payload ->
-                themeSlotTableCapture?.captureFallbackValues(typography, shapes)
+                themeFallbackCapture?.capture(typography, shapes)
                 themeCapture.capture(spec.previewId, payload)
               }
             }
@@ -242,8 +248,8 @@ class RenderEngine(
                 InvokeComposable(composableMethod)
               }
             }
-            if (themeSlotTableCapture != null) {
-              InspectableThemeContent(themeSlotTableCapture, content)
+            if (slotTableCapture != null) {
+              InspectablePreviewContent(slotTableCapture, content)
             } else {
               content()
             }
@@ -267,7 +273,8 @@ class RenderEngine(
       density = density,
       outputFile = outputFile,
       previousContext = previousContext,
-      themeSlotTableCapture = themeSlotTableCapture,
+      slotTableCapture = slotTableCapture,
+      themeFallbackCapture = themeFallbackCapture,
     )
   }
 
@@ -297,8 +304,23 @@ class RenderEngine(
     // as `:renderer-desktop`'s renderPreview.
     trace.section("compose:frame") { renderFrame(state, useWallClockFrameTime) }
     val image = trace.section("compose:captureFrame") { renderFrame(state, useWallClockFrameTime) }
-    state.themeSlotTableCapture?.themePayloadFromMaterialThemeCall()?.let { payload ->
-      themeCapture?.capture(state.spec.previewId, payload)
+    state.slotTableCapture?.let { capture ->
+      val context =
+        PreviewContext.Builder(
+            previewId = state.spec.previewId,
+            backend = BackendKind.DESKTOP,
+            renderMode = state.spec.renderMode,
+            outputBaseName = state.spec.outputBaseName,
+          )
+          .parameterInformationCollected()
+          .addSlotTables(capture.snapshot())
+          .build()
+      themePayloadFromPreviewContext(
+          context = context,
+          fallbackTypography = state.themeFallbackCapture?.typography,
+          fallbackShapes = state.themeFallbackCapture?.shapes,
+        )
+        ?.let { payload -> themeCapture?.capture(state.spec.previewId, payload) }
     }
 
     val pngData =
@@ -363,7 +385,8 @@ class RenderEngine(
     val density: Density,
     val outputFile: File,
     internal val previousContext: ClassLoader?,
-    internal val themeSlotTableCapture: ThemeSlotTableCapture?,
+    internal val slotTableCapture: PreviewSlotTableCapture?,
+    internal val themeFallbackCapture: MaterialThemeFallbackCapture?,
   )
 
   interface ThemeCapture {
@@ -558,49 +581,32 @@ private fun CaptureMaterialTheme(
   }
 }
 
-internal class ThemeSlotTableCapture {
+internal class PreviewSlotTableCapture {
   val store: MutableSet<CompositionData> = Collections.newSetFromMap(WeakHashMap())
-  private var fallbackTypography: Typography? = null
-  private var fallbackShapes: Shapes? = null
 
-  fun themePayloadFromMaterialThemeCall(): ThemePayload? {
-    val materialThemeCalls =
-      store
-        .flatMap { data -> data.compositionGroups.flatMap { it.flattenGroups() } }
-        .filter { group -> group.sourceInfo?.startsWith("C(MaterialTheme)") == true }
+  fun snapshot(): List<CompositionData> = store.filterNotNull()
+}
 
-    for (group in materialThemeCalls.asReversed()) {
-      val values = group.data.toList()
-      val colorSource = values.lastOrNull { colorTokens(it).isNotEmpty() } ?: continue
-      val typographySource = values.lastOrNull { typographyTokens(it).isNotEmpty() }
-      val shapesSource = values.lastOrNull { shapeTokens(it).isNotEmpty() }
-      return themePayloadFromThemeObjects(
-        colorSource = colorSource,
-        typographySource = typographySource,
-        shapesSource = shapesSource,
-        fallbackTypography = fallbackTypography,
-        fallbackShapes = fallbackShapes,
-      )
-    }
-    return null
-  }
+internal class MaterialThemeFallbackCapture {
+  var typography: Typography? = null
+    private set
 
-  fun captureFallbackValues(typography: Typography, shapes: Shapes) {
-    fallbackTypography = typography
-    fallbackShapes = shapes
+  var shapes: Shapes? = null
+    private set
+
+  fun capture(typography: Typography, shapes: Shapes) {
+    this.typography = typography
+    this.shapes = shapes
   }
 }
 
 @OptIn(InternalComposeApi::class)
 @androidx.compose.runtime.Composable
-private fun InspectableThemeContent(
-  capture: ThemeSlotTableCapture,
+private fun InspectablePreviewContent(
+  capture: PreviewSlotTableCapture,
   content: @androidx.compose.runtime.Composable () -> Unit,
 ) {
   currentComposer.collectParameterInformation()
   capture.store.add(currentComposer.compositionData)
   CompositionLocalProvider(LocalInspectionTables provides capture.store, content = content)
 }
-
-private fun CompositionGroup.flattenGroups(): List<CompositionGroup> =
-  listOf(this) + compositionGroups.flatMap { it.flattenGroups() }

--- a/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
+++ b/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
@@ -3,6 +3,8 @@ package ee.schimke.composeai.daemon
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.Shapes
 import androidx.compose.material3.Typography
+import androidx.compose.runtime.tooling.CompositionData
+import androidx.compose.runtime.tooling.CompositionGroup
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.TextStyle
@@ -175,6 +177,36 @@ fun themePayloadFromThemeObjects(
   )
 }
 
+fun themePayloadFromPreviewContext(
+  context: PreviewContext,
+  fallbackTypography: Typography?,
+  fallbackShapes: Shapes?,
+): ThemePayload? {
+  val materialThemeCalls =
+    context.inspection.slotTables
+      .asSequence()
+      .filterIsInstance<CompositionData>()
+      .flatMap { data -> data.compositionGroups.asSequence() }
+      .flatMap { group -> group.flattenGroups().asSequence() }
+      .filter { group -> group.sourceInfo?.startsWith("C(MaterialTheme)") == true }
+      .toList()
+
+  for (group in materialThemeCalls.asReversed()) {
+    val values = group.data.toList()
+    val colorSource = values.lastOrNull { colorTokens(it).isNotEmpty() } ?: continue
+    val typographySource = values.lastOrNull { typographyTokens(it).isNotEmpty() }
+    val shapesSource = values.lastOrNull { shapeTokens(it).isNotEmpty() }
+    return themePayloadFromThemeObjects(
+      colorSource = colorSource,
+      typographySource = typographySource,
+      shapesSource = shapesSource,
+      fallbackTypography = fallbackTypography,
+      fallbackShapes = fallbackShapes,
+    )
+  }
+  return null
+}
+
 fun colorTokens(source: Any?): Map<String, String> =
   when (source) {
     null -> emptyMap()
@@ -310,3 +342,6 @@ private fun TextStyle.token(): TypographyToken =
     letterSpacing = letterSpacing.takeIf { it.isSpecified }?.value,
     letterSpacingUnit = letterSpacing.takeIf { it.isSpecified }?.type?.toString(),
   )
+
+private fun CompositionGroup.flattenGroups(): List<CompositionGroup> =
+  listOf(this) + compositionGroups.flatMap { it.flattenGroups() }


### PR DESCRIPTION
## Summary
- add shared PreviewContext / PreviewAnimationContext in :data-render-core so standalone renderers, daemon backends, and data products can use the same context contract
- keep daemon-specific plumbing in :daemon:core: RenderResult carries an optional PreviewContext and DataProductRegistry has an onRender(..., previewContext) hook
- refactor desktop compose/theme to consume durable theme values from PreviewContext, while still using raw slot tables before scene teardown
- update Android animation curve inspection to attach through PreviewContext instead of only through the local SlotTreeCapture shape

## Notes
- Raw Compose slot tables are volatile after scene teardown, so renderers should put durable product-ready values into PreviewContext.inspection.values when delayed daemon consumption is needed.
- Issue #586 has the follow-up list for Android/Robolectric theme capture, broader capability declarations, and richer effective render metadata.

## Tests
- ./gradlew :data-render-core:compileKotlin :daemon:core:compileKotlin :data-theme-connector:compileKotlin :daemon:desktop:compileKotlin :renderer-android:compileDebugKotlin :daemon:desktop:test --tests ee.schimke.composeai.daemon.ThemeDataProductRegistryTest
- ./gradlew ktfmtFormatAll