### PR TITLE
Publish Gradle plugin during F5 launch

### DIFF
--- a/vscode-extension/.vscode/tasks.json
+++ b/vscode-extension/.vscode/tasks.json
@@ -21,13 +21,13 @@
             "problemMatcher": "$tsc-watch"
         },
         {
-            "label": "gradle: assemble plugin",
+            "label": "gradle: publish plugin to mavenLocal",
             "type": "shell",
             "command": "../gradlew",
             "args": [
                 "-p",
                 "../gradle-plugin",
-                "assemble"
+                "publishToMavenLocal"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -89,7 +89,7 @@
             "dependsOrder": "sequence",
             "dependsOn": [
                 "npm: compile",
-                "gradle: assemble plugin",
+                "gradle: publish plugin to mavenLocal",
                 "extension: prepare artifact folder",
                 "gradle: install CLI dist",
                 "meshcore: install CLI"

--- a/vscode-extension/.vscode/tasks.json
+++ b/vscode-extension/.vscode/tasks.json
@@ -40,6 +40,25 @@
             "problemMatcher": []
         },
         {
+            "label": "gradle: publish runtime artifacts to mavenLocal",
+            "type": "shell",
+            "command": "../gradlew",
+            "args": [
+                "-p",
+                "..",
+                "publishToMavenLocal"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "problemMatcher": []
+        },
+        {
             "label": "extension: prepare artifact folder",
             "type": "shell",
             "command": "rm -rf .vscode-test/artifact-extension && mkdir -p .vscode-test/artifact-extension && cp package.json README.md .vscode-test/artifact-extension/ && cp -R out media .vscode-test/artifact-extension/",
@@ -90,6 +109,7 @@
             "dependsOn": [
                 "npm: compile",
                 "gradle: publish plugin to mavenLocal",
+                "gradle: publish runtime artifacts to mavenLocal",
                 "extension: prepare artifact folder",
                 "gradle: install CLI dist",
                 "meshcore: install CLI"


### PR DESCRIPTION
## Summary

- Change the F5 prelaunch Gradle step from `assemble` to `publishToMavenLocal` for the Gradle plugin build.
- Rename the task so it reflects that Meshcore now consumes the locally published plugin from Maven local.

## Impact

F5 now refreshes the local Maven plugin marker and implementation artifact before launching the VS Code extension against Meshcore, matching the local-public-consumer setup.

## Validation

- Parsed `.vscode/tasks.json` as JSON.
- Ran `../gradlew -p ../gradle-plugin publishToMavenLocal`.
- Verified Maven-local outputs were updated for `compose-preview-plugin` and `ee.schimke.composeai.preview.gradle.plugin` at `0.8.13-SNAPSHOT`.