### PR TITLE
Restore scroll extra previews in baselines

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -77,7 +77,14 @@ data class PreviewInfo(
   val dataProducts: List<PreviewDataProduct> = emptyList(),
 )
 
-@Serializable data class PreviewDataProduct(val kind: String, val output: String = "")
+@Serializable
+data class PreviewDataProduct(
+  val kind: String,
+  val output: String = "",
+  val mediaTypes: List<String> = emptyList(),
+  val advanceTimeMillis: Long? = null,
+  val scroll: ScrollCapture? = null,
+)
 
 @Serializable
 data class PreviewManifest(
@@ -415,7 +422,14 @@ abstract class Command(protected val args: List<String>) {
           } else {
             p.captures
           }
-        val captureResults = captures.mapIndexed { index, capture ->
+        val productCaptures = p.dataProducts.mapNotNull { it.asPreviewArtifactCapture() }
+        val resultCaptures =
+          if (captures.isSingleStaticCapture() && productCaptures.isNotEmpty()) {
+            productCaptures
+          } else {
+            captures + productCaptures
+          }
+        val captureResults = resultCaptures.mapIndexed { index, capture ->
           val pngFile =
             capture.renderOutput
               .takeIf { it.isNotEmpty() }
@@ -475,6 +489,19 @@ abstract class Command(protected val args: List<String>) {
   /** True if the preview has at least one capture with `changed = true`. */
   protected fun PreviewResult.anyChanged(): Boolean =
     captures.any { it.changed == true } || changed == true
+
+  private fun List<Capture>.isSingleStaticCapture(): Boolean =
+    size == 1 && single().advanceTimeMillis == null && single().scroll == null
+
+  private fun PreviewDataProduct.asPreviewArtifactCapture(): Capture? {
+    if (output.isBlank()) return null
+    val isImageOrAnimation =
+      mediaTypes.any { it.startsWith("image/") } ||
+        output.endsWith(".png") ||
+        output.endsWith(".gif")
+    if (!isImageOrAnimation) return null
+    return Capture(advanceTimeMillis = advanceTimeMillis, scroll = scroll, renderOutput = output)
+  }
 
   /**
    * Globs the on-disk `<stem>_<suffix>.<ext>` fan-out for a parameterized preview capture. The

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.cli
 
+import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -122,5 +123,57 @@ class PreviewListResponseTest {
     assertEquals("g", parsed.previews.single().params.group)
     // Default capture list is a single empty capture.
     assertEquals(1, parsed.previews.single().captures.size)
+  }
+
+  @Test
+  fun `scroll artifact data products surface as preview captures`() {
+    val projectDir = Files.createTempDirectory("preview-result-test").toFile()
+    val clean =
+      projectDir.resolve("build/compose-previews/renders/LongPreview.png").also {
+        it.parentFile.mkdirs()
+        it.writeBytes(byteArrayOf(1, 2, 3))
+      }
+    val long =
+      projectDir.resolve("build/compose-previews/data/render-scroll-long/LongPreview.png").also {
+        it.parentFile.mkdirs()
+        it.writeBytes(byteArrayOf(4, 5, 6))
+      }
+    val manifest =
+      PreviewManifest(
+        module = "app",
+        variant = "debug",
+        previews =
+          listOf(
+            PreviewInfo(
+              id = "com.example.LongPreview",
+              functionName = "LongPreview",
+              className = "com.example.PreviewsKt",
+              captures = listOf(Capture(renderOutput = "renders/${clean.name}")),
+              dataProducts =
+                listOf(
+                  PreviewDataProduct(
+                    kind = "render/scroll/long",
+                    output = "data/render-scroll-long/${long.name}",
+                    mediaTypes = listOf("image/png"),
+                    scroll = ScrollCapture(mode = "LONG"),
+                  )
+                ),
+            )
+          ),
+      )
+
+    val result = ResultHarness().results(PreviewModule("app", projectDir), manifest).single()
+
+    assertEquals(long.canonicalFile.absolutePath, result.pngPath)
+    assertEquals(1, result.captures.size)
+    assertEquals(long.canonicalFile.absolutePath, result.captures.single().pngPath)
+    assertEquals("LONG", result.captures.single().scroll?.mode)
+  }
+
+  private class ResultHarness : Command(emptyList()) {
+    override fun run() = Unit
+
+    fun results(module: PreviewModule, manifest: PreviewManifest): List<PreviewResult> =
+      buildResults(listOf(module to manifest))
   }
 }

--- a/skills/compose-preview-review/design/CI_PREVIEWS.md
+++ b/skills/compose-preview-review/design/CI_PREVIEWS.md
@@ -179,6 +179,12 @@ Or via raw URL:
 https://raw.githubusercontent.com/<owner>/<repo>/compose-preview/main/renders/<module>/<id>.png
 ```
 
+The composable baseline gallery includes suggested extra preview artifacts
+that the plugin emits as image data products, such as `@ScrollingPreview`
+LONG PNGs and GIFs. In CLI JSON these appear as extra `captures[]` rows
+with labels like `scroll long` or `scroll gif`, so baseline generation must
+consume every capture row rather than only the top-level `pngPath`.
+
 ## Branch durability
 
 Both `compose-preview/main` and `compose-preview/pr` are append-only:


### PR DESCRIPTION
## Summary

Follow-up to the preview branch comparison between `preview_main` and `compose-preview/main`.

- Surfaces rendered image/GIF data products as CLI `captures[]` rows so baseline generation can see suggested extra preview artifacts.
- For product-only `@ScrollingPreview(LONG/GIF)` previews, replaces the plain static capture row with the long PNG/GIF artifact, restoring the old baseline behavior where the gallery shows the actual extra preview.
- Documents that the preview workflow must consume every capture row, including `scroll long` / `scroll gif` rows, when generating `compose-preview/main`.

## Validation

- `./gradlew :cli:ktfmtCheck :cli:test --tests ee.schimke.composeai.cli.PreviewListResponseTest`
- `python3 .github/actions/lib/test_compare_previews.py`