### PR TITLE
Improve focus inspector usability

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -376,9 +376,9 @@ body {
 }
 
 .focus-inspector {
-    display: grid;
-    grid-template-columns: minmax(150px, 0.8fr) minmax(240px, 1.6fr) minmax(150px, 0.8fr);
-    gap: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
     padding: 0 8px 8px;
 }
 
@@ -403,6 +403,29 @@ body {
     font-size: calc(var(--vscode-font-size) - 2px);
     font-weight: 600;
     text-transform: uppercase;
+}
+
+.focus-panel-header::-webkit-details-marker,
+.focus-product-summary::-webkit-details-marker {
+    display: none;
+}
+
+.focus-history-summary {
+    cursor: pointer;
+    border-bottom: none;
+}
+
+.focus-history-panel[open] .focus-history-summary {
+    border-bottom: 1px solid var(--card-border);
+}
+
+.focus-summary-chevron {
+    margin-left: auto;
+}
+
+.focus-product-picker[open] .focus-summary-chevron,
+.focus-history-panel[open] .focus-summary-chevron {
+    transform: rotate(180deg);
 }
 
 .focus-actions {
@@ -435,15 +458,43 @@ body {
     outline-offset: -1px;
 }
 
-.focus-product-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-    gap: 4px;
+.focus-product-picker {
     padding: 8px;
+    position: relative;
 }
 
-.focus-product-chip {
+.focus-product-summary {
     display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: var(--control-height);
+    padding: 2px 8px;
+    border: 1px solid var(--card-border);
+    border-radius: 3px;
+    background: var(--vscode-dropdown-background);
+    color: var(--vscode-dropdown-foreground);
+    cursor: pointer;
+}
+
+.focus-product-summary:hover {
+    background: var(--toolbar-hover);
+}
+
+.focus-product-summary:focus-visible {
+    outline: 1px solid var(--vscode-focusBorder);
+    outline-offset: -1px;
+}
+
+.focus-product-menu {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(136px, 1fr));
+    gap: 4px;
+    margin-top: 6px;
+}
+
+.focus-product-option {
+    display: grid;
+    grid-template-columns: auto auto minmax(0, 1fr);
     align-items: center;
     gap: 6px;
     min-width: 0;
@@ -452,39 +503,41 @@ body {
     border-radius: 3px;
     background: color-mix(in srgb, var(--text-secondary) 6%, transparent);
     color: inherit;
-    font: inherit;
-    text-align: left;
     cursor: pointer;
 }
 
-.focus-product-chip:hover,
-.focus-product-chip[aria-pressed="true"] {
+.focus-product-option:hover,
+.focus-product-option:has(input:checked) {
     background: var(--toolbar-hover);
 }
 
-.focus-product-chip:focus-visible {
+.focus-product-option:focus-within {
     outline: 1px solid var(--vscode-focusBorder);
     outline-offset: -1px;
 }
 
-.focus-product-chip[data-state="ok"] {
+.focus-product-option[data-state="ok"] {
     border-color: color-mix(in srgb, var(--vscode-charts-green, #89d185) 45%, var(--card-border));
 }
 
-.focus-product-chip[data-state="warn"] {
+.focus-product-option[data-state="warn"] {
     border-color: color-mix(in srgb, var(--vscode-editorWarning-foreground, #cca700) 55%, var(--card-border));
 }
 
-.focus-product-chip > .codicon {
+.focus-product-option > input {
+    margin: 0;
+}
+
+.focus-product-option > .codicon {
     flex: 0 0 auto;
     color: var(--text-secondary);
 }
 
-.focus-product-chip[data-state="ok"] > .codicon {
+.focus-product-option[data-state="ok"] > .codicon {
     color: var(--vscode-charts-green, #89d185);
 }
 
-.focus-product-chip[data-state="warn"] > .codicon {
+.focus-product-option[data-state="warn"] > .codicon {
     color: var(--vscode-editorWarning-foreground, #cca700);
 }
 
@@ -514,15 +567,15 @@ body {
 }
 
 .focus-placeholder-list {
-    grid-column: 1 / -1;
-}
-
-.focus-placeholder-list .focus-panel-header {
-    border-bottom: none;
+    border-top: 1px solid var(--card-border);
 }
 
 .focus-placeholder {
-    border-top: 1px solid var(--card-border);
+    border-top: 1px solid color-mix(in srgb, var(--card-border) 70%, transparent);
+}
+
+.focus-placeholder:first-child {
+    border-top: none;
 }
 
 .focus-placeholder > summary {
@@ -539,12 +592,6 @@ body {
     padding: 0 8px 8px 22px;
     color: var(--text-secondary);
     font-size: calc(var(--vscode-font-size) - 2px);
-}
-
-@media (max-width: 560px) {
-    .focus-inspector {
-        grid-template-columns: 1fr;
-    }
 }
 
 /* -- Preview card ----------------------------------------------------- */

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -168,6 +168,8 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         // the toggle to the new target.
         let a11yOverlayPreviewId = null;
         const enabledFocusProducts = new Set();
+        let focusProductPickerOpen = false;
+        let focusHistoryOpen = false;
         const focusPosition = document.getElementById('focus-position');
         const progressBar = document.getElementById('progress-bar');
         const progressFill = progressBar.querySelector('.progress-fill');
@@ -1035,71 +1037,50 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             const p = allPreviews.find(pp => pp.id === previewId);
             if (!previewId || !p) return;
 
-            const history = document.createElement('section');
-            history.className = 'focus-panel focus-history-panel';
-            history.appendChild(sectionHeader('history', 'History'));
-            const historyActions = document.createElement('div');
-            historyActions.className = 'focus-actions';
-            historyActions.appendChild(actionButton('git-compare', 'HEAD', 'Diff vs last archived render', () => {
-                requestFocusedDiff('head');
-            }));
-            historyActions.appendChild(actionButton('source-control', 'main', 'Diff vs latest archived main render', () => {
-                requestFocusedDiff('main');
-            }));
-            history.appendChild(historyActions);
-
-            const data = document.createElement('section');
-            data.className = 'focus-panel focus-products-panel';
-            data.appendChild(sectionHeader('layers', 'Data Products'));
-            const products = document.createElement('div');
-            products.className = 'focus-product-grid';
+            const inspect = document.createElement('section');
+            inspect.className = 'focus-panel focus-inspect-panel';
+            inspect.appendChild(sectionHeader('search', 'Inspect'));
             const findings = cardA11yFindings.get(previewId) || p.a11yFindings || [];
             const nodes = cardA11yNodes.get(previewId) || p.a11yNodes || [];
-            products.appendChild(productToggle('eye', 'Accessibility', findings.length > 0
-                ? findings.length + ' finding' + (findings.length === 1 ? '' : 's')
-                : 'Overlay', previewId === a11yOverlayPreviewId, findings.length > 0 ? 'warn' : 'idle',
-                () => toggleA11yOverlay()));
-            products.appendChild(productToggle('list-tree', 'Layout', nodes.length > 0
-                ? nodes.length + ' node' + (nodes.length === 1 ? '' : 's')
-                : 'Overlay', previewId === a11yOverlayPreviewId, nodes.length > 0 ? 'ok' : 'idle',
-                () => toggleA11yOverlay()));
-            products.appendChild(productToggle('symbol-string', 'Strings', 'Section',
-                enabledFocusProducts.has('strings'), 'idle', () => toggleFocusProduct('strings')));
-            products.appendChild(productToggle('file-code', 'Resources', 'Section',
-                enabledFocusProducts.has('resources'), 'idle', () => toggleFocusProduct('resources')));
-            products.appendChild(productToggle('text-size', 'Fonts', 'Section',
-                enabledFocusProducts.has('fonts'), 'idle', () => toggleFocusProduct('fonts')));
-            products.appendChild(productToggle('pulse', 'Render', 'Section',
-                enabledFocusProducts.has('render'), 'idle', () => toggleFocusProduct('render')));
-            products.appendChild(productToggle('symbol-color', 'Theme', 'Section',
-                enabledFocusProducts.has('theme'), 'idle', () => toggleFocusProduct('theme')));
-            products.appendChild(productToggle('sync', 'Recomposition', interactivePreviewIds.has(previewId) ? 'Live' : 'Section',
-                enabledFocusProducts.has('recomposition') || interactivePreviewIds.has(previewId),
-                interactivePreviewIds.has(previewId) ? 'ok' : 'idle',
-                () => toggleFocusProduct('recomposition')));
-            data.appendChild(products);
-
-            const controls = document.createElement('section');
-            controls.className = 'focus-panel focus-controls-panel';
-            controls.appendChild(sectionHeader('settings-gear', 'Tools'));
-            const toolActions = document.createElement('div');
-            toolActions.className = 'focus-actions';
-            toolActions.appendChild(actionButton('eye', 'A11y', 'Toggle accessibility overlay', () => {
-                toggleA11yOverlay();
-            }));
-            toolActions.appendChild(actionButton('device-mobile', 'Device', 'Launch on connected Android device', () => {
-                requestLaunchOnDevice();
-            }));
-            toolActions.appendChild(actionButton('circle-large-outline', 'Live', 'Toggle live preview', () => {
-                toggleInteractive(false);
-            }));
-            controls.appendChild(toolActions);
-
-            focusInspector.appendChild(history);
-            focusInspector.appendChild(data);
-            focusInspector.appendChild(controls);
-            const placeholders = buildFocusPlaceholders(p);
-            if (placeholders) focusInspector.appendChild(placeholders);
+            inspect.appendChild(productPicker([
+                {
+                    icon: 'eye',
+                    label: 'Accessibility',
+                    value: findings.length > 0
+                        ? findings.length + ' finding' + (findings.length === 1 ? '' : 's')
+                        : 'Overlay',
+                    enabled: previewId === a11yOverlayPreviewId,
+                    state: findings.length > 0 ? 'warn' : 'idle',
+                    onToggle: () => toggleA11yOverlay(),
+                },
+                {
+                    icon: 'list-tree',
+                    label: 'Layout',
+                    value: nodes.length > 0
+                        ? nodes.length + ' node' + (nodes.length === 1 ? '' : 's')
+                        : 'Placeholder',
+                    enabled: enabledFocusProducts.has('layout'),
+                    state: nodes.length > 0 ? 'ok' : 'idle',
+                    onToggle: () => toggleFocusProduct('layout'),
+                },
+                productSpec('symbol-string', 'Strings', 'strings'),
+                productSpec('file-code', 'Resources', 'resources'),
+                productSpec('text-size', 'Fonts', 'fonts'),
+                productSpec('pulse', 'Render', 'render'),
+                productSpec('symbol-color', 'Theme', 'theme'),
+                {
+                    icon: 'sync',
+                    label: 'Recomposition',
+                    value: interactivePreviewIds.has(previewId) ? 'Live' : 'Placeholder',
+                    enabled: enabledFocusProducts.has('recomposition') || interactivePreviewIds.has(previewId),
+                    state: interactivePreviewIds.has(previewId) ? 'ok' : 'idle',
+                    onToggle: () => toggleFocusProduct('recomposition'),
+                },
+            ]));
+            const placeholders = buildFocusPlaceholders();
+            if (placeholders) inspect.appendChild(placeholders);
+            focusInspector.appendChild(inspect);
+            focusInspector.appendChild(historyPanel());
         }
 
         function sectionHeader(icon, label) {
@@ -1125,27 +1106,104 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             return btn;
         }
 
-        function productToggle(icon, label, value, enabled, state, onClick) {
-            const chip = document.createElement('button');
-            chip.type = 'button';
-            chip.className = 'focus-product-chip';
-            chip.dataset.state = state || 'idle';
-            chip.setAttribute('aria-pressed', enabled ? 'true' : 'false');
-            chip.title = enabled ? 'Disable ' + label : 'Enable ' + label;
-            chip.innerHTML = '<i class="codicon codicon-' + icon + '" aria-hidden="true"></i>';
+        function historyPanel() {
+            const history = document.createElement('details');
+            history.className = 'focus-panel focus-history-panel';
+            history.open = focusHistoryOpen;
+            history.addEventListener('toggle', () => {
+                focusHistoryOpen = history.open;
+            });
+            const summary = document.createElement('summary');
+            summary.className = 'focus-panel-header focus-history-summary';
+            summary.innerHTML = '<i class="codicon codicon-history" aria-hidden="true"></i>';
+            const label = document.createElement('span');
+            label.textContent = 'History';
+            summary.appendChild(label);
+            const chevron = document.createElement('i');
+            chevron.className = 'codicon codicon-chevron-down focus-summary-chevron';
+            chevron.setAttribute('aria-hidden', 'true');
+            summary.appendChild(chevron);
+            history.appendChild(summary);
+            const historyActions = document.createElement('div');
+            historyActions.className = 'focus-actions';
+            historyActions.appendChild(actionButton('git-compare', 'HEAD', 'Diff vs last archived render', () => {
+                requestFocusedDiff('head');
+            }));
+            historyActions.appendChild(actionButton('source-control', 'main', 'Diff vs latest archived main render', () => {
+                requestFocusedDiff('main');
+            }));
+            history.appendChild(historyActions);
+            return history;
+        }
+
+        function productSpec(icon, label, id) {
+            return {
+                icon,
+                label,
+                value: 'Placeholder',
+                enabled: enabledFocusProducts.has(id),
+                state: 'idle',
+                onToggle: () => toggleFocusProduct(id),
+            };
+        }
+
+        function productPicker(products) {
+            const picker = document.createElement('details');
+            picker.className = 'focus-product-picker';
+            picker.open = focusProductPickerOpen;
+            picker.addEventListener('toggle', () => {
+                focusProductPickerOpen = picker.open;
+            });
+            const summary = document.createElement('summary');
+            summary.className = 'focus-product-summary';
+            const selected = products.filter(product => product.enabled);
+            const summaryText = document.createElement('span');
+            summaryText.textContent = selected.length === 0
+                ? 'Choose inspection layers'
+                : selected.length === 1
+                    ? selected[0].label
+                    : selected.length + ' layers selected';
+            summary.appendChild(summaryText);
+            const chevron = document.createElement('i');
+            chevron.className = 'codicon codicon-chevron-down focus-summary-chevron';
+            chevron.setAttribute('aria-hidden', 'true');
+            summary.appendChild(chevron);
+            picker.appendChild(summary);
+
+            const menu = document.createElement('div');
+            menu.className = 'focus-product-menu';
+            products.forEach(product => {
+                menu.appendChild(productOption(product));
+            });
+            picker.appendChild(menu);
+            return picker;
+        }
+
+        function productOption(product) {
+            const option = document.createElement('label');
+            option.className = 'focus-product-option';
+            option.dataset.state = product.state || 'idle';
+            const input = document.createElement('input');
+            input.type = 'checkbox';
+            input.checked = product.enabled;
+            input.addEventListener('change', product.onToggle);
+            option.appendChild(input);
+            const icon = document.createElement('i');
+            icon.className = 'codicon codicon-' + product.icon;
+            icon.setAttribute('aria-hidden', 'true');
+            option.appendChild(icon);
             const text = document.createElement('div');
             text.className = 'focus-product-text';
             const name = document.createElement('span');
             name.className = 'focus-product-name';
-            name.textContent = label;
+            name.textContent = product.label;
             const val = document.createElement('span');
             val.className = 'focus-product-value';
-            val.textContent = value;
+            val.textContent = product.value;
             text.appendChild(name);
             text.appendChild(val);
-            chip.appendChild(text);
-            chip.addEventListener('click', onClick);
-            return chip;
+            option.appendChild(text);
+            return option;
         }
 
         function toggleFocusProduct(id) {
@@ -1158,8 +1216,9 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             if (layoutMode.value === 'focus' && card) renderFocusInspector(card);
         }
 
-        function buildFocusPlaceholders(p) {
+        function buildFocusPlaceholders() {
             const defs = [
+                ['layout', 'Layout', 'layout tree and bounds'],
                 ['strings', 'Strings', 'text/strings and i18n/translations'],
                 ['resources', 'Resources', 'resources/used'],
                 ['fonts', 'Fonts', 'fonts/used'],
@@ -1168,9 +1227,8 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 ['recomposition', 'Recomposition', 'compose/recomposition'],
             ].filter(([id]) => enabledFocusProducts.has(id));
             if (defs.length === 0) return null;
-            const wrapper = document.createElement('section');
-            wrapper.className = 'focus-panel focus-placeholder-list';
-            wrapper.appendChild(sectionHeader('panel', 'Enabled'));
+            const wrapper = document.createElement('div');
+            wrapper.className = 'focus-placeholder-list';
             defs.forEach(([id, label, kind]) => {
                 const details = document.createElement('details');
                 details.className = 'focus-placeholder';


### PR DESCRIPTION
## Summary
- replace the three-column focus inspector with a compact Inspect selector
- remove the duplicate Tools panel and leave those actions in the focus toolbar
- move History into a collapsed bottom section

## Test
- npm run compile
- git diff --check