### PR TITLE
Surface Gradle access failures in CLI diagnostics

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/Commands.kt
@@ -284,6 +284,17 @@ abstract class Command(protected val args: List<String>) {
       // any custom `project.projectDir` override.
       val one = gradle.findPreviewModule(explicitModule)
       if (one == null) {
+        gradle.lastModelAccessFailure?.let {
+          System.err.println(
+            "Could not query Gradle project model while resolving module '$explicitModule'."
+          )
+          System.err.println("Gradle ${it.operation} failed: ${it.message}")
+          it.detail?.let { detail -> System.err.println("Caused by: $detail") }
+          System.err.println(
+            "Check Gradle wrapper/cache access, then rerun with --verbose for full output."
+          )
+          exitProcess(1)
+        }
         System.err.println(
           "Module '$explicitModule' not found or does not apply the compose-ai-tools plugin."
         )
@@ -294,6 +305,15 @@ abstract class Command(protected val args: List<String>) {
 
     val modules = gradle.findPreviewModules()
     if (modules.isEmpty()) {
+      gradle.lastModelAccessFailure?.let {
+        System.err.println("Could not query Gradle project model.")
+        System.err.println("Gradle ${it.operation} failed: ${it.message}")
+        it.detail?.let { detail -> System.err.println("Caused by: $detail") }
+        System.err.println(
+          "Check Gradle wrapper/cache access, then rerun with --verbose for full output."
+        )
+        exitProcess(1)
+      }
       System.err.println("No modules with compose-ai-tools plugin found.")
       System.err.println("Apply the plugin: id(\"ee.schimke.composeai.preview\")")
       exitProcess(1)

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/DoctorCommand.kt
@@ -291,6 +291,7 @@ class DoctorCommand(args: List<String>) {
   private var daemonJavaMajor: Int? = null
 
   private fun runProjectChecks(projectDir: File) {
+    var gradleAccessFailure: GradleAccessFailure? = null
     val model =
       try {
         GradleConnection(projectDir, verbose = verbose).use { gc ->
@@ -298,7 +299,9 @@ class DoctorCommand(args: List<String>) {
           // project-scope checks can compare against the daemon's JDK
           // (e.g. flagging test worker mismatch in #142).
           checkGradleDaemon(gc)
-          gc.runBuildAction(GatherComposePreviewModelAction())
+          gc.runBuildAction(GatherComposePreviewModelAction()).also {
+            gradleAccessFailure = gc.lastModelAccessFailure
+          }
         }
       } catch (e: Exception) {
         addCheck(
@@ -317,7 +320,51 @@ class DoctorCommand(args: List<String>) {
         return
       }
 
-    if (model == null || model.modules.isEmpty()) {
+    if (model == null) {
+      gradleAccessFailure?.let {
+        addCheck(
+          DoctorCheck(
+            id = "project.gradle-access",
+            category = "project",
+            status = "error",
+            message = "could not query Gradle project model",
+            detail =
+              "Gradle ${it.operation} failed: ${it.message}" +
+                (it.detail?.let { d -> " Caused by: $d" } ?: ""),
+            remediation =
+              DoctorRemediation(
+                summary =
+                  "Ensure the CLI can access the Gradle wrapper, distribution cache, and lock files, then rerun doctor.",
+                commands = listOf("./gradlew help"),
+              ),
+          )
+        )
+        addCheck(
+          DoctorCheck(
+            id = "project.plugin-applied",
+            category = "project",
+            status = "skipped",
+            message = "plugin application check skipped because Gradle model access failed",
+          )
+        )
+        return
+      }
+      addCheck(
+        DoctorCheck(
+          id = "project.model",
+          category = "project",
+          status = "error",
+          message = "could not fetch plugin Tooling model",
+          remediation =
+            DoctorRemediation(
+              summary = "Ensure the project builds (`./gradlew help`) and the plugin is applied."
+            ),
+        )
+      )
+      return
+    }
+
+    if (model.modules.isEmpty()) {
       addCheck(
         DoctorCheck(
           id = "project.plugin-applied",

--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/GradleConnector.kt
@@ -28,6 +28,12 @@ import org.gradle.tooling.events.test.TestOperationDescriptor
  */
 data class PreviewModule(val gradlePath: String, val projectDir: File)
 
+data class GradleAccessFailure(
+  val operation: String,
+  val message: String,
+  val detail: String? = null,
+)
+
 class GradleConnection(
   private val projectDir: File,
   private val verbose: Boolean,
@@ -35,6 +41,10 @@ class GradleConnection(
 ) : AutoCloseable {
   private val connector = GradleConnector.newConnector().forProjectDirectory(projectDir)
   private val connection = connector.connect()
+  private var modelAccessFailure: GradleAccessFailure? = null
+
+  val lastModelAccessFailure: GradleAccessFailure?
+    get() = modelAccessFailure
 
   private val capturedTestFailures =
     Collections.synchronizedList(mutableListOf<CapturedTestFailure>())
@@ -312,10 +322,13 @@ class GradleConnection(
           }
         }
         .run()
+        .also { modelAccessFailure = null }
     } catch (e: org.gradle.tooling.GradleConnectionException) {
+      recordModelAccessFailure("BuildAction", e)
       if (verbose) System.err.println("Gradle connection failed: ${e.message}")
       null
     } catch (e: org.gradle.tooling.BuildException) {
+      recordModelAccessFailure("BuildAction", e)
       if (verbose) System.err.println("Build action failed: ${e.message}")
       null
     } finally {
@@ -331,8 +344,11 @@ class GradleConnection(
    */
   fun buildEnvironment(): org.gradle.tooling.model.build.BuildEnvironment? {
     return try {
-      connection.model(org.gradle.tooling.model.build.BuildEnvironment::class.java).get()
+      connection.model(org.gradle.tooling.model.build.BuildEnvironment::class.java).get().also {
+        modelAccessFailure = null
+      }
     } catch (e: Exception) {
+      recordModelAccessFailure("BuildEnvironment", e)
       if (verbose) System.err.println("Could not query BuildEnvironment: ${e.message}")
       null
     }
@@ -352,6 +368,7 @@ class GradleConnection(
   fun findPreviewModules(): List<PreviewModule> {
     return try {
       val model = connection.model(org.gradle.tooling.model.GradleProject::class.java).get()
+      modelAccessFailure = null
       val modules = mutableListOf<PreviewModule>()
       fun visit(project: org.gradle.tooling.model.GradleProject) {
         val hasPreviewTask = project.tasks.any { it.name == "discoverPreviews" }
@@ -366,6 +383,7 @@ class GradleConnection(
       visit(model)
       modules
     } catch (e: Exception) {
+      recordModelAccessFailure("GradleProject", e)
       if (verbose) System.err.println("Could not query project model: ${e.message}")
       emptyList()
     }
@@ -385,6 +403,16 @@ class GradleConnection(
   override fun close() {
     connection.close()
   }
+
+  private fun recordModelAccessFailure(operation: String, error: Throwable) {
+    val messages = error.causeMessages()
+    modelAccessFailure =
+      GradleAccessFailure(
+        operation = operation,
+        message = messages.firstOrNull() ?: error::class.java.simpleName,
+        detail = messages.drop(1).takeIf { it.isNotEmpty() }?.joinToString(" -> "),
+      )
+  }
 }
 
 private object NullOutputStream : OutputStream() {
@@ -393,4 +421,14 @@ private object NullOutputStream : OutputStream() {
   override fun write(b: ByteArray) {}
 
   override fun write(b: ByteArray, off: Int, len: Int) {}
+}
+
+private fun Throwable.causeMessages(): List<String> {
+  val messages = mutableListOf<String>()
+  var cause: Throwable? = this
+  while (cause != null) {
+    cause.message?.takeIf { it.isNotBlank() && it !in messages }?.let(messages::add)
+    cause = cause.cause
+  }
+  return messages
 }


### PR DESCRIPTION
## Summary

Fixes #661.

This changes CLI Gradle model lookup diagnostics so Tooling API access failures are not flattened into missing-plugin or missing-module errors.

## What changed

- Record the last Gradle model access failure in `GradleConnection` for BuildAction, BuildEnvironment, and GradleProject queries.
- Make `doctor --json` report `project.gradle-access` when the plugin model cannot be queried because Gradle access failed.
- Mark `project.plugin-applied` as skipped when Gradle model access failed, instead of reporting that no modules apply the plugin.
- Make module resolution commands report the Gradle project model failure for `--module ...` instead of saying the module is missing or does not apply the plugin.

## Validation

- `./gradlew :cli:test`
- `./gradlew :cli:run --args='--module :samples:wear list --json --brief --timeout 30'`
- Simulated bad Gradle cache access with an invalid `GRADLE_USER_HOME`; verified `doctor --json` emits `project.gradle-access` and `list --module` prints the Gradle model access failure.