### PR TITLE
Reduce VS Code startup Gradle work

### DIFF
--- a/vscode-extension/src/daemon/daemonGate.ts
+++ b/vscode-extension/src/daemon/daemonGate.ts
@@ -21,6 +21,7 @@ const LEGACY_SETTING_ENABLED = 'experimental.daemon.enabled';
  */
 export class DaemonGate {
     private readonly daemons = new Map<string, ManagedDaemon>();
+    private readonly spawns = new Map<string, Promise<DaemonClient>>();
     private disposed = false;
     private warnedUserDisabled = false;
     private readonly warnedBuildDisabled = new Set<string>();
@@ -74,6 +75,8 @@ export class DaemonGate {
         if (existing && existing.client.isClosed()) {
             this.daemons.delete(moduleId);
         }
+        const inFlight = this.spawns.get(moduleId);
+        if (inFlight) { return inFlight; }
 
         const descriptor = readLaunchDescriptor(this.workspaceRoot, moduleId, this.logger);
         if (!descriptor) {
@@ -96,7 +99,10 @@ export class DaemonGate {
         }
 
         try {
-            return await this.spawn(moduleId, descriptor, events);
+            const spawn = this.spawn(moduleId, descriptor, events)
+                .finally(() => this.spawns.delete(moduleId));
+            this.spawns.set(moduleId, spawn);
+            return await spawn;
         } catch (err) {
             const message = `[daemon] spawn failed for ${moduleId}: ${(err as Error).message}`;
             this.logger.appendLine(message);

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -123,7 +123,6 @@ export class DaemonScheduler {
      *  Stops the per-render ENOENT spam when the daemon (B1.5) emits
      *  synthetic `daemon-stub-N.png` paths that don't exist on disk. */
     private warnedStubModules = new Set<string>();
-    private settledBootstrapTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
     constructor(
         private readonly gate: DaemonGate,
@@ -139,7 +138,6 @@ export class DaemonScheduler {
          * `vscode.workspace.getConfiguration('composePreview').get('a11y.alwaysSubscribe')`.
          */
         private readonly isA11yAlwaysSubscribed: () => boolean = () => false,
-        private readonly settledBootstrapDelayMs: number = 5_000,
     ) {}
 
     /**
@@ -175,7 +173,6 @@ export class DaemonScheduler {
         if (!this.gate.isEnabled()) { return false; }
         if (this.gate.isDaemonReady(moduleId)) {
             progress?.('ready');
-            this.scheduleSettledBootstrap(gradleService, moduleId);
             return true;
         }
         progress?.('spawning');
@@ -183,7 +180,6 @@ export class DaemonScheduler {
             const ok = await this.ensureModule(moduleId);
             if (ok) {
                 progress?.('ready');
-                this.scheduleSettledBootstrap(gradleService, moduleId);
                 return true;
             }
         } catch (err) {
@@ -213,29 +209,6 @@ export class DaemonScheduler {
         }
         progress?.(ok ? 'ready' : 'fallback');
         return ok;
-    }
-
-    private scheduleSettledBootstrap(gradleService: GradleService, moduleId: string): void {
-        if (this.settledBootstrapDelayMs < 0) { return; }
-        const existing = this.settledBootstrapTimers.get(moduleId);
-        if (existing) { clearTimeout(existing); }
-        const refresh = async () => {
-            this.settledBootstrapTimers.delete(moduleId);
-            try {
-                await gradleService.runDaemonBootstrap(moduleId);
-            } catch (err) {
-                this.logger.appendLine(
-                    `[daemon] settled bootstrap refresh failed for ${moduleId}: ${(err as Error).message}`,
-                );
-            }
-        };
-        if (this.settledBootstrapDelayMs === 0) {
-            void refresh();
-            return;
-        }
-        const timer = setTimeout(() => void refresh(), this.settledBootstrapDelayMs);
-        timer.unref?.();
-        this.settledBootstrapTimers.set(moduleId, timer);
     }
 
     /**

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -655,11 +655,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         ),
     );
 
-    // Refresh doctor diagnostics on first load, on-demand from the command,
-    // and whenever we discover new modules. Each refresh kicks the
-    // `composePreviewDoctor` task per module — cheap (no render), but we
-    // don't want to spam on every keystroke, hence the explicit trigger
-    // points rather than a document-change hook.
+    // Refresh doctor diagnostics on demand from the command. The task is useful
+    // but can be expensive in large workspaces because it configures Gradle per
+    // module; keep it out of the activation path so preview startup stabilises
+    // before background diagnostics run.
     const refreshDoctor = async () => {
         // gradleService is non-null inside this activation scope (initialised
         // a few lines up), but the module-scope nullable declaration forces
@@ -678,16 +677,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         vscode.commands.registerCommand('composePreview.launchOnDevice',
             (previewId?: string) => launchOnDevice(previewId)),
     );
-    // Refresh applied-markers in the background, then replay the doctor refresh
-    // so it picks up any modules that only become visible via the authoritative
-    // `applied.json` path (e.g. a module whose build.gradle.kts uses a
-    // non-standard catalog accessor our scan doesn't recognise). First-activation
-    // doctor run still fires immediately off the scan result — we don't want to
-    // gate startup diagnostics on a Gradle configuration.
-    void refreshDoctor();
-    void gradleService.bootstrapAppliedMarkers().then(() => {
-        void refreshDoctor();
-    });
+    // Refresh applied-markers in the background so future module resolution can
+    // use the authoritative `applied.json` path. Doctor stays explicit via
+    // `composePreview.runDoctor`.
+    void gradleService.bootstrapAppliedMarkers();
 
     context.subscriptions.push(
         vscode.window.onDidChangeActiveTextEditor(editor => {

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -98,7 +98,6 @@ interface CapturedImage {
 interface BuildOptions {
     /** D2 — drives `composePreview.a11y.alwaysSubscribe`. Defaults to false to mirror prod. */
     a11yAlwaysSubscribe?: () => boolean;
-    settledBootstrapDelayMs?: number;
 }
 
 function build(opts: BuildOptions = {}) {
@@ -143,7 +142,6 @@ function build(opts: BuildOptions = {}) {
         events,
         { appendLine: (s) => log.push(s) },
         opts.a11yAlwaysSubscribe ?? (() => false),
-        opts.settledBootstrapDelayMs ?? -1,
     );
     return { gate, scheduler, log, images, failures, dirty, discovery, dataProducts, channelClosed };
 }
@@ -446,21 +444,6 @@ describe('DaemonScheduler', () => {
             assert.deepStrictEqual(gradle.bootstrapCalls, [], 'cached descriptor should start without blocking on Gradle');
         });
 
-        it('quietly refreshes the bootstrap descriptor after a cached warm succeeds', async () => {
-            const { scheduler } = build({ settledBootstrapDelayMs: 0 });
-            const gradle = new FakeGradleService();
-            const states: string[] = [];
-            const ok = await scheduler.warmModule(
-                gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
-                'mod',
-                (s) => states.push(s),
-            );
-            assert.strictEqual(ok, true);
-            assert.deepStrictEqual(states, ['spawning', 'ready']);
-            await Promise.resolve();
-            assert.deepStrictEqual(gradle.bootstrapCalls, ['mod']);
-        });
-
         it('drives progress through bootstrap fallback when the cached descriptor is missing', async () => {
             const { gate, scheduler, log } = build();
             gate.getOrSpawnErrors.push(new Error('[daemon] no launch descriptor for mod'));
@@ -491,22 +474,6 @@ describe('DaemonScheduler', () => {
             assert.strictEqual(ok, true);
             assert.deepStrictEqual(states, ['ready']);
             assert.deepStrictEqual(gradle.bootstrapCalls, [], 'bootstrap should not run when daemon is ready');
-        });
-
-        it('quietly refreshes the bootstrap descriptor after an already-ready warm', async () => {
-            const { gate, scheduler } = build({ settledBootstrapDelayMs: 0 });
-            gate.ready = true;
-            const gradle = new FakeGradleService();
-            const states: string[] = [];
-            const ok = await scheduler.warmModule(
-                gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
-                'mod',
-                (s) => states.push(s),
-            );
-            assert.strictEqual(ok, true);
-            assert.deepStrictEqual(states, ['ready']);
-            await Promise.resolve();
-            assert.deepStrictEqual(gradle.bootstrapCalls, ['mod']);
         });
 
         it('throws when the bootstrap task fails while the daemon is enabled', async () => {


### PR DESCRIPTION
## Summary

Fixes #590.

This trims the VS Code extension's warm-start work so a second launch does not immediately queue background Gradle work that competes with the active preview path.

Changes:

- coalesce same-module daemon spawns in `DaemonGate`, so concurrent startup callers share one in-flight JVM start instead of launching duplicate daemons
- remove the delayed post-ready `composePreviewDaemonStart` refresh from `DaemonScheduler`; if the cached descriptor works, startup no longer schedules another bootstrap task five seconds later
- keep doctor diagnostics explicit via `Compose Preview: Run Doctor` instead of running project-wide doctor sweeps during activation and again after `composePreviewApplied`

## Investigation notes

The startup log in #590 showed three independent sources of extra work:

- two daemon JVMs spawned for `samples/wear`, which is possible because `DaemonGate` only registered a daemon after `spawnDaemon()` resolved
- a warm cached launch still scheduled `composePreviewDaemonStart` after readiness via the scheduler's settled-bootstrap timer
- activation ran doctor diagnostics immediately and then again after `composePreviewApplied`, producing repeated/cancelled per-module Gradle tasks and failures for stale/non-doctor modules

## Verification

- `npm run compile`
- `npm test` (`321 passing`)
- `git diff --check`