### PR TITLE
Add artifact-based F5 launch config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ local.properties
 # Node / VS Code extension
 node_modules/
 vscode-extension/out/
+vscode-extension/.vscode-test/
 *.vsix
 
 # Python (for .github/actions/lib/ scripts and their tests)

--- a/vscode-extension/.vscode/launch.json
+++ b/vscode-extension/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run Extension (artifacts, Meshcore)",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}/.vscode-test/artifact-extension",
+                "${env:HOME}/workspace/meshcore-mobile"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/.vscode-test/artifact-extension/out/**/*.js"
+            ],
+            "preLaunchTask": "build: F5 artifacts"
+        },
+        {
+            "name": "Extension Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}",
+                "--extensionTestsPath=${workspaceFolder}/out/test/electron/suite/index"
+            ],
+            "outFiles": [
+                "${workspaceFolder}/out/test/**/*.js"
+            ],
+            "preLaunchTask": "npm: compile"
+        }
+    ]
+}

--- a/vscode-extension/.vscode/tasks.json
+++ b/vscode-extension/.vscode/tasks.json
@@ -1,0 +1,104 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "compile",
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$tsc"
+        },
+        {
+            "type": "npm",
+            "script": "watch",
+            "group": "build",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "never"
+            },
+            "problemMatcher": "$tsc-watch"
+        },
+        {
+            "label": "gradle: assemble plugin",
+            "type": "shell",
+            "command": "../gradlew",
+            "args": [
+                "-p",
+                "../gradle-plugin",
+                "assemble"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "extension: prepare artifact folder",
+            "type": "shell",
+            "command": "rm -rf .vscode-test/artifact-extension && mkdir -p .vscode-test/artifact-extension && cp package.json README.md .vscode-test/artifact-extension/ && cp -R out media .vscode-test/artifact-extension/",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "gradle: install CLI dist",
+            "type": "shell",
+            "command": "../gradlew",
+            "args": [
+                "-p",
+                "..",
+                ":cli:installDist"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "meshcore: install CLI",
+            "type": "shell",
+            "command": "rm -rf ${env:HOME}/workspace/meshcore-mobile/.compose-preview-cli && mkdir -p ${env:HOME}/workspace/meshcore-mobile/.compose-preview-cli && cp -R ${workspaceFolder}/../cli/build/install/compose-preview/. ${env:HOME}/workspace/meshcore-mobile/.compose-preview-cli/",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "build: F5 artifacts",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "npm: compile",
+                "gradle: assemble plugin",
+                "extension: prepare artifact folder",
+                "gradle: install CLI dist",
+                "meshcore: install CLI"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

- Add tracked VS Code launch/tasks config for the extension workspace.
- Make F5 run a one-off TypeScript extension compile and Gradle plugin assemble before launching.
- Build the Compose Preview CLI distribution and install it into `~/workspace/meshcore-mobile/.compose-preview-cli` before launch.
- Launch the extension host from a prepared artifact-only extension folder and open `~/workspace/meshcore-mobile` as the test workspace.
- Ignore the generated `.vscode-test` artifact folder created by the launch workflow.

## Impact

This makes the default debug loop closer to the public extension experience: VS Code loads the extension from copied build artifacts instead of the source checkout, validates the Gradle plugin assembles before launch, and gives the launched Meshcore workspace a local CLI install without checking it into source control.

## Validation

- Parsed `.vscode/launch.json` and `.vscode/tasks.json` as JSON.
- Ran `npm run compile`.
- Ran `../gradlew -p ../gradle-plugin assemble`.
- Ran `../gradlew -p .. :cli:installDist`.
- Installed the CLI into Meshcore and verified `.compose-preview-cli/bin/compose-preview --version` reports `compose-preview 0.8.13-SNAPSHOT`.