### PR TITLE
Move scroll screenshots to data products

### DIFF
--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -558,6 +558,24 @@ for rectangular/default devices, or:
 for round Wear-style devices. It does not require a render pass and is
 available on both Android and desktop daemons.
 
+`render/scroll/long` and `render/scroll/gif` are annotation-sourced render
+products produced from `@ScrollingPreview(modes = [LONG, GIF])`. The typed
+annotation remains the authoring API; discovery maps those modes to data-product
+requests instead of adding long/GIF artefacts to the primary capture list. Gradle
+renders write path-backed product files under `build/compose-previews/data/`:
+
+```json
+{
+  "kind": "render/scroll/long",
+  "schemaVersion": 1,
+  "path": ".../build/compose-previews/data/render-scroll-long/Foo.png"
+}
+```
+
+`render/scroll/long` is a stitched PNG. `render/scroll/gif` is an animated GIF
+showing the scroll from top to bottom. Non-scrollable previews no-op through the
+same fallback behaviour as the renderer's scroll capture path.
+
 `history/diff/regions` is a cheap, inline, fetchable and attachable data product
 derived from the daemon history archive. It is advertised only when
 `HistoryManager` is active. Fetch and subscribe calls must pass an explicit

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -354,7 +354,11 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         preview.captures.map { c ->
           c.copy(renderOutput = rewriteRenderStem(c.renderOutput, preview.id, newStem))
         }
-      preview.copy(captures = rewritten)
+      val rewrittenProducts =
+        preview.dataProducts.map { p ->
+          p.copy(output = rewriteRenderStem(p.output, preview.id, newStem))
+        }
+      preview.copy(captures = rewritten, dataProducts = rewrittenProducts)
     }
   }
 
@@ -437,11 +441,11 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
   ) {
     // @PreviewWrapper and @ScrollingPreview are both non-repeatable and apply
     // to every @Preview on the function (including expansions from
-    // multi-preview meta-annotations). `@ScrollingPreview.modes` fans out
-    // one capture per entry — see [buildCaptures]. `@AnimatedPreview` is
-    // single-shot (one GIF per function) so it doesn't fan out, but follows
-    // the same "one annotation per function, applies to every preview
-    // expansion" policy.
+    // multi-preview meta-annotations). `@ScrollingPreview.modes` maps TOP/END
+    // to normal captures and LONG/GIF to data products — see [buildOutputPlan].
+    // `@AnimatedPreview` is single-shot (one GIF per function) so it doesn't
+    // fan out, but follows the same "one annotation per function, applies to
+    // every preview expansion" policy.
     val wrapperFqn = extractWrapperFqn(annotations)
     val scrollSpecs = extractScrollSpecs(annotations)
     val animationSpec = extractAnimationSpec(annotations)
@@ -526,13 +530,18 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
   // renderer inflates a View via `TileRenderer` and has no Compose
   // animation clock / scrollable), so both dimensional annotations are
   // no-ops for tiles.
-  private fun buildCaptures(
+  private data class PreviewOutputPlan(
+    val captures: List<Capture>,
+    val dataProducts: List<PreviewDataProduct>,
+  )
+
+  private fun buildOutputPlan(
     ann: AnnotationInfo,
     previewId: String,
     scrolls: List<ScrollCapture>,
     animation: AnimationCapture?,
     timings: List<Long>,
-  ): List<Capture> {
+  ): PreviewOutputPlan {
     val isTile = ann.name == TILE_PREVIEW_FQN
     val effectiveTimings = if (isTile) emptyList() else timings
     val effectiveScrolls = if (isTile) emptyList() else scrolls
@@ -562,11 +571,18 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     // old single-valued `mode = …` annotation land on identical paths.
     // Multi-mode adds `_SCROLL_<mode>` to disambiguate siblings, same
     // pattern as `_TIME_<ms>ms` for the time dimension.
+    val captureScrolls = effectiveScrolls.filterNot {
+      it.mode == ScrollMode.LONG || it.mode == ScrollMode.GIF
+    }
+    val productScrolls = effectiveScrolls.filter {
+      it.mode == ScrollMode.LONG || it.mode == ScrollMode.GIF
+    }
+
     val scrollRows: List<Pair<ScrollCapture?, String>> =
       when {
-        effectiveScrolls.isEmpty() -> listOf(null to "")
-        effectiveScrolls.size == 1 -> listOf(effectiveScrolls[0] to "")
-        else -> effectiveScrolls.map { it to "_SCROLL_${it.mode.name.lowercase()}" }
+        captureScrolls.isEmpty() -> listOf(null to "")
+        captureScrolls.size == 1 -> listOf(captureScrolls[0] to "")
+        else -> captureScrolls.map { it to "_SCROLL_${it.mode.name.lowercase()}" }
       }
     val timeRows: List<Pair<Long?, String>> =
       if (effectiveTimings.isEmpty()) listOf(null to "")
@@ -577,20 +593,16 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     // PNG capture. Suppress that to keep `@AnimatedPreview` a clean
     // single-output annotation.
     val emitStaticCross =
-      effectiveScrolls.isNotEmpty() || effectiveTimings.isNotEmpty() || effectiveAnimation == null
+      captureScrolls.isNotEmpty() || effectiveTimings.isNotEmpty() || effectiveAnimation == null
 
     val scrollTimeCaptures: List<Capture> =
       if (!emitStaticCross) emptyList()
       else {
         scrollRows.flatMap { (scroll, scrollSuffix) ->
           timeRows.map { (ms, timeSuffix) ->
-            // GIF captures land on `.gif`; everything else is `.png`.
-            // Branching the extension per-capture (rather than per-preview)
-            // keeps multi-mode annotations like `modes = [TOP, GIF]`
-            // producing one PNG + one GIF from the same function.
-            val ext = if (scroll?.mode == ScrollMode.GIF) "gif" else "png"
+            val ext = "png"
             // Cost is normalised to a static @Preview = 1.0. The mode
-            // ladder (TOP < END ≪ LONG < GIF) reflects how much extra
+            // ladder (TOP < END) reflects how much extra
             // work each scroll variant adds on top of the baseline
             // compose pass. `advanceTimeMillis` alone is still one
             // pass at a specific virtual time, so it doesn't bump the
@@ -615,7 +627,34 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
         }
       }
 
-    return scrollTimeCaptures + animationCaptures
+    val dataProducts = productScrolls.flatMap { scroll ->
+      val productSuffix =
+        if (productScrolls.size == 1 && captureScrolls.isEmpty()) ""
+        else "_SCROLL_${scroll.mode.name.lowercase()}"
+      val ext = if (scroll.mode == ScrollMode.GIF) "gif" else "png"
+      val cost = if (scroll.mode == ScrollMode.GIF) SCROLL_GIF_COST else SCROLL_LONG_COST
+      val kind =
+        when (scroll.mode) {
+          ScrollMode.LONG -> "render/scroll/long"
+          ScrollMode.GIF -> "render/scroll/gif"
+          else -> error("non-product scroll mode ${scroll.mode}")
+        }
+      timeRows.map { (ms, timeSuffix) ->
+        PreviewDataProduct(
+          kind = kind,
+          advanceTimeMillis = ms,
+          scroll = scroll,
+          output =
+            "data/${kind.replace('/', '-')}/${previewId}${productSuffix}${timeSuffix}.${ext}",
+          cost = cost,
+        )
+      }
+    }
+
+    return PreviewOutputPlan(
+      captures = scrollTimeCaptures + animationCaptures,
+      dataProducts = dataProducts,
+    )
   }
 
   // Reads `@RoboComposePreviewOptions(manualClockOptions = [...])` on the
@@ -798,13 +837,15 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
     val fqn = "${classInfo.name}.${method.name}"
     val suffix = buildVariantSuffix(params)
     val id = fqn + suffix
+    val outputPlan = buildOutputPlan(ann, id, scrolls, animation, timings)
     return PreviewInfo(
       id = id,
       functionName = method.name,
       className = classInfo.name,
       sourceFile = packageQualifiedSourcePath(classInfo),
       params = params,
-      captures = buildCaptures(ann, id, scrolls, animation, timings),
+      captures = outputPlan.captures,
+      dataProducts = outputPlan.dataProducts,
     )
   }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -194,6 +194,28 @@ data class Capture(
   val cost: Float = STATIC_COST,
 )
 
+/**
+ * Annotation-sourced data product request for a preview. This keeps feature-specific authoring APIs
+ * (for example `@ScrollingPreview(modes = [LONG, GIF])`) type-safe while moving heavyweight,
+ * non-primary artefacts out of the privileged capture carousel.
+ */
+@Serializable
+data class PreviewDataProduct(
+  /** Data-product kind, e.g. `render/scroll/long`. */
+  val kind: String,
+  /**
+   * Optional virtual clock coordinate shared with [Capture.advanceTimeMillis]. `null` means the
+   * renderer's default capture advance.
+   */
+  val advanceTimeMillis: Long? = null,
+  /** Scroll intent when this product is backed by `@ScrollingPreview`; null for other products. */
+  val scroll: ScrollCapture? = null,
+  /** Module-relative product file path under `build/compose-previews`, e.g. `data/.../Foo.png`. */
+  val output: String = "",
+  /** Estimated render cost on the same scale as [Capture.cost]. */
+  val cost: Float = STATIC_COST,
+)
+
 @Serializable
 data class PreviewInfo(
   val id: String,
@@ -206,6 +228,11 @@ data class PreviewInfo(
    * capture with null dimensions; an animated / scrolled preview can have many.
    */
   val captures: List<Capture> = listOf(Capture()),
+  /**
+   * Additional annotation-sourced products available for this preview. These are not primary
+   * screenshots; clients fetch or surface them through the data-product path.
+   */
+  val dataProducts: List<PreviewDataProduct> = emptyList(),
 )
 
 @Serializable

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewDataTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewDataTest.kt
@@ -35,6 +35,16 @@ class PreviewDataTest {
                 listOf(
                   Capture(renderOutput = "renders/com.example.PreviewsKt.RedBoxPreview_Red Box.png")
                 ),
+              dataProducts =
+                listOf(
+                  PreviewDataProduct(
+                    kind = "render/scroll/long",
+                    scroll = ScrollCapture(mode = ScrollMode.LONG),
+                    output =
+                      "data/render-scroll-long/com.example.PreviewsKt.RedBoxPreview_Red Box.png",
+                    cost = SCROLL_LONG_COST,
+                  )
+                ),
             )
           ),
       )
@@ -45,6 +55,7 @@ class PreviewDataTest {
     assertThat(deserialized).isEqualTo(manifest)
     assertThat(deserialized.previews).hasSize(1)
     assertThat(deserialized.previews[0].params.backgroundColor).isEqualTo(0xFFFF0000)
+    assertThat(deserialized.previews[0].dataProducts.single().kind).isEqualTo("render/scroll/long")
   }
 
   @Test

--- a/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/ScrollingPreview.kt
+++ b/preview-annotations/src/main/kotlin/ee/schimke/composeai/preview/ScrollingPreview.kt
@@ -8,12 +8,10 @@ package ee.schimke.composeai.preview
  * that want to use the annotation in their own code depend on
  * `ee.schimke.composeai:preview-annotations`.
  *
- * Each entry in [modes] fans out into its own capture. TOP / END / LONG produce a single PNG per
- * capture; GIF produces an animated `.gif`. Shared knobs — [axis], [maxScrollPx], [reduceMotion] —
- * apply to every capture produced by a single annotation instance. A single-mode annotation (e.g.
- * `modes = [ScrollMode.END]`) keeps the plain `renders/<id>.<ext>` filename; multi-mode annotations
- * disambiguate siblings with a `_SCROLL_<mode>` suffix (`renders/<id>_SCROLL_top.png`,
- * `renders/<id>_SCROLL_end.png`, `renders/<id>_SCROLL_gif.gif`, …).
+ * TOP / END produce normal preview captures. LONG and GIF are mapped to data products
+ * (`render/scroll/long`, `render/scroll/gif`) so tooling can request them without giving them a
+ * privileged place in the primary preview carousel. Shared knobs — [axis], [maxScrollPx],
+ * [reduceMotion] — apply to every output produced by a single annotation instance.
  */
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.FUNCTION)

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -97,6 +97,11 @@ data class RenderPreviewEntry(
      * and the PNG path it lands at. Always at least one element.
      */
     val captures: List<RenderPreviewCapture> = listOf(RenderPreviewCapture()),
+    /**
+     * Annotation-sourced products available for this preview. These are rendered as data-product
+     * artefacts, not as primary screenshots in the preview capture list.
+     */
+    val dataProducts: List<RenderPreviewDataProduct> = emptyList(),
 )
 
 @Serializable
@@ -110,6 +115,15 @@ data class RenderPreviewCapture(
      * the plugin's `Capture.cost` for the full catalogue. Defaults to `1.0`
      * so older manifests parse as cheap-everywhere.
      */
+    val cost: Float = 1.0f,
+)
+
+@Serializable
+data class RenderPreviewDataProduct(
+    val kind: String,
+    val advanceTimeMillis: Long? = null,
+    val scroll: ScrollCapture? = null,
+    val output: String = "",
     val cost: Float = 1.0f,
 )
 

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -68,18 +68,23 @@ object PreviewManifestLoader {
         // not JSON-representable.
         val expanded = manifest.previews.flatMap { expandParameterProvider(it) }
         // Tier filter (set by the plugin via TierSystemPropProvider). When
-        // `fast`, drop captures classified HEAVY (`@AnimatedPreview` and
-        // non-TOP `@ScrollingPreview`) — the interactive save loop only
-        // re-renders cheap captures; heavy ones keep their previous PNG/GIF
-        // on disk and stay reachable via VS Code's per-card refresh action.
-        // Entries left with zero captures are dropped from sharding entirely
-        // so shards don't allocate a row for a no-op render.
+        // `fast`, drop heavyweight captures and annotation-sourced data
+        // products. Heavy outputs keep their previous files on disk and stay
+        // reachable via explicit product fetch / refresh paths.
+        // Entries left with no outputs are dropped from sharding entirely so
+        // shards don't allocate a row for a no-op render.
         val isFast = System.getProperty("composeai.render.tier", "full")
             .equals("fast", ignoreCase = true)
         val filtered = if (!isFast) expanded else expanded.mapNotNull { row ->
             val keep = row.entry.captures.filter { it.cost <= HEAVY_COST_THRESHOLD }
-            if (keep.isEmpty()) null
-            else PreviewRow(row.entry.copy(captures = keep), row.previewArgs)
+            val keepProducts = row.entry.dataProducts.filter { it.cost <= HEAVY_COST_THRESHOLD }
+            if (keep.isEmpty() && keepProducts.isEmpty()) null
+            else {
+                PreviewRow(
+                    row.entry.copy(captures = keep, dataProducts = keepProducts),
+                    row.previewArgs,
+                )
+            }
         }
         return assignToShard(filtered, shardCount, shardIndex)
             .map { arrayOf<Any>(it.entry, it.previewArgs) }
@@ -121,7 +126,8 @@ object PreviewManifestLoader {
         if (shardCount == 1) return rows
 
         val rowsWithCost = rows.map { row ->
-            row to row.entry.captures.sumOf { it.cost.toDouble() }
+            row to row.entry.captures.sumOf { it.cost.toDouble() } +
+                row.entry.dataProducts.sumOf { it.cost.toDouble() }
         }.sortedWith(
             compareByDescending<Pair<PreviewRow, Double>> { it.second }
                 .thenBy { it.first.entry.id },
@@ -160,8 +166,14 @@ object PreviewManifestLoader {
             val newCaptures = entry.captures.map { c ->
                 c.copy(renderOutput = insertBeforeExtension(c.renderOutput, paramSuffix))
             }
+            val newProducts = entry.dataProducts.map { p ->
+                p.copy(output = insertBeforeExtension(p.output, paramSuffix))
+            }
             val newId = entry.id + paramSuffix
-            PreviewRow(entry.copy(id = newId, captures = newCaptures), listOf(value))
+            PreviewRow(
+                entry.copy(id = newId, captures = newCaptures, dataProducts = newProducts),
+                listOf(value),
+            )
         }
         // The renderer is authoritative about which fan-out files will exist
         // for this preview — delete any `<stem>_*<ext>` files from prior runs
@@ -405,6 +417,33 @@ abstract class RobolectricRenderTestBase(
         return File(outputDir, leafName)
     }
 
+    private fun outputFileFor(product: RenderPreviewDataProduct, outputDir: File): File {
+        val rootDir = outputDir.parentFile ?: outputDir
+        return File(rootDir, product.output)
+    }
+
+    private sealed interface RenderJob {
+        val advanceTimeMillis: Long?
+        val scroll: ScrollCapture?
+        val outputFile: File
+    }
+
+    private data class CaptureRenderJob(
+        val capture: RenderPreviewCapture,
+        override val outputFile: File,
+    ) : RenderJob {
+        override val advanceTimeMillis: Long? = capture.advanceTimeMillis
+        override val scroll: ScrollCapture? = capture.scroll
+    }
+
+    private data class ProductRenderJob(
+        val product: RenderPreviewDataProduct,
+        override val outputFile: File,
+    ) : RenderJob {
+        override val advanceTimeMillis: Long? = product.advanceTimeMillis
+        override val scroll: ScrollCapture? = product.scroll
+    }
+
     /**
      * Default render path — paused `mainClock`, pump by [CAPTURE_ADVANCE_MS], capture.
      *
@@ -544,7 +583,8 @@ abstract class RobolectricRenderTestBase(
                 // transient UI stays visible at stitched seams). See
                 // [ScrollCaptureInProgressLocal].
                 val scrollCaptureInProgress =
-                    preview.captures.any { it.scroll?.mode == ScrollMode.LONG }
+                    preview.captures.any { it.scroll?.mode == ScrollMode.LONG } ||
+                        preview.dataProducts.any { it.scroll?.mode == ScrollMode.LONG }
                 val scrollCaptureProvidable =
                     if (scrollCaptureInProgress) ScrollCaptureInProgressLocal.get() else null
                 // Wear-only: flatten `TransformingLazyColumn` item scaling for
@@ -558,7 +598,8 @@ abstract class RobolectricRenderTestBase(
                 // Wear Compose compile dep; on non-Wear modules the lookup
                 // returns null and the flag is a no-op.
                 val reduceMotion =
-                    preview.captures.any { it.scroll?.reduceMotion == true }
+                    preview.captures.any { it.scroll?.reduceMotion == true } ||
+                        preview.dataProducts.any { it.scroll?.reduceMotion == true }
                 val reduceMotionLocal =
                     if (reduceMotion) WearReduceMotionLocal.get() else null
                 // @AnimatedPreview(showCurves = true): capture the slot table
@@ -630,10 +671,20 @@ abstract class RobolectricRenderTestBase(
                 // ascending `advanceTimeMillis`, so we accumulate forward-only.
                 var currentTime = 0L
                 val onRoot = rule.onRoot()
-                preview.captures.forEachIndexed { idx, capture ->
-                    val target = capture.advanceTimeMillis ?: CAPTURE_ADVANCE_MS
+                val jobs =
+                    (
+                        preview.captures.map {
+                            CaptureRenderJob(it, outputFileFor(it, outputDir))
+                        } +
+                            preview.dataProducts.map {
+                                ProductRenderJob(it, outputFileFor(it, outputDir))
+                            }
+                        ).sortedBy { it.advanceTimeMillis ?: CAPTURE_ADVANCE_MS }
+                var captureIndex = 0
+                jobs.forEach { job ->
+                    val target = job.advanceTimeMillis ?: CAPTURE_ADVANCE_MS
                     require(target >= currentTime) {
-                        "Preview ${preview.id}: capture advanceTimeMillis must be ascending " +
+                        "Preview ${preview.id}: output advanceTimeMillis must be ascending " +
                             "(got $target after clock was at $currentTime)"
                     }
                     val delta = target - currentTime
@@ -649,10 +700,10 @@ abstract class RobolectricRenderTestBase(
                     // viewport-height of scroll, then Java2D-stitched into one
                     // tall PNG with an optional Wear pill clip. See
                     // [handleLongCapture].
-                    val outputFile = outputFileFor(capture, outputDir)
+                    val outputFile = job.outputFile
                     outputFile.parentFile?.mkdirs()
 
-                    val scroll = capture.scroll
+                    val scroll = job.scroll
                     val longHandled = scroll != null &&
                         scroll.mode == ScrollMode.LONG &&
                         scroll.axis == ScrollAxis.VERTICAL &&
@@ -691,10 +742,11 @@ abstract class RobolectricRenderTestBase(
                     // `AnimationInspector` to sample property values across
                     // the same time window.
                     val animationHandled = !longHandled && !gifHandled &&
-                        capture.animation != null &&
+                        job is CaptureRenderJob &&
+                        job.capture.animation != null &&
                         handleAnimatedCapture(
                             rule = rule,
-                            animation = capture.animation,
+                            animation = job.capture.animation,
                             previewId = preview.id,
                             isRound = isRoundDevice(params.device) &&
                                 (params.showSystemUi || params.kind == PreviewKind.TILE),
@@ -705,7 +757,7 @@ abstract class RobolectricRenderTestBase(
                             // by the animation pass — keep our local marker in
                             // sync so any subsequent capture in the same
                             // composition asserts ascending time correctly.
-                            if (handled) currentTime += capture.animation.durationMs.toLong()
+                            if (handled) currentTime += job.capture.animation.durationMs.toLong()
                         }
 
                     if (!longHandled && !gifHandled && !animationHandled) {
@@ -748,7 +800,11 @@ abstract class RobolectricRenderTestBase(
                         )
                     }
 
-                    if (a11yEnabled && idx == a11yCaptureIndex()) {
+                    if (
+                        job is CaptureRenderJob &&
+                            a11yEnabled &&
+                            captureIndex == a11yCaptureIndex()
+                    ) {
                         // `fetchSemanticsNode().root as ViewRootForTest` is the
                         // exact view roborazzi-accessibility-check's
                         // `checkRoboAccessibility` walks — it's the only view
@@ -775,6 +831,7 @@ abstract class RobolectricRenderTestBase(
                                     preview.params.kind == PreviewKind.TILE),
                         )
                     }
+                    if (job is CaptureRenderJob) captureIndex++
                 }
             }
         }

--- a/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderShardTest.kt
+++ b/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/PreviewManifestLoaderShardTest.kt
@@ -30,8 +30,29 @@ class PreviewManifestLoaderShardTest {
         return PreviewRow(entry, emptyList())
     }
 
+    private fun productRow(id: String, cost: Float): PreviewRow {
+        val entry = RenderPreviewEntry(
+            id = id,
+            functionName = id,
+            className = "com.example.PreviewsKt",
+            captures = listOf(RenderPreviewCapture(renderOutput = "renders/$id.png", cost = 1f)),
+            dataProducts =
+                listOf(
+                    RenderPreviewDataProduct(
+                        kind = "render/scroll/long",
+                        output = "data/render-scroll-long/$id.png",
+                        cost = cost,
+                    )
+                ),
+        )
+        return PreviewRow(entry, emptyList())
+    }
+
     private fun loadOf(rows: List<PreviewRow>): Double =
-        rows.sumOf { it.entry.captures.sumOf { c -> c.cost.toDouble() } }
+        rows.sumOf { row ->
+            row.entry.captures.sumOf { c -> c.cost.toDouble() } +
+                row.entry.dataProducts.sumOf { p -> p.cost.toDouble() }
+        }
 
     @Test
     fun `shardCount of 1 returns every row regardless of cost ordering`() {
@@ -122,6 +143,16 @@ class PreviewManifestLoaderShardTest {
         assertTrue(
             "expected the 50-cost row on shard 0; got ${shard0.map { it.entry.id }}",
             shard0.any { it.entry.id == "anim" },
+        )
+    }
+
+    @Test
+    fun `data product cost participates in shard assignment`() {
+        val rows = listOf(productRow("long", 40f), row("static", 1f))
+        val shard0 = assignToShard(rows, shardCount = 2, shardIndex = 0)
+        assertTrue(
+            "expected the heavy data-product row on shard 0; got ${shard0.map { it.entry.id }}",
+            shard0.any { it.entry.id == "long" },
         )
     }
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1859,15 +1859,17 @@ function sendModuleList() {
 }
 
 /**
- * Modules where the most recent render was `tier='fast'` — heavy captures
- * (LONG / GIF / animated) are stale on disk relative to the user's source.
+ * Modules where the most recent render was `tier='fast'` — heavy outputs
+ * (animated captures and heavy data products such as LONG / GIF scroll products)
+ * are stale on disk relative to the user's source.
  * The webview reads this to decorate heavy cards with a "stale, click to
  * refresh" badge. Cleared per module on a successful `tier='full'` render.
  */
 const fastTierModules = new Set<string>();
 
 function hasHeavyCapture(preview: PreviewInfo): boolean {
-    return preview.captures.some(c => (c.cost ?? 1) > HEAVY_COST_THRESHOLD);
+    return preview.captures.some(c => (c.cost ?? 1) > HEAVY_COST_THRESHOLD)
+        || (preview.dataProducts ?? []).some(p => (p.cost ?? 1) > HEAVY_COST_THRESHOLD);
 }
 
 function optInHeavyRefresh(moduleId: string, previewId: string): void {

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -41,8 +41,8 @@ export interface ScrollCapture {
 }
 
 /**
- * Threshold above which a capture's `cost` is considered "heavy" — dropped
- * from `composePreview.tier=fast` renders, surfaces in VS Code with a
+ * Threshold above which an output's `cost` is considered "heavy" — dropped
+ * from `composePreview.tier=fast` renders, surfaced in VS Code with a
  * stale-state badge, refreshed only on explicit user action. Mirrors the
  * plugin's `HEAVY_COST_THRESHOLD` in `PreviewData.kt`.
  */
@@ -74,6 +74,16 @@ export interface Capture {
     cost?: number;
 }
 
+export interface PreviewDataProduct {
+    /** Data-product kind, for example `render/scroll/long`. */
+    kind: string;
+    advanceTimeMillis: number | null;
+    scroll: ScrollCapture | null;
+    /** Module-relative product file path under `build/compose-previews`. */
+    output: string;
+    cost?: number;
+}
+
 export interface PreviewInfo {
     id: string;
     functionName: string;
@@ -82,6 +92,8 @@ export interface PreviewInfo {
     params: PreviewParams;
     /** Rendered snapshots — always at least one. Length > 1 ⇔ carousel. */
     captures: Capture[];
+    /** Annotation-sourced data products, such as long and scrolling screenshots. */
+    dataProducts?: PreviewDataProduct[];
     /**
      * Populated by the extension from the sidecar accessibility.json referenced
      * in [PreviewManifest.accessibilityReport]. `null`/`undefined` means
@@ -296,7 +308,7 @@ export type ExtensionToWebview =
           previews: PreviewInfo[];
           moduleDir: string;
           /**
-           * IDs of previews whose heavy captures (LONG / GIF / animated)
+           * IDs of previews whose heavy outputs (animated captures, LONG / GIF data products)
            * were skipped this render — the on-disk PNG/GIF is from a
            * previous full run. Drives the "stale, click to refresh" badge.
            * Empty when the module was last rendered with `tier=full`.


### PR DESCRIPTION
## Summary
- map @ScrollingPreview LONG/GIF modes to annotation-sourced data product specs instead of primary captures
- render scroll data products under build/compose-previews/data while keeping TOP/END as normal captures
- include data-product cost in renderer sharding and VS Code heavy-output stale detection

## Tests
- ./gradlew :gradle-plugin:compileKotlin :renderer-android:compileDebugKotlin :gradle-plugin:test --tests ee.schimke.composeai.plugin.PreviewDataTest :renderer-android:testDebugUnitTest --tests ee.schimke.composeai.renderer.PreviewManifestLoaderShardTest

Note: npm run compile in vscode-extension is blocked in this workspace because node_modules is missing @types/mocha and @types/node.