### PR TITLE
feat(cli): add daemon library foundation

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,3 +1,10 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
@@ -49,6 +56,44 @@ dependencies {
 }
 
 tasks.withType<Test>().configureEach { useJUnitPlatform() }
+
+abstract class CheckCliDaemonLibraryBoundary : DefaultTask() {
+  @get:Classpath abstract val runtimeClasspath: ConfigurableFileCollection
+
+  @get:Input abstract val forbiddenProjectDirs: ListProperty<String>
+
+  @TaskAction
+  fun checkBoundary() {
+    val forbiddenDirs = forbiddenProjectDirs.get()
+    val forbidden =
+      runtimeClasspath.files
+        .filter { file ->
+          val path = file.invariantSeparatorsPath
+          forbiddenDirs.any { forbiddenDir -> path.startsWith("$forbiddenDir/") }
+        }
+        .map { it.path }
+        .sorted()
+
+    check(forbidden.isEmpty()) {
+      "CLI may depend on renderer-agnostic :daemon:core only; forbidden renderer artifacts on " +
+        "runtimeClasspath: ${forbidden.joinToString(", ")}"
+    }
+  }
+}
+
+tasks.register<CheckCliDaemonLibraryBoundary>("checkCliDaemonLibraryBoundary") {
+  description = "Fails if renderer implementations leak onto the CLI runtime classpath."
+  group = "verification"
+
+  runtimeClasspath.from(configurations.named("runtimeClasspath"))
+  forbiddenProjectDirs.set(
+    listOf(":daemon:android", ":daemon:desktop", ":renderer-android", ":renderer-desktop").map {
+      project(it).projectDir.invariantSeparatorsPath
+    }
+  )
+}
+
+tasks.named("check") { dependsOn("checkCliDaemonLibraryBoundary") }
 
 // Bake the resolved Gradle build version into a properties resource the CLI reads at runtime
 // (see `Version.kt#BUNDLE_VERSION`). Avoids the previous hand-edited literal in source — which

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DeviceCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DeviceCommands.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
+import ee.schimke.composeai.daemon.protocol.KnownDevice
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -14,15 +15,7 @@ private val devicesJson = Json {
 @Serializable
 data class DeviceCatalogResponse(
   val schema: String = DEVICES_SCHEMA,
-  val devices: List<DeviceCatalogEntry>,
-)
-
-@Serializable
-data class DeviceCatalogEntry(
-  val id: String,
-  val widthDp: Int,
-  val heightDp: Int,
-  val density: Float,
+  val devices: List<KnownDevice>,
 )
 
 class DevicesCommand(private val args: List<String>) {
@@ -69,11 +62,12 @@ internal fun buildDeviceCatalogResponse(): DeviceCatalogResponse =
     devices =
       DeviceDimensions.KNOWN_DEVICE_IDS.sorted().map { id ->
         val spec = DeviceDimensions.resolve(id)
-        DeviceCatalogEntry(
+        KnownDevice(
           id = id,
           widthDp = spec.widthDp,
           heightDp = spec.heightDp,
           density = spec.density,
+          isRound = spec.isRound,
         )
       }
   )

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DeviceCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DeviceCommandTest.kt
@@ -25,6 +25,9 @@ class DeviceCommandTest {
     assertEquals(393, pixel5.widthDp)
     assertEquals(851, pixel5.heightDp)
     assertEquals(2.75f, pixel5.density)
+
+    val wear = parsed.devices.single { it.id == "id:wearos_large_round" }
+    assertEquals(true, wear.isRound)
   }
 
   @Test

--- a/docs/daemon/LAYERING.md
+++ b/docs/daemon/LAYERING.md
@@ -65,11 +65,16 @@ the contract for "the simple way". Constraints:
   existing behaviour and does not require a running daemon. Editor
   integrations use the top-level `daemon { … }` DSL, which defaults to
   enabled and can be disabled temporarily.
-- **No daemon code on the Layer 1 classpath.** `:gradle-plugin` does
-  not depend on `:daemon:core`. The daemon-bootstrap task
-  the plugin registers (`composePreviewDaemonStart`) emits a
-  descriptor file; it does not import or instantiate anything from
-  the daemon modules.
+- **No daemon code on the Gradle plugin classpath.** `:gradle-plugin`
+  does not depend on `:daemon:core`. The daemon-bootstrap task the
+  plugin registers (`composePreviewDaemonStart`) emits a descriptor
+  file; it does not import or instantiate anything from the daemon
+  modules.
+- **CLI daemon-library access is narrow and renderer-agnostic.**
+  `:cli` may depend on `:daemon:core` for pure catalog/protocol helpers
+  such as `DeviceDimensions`, `KnownDevice`, protocol DTOs, and local
+  history models. The CLI must not depend on `:daemon:android`,
+  `:daemon:desktop`, `:renderer-android`, or `:renderer-desktop`.
 - **No conditional branches in `renderPreviews`** for "is the daemon
   running?". The Gradle task path is unaware of the daemon's
   existence. (The daemon can read state Gradle wrote; Gradle does not
@@ -99,10 +104,11 @@ The daemon is a separate JVM started by an explicit task. It speaks
 JSON-RPC ([PROTOCOL.md](PROTOCOL.md)) to one client at a time over
 stdio. Constraints:
 
-- **Daemon code lives only in `:daemon:core` and the two
-  per-target modules** (`:daemon:android`,
-  `:daemon:desktop`). The Gradle plugin does not import
-  these modules; nor does the existing CLI.
+- **Daemon runtime code lives only in `:daemon:core` and the two
+  per-target modules** (`:daemon:android`, `:daemon:desktop`). The
+  Gradle plugin does not import these modules. The CLI may import
+  renderer-agnostic `:daemon:core` catalog/protocol helpers, but it
+  must not instantiate daemon runtime services or renderer hosts.
 - **Daemon ↔ Gradle plumbing is a one-way file handoff.** The
   `composePreviewDaemonStart` task writes a launch descriptor JSON
   file (classpath, JVM args, target). The daemon reads that file at
@@ -120,13 +126,77 @@ What Layer 2 *may* be consumed by:
 - The VS Code extension's `daemonClient.ts` (Stream C work).
 - The harness in `:daemon:harness`.
 - Layer 3's MCP server, as a JSON-RPC client.
+- The CLI as a **local library** for pure, renderer-agnostic helpers
+  from `:daemon:core` only. Examples: protocol DTOs, known-device
+  catalog entries, override-field names, and local file-backed history
+  value types.
 
 What Layer 2 must **not** be consumed by:
 
 - `renderPreviews`. (See Layer 1 constraint above.)
-- The CLI binary's default code path. A `--daemon` CLI subcommand may
-  exist in v2+; it would be its own entry point that *clients* the
-  daemon, not embeds it.
+- The CLI as an embedded daemon runtime. Commands that need module or
+  runtime state must either use the existing Gradle task path or client
+  a daemon process through the protocol; they must not call renderer
+  implementations in-process.
+
+## CLI local-library boundary
+
+The CLI has two valid daemon-adjacent modes:
+
+1. **Local-library mode** for pure data. The command imports
+   `:daemon:core` classes directly and does not run Gradle or spawn a
+   daemon. `compose-preview devices` is the reference example: it reads
+   `DeviceDimensions` and emits protocol-shaped `KnownDevice` rows.
+2. **Daemon-client mode** for runtime state. The command obtains a
+   launch descriptor from Gradle and connects to a daemon process through
+   JSON-RPC using [PROTOCOL.md](PROTOCOL.md). It may start the daemon
+   when explicitly asked, but the efficient path for repeated CLI calls is
+   to attach to an already-running daemon or supervisor. This is required
+   for render queues, live preview state, data products that require a
+   render, interactive sessions, and backend-specific capabilities.
+
+Prefer local-library mode for repeated one-shot CLI workflows. Starting a
+daemon per CLI invocation can easily cost more than the work being asked
+for, especially in scripts that call the CLI several times. Before adding a
+daemon-backed CLI command, first ask whether the needed data product can be
+split into a reusable `core` model/producer and consumed from the CLI after
+the existing Gradle render path has written its files.
+
+When a command does need daemon state, prefer amortized daemon-client
+access over per-command startup:
+
+- connect to a daemon already started by VS Code, MCP, or an explicit CLI
+  warmup command;
+- or connect to a long-lived supervisor that owns daemon lifecycles across
+  modules/workspaces.
+
+Hosting that supervisor in the MCP process is allowed as an optimization:
+the CLI still talks over a protocol boundary and does not import renderer
+implementations. The hosting choice must be treated as lifecycle/packaging,
+not as permission for CLI code to reach into daemon internals. A Unix
+domain socket is a plausible local transport for that future mode, but it
+is not part of the foundation contract; stdio JSON-RPC and local-library
+access remain the supported baseline until a concrete repeated-call
+workflow proves the extra lifecycle surface is worth it.
+
+Allowed CLI compile-time dependencies:
+
+- `:daemon:core` for protocol/catalog/history DTOs and other
+  renderer-agnostic helpers.
+- `:mcp` for the bundled `compose-preview mcp serve` entry point.
+- Data-product `core` modules when they are renderer-agnostic or expose
+  reusable file/model helpers for outputs the Gradle path already writes.
+
+Forbidden CLI compile-time/runtime dependencies:
+
+- `:daemon:android` and `:daemon:desktop`.
+- `:renderer-android` and `:renderer-desktop`.
+- Any connector module that exists only to adapt renderer output into
+  daemon runtime hooks, unless it has first been split into a reusable
+  `core` module.
+
+The `:cli:checkCliDaemonLibraryBoundary` verification task enforces the
+renderer-module part of this rule on the CLI runtime classpath.
 
 ## Layer 3 — what the MCP server owns
 
@@ -186,6 +256,7 @@ not on this list is a layering violation.
 | Daemon JSON-RPC over stdio | L2 ↔ extension/supervisor | `PROTOCOL.md` | L2 |
 | MCP wire format ↔ daemon JSON-RPC translation | L3 ↔ L2 | `:mcp` shim | L3 |
 | `:daemon:core` `Messages.kt` types | shared by L2 + L3 | Kotlin data classes | L2 |
+| `:daemon:core` catalog/protocol helpers → CLI | L2 → L1 CLI | local-library dependency, no daemon process | L1 CLI |
 | `composePreviewDaemonStart` → spawn-daemon helper used by L3's `DaemonSupervisor` | L3 → L1 | shells out to Gradle | L3 |
 
 If a future change wants to add a new seam, it goes here first. If
@@ -206,6 +277,8 @@ Each layer can be removed without breaking the layers below it.
 - Delete `:daemon:core`, `:daemon:android`,
   `:daemon:desktop`, `:daemon:harness`,
   `:mcp`.
+- Move or replace CLI commands that intentionally use local-library
+  helpers from `:daemon:core` (for example the known-device catalog).
 - Remove the `daemon` DSL block and the
   `composePreviewDaemonStart` task registration from `:gradle-plugin`.
 - The base `composePreview { … }` DSL and `renderPreviews` task work

--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -183,6 +183,16 @@ Highest-value simple additions:
      `build/compose-previews/data/<previewId>/<kind-with-slashes-as-dashes>.json`.
      This covers cheap/ambient products without adding a daemon lifecycle to
      the command.
+   - Prefer refactoring reusable data-product models/producers into `core`
+     modules over starting a daemon for every one-shot CLI call. A daemon
+     startup can dominate total cost when scripts invoke the CLI repeatedly.
+     When daemon-backed fetch is needed, prefer attaching to an existing
+     daemon/supervisor, including one hosted by MCP, so startup is amortized.
+     Reserve daemon-backed fetch for products that need live renderer state
+     or re-render-on-demand behavior. A Unix domain socket could be a good
+     local transport for CLI to MCP-hosted supervisor later, but keep it out
+     of the first CLI foundation unless repeated-call latency justifies the
+     added lifecycle and cleanup rules.
    - Better second implementation: daemon-backed fetch with the MCP
      supervisor so the command can auto-render one preview and handle
      re-render-on-demand products.
@@ -192,8 +202,9 @@ Highest-value simple additions:
    - Value: gives scripts and agents the legal `id:*` device strings and
      resolved dimensions for override planning.
    - Simple implementation: read `DeviceDimensions.KNOWN_DEVICE_IDS`
-     directly. The CLI already bundles `:mcp`, which depends on daemon
-     protocol/core, so no new process or Gradle invocation is required.
+     directly from `:daemon:core` and emit protocol-shaped `KnownDevice`
+     rows. This is the reference CLI local-library use case: no new
+     process or Gradle invocation is required.
 
 4. **`compose-preview history list|diff [--module M] [--id PREVIEW] [--json]`**
    - Maps to MCP `history_list` and `history_diff`.


### PR DESCRIPTION
## Summary

- Add a CLI daemon-library foundation so pure catalog/protocol features can reuse shared daemon code without starting a daemon process.
- Wire `compose-preview devices` to consume shared daemon-core catalog/protocol types directly.
- Add a CLI runtime classpath boundary check to keep renderer implementations out of the CLI dependency graph.
- Document the local-library versus daemon-client boundary in the daemon layering and MCP docs.

Closes #566.

## Validation

- `./gradlew :cli:test :cli:checkCliDaemonLibraryBoundary`
- `git diff --check origin/main..HEAD`