### PR TITLE
Document agent data product audits

### DIFF
--- a/docs/daemon/DATA-PRODUCT-DOC-WORKPLAN.md
+++ b/docs/daemon/DATA-PRODUCT-DOC-WORKPLAN.md
@@ -1,0 +1,142 @@
+# Data-product documentation workplan
+
+This is the repo-internal brief for splitting data-product documentation work
+across implementation agents. User-facing review guidance belongs in the
+`compose-preview` and `compose-preview-review` skill references; this document
+is for contributors changing compose-ai-tools itself.
+
+## Common brief
+
+Goal: make every preview data product understandable to both humans and
+agents. Humans need a stable product contract on GitHub; agents using the
+tooling need compact recipes that say when to request each product, how to
+combine it with others, and what evidence is strong enough to cite in a PR
+review.
+
+Before splitting work, read the common contract template in
+[DATA-PRODUCTS.md § Documenting a kind](./DATA-PRODUCTS.md#documenting-a-kind).
+
+Shared rules for every implementation agent:
+
+- Keep CI and PR workflows intact: previews, resources, accessibility, and
+  other review evidence should stay available through agent/MCP workflows even
+  when CLI-facing configuration is reduced.
+- Separate contract docs from agent heuristics. Human docs should not need to
+  read like agent prompts; skill references should not duplicate every schema
+  field.
+- For each product, document availability, platform constraints, cost, schema
+  shape, media type or transport, failure/unavailable behavior, and at least
+  one realistic example.
+- Name companion products explicitly. For example, an `a11y/atf` warning is
+  easier to review with `a11y/overlay`, `compose/semantics`, and
+  `text/strings`.
+- Avoid overclaiming from one product. Prefer phrasing such as "the ATF
+  product reports..." or "the screenshot shows..." when the evidence is
+  tool-specific.
+
+## Documentation levels
+
+Human-facing GitHub docs should define the durable contract:
+
+- Product name, version, producer, and consuming workflows.
+- Supported targets, preview modes, daemon requirements, and graceful
+  degradation when unavailable.
+- Schema fields, correlation keys, binary attachments, and example payloads.
+- Privacy/security notes for strings, resources, fonts, traces, and screenshots.
+- Relationships between products, especially products that are easy to confuse.
+
+Agent-facing skill references should stay operational:
+
+- Which products to request for a review task.
+- Product combinations that give stronger evidence than any single product.
+- Audit checklists, fallback behavior, and wording guidance for PR comments.
+- Known platform traps, such as Wear clipping, locale fallback, and desktop vs
+  Android accessibility differences.
+
+Issue bodies should be implementation work orders:
+
+- Scope, acceptance criteria, example payloads, and tests.
+- Links to the human contract section and any agent recipe that will consume
+  the product.
+- Open questions that need a design decision before implementation.
+
+## Data-product issue clusters
+
+### 1. Accessibility and semantics
+
+Issues:
+[#597](https://github.com/yschimke/compose-ai-tools/issues/597),
+[#598](https://github.com/yschimke/compose-ai-tools/issues/598),
+[#599](https://github.com/yschimke/compose-ai-tools/issues/599),
+[#600](https://github.com/yschimke/compose-ai-tools/issues/600),
+[#601](https://github.com/yschimke/compose-ai-tools/issues/601),
+[#480](https://github.com/yschimke/compose-ai-tools/issues/480).
+
+This agent should define the accessibility stack: ATF findings,
+accessibility hierarchy, touch targets, annotated overlays, and raw Compose
+semantics. The important split is raw evidence vs reviewer conclusions. The
+human docs should say what each product reports; the agent docs should say how
+to combine products to check visible text, semantics labels, roles, target
+sizes, and new regressions.
+
+### 2. Text, localisation, resources, and fonts
+
+Issues:
+[#604](https://github.com/yschimke/compose-ai-tools/issues/604),
+[#605](https://github.com/yschimke/compose-ai-tools/issues/605),
+[#606](https://github.com/yschimke/compose-ai-tools/issues/606),
+[#609](https://github.com/yschimke/compose-ai-tools/issues/609),
+[#450](https://github.com/yschimke/compose-ai-tools/issues/450),
+[#451](https://github.com/yschimke/compose-ai-tools/issues/451).
+
+This agent should document how rendered strings connect back to resource
+usage, translation coverage, locale selection, and font resolution. The
+highest-value agent recipe is a localisation audit: render or request preview
+variants in target locales, compare visible strings with `text/strings`, check
+`i18n/translations` for missing or fallback translations, and cite
+`resources/used` when a wrong resource is selected.
+
+### 3. Layout, Wear, and visual geometry
+
+Issues:
+[#612](https://github.com/yschimke/compose-ai-tools/issues/612),
+[#611](https://github.com/yschimke/compose-ai-tools/issues/611),
+[#610](https://github.com/yschimke/compose-ai-tools/issues/610),
+[#447](https://github.com/yschimke/compose-ai-tools/issues/447),
+[#454](https://github.com/yschimke/compose-ai-tools/issues/454),
+[#645](https://github.com/yschimke/compose-ai-tools/issues/645).
+
+This agent should connect layout inspection, device clipping, changed regions,
+and static capture behavior. Wear deserves explicit coverage: round displays,
+safe areas, clipped top/bottom content, TransformingLazyColumn behavior, and
+edge buttons that can be visually present but partly outside the useful bounds.
+
+### 4. Theme, performance, and runtime traces
+
+Issues:
+[#603](https://github.com/yschimke/compose-ai-tools/issues/603),
+[#602](https://github.com/yschimke/compose-ai-tools/issues/602),
+[#607](https://github.com/yschimke/compose-ai-tools/issues/607),
+[#608](https://github.com/yschimke/compose-ai-tools/issues/608),
+[#585](https://github.com/yschimke/compose-ai-tools/issues/585),
+[#586](https://github.com/yschimke/compose-ai-tools/issues/586),
+[#449](https://github.com/yschimke/compose-ai-tools/issues/449),
+[#452](https://github.com/yschimke/compose-ai-tools/issues/452).
+
+This agent should document design-system and runtime diagnostics: theme
+tokens, recomposition, Compose AI traces, generic render traces, and shared
+preview context. The agent guidance should explain when these products support
+PR review directly, and when they are mainly triage evidence for a follow-up
+issue.
+
+### 5. Product surface, protocol, and failure handling
+
+Issues:
+[#641](https://github.com/yschimke/compose-ai-tools/issues/641),
+[#568](https://github.com/yschimke/compose-ai-tools/issues/568),
+[#455](https://github.com/yschimke/compose-ai-tools/issues/455).
+
+This agent should keep the catalogue coherent across human docs, MCP flows,
+and the reduced CLI surface. It owns naming, discovery, versioning,
+unavailable-product responses, and how test or render failures are surfaced to
+reviewers without requiring CLI-only configuration.

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -137,6 +137,61 @@ A producer picks one transport per kind, advertised in capabilities. A
 producer MAY support both `inline` and `path`; the caller picks via
 the `inline` flag on `data/fetch`.
 
+## Documenting a kind
+
+Every data product added to the catalogue should have a human-facing contract
+that follows the same shape. Keep this section stable enough that individual
+product issues can point at it instead of restating the whole contract.
+
+Template:
+
+```markdown
+### `<namespace/name>`
+
+Status: proposed | shipped | deprecated
+Producer: renderer-android | renderer-desktop | daemon | Gradle task
+Mode: default | a11y | instrumented | live | failed render
+Cost: low | medium | high
+Transport: inline | path | inline-or-path | extra-only
+Schema version: 1
+Platforms: Android | Desktop | Wear | shared
+Availability: fetch | subscribe | global attach | on-disk CLI | failed-render only
+Companion products: `kind/a`, `kind/b`
+
+Purpose:
+
+- What question this product answers for a human or agent.
+- What it deliberately does not answer.
+
+Payload:
+
+- Field names, types, units, coordinate space, and stable identifiers.
+- Correlation keys back to preview ids, source refs, nodes, resources, or
+  screenshot regions.
+- Redaction, privacy, and truncation behavior.
+
+Extras:
+
+- Any derived files, media types, and lifecycle.
+
+Failure and unavailable behavior:
+
+- When callers get `DataProductUnknown`, `DataProductNotAvailable`,
+  `DataProductFetchFailed`, or a partial payload.
+- Whether a missing payload is a product bug, a disabled producer, or a normal
+  platform limitation.
+
+Examples:
+
+- One small JSON payload.
+- One review sentence an agent could write from the payload.
+```
+
+Human-facing docs should explain the stable contract above. Agent-facing skill
+docs should not duplicate the full schema; they should explain when to request
+the product, which companion products improve the evidence, and how to word a
+PR comment without overstating what the product proves.
+
 ### Image processors and extras
 
 A kind's primary payload is JSON or a JSON-shaped path. Some producers

--- a/skills/compose-preview-review/SKILL.md
+++ b/skills/compose-preview-review/SKILL.md
@@ -67,6 +67,7 @@ Pick the workflow that matches the task:
 | Path | When to read |
 |---|---|
 | [design/AGENT_PR.md](./design/AGENT_PR.md) | Full PR review + agent PR authoring guidance: comment structure, image hosting choices, things to flag, integration with `preview-comment` CI when present. |
+| [design/AGENT_AUDITS.md](./design/AGENT_AUDITS.md) | Agent audit recipes and data-product documentation clusters: accessibility, localisation, Wear clipping, resources, theme, traces, and failure triage. |
 | [design/CI_PREVIEWS.md](./design/CI_PREVIEWS.md) | `compose-preview/main` baselines branch + PR-comment GitHub Actions: workflow YAML, action inputs, branch durability. |
 | [design/MCP_REVIEW.md](./design/MCP_REVIEW.md) | Driving a PR review through the MCP server (two-workspace base+head flow, push notifications, edit-on-top iteration). |
 

--- a/skills/compose-preview-review/design/AGENT_AUDITS.md
+++ b/skills/compose-preview-review/design/AGENT_AUDITS.md
@@ -1,0 +1,100 @@
+# Agent PR audits
+
+Use this reference when reviewing a Compose app PR with compose-ai-tools and a
+focused audit is needed beyond the basic before/after screenshot diff. Keep
+comments evidence-based: cite the preview, locale/device when relevant, and the
+data product or screenshot that supports the finding.
+
+### Accessibility audit
+
+Sample command: `compose-preview a11y --filter <screen> --json --fail-on warnings`
+
+Check:
+
+- No new ATF warnings or errors on the changed preview.
+- Visible text is readable and consistent with the semantics.
+- Labels, roles, actions, and state descriptions make sense for assistive
+  technology.
+- Touch target warnings are real regressions, not hidden decorative nodes.
+
+### Localisation audit
+
+Sample command: `render_preview uri=<preview-uri> overrides.localeTag=fr-FR`
+
+Check:
+
+- Representative locales render the expected translated copy.
+- Missing translations and accidental fallbacks are named concretely.
+- Locale-specific resources are selected where expected.
+- Long translated strings remain visible and do not overlap adjacent content.
+
+### Wear and round-device audit
+
+Sample command: `get_preview_data uri=<wear-preview-uri> kind=render/deviceClip`
+
+Check:
+
+- TransformingLazyColumn (TLC) content is not clipped at the top or bottom in
+  the initial captured state.
+- Text bounds and controls stay inside the useful circular area.
+- Edge buttons are fully visible, tappable, and not hidden by system chrome.
+- Scrollable content does not rely on a first or last item that is only
+  partially visible.
+
+### Text overflow and readability audit
+
+Sample command: `get_preview_data uri=<preview-uri> kind=text/strings`
+
+Check:
+
+- Long labels, numbers, and dynamic strings remain legible.
+- Text does not overlap icons, controls, or neighboring text.
+- Important content is not only present in semantics while visually clipped.
+- Font fallback or weight changes are intentional.
+
+### Resource and theme provenance audit
+
+Sample command: `get_preview_data uri=<preview-uri> kind=resources/used`
+
+Check:
+
+- Colors, typography, dimensions, strings, images, and fonts come from the
+  expected resources or theme tokens.
+- Dark mode, dynamic color, and preview-local overrides do not accidentally
+  hide content.
+- Changed resources map to visible preview changes, or the absence of visual
+  change is explained.
+
+### Visual regression and changed-region audit
+
+Sample command: `compose-preview show --filter <screen> --json --changed-only`
+
+Check:
+
+- Changed regions match the intended UI area.
+- Unexpected changed pixels are explained by animation, rendering variance, or
+  a real regression.
+- New or removed previews are called out separately from changed previews.
+
+### Runtime and recomposition audit
+
+Sample command: `get_preview_data uri=<preview-uri> kind=compose/recomposition`
+
+Check:
+
+- A preview does not become unexpectedly slow or noisy to render.
+- Recomposition changes are tied to the relevant component.
+- Trace output is treated as triage evidence unless the PR explicitly targets
+  runtime behavior.
+
+### Failure triage audit
+
+Sample command: `get_preview_data uri=<preview-uri> kind=test/failure`
+
+Check:
+
+- The failure is reported with the preview id, target, and shortest useful
+  error.
+- Unavailable data products are distinguished from failing previews.
+- Follow-up issues are raised for infrastructure or schema gaps that are too
+  complex to fix inside the reviewed PR.

--- a/skills/compose-preview/design/DATA_PRODUCTS.md
+++ b/skills/compose-preview/design/DATA_PRODUCTS.md
@@ -23,6 +23,25 @@ Two surfaces:
 The full kind catalogue, per-kind schemas, transports, and re-render
 cost notes live in
 [`docs/daemon/DATA-PRODUCTS.md`](../../../docs/daemon/DATA-PRODUCTS.md).
+That daemon doc is the human-facing contract. This skill keeps only the
+agent-facing review guidance: which evidence is useful, how to combine it, and
+how much confidence it supports.
+
+## Agent evidence conventions
+
+- Prefer combinations over single-product conclusions. For example, pair
+  `a11y/atf` with `a11y/overlay`, `compose/semantics`, and `text/strings`;
+  pair `i18n/translations` with `resources/used` and a locale screenshot.
+- Distinguish visible output from semantic output. Screenshots and
+  `text/strings` describe what the user sees; `compose/semantics` and
+  `a11y/hierarchy` describe assistive-technology intent.
+- Cite evidence precisely: product kind, preview id, locale/device when
+  relevant, and screenshot or extra path when available.
+- Treat unavailable products as review context, not proof that the UI is
+  correct.
+- Use
+  [`compose-preview-review/design/AGENT_AUDITS.md`](../../compose-preview-review/design/AGENT_AUDITS.md)
+  for focused app-review checklists.
 
 ## Enabling a kind
 


### PR DESCRIPTION
## Goal
Create shared documentation inputs for the data-product documentation work, while keeping the compose-preview review skill focused on agents reviewing downstream Compose apps. Also make the MCP install path cover Antigravity directly.

## What changed
- Added `docs/daemon/DATA-PRODUCT-DOC-WORKPLAN.md` as the repo-internal common brief, documentation-level split, and five issue clusters for future data-product documentation work.
- Added a reusable per-kind documentation template to `docs/daemon/DATA-PRODUCTS.md` so product-specific issues can share one contract shape.
- Added tight agent evidence conventions to `skills/compose-preview/design/DATA_PRODUCTS.md`.
- Added `skills/compose-preview-review/design/AGENT_AUDITS.md` as a compact downstream app-review checklist for accessibility, localisation, Wear/TLC clipping, text overflow, resources/theme, visual regression, runtime, and failure triage, with one sample command per audit.
- Added `compose-preview mcp install --antigravity`, which writes `~/.gemini/antigravity/mcp_config.json` using an absolute `compose-preview` launcher path and the resolved absolute project path.
- Updated MCP setup docs to default `--project` from the current project root.

## Verification
- `./gradlew :cli:ktfmtFormatMain`
- `./gradlew :cli:compileKotlin`
- `git diff --check HEAD~1 HEAD`