### PR TITLE
feat(cli): add history commands

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommands.kt
@@ -1,0 +1,201 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.daemon.history.HistoryEntry
+import ee.schimke.composeai.daemon.history.HistoryFilter
+import ee.schimke.composeai.daemon.history.LocalFsHistorySource
+import java.io.File
+import kotlin.system.exitProcess
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+internal const val HISTORY_LIST_SCHEMA = "compose-preview-history-list/v1"
+internal const val HISTORY_DIFF_SCHEMA = "compose-preview-history-diff/v1"
+
+private val historyJson = Json {
+  ignoreUnknownKeys = true
+  prettyPrint = true
+  encodeDefaults = true
+}
+
+@Serializable
+data class CliHistoryListResponse(
+  val schema: String = HISTORY_LIST_SCHEMA,
+  val entries: List<HistoryEntry>,
+  val totalCount: Int,
+)
+
+@Serializable
+data class CliHistoryDiffResponse(
+  val schema: String = HISTORY_DIFF_SCHEMA,
+  val pngHashChanged: Boolean,
+  val fromMetadata: HistoryEntry,
+  val toMetadata: HistoryEntry,
+)
+
+class HistoryCommand(args: List<String>) : Command(args) {
+  private val subcommand = args.historySubcommand()
+  private val jsonOutput = "--json" in args
+  private val from: String? = args.flagValue("--from")
+  private val to: String? = args.flagValue("--to")
+  private val limit: Int? = args.flagValue("--limit")?.toIntOrNull()
+
+  override fun run() {
+    if ("--help" in args || "-h" in args || subcommand == "help") {
+      printUsage()
+      return
+    }
+    when (subcommand) {
+      "list" -> runList()
+      "diff" -> runDiff()
+      null -> {
+        System.err.println("No history subcommand specified.")
+        printUsage()
+        exitProcess(1)
+      }
+      else -> {
+        System.err.println("Unknown history subcommand: $subcommand")
+        printUsage()
+        exitProcess(1)
+      }
+    }
+  }
+
+  private fun runList() {
+    withGradle { gradle ->
+      val modules = resolveModules(gradle)
+      val response = listLocalHistory(modules = modules, previewId = exactId, limit = limit)
+      if (jsonOutput) {
+        println(historyJson.encodeToString(CliHistoryListResponse.serializer(), response))
+      } else {
+        printHistoryList(response)
+      }
+    }
+  }
+
+  private fun runDiff() {
+    val fromId =
+      from
+        ?: run {
+          System.err.println("history diff requires --from <entry-id>.")
+          exitProcess(1)
+        }
+    val toId =
+      to
+        ?: run {
+          System.err.println("history diff requires --to <entry-id>.")
+          exitProcess(1)
+        }
+
+    withGradle { gradle ->
+      val modules = resolveModules(gradle)
+      val response =
+        diffLocalHistory(modules = modules, fromId = fromId, toId = toId)
+          ?: run {
+            System.err.println(
+              "History entry not found or unreadable: from='$fromId' to='$toId'. " +
+                "Check .compose-preview-history sidecars and PNG paths."
+            )
+            exitProcess(3)
+          }
+      if (response.fromMetadata.previewId != response.toMetadata.previewId) {
+        System.err.println(
+          "History entries are for different previews: " +
+            "'${response.fromMetadata.previewId}' vs '${response.toMetadata.previewId}'."
+        )
+        exitProcess(1)
+      }
+      if (jsonOutput) {
+        println(historyJson.encodeToString(CliHistoryDiffResponse.serializer(), response))
+      } else {
+        val changed = if (response.pngHashChanged) "changed" else "unchanged"
+        println("${response.fromMetadata.id} -> ${response.toMetadata.id}: png hash $changed")
+      }
+    }
+  }
+
+  private fun printHistoryList(response: CliHistoryListResponse) {
+    if (response.entries.isEmpty()) {
+      println("No history entries found.")
+      return
+    }
+    for (entry in response.entries) {
+      val shortHash = entry.pngHash.take(12)
+      println(
+        "${entry.timestamp}  ${entry.module}  ${entry.previewId}  ${entry.id}  sha=$shortHash"
+      )
+    }
+  }
+
+  private fun printUsage() {
+    println(
+      """
+      compose-preview history list [--module M] [--id PREVIEW] [--limit N] [--json]
+      compose-preview history diff --from ENTRY --to ENTRY [--module M] [--json]
+
+      Reads local .compose-preview-history entries using the daemon history
+      model. The first diff mode is metadata/hash only; it does not compute a
+      pixel diff and does not read git-ref history sources.
+      """
+        .trimIndent()
+    )
+  }
+}
+
+internal fun listLocalHistory(
+  modules: List<PreviewModule>,
+  previewId: String? = null,
+  limit: Int? = null,
+): CliHistoryListResponse {
+  val all =
+    modules
+      .flatMap { module ->
+        localHistorySource(module.projectDir)
+          .list(HistoryFilter(previewId = previewId, limit = LocalFsHistorySource.MAX_LIMIT))
+          .entries
+      }
+      .sortedWith(compareByDescending<HistoryEntry> { it.timestamp }.thenByDescending { it.id })
+  val capped =
+    all.take(
+      (limit ?: LocalFsHistorySource.DEFAULT_LIMIT).coerceIn(1, LocalFsHistorySource.MAX_LIMIT)
+    )
+  return CliHistoryListResponse(entries = capped, totalCount = all.size)
+}
+
+internal fun diffLocalHistory(
+  modules: List<PreviewModule>,
+  fromId: String,
+  toId: String,
+): CliHistoryDiffResponse? {
+  val from = readUniqueHistoryEntry(modules, fromId) ?: return null
+  val to = readUniqueHistoryEntry(modules, toId) ?: return null
+  return CliHistoryDiffResponse(
+    pngHashChanged = from.pngHash != to.pngHash,
+    fromMetadata = from,
+    toMetadata = to,
+  )
+}
+
+private fun readUniqueHistoryEntry(modules: List<PreviewModule>, entryId: String): HistoryEntry? {
+  val matches = modules.mapNotNull { module ->
+    localHistorySource(module.projectDir).read(entryId)?.entry
+  }
+  return matches.singleOrNull()
+}
+
+private fun localHistorySource(projectDir: File): LocalFsHistorySource =
+  LocalFsHistorySource(projectDir.resolve(".compose-preview-history").toPath())
+
+private fun List<String>.historySubcommand(): String? {
+  val valuedFlags = setOf("--module", "--id", "--from", "--to", "--limit", "--timeout")
+  var i = 0
+  while (i < size) {
+    val arg = this[i]
+    when {
+      valuedFlags.any { arg.startsWith("$it=") } -> i++
+      arg in valuedFlags -> i += 2
+      arg.startsWith("-") -> i++
+      else -> return arg
+    }
+  }
+  return null
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -28,6 +28,9 @@ fun main(args: Array<String>) {
       "--plugin-version",
       "--fail-on",
       "--kind",
+      "--from",
+      "--to",
+      "--limit",
       "--desc",
       "--branch",
       "--remote",
@@ -45,6 +48,7 @@ fun main(args: Array<String>) {
       "devices",
       "data-products",
       "data",
+      "history",
       "share-gist",
       "publish-images",
       "mcp",
@@ -92,6 +96,7 @@ fun main(args: Array<String>) {
     "devices" -> DevicesCommand(allArgs).run()
     "data-products" -> DataProductsCommand(allArgs).run()
     "data" -> DataCommand(allArgs).run()
+    "history" -> HistoryCommand(allArgs).run()
     "share-gist" -> ShareGistCommand(allArgs).run()
     "publish-images" -> PublishImagesCommand(allArgs).run()
     "mcp" -> McpCommand(allArgs).run()
@@ -126,6 +131,7 @@ private fun printUsage() {
       devices          List known @Preview(device=...) ids and resolved geometry
       data-products    List data-product kinds already emitted for rendered previews
       data             Data-product commands: get
+      history          History commands: list | diff
       share-gist       Create a gist from a markdown file plus image attachments
       publish-images   Push a directory of rendered PNGs to a shared branch (default compose-preview/pr)
       mcp              MCP server lifecycle: serve | install | doctor (see `mcp help`)
@@ -138,7 +144,10 @@ private fun printUsage() {
       --filter <pattern>   Case-insensitive substring match on preview id
       --id <exact>         Exact match on preview id
       --kind <kind>        data get: data-product kind (for example a11y/atf)
-      --json               Emit JSON (show, list, a11y, data-products, data get)
+      --from <entry>       history diff: source entry id
+      --to <entry>         history diff: target entry id
+      --limit <n>          history list: maximum entries to emit
+      --json               Emit JSON (show, list, a11y, data-products, data get, history)
       --brief              JSON only: drop functionName/className/sourceFile/params
       --changed-only       JSON only (show, a11y): drop previews with no changed capture
       --output <path>      Copy matched preview PNG to this path (render)

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryCommandsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryCommandsTest.kt
@@ -1,0 +1,98 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.daemon.history.HistoryEntry
+import ee.schimke.composeai.daemon.history.HistorySourceInfo
+import ee.schimke.composeai.daemon.history.LocalFsHistorySource
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+
+class HistoryCommandsTest {
+  private val json = Json {
+    prettyPrint = false
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+  }
+
+  @Test
+  fun `history list response pins schema and returns newest entries first`() {
+    val projectDir = tempModule()
+    val source = LocalFsHistorySource(projectDir.resolve(".compose-preview-history").toPath())
+    source.write(historyEntry(source, id = "old", timestamp = "2026-05-03T07:00:00Z"), bytes("old"))
+    source.write(historyEntry(source, id = "new", timestamp = "2026-05-03T07:01:00Z"), bytes("new"))
+
+    val response = listLocalHistory(listOf(PreviewModule("app", projectDir)))
+    val encoded = json.encodeToString(CliHistoryListResponse.serializer(), response)
+    val parsed = json.decodeFromString(CliHistoryListResponse.serializer(), encoded)
+
+    assertEquals(HISTORY_LIST_SCHEMA, parsed.schema)
+    assertTrue(""""schema":"$HISTORY_LIST_SCHEMA"""" in encoded)
+    assertEquals(2, parsed.totalCount)
+    assertEquals(listOf("new", "old"), parsed.entries.map { it.id })
+  }
+
+  @Test
+  fun `history diff response reports png hash changes and includes metadata`() {
+    val projectDir = tempModule()
+    val source = LocalFsHistorySource(projectDir.resolve(".compose-preview-history").toPath())
+    source.write(historyEntry(source, id = "a", timestamp = "2026-05-03T07:00:00Z"), bytes("a"))
+    source.write(historyEntry(source, id = "b", timestamp = "2026-05-03T07:01:00Z"), bytes("b"))
+
+    val response =
+      assertNotNull(
+        diffLocalHistory(listOf(PreviewModule("app", projectDir)), fromId = "a", toId = "b")
+      )
+    val encoded = json.encodeToString(CliHistoryDiffResponse.serializer(), response)
+    val parsed = json.decodeFromString(CliHistoryDiffResponse.serializer(), encoded)
+
+    assertEquals(HISTORY_DIFF_SCHEMA, parsed.schema)
+    assertTrue(parsed.pngHashChanged)
+    assertEquals("a", parsed.fromMetadata.id)
+    assertEquals("b", parsed.toMetadata.id)
+  }
+
+  @Test
+  fun `history diff returns null for missing entries`() {
+    val projectDir = tempModule()
+    LocalFsHistorySource(projectDir.resolve(".compose-preview-history").toPath())
+
+    assertNull(
+      diffLocalHistory(
+        listOf(PreviewModule("app", projectDir)),
+        fromId = "missing-a",
+        toId = "missing-b",
+      )
+    )
+  }
+
+  private fun tempModule(): File = Files.createTempDirectory("history-command-test").toFile()
+
+  private fun historyEntry(
+    source: LocalFsHistorySource,
+    id: String,
+    timestamp: String,
+    previewId: String = "com.example.Foo",
+  ): HistoryEntry {
+    val png = bytes(id)
+    return HistoryEntry(
+      id = id,
+      previewId = previewId,
+      module = ":app",
+      timestamp = timestamp,
+      pngHash = LocalFsHistorySource.sha256Hex(png),
+      pngSize = png.size.toLong(),
+      pngPath = "$id.png",
+      producer = "daemon",
+      trigger = "manual",
+      source = HistorySourceInfo(kind = source.kind, id = source.id),
+      renderTookMs = 1,
+    )
+  }
+
+  private fun bytes(text: String): ByteArray = text.toByteArray(Charsets.UTF_8)
+}


### PR DESCRIPTION
## Summary

- Add `compose-preview history list` for local `.compose-preview-history` entries, using the daemon `HistoryEntry` model and `LocalFsHistorySource` reader.
- Add `compose-preview history diff --from ENTRY --to ENTRY` for metadata/hash diff mode.
- Add versioned JSON envelopes and tests for list schema ordering, diff hash changes, and missing entries.

Closes #569.

## Notes

This is the first local-filesystem implementation described in #569. It reads each module's `.compose-preview-history` archive and does not query daemon state, git-ref history, or pixel diff output.

## Validation

- `./gradlew :cli:ktfmtFormatMain :cli:ktfmtFormatTest :cli:test :cli:checkCliDaemonLibraryBoundary`
- `git diff --check origin/main..HEAD`