### PR TITLE
Add preview extension pipeline metadata

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -7,6 +7,9 @@ import ee.schimke.composeai.daemon.history.GitProvenance
 import ee.schimke.composeai.daemon.history.GitRefHistorySource
 import ee.schimke.composeai.daemon.history.HistoryManager
 import ee.schimke.composeai.daemon.history.HistoryPruneConfig
+import ee.schimke.composeai.data.render.RenderPreviewExtension
+import ee.schimke.composeai.renderer.AccessibilityChecksPreviewExtension
+import ee.schimke.composeai.renderer.AccessibilityOverlayPreviewExtension
 import java.io.File
 import java.nio.file.Path
 
@@ -297,6 +300,16 @@ fun main(args: Array<String>) {
         }
       }
       .let(::CompositeDataProductRegistry)
+  val previewExtensions =
+    buildList {
+      add(RenderPreviewExtension.deviceClipDescriptor)
+      add(RenderPreviewExtension.renderTraceDescriptor)
+      add(RenderPreviewExtension.composeTraceDescriptor)
+      if (a11yPreviewExtensionEnabled) {
+        add(AccessibilityChecksPreviewExtension.descriptor)
+        add(AccessibilityOverlayPreviewExtension.descriptor)
+      }
+    }
 
   val server =
     JsonRpcServer(
@@ -308,6 +321,7 @@ fun main(args: Array<String>) {
       incrementalDiscovery = incrementalDiscovery,
       historyManager = historyManager,
       dataProducts = dataProducts,
+      previewExtensions = previewExtensions,
     )
   server.run()
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -50,6 +50,7 @@ import ee.schimke.composeai.daemon.protocol.ServerCapabilities
 import ee.schimke.composeai.daemon.protocol.SetFocusParams
 import ee.schimke.composeai.daemon.protocol.SetVisibleParams
 import ee.schimke.composeai.daemon.protocol.UiMode
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
 import java.io.ByteArrayOutputStream
 import java.io.EOFException
 import java.io.IOException
@@ -182,6 +183,7 @@ class JsonRpcServer(
    * in `renderer-android`) is the first concrete implementation that gets wired in by `DaemonMain`.
    */
   private val dataProducts: DataProductRegistry = DataProductRegistry.Empty,
+  private val previewExtensions: List<PreviewExtensionDescriptor> = emptyList(),
   /**
    * D3 — per-request budget for `data/fetch` re-render-on-demand (DATA-PRODUCTS.md § "Re-render
    * semantics"). When the registry returns [DataProductRegistry.Outcome.RequiresRerender] the
@@ -637,6 +639,7 @@ class JsonRpcServer(
             leakDetection = emptyList<LeakDetectionMode>(),
             // D1 — advertised kinds. Empty when no producer was wired (pre-D2 default).
             dataProducts = dataProducts.capabilities,
+            previewExtensions = previewExtensions,
             // INTERACTIVE.md § 9 — `true` when the host's `acquireInteractiveSession` returns a
             // real held-scene session (DesktopHost). `false` for hosts that inherit the throwing
             // default (FakeHost, RobolectricHost today) — clients fall back to v1 dispatch.

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.daemon.protocol
 
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
+import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
@@ -138,6 +140,11 @@ data class ServerCapabilities(
   // client side treats absent and `[]` identically). See
   // docs/daemon/DATA-PRODUCTS.md § "Wire surface".
   val dataProducts: List<DataProductCapability> = emptyList(),
+  /**
+   * Metadata for extension steps the daemon can plan into a render pipeline. Clients should use
+   * this for generic UI affordances and validation instead of keying behavior off product strings.
+   */
+  val previewExtensions: List<PreviewExtensionDescriptor> = emptyList(),
   // INTERACTIVE.md § 9 — `true` when the daemon's host can dispatch
   // `interactive/input` events into a held composition (v2). `false` means
   // `interactive/start` still works but inputs trigger a re-render rather than
@@ -240,6 +247,10 @@ data class DataProductCapability(
   val attachable: Boolean,
   val fetchable: Boolean,
   val requiresRerender: Boolean,
+  val displayName: String? = null,
+  val facets: List<DataProductFacet> = emptyList(),
+  val mediaTypes: List<String> = emptyList(),
+  val sampling: SamplingPolicy? = null,
 )
 
 @Serializable
@@ -247,6 +258,19 @@ enum class DataProductTransport {
   @SerialName("inline") INLINE,
   @SerialName("path") PATH,
   @SerialName("both") BOTH,
+}
+
+@Serializable
+enum class DataProductFacet {
+  @SerialName("structured") STRUCTURED,
+  @SerialName("artifact") ARTIFACT,
+  @SerialName("image") IMAGE,
+  @SerialName("animation") ANIMATION,
+  @SerialName("overlay") OVERLAY,
+  @SerialName("check") CHECK,
+  @SerialName("diagnostic") DIAGNOSTIC,
+  @SerialName("profile") PROFILE,
+  @SerialName("interactive") INTERACTIVE,
 }
 
 @Serializable

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -6,6 +6,7 @@ import ee.schimke.composeai.daemon.history.GitProvenance
 import ee.schimke.composeai.daemon.history.GitRefHistorySource
 import ee.schimke.composeai.daemon.history.HistoryManager
 import ee.schimke.composeai.daemon.history.HistoryPruneConfig
+import ee.schimke.composeai.data.render.RenderPreviewExtension
 import java.io.File
 import java.nio.file.Path
 
@@ -258,6 +259,12 @@ fun main(args: Array<String>) {
       // path as a future Compose API rename. Wiring is intentionally global — kinds advertised
       // in `initialize.capabilities.dataProducts` reflect the daemon's whole surface.
       dataProducts = dataProducts,
+      previewExtensions =
+        listOf(
+          RenderPreviewExtension.deviceClipDescriptor,
+          RenderPreviewExtension.renderTraceDescriptor,
+          RenderPreviewExtension.composeTraceDescriptor,
+        ),
     )
 
   installSigtermShutdownHook(host, originalStdin = System.`in`)

--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
@@ -4,7 +4,9 @@ import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductExtra
+import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import ee.schimke.composeai.renderer.AccessibilityFinding
 import ee.schimke.composeai.renderer.AccessibilityNode
 import java.io.File
@@ -237,6 +239,9 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
         attachable = true,
         fetchable = true,
         requiresRerender = false,
+        displayName = "Accessibility findings",
+        facets = listOf(DataProductFacet.STRUCTURED, DataProductFacet.CHECK, DataProductFacet.DIAGNOSTIC),
+        sampling = SamplingPolicy.End,
       ),
       DataProductCapability(
         kind = AccessibilityDataProducer.KIND_HIERARCHY,
@@ -245,6 +250,10 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
         attachable = true,
         fetchable = true,
         requiresRerender = false,
+        displayName = "Accessibility hierarchy",
+        facets = listOf(DataProductFacet.STRUCTURED),
+        mediaTypes = listOf("application/json"),
+        sampling = SamplingPolicy.End,
       ),
       DataProductCapability(
         kind = AccessibilityDataProducer.KIND_TOUCH_TARGETS,
@@ -253,6 +262,9 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
         attachable = true,
         fetchable = true,
         requiresRerender = false,
+        displayName = "Touch target findings",
+        facets = listOf(DataProductFacet.STRUCTURED, DataProductFacet.CHECK, DataProductFacet.DIAGNOSTIC),
+        sampling = SamplingPolicy.End,
       ),
       DataProductCapability(
         kind = AccessibilityDataProducer.KIND_OVERLAY,
@@ -261,6 +273,10 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
         attachable = true,
         fetchable = true,
         requiresRerender = false,
+        displayName = "Accessibility overlay",
+        facets = listOf(DataProductFacet.ARTIFACT, DataProductFacet.IMAGE, DataProductFacet.OVERLAY),
+        mediaTypes = listOf("image/png"),
+        sampling = SamplingPolicy.End,
       ),
     )
 

--- a/data/a11y/core/build.gradle.kts
+++ b/data/a11y/core/build.gradle.kts
@@ -69,6 +69,7 @@ android {
 }
 
 dependencies {
+  api(project(":data-render-core"))
   api(libs.kotlinx.serialization.json)
 
   // ATF (`accessibility-test-framework`) — directly referenced by `AccessibilityChecker.kt`.

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtension.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtension.kt
@@ -1,0 +1,89 @@
+package ee.schimke.composeai.renderer
+
+import ee.schimke.composeai.data.render.pipeline.ExtractionSpec
+import ee.schimke.composeai.data.render.pipeline.PipelineCapability
+import ee.schimke.composeai.data.render.pipeline.PipelineStepTrait
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
+import ee.schimke.composeai.data.render.pipeline.PreviewPipelineStep
+import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
+
+/** Pipeline metadata for accessibility checks. */
+object AccessibilityChecksPreviewExtension {
+  const val ID: String = "a11y-checks"
+  const val KIND_ATF: String = "a11y/atf"
+  const val KIND_HIERARCHY: String = "a11y/hierarchy"
+  const val KIND_TOUCH_TARGETS: String = "a11y/touchTargets"
+
+  /**
+   * Static/single-output a11y extraction: collect semantics and ATF findings at the final render
+   * sample.
+   */
+  val finalSampleExtractor: PreviewPipelineStep =
+    PreviewPipelineStep(
+      id = "a11y.extract.end",
+      displayName = "Accessibility extraction",
+      productKinds = listOf(KIND_ATF, KIND_HIERARCHY, KIND_TOUCH_TARGETS),
+      traits = setOf(PipelineStepTrait.DataExtractor, PipelineStepTrait.Check),
+      requires = setOf(PipelineCapability.SemanticsSnapshot),
+      provides = setOf(PipelineCapability.AccessibilityFindings),
+      extraction =
+        ExtractionSpec(
+          kind = KIND_ATF,
+          sampling = SamplingPolicy.End,
+          requiresSemantics = true,
+        ),
+    )
+
+  /**
+   * Animated/scrolling a11y extraction: collect findings for each captured frame so overlays can be
+   * painted before GIF encoding.
+   */
+  val eachFrameExtractor: PreviewPipelineStep =
+    finalSampleExtractor.copy(
+      id = "a11y.extract.eachFrame",
+      productKinds = listOf(KIND_ATF, KIND_HIERARCHY, KIND_TOUCH_TARGETS),
+      extraction =
+        ExtractionSpec(
+          kind = KIND_ATF,
+          sampling = SamplingPolicy.EachFrame,
+          requiresImage = true,
+          requiresSemantics = true,
+          aggregate = true,
+        ),
+    )
+
+  val descriptor: PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = ID,
+      displayName = "Accessibility checks",
+      steps = listOf(finalSampleExtractor, eachFrameExtractor),
+    )
+}
+
+/** Pipeline metadata for painting accessibility findings onto rendered images. */
+object AccessibilityOverlayPreviewExtension {
+  const val ID: String = "a11y-overlay"
+  const val KIND_OVERLAY: String = "a11y/overlay"
+
+  val overlayProcessor: PreviewPipelineStep =
+    PreviewPipelineStep(
+      id = "a11y.overlay",
+      displayName = "Accessibility overlay",
+      productKinds = listOf(KIND_OVERLAY),
+      traits = setOf(PipelineStepTrait.FrameProcessor),
+      requires =
+        setOf(
+          PipelineCapability.ImageArtifact,
+          PipelineCapability.AccessibilityFindings,
+          PipelineCapability.DeviceGeometry,
+        ),
+      provides = setOf(PipelineCapability.ImageArtifact),
+    )
+
+  val descriptor: PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = ID,
+      displayName = "Accessibility overlay",
+      steps = listOf(overlayProcessor),
+    )
+}

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtensionTest.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtensionTest.kt
@@ -1,0 +1,52 @@
+package ee.schimke.composeai.renderer
+
+import ee.schimke.composeai.data.render.pipeline.PipelineCapability
+import ee.schimke.composeai.data.render.pipeline.PreviewPipelinePlan
+import ee.schimke.composeai.data.render.pipeline.PreviewPipelineValidator
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AccessibilityPreviewExtensionTest {
+  @Test
+  fun overlayCanUseFinalSampleExtraction() {
+    val plan =
+      PreviewPipelinePlan(
+        steps =
+          listOf(
+            AccessibilityChecksPreviewExtension.finalSampleExtractor,
+            AccessibilityOverlayPreviewExtension.overlayProcessor,
+          ),
+        initialCapabilities =
+          setOf(
+            PipelineCapability.SingleFrame,
+            PipelineCapability.DeviceGeometry,
+            PipelineCapability.SemanticsSnapshot,
+            PipelineCapability.ImageArtifact,
+          ),
+      )
+
+    assertTrue(PreviewPipelineValidator.validate(plan).isEmpty())
+  }
+
+  @Test
+  fun overlayCanUseEachFrameExtraction() {
+    val plan =
+      PreviewPipelinePlan(
+        steps =
+          listOf(
+            AccessibilityChecksPreviewExtension.eachFrameExtractor,
+            AccessibilityOverlayPreviewExtension.overlayProcessor,
+          ),
+        initialCapabilities =
+          setOf(
+            PipelineCapability.Frames,
+            PipelineCapability.MultipleFrames,
+            PipelineCapability.DeviceGeometry,
+            PipelineCapability.SemanticsSnapshot,
+            PipelineCapability.ImageArtifact,
+          ),
+      )
+
+    assertTrue(PreviewPipelineValidator.validate(plan).isEmpty())
+  }
+}

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -12,8 +12,10 @@ import androidx.compose.ui.unit.TextUnitType
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
+import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import java.io.File
 import java.util.Locale
 import kotlinx.serialization.json.Json
@@ -161,6 +163,10 @@ class ComposeSemanticsDataProductRegistry(private val rootDir: File) : DataProdu
         attachable = true,
         fetchable = true,
         requiresRerender = false,
+        displayName = "Compose semantics",
+        facets = listOf(DataProductFacet.STRUCTURED),
+        mediaTypes = listOf("application/json"),
+        sampling = SamplingPolicy.End,
       )
     )
 

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProduct.kt
@@ -4,10 +4,12 @@ import ee.schimke.composeai.daemon.devices.DeviceDimensions
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.PreviewDeviceContext
 import ee.schimke.composeai.data.render.PreviewDeviceSpec
+import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
@@ -45,6 +47,9 @@ class DeviceClipDataProductRegistry(previewIndex: PreviewIndex) : DataProductReg
         attachable = true,
         fetchable = true,
         requiresRerender = false,
+        displayName = "Device clip",
+        facets = listOf(DataProductFacet.STRUCTURED),
+        sampling = SamplingPolicy.End,
       )
     )
 

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/PerfettoTraceDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/PerfettoTraceDataProduct.kt
@@ -4,7 +4,9 @@ import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductExtra
+import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import java.io.File
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -76,6 +78,10 @@ class PerfettoTraceDataProductRegistry(private val rootDir: File) : DataProductR
         attachable = true,
         fetchable = true,
         requiresRerender = false,
+        displayName = "Perfetto trace",
+        facets = listOf(DataProductFacet.ARTIFACT, DataProductFacet.PROFILE),
+        mediaTypes = listOf("application/json"),
+        sampling = SamplingPolicy.Aggregate,
       )
     )
 

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/RenderTraceDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/RenderTraceDataProduct.kt
@@ -3,8 +3,10 @@ package ee.schimke.composeai.daemon
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.data.render.RenderTraceDataProduct
+import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.JsonElement
 
@@ -27,6 +29,9 @@ class RenderTraceDataProductRegistry : DataProductRegistry {
         attachable = true,
         fetchable = true,
         requiresRerender = false,
+        displayName = "Render trace",
+        facets = listOf(DataProductFacet.STRUCTURED, DataProductFacet.PROFILE),
+        sampling = SamplingPolicy.Aggregate,
       )
     )
 

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/TestFailureDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/TestFailureDataProduct.kt
@@ -3,8 +3,10 @@ package ee.schimke.composeai.daemon
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.data.render.TestFailureDataProduct
+import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.JsonElement
 
@@ -22,6 +24,9 @@ class TestFailureDataProductRegistry : DataProductRegistry {
         attachable = false,
         fetchable = true,
         requiresRerender = false,
+        displayName = "Render failure",
+        facets = listOf(DataProductFacet.STRUCTURED, DataProductFacet.DIAGNOSTIC),
+        sampling = SamplingPolicy.Failure,
       )
     )
 

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderPreviewExtension.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderPreviewExtension.kt
@@ -1,0 +1,67 @@
+package ee.schimke.composeai.data.render
+
+import ee.schimke.composeai.data.render.pipeline.PipelineCapability
+import ee.schimke.composeai.data.render.pipeline.PipelineStepTrait
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
+import ee.schimke.composeai.data.render.pipeline.PreviewPipelineStep
+import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
+
+/** Pipeline metadata for built-in render-level preview extension steps. */
+object RenderPreviewExtension {
+  const val ID: String = "render"
+  const val KIND_DEVICE_CLIP: String = "render/deviceClip"
+  const val KIND_TRACE: String = "render/trace"
+  const val KIND_COMPOSE_AI_TRACE: String = "render/composeAiTrace"
+  const val KIND_TEST_FAILURE: String = "test/failure"
+
+  val deviceClipProcessor: PreviewPipelineStep =
+    PreviewPipelineStep(
+      id = "render.deviceClip",
+      displayName = "Device clip",
+      productKinds = listOf(KIND_DEVICE_CLIP),
+      traits = setOf(PipelineStepTrait.FrameProcessor),
+      requires = setOf(PipelineCapability.DeviceGeometry, PipelineCapability.ImageArtifact),
+      provides = setOf(PipelineCapability.DeviceClip, PipelineCapability.ImageArtifact),
+    )
+
+  val renderTraceProfiler: PreviewPipelineStep =
+    PreviewPipelineStep(
+      id = "render.trace",
+      displayName = "Render trace",
+      productKinds = listOf(KIND_TRACE),
+      traits = setOf(PipelineStepTrait.Profiler),
+      provides = setOf(PipelineCapability.TraceEvents),
+      sampling = SamplingPolicy.Aggregate,
+    )
+
+  val composeTraceProfiler: PreviewPipelineStep =
+    PreviewPipelineStep(
+      id = "render.composeAiTrace",
+      displayName = "Compose composition trace",
+      productKinds = listOf(KIND_COMPOSE_AI_TRACE),
+      traits = setOf(PipelineStepTrait.Profiler),
+      provides = setOf(PipelineCapability.TraceEvents),
+      sampling = SamplingPolicy.Aggregate,
+    )
+
+  val deviceClipDescriptor: PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "render-device-clip",
+      displayName = "Device clip",
+      steps = listOf(deviceClipProcessor),
+    )
+
+  val renderTraceDescriptor: PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "render-trace",
+      displayName = "Render trace",
+      steps = listOf(renderTraceProfiler),
+    )
+
+  val composeTraceDescriptor: PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "compose-trace",
+      displayName = "Compose composition trace",
+      steps = listOf(composeTraceProfiler),
+    )
+}

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewPipeline.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewPipeline.kt
@@ -1,0 +1,209 @@
+package ee.schimke.composeai.data.render.pipeline
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Renderer-agnostic description of a preview extension step.
+ *
+ * This is intentionally metadata-first: renderers and clients can validate a planned product before
+ * they allocate a Compose scene, and UI clients can explain why a requested combination is not
+ * available.
+ */
+@Serializable
+data class PreviewPipelineStep(
+  val id: String,
+  val displayName: String = id,
+  val productKinds: List<String> = emptyList(),
+  val usageModes: Set<PreviewExtensionUsageMode> = setOf(PreviewExtensionUsageMode.ExplicitEffect),
+  val traits: Set<PipelineStepTrait> = emptySet(),
+  val requires: Set<PipelineCapability> = emptySet(),
+  val provides: Set<PipelineCapability> = emptySet(),
+  val conflictsWith: Set<PipelineStepTrait> = emptySet(),
+  val sampling: SamplingPolicy? = null,
+  val extraction: ExtractionSpec? = null,
+)
+
+@Serializable
+enum class PreviewExtensionUsageMode {
+  ExplicitEffect,
+  SuggestedExtraPreview,
+}
+
+@Serializable
+data class PreviewExtensionDescriptor(
+  val id: String,
+  val displayName: String = id,
+  val steps: List<PreviewPipelineStep> = emptyList(),
+)
+
+@Serializable
+enum class PipelineStepTrait {
+  ScenarioDriver,
+  InteractiveDriver,
+  FrameProcessor,
+  FinalArtifactProcessor,
+  DataExtractor,
+  Check,
+  Encoder,
+  Profiler,
+}
+
+@Serializable
+enum class PipelineCapability {
+  Frames,
+  SingleFrame,
+  MultipleFrames,
+  DeviceGeometry,
+  DeviceClip,
+  ScrollState,
+  SemanticsSnapshot,
+  AccessibilityFindings,
+  ImageArtifact,
+  AnimatedArtifact,
+  InteractiveSession,
+  TraceEvents,
+}
+
+@Serializable
+enum class SamplingPolicy {
+  Start,
+  End,
+  EachFrame,
+  OnDemand,
+  Aggregate,
+  Failure,
+}
+
+@Serializable
+data class ExtractionSpec(
+  val kind: String,
+  val sampling: SamplingPolicy,
+  val requiresImage: Boolean = false,
+  val requiresSemantics: Boolean = false,
+  val aggregate: Boolean = false,
+)
+
+data class PreviewPipelinePlan(
+  val steps: List<PreviewPipelineStep>,
+  val initialCapabilities: Set<PipelineCapability> = emptySet(),
+) {
+  val providedCapabilities: Set<PipelineCapability> =
+    steps.fold(initialCapabilities) { provided, step -> provided + step.provides }
+}
+
+data class PipelineValidationError(
+  val code: String,
+  val message: String,
+  val steps: List<String> = emptyList(),
+)
+
+object PreviewPipelineValidator {
+  fun validate(plan: PreviewPipelinePlan): List<PipelineValidationError> = buildList {
+    val steps = plan.steps
+
+    addAtMostOneTraitError(
+      steps = steps,
+      trait = PipelineStepTrait.ScenarioDriver,
+      code = "MultipleScenarioDrivers",
+      label = "scenario driver",
+    )
+    addAtMostOneTraitError(
+      steps = steps,
+      trait = PipelineStepTrait.InteractiveDriver,
+      code = "MultipleInteractiveDrivers",
+      label = "interactive driver",
+    )
+    addAtMostOneTraitError(
+      steps = steps,
+      trait = PipelineStepTrait.Encoder,
+      code = "MultipleEncoders",
+      label = "encoder",
+    )
+
+    var provided = plan.initialCapabilities
+    for (step in steps) {
+      val missing = step.requires - provided
+      if (missing.isNotEmpty()) {
+        add(
+          PipelineValidationError(
+            code = "MissingCapability",
+            message =
+              "Step '${step.id}' requires ${missing.joinToString()} but the pipeline does not " +
+                "provide ${if (missing.size == 1) "it" else "them"}.",
+            steps = listOf(step.id),
+          )
+        )
+      }
+
+      val conflictingSteps = steps.filter { other ->
+        other.id != step.id && other.traits.any { it in step.conflictsWith }
+      }
+      if (conflictingSteps.isNotEmpty()) {
+        add(
+          PipelineValidationError(
+            code = "ConflictingSteps",
+            message =
+              "Step '${step.id}' conflicts with ${conflictingSteps.joinToString { it.id }}.",
+            steps = listOf(step.id) + conflictingSteps.map { it.id },
+          )
+        )
+      }
+
+      val extraction = step.extraction
+      if (extraction != null) {
+        if (extraction.requiresImage && PipelineCapability.ImageArtifact !in provided) {
+          add(
+            PipelineValidationError(
+              code = "ExtractionRequiresImage",
+              message = "Extractor '${step.id}' requires an image artifact.",
+              steps = listOf(step.id),
+            )
+          )
+        }
+        if (extraction.requiresSemantics && PipelineCapability.SemanticsSnapshot !in provided) {
+          add(
+            PipelineValidationError(
+              code = "ExtractionRequiresSemantics",
+              message = "Extractor '${step.id}' requires a semantics snapshot.",
+              steps = listOf(step.id),
+            )
+          )
+        }
+        if (
+          extraction.sampling == SamplingPolicy.EachFrame &&
+            PipelineCapability.Frames !in provided &&
+            PipelineCapability.SingleFrame !in provided &&
+            PipelineCapability.MultipleFrames !in provided
+        ) {
+          add(
+            PipelineValidationError(
+              code = "EachFrameExtractionRequiresFrames",
+              message = "Extractor '${step.id}' samples each frame but the pipeline has no frames.",
+              steps = listOf(step.id),
+            )
+          )
+        }
+      }
+
+      provided = provided + step.provides
+    }
+  }
+
+  private fun MutableList<PipelineValidationError>.addAtMostOneTraitError(
+    steps: List<PreviewPipelineStep>,
+    trait: PipelineStepTrait,
+    code: String,
+    label: String,
+  ) {
+    val matches = steps.filter { trait in it.traits }
+    if (matches.size > 1) {
+      add(
+        PipelineValidationError(
+          code = code,
+          message = "Pipeline has multiple $label steps: ${matches.joinToString { it.id }}.",
+          steps = matches.map { it.id },
+        )
+      )
+    }
+  }
+}

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewPipelineValidatorTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewPipelineValidatorTest.kt
@@ -1,0 +1,170 @@
+package ee.schimke.composeai.data.render.pipeline
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PreviewPipelineValidatorTest {
+  @Test
+  fun validScrollGifWithDeviceClipAndA11yOverlay() {
+    val plan =
+      PreviewPipelinePlan(
+        listOf(
+          PreviewPipelineStep(
+            id = "scroll-gif",
+            traits = setOf(PipelineStepTrait.ScenarioDriver),
+            provides =
+              setOf(
+                PipelineCapability.Frames,
+                PipelineCapability.MultipleFrames,
+                PipelineCapability.ScrollState,
+                PipelineCapability.DeviceGeometry,
+                PipelineCapability.SemanticsSnapshot,
+                PipelineCapability.ImageArtifact,
+              ),
+          ),
+          PreviewPipelineStep(
+            id = "device-clip",
+            traits = setOf(PipelineStepTrait.FrameProcessor),
+            requires = setOf(PipelineCapability.DeviceGeometry, PipelineCapability.ImageArtifact),
+            provides = setOf(PipelineCapability.DeviceClip, PipelineCapability.ImageArtifact),
+          ),
+          PreviewPipelineStep(
+            id = "a11y-each-frame",
+            traits = setOf(PipelineStepTrait.DataExtractor),
+            provides =
+              setOf(PipelineCapability.SemanticsSnapshot, PipelineCapability.AccessibilityFindings),
+            extraction =
+              ExtractionSpec(
+                kind = "a11y/atf",
+                sampling = SamplingPolicy.EachFrame,
+                requiresImage = true,
+                requiresSemantics = true,
+              ),
+          ),
+          PreviewPipelineStep(
+            id = "a11y-overlay",
+            traits = setOf(PipelineStepTrait.FrameProcessor),
+            requires =
+              setOf(
+                PipelineCapability.ImageArtifact,
+                PipelineCapability.AccessibilityFindings,
+                PipelineCapability.DeviceGeometry,
+              ),
+            provides = setOf(PipelineCapability.ImageArtifact),
+          ),
+          PreviewPipelineStep(
+            id = "gif-encoder",
+            traits = setOf(PipelineStepTrait.Encoder),
+            requires = setOf(PipelineCapability.MultipleFrames, PipelineCapability.ImageArtifact),
+            provides = setOf(PipelineCapability.AnimatedArtifact),
+          ),
+        )
+      )
+
+    assertTrue(PreviewPipelineValidator.validate(plan).isEmpty())
+  }
+
+  @Test
+  fun rejectsMultipleInteractiveDrivers() {
+    val errors =
+      PreviewPipelineValidator.validate(
+        PreviewPipelinePlan(
+          listOf(
+            PreviewPipelineStep(
+              id = "interactive-session",
+              traits = setOf(PipelineStepTrait.InteractiveDriver),
+            ),
+            PreviewPipelineStep(
+              id = "scripted-touch",
+              traits = setOf(PipelineStepTrait.InteractiveDriver),
+            ),
+          )
+        )
+      )
+
+    assertEquals(listOf("MultipleInteractiveDrivers"), errors.map { it.code })
+  }
+
+  @Test
+  fun rejectsTwoScenarioDrivers() {
+    val errors =
+      PreviewPipelineValidator.validate(
+        PreviewPipelinePlan(
+          listOf(
+            PreviewPipelineStep(id = "scroll", traits = setOf(PipelineStepTrait.ScenarioDriver)),
+            PreviewPipelineStep(id = "animation", traits = setOf(PipelineStepTrait.ScenarioDriver)),
+          )
+        )
+      )
+
+    assertEquals(listOf("MultipleScenarioDrivers"), errors.map { it.code })
+  }
+
+  @Test
+  fun rejectsMissingOverlayInputs() {
+    val errors =
+      PreviewPipelineValidator.validate(
+        PreviewPipelinePlan(
+          listOf(
+            PreviewPipelineStep(
+              id = "a11y-overlay",
+              traits = setOf(PipelineStepTrait.FrameProcessor),
+              requires =
+                setOf(PipelineCapability.AccessibilityFindings, PipelineCapability.DeviceGeometry),
+            )
+          )
+        )
+      )
+
+    assertEquals(listOf("MissingCapability"), errors.map { it.code })
+  }
+
+  @Test
+  fun rejectsProcessorBeforeItsInputsExist() {
+    val errors =
+      PreviewPipelineValidator.validate(
+        PreviewPipelinePlan(
+          listOf(
+            PreviewPipelineStep(
+              id = "a11y-overlay",
+              traits = setOf(PipelineStepTrait.FrameProcessor),
+              requires = setOf(PipelineCapability.AccessibilityFindings),
+            ),
+            PreviewPipelineStep(
+              id = "a11y-extract",
+              traits = setOf(PipelineStepTrait.DataExtractor),
+              provides = setOf(PipelineCapability.AccessibilityFindings),
+            ),
+          )
+        )
+      )
+
+    assertEquals(listOf("MissingCapability"), errors.map { it.code })
+  }
+
+  @Test
+  fun rejectsEachFrameExtractorWithoutFrames() {
+    val errors =
+      PreviewPipelineValidator.validate(
+        PreviewPipelinePlan(
+          steps =
+            listOf(
+              PreviewPipelineStep(
+                id = "strings",
+                traits = setOf(PipelineStepTrait.DataExtractor),
+                extraction =
+                  ExtractionSpec(
+                    kind = "text/strings",
+                    sampling = SamplingPolicy.EachFrame,
+                    requiresImage = true,
+                  ),
+              )
+            ),
+          initialCapabilities = setOf(PipelineCapability.ImageArtifact),
+        )
+      )
+
+    assertEquals(listOf("EachFrameExtractionRequiresFrames"), errors.map { it.code })
+  }
+}

--- a/data/scroll/core/build.gradle.kts
+++ b/data/scroll/core/build.gradle.kts
@@ -51,6 +51,8 @@ android {
 }
 
 dependencies {
+  api(project(":data-render-core"))
+
   compileOnly(platform(libs.compose.bom.compat))
   compileOnly(libs.compose.ui)
   compileOnly("androidx.compose.ui:ui-test-junit4")

--- a/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtension.kt
+++ b/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtension.kt
@@ -1,0 +1,85 @@
+package ee.schimke.composeai.scroll
+
+import ee.schimke.composeai.data.render.pipeline.PipelineCapability
+import ee.schimke.composeai.data.render.pipeline.PipelineStepTrait
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionUsageMode
+import ee.schimke.composeai.data.render.pipeline.PreviewPipelineStep
+
+/** Pipeline metadata for the scroll preview extension. */
+object ScrollPreviewExtension {
+  const val ID: String = "scroll"
+  const val KIND_LONG: String = "render/scroll/long"
+  const val KIND_GIF: String = "render/scroll/gif"
+
+  /** Long scroll owns scroll position over a sequence of viewport captures. */
+  val longScrollScenario: PreviewPipelineStep =
+    PreviewPipelineStep(
+      id = "scroll.long.scenario",
+      displayName = "Long scroll scenario",
+      usageModes =
+        setOf(PreviewExtensionUsageMode.ExplicitEffect, PreviewExtensionUsageMode.SuggestedExtraPreview),
+      traits = setOf(PipelineStepTrait.ScenarioDriver),
+      provides =
+        setOf(
+          PipelineCapability.Frames,
+          PipelineCapability.MultipleFrames,
+          PipelineCapability.ScrollState,
+          PipelineCapability.DeviceGeometry,
+          PipelineCapability.SemanticsSnapshot,
+          PipelineCapability.ImageArtifact,
+        ),
+    )
+
+  /** GIF scroll owns scroll position and frame timing over a sequence of viewport captures. */
+  val gifScrollScenario: PreviewPipelineStep =
+    PreviewPipelineStep(
+      id = "scroll.gif.scenario",
+      displayName = "Scroll GIF scenario",
+      usageModes =
+        setOf(PreviewExtensionUsageMode.ExplicitEffect, PreviewExtensionUsageMode.SuggestedExtraPreview),
+      traits = setOf(PipelineStepTrait.ScenarioDriver),
+      provides =
+        setOf(
+          PipelineCapability.Frames,
+          PipelineCapability.MultipleFrames,
+          PipelineCapability.ScrollState,
+          PipelineCapability.DeviceGeometry,
+          PipelineCapability.SemanticsSnapshot,
+          PipelineCapability.ImageArtifact,
+        ),
+    )
+
+  /** Stitches long-scroll frames into one final still image. */
+  val longScrollEncoder: PreviewPipelineStep =
+    PreviewPipelineStep(
+      id = "scroll.long.encoder",
+      displayName = "Long scroll stitcher",
+      productKinds = listOf(KIND_LONG),
+      usageModes =
+        setOf(PreviewExtensionUsageMode.ExplicitEffect, PreviewExtensionUsageMode.SuggestedExtraPreview),
+      traits = setOf(PipelineStepTrait.Encoder),
+      requires = setOf(PipelineCapability.MultipleFrames, PipelineCapability.ImageArtifact),
+      provides = setOf(PipelineCapability.ImageArtifact),
+    )
+
+  /** Encodes scroll frames into an animated GIF. */
+  val gifScrollEncoder: PreviewPipelineStep =
+    PreviewPipelineStep(
+      id = "scroll.gif.encoder",
+      displayName = "Scroll GIF encoder",
+      productKinds = listOf(KIND_GIF),
+      usageModes =
+        setOf(PreviewExtensionUsageMode.ExplicitEffect, PreviewExtensionUsageMode.SuggestedExtraPreview),
+      traits = setOf(PipelineStepTrait.Encoder),
+      requires = setOf(PipelineCapability.MultipleFrames, PipelineCapability.ImageArtifact),
+      provides = setOf(PipelineCapability.AnimatedArtifact),
+    )
+
+  val descriptor: PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = ID,
+      displayName = "Scroll",
+      steps = listOf(longScrollScenario, gifScrollScenario, longScrollEncoder, gifScrollEncoder),
+    )
+}

--- a/data/scroll/core/src/test/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtensionTest.kt
+++ b/data/scroll/core/src/test/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtensionTest.kt
@@ -1,0 +1,51 @@
+package ee.schimke.composeai.scroll
+
+import ee.schimke.composeai.data.render.RenderPreviewExtension
+import ee.schimke.composeai.data.render.pipeline.PreviewPipelinePlan
+import ee.schimke.composeai.data.render.pipeline.PreviewPipelineValidator
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ScrollPreviewExtensionTest {
+  @Test
+  fun gifScenarioCanBeClippedBeforeEncoding() {
+    val plan =
+      PreviewPipelinePlan(
+        listOf(
+          ScrollPreviewExtension.gifScrollScenario,
+          RenderPreviewExtension.deviceClipProcessor,
+          ScrollPreviewExtension.gifScrollEncoder,
+        )
+      )
+
+    assertTrue(PreviewPipelineValidator.validate(plan).isEmpty())
+  }
+
+  @Test
+  fun gifScenarioCanCollectAggregateComposeTraceWhileScrolling() {
+    val plan =
+      PreviewPipelinePlan(
+        listOf(
+          ScrollPreviewExtension.gifScrollScenario,
+          RenderPreviewExtension.composeTraceProfiler,
+          ScrollPreviewExtension.gifScrollEncoder,
+        )
+      )
+
+    assertTrue(PreviewPipelineValidator.validate(plan).isEmpty())
+  }
+
+  @Test
+  fun longScenarioCanBeClippedBeforeStitching() {
+    val plan =
+      PreviewPipelinePlan(
+        listOf(
+          ScrollPreviewExtension.longScrollScenario,
+          RenderPreviewExtension.deviceClipProcessor,
+          ScrollPreviewExtension.longScrollEncoder,
+        )
+      )
+
+    assertTrue(PreviewPipelineValidator.validate(plan).isEmpty())
+  }
+}

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -639,9 +639,44 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
           ScrollMode.GIF -> "render/scroll/gif"
           else -> error("non-product scroll mode ${scroll.mode}")
         }
+      val displayName =
+        when (scroll.mode) {
+          ScrollMode.LONG -> "Long scroll"
+          ScrollMode.GIF -> "Scroll GIF"
+          else -> error("non-product scroll mode ${scroll.mode}")
+        }
+      val effectId =
+        when (scroll.mode) {
+          ScrollMode.LONG -> "long"
+          ScrollMode.GIF -> "gif"
+          else -> error("non-product scroll mode ${scroll.mode}")
+        }
+      val facets =
+        when (scroll.mode) {
+          ScrollMode.LONG -> listOf(PreviewDataProductFacet.ARTIFACT, PreviewDataProductFacet.IMAGE)
+          ScrollMode.GIF ->
+            listOf(PreviewDataProductFacet.ARTIFACT, PreviewDataProductFacet.ANIMATION)
+          else -> error("non-product scroll mode ${scroll.mode}")
+        }
+      val mediaTypes =
+        when (scroll.mode) {
+          ScrollMode.LONG -> listOf("image/png")
+          ScrollMode.GIF -> listOf("image/gif")
+          else -> error("non-product scroll mode ${scroll.mode}")
+        }
       timeRows.map { (ms, timeSuffix) ->
         PreviewDataProduct(
           kind = kind,
+          extensionId = "scroll",
+          effectId = effectId,
+          usageMode = PreviewExtensionUsageMode.SUGGESTED_EXTRA_PREVIEW,
+          suggestedBy = SCROLLING_PREVIEW_FQN,
+          displayName = displayName,
+          facets = facets,
+          mediaTypes = mediaTypes,
+          sampling =
+            if (scroll.mode == ScrollMode.GIF) PreviewDataProductSampling.EACH_FRAME
+            else PreviewDataProductSampling.AGGREGATE,
           advanceTimeMillis = ms,
           scroll = scroll,
           output =

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/PreviewData.kt
@@ -203,6 +203,22 @@ data class Capture(
 data class PreviewDataProduct(
   /** Data-product kind, e.g. `render/scroll/long`. */
   val kind: String,
+  /** Extension that owns this suggested extra preview effect, e.g. `scroll`. */
+  val extensionId: String? = null,
+  /** Extension-local effect id, e.g. `long` or `gif`. */
+  val effectId: String? = null,
+  /** How the extension request is meant to be applied. */
+  val usageMode: PreviewExtensionUsageMode? = null,
+  /** Where this extra preview suggestion came from, e.g. an annotation FQN. */
+  val suggestedBy: String? = null,
+  /** Human-readable label clients can use without hardcoding every kind. */
+  val displayName: String? = null,
+  /** Generic shape markers clients can use to group and present products. */
+  val facets: List<PreviewDataProductFacet> = emptyList(),
+  /** Expected media types for path-backed artifacts. */
+  val mediaTypes: List<String> = emptyList(),
+  /** When the product samples a scenario. */
+  val sampling: PreviewDataProductSampling? = null,
   /**
    * Optional virtual clock coordinate shared with [Capture.advanceTimeMillis]. `null` means the
    * renderer's default capture advance.
@@ -215,6 +231,35 @@ data class PreviewDataProduct(
   /** Estimated render cost on the same scale as [Capture.cost]. */
   val cost: Float = STATIC_COST,
 )
+
+@Serializable
+enum class PreviewDataProductFacet {
+  STRUCTURED,
+  ARTIFACT,
+  IMAGE,
+  ANIMATION,
+  OVERLAY,
+  CHECK,
+  DIAGNOSTIC,
+  PROFILE,
+  INTERACTIVE,
+}
+
+@Serializable
+enum class PreviewDataProductSampling {
+  START,
+  END,
+  EACH_FRAME,
+  ON_DEMAND,
+  AGGREGATE,
+  FAILURE,
+}
+
+@Serializable
+enum class PreviewExtensionUsageMode {
+  EXPLICIT_EFFECT,
+  SUGGESTED_EXTRA_PREVIEW,
+}
 
 @Serializable
 data class PreviewInfo(

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewDataTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewDataTest.kt
@@ -39,6 +39,14 @@ class PreviewDataTest {
                 listOf(
                   PreviewDataProduct(
                     kind = "render/scroll/long",
+                    extensionId = "scroll",
+                    effectId = "long",
+                    usageMode = PreviewExtensionUsageMode.SUGGESTED_EXTRA_PREVIEW,
+                    suggestedBy = "ee.schimke.composeai.preview.ScrollingPreview",
+                    facets =
+                      listOf(PreviewDataProductFacet.ARTIFACT, PreviewDataProductFacet.IMAGE),
+                    mediaTypes = listOf("image/png"),
+                    sampling = PreviewDataProductSampling.AGGREGATE,
                     scroll = ScrollCapture(mode = ScrollMode.LONG),
                     output =
                       "data/render-scroll-long/com.example.PreviewsKt.RedBoxPreview_Red Box.png",

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -123,6 +123,84 @@ export interface DataProductCapability {
     attachable: boolean;
     fetchable: boolean;
     requiresRerender: boolean;
+    displayName?: string;
+    facets?: DataProductFacet[];
+    mediaTypes?: string[];
+    sampling?: SamplingPolicy;
+}
+
+export type DataProductFacet =
+    | 'structured'
+    | 'artifact'
+    | 'image'
+    | 'animation'
+    | 'overlay'
+    | 'check'
+    | 'diagnostic'
+    | 'profile'
+    | 'interactive';
+
+export type SamplingPolicy =
+    | 'Start'
+    | 'End'
+    | 'EachFrame'
+    | 'OnDemand'
+    | 'Aggregate'
+    | 'Failure';
+
+export interface PreviewExtensionDescriptor {
+    id: string;
+    displayName?: string;
+    steps?: PreviewPipelineStep[];
+}
+
+export interface PreviewPipelineStep {
+    id: string;
+    displayName?: string;
+    productKinds?: string[];
+    usageModes?: PreviewExtensionUsageMode[];
+    traits?: PipelineStepTrait[];
+    requires?: PipelineCapability[];
+    provides?: PipelineCapability[];
+    conflictsWith?: PipelineStepTrait[];
+    sampling?: SamplingPolicy | null;
+    extraction?: ExtractionSpec | null;
+}
+
+export type PreviewExtensionUsageMode =
+    | 'ExplicitEffect'
+    | 'SuggestedExtraPreview';
+
+export type PipelineStepTrait =
+    | 'ScenarioDriver'
+    | 'InteractiveDriver'
+    | 'FrameProcessor'
+    | 'FinalArtifactProcessor'
+    | 'DataExtractor'
+    | 'Check'
+    | 'Encoder'
+    | 'Profiler';
+
+export type PipelineCapability =
+    | 'Frames'
+    | 'SingleFrame'
+    | 'MultipleFrames'
+    | 'DeviceGeometry'
+    | 'DeviceClip'
+    | 'ScrollState'
+    | 'SemanticsSnapshot'
+    | 'AccessibilityFindings'
+    | 'ImageArtifact'
+    | 'AnimatedArtifact'
+    | 'InteractiveSession'
+    | 'TraceEvents';
+
+export interface ExtractionSpec {
+    kind: string;
+    sampling: SamplingPolicy;
+    requiresImage?: boolean;
+    requiresSemantics?: boolean;
+    aggregate?: boolean;
 }
 
 export interface InitializeResult {
@@ -140,6 +218,7 @@ export interface InitializeResult {
          * kinds in subscribe/fetch with `DataProductUnknown` (-32020).
          */
         dataProducts: DataProductCapability[];
+        previewExtensions?: PreviewExtensionDescriptor[];
         /**
          * INTERACTIVE.md § 9 — `true` when the daemon's host can dispatch
          * `interactive/input` events into a held composition (v2 — clicks

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -77,12 +77,43 @@ export interface Capture {
 export interface PreviewDataProduct {
     /** Data-product kind, for example `render/scroll/long`. */
     kind: string;
+    extensionId?: string | null;
+    effectId?: string | null;
+    usageMode?: PreviewExtensionUsageMode | null;
+    suggestedBy?: string | null;
+    displayName?: string | null;
+    facets?: PreviewDataProductFacet[];
+    mediaTypes?: string[];
+    sampling?: PreviewDataProductSampling | null;
     advanceTimeMillis: number | null;
     scroll: ScrollCapture | null;
     /** Module-relative product file path under `build/compose-previews`. */
     output: string;
     cost?: number;
 }
+
+export type PreviewDataProductFacet =
+    | 'STRUCTURED'
+    | 'ARTIFACT'
+    | 'IMAGE'
+    | 'ANIMATION'
+    | 'OVERLAY'
+    | 'CHECK'
+    | 'DIAGNOSTIC'
+    | 'PROFILE'
+    | 'INTERACTIVE';
+
+export type PreviewDataProductSampling =
+    | 'START'
+    | 'END'
+    | 'EACH_FRAME'
+    | 'ON_DEMAND'
+    | 'AGGREGATE'
+    | 'FAILURE';
+
+export type PreviewExtensionUsageMode =
+    | 'EXPLICIT_EFFECT'
+    | 'SUGGESTED_EXTRA_PREVIEW';
 
 export interface PreviewInfo {
     id: string;


### PR DESCRIPTION
## Summary
- Add renderer-agnostic preview extension descriptors, pipeline steps, capabilities, traits, usage modes, sampling, and ordered validation.
- Advertise split built-in extensions for render device clip, render trace, compose trace, accessibility checks, accessibility overlay, and scroll.
- Annotate data product capabilities and manifest-suggested scroll extras with facets/media/sampling so VS Code and CLI can reason about outputs without hardcoded kind logic.
- Keep `@ScrollingPreview` as authoring intent that suggests an extra preview/effect for exports via `extensionId`, `effectId`, `usageMode`, and `suggestedBy` metadata.

## Validation
- `./gradlew ktfmtFormatAll :gradle-plugin:test :gradle-plugin:compileKotlin :data-render-core:test :data-render-connector:test :daemon:core:compileKotlin :daemon:desktop:compileKotlin`

## Follow-up
- Split the current a11y overlay implementation further into a generic overlay/legend extension, then model the current a11y feature as a composition of ATF checks + a11y extraction + generic overlay/legend plus a suggested extra preview.