### PR TITLE
Expose preview extension CLI commands

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ExtensionCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ExtensionCommands.kt
@@ -1,0 +1,303 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.data.render.RenderPreviewExtension
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionCliCommand
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionUsageMode
+import kotlin.system.exitProcess
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+internal const val EXTENSION_COMMANDS_SCHEMA = "compose-preview-extension-commands/v1"
+
+private val extensionJson = Json {
+  prettyPrint = true
+  encodeDefaults = true
+}
+
+@Serializable
+data class ExtensionCommandsResponse(
+  val schema: String = EXTENSION_COMMANDS_SCHEMA,
+  val extensions: List<PreviewExtensionDescriptor>,
+) {
+  val commandCount: Int = extensions.sumOf { it.cliCommands.size }
+}
+
+class ExtensionCommandsCommand(private val args: List<String>) {
+  private val jsonOutput = "--json" in args
+  private val onlyAgentRecommended = "--agent" in args || "--agent-recommended" in args
+
+  fun run() {
+    if ("--help" in args || "-h" in args) {
+      printUsage()
+      return
+    }
+
+    when (args.firstOrNull { !it.startsWith("-") } ?: "commands") {
+      "commands",
+      "list" -> printCommands()
+      else -> {
+        System.err.println("extensions supports: commands")
+        printUsage()
+        exitProcess(1)
+      }
+    }
+  }
+
+  private fun printCommands() {
+    val response = ExtensionCommandsResponse(extensions = BuiltInExtensionCliCatalog.extensions)
+    val filtered =
+      if (onlyAgentRecommended) {
+        response.copy(
+          extensions =
+            response.extensions
+              .map { descriptor ->
+                descriptor.copy(cliCommands = descriptor.cliCommands.filter { it.agentRecommended })
+              }
+              .filter { it.cliCommands.isNotEmpty() }
+        )
+      } else {
+        response
+      }
+
+    if (jsonOutput) {
+      println(extensionJson.encodeToString(ExtensionCommandsResponse.serializer(), filtered))
+    } else {
+      printText(filtered)
+    }
+  }
+
+  private fun printText(response: ExtensionCommandsResponse) {
+    response.extensions.forEach { extension ->
+      if (extension.cliCommands.isEmpty()) return@forEach
+      println("${extension.id} - ${extension.displayName}")
+      extension.cliCommands.forEach { command ->
+        val marker = if (command.agentRecommended) " [agent]" else ""
+        println("  ${command.id}$marker")
+        if (command.summary.isNotBlank()) {
+          println("    ${command.summary}")
+        }
+        println("    ${command.command.joinToString(" ")}")
+      }
+    }
+  }
+
+  private fun printUsage() {
+    println(
+      """
+      compose-preview extensions commands [--json] [--agent]
+
+      Lists command metadata contributed by built-in preview extensions. This is
+      daemon-free: clients can discover extension-oriented CLI entry points
+      without starting a render daemon.
+      """
+        .trimIndent()
+    )
+  }
+}
+
+private object BuiltInExtensionCliCatalog {
+  val extensions: List<PreviewExtensionDescriptor> =
+    listOf(
+      RenderPreviewExtension.deviceClipDescriptor,
+      RenderPreviewExtension.renderTraceDescriptor,
+      RenderPreviewExtension.composeTraceDescriptor,
+      RenderPreviewExtension.overlayLegendDescriptor,
+      accessibilityHierarchy(),
+      atfChecks(),
+      accessibilityOverlay(),
+      accessibilityAnnotatedPreview(),
+      scrollAnnotation(),
+      scrollLong(),
+      scrollGif(),
+    )
+
+  private fun accessibilityHierarchy(): PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "a11y",
+      displayName = "Accessibility hierarchy",
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "a11y.hierarchy.get",
+            displayName = "Fetch accessibility hierarchy",
+            summary = "Reads the structured accessibility hierarchy for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "data",
+                "get",
+                "--id",
+                "<preview-id>",
+                "--kind",
+                "a11y/hierarchy",
+                "--json",
+              ),
+            agentRecommended = true,
+            productKinds = listOf("a11y/hierarchy"),
+          )
+        ),
+    )
+
+  private fun atfChecks(): PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "atf-checks",
+      displayName = "ATF checks",
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "atf-checks.run",
+            displayName = "Run ATF accessibility checks",
+            summary = "Renders previews and returns ATF accessibility findings.",
+            command = listOf("compose-preview", "a11y", "--json"),
+            agentRecommended = true,
+            productKinds = listOf("a11y/atf", "a11y/touchTargets"),
+          ),
+          PreviewExtensionCliCommand(
+            id = "atf-checks.get",
+            displayName = "Fetch ATF findings",
+            summary = "Reads previously emitted ATF findings for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "data",
+                "get",
+                "--id",
+                "<preview-id>",
+                "--kind",
+                "a11y/atf",
+                "--json",
+              ),
+            productKinds = listOf("a11y/atf"),
+          ),
+        ),
+    )
+
+  private fun accessibilityOverlay(): PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "a11y-overlay",
+      displayName = "Accessibility overlay annotations",
+      componentExtensionIds = listOf("a11y", "atf-checks"),
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "a11y-overlay.get",
+            displayName = "Fetch accessibility overlay",
+            summary = "Reads the rendered accessibility overlay artifact for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "data",
+                "get",
+                "--id",
+                "<preview-id>",
+                "--kind",
+                "a11y/overlay",
+                "--output",
+                "<path>",
+              ),
+            productKinds = listOf("a11y/overlay"),
+          )
+        ),
+    )
+
+  private fun accessibilityAnnotatedPreview(): PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "a11y-annotated-preview",
+      displayName = "Accessibility annotated preview",
+      usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
+      componentExtensionIds = listOf("a11y", "atf-checks", "a11y-overlay", "overlay-legend"),
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "a11y-annotated-preview.render",
+            displayName = "Render accessibility annotated previews",
+            summary = "Discovers and renders suggested accessibility annotated preview extras.",
+            command = listOf("compose-preview", "show", "--json"),
+            usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
+          )
+        ),
+    )
+
+  private fun scrollAnnotation(): PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "scrolling-preview-annotation",
+      displayName = "ScrollingPreview annotation",
+      usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "scrolling-preview-annotation.render",
+            displayName = "Render scroll annotation suggestions",
+            summary = "Discovers @ScrollingPreview annotations and renders their suggested extras.",
+            command = listOf("compose-preview", "show", "--json"),
+            agentRecommended = true,
+            usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
+          )
+        ),
+    )
+
+  private fun scrollLong(): PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "scroll-long",
+      displayName = "Long scroll",
+      usageModes =
+        setOf(
+          PreviewExtensionUsageMode.ExplicitEffect,
+          PreviewExtensionUsageMode.SuggestedExtraPreview,
+        ),
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "scroll-long.get",
+            displayName = "Fetch long scroll image",
+            summary = "Reads a stitched long-scroll image artifact for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "data",
+                "get",
+                "--id",
+                "<preview-id>",
+                "--kind",
+                "render/scroll/long",
+                "--output",
+                "<path>",
+              ),
+            productKinds = listOf("render/scroll/long"),
+          )
+        ),
+    )
+
+  private fun scrollGif(): PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "scroll-gif",
+      displayName = "Scroll GIF",
+      usageModes =
+        setOf(
+          PreviewExtensionUsageMode.ExplicitEffect,
+          PreviewExtensionUsageMode.SuggestedExtraPreview,
+        ),
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "scroll-gif.get",
+            displayName = "Fetch scroll GIF",
+            summary = "Reads an animated scroll GIF artifact for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "data",
+                "get",
+                "--id",
+                "<preview-id>",
+                "--kind",
+                "render/scroll/gif",
+                "--output",
+                "<path>",
+              ),
+            productKinds = listOf("render/scroll/gif"),
+          )
+        ),
+    )
+}

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Main.kt
@@ -46,6 +46,7 @@ fun main(args: Array<String>) {
       "a11y",
       "doctor",
       "devices",
+      "extensions",
       "data-products",
       "data",
       "history",
@@ -94,6 +95,7 @@ fun main(args: Array<String>) {
     "a11y" -> A11yCommand(allArgs).run()
     "doctor" -> DoctorCommand(allArgs).run()
     "devices" -> DevicesCommand(allArgs).run()
+    "extensions" -> ExtensionCommandsCommand(allArgs).run()
     "data-products" -> DataProductsCommand(allArgs).run()
     "data" -> DataCommand(allArgs).run()
     "history" -> HistoryCommand(allArgs).run()
@@ -129,6 +131,7 @@ private fun printUsage() {
       a11y             Render previews and print ATF accessibility findings
       doctor           Verify Java 17 + Compose/AGP environment before editing Gradle files
       devices          List known @Preview(device=...) ids and resolved geometry
+      extensions       List daemon-free preview extension command metadata
       data-products    List data-product kinds already emitted for rendered previews
       data             Data-product commands: get
       history          History commands: list | diff

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ExtensionCommandsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ExtensionCommandsTest.kt
@@ -1,0 +1,42 @@
+package ee.schimke.composeai.cli
+
+import ee.schimke.composeai.data.render.RenderPreviewExtension
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+
+class ExtensionCommandsTest {
+  private val json = Json {
+    prettyPrint = false
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+  }
+
+  @Test
+  fun `extension command response pins schema and exposes agent commands`() {
+    val response =
+      ExtensionCommandsResponse(extensions = listOf(RenderPreviewExtension.composeTraceDescriptor))
+
+    val encoded = json.encodeToString(ExtensionCommandsResponse.serializer(), response)
+    val parsed = json.decodeFromString(ExtensionCommandsResponse.serializer(), encoded)
+    val command = parsed.extensions.single().cliCommands.single()
+
+    assertEquals(EXTENSION_COMMANDS_SCHEMA, parsed.schema)
+    assertEquals("compose-trace.get", command.id)
+    assertTrue(command.agentRecommended)
+    assertEquals(
+      listOf(
+        "compose-preview",
+        "data",
+        "get",
+        "--id",
+        "<preview-id>",
+        "--kind",
+        "render/composeAiTrace",
+        "--json",
+      ),
+      command.command,
+    )
+  }
+}

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtension.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtension.kt
@@ -4,6 +4,7 @@ import ee.schimke.composeai.data.render.RenderPreviewExtension
 import ee.schimke.composeai.data.render.pipeline.ExtractionSpec
 import ee.schimke.composeai.data.render.pipeline.PipelineCapability
 import ee.schimke.composeai.data.render.pipeline.PipelineStepTrait
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionCliCommand
 import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
 import ee.schimke.composeai.data.render.pipeline.PreviewExtensionUsageMode
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelineStep
@@ -47,6 +48,27 @@ object AccessibilitySemanticsPreviewExtension {
     PreviewExtensionDescriptor(
       id = ID,
       displayName = "Accessibility hierarchy",
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "a11y.hierarchy.get",
+            displayName = "Fetch accessibility hierarchy",
+            summary = "Reads the structured accessibility hierarchy for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "data",
+                "get",
+                "--id",
+                "<preview-id>",
+                "--kind",
+                KIND_HIERARCHY,
+                "--json",
+              ),
+            agentRecommended = true,
+            productKinds = listOf(KIND_HIERARCHY),
+          )
+        ),
       steps = listOf(finalSampleExtractor, eachFrameExtractor),
     )
 }
@@ -88,6 +110,34 @@ object AtfChecksPreviewExtension {
     PreviewExtensionDescriptor(
       id = ID,
       displayName = "ATF checks",
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "atf-checks.run",
+            displayName = "Run ATF accessibility checks",
+            summary = "Renders previews and returns ATF accessibility findings.",
+            command = listOf("compose-preview", "a11y", "--json"),
+            agentRecommended = true,
+            productKinds = listOf(KIND_ATF, KIND_TOUCH_TARGETS),
+          ),
+          PreviewExtensionCliCommand(
+            id = "atf-checks.get",
+            displayName = "Fetch ATF findings",
+            summary = "Reads previously emitted ATF findings for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "data",
+                "get",
+                "--id",
+                "<preview-id>",
+                "--kind",
+                KIND_ATF,
+                "--json",
+              ),
+            productKinds = listOf(KIND_ATF),
+          ),
+        ),
       steps = listOf(finalSampleChecker, eachFrameChecker),
     )
 }
@@ -116,6 +166,27 @@ object AccessibilityOverlayPreviewExtension {
       id = ID,
       displayName = "Accessibility overlay annotations",
       componentExtensionIds = listOf(AccessibilitySemanticsPreviewExtension.ID, AtfChecksPreviewExtension.ID),
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "a11y-overlay.get",
+            displayName = "Fetch accessibility overlay",
+            summary = "Reads the rendered accessibility overlay artifact for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "data",
+                "get",
+                "--id",
+                "<preview-id>",
+                "--kind",
+                KIND_OVERLAY,
+                "--output",
+                "<path>",
+              ),
+            productKinds = listOf(KIND_OVERLAY),
+          )
+        ),
       steps = listOf(annotationProcessor),
     )
 }
@@ -135,6 +206,16 @@ object AccessibilityAnnotatedPreviewExtension {
           AtfChecksPreviewExtension.ID,
           AccessibilityOverlayPreviewExtension.ID,
           "overlay-legend",
+        ),
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "a11y-annotated-preview.render",
+            displayName = "Render accessibility annotated previews",
+            summary = "Discovers and renders suggested accessibility annotated preview extras.",
+            command = listOf("compose-preview", "show", "--json"),
+            usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
+          )
         ),
       steps =
         listOf(

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderPreviewExtension.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderPreviewExtension.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.data.render
 
 import ee.schimke.composeai.data.render.pipeline.PipelineCapability
 import ee.schimke.composeai.data.render.pipeline.PipelineStepTrait
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionCliCommand
 import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelineStep
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
@@ -57,6 +58,27 @@ object RenderPreviewExtension {
     PreviewExtensionDescriptor(
       id = "render-device-clip",
       displayName = "Device clip",
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "render-device-clip.get",
+            displayName = "Fetch device-clipped image",
+            summary = "Reads a rendered device-clipped image artifact for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "data",
+                "get",
+                "--id",
+                "<preview-id>",
+                "--kind",
+                KIND_DEVICE_CLIP,
+                "--output",
+                "<path>",
+              ),
+            productKinds = listOf(KIND_DEVICE_CLIP),
+          )
+        ),
       steps = listOf(deviceClipProcessor),
     )
 
@@ -64,6 +86,27 @@ object RenderPreviewExtension {
     PreviewExtensionDescriptor(
       id = "render-trace",
       displayName = "Render trace",
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "render-trace.get",
+            displayName = "Fetch render trace",
+            summary = "Reads aggregate render trace data for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "data",
+                "get",
+                "--id",
+                "<preview-id>",
+                "--kind",
+                KIND_TRACE,
+                "--json",
+              ),
+            agentRecommended = true,
+            productKinds = listOf(KIND_TRACE),
+          )
+        ),
       steps = listOf(renderTraceProfiler),
     )
 
@@ -71,6 +114,27 @@ object RenderPreviewExtension {
     PreviewExtensionDescriptor(
       id = "compose-trace",
       displayName = "Compose composition trace",
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "compose-trace.get",
+            displayName = "Fetch Compose composition trace",
+            summary = "Reads aggregate Compose composition tracing data for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "data",
+                "get",
+                "--id",
+                "<preview-id>",
+                "--kind",
+                KIND_COMPOSE_AI_TRACE,
+                "--json",
+              ),
+            agentRecommended = true,
+            productKinds = listOf(KIND_COMPOSE_AI_TRACE),
+          )
+        ),
       steps = listOf(composeTraceProfiler),
     )
 

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewPipeline.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewPipeline.kt
@@ -36,7 +36,20 @@ data class PreviewExtensionDescriptor(
   val displayName: String = id,
   val usageModes: Set<PreviewExtensionUsageMode> = setOf(PreviewExtensionUsageMode.ExplicitEffect),
   val componentExtensionIds: List<String> = emptyList(),
+  val cliCommands: List<PreviewExtensionCliCommand> = emptyList(),
   val steps: List<PreviewPipelineStep> = emptyList(),
+)
+
+@Serializable
+data class PreviewExtensionCliCommand(
+  val id: String,
+  val displayName: String = id,
+  val summary: String = "",
+  val command: List<String>,
+  val agentRecommended: Boolean = false,
+  val requiresDaemon: Boolean = false,
+  val usageModes: Set<PreviewExtensionUsageMode> = emptySet(),
+  val productKinds: List<String> = emptyList(),
 )
 
 @Serializable

--- a/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtension.kt
+++ b/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtension.kt
@@ -2,6 +2,7 @@ package ee.schimke.composeai.scroll
 
 import ee.schimke.composeai.data.render.pipeline.PipelineCapability
 import ee.schimke.composeai.data.render.pipeline.PipelineStepTrait
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionCliCommand
 import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
 import ee.schimke.composeai.data.render.pipeline.PreviewExtensionUsageMode
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelineStep
@@ -95,6 +96,27 @@ object ScrollPreviewExtension {
       displayName = "Long scroll",
       usageModes =
         setOf(PreviewExtensionUsageMode.ExplicitEffect, PreviewExtensionUsageMode.SuggestedExtraPreview),
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "scroll-long.get",
+            displayName = "Fetch long scroll image",
+            summary = "Reads a stitched long-scroll image artifact for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "data",
+                "get",
+                "--id",
+                "<preview-id>",
+                "--kind",
+                KIND_LONG,
+                "--output",
+                "<path>",
+              ),
+            productKinds = listOf(KIND_LONG),
+          )
+        ),
       steps = listOf(longScrollScenario, longScrollEncoder),
     )
 
@@ -103,6 +125,17 @@ object ScrollPreviewExtension {
       id = ANNOTATION_ID,
       displayName = "ScrollingPreview annotation",
       usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "scrolling-preview-annotation.render",
+            displayName = "Render scroll annotation suggestions",
+            summary = "Discovers @ScrollingPreview annotations and renders their suggested extras.",
+            command = listOf("compose-preview", "show", "--json"),
+            agentRecommended = true,
+            usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
+          )
+        ),
       steps = listOf(annotationSuggester),
     )
 
@@ -112,6 +145,27 @@ object ScrollPreviewExtension {
       displayName = "Scroll GIF",
       usageModes =
         setOf(PreviewExtensionUsageMode.ExplicitEffect, PreviewExtensionUsageMode.SuggestedExtraPreview),
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "scroll-gif.get",
+            displayName = "Fetch scroll GIF",
+            summary = "Reads an animated scroll GIF artifact for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "data",
+                "get",
+                "--id",
+                "<preview-id>",
+                "--kind",
+                KIND_GIF,
+                "--output",
+                "<path>",
+              ),
+            productKinds = listOf(KIND_GIF),
+          )
+        ),
       steps = listOf(gifScrollScenario, gifScrollEncoder),
     )
 }

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -153,7 +153,19 @@ export interface PreviewExtensionDescriptor {
     displayName?: string;
     usageModes?: PreviewExtensionUsageMode[];
     componentExtensionIds?: string[];
+    cliCommands?: PreviewExtensionCliCommand[];
     steps?: PreviewPipelineStep[];
+}
+
+export interface PreviewExtensionCliCommand {
+    id: string;
+    displayName?: string;
+    summary?: string;
+    command: string[];
+    agentRecommended?: boolean;
+    requiresDaemon?: boolean;
+    usageModes?: PreviewExtensionUsageMode[];
+    productKinds?: string[];
 }
 
 export interface PreviewPipelineStep {


### PR DESCRIPTION
## Summary
- Add `cliCommands` metadata to preview extension descriptors and surface it in the VS Code daemon protocol types.
- Attach command metadata to render, a11y, ATF, overlay, scroll, and annotation-driven preview extensions.
- Add daemon-free `compose-preview extensions commands [--json] [--agent]` so agents and clients can discover extension-oriented CLI entry points without starting the daemon.

## Validation
- `./gradlew ktfmtFormatAll :cli:test :data-render-core:test :daemon:core:compileKotlin :daemon:desktop:compileKotlin`
- `./gradlew :cli:run --args='extensions commands --json'`
- `./gradlew :data-a11y-core:testDebugUnitTest :data-scroll-core:testDebugUnitTest :daemon:android:compileDebugKotlin`
- After rebasing on `origin/main`: `./gradlew ktfmtFormatAll :cli:test :data-render-core:test :daemon:core:compileKotlin :daemon:desktop:compileKotlin :data-a11y-core:testDebugUnitTest :data-scroll-core:testDebugUnitTest :daemon:android:compileDebugKotlin`