### PR TITLE
[codex] Fix simple Codex review findings

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DataCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DataCommands.kt
@@ -229,13 +229,20 @@ internal fun scanDataProducts(module: String, projectDir: File): DataProductsMod
       ?.filter { it.isDirectory }
       ?.filter { it.name !in manifestProductBuckets }
       ?.sortedBy { it.name }
-      ?.forEach { previewDir ->
-        previewDir
+      ?.forEach { productDir ->
+        val directoryDescriptor = descriptorForDirectory(productDir.name)
+        productDir
           .listFiles()
           ?.filter { it.isFile }
-          ?.mapNotNull(::descriptorForFile)
-          ?.forEach { descriptor ->
-            byKind.getOrPut(descriptor.kind) { linkedSetOf() } += previewDir.name
+          ?.forEach { file ->
+            if (directoryDescriptor != null) {
+              byKind.getOrPut(directoryDescriptor.kind) { linkedSetOf() } +=
+                file.nameWithoutExtension
+            } else {
+              descriptorForFile(file)?.let { descriptor ->
+                byKind.getOrPut(descriptor.kind) { linkedSetOf() } += productDir.name
+              }
+            }
           }
       }
   }
@@ -275,7 +282,8 @@ internal fun findDataProduct(
   kind: String,
 ): LocalDataProduct? {
   val descriptor = descriptorForKind(kind)
-  val file = dataRoot(module.projectDir).resolve(previewId).resolve(descriptor.fileName)
+  val root = dataRoot(module.projectDir)
+  val file = root.resolve(previewId).resolve(descriptor.fileName)
   if (file.exists() && file.isFile) {
     return LocalDataProduct(module.gradlePath, previewId, descriptor, file.absoluteFile)
   }
@@ -284,15 +292,22 @@ internal fun findDataProduct(
       ?.previews
       ?.firstOrNull { it.id == previewId }
       ?.dataProducts
-      ?.firstOrNull { it.kind == kind && it.output.isNotBlank() } ?: return null
-  val manifestFile = module.projectDir.resolve("build/compose-previews/${manifestProduct.output}")
-  if (!manifestFile.isFile) return null
-  return LocalDataProduct(
-    module.gradlePath,
-    previewId,
-    descriptorForManifestProduct(manifestProduct, manifestFile),
-    manifestFile.absoluteFile,
-  )
+      ?.firstOrNull { it.kind == kind && it.output.isNotBlank() }
+  if (manifestProduct != null) {
+    val manifestFile = module.projectDir.resolve("build/compose-previews/${manifestProduct.output}")
+    if (manifestFile.isFile) {
+      return LocalDataProduct(
+        module.gradlePath,
+        previewId,
+        descriptorForManifestProduct(manifestProduct, manifestFile),
+        manifestFile.absoluteFile,
+      )
+    }
+  }
+  val kindScopedFile =
+    root.resolve(kind.replace('/', '-')).resolve("$previewId.${descriptor.extension}")
+  if (!kindScopedFile.isFile) return null
+  return LocalDataProduct(module.gradlePath, previewId, descriptor, kindScopedFile.absoluteFile)
 }
 
 internal fun buildDataGetResponse(product: LocalDataProduct): DataGetResponse {
@@ -323,7 +338,9 @@ internal data class LocalDataProductDescriptor(
   val schemaVersion: Int,
   val transport: DataProductTransport,
   val fileName: String,
-)
+) {
+  val extension: String = fileName.substringAfterLast('.', missingDelimiterValue = "json")
+}
 
 private fun dataRoot(projectDir: File): File = projectDir.resolve("build/compose-previews/data")
 
@@ -368,10 +385,23 @@ private val knownLocalDataProducts =
       DataProductTransport.PATH,
       "render-perfetto-trace.json",
     ),
+    LocalDataProductDescriptor(
+      "render/scroll/long",
+      1,
+      DataProductTransport.PATH,
+      "render-scroll-long.png",
+    ),
+    LocalDataProductDescriptor(
+      "render/scroll/gif",
+      1,
+      DataProductTransport.PATH,
+      "render-scroll-gif.gif",
+    ),
   )
 
 private val knownByKind = knownLocalDataProducts.associateBy { it.kind }
 private val knownByFileName = knownLocalDataProducts.associateBy { it.fileName }
+private val knownByDirectoryName = knownLocalDataProducts.associateBy { it.kind.replace('/', '-') }
 
 private fun descriptorForKind(kind: String): LocalDataProductDescriptor =
   knownByKind[kind]
@@ -427,3 +457,6 @@ private fun descriptorForFile(file: File): LocalDataProductDescriptor? =
         )
       else -> null
     }
+
+private fun descriptorForDirectory(name: String): LocalDataProductDescriptor? =
+  knownByDirectoryName[name]

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/HistoryCommands.kt
@@ -146,19 +146,19 @@ internal fun listLocalHistory(
   previewId: String? = null,
   limit: Int? = null,
 ): CliHistoryListResponse {
-  val all =
-    modules
-      .flatMap { module ->
-        localHistorySource(module.projectDir)
-          .list(HistoryFilter(previewId = previewId, limit = LocalFsHistorySource.MAX_LIMIT))
-          .entries
-      }
+  val all = modules.map { module ->
+    localHistorySource(module.projectDir)
+      .list(HistoryFilter(previewId = previewId, limit = LocalFsHistorySource.MAX_LIMIT))
+  }
+  val entries =
+    all
+      .flatMap { it.entries }
       .sortedWith(compareByDescending<HistoryEntry> { it.timestamp }.thenByDescending { it.id })
   val capped =
-    all.take(
+    entries.take(
       (limit ?: LocalFsHistorySource.DEFAULT_LIMIT).coerceIn(1, LocalFsHistorySource.MAX_LIMIT)
     )
-  return CliHistoryListResponse(entries = capped, totalCount = all.size)
+  return CliHistoryListResponse(entries = capped, totalCount = all.sumOf { it.totalCount })
 }
 
 internal fun diffLocalHistory(

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DataCommandsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DataCommandsTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.Test
@@ -130,6 +131,41 @@ class DataCommandsTest {
     assertEquals("render/scroll/long", summary.kind)
     assertEquals(listOf("P"), summary.previews)
     assertEquals(file.absolutePath, product!!.file.path)
+  }
+
+  @Test
+  fun `data-products scans kind-scoped image products`() {
+    val projectDir = tempModule()
+    val file =
+      projectDir.resolve("build/compose-previews/data/render-scroll-long/com.example.Foo.png")
+    file.parentFile.mkdirs()
+    file.writeBytes(byteArrayOf(1, 2, 3))
+
+    val product = scanDataProducts("app", projectDir).products.single()
+
+    assertEquals("render/scroll/long", product.kind)
+    assertEquals(listOf("com.example.Foo"), product.previews)
+  }
+
+  @Test
+  fun `data get resolves kind-scoped image products`() {
+    val projectDir = tempModule()
+    val file =
+      projectDir.resolve("build/compose-previews/data/render-scroll-long/com.example.Foo.png")
+    file.parentFile.mkdirs()
+    file.writeBytes(byteArrayOf(1, 2, 3))
+
+    val product =
+      assertNotNull(
+        findDataProduct(
+          PreviewModule("app", projectDir),
+          previewId = "com.example.Foo",
+          kind = "render/scroll/long",
+        )
+      )
+
+    assertEquals(file.absolutePath, product.file.path)
+    assertEquals(DataProductTransport.PATH, product.descriptor.transport)
   }
 
   private fun tempModule(): File = Files.createTempDirectory("data-command-test").toFile()

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryCommandsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/HistoryCommandsTest.kt
@@ -37,6 +37,27 @@ class HistoryCommandsTest {
   }
 
   @Test
+  fun `history list reports total matches before module pagination`() {
+    val projectDir = tempModule()
+    val source = LocalFsHistorySource(projectDir.resolve(".compose-preview-history").toPath())
+    repeat(LocalFsHistorySource.MAX_LIMIT + 1) { index ->
+      source.write(
+        historyEntry(
+          source,
+          id = "entry-$index",
+          timestamp = "2026-05-03T07:${(index % 60).toString().padStart(2, '0')}:00Z",
+        ),
+        bytes("entry-$index"),
+      )
+    }
+
+    val response = listLocalHistory(listOf(PreviewModule("app", projectDir)), limit = 1)
+
+    assertEquals(LocalFsHistorySource.MAX_LIMIT + 1, response.totalCount)
+    assertEquals(1, response.entries.size)
+  }
+
+  @Test
   fun `history diff response reports png hash changes and includes metadata`() {
     val projectDir = tempModule()
     val source = LocalFsHistorySource(projectDir.resolve(".compose-preview-history").toPath())

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -247,6 +247,7 @@ fun main(args: Array<String>) {
   val renderOutputDir = System.getProperty(RenderEngine.OUTPUT_DIR_PROP)
   val a11yPreviewExtensionEnabled =
     System.getProperty(RenderEngine.A11Y_PREVIEW_EXTENSION_ENABLED_PROP) == "true"
+  val composeTraceEnabled = renderOutputDir != null && PerfettoTraceDataProducer.enabled()
   val dataProducts: DataProductRegistry =
     buildList {
         System.err.println("compose-ai-tools daemon: DeviceClipDataProductRegistry active")
@@ -283,7 +284,7 @@ fun main(args: Array<String>) {
             "compose-ai-tools daemon: FontsUsedDataProductRegistry active (dataRoot=$dataRoot)"
           )
           add(FontsUsedDataProductRegistry(rootDir = dataRoot))
-          if (PerfettoTraceDataProducer.enabled()) {
+          if (composeTraceEnabled) {
             System.err.println(
               "compose-ai-tools daemon: PerfettoTraceDataProductRegistry active (dataRoot=$dataRoot)"
             )
@@ -310,7 +311,9 @@ fun main(args: Array<String>) {
     buildList {
       add(RenderPreviewExtension.deviceClipDescriptor)
       add(RenderPreviewExtension.renderTraceDescriptor)
-      add(RenderPreviewExtension.composeTraceDescriptor)
+      if (composeTraceEnabled) {
+        add(RenderPreviewExtension.composeTraceDescriptor)
+      }
       add(RenderPreviewExtension.overlayLegendDescriptor)
       if (a11yPreviewExtensionEnabled) {
         add(AccessibilitySemanticsPreviewExtension.descriptor)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -216,6 +216,8 @@ fun main(args: Array<String>) {
     )
   }
 
+  val composeTraceEnabled =
+    PerfettoTraceDataProducer.enabled() && System.getProperty(RenderEngine.OUTPUT_DIR_PROP) != null
   val dataProducts =
     CompositeDataProductRegistry(
       buildList {
@@ -224,7 +226,7 @@ fun main(args: Array<String>) {
         add(TestFailureDataProductRegistry())
         add(themeRegistry)
         add(recompositionRegistry)
-        if (PerfettoTraceDataProducer.enabled()) {
+        if (composeTraceEnabled) {
           System.getProperty(RenderEngine.OUTPUT_DIR_PROP)?.let { renderOutputDir ->
             val dataRoot =
               File(renderOutputDir).parentFile?.resolve("data") ?: File(renderOutputDir)
@@ -260,12 +262,14 @@ fun main(args: Array<String>) {
       // in `initialize.capabilities.dataProducts` reflect the daemon's whole surface.
       dataProducts = dataProducts,
       previewExtensions =
-        listOf(
-          RenderPreviewExtension.deviceClipDescriptor,
-          RenderPreviewExtension.renderTraceDescriptor,
-          RenderPreviewExtension.composeTraceDescriptor,
-          RenderPreviewExtension.overlayLegendDescriptor,
-        ),
+        buildList {
+          add(RenderPreviewExtension.deviceClipDescriptor)
+          add(RenderPreviewExtension.renderTraceDescriptor)
+          if (composeTraceEnabled) {
+            add(RenderPreviewExtension.composeTraceDescriptor)
+          }
+          add(RenderPreviewExtension.overlayLegendDescriptor)
+        },
     )
 
   installSigtermShutdownHook(host, originalStdin = System.`in`)

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -395,7 +395,9 @@ object LayoutInspectorDataProducer {
 
   private fun String.sourceLocation(): String? {
     val file = Regex("""([A-Za-z0-9_./-]+\.kt)""").find(this)?.groupValues?.getOrNull(1)
-    val line = Regex("""(?::|@)(\d+)""").find(this)?.groupValues?.getOrNull(1)
+    val line =
+      Regex("""@(?:\d+)?L(\d+)""").find(this)?.groupValues?.getOrNull(1)
+        ?: Regex("""(?::|@)(\d+)""").find(this)?.groupValues?.getOrNull(1)
     return when {
       file != null && line != null -> "${file.substringAfterLast('/')}:$line"
       file != null -> file.substringAfterLast('/')

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -651,7 +651,12 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
           ScrollMode.GIF -> "gif"
           else -> error("non-product scroll mode ${scroll.mode}")
         }
-      val extensionId = "scrolling-preview-annotation"
+      val extensionId =
+        when (scroll.mode) {
+          ScrollMode.LONG -> "scroll-long"
+          ScrollMode.GIF -> "scroll-gif"
+          else -> error("non-product scroll mode ${scroll.mode}")
+        }
       val facets =
         when (scroll.mode) {
           ScrollMode.LONG -> listOf(PreviewDataProductFacet.ARTIFACT, PreviewDataProductFacet.IMAGE)

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewDataTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/PreviewDataTest.kt
@@ -39,7 +39,7 @@ class PreviewDataTest {
                 listOf(
                   PreviewDataProduct(
                     kind = "render/scroll/long",
-                    extensionId = "scrolling-preview-annotation",
+                    extensionId = "scroll-long",
                     effectId = "long",
                     usageMode = PreviewExtensionUsageMode.SUGGESTED_EXTRA_PREVIEW,
                     suggestedBy = "ee.schimke.composeai.preview.ScrollingPreview",


### PR DESCRIPTION
## Summary

Fixes the simple Codex review findings from PRs updated on 2026-05-03:

- parse Compose source-info line markers before bytecode offsets for layout inspector semantics source locations
- preserve full local history match counts instead of reporting only the capped page size
- advertise compose trace preview extensions only when the matching Perfetto data registry is enabled
- stamp scroll long/GIF products with their effect extension IDs instead of the suggester ID
- support kind-scoped local data product outputs such as `data/render-scroll-long/<preview>.png` in CLI scan/get flows

## Follow-ups Raised

- #629 tracks serializing focus-view recording mutations from PR #621, because that code is not on `main` yet
- #630 tracks the a11y overlay descriptor ownership comment from PR #623, which needs a pipeline metadata/API decision

## Verification

- `./gradlew ktfmtFormatAll`
- `./gradlew :cli:test --tests ee.schimke.composeai.cli.DataCommandsTest --tests ee.schimke.composeai.cli.HistoryCommandsTest :gradle-plugin:test --tests ee.schimke.composeai.plugin.PreviewDataTest :daemon:desktop:compileKotlin :daemon:android:compileDebugKotlin :data-layoutinspector-connector:compileDebugKotlin`