### PR TITLE
Move PreviewContext to shared render data

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -21,7 +21,10 @@ import androidx.compose.ui.test.onRoot
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import com.github.takahirom.roborazzi.RoborazziOptions
 import com.github.takahirom.roborazzi.captureRoboImage
-import ee.schimke.composeai.daemon.protocol.BackendKind
+import ee.schimke.composeai.data.render.PreviewBackends
+import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.PreviewDeviceSpec
+import ee.schimke.composeai.daemon.devices.DeviceDimensions
 import ee.schimke.composeai.renderer.AccessibilityChecker
 import java.io.File
 
@@ -399,11 +402,17 @@ class RenderEngine(
     val previewContext =
       PreviewContext.Builder(
           previewId = spec.previewId,
-          backend = BackendKind.ANDROID,
+          backend = PreviewBackends.ANDROID,
           renderMode = null,
           outputBaseName = spec.outputBaseName,
         )
-        .deviceFromRenderPixels(spec.device, spec.widthPx, spec.heightPx, spec.density)
+        .deviceFromRenderPixels(
+          spec.device,
+          spec.widthPx,
+          spec.heightPx,
+          spec.density,
+          resolvedDevice = spec.device?.let(DeviceDimensions::resolve)?.previewDeviceSpec(),
+        )
         .build()
     return RenderResult(
       id = requestId,
@@ -506,6 +515,9 @@ class RenderEngine(
     private const val CAPTURE_ADVANCE_MS = 32L
   }
 }
+
+private fun DeviceDimensions.DeviceSpec.previewDeviceSpec(): PreviewDeviceSpec =
+  PreviewDeviceSpec(widthDp = widthDp, heightDp = heightDp, density = density, isRound = isRound)
 
 /**
  * Detects whether a Compose `@Preview(device = ...)` string refers to a round (circular) display —

--- a/daemon/core/build.gradle.kts
+++ b/daemon/core/build.gradle.kts
@@ -31,6 +31,8 @@ version =
     }
 
 dependencies {
+  api(project(":data-render-core"))
+
   // Protocol message types are @Serializable. Exposed as `api` so downstream
   // daemon modules (e.g. :daemon:android) get
   // kotlinx-serialization-json on their compile classpath without re-declaring

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/CompositeDataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/CompositeDataProductRegistry.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.render.PreviewContext
 import kotlinx.serialization.json.JsonElement
 
 /**
@@ -35,11 +36,20 @@ class CompositeDataProductRegistry(private val registries: List<DataProductRegis
     }
 
   override fun onRender(previewId: String, result: RenderResult) {
-    registries.forEach { it.onRender(previewId, result, overrides = null) }
+    registries.forEach { it.onRender(previewId, result, overrides = null, result.previewContext) }
   }
 
   override fun onRender(previewId: String, result: RenderResult, overrides: PreviewOverrides?) {
-    registries.forEach { it.onRender(previewId, result, overrides) }
+    registries.forEach { it.onRender(previewId, result, overrides, result.previewContext) }
+  }
+
+  override fun onRender(
+    previewId: String,
+    result: RenderResult,
+    overrides: PreviewOverrides?,
+    previewContext: PreviewContext?,
+  ) {
+    registries.forEach { it.onRender(previewId, result, overrides, previewContext) }
   }
 
   override fun onSubscribe(previewId: String, kind: String, params: JsonElement?) {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
@@ -4,6 +4,7 @@ import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
+import ee.schimke.composeai.data.render.PreviewContext
 import kotlinx.serialization.json.JsonElement
 
 /**
@@ -69,6 +70,21 @@ interface DataProductRegistry {
    */
   fun onRender(previewId: String, result: RenderResult, overrides: PreviewOverrides?) {
     onRender(previewId, result)
+  }
+
+  /**
+   * Render lifecycle hook with renderer-collected context. Producers that need slot tables,
+   * composition-local snapshots, frame-clock semantics, or animation sampling metadata should read
+   * them from [previewContext] here. Older producers can keep overriding the two- or three-argument
+   * [onRender] overloads; the default forwards to the existing override chain.
+   */
+  fun onRender(
+    previewId: String,
+    result: RenderResult,
+    overrides: PreviewOverrides?,
+    previewContext: PreviewContext?,
+  ) {
+    onRender(previewId, result, overrides)
   }
 
   /**

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -950,7 +950,12 @@ class JsonRpcServer(
     // and we emit `tookMs = 0`. Other RenderMetrics fields (heap / native / sandbox-age) stay
     // null until B2.3 wires the cost-model collection path.
     try {
-      dataProducts.onRender(previewId, result, hostIdToOverrides.remove(result.id))
+      dataProducts.onRender(
+        previewId,
+        result,
+        hostIdToOverrides.remove(result.id),
+        result.previewContext,
+      )
     } catch (t: Throwable) {
       System.err.println(
         "compose-ai-daemon: data product onRender failed for $previewId " +

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.data.render.PreviewContext
 import java.util.concurrent.atomic.AtomicLong
 
 /**

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -100,14 +100,10 @@ fun main(args: Array<String>) {
   val themeRegistry = ThemeDataProductRegistry()
   val renderEngine =
     RenderEngine(
-      themeCapture =
-        object : RenderEngine.ThemeCapture {
+      previewContextCapture =
+        object : RenderEngine.PreviewContextCapture {
           override fun shouldCapture(previewId: String?, renderMode: String?): Boolean =
             themeRegistry.shouldCapture(previewId, renderMode)
-
-          override fun capture(previewId: String?, payload: ThemePayload) {
-            themeRegistry.capture(previewId, payload)
-          }
         }
     )
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -26,7 +26,10 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.intl.LocaleList
 import androidx.compose.ui.unit.Density
-import ee.schimke.composeai.daemon.protocol.BackendKind
+import ee.schimke.composeai.daemon.devices.DeviceDimensions
+import ee.schimke.composeai.data.render.PreviewBackends
+import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.PreviewDeviceSpec
 import java.io.File
 import java.util.Collections
 import java.util.WeakHashMap
@@ -78,7 +81,7 @@ class RenderEngine(
         ?: "${System.getProperty("user.dir")}/.compose-preview-history/daemon-renders"
     ),
   private val dataDir: File = (outputDir.parentFile ?: outputDir).resolve("data"),
-  private val themeCapture: ThemeCapture? = null,
+  private val previewContextCapture: PreviewContextCapture? = null,
   private val frameNanoTime: () -> Long = System::nanoTime,
 ) {
 
@@ -180,13 +183,13 @@ class RenderEngine(
 
     val localeProviders = localeProviders(spec.localeTag)
     val themeFallbackCapture =
-      if (themeCapture?.shouldCapture(spec.previewId, spec.renderMode) == true) {
+      if (previewContextCapture?.shouldCapture(spec.previewId, spec.renderMode) == true) {
         MaterialThemeFallbackCapture()
       } else {
         null
       }
     val slotTableCapture =
-      if (themeCapture?.shouldCapture(spec.previewId, spec.renderMode) == true) {
+      if (previewContextCapture?.shouldCapture(spec.previewId, spec.renderMode) == true) {
         PreviewSlotTableCapture()
       } else {
         null
@@ -229,10 +232,10 @@ class RenderEngine(
             LocalDensity provides density,
             *localeProviders,
           ) {
-            if (themeCapture?.shouldCapture(spec.previewId, spec.renderMode) == true) {
+            if (previewContextCapture?.shouldCapture(spec.previewId, spec.renderMode) == true) {
               CaptureMaterialTheme { _, typography, shapes, payload ->
                 themeFallbackCapture?.capture(typography, shapes)
-                themeCapture.capture(spec.previewId, payload)
+                themeFallbackCapture?.capture(payload)
               }
             }
             val content: @Composable () -> Unit = {
@@ -304,30 +307,7 @@ class RenderEngine(
     // as `:renderer-desktop`'s renderPreview.
     trace.section("compose:frame") { renderFrame(state, useWallClockFrameTime) }
     val image = trace.section("compose:captureFrame") { renderFrame(state, useWallClockFrameTime) }
-    val contextBuilder =
-      PreviewContext.Builder(
-          previewId = state.spec.previewId,
-          backend = BackendKind.DESKTOP,
-          renderMode = state.spec.renderMode,
-          outputBaseName = state.spec.outputBaseName,
-        )
-        .deviceFromRenderPixels(
-          state.spec.device,
-          state.spec.widthPx,
-          state.spec.heightPx,
-          state.spec.density,
-        )
-    state.slotTableCapture?.let { capture ->
-      val context =
-        contextBuilder.parameterInformationCollected().addSlotTables(capture.snapshot()).build()
-      themePayloadFromPreviewContext(
-          context = context,
-          fallbackTypography = state.themeFallbackCapture?.typography,
-          fallbackShapes = state.themeFallbackCapture?.shapes,
-        )
-        ?.let { payload -> themeCapture?.capture(state.spec.previewId, payload) }
-    }
-    val previewContext = contextBuilder.build()
+    val previewContext = state.previewContext()
 
     val pngData =
       trace.section("render:encodePng") {
@@ -394,12 +374,57 @@ class RenderEngine(
     internal val previousContext: ClassLoader?,
     internal val slotTableCapture: PreviewSlotTableCapture?,
     internal val themeFallbackCapture: MaterialThemeFallbackCapture?,
-  )
+  ) {
+    internal fun previewContext(): PreviewContext {
+      val slotTables = slotTableCapture?.snapshot().orEmpty()
+      val rawContext =
+        PreviewContext.Builder(
+            previewId = spec.previewId,
+            backend = PreviewBackends.DESKTOP,
+            renderMode = spec.renderMode,
+            outputBaseName = spec.outputBaseName,
+          )
+          .deviceFromRenderPixels(
+            spec.device,
+            spec.widthPx,
+            spec.heightPx,
+            spec.density,
+            resolvedDevice = spec.device?.let(DeviceDimensions::resolve)?.previewDeviceSpec(),
+          )
+          .parameterInformationCollected()
+          .addSlotTables(slotTables)
+          .build()
+      val materialThemePayload =
+        themePayloadFromPreviewContext(
+          context = rawContext,
+          fallbackTypography = themeFallbackCapture?.typography,
+          fallbackShapes = themeFallbackCapture?.shapes,
+        ) ?: themeFallbackCapture?.payload
+      val builder =
+        PreviewContext.Builder(
+            previewId = spec.previewId,
+            backend = PreviewBackends.DESKTOP,
+            renderMode = spec.renderMode,
+            outputBaseName = spec.outputBaseName,
+          )
+          .deviceFromRenderPixels(
+            spec.device,
+            spec.widthPx,
+            spec.heightPx,
+            spec.density,
+            resolvedDevice = spec.device?.let(DeviceDimensions::resolve)?.previewDeviceSpec(),
+          )
+          .parameterInformationCollected()
+          .addSlotTables(slotTables)
+      materialThemePayload?.let {
+        builder.putInspectionValue(MATERIAL3_THEME_PAYLOAD_CONTEXT_KEY, it)
+      }
+      return builder.build()
+    }
+  }
 
-  interface ThemeCapture {
+  interface PreviewContextCapture {
     fun shouldCapture(previewId: String?, renderMode: String?): Boolean
-
-    fun capture(previewId: String?, payload: ThemePayload)
   }
 
   companion object {
@@ -601,9 +626,16 @@ internal class MaterialThemeFallbackCapture {
   var shapes: Shapes? = null
     private set
 
+  var payload: ThemePayload? = null
+    private set
+
   fun capture(typography: Typography, shapes: Shapes) {
     this.typography = typography
     this.shapes = shapes
+  }
+
+  fun capture(payload: ThemePayload) {
+    this.payload = payload
   }
 }
 
@@ -617,3 +649,6 @@ private fun InspectablePreviewContent(
   capture.store.add(currentComposer.compositionData)
   CompositionLocalProvider(LocalInspectionTables provides capture.store, content = content)
 }
+
+private fun DeviceDimensions.DeviceSpec.previewDeviceSpec(): PreviewDeviceSpec =
+  PreviewDeviceSpec(widthDp = widthDp, heightDp = heightDp, density = density, isRound = isRound)

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/ThemeDataProductRegistryTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/ThemeDataProductRegistryTest.kt
@@ -42,31 +42,29 @@ class ThemeDataProductRegistryTest {
     val engine =
       RenderEngine(
         outputDir = outputDir,
-        themeCapture =
-          object : RenderEngine.ThemeCapture {
+        previewContextCapture =
+          object : RenderEngine.PreviewContextCapture {
             override fun shouldCapture(previewId: String?, renderMode: String?): Boolean =
               registry.shouldCapture(previewId, renderMode)
-
-            override fun capture(previewId: String?, payload: ThemePayload) {
-              registry.capture(previewId, payload)
-            }
           },
       )
 
-    engine.render(
-      spec =
-        RenderSpec(
-          previewId = "preview-1",
-          renderMode = "theme",
-          className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
-          functionName = "RedSquare",
-          widthPx = 32,
-          heightPx = 32,
-          density = 1.0f,
-          outputBaseName = "theme-red-square",
-        ),
-      requestId = RenderHost.nextRequestId(),
-    )
+    val result =
+      engine.render(
+        spec =
+          RenderSpec(
+            previewId = "preview-1",
+            renderMode = "theme",
+            className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+            functionName = "RedSquare",
+            widthPx = 32,
+            heightPx = 32,
+            density = 1.0f,
+            outputBaseName = "theme-red-square",
+          ),
+        requestId = RenderHost.nextRequestId(),
+      )
+    registry.onRender("preview-1", result)
 
     val fetch =
       registry.fetch("preview-1", "compose/theme", params = null, inline = true)
@@ -101,31 +99,29 @@ class ThemeDataProductRegistryTest {
     val engine =
       RenderEngine(
         outputDir = outputDir,
-        themeCapture =
-          object : RenderEngine.ThemeCapture {
+        previewContextCapture =
+          object : RenderEngine.PreviewContextCapture {
             override fun shouldCapture(previewId: String?, renderMode: String?): Boolean =
               registry.shouldCapture(previewId, renderMode)
-
-            override fun capture(previewId: String?, payload: ThemePayload) {
-              registry.capture(previewId, payload)
-            }
           },
       )
 
-    engine.render(
-      spec =
-        RenderSpec(
-          previewId = "preview-local-theme",
-          renderMode = "theme",
-          className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
-          functionName = "ThemedPrimarySquare",
-          widthPx = 32,
-          heightPx = 32,
-          density = 1.0f,
-          outputBaseName = "theme-local-square",
-        ),
-      requestId = RenderHost.nextRequestId(),
-    )
+    val result =
+      engine.render(
+        spec =
+          RenderSpec(
+            previewId = "preview-local-theme",
+            renderMode = "theme",
+            className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+            functionName = "ThemedPrimarySquare",
+            widthPx = 32,
+            heightPx = 32,
+            density = 1.0f,
+            outputBaseName = "theme-local-square",
+          ),
+        requestId = RenderHost.nextRequestId(),
+      )
+    registry.onRender("preview-local-theme", result)
 
     val fetch =
       registry.fetch("preview-local-theme", "compose/theme", params = null, inline = true)
@@ -143,30 +139,28 @@ class ThemeDataProductRegistryTest {
     val engine =
       RenderEngine(
         outputDir = outputDir,
-        themeCapture =
-          object : RenderEngine.ThemeCapture {
+        previewContextCapture =
+          object : RenderEngine.PreviewContextCapture {
             override fun shouldCapture(previewId: String?, renderMode: String?): Boolean =
               registry.shouldCapture(previewId, renderMode)
-
-            override fun capture(previewId: String?, payload: ThemePayload) {
-              registry.capture(previewId, payload)
-            }
           },
       )
 
-    engine.render(
-      spec =
-        RenderSpec(
-          previewId = "preview-2",
-          className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
-          functionName = "RedSquare",
-          widthPx = 32,
-          heightPx = 32,
-          density = 1.0f,
-          outputBaseName = "subscribed-theme-red-square",
-        ),
-      requestId = RenderHost.nextRequestId(),
-    )
+    val result =
+      engine.render(
+        spec =
+          RenderSpec(
+            previewId = "preview-2",
+            className = "ee.schimke.composeai.daemon.RedFixturePreviewsKt",
+            functionName = "RedSquare",
+            widthPx = 32,
+            heightPx = 32,
+            density = 1.0f,
+            outputBaseName = "subscribed-theme-red-square",
+          ),
+        requestId = RenderHost.nextRequestId(),
+      )
+    registry.onRender("preview-2", result)
 
     val outcome = registry.fetch("preview-2", "compose/theme", params = null, inline = true)
     assertTrue(outcome is DataProductRegistry.Outcome.Ok)
@@ -179,14 +173,10 @@ class ThemeDataProductRegistryTest {
     val engine =
       RenderEngine(
         outputDir = outputDir,
-        themeCapture =
-          object : RenderEngine.ThemeCapture {
+        previewContextCapture =
+          object : RenderEngine.PreviewContextCapture {
             override fun shouldCapture(previewId: String?, renderMode: String?): Boolean =
               registry.shouldCapture(previewId, renderMode)
-
-            override fun capture(previewId: String?, payload: ThemePayload) {
-              registry.capture(previewId, payload)
-            }
           },
       )
     val host =

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProduct.kt
@@ -1,9 +1,13 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.devices.DeviceDimensions
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.PreviewDeviceContext
+import ee.schimke.composeai.data.render.PreviewDeviceSpec
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
@@ -27,7 +31,7 @@ class DeviceClipDataProductRegistry(previewIndex: PreviewIndex) : DataProductReg
             renderMode = null,
             outputBaseName = null,
           )
-          .device(PreviewDeviceContext.fromPreviewInfo(preview))
+          .device(preview.previewDeviceContext())
           .build()
       }
     )
@@ -95,3 +99,19 @@ class DeviceClipDataProductRegistry(previewIndex: PreviewIndex) : DataProductReg
     const val SCHEMA_VERSION: Int = 1
   }
 }
+
+private fun PreviewInfoDto.previewDeviceContext(): PreviewDeviceContext {
+  val params = params
+  val device = params?.device?.takeIf { it.isNotBlank() }
+  val resolvedDevice = device?.let(DeviceDimensions::resolve)
+  return PreviewDeviceContext(
+    device = device,
+    widthDp = params?.widthDp?.toDouble() ?: resolvedDevice?.widthDp?.toDouble(),
+    heightDp = params?.heightDp?.toDouble() ?: resolvedDevice?.heightDp?.toDouble(),
+    density = params?.density ?: resolvedDevice?.density,
+    resolvedDevice = resolvedDevice?.previewDeviceSpec(),
+  )
+}
+
+private fun DeviceDimensions.DeviceSpec.previewDeviceSpec(): PreviewDeviceSpec =
+  PreviewDeviceSpec(widthDp = widthDp, heightDp = heightDp, density = density, isRound = isRound)

--- a/data/render/connector/src/test/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProductRegistryTest.kt
+++ b/data/render/connector/src/test/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProductRegistryTest.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.PreviewDeviceSpec
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -191,6 +193,7 @@ class DeviceClipDataProductRegistryTest {
                 widthPx = 600,
                 heightPx = 600,
                 density = 2f,
+                resolvedDevice = PreviewDeviceSpec(227, 227, 2f, isRound = true),
               )
               .build(),
         ),

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PreviewContext.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/PreviewContext.kt
@@ -1,19 +1,16 @@
-package ee.schimke.composeai.daemon
-
-import ee.schimke.composeai.daemon.devices.DeviceDimensions
-import ee.schimke.composeai.daemon.protocol.BackendKind
+package ee.schimke.composeai.data.render
 
 /**
  * Per-render context passed from a renderer backend to data products.
  *
- * The core module deliberately keeps renderer objects opaque. Compose-backed renderers may attach
- * slot-table roots (currently `androidx.compose.runtime.tooling.CompositionData`) through
- * [inspection]; data products that understand that runtime can cast and inspect them, while the
- * daemon protocol and non-Compose producers stay decoupled from Compose internals.
+ * Renderer objects stay opaque. Compose-backed renderers may attach slot-table roots (currently
+ * `androidx.compose.runtime.tooling.CompositionData`) through [inspection]; data products that
+ * understand that runtime can cast and inspect them, while standalone renderers, daemon adapters,
+ * and non-Compose producers stay decoupled from Compose internals.
  */
 data class PreviewContext(
   val previewId: String?,
-  val backend: BackendKind?,
+  val backend: String?,
   val renderMode: String?,
   val outputBaseName: String?,
   val device: PreviewDeviceContext = PreviewDeviceContext(),
@@ -23,7 +20,7 @@ data class PreviewContext(
 ) {
   class Builder(
     private val previewId: String?,
-    private val backend: BackendKind?,
+    private val backend: String?,
     private val renderMode: String?,
     private val outputBaseName: String?,
   ) {
@@ -31,6 +28,7 @@ data class PreviewContext(
     private var frameTime: PreviewFrameTime = PreviewFrameTime()
     private var animation: PreviewAnimationContext? = null
     private val slotTables = mutableListOf<Any>()
+    private val inspectionValues = linkedMapOf<String, Any>()
     private var parameterInformationCollected: Boolean = false
 
     fun device(device: PreviewDeviceContext): Builder = apply { this.device = device }
@@ -40,8 +38,10 @@ data class PreviewContext(
       widthPx: Int,
       heightPx: Int,
       density: Float,
+      resolvedDevice: PreviewDeviceSpec? = null,
     ): Builder = apply {
-      this.device = PreviewDeviceContext.fromRenderPixels(device, widthPx, heightPx, density)
+      this.device =
+        PreviewDeviceContext.fromRenderPixels(device, widthPx, heightPx, density, resolvedDevice)
     }
 
     fun frameTime(frameTime: PreviewFrameTime): Builder = apply { this.frameTime = frameTime }
@@ -51,6 +51,10 @@ data class PreviewContext(
     }
 
     fun addSlotTables(tables: Iterable<Any>): Builder = apply { slotTables.addAll(tables) }
+
+    fun putInspectionValue(key: String, value: Any): Builder = apply {
+      inspectionValues[key] = value
+    }
 
     fun parameterInformationCollected(): Builder = apply { parameterInformationCollected = true }
 
@@ -65,11 +69,17 @@ data class PreviewContext(
         inspection =
           PreviewInspectionContext(
             slotTables = slotTables.toList(),
+            values = inspectionValues.toMap(),
             parameterInformationCollected = parameterInformationCollected,
           ),
         animation = animation,
       )
   }
+}
+
+object PreviewBackends {
+  const val DESKTOP: String = "desktop"
+  const val ANDROID: String = "android"
 }
 
 /**
@@ -85,34 +95,20 @@ data class PreviewDeviceContext(
   val widthDp: Double? = null,
   val heightDp: Double? = null,
   val density: Float? = null,
-  val resolvedDevice: DeviceDimensions.DeviceSpec? = null,
+  val resolvedDevice: PreviewDeviceSpec? = null,
 ) {
   val isRound: Boolean
     get() = resolvedDevice?.isRound == true
 
   companion object {
-    fun fromPreviewInfo(info: PreviewInfoDto): PreviewDeviceContext = fromPreviewParams(info.params)
-
-    fun fromPreviewParams(params: PreviewParamsDto?): PreviewDeviceContext {
-      val device = params?.device?.takeIf { it.isNotBlank() }
-      val resolvedDevice = device?.let(DeviceDimensions::resolve)
-      return PreviewDeviceContext(
-        device = device,
-        widthDp = params?.widthDp?.toDouble() ?: resolvedDevice?.widthDp?.toDouble(),
-        heightDp = params?.heightDp?.toDouble() ?: resolvedDevice?.heightDp?.toDouble(),
-        density = params?.density ?: resolvedDevice?.density,
-        resolvedDevice = resolvedDevice,
-      )
-    }
-
     fun fromRenderPixels(
       device: String?,
       widthPx: Int,
       heightPx: Int,
       density: Float,
+      resolvedDevice: PreviewDeviceSpec? = null,
     ): PreviewDeviceContext {
       val safeDensity = density.takeIf { it > 0f }
-      val resolvedDevice = device?.takeIf { it.isNotBlank() }?.let(DeviceDimensions::resolve)
       return PreviewDeviceContext(
         device = device?.takeIf { it.isNotBlank() },
         widthDp = safeDensity?.let { widthPx / it.toDouble() },
@@ -123,6 +119,13 @@ data class PreviewDeviceContext(
     }
   }
 }
+
+data class PreviewDeviceSpec(
+  val widthDp: Int,
+  val heightDp: Int,
+  val density: Float,
+  val isRound: Boolean = false,
+)
 
 /**
  * Frame-clock semantics for the data represented by a [PreviewContext].
@@ -150,11 +153,13 @@ data class PreviewFrameTime(
  * Inspection capability captured during composition.
  *
  * [slotTables] is intentionally `Any`: on Compose backends each entry is a `CompositionData`, but
- * core must not expose a Compose dependency. The capture wrapper must call Compose's parameter-info
- * collection before composing content when consumers need call-site values from the slot table.
+ * this module must not expose a Compose dependency. The capture wrapper must call Compose's
+ * parameter-info collection before composing content when consumers need call-site values from the
+ * slot table.
  */
 data class PreviewInspectionContext(
   val slotTables: List<Any> = emptyList(),
+  val values: Map<String, Any> = emptyMap(),
   val parameterInformationCollected: Boolean = false,
 )
 

--- a/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
+++ b/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
@@ -13,11 +13,14 @@ import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.render.PreviewContext
 import java.lang.reflect.Method
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+
+const val MATERIAL3_THEME_PAYLOAD_CONTEXT_KEY: String = "compose.material3.themePayload"
 
 /**
  * Desktop v1 producer for `compose/theme`.
@@ -86,6 +89,19 @@ class ThemeDataProductRegistry : DataProductRegistry {
   }
 
   override fun onRender(previewId: String, result: RenderResult) {
+    onRender(previewId, result, overrides = null, previewContext = result.previewContext)
+  }
+
+  override fun onRender(
+    previewId: String,
+    result: RenderResult,
+    overrides: ee.schimke.composeai.daemon.protocol.PreviewOverrides?,
+    previewContext: PreviewContext?,
+  ) {
+    previewContext
+      ?.takeIf { shouldCapture(previewId, it.renderMode) }
+      ?.let(::themePayloadFromPreviewContext)
+      ?.let { capture(previewId, it) }
     if (!capturedThisRender.remove(previewId)) {
       latestPayloads.remove(previewId)
     }
@@ -204,8 +220,11 @@ fun themePayloadFromPreviewContext(
       fallbackShapes = fallbackShapes,
     )
   }
-  return null
+  return context.inspection.values[MATERIAL3_THEME_PAYLOAD_CONTEXT_KEY] as? ThemePayload
 }
+
+fun themePayloadFromPreviewContext(context: PreviewContext): ThemePayload? =
+  themePayloadFromPreviewContext(context, fallbackTypography = null, fallbackShapes = null)
 
 fun colorTokens(source: Any?): Map<String, String> =
   when (source) {

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
   // `ee.schimke.composeai.renderer.AccessibilityChecker` etc. still resolve and downstream
   // consumers (`RobolectricRenderTest`) compile unchanged.
   api(project(":data-a11y-core"))
+  implementation(project(":data-render-core"))
 
   implementation(libs.robolectric)
   implementation(libs.junit)

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AnimationInspector.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/AnimationInspector.kt
@@ -9,6 +9,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.tooling.CompositionData
 import androidx.compose.ui.tooling.data.asTree
+import ee.schimke.composeai.data.render.PreviewAnimationContext
+import ee.schimke.composeai.data.render.PreviewBackends
+import ee.schimke.composeai.data.render.PreviewContext
 import java.lang.reflect.Method
 import java.util.concurrent.atomic.AtomicReference
 
@@ -97,7 +100,10 @@ internal class AnimationInspector private constructor(
          * static preview); throws with a Compose-version diagnostic if the
          * tooling API isn't available.
          */
-        fun attach(capture: SlotTreeCapture): AnimationInspector? {
+        fun attach(capture: SlotTreeCapture): AnimationInspector? =
+            attach(capture.previewContext(previewId = null, renderMode = null, outputBaseName = null))
+
+        fun attach(context: PreviewContext): AnimationInspector? {
             val clockClass = loadClass(PREVIEW_ANIMATION_CLOCK_FQN)
                 ?: failNotInstalled(PREVIEW_ANIMATION_CLOCK_FQN)
             val searchClass = loadClass(ANIMATION_SEARCH_FQN)
@@ -105,7 +111,7 @@ internal class AnimationInspector private constructor(
             val animatedPropertyClass = loadClass(COMPOSE_ANIMATED_PROPERTY_FQN)
                 ?: failNotInstalled(COMPOSE_ANIMATED_PROPERTY_FQN)
 
-            val compositionData = capture.compositionData
+            val compositionData = context.inspection.slotTables.filterIsInstance<CompositionData>().firstOrNull()
             if (compositionData == null) {
                 System.err.println(
                     "@AnimatedPreview(showCurves=true): composition didn't populate the slot " +
@@ -327,6 +333,23 @@ internal class SlotTreeCapture {
         set(value) {
             ref.set(value)
         }
+
+    fun previewContext(
+        previewId: String?,
+        renderMode: String?,
+        outputBaseName: String?,
+        animation: PreviewAnimationContext? = null,
+    ): PreviewContext =
+        PreviewContext.Builder(
+                previewId = previewId,
+                backend = PreviewBackends.ANDROID,
+                renderMode = renderMode,
+                outputBaseName = outputBaseName,
+            )
+            .parameterInformationCollected()
+            .addSlotTables(listOfNotNull(compositionData))
+            .animation(animation)
+            .build()
 }
 
 /**

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -27,6 +27,7 @@ import com.github.takahirom.roborazzi.inspectionMode
 import com.github.takahirom.roborazzi.locale
 import com.github.takahirom.roborazzi.size
 import com.github.takahirom.roborazzi.uiMode
+import ee.schimke.composeai.data.render.PreviewAnimationContext
 import java.awt.image.BufferedImage
 import java.io.File
 import kotlinx.serialization.json.Json
@@ -1346,7 +1347,20 @@ private fun handleAnimatedCapture(
     // the slot table.
     rule.mainClock.advanceTimeByFrame()
     val inspector = if (animation.showCurves && curveCapture != null) {
-        runCatching { AnimationInspector.attach(curveCapture) }
+        val context =
+            curveCapture.previewContext(
+                previewId = previewId,
+                renderMode = "animation",
+                outputBaseName = outputFile.nameWithoutExtension,
+                animation =
+                    PreviewAnimationContext(
+                        showCurves = true,
+                        requestedDurationMs = animation.durationMs,
+                        effectiveDurationMs = null,
+                        frameIntervalMs = frameIntervalMs,
+                    ),
+            )
+        runCatching { AnimationInspector.attach(context) }
             .onFailure { e ->
                 // Graceful degradation: incompat Compose UI Tooling (e.g. consumers
                 // on a Compose runtime older than the AnimationInspector reflective


### PR DESCRIPTION
## Summary
- move PreviewContext / PreviewAnimationContext from daemon-core to data-render-core so standalone renderers and data connectors can use the same context contract
- keep daemon-specific transport as RenderResult.previewContext plus DataProductRegistry.onRender(..., previewContext)
- preserve durable desktop theme extraction by storing product-ready values in PreviewContext.inspection.values before scene teardown
- wire Android animation curve inspection through shared PreviewContext instead of the local SlotTreeCapture-only path

## Why
The version currently on main has PreviewContext inside daemon-core, which makes it awkward for renderer-android and non-daemon data modules. This keeps the reusable context in the shared render-data layer and leaves daemon-core responsible only for lifecycle delivery.

## Tests
- ./gradlew :data-render-core:compileKotlin :daemon:core:compileKotlin :data-theme-connector:compileKotlin :daemon:desktop:compileKotlin :renderer-android:compileDebugKotlin :daemon:desktop:test --tests ee.schimke.composeai.daemon.ThemeDataProductRegistryTest
- ./gradlew ktfmtFormatAll