### PR TITLE
[codex] Clarify a11y overlay product ownership

### DIFF
--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtension.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtension.kt
@@ -149,7 +149,6 @@ object AccessibilityOverlayPreviewExtension {
     PreviewPipelineStep(
       id = "a11y.overlayAnnotations",
       displayName = "Accessibility overlay annotations",
-      productKinds = listOf(KIND_OVERLAY),
       traits = setOf(PipelineStepTrait.FrameProcessor),
       requires =
         setOf(
@@ -164,26 +163,6 @@ object AccessibilityOverlayPreviewExtension {
       id = ID,
       displayName = "Accessibility overlay annotations",
       componentExtensionIds = listOf(AccessibilitySemanticsPreviewExtension.ID, AtfChecksPreviewExtension.ID),
-      cliCommands =
-        listOf(
-          PreviewExtensionCliCommand(
-            id = "a11y-overlay.get",
-            displayName = "Fetch accessibility overlay",
-            summary = "Reads the rendered accessibility overlay artifact for one preview.",
-            command =
-              listOf(
-                "compose-preview",
-                "extensions",
-                "run",
-                "a11y-overlay.get",
-                "--id",
-                "<preview-id>",
-                "--output",
-                "<path>",
-              ),
-            productKinds = listOf(KIND_OVERLAY),
-          )
-        ),
       steps = listOf(annotationProcessor),
     )
 }
@@ -213,6 +192,23 @@ object AccessibilityAnnotatedPreviewExtension {
             command =
               listOf("compose-preview", "extensions", "run", "a11y-annotated-preview.render", "--json"),
             usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
+          ),
+          PreviewExtensionCliCommand(
+            id = "a11y-overlay.get",
+            displayName = "Fetch accessibility overlay",
+            summary = "Reads the rendered accessibility overlay artifact for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "extensions",
+                "run",
+                "a11y-overlay.get",
+                "--id",
+                "<preview-id>",
+                "--output",
+                "<path>",
+              ),
+            productKinds = listOf(AccessibilityOverlayPreviewExtension.KIND_OVERLAY),
           )
         ),
       steps =
@@ -220,7 +216,9 @@ object AccessibilityAnnotatedPreviewExtension {
           AccessibilitySemanticsPreviewExtension.finalSampleExtractor,
           AtfChecksPreviewExtension.finalSampleChecker,
           AccessibilityOverlayPreviewExtension.annotationProcessor,
-          RenderPreviewExtension.overlayLegendProcessor,
+          RenderPreviewExtension.overlayLegendProcessor.copy(
+            productKinds = listOf(AccessibilityOverlayPreviewExtension.KIND_OVERLAY)
+          ),
         ),
     )
 }

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtensionTest.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtensionTest.kt
@@ -4,6 +4,7 @@ import ee.schimke.composeai.data.render.RenderPreviewExtension
 import ee.schimke.composeai.data.render.pipeline.PipelineCapability
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelinePlan
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelineValidator
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -101,5 +102,22 @@ class AccessibilityPreviewExtensionTest {
       )
 
     assertTrue(PreviewPipelineValidator.validate(plan).isEmpty())
+  }
+
+  @Test
+  fun accessibilityOverlayProductBelongsToImageProducingComposedStep() {
+    assertTrue(AccessibilityOverlayPreviewExtension.annotationProcessor.productKinds.isEmpty())
+    assertTrue(AccessibilityOverlayPreviewExtension.descriptor.cliCommands.isEmpty())
+
+    val overlayStep =
+      AccessibilityAnnotatedPreviewExtension.descriptor.steps.single {
+        it.id == RenderPreviewExtension.overlayLegendProcessor.id
+      }
+    assertEquals(listOf(AccessibilityOverlayPreviewExtension.KIND_OVERLAY), overlayStep.productKinds)
+    assertTrue(overlayStep.provides.contains(PipelineCapability.AnnotatedImageArtifact))
+
+    val command =
+      AccessibilityAnnotatedPreviewExtension.descriptor.cliCommands.single { it.id == "a11y-overlay.get" }
+    assertEquals(listOf(AccessibilityOverlayPreviewExtension.KIND_OVERLAY), command.productKinds)
   }
 }

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewExtensionCommandCatalog.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewExtensionCommandCatalog.kt
@@ -94,26 +94,6 @@ object PreviewExtensionCommandCatalog {
       id = "a11y-overlay",
       displayName = "Accessibility overlay annotations",
       componentExtensionIds = listOf("a11y", "atf-checks"),
-      cliCommands =
-        listOf(
-          PreviewExtensionCliCommand(
-            id = "a11y-overlay.get",
-            displayName = "Fetch accessibility overlay",
-            summary = "Reads the rendered accessibility overlay artifact for one preview.",
-            command =
-              listOf(
-                "compose-preview",
-                "extensions",
-                "run",
-                "a11y-overlay.get",
-                "--id",
-                "<preview-id>",
-                "--output",
-                "<path>",
-              ),
-            productKinds = listOf("a11y/overlay"),
-          )
-        ),
     )
 
   private fun accessibilityAnnotatedPreview(): PreviewExtensionDescriptor =
@@ -137,7 +117,24 @@ object PreviewExtensionCommandCatalog {
                 "--json",
               ),
             usageModes = setOf(PreviewExtensionUsageMode.SuggestedExtraPreview),
-          )
+          ),
+          PreviewExtensionCliCommand(
+            id = "a11y-overlay.get",
+            displayName = "Fetch accessibility overlay",
+            summary = "Reads the rendered accessibility overlay artifact for one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "extensions",
+                "run",
+                "a11y-overlay.get",
+                "--id",
+                "<preview-id>",
+                "--output",
+                "<path>",
+              ),
+            productKinds = listOf("a11y/overlay"),
+          ),
         ),
     )
 

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewExtensionCommandCatalogTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewExtensionCommandCatalogTest.kt
@@ -1,0 +1,21 @@
+package ee.schimke.composeai.data.render.pipeline
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PreviewExtensionCommandCatalogTest {
+  @Test
+  fun accessibilityOverlayCommandIsOwnedByAnnotatedPreviewDescriptor() {
+    val overlayDescriptor =
+      PreviewExtensionCommandCatalog.extensions.single { it.id == "a11y-overlay" }
+    val annotatedDescriptor =
+      PreviewExtensionCommandCatalog.extensions.single { it.id == "a11y-annotated-preview" }
+
+    assertTrue(overlayDescriptor.cliCommands.isEmpty())
+
+    val command = annotatedDescriptor.cliCommands.single { it.id == "a11y-overlay.get" }
+    assertEquals(listOf("a11y/overlay"), command.productKinds)
+    assertEquals(command, PreviewExtensionCommandCatalog.commandById("a11y-overlay.get"))
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #630 by separating accessibility overlay annotation metadata from the final image artifact metadata.

- Keeps `a11y-overlay` as the annotation-producing extension only.
- Moves the `a11y/overlay` product kind and `a11y-overlay.get` command to the composed `a11y-annotated-preview` extension, where the generic overlay legend frame processor produces the annotated image artifact.
- Adds regression tests for both the full a11y descriptor and the lightweight command catalog.

## Validation

- `./gradlew :data-a11y-core:ktfmtCheck :data-render-core:ktfmtCheck :data-a11y-core:test :data-render-core:test`