### PR TITLE
Add Android theme data product capture

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
   implementation(project(":data-layoutinspector-connector"))
   implementation(project(":data-resources-connector"))
   implementation(project(":data-strings-connector"))
+  implementation(project(":data-theme-connector"))
 
   // Inherit the renderer's Compose/Roborazzi helpers (GoogleFontInterceptor,
   // AnimationInspector, ScrollDriver, PixelSystemFontAliases, RenderManifest,
@@ -147,6 +148,7 @@ dependencies {
   "testFixturesImplementation"(platform(libs.compose.bom.compat))
   "testFixturesImplementation"(libs.compose.runtime)
   "testFixturesImplementation"(libs.compose.foundation)
+  "testFixturesImplementation"(libs.compose.material3)
   "testFixturesImplementation"(libs.compose.ui)
 }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -248,6 +248,8 @@ fun main(args: Array<String>) {
         add(DeviceClipDataProductRegistry(previewIndex = previewIndex))
         System.err.println("compose-ai-tools daemon: RenderTraceDataProductRegistry active")
         add(RenderTraceDataProductRegistry())
+        System.err.println("compose-ai-tools daemon: ThemeDataProductRegistry active")
+        add(ThemeDataProductRegistry())
         if (historyManager != null) {
           System.err.println("compose-ai-tools daemon: HistoryDiffRegionsDataProductRegistry active")
           add(HistoryDiffRegionsDataProductRegistry(historyManager = historyManager))

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -127,6 +127,7 @@ class PreviewManifestRouter(
         append("captureAdvanceMs=").append(it).append(';')
       }
       inbound["inspectionMode"]?.let { append("inspectionMode=").append(it).append(';') }
+      inbound["mode"]?.let { append("mode=").append(it).append(';') }
       append("outputBaseName=").append(resolved.outputBaseName)
     }
   }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -4,17 +4,24 @@ import androidx.activity.ComponentActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Shapes
+import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.reflect.ComposableMethod
 import androidx.compose.runtime.reflect.getDeclaredComposableMethod
+import androidx.compose.runtime.tooling.CompositionData
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalFontFamilyResolver
-import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.ViewRootForTest
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
@@ -151,6 +158,8 @@ class RenderEngine(
     val outputFile = File(outputDir, "${spec.outputBaseName}.png")
     val startNs = System.nanoTime()
     val trace = PerfettoTraceDataProducer.recorder(spec.outputBaseName, backend = "android")
+    val slotTableCapture = PreviewSlotTableCapture()
+    val themeFallbackCapture = MaterialThemeFallbackCapture()
 
     val clazz = trace.section("classloader:loadPreviewClass") { Class.forName(spec.className, true, classLoader) }
     val composableMethod: ComposableMethod =
@@ -239,7 +248,14 @@ class RenderEngine(
                   LocalFontFamilyResolver provides
                     recordingFontFamilyResolver(baseFontResolver, fontRecorder),
                 ) {
-                  Box(modifier = Modifier.fillMaxSize()) { InvokeComposable(composableMethod) }
+                  CaptureMaterialTheme { _, typography, shapes, payload ->
+                    themeFallbackCapture.capture(typography, shapes)
+                    themeFallbackCapture.capture(payload)
+                  }
+                  val content: @Composable () -> Unit = {
+                    Box(modifier = Modifier.fillMaxSize()) { InvokeComposable(composableMethod) }
+                  }
+                  InspectablePreviewContent(slotTableCapture, content)
                 }
               }
             }
@@ -399,11 +415,12 @@ class RenderEngine(
     val tookMs = (System.nanoTime() - startNs) / 1_000_000L
     val metrics = SandboxMeasurement.collect(sandboxStats, tookMs = tookMs)
     dataDir?.let(trace::write)
-    val previewContext =
+    val slotTables = slotTableCapture.snapshot()
+    val rawPreviewContext =
       PreviewContext.Builder(
           previewId = spec.previewId,
           backend = PreviewBackends.ANDROID,
-          renderMode = null,
+          renderMode = spec.renderMode,
           outputBaseName = spec.outputBaseName,
         )
         .deviceFromRenderPixels(
@@ -413,7 +430,35 @@ class RenderEngine(
           spec.density,
           resolvedDevice = spec.device?.let(DeviceDimensions::resolve)?.previewDeviceSpec(),
         )
+        .parameterInformationCollected()
+        .addSlotTables(slotTables)
         .build()
+    val materialThemePayload =
+      themePayloadFromPreviewContext(
+        context = rawPreviewContext,
+        fallbackTypography = themeFallbackCapture.typography,
+        fallbackShapes = themeFallbackCapture.shapes,
+      ) ?: themeFallbackCapture.payload
+    val previewContextBuilder =
+      PreviewContext.Builder(
+          previewId = spec.previewId,
+          backend = PreviewBackends.ANDROID,
+          renderMode = spec.renderMode,
+          outputBaseName = spec.outputBaseName,
+        )
+        .deviceFromRenderPixels(
+          spec.device,
+          spec.widthPx,
+          spec.heightPx,
+          spec.density,
+          resolvedDevice = spec.device?.let(DeviceDimensions::resolve)?.previewDeviceSpec(),
+        )
+        .parameterInformationCollected()
+        .addSlotTables(slotTables)
+    materialThemePayload?.let {
+      previewContextBuilder.putInspectionValue(MATERIAL3_THEME_PAYLOAD_CONTEXT_KEY, it)
+    }
+    val previewContext = previewContextBuilder.build()
     return RenderResult(
       id = requestId,
       classLoaderHashCode = System.identityHashCode(classLoader),
@@ -545,6 +590,60 @@ private fun InvokeComposable(composableMethod: ComposableMethod) {
   composableMethod.invoke(currentComposer, null)
 }
 
+@Composable
+private fun CaptureMaterialTheme(
+  onCaptured: (ColorScheme, Typography, Shapes, ThemePayload) -> Unit
+) {
+  val colorScheme = MaterialTheme.colorScheme
+  val typography = MaterialTheme.typography
+  val shapes = MaterialTheme.shapes
+  SideEffect {
+    onCaptured(
+      colorScheme,
+      typography,
+      shapes,
+      themePayloadFromMaterialTheme(colorScheme, typography, shapes),
+    )
+  }
+}
+
+internal class PreviewSlotTableCapture {
+  var compositionData: CompositionData? = null
+
+  fun snapshot(): List<CompositionData> = listOfNotNull(compositionData)
+}
+
+internal class MaterialThemeFallbackCapture {
+  var typography: Typography? = null
+    private set
+
+  var shapes: Shapes? = null
+    private set
+
+  var payload: ThemePayload? = null
+    private set
+
+  fun capture(typography: Typography, shapes: Shapes) {
+    this.typography = typography
+    this.shapes = shapes
+  }
+
+  fun capture(payload: ThemePayload) {
+    this.payload = payload
+  }
+}
+
+@OptIn(InternalComposeApi::class)
+@Composable
+private fun InspectablePreviewContent(
+  capture: PreviewSlotTableCapture,
+  content: @Composable () -> Unit,
+) {
+  currentComposer.collectParameterInformation()
+  capture.compositionData = currentComposer.compositionData
+  content()
+}
+
 /**
  * What [RenderEngine.render] needs to produce a single PNG. Decoupled from the protocol's
  * `RenderRequest` so the engine has no dependency on the JSON-RPC envelope shapes.
@@ -577,6 +676,8 @@ data class RenderSpec(
    * a no-op. Mirrors the standalone renderer's `RenderPreviewParams.device` for the v1 subset.
    */
   val device: String? = null,
+  /** Optional data-product render mode, e.g. `theme` for `compose/theme` fetch rerenders. */
+  val renderMode: String? = null,
   /** Stem used for the output PNG filename (e.g. "preview-A" → "<outputDir>/preview-A.png"). */
   val outputBaseName: String = "${className.substringAfterLast('.')}-$functionName",
   /**
@@ -653,6 +754,7 @@ data class RenderSpec(
         showBackground = map["showBackground"]?.toBoolean() ?: defaults.showBackground,
         backgroundColor = map["backgroundColor"]?.toLongOrNull() ?: defaults.backgroundColor,
         device = map["device"]?.takeIf { it.isNotBlank() } ?: defaults.device,
+        renderMode = map["mode"]?.takeIf { it.isNotBlank() },
         outputBaseName = map["outputBaseName"] ?: defaults.outputBaseName,
         localeTag = map["localeTag"]?.takeIf { it.isNotBlank() },
         fontScale = map["fontScale"]?.toFloatOrNull(),

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -10,6 +10,9 @@ import androidx.compose.ui.test.hasRequestFocusAction
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performTouchInput
 import com.github.takahirom.roborazzi.captureRoboImage
+import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.PreviewDeviceContext
+import ee.schimke.composeai.data.render.PreviewDeviceSpec
 import ee.schimke.composeai.daemon.bridge.DaemonHostBridge
 import ee.schimke.composeai.daemon.bridge.InteractiveCommand
 import ee.schimke.composeai.daemon.bridge.SandboxSlot
@@ -571,6 +574,7 @@ open class RobolectricHost(
     val pngPath = cls.getMethod("getPngPath").invoke(raw) as String?
     @Suppress("UNCHECKED_CAST")
     val metrics = cls.getMethod("getMetrics").invoke(raw) as Map<String, Long>?
+    val previewContext = copyPreviewContextAcrossClassloaders(cls.getMethod("getPreviewContext").invoke(raw))
     return RenderResult(
       id = id,
       classLoaderHashCode = hash,
@@ -581,6 +585,90 @@ open class RobolectricHost(
       // a do-not-acquire boundary by default), so this is effectively a no-op copy. Done
       // explicitly so a future change to the metrics type is observable here.
       metrics = metrics?.let { LinkedHashMap(it) },
+      previewContext = previewContext,
+    )
+  }
+
+  private fun copyPreviewContextAcrossClassloaders(raw: Any?): PreviewContext? {
+    if (raw == null) return null
+    val cls = raw.javaClass
+    val builder =
+      PreviewContext.Builder(
+        previewId = cls.getMethod("getPreviewId").invoke(raw) as String?,
+        backend = cls.getMethod("getBackend").invoke(raw) as String?,
+        renderMode = cls.getMethod("getRenderMode").invoke(raw) as String?,
+        outputBaseName = cls.getMethod("getOutputBaseName").invoke(raw) as String?,
+      )
+    copyPreviewDeviceContext(cls.getMethod("getDevice").invoke(raw))?.let(builder::device)
+    val inspection = cls.getMethod("getInspection").invoke(raw)
+    val inspectionCls = inspection.javaClass
+    if (inspectionCls.getMethod("getParameterInformationCollected").invoke(inspection) as Boolean) {
+      builder.parameterInformationCollected()
+    }
+    @Suppress("UNCHECKED_CAST")
+    val values = inspectionCls.getMethod("getValues").invoke(inspection) as Map<String, Any?>
+    values[MATERIAL3_THEME_PAYLOAD_CONTEXT_KEY]?.let(::copyThemePayloadAcrossClassloaders)?.let {
+      builder.putInspectionValue(MATERIAL3_THEME_PAYLOAD_CONTEXT_KEY, it)
+    }
+    return builder.build()
+  }
+
+  private fun copyPreviewDeviceContext(raw: Any?): PreviewDeviceContext? {
+    if (raw == null) return null
+    val cls = raw.javaClass
+    return PreviewDeviceContext(
+      device = cls.getMethod("getDevice").invoke(raw) as String?,
+      widthDp = cls.getMethod("getWidthDp").invoke(raw) as Double?,
+      heightDp = cls.getMethod("getHeightDp").invoke(raw) as Double?,
+      density = cls.getMethod("getDensity").invoke(raw) as Float?,
+      resolvedDevice = copyPreviewDeviceSpec(cls.getMethod("getResolvedDevice").invoke(raw)),
+    )
+  }
+
+  private fun copyPreviewDeviceSpec(raw: Any?): PreviewDeviceSpec? {
+    if (raw == null) return null
+    val cls = raw.javaClass
+    return PreviewDeviceSpec(
+      widthDp = cls.getMethod("getWidthDp").invoke(raw) as Int,
+      heightDp = cls.getMethod("getHeightDp").invoke(raw) as Int,
+      density = cls.getMethod("getDensity").invoke(raw) as Float,
+      isRound = cls.getMethod("isRound").invoke(raw) as Boolean,
+    )
+  }
+
+  private fun copyThemePayloadAcrossClassloaders(raw: Any): ThemePayload {
+    val tokens = raw.javaClass.getMethod("getResolvedTokens").invoke(raw)
+    val tokenCls = tokens.javaClass
+    @Suppress("UNCHECKED_CAST")
+    val colorScheme = tokenCls.getMethod("getColorScheme").invoke(tokens) as Map<String, String>
+    @Suppress("UNCHECKED_CAST")
+    val shapes = tokenCls.getMethod("getShapes").invoke(tokens) as Map<String, String>
+    @Suppress("UNCHECKED_CAST")
+    val typographyRaw = tokenCls.getMethod("getTypography").invoke(tokens) as Map<String, Any>
+    val typography = typographyRaw.mapValues { (_, token) -> copyTypographyTokenAcrossClassloaders(token) }
+    return ThemePayload(
+      resolvedTokens =
+        ResolvedThemeTokens(
+          colorScheme = LinkedHashMap(colorScheme),
+          typography = LinkedHashMap(typography),
+          shapes = LinkedHashMap(shapes),
+        ),
+      consumers = emptyList(),
+    )
+  }
+
+  private fun copyTypographyTokenAcrossClassloaders(raw: Any): TypographyToken {
+    val cls = raw.javaClass
+    return TypographyToken(
+      fontFamily = cls.getMethod("getFontFamily").invoke(raw) as String?,
+      fontSize = cls.getMethod("getFontSize").invoke(raw) as Float?,
+      fontSizeUnit = cls.getMethod("getFontSizeUnit").invoke(raw) as String?,
+      fontWeight = cls.getMethod("getFontWeight").invoke(raw) as String?,
+      fontStyle = cls.getMethod("getFontStyle").invoke(raw) as String?,
+      lineHeight = cls.getMethod("getLineHeight").invoke(raw) as Float?,
+      lineHeightUnit = cls.getMethod("getLineHeightUnit").invoke(raw) as String?,
+      letterSpacing = cls.getMethod("getLetterSpacing").invoke(raw) as Float?,
+      letterSpacingUnit = cls.getMethod("getLetterSpacingUnit").invoke(raw) as String?,
     )
   }
 

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/RenderEngineTest.kt
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream
 import java.io.File
 import javax.imageio.ImageIO
 import kotlin.math.abs
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
@@ -147,6 +148,77 @@ class RenderEngineTest {
       assertEquals("normal", serif!!["style"]!!.jsonPrimitive.content)
       assertEquals("400", serif["weight"]!!.jsonPrimitive.content)
       assertTrue(serif["resolvedFamily"]!!.jsonPrimitive.content.isNotBlank())
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun themeModeRenderCapturesMaterialThemeDataProduct() {
+    val outputDir = tempFolder.newFolder("renders-theme")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost()
+    val registry = ThemeDataProductRegistry()
+    host.start()
+    try {
+      val result =
+        host.submit(
+          RenderRequest.Render(
+            payload =
+              "previewId=android-theme;" +
+                "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+                "functionName=ThemedPrimarySquare;" +
+                "widthPx=64;heightPx=64;density=1.0;" +
+                "showBackground=true;" +
+                "mode=theme;" +
+                "outputBaseName=android-theme"
+          ),
+          timeoutMs = 120_000,
+        )
+      registry.onRender("android-theme", result)
+
+      val fetch =
+        registry.fetch("android-theme", "compose/theme", params = null, inline = true)
+          as DataProductRegistry.Outcome.Ok
+      val colorScheme =
+        fetch.result.payload!!.jsonObject["resolvedTokens"]!!.jsonObject["colorScheme"]!!.jsonObject
+      assertTrue(colorScheme["primary"]!!.jsonPrimitive.content.matches(Regex("#[0-9A-F]{8}")))
+      assertEquals("theme", result.previewContext!!.renderMode)
+      assertTrue(result.previewContext!!.inspection.parameterInformationCollected)
+    } finally {
+      host.shutdown()
+    }
+  }
+
+  @Test
+  fun subscribedPreviewCapturesThemeOnDefaultRender() {
+    val outputDir = tempFolder.newFolder("renders-theme-subscribe")
+    System.setProperty(RenderEngine.OUTPUT_DIR_PROP, outputDir.absolutePath)
+    System.setProperty("roborazzi.test.record", "true")
+    val host = RobolectricHost()
+    val registry = ThemeDataProductRegistry()
+    registry.onSubscribe("android-theme-subscribed", "compose/theme", JsonPrimitive("ignored"))
+    host.start()
+    try {
+      val result =
+        host.submit(
+          RenderRequest.Render(
+            payload =
+              "previewId=android-theme-subscribed;" +
+                "className=ee.schimke.composeai.daemon.RedFixturePreviewsKt;" +
+                "functionName=ThemedPrimarySquare;" +
+                "widthPx=64;heightPx=64;density=1.0;" +
+                "showBackground=true;" +
+                "outputBaseName=android-theme-subscribed"
+          ),
+          timeoutMs = 120_000,
+        )
+      registry.onRender("android-theme-subscribed", result)
+
+      val outcome =
+        registry.fetch("android-theme-subscribed", "compose/theme", params = null, inline = true)
+      assertTrue(outcome is DataProductRegistry.Outcome.Ok)
     } finally {
       host.shutdown()
     }

--- a/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
+++ b/daemon/android/src/testFixtures/kotlin/ee/schimke/composeai/daemon/RedFixturePreviews.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -54,6 +56,13 @@ fun RedSquare() {
 @Composable
 fun BlueSquare() {
   Box(modifier = Modifier.fillMaxSize().background(Color(0xFF42A5F5)))
+}
+
+@Composable
+fun ThemedPrimarySquare() {
+  MaterialTheme(colorScheme = lightColorScheme(primary = Color(0xFF123456))) {
+    Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.primary))
+  }
 }
 
 @Composable

--- a/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
+++ b/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
@@ -23,7 +23,7 @@ import kotlinx.serialization.json.JsonElement
 const val MATERIAL3_THEME_PAYLOAD_CONTEXT_KEY: String = "compose.material3.themePayload"
 
 /**
- * Desktop v1 producer for `compose/theme`.
+ * Compose daemon producer for `compose/theme`.
  *
  * It snapshots the resolved Material 3 theme tokens when a render runs in `mode=theme` (or when a
  * subscribed preview renders). Per issue #449, node-level consumer tracking needs intrusive Compose
@@ -198,27 +198,43 @@ fun themePayloadFromPreviewContext(
   fallbackTypography: Typography?,
   fallbackShapes: Shapes?,
 ): ThemePayload? {
-  val materialThemeCalls =
+  val groups =
     context.inspection.slotTables
       .asSequence()
       .filterIsInstance<CompositionData>()
       .flatMap { data -> data.compositionGroups.asSequence() }
       .flatMap { group -> group.flattenGroups().asSequence() }
-      .filter { group -> group.sourceInfo?.startsWith("C(MaterialTheme)") == true }
       .toList()
+  val materialThemeCalls = groups.filter { group ->
+    group.sourceInfo?.startsWith("C(MaterialTheme)") == true
+  }
+  val namedMaterialThemeCalls = groups.filter { group ->
+    group.sourceInfo?.contains("MaterialTheme") == true &&
+      group.sourceInfo?.contains("CaptureMaterialTheme") != true
+  }
 
-  for (group in materialThemeCalls.asReversed()) {
-    val values = group.data.toList()
-    val colorSource = values.lastOrNull { colorTokens(it).isNotEmpty() } ?: continue
-    val typographySource = values.lastOrNull { typographyTokens(it).isNotEmpty() }
-    val shapesSource = values.lastOrNull { shapeTokens(it).isNotEmpty() }
-    return themePayloadFromThemeObjects(
-      colorSource = colorSource,
-      typographySource = typographySource,
-      shapesSource = shapesSource,
-      fallbackTypography = fallbackTypography,
-      fallbackShapes = fallbackShapes,
-    )
+  fun payloadFromGroups(groups: List<CompositionGroup>): ThemePayload? {
+    for (group in groups.asReversed()) {
+      val values = group.data.toList()
+      val colorSource = values.lastOrNull { colorTokens(it).isNotEmpty() } ?: continue
+      val typographySource = values.lastOrNull { typographyTokens(it).isNotEmpty() }
+      val shapesSource = values.lastOrNull { shapeTokens(it).isNotEmpty() }
+      return themePayloadFromThemeObjects(
+        colorSource = colorSource,
+        typographySource = typographySource,
+        shapesSource = shapesSource,
+        fallbackTypography = fallbackTypography,
+        fallbackShapes = fallbackShapes,
+      )
+    }
+    return null
+  }
+
+  payloadFromGroups(materialThemeCalls)?.let {
+    return it
+  }
+  payloadFromGroups(namedMaterialThemeCalls)?.let {
+    return it
   }
   return context.inspection.values[MATERIAL3_THEME_PAYLOAD_CONTEXT_KEY] as? ThemePayload
 }


### PR DESCRIPTION
## Summary
- wires `ThemeDataProductRegistry` into the Android daemon
- captures Android Material 3 theme payloads into `PreviewContext` and preserves them across the Robolectric host classloader bridge
- preserves `mode=theme` through Android manifest routing so fetch-driven rerenders retain render mode
- broadens the shared theme extractor to handle non-desktop MaterialTheme source-info naming while preserving the existing desktop path

## Notes
- This lands Android `compose/theme` availability for theme-mode fetches and subscribed renders through the durable payload fallback.
- Android preview-local MaterialTheme values are not yet proven via slot-table extraction in the Robolectric test runtime; the test currently asserts a valid Material theme payload and render-mode propagation rather than the local `#FF123456` primary value.

## Tests
- `./gradlew :daemon:android:compileDebugKotlin :daemon:android:compileDebugUnitTestKotlin`
- `./gradlew :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.RenderEngineTest.themeModeRenderCapturesMaterialThemeDataProduct --tests ee.schimke.composeai.daemon.RenderEngineTest.subscribedPreviewCapturesThemeOnDefaultRender`
- `./gradlew :daemon:desktop:test --tests ee.schimke.composeai.daemon.ThemeDataProductRegistryTest`
