### PR TITLE
feat(vscode): gate early focus features

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -91,7 +91,8 @@
             {
                 "command": "composePreview.diffAllVsMain",
                 "title": "Diff All Previews vs Main",
-                "category": "Compose Preview"
+                "category": "Compose Preview",
+                "enablement": "config.composePreview.earlyFeatures.enabled"
             },
             {
                 "command": "composePreview.launchOnDevice",
@@ -137,6 +138,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "When on, the panel auto-subscribes to a11y data products (`a11y/atf` for diagnostic squigglies, `a11y/hierarchy` for the local overlay) for every visible preview in daemon mode — diagnostics fire ambient without entering focus mode. Off (the default) keeps the focus-mode 'Show accessibility overlay' button as the only opt-in. The producer side must also be enabled with the Gradle preview extension (`composePreview { previewExtensions { a11y { enableAllChecks() } } }` or the matching `-PcomposePreview.previewExtensions.a11y.*` properties); when the daemon advertises no a11y kinds this setting has no effect."
+                },
+                "composePreview.earlyFeatures.enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Enable early, unstable preview features in the VS Code panel, including focus-mode diffs, focus inspector extension layers, a11y overlay controls, recording, and diff-all commands. Focus mode and live interactive previews remain available when this is off."
                 },
                 "composePreview.logging.level": {
                     "type": "string",

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -170,6 +170,12 @@ let warnedJdkImageThisSession = false;
 const SETUP_DOCS_URL = 'https://github.com/yschimke/compose-ai-tools/tree/main/vscode-extension#readme';
 const JDK_DOCS_URL = 'https://github.com/yschimke/compose-ai-tools/blob/main/docs/AGENTS.md#important-constraints';
 
+function earlyFeaturesEnabled(): boolean {
+    return vscode.workspace
+        .getConfiguration('composePreview')
+        .get<boolean>('earlyFeatures.enabled', false);
+}
+
 /**
  * Show the remediation notification for a detected JdkImageError. The offered
  * "Open JDK setting" action reveals `java.import.gradle.java.home` — the
@@ -484,6 +490,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     panel = new PreviewPanel(
         context.extensionUri,
         handleWebviewMessage,
+        () => earlyFeaturesEnabled(),
     );
     if (isTestMode) {
         // Tap into every outgoing webview message so the test API can assert
@@ -690,6 +697,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     void gradleService.bootstrapAppliedMarkers();
 
     context.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration((event) => {
+            if (event.affectsConfiguration('composePreview.earlyFeatures.enabled')) {
+                panel?.postMessage({
+                    command: 'setEarlyFeatures',
+                    enabled: earlyFeaturesEnabled(),
+                });
+            }
+        }),
         vscode.window.onDidChangeActiveTextEditor(editor => {
             if (editor?.document.languageId === 'kotlin') {
                 const filePath = editor.document.uri.fsPath;
@@ -2529,7 +2544,9 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             void openSourceByFileName(msg.fileName, msg.line, msg.className);
             break;
         case 'requestPreviewDiff':
-            void runLivePreviewDiff(msg.previewId, msg.against);
+            if (earlyFeaturesEnabled()) {
+                void runLivePreviewDiff(msg.previewId, msg.against);
+            }
             break;
         case 'requestLaunchOnDevice':
             if (msg.previewId) {
@@ -2540,7 +2557,9 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             queueInteractiveMutation(msg.previewId, msg.enabled);
             break;
         case 'setRecording':
-            queueRecordingMutation(msg.previewId, msg.enabled, msg.format ?? 'apng');
+            if (earlyFeaturesEnabled()) {
+                queueRecordingMutation(msg.previewId, msg.enabled, msg.format ?? 'apng');
+            }
             break;
         case 'recordInteractiveInput':
             logLine(
@@ -2552,7 +2571,9 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             void forwardRecordingInput(msg);
             break;
         case 'setA11yOverlay':
-            void handleSetA11yOverlay(msg.previewId, msg.enabled);
+            if (earlyFeaturesEnabled()) {
+                void handleSetA11yOverlay(msg.previewId, msg.enabled);
+            }
             break;
     }
 }
@@ -2684,6 +2705,7 @@ async function runLivePreviewDiff(
     previewId: string,
     against: 'head' | 'main',
 ): Promise<void> {
+    if (!earlyFeaturesEnabled()) { return; }
     if (!panel || !historySource) { return; }
     const moduleId = previewModuleMap.get(previewId);
     const manifest = moduleId ? moduleManifestCache.get(moduleId) : undefined;
@@ -2981,6 +3003,12 @@ async function resolveLaunchPreview(
 }
 
 async function diffAllVsMain(): Promise<void> {
+    if (!earlyFeaturesEnabled()) {
+        vscode.window.showInformationMessage(
+            'Compose Preview: enable composePreview.earlyFeatures.enabled to use Diff All vs Main.',
+        );
+        return;
+    }
     if (!gradleService || !panel || !historySource) {
         vscode.window.showInformationMessage('Compose Preview is not ready yet.');
         return;

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -7,15 +7,18 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
     private view?: vscode.WebviewView;
     private extensionUri: vscode.Uri;
     private onMessage: (msg: WebviewToExtension) => void;
+    private earlyFeaturesEnabled: () => boolean;
     private shouldRestoreVisibility: () => boolean;
 
     constructor(
         extensionUri: vscode.Uri,
         onMessage: (msg: WebviewToExtension) => void,
+        earlyFeaturesEnabled: () => boolean = () => false,
         shouldRestoreVisibility: () => boolean = () => false,
     ) {
         this.extensionUri = extensionUri;
         this.onMessage = onMessage;
+        this.earlyFeaturesEnabled = earlyFeaturesEnabled;
         this.shouldRestoreVisibility = shouldRestoreVisibility;
     }
 
@@ -45,6 +48,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 
     private getHtml(webview: vscode.Webview): string {
         const nonce = getNonce();
+        const earlyFeaturesEnabled = this.earlyFeaturesEnabled();
         const styleUri = webview.asWebviewUri(
             vscode.Uri.joinPath(this.extensionUri, 'media', 'preview.css'),
         );
@@ -151,6 +155,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
     (function() {
         const vscode = acquireVsCodeApi();
         const state = vscode.getState() || { filters: {} };
+        let earlyFeaturesEnabled = ${earlyFeaturesEnabled ? 'true' : 'false'};
 
         const grid = document.getElementById('preview-grid');
         const focusInspector = document.getElementById('focus-inspector');
@@ -405,6 +410,17 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         // declarations below are hoisted, so call sites above this block
         // resolve fine.
 
+        function applyEarlyFeatureVisibility() {
+            btnDiffHead.hidden = !earlyFeaturesEnabled;
+            btnDiffMain.hidden = !earlyFeaturesEnabled;
+            btnA11yOverlay.hidden = !earlyFeaturesEnabled || layoutMode.value !== 'focus';
+            btnRecording.hidden = !earlyFeaturesEnabled || layoutMode.value !== 'focus';
+            recordingFormat.hidden = !earlyFeaturesEnabled || layoutMode.value !== 'focus';
+            if (!earlyFeaturesEnabled) {
+                focusInspector.hidden = true;
+            }
+        }
+
         function isFocusedDaemonReady() {
             // The webview doesn't know moduleId per preview today. We fall
             // back to "any module ready" because the extension-side panel
@@ -481,9 +497,9 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 
         function applyRecordingButtonState() {
             const inFocus = layoutMode.value === 'focus';
-            btnRecording.hidden = !inFocus;
-            recordingFormat.hidden = !inFocus;
-            if (!inFocus) {
+            btnRecording.hidden = !earlyFeaturesEnabled || !inFocus;
+            recordingFormat.hidden = !earlyFeaturesEnabled || !inFocus;
+            if (!earlyFeaturesEnabled || !inFocus) {
                 btnRecording.setAttribute('aria-pressed', 'false');
                 btnRecording.classList.remove('recording-on');
                 recordingFormat.disabled = true;
@@ -510,8 +526,8 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         // tracks whether the currently focused preview has the overlay subscription on.
         function applyA11yOverlayButtonState() {
             const inFocus = layoutMode.value === 'focus';
-            btnA11yOverlay.hidden = !inFocus;
-            if (!inFocus) {
+            btnA11yOverlay.hidden = !earlyFeaturesEnabled || !inFocus;
+            if (!earlyFeaturesEnabled || !inFocus) {
                 btnA11yOverlay.setAttribute('aria-pressed', 'false');
                 return;
             }
@@ -530,6 +546,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         // tears down immediately rather than waiting for a next render. When turning ON for a
         // different preview, first turn the previous one off so the wire stays clean.
         function toggleA11yOverlay() {
+            if (!earlyFeaturesEnabled) return;
             if (layoutMode.value !== 'focus') return;
             const card = getVisibleCards()[focusIndex];
             const previewId = card ? card.dataset.previewId : null;
@@ -670,6 +687,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         }
 
         function toggleRecording() {
+            if (!earlyFeaturesEnabled) return;
             if (layoutMode.value !== 'focus') return;
             const card = getVisibleCards()[focusIndex];
             const previewId = card ? card.dataset.previewId : null;
@@ -1036,17 +1054,20 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                 const visible = getVisibleCards();
                 const card = mode === 'focus' ? visible[focusIndex] : null;
                 if (!card || card.dataset.previewId !== a11yOverlayPreviewId) {
-                    vscode.postMessage({
-                        command: 'setA11yOverlay',
-                        previewId: a11yOverlayPreviewId,
-                        enabled: false,
-                    });
+                    if (earlyFeaturesEnabled) {
+                        vscode.postMessage({
+                            command: 'setA11yOverlay',
+                            previewId: a11yOverlayPreviewId,
+                            enabled: false,
+                        });
+                    }
                     a11yOverlayPreviewId = null;
                 }
             }
             applyInteractiveButtonState();
             applyRecordingButtonState();
             applyA11yOverlayButtonState();
+            applyEarlyFeatureVisibility();
         }
 
         // Compute the focus-mode previewId. History is intentionally focus-only:
@@ -1104,8 +1125,8 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 
         function renderFocusInspector(card) {
             focusInspector.innerHTML = '';
-            focusInspector.hidden = !card;
-            if (!card) return;
+            focusInspector.hidden = !earlyFeaturesEnabled || !card;
+            if (!earlyFeaturesEnabled || !card) return;
             const previewId = card.dataset.previewId;
             const p = allPreviews.find(pp => pp.id === previewId);
             if (!previewId || !p) return;
@@ -1355,6 +1376,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         // resolve the comparison anchor (HEAD = latest archived render,
         // main = latest archived render on the main branch).
         function requestFocusedDiff(against) {
+            if (!earlyFeaturesEnabled) return;
             if (layoutMode.value !== 'focus') return;
             const visible = getVisibleCards();
             const card = visible[focusIndex];
@@ -2507,7 +2529,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             // the new render without clicking — symmetric with the
             // compose-preview/main ref watcher's auto-refresh on the right anchor.
             const openDiff = container.querySelector('.preview-diff-overlay');
-            if (openDiff) {
+            if (earlyFeaturesEnabled && openDiff) {
                 const against = openDiff.dataset.against;
                 if (against === 'head' || against === 'main') {
                     showDiffOverlay(card, against, null, null);
@@ -2946,6 +2968,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     break;
 
                 case 'previewDiffReady': {
+                    if (!earlyFeaturesEnabled) break;
                     const card = document.getElementById('preview-' + sanitizeId(msg.previewId));
                     if (!card) break;
                     showDiffOverlay(card, msg.against, {
@@ -2957,12 +2980,14 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     break;
                 }
                 case 'previewDiffError': {
+                    if (!earlyFeaturesEnabled) break;
                     const card = document.getElementById('preview-' + sanitizeId(msg.previewId));
                     if (!card) break;
                     showDiffOverlay(card, msg.against, null, msg.message || 'Diff unavailable.');
                     break;
                 }
                 case 'focusAndDiff': {
+                    if (!earlyFeaturesEnabled) break;
                     const card = document.getElementById('preview-' + sanitizeId(msg.previewId));
                     if (!card) break;
                     focusOnCard(card);
@@ -3021,6 +3046,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                     break;
                 }
                 case 'previewMainRefChanged': {
+                    if (!earlyFeaturesEnabled) break;
                     // compose-preview/main moved — re-issue any open vs-main
                     // diff overlay so the user sees the new bytes without
                     // clicking. Other diffs (HEAD, current, previous) are
@@ -3038,6 +3064,34 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
                             against: 'main',
                         });
                     });
+                    break;
+                }
+                case 'setEarlyFeatures': {
+                    earlyFeaturesEnabled = !!msg.enabled;
+                    if (!earlyFeaturesEnabled) {
+                        document.querySelectorAll('.preview-diff-overlay').forEach(overlay => overlay.remove());
+                        enabledFocusProducts.clear();
+                        if (a11yOverlayPreviewId) {
+                            vscode.postMessage({
+                                command: 'setA11yOverlay',
+                                previewId: a11yOverlayPreviewId,
+                                enabled: false,
+                            });
+                            a11yOverlayPreviewId = null;
+                        }
+                        if (recordingPreviewIds.size > 0) {
+                            recordingPreviewIds.forEach(previewId => {
+                                vscode.postMessage({
+                                    command: 'setRecording',
+                                    previewId,
+                                    enabled: false,
+                                    format: recordingFormat.value,
+                                });
+                            });
+                            recordingPreviewIds.clear();
+                        }
+                    }
+                    applyLayout();
                     break;
                 }
             }

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -464,7 +464,8 @@ export type ExtensionToWebview =
      * race the extension's flush). See INTERACTIVE.md § 3.
      */
     | { command: 'clearInteractive'; previewId?: string }
-    | { command: 'clearRecording'; previewId?: string };
+    | { command: 'clearRecording'; previewId?: string }
+    | { command: 'setEarlyFeatures'; enabled: boolean };
 
 /** Messages from webview to extension */
 export type WebviewToExtension =


### PR DESCRIPTION
## Summary
- add `composePreview.earlyFeatures.enabled`, defaulting to false
- keep focus mode and live interactive previews available by default
- hide/guard focus-mode diffs, focus inspector extension layers, a11y overlay controls, recording, and Diff All vs Main behind the early-features flag
- update the webview when the setting changes without requiring a reload

## Validation
- `npm --prefix vscode-extension test`