### PR TITLE
Route preview extension commands through command catalog

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -74,7 +74,10 @@ data class PreviewInfo(
   val sourceFile: String? = null,
   val params: PreviewParams = PreviewParams(),
   val captures: List<Capture> = listOf(Capture()),
+  val dataProducts: List<PreviewDataProduct> = emptyList(),
 )
+
+@Serializable data class PreviewDataProduct(val kind: String, val output: String = "")
 
 @Serializable
 data class PreviewManifest(

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DataCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DataCommands.kt
@@ -213,11 +213,21 @@ private fun List<String>.dataSubcommand(): String? {
 
 internal fun scanDataProducts(module: String, projectDir: File): DataProductsModule {
   val dataDir = dataRoot(projectDir)
+  val manifest = readDataManifest(projectDir)
+  val manifestProductBuckets =
+    manifest
+      ?.previews
+      ?.flatMap { it.dataProducts }
+      ?.mapNotNull { product ->
+        product.output.removePrefix("data/").substringBefore('/').takeIf { it.isNotBlank() }
+      }
+      ?.toSet() ?: emptySet()
   val byKind = linkedMapOf<String, MutableSet<String>>()
   if (dataDir.isDirectory) {
     dataDir
       .listFiles()
       ?.filter { it.isDirectory }
+      ?.filter { it.name !in manifestProductBuckets }
       ?.sortedBy { it.name }
       ?.forEach { previewDir ->
         previewDir
@@ -228,6 +238,14 @@ internal fun scanDataProducts(module: String, projectDir: File): DataProductsMod
             byKind.getOrPut(descriptor.kind) { linkedSetOf() } += previewDir.name
           }
       }
+  }
+  manifest?.previews?.forEach { preview ->
+    preview.dataProducts.forEach { product ->
+      val file = projectDir.resolve("build/compose-previews/${product.output}")
+      if (product.output.isNotBlank() && file.isFile) {
+        byKind.getOrPut(product.kind) { linkedSetOf() } += preview.id
+      }
+    }
   }
 
   val products =
@@ -258,8 +276,23 @@ internal fun findDataProduct(
 ): LocalDataProduct? {
   val descriptor = descriptorForKind(kind)
   val file = dataRoot(module.projectDir).resolve(previewId).resolve(descriptor.fileName)
-  if (!file.exists() || !file.isFile) return null
-  return LocalDataProduct(module.gradlePath, previewId, descriptor, file.absoluteFile)
+  if (file.exists() && file.isFile) {
+    return LocalDataProduct(module.gradlePath, previewId, descriptor, file.absoluteFile)
+  }
+  val manifestProduct =
+    readDataManifest(module.projectDir)
+      ?.previews
+      ?.firstOrNull { it.id == previewId }
+      ?.dataProducts
+      ?.firstOrNull { it.kind == kind && it.output.isNotBlank() } ?: return null
+  val manifestFile = module.projectDir.resolve("build/compose-previews/${manifestProduct.output}")
+  if (!manifestFile.isFile) return null
+  return LocalDataProduct(
+    module.gradlePath,
+    previewId,
+    descriptorForManifestProduct(manifestProduct, manifestFile),
+    manifestFile.absoluteFile,
+  )
 }
 
 internal fun buildDataGetResponse(product: LocalDataProduct): DataGetResponse {
@@ -348,6 +381,32 @@ private fun descriptorForKind(kind: String): LocalDataProductDescriptor =
       transport = DataProductTransport.INLINE,
       fileName = "${kind.replace('/', '-')}.json",
     )
+
+private fun readDataManifest(projectDir: File): PreviewManifest? {
+  val manifestFile = projectDir.resolve("build/compose-previews/previews.json")
+  if (!manifestFile.isFile) return null
+  return runCatching {
+      dataJson.decodeFromString(PreviewManifest.serializer(), manifestFile.readText())
+    }
+    .getOrNull()
+}
+
+private fun descriptorForManifestProduct(
+  product: PreviewDataProduct,
+  file: File,
+): LocalDataProductDescriptor {
+  val transport =
+    when (file.extension.lowercase()) {
+      "json" -> DataProductTransport.INLINE
+      else -> DataProductTransport.PATH
+    }
+  return LocalDataProductDescriptor(
+    kind = product.kind,
+    schemaVersion = descriptorForKind(product.kind).schemaVersion,
+    transport = transport,
+    fileName = file.name,
+  )
+}
 
 private fun descriptorForFile(file: File): LocalDataProductDescriptor? =
   knownByFileName[file.name]

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ExtensionCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ExtensionCommands.kt
@@ -1,9 +1,7 @@
 package ee.schimke.composeai.cli
 
-import ee.schimke.composeai.data.render.RenderPreviewExtension
-import ee.schimke.composeai.data.render.pipeline.PreviewExtensionCliCommand
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionCommandCatalog
 import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
-import ee.schimke.composeai.data.render.pipeline.PreviewExtensionUsageMode
 import kotlin.system.exitProcess
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -26,6 +24,7 @@ data class ExtensionCommandsResponse(
 class ExtensionCommandsCommand(private val args: List<String>) {
   private val jsonOutput = "--json" in args
   private val onlyAgentRecommended = "--agent" in args || "--agent-recommended" in args
+  private val positionals = args.filter { !it.startsWith("-") }
 
   fun run() {
     if ("--help" in args || "-h" in args) {
@@ -33,11 +32,12 @@ class ExtensionCommandsCommand(private val args: List<String>) {
       return
     }
 
-    when (args.firstOrNull { !it.startsWith("-") } ?: "commands") {
+    when (positionals.firstOrNull() ?: "commands") {
       "commands",
       "list" -> printCommands()
+      "run" -> runExtensionCommand()
       else -> {
-        System.err.println("extensions supports: commands")
+        System.err.println("extensions supports: commands, run")
         printUsage()
         exitProcess(1)
       }
@@ -45,14 +45,17 @@ class ExtensionCommandsCommand(private val args: List<String>) {
   }
 
   private fun printCommands() {
-    val response = ExtensionCommandsResponse(extensions = BuiltInExtensionCliCatalog.extensions)
+    val response = ExtensionCommandsResponse(extensions = PreviewExtensionCommandCatalog.extensions)
     val filtered =
       if (onlyAgentRecommended) {
         response.copy(
           extensions =
             response.extensions
               .map { descriptor ->
-                descriptor.copy(cliCommands = descriptor.cliCommands.filter { it.agentRecommended })
+                descriptor.copy(
+                  cliCommands =
+                    descriptor.cliCommands.filter { it.agentRecommended && !it.requiresDaemon }
+                )
               }
               .filter { it.cliCommands.isNotEmpty() }
         )
@@ -86,218 +89,78 @@ class ExtensionCommandsCommand(private val args: List<String>) {
     println(
       """
       compose-preview extensions commands [--json] [--agent]
+      compose-preview extensions run COMMAND_ID [command options]
 
-      Lists command metadata contributed by built-in preview extensions. This is
-      daemon-free: clients can discover extension-oriented CLI entry points
-      without starting a render daemon.
+      Lists or runs command metadata contributed by built-in preview extensions.
+      Discovery is daemon-free; run routes shrinkwrapped command ids to stable
+      CLI primitives such as show, a11y, and data get.
       """
         .trimIndent()
     )
   }
+
+  private fun runExtensionCommand() {
+    val commandId =
+      positionals.getOrNull(1)
+        ?: run {
+          System.err.println("extensions run requires COMMAND_ID.")
+          printUsage()
+          exitProcess(1)
+        }
+    if (PreviewExtensionCommandCatalog.commandById(commandId) == null) {
+      System.err.println("Unknown extension command: $commandId")
+      printUsage()
+      exitProcess(1)
+    }
+    val passthrough = args.withoutFirstPositionals(2)
+    when (commandId) {
+      "atf-checks.run" -> A11yCommand(passthrough.withDefault("--json")).run()
+      "a11y-annotated-preview.render",
+      "scrolling-preview-annotation.render" -> ShowCommand(passthrough.withDefault("--json")).run()
+      "a11y.hierarchy.get" ->
+        DataCommand(passthrough.dataGet("a11y/hierarchy", defaultJson = true)).run()
+      "atf-checks.get" -> DataCommand(passthrough.dataGet("a11y/atf", defaultJson = true)).run()
+      "a11y-overlay.get" ->
+        DataCommand(passthrough.dataGet("a11y/overlay", defaultJson = false)).run()
+      "compose-trace.get" ->
+        DataCommand(passthrough.dataGet("render/composeAiTrace", defaultJson = true)).run()
+      "scroll-long.get" ->
+        DataCommand(passthrough.dataGet("render/scroll/long", defaultJson = false)).run()
+      "scroll-gif.get" ->
+        DataCommand(passthrough.dataGet("render/scroll/gif", defaultJson = false)).run()
+      "render-device-clip.get",
+      "render-trace.get" -> {
+        System.err.println(
+          "Extension command '$commandId' requires daemon data/fetch. Use MCP run_extension_command."
+        )
+        exitProcess(1)
+      }
+      else -> {
+        System.err.println("Extension command '$commandId' has no CLI runner yet.")
+        exitProcess(1)
+      }
+    }
+  }
 }
 
-private object BuiltInExtensionCliCatalog {
-  val extensions: List<PreviewExtensionDescriptor> =
-    listOf(
-      RenderPreviewExtension.deviceClipDescriptor,
-      RenderPreviewExtension.renderTraceDescriptor,
-      RenderPreviewExtension.composeTraceDescriptor,
-      RenderPreviewExtension.overlayLegendDescriptor,
-      accessibilityHierarchy(),
-      atfChecks(),
-      accessibilityOverlay(),
-      accessibilityAnnotatedPreview(),
-      scrollAnnotation(),
-      scrollLong(),
-      scrollGif(),
-    )
+private fun List<String>.withoutFirstPositionals(count: Int): List<String> {
+  var remaining = count
+  return filter { arg ->
+    if (remaining > 0 && !arg.startsWith("-")) {
+      remaining--
+      false
+    } else {
+      true
+    }
+  }
+}
 
-  private fun accessibilityHierarchy(): PreviewExtensionDescriptor =
-    PreviewExtensionDescriptor(
-      id = "a11y",
-      displayName = "Accessibility hierarchy",
-      cliCommands =
-        listOf(
-          PreviewExtensionCliCommand(
-            id = "a11y.hierarchy.get",
-            displayName = "Fetch accessibility hierarchy",
-            summary = "Reads the structured accessibility hierarchy for one preview.",
-            command =
-              listOf(
-                "compose-preview",
-                "data",
-                "get",
-                "--id",
-                "<preview-id>",
-                "--kind",
-                "a11y/hierarchy",
-                "--json",
-              ),
-            agentRecommended = true,
-            productKinds = listOf("a11y/hierarchy"),
-          )
-        ),
-    )
+private fun List<String>.withDefault(flag: String): List<String> =
+  if (flag in this) this else this + flag
 
-  private fun atfChecks(): PreviewExtensionDescriptor =
-    PreviewExtensionDescriptor(
-      id = "atf-checks",
-      displayName = "ATF checks",
-      cliCommands =
-        listOf(
-          PreviewExtensionCliCommand(
-            id = "atf-checks.run",
-            displayName = "Run ATF accessibility checks",
-            summary = "Renders previews and returns ATF accessibility findings.",
-            command = listOf("compose-preview", "a11y", "--json"),
-            agentRecommended = true,
-            productKinds = listOf("a11y/atf", "a11y/touchTargets"),
-          ),
-          PreviewExtensionCliCommand(
-            id = "atf-checks.get",
-            displayName = "Fetch ATF findings",
-            summary = "Reads previously emitted ATF findings for one preview.",
-            command =
-              listOf(
-                "compose-preview",
-                "data",
-                "get",
-                "--id",
-                "<preview-id>",
-                "--kind",
-                "a11y/atf",
-                "--json",
-              ),
-            productKinds = listOf("a11y/atf"),
-          ),
-        ),
-    )
-
-  private fun accessibilityOverlay(): PreviewExtensionDescriptor =
-    PreviewExtensionDescriptor(
-      id = "a11y-overlay",
-      displayName = "Accessibility overlay annotations",
-      componentExtensionIds = listOf("a11y", "atf-checks"),
-      cliCommands =
-        listOf(
-          PreviewExtensionCliCommand(
-            id = "a11y-overlay.get",
-            displayName = "Fetch accessibility overlay",
-            summary = "Reads the rendered accessibility overlay artifact for one preview.",
-            command =
-              listOf(
-                "compose-preview",
-                "data",
-                "get",
-                "--id",
-                "<preview-id>",
-                "--kind",
-                "a11y/overlay",
-                "--output",
-                "<path>",
-              ),
-            productKinds = listOf("a11y/overlay"),
-          )
-        ),
-    )
-
-  private fun accessibilityAnnotatedPreview(): PreviewExtensionDescriptor =
-    PreviewExtensionDescriptor(
-      id = "a11y-annotated-preview",
-      displayName = "Accessibility annotated preview",
-      usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
-      componentExtensionIds = listOf("a11y", "atf-checks", "a11y-overlay", "overlay-legend"),
-      cliCommands =
-        listOf(
-          PreviewExtensionCliCommand(
-            id = "a11y-annotated-preview.render",
-            displayName = "Render accessibility annotated previews",
-            summary = "Discovers and renders suggested accessibility annotated preview extras.",
-            command = listOf("compose-preview", "show", "--json"),
-            usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
-          )
-        ),
-    )
-
-  private fun scrollAnnotation(): PreviewExtensionDescriptor =
-    PreviewExtensionDescriptor(
-      id = "scrolling-preview-annotation",
-      displayName = "ScrollingPreview annotation",
-      usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
-      cliCommands =
-        listOf(
-          PreviewExtensionCliCommand(
-            id = "scrolling-preview-annotation.render",
-            displayName = "Render scroll annotation suggestions",
-            summary = "Discovers @ScrollingPreview annotations and renders their suggested extras.",
-            command = listOf("compose-preview", "show", "--json"),
-            agentRecommended = true,
-            usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
-          )
-        ),
-    )
-
-  private fun scrollLong(): PreviewExtensionDescriptor =
-    PreviewExtensionDescriptor(
-      id = "scroll-long",
-      displayName = "Long scroll",
-      usageModes =
-        setOf(
-          PreviewExtensionUsageMode.ExplicitEffect,
-          PreviewExtensionUsageMode.SuggestedExtraPreview,
-        ),
-      cliCommands =
-        listOf(
-          PreviewExtensionCliCommand(
-            id = "scroll-long.get",
-            displayName = "Fetch long scroll image",
-            summary = "Reads a stitched long-scroll image artifact for one preview.",
-            command =
-              listOf(
-                "compose-preview",
-                "data",
-                "get",
-                "--id",
-                "<preview-id>",
-                "--kind",
-                "render/scroll/long",
-                "--output",
-                "<path>",
-              ),
-            productKinds = listOf("render/scroll/long"),
-          )
-        ),
-    )
-
-  private fun scrollGif(): PreviewExtensionDescriptor =
-    PreviewExtensionDescriptor(
-      id = "scroll-gif",
-      displayName = "Scroll GIF",
-      usageModes =
-        setOf(
-          PreviewExtensionUsageMode.ExplicitEffect,
-          PreviewExtensionUsageMode.SuggestedExtraPreview,
-        ),
-      cliCommands =
-        listOf(
-          PreviewExtensionCliCommand(
-            id = "scroll-gif.get",
-            displayName = "Fetch scroll GIF",
-            summary = "Reads an animated scroll GIF artifact for one preview.",
-            command =
-              listOf(
-                "compose-preview",
-                "data",
-                "get",
-                "--id",
-                "<preview-id>",
-                "--kind",
-                "render/scroll/gif",
-                "--output",
-                "<path>",
-              ),
-            productKinds = listOf("render/scroll/gif"),
-          )
-        ),
-    )
+private fun List<String>.dataGet(kind: String, defaultJson: Boolean): List<String> {
+  val out = mutableListOf("get", "--kind", kind)
+  out += this
+  if (defaultJson && "--json" !in out && "--output" !in out) out += "--json"
+  return out
 }

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DataCommandsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DataCommandsTest.kt
@@ -95,6 +95,43 @@ class DataCommandsTest {
     assertEquals("custom/kind", module.products.single().kind)
   }
 
+  @Test
+  fun `manifest data products are discoverable by kind and preview id`() {
+    val projectDir = tempModule()
+    val file = projectDir.resolve("build/compose-previews/data/render-scroll-long/P.png")
+    file.parentFile.mkdirs()
+    file.writeBytes(byteArrayOf(1, 2, 3))
+    projectDir
+      .resolve("build/compose-previews/previews.json")
+      .writeText(
+        """
+        {
+          "module": "app",
+          "variant": "debug",
+          "previews": [
+            {
+              "id": "P",
+              "functionName": "P",
+              "className": "Previews",
+              "captures": [{"renderOutput": "renders/P.png"}],
+              "dataProducts": [
+                {"kind": "render/scroll/long", "output": "data/render-scroll-long/P.png"}
+              ]
+            }
+          ]
+        }
+        """
+          .trimIndent()
+      )
+
+    val summary = scanDataProducts("app", projectDir).products.single()
+    val product = findDataProduct(PreviewModule("app", projectDir), "P", "render/scroll/long")
+
+    assertEquals("render/scroll/long", summary.kind)
+    assertEquals(listOf("P"), summary.previews)
+    assertEquals(file.absolutePath, product!!.file.path)
+  }
+
   private fun tempModule(): File = Files.createTempDirectory("data-command-test").toFile()
 
   private fun writeProduct(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/ExtensionCommandsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/ExtensionCommandsTest.kt
@@ -28,12 +28,11 @@ class ExtensionCommandsTest {
     assertEquals(
       listOf(
         "compose-preview",
-        "data",
-        "get",
+        "extensions",
+        "run",
+        "compose-trace.get",
         "--id",
         "<preview-id>",
-        "--kind",
-        "render/composeAiTrace",
         "--json",
       ),
       command.command,

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtension.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtension.kt
@@ -57,12 +57,11 @@ object AccessibilitySemanticsPreviewExtension {
             command =
               listOf(
                 "compose-preview",
-                "data",
-                "get",
+                "extensions",
+                "run",
+                "a11y.hierarchy.get",
                 "--id",
                 "<preview-id>",
-                "--kind",
-                KIND_HIERARCHY,
                 "--json",
               ),
             agentRecommended = true,
@@ -116,7 +115,7 @@ object AtfChecksPreviewExtension {
             id = "atf-checks.run",
             displayName = "Run ATF accessibility checks",
             summary = "Renders previews and returns ATF accessibility findings.",
-            command = listOf("compose-preview", "a11y", "--json"),
+            command = listOf("compose-preview", "extensions", "run", "atf-checks.run", "--json"),
             agentRecommended = true,
             productKinds = listOf(KIND_ATF, KIND_TOUCH_TARGETS),
           ),
@@ -127,12 +126,11 @@ object AtfChecksPreviewExtension {
             command =
               listOf(
                 "compose-preview",
-                "data",
-                "get",
+                "extensions",
+                "run",
+                "atf-checks.get",
                 "--id",
                 "<preview-id>",
-                "--kind",
-                KIND_ATF,
                 "--json",
               ),
             productKinds = listOf(KIND_ATF),
@@ -175,12 +173,11 @@ object AccessibilityOverlayPreviewExtension {
             command =
               listOf(
                 "compose-preview",
-                "data",
-                "get",
+                "extensions",
+                "run",
+                "a11y-overlay.get",
                 "--id",
                 "<preview-id>",
-                "--kind",
-                KIND_OVERLAY,
                 "--output",
                 "<path>",
               ),
@@ -213,7 +210,8 @@ object AccessibilityAnnotatedPreviewExtension {
             id = "a11y-annotated-preview.render",
             displayName = "Render accessibility annotated previews",
             summary = "Discovers and renders suggested accessibility annotated preview extras.",
-            command = listOf("compose-preview", "show", "--json"),
+            command =
+              listOf("compose-preview", "extensions", "run", "a11y-annotated-preview.render", "--json"),
             usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
           )
         ),

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderPreviewExtension.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderPreviewExtension.kt
@@ -67,15 +67,14 @@ object RenderPreviewExtension {
             command =
               listOf(
                 "compose-preview",
-                "data",
-                "get",
+                "extensions",
+                "run",
+                "render-device-clip.get",
                 "--id",
                 "<preview-id>",
-                "--kind",
-                KIND_DEVICE_CLIP,
-                "--output",
-                "<path>",
+                "--json",
               ),
+            requiresDaemon = true,
             productKinds = listOf(KIND_DEVICE_CLIP),
           )
         ),
@@ -95,15 +94,15 @@ object RenderPreviewExtension {
             command =
               listOf(
                 "compose-preview",
-                "data",
-                "get",
+                "extensions",
+                "run",
+                "render-trace.get",
                 "--id",
                 "<preview-id>",
-                "--kind",
-                KIND_TRACE,
                 "--json",
               ),
             agentRecommended = true,
+            requiresDaemon = true,
             productKinds = listOf(KIND_TRACE),
           )
         ),
@@ -123,12 +122,11 @@ object RenderPreviewExtension {
             command =
               listOf(
                 "compose-preview",
-                "data",
-                "get",
+                "extensions",
+                "run",
+                "compose-trace.get",
                 "--id",
                 "<preview-id>",
-                "--kind",
-                KIND_COMPOSE_AI_TRACE,
                 "--json",
               ),
             agentRecommended = true,

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewExtensionCommandCatalog.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewExtensionCommandCatalog.kt
@@ -1,0 +1,230 @@
+package ee.schimke.composeai.data.render.pipeline
+
+import ee.schimke.composeai.data.render.RenderPreviewExtension
+
+/**
+ * Daemon-free command catalog for built-in preview extensions.
+ *
+ * Renderer modules still advertise their full descriptors, including concrete pipeline steps, at
+ * daemon initialize time. This catalog is intentionally lighter: it gives CLI and MCP clients a
+ * single shrinkwrapped command surface they can list or route without depending on Android-only
+ * extension modules or starting a daemon.
+ */
+object PreviewExtensionCommandCatalog {
+  val extensions: List<PreviewExtensionDescriptor> =
+    listOf(
+      RenderPreviewExtension.deviceClipDescriptor,
+      RenderPreviewExtension.renderTraceDescriptor,
+      RenderPreviewExtension.composeTraceDescriptor,
+      RenderPreviewExtension.overlayLegendDescriptor,
+      accessibilityHierarchy(),
+      atfChecks(),
+      accessibilityOverlay(),
+      accessibilityAnnotatedPreview(),
+      scrollAnnotation(),
+      scrollLong(),
+      scrollGif(),
+    )
+
+  val commands: List<PreviewExtensionCliCommand> = extensions.flatMap { it.cliCommands }
+
+  fun commandById(id: String): PreviewExtensionCliCommand? = commands.firstOrNull { it.id == id }
+
+  private fun accessibilityHierarchy(): PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "a11y",
+      displayName = "Accessibility hierarchy",
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "a11y.hierarchy.get",
+            displayName = "Fetch accessibility hierarchy",
+            summary = "Reads the structured accessibility hierarchy for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "extensions",
+                "run",
+                "a11y.hierarchy.get",
+                "--id",
+                "<preview-id>",
+                "--json",
+              ),
+            agentRecommended = true,
+            productKinds = listOf("a11y/hierarchy"),
+          )
+        ),
+    )
+
+  private fun atfChecks(): PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "atf-checks",
+      displayName = "ATF checks",
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "atf-checks.run",
+            displayName = "Run ATF accessibility checks",
+            summary = "Renders previews and returns ATF accessibility findings.",
+            command = listOf("compose-preview", "extensions", "run", "atf-checks.run", "--json"),
+            agentRecommended = true,
+            productKinds = listOf("a11y/atf", "a11y/touchTargets"),
+          ),
+          PreviewExtensionCliCommand(
+            id = "atf-checks.get",
+            displayName = "Fetch ATF findings",
+            summary = "Reads previously emitted ATF findings for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "extensions",
+                "run",
+                "atf-checks.get",
+                "--id",
+                "<preview-id>",
+                "--json",
+              ),
+            productKinds = listOf("a11y/atf"),
+          ),
+        ),
+    )
+
+  private fun accessibilityOverlay(): PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "a11y-overlay",
+      displayName = "Accessibility overlay annotations",
+      componentExtensionIds = listOf("a11y", "atf-checks"),
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "a11y-overlay.get",
+            displayName = "Fetch accessibility overlay",
+            summary = "Reads the rendered accessibility overlay artifact for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "extensions",
+                "run",
+                "a11y-overlay.get",
+                "--id",
+                "<preview-id>",
+                "--output",
+                "<path>",
+              ),
+            productKinds = listOf("a11y/overlay"),
+          )
+        ),
+    )
+
+  private fun accessibilityAnnotatedPreview(): PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "a11y-annotated-preview",
+      displayName = "Accessibility annotated preview",
+      usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
+      componentExtensionIds = listOf("a11y", "atf-checks", "a11y-overlay", "overlay-legend"),
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "a11y-annotated-preview.render",
+            displayName = "Render accessibility annotated previews",
+            summary = "Discovers and renders suggested accessibility annotated preview extras.",
+            command =
+              listOf(
+                "compose-preview",
+                "extensions",
+                "run",
+                "a11y-annotated-preview.render",
+                "--json",
+              ),
+            usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
+          )
+        ),
+    )
+
+  private fun scrollAnnotation(): PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "scrolling-preview-annotation",
+      displayName = "ScrollingPreview annotation",
+      usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "scrolling-preview-annotation.render",
+            displayName = "Render scroll annotation suggestions",
+            summary = "Discovers @ScrollingPreview annotations and renders their suggested extras.",
+            command =
+              listOf(
+                "compose-preview",
+                "extensions",
+                "run",
+                "scrolling-preview-annotation.render",
+                "--json",
+              ),
+            agentRecommended = true,
+            usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
+          )
+        ),
+    )
+
+  private fun scrollLong(): PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "scroll-long",
+      displayName = "Long scroll",
+      usageModes =
+        setOf(
+          PreviewExtensionUsageMode.ExplicitEffect,
+          PreviewExtensionUsageMode.SuggestedExtraPreview,
+        ),
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "scroll-long.get",
+            displayName = "Fetch long scroll image",
+            summary = "Reads a stitched long-scroll image artifact for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "extensions",
+                "run",
+                "scroll-long.get",
+                "--id",
+                "<preview-id>",
+                "--output",
+                "<path>",
+              ),
+            productKinds = listOf("render/scroll/long"),
+          )
+        ),
+    )
+
+  private fun scrollGif(): PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "scroll-gif",
+      displayName = "Scroll GIF",
+      usageModes =
+        setOf(
+          PreviewExtensionUsageMode.ExplicitEffect,
+          PreviewExtensionUsageMode.SuggestedExtraPreview,
+        ),
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "scroll-gif.get",
+            displayName = "Fetch scroll GIF",
+            summary = "Reads an animated scroll GIF artifact for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "extensions",
+                "run",
+                "scroll-gif.get",
+                "--id",
+                "<preview-id>",
+                "--output",
+                "<path>",
+              ),
+            productKinds = listOf("render/scroll/gif"),
+          )
+        ),
+    )
+}

--- a/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtension.kt
+++ b/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtension.kt
@@ -105,12 +105,11 @@ object ScrollPreviewExtension {
             command =
               listOf(
                 "compose-preview",
-                "data",
-                "get",
+                "extensions",
+                "run",
+                "scroll-long.get",
                 "--id",
                 "<preview-id>",
-                "--kind",
-                KIND_LONG,
                 "--output",
                 "<path>",
               ),
@@ -131,7 +130,8 @@ object ScrollPreviewExtension {
             id = "scrolling-preview-annotation.render",
             displayName = "Render scroll annotation suggestions",
             summary = "Discovers @ScrollingPreview annotations and renders their suggested extras.",
-            command = listOf("compose-preview", "show", "--json"),
+            command =
+              listOf("compose-preview", "extensions", "run", "scrolling-preview-annotation.render", "--json"),
             agentRecommended = true,
             usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
           )
@@ -154,12 +154,11 @@ object ScrollPreviewExtension {
             command =
               listOf(
                 "compose-preview",
-                "data",
-                "get",
+                "extensions",
+                "run",
+                "scroll-gif.get",
                 "--id",
                 "<preview-id>",
-                "--kind",
-                KIND_GIF,
                 "--output",
                 "<path>",
               ),

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -9,6 +9,8 @@ import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
 import ee.schimke.composeai.daemon.protocol.RenderTier
 import ee.schimke.composeai.daemon.protocol.UiMode
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionCommandCatalog
+import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
 import ee.schimke.composeai.mcp.protocol.CallToolResult
 import ee.schimke.composeai.mcp.protocol.ContentBlock
 import ee.schimke.composeai.mcp.protocol.Implementation
@@ -31,6 +33,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
@@ -720,6 +723,50 @@ class DaemonMcpServer(
           ),
       ),
       ToolDef(
+        name = "list_extension_commands",
+        description =
+          "List preview-extension command ids exposed by the built-in command catalog. These are " +
+            "shrinkwrapped shortcuts over generic tools such as get_preview_data, " +
+            "render_preview_overlay, and render_preview. Use run_extension_command to invoke one by id.",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "agentRecommended":{"type":"boolean","description":"When true, only return commands marked as useful defaults for agents."}
+              }
+            }
+            """
+              .trimIndent()
+          ),
+      ),
+      ToolDef(
+        name = "run_extension_command",
+        description =
+          "Run a preview-extension command by id. This keeps high-level shortcuts discoverable " +
+            "through list_extension_commands while routing execution through stable generic MCP " +
+            "tools. Most commands require `uri`; render/data commands accept `inline`, `overrides`, " +
+            "and `params` where the underlying tool supports them.",
+        inputSchema =
+          parseSchema(
+            """
+            {
+              "type":"object",
+              "properties":{
+                "commandId":{"type":"string","description":"Extension command id from list_extension_commands."},
+                "uri":{"type":"string","description":"compose-preview://<workspace>/<module>/<fqn>?config=<qualifier>"},
+                "inline":{"type":"boolean","description":"For data/media commands, return inline content when supported."},
+                "params":{"type":"object","description":"Optional data/fetch params, forwarded for data commands."},
+                "overrides":{"type":"object","description":"Optional render overrides for render/media commands. Same shape as render_preview.overrides."}
+              },
+              "required":["commandId"]
+            }
+            """
+              .trimIndent()
+          ),
+      ),
+      ToolDef(
         name = "get_preview_data",
         description =
           "Fetch one data product (a11y findings, a11y hierarchy, layout tree, …) for a preview. The kind names a structured payload the daemon can produce alongside the PNG; call list_data_products first to see what each daemon advertises. Returns the JSON payload as a single text content block. Auto-renders the preview if it hasn't rendered yet (so the agent doesn't need to call render_preview first). Cache short-circuit: if the kind has been subscribed (subscribe_preview_data) or globally attached (--attach-data-product server flag), the latest renderFinished payload is served from an in-memory cache with zero daemon round-trip — the response carries `cached: true`. When the daemon's latest render didn't compute the kind and it's not cached, the daemon may queue a re-render in the right mode; this is bounded by the daemon's per-request budget (DataProductBudgetExceeded if exceeded). `inline` defaults to true so the agent gets JSON back rather than a path it may not be able to read; flip to false on local-FS callers that prefer to read sibling files directly.",
@@ -941,6 +988,8 @@ class DaemonMcpServer(
       "history_list" -> toolHistoryList(args)
       "history_diff" -> toolHistoryDiff(args)
       "list_data_products" -> toolListDataProducts(args)
+      "list_extension_commands" -> toolListExtensionCommands(args)
+      "run_extension_command" -> toolRunExtensionCommand(args)
       "get_preview_data" -> toolGetPreviewData(args)
       "render_preview_overlay" -> toolRenderPreviewOverlay(args)
       "get_preview_extras" -> toolGetPreviewExtras(args)
@@ -1487,6 +1536,89 @@ class DaemonMcpServer(
       }
     }
     return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
+  }
+
+  private fun toolListExtensionCommands(args: JsonObject): CallToolResult {
+    val agentRecommended =
+      args["agentRecommended"]?.jsonPrimitive?.contentOrNull?.toBooleanStrictOrNull() ?: false
+    val extensions =
+      if (agentRecommended) {
+        PreviewExtensionCommandCatalog.extensions
+          .map { extension ->
+            extension.copy(cliCommands = extension.cliCommands.filter { it.agentRecommended })
+          }
+          .filter { it.cliCommands.isNotEmpty() }
+      } else {
+        PreviewExtensionCommandCatalog.extensions
+      }
+    val payload = buildJsonObject {
+      put("schema", "compose-preview-extension-commands/v1")
+      putJsonArray("extensions") {
+        extensions.forEach { extension ->
+          add(json.encodeToJsonElement(PreviewExtensionDescriptor.serializer(), extension))
+        }
+      }
+      put("commandCount", extensions.sumOf { it.cliCommands.size })
+    }
+    return textCallToolResult(payload.toString())
+  }
+
+  private fun toolRunExtensionCommand(args: JsonObject): CallToolResult {
+    val commandId =
+      args["commandId"]?.jsonPrimitive?.contentOrNull
+        ?: return errorCallToolResult("run_extension_command: missing 'commandId'")
+    if (PreviewExtensionCommandCatalog.commandById(commandId) == null) {
+      return errorCallToolResult("run_extension_command: unknown command '$commandId'")
+    }
+    fun data(kind: String, defaultInline: Boolean = true): CallToolResult {
+      val routed = buildJsonObject {
+        copyArg(args, "uri")
+        put("kind", kind)
+        args["params"]?.let { put("params", it) }
+        put(
+          "inline",
+          JsonPrimitive(
+            args["inline"]?.jsonPrimitive?.contentOrNull?.toBooleanStrictOrNull() ?: defaultInline
+          ),
+        )
+      }
+      return toolGetPreviewData(routed)
+    }
+    fun overlay(kind: String): CallToolResult {
+      val routed = buildJsonObject {
+        copyArg(args, "uri")
+        put("kind", kind)
+        args["inline"]?.let { put("inline", it) }
+        args["overrides"]?.let { put("overrides", it) }
+      }
+      return toolRenderPreviewOverlay(routed)
+    }
+    fun render(): CallToolResult {
+      val routed = buildJsonObject {
+        copyArg(args, "uri")
+        args["overrides"]?.let { put("overrides", it) }
+      }
+      return toolRenderPreview(routed)
+    }
+    return when (commandId) {
+      "render-device-clip.get" -> data("render/deviceClip")
+      "render-trace.get" -> data("render/trace")
+      "compose-trace.get" -> data("render/composeAiTrace")
+      "a11y.hierarchy.get" -> data("a11y/hierarchy")
+      "atf-checks.run",
+      "atf-checks.get" -> data("a11y/atf")
+      "a11y-overlay.get" -> overlay("a11y/overlay")
+      "a11y-annotated-preview.render",
+      "scrolling-preview-annotation.render" -> render()
+      "scroll-long.get" -> data("render/scroll/long", defaultInline = false)
+      "scroll-gif.get" -> data("render/scroll/gif", defaultInline = false)
+      else ->
+        errorCallToolResult("run_extension_command: command '$commandId' has no MCP runner yet")
+    }
+  }
+
+  private fun JsonObjectBuilder.copyArg(source: JsonObject, name: String) {
+    source[name]?.let { put(name, it) }
   }
 
   private fun toolGetPreviewData(args: JsonObject): CallToolResult {

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -104,6 +104,8 @@ class DaemonMcpServerTest {
         "history_list",
         "history_diff",
         "list_data_products",
+        "list_extension_commands",
+        "run_extension_command",
         "get_preview_data",
         "subscribe_preview_data",
         "unsubscribe_preview_data",


### PR DESCRIPTION
## Plan
1. Keep shrinkwrapped command entry points, but make them discoverable as preview-extension commands instead of undocumented CLI/MCP one-offs.
2. Share the built-in command catalog from renderer-agnostic core so CLI and MCP do not each carry separate extension-specific lists.
3. Route compatibility commands through `extensions run` and `run_extension_command`, while generic primitives (`data get`, `get_preview_data`, `render_preview_overlay`) remain the execution backend.
4. Keep daemon-only commands marked separately so daemon-free CLI agent discovery does not advertise commands it cannot execute locally.

## Summary
- Add `PreviewExtensionCommandCatalog` in `data-render-core` and route built-in command metadata through `compose-preview extensions run <command-id>`.
- Add MCP `list_extension_commands` and `run_extension_command` tools so MCP clients can discover and invoke the same shrinkwrapped commands by id.
- Teach CLI data-product lookup about manifest-declared products such as `render/scroll/long` and `render/scroll/gif`.
- Update render/a11y/scroll extension command metadata to point at the command mechanism rather than raw hardcoded CLI primitives.

## Validation
- `./gradlew ktfmtFormatAll :data-render-core:test :cli:test :mcp:test :mcp:compileKotlin :daemon:core:compileKotlin`
- `./gradlew :data-a11y-core:testDebugUnitTest :data-scroll-core:testDebugUnitTest :daemon:android:compileDebugKotlin`
- `./gradlew :cli:run --args='extensions commands --agent --json'`