### PR TITLE
fix: publish daemon data product dependencies

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -66,8 +66,19 @@ jobs:
             :gradle-plugin:publishToMavenLocal \
             :data-a11y-core:publishToMavenLocal \
             :data-a11y-connector:publishToMavenLocal \
+            :data-fonts-core:publishToMavenLocal \
+            :data-fonts-connector:publishToMavenLocal \
+            :data-history-connector:publishToMavenLocal \
+            :data-layoutinspector-core:publishToMavenLocal \
+            :data-layoutinspector-connector:publishToMavenLocal \
             :data-render-core:publishToMavenLocal \
+            :data-render-connector:publishToMavenLocal \
+            :data-resources-core:publishToMavenLocal \
+            :data-resources-connector:publishToMavenLocal \
             :data-scroll-core:publishToMavenLocal \
+            :data-strings-core:publishToMavenLocal \
+            :data-strings-connector:publishToMavenLocal \
+            :data-theme-connector:publishToMavenLocal \
             :renderer-android:publishToMavenLocal \
             :daemon:core:publishToMavenLocal \
             :daemon:desktop:publishToMavenLocal \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,8 +99,19 @@ jobs:
             :gradle-plugin:publishAllPublicationsToGitHubPackagesRepository \
             :data-a11y-core:publishAllPublicationsToGitHubPackagesRepository \
             :data-a11y-connector:publishAllPublicationsToGitHubPackagesRepository \
+            :data-fonts-core:publishAllPublicationsToGitHubPackagesRepository \
+            :data-fonts-connector:publishAllPublicationsToGitHubPackagesRepository \
+            :data-history-connector:publishAllPublicationsToGitHubPackagesRepository \
+            :data-layoutinspector-core:publishAllPublicationsToGitHubPackagesRepository \
+            :data-layoutinspector-connector:publishAllPublicationsToGitHubPackagesRepository \
             :data-render-core:publishAllPublicationsToGitHubPackagesRepository \
+            :data-render-connector:publishAllPublicationsToGitHubPackagesRepository \
+            :data-resources-core:publishAllPublicationsToGitHubPackagesRepository \
+            :data-resources-connector:publishAllPublicationsToGitHubPackagesRepository \
             :data-scroll-core:publishAllPublicationsToGitHubPackagesRepository \
+            :data-strings-core:publishAllPublicationsToGitHubPackagesRepository \
+            :data-strings-connector:publishAllPublicationsToGitHubPackagesRepository \
+            :data-theme-connector:publishAllPublicationsToGitHubPackagesRepository \
             :renderer-android:publishAllPublicationsToGitHubPackagesRepository \
             :preview-annotations:publishAllPublicationsToGitHubPackagesRepository \
             :daemon:core:publishAllPublicationsToGitHubPackagesRepository \
@@ -115,8 +126,19 @@ jobs:
             :gradle-plugin:publishAndReleaseToMavenCentral \
             :data-a11y-core:publishAndReleaseToMavenCentral \
             :data-a11y-connector:publishAndReleaseToMavenCentral \
+            :data-fonts-core:publishAndReleaseToMavenCentral \
+            :data-fonts-connector:publishAndReleaseToMavenCentral \
+            :data-history-connector:publishAndReleaseToMavenCentral \
+            :data-layoutinspector-core:publishAndReleaseToMavenCentral \
+            :data-layoutinspector-connector:publishAndReleaseToMavenCentral \
             :data-render-core:publishAndReleaseToMavenCentral \
+            :data-render-connector:publishAndReleaseToMavenCentral \
+            :data-resources-core:publishAndReleaseToMavenCentral \
+            :data-resources-connector:publishAndReleaseToMavenCentral \
             :data-scroll-core:publishAndReleaseToMavenCentral \
+            :data-strings-core:publishAndReleaseToMavenCentral \
+            :data-strings-connector:publishAndReleaseToMavenCentral \
+            :data-theme-connector:publishAndReleaseToMavenCentral \
             :renderer-android:publishAndReleaseToMavenCentral \
             :preview-annotations:publishAndReleaseToMavenCentral \
             :daemon:core:publishAndReleaseToMavenCentral \

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -54,8 +54,19 @@ jobs:
             :gradle-plugin:publishToMavenCentral \
             :data-a11y-core:publishToMavenCentral \
             :data-a11y-connector:publishToMavenCentral \
+            :data-fonts-core:publishToMavenCentral \
+            :data-fonts-connector:publishToMavenCentral \
+            :data-history-connector:publishToMavenCentral \
+            :data-layoutinspector-core:publishToMavenCentral \
+            :data-layoutinspector-connector:publishToMavenCentral \
             :data-render-core:publishToMavenCentral \
+            :data-render-connector:publishToMavenCentral \
+            :data-resources-core:publishToMavenCentral \
+            :data-resources-connector:publishToMavenCentral \
             :data-scroll-core:publishToMavenCentral \
+            :data-strings-core:publishToMavenCentral \
+            :data-strings-connector:publishToMavenCentral \
+            :data-theme-connector:publishToMavenCentral \
             :renderer-android:publishToMavenCentral \
             :preview-annotations:publishToMavenCentral \
             :daemon:core:publishToMavenCentral \

--- a/data/fonts/connector/build.gradle.kts
+++ b/data/fonts/connector/build.gradle.kts
@@ -1,11 +1,20 @@
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
 
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.0.0-SNAPSHOT"
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
 
 dependencies {
   api(project(":data-fonts-core"))
@@ -16,3 +25,55 @@ dependencies {
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+  coordinates("ee.schimke.composeai", "data-fonts-connector", version.toString())
+  pom {
+    name.set("Compose Preview - Fonts Data Product Connector")
+    description.set("Daemon-side fonts data-product connector for Compose Preview.")
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2026")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
+}

--- a/data/fonts/core/build.gradle.kts
+++ b/data/fonts/core/build.gradle.kts
@@ -1,11 +1,20 @@
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
 
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.0.0-SNAPSHOT"
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
 
 dependencies {
   api(libs.kotlinx.serialization.json)
@@ -15,3 +24,55 @@ dependencies {
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+  coordinates("ee.schimke.composeai", "data-fonts-core", version.toString())
+  pom {
+    name.set("Compose Preview - Fonts Data Product Core")
+    description.set("Shared fonts data-product model classes for Compose Preview.")
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2026")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
+}

--- a/data/history/connector/build.gradle.kts
+++ b/data/history/connector/build.gradle.kts
@@ -1,11 +1,20 @@
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
 
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.0.0-SNAPSHOT"
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
 
 dependencies {
   api(project(":daemon:core"))
@@ -15,3 +24,55 @@ dependencies {
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+  coordinates("ee.schimke.composeai", "data-history-connector", version.toString())
+  pom {
+    name.set("Compose Preview - History Data Product Connector")
+    description.set("Daemon-side history data-product connector for Compose Preview.")
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2026")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
+}

--- a/data/layoutinspector/connector/build.gradle.kts
+++ b/data/layoutinspector/connector/build.gradle.kts
@@ -1,12 +1,23 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.kotlin.serialization)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
 
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.0.0-SNAPSHOT"
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
 
 android {
   namespace = "ee.schimke.composeai.data.layoutinspector.connector"
@@ -28,4 +39,59 @@ dependencies {
   testImplementation(libs.compose.ui)
   testImplementation(libs.junit)
   testImplementation(libs.kotlinx.serialization.json)
+}
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  configure(
+    AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true)
+  )
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+  coordinates("ee.schimke.composeai", "data-layoutinspector-connector", version.toString())
+  pom {
+    name.set("Compose Preview - Layout Inspector Data Product Connector")
+    description.set("Daemon-side layout inspector data-product connector for Compose Preview.")
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2026")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
 }

--- a/data/layoutinspector/core/build.gradle.kts
+++ b/data/layoutinspector/core/build.gradle.kts
@@ -1,11 +1,20 @@
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
 
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.0.0-SNAPSHOT"
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
 
 dependencies {
   api(libs.kotlinx.serialization.json)
@@ -15,3 +24,55 @@ dependencies {
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+  coordinates("ee.schimke.composeai", "data-layoutinspector-core", version.toString())
+  pom {
+    name.set("Compose Preview - Layout Inspector Data Product Core")
+    description.set("Shared layout inspector data-product model classes for Compose Preview.")
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2026")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
+}

--- a/data/render/connector/build.gradle.kts
+++ b/data/render/connector/build.gradle.kts
@@ -1,11 +1,20 @@
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
 
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.0.0-SNAPSHOT"
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
 
 dependencies {
   api(project(":data-render-core"))
@@ -16,3 +25,55 @@ dependencies {
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+  coordinates("ee.schimke.composeai", "data-render-connector", version.toString())
+  pom {
+    name.set("Compose Preview - Render Data Product Connector")
+    description.set("Daemon-side render data-product connector for Compose Preview.")
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2026")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
+}

--- a/data/resources/connector/build.gradle.kts
+++ b/data/resources/connector/build.gradle.kts
@@ -1,11 +1,22 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.kotlin.serialization)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
 
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.0.0-SNAPSHOT"
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
 
 android {
   namespace = "ee.schimke.composeai.data.resources.connector"
@@ -24,4 +35,59 @@ dependencies {
   testImplementation(libs.junit)
   testImplementation(libs.kotlinx.serialization.json)
   testImplementation(libs.robolectric)
+}
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  configure(
+    AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true)
+  )
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+  coordinates("ee.schimke.composeai", "data-resources-connector", version.toString())
+  pom {
+    name.set("Compose Preview - Resources Data Product Connector")
+    description.set("Daemon-side resources data-product connector for Compose Preview.")
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2026")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
 }

--- a/data/resources/core/build.gradle.kts
+++ b/data/resources/core/build.gradle.kts
@@ -1,11 +1,20 @@
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
 
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.0.0-SNAPSHOT"
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
 
 dependencies {
   api(libs.kotlinx.serialization.json)
@@ -15,3 +24,55 @@ dependencies {
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+  coordinates("ee.schimke.composeai", "data-resources-core", version.toString())
+  pom {
+    name.set("Compose Preview - Resources Data Product Core")
+    description.set("Shared resources data-product model classes for Compose Preview.")
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2026")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
+}

--- a/data/strings/connector/build.gradle.kts
+++ b/data/strings/connector/build.gradle.kts
@@ -1,11 +1,22 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+
 plugins {
   alias(libs.plugins.android.library)
   alias(libs.plugins.kotlin.serialization)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
 
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.0.0-SNAPSHOT"
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
 
 android {
   namespace = "ee.schimke.composeai.data.strings.connector"
@@ -26,4 +37,59 @@ dependencies {
   compileOnly(libs.compose.ui)
   testImplementation(libs.junit)
   testImplementation(libs.kotlinx.serialization.json)
+}
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  configure(
+    AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true)
+  )
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+  coordinates("ee.schimke.composeai", "data-strings-connector", version.toString())
+  pom {
+    name.set("Compose Preview - Strings Data Product Connector")
+    description.set("Daemon-side strings data-product connector for Compose Preview.")
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2026")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
 }

--- a/data/strings/core/build.gradle.kts
+++ b/data/strings/core/build.gradle.kts
@@ -1,11 +1,20 @@
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
 
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.0.0-SNAPSHOT"
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
 
 dependencies {
   api(libs.kotlinx.serialization.json)
@@ -15,3 +24,55 @@ dependencies {
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+  coordinates("ee.schimke.composeai", "data-strings-core", version.toString())
+  pom {
+    name.set("Compose Preview - Strings Data Product Core")
+    description.set("Shared strings data-product model classes for Compose Preview.")
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2026")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
+}

--- a/data/theme/connector/build.gradle.kts
+++ b/data/theme/connector/build.gradle.kts
@@ -3,11 +3,20 @@ plugins {
   alias(libs.plugins.compose.multiplatform)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.kotlin.serialization)
+  `maven-publish`
+  alias(libs.plugins.maven.publish)
 }
 
 group = "ee.schimke.composeai"
 
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.0.0-SNAPSHOT"
+version =
+  providers.environmentVariable("PLUGIN_VERSION").orNull
+    ?: run {
+      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
+      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
+      val (major, minor, patch) = current.split(".").map { it.toInt() }
+      "$major.$minor.${patch + 1}-SNAPSHOT"
+    }
 
 dependencies {
   api(project(":daemon:core"))
@@ -25,3 +34,55 @@ dependencies {
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
+
+publishing {
+  repositories {
+    maven {
+      name = "GitHubPackages"
+      url =
+        uri(
+          providers
+            .environmentVariable("GITHUB_REPOSITORY")
+            .map { "https://maven.pkg.github.com/$it" }
+            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+        )
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+      }
+    }
+  }
+}
+
+mavenPublishing {
+  publishToMavenCentral(automaticRelease = true)
+  if (!version.toString().endsWith("SNAPSHOT")) {
+    signAllPublications()
+  }
+  coordinates("ee.schimke.composeai", "data-theme-connector", version.toString())
+  pom {
+    name.set("Compose Preview - Theme Data Product Connector")
+    description.set("Daemon-side theme data-product connector for Compose Preview.")
+    url.set("https://github.com/yschimke/compose-ai-tools")
+    inceptionYear.set("2026")
+    licenses {
+      license {
+        name.set("The Apache License, Version 2.0")
+        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        distribution.set("repo")
+      }
+    }
+    developers {
+      developer {
+        id.set("yschimke")
+        name.set("Yuri Schimke")
+        url.set("https://github.com/yschimke")
+      }
+    }
+    scm {
+      url.set("https://github.com/yschimke/compose-ai-tools")
+      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- make the daemon data-product connector/core modules publishable with the same versioning rule as the existing published modules
- publish those artifacts in integration, release, and snapshot workflows
- keep `daemon-android` external consumers from resolving missing transitive `ee.schimke.composeai:data-*` artifacts

## Validation
- `./gradlew ktfmtFormatAll`
- `./gradlew :gradle-plugin:publishToMavenLocal :data-a11y-core:publishToMavenLocal :data-a11y-connector:publishToMavenLocal :data-fonts-core:publishToMavenLocal :data-fonts-connector:publishToMavenLocal :data-history-connector:publishToMavenLocal :data-layoutinspector-core:publishToMavenLocal :data-layoutinspector-connector:publishToMavenLocal :data-render-core:publishToMavenLocal :data-render-connector:publishToMavenLocal :data-resources-core:publishToMavenLocal :data-resources-connector:publishToMavenLocal :data-scroll-core:publishToMavenLocal :data-strings-core:publishToMavenLocal :data-strings-connector:publishToMavenLocal :data-theme-connector:publishToMavenLocal :renderer-android:publishToMavenLocal :daemon:core:publishToMavenLocal :daemon:desktop:publishToMavenLocal :daemon:android:publishToMavenLocal --stacktrace`