### PR TITLE
Document scripted interactive preview feedback

### DIFF
--- a/docs/daemon/INTERACTIVE-ANDROID.md
+++ b/docs/daemon/INTERACTIVE-ANDROID.md
@@ -1,11 +1,9 @@
 # Interactive mode on Android (Robolectric) — v3 design
 
-> **Status:** design only. v2 ships click-into-composition for the
-> desktop backend (#406, #408, #409). Android continues to fall back to
-> the v1 stateless dispatch path; the panel surfaces the v1-fallback
-> hint via #431. This doc captures the architecture for Android v3
-> behind a sandbox-pinning approach, with concrete bridge changes and a
-> three-PR rollout. Companion to
+> **Status:** implemented for MCP scripted recordings and daemon
+> held-session plumbing. This doc captures the Android/Robolectric
+> architecture behind the sandbox-pinning approach and remains the design
+> background for the implementation. Companion to
 > [INTERACTIVE.md § 9](INTERACTIVE.md#9-v2--click-dispatch-into-composition)
 > (desktop v2) and INTERACTIVE.md § 9.10 (which originally punted
 > Android to v3 with a "see this doc" pointer once it lands).

--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -1,14 +1,16 @@
 # Interactive mode (VS Code panel ↔ daemon)
 
-> **Status:** v1 — live-streaming surface plus `interactive/start` /
-> `interactive/stop` / `interactive/input` RPCs in the daemon. The daemon is
-> enabled by default through `composePreview.daemon.enabled`. Click coordinates are
-> forwarded to the daemon as `interactive/input` notifications; today the
-> daemon treats each input as a render trigger (LocalInspectionMode is still
-> true, so the renderer doesn't yet dispatch the click into the composition —
-> that's the v2 follow-up). Frame deduplication ships in v1: bytes-identical
-> follow-up renders carry `renderFinished.unchanged: true`, the client
-> short-circuits, and history is not re-archived. See
+> **Status:** implemented for daemon and MCP scripted recording paths. The
+> daemon exposes `interactive/start` / `interactive/stop` /
+> `interactive/input` plus `recording/*` RPCs; MCP `record_preview` drives a
+> held scene, dispatches scripted pointer input into the composition, and
+> returns an APNG/MP4/WebM plus metadata. Android/Robolectric and desktop
+> backends can keep composition state alive across recorded clicks. The VS Code
+> panel still uses its live-preview UI path separately; use
+> [MCP.md](MCP.md#scripted-interaction-recordings) for agent-facing scripted
+> interactions. Frame deduplication remains part of the live stream:
+> bytes-identical follow-up renders carry `renderFinished.unchanged: true`, the
+> client short-circuits, and history is not re-archived. See
 > [PROTOCOL.md](PROTOCOL.md) for the wire contract this builds on.
 
 ## 1. What it is
@@ -31,10 +33,11 @@ is the **UI shell** that:
    sequence of independent reloads.
 3. Surfaces "daemon not ready for this module" cleanly: the toggle is
    disabled with a tooltip rather than failing silently.
-4. Captures mouse-click coordinates on the rendered image and **logs them
-   to the extension output channel** for now, so the wire shape is
-   exercised and the click-target geometry is debuggable before any
-   round-trip RPC ships.
+4. Captures mouse-click coordinates on the rendered image in image-natural
+   pixel space. The MCP `record_preview` path uses the same coordinate
+   contract to drive daemon-side pointer input; the VS Code panel path can
+   route through `interactive/input` when it needs click-into-composition
+   behavior.
 
 ## 2. Why daemon-only
 
@@ -187,9 +190,9 @@ The webview attaches a click handler to the focused card's `<img>`
 }
 ```
 
-Extension logs the message to the output channel. **No daemon call is
-issued today.** Once `interactive/input` lands (§ 7) the same payload
-shape feeds the RPC.
+The same payload shape feeds daemon-side pointer input. MCP
+`record_preview.events` uses this coordinate contract directly; VS Code panel
+traffic can forward it through `interactive/input` for live click dispatch.
 
 ## 8. Click-input RPC (v1)
 
@@ -277,7 +280,7 @@ multiple concurrent streams coexist. The dispatch flow inside `JsonRpcServer`:
    demuxes through the existing render-watcher thread back into
    `renderFinished`.
 
-### Open questions for the v2 protocol
+### Follow-up questions for richer input
 
 1. **Coalescing.** Should the daemon coalesce a burst of `pointerMove` into
    one render, or render every event? Today's frame budget says coalesce
@@ -287,15 +290,10 @@ multiple concurrent streams coexist. The dispatch flow inside `JsonRpcServer`:
    only needs to recompose; we can probably skip the
    `setQualifiers`/sandbox setup. Daemon-side optimisation, not visible
    on the wire.
-3. **Hit testing.** The renderer needs to know which composable received
-   the click. For PNG-only output this is "send pixel coords, let Compose
-   figure it out via its existing pointer-input pipeline." Works as long
-   as `LocalInspectionMode = false` during interactive renders — see
-   [DESIGN § 8](DESIGN.md) on the inspection-mode trade-off. v1 leaves
-   `LocalInspectionMode = true`, so today's "click triggers a re-render"
-   doesn't yet route the input into the composition; v2 flips the local
-   to false during interactive frames and dispatches the pixel coords
-   into the active `ImageComposeScene`.
+3. **Hit testing.** The renderer receives image-natural pixel coordinates
+   and lets Compose route them through its pointer-input pipeline. Keep this
+   contract for new clients instead of inventing a separate component-level
+   hit-test API.
 
 ## 8a. Display overrides
 
@@ -360,9 +358,9 @@ rather than mutating JVM-wide `Locale.setDefault(...)`:
 
 ## 9. v2 — click dispatch into composition
 
-> **Status:** design only. v1 ships the wire shape; v2 makes
-> `interactive/input` actually mutate the composition. No protocol
-> changes — the v1 wire format already carries everything v2 needs.
+> **Status:** implemented for held-session backends and MCP scripted
+> recordings. This section is retained as the design rationale for why click
+> dispatch requires a held composition.
 
 ### 9.1 Why v1 isn't enough
 

--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -144,12 +144,57 @@ Current tools:
 | `unsubscribe_preview_data(uri, kind)` | Drop a preview data-product subscription. | MCP/session only. |
 | `render_preview_overlay(uri, kind?, inline?, overrides?)` | Render a preview and return an annotated overlay image. | Good later CLI fit, probably as `data get --extra overlay --output`. |
 | `get_preview_extras(uri, kind)` | List non-JSON outputs produced alongside a data product. | Good later CLI fit once `data get` exists. |
-| `record_preview(uri, fps?, scale?, format?, events, overrides?)` | Record a scripted preview interaction to APNG/MP4/WebM. | High value but not simple; keep MCP-first for now. |
+| `record_preview(uri, fps?, scale?, format?, events, overrides?)` | Record a scripted preview interaction to APNG/MP4/WebM. | Agent-facing MCP path for click/scroll verification; keep CLI direct support as a follow-up. |
 
 Note: the daemon's render queue is still single-priority FIFO today, so
 `setVisible` / `setFocus` traffic flows through the wire but doesn't yet
 reorder the queue. The plumbing is in place for B2.5 / predictive
 prefetch ([PREDICTIVE.md](PREDICTIVE.md)) to start honouring focus.
+
+### Scripted interaction recordings
+
+Use `record_preview` when an agent needs to prove that a preview changes after
+input, capture an interaction artifact, or exercise a Wear/scroll/toggle flow.
+It drives the daemon's `recording/start` → `recording/script` →
+`recording/stop` → `recording/encode` sequence against a held scene, so
+Compose state can survive across scripted events.
+
+Typical agent flow:
+
+1. Install or verify the MCP server with `compose-preview mcp install --module
+   <module>` and `compose-preview mcp doctor --json`.
+2. Call `register_project` or start `mcp serve --project <root>`, then `watch`
+   the workspace/module of interest.
+3. Wait for `notifications/resources/list_changed`, then call
+   `resources/list`. Daemon discovery can still be warming up when `watch`
+   returns, especially on Android/Robolectric, so retry `resources/list` until
+   the target `compose-preview://...` URI appears.
+4. Call `record_preview` with image-natural pixel coordinates:
+
+```json
+{
+  "uri": "compose-preview://workspace/_samples_android/com.example.TogglePreview",
+  "fps": 12,
+  "format": "apng",
+  "events": [
+    { "tMs": 0, "kind": "click", "pixelX": 120, "pixelY": 80 },
+    { "tMs": 400, "kind": "click", "pixelX": 120, "pixelY": 80 }
+  ]
+}
+```
+
+On success the tool returns an inline media block plus a JSON metadata text
+block containing `recordingId`, `videoPath`, `mimeType`, `sizeBytes`,
+`frameCount`, `durationMs`, `framesDir`, `frameWidthPx`, and
+`frameHeightPx`. The raw PNG frames live at
+`<framesDir>/frame-00000.png`, `<framesDir>/frame-00001.png`, and so on, which
+is useful when a client cannot display APNG or wants to inspect individual
+frames.
+
+Sandbox note: Android recordings run through Robolectric. Restricted agent
+sandboxes must allow Robolectric to create its host cache/lock files, including
+`$HOME/.robolectric-download-lock`, or use a pre-warmed cache from an
+unrestricted run.
 
 ## CLI candidates from the MCP surface
 

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -2074,6 +2074,7 @@ class DaemonMcpServer(
           put("sizeBytes", encoded.sizeBytes)
           put("frameCount", stopResult.frameCount)
           put("durationMs", stopResult.durationMs)
+          put("framesDir", stopResult.framesDir)
           put("frameWidthPx", stopResult.frameWidthPx)
           put("frameHeightPx", stopResult.frameHeightPx)
         }

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -792,8 +792,8 @@ class DaemonMcpServerTest {
     //   2. The tool result carries an image content block (mimeType = image/apng) whose data
     //      decodes to the canned APNG bytes the fake daemon wrote.
     //   3. A sibling text block carries the metadata (recordingId, frameCount, durationMs,
-    //      sizeBytes) so an agent that prefers the path / metrics doesn't need to base64-decode
-    //      the bytes to find them.
+    //      framesDir, sizeBytes) so an agent that prefers the path / metrics doesn't need to
+    //      base64-decode the bytes to find them.
     //
     // The fake daemon doesn't actually render anything — its `recording/encode` handler writes
     // the pre-loaded bytes to a temp file and the MCP server reads them back. That's enough to
@@ -901,6 +901,8 @@ class DaemonMcpServerTest {
     assertThat(metadata["mimeType"]?.jsonPrimitive?.contentOrNull).isEqualTo("image/apng")
     assertThat(metadata["frameCount"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()).isEqualTo(16)
     assertThat(metadata["durationMs"]?.jsonPrimitive?.contentOrNull?.toLongOrNull()).isEqualTo(500L)
+    assertThat(metadata["framesDir"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("${recordingsDir.absolutePath}/frames")
     assertThat(metadata["frameWidthPx"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()).isEqualTo(240)
     assertThat(metadata["frameHeightPx"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()).isEqualTo(80)
     assertThat(metadata["sizeBytes"]?.jsonPrimitive?.contentOrNull?.toLongOrNull())


### PR DESCRIPTION
## Summary
- update interactive daemon docs to reflect held-session scripted recording support on Android/Robolectric and desktop
- document the agent-facing `record_preview` flow, discovery warm-up behavior, Robolectric sandbox caveat, and raw frame directory usage
- include `framesDir` in `record_preview` MCP metadata so agents can inspect raw frames without decoding APNG

Fixes part of #644.
Follow-ups filed: #652 for watch/discovery readiness and #653 for richer per-frame verification metadata.

## Testing
- `./gradlew ktfmtFormatAll :mcp:test`