### PR TITLE
ci: detect compose preview plugin aliases

### DIFF
--- a/.github/ci/patch-consumer.py
+++ b/.github/ci/patch-consumer.py
@@ -57,10 +57,21 @@ EXISTING_PLUGIN_RE = re.compile(
         id\("{re.escape(PLUGIN_ID)}"\)
         |
         id\s+["']{re.escape(PLUGIN_ID)}["']
+        |
+        alias\(
+            [^)\n]*libs\.plugins\.
+            (?i:
+                compose(?:[._-])?preview
+                |
+                compose(?:[._-])?ai(?:[._-])?preview
+                |
+                compose(?:[._-])?ai
+            )
+            (?:\b|[)\s])
+            [^)\n]*
+        \)
     )
-    (?:[ \t]+version(?:\s*\([ \t]*["'][^"']+["'][ \t]*\)|[ \t]+["'][^"']+["']))?
-    (?:[ \t]+apply[ \t]+false)?
-    [ \t]*$
+    [^\n]*$
     """
 )
 


### PR DESCRIPTION
## Summary
- replace likely compose-ai plugin version-catalog aliases with the CI plugin version
- keep preserving unrelated plugin aliases such as JetBrains Compose
- also handle non-literal direct plugin version expressions from the landed patcher behavior

## Test
- python3 -m py_compile .github/ci/patch-consumer.py
- focused temp-file alias checks