### PR TITLE
refactor: split build logic convention plugins

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -23,13 +23,13 @@ gradlePlugin {
       id = "composeai.jvm-conventions"
       implementationClass = "ee.schimke.composeai.buildlogic.ComposeAiJvmConventionsPlugin"
     }
+    register("composeAiKotlinConventions") {
+      id = "composeai.kotlin-conventions"
+      implementationClass = "ee.schimke.composeai.buildlogic.ComposeAiKotlinConventionsPlugin"
+    }
     register("composeAiMavenPublishing") {
       id = "composeai.maven-publishing"
       implementationClass = "ee.schimke.composeai.buildlogic.ComposeAiMavenPublishingPlugin"
-    }
-    register("composeAiTapmocConventions") {
-      id = "composeai.tapmoc-conventions"
-      implementationClass = "ee.schimke.composeai.buildlogic.ComposeAiTapmocConventionsPlugin"
     }
   }
 }

--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiAndroidConventionsPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiAndroidConventionsPlugin.kt
@@ -1,0 +1,43 @@
+package ee.schimke.composeai.buildlogic
+
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+
+class ComposeAiAndroidConventionsPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+    project.configureCommonAndroid()
+  }
+}
+
+private fun Project.configureCommonAndroid() {
+  pluginManager.withPlugin("com.android.library") {
+    extensions.configure<LibraryExtension> { configureLibraryDefaults() }
+  }
+  pluginManager.withPlugin("com.android.application") {
+    extensions.configure<ApplicationExtension> { configureApplicationDefaults() }
+  }
+}
+
+private fun LibraryExtension.configureLibraryDefaults() {
+  compileSdk = 36
+  defaultConfig { minSdk = 24 }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+  testOptions { unitTests { isIncludeAndroidResources = true } }
+}
+
+private fun ApplicationExtension.configureApplicationDefaults() {
+  compileSdk = 36
+  defaultConfig { minSdk = 24 }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+  }
+  testOptions { unitTests { isIncludeAndroidResources = true } }
+}

--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiJvmConventionsPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiJvmConventionsPlugin.kt
@@ -1,0 +1,24 @@
+package ee.schimke.composeai.buildlogic
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+
+class ComposeAiJvmConventionsPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+    project.configureCommonJvm()
+  }
+}
+
+private fun Project.configureCommonJvm() {
+  pluginManager.withPlugin("java") {
+    extensions.configure<JavaPluginExtension> {
+      toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
+    }
+    tasks.withType<Test>().configureEach { useJUnit() }
+  }
+}

--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiKotlinConventionsPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiKotlinConventionsPlugin.kt
@@ -1,0 +1,35 @@
+package ee.schimke.composeai.buildlogic
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+import tapmoc.TapmocExtension
+import tapmoc.configureKotlinCompatibility
+
+class ComposeAiKotlinConventionsPlugin : Plugin<Project> {
+  override fun apply(project: Project) {
+    project.configureCommonKotlin()
+  }
+}
+
+private fun Project.configureCommonKotlin() {
+  pluginManager.withPlugin("com.gradleup.tapmoc") {
+    val kotlinCoreLibraries =
+      extensions
+        .getByType<VersionCatalogsExtension>()
+        .named("libs")
+        .findVersion("kotlinCoreLibraries")
+        .get()
+        .requiredVersion
+
+    configureKotlinCompatibility(version = kotlinCoreLibraries)
+    tasks.withType<KotlinCompilationTask<*>>().configureEach {
+      compilerOptions.freeCompilerArgs.add("-Xsuppress-version-warnings")
+    }
+    extensions.configure<TapmocExtension> { checkDependencies() }
+  }
+}

--- a/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
+++ b/build-logic/src/main/kotlin/ee/schimke/composeai/buildlogic/ComposeAiMavenPublishingPlugin.kt
@@ -1,26 +1,14 @@
 package ee.schimke.composeai.buildlogic
 
-import com.android.build.api.dsl.ApplicationExtension
-import com.android.build.api.dsl.LibraryExtension
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import java.io.File
 import javax.inject.Inject
-import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.provider.Property
 import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.tasks.testing.Test
-import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.getByType
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-import tapmoc.TapmocExtension
-import tapmoc.configureKotlinCompatibility
 
 abstract class ComposeAiMavenPublishingExtension
 @Inject
@@ -41,7 +29,7 @@ class ComposeAiMavenPublishingPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     project.pluginManager.apply("composeai.android-conventions")
     project.pluginManager.apply("composeai.jvm-conventions")
-    project.pluginManager.apply("composeai.tapmoc-conventions")
+    project.pluginManager.apply("composeai.kotlin-conventions")
     project.pluginManager.apply("maven-publish")
     project.pluginManager.apply("com.vanniktech.maven.publish")
 
@@ -116,80 +104,6 @@ class ComposeAiMavenPublishingPlugin : Plugin<Project> {
         }
       }
     }
-  }
-}
-
-class ComposeAiAndroidConventionsPlugin : Plugin<Project> {
-  override fun apply(project: Project) {
-    project.configureCommonAndroid()
-  }
-}
-
-class ComposeAiJvmConventionsPlugin : Plugin<Project> {
-  override fun apply(project: Project) {
-    project.configureCommonJvm()
-  }
-}
-
-class ComposeAiTapmocConventionsPlugin : Plugin<Project> {
-  override fun apply(project: Project) {
-    project.configureTapmocCompatibility()
-  }
-}
-
-private fun Project.configureCommonAndroid() {
-  pluginManager.withPlugin("com.android.library") {
-    extensions.configure<LibraryExtension> { configureLibraryDefaults() }
-  }
-  pluginManager.withPlugin("com.android.application") {
-    extensions.configure<ApplicationExtension> { configureApplicationDefaults() }
-  }
-}
-
-private fun LibraryExtension.configureLibraryDefaults() {
-  compileSdk = 36
-  defaultConfig { minSdk = 24 }
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
-  testOptions { unitTests { isIncludeAndroidResources = true } }
-}
-
-private fun ApplicationExtension.configureApplicationDefaults() {
-  compileSdk = 36
-  defaultConfig { minSdk = 24 }
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-  }
-  testOptions { unitTests { isIncludeAndroidResources = true } }
-}
-
-private fun Project.configureCommonJvm() {
-  pluginManager.withPlugin("java") {
-    extensions.configure<JavaPluginExtension> {
-      toolchain { languageVersion.set(JavaLanguageVersion.of(17)) }
-    }
-    tasks.withType<Test>().configureEach { useJUnit() }
-  }
-}
-
-private fun Project.configureTapmocCompatibility() {
-  pluginManager.withPlugin("com.gradleup.tapmoc") {
-    val kotlinCoreLibraries =
-      extensions
-        .getByType<VersionCatalogsExtension>()
-        .named("libs")
-        .findVersion("kotlinCoreLibraries")
-        .get()
-        .requiredVersion
-
-    configureKotlinCompatibility(version = kotlinCoreLibraries)
-    tasks.withType<KotlinCompilationTask<*>>().configureEach {
-      compilerOptions.freeCompilerArgs.add("-Xsuppress-version-warnings")
-    }
-    extensions.configure<TapmocExtension> { checkDependencies() }
   }
 }
 


### PR DESCRIPTION
## Summary
- split the build-logic convention plugins into focused Android, JVM, Kotlin, and Maven publishing files
- keep Tapmoc as an implementation detail of the Kotlin convention rather than exposing it as a convention name
- leave existing plugin IDs and build behavior unchanged except for replacing the internal `composeai.tapmoc-conventions` wiring with `composeai.kotlin-conventions`

## Validation
- `./gradlew ktfmtCheckAll`
- `PLUGIN_VERSION=0.8.13-test-abcdef1-SNAPSHOT ORG_GRADLE_PROJECT_mavenCentralUsername=dummy ORG_GRADLE_PROJECT_mavenCentralPassword=dummy ./gradlew --dry-run :gradle-plugin:publishToMavenCentral :data-a11y-core:publishToMavenCentral :data-a11y-connector:publishToMavenCentral :data-fonts-core:publishToMavenCentral :data-fonts-connector:publishToMavenCentral :data-history-connector:publishToMavenCentral :data-layoutinspector-core:publishToMavenCentral :data-layoutinspector-connector:publishToMavenCentral :data-recomposition-connector:publishToMavenCentral :data-render-core:publishToMavenCentral :data-render-connector:publishToMavenCentral :data-resources-core:publishToMavenCentral :data-resources-connector:publishToMavenCentral :data-scroll-core:publishToMavenCentral :data-strings-core:publishToMavenCentral :data-strings-connector:publishToMavenCentral :data-theme-connector:publishToMavenCentral :renderer-android:publishToMavenCentral :preview-annotations:publishToMavenCentral :daemon:core:publishToMavenCentral :daemon:desktop:publishToMavenCentral :daemon:android:publishToMavenCentral`