### PR TITLE
Implement test/failure data product

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -248,6 +248,8 @@ fun main(args: Array<String>) {
         add(DeviceClipDataProductRegistry(previewIndex = previewIndex))
         System.err.println("compose-ai-tools daemon: RenderTraceDataProductRegistry active")
         add(RenderTraceDataProductRegistry())
+        System.err.println("compose-ai-tools daemon: TestFailureDataProductRegistry active")
+        add(TestFailureDataProductRegistry())
         System.err.println("compose-ai-tools daemon: ThemeDataProductRegistry active")
         add(ThemeDataProductRegistry())
         if (historyManager != null) {

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/CompositeDataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/CompositeDataProductRegistry.kt
@@ -52,6 +52,10 @@ class CompositeDataProductRegistry(private val registries: List<DataProductRegis
     registries.forEach { it.onRender(previewId, result, overrides, previewContext) }
   }
 
+  override fun onRenderFailed(previewId: String, cause: Throwable) {
+    registries.forEach { it.onRenderFailed(previewId, cause) }
+  }
+
   override fun onSubscribe(previewId: String, kind: String, params: JsonElement?) {
     registries.firstOrNull { it.isKnown(kind) }?.onSubscribe(previewId, kind, params)
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/DataProductRegistry.kt
@@ -88,6 +88,12 @@ interface DataProductRegistry {
   }
 
   /**
+   * Render failure lifecycle hook. Called before `renderFailed` is emitted so failure-oriented
+   * producers can snapshot the throwable for a later `data/fetch`.
+   */
+  fun onRenderFailed(previewId: String, cause: Throwable) {}
+
+  /**
    * Producer-side subscription lifecycle hook. Called by the dispatcher when a client issues a
    * successful `data/subscribe` for `(previewId, kind)`. [params] carries the per-kind subscription
    * option bag — `compose/recomposition` reads `{ frameStreamId, mode }` from it; stateless kinds

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -1386,6 +1386,14 @@ class JsonRpcServer(
     hostIdToOverrides.remove(failure.hostId)
     inFlightRenders.remove(failure.hostId)
     previewIdsWithOverridesInFlight.remove(previewId)
+    try {
+      dataProducts.onRenderFailed(previewId, failure.cause)
+    } catch (t: Throwable) {
+      System.err.println(
+        "compose-ai-daemon: data product onRenderFailed failed for $previewId " +
+          "(${t.javaClass.simpleName}: ${t.message})"
+      )
+    }
     // D3 — wake any data/fetch waiter that queued this render so it can return
     // DataProductFetchFailed rather than ride out its budget.
     dataFetchWaiters

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/JsonRpcServerIntegrationTest.kt
@@ -209,6 +209,84 @@ class JsonRpcServerIntegrationTest {
     }
   }
 
+  @Test(timeout = 30_000)
+  fun render_failure_notifies_data_product_registry_before_render_failed() {
+    val clientToServerOut = PipedOutputStream()
+    val clientToServerIn = PipedInputStream(clientToServerOut, 64 * 1024)
+    val serverToClientOut = PipedOutputStream()
+    val serverToClientIn = PipedInputStream(serverToClientOut, 64 * 1024)
+
+    val registry = FailureRecordingDataProductRegistry()
+    val host = FakeRenderHost(failureToThrow = IllegalStateException("deliberate test failure"))
+    val server =
+      JsonRpcServer(
+        input = clientToServerIn,
+        output = serverToClientOut,
+        host = host,
+        daemonVersion = "test",
+        dataProducts = registry,
+      )
+    val serverThread =
+      Thread({ server.run() }, "json-rpc-server-test-failure-data").apply { isDaemon = true }
+    serverThread.start()
+
+    val reader = ContentLengthFramer(serverToClientIn)
+    val received = LinkedBlockingQueue<JsonObject>()
+    Thread(
+        {
+          try {
+            while (true) {
+              val frame = reader.readFrame() ?: break
+              val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
+              received.put(obj)
+            }
+          } catch (_: Throwable) {}
+        },
+        "json-rpc-server-test-failure-data-reader",
+      )
+      .apply { isDaemon = true }
+      .start()
+
+    try {
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+              "protocolVersion":1,"clientVersion":"test","workspaceRoot":"/tmp",
+              "moduleId":":test","moduleProjectDir":"/tmp",
+              "capabilities":{"visibility":true,"metrics":false}}}""",
+      )
+      assertNotNull(pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 1 })
+      writeFrame(clientToServerOut, """{"jsonrpc":"2.0","method":"initialized","params":{}}""")
+
+      writeFrame(
+        clientToServerOut,
+        """{"jsonrpc":"2.0","id":2,"method":"renderNow","params":{
+              "previews":["preview-fails"],"tier":"fast"}}""",
+      )
+
+      val renderResponse = pollUntil(received) { it["id"]?.jsonPrimitive?.intOrNull == 2 }
+      assertNotNull("renderNow response should arrive", renderResponse)
+
+      assertNotNull(
+        "renderFailed notification should be emitted",
+        pollUntil(received) {
+          it["method"]?.jsonPrimitive?.contentOrNull == "renderFailed" &&
+            it["params"]?.jsonObject?.get("id")?.jsonPrimitive?.contentOrNull == "preview-fails"
+        },
+      )
+      assertTrue(
+        "data product registry should receive the render failure",
+        registry.failureLatch.await(5, TimeUnit.SECONDS),
+      )
+      assertEquals("preview-fails", registry.previewId)
+      assertEquals("deliberate test failure", registry.cause?.message)
+    } finally {
+      clientToServerOut.close()
+      serverToClientOut.close()
+      serverThread.join(5_000)
+    }
+  }
+
   /**
    * B2.2 phase 1 — when the daemon is constructed with a non-empty [PreviewIndex], the `initialize`
    * response's `manifest` block reports the absolute path of the loaded `previews.json` and the
@@ -1299,6 +1377,7 @@ private class FakeRenderHost(
    */
   private val metricsToReturn: Map<String, Long>? = null,
   private val androidSdkToAdvertise: Int? = null,
+  private val failureToThrow: Throwable? = null,
 ) : RenderHost {
 
   override val androidSdk: Int?
@@ -1347,6 +1426,7 @@ private class FakeRenderHost(
 
   override fun submit(request: RenderRequest, timeoutMs: Long): RenderResult {
     require(request is RenderRequest.Render)
+    failureToThrow?.let { throw it }
     queue.put(request)
     val q = results.computeIfAbsent(request.id) { LinkedBlockingQueue() }
     return q.poll(timeoutMs, TimeUnit.MILLISECONDS)
@@ -1357,6 +1437,33 @@ private class FakeRenderHost(
     stopped = true
     queue.put(RenderRequest.Shutdown)
     worker.join(timeoutMs)
+  }
+}
+
+private class FailureRecordingDataProductRegistry : DataProductRegistry {
+  val failureLatch = CountDownLatch(1)
+  @Volatile var previewId: String? = null
+  @Volatile var cause: Throwable? = null
+
+  override val capabilities =
+    emptyList<ee.schimke.composeai.daemon.protocol.DataProductCapability>()
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: kotlinx.serialization.json.JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome = DataProductRegistry.Outcome.Unknown
+
+  override fun attachmentsFor(
+    previewId: String,
+    kinds: Set<String>,
+  ): List<ee.schimke.composeai.daemon.protocol.DataProductAttachment> = emptyList()
+
+  override fun onRenderFailed(previewId: String, cause: Throwable) {
+    this.previewId = previewId
+    this.cause = cause
+    failureLatch.countDown()
   }
 }
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -220,6 +220,7 @@ fun main(args: Array<String>) {
       buildList {
         add(DeviceClipDataProductRegistry(previewIndex = previewIndex))
         add(RenderTraceDataProductRegistry())
+        add(TestFailureDataProductRegistry())
         add(themeRegistry)
         add(recompositionRegistry)
         if (PerfettoTraceDataProducer.enabled()) {

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/TestFailureDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/TestFailureDataProduct.kt
@@ -1,0 +1,56 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.render.TestFailureDataProduct
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.serialization.json.JsonElement
+
+/** `test/failure` v1 backed by the latest failed render for a preview. */
+class TestFailureDataProductRegistry : DataProductRegistry {
+
+  private val latestFailures = ConcurrentHashMap<String, JsonElement>()
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = false,
+        fetchable = true,
+        requiresRerender = false,
+      )
+    )
+
+  override fun onRender(previewId: String, result: RenderResult) {
+    latestFailures.remove(previewId)
+  }
+
+  override fun onRenderFailed(previewId: String, cause: Throwable) {
+    latestFailures[previewId] = TestFailureDataProduct.payloadFrom(cause)
+  }
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != KIND) return DataProductRegistry.Outcome.Unknown
+    val payload = latestFailures[previewId] ?: return DataProductRegistry.Outcome.NotAvailable
+    return DataProductRegistry.Outcome.Ok(
+      DataFetchResult(kind = KIND, schemaVersion = SCHEMA_VERSION, payload = payload)
+    )
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> =
+    emptyList()
+
+  companion object {
+    const val KIND: String = TestFailureDataProduct.KIND
+    const val SCHEMA_VERSION: Int = TestFailureDataProduct.SCHEMA_VERSION
+  }
+}

--- a/data/render/connector/src/test/kotlin/ee/schimke/composeai/daemon/TestFailureDataProductRegistryTest.kt
+++ b/data/render/connector/src/test/kotlin/ee/schimke/composeai/daemon/TestFailureDataProductRegistryTest.kt
@@ -1,0 +1,110 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TestFailureDataProductRegistryTest {
+  @Test
+  fun `capability advertises inline fetchable failure product`() {
+    val registry = TestFailureDataProductRegistry()
+
+    val cap = registry.capabilities.single()
+    assertEquals(TestFailureDataProductRegistry.KIND, cap.kind)
+    assertEquals(1, cap.schemaVersion)
+    assertEquals(DataProductTransport.INLINE, cap.transport)
+    assertTrue(!cap.attachable)
+    assertTrue(cap.fetchable)
+    assertTrue(!cap.requiresRerender)
+  }
+
+  @Test
+  fun `fetch returns not available before a failure lands`() {
+    val registry = TestFailureDataProductRegistry()
+
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch(
+        previewId = "preview",
+        kind = TestFailureDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      ),
+    )
+  }
+
+  @Test
+  fun `onRenderFailed stores a failure postmortem payload`() {
+    val registry = TestFailureDataProductRegistry()
+    val cause =
+      IllegalStateException("Missing PreviewParameter value").also {
+        it.stackTrace =
+          arrayOf(
+            StackTraceElement(
+              "com.example.ExamplePreviewKt",
+              "ExamplePreview",
+              "ExamplePreview.kt",
+              37,
+            )
+          )
+      }
+
+    registry.onRenderFailed(previewId = "preview", cause = cause)
+
+    val outcome =
+      registry.fetch(
+        previewId = "preview",
+        kind = TestFailureDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      )
+
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    val payload = (outcome as DataProductRegistry.Outcome.Ok).result.payload!!.jsonObject
+    assertEquals("failed", payload["status"]!!.jsonPrimitive.content)
+    assertEquals("unknown", payload["phase"]!!.jsonPrimitive.content)
+    val error = payload["error"]!!.jsonObject
+    assertEquals("IllegalStateException", error["type"]!!.jsonPrimitive.content)
+    assertEquals("Missing PreviewParameter value", error["message"]!!.jsonPrimitive.content)
+    assertEquals("ExamplePreview.kt:37", error["topFrame"]!!.jsonPrimitive.content)
+    assertEquals(1, (error["stackTrace"] as JsonArray).size)
+    assertEquals("false", payload["partialScreenshotAvailable"]!!.jsonPrimitive.content)
+    val snapshot = payload["lastSnapshotSummary"]!!.jsonObject
+    assertEquals("false", snapshot["valuesCaptured"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `successful render clears stale failure`() {
+    val registry = TestFailureDataProductRegistry()
+    registry.onRenderFailed(previewId = "preview", cause = IllegalStateException("boom"))
+
+    registry.onRender(
+      previewId = "preview",
+      result = RenderResult(id = 1L, classLoaderHashCode = 2, classLoaderName = "test"),
+    )
+
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch(
+        previewId = "preview",
+        kind = TestFailureDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      ),
+    )
+  }
+
+  @Test
+  fun `attachments are empty because failures are fetched after renderFailed`() {
+    val registry = TestFailureDataProductRegistry()
+    registry.onRenderFailed(previewId = "preview", cause = IllegalStateException("boom"))
+
+    assertTrue(
+      registry.attachmentsFor("preview", setOf(TestFailureDataProductRegistry.KIND)).isEmpty()
+    )
+  }
+}

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/TestFailureDataProduct.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/TestFailureDataProduct.kt
@@ -1,0 +1,52 @@
+package ee.schimke.composeai.data.render
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+
+object TestFailureDataProduct {
+  const val KIND: String = "test/failure"
+  const val SCHEMA_VERSION: Int = 1
+
+  fun payloadFrom(cause: Throwable, phase: String = "unknown"): JsonElement {
+    val stackFrames = cause.stackTrace.map { it.toString() }
+    return buildJsonObject {
+      put("status", "failed")
+      put("phase", phase)
+      putJsonObject("error") {
+        put("type", cause.javaClass.simpleName.ifBlank { cause.javaClass.name })
+        put("message", cause.message ?: cause.javaClass.name)
+        put("topFrame", topFrame(cause))
+        put(
+          "stackTrace",
+          buildJsonArray { stackFrames.take(MAX_STACK_FRAMES).forEach { add(JsonPrimitive(it)) } },
+        )
+      }
+      put("partialScreenshot", JsonNull)
+      put("partialScreenshotAvailable", false)
+      put("pendingEffects", buildJsonArray {})
+      put("runningAnimations", buildJsonArray {})
+      putJsonObject("frameClockState") { put("status", "unknown") }
+      putJsonObject("lastSnapshotSummary") {
+        put("stateObjects", JsonNull)
+        put("valuesCaptured", false)
+        put("redaction", "state values are not captured in schema v1")
+      }
+    }
+  }
+
+  private fun topFrame(cause: Throwable): String? =
+    cause.stackTrace.firstOrNull()?.let { frame ->
+      when {
+        frame.fileName != null && frame.lineNumber > 0 -> "${frame.fileName}:${frame.lineNumber}"
+        frame.fileName != null -> frame.fileName
+        else -> "${frame.className}.${frame.methodName}"
+      }
+    }
+
+  private const val MAX_STACK_FRAMES = 32
+}

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -383,7 +383,7 @@ SHIPPED; everything else is "we know the shape, no code yet."
 | `render/trace`             | default | low | Phase breakdown. **Android + desktop daemon implementation:** v1 exposes the latest render as a trace-shaped payload from render metrics; nested `Trace.beginSection` markers are a follow-up. |
 | `fonts/used`               | default | low | Font families with weight/style fallback chain. |
 | `history/diff/regions`     | default | low | Per-pixel bbox of changed regions vs. another history entry. **D6 — shipped inline payload when daemon history is enabled.** |
-| `test/failure`             | failed render | low | Partial bitmap + last Snapshot state + pending `LaunchedEffect` queue. |
+| `test/failure`             | failed render | low | Failed-render postmortem bundle. **Android + desktop daemon implementation:** v1 stores the latest failed render's error type, message, top stack frame, bounded stack trace, and explicit fallback fields for data that cannot yet be captured (`partialScreenshotAvailable=false`, redacted snapshot summary, unknown frame-clock/effect state). Fetch-only after `renderFailed`; successful renders clear the stale failure for that preview. |
 
 "Mode" picks which render configuration produces the data; "cost" is
 relative — the medium-cost kinds are why we default to opt-in.
@@ -426,6 +426,42 @@ input: the instrumentation runs for the lifetime of the interactive
 session, and counters reset at flush points rather than at sandbox
 boundaries. This keeps interactive-mode latency unchanged when the
 client isn't subscribed.
+
+## Worked example: `test/failure`
+
+`test/failure` is fetch-only and exists to make a `renderFailed`
+notification actionable. Agents should request it after a failed render
+instead of scraping daemon stderr; the payload is the structured
+postmortem for the latest failed render of that preview.
+
+```ts
+// schemaVersion: 1
+{
+  status: "failed";
+  phase: "unknown" | "composition" | "layout" | "draw" | "capture" | "timeout";
+  error: {
+    type: string;
+    message: string;
+    topFrame: string | null;      // e.g. "ExamplePreview.kt:37"
+    stackTrace: string[];         // bounded to the first 32 frames
+  };
+  partialScreenshot: string | null;
+  partialScreenshotAvailable: boolean;
+  pendingEffects: string[];
+  runningAnimations: string[];
+  frameClockState: { status: string };
+  lastSnapshotSummary: {
+    stateObjects: number | null;
+    valuesCaptured: boolean;
+    redaction: string;
+  };
+}
+```
+
+Schema v1 deliberately does not capture state values. Until renderer-side
+partial screenshot and Compose runtime state hooks land, those fields are
+present as explicit fallback values so callers can distinguish "not
+captured" from "missing due to an older daemon."
 
 ## Worked example: `a11y/hierarchy`
 

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -730,7 +730,7 @@ class DaemonMcpServer(
               "type":"object",
               "properties":{
                 "uri":{"type":"string","description":"compose-preview://<workspace>/<module>/<fqn>?config=<qualifier>"},
-                "kind":{"type":"string","description":"Data-product kind, e.g. a11y/hierarchy, a11y/atf, layout/inspector, compose/semantics."},
+                "kind":{"type":"string","description":"Data-product kind, e.g. a11y/hierarchy, a11y/atf, layout/inspector, compose/semantics, test/failure."},
                 "params":{"type":"object","description":"Optional per-kind parameters (e.g. {nodeId} for layout/inspector). Forwarded verbatim to the daemon's data/fetch."},
                 "inline":{"type":"boolean","description":"Default true. When false, the daemon returns a `path` to a sibling JSON file instead of inlining the payload."}
               },

--- a/skills/compose-preview/design/DATA_PRODUCTS.md
+++ b/skills/compose-preview/design/DATA_PRODUCTS.md
@@ -112,3 +112,10 @@ renderer-side producers).
 For accessibility specifically the older
 `build/compose-previews/accessibility-per-preview/<id>.json` location
 stays for one release as a back-compat alias, then retires.
+
+`test/failure` is daemon fetch-only. After a `renderFailed`
+notification, call `get_preview_data(..., kind = "test/failure")` to
+retrieve the latest failed-render postmortem for that preview: error
+type/message/top stack frame, a bounded stack trace, and explicit v1
+fallback fields for partial screenshot, pending effects, animation state,
+and redacted snapshot summary.


### PR DESCRIPTION
## Summary

Implements the `test/failure` data product requested in #613.

- adds a fetch-only `test/failure` schema and registry backed by the latest failed render
- wires render failure lifecycle notifications through the data product registry and registers the product in Android and desktop daemons
- documents the v1 payload shape, including explicit fallback/redaction fields for partial screenshots and snapshot state
- updates MCP tool copy to include `test/failure`

## Validation

- `./gradlew :data-render-connector:test --tests ee.schimke.composeai.daemon.TestFailureDataProductRegistryTest`
- `./gradlew :daemon:core:test --tests ee.schimke.composeai.daemon.JsonRpcServerIntegrationTest.render_failure_notifies_data_product_registry_before_render_failed`
- `./gradlew :data-render-connector:test --tests ee.schimke.composeai.daemon.TestFailureDataProductRegistryTest :data-render-connector:ktfmtCheck :daemon:core:ktfmtCheck :daemon:android:ktfmtCheck :daemon:desktop:ktfmtCheck :mcp:ktfmtCheck :daemon:android:compileReleaseKotlin :daemon:desktop:compileKotlin :mcp:compileKotlin`

Closes #613.