### PR TITLE
refactor: centralize Gradle build conventions

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins { `kotlin-dsl` }
 
 dependencies {
+  implementation("com.android.tools.build:gradle:${libs.versions.agp.get()}")
+  implementation("com.gradleup.tapmoc:tapmoc-gradle-plugin:${libs.versions.tapmoc.get()}")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlin.get()}")
   implementation(
     "com.vanniktech:gradle-maven-publish-plugin:${libs.versions.maven.publish.get()}"
   )
@@ -8,9 +11,25 @@ dependencies {
 
 gradlePlugin {
   plugins {
+    register("composeAiAndroidConventions") {
+      id = "composeai.android-conventions"
+      implementationClass = "ee.schimke.composeai.buildlogic.ComposeAiAndroidConventionsPlugin"
+    }
+    register("composeAiAndroidLibraryConventions") {
+      id = "composeai.android-library-conventions"
+      implementationClass = "ee.schimke.composeai.buildlogic.ComposeAiAndroidConventionsPlugin"
+    }
+    register("composeAiJvmConventions") {
+      id = "composeai.jvm-conventions"
+      implementationClass = "ee.schimke.composeai.buildlogic.ComposeAiJvmConventionsPlugin"
+    }
     register("composeAiMavenPublishing") {
       id = "composeai.maven-publishing"
       implementationClass = "ee.schimke.composeai.buildlogic.ComposeAiMavenPublishingPlugin"
+    }
+    register("composeAiTapmocConventions") {
+      id = "composeai.tapmoc-conventions"
+      implementationClass = "ee.schimke.composeai.buildlogic.ComposeAiTapmocConventionsPlugin"
     }
   }
 }

--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
@@ -1,14 +1,26 @@
 package ee.schimke.composeai.buildlogic
 
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.LibraryExtension
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import java.io.File
 import javax.inject.Inject
+import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.Property
 import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+import tapmoc.TapmocExtension
+import tapmoc.configureKotlinCompatibility
 
 abstract class ComposeAiMavenPublishingExtension
 @Inject
@@ -27,6 +39,9 @@ constructor(objects: ObjectFactory) {
 
 class ComposeAiMavenPublishingPlugin : Plugin<Project> {
   override fun apply(project: Project) {
+    project.pluginManager.apply("composeai.android-conventions")
+    project.pluginManager.apply("composeai.jvm-conventions")
+    project.pluginManager.apply("composeai.tapmoc-conventions")
     project.pluginManager.apply("maven-publish")
     project.pluginManager.apply("com.vanniktech.maven.publish")
 
@@ -101,6 +116,80 @@ class ComposeAiMavenPublishingPlugin : Plugin<Project> {
         }
       }
     }
+  }
+}
+
+class ComposeAiAndroidConventionsPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+    project.configureCommonAndroid()
+  }
+}
+
+class ComposeAiJvmConventionsPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+    project.configureCommonJvm()
+  }
+}
+
+class ComposeAiTapmocConventionsPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+    project.configureTapmocCompatibility()
+  }
+}
+
+private fun Project.configureCommonAndroid() {
+  pluginManager.withPlugin("com.android.library") {
+    extensions.configure<LibraryExtension> { configureLibraryDefaults() }
+  }
+  pluginManager.withPlugin("com.android.application") {
+    extensions.configure<ApplicationExtension> { configureApplicationDefaults() }
+  }
+}
+
+private fun LibraryExtension.configureLibraryDefaults() {
+  compileSdk = 36
+  defaultConfig { minSdk = 24 }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+  testOptions { unitTests { isIncludeAndroidResources = true } }
+}
+
+private fun ApplicationExtension.configureApplicationDefaults() {
+  compileSdk = 36
+  defaultConfig { minSdk = 24 }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+  testOptions { unitTests { isIncludeAndroidResources = true } }
+}
+
+private fun Project.configureCommonJvm() {
+  pluginManager.withPlugin("java") {
+    extensions.configure<JavaPluginExtension> {
+      toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+    }
+    tasks.withType<Test>().configureEach { useJUnit() }
+  }
+}
+
+private fun Project.configureTapmocCompatibility() {
+  pluginManager.withPlugin("com.gradleup.tapmoc") {
+    val kotlinCoreLibraries =
+      extensions
+        .getByType<VersionCatalogsExtension>()
+        .named("libs")
+        .findVersion("kotlinCoreLibraries")
+        .get()
+        .requiredVersion
+
+    configureKotlinCompatibility(version = kotlinCoreLibraries)
+    tasks.withType<KotlinCompilationTask<*>>().configureEach {
+      compilerOptions.freeCompilerArgs.add("-Xsuppress-version-warnings")
+    }
+    extensions.configure<TapmocExtension> { checkDependencies() }
   }
 }
 

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -6,6 +6,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 
 plugins {
+  id("composeai.jvm-conventions")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
   application
@@ -113,5 +114,3 @@ val generateCliVersionResource by tasks.registering {
 }
 
 sourceSets.main.get().resources.srcDir(generateCliVersionResource)
-
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }

--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -34,17 +34,6 @@ plugins {
 
 android {
   namespace = "ee.schimke.composeai.daemon"
-  compileSdk = 36
-
-  defaultConfig { minSdk = 24 }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
-
-  testOptions { unitTests { isIncludeAndroidResources = true } }
-
   // D-harness.v2 — promote the fixture composables (RedSquare/BlueSquare/GreenSquare/SlowSquare/
   // BoomComposable) from this module's `src/test/...` into a real testFixtures source set so
   // `:daemon:harness`'s test runtime classpath can pull them via

--- a/daemon/core/build.gradle.kts
+++ b/daemon/core/build.gradle.kts
@@ -37,10 +37,6 @@ dependencies {
   testImplementation(libs.junit)
 }
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
-tasks.withType<Test>().configureEach { useJUnit() }
-
 // GitHub Packages mirror — same shape as `:renderer-android` and `:preview-annotations`.
 
 composeAiMavenPublishing {

--- a/daemon/desktop/build.gradle.kts
+++ b/daemon/desktop/build.gradle.kts
@@ -103,10 +103,6 @@ dependencies {
   "testFixturesImplementation"(compose.material3)
 }
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
-tasks.withType<Test>().configureEach { useJUnit() }
-
 // Convenience task — equivalent to `java -cp $(runtimeClasspath) ee.schimke.composeai.daemon
 // .DaemonMain`. Lets local verification of the daemon happen without applying the
 // `application` plugin (which would add `distZip`/`distTar`/etc. tasks we don't need yet). Wire-up

--- a/daemon/harness/build.gradle.kts
+++ b/daemon/harness/build.gradle.kts
@@ -16,6 +16,7 @@
 import java.net.URLClassLoader
 
 plugins {
+  id("composeai.jvm-conventions")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
 }
@@ -124,10 +125,7 @@ tasks.withType<Test>().configureEach {
   )
 }
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
 tasks.withType<Test>().configureEach {
-  useJUnit()
   // D-harness.v1.5a — `-Pharness.host=fake|real` flag. Default `fake` keeps the existing 7
   // scenarios self-contained (no Compose Desktop spawn cost when verifying scenario logic).
   // Real-mode flips the launcher in `HarnessTestSupport.launcherFor(...)` and unblocks
@@ -249,7 +247,6 @@ val regenerateBaselines by
     systemProperty("composeai.harness.host", "real")
     systemProperty("composeai.harness.target", findProperty("harness.target") ?: "desktop")
     systemProperty("composeai.harness.regenerate", "true")
-    useJUnit()
     val baseTest = tasks.test.get()
     classpath = baseTest.classpath
     testClassesDirs = baseTest.testClassesDirs

--- a/data/a11y/connector/build.gradle.kts
+++ b/data/a11y/connector/build.gradle.kts
@@ -1,7 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-import tapmoc.TapmocExtension
-import tapmoc.configureKotlinCompatibility
-
 // D2.2 — `:data-a11y-connector` glues `:data-a11y-core` (the generic Android piece) to the
 // daemon's data-product API: `AccessibilityDataProducer` writes the per-render JSON
 // artefacts, `AccessibilityDataProductRegistry` advertises kinds + serves
@@ -18,27 +14,7 @@ plugins {
   alias(libs.plugins.tapmoc)
 }
 
-configureKotlinCompatibility(version = libs.versions.kotlinCoreLibraries.get())
-
-tasks.withType<KotlinCompilationTask<*>>().configureEach {
-  compilerOptions.freeCompilerArgs.add("-Xsuppress-version-warnings")
-}
-
-extensions.configure<TapmocExtension> { checkDependencies() }
-
-android {
-  namespace = "ee.schimke.composeai.data.a11y.connector"
-  compileSdk = 36
-
-  defaultConfig { minSdk = 24 }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
-
-  testOptions { unitTests { isIncludeAndroidResources = true } }
-}
+android { namespace = "ee.schimke.composeai.data.a11y.connector" }
 
 dependencies {
   // Core a11y types + ATF wrapper + overlay generator. Re-exported via `api` so consumers

--- a/data/a11y/core/build.gradle.kts
+++ b/data/a11y/core/build.gradle.kts
@@ -5,9 +5,6 @@
 // types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
 
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-import tapmoc.TapmocExtension
-import tapmoc.configureKotlinCompatibility
 
 // D2.2 — `:data-a11y-core` is the **published** generic-Android piece of the
 // accessibility data product: the ATF wrapper (`AccessibilityChecker`), the
@@ -28,31 +25,7 @@ plugins {
   alias(libs.plugins.tapmoc)
 }
 
-// See preview-annotations/build.gradle.kts for the rationale.
-configureKotlinCompatibility(version = libs.versions.kotlinCoreLibraries.get())
-
-// Mirror preview-annotations: silence the 2.3.x compiler's
-// `Language version 2.0 is deprecated …` warning while we hold the floor
-// at 2.0 (see `kotlinCoreLibraries` in libs.versions.toml).
-tasks.withType<KotlinCompilationTask<*>>().configureEach {
-  compilerOptions.freeCompilerArgs.add("-Xsuppress-version-warnings")
-}
-
-extensions.configure<TapmocExtension> { checkDependencies() }
-
-android {
-  namespace = "ee.schimke.composeai.data.a11y.core"
-  compileSdk = 36
-
-  defaultConfig { minSdk = 24 }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
-
-  testOptions { unitTests { isIncludeAndroidResources = true } }
-}
+android { namespace = "ee.schimke.composeai.data.a11y.core" }
 
 dependencies {
   api(project(":data-render-core"))

--- a/data/fonts/connector/build.gradle.kts
+++ b/data/fonts/connector/build.gradle.kts
@@ -10,10 +10,6 @@ dependencies {
   testImplementation(libs.junit)
 }
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
-tasks.withType<Test>().configureEach { useJUnit() }
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-fonts-connector",

--- a/data/fonts/core/build.gradle.kts
+++ b/data/fonts/core/build.gradle.kts
@@ -9,10 +9,6 @@ dependencies {
   testImplementation(libs.junit)
 }
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
-tasks.withType<Test>().configureEach { useJUnit() }
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-fonts-core",

--- a/data/history/connector/build.gradle.kts
+++ b/data/history/connector/build.gradle.kts
@@ -9,10 +9,6 @@ dependencies {
   testImplementation(libs.junit)
 }
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
-tasks.withType<Test>().configureEach { useJUnit() }
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-history-connector",

--- a/data/layoutinspector/connector/build.gradle.kts
+++ b/data/layoutinspector/connector/build.gradle.kts
@@ -7,16 +7,7 @@ plugins {
   alias(libs.plugins.kotlin.serialization)
 }
 
-android {
-  namespace = "ee.schimke.composeai.data.layoutinspector.connector"
-  compileSdk = 36
-  defaultConfig { minSdk = 24 }
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
-  testOptions { unitTests { isIncludeAndroidResources = true } }
-}
+android { namespace = "ee.schimke.composeai.data.layoutinspector.connector" }
 
 dependencies {
   api(project(":data-layoutinspector-core"))

--- a/data/layoutinspector/core/build.gradle.kts
+++ b/data/layoutinspector/core/build.gradle.kts
@@ -9,10 +9,6 @@ dependencies {
   testImplementation(libs.junit)
 }
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
-tasks.withType<Test>().configureEach { useJUnit() }
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-layoutinspector-core",

--- a/data/recomposition/connector/build.gradle.kts
+++ b/data/recomposition/connector/build.gradle.kts
@@ -13,10 +13,6 @@ dependencies {
   testImplementation(libs.junit)
 }
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
-tasks.withType<Test>().configureEach { useJUnit() }
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-recomposition-connector",

--- a/data/render/connector/build.gradle.kts
+++ b/data/render/connector/build.gradle.kts
@@ -10,10 +10,6 @@ dependencies {
   testImplementation(libs.junit)
 }
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
-tasks.withType<Test>().configureEach { useJUnit() }
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-render-connector",

--- a/data/render/core/build.gradle.kts
+++ b/data/render/core/build.gradle.kts
@@ -1,7 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-import tapmoc.TapmocExtension
-import tapmoc.configureKotlinCompatibility
-
 plugins {
   id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
@@ -9,23 +5,10 @@ plugins {
   alias(libs.plugins.tapmoc)
 }
 
-// See preview-annotations/build.gradle.kts for the rationale.
-configureKotlinCompatibility(version = libs.versions.kotlinCoreLibraries.get())
-
-tasks.withType<KotlinCompilationTask<*>>().configureEach {
-  compilerOptions.freeCompilerArgs.add("-Xsuppress-version-warnings")
-}
-
-extensions.configure<TapmocExtension> { checkDependencies() }
-
 dependencies {
   api(libs.kotlinx.serialization.json)
   testImplementation(libs.junit)
 }
-
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
-tasks.withType<Test>().configureEach { useJUnit() }
 
 composeAiMavenPublishing {
   coordinates(

--- a/data/resources/connector/build.gradle.kts
+++ b/data/resources/connector/build.gradle.kts
@@ -6,16 +6,7 @@ plugins {
   alias(libs.plugins.kotlin.serialization)
 }
 
-android {
-  namespace = "ee.schimke.composeai.data.resources.connector"
-  compileSdk = 36
-  defaultConfig { minSdk = 24 }
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
-  testOptions { unitTests { isIncludeAndroidResources = true } }
-}
+android { namespace = "ee.schimke.composeai.data.resources.connector" }
 
 dependencies {
   api(project(":data-resources-core"))

--- a/data/resources/core/build.gradle.kts
+++ b/data/resources/core/build.gradle.kts
@@ -9,10 +9,6 @@ dependencies {
   testImplementation(libs.junit)
 }
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
-tasks.withType<Test>().configureEach { useJUnit() }
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-resources-core",

--- a/data/scroll/core/build.gradle.kts
+++ b/data/scroll/core/build.gradle.kts
@@ -5,9 +5,6 @@
 // types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
 
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-import tapmoc.TapmocExtension
-import tapmoc.configureKotlinCompatibility
 
 plugins {
   id("composeai.maven-publishing")
@@ -15,28 +12,7 @@ plugins {
   alias(libs.plugins.tapmoc)
 }
 
-// See preview-annotations/build.gradle.kts for the rationale.
-configureKotlinCompatibility(version = libs.versions.kotlinCoreLibraries.get())
-
-tasks.withType<KotlinCompilationTask<*>>().configureEach {
-  compilerOptions.freeCompilerArgs.add("-Xsuppress-version-warnings")
-}
-
-extensions.configure<TapmocExtension> { checkDependencies() }
-
-android {
-  namespace = "ee.schimke.composeai.data.scroll.core"
-  compileSdk = 36
-
-  defaultConfig { minSdk = 24 }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
-
-  testOptions { unitTests { isIncludeAndroidResources = true } }
-}
+android { namespace = "ee.schimke.composeai.data.scroll.core" }
 
 dependencies {
   api(project(":data-render-core"))

--- a/data/strings/connector/build.gradle.kts
+++ b/data/strings/connector/build.gradle.kts
@@ -6,16 +6,7 @@ plugins {
   alias(libs.plugins.kotlin.serialization)
 }
 
-android {
-  namespace = "ee.schimke.composeai.data.strings.connector"
-  compileSdk = 36
-  defaultConfig { minSdk = 24 }
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
-  testOptions { unitTests { isIncludeAndroidResources = true } }
-}
+android { namespace = "ee.schimke.composeai.data.strings.connector" }
 
 dependencies {
   api(project(":data-strings-core"))

--- a/data/strings/core/build.gradle.kts
+++ b/data/strings/core/build.gradle.kts
@@ -9,10 +9,6 @@ dependencies {
   testImplementation(libs.junit)
 }
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
-tasks.withType<Test>().configureEach { useJUnit() }
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-strings-core",

--- a/data/theme/connector/build.gradle.kts
+++ b/data/theme/connector/build.gradle.kts
@@ -19,10 +19,6 @@ dependencies {
   testImplementation(compose.material3)
 }
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
-tasks.withType<Test>().configureEach { useJUnit() }
-
 composeAiMavenPublishing {
   coordinates(
     artifactId = "data-theme-connector",

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,6 +1,3 @@
-import tapmoc.TapmocExtension
-import tapmoc.configureKotlinCompatibility
-
 plugins {
   id("composeai.maven-publishing")
   `java-gradle-plugin`
@@ -11,14 +8,6 @@ plugins {
 }
 
 ktfmt { googleStyle() }
-
-// `kotlin-dsl` already pins the language/api version to Gradle's embedded
-// Kotlin (currently 2.x); tapmoc is wired here primarily for
-// `checkDependencies()`, which surfaces if any KGP/AGP transitive raises the
-// Kotlin floor we'd push onto plugin consumers' buildscript classpaths.
-configureKotlinCompatibility(version = libs.versions.kotlinCoreLibraries.get())
-
-extensions.configure<TapmocExtension> { checkDependencies() }
 
 gradlePlugin {
   website.set("https://github.com/yschimke/compose-ai-tools")
@@ -48,8 +37,6 @@ dependencies {
   testImplementation(libs.truth)
   testImplementation(gradleTestKit())
 }
-
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 // Functional tests use Gradle TestKit
 val functionalTest by sourceSets.creating {

--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -10,6 +10,7 @@
 // projects or worktrees — see `DaemonSupervisor` for the workspace-id derivation.
 
 plugins {
+  id("composeai.jvm-conventions")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.serialization)
   application
@@ -59,10 +60,7 @@ dependencies {
 //   `:daemon:core` `JsonRpcServer` framing, and removes a 0.x-version-pin risk.
 // - The SDK can be reintroduced as a non-breaking internal refactor once the surface stabilises.
 
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
-
 tasks.withType<Test>().configureEach {
-  useJUnit()
   // Opt-in real-mode: `-Pmcp.real=true` flips the JUnit `Assume` gate in
   // `RealMcpEndToEndTest`. Mirrors `:daemon:harness`'s `-Pharness.host=real` pattern.
   // The optional `-Pmcp.workdir=<path>` lets out-of-tree runs point the test at a different

--- a/preview-annotations/build.gradle.kts
+++ b/preview-annotations/build.gradle.kts
@@ -1,29 +1,8 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-import tapmoc.TapmocExtension
-import tapmoc.configureKotlinCompatibility
-
 plugins {
   id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.tapmoc)
 }
-
-// Pin the Kotlin language/api surface to `kotlinCoreLibraries` (lower than
-// the compiler `kotlin` version) so consumers on older Kotlin can still link
-// against this artifact. `checkDependencies()` fails the build if a
-// transitive API dep raises the floor.
-configureKotlinCompatibility(version = libs.versions.kotlinCoreLibraries.get())
-
-// Silence `Language version 2.0 is deprecated …` from the 2.3.x compiler.
-// We intentionally hold the floor at 2.0 (see `kotlinCoreLibraries` in
-// libs.versions.toml); drop this when that version bumps to 2.1+.
-tasks.withType<KotlinCompilationTask<*>>().configureEach {
-  compilerOptions.freeCompilerArgs.add("-Xsuppress-version-warnings")
-}
-
-extensions.configure<TapmocExtension> { checkDependencies() }
-
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 // Annotation-only artifact — deliberately no runtime deps so adding it to a
 // Compose app classpath never drags anything else in.

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -5,9 +5,6 @@
 // types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
 
 import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-import tapmoc.TapmocExtension
-import tapmoc.configureKotlinCompatibility
 
 plugins {
   id("composeai.maven-publishing")
@@ -17,30 +14,8 @@ plugins {
   alias(libs.plugins.tapmoc)
 }
 
-// See preview-annotations/build.gradle.kts for the rationale.
-configureKotlinCompatibility(version = libs.versions.kotlinCoreLibraries.get())
-
-// Mirror preview-annotations: silence the 2.3.x compiler's
-// `Language version 2.0 is deprecated …` warning while we hold the floor
-// at 2.0 (see `kotlinCoreLibraries` in libs.versions.toml).
-tasks.withType<KotlinCompilationTask<*>>().configureEach {
-  compilerOptions.freeCompilerArgs.add("-Xsuppress-version-warnings")
-}
-
-extensions.configure<TapmocExtension> { checkDependencies() }
-
 android {
   namespace = "ee.schimke.composeai.renderer"
-  compileSdk = 36
-
-  defaultConfig { minSdk = 24 }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
-
-  testOptions { unitTests { isIncludeAndroidResources = true } }
   // `AndroidSingleVariantLibrary` in `mavenPublishing {}` below wires the
   // `singleVariant("release")` publication for us — don't declare it twice.
 }

--- a/renderer-desktop/build.gradle.kts
+++ b/renderer-desktop/build.gradle.kts
@@ -1,6 +1,7 @@
 @file:Suppress("DEPRECATION")
 
 plugins {
+  id("composeai.jvm-conventions")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.compose.multiplatform)
   alias(libs.plugins.compose.compiler)
@@ -16,5 +17,3 @@ dependencies {
 
   testImplementation(libs.junit)
 }
-
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }

--- a/samples/android-daemon-bench/build.gradle.kts
+++ b/samples/android-daemon-bench/build.gradle.kts
@@ -18,6 +18,7 @@ import java.time.Instant
 import org.w3c.dom.Element
 
 plugins {
+  id("composeai.android-conventions")
   alias(libs.plugins.android.application)
   alias(libs.plugins.compose.compiler)
   id("ee.schimke.composeai.preview")
@@ -25,19 +26,12 @@ plugins {
 
 android {
   namespace = "com.example.daemonbench"
-  compileSdk = 36
 
   defaultConfig {
     applicationId = "com.example.daemonbench"
-    minSdk = 24
     targetSdk = 36
     versionCode = 1
     versionName = "1.0"
-  }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
   }
 
   buildFeatures { compose = true }

--- a/samples/android-library/build.gradle.kts
+++ b/samples/android-library/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("composeai.android-conventions")
   alias(libs.plugins.android.library)
   alias(libs.plugins.compose.compiler)
   id("ee.schimke.composeai.preview")
@@ -12,14 +13,6 @@ plugins {
 
 android {
   namespace = "com.example.samplelibrary"
-  compileSdk = 36
-
-  defaultConfig { minSdk = 24 }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
 
   buildFeatures { compose = true }
 

--- a/samples/android-screenshot-test/build.gradle.kts
+++ b/samples/android-screenshot-test/build.gradle.kts
@@ -11,6 +11,7 @@
 @file:Suppress("UnstableApiUsage")
 
 plugins {
+  id("composeai.android-conventions")
   alias(libs.plugins.android.application)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.android.compose.screenshot)
@@ -19,19 +20,12 @@ plugins {
 
 android {
   namespace = "com.example.sampleandroidscreenshot"
-  compileSdk = 36
 
   defaultConfig {
     applicationId = "com.example.sampleandroidscreenshot"
-    minSdk = 24
     targetSdk = 36
     versionCode = 1
     versionName = "1.0"
-  }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
   }
 
   buildFeatures { compose = true }

--- a/samples/android/build.gradle.kts
+++ b/samples/android/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("composeai.android-conventions")
   alias(libs.plugins.android.application)
   alias(libs.plugins.compose.compiler)
   id("ee.schimke.composeai.preview")
@@ -23,19 +24,12 @@ composePreview {
 
 android {
   namespace = "com.example.sampleandroid"
-  compileSdk = 36
 
   defaultConfig {
     applicationId = "com.example.sampleandroid"
-    minSdk = 24
     targetSdk = 36
     versionCode = 1
     versionName = "1.0"
-  }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
   }
 
   buildFeatures { compose = true }

--- a/samples/cmp-shared/build.gradle.kts
+++ b/samples/cmp-shared/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("composeai.jvm-conventions")
   // KGP, the KMP-Android plugin and `kotlin.plugin.compose` all ship inside
   // the same buildscript-classpath bundle that AGP 9 brings in for any
   // module already applying an AGP plugin elsewhere in the build. Applying
@@ -75,5 +76,3 @@ kotlin {
     }
   }
 }
-
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }

--- a/samples/cmp/build.gradle.kts
+++ b/samples/cmp/build.gradle.kts
@@ -1,6 +1,7 @@
 @file:Suppress("DEPRECATION")
 
 plugins {
+  id("composeai.jvm-conventions")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.compose.multiplatform)
   alias(libs.plugins.compose.compiler)
@@ -15,5 +16,3 @@ dependencies {
   implementation(compose.uiTooling)
   implementation(compose.components.uiToolingPreview)
 }
-
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }

--- a/samples/desktop-daemon-bench/build.gradle.kts
+++ b/samples/desktop-daemon-bench/build.gradle.kts
@@ -20,6 +20,7 @@ import java.time.Duration
 import java.time.Instant
 
 plugins {
+  id("composeai.jvm-conventions")
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.compose.multiplatform)
   alias(libs.plugins.compose.compiler)
@@ -33,8 +34,6 @@ dependencies {
   implementation(compose.ui)
   implementation(compose.components.uiToolingPreview)
 }
-
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 // --- Bench task ---------------------------------------------------------
 

--- a/samples/remotecompose/build.gradle.kts
+++ b/samples/remotecompose/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("composeai.android-conventions")
   alias(libs.plugins.android.application)
   alias(libs.plugins.compose.compiler)
   id("ee.schimke.composeai.preview")
@@ -20,11 +21,6 @@ android {
     targetSdk = 37
     versionCode = 1
     versionName = "1.0"
-  }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
   }
 
   buildFeatures { compose = true }

--- a/samples/wear/build.gradle.kts
+++ b/samples/wear/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+  id("composeai.android-conventions")
   alias(libs.plugins.android.application)
   alias(libs.plugins.compose.compiler)
   id("ee.schimke.composeai.preview")
@@ -18,7 +19,6 @@ composePreview {
 
 android {
   namespace = "com.example.samplewear"
-  compileSdk = 36
 
   defaultConfig {
     applicationId = "com.example.samplewear"
@@ -26,11 +26,6 @@ android {
     targetSdk = 36
     versionCode = 1
     versionName = "1.0"
-  }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
   }
 
   buildFeatures { compose = true }


### PR DESCRIPTION
## Summary
- add build-logic convention plugins for shared JVM, Android, Tapmoc/Kotlin compatibility, and Maven publishing setup
- have `composeai.maven-publishing` apply the common conventions transitively for published artifacts
- remove repeated Java 17, Android SDK/test defaults, Tapmoc compatibility, and JUnit setup from module build scripts
- opt non-published CLI, MCP, harness, renderer, and sample modules into the shared JVM/Android conventions directly

## Validation
- `./gradlew ktfmtCheckAll`
- `PLUGIN_VERSION=0.8.13-test-abcdef1-SNAPSHOT ORG_GRADLE_PROJECT_mavenCentralUsername=dummy ORG_GRADLE_PROJECT_mavenCentralPassword=dummy ./gradlew --dry-run :gradle-plugin:publishToMavenCentral :data-a11y-core:publishToMavenCentral :data-a11y-connector:publishToMavenCentral :data-fonts-core:publishToMavenCentral :data-fonts-connector:publishToMavenCentral :data-history-connector:publishToMavenCentral :data-layoutinspector-core:publishToMavenCentral :data-layoutinspector-connector:publishToMavenCentral :data-recomposition-connector:publishToMavenCentral :data-render-core:publishToMavenCentral :data-render-connector:publishToMavenCentral :data-resources-core:publishToMavenCentral :data-resources-connector:publishToMavenCentral :data-scroll-core:publishToMavenCentral :data-strings-core:publishToMavenCentral :data-strings-connector:publishToMavenCentral :data-theme-connector:publishToMavenCentral :renderer-android:publishToMavenCentral :preview-annotations:publishToMavenCentral :daemon:core:publishToMavenCentral :daemon:desktop:publishToMavenCentral :daemon:android:publishToMavenCentral`