### PR TITLE
feat(cli): add data product commands

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,3 +1,10 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
@@ -49,6 +56,44 @@ dependencies {
 }
 
 tasks.withType<Test>().configureEach { useJUnitPlatform() }
+
+abstract class CheckCliDaemonLibraryBoundary : DefaultTask() {
+  @get:Classpath abstract val runtimeClasspath: ConfigurableFileCollection
+
+  @get:Input abstract val forbiddenProjectDirs: ListProperty<String>
+
+  @TaskAction
+  fun checkBoundary() {
+    val forbiddenDirs = forbiddenProjectDirs.get()
+    val forbidden =
+      runtimeClasspath.files
+        .filter { file ->
+          val path = file.invariantSeparatorsPath
+          forbiddenDirs.any { forbiddenDir -> path.startsWith("$forbiddenDir/") }
+        }
+        .map { it.path }
+        .sorted()
+
+    check(forbidden.isEmpty()) {
+      "CLI may depend on renderer-agnostic :daemon:core only; forbidden renderer artifacts on " +
+        "runtimeClasspath: ${forbidden.joinToString(", ")}"
+    }
+  }
+}
+
+tasks.register<CheckCliDaemonLibraryBoundary>("checkCliDaemonLibraryBoundary") {
+  description = "Fails if renderer implementations leak onto the CLI runtime classpath."
+  group = "verification"
+
+  runtimeClasspath.from(configurations.named("runtimeClasspath"))
+  forbiddenProjectDirs.set(
+    listOf(":daemon:android", ":daemon:desktop", ":renderer-android", ":renderer-desktop").map {
+      project(it).projectDir.invariantSeparatorsPath
+    }
+  )
+}
+
+tasks.named("check") { dependsOn("checkCliDaemonLibraryBoundary") }
 
 // Bake the resolved Gradle build version into a properties resource the CLI reads at runtime
 // (see `Version.kt#BUNDLE_VERSION`). Avoids the previous hand-edited literal in source — which

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DataCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DataCommands.kt
@@ -1,0 +1,370 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import java.io.File
+import kotlin.system.exitProcess
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+internal const val DATA_PRODUCTS_SCHEMA = "compose-preview-data-products/v1"
+internal const val DATA_GET_SCHEMA = "compose-preview-data-get/v1"
+
+private val dataJson = Json {
+  ignoreUnknownKeys = true
+  prettyPrint = true
+  encodeDefaults = true
+}
+
+@Serializable
+data class DataProductsResponse(
+  val schema: String = DATA_PRODUCTS_SCHEMA,
+  val modules: List<DataProductsModule>,
+)
+
+@Serializable
+data class DataProductsModule(
+  val module: String,
+  val dataDir: String,
+  val products: List<DataProductSummary>,
+)
+
+@Serializable
+data class DataProductSummary(
+  val kind: String,
+  val schemaVersion: Int,
+  val transport: DataProductTransport,
+  val fetchable: Boolean,
+  val previews: List<String>,
+)
+
+@Serializable
+data class DataGetResponse(
+  val schema: String = DATA_GET_SCHEMA,
+  val module: String,
+  val previewId: String,
+  val kind: String,
+  val schemaVersion: Int,
+  val transport: DataProductTransport,
+  val path: String,
+  val payload: JsonElement? = null,
+)
+
+class DataProductsCommand(args: List<String>) : Command(args) {
+  private val jsonOutput = "--json" in args
+
+  override fun run() {
+    if ("--help" in args || "-h" in args) {
+      printUsage()
+      return
+    }
+
+    withGradle { gradle ->
+      val modules = resolveModules(gradle)
+      val response =
+        DataProductsResponse(
+          modules = modules.map { scanDataProducts(it.gradlePath, it.projectDir) }
+        )
+      if (jsonOutput) {
+        println(dataJson.encodeToString(DataProductsResponse.serializer(), response))
+      } else {
+        printText(response)
+      }
+    }
+  }
+
+  private fun printUsage() {
+    println(
+      """
+      compose-preview data-products [--module M] [--json]
+
+      Lists data-product files already emitted under
+      <module>/build/compose-previews/data. This local-library command does
+      not run Gradle and does not start a daemon; run `compose-preview show`
+      first when no products are present.
+      """
+        .trimIndent()
+    )
+  }
+
+  private fun printText(response: DataProductsResponse) {
+    var any = false
+    for (module in response.modules) {
+      if (module.products.isEmpty()) continue
+      any = true
+      println("[${module.module}]")
+      for (product in module.products) {
+        println(
+          "  ${product.kind}  schema=v${product.schemaVersion}  " +
+            "transport=${product.transport.name.lowercase()}  previews=${product.previews.size}"
+        )
+      }
+    }
+    if (!any) {
+      println("No data products found. Run `compose-preview show` to render previews first.")
+    }
+  }
+}
+
+class DataCommand(args: List<String>) : Command(args) {
+  private val subcommand = args.dataSubcommand()
+  private val jsonOutput = "--json" in args
+  private val output: String? = args.flagValue("--output")
+  private val kind: String? = args.flagValue("--kind")
+
+  override fun run() {
+    if ("--help" in args || "-h" in args || subcommand == "help") {
+      printUsage()
+      return
+    }
+    when (subcommand) {
+      "get" -> runGet()
+      null -> {
+        System.err.println("No data subcommand specified.")
+        printUsage()
+        exitProcess(1)
+      }
+      else -> {
+        System.err.println("Unknown data subcommand: $subcommand")
+        printUsage()
+        exitProcess(1)
+      }
+    }
+  }
+
+  private fun runGet() {
+    val previewId =
+      exactId
+        ?: run {
+          System.err.println("data get requires --id <preview-id>.")
+          exitProcess(1)
+        }
+    val productKind =
+      kind
+        ?: run {
+          System.err.println("data get requires --kind <kind>.")
+          exitProcess(1)
+        }
+    if (jsonOutput && output != null) {
+      System.err.println("data get accepts either --json or --output, not both.")
+      exitProcess(1)
+    }
+
+    withGradle { gradle ->
+      val modules = resolveModules(gradle)
+      val matches = modules.mapNotNull { module -> findDataProduct(module, previewId, productKind) }
+      when {
+        matches.isEmpty() -> {
+          System.err.println(
+            "Data product not available: id='$previewId' kind='$productKind'. " +
+              "Run `compose-preview show` first, or check that the kind is enabled for this module."
+          )
+          exitProcess(3)
+        }
+        matches.size > 1 && explicitModule == null -> {
+          System.err.println(
+            "Data product matched multiple modules: ${matches.joinToString { it.module }}. " +
+              "Pass --module <name>."
+          )
+          exitProcess(1)
+        }
+      }
+
+      val response = buildDataGetResponse(matches.single())
+      if (output != null) {
+        File(response.path).copyTo(File(output), overwrite = true)
+        println("Wrote ${response.kind} for ${response.previewId} to $output")
+      } else if (jsonOutput) {
+        println(dataJson.encodeToString(DataGetResponse.serializer(), response))
+      } else {
+        println(response.path)
+      }
+    }
+  }
+
+  private fun printUsage() {
+    println(
+      """
+      compose-preview data get --id PREVIEW --kind KIND [--module M] [--json|--output PATH]
+
+      Reads one data product already emitted under
+      <module>/build/compose-previews/data/<preview-id>/. This first
+      implementation does not auto-render and does not call daemon data/fetch.
+      """
+        .trimIndent()
+    )
+  }
+}
+
+private fun List<String>.dataSubcommand(): String? {
+  val valuedFlags = setOf("--module", "--id", "--kind", "--output", "--timeout")
+  var i = 0
+  while (i < size) {
+    val arg = this[i]
+    when {
+      valuedFlags.any { arg.startsWith("$it=") } -> i++
+      arg in valuedFlags -> i += 2
+      arg.startsWith("-") -> i++
+      else -> return arg
+    }
+  }
+  return null
+}
+
+internal fun scanDataProducts(module: String, projectDir: File): DataProductsModule {
+  val dataDir = dataRoot(projectDir)
+  val byKind = linkedMapOf<String, MutableSet<String>>()
+  if (dataDir.isDirectory) {
+    dataDir
+      .listFiles()
+      ?.filter { it.isDirectory }
+      ?.sortedBy { it.name }
+      ?.forEach { previewDir ->
+        previewDir
+          .listFiles()
+          ?.filter { it.isFile }
+          ?.mapNotNull(::descriptorForFile)
+          ?.forEach { descriptor ->
+            byKind.getOrPut(descriptor.kind) { linkedSetOf() } += previewDir.name
+          }
+      }
+  }
+
+  val products =
+    byKind
+      .map { (kind, previews) ->
+        val descriptor = descriptorForKind(kind)
+        DataProductSummary(
+          kind = kind,
+          schemaVersion = descriptor.schemaVersion,
+          transport = descriptor.transport,
+          fetchable = true,
+          previews = previews.toList().sorted(),
+        )
+      }
+      .sortedBy { it.kind }
+
+  return DataProductsModule(
+    module = module,
+    dataDir = dataDir.absoluteFile.path,
+    products = products,
+  )
+}
+
+internal fun findDataProduct(
+  module: PreviewModule,
+  previewId: String,
+  kind: String,
+): LocalDataProduct? {
+  val descriptor = descriptorForKind(kind)
+  val file = dataRoot(module.projectDir).resolve(previewId).resolve(descriptor.fileName)
+  if (!file.exists() || !file.isFile) return null
+  return LocalDataProduct(module.gradlePath, previewId, descriptor, file.absoluteFile)
+}
+
+internal fun buildDataGetResponse(product: LocalDataProduct): DataGetResponse {
+  val payload =
+    product.file
+      .takeIf { it.extension.equals("json", ignoreCase = true) }
+      ?.let { dataJson.parseToJsonElement(it.readText()) }
+  return DataGetResponse(
+    module = product.module,
+    previewId = product.previewId,
+    kind = product.descriptor.kind,
+    schemaVersion = product.descriptor.schemaVersion,
+    transport = product.descriptor.transport,
+    path = product.file.path,
+    payload = payload,
+  )
+}
+
+internal data class LocalDataProduct(
+  val module: String,
+  val previewId: String,
+  val descriptor: LocalDataProductDescriptor,
+  val file: File,
+)
+
+internal data class LocalDataProductDescriptor(
+  val kind: String,
+  val schemaVersion: Int,
+  val transport: DataProductTransport,
+  val fileName: String,
+)
+
+private fun dataRoot(projectDir: File): File = projectDir.resolve("build/compose-previews/data")
+
+private val knownLocalDataProducts =
+  listOf(
+    LocalDataProductDescriptor("a11y/atf", 1, DataProductTransport.INLINE, "a11y-atf.json"),
+    LocalDataProductDescriptor(
+      "a11y/hierarchy",
+      1,
+      DataProductTransport.PATH,
+      "a11y-hierarchy.json",
+    ),
+    LocalDataProductDescriptor(
+      "a11y/touchTargets",
+      1,
+      DataProductTransport.INLINE,
+      "a11y-touchTargets.json",
+    ),
+    LocalDataProductDescriptor("a11y/overlay", 1, DataProductTransport.PATH, "a11y-overlay.png"),
+    LocalDataProductDescriptor(
+      "compose/semantics",
+      1,
+      DataProductTransport.INLINE,
+      "compose-semantics.json",
+    ),
+    LocalDataProductDescriptor(
+      "resources/used",
+      1,
+      DataProductTransport.INLINE,
+      "resources-used.json",
+    ),
+    LocalDataProductDescriptor(
+      "i18n/translations",
+      1,
+      DataProductTransport.INLINE,
+      "i18n-translations.json",
+    ),
+    LocalDataProductDescriptor("fonts/used", 1, DataProductTransport.PATH, "fonts-used.json"),
+    LocalDataProductDescriptor(
+      "render/composeAiTrace",
+      1,
+      DataProductTransport.PATH,
+      "render-perfetto-trace.json",
+    ),
+  )
+
+private val knownByKind = knownLocalDataProducts.associateBy { it.kind }
+private val knownByFileName = knownLocalDataProducts.associateBy { it.fileName }
+
+private fun descriptorForKind(kind: String): LocalDataProductDescriptor =
+  knownByKind[kind]
+    ?: LocalDataProductDescriptor(
+      kind = kind,
+      schemaVersion = 1,
+      transport = DataProductTransport.INLINE,
+      fileName = "${kind.replace('/', '-')}.json",
+    )
+
+private fun descriptorForFile(file: File): LocalDataProductDescriptor? =
+  knownByFileName[file.name]
+    ?: when (file.extension.lowercase()) {
+      "json" ->
+        LocalDataProductDescriptor(
+          kind = file.nameWithoutExtension.replace('-', '/'),
+          schemaVersion = 1,
+          transport = DataProductTransport.INLINE,
+          fileName = file.name,
+        )
+      "png" ->
+        LocalDataProductDescriptor(
+          kind = file.nameWithoutExtension.replace('-', '/'),
+          schemaVersion = 1,
+          transport = DataProductTransport.PATH,
+          fileName = file.name,
+        )
+      else -> null
+    }

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DeviceCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DeviceCommands.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.cli
 
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
+import ee.schimke.composeai.daemon.protocol.KnownDevice
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -14,15 +15,7 @@ private val devicesJson = Json {
 @Serializable
 data class DeviceCatalogResponse(
   val schema: String = DEVICES_SCHEMA,
-  val devices: List<DeviceCatalogEntry>,
-)
-
-@Serializable
-data class DeviceCatalogEntry(
-  val id: String,
-  val widthDp: Int,
-  val heightDp: Int,
-  val density: Float,
+  val devices: List<KnownDevice>,
 )
 
 class DevicesCommand(private val args: List<String>) {
@@ -69,11 +62,12 @@ internal fun buildDeviceCatalogResponse(): DeviceCatalogResponse =
     devices =
       DeviceDimensions.KNOWN_DEVICE_IDS.sorted().map { id ->
         val spec = DeviceDimensions.resolve(id)
-        DeviceCatalogEntry(
+        KnownDevice(
           id = id,
           widthDp = spec.widthDp,
           heightDp = spec.heightDp,
           density = spec.density,
+          isRound = spec.isRound,
         )
       }
   )

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -27,6 +27,7 @@ fun main(args: Array<String>) {
       "--timeout",
       "--plugin-version",
       "--fail-on",
+      "--kind",
       "--desc",
       "--branch",
       "--remote",
@@ -42,6 +43,8 @@ fun main(args: Array<String>) {
       "a11y",
       "doctor",
       "devices",
+      "data-products",
+      "data",
       "share-gist",
       "publish-images",
       "mcp",
@@ -87,6 +90,8 @@ fun main(args: Array<String>) {
     "a11y" -> A11yCommand(allArgs).run()
     "doctor" -> DoctorCommand(allArgs).run()
     "devices" -> DevicesCommand(allArgs).run()
+    "data-products" -> DataProductsCommand(allArgs).run()
+    "data" -> DataCommand(allArgs).run()
     "share-gist" -> ShareGistCommand(allArgs).run()
     "publish-images" -> PublishImagesCommand(allArgs).run()
     "mcp" -> McpCommand(allArgs).run()
@@ -119,6 +124,8 @@ private fun printUsage() {
       a11y             Render previews and print ATF accessibility findings
       doctor           Verify Java 17 + Compose/AGP environment before editing Gradle files
       devices          List known @Preview(device=...) ids and resolved geometry
+      data-products    List data-product kinds already emitted for rendered previews
+      data             Data-product commands: get
       share-gist       Create a gist from a markdown file plus image attachments
       publish-images   Push a directory of rendered PNGs to a shared branch (default compose-preview/pr)
       mcp              MCP server lifecycle: serve | install | doctor (see `mcp help`)
@@ -130,7 +137,8 @@ private fun printUsage() {
       --module <name>      Target module (default: auto-detect all)
       --filter <pattern>   Case-insensitive substring match on preview id
       --id <exact>         Exact match on preview id
-      --json               Emit JSON (show, list, a11y)
+      --kind <kind>        data get: data-product kind (for example a11y/atf)
+      --json               Emit JSON (show, list, a11y, data-products, data get)
       --brief              JSON only: drop functionName/className/sourceFile/params
       --changed-only       JSON only (show, a11y): drop previews with no changed capture
       --output <path>      Copy matched preview PNG to this path (render)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DataCommandsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DataCommandsTest.kt
@@ -1,0 +1,111 @@
+package ee.schimke.composeai.cli
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class DataCommandsTest {
+  private val json = Json {
+    prettyPrint = false
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+  }
+
+  @Test
+  fun `data-products response pins schema and lists emitted JSON products`() {
+    val projectDir = tempModule()
+    writeProduct(
+      projectDir,
+      previewId = "com.example.Foo",
+      fileName = "a11y-atf.json",
+      text = """{"findings":[]}""",
+    )
+
+    val response = DataProductsResponse(modules = listOf(scanDataProducts("app", projectDir)))
+    val encoded = json.encodeToString(DataProductsResponse.serializer(), response)
+    val parsed = json.decodeFromString(DataProductsResponse.serializer(), encoded)
+
+    assertEquals(DATA_PRODUCTS_SCHEMA, parsed.schema)
+    assertTrue(""""schema":"$DATA_PRODUCTS_SCHEMA"""" in encoded)
+
+    val product = parsed.modules.single().products.single()
+    assertEquals("a11y/atf", product.kind)
+    assertEquals(1, product.schemaVersion)
+    assertEquals(listOf("com.example.Foo"), product.previews)
+  }
+
+  @Test
+  fun `data get response includes parsed JSON payload and absolute path`() {
+    val projectDir = tempModule()
+    val file =
+      writeProduct(
+        projectDir,
+        previewId = "com.example.Foo",
+        fileName = "resources-used.json",
+        text =
+          """{"references":[{"resourceType":"string","resourceName":"title","packageName":"app","consumers":[]}]}""",
+      )
+
+    val product =
+      assertNotNull(
+        findDataProduct(
+          PreviewModule("app", projectDir),
+          previewId = "com.example.Foo",
+          kind = "resources/used",
+        )
+      )
+    val response = buildDataGetResponse(product)
+    val encoded = json.encodeToString(DataGetResponse.serializer(), response)
+    val parsed = json.decodeFromString(DataGetResponse.serializer(), encoded)
+
+    assertEquals(DATA_GET_SCHEMA, parsed.schema)
+    assertEquals(file.absolutePath, parsed.path)
+    assertEquals("resources/used", parsed.kind)
+    assertEquals(
+      "title",
+      parsed.payload!!
+        .jsonObject["references"]!!
+        .jsonArray
+        .single()
+        .jsonObject["resourceName"]!!
+        .jsonPrimitive
+        .content,
+    )
+  }
+
+  @Test
+  fun `unknown JSON filenames follow slash dash convention`() {
+    val projectDir = tempModule()
+    writeProduct(
+      projectDir,
+      previewId = "P",
+      fileName = "custom-kind.json",
+      text = """{"ok":true}""",
+    )
+
+    val module = scanDataProducts("app", projectDir)
+
+    assertEquals("custom/kind", module.products.single().kind)
+  }
+
+  private fun tempModule(): File = Files.createTempDirectory("data-command-test").toFile()
+
+  private fun writeProduct(
+    projectDir: File,
+    previewId: String,
+    fileName: String,
+    text: String,
+  ): File {
+    val file = projectDir.resolve("build/compose-previews/data/$previewId/$fileName")
+    file.parentFile.mkdirs()
+    file.writeText(text)
+    return file
+  }
+}

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DeviceCommandTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DeviceCommandTest.kt
@@ -25,6 +25,9 @@ class DeviceCommandTest {
     assertEquals(393, pixel5.widthDp)
     assertEquals(851, pixel5.heightDp)
     assertEquals(2.75f, pixel5.density)
+
+    val wear = parsed.devices.single { it.id == "id:wearos_large_round" }
+    assertEquals(true, wear.isRound)
   }
 
   @Test

--- a/docs/daemon/LAYERING.md
+++ b/docs/daemon/LAYERING.md
@@ -65,11 +65,16 @@ the contract for "the simple way". Constraints:
   existing behaviour and does not require a running daemon. Editor
   integrations use the top-level `daemon { … }` DSL, which defaults to
   enabled and can be disabled temporarily.
-- **No daemon code on the Layer 1 classpath.** `:gradle-plugin` does
-  not depend on `:daemon:core`. The daemon-bootstrap task
-  the plugin registers (`composePreviewDaemonStart`) emits a
-  descriptor file; it does not import or instantiate anything from
-  the daemon modules.
+- **No daemon code on the Gradle plugin classpath.** `:gradle-plugin`
+  does not depend on `:daemon:core`. The daemon-bootstrap task the
+  plugin registers (`composePreviewDaemonStart`) emits a descriptor
+  file; it does not import or instantiate anything from the daemon
+  modules.
+- **CLI daemon-library access is narrow and renderer-agnostic.**
+  `:cli` may depend on `:daemon:core` for pure catalog/protocol helpers
+  such as `DeviceDimensions`, `KnownDevice`, protocol DTOs, and local
+  history models. The CLI must not depend on `:daemon:android`,
+  `:daemon:desktop`, `:renderer-android`, or `:renderer-desktop`.
 - **No conditional branches in `renderPreviews`** for "is the daemon
   running?". The Gradle task path is unaware of the daemon's
   existence. (The daemon can read state Gradle wrote; Gradle does not
@@ -99,10 +104,11 @@ The daemon is a separate JVM started by an explicit task. It speaks
 JSON-RPC ([PROTOCOL.md](PROTOCOL.md)) to one client at a time over
 stdio. Constraints:
 
-- **Daemon code lives only in `:daemon:core` and the two
-  per-target modules** (`:daemon:android`,
-  `:daemon:desktop`). The Gradle plugin does not import
-  these modules; nor does the existing CLI.
+- **Daemon runtime code lives only in `:daemon:core` and the two
+  per-target modules** (`:daemon:android`, `:daemon:desktop`). The
+  Gradle plugin does not import these modules. The CLI may import
+  renderer-agnostic `:daemon:core` catalog/protocol helpers, but it
+  must not instantiate daemon runtime services or renderer hosts.
 - **Daemon ↔ Gradle plumbing is a one-way file handoff.** The
   `composePreviewDaemonStart` task writes a launch descriptor JSON
   file (classpath, JVM args, target). The daemon reads that file at
@@ -120,13 +126,77 @@ What Layer 2 *may* be consumed by:
 - The VS Code extension's `daemonClient.ts` (Stream C work).
 - The harness in `:daemon:harness`.
 - Layer 3's MCP server, as a JSON-RPC client.
+- The CLI as a **local library** for pure, renderer-agnostic helpers
+  from `:daemon:core` only. Examples: protocol DTOs, known-device
+  catalog entries, override-field names, and local file-backed history
+  value types.
 
 What Layer 2 must **not** be consumed by:
 
 - `renderPreviews`. (See Layer 1 constraint above.)
-- The CLI binary's default code path. A `--daemon` CLI subcommand may
-  exist in v2+; it would be its own entry point that *clients* the
-  daemon, not embeds it.
+- The CLI as an embedded daemon runtime. Commands that need module or
+  runtime state must either use the existing Gradle task path or client
+  a daemon process through the protocol; they must not call renderer
+  implementations in-process.
+
+## CLI local-library boundary
+
+The CLI has two valid daemon-adjacent modes:
+
+1. **Local-library mode** for pure data. The command imports
+   `:daemon:core` classes directly and does not run Gradle or spawn a
+   daemon. `compose-preview devices` is the reference example: it reads
+   `DeviceDimensions` and emits protocol-shaped `KnownDevice` rows.
+2. **Daemon-client mode** for runtime state. The command obtains a
+   launch descriptor from Gradle and connects to a daemon process through
+   JSON-RPC using [PROTOCOL.md](PROTOCOL.md). It may start the daemon
+   when explicitly asked, but the efficient path for repeated CLI calls is
+   to attach to an already-running daemon or supervisor. This is required
+   for render queues, live preview state, data products that require a
+   render, interactive sessions, and backend-specific capabilities.
+
+Prefer local-library mode for repeated one-shot CLI workflows. Starting a
+daemon per CLI invocation can easily cost more than the work being asked
+for, especially in scripts that call the CLI several times. Before adding a
+daemon-backed CLI command, first ask whether the needed data product can be
+split into a reusable `core` model/producer and consumed from the CLI after
+the existing Gradle render path has written its files.
+
+When a command does need daemon state, prefer amortized daemon-client
+access over per-command startup:
+
+- connect to a daemon already started by VS Code, MCP, or an explicit CLI
+  warmup command;
+- or connect to a long-lived supervisor that owns daemon lifecycles across
+  modules/workspaces.
+
+Hosting that supervisor in the MCP process is allowed as an optimization:
+the CLI still talks over a protocol boundary and does not import renderer
+implementations. The hosting choice must be treated as lifecycle/packaging,
+not as permission for CLI code to reach into daemon internals. A Unix
+domain socket is a plausible local transport for that future mode, but it
+is not part of the foundation contract; stdio JSON-RPC and local-library
+access remain the supported baseline until a concrete repeated-call
+workflow proves the extra lifecycle surface is worth it.
+
+Allowed CLI compile-time dependencies:
+
+- `:daemon:core` for protocol/catalog/history DTOs and other
+  renderer-agnostic helpers.
+- `:mcp` for the bundled `compose-preview mcp serve` entry point.
+- Data-product `core` modules when they are renderer-agnostic or expose
+  reusable file/model helpers for outputs the Gradle path already writes.
+
+Forbidden CLI compile-time/runtime dependencies:
+
+- `:daemon:android` and `:daemon:desktop`.
+- `:renderer-android` and `:renderer-desktop`.
+- Any connector module that exists only to adapt renderer output into
+  daemon runtime hooks, unless it has first been split into a reusable
+  `core` module.
+
+The `:cli:checkCliDaemonLibraryBoundary` verification task enforces the
+renderer-module part of this rule on the CLI runtime classpath.
 
 ## Layer 3 — what the MCP server owns
 
@@ -186,6 +256,7 @@ not on this list is a layering violation.
 | Daemon JSON-RPC over stdio | L2 ↔ extension/supervisor | `PROTOCOL.md` | L2 |
 | MCP wire format ↔ daemon JSON-RPC translation | L3 ↔ L2 | `:mcp` shim | L3 |
 | `:daemon:core` `Messages.kt` types | shared by L2 + L3 | Kotlin data classes | L2 |
+| `:daemon:core` catalog/protocol helpers → CLI | L2 → L1 CLI | local-library dependency, no daemon process | L1 CLI |
 | `composePreviewDaemonStart` → spawn-daemon helper used by L3's `DaemonSupervisor` | L3 → L1 | shells out to Gradle | L3 |
 
 If a future change wants to add a new seam, it goes here first. If
@@ -206,6 +277,8 @@ Each layer can be removed without breaking the layers below it.
 - Delete `:daemon:core`, `:daemon:android`,
   `:daemon:desktop`, `:daemon:harness`,
   `:mcp`.
+- Move or replace CLI commands that intentionally use local-library
+  helpers from `:daemon:core` (for example the known-device catalog).
 - Remove the `daemon` DSL block and the
   `composePreviewDaemonStart` task registration from `:gradle-plugin`.
 - The base `composePreview { … }` DSL and `renderPreviews` task work

--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -183,6 +183,16 @@ Highest-value simple additions:
      `build/compose-previews/data/<previewId>/<kind-with-slashes-as-dashes>.json`.
      This covers cheap/ambient products without adding a daemon lifecycle to
      the command.
+   - Prefer refactoring reusable data-product models/producers into `core`
+     modules over starting a daemon for every one-shot CLI call. A daemon
+     startup can dominate total cost when scripts invoke the CLI repeatedly.
+     When daemon-backed fetch is needed, prefer attaching to an existing
+     daemon/supervisor, including one hosted by MCP, so startup is amortized.
+     Reserve daemon-backed fetch for products that need live renderer state
+     or re-render-on-demand behavior. A Unix domain socket could be a good
+     local transport for CLI to MCP-hosted supervisor later, but keep it out
+     of the first CLI foundation unless repeated-call latency justifies the
+     added lifecycle and cleanup rules.
    - Better second implementation: daemon-backed fetch with the MCP
      supervisor so the command can auto-render one preview and handle
      re-render-on-demand products.
@@ -192,8 +202,9 @@ Highest-value simple additions:
    - Value: gives scripts and agents the legal `id:*` device strings and
      resolved dimensions for override planning.
    - Simple implementation: read `DeviceDimensions.KNOWN_DEVICE_IDS`
-     directly. The CLI already bundles `:mcp`, which depends on daemon
-     protocol/core, so no new process or Gradle invocation is required.
+     directly from `:daemon:core` and emit protocol-shaped `KnownDevice`
+     rows. This is the reference CLI local-library use case: no new
+     process or Gradle invocation is required.
 
 4. **`compose-preview history list|diff [--module M] [--id PREVIEW] [--json]`**
    - Maps to MCP `history_list` and `history_diff`.


### PR DESCRIPTION
## Summary

- Add the CLI daemon-library foundation needed for local protocol/catalog reuse.
- Add `compose-preview data-products` to list data-product files already emitted under `build/compose-previews/data`.
- Add `compose-preview data get --id PREVIEW --kind KIND` with JSON and file-output modes for one existing local product.
- Add stable JSON envelopes for the data commands and tests for schema pins, JSON payload fetch, and slash/dash kind mapping.

Closes #566.
Closes #568.

## Notes

This is the first local-file implementation described in #568. It does not start a daemon, run Gradle, auto-render, or call daemon `data/fetch`; users should run `compose-preview show` first when no data products are present.

Retargeted directly to `main`, so this PR includes the #566 foundation work that #568 depends on.

## Validation

- `./gradlew :cli:ktfmtFormatMain :cli:test :cli:checkCliDaemonLibraryBoundary`
- `git diff --check`