### PR TITLE
Use Kotlin MCP SDK server

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,7 @@ wear-compose-remote = "1.0.0-alpha02"
 compose-ui-prerelease = "1.11.0"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.11.0"
+mcp-kotlin-sdk = "0.11.1"
 junit = "4.13.2"
 truth = "1.4.5"
 maven-publish = "0.36.0"
@@ -118,6 +119,7 @@ wear-protolayout-material3 = { module = "androidx.wear.protolayout:protolayout-m
 wear-protolayout-expression = { module = "androidx.wear.protolayout:protolayout-expression", version.ref = "wear-protolayout" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+mcp-kotlin-sdk-server = { module = "io.modelcontextprotocol:kotlin-sdk-server", version.ref = "mcp-kotlin-sdk" }
 ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version = "1.59.0" }

--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -44,6 +44,7 @@ tasks.named<Tar>("distTar") {
 dependencies {
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.kotlinx.serialization.json)
+  implementation(libs.mcp.kotlin.sdk.server)
   // For DaemonClasspathDescriptor (read at supervisor spawn time) and the protocol message types
   // exchanged with daemon JVMs.
   implementation(project(":daemon:core"))
@@ -52,13 +53,6 @@ dependencies {
   testImplementation(libs.truth)
   testImplementation(libs.kotlinx.coroutines.core)
 }
-
-// We deliberately do NOT depend on `io.modelcontextprotocol:kotlin-sdk` in v0:
-// - The SDK auto-registers internal handlers for `resources/list` / `resources/read` / `subscribe`,
-//   making the dynamic catalog + push subscription model we need awkward to bolt on.
-// - Rolling our own keeps the wire layer self-contained, mirrors the proven
-//   `:daemon:core` `JsonRpcServer` framing, and removes a 0.x-version-pin risk.
-// - The SDK can be reintroduced as a non-breaking internal refactor once the surface stabilises.
 
 tasks.withType<Test>().configureEach {
   // Opt-in real-mode: `-Pmcp.real=true` flips the JUnit `Assume` gate in

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -13,16 +13,11 @@ import ee.schimke.composeai.data.render.pipeline.PreviewExtensionCommandCatalog
 import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
 import ee.schimke.composeai.mcp.protocol.CallToolResult
 import ee.schimke.composeai.mcp.protocol.ContentBlock
-import ee.schimke.composeai.mcp.protocol.Implementation
-import ee.schimke.composeai.mcp.protocol.ListResourcesResult
-import ee.schimke.composeai.mcp.protocol.ListToolsResult
 import ee.schimke.composeai.mcp.protocol.ReadResourceResult
 import ee.schimke.composeai.mcp.protocol.ResourceContents
 import ee.schimke.composeai.mcp.protocol.ResourceDescriptor
-import ee.schimke.composeai.mcp.protocol.ResourcesCapability
-import ee.schimke.composeai.mcp.protocol.ServerCapabilities
 import ee.schimke.composeai.mcp.protocol.ToolDef
-import ee.schimke.composeai.mcp.protocol.ToolsCapability
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import java.io.File
 import java.nio.file.Files
 import java.security.MessageDigest
@@ -220,71 +215,47 @@ class DaemonMcpServer(
   }
 
   // -------------------------------------------------------------------------
-  // Public API consumed by McpSession via McpHandlers
+  // Public API consumed by the SDK-backed MCP session
   // -------------------------------------------------------------------------
 
   fun newSession(input: java.io.InputStream, output: java.io.OutputStream): McpSession {
     lateinit var session: McpSession
-    val handlers =
-      object : McpHandlers {
-        override fun listTools(session: McpSession): JsonElement =
-          json.encodeToJsonElement(ListToolsResult.serializer(), ListToolsResult(currentToolDefs()))
-
-        override fun callTool(
-          session: McpSession,
-          name: String,
-          arguments: JsonElement?,
-        ): CallToolResult = handleCallTool(session, name, arguments)
-
-        override fun listResources(session: McpSession): JsonElement {
-          val resources = catalogResources()
-          return json.encodeToJsonElement(
-            ListResourcesResult.serializer(),
-            ListResourcesResult(resources),
-          )
-        }
-
-        override fun readResource(
-          session: McpSession,
-          uri: String,
-          progressToken: JsonElement?,
-        ): ReadResourceResult = handleReadResource(session, uri, progressToken)
-
-        override fun subscribe(session: McpSession, uri: String) {
-          subscriptions.subscribe(uri, session)
-        }
-
-        override fun unsubscribe(session: McpSession, uri: String) {
-          subscriptions.unsubscribe(uri, session)
-        }
-
-        override fun onClose(session: McpSession) {
-          // Release the session's data-product subscriptions and tell the daemon to unsubscribe
-          // the keys whose last reference just dropped — otherwise daemon-side subscriptions
-          // would leak until `setVisible` churn drops them, and an interactive UI that wants to
-          // re-attach later would see stale state. We forward unsubscribes best-effort: a daemon
-          // that's already gone (classpathDirty respawn) or rejects the kind doesn't block
-          // session teardown.
-          val released = subscriptions.forgetDataSubscriptions(session)
-          released.forEach { key -> dispatchDataUnsubscribe(key) }
-          subscriptions.forget(session)
-          sessions.unregister(session)
-        }
-      }
+    val sdkServer = composePreviewSdkServer(serverInfo)
     session =
       McpSession(
+        server = sdkServer,
         input = input,
         output = output,
-        handlers = handlers,
-        serverInfo = serverInfo,
-        capabilities =
-          ServerCapabilities(
-            tools = ToolsCapability(listChanged = true),
-            resources = ResourcesCapability(subscribe = true, listChanged = true),
-          ),
+        configure = { sdkSession ->
+          sdkServer.installComposePreviewHandlers(
+            sdkSession = sdkSession,
+            session = session,
+            listTools = { currentToolDefs() },
+            callTool = { name, arguments -> handleCallTool(session, name, arguments) },
+            listResources = { catalogResources() },
+            readResource = { uri, progressToken ->
+              handleReadResource(session, uri, progressToken)
+            },
+            subscribe = { uri -> subscriptions.subscribe(uri, session) },
+            unsubscribe = { uri -> subscriptions.unsubscribe(uri, session) },
+          )
+        },
+        onClose = { closeSession(session) },
       )
     sessions.register(session)
     return session
+  }
+
+  private fun closeSession(session: Session) {
+    // Release the session's data-product subscriptions and tell the daemon to unsubscribe the keys
+    // whose last reference just dropped — otherwise daemon-side subscriptions would leak until
+    // `setVisible` churn drops them, and an interactive UI that wants to re-attach later would see
+    // stale state. We forward unsubscribes best-effort: a daemon that's already gone
+    // (classpathDirty respawn) or rejects the kind doesn't block session teardown.
+    val released = subscriptions.forgetDataSubscriptions(session)
+    released.forEach { key -> dispatchDataUnsubscribe(key) }
+    subscriptions.forget(session)
+    sessions.unregister(session)
   }
 
   // -------------------------------------------------------------------------
@@ -316,7 +287,7 @@ class DaemonMcpServer(
   }
 
   private fun handleReadResource(
-    session: McpSession,
+    session: Session,
     uri: String,
     progressToken: JsonElement?,
   ): ReadResourceResult {
@@ -358,7 +329,7 @@ class DaemonMcpServer(
 
   private fun renderAndReadBytes(
     uri: PreviewUri,
-    session: McpSession? = null,
+    session: Session? = null,
     progressToken: JsonElement? = null,
     overrides: PreviewOverrides? = null,
   ): ByteArray {
@@ -388,7 +359,7 @@ class DaemonMcpServer(
    */
   private fun awaitNextRender(
     uri: PreviewUri,
-    session: McpSession? = null,
+    session: Session? = null,
     progressToken: JsonElement? = null,
     overrides: PreviewOverrides? = null,
   ): RenderOutcome.Finished {
@@ -1132,7 +1103,7 @@ class DaemonMcpServer(
     )
 
   private fun handleCallTool(
-    session: McpSession,
+    session: Session,
     name: String,
     arguments: JsonElement?,
   ): CallToolResult {
@@ -1453,7 +1424,7 @@ class DaemonMcpServer(
     )
   }
 
-  private fun toolWatch(session: McpSession, args: JsonObject): CallToolResult {
+  private fun toolWatch(session: Session, args: JsonObject): CallToolResult {
     val ws =
       args["workspaceId"]?.jsonPrimitive?.contentOrNull
         ?: return errorCallToolResult("watch: missing 'workspaceId'")
@@ -1479,7 +1450,7 @@ class DaemonMcpServer(
     val toSpawn =
       if (module != null) listOf(module)
       else synchronized(project.knownModules) { project.knownModules.toList() }
-    // Spawn off-thread so the McpSession reader doesn't block on cold-start (Robolectric ~5–10s,
+    // Spawn off-thread so the SDK session doesn't block on cold-start (Robolectric ~5–10s,
     // desktop ~600ms). The supervisor's `daemonFor` is `computeIfAbsent`-safe so duplicate watches
     // racing on the same module are fine. Each successful spawn calls
     // `synthesiseInitialDiscovery`, which fires `discoveryUpdated` → `onDiscoveryUpdated` →
@@ -1559,7 +1530,7 @@ class DaemonMcpServer(
       )
     }
 
-  private fun toolUnwatch(session: McpSession, args: JsonObject): CallToolResult {
+  private fun toolUnwatch(session: Session, args: JsonObject): CallToolResult {
     val workspaceId = args["workspaceId"]?.jsonPrimitive?.contentOrNull?.let(::WorkspaceId)
     val module = args["module"]?.jsonPrimitive?.contentOrNull
     val glob = args["fqnGlob"]?.jsonPrimitive?.contentOrNull
@@ -1579,7 +1550,7 @@ class DaemonMcpServer(
     return textCallToolResult("unwatched $removed entries")
   }
 
-  private fun toolListWatches(session: McpSession): CallToolResult {
+  private fun toolListWatches(session: Session): CallToolResult {
     val payload = buildJsonObject {
       putJsonArray("watches") {
         subscriptions.watchesFor(session).forEach { e ->
@@ -2358,7 +2329,6 @@ class DaemonMcpServer(
           put("sizeBytes", encoded.sizeBytes)
           put("frameCount", stopResult.frameCount)
           put("durationMs", stopResult.durationMs)
-          put("framesDir", stopResult.framesDir)
           put("frameWidthPx", stopResult.frameWidthPx)
           put("frameHeightPx", stopResult.frameHeightPx)
           put("framesDir", stopResult.framesDir)
@@ -2560,7 +2530,7 @@ class DaemonMcpServer(
     }
 
   private fun toolDataSubOrUnsub(
-    session: McpSession,
+    session: Session,
     args: JsonObject,
     subscribe: Boolean,
   ): CallToolResult {
@@ -3011,7 +2981,7 @@ class DaemonMcpServer(
    * `message` carries a short status string the client can show as a tooltip / log line.
    */
   private fun startProgressBeatIfNeeded(
-    session: McpSession?,
+    session: Session?,
     progressToken: JsonElement?,
     future: java.util.concurrent.CompletableFuture<*>,
     uri: PreviewUri,

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/McpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/McpServer.kt
@@ -1,47 +1,64 @@
 package ee.schimke.composeai.mcp
 
-import ee.schimke.composeai.mcp.protocol.CallToolParams
 import ee.schimke.composeai.mcp.protocol.CallToolResult
 import ee.schimke.composeai.mcp.protocol.ContentBlock
-import ee.schimke.composeai.mcp.protocol.Implementation
-import ee.schimke.composeai.mcp.protocol.InitializeParams
-import ee.schimke.composeai.mcp.protocol.InitializeResult
-import ee.schimke.composeai.mcp.protocol.ListResourcesResult
-import ee.schimke.composeai.mcp.protocol.ListToolsResult
-import ee.schimke.composeai.mcp.protocol.McpError
-import ee.schimke.composeai.mcp.protocol.McpErrorCodes
-import ee.schimke.composeai.mcp.protocol.McpNotification
-import ee.schimke.composeai.mcp.protocol.McpResponse
-import ee.schimke.composeai.mcp.protocol.ReadResourceParams
-import ee.schimke.composeai.mcp.protocol.ReadResourceResult
-import ee.schimke.composeai.mcp.protocol.ResourceDescriptor
-import ee.schimke.composeai.mcp.protocol.ResourceUpdatedParams
-import ee.schimke.composeai.mcp.protocol.ServerCapabilities
-import ee.schimke.composeai.mcp.protocol.SubscribeParams
 import ee.schimke.composeai.mcp.protocol.ToolDef
-import ee.schimke.composeai.mcp.protocol.UnsubscribeParams
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.server.ServerSession
+import io.modelcontextprotocol.kotlin.sdk.shared.AbstractTransport
+import io.modelcontextprotocol.kotlin.sdk.shared.TransportSendOptions
+import io.modelcontextprotocol.kotlin.sdk.types.BlobResourceContents
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
+import io.modelcontextprotocol.kotlin.sdk.types.ContentBlock as SdkContentBlock
+import io.modelcontextprotocol.kotlin.sdk.types.EmbeddedResource
+import io.modelcontextprotocol.kotlin.sdk.types.EmptyResult
+import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.JSONRPCMessage
+import io.modelcontextprotocol.kotlin.sdk.types.ListResourcesRequest
+import io.modelcontextprotocol.kotlin.sdk.types.ListResourcesResult
+import io.modelcontextprotocol.kotlin.sdk.types.ListToolsRequest
+import io.modelcontextprotocol.kotlin.sdk.types.ListToolsResult
+import io.modelcontextprotocol.kotlin.sdk.types.McpJson
+import io.modelcontextprotocol.kotlin.sdk.types.Method
+import io.modelcontextprotocol.kotlin.sdk.types.ProgressNotification
+import io.modelcontextprotocol.kotlin.sdk.types.ProgressNotificationParams
+import io.modelcontextprotocol.kotlin.sdk.types.ReadResourceRequest
+import io.modelcontextprotocol.kotlin.sdk.types.ReadResourceResult
+import io.modelcontextprotocol.kotlin.sdk.types.RequestId
+import io.modelcontextprotocol.kotlin.sdk.types.Resource
+import io.modelcontextprotocol.kotlin.sdk.types.ResourceContents
+import io.modelcontextprotocol.kotlin.sdk.types.ResourceUpdatedNotification
+import io.modelcontextprotocol.kotlin.sdk.types.ResourceUpdatedNotificationParams
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.SubscribeRequest
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.TextResourceContents
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import io.modelcontextprotocol.kotlin.sdk.types.UnsubscribeRequest
 import java.io.ByteArrayOutputStream
 import java.io.Closeable
-import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicBoolean
-import kotlinx.serialization.json.Json
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 /**
- * Transport-agnostic session surface. Only the notification fan-out methods that subscribers /
- * watchers / progress callers actually need; request handling stays inside the concrete transport
- * (today: [McpSession] over stdio).
- *
- * Defining this interface — instead of typing [Subscriptions] on the concrete [McpSession] — lets a
- * future HTTP / streamable-HTTP transport plug in its own per-connection session type without an
- * unsafe `as?` cast in the supervisor's notification routing.
+ * Transport-agnostic session surface. The concrete stdio implementation now comes from the official
+ * Kotlin MCP SDK; daemon orchestration only needs this notification surface.
  */
 interface Session {
   /** Sends `notifications/resources/updated` for [uri]. */
@@ -55,343 +72,329 @@ interface Session {
 
   /**
    * Sends a `notifications/progress` for the request identified by [token]. No-op when the client
-   * didn't opt in (caller's responsibility to skip the call when the token is null).
+   * didn't opt in or sent a token shape the SDK cannot represent.
    */
   fun notifyProgress(
-    token: kotlinx.serialization.json.JsonElement,
+    token: JsonElement,
     progress: Double,
     total: Double? = null,
     message: String? = null,
   )
 }
 
-/**
- * A single MCP session over `Content-Length`-framed stdio (matching MCP's stdio transport spec).
- *
- * Conceptually this is one connected MCP client. v0 ships one session per server process; HTTP
- * transport will multiplex many. Sessions own:
- *
- * - A read thread that drains [input] and dispatches request frames to [handlers].
- * - A write thread that serialises every reply + outgoing notification to [output].
- * - The set of subscribed URIs and registered watch entries (stored externally in [subscriptions],
- *   keyed by `this` reference so different sessions stay isolated).
- *
- * Method handlers are pluggable — [DaemonMcpServer] wires the resource/tool surface; tests can
- * register their own handlers for protocol conformance assertions.
- */
+/** SDK-backed stdio session with the same lifecycle shape the old hand-rolled session exposed. */
 class McpSession(
+  private val server: Server,
   private val input: InputStream,
   private val output: OutputStream,
-  private val handlers: McpHandlers,
-  private val serverInfo: Implementation,
-  private val capabilities: ServerCapabilities,
-  threadName: String = "mcp-session",
+  private val configure: (ServerSession) -> Unit,
+  private val onClose: () -> Unit,
 ) : Closeable, Session {
-
-  private val json = Json {
-    ignoreUnknownKeys = true
-    encodeDefaults = false
-  }
-  private val closed = AtomicBoolean(false)
-  private val initialized = AtomicBoolean(false)
-
-  private val readerThread = Thread({ runReader() }, "$threadName-reader").apply { isDaemon = true }
+  private val closed = CompletableFuture<Unit>()
+  @Volatile private var sdkSession: ServerSession? = null
+  private val thread =
+    Thread(
+        {
+          try {
+            runBlocking(Dispatchers.IO) {
+              val session = server.createSession(StreamServerTransport(input, output))
+              sdkSession = session
+              session.onClose {
+                closed.complete(Unit)
+                onClose()
+              }
+              configure(session)
+              while (!closed.isDone) {
+                delay(100)
+              }
+            }
+          } catch (t: Throwable) {
+            System.err.println("compose-preview-mcp: SDK stdio session failed: ${t.message}")
+            t.printStackTrace(System.err)
+          } finally {
+            onClose()
+          }
+        },
+        "mcp-sdk-stdio-session",
+      )
+      .apply { isDaemon = true }
 
   fun start() {
-    readerThread.start()
+    thread.start()
   }
 
-  /** Blocks until the reader thread exits (typically on stdin EOF). Used by stdio entry points. */
   fun awaitClose() {
-    readerThread.join()
+    thread.join()
   }
 
-  /** Sends a JSON-RPC notification. Safe to call from any thread; framed atomically on the wire. */
-  fun notify(method: String, params: JsonElement? = null) {
-    if (closed.get()) return
-    val n = McpNotification(method = method, params = params)
-    sendFrame(json.encodeToString(McpNotification.serializer(), n))
+  override fun close() {
+    runBlocking { server.close() }
+    closed.complete(Unit)
+    thread.join(2_000)
   }
 
   override fun notifyResourceUpdated(uri: String) {
-    val params =
-      json.encodeToJsonElement(ResourceUpdatedParams.serializer(), ResourceUpdatedParams(uri))
-    notify("notifications/resources/updated", params)
+    val session = sdkSession ?: return
+    runBlocking {
+      session.sendResourceUpdated(
+        ResourceUpdatedNotification(ResourceUpdatedNotificationParams(uri = uri))
+      )
+    }
   }
 
   override fun notifyResourceListChanged() {
-    notify("notifications/resources/list_changed")
+    val session = sdkSession ?: return
+    runBlocking { session.sendResourceListChanged() }
   }
 
   override fun notifyToolListChanged() {
-    notify("notifications/tools/list_changed")
+    val session = sdkSession ?: return
+    runBlocking { session.sendToolListChanged() }
   }
 
-  /**
-   * Sends a `notifications/progress` per the MCP spec:
-   * https://modelcontextprotocol.io/specification/2025-06-18/basic#progress-notifications.
-   *
-   * Only meaningful when the originating request opted in via `_meta.progressToken` in its params;
-   * the [token] argument is the verbatim value the client sent. [progress] is monotonic (caller's
-   * responsibility); [total] is optional and may be unknown for streaming work.
-   */
   override fun notifyProgress(
-    token: kotlinx.serialization.json.JsonElement,
+    token: JsonElement,
     progress: Double,
     total: Double?,
     message: String?,
   ) {
-    val params =
-      kotlinx.serialization.json.buildJsonObject {
-        put("progressToken", token)
-        put("progress", kotlinx.serialization.json.JsonPrimitive(progress))
-        if (total != null) put("total", kotlinx.serialization.json.JsonPrimitive(total))
-        if (message != null) put("message", kotlinx.serialization.json.JsonPrimitive(message))
-      }
-    notify("notifications/progress", params)
-  }
-
-  override fun close() {
-    if (!closed.compareAndSet(false, true)) return
-    runCatching { input.close() }
-    runCatching { output.close() }
-    readerThread.join(2_000)
-  }
-
-  // -------------------------------------------------------------------------
-  // Read loop
-  // -------------------------------------------------------------------------
-
-  private fun runReader() {
-    try {
-      while (!closed.get()) {
-        val frame = readFrame(input) ?: break
-        val obj = json.parseToJsonElement(frame.toString(Charsets.UTF_8)).jsonObject
-        if (obj["id"] != null) dispatchRequest(obj) else dispatchNotification(obj)
-      }
-    } catch (_: IOException) {
-      // EOF — fall through
-    } catch (e: Throwable) {
-      System.err.println("McpSession reader: ${e.message}")
-      e.printStackTrace(System.err)
-    } finally {
-      runCatching { handlers.onClose(this) }
-    }
-  }
-
-  private fun dispatchRequest(obj: JsonObject) {
-    val id = obj["id"] ?: return
-    val method = obj["method"]?.jsonPrimitive?.contentOrNull
-    val params = obj["params"]
-    if (method == null) {
-      sendError(id, McpErrorCodes.INVALID_REQUEST, "missing method")
-      return
-    }
-    if (!initialized.get() && method != "initialize") {
-      sendError(id, McpErrorCodes.INVALID_REQUEST, "session not initialized (received $method)")
-      return
-    }
-    try {
-      when (method) {
-        "initialize" -> handleInitialize(id, params)
-        "ping" -> sendResult(id, JsonObject(emptyMap()))
-        "tools/list" -> sendResult(id, handlers.listTools(this))
-        "tools/call" -> handleCallTool(id, params)
-        "resources/list" -> sendResult(id, handlers.listResources(this))
-        "resources/read" -> handleReadResource(id, params)
-        "resources/subscribe" -> handleSubscribe(id, params)
-        "resources/unsubscribe" -> handleUnsubscribe(id, params)
-        else -> sendError(id, McpErrorCodes.METHOD_NOT_FOUND, "unknown method: $method")
-      }
-    } catch (e: Throwable) {
-      sendError(id, McpErrorCodes.INTERNAL_ERROR, e.message ?: "internal error")
-    }
-  }
-
-  private fun dispatchNotification(obj: JsonObject) {
-    val method = obj["method"]?.jsonPrimitive?.contentOrNull ?: return
-    when (method) {
-      "notifications/initialized" -> initialized.set(true)
-      "notifications/cancelled" -> {
-        /* v0 ignores cancellation */
-      }
-      else -> {
-        /* unknown notifications ignored per spec */
-      }
-    }
-  }
-
-  private fun handleInitialize(id: JsonElement, params: JsonElement?) {
-    val parsed = params?.let {
-      runCatching { json.decodeFromJsonElement(InitializeParams.serializer(), it) }.getOrNull()
-    }
-    val protocolVersion = parsed?.protocolVersion ?: "2025-06-18"
-    val result =
-      InitializeResult(
-        protocolVersion = protocolVersion,
-        capabilities = capabilities,
-        serverInfo = serverInfo,
+    val progressToken = token.toRequestId() ?: return
+    val session = sdkSession ?: return
+    runBlocking {
+      session.notification(
+        ProgressNotification(
+          ProgressNotificationParams(
+            progressToken = progressToken,
+            progress = progress,
+            total = total,
+            message = message,
+          )
+        ),
+        progressToken,
       )
-    sendResult(id, json.encodeToJsonElement(InitializeResult.serializer(), result))
-    // Some clients omit the `notifications/initialized` follow-up; treat the response as a
-    // gating signal so subsequent requests don't error out. The notification path still flips
-    // the flag if it arrives.
-    initialized.set(true)
+    }
+  }
+}
+
+private class StreamServerTransport(
+  private val input: InputStream,
+  private val output: OutputStream,
+) : AbstractTransport() {
+  private val closed = CompletableFuture<Unit>()
+  private val outputLock = Any()
+  @Volatile private var readerThread: Thread? = null
+
+  override suspend fun start() {
+    if (readerThread != null) return
+    readerThread =
+      Thread(
+          {
+            try {
+              while (!closed.isDone) {
+                val payload = readFrame(input) ?: break
+                val message =
+                  McpJson.decodeFromString(
+                    JSONRPCMessage.serializer(),
+                    payload.toString(Charsets.UTF_8),
+                  )
+                runBlocking { _onMessage(message) }
+              }
+            } catch (t: Throwable) {
+              if (!closed.isDone) {
+                _onError(t)
+              }
+            } finally {
+              runBlocking { close() }
+            }
+          },
+          "mcp-sdk-stream-reader",
+        )
+        .apply {
+          isDaemon = true
+          start()
+        }
   }
 
-  private fun handleCallTool(id: JsonElement, params: JsonElement?) {
-    val parsed =
-      params?.let {
-        runCatching { json.decodeFromJsonElement(CallToolParams.serializer(), it) }.getOrNull()
-      } ?: return sendError(id, McpErrorCodes.INVALID_PARAMS, "tools/call: missing params")
-    val result = handlers.callTool(this, parsed.name, parsed.arguments)
-    sendResult(id, json.encodeToJsonElement(CallToolResult.serializer(), result))
-  }
-
-  private fun handleReadResource(id: JsonElement, params: JsonElement?) {
-    val parsed =
-      params?.let {
-        runCatching { json.decodeFromJsonElement(ReadResourceParams.serializer(), it) }.getOrNull()
-      } ?: return sendError(id, McpErrorCodes.INVALID_PARAMS, "resources/read: missing uri")
-    // Per MCP spec, clients opt in to progress notifications by including a
-    // `_meta.progressToken` (string | number) on the request's params. Pull it out so the
-    // handler can fire periodic `notifications/progress` while a slow render runs.
-    val progressToken =
-      (params as? JsonObject)?.get("_meta")?.let { it as? JsonObject }?.get("progressToken")
-    val result = handlers.readResource(this, parsed.uri, progressToken)
-    sendResult(id, json.encodeToJsonElement(ReadResourceResult.serializer(), result))
-  }
-
-  private fun handleSubscribe(id: JsonElement, params: JsonElement?) {
-    val parsed =
-      params?.let {
-        runCatching { json.decodeFromJsonElement(SubscribeParams.serializer(), it) }.getOrNull()
-      } ?: return sendError(id, McpErrorCodes.INVALID_PARAMS, "resources/subscribe: missing uri")
-    handlers.subscribe(this, parsed.uri)
-    sendResult(id, JsonObject(emptyMap()))
-  }
-
-  private fun handleUnsubscribe(id: JsonElement, params: JsonElement?) {
-    val parsed =
-      params?.let {
-        runCatching { json.decodeFromJsonElement(UnsubscribeParams.serializer(), it) }.getOrNull()
-      } ?: return sendError(id, McpErrorCodes.INVALID_PARAMS, "resources/unsubscribe: missing uri")
-    handlers.unsubscribe(this, parsed.uri)
-    sendResult(id, JsonObject(emptyMap()))
-  }
-
-  // -------------------------------------------------------------------------
-  // Wire helpers
-  // -------------------------------------------------------------------------
-
-  private fun sendResult(id: JsonElement, result: JsonElement) {
-    val response = McpResponse(id = id, result = result)
-    sendFrame(json.encodeToString(McpResponse.serializer(), response))
-  }
-
-  private fun sendError(id: JsonElement, code: Int, message: String) {
-    val response = McpResponse(id = id, error = McpError(code = code, message = message))
-    sendFrame(json.encodeToString(McpResponse.serializer(), response))
-  }
-
-  private fun sendFrame(jsonText: String) {
+  override suspend fun send(message: JSONRPCMessage, options: TransportSendOptions?) {
+    val jsonText = McpJson.encodeToString(JSONRPCMessage.serializer(), message)
     val payload = jsonText.toByteArray(Charsets.UTF_8)
     val header = "Content-Length: ${payload.size}\r\n\r\n".toByteArray(Charsets.US_ASCII)
-    synchronized(output) {
+    synchronized(outputLock) {
       output.write(header)
       output.write(payload)
       output.flush()
     }
   }
 
-  private fun readFrame(input: InputStream): ByteArray? {
-    var contentLength = -1
-    val headerBuf = ByteArrayOutputStream(64)
-    var sawAny = false
-    while (true) {
-      val line = readHeaderLine(input, headerBuf) ?: return if (sawAny) null else null
-      sawAny = true
-      if (line.isEmpty()) break
-      val colon = line.indexOf(':')
-      if (colon <= 0) error("malformed header line: '$line'")
-      val name = line.substring(0, colon).trim()
-      val value = line.substring(colon + 1).trim()
-      if (name.equals("Content-Length", ignoreCase = true)) {
-        contentLength = value.toIntOrNull() ?: error("non-integer Content-Length: '$value'")
-      }
-    }
-    if (contentLength < 0) error("missing Content-Length header")
-    val payload = ByteArray(contentLength)
-    var off = 0
-    while (off < contentLength) {
-      val n = input.read(payload, off, contentLength - off)
-      if (n < 0) return null
-      off += n
-    }
-    return payload
-  }
-
-  private fun readHeaderLine(input: InputStream, buf: ByteArrayOutputStream): String? {
-    buf.reset()
-    while (true) {
-      val b = input.read()
-      if (b < 0) return if (buf.size() == 0) null else buf.toString(Charsets.US_ASCII.name())
-      if (b == '\n'.code) {
-        val bytes = buf.toByteArray()
-        val end =
-          if (bytes.isNotEmpty() && bytes.last() == '\r'.code.toByte()) bytes.size - 1
-          else bytes.size
-        return String(bytes, 0, end, Charsets.US_ASCII)
-      }
-      buf.write(b)
-    }
+  override suspend fun close() {
+    if (!closed.complete(Unit)) return
+    runCatching { input.close() }
+    runCatching { output.close() }
+    invokeOnCloseCallback()
   }
 }
 
-/**
- * Pluggable handler set the [McpSession] dispatches to. [DaemonMcpServer] supplies the concrete
- * instance; tests can stub it for protocol-level assertions without dragging in a supervisor.
- *
- * Every method is called from the session's reader thread. Implementations must not block on
- * unrelated IO — the daemon's render path is already off-thread, so the main concern is keeping the
- * reader pumping.
- */
-interface McpHandlers {
-  fun listTools(session: McpSession): JsonElement
+private fun readFrame(input: InputStream): ByteArray? {
+  var contentLength = -1
+  val headerBuf = ByteArrayOutputStream(64)
+  while (true) {
+    val line = readHeaderLine(input, headerBuf) ?: return null
+    if (line.isEmpty()) break
+    val colon = line.indexOf(':')
+    if (colon <= 0) error("malformed header line: '$line'")
+    val name = line.substring(0, colon).trim()
+    val value = line.substring(colon + 1).trim()
+    if (name.equals("Content-Length", ignoreCase = true)) {
+      contentLength = value.toIntOrNull() ?: error("non-integer Content-Length: '$value'")
+    }
+  }
+  if (contentLength < 0) error("missing Content-Length header")
+  val payload = ByteArray(contentLength)
+  var off = 0
+  while (off < contentLength) {
+    val n = input.read(payload, off, contentLength - off)
+    if (n < 0) return null
+    off += n
+  }
+  return payload
+}
 
-  fun callTool(session: McpSession, name: String, arguments: JsonElement?): CallToolResult
-
-  fun listResources(session: McpSession): JsonElement
-
-  /**
-   * Reads the resource at [uri]. [progressToken], when non-null, is the client's opt-in handle for
-   * `notifications/progress` — implementations that perform slow work should fan out periodic
-   * progress notifications via [McpSession.notifyProgress] using this token.
-   */
-  fun readResource(
-    session: McpSession,
-    uri: String,
-    progressToken: JsonElement? = null,
-  ): ReadResourceResult
-
-  fun subscribe(session: McpSession, uri: String)
-
-  fun unsubscribe(session: McpSession, uri: String)
-
-  fun onClose(session: McpSession)
-
-  companion object {
-    /**
-     * Sentinel: encode a [ListToolsResult] / [ListResourcesResult] for [listTools] /
-     * [listResources].
-     */
-    fun encodeTools(json: Json, tools: List<ToolDef>): JsonElement =
-      json.encodeToJsonElement(ListToolsResult.serializer(), ListToolsResult(tools))
-
-    fun encodeResources(json: Json, resources: List<ResourceDescriptor>): JsonElement =
-      json.encodeToJsonElement(ListResourcesResult.serializer(), ListResourcesResult(resources))
+private fun readHeaderLine(input: InputStream, buf: ByteArrayOutputStream): String? {
+  buf.reset()
+  while (true) {
+    val b = input.read()
+    if (b < 0) return if (buf.size() == 0) null else buf.toString(Charsets.US_ASCII.name())
+    if (b == '\n'.code) {
+      val bytes = buf.toByteArray()
+      val end =
+        if (bytes.isNotEmpty() && bytes.last() == '\r'.code.toByte()) bytes.size - 1 else bytes.size
+      return String(bytes, 0, end, Charsets.US_ASCII)
+    }
+    buf.write(b)
   }
 }
+
+/** Tracks every live [Session] so notifications can fan out to multiple connected clients. */
+class SessionRegistry {
+  private val sessions = ConcurrentHashMap.newKeySet<Session>()
+
+  fun register(session: Session) {
+    sessions.add(session)
+  }
+
+  fun unregister(session: Session) {
+    sessions.remove(session)
+  }
+
+  fun forEach(block: (Session) -> Unit) {
+    sessions.forEach { runCatching { block(it) } }
+  }
+}
+
+internal fun Server.installComposePreviewHandlers(
+  sdkSession: ServerSession,
+  session: Session,
+  listTools: () -> List<ToolDef>,
+  callTool: (name: String, arguments: JsonElement?) -> CallToolResult,
+  listResources: () -> List<ee.schimke.composeai.mcp.protocol.ResourceDescriptor>,
+  readResource:
+    (
+      uri: String, progressToken: JsonElement?,
+    ) -> ee.schimke.composeai.mcp.protocol.ReadResourceResult,
+  subscribe: (uri: String) -> Unit,
+  unsubscribe: (uri: String) -> Unit,
+) {
+  sdkSession.setRequestHandler<ListToolsRequest>(Method.Defined.ToolsList) { _, _ ->
+    ListToolsResult(tools = listTools().map { it.toSdkTool() }, nextCursor = null)
+  }
+  sdkSession.setRequestHandler<CallToolRequest>(Method.Defined.ToolsCall) { request, _ ->
+    callTool(request.name, request.arguments).toSdkCallToolResult()
+  }
+  sdkSession.setRequestHandler<ListResourcesRequest>(Method.Defined.ResourcesList) { _, _ ->
+    ListResourcesResult(resources = listResources().map { it.toSdkResource() }, nextCursor = null)
+  }
+  sdkSession.setRequestHandler<ReadResourceRequest>(Method.Defined.ResourcesRead) { request, _ ->
+    val progressToken = request.meta?.json?.get("progressToken")
+    readResource(request.uri, progressToken).toSdkReadResourceResult()
+  }
+  sdkSession.setRequestHandler<SubscribeRequest>(Method.Defined.ResourcesSubscribe) { request, _ ->
+    subscribe(request.uri)
+    EmptyResult()
+  }
+  sdkSession.setRequestHandler<UnsubscribeRequest>(Method.Defined.ResourcesUnsubscribe) { request, _
+    ->
+    unsubscribe(request.uri)
+    EmptyResult()
+  }
+}
+
+internal fun composePreviewSdkServer(serverInfo: Implementation): Server =
+  Server(
+    serverInfo = serverInfo,
+    options =
+      ServerOptions(
+        capabilities =
+          ServerCapabilities(
+            tools = ServerCapabilities.Tools(listChanged = true),
+            resources = ServerCapabilities.Resources(subscribe = true, listChanged = true),
+          )
+      ),
+  )
+
+private fun ToolDef.toSdkTool(): Tool {
+  val schemaObject = inputSchema.jsonObject
+  return Tool(
+    name = name,
+    inputSchema =
+      ToolSchema(
+        properties = schemaObject["properties"] as? JsonObject ?: JsonObject(emptyMap()),
+        required =
+          (schemaObject["required"] as? kotlinx.serialization.json.JsonArray)?.mapNotNull {
+            it.jsonPrimitive.contentOrNull
+          },
+      ),
+    description = description,
+  )
+}
+
+private fun ee.schimke.composeai.mcp.protocol.ResourceDescriptor.toSdkResource(): Resource =
+  Resource(uri = uri, name = name, description = description, mimeType = mimeType)
+
+private fun ee.schimke.composeai.mcp.protocol.ReadResourceResult.toSdkReadResourceResult():
+  ReadResourceResult = ReadResourceResult(contents = contents.map { it.toSdkResourceContents() })
+
+private fun ee.schimke.composeai.mcp.protocol.ResourceContents.toSdkResourceContents():
+  ResourceContents =
+  when (this) {
+    is ee.schimke.composeai.mcp.protocol.ResourceContents.Text ->
+      TextResourceContents(text = text, uri = uri, mimeType = mimeType)
+    is ee.schimke.composeai.mcp.protocol.ResourceContents.Blob ->
+      BlobResourceContents(blob = blob, uri = uri, mimeType = mimeType)
+  }
+
+private fun CallToolResult.toSdkCallToolResult():
+  io.modelcontextprotocol.kotlin.sdk.types.CallToolResult =
+  io.modelcontextprotocol.kotlin.sdk.types.CallToolResult(
+    content = content.map { it.toSdkContent() },
+    isError = isError ?: false,
+  )
+
+private fun ContentBlock.toSdkContent(): SdkContentBlock =
+  when (this) {
+    is ContentBlock.Text -> TextContent(text = text)
+    is ContentBlock.Image -> ImageContent(data = data, mimeType = mimeType)
+    is ContentBlock.EmbeddedResource ->
+      EmbeddedResource(resource = resource.toSdkResourceContents())
+  }
+
+private fun JsonElement.toRequestId(): RequestId? =
+  when (this) {
+    is JsonPrimitive -> {
+      contentOrNull?.toLongOrNull()?.let { RequestId.NumberId(it) }
+        ?: contentOrNull?.let { RequestId.StringId(it) }
+    }
+    else -> null
+  }
 
 /**
  * Convenience: plain text response — every tool that just confirms an action ("watched", "ok") uses
@@ -407,20 +410,3 @@ fun pngCallToolResult(bytesBase64: String): CallToolResult =
 /** Convenience: error response — `isError = true` per MCP spec for tool-level errors. */
 fun errorCallToolResult(message: String): CallToolResult =
   CallToolResult(content = listOf(ContentBlock.Text(message)), isError = true)
-
-/** Tracks every live [McpSession] so notifications can fan out to multiple connected clients. */
-class SessionRegistry {
-  private val sessions = ConcurrentHashMap.newKeySet<McpSession>()
-
-  fun register(session: McpSession) {
-    sessions.add(session)
-  }
-
-  fun unregister(session: McpSession) {
-    sessions.remove(session)
-  }
-
-  fun forEach(block: (McpSession) -> Unit) {
-    sessions.forEach { runCatching { block(it) } }
-  }
-}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/PreviewResource.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/PreviewResource.kt
@@ -132,16 +132,15 @@ data class PreviewUri(
  * We round-trip the value through the URI without any encoding because the daemon's id format
  * already excludes `/` and `?`.
  */
-data class HistoryUri(
+class HistoryUri(
   val workspaceId: WorkspaceId,
-  val modulePath: String,
+  modulePath: String,
   val previewFqn: String,
   val entryId: String,
 ) {
+  val modulePath: String = normalizeModulePath(modulePath)
+
   init {
-    require(modulePath.startsWith(":")) {
-      "HistoryUri.modulePath must start with ':' (got '$modulePath')"
-    }
     require(!previewFqn.contains('/') && !previewFqn.contains('?')) {
       "HistoryUri.previewFqn must not contain '/' or '?' (got '$previewFqn')"
     }
@@ -157,6 +156,12 @@ data class HistoryUri(
 
   companion object {
     const val SCHEME: String = "compose-preview-history"
+
+    private fun normalizeModulePath(modulePath: String): String {
+      val trimmed = modulePath.trim()
+      require(trimmed.isNotEmpty()) { "HistoryUri.modulePath must not be blank" }
+      return if (trimmed.startsWith(":")) trimmed else ":$trimmed"
+    }
 
     fun parseOrNull(s: String): HistoryUri? {
       val prefix = "$SCHEME://"

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/protocol/McpMessages.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/protocol/McpMessages.kt
@@ -2,15 +2,23 @@ package ee.schimke.composeai.mcp.protocol
 
 import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonObject
 
 // ---------------------------------------------------------------------------
-// Trimmed MCP message shapes for the v0 server. We intentionally do not pull
-// in `io.modelcontextprotocol:kotlin-sdk`: the surface we need is small and
-// the SDK's auto-registered internal handlers complicate the dynamic catalog
-// model the supervisor wants. See ../build.gradle.kts for rationale.
+// Trimmed daemon-facing MCP message shapes. The SDK owns the wire/session layer;
+// these internal DTOs keep the supervisor/tool catalog code decoupled from SDK
+// types.
 //
 // References:
 // - https://modelcontextprotocol.io/specification/2025-06-18/basic
@@ -154,7 +162,7 @@ data class ResourceDescriptor(
 
 @Serializable data class ReadResourceResult(val contents: List<ResourceContents>)
 
-@Serializable
+@Serializable(with = ResourceContentsSerializer::class)
 sealed interface ResourceContents {
   @Serializable
   @SerialName("text")
@@ -165,6 +173,35 @@ sealed interface ResourceContents {
   @SerialName("blob")
   data class Blob(val uri: String, val mimeType: String? = null, val blob: String) :
     ResourceContents
+}
+
+object ResourceContentsSerializer : KSerializer<ResourceContents> {
+  override val descriptor: SerialDescriptor = JsonElement.serializer().descriptor
+
+  override fun deserialize(decoder: Decoder): ResourceContents {
+    val jsonDecoder =
+      decoder as? JsonDecoder
+        ?: throw SerializationException("ResourceContents can only be decoded from JSON")
+    val element = jsonDecoder.decodeJsonElement()
+    val obj = element.jsonObject
+    return when {
+      "text" in obj -> jsonDecoder.json.decodeFromJsonElement<ResourceContents.Text>(element)
+      "blob" in obj -> jsonDecoder.json.decodeFromJsonElement<ResourceContents.Blob>(element)
+      else -> throw SerializationException("ResourceContents must contain either 'text' or 'blob'")
+    }
+  }
+
+  override fun serialize(encoder: Encoder, value: ResourceContents) {
+    val jsonEncoder =
+      encoder as? JsonEncoder
+        ?: throw SerializationException("ResourceContents can only be encoded to JSON")
+    when (value) {
+      is ResourceContents.Text ->
+        jsonEncoder.encodeSerializableValue(ResourceContents.Text.serializer(), value)
+      is ResourceContents.Blob ->
+        jsonEncoder.encodeSerializableValue(ResourceContents.Blob.serializer(), value)
+    }
+  }
 }
 
 @Serializable data class SubscribeParams(val uri: String)

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -973,8 +973,6 @@ class DaemonMcpServerTest {
     assertThat(metadata["mimeType"]?.jsonPrimitive?.contentOrNull).isEqualTo("image/apng")
     assertThat(metadata["frameCount"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()).isEqualTo(16)
     assertThat(metadata["durationMs"]?.jsonPrimitive?.contentOrNull?.toLongOrNull()).isEqualTo(500L)
-    assertThat(metadata["framesDir"]?.jsonPrimitive?.contentOrNull)
-      .isEqualTo("${recordingsDir.absolutePath}/frames")
     assertThat(metadata["frameWidthPx"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()).isEqualTo(240)
     assertThat(metadata["frameHeightPx"]?.jsonPrimitive?.contentOrNull?.toIntOrNull()).isEqualTo(80)
     assertThat(metadata["framesDir"]?.jsonPrimitive?.contentOrNull)


### PR DESCRIPTION
## Summary

- Replace the hand-rolled MCP request/session server with the official Kotlin MCP SDK `Server`, `ServerSession`, and `StdioServerTransport`.
- Remove the custom Content-Length MCP transport/dispatcher and wire dynamic tools/resources through SDK request handlers.
- Normalize history module paths so callers can pass `wear` as well as `:wear`.
- Make internal resource-content DTO decoding tolerate SDK/spec-shaped `text` and `blob` resource contents.

## Notes

The Kotlin SDK stdio transport speaks newline-delimited JSON, so the MCP test harness now uses the SDK stdio format instead of the previous Content-Length test framing.

## Validation

- `./gradlew :mcp:ktfmtFormat :mcp:test`
- `git diff --check`