### PR TITLE
Restore a11y report overlays

### DIFF
--- a/.github/actions/a11y-report/action.yml
+++ b/.github/actions/a11y-report/action.yml
@@ -34,12 +34,13 @@ runs:
         MODULE: ${{ inputs.module }}
       run: |
         set -euo pipefail
-        # `-PcomposePreview.accessibilityChecks.enabled=true` overrides the
-        # module DSL default so `./gradlew check` stays clean while CI still
-        # exercises the a11y path. The module's `verifyAccessibility` task is
-        # always registered; the property flips its `onlyIf` predicate.
+        # These properties override the module DSL default so `./gradlew check`
+        # stays clean while CI still exercises the a11y + ATF + overlay path.
+        # The module's `verifyAccessibility` task is always registered; the
+        # enableAllChecks property flips its `onlyIf` predicate.
         ./gradlew ":${MODULE}:renderAllPreviews" \
-          -PcomposePreview.accessibilityChecks.enabled=true \
+          -PcomposePreview.previewExtensions.a11y.enableAllChecks=true \
+          -PcomposePreview.previewExtensions.a11y.annotateScreenshots=true \
           --no-daemon
 
     - name: Copy annotated PNGs and emit findings.json

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -297,8 +297,12 @@ abstract class Command(protected val args: List<String>) {
     return modules
   }
 
-  protected fun runGradle(gradle: GradleConnection, vararg tasks: String): Boolean {
-    return gradle.runTasks(*tasks, timeoutSeconds = timeoutSeconds)
+  protected fun runGradle(
+    gradle: GradleConnection,
+    vararg tasks: String,
+    arguments: List<String> = emptyList(),
+  ): Boolean {
+    return gradle.runTasks(*tasks, timeoutSeconds = timeoutSeconds, arguments = arguments)
   }
 
   /**
@@ -829,7 +833,7 @@ class RenderCommand(args: List<String>) : Command(args) {
  * (i.e. the configured `failOnErrors`/`failOnWarnings` threshold tripped) or if `--fail-on`
  * overrides the threshold at the CLI level.
  */
-class A11yCommand(args: List<String>) : Command(args) {
+class A11yCommand(args: List<String>, private val forceEnable: Boolean = false) : Command(args) {
   private val jsonOutput = "--json" in args
   // "errors" | "warnings" | "none". When not set, exit code mirrors Gradle.
   private val failOn: String? = args.flagValue("--fail-on")
@@ -838,7 +842,16 @@ class A11yCommand(args: List<String>) : Command(args) {
     withGradle { gradle ->
       val modules = resolveModules(gradle)
       val tasks = modules.map { ":${it.gradlePath}:renderAllPreviews" }.toTypedArray()
-      val buildOk = runGradle(gradle, *tasks)
+      val gradleArguments =
+        if (forceEnable) {
+          listOf(
+            "-PcomposePreview.previewExtensions.a11y.enableAllChecks=true",
+            "-PcomposePreview.previewExtensions.a11y.annotateScreenshots=true",
+          )
+        } else {
+          emptyList()
+        }
+      val buildOk = runGradle(gradle, *tasks, arguments = gradleArguments)
       if (!buildOk) reportRenderFailures(gradle)
 
       val manifests = readAllManifests(modules)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/ExtensionCommands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/ExtensionCommands.kt
@@ -114,8 +114,9 @@ class ExtensionCommandsCommand(private val args: List<String>) {
     }
     val passthrough = args.withoutFirstPositionals(2)
     when (commandId) {
-      "atf-checks.run" -> A11yCommand(passthrough.withDefault("--json")).run()
-      "a11y-annotated-preview.render",
+      "atf-checks.run",
+      "a11y-annotated-preview.render" ->
+        A11yCommand(passthrough.withDefault("--json"), forceEnable = true).run()
       "scrolling-preview-annotation.render" -> ShowCommand(passthrough.withDefault("--json")).run()
       "a11y.hierarchy.get" ->
         DataCommand(passthrough.dataGet("a11y/hierarchy", defaultJson = true)).run()

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -47,7 +47,11 @@ class GradleConnection(
   fun lastTestFailures(): List<CapturedTestFailure> =
     synchronized(capturedTestFailures) { capturedTestFailures.toList() }
 
-  fun runTasks(vararg tasks: String, timeoutSeconds: Long = 300): Boolean {
+  fun runTasks(
+    vararg tasks: String,
+    timeoutSeconds: Long = 300,
+    arguments: List<String> = emptyList(),
+  ): Boolean {
     val tokenSource: CancellationTokenSource = GradleConnector.newCancellationTokenSource()
     val startTime = System.currentTimeMillis()
     val runningTasks = Collections.synchronizedSet(linkedSetOf<String>())
@@ -109,6 +113,9 @@ class GradleConnection(
     return try {
       val launcher =
         connection.newBuild().forTasks(*tasks).withCancellationToken(tokenSource.token())
+      if (arguments.isNotEmpty()) {
+        launcher.withArguments(arguments)
+      }
 
       if (verbose) {
         launcher.setStandardOutput(System.err)

--- a/skills/compose-preview-review/design/CI_PREVIEWS.md
+++ b/skills/compose-preview-review/design/CI_PREVIEWS.md
@@ -13,6 +13,33 @@ purposes:
 Both workflows ship from this repo as composite actions. Add two
 workflow files to your project; you're done.
 
+## Optional a11y overlay report
+
+Use `.github/actions/a11y-report` when you want a separate accessibility
+gallery. On pushes it renders with the built-in a11y hierarchy, ATF checks,
+and overlay annotation path enabled, then appends the annotated PNGs and
+`findings.json` to `compose-preview/a11y/main`. On pull requests it writes
+to `compose-preview/a11y/pr` and upserts a `<!-- a11y-report -->` comment.
+
+The action deliberately uses Gradle overrides instead of requiring every
+sample or app module to opt in permanently:
+
+```bash
+./gradlew ":samples:wear:renderAllPreviews" \
+  -PcomposePreview.previewExtensions.a11y.enableAllChecks=true \
+  -PcomposePreview.previewExtensions.a11y.annotateScreenshots=true
+```
+
+For local agent review outside CI, prefer the equivalent extension command:
+
+```bash
+compose-preview extensions run a11y-annotated-preview.render --module samples:wear --json
+```
+
+Then read `a11yAnnotatedPath` for the selected preview. A populated a11y
+baseline branch should contain `.a11y.png` files next to the clean PNGs; if
+the README only links clean PNGs, the a11y render path did not run.
+
 ## Workflow 1 — update baselines on push to `main`
 
 <!-- x-release-please-start-version -->

--- a/skills/compose-preview/SKILL.md
+++ b/skills/compose-preview/SKILL.md
@@ -61,6 +61,8 @@ Commands:
   list     List discovered previews
   render   Render previews; with --output copies a single match to disk
   a11y     Render previews and print ATF accessibility findings
+  extensions run a11y-annotated-preview.render
+           One-shot a11y hierarchy + ATF + annotated overlay render
   doctor   Verify Java 17+ + project compatibility (run before Setup)
 
 Options:

--- a/skills/compose-preview/design/A11Y.md
+++ b/skills/compose-preview/design/A11Y.md
@@ -41,9 +41,17 @@ PNG with numbered badges.
 compose-preview a11y                       # human-readable findings
 compose-preview a11y --json --changed-only # for re-render loops
 compose-preview a11y --fail-on errors      # non-zero on ERROR-level
+compose-preview extensions run a11y-annotated-preview.render --json
 ```
 
 JSON entries include `a11yFindings[]` (level/type/message/viewDescription)
 and `a11yAnnotatedPath`. Read the annotated PNG to map numbered badges back
 to findings. Trade-off: a11y mode disables the paused clock, so infinite
 animations tick during capture — toggle it off for animation-heavy previews.
+
+Use the `a11y-annotated-preview.render` extension command when you need a
+one-shot command that turns on the built-in a11y hierarchy, ATF checks, and
+overlay annotation path even if the module build script has not opted in.
+It passes the same Gradle overrides the CI report uses:
+`-PcomposePreview.previewExtensions.a11y.enableAllChecks=true` and
+`-PcomposePreview.previewExtensions.a11y.annotateScreenshots=true`.


### PR DESCRIPTION
## Summary

Restores annotated overlay PNGs on the `compose-preview/a11y/*` report branches and updates the agent-facing workflow docs.

- Switches the a11y report action from the stale `composePreview.accessibilityChecks.enabled` property to the current preview extension overrides: `composePreview.previewExtensions.a11y.enableAllChecks` and `composePreview.previewExtensions.a11y.annotateScreenshots`.
- Routes `compose-preview extensions run atf-checks.run` and `a11y-annotated-preview.render` through `A11yCommand` with those overrides, so agents have a one-shot command for a11y hierarchy + ATF + annotated overlays even when the module DSL is not opted in.
- Updates the compose-preview and compose-preview-review skills with the new a11y overlay/report command path.

## Validation

- `./gradlew :cli:ktfmtCheck :cli:test --tests ee.schimke.composeai.cli.ExtensionCommandsTest`
- `python3 .github/actions/lib/test_a11y_report.py`
- `./gradlew :samples:wear:renderAllPreviews -PcomposePreview.previewExtensions.a11y.enableAllChecks=true -PcomposePreview.previewExtensions.a11y.annotateScreenshots=true --no-daemon`
- `python3 .github/actions/lib/a11y-report.py copy-annotated --build-dir samples/wear/build/compose-previews --output-dir /private/tmp/a11y-report-check`

The sample render produced `accessibility.json` with 19 entries and 17 real annotated paths, and the report helper copied `.a11y.png` files including `BadWearButtonPreview`.