### PR TITLE
Filter kind-scoped data product files

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DataCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DataCommands.kt
@@ -236,8 +236,10 @@ internal fun scanDataProducts(module: String, projectDir: File): DataProductsMod
           ?.filter { it.isFile }
           ?.forEach { file ->
             if (directoryDescriptor != null) {
-              byKind.getOrPut(directoryDescriptor.kind) { linkedSetOf() } +=
-                file.nameWithoutExtension
+              if (file.extension == directoryDescriptor.extension) {
+                byKind.getOrPut(directoryDescriptor.kind) { linkedSetOf() } +=
+                  file.nameWithoutExtension
+              }
             } else {
               descriptorForFile(file)?.let { descriptor ->
                 byKind.getOrPut(descriptor.kind) { linkedSetOf() } += productDir.name

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/DataCommandsTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/DataCommandsTest.kt
@@ -140,6 +140,8 @@ class DataCommandsTest {
       projectDir.resolve("build/compose-previews/data/render-scroll-long/com.example.Foo.png")
     file.parentFile.mkdirs()
     file.writeBytes(byteArrayOf(1, 2, 3))
+    file.parentFile.resolve("com.example.Bar.txt").writeText("not a scroll artifact")
+    file.parentFile.resolve(".DS_Store").writeText("ignored")
 
     val product = scanDataProducts("app", projectDir).products.single()
 


### PR DESCRIPTION
## Summary

Addresses the Codex review comment from #634: https://github.com/yschimke/compose-ai-tools/pull/634#discussion_r3177876043

- Only advertise files from known kind-scoped data product directories when their extension matches the product descriptor.
- Covers ignored/non-artifact files in `render-scroll-long` so `data-products` no longer lists preview ids that `data get` cannot resolve.

## Validation

- `./gradlew :cli:ktfmtCheck :cli:test --tests ee.schimke.composeai.cli.DataCommandsTest`