### PR TITLE
Expose record_preview frame metadata

### DIFF
--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -25,10 +25,12 @@ import ee.schimke.composeai.mcp.protocol.ToolDef
 import ee.schimke.composeai.mcp.protocol.ToolsCapability
 import java.io.File
 import java.nio.file.Files
+import java.security.MessageDigest
 import java.time.Instant
 import java.util.Base64
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
+import javax.imageio.ImageIO
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -910,6 +912,10 @@ class DaemonMcpServer(
             "`rememberInfiniteTransition` advance with virtual time, not wall-clock — agents can " +
             "compose a multi-second timeline in milliseconds of agent latency and the video plays " +
             "back at human cadence. " +
+            "**Verification metadata.** The text metadata block includes `frames[]` with per-frame " +
+            "paths, SHA-256 hashes, and changed-pixel counts from the previous frame, plus " +
+            "`changedFrameCount` / first-last changed-frame paths so agents can assert that a " +
+            "click or scroll changed UI without decoding APNG/MP4/WebM bytes. " +
             "**Component previews.** Pass `overrides.{widthPx,heightPx,backgroundColor}` to record " +
             "a button-sized preview at native size with a custom background; raise `scale` to " +
             "upsample for legibility. Pointer coords always reference image-natural pixels, never " +
@@ -2065,6 +2071,7 @@ class DaemonMcpServer(
           daemon.client.recordingScript(recordingId, events)
         }
         val stopResult = daemon.client.recordingStop(recordingId)
+        val frameMetadata = inspectRecordingFrames(File(stopResult.framesDir))
         val encoded = daemon.client.recordingEncode(recordingId, format)
         val videoBytes = Files.readAllBytes(File(encoded.videoPath).toPath())
         val payload = buildJsonObject {
@@ -2076,6 +2083,38 @@ class DaemonMcpServer(
           put("durationMs", stopResult.durationMs)
           put("frameWidthPx", stopResult.frameWidthPx)
           put("frameHeightPx", stopResult.frameHeightPx)
+          put("framesDir", stopResult.framesDir)
+          put("changedFrameCount", frameMetadata.count { it.changedFromPrevious })
+          frameMetadata.firstOrNull()?.let { put("firstFramePath", it.path) }
+          frameMetadata.lastOrNull()?.let { put("lastFramePath", it.path) }
+          frameMetadata
+            .firstOrNull { it.changedFromPrevious }
+            ?.let {
+              put("firstChangedFramePath", it.path)
+              put("firstChangedFrameIndex", it.index)
+            }
+          frameMetadata
+            .lastOrNull { it.changedFromPrevious }
+            ?.let {
+              put("lastChangedFramePath", it.path)
+              put("lastChangedFrameIndex", it.index)
+            }
+          putJsonArray("frames") {
+            for (frame in frameMetadata) {
+              add(
+                buildJsonObject {
+                  put("index", frame.index)
+                  put("path", frame.path)
+                  put("sha256", frame.sha256)
+                  put("changedFromPrevious", frame.changedFromPrevious)
+                  frame.changedPixelsFromPrevious?.let { put("changedPixelsFromPrevious", it) }
+                  frame.dimensionChangedFromPrevious?.let {
+                    put("dimensionChangedFromPrevious", it)
+                  }
+                }
+              )
+            }
+          }
         }
         // Per the MCP 2025-06-18 spec, only `image/*` mimeTypes belong in `ContentBlock.Image`;
         // strict clients reject mismatches. APNG (`image/apng`) round-trips as an image; mp4 /
@@ -2098,6 +2137,83 @@ class DaemonMcpServer(
         CallToolResult(content = listOf(mediaBlock, ContentBlock.Text(payload.toString())))
       }
       .getOrElse { errorCallToolResult("record_preview failed: ${it.message}") }
+  }
+
+  private data class RecordingFrameMetadata(
+    val index: Int,
+    val path: String,
+    val sha256: String,
+    val changedFromPrevious: Boolean,
+    val changedPixelsFromPrevious: Int?,
+    val dimensionChangedFromPrevious: Boolean?,
+  )
+
+  private fun inspectRecordingFrames(framesDir: File): List<RecordingFrameMetadata> {
+    val frames =
+      framesDir
+        .listFiles { f -> f.isFile && f.extension.equals("png", ignoreCase = true) }
+        ?.sortedBy { it.name }
+        .orEmpty()
+    var previous: java.awt.image.BufferedImage? = null
+    return frames.mapIndexed { index, frame ->
+      val image = runCatching { ImageIO.read(frame) }.getOrNull()
+      val previousImage = previous
+      val changedPixels =
+        if (previousImage != null && image != null && sameDimensions(previousImage, image)) {
+          countChangedPixels(previousImage, image)
+        } else {
+          null
+        }
+      val dimensionChanged =
+        if (previousImage != null && image != null) !sameDimensions(previousImage, image) else null
+      val changedFromPrevious =
+        when {
+          index == 0 -> false
+          changedPixels != null -> changedPixels > 0
+          dimensionChanged == true -> true
+          else -> false
+        }
+      if (image != null) previous = image
+      RecordingFrameMetadata(
+        index = index,
+        path = frame.absolutePath,
+        sha256 = sha256Hex(frame),
+        changedFromPrevious = changedFromPrevious,
+        changedPixelsFromPrevious = changedPixels,
+        dimensionChangedFromPrevious = dimensionChanged,
+      )
+    }
+  }
+
+  private fun sameDimensions(
+    a: java.awt.image.BufferedImage,
+    b: java.awt.image.BufferedImage,
+  ): Boolean = a.width == b.width && a.height == b.height
+
+  private fun countChangedPixels(
+    a: java.awt.image.BufferedImage,
+    b: java.awt.image.BufferedImage,
+  ): Int {
+    var changed = 0
+    for (y in 0 until a.height) {
+      for (x in 0 until a.width) {
+        if (a.getRGB(x, y) != b.getRGB(x, y)) changed++
+      }
+    }
+    return changed
+  }
+
+  private fun sha256Hex(file: File): String {
+    val digest = MessageDigest.getInstance("SHA-256")
+    file.inputStream().buffered().use { input ->
+      val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+      while (true) {
+        val read = input.read(buffer)
+        if (read < 0) break
+        digest.update(buffer, 0, read)
+      }
+    }
+    return digest.digest().joinToString("") { "%02x".format(it) }
   }
 
   /**

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import ee.schimke.composeai.mcp.protocol.ListToolsResult
 import ee.schimke.composeai.mcp.protocol.ReadResourceResult
 import ee.schimke.composeai.mcp.protocol.ResourceContents
+import java.awt.image.BufferedImage
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
@@ -15,6 +16,7 @@ import java.util.Base64
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
+import javax.imageio.ImageIO
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -799,6 +801,10 @@ class DaemonMcpServerTest {
     // the pre-loaded bytes to a temp file and the MCP server reads them back. That's enough to
     // verify the wire flow without standing up a real Compose backend.
     val recordingsDir = tmp.newFolder("recordings-out")
+    val framesDir = tmp.newFolder("recording-frames")
+    writeSolidPng(framesDir.resolve("frame-00000.png"), 0xFF000000.toInt())
+    writeSolidPng(framesDir.resolve("frame-00001.png"), 0xFFFFFFFF.toInt())
+    writeSolidPng(framesDir.resolve("frame-00002.png"), 0xFFFFFFFF.toInt())
     val cannedApngBytes =
       // PNG signature + an arbitrary tail. The MCP server reads these verbatim; we don't decode.
       byteArrayOf(-119, 80, 78, 71, 13, 10, 26, 10, 0x01, 0x02, 0x03, 0x04, 0x05)
@@ -809,7 +815,7 @@ class DaemonMcpServerTest {
         ee.schimke.composeai.daemon.protocol.RecordingStopResult(
           frameCount = 16,
           durationMs = 500L,
-          framesDir = "${recordingsDir.absolutePath}/frames",
+          framesDir = framesDir.absolutePath,
           frameWidthPx = 240,
           frameHeightPx = 80,
         )
@@ -903,6 +909,45 @@ class DaemonMcpServerTest {
     assertThat(metadata["durationMs"]?.jsonPrimitive?.contentOrNull?.toLongOrNull()).isEqualTo(500L)
     assertThat(metadata["frameWidthPx"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()).isEqualTo(240)
     assertThat(metadata["frameHeightPx"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()).isEqualTo(80)
+    assertThat(metadata["framesDir"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo(framesDir.absolutePath)
+    assertThat(metadata["changedFrameCount"]?.jsonPrimitive?.contentOrNull?.toIntOrNull())
+      .isEqualTo(1)
+    assertThat(metadata["firstFramePath"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo(framesDir.resolve("frame-00000.png").absolutePath)
+    assertThat(metadata["lastFramePath"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo(framesDir.resolve("frame-00002.png").absolutePath)
+    assertThat(metadata["firstChangedFramePath"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo(framesDir.resolve("frame-00001.png").absolutePath)
+    assertThat(metadata["lastChangedFrameIndex"]?.jsonPrimitive?.contentOrNull?.toIntOrNull())
+      .isEqualTo(1)
+    val frames = metadata["frames"]!!.jsonArray
+    assertThat(frames).hasSize(3)
+    assertThat(frames[0].jsonObject["index"]?.jsonPrimitive?.contentOrNull?.toIntOrNull())
+      .isEqualTo(0)
+    assertThat(frames[0].jsonObject["sha256"]?.jsonPrimitive?.contentOrNull).hasLength(64)
+    assertThat(frames[0].jsonObject["changedFromPrevious"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("false")
+    assertThat(frames[1].jsonObject["changedFromPrevious"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("true")
+    assertThat(
+        frames[1]
+          .jsonObject["changedPixelsFromPrevious"]
+          ?.jsonPrimitive
+          ?.contentOrNull
+          ?.toIntOrNull()
+      )
+      .isEqualTo(4)
+    assertThat(frames[2].jsonObject["changedFromPrevious"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("false")
+    assertThat(
+        frames[2]
+          .jsonObject["changedPixelsFromPrevious"]
+          ?.jsonPrimitive
+          ?.contentOrNull
+          ?.toIntOrNull()
+      )
+      .isEqualTo(0)
     assertThat(metadata["sizeBytes"]?.jsonPrimitive?.contentOrNull?.toLongOrNull())
       .isEqualTo(cannedApngBytes.size.toLong())
   }
@@ -1912,6 +1957,16 @@ class DaemonMcpServerTest {
     // the fake responds and the spawn is recorded in factory.daemons.
     supervisor.daemonFor(workspaceId, modulePath)
     return factory.daemons.getValue(workspaceId to modulePath)
+  }
+
+  private fun writeSolidPng(file: java.io.File, argb: Int) {
+    val image = BufferedImage(2, 2, BufferedImage.TYPE_INT_ARGB)
+    for (y in 0 until image.height) {
+      for (x in 0 until image.width) {
+        image.setRGB(x, y, argb)
+      }
+    }
+    ImageIO.write(image, "png", file)
   }
 
   private fun pipedPair(): Pair<OutputStream, InputStream> {


### PR DESCRIPTION
## Summary

Fixes #653.

- Adds frame-level metadata to the `record_preview` text payload: frame paths, SHA-256 hashes, and changed-pixel counts from the previous frame.
- Adds aggregate verification fields such as `changedFrameCount`, first/last frame paths, and first/last changed frame indexes/paths.
- Documents the verification metadata in the `record_preview` tool description while keeping APNG/MP4/WebM media output unchanged.

## Validation

- `./gradlew :mcp:ktfmtCheck :mcp:test --tests ee.schimke.composeai.mcp.DaemonMcpServerTest`