### PR TITLE
fix: report MCP watch discovery readiness

### DIFF
--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -107,6 +107,15 @@ not two (set semantics in [`Subscriptions`](../../mcp/src/main/kotlin/ee/schimke
 `discoveryUpdated` (the daemon's "set of previews changed" signal) maps
 to `notifications/resources/list_changed`.
 
+`watch` is non-blocking by default: it records the area of interest and
+starts any matching daemons in the background. The tool response includes
+per-module readiness (`spawned`, `discoveryReady`, `previewCount`, and
+`retryAfterMs` when not ready), so agents can tell whether an immediate
+`resources/list` is expected to include discovered previews yet. Agents that
+need deterministic startup can call `watch(..., awaitDiscovery=true)`, which
+keeps the existing watch semantics but waits until matched daemon startup has
+completed its initial discovery pass before returning.
+
 `historyAdded` (a new history entry landed for a preview) also maps to
 `notifications/resources/list_changed` — the entry-set for that preview
 grew by one, and a subscriber filtering on the `compose-preview-history://`
@@ -130,7 +139,7 @@ Current tools:
 | `list_projects()` | List registered projects. | MCP lifecycle only. |
 | `list_devices()` | List the known `@Preview(device=...)` catalog with resolved geometry. | **Good CLI fit:** pure query, no daemon spawn needed. |
 | `render_preview(uri, overrides?)` | Force-render a preview, returning the PNG inline. | Partly covered by `render`; daemon-backed overrides are a larger follow-up. |
-| `watch(workspaceId, module?, fqnGlob?)` | Register an area of interest and keep matching previews warm. | MCP/session only. |
+| `watch(workspaceId, module?, fqnGlob?, awaitDiscovery?, awaitTimeoutMs?)` | Register an area of interest and keep matching previews warm. With `awaitDiscovery=true`, wait for matched daemon startup/initial discovery before returning readiness. | MCP/session only. |
 | `unwatch(workspaceId?, module?, fqnGlob?)` | Drop matching watches. | MCP/session only. |
 | `list_watches()` | List watches registered by the current session. | MCP/session only. |
 | `notify_file_changed(workspaceId, path, kind?, changeType?)` | Forward a file-edit notification to daemon(s). | MCP/session only; CLI already uses Gradle tasks for one-shot freshness. |

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -27,6 +27,7 @@ import java.io.File
 import java.nio.file.Files
 import java.time.Instant
 import java.util.Base64
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import kotlinx.serialization.json.Json
@@ -559,7 +560,9 @@ class DaemonMcpServer(
               "properties":{
                 "workspaceId":{"type":"string"},
                 "module":{"type":"string","description":"Optional Gradle module path; null = every module in the workspace."},
-                "fqnGlob":{"type":"string","description":"Optional FQN glob; '*' matches non-dot, '**' matches anything, '?' one non-dot char."}
+                "fqnGlob":{"type":"string","description":"Optional FQN glob; '*' matches non-dot, '**' matches anything, '?' one non-dot char."},
+                "awaitDiscovery":{"type":"boolean","description":"When true, block until every matched daemon has completed initial discovery, then return per-module readiness. Default false preserves non-blocking watch."},
+                "awaitTimeoutMs":{"type":"integer","description":"Maximum time to wait when awaitDiscovery=true. Defaults to the server render timeout."}
               },
               "required":["workspaceId"]
             }
@@ -1242,6 +1245,10 @@ class DaemonMcpServer(
         )
     val module = args["module"]?.jsonPrimitive?.contentOrNull
     val glob = args["fqnGlob"]?.jsonPrimitive?.contentOrNull
+    val awaitDiscovery =
+      args["awaitDiscovery"]?.jsonPrimitive?.contentOrNull?.toBooleanStrictOrNull() ?: false
+    val awaitTimeoutMs =
+      args["awaitTimeoutMs"]?.jsonPrimitive?.contentOrNull?.toLongOrNull() ?: renderTimeoutMs
     val entry = WatchEntry(workspaceId = workspaceId, modulePath = module, fqnGlobPattern = glob)
     subscriptions.watch(session, entry)
     // Eagerly spawn the daemons matching this watch so they begin emitting `discoveryUpdated`
@@ -1261,20 +1268,76 @@ class DaemonMcpServer(
     val toSpawnSet = toSpawn.toSet()
     val alreadySpawned = toSpawnSet.filter { project.daemons.containsKey(it) }
     val pending = toSpawnSet - alreadySpawned.toSet()
+    val pendingFutures = mutableMapOf<String, CompletableFuture<SupervisedDaemon>>()
     pending.forEach { mp ->
-      daemonLifecycleExecutor.execute {
-        runCatching { supervisor.daemonFor(workspaceId, mp) }
-          .onFailure { System.err.println("watch: async spawn failed for $mp: ${it.message}") }
-      }
+      pendingFutures[mp] =
+        CompletableFuture.supplyAsync(
+            { supervisor.daemonFor(workspaceId, mp) },
+            daemonLifecycleExecutor,
+          )
+          .whenComplete { _, error ->
+            if (error != null) {
+              System.err.println("watch: async spawn failed for $mp: ${error.message}")
+            }
+          }
     }
     // For daemons that are ALREADY up, recompute synchronously — the propagator skips daemons
     // whose URI set didn't change. The async spawns above will recompute themselves once their
     // initial discovery lands in `onDiscoveryUpdated`.
     alreadySpawned.forEach { mp -> project.daemons[mp]?.let { watchPropagator.recompute(it) } }
-    return textCallToolResult(
-      "watching $entry (already-up: ${alreadySpawned.size}, spawning: ${pending.size})"
-    )
+    if (awaitDiscovery && pendingFutures.isNotEmpty()) {
+      val deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(awaitTimeoutMs)
+      for ((mp, future) in pendingFutures) {
+        val remainingMs = TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime())
+        if (remainingMs <= 0) break
+        runCatching { future.get(remainingMs, TimeUnit.MILLISECONDS) }
+          .onFailure { System.err.println("watch: awaitDiscovery failed for $mp: ${it.message}") }
+      }
+    }
+    val readiness = watchReadiness(project, toSpawnSet)
+    val readyCount = readiness.count { it.discoveryReady }
+    val payload = buildJsonObject {
+      put("message", "watching $entry")
+      put("workspaceId", workspaceId.value)
+      module?.let { put("module", it) }
+      glob?.let { put("fqnGlob", it) }
+      put("awaitDiscovery", awaitDiscovery)
+      put("alreadyUp", alreadySpawned.size)
+      put("spawning", pending.size)
+      put("ready", readyCount == readiness.size)
+      put("readyModules", readyCount)
+      put("totalModules", readiness.size)
+      if (readyCount < readiness.size) put("retryAfterMs", WATCH_DISCOVERY_RETRY_AFTER_MS)
+      putJsonArray("modules") {
+        readiness.forEach { state ->
+          add(
+            buildJsonObject {
+              put("module", state.modulePath)
+              put("spawned", state.spawned)
+              put("discoveryReady", state.discoveryReady)
+              put("previewCount", state.previewCount)
+            }
+          )
+        }
+      }
+    }
+    return CallToolResult(content = listOf(ContentBlock.Text(payload.toString())))
   }
+
+  private fun watchReadiness(
+    project: RegisteredProject,
+    modulePaths: Set<String>,
+  ): List<WatchReadiness> =
+    modulePaths.sorted().map { mp ->
+      val daemon = project.daemons[mp]
+      val addr = DaemonAddr(project.workspaceId, mp)
+      WatchReadiness(
+        modulePath = mp,
+        spawned = daemon != null,
+        discoveryReady = daemon?.initialDiscoveryComplete == true,
+        previewCount = catalog[addr]?.size ?: 0,
+      )
+    }
 
   private fun toolUnwatch(session: McpSession, args: JsonObject): CallToolResult {
     val workspaceId = args["workspaceId"]?.jsonPrimitive?.contentOrNull?.let(::WorkspaceId)
@@ -2291,6 +2354,7 @@ class DaemonMcpServer(
   // -------------------------------------------------------------------------
 
   private fun onDiscoveryUpdated(daemon: SupervisedDaemon, params: JsonObject?) {
+    daemon.initialDiscoveryComplete = true
     val addr = DaemonAddr(daemon.workspaceId, daemon.modulePath)
     val byId = catalog.computeIfAbsent(addr) { ConcurrentHashMap() }
     val added = (params?.get("added") as? JsonArray)?.mapNotNull { it as? JsonObject }.orEmpty()
@@ -2590,6 +2654,13 @@ class DaemonMcpServer(
     val extras: JsonElement? = null,
   )
 
+  private data class WatchReadiness(
+    val modulePath: String,
+    val spawned: Boolean,
+    val discoveryReady: Boolean,
+    val previewCount: Int,
+  )
+
   private sealed interface RenderOutcome {
     data class Finished(val pngPath: String) : RenderOutcome
 
@@ -2663,6 +2734,9 @@ class DaemonMcpServer(
      * replica-spawn pool cap.
      */
     private const val DAEMON_LIFECYCLE_THREADS: Int = 4
+
+    /** Suggested delay before polling `watch(awaitDiscovery=false)` readiness again. */
+    private const val WATCH_DISCOVERY_RETRY_AFTER_MS: Long = 500
 
     /**
      * D2.1 — default `kind` for `render_preview_overlay` when the caller doesn't specify one.

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -196,37 +196,44 @@ class DaemonSupervisor(
     )
     supervised.attachSpawn(spawn)
     runCatching {
-      val result =
-        spawn.client.initialize(
-          workspaceRoot = project.path.absolutePath,
-          moduleId = descriptor.modulePath,
-          moduleProjectDir = descriptor.workingDirectory,
-          attachDataProducts = globalAttachDataProducts.takeIf { it.isNotEmpty() },
+        val result =
+          spawn.client.initialize(
+            workspaceRoot = project.path.absolutePath,
+            moduleId = descriptor.modulePath,
+            moduleProjectDir = descriptor.workingDirectory,
+            attachDataProducts = globalAttachDataProducts.takeIf { it.isNotEmpty() },
+          )
+        // D1 — surface the daemon's advertised data-product kinds so the MCP server's
+        // `list_data_products` tool can answer without a wire round-trip. Empty list on pre-D2
+        // daemons; the field is also `emptyList()` by default in [ServerCapabilities] so absent
+        // and `[]` collapse the same way client-side.
+        supervised.dataProductCapabilities = result.capabilities.dataProducts
+        // PROTOCOL.md § 3 — cache the daemon's advertised supportedOverrides + knownDevice ids so
+        // `DaemonMcpServer.toolRenderPreview` can validate inbound `overrides` against what this
+        // backend will actually apply (instead of silently no-op'ing fields the backend ignores)
+        // and
+        // reject typo'd `device` ids before they fall back to the default. Pre-feature daemons
+        // advertise `[]` for both, in which case validation falls open — clients are exactly where
+        // they were before the capability landed.
+        supervised.supportedOverrides = result.capabilities.supportedOverrides.toSet()
+        supervised.knownDeviceIds = result.capabilities.knownDevices.map { it.id }.toSet()
+        supervised.backendKind = result.capabilities.backend
+        // RECORDING.md § "encoded formats" — same pattern. Empty list pre-feature; validation falls
+        // open and `record_preview` calls round-trip without the diagnostic.
+        supervised.recordingFormats = result.capabilities.recordingFormats.toSet()
+        // The daemon only emits `discoveryUpdated` for *deltas* — the initial preview set comes
+        // via `initialize.manifest.path` (a `previews.json` written by the gradle plugin's
+        // `discoverPreviews` task). Synthesise an initial `discoveryUpdated` notification by
+        // reading that file and dispatching it through the router as if it were a wire-level
+        // event.
+        synthesiseInitialDiscovery(supervised, result.manifest.path)
+        supervised.initialDiscoveryComplete = true
+      }
+      .onFailure { e ->
+        System.err.println(
+          "daemon initialize failed for ${project.workspaceId}/${descriptor.modulePath}: ${e.message}"
         )
-      // D1 — surface the daemon's advertised data-product kinds so the MCP server's
-      // `list_data_products` tool can answer without a wire round-trip. Empty list on pre-D2
-      // daemons; the field is also `emptyList()` by default in [ServerCapabilities] so absent
-      // and `[]` collapse the same way client-side.
-      supervised.dataProductCapabilities = result.capabilities.dataProducts
-      // PROTOCOL.md § 3 — cache the daemon's advertised supportedOverrides + knownDevice ids so
-      // `DaemonMcpServer.toolRenderPreview` can validate inbound `overrides` against what this
-      // backend will actually apply (instead of silently no-op'ing fields the backend ignores) and
-      // reject typo'd `device` ids before they fall back to the default. Pre-feature daemons
-      // advertise `[]` for both, in which case validation falls open — clients are exactly where
-      // they were before the capability landed.
-      supervised.supportedOverrides = result.capabilities.supportedOverrides.toSet()
-      supervised.knownDeviceIds = result.capabilities.knownDevices.map { it.id }.toSet()
-      supervised.backendKind = result.capabilities.backend
-      // RECORDING.md § "encoded formats" — same pattern. Empty list pre-feature; validation falls
-      // open and `record_preview` calls round-trip without the diagnostic.
-      supervised.recordingFormats = result.capabilities.recordingFormats.toSet()
-      // The daemon only emits `discoveryUpdated` for *deltas* — the initial preview set comes
-      // via `initialize.manifest.path` (a `previews.json` written by the gradle plugin's
-      // `discoverPreviews` task). Synthesise an initial `discoveryUpdated` notification by
-      // reading that file and dispatching it through the router as if it were a wire-level
-      // event.
-      synthesiseInitialDiscovery(supervised, result.manifest.path)
-    }
+      }
 
     return supervised
   }
@@ -298,6 +305,16 @@ class SupervisedDaemon(val workspaceId: WorkspaceId, val modulePath: String) {
    * caller thread reads this through [client] / [allClients] without external synchronisation.
    */
   @Volatile private var spawn: DaemonSpawn? = null
+
+  /**
+   * True once the supervisor has completed the initialize round-trip and attempted to seed the MCP
+   * catalog from the daemon's initial manifest. A daemon can be discovery-complete with zero
+   * previews; clients should pair this flag with the MCP catalog's preview count rather than
+   * treating an empty resource list as "still warming".
+   */
+  @Volatile
+  var initialDiscoveryComplete: Boolean = false
+    internal set
 
   /**
    * D1 — kinds the daemon advertised via `initialize.capabilities.dataProducts`. Populated by

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -208,11 +208,60 @@ class DaemonMcpServerTest {
         },
       )
     assertThat(watchResp.firstTextContent()).contains("watching")
+    val watchPayload = json.parseToJsonElement(watchResp.firstTextContent()).jsonObject
+    assertThat(watchPayload["ready"]?.jsonPrimitive?.contentOrNull).isEqualTo("true")
+    val moduleState = watchPayload["modules"]!!.jsonArray.single().jsonObject
+    assertThat(moduleState["discoveryReady"]?.jsonPrimitive?.contentOrNull).isEqualTo("true")
+    assertThat(moduleState["previewCount"]?.jsonPrimitive?.contentOrNull?.toInt()).isEqualTo(2)
 
     val visible = daemon.visibleSets.poll(2_000, TimeUnit.MILLISECONDS)
     val focus = daemon.focusSets.poll(2_000, TimeUnit.MILLISECONDS)
     assertThat(visible).isEqualTo(listOf("com.example.Red"))
     assertThat(focus).isEqualTo(listOf("com.example.Red"))
+  }
+
+  @Test
+  fun `watch awaitDiscovery waits for daemon startup and reports readiness`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val register =
+      client.callTool(
+        "register_project",
+        buildJsonObject {
+          put("path", projectDir.absolutePath)
+          put("rootProjectName", "demo")
+          putJsonArray("modules") { add(JsonPrimitive(":module")) }
+        },
+      )
+    val workspaceId =
+      WorkspaceId(
+        json
+          .parseToJsonElement(register.firstTextContent())
+          .jsonObject["workspaceId"]!!
+          .jsonPrimitive
+          .content
+      )
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val watchResp =
+      client.callTool(
+        "watch",
+        buildJsonObject {
+          put("workspaceId", workspaceId.value)
+          put("awaitDiscovery", true)
+        },
+      )
+    val payload = json.parseToJsonElement(watchResp.firstTextContent()).jsonObject
+    assertThat(payload["awaitDiscovery"]?.jsonPrimitive?.contentOrNull).isEqualTo("true")
+    assertThat(payload["ready"]?.jsonPrimitive?.contentOrNull).isEqualTo("true")
+    assertThat(payload["spawning"]?.jsonPrimitive?.contentOrNull?.toInt()).isEqualTo(1)
+    val moduleState = payload["modules"]!!.jsonArray.single().jsonObject
+    assertThat(moduleState["module"]?.jsonPrimitive?.contentOrNull).isEqualTo(":module")
+    assertThat(moduleState["spawned"]?.jsonPrimitive?.contentOrNull).isEqualTo("true")
+    assertThat(moduleState["discoveryReady"]?.jsonPrimitive?.contentOrNull).isEqualTo("true")
+    assertThat(moduleState["previewCount"]?.jsonPrimitive?.contentOrNull?.toInt()).isEqualTo(0)
+    assertThat(factory.spawnHistory).hasSize(1)
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Add `awaitDiscovery` / `awaitTimeoutMs` to the MCP `watch` tool while preserving the default non-blocking behavior.
- Return structured watch readiness JSON with per-module `spawned`, `discoveryReady`, and `previewCount` fields plus retry hints when discovery is still pending.
- Track initial daemon discovery completion separately from preview count so empty modules can still report ready.
- Document the updated agent flow in `docs/daemon/MCP.md`.

Fixes #652.

## Validation
- `./gradlew :mcp:test --tests ee.schimke.composeai.mcp.DaemonMcpServerTest`
- `./gradlew :mcp:test`