### PR TITLE
ci: publish branch Maven snapshots

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
             :data-history-connector:publishAllPublicationsToGitHubPackagesRepository \
             :data-layoutinspector-core:publishAllPublicationsToGitHubPackagesRepository \
             :data-layoutinspector-connector:publishAllPublicationsToGitHubPackagesRepository \
+            :data-recomposition-connector:publishAllPublicationsToGitHubPackagesRepository \
             :data-render-core:publishAllPublicationsToGitHubPackagesRepository \
             :data-render-connector:publishAllPublicationsToGitHubPackagesRepository \
             :data-resources-core:publishAllPublicationsToGitHubPackagesRepository \
@@ -131,6 +132,7 @@ jobs:
             :data-history-connector:publishAndReleaseToMavenCentral \
             :data-layoutinspector-core:publishAndReleaseToMavenCentral \
             :data-layoutinspector-connector:publishAndReleaseToMavenCentral \
+            :data-recomposition-connector:publishAndReleaseToMavenCentral \
             :data-render-core:publishAndReleaseToMavenCentral \
             :data-render-connector:publishAndReleaseToMavenCentral \
             :data-resources-core:publishAndReleaseToMavenCentral \

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -9,9 +9,16 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      suffix:
+        description: >-
+          Optional version suffix inserted before -SNAPSHOT. Leave blank to use
+          the plain next-patch snapshot on main, or a ref+SHA suffix on branches.
+        required: false
+        type: string
 
 concurrency:
-  group: snapshot-${{ github.ref }}
+  group: snapshot-${{ github.ref }}-${{ inputs.suffix || 'auto' }}
   cancel-in-progress: true
 
 # Snapshot publish only reads repo contents; auth for Central is via
@@ -29,9 +36,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - id: version
-        name: Compute snapshot version from last tag
+        name: Compute snapshot version
         # Take the latest `v*` tag, strip leading `v`, bump the patch digit,
-        # append `-SNAPSHOT`. Falls back to 0.0.1-SNAPSHOT if no tag exists yet.
+        # append `-SNAPSHOT`. Main keeps the stable next-patch coordinate
+        # documented for downstream consumers. Manual runs on branches get a
+        # ref+SHA suffix by default so PR snapshots can be tested without
+        # overwriting the main snapshot coordinate.
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_SUFFIX: ${{ inputs.suffix || '' }}
         run: |
           last_tag="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo v0.0.0)"
           base="${last_tag#v}"
@@ -40,9 +53,31 @@ jobs:
           minor="${rest%%.*}"
           patch="${rest#*.}"
           patch="${patch%%-*}"                    # drop any pre-release suffix
-          next="${major}.${minor}.$((patch + 1))-SNAPSHOT"
-          echo "Last tag: $last_tag → snapshot version: $next"
+          next_base="${major}.${minor}.$((patch + 1))"
+
+          suffix="$INPUT_SUFFIX"
+          if [[ -z "$suffix" && "$REF_NAME" != "main" ]]; then
+            suffix="${REF_NAME}-${GITHUB_SHA::7}"
+          fi
+          if [[ -n "$suffix" ]]; then
+            suffix="$(
+              printf '%s' "$suffix" |
+                tr '[:upper:]' '[:lower:]' |
+                sed -E 's/[^a-z0-9.-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
+            )"
+            if [[ -z "$suffix" ]]; then
+              echo "Snapshot suffix resolved to empty after sanitization." >&2
+              exit 1
+            fi
+            next="${next_base}-${suffix}-SNAPSHOT"
+          else
+            next="${next_base}-SNAPSHOT"
+          fi
+
+          echo "Last tag: $last_tag -> snapshot version: $next"
           echo "version=$next" >> "$GITHUB_OUTPUT"
+          echo "### Maven snapshot" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`$next\`" >> "$GITHUB_STEP_SUMMARY"
       - uses: ./.github/actions/setup
       - name: Publish -SNAPSHOT to Maven Central snapshots
         env:
@@ -59,6 +94,7 @@ jobs:
             :data-history-connector:publishToMavenCentral \
             :data-layoutinspector-core:publishToMavenCentral \
             :data-layoutinspector-connector:publishToMavenCentral \
+            :data-recomposition-connector:publishToMavenCentral \
             :data-render-core:publishToMavenCentral \
             :data-render-connector:publishToMavenCentral \
             :data-resources-core:publishToMavenCentral \

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins { `kotlin-dsl` }
+
+dependencies {
+  implementation(
+    "com.vanniktech:gradle-maven-publish-plugin:${libs.versions.maven.publish.get()}"
+  )
+}
+
+gradlePlugin {
+  plugins {
+    register("composeAiMavenPublishing") {
+      id = "composeai.maven-publishing"
+      implementationClass = "ee.schimke.composeai.buildlogic.ComposeAiMavenPublishingPlugin"
+    }
+  }
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,5 +1,4 @@
 pluginManagement {
-  includeBuild("../build-logic")
   repositories {
     gradlePluginPortal()
     google()
@@ -13,6 +12,7 @@ dependencyResolutionManagement {
     google()
     mavenCentral()
   }
+  versionCatalogs { create("libs") { from(files("../gradle/libs.versions.toml")) } }
 }
 
-rootProject.name = "gradle-plugin"
+rootProject.name = "compose-ai-tools-build-logic"

--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
@@ -1,0 +1,116 @@
+package ee.schimke.composeai.buildlogic
+
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import java.io.File
+import javax.inject.Inject
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.kotlin.dsl.configure
+
+abstract class ComposeAiMavenPublishingExtension
+@Inject
+constructor(objects: ObjectFactory) {
+  val artifactId: Property<String> = objects.property(String::class.java)
+  val displayName: Property<String> = objects.property(String::class.java)
+  val description: Property<String> = objects.property(String::class.java)
+  val inceptionYear: Property<String> = objects.property(String::class.java).convention("2026")
+
+  fun coordinates(artifactId: String, displayName: String, description: String) {
+    this.artifactId.set(artifactId)
+    this.displayName.set(displayName)
+    this.description.set(description)
+  }
+}
+
+class ComposeAiMavenPublishingPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+    project.pluginManager.apply("maven-publish")
+    project.pluginManager.apply("com.vanniktech.maven.publish")
+
+    val extension =
+      project.extensions.create(
+        "composeAiMavenPublishing",
+        ComposeAiMavenPublishingExtension::class.java,
+      )
+
+    project.group = "ee.schimke.composeai"
+    project.version =
+      project.providers.environmentVariable("PLUGIN_VERSION").orNull
+        ?: project.nextPatchSnapshotVersion()
+
+    project.extensions.configure<PublishingExtension> {
+      repositories.maven {
+        name = "GitHubPackages"
+        url =
+          project.uri(
+            project.providers
+              .environmentVariable("GITHUB_REPOSITORY")
+              .map { "https://maven.pkg.github.com/$it" }
+              .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
+          )
+        credentials {
+          username = project.providers.environmentVariable("GITHUB_ACTOR").orNull
+          password = project.providers.environmentVariable("GITHUB_TOKEN").orNull
+        }
+      }
+    }
+
+    project.afterEvaluate {
+      val artifactId =
+        extension.artifactId.orNull ?: error("composeAiMavenPublishing.artifactId is required")
+      val displayName =
+        extension.displayName.orNull ?: error("composeAiMavenPublishing.displayName is required")
+      val artifactDescription =
+        extension.description.orNull ?: error("composeAiMavenPublishing.description is required")
+
+      project.extensions.configure<MavenPublishBaseExtension> {
+        publishToMavenCentral(automaticRelease = true)
+        if (!project.version.toString().endsWith("SNAPSHOT")) {
+          signAllPublications()
+        }
+        coordinates("ee.schimke.composeai", artifactId, project.version.toString())
+        pom {
+          name.set(displayName)
+          description.set(artifactDescription)
+          url.set("https://github.com/yschimke/compose-ai-tools")
+          inceptionYear.set(extension.inceptionYear)
+          licenses {
+            license {
+              name.set("The Apache License, Version 2.0")
+              url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+              distribution.set("repo")
+            }
+          }
+          developers {
+            developer {
+              id.set("yschimke")
+              name.set("Yuri Schimke")
+              url.set("https://github.com/yschimke")
+            }
+          }
+          scm {
+            url.set("https://github.com/yschimke/compose-ai-tools")
+            connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
+            developerConnection.set(
+              "scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git"
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+private fun Project.nextPatchSnapshotVersion(): String {
+  val manifest =
+    generateSequence(rootDir) { it.parentFile }
+      .map { it.resolve(".release-please-manifest.json") }
+      .firstOrNull(File::isFile)
+      ?: error("Could not find .release-please-manifest.json from $rootDir")
+  val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest.readText())!!.groupValues[1]
+  val (major, minor, patch) = current.split(".").map { it.toInt() }
+  return "$major.$minor.${patch + 1}-SNAPSHOT"
+}

--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -17,6 +17,7 @@
 // Pre-1.0; expect API breakage across minor versions.
 
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
   // D-harness.v2 — `PreviewManifestRouter` (mirrors :daemon:desktop's) reads a JSON
@@ -24,25 +25,12 @@ plugins {
   // the @Serializable processor; kotlinx-serialization-json is already on the classpath via
   // `:daemon:core`'s `api(libs.kotlinx.serialization.json)`.
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
 }
 
 // The daemon is launched as a local JVM process by the Gradle plugin (or
 // directly via the published JAR for embedders), so the older-Kotlin-runtime
 // ABI dance done in :renderer-android (via tapmoc.configureKotlinCompatibility)
 // is not required here. We get the project's default Kotlin stdlib at runtime.
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 android {
   namespace = "ee.schimke.composeai.daemon"
@@ -280,24 +268,6 @@ val daemonHarnessClasspathFile by configurations.creating {
 }
 
 // GitHub Packages mirror — same shape as `:renderer-android`.
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
 
 // Use the new (non-deprecated) AndroidSingleVariantLibrary constructor — takes typed JavadocJar /
 // SourcesJar instead of booleans. `JavadocJar.Empty()` ships an empty javadoc jar (Maven Central
@@ -344,45 +314,16 @@ afterEvaluate {
   }
 }
 
-mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
-  configure(androidSingleVariantLibrary)
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-
-  coordinates("ee.schimke.composeai", "daemon-android", version.toString())
-
-  pom {
-    name.set("Compose Preview — Daemon Android")
-    description.set(
-      "Robolectric-based Android backend of the compose-preview daemon: holds a long-lived " +
-        "Robolectric sandbox open via the dummy-@Test trick, renders @Preview composables to " +
-        "PNG. Compose / Roborazzi / UI-test stay compileOnly — consumer supplies runtime " +
-        "versions, same as :renderer-android. Pre-1.0; pairs with daemon-core."
-    )
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2025")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
-}
-
 artifacts { add(daemonHarnessClasspathFile.name, writeDaemonClasspath) }
+
+mavenPublishing { configure(androidSingleVariantLibrary) }
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "daemon-android",
+    displayName = "Compose Preview — Daemon Android",
+    description =
+      "Robolectric-based Android backend of the compose-preview daemon: holds a long-lived Robolectric sandbox open via the dummy-@Test trick, renders @Preview composables to PNG. Compose / Roborazzi / UI-test stay compileOnly — consumer supplies runtime versions, same as :renderer-android. Pre-1.0; pairs with daemon-core.",
+  )
+  inceptionYear.set("2025")
+}

--- a/daemon/core/build.gradle.kts
+++ b/daemon/core/build.gradle.kts
@@ -13,22 +13,10 @@
 // see DESIGN.md § 17 (decisions log).
 
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
 }
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 dependencies {
   api(project(":data-render-core"))
@@ -54,60 +42,13 @@ java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 tasks.withType<Test>().configureEach { useJUnit() }
 
 // GitHub Packages mirror — same shape as `:renderer-android` and `:preview-annotations`.
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
 
-mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-
-  coordinates("ee.schimke.composeai", "daemon-core", version.toString())
-
-  pom {
-    name.set("Compose Preview — Daemon Core")
-    description.set(
-      "Renderer-agnostic core of the compose-preview daemon: JSON-RPC server, " +
-        "protocol types (@Serializable), and the RenderHost abstraction. " +
-        "Pre-1.0; consumed by daemon-android and daemon-desktop."
-    )
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2025")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "daemon-core",
+    displayName = "Compose Preview — Daemon Core",
+    description =
+      "Renderer-agnostic core of the compose-preview daemon: JSON-RPC server, protocol types (@Serializable), and the RenderHost abstraction. Pre-1.0; consumed by daemon-android and daemon-desktop.",
+  )
+  inceptionYear.set("2025")
 }

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -24,6 +24,7 @@
 // Pre-1.0; see DESIGN.md § 17.
 
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.compose.multiplatform)
   alias(libs.plugins.compose.compiler)
@@ -38,20 +39,7 @@ plugins {
   // `RedFixturePreviews` is unchanged; the testFixtures source set re-exports `RedSquare` for
   // cross-module consumers.
   `java-test-fixtures`
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
 }
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 dependencies {
   // Renderer-agnostic protocol types, JsonRpcServer, RenderHost interface,
@@ -159,60 +147,13 @@ afterEvaluate {
 }
 
 // GitHub Packages mirror — same shape as `:renderer-android` and `:preview-annotations`.
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
 
-mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-
-  coordinates("ee.schimke.composeai", "daemon-desktop", version.toString())
-
-  pom {
-    name.set("Compose Preview — Daemon Desktop")
-    description.set(
-      "Compose Multiplatform desktop backend of the compose-preview daemon: " +
-        "long-lived JVM + Skiko render thread, per-render ImageComposeScene. " +
-        "Pre-1.0; pairs with daemon-core."
-    )
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2025")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "daemon-desktop",
+    displayName = "Compose Preview — Daemon Desktop",
+    description =
+      "Compose Multiplatform desktop backend of the compose-preview daemon: long-lived JVM + Skiko render thread, per-render ImageComposeScene. Pre-1.0; pairs with daemon-core.",
+  )
+  inceptionYear.set("2025")
 }

--- a/data/a11y/connector/build.gradle.kts
+++ b/data/a11y/connector/build.gradle.kts
@@ -12,10 +12,9 @@ import tapmoc.configureKotlinCompatibility
 // See docs/daemon/DATA-PRODUCTS.md § "Module split (D2.2)" for the rationale.
 
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.android.library)
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
   alias(libs.plugins.tapmoc)
 }
 
@@ -26,17 +25,6 @@ tasks.withType<KotlinCompilationTask<*>>().configureEach {
 }
 
 extensions.configure<TapmocExtension> { checkDependencies() }
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 android {
   namespace = "ee.schimke.composeai.data.a11y.connector"
@@ -66,27 +54,7 @@ dependencies {
   testImplementation(libs.kotlinx.serialization.json)
 }
 
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
 mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
   configure(
     com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
       javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
@@ -94,38 +62,14 @@ mavenPublishing {
       variant = "release",
     )
   )
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
+}
 
-  coordinates("ee.schimke.composeai", "data-a11y-connector", version.toString())
-
-  pom {
-    name.set("Compose Preview — Accessibility Data Product (Connector)")
-    description.set(
-      "Daemon-side accessibility data-product connector: wires data-a11y-core into the " +
-        "compose-preview daemon's data/* JSON-RPC surface and overlay image processor."
-    )
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2026")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-a11y-connector",
+    displayName = "Compose Preview — Accessibility Data Product (Connector)",
+    description =
+      "Daemon-side accessibility data-product connector: wires data-a11y-core into the compose-preview daemon's data/* JSON-RPC surface and overlay image processor.",
+  )
+  inceptionYear.set("2026")
 }

--- a/data/a11y/core/build.gradle.kts
+++ b/data/a11y/core/build.gradle.kts
@@ -22,10 +22,9 @@ import tapmoc.configureKotlinCompatibility
 // "Module split (D2.2)".
 
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.android.library)
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
   alias(libs.plugins.tapmoc)
 }
 
@@ -40,19 +39,6 @@ tasks.withType<KotlinCompilationTask<*>>().configureEach {
 }
 
 extensions.configure<TapmocExtension> { checkDependencies() }
-
-group = "ee.schimke.composeai"
-
-// Same versioning rule as `:renderer-android`. CI sets PLUGIN_VERSION; local builds derive a
-// SNAPSHOT version from `.release-please-manifest.json`.
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 android {
   namespace = "ee.schimke.composeai.data.a11y.core"
@@ -94,64 +80,23 @@ dependencies {
 // GitHub Packages repo kept alongside Maven Central for internal/CI convenience.
 // Vanniktech's `AndroidSingleVariantLibrary` creates the release publication
 // (with sources + javadoc jar) — do not create one manually; it clashes.
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
 
 mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
   configure(
-    AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true)
-  )
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-
-  coordinates("ee.schimke.composeai", "data-a11y-core", version.toString())
-
-  pom {
-    name.set("Compose Preview — Accessibility Data Product (Core)")
-    description.set(
-      "Generic Android accessibility data-product primitives: ATF check wrapper, " +
-        "Paparazzi-style overlay PNG generator, and the JSON model classes the " +
-        "Gradle plugin / CLI / daemon all read. Pairs with the connector module that " +
-        "wires this into the compose-preview daemon's data/* JSON-RPC surface."
+    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
+      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
+      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
+      variant = "release",
     )
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2026")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+  )
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-a11y-core",
+    displayName = "Compose Preview — Accessibility Data Product (Core)",
+    description =
+      "Generic Android accessibility data-product primitives: ATF check wrapper, Paparazzi-style overlay PNG generator, and the JSON model classes the Gradle plugin / CLI / daemon all read. Pairs with the connector module that wires this into the compose-preview daemon's data/* JSON-RPC surface.",
+  )
+  inceptionYear.set("2026")
 }

--- a/data/fonts/connector/build.gradle.kts
+++ b/data/fonts/connector/build.gradle.kts
@@ -1,20 +1,8 @@
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
 }
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 dependencies {
   api(project(":data-fonts-core"))
@@ -26,54 +14,11 @@ java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
 
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
-mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-  coordinates("ee.schimke.composeai", "data-fonts-connector", version.toString())
-  pom {
-    name.set("Compose Preview - Fonts Data Product Connector")
-    description.set("Daemon-side fonts data-product connector for Compose Preview.")
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2026")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-fonts-connector",
+    displayName = "Compose Preview - Fonts Data Product Connector",
+    description = "Daemon-side fonts data-product connector for Compose Preview.",
+  )
+  inceptionYear.set("2026")
 }

--- a/data/fonts/core/build.gradle.kts
+++ b/data/fonts/core/build.gradle.kts
@@ -1,20 +1,8 @@
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
 }
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 dependencies {
   api(libs.kotlinx.serialization.json)
@@ -25,54 +13,11 @@ java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
 
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
-mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-  coordinates("ee.schimke.composeai", "data-fonts-core", version.toString())
-  pom {
-    name.set("Compose Preview - Fonts Data Product Core")
-    description.set("Shared fonts data-product model classes for Compose Preview.")
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2026")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-fonts-core",
+    displayName = "Compose Preview - Fonts Data Product Core",
+    description = "Shared fonts data-product model classes for Compose Preview.",
+  )
+  inceptionYear.set("2026")
 }

--- a/data/history/connector/build.gradle.kts
+++ b/data/history/connector/build.gradle.kts
@@ -1,20 +1,8 @@
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
 }
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 dependencies {
   api(project(":daemon:core"))
@@ -25,54 +13,11 @@ java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
 
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
-mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-  coordinates("ee.schimke.composeai", "data-history-connector", version.toString())
-  pom {
-    name.set("Compose Preview - History Data Product Connector")
-    description.set("Daemon-side history data-product connector for Compose Preview.")
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2026")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-history-connector",
+    displayName = "Compose Preview - History Data Product Connector",
+    description = "Daemon-side history data-product connector for Compose Preview.",
+  )
+  inceptionYear.set("2026")
 }

--- a/data/layoutinspector/connector/build.gradle.kts
+++ b/data/layoutinspector/connector/build.gradle.kts
@@ -1,23 +1,11 @@
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
 }
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 android {
   namespace = "ee.schimke.composeai.data.layoutinspector.connector"
@@ -41,57 +29,17 @@ dependencies {
   testImplementation(libs.kotlinx.serialization.json)
 }
 
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
 mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
   configure(
     AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true)
   )
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-  coordinates("ee.schimke.composeai", "data-layoutinspector-connector", version.toString())
-  pom {
-    name.set("Compose Preview - Layout Inspector Data Product Connector")
-    description.set("Daemon-side layout inspector data-product connector for Compose Preview.")
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2026")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-layoutinspector-connector",
+    displayName = "Compose Preview - Layout Inspector Data Product Connector",
+    description = "Daemon-side layout inspector data-product connector for Compose Preview.",
+  )
+  inceptionYear.set("2026")
 }

--- a/data/layoutinspector/core/build.gradle.kts
+++ b/data/layoutinspector/core/build.gradle.kts
@@ -1,20 +1,8 @@
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
 }
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 dependencies {
   api(libs.kotlinx.serialization.json)
@@ -25,54 +13,11 @@ java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
 
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
-mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-  coordinates("ee.schimke.composeai", "data-layoutinspector-core", version.toString())
-  pom {
-    name.set("Compose Preview - Layout Inspector Data Product Core")
-    description.set("Shared layout inspector data-product model classes for Compose Preview.")
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2026")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-layoutinspector-core",
+    displayName = "Compose Preview - Layout Inspector Data Product Core",
+    description = "Shared layout inspector data-product model classes for Compose Preview.",
+  )
+  inceptionYear.set("2026")
 }

--- a/data/recomposition/connector/build.gradle.kts
+++ b/data/recomposition/connector/build.gradle.kts
@@ -1,13 +1,10 @@
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.compose.multiplatform)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.kotlin.serialization)
 }
-
-group = "ee.schimke.composeai"
-
-version = providers.environmentVariable("PLUGIN_VERSION").orNull ?: "0.0.0-SNAPSHOT"
 
 dependencies {
   api(project(":daemon:core"))
@@ -19,3 +16,12 @@ dependencies {
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-recomposition-connector",
+    displayName = "Compose Preview - Recomposition Data Product Connector",
+    description = "Daemon-side recomposition data-product connector for Compose Preview.",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/render/connector/build.gradle.kts
+++ b/data/render/connector/build.gradle.kts
@@ -1,20 +1,8 @@
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
 }
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 dependencies {
   api(project(":data-render-core"))
@@ -26,54 +14,11 @@ java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
 
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
-mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-  coordinates("ee.schimke.composeai", "data-render-connector", version.toString())
-  pom {
-    name.set("Compose Preview - Render Data Product Connector")
-    description.set("Daemon-side render data-product connector for Compose Preview.")
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2026")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-render-connector",
+    displayName = "Compose Preview - Render Data Product Connector",
+    description = "Daemon-side render data-product connector for Compose Preview.",
+  )
+  inceptionYear.set("2026")
 }

--- a/data/render/core/build.gradle.kts
+++ b/data/render/core/build.gradle.kts
@@ -3,10 +3,9 @@ import tapmoc.TapmocExtension
 import tapmoc.configureKotlinCompatibility
 
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
   alias(libs.plugins.tapmoc)
 }
 
@@ -19,17 +18,6 @@ tasks.withType<KotlinCompilationTask<*>>().configureEach {
 
 extensions.configure<TapmocExtension> { checkDependencies() }
 
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
-
 dependencies {
   api(libs.kotlinx.serialization.json)
   testImplementation(libs.junit)
@@ -39,59 +27,12 @@ java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
 
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
-mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-
-  coordinates("ee.schimke.composeai", "data-render-core", version.toString())
-
-  pom {
-    name.set("Compose Preview — Render Data Product (Core)")
-    description.set(
-      "Renderer-agnostic preview context and render data-product model classes shared by " +
-        "the Android renderer and daemon data-product connectors."
-    )
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2026")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-render-core",
+    displayName = "Compose Preview — Render Data Product (Core)",
+    description =
+      "Shared render data-product protocol: preview context, theme payloads, device clip, render trace, and failure records exchanged by renderer and daemon connectors.",
+  )
+  inceptionYear.set("2026")
 }

--- a/data/resources/connector/build.gradle.kts
+++ b/data/resources/connector/build.gradle.kts
@@ -1,22 +1,10 @@
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.android.library)
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
 }
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 android {
   namespace = "ee.schimke.composeai.data.resources.connector"
@@ -37,57 +25,17 @@ dependencies {
   testImplementation(libs.robolectric)
 }
 
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
 mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
   configure(
     AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true)
   )
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-  coordinates("ee.schimke.composeai", "data-resources-connector", version.toString())
-  pom {
-    name.set("Compose Preview - Resources Data Product Connector")
-    description.set("Daemon-side resources data-product connector for Compose Preview.")
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2026")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-resources-connector",
+    displayName = "Compose Preview - Resources Data Product Connector",
+    description = "Daemon-side resources data-product connector for Compose Preview.",
+  )
+  inceptionYear.set("2026")
 }

--- a/data/resources/core/build.gradle.kts
+++ b/data/resources/core/build.gradle.kts
@@ -1,20 +1,8 @@
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
 }
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 dependencies {
   api(libs.kotlinx.serialization.json)
@@ -25,54 +13,11 @@ java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
 
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
-mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-  coordinates("ee.schimke.composeai", "data-resources-core", version.toString())
-  pom {
-    name.set("Compose Preview - Resources Data Product Core")
-    description.set("Shared resources data-product model classes for Compose Preview.")
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2026")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-resources-core",
+    displayName = "Compose Preview - Resources Data Product Core",
+    description = "Shared resources data-product model classes for Compose Preview.",
+  )
+  inceptionYear.set("2026")
 }

--- a/data/scroll/core/build.gradle.kts
+++ b/data/scroll/core/build.gradle.kts
@@ -10,9 +10,8 @@ import tapmoc.TapmocExtension
 import tapmoc.configureKotlinCompatibility
 
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.android.library)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
   alias(libs.plugins.tapmoc)
 }
 
@@ -24,17 +23,6 @@ tasks.withType<KotlinCompilationTask<*>>().configureEach {
 }
 
 extensions.configure<TapmocExtension> { checkDependencies() }
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 android {
   namespace = "ee.schimke.composeai.data.scroll.core"
@@ -61,62 +49,18 @@ dependencies {
   testImplementation(libs.robolectric)
 }
 
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
 mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
   configure(
     AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true)
   )
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
+}
 
-  coordinates("ee.schimke.composeai", "data-scroll-core", version.toString())
-
-  pom {
-    name.set("Compose Preview — Scroll Data Product (Core)")
-    description.set(
-      "Generic Android scroll data-product primitives: Compose test-rule scroll drivers, " +
-        "long-screenshot stitching, Wear pill clipping, and GIF encoding."
-    )
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2026")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-scroll-core",
+    displayName = "Compose Preview — Scroll Data Product (Core)",
+    description =
+      "Generic Android scroll data-product primitives: Compose test-rule scroll drivers, long-screenshot stitching, Wear pill clipping, and GIF encoding.",
+  )
+  inceptionYear.set("2026")
 }

--- a/data/strings/connector/build.gradle.kts
+++ b/data/strings/connector/build.gradle.kts
@@ -1,22 +1,10 @@
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
 
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.android.library)
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
 }
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 android {
   namespace = "ee.schimke.composeai.data.strings.connector"
@@ -39,57 +27,17 @@ dependencies {
   testImplementation(libs.kotlinx.serialization.json)
 }
 
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
 mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
   configure(
     AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true)
   )
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-  coordinates("ee.schimke.composeai", "data-strings-connector", version.toString())
-  pom {
-    name.set("Compose Preview - Strings Data Product Connector")
-    description.set("Daemon-side strings data-product connector for Compose Preview.")
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2026")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-strings-connector",
+    displayName = "Compose Preview - Strings Data Product Connector",
+    description = "Daemon-side strings data-product connector for Compose Preview.",
+  )
+  inceptionYear.set("2026")
 }

--- a/data/strings/core/build.gradle.kts
+++ b/data/strings/core/build.gradle.kts
@@ -1,20 +1,8 @@
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
 }
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 dependencies {
   api(libs.kotlinx.serialization.json)
@@ -25,54 +13,11 @@ java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
 
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
-mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-  coordinates("ee.schimke.composeai", "data-strings-core", version.toString())
-  pom {
-    name.set("Compose Preview - Strings Data Product Core")
-    description.set("Shared strings data-product model classes for Compose Preview.")
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2026")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-strings-core",
+    displayName = "Compose Preview - Strings Data Product Core",
+    description = "Shared strings data-product model classes for Compose Preview.",
+  )
+  inceptionYear.set("2026")
 }

--- a/data/theme/connector/build.gradle.kts
+++ b/data/theme/connector/build.gradle.kts
@@ -1,22 +1,10 @@
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.compose.multiplatform)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
 }
-
-group = "ee.schimke.composeai"
-
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 dependencies {
   api(project(":daemon:core"))
@@ -35,54 +23,11 @@ java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 tasks.withType<Test>().configureEach { useJUnit() }
 
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
-mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-  coordinates("ee.schimke.composeai", "data-theme-connector", version.toString())
-  pom {
-    name.set("Compose Preview - Theme Data Product Connector")
-    description.set("Daemon-side theme data-product connector for Compose Preview.")
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2026")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-theme-connector",
+    displayName = "Compose Preview - Theme Data Product Connector",
+    description = "Daemon-side theme data-product connector for Compose Preview.",
+  )
+  inceptionYear.set("2026")
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -255,10 +255,12 @@ exist.
 ## Testing a downstream project against a `-SNAPSHOT`
 
 Every push to `main` publishes a `-SNAPSHOT` build to the Central
-snapshots repository, so a downstream project can try an unreleased
-change without going through `includeBuild` or `mavenLocal`. Add the
-snapshots repo to `pluginManagement` and bump the plugin version to the
-next patch `-SNAPSHOT`:
+snapshots repository. To test a PR before it merges, run the **Publish
+snapshot** workflow manually from that branch; it publishes the same
+Maven artifacts with a branch-qualified snapshot version so it does not
+collide with the `main` snapshot. Add the snapshots repo to
+`pluginManagement` and bump the plugin version to the version printed in
+the workflow summary:
 
 ```kotlin
 // settings.gradle.kts
@@ -277,10 +279,14 @@ pluginManagement {
 ```kotlin
 // <module>/build.gradle.kts
 plugins {
-    id("ee.schimke.composeai.preview") version "0.3.5-SNAPSHOT"
+    id("ee.schimke.composeai.preview") version "0.8.13-feature-layout-data-abc1234-SNAPSHOT"
 }
 ```
 
-The snapshot version is the next patch ahead of the latest release
-(e.g. last tag `v0.3.4` → `0.3.5-SNAPSHOT`). Snapshots are unsigned.
-See [RELEASING.md](RELEASING.md) for more detail.
+For pushes to `main`, the snapshot version remains the next patch ahead
+of the latest release (e.g. last tag `v0.8.12` →
+`0.8.13-SNAPSHOT`). Manual branch runs default to
+`<next-patch>-<branch-name>-<short-sha>-SNAPSHOT`; the workflow also
+accepts a shorter `suffix` input if you want a stable test coordinate
+such as `0.8.13-issue-612-SNAPSHOT`. Snapshots are unsigned. See
+[RELEASING.md](RELEASING.md) for more detail.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -44,6 +44,7 @@ Both fallbacks share the same concurrency group as the primary path, so they can
    - **Daemon core** (pre-1.0) — `ee.schimke.composeai:daemon-core` — renderer-agnostic JSON-RPC server, protocol types, RenderHost interface
    - **Daemon desktop** (pre-1.0) — `ee.schimke.composeai:daemon-desktop` — Compose Multiplatform desktop backend (DesktopHost + DaemonMain)
    - **Daemon android** (pre-1.0) — `ee.schimke.composeai:daemon-android` — Robolectric backend; Compose / Roborazzi / UI-test stay `compileOnly`, consumer supplies runtime versions
+   - **Data product connectors** — `ee.schimke.composeai:data-*-connector` artifacts used by daemon modules, including recomposition
 2. Builds the **CLI** as `.zip` and `.tar.gz` distributions.
 3. Packages the **VS Code extension** as a `.vsix` file and publishes it to the **VS Code Marketplace** and **Open VSX** (runs alongside the Release upload, so a marketplace outage can't block the GitHub Release).
 4. Uploads the CLI + VS Code extension artifacts onto the GitHub Release that release-please created (falling back to creating the Release itself if invoked outside the release-please path, e.g. from a manual tag push).
@@ -77,6 +78,26 @@ https://central.sonatype.com/repository/maven-snapshots/
 
 Snapshots are unsigned, so they only need `MAVEN_CENTRAL_USERNAME` /
 `MAVEN_CENTRAL_PASSWORD`.
+
+For pre-merge testing, run **Publish snapshot** manually from the branch
+you want to test. Branch/manual runs publish the same Maven artifacts
+with a branch-qualified version by default:
+
+```
+<next-patch>-<branch-name>-<short-sha>-SNAPSHOT
+```
+
+For example, a run from `feature/layout-data` at `abc1234` after
+`v0.8.12` publishes `0.8.13-feature-layout-data-abc1234-SNAPSHOT`.
+The workflow also accepts an optional `suffix` input if you need a
+shorter coordinate, for example `issue-612` →
+`0.8.13-issue-612-SNAPSHOT`.
+
+This branch-qualified coordinate is what makes snapshots usable for
+testing in other projects before the PR merges. The older documented
+main-only coordinate is still published from pushes to `main`, but it is
+not enough for PR testing because every branch would otherwise publish
+to the same `0.8.13-SNAPSHOT` version.
 
 ## Consuming the artifacts
 
@@ -128,6 +149,15 @@ Then reference a `-SNAPSHOT` version:
 ```kotlin
 plugins {
     id("ee.schimke.composeai.preview") version "0.3.4-SNAPSHOT"
+}
+```
+
+For a branch snapshot, use the version printed in the workflow summary,
+for example:
+
+```kotlin
+plugins {
+    id("ee.schimke.composeai.preview") version "0.8.13-feature-layout-data-abc1234-SNAPSHOT"
 }
 ```
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -2,11 +2,10 @@ import tapmoc.TapmocExtension
 import tapmoc.configureKotlinCompatibility
 
 plugins {
+  id("composeai.maven-publishing")
   `java-gradle-plugin`
   `kotlin-dsl`
-  `maven-publish`
   alias(libs.plugins.kotlin.serialization)
-  alias(libs.plugins.maven.publish)
   alias(libs.plugins.ktfmt)
   alias(libs.plugins.tapmoc)
 }
@@ -20,22 +19,6 @@ ktfmt { googleStyle() }
 configureKotlinCompatibility(version = libs.versions.kotlinCoreLibraries.get())
 
 extensions.configure<TapmocExtension> { checkDependencies() }
-
-group = "ee.schimke.composeai"
-
-// CI sets PLUGIN_VERSION: release.yml passes the git tag (stripped of `v`);
-// snapshot.yml passes `<last-tag-patch+1>-SNAPSHOT`. Local builds fall back
-// to the next-patch SNAPSHOT derived from `.release-please-manifest.json`
-// at the outer repo root (this project is loaded as an included build, so
-// its own rootDir is `gradle-plugin/` — walk up one level).
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.parentFile.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 gradlePlugin {
   website.set("https://github.com/yschimke/compose-ai-tools")
@@ -55,72 +38,6 @@ gradlePlugin {
 // Publish to both GitHub Packages (legacy / CI convenience) and Maven Central
 // via the new Central Portal. Snapshots (version ending in `-SNAPSHOT`) route
 // automatically to `https://central.sonatype.com/repository/maven-snapshots/`.
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
-mavenPublishing {
-  // Central Portal (https://central.sonatype.com) is the only target in
-  // vanniktech ≥ 0.34. `automaticRelease = true` promotes to the central
-  // repo without a manual "release" click in the Portal UI. Snapshots route
-  // to https://central.sonatype.com/repository/maven-snapshots/ automatically.
-  publishToMavenCentral(automaticRelease = true)
-  // Vanniktech auto-detects `java-gradle-plugin` and publishes the plugin +
-  // marker artifacts with sources/javadoc jars. (If we ever apply the
-  // `com.gradle.plugin-publish` plugin for Plugin Portal, swap in
-  // `configure(GradlePublishPlugin())`.)
-  // Only require signing for non-snapshot builds — snapshots are unsigned on
-  // the Central snapshots repo, which is convenient for local/dev publishes.
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-
-  coordinates("ee.schimke.composeai", "compose-preview-plugin", version.toString())
-
-  pom {
-    name.set("Compose Preview Gradle Plugin")
-    description.set(
-      "Gradle plugin to discover and render Jetpack Compose / Compose Multiplatform " +
-        "@Preview functions to PNG outside Android Studio."
-    )
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2025")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
-}
 
 dependencies {
   implementation(libs.classgraph)
@@ -173,3 +90,13 @@ val generatePluginVersionResource by tasks.registering {
 }
 
 sourceSets.main.get().resources.srcDir(generatePluginVersionResource)
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "compose-preview-plugin",
+    displayName = "Compose Preview Gradle Plugin",
+    description =
+      "Gradle plugin to discover and render Jetpack Compose / Compose Multiplatform @Preview functions to PNG outside Android Studio.",
+  )
+  inceptionYear.set("2025")
+}

--- a/preview-annotations/build.gradle.kts
+++ b/preview-annotations/build.gradle.kts
@@ -3,9 +3,8 @@ import tapmoc.TapmocExtension
 import tapmoc.configureKotlinCompatibility
 
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
   alias(libs.plugins.tapmoc)
 }
 
@@ -24,78 +23,17 @@ tasks.withType<KotlinCompilationTask<*>>().configureEach {
 
 extensions.configure<TapmocExtension> { checkDependencies() }
 
-group = "ee.schimke.composeai"
-
-// See gradle-plugin/build.gradle.kts for how CI sets PLUGIN_VERSION. Local
-// builds derive the SNAPSHOT version from `.release-please-manifest.json`.
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
-
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 // Annotation-only artifact — deliberately no runtime deps so adding it to a
 // Compose app classpath never drags anything else in.
 
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
-mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
-
-  coordinates("ee.schimke.composeai", "preview-annotations", version.toString())
-
-  pom {
-    name.set("Compose Preview — Annotations")
-    description.set(
-      "Annotations consumed by the compose-preview Gradle plugin — e.g. " +
-        "@ScrollingPreview for opting @Preview composables into scrolling " +
-        "screenshot capture."
-    )
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2025")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "preview-annotations",
+    displayName = "Compose Preview — Annotations",
+    description =
+      "Annotations consumed by the compose-preview Gradle plugin — e.g. @ScrollingPreview for opting @Preview composables into scrolling screenshot capture.",
+  )
+  inceptionYear.set("2025")
 }

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -10,11 +10,10 @@ import tapmoc.TapmocExtension
 import tapmoc.configureKotlinCompatibility
 
 plugins {
+  id("composeai.maven-publishing")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.kotlin.serialization)
-  `maven-publish`
-  alias(libs.plugins.maven.publish)
   alias(libs.plugins.tapmoc)
 }
 
@@ -29,19 +28,6 @@ tasks.withType<KotlinCompilationTask<*>>().configureEach {
 }
 
 extensions.configure<TapmocExtension> { checkDependencies() }
-
-group = "ee.schimke.composeai"
-
-// See gradle-plugin/build.gradle.kts for how CI sets PLUGIN_VERSION. Local
-// builds derive the SNAPSHOT version from `.release-please-manifest.json`.
-version =
-  providers.environmentVariable("PLUGIN_VERSION").orNull
-    ?: run {
-      val manifest = rootDir.resolve(".release-please-manifest.json").readText()
-      val current = Regex(""""\.":\s*"([^"]+)"""").find(manifest)!!.groupValues[1]
-      val (major, minor, patch) = current.split(".").map { it.toInt() }
-      "$major.$minor.${patch + 1}-SNAPSHOT"
-    }
 
 android {
   namespace = "ee.schimke.composeai.renderer"
@@ -196,65 +182,18 @@ dependencies {
   compileOnly(libs.wear.protolayout.expression)
 }
 
-// GitHub Packages repo kept alongside Maven Central for internal/CI convenience.
-// Vanniktech's `AndroidSingleVariantLibrary` creates the release publication
-// (with sources + javadoc jar) — do not create one manually; it clashes.
-publishing {
-  repositories {
-    maven {
-      name = "GitHubPackages"
-      url =
-        uri(
-          providers
-            .environmentVariable("GITHUB_REPOSITORY")
-            .map { "https://maven.pkg.github.com/$it" }
-            .orElse("https://maven.pkg.github.com/yschimke/compose-ai-tools")
-        )
-      credentials {
-        username = providers.environmentVariable("GITHUB_ACTOR").orNull
-        password = providers.environmentVariable("GITHUB_TOKEN").orNull
-      }
-    }
-  }
-}
-
 mavenPublishing {
-  publishToMavenCentral(automaticRelease = true)
   configure(
     AndroidSingleVariantLibrary(variant = "release", sourcesJar = true, publishJavadocJar = true)
   )
-  if (!version.toString().endsWith("SNAPSHOT")) {
-    signAllPublications()
-  }
+}
 
-  coordinates("ee.schimke.composeai", "renderer-android", version.toString())
-
-  pom {
-    name.set("Compose Preview — Android Renderer")
-    description.set(
-      "Robolectric-based renderer for Jetpack Compose @Preview functions, " +
-        "used by the compose-preview Gradle plugin to produce PNGs off-device."
-    )
-    url.set("https://github.com/yschimke/compose-ai-tools")
-    inceptionYear.set("2025")
-    licenses {
-      license {
-        name.set("The Apache License, Version 2.0")
-        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-        distribution.set("repo")
-      }
-    }
-    developers {
-      developer {
-        id.set("yschimke")
-        name.set("Yuri Schimke")
-        url.set("https://github.com/yschimke")
-      }
-    }
-    scm {
-      url.set("https://github.com/yschimke/compose-ai-tools")
-      connection.set("scm:git:https://github.com/yschimke/compose-ai-tools.git")
-      developerConnection.set("scm:git:ssh://git@github.com/yschimke/compose-ai-tools.git")
-    }
-  }
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "renderer-android",
+    displayName = "Compose Preview — Android Renderer",
+    description =
+      "Robolectric-based renderer for Jetpack Compose @Preview functions, used by the compose-preview Gradle plugin to produce PNGs off-device.",
+  )
+  inceptionYear.set("2025")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 pluginManagement {
+  includeBuild("build-logic")
   repositories {
     gradlePluginPortal()
     google()


### PR DESCRIPTION
## Summary
- make `snapshot.yml` usable for pre-merge testing by giving manual branch runs branch-qualified Maven `-SNAPSHOT` versions and printing the coordinate in the workflow summary
- add Maven publishing for `data-recomposition-connector`, which `daemon-desktop` depends on, and include it in snapshot/release Maven publish lists
- move shared Maven publishing setup into a `build-logic` convention plugin backed by the existing version catalog
- update docs with main snapshot vs branch snapshot consumption guidance

## Why it was not working
- docs only described the `main` push snapshot (`<next-patch>-SNAPSHOT`), which is not useful for testing PR changes before merge
- manual branch runs used the same unqualified next-patch snapshot coordinate, so they could collide with or overwrite the main snapshot coordinate
- `daemon-desktop` depended on `data-recomposition-connector`, but that module was not published as a Maven artifact

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/snapshot.yml"); YAML.load_file(".github/workflows/release.yml"); puts "workflows parsed"'`
- `./gradlew ktfmtCheckAll`
- `PLUGIN_VERSION=0.8.13-test-abcdef1-SNAPSHOT ORG_GRADLE_PROJECT_mavenCentralUsername=dummy ORG_GRADLE_PROJECT_mavenCentralPassword=dummy ./gradlew --dry-run :gradle-plugin:publishToMavenCentral :data-a11y-core:publishToMavenCentral :data-a11y-connector:publishToMavenCentral :data-fonts-core:publishToMavenCentral :data-fonts-connector:publishToMavenCentral :data-history-connector:publishToMavenCentral :data-layoutinspector-core:publishToMavenCentral :data-layoutinspector-connector:publishToMavenCentral :data-recomposition-connector:publishToMavenCentral :data-render-core:publishToMavenCentral :data-render-connector:publishToMavenCentral :data-resources-core:publishToMavenCentral :data-resources-connector:publishToMavenCentral :data-scroll-core:publishToMavenCentral :data-strings-core:publishToMavenCentral :data-strings-connector:publishToMavenCentral :data-theme-connector:publishToMavenCentral :renderer-android:publishToMavenCentral :preview-annotations:publishToMavenCentral :daemon:core:publishToMavenCentral :daemon:desktop:publishToMavenCentral :daemon:android:publishToMavenCentral`