### PR TITLE
refactor: move scroll product logic into data module

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: ./.github/actions/setup
 
-      - name: Publish plugin + renderer-android + data-a11y-* + daemon-* to mavenLocal
+      - name: Publish plugin + renderer-android + data-* + daemon-* to mavenLocal
         # Both `gradle-plugin` and `renderer-android` are needed end-to-end:
         # the plugin resolves through pluginManagement when the consumer's
         # `plugins { }` block is patched, and it wires
@@ -66,6 +66,8 @@ jobs:
             :gradle-plugin:publishToMavenLocal \
             :data-a11y-core:publishToMavenLocal \
             :data-a11y-connector:publishToMavenLocal \
+            :data-render-core:publishToMavenLocal \
+            :data-scroll-core:publishToMavenLocal \
             :renderer-android:publishToMavenLocal \
             :daemon:core:publishToMavenLocal \
             :daemon:desktop:publishToMavenLocal \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache-read-only: 'true'
-      - name: Publish plugin, renderer-android, data-a11y-*, preview-annotations, daemon-* to GitHub Packages
+      - name: Publish plugin, renderer-android, data-*, preview-annotations, daemon-* to GitHub Packages
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -99,12 +99,14 @@ jobs:
             :gradle-plugin:publishAllPublicationsToGitHubPackagesRepository \
             :data-a11y-core:publishAllPublicationsToGitHubPackagesRepository \
             :data-a11y-connector:publishAllPublicationsToGitHubPackagesRepository \
+            :data-render-core:publishAllPublicationsToGitHubPackagesRepository \
+            :data-scroll-core:publishAllPublicationsToGitHubPackagesRepository \
             :renderer-android:publishAllPublicationsToGitHubPackagesRepository \
             :preview-annotations:publishAllPublicationsToGitHubPackagesRepository \
             :daemon:core:publishAllPublicationsToGitHubPackagesRepository \
             :daemon:desktop:publishAllPublicationsToGitHubPackagesRepository \
             :daemon:android:publishAllPublicationsToGitHubPackagesRepository
-      - name: Publish plugin, renderer-android, data-a11y-*, preview-annotations, daemon-* to Maven Central
+      - name: Publish plugin, renderer-android, data-*, preview-annotations, daemon-* to Maven Central
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
@@ -113,6 +115,8 @@ jobs:
             :gradle-plugin:publishAndReleaseToMavenCentral \
             :data-a11y-core:publishAndReleaseToMavenCentral \
             :data-a11y-connector:publishAndReleaseToMavenCentral \
+            :data-render-core:publishAndReleaseToMavenCentral \
+            :data-scroll-core:publishAndReleaseToMavenCentral \
             :renderer-android:publishAndReleaseToMavenCentral \
             :preview-annotations:publishAndReleaseToMavenCentral \
             :daemon:core:publishAndReleaseToMavenCentral \

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -54,6 +54,8 @@ jobs:
             :gradle-plugin:publishToMavenCentral \
             :data-a11y-core:publishToMavenCentral \
             :data-a11y-connector:publishToMavenCentral \
+            :data-render-core:publishToMavenCentral \
+            :data-scroll-core:publishToMavenCentral \
             :renderer-android:publishToMavenCentral \
             :preview-annotations:publishToMavenCentral \
             :daemon:core:publishToMavenCentral \

--- a/data/render/core/build.gradle.kts
+++ b/data/render/core/build.gradle.kts
@@ -1,11 +1,34 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+import tapmoc.TapmocExtension
+import tapmoc.configureKotlinCompatibility
+
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
+  alias(libs.plugins.tapmoc)
 }
+
+// See preview-annotations/build.gradle.kts for the rationale.
+configureKotlinCompatibility(version = libs.versions.kotlinCoreLibraries.get())
+
+tasks.withType<KotlinCompilationTask<*>>().configureEach {
+  compilerOptions.freeCompilerArgs.add("-Xsuppress-version-warnings")
+}
+
+extensions.configure<TapmocExtension> { checkDependencies() }
 
 group = "ee.schimke.composeai"
 
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.0.0-SNAPSHOT"
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
 
 dependencies {
   api(libs.kotlinx.serialization.json)
@@ -15,3 +38,60 @@ dependencies {
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+
+  coordinates("ee.schimke.composeai", "data-render-core", version.toString())
+
+  pom {
+    name.set("Compose Preview — Render Data Product (Core)")
+    description.set(
+      "Renderer-agnostic preview context and render data-product model classes shared by " +
+        "the Android renderer and daemon data-product connectors."
+    )
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2026")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
+}

--- a/data/scroll/core/build.gradle.kts
+++ b/data/scroll/core/build.gradle.kts
@@ -1,0 +1,120 @@
+@file:Suppress(
+  "DEPRECATION"
+) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
+
+// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
+
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+import tapmoc.TapmocExtension
+import tapmoc.configureKotlinCompatibility
+
+plugins {
+  alias(libs.plugins.android.library)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
+  alias(libs.plugins.tapmoc)
+}
+
+// See preview-annotations/build.gradle.kts for the rationale.
+configureKotlinCompatibility(version = libs.versions.kotlinCoreLibraries.get())
+
+tasks.withType<KotlinCompilationTask<*>>().configureEach {
+  compilerOptions.freeCompilerArgs.add("-Xsuppress-version-warnings")
+}
+
+extensions.configure<TapmocExtension> { checkDependencies() }
+
+group = "ee.schimke.composeai"
+
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
+
+android {
+  namespace = "ee.schimke.composeai.data.scroll.core"
+  compileSdk = 36
+
+  defaultConfig { minSdk = 24 }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+
+  testOptions { unitTests { isIncludeAndroidResources = true } }
+}
+
+dependencies {
+  compileOnly(platform(libs.compose.bom.compat))
+  compileOnly(libs.compose.ui)
+  compileOnly("androidx.compose.ui:ui-test-junit4")
+
+  testImplementation(libs.junit)
+  testImplementation(libs.robolectric)
+}
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  configure(
+    AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true)
+  )
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+
+  coordinates("ee.schimke.composeai", "data-scroll-core", version.toString())
+
+  pom {
+    name.set("Compose Preview — Scroll Data Product (Core)")
+    description.set(
+      "Generic Android scroll data-product primitives: Compose test-rule scroll drivers, " +
+        "long-screenshot stitching, Wear pill clipping, and GIF encoding."
+    )
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2026")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
+}

--- a/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/GifScrollScript.kt
+++ b/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/GifScrollScript.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.renderer
+package ee.schimke.composeai.scroll
 
 /**
  * One planned frame in the scripted `ScrollMode.GIF` walk.
@@ -12,7 +12,7 @@ package ee.schimke.composeai.renderer
  * the scripted sequence (see `handleGifCapture`) rather than appearing
  * here, so the script is purely the in-motion portion.
  */
-internal data class GifScrollStep(val scrollPx: Float, val delayMs: Int)
+data class GifScrollStep(val scrollPx: Float, val delayMs: Int)
 
 /**
  * Shapes a "realistic user" scroll for `ScrollMode.GIF`: the playback is
@@ -38,7 +38,7 @@ internal data class GifScrollStep(val scrollPx: Float, val delayMs: Int)
  * with no fling.
  */
 @Suppress("LongParameterList")
-internal fun buildGifScrollScript(
+fun buildGifScrollScript(
     contentExtentPxHint: Float,
     viewportPx: Float,
     density: Float,
@@ -112,17 +112,17 @@ internal fun buildGifScrollScript(
 // stay consistent across densities.
 // -----------------------------------------------------------------------------
 
-internal const val HOLD_START_MS: Int = 1000
-internal const val HOLD_END_MS: Int = 1000
+const val HOLD_START_MS: Int = 1000
+const val HOLD_END_MS: Int = 1000
 
-internal const val SLOW_RAMP_STEP_DP: Float = 30f
-internal const val SLOW_RAMP_FRAMES: Int = 4
+const val SLOW_RAMP_STEP_DP: Float = 30f
+const val SLOW_RAMP_FRAMES: Int = 4
 
 // 120 dp/frame at 80 ms cadence ≈ 1500 dp/s peak fling velocity — the
 // high end of a deliberate Android swipe.
-internal const val FLING_PEAK_DP_PER_FRAME: Float = 120f
-internal const val FLING_DECAY: Float = 0.85f
-internal const val FLING_MIN_STEP_DP: Float = 12f
-internal const val FLING_MAX_DISTANCE_VIEWPORTS: Float = 1.5f
+const val FLING_PEAK_DP_PER_FRAME: Float = 120f
+const val FLING_DECAY: Float = 0.85f
+const val FLING_MIN_STEP_DP: Float = 12f
+const val FLING_MAX_DISTANCE_VIEWPORTS: Float = 1.5f
 
-internal const val INTER_FLING_HOLD_MS: Int = 240
+const val INTER_FLING_HOLD_MS: Int = 240

--- a/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollAxis.kt
+++ b/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollAxis.kt
@@ -1,0 +1,7 @@
+package ee.schimke.composeai.scroll
+
+/** Axis to drive when producing scroll data products. */
+enum class ScrollAxis {
+  VERTICAL,
+  HORIZONTAL,
+}

--- a/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollDriver.kt
+++ b/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollDriver.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.renderer
+package ee.schimke.composeai.scroll
 
 import androidx.compose.ui.semantics.ScrollAxisRange
 import androidx.compose.ui.semantics.SemanticsActions
@@ -24,7 +24,7 @@ import androidx.compose.ui.test.junit4.AndroidComposeTestRule
  * the composition has drawn.
  */
 @Suppress("LongParameterList")
-internal fun driveScrollToEnd(
+fun driveScrollToEnd(
     rule: AndroidComposeTestRule<*, *>,
     axis: ScrollAxis,
     maxScrollPx: Int,
@@ -85,7 +85,7 @@ internal fun driveScrollToEnd(
  * jump to the bottom.
  */
 @Suppress("LongParameterList")
-internal fun driveScrollByViewport(
+fun driveScrollByViewport(
     rule: AndroidComposeTestRule<*, *>,
     axis: ScrollAxis,
     stepPx: Float,
@@ -148,7 +148,7 @@ internal fun driveScrollByViewport(
  * them by default — see issue #154.
  */
 @Suppress("LongParameterList")
-internal fun driveScrollToStart(
+fun driveScrollToStart(
     rule: AndroidComposeTestRule<*, *>,
     axis: ScrollAxis,
     maxIterations: Int = DEFAULT_MAX_ITERATIONS,
@@ -200,7 +200,7 @@ internal fun driveScrollToStart(
  * the GIF script builder can shape the sequence (slow ramp, fling decay,
  * inter-fling holds) without fighting the driver.
  */
-internal fun driveScrollBy(
+fun driveScrollBy(
     rule: AndroidComposeTestRule<*, *>,
     axis: ScrollAxis,
     deltaPx: Float,
@@ -238,7 +238,7 @@ internal fun driveScrollBy(
  * building the GIF scroll script; final length is still adaptive at
  * runtime because LazyList reports its max progressively.
  */
-internal fun remainingScrollPx(
+fun remainingScrollPx(
     rule: AndroidComposeTestRule<*, *>,
     axis: ScrollAxis,
 ): Float {
@@ -253,7 +253,7 @@ internal fun remainingScrollPx(
     return (range.maxValue() - range.value()).coerceAtLeast(0f)
 }
 
-internal sealed interface ScrollDriveResult {
+sealed interface ScrollDriveResult {
     /** No scrollable composable found on the requested axis. */
     data object NoScrollable : ScrollDriveResult
 

--- a/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollGifEncoder.kt
+++ b/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollGifEncoder.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.renderer
+package ee.schimke.composeai.scroll
 
 import java.awt.image.BufferedImage
 import java.io.File
@@ -35,7 +35,7 @@ import javax.imageio.stream.FileImageOutputStream
  * step. Returns the written file, or `null` if [frames] is empty or the
  * GIF writer plugin isn't registered (never, on a standard JRE).
  */
-internal object ScrollGifEncoder {
+object ScrollGifEncoder {
     const val DEFAULT_FRAME_DELAY_MS: Int = 80
     const val MIN_FRAME_DELAY_MS: Int = 20
 

--- a/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollSliceStitcher.kt
+++ b/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollSliceStitcher.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.renderer
+package ee.schimke.composeai.scroll
 
 import java.awt.AlphaComposite
 import java.awt.Color
@@ -20,7 +20,7 @@ import kotlin.math.sqrt
  * offset is now used only as a **hint** to narrow the overlap search; the
  * actual alignment is driven by pixel content ([findOverlapShift]).
  */
-internal data class SliceCapture(val scrolledLayoutPx: Float, val file: File)
+data class SliceCapture(val scrolledLayoutPx: Float, val file: File)
 
 /**
  * Stitches per-viewport slices (see `driveScrollByViewport`) into a single
@@ -57,7 +57,7 @@ internal data class SliceCapture(val scrolledLayoutPx: Float, val file: File)
  *
  * Returns the written file, or `null` if [slices] is empty.
  */
-internal fun stitchSlices(
+fun stitchSlices(
     slices: List<SliceCapture>,
     viewportLayoutPx: Int,
     outputFile: File,
@@ -104,7 +104,7 @@ internal fun stitchSlices(
  * Falls back to writing [finalFrameFile] directly when [slices] has one
  * entry (no scroll history).
  */
-internal fun stitchSlicesWithFinalFrame(
+fun stitchSlicesWithFinalFrame(
     slices: List<SliceCapture>,
     finalFrameFile: File,
     viewportLayoutPx: Int,
@@ -925,7 +925,7 @@ private fun findBestAnchorMatch(
  * so the rendered scroll visually preserves the round screen edge at the top
  * of the first frame and the bottom of the last frame.
  */
-internal fun applyWearPillClip(file: File) {
+fun applyWearPillClip(file: File) {
     val src = ImageIO.read(file) ?: return
     val w = src.width
     val h = src.height

--- a/data/scroll/core/src/test/kotlin/ee/schimke/composeai/scroll/GifScrollScriptTest.kt
+++ b/data/scroll/core/src/test/kotlin/ee/schimke/composeai/scroll/GifScrollScriptTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.renderer
+package ee.schimke.composeai.scroll
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse

--- a/data/scroll/core/src/test/kotlin/ee/schimke/composeai/scroll/ScrollSliceStitcherTest.kt
+++ b/data/scroll/core/src/test/kotlin/ee/schimke/composeai/scroll/ScrollSliceStitcherTest.kt
@@ -1,4 +1,4 @@
-package ee.schimke.composeai.renderer
+package ee.schimke.composeai.scroll
 
 import java.awt.Color
 import java.awt.image.BufferedImage

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/DiscoveryFunctionalTest.kt
@@ -648,7 +648,8 @@ class DiscoveryFunctionalTest {
     }
 
     val longPreview = manifest.previews.single { it.functionName == "LongScrollPreview" }
-    assertThat(longPreview.captures.single().scroll)
+    assertThat(longPreview.captures.single().scroll).isNull()
+    assertThat(longPreview.dataProducts.single().scroll)
       .isEqualTo(
         ScrollCapture(
           mode = ScrollMode.LONG,
@@ -658,6 +659,9 @@ class DiscoveryFunctionalTest {
           frameIntervalMs = 80,
         )
       )
+    assertThat(longPreview.dataProducts.single().kind).isEqualTo("render/scroll/long")
+    assertThat(longPreview.dataProducts.single().output)
+      .isEqualTo("data/render-scroll-long/LongScrollPreview.png")
 
     val plain = manifest.previews.single { it.functionName == "PlainPreview" }
     assertThat(plain.captures.single().scroll).isNull()
@@ -682,12 +686,13 @@ class DiscoveryFunctionalTest {
       )
       .inOrder()
 
-    // Single-mode GIF: keeps the plain `renders/<id>.gif` name (no
+    // Single-mode GIF: moves to the scroll data-product path (no
     // `_SCROLL_gif` suffix) and round-trips `frameIntervalMs` onto the
     // manifest so the renderer can honour it.
     val gifOnly = manifest.previews.single { it.functionName == "GifScrollPreview" }
     assertThat(gifOnly.captures).hasSize(1)
-    assertThat(gifOnly.captures.single().scroll)
+    assertThat(gifOnly.captures.single().scroll).isNull()
+    assertThat(gifOnly.dataProducts.single().scroll)
       .isEqualTo(
         ScrollCapture(
           mode = ScrollMode.GIF,
@@ -697,22 +702,21 @@ class DiscoveryFunctionalTest {
           frameIntervalMs = 120,
         )
       )
-    assertThat(gifOnly.captures.single().renderOutput).isEqualTo("renders/GifScrollPreview_Gif.gif")
+    assertThat(gifOnly.dataProducts.single().kind).isEqualTo("render/scroll/gif")
+    assertThat(gifOnly.dataProducts.single().output)
+      .isEqualTo("data/render-scroll-gif/GifScrollPreview_Gif.gif")
 
-    // Multi-mode with GIF sibling: each capture gets its mode's
-    // extension (PNG for END, GIF for GIF) — the extension branches
-    // per-capture rather than per-preview.
+    // Multi-mode with GIF sibling: END remains a normal capture; GIF moves
+    // to a data product with its own `_SCROLL_gif` output path.
     val endAndGif = manifest.previews.single { it.functionName == "EndAndGifScrollPreview" }
-    assertThat(endAndGif.captures).hasSize(2)
-    assertThat(endAndGif.captures.map { it.scroll?.mode })
-      .containsExactly(ScrollMode.END, ScrollMode.GIF)
-      .inOrder()
+    assertThat(endAndGif.captures).hasSize(1)
+    assertThat(endAndGif.captures.map { it.scroll?.mode }).containsExactly(ScrollMode.END).inOrder()
     assertThat(endAndGif.captures.map { it.renderOutput })
-      .containsExactly(
-        "renders/EndAndGifScrollPreview_EndAndGif_SCROLL_end.png",
-        "renders/EndAndGifScrollPreview_EndAndGif_SCROLL_gif.gif",
-      )
+      .containsExactly("renders/EndAndGifScrollPreview_EndAndGif.png")
       .inOrder()
+    assertThat(endAndGif.dataProducts.single().scroll?.mode).isEqualTo(ScrollMode.GIF)
+    assertThat(endAndGif.dataProducts.single().output)
+      .isEqualTo("data/render-scroll-gif/EndAndGifScrollPreview_EndAndGif_SCROLL_gif.gif")
   }
 
   @Test

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
   // consumers (`RobolectricRenderTest`) compile unchanged.
   api(project(":data-a11y-core"))
   implementation(project(":data-render-core"))
+  implementation(project(":data-scroll-core"))
 
   implementation(libs.robolectric)
   implementation(libs.junit)

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RenderManifest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.renderer
 
+import ee.schimke.composeai.scroll.ScrollGifEncoder
 import kotlinx.serialization.Serializable
 
 enum class PreviewKind {

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/ResourcePreviewRenderTest.kt
@@ -12,6 +12,7 @@ import android.graphics.drawable.Animatable
 import android.graphics.drawable.Drawable
 import androidx.core.content.ContextCompat
 import androidx.test.core.app.ApplicationProvider
+import ee.schimke.composeai.scroll.ScrollGifEncoder
 import java.awt.image.BufferedImage
 import java.io.File
 import kotlinx.serialization.json.Json

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -28,12 +28,37 @@ import com.github.takahirom.roborazzi.locale
 import com.github.takahirom.roborazzi.size
 import com.github.takahirom.roborazzi.uiMode
 import ee.schimke.composeai.data.render.PreviewAnimationContext
+import ee.schimke.composeai.scroll.FLING_DECAY
+import ee.schimke.composeai.scroll.FLING_MAX_DISTANCE_VIEWPORTS
+import ee.schimke.composeai.scroll.FLING_MIN_STEP_DP
+import ee.schimke.composeai.scroll.FLING_PEAK_DP_PER_FRAME
+import ee.schimke.composeai.scroll.HOLD_END_MS
+import ee.schimke.composeai.scroll.HOLD_START_MS
+import ee.schimke.composeai.scroll.INTER_FLING_HOLD_MS
+import ee.schimke.composeai.scroll.ScrollAxis as ProductScrollAxis
+import ee.schimke.composeai.scroll.ScrollDriveResult
+import ee.schimke.composeai.scroll.ScrollGifEncoder
+import ee.schimke.composeai.scroll.SliceCapture
+import ee.schimke.composeai.scroll.applyWearPillClip
+import ee.schimke.composeai.scroll.buildGifScrollScript
+import ee.schimke.composeai.scroll.driveScrollBy
+import ee.schimke.composeai.scroll.driveScrollByViewport
+import ee.schimke.composeai.scroll.driveScrollToEnd
+import ee.schimke.composeai.scroll.driveScrollToStart
+import ee.schimke.composeai.scroll.remainingScrollPx
+import ee.schimke.composeai.scroll.stitchSlicesWithFinalFrame
 import java.awt.image.BufferedImage
 import java.io.File
 import kotlinx.serialization.json.Json
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
+
+private fun ScrollAxis.toProductAxis(): ProductScrollAxis =
+    when (this) {
+        ScrollAxis.VERTICAL -> ProductScrollAxis.VERTICAL
+        ScrollAxis.HORIZONTAL -> ProductScrollAxis.HORIZONTAL
+    }
 
 /**
  * Loads the previews manifest and returns the subset assigned to `shardIndex`
@@ -679,7 +704,14 @@ abstract class RobolectricRenderTestBase(
                             preview.dataProducts.map {
                                 ProductRenderJob(it, outputFileFor(it, outputDir))
                             }
-                        ).sortedBy { it.advanceTimeMillis ?: CAPTURE_ADVANCE_MS }
+                        ).sortedWith(
+                            compareBy<RenderJob> { it.advanceTimeMillis ?: CAPTURE_ADVANCE_MS }
+                                // Animated captures consume a time window after their target.
+                                // Keep same-target still/product jobs before that window opens.
+                                .thenBy {
+                                    if (it is CaptureRenderJob && it.capture.animation != null) 1 else 0
+                                }
+                        )
                 var captureIndex = 0
                 jobs.forEach { job ->
                     val target = job.advanceTimeMillis ?: CAPTURE_ADVANCE_MS
@@ -768,7 +800,7 @@ abstract class RobolectricRenderTestBase(
                         if (scroll != null && scroll.mode == ScrollMode.END) {
                             val result = driveScrollToEnd(
                                 rule = rule,
-                                axis = scroll.axis,
+                                axis = scroll.axis.toProductAxis(),
                                 maxScrollPx = scroll.maxScrollPx,
                             )
                             if (result is ScrollDriveResult.NoScrollable) {
@@ -1042,7 +1074,7 @@ private fun handleLongCapture(
         // slicing — otherwise the first slice is the end state and
         // `driveScrollByViewport`'s first iteration bails with
         // remaining ≈ 0, yielding a single "stitched" slice. See #154.
-        driveScrollToStart(rule, scroll.axis)
+        driveScrollToStart(rule, scroll.axis.toProductAxis())
 
         // Drive at 80% of the viewport so each consecutive slice pair has a
         // ~20% physical overlap for the content-aware stitcher to lock onto.
@@ -1050,7 +1082,7 @@ private fun handleLongCapture(
         // placement is decided by pixel matching.
         val result = driveScrollByViewport(
             rule = rule,
-            axis = scroll.axis,
+            axis = scroll.axis.toProductAxis(),
             stepPx = viewportLayoutPx * 0.8f,
             maxScrollPx = scroll.maxScrollPx,
         ) { scrolledPx ->
@@ -1188,7 +1220,7 @@ private fun handleGifCapture(
         // would animate "from end to end" — a single frame indistinguishable
         // from the END capture. Reset to the top before the frame walk
         // starts. Fix for #154.
-        val resetResult = driveScrollToStart(rule, scroll.axis)
+        val resetResult = driveScrollToStart(rule, scroll.axis.toProductAxis())
         if (resetResult is ScrollDriveResult.NoScrollable) {
             System.err.println(
                 "@ScrollingPreview(GIF) on '$previewId': no scrollable composable — falling through.",
@@ -1203,7 +1235,7 @@ private fun handleGifCapture(
         // Upfront extent hint — capped to `maxScrollPx` when the
         // annotation sets one. Runtime clamps each step to live remaining
         // anyway, so LazyList's progressive maxValue doesn't over-scroll.
-        val liveRemaining = remainingScrollPx(rule, scroll.axis)
+        val liveRemaining = remainingScrollPx(rule, scroll.axis.toProductAxis())
         val cap = if (scroll.maxScrollPx > 0) scroll.maxScrollPx.toFloat() else Float.POSITIVE_INFINITY
         val extentHint = minOf(liveRemaining, cap)
 
@@ -1224,7 +1256,7 @@ private fun handleGifCapture(
                     scriptHitEnd = true
                     break
                 }
-                val actual = driveScrollBy(rule, scroll.axis, target)
+                val actual = driveScrollBy(rule, scroll.axis.toProductAxis(), target)
                 if (actual <= 0f) {
                     scriptHitEnd = true
                     break
@@ -1248,7 +1280,7 @@ private fun handleGifCapture(
         if (!scriptHitEnd) {
             emitTailFlings(
                 rule = rule,
-                axis = scroll.axis,
+                axis = scroll.axis.toProductAxis(),
                 density = density,
                 viewportPx = viewportLayoutPx.toFloat(),
                 frameIntervalMs = frameIntervalMs,
@@ -1300,7 +1332,7 @@ private fun handleGifCapture(
 @Suppress("LongParameterList")
 private fun emitTailFlings(
     rule: AndroidComposeTestRule<*, *>,
-    axis: ScrollAxis,
+    axis: ProductScrollAxis,
     density: Float,
     viewportPx: Float,
     frameIntervalMs: Int,

--- a/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/LongScrollGhostOverlayTest.kt
+++ b/renderer-android/src/test/kotlin/ee/schimke/composeai/renderer/LongScrollGhostOverlayTest.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.renderer
 
+import ee.schimke.composeai.scroll.SliceCapture
+import ee.schimke.composeai.scroll.stitchSlicesWithFinalFrame
 import java.awt.Color
 import java.awt.image.BufferedImage
 import javax.imageio.ImageIO

--- a/samples/wear/src/test/kotlin/com/example/samplewear/LongScrollPreviewPixelTest.kt
+++ b/samples/wear/src/test/kotlin/com/example/samplewear/LongScrollPreviewPixelTest.kt
@@ -20,7 +20,8 @@ import org.junit.Test
 class LongScrollPreviewPixelTest {
 
     private val longPng = File(
-        "build/compose-previews/renders/PreviewsKt.ActivityListLongPreview_Devices_-_Large_Round.png",
+        "build/compose-previews/data/render-scroll-long/" +
+            "PreviewsKt.ActivityListLongPreview_Devices_-_Large_Round.png",
     )
 
     @Test

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -81,6 +81,10 @@ include(":data-render-connector")
 
 project(":data-render-connector").projectDir = file("data/render/connector")
 
+include(":data-scroll-core")
+
+project(":data-scroll-core").projectDir = file("data/scroll/core")
+
 include(":data-history-connector")
 
 project(":data-history-connector").projectDir = file("data/history/connector")


### PR DESCRIPTION
## Summary
- add `data-scroll-core` as the reusable scroll data-product module
- move scroll drivers, long screenshot stitching, Wear pill clipping, GIF script/encoding, and related tests out of `renderer-android`
- keep renderer-specific adaptation in `renderer-android`, including ordering same-time product jobs before animated captures so animation clock advancement does not break pending scroll products
- update CI/release publishing for renderer transitive data modules and align tests with scroll data-product outputs

## Validation
- `./gradlew :data-scroll-core:compileDebugKotlin :renderer-android:compileDebugKotlin :gradle-plugin:test --tests ee.schimke.composeai.plugin.PreviewDataTest :renderer-android:testDebugUnitTest --tests ee.schimke.composeai.renderer.PreviewManifestLoaderShardTest`
- `./gradlew :data-scroll-core:testDebugUnitTest`
- `./gradlew :gradle-plugin:functionalTest --tests ee.schimke.composeai.plugin.DiscoveryFunctionalTest.discoverPreviews\ picks\ up\ @ScrollingPreview :samples:wear:testDebugUnitTest --tests com.example.samplewear.LongScrollPreviewPixelTest`
- `./gradlew :gradle-plugin:publishToMavenLocal :data-a11y-core:publishToMavenLocal :data-a11y-connector:publishToMavenLocal :data-render-core:publishToMavenLocal :data-scroll-core:publishToMavenLocal :renderer-android:publishToMavenLocal :daemon:core:publishToMavenLocal :daemon:desktop:publishToMavenLocal :daemon:android:publishToMavenLocal --stacktrace`