### PR TITLE
Split composed preview extensions

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -8,8 +8,10 @@ import ee.schimke.composeai.daemon.history.GitRefHistorySource
 import ee.schimke.composeai.daemon.history.HistoryManager
 import ee.schimke.composeai.daemon.history.HistoryPruneConfig
 import ee.schimke.composeai.data.render.RenderPreviewExtension
-import ee.schimke.composeai.renderer.AccessibilityChecksPreviewExtension
+import ee.schimke.composeai.renderer.AccessibilityAnnotatedPreviewExtension
 import ee.schimke.composeai.renderer.AccessibilityOverlayPreviewExtension
+import ee.schimke.composeai.renderer.AccessibilitySemanticsPreviewExtension
+import ee.schimke.composeai.renderer.AtfChecksPreviewExtension
 import java.io.File
 import java.nio.file.Path
 
@@ -305,9 +307,12 @@ fun main(args: Array<String>) {
       add(RenderPreviewExtension.deviceClipDescriptor)
       add(RenderPreviewExtension.renderTraceDescriptor)
       add(RenderPreviewExtension.composeTraceDescriptor)
+      add(RenderPreviewExtension.overlayLegendDescriptor)
       if (a11yPreviewExtensionEnabled) {
-        add(AccessibilityChecksPreviewExtension.descriptor)
+        add(AccessibilitySemanticsPreviewExtension.descriptor)
+        add(AtfChecksPreviewExtension.descriptor)
         add(AccessibilityOverlayPreviewExtension.descriptor)
+        add(AccessibilityAnnotatedPreviewExtension.descriptor)
       }
     }
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -264,6 +264,7 @@ fun main(args: Array<String>) {
           RenderPreviewExtension.deviceClipDescriptor,
           RenderPreviewExtension.renderTraceDescriptor,
           RenderPreviewExtension.composeTraceDescriptor,
+          RenderPreviewExtension.overlayLegendDescriptor,
         ),
     )
 

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtension.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtension.kt
@@ -1,50 +1,41 @@
 package ee.schimke.composeai.renderer
 
+import ee.schimke.composeai.data.render.RenderPreviewExtension
 import ee.schimke.composeai.data.render.pipeline.ExtractionSpec
 import ee.schimke.composeai.data.render.pipeline.PipelineCapability
 import ee.schimke.composeai.data.render.pipeline.PipelineStepTrait
 import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionUsageMode
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelineStep
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 
-/** Pipeline metadata for accessibility checks. */
-object AccessibilityChecksPreviewExtension {
-  const val ID: String = "a11y-checks"
-  const val KIND_ATF: String = "a11y/atf"
+/** Pipeline metadata for accessibility hierarchy extraction. */
+object AccessibilitySemanticsPreviewExtension {
+  const val ID: String = "a11y"
   const val KIND_HIERARCHY: String = "a11y/hierarchy"
-  const val KIND_TOUCH_TARGETS: String = "a11y/touchTargets"
 
-  /**
-   * Static/single-output a11y extraction: collect semantics and ATF findings at the final render
-   * sample.
-   */
   val finalSampleExtractor: PreviewPipelineStep =
     PreviewPipelineStep(
-      id = "a11y.extract.end",
-      displayName = "Accessibility extraction",
-      productKinds = listOf(KIND_ATF, KIND_HIERARCHY, KIND_TOUCH_TARGETS),
-      traits = setOf(PipelineStepTrait.DataExtractor, PipelineStepTrait.Check),
+      id = "a11y.semantics.end",
+      displayName = "Accessibility hierarchy",
+      productKinds = listOf(KIND_HIERARCHY),
+      traits = setOf(PipelineStepTrait.DataExtractor),
       requires = setOf(PipelineCapability.SemanticsSnapshot),
-      provides = setOf(PipelineCapability.AccessibilityFindings),
+      provides = setOf(PipelineCapability.AccessibilityNodes),
       extraction =
         ExtractionSpec(
-          kind = KIND_ATF,
+          kind = KIND_HIERARCHY,
           sampling = SamplingPolicy.End,
           requiresSemantics = true,
         ),
     )
 
-  /**
-   * Animated/scrolling a11y extraction: collect findings for each captured frame so overlays can be
-   * painted before GIF encoding.
-   */
   val eachFrameExtractor: PreviewPipelineStep =
     finalSampleExtractor.copy(
-      id = "a11y.extract.eachFrame",
-      productKinds = listOf(KIND_ATF, KIND_HIERARCHY, KIND_TOUCH_TARGETS),
+      id = "a11y.semantics.eachFrame",
       extraction =
         ExtractionSpec(
-          kind = KIND_ATF,
+          kind = KIND_HIERARCHY,
           sampling = SamplingPolicy.EachFrame,
           requiresImage = true,
           requiresSemantics = true,
@@ -55,35 +46,102 @@ object AccessibilityChecksPreviewExtension {
   val descriptor: PreviewExtensionDescriptor =
     PreviewExtensionDescriptor(
       id = ID,
-      displayName = "Accessibility checks",
+      displayName = "Accessibility hierarchy",
       steps = listOf(finalSampleExtractor, eachFrameExtractor),
     )
 }
 
-/** Pipeline metadata for painting accessibility findings onto rendered images. */
-object AccessibilityOverlayPreviewExtension {
-  const val ID: String = "a11y-overlay"
-  const val KIND_OVERLAY: String = "a11y/overlay"
+/** Pipeline metadata for ATF checks over accessibility hierarchy data. */
+object AtfChecksPreviewExtension {
+  const val ID: String = "atf-checks"
+  const val KIND_ATF: String = "a11y/atf"
+  const val KIND_TOUCH_TARGETS: String = "a11y/touchTargets"
 
-  val overlayProcessor: PreviewPipelineStep =
+  val finalSampleChecker: PreviewPipelineStep =
     PreviewPipelineStep(
-      id = "a11y.overlay",
-      displayName = "Accessibility overlay",
-      productKinds = listOf(KIND_OVERLAY),
-      traits = setOf(PipelineStepTrait.FrameProcessor),
-      requires =
-        setOf(
-          PipelineCapability.ImageArtifact,
-          PipelineCapability.AccessibilityFindings,
-          PipelineCapability.DeviceGeometry,
+      id = "atf.check.end",
+      displayName = "ATF checks",
+      productKinds = listOf(KIND_ATF, KIND_TOUCH_TARGETS),
+      traits = setOf(PipelineStepTrait.Check),
+      requires = setOf(PipelineCapability.AccessibilityNodes),
+      provides = setOf(PipelineCapability.AccessibilityFindings),
+      extraction =
+        ExtractionSpec(
+          kind = KIND_ATF,
+          sampling = SamplingPolicy.End,
         ),
-      provides = setOf(PipelineCapability.ImageArtifact),
+    )
+
+  val eachFrameChecker: PreviewPipelineStep =
+    finalSampleChecker.copy(
+      id = "atf.check.eachFrame",
+      extraction =
+        ExtractionSpec(
+          kind = KIND_ATF,
+          sampling = SamplingPolicy.EachFrame,
+          requiresImage = true,
+          aggregate = true,
+        ),
     )
 
   val descriptor: PreviewExtensionDescriptor =
     PreviewExtensionDescriptor(
       id = ID,
-      displayName = "Accessibility overlay",
-      steps = listOf(overlayProcessor),
+      displayName = "ATF checks",
+      steps = listOf(finalSampleChecker, eachFrameChecker),
+    )
+}
+
+/** Pipeline metadata for adapting accessibility findings into generic overlay annotations. */
+object AccessibilityOverlayPreviewExtension {
+  const val ID: String = "a11y-overlay"
+  const val KIND_OVERLAY: String = "a11y/overlay"
+
+  val annotationProcessor: PreviewPipelineStep =
+    PreviewPipelineStep(
+      id = "a11y.overlayAnnotations",
+      displayName = "Accessibility overlay annotations",
+      productKinds = listOf(KIND_OVERLAY),
+      traits = setOf(PipelineStepTrait.FrameProcessor),
+      requires =
+        setOf(
+          PipelineCapability.AccessibilityNodes,
+          PipelineCapability.AccessibilityFindings,
+        ),
+      provides = setOf(PipelineCapability.OverlayAnnotations),
+    )
+
+  val descriptor: PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = ID,
+      displayName = "Accessibility overlay annotations",
+      componentExtensionIds = listOf(AccessibilitySemanticsPreviewExtension.ID, AtfChecksPreviewExtension.ID),
+      steps = listOf(annotationProcessor),
+    )
+}
+
+/** Suggested a11y annotated image composed from a11y data, ATF checks, and generic overlay legend. */
+object AccessibilityAnnotatedPreviewExtension {
+  const val ID: String = "a11y-annotated-preview"
+
+  val descriptor: PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = ID,
+      displayName = "Accessibility annotated preview",
+      usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
+      componentExtensionIds =
+        listOf(
+          AccessibilitySemanticsPreviewExtension.ID,
+          AtfChecksPreviewExtension.ID,
+          AccessibilityOverlayPreviewExtension.ID,
+          "overlay-legend",
+        ),
+      steps =
+        listOf(
+          AccessibilitySemanticsPreviewExtension.finalSampleExtractor,
+          AtfChecksPreviewExtension.finalSampleChecker,
+          AccessibilityOverlayPreviewExtension.annotationProcessor,
+          RenderPreviewExtension.overlayLegendProcessor,
+        ),
     )
 }

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtensionTest.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtensionTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.renderer
 
+import ee.schimke.composeai.data.render.RenderPreviewExtension
 import ee.schimke.composeai.data.render.pipeline.PipelineCapability
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelinePlan
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelineValidator
@@ -8,13 +9,46 @@ import org.junit.Test
 
 class AccessibilityPreviewExtensionTest {
   @Test
+  fun atfChecksCanRunOverAccessibilityNodes() {
+    val plan =
+      PreviewPipelinePlan(
+        steps = listOf(AtfChecksPreviewExtension.finalSampleChecker),
+        initialCapabilities = setOf(PipelineCapability.AccessibilityNodes),
+      )
+
+    assertTrue(PreviewPipelineValidator.validate(plan).isEmpty())
+  }
+
+  @Test
+  fun genericOverlayLegendCanUseAccessibilityOverlayAnnotations() {
+    val plan =
+      PreviewPipelinePlan(
+        steps =
+          listOf(
+            AccessibilityOverlayPreviewExtension.annotationProcessor,
+            RenderPreviewExtension.overlayLegendProcessor,
+          ),
+        initialCapabilities =
+          setOf(
+            PipelineCapability.ImageArtifact,
+            PipelineCapability.AccessibilityNodes,
+            PipelineCapability.AccessibilityFindings,
+          ),
+      )
+
+    assertTrue(PreviewPipelineValidator.validate(plan).isEmpty())
+  }
+
+  @Test
   fun overlayCanUseFinalSampleExtraction() {
     val plan =
       PreviewPipelinePlan(
         steps =
           listOf(
-            AccessibilityChecksPreviewExtension.finalSampleExtractor,
-            AccessibilityOverlayPreviewExtension.overlayProcessor,
+            AccessibilitySemanticsPreviewExtension.finalSampleExtractor,
+            AtfChecksPreviewExtension.finalSampleChecker,
+            AccessibilityOverlayPreviewExtension.annotationProcessor,
+            RenderPreviewExtension.overlayLegendProcessor,
           ),
         initialCapabilities =
           setOf(
@@ -34,13 +68,32 @@ class AccessibilityPreviewExtensionTest {
       PreviewPipelinePlan(
         steps =
           listOf(
-            AccessibilityChecksPreviewExtension.eachFrameExtractor,
-            AccessibilityOverlayPreviewExtension.overlayProcessor,
+            AccessibilitySemanticsPreviewExtension.eachFrameExtractor,
+            AtfChecksPreviewExtension.eachFrameChecker,
+            AccessibilityOverlayPreviewExtension.annotationProcessor,
+            RenderPreviewExtension.overlayLegendProcessor,
           ),
         initialCapabilities =
           setOf(
             PipelineCapability.Frames,
             PipelineCapability.MultipleFrames,
+            PipelineCapability.DeviceGeometry,
+            PipelineCapability.SemanticsSnapshot,
+            PipelineCapability.ImageArtifact,
+          ),
+      )
+
+    assertTrue(PreviewPipelineValidator.validate(plan).isEmpty())
+  }
+
+  @Test
+  fun annotatedPreviewDescriptorComposesA11yChecksAndGenericOverlayLegend() {
+    val plan =
+      PreviewPipelinePlan(
+        steps = AccessibilityAnnotatedPreviewExtension.descriptor.steps,
+        initialCapabilities =
+          setOf(
+            PipelineCapability.SingleFrame,
             PipelineCapability.DeviceGeometry,
             PipelineCapability.SemanticsSnapshot,
             PipelineCapability.ImageArtifact,

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderPreviewExtension.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderPreviewExtension.kt
@@ -44,6 +44,15 @@ object RenderPreviewExtension {
       sampling = SamplingPolicy.Aggregate,
     )
 
+  val overlayLegendProcessor: PreviewPipelineStep =
+    PreviewPipelineStep(
+      id = "render.overlayLegend",
+      displayName = "Overlay with legend",
+      traits = setOf(PipelineStepTrait.FrameProcessor),
+      requires = setOf(PipelineCapability.ImageArtifact, PipelineCapability.OverlayAnnotations),
+      provides = setOf(PipelineCapability.ImageArtifact, PipelineCapability.AnnotatedImageArtifact),
+    )
+
   val deviceClipDescriptor: PreviewExtensionDescriptor =
     PreviewExtensionDescriptor(
       id = "render-device-clip",
@@ -63,5 +72,12 @@ object RenderPreviewExtension {
       id = "compose-trace",
       displayName = "Compose composition trace",
       steps = listOf(composeTraceProfiler),
+    )
+
+  val overlayLegendDescriptor: PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "overlay-legend",
+      displayName = "Overlay with legend",
+      steps = listOf(overlayLegendProcessor),
     )
 }

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewPipeline.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewPipeline.kt
@@ -14,6 +14,7 @@ data class PreviewPipelineStep(
   val id: String,
   val displayName: String = id,
   val productKinds: List<String> = emptyList(),
+  val annotationFqns: List<String> = emptyList(),
   val usageModes: Set<PreviewExtensionUsageMode> = setOf(PreviewExtensionUsageMode.ExplicitEffect),
   val traits: Set<PipelineStepTrait> = emptySet(),
   val requires: Set<PipelineCapability> = emptySet(),
@@ -33,6 +34,8 @@ enum class PreviewExtensionUsageMode {
 data class PreviewExtensionDescriptor(
   val id: String,
   val displayName: String = id,
+  val usageModes: Set<PreviewExtensionUsageMode> = setOf(PreviewExtensionUsageMode.ExplicitEffect),
+  val componentExtensionIds: List<String> = emptyList(),
   val steps: List<PreviewPipelineStep> = emptyList(),
 )
 
@@ -40,6 +43,8 @@ data class PreviewExtensionDescriptor(
 enum class PipelineStepTrait {
   ScenarioDriver,
   InteractiveDriver,
+  AnnotationInspector,
+  ExtraPreviewSuggester,
   FrameProcessor,
   FinalArtifactProcessor,
   DataExtractor,
@@ -53,12 +58,17 @@ enum class PipelineCapability {
   Frames,
   SingleFrame,
   MultipleFrames,
+  PreviewFunctionAnnotations,
+  SuggestedPreviews,
   DeviceGeometry,
   DeviceClip,
   ScrollState,
   SemanticsSnapshot,
+  AccessibilityNodes,
   AccessibilityFindings,
+  OverlayAnnotations,
   ImageArtifact,
+  AnnotatedImageArtifact,
   AnimatedArtifact,
   InteractiveSession,
   TraceEvents,

--- a/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtension.kt
+++ b/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtension.kt
@@ -9,8 +9,21 @@ import ee.schimke.composeai.data.render.pipeline.PreviewPipelineStep
 /** Pipeline metadata for the scroll preview extension. */
 object ScrollPreviewExtension {
   const val ID: String = "scroll"
+  const val ANNOTATION_ID: String = "scrolling-preview-annotation"
+  const val ANNOTATION_FQN: String = "ee.schimke.composeai.preview.ScrollingPreview"
   const val KIND_LONG: String = "render/scroll/long"
   const val KIND_GIF: String = "render/scroll/gif"
+
+  val annotationSuggester: PreviewPipelineStep =
+    PreviewPipelineStep(
+      id = "scroll.annotation.suggest",
+      displayName = "ScrollingPreview suggestions",
+      annotationFqns = listOf(ANNOTATION_FQN),
+      usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
+      traits = setOf(PipelineStepTrait.AnnotationInspector, PipelineStepTrait.ExtraPreviewSuggester),
+      requires = setOf(PipelineCapability.PreviewFunctionAnnotations),
+      provides = setOf(PipelineCapability.SuggestedPreviews),
+    )
 
   /** Long scroll owns scroll position over a sequence of viewport captures. */
   val longScrollScenario: PreviewPipelineStep =
@@ -76,10 +89,29 @@ object ScrollPreviewExtension {
       provides = setOf(PipelineCapability.AnimatedArtifact),
     )
 
-  val descriptor: PreviewExtensionDescriptor =
+  val longScrollDescriptor: PreviewExtensionDescriptor =
     PreviewExtensionDescriptor(
-      id = ID,
-      displayName = "Scroll",
-      steps = listOf(longScrollScenario, gifScrollScenario, longScrollEncoder, gifScrollEncoder),
+      id = "scroll-long",
+      displayName = "Long scroll",
+      usageModes =
+        setOf(PreviewExtensionUsageMode.ExplicitEffect, PreviewExtensionUsageMode.SuggestedExtraPreview),
+      steps = listOf(longScrollScenario, longScrollEncoder),
+    )
+
+  val annotationDescriptor: PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = ANNOTATION_ID,
+      displayName = "ScrollingPreview annotation",
+      usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
+      steps = listOf(annotationSuggester),
+    )
+
+  val gifScrollDescriptor: PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "scroll-gif",
+      displayName = "Scroll GIF",
+      usageModes =
+        setOf(PreviewExtensionUsageMode.ExplicitEffect, PreviewExtensionUsageMode.SuggestedExtraPreview),
+      steps = listOf(gifScrollScenario, gifScrollEncoder),
     )
 }

--- a/data/scroll/core/src/test/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtensionTest.kt
+++ b/data/scroll/core/src/test/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtensionTest.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.scroll
 
 import ee.schimke.composeai.data.render.RenderPreviewExtension
+import ee.schimke.composeai.data.render.pipeline.PipelineCapability
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelinePlan
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelineValidator
 import org.junit.Assert.assertTrue
@@ -22,6 +23,17 @@ class ScrollPreviewExtensionTest {
   }
 
   @Test
+  fun annotationDescriptorSuggestsExtraPreviewsFromAnnotations() {
+    val plan =
+      PreviewPipelinePlan(
+        steps = ScrollPreviewExtension.annotationDescriptor.steps,
+        initialCapabilities = setOf(PipelineCapability.PreviewFunctionAnnotations),
+      )
+
+    assertTrue(PreviewPipelineValidator.validate(plan).isEmpty())
+  }
+
+  @Test
   fun gifScenarioCanCollectAggregateComposeTraceWhileScrolling() {
     val plan =
       PreviewPipelinePlan(
@@ -36,6 +48,13 @@ class ScrollPreviewExtensionTest {
   }
 
   @Test
+  fun gifDescriptorIsIndependentlyValid() {
+    val plan = PreviewPipelinePlan(ScrollPreviewExtension.gifScrollDescriptor.steps)
+
+    assertTrue(PreviewPipelineValidator.validate(plan).isEmpty())
+  }
+
+  @Test
   fun longScenarioCanBeClippedBeforeStitching() {
     val plan =
       PreviewPipelinePlan(
@@ -45,6 +64,13 @@ class ScrollPreviewExtensionTest {
           ScrollPreviewExtension.longScrollEncoder,
         )
       )
+
+    assertTrue(PreviewPipelineValidator.validate(plan).isEmpty())
+  }
+
+  @Test
+  fun longDescriptorIsIndependentlyValid() {
+    val plan = PreviewPipelinePlan(ScrollPreviewExtension.longScrollDescriptor.steps)
 
     assertTrue(PreviewPipelineValidator.validate(plan).isEmpty())
   }

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -651,6 +651,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
           ScrollMode.GIF -> "gif"
           else -> error("non-product scroll mode ${scroll.mode}")
         }
+      val extensionId = "scrolling-preview-annotation"
       val facets =
         when (scroll.mode) {
           ScrollMode.LONG -> listOf(PreviewDataProductFacet.ARTIFACT, PreviewDataProductFacet.IMAGE)
@@ -667,7 +668,7 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
       timeRows.map { (ms, timeSuffix) ->
         PreviewDataProduct(
           kind = kind,
-          extensionId = "scroll",
+          extensionId = extensionId,
           effectId = effectId,
           usageMode = PreviewExtensionUsageMode.SUGGESTED_EXTRA_PREVIEW,
           suggestedBy = SCROLLING_PREVIEW_FQN,

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewDataTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewDataTest.kt
@@ -39,7 +39,7 @@ class PreviewDataTest {
                 listOf(
                   PreviewDataProduct(
                     kind = "render/scroll/long",
-                    extensionId = "scroll",
+                    extensionId = "scrolling-preview-annotation",
                     effectId = "long",
                     usageMode = PreviewExtensionUsageMode.SUGGESTED_EXTRA_PREVIEW,
                     suggestedBy = "ee.schimke.composeai.preview.ScrollingPreview",

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -151,6 +151,8 @@ export type SamplingPolicy =
 export interface PreviewExtensionDescriptor {
     id: string;
     displayName?: string;
+    usageModes?: PreviewExtensionUsageMode[];
+    componentExtensionIds?: string[];
     steps?: PreviewPipelineStep[];
 }
 
@@ -158,6 +160,7 @@ export interface PreviewPipelineStep {
     id: string;
     displayName?: string;
     productKinds?: string[];
+    annotationFqns?: string[];
     usageModes?: PreviewExtensionUsageMode[];
     traits?: PipelineStepTrait[];
     requires?: PipelineCapability[];
@@ -174,6 +177,8 @@ export type PreviewExtensionUsageMode =
 export type PipelineStepTrait =
     | 'ScenarioDriver'
     | 'InteractiveDriver'
+    | 'AnnotationInspector'
+    | 'ExtraPreviewSuggester'
     | 'FrameProcessor'
     | 'FinalArtifactProcessor'
     | 'DataExtractor'
@@ -185,12 +190,17 @@ export type PipelineCapability =
     | 'Frames'
     | 'SingleFrame'
     | 'MultipleFrames'
+    | 'PreviewFunctionAnnotations'
+    | 'SuggestedPreviews'
     | 'DeviceGeometry'
     | 'DeviceClip'
     | 'ScrollState'
     | 'SemanticsSnapshot'
+    | 'AccessibilityNodes'
     | 'AccessibilityFindings'
+    | 'OverlayAnnotations'
     | 'ImageArtifact'
+    | 'AnnotatedImageArtifact'
     | 'AnimatedArtifact'
     | 'InteractiveSession'
     | 'TraceEvents';


### PR DESCRIPTION
## Summary
- Split the a11y annotated-image path into separate metadata extensions for accessibility hierarchy extraction, ATF checks, accessibility overlay annotations, and generic overlay-with-legend rendering.
- Add extension composition metadata plus generic overlay/annotation capabilities so the current a11y feature can be modeled as composed pieces.
- Model `@ScrollingPreview` as an annotation-inspecting suggestion-provider extension, and keep long-scroll/GIF as separate concrete scroll effects.
- Add validation coverage for the composed a11y overlay pipeline and split scroll descriptors.

## Validation
- `./gradlew ktfmtFormatAll :gradle-plugin:test :gradle-plugin:compileKotlin :data-render-core:test :data-render-connector:test :daemon:core:compileKotlin :daemon:desktop:compileKotlin`