### PR TITLE
Preserve static preview fallback for missing scroll artifacts

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -422,7 +422,7 @@ abstract class Command(protected val args: List<String>) {
           } else {
             p.captures
           }
-        val productCaptures = p.dataProducts.mapNotNull { it.asPreviewArtifactCapture() }
+        val productCaptures = p.dataProducts.mapNotNull { it.asPreviewArtifactCapture(module) }
         val resultCaptures =
           if (captures.isSingleStaticCapture() && productCaptures.isNotEmpty()) {
             productCaptures
@@ -493,13 +493,14 @@ abstract class Command(protected val args: List<String>) {
   private fun List<Capture>.isSingleStaticCapture(): Boolean =
     size == 1 && single().advanceTimeMillis == null && single().scroll == null
 
-  private fun PreviewDataProduct.asPreviewArtifactCapture(): Capture? {
+  private fun PreviewDataProduct.asPreviewArtifactCapture(module: PreviewModule): Capture? {
     if (output.isBlank()) return null
     val isImageOrAnimation =
       mediaTypes.any { it.startsWith("image/") } ||
         output.endsWith(".png") ||
         output.endsWith(".gif")
     if (!isImageOrAnimation) return null
+    if (!module.projectDir.resolve("build/compose-previews/$output").exists()) return null
     return Capture(advanceTimeMillis = advanceTimeMillis, scroll = scroll, renderOutput = output)
   }
 

--- a/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
+++ b/cli/src/test/kotlin/ee/schimke/composeai/cli/PreviewListResponseTest.kt
@@ -170,6 +170,46 @@ class PreviewListResponseTest {
     assertEquals("LONG", result.captures.single().scroll?.mode)
   }
 
+  @Test
+  fun `missing scroll artifact data products keep static preview capture`() {
+    val projectDir = Files.createTempDirectory("preview-result-test").toFile()
+    val clean =
+      projectDir.resolve("build/compose-previews/renders/LongPreview.png").also {
+        it.parentFile.mkdirs()
+        it.writeBytes(byteArrayOf(1, 2, 3))
+      }
+    val manifest =
+      PreviewManifest(
+        module = "app",
+        variant = "debug",
+        previews =
+          listOf(
+            PreviewInfo(
+              id = "com.example.LongPreview",
+              functionName = "LongPreview",
+              className = "com.example.PreviewsKt",
+              captures = listOf(Capture(renderOutput = "renders/${clean.name}")),
+              dataProducts =
+                listOf(
+                  PreviewDataProduct(
+                    kind = "render/scroll/long",
+                    output = "data/render-scroll-long/${clean.name}",
+                    mediaTypes = listOf("image/png"),
+                    scroll = ScrollCapture(mode = "LONG"),
+                  )
+                ),
+            )
+          ),
+      )
+
+    val result = ResultHarness().results(PreviewModule("app", projectDir), manifest).single()
+
+    assertEquals(clean.canonicalFile.absolutePath, result.pngPath)
+    assertEquals(1, result.captures.size)
+    assertEquals(clean.canonicalFile.absolutePath, result.captures.single().pngPath)
+    assertEquals(null, result.captures.single().scroll)
+  }
+
   private class ResultHarness : Command(emptyList()) {
     override fun run() = Unit
 


### PR DESCRIPTION
## Summary

Follow-up to #643.

- Only converts image/GIF data products into preview capture rows after the artifact exists on disk.
- Keeps the normal static capture when a heavy scroll artifact was skipped, such as fast-tier rendering.
- Adds regression coverage for the missing-artifact fallback.

## Validation

- `./gradlew :cli:ktfmtCheck :cli:test --tests ee.schimke.composeai.cli.PreviewListResponseTest`