### PR TITLE
Carry device metadata in PreviewContext

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.test.onRoot
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.captureRoboImage
+import ee.schimke.composeai.daemon.protocol.BackendKind
 import ee.schimke.composeai.renderer.AccessibilityChecker
 import java.io.File
 
@@ -395,12 +396,22 @@ class RenderEngine(
     val tookMs = (System.nanoTime() - startNs) / 1_000_000L
     val metrics = SandboxMeasurement.collect(sandboxStats, tookMs = tookMs)
     dataDir?.let(trace::write)
+    val previewContext =
+      PreviewContext.Builder(
+          previewId = spec.previewId,
+          backend = BackendKind.ANDROID,
+          renderMode = null,
+          outputBaseName = spec.outputBaseName,
+        )
+        .deviceFromRenderPixels(spec.device, spec.widthPx, spec.heightPx, spec.density)
+        .build()
     return RenderResult(
       id = requestId,
       classLoaderHashCode = System.identityHashCode(classLoader),
       classLoaderName = classLoader.javaClass.name,
       pngPath = outputFile.absolutePath,
       metrics = metrics,
+      previewContext = previewContext,
     )
   }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewContext.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewContext.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.devices.DeviceDimensions
 import ee.schimke.composeai.daemon.protocol.BackendKind
 
 /**
@@ -15,6 +16,7 @@ data class PreviewContext(
   val backend: BackendKind?,
   val renderMode: String?,
   val outputBaseName: String?,
+  val device: PreviewDeviceContext = PreviewDeviceContext(),
   val frameTime: PreviewFrameTime = PreviewFrameTime(),
   val inspection: PreviewInspectionContext = PreviewInspectionContext(),
   val animation: PreviewAnimationContext? = null,
@@ -25,10 +27,22 @@ data class PreviewContext(
     private val renderMode: String?,
     private val outputBaseName: String?,
   ) {
+    private var device: PreviewDeviceContext = PreviewDeviceContext()
     private var frameTime: PreviewFrameTime = PreviewFrameTime()
     private var animation: PreviewAnimationContext? = null
     private val slotTables = mutableListOf<Any>()
     private var parameterInformationCollected: Boolean = false
+
+    fun device(device: PreviewDeviceContext): Builder = apply { this.device = device }
+
+    fun deviceFromRenderPixels(
+      device: String?,
+      widthPx: Int,
+      heightPx: Int,
+      density: Float,
+    ): Builder = apply {
+      this.device = PreviewDeviceContext.fromRenderPixels(device, widthPx, heightPx, density)
+    }
 
     fun frameTime(frameTime: PreviewFrameTime): Builder = apply { this.frameTime = frameTime }
 
@@ -46,6 +60,7 @@ data class PreviewContext(
         backend = backend,
         renderMode = renderMode,
         outputBaseName = outputBaseName,
+        device = device,
         frameTime = frameTime,
         inspection =
           PreviewInspectionContext(
@@ -54,6 +69,58 @@ data class PreviewContext(
           ),
         animation = animation,
       )
+  }
+}
+
+/**
+ * Device and size metadata resolved for a preview render.
+ *
+ * [device] is the raw `@Preview(device = ...)` string when known. [widthDp], [heightDp], and
+ * [density] describe the effective rendered surface. [resolvedDevice] carries catalog metadata such
+ * as roundness; dimensions may differ from [resolvedDevice] when runtime overrides change the
+ * render size.
+ */
+data class PreviewDeviceContext(
+  val device: String? = null,
+  val widthDp: Double? = null,
+  val heightDp: Double? = null,
+  val density: Float? = null,
+  val resolvedDevice: DeviceDimensions.DeviceSpec? = null,
+) {
+  val isRound: Boolean
+    get() = resolvedDevice?.isRound == true
+
+  companion object {
+    fun fromPreviewInfo(info: PreviewInfoDto): PreviewDeviceContext = fromPreviewParams(info.params)
+
+    fun fromPreviewParams(params: PreviewParamsDto?): PreviewDeviceContext {
+      val device = params?.device?.takeIf { it.isNotBlank() }
+      val resolvedDevice = device?.let(DeviceDimensions::resolve)
+      return PreviewDeviceContext(
+        device = device,
+        widthDp = params?.widthDp?.toDouble() ?: resolvedDevice?.widthDp?.toDouble(),
+        heightDp = params?.heightDp?.toDouble() ?: resolvedDevice?.heightDp?.toDouble(),
+        density = params?.density ?: resolvedDevice?.density,
+        resolvedDevice = resolvedDevice,
+      )
+    }
+
+    fun fromRenderPixels(
+      device: String?,
+      widthPx: Int,
+      heightPx: Int,
+      density: Float,
+    ): PreviewDeviceContext {
+      val safeDensity = density.takeIf { it > 0f }
+      val resolvedDevice = device?.takeIf { it.isNotBlank() }?.let(DeviceDimensions::resolve)
+      return PreviewDeviceContext(
+        device = device?.takeIf { it.isNotBlank() },
+        widthDp = safeDensity?.let { widthPx / it.toDouble() },
+        heightDp = safeDensity?.let { heightPx / it.toDouble() },
+        density = safeDensity,
+        resolvedDevice = resolvedDevice,
+      )
+    }
   }
 }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -273,6 +273,9 @@ sealed interface RenderRequest {
  * B2.3 once the daemon tracks heap / sandbox-age etc.). Both default to `null` so the B1.5-era stub
  * paths in `JsonRpcServer.renderFinishedFromResult` keep emitting the placeholder
  * `daemon-stub-${id}.png`.
+ *
+ * [previewContext] carries the effective render metadata and optional inspection captures that data
+ * products can project from after the render completes.
  */
 data class RenderResult(
   val id: Long,
@@ -280,4 +283,5 @@ data class RenderResult(
   val classLoaderName: String,
   val pngPath: String? = null,
   val metrics: Map<String, Long>? = null,
+  val previewContext: PreviewContext? = null,
 )

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -304,17 +304,22 @@ class RenderEngine(
     // as `:renderer-desktop`'s renderPreview.
     trace.section("compose:frame") { renderFrame(state, useWallClockFrameTime) }
     val image = trace.section("compose:captureFrame") { renderFrame(state, useWallClockFrameTime) }
+    val contextBuilder =
+      PreviewContext.Builder(
+          previewId = state.spec.previewId,
+          backend = BackendKind.DESKTOP,
+          renderMode = state.spec.renderMode,
+          outputBaseName = state.spec.outputBaseName,
+        )
+        .deviceFromRenderPixels(
+          state.spec.device,
+          state.spec.widthPx,
+          state.spec.heightPx,
+          state.spec.density,
+        )
     state.slotTableCapture?.let { capture ->
       val context =
-        PreviewContext.Builder(
-            previewId = state.spec.previewId,
-            backend = BackendKind.DESKTOP,
-            renderMode = state.spec.renderMode,
-            outputBaseName = state.spec.outputBaseName,
-          )
-          .parameterInformationCollected()
-          .addSlotTables(capture.snapshot())
-          .build()
+        contextBuilder.parameterInformationCollected().addSlotTables(capture.snapshot()).build()
       themePayloadFromPreviewContext(
           context = context,
           fallbackTypography = state.themeFallbackCapture?.typography,
@@ -322,6 +327,7 @@ class RenderEngine(
         )
         ?.let { payload -> themeCapture?.capture(state.spec.previewId, payload) }
     }
+    val previewContext = contextBuilder.build()
 
     val pngData =
       trace.section("render:encodePng") {
@@ -343,6 +349,7 @@ class RenderEngine(
       classLoaderName = state.classLoader.javaClass.name,
       pngPath = state.outputFile.absolutePath,
       metrics = metrics,
+      previewContext = previewContext,
     )
   }
 

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProduct.kt
@@ -1,19 +1,37 @@
 package ee.schimke.composeai.daemon
 
-import ee.schimke.composeai.daemon.devices.DeviceDimensions
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
 /**
- * Stateless metadata product describing the device-frame clip implied by `@Preview(device = ...)`.
+ * Metadata product describing the device-frame clip implied by the preview render context.
+ *
+ * The registry seeds contexts from [PreviewIndex] so clients can fetch the product before a render
+ * has completed. When a render finishes, the actual [PreviewContext] replaces the seed so runtime
+ * overrides and backend-resolved dimensions win.
  */
-class DeviceClipDataProductRegistry(private val previewIndex: PreviewIndex) : DataProductRegistry {
+class DeviceClipDataProductRegistry(previewIndex: PreviewIndex) : DataProductRegistry {
+  private val contexts: ConcurrentHashMap<String, PreviewContext> =
+    ConcurrentHashMap(
+      previewIndex.snapshot().mapValues { (_, preview) ->
+        PreviewContext.Builder(
+            previewId = preview.id,
+            backend = null,
+            renderMode = null,
+            outputBaseName = null,
+          )
+          .device(PreviewDeviceContext.fromPreviewInfo(preview))
+          .build()
+      }
+    )
+
   override val capabilities: List<DataProductCapability> =
     listOf(
       DataProductCapability(
@@ -47,16 +65,17 @@ class DeviceClipDataProductRegistry(private val previewIndex: PreviewIndex) : Da
     )
   }
 
+  override fun onRender(previewId: String, result: RenderResult) {
+    val context = result.previewContext ?: return
+    contexts[previewId] = context
+  }
+
   private fun payloadFor(previewId: String): JsonElement? {
-    val preview = previewIndex.byId(previewId) ?: return null
-    val params = preview.params
-    val device = params?.device?.takeIf { it.isNotBlank() }
-    val deviceSpec = device?.let(DeviceDimensions::resolve)
-    val isRound = deviceSpec?.isRound == true
-    val widthDp = params?.widthDp ?: deviceSpec?.widthDp
-    val heightDp = params?.heightDp ?: deviceSpec?.heightDp
+    val device = contexts[previewId]?.device ?: return null
+    val widthDp = device.widthDp
+    val heightDp = device.heightDp
     val clip =
-      if (isRound && widthDp != null && heightDp != null) {
+      if (device.isRound && widthDp != null && heightDp != null) {
         val diameter = minOf(widthDp, heightDp)
         val radius = diameter / 2.0
         buildJsonObject {

--- a/data/render/connector/src/test/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProductRegistryTest.kt
+++ b/data/render/connector/src/test/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProductRegistryTest.kt
@@ -155,6 +155,64 @@ class DeviceClipDataProductRegistryTest {
   }
 
   @Test
+  fun `render context replaces discovery seed`() {
+    val registry =
+      DeviceClipDataProductRegistry(
+        PreviewIndex.fromMap(
+          path = null,
+          byId =
+            mapOf(
+              "wear" to
+                PreviewInfoDto(
+                  id = "wear",
+                  className = "com.example.WearKt",
+                  methodName = "Wear",
+                  params = PreviewParamsDto(device = "id:wearos_small_round"),
+                )
+            ),
+        )
+      )
+    registry.onRender(
+      previewId = "wear",
+      result =
+        RenderResult(
+          id = 1,
+          classLoaderHashCode = 1,
+          classLoaderName = "loader",
+          previewContext =
+            PreviewContext.Builder(
+                previewId = "wear",
+                backend = null,
+                renderMode = null,
+                outputBaseName = "wear",
+              )
+              .deviceFromRenderPixels(
+                "id:wearos_large_round",
+                widthPx = 600,
+                heightPx = 600,
+                density = 2f,
+              )
+              .build(),
+        ),
+    )
+
+    val outcome =
+      registry.fetch(
+        previewId = "wear",
+        kind = DeviceClipDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      )
+
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    val payload = (outcome as DataProductRegistry.Outcome.Ok).result.payload!!.jsonObject
+    val clip = payload["clip"]!!.jsonObject
+    assertEquals("150.0", clip["centerXDp"]!!.jsonPrimitive.content)
+    assertEquals("150.0", clip["centerYDp"]!!.jsonPrimitive.content)
+    assertEquals("150.0", clip["radiusDp"]!!.jsonPrimitive.content)
+  }
+
+  @Test
   fun `unknown preview is not available`() {
     val registry = DeviceClipDataProductRegistry(PreviewIndex.empty())
 

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -533,7 +533,10 @@ that the matching processor downcasts at runtime.
 ## Built-in render metadata products
 
 `render/deviceClip` is a cheap, inline, fetchable and attachable data product
-derived from the daemon's `PreviewIndex` plus `DeviceDimensions`. Its payload is:
+derived from `PreviewContext.device`. The registry seeds that context from the
+daemon's `PreviewIndex`, so clients can fetch it before the first render; after
+a render completes, the actual render context replaces the seed so overrides and
+backend-resolved dimensions win. Its payload is:
 
 ```json
 { "clip": null }


### PR DESCRIPTION
## Summary
- add resolved device metadata to PreviewContext
- attach PreviewContext to RenderResult from Android and desktop render engines
- make render/deviceClip project from PreviewContext while seeding from PreviewIndex for pre-render fetches
- document that deviceClip can be fetched before render and later updated from actual render context

## Tests
- ./gradlew :daemon:core:ktfmtCheck :daemon:android:ktfmtCheck :daemon:desktop:ktfmtCheck :data-render-connector:ktfmtCheck
- ./gradlew :data-render-connector:test --tests ee.schimke.composeai.daemon.DeviceClipDataProductRegistryTest
- ./gradlew :daemon:core:compileKotlin :daemon:android:compileDebugKotlin :daemon:desktop:compileKotlin
- git diff --check HEAD~1..HEAD