### PR TITLE
Add Prettier format checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Verify staged Kotlin files are ktfmt-formatted before allowing the commit.
+# Verify staged Kotlin files are ktfmt-formatted and VS Code extension files are
+# Prettier-formatted before allowing the commit.
 # Install with `scripts/install-git-hooks.sh` (sets `core.hooksPath`).
 
 set -euo pipefail
@@ -9,23 +10,47 @@ cd "$repo_root"
 
 # Portable replacement for `mapfile -d ''` — bash 3.2 (macOS system bash)
 # doesn't have mapfile.
-staged=()
+kt_staged=()
 while IFS= read -r -d '' file; do
-  staged+=("$file")
+  kt_staged+=("$file")
 done < <(git diff --cached --name-only --diff-filter=ACMR -z -- '*.kt' '*.kts')
 
-if [ ${#staged[@]} -eq 0 ]; then
+extension_staged=()
+while IFS= read -r -d '' file; do
+  extension_staged+=("$file")
+done < <(git diff --cached --name-only --diff-filter=ACMR -z -- \
+  'vscode-extension/package.json' \
+  'vscode-extension/package-lock.json' \
+  'vscode-extension/tsconfig.json' \
+  'vscode-extension/README.md' \
+  'vscode-extension/src/**/*.ts' \
+  'vscode-extension/src/**/*.json' \
+  'vscode-extension/media/**/*.css')
+
+if [ ${#kt_staged[@]} -eq 0 ] && [ ${#extension_staged[@]} -eq 0 ]; then
   exit 0
 fi
 
 # `ktfmtCheck` is fast on the configuration cache once warm, but does a full
 # repo scan. For now that's the simplest correct option: same code path as CI.
-if ! ./gradlew --quiet ktfmtCheckAll; then
+if [ ${#kt_staged[@]} -gt 0 ] && ! ./gradlew --quiet ktfmtCheckAll; then
   cat <<'MSG' >&2
 
 ktfmt found unformatted Kotlin code. Run:
 
     ./gradlew ktfmtFormatAll
+
+then `git add` the changes and re-commit.
+MSG
+  exit 1
+fi
+
+if [ ${#extension_staged[@]} -gt 0 ] && ! npm --prefix vscode-extension run format:check; then
+  cat <<'MSG' >&2
+
+Prettier found unformatted VS Code extension files. Run:
+
+    npm --prefix vscode-extension run format
 
 then `git add` the changes and re-commit.
 MSG

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -37,12 +37,14 @@ Add
 to the module whose previews you want to render:
 
 <!-- x-release-please-start-version -->
+
 ```kotlin
 // <module>/build.gradle.kts
 plugins {
     id("ee.schimke.composeai.preview") version "0.9.0"
 }
 ```
+
 <!-- x-release-please-end -->
 
 The plugin is on Maven Central, so no extra repository setup is needed when
@@ -59,16 +61,16 @@ snapshot builds.
 
 ### Commands
 
-| Command | Description |
-|---|---|
-| `Compose Preview: Refresh Previews` | Re-read `previews.json` and rendered PNGs from `build/compose-previews/`. |
+| Command                                | Description                                                                |
+| -------------------------------------- | -------------------------------------------------------------------------- |
+| `Compose Preview: Refresh Previews`    | Re-read `previews.json` and rendered PNGs from `build/compose-previews/`.  |
 | `Compose Preview: Render All Previews` | Run the `renderAllPreviews` Gradle task to discover and render everything. |
 
 ### Settings
 
-| Setting | Default | Description |
-|---|---|---|
-| `composePreview.variant` | `debug` | Build variant to use for preview rendering (Android). |
+| Setting                        | Default  | Description                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `composePreview.variant`       | `debug`  | Build variant to use for preview rendering (Android).                                                                                                                                                                                                                                                                                        |
 | `composePreview.logging.level` | `normal` | Verbosity for the "Compose Preview" output channel. `quiet` shows only errors and the BUILD outcome; `normal` keeps active task headers and summary lines but drops UP-TO-DATE/SKIPPED noise, configuration-cache bookkeeping, and dedupes the repeated Roborazzi ActionBar warnings; `verbose` shows every line from Gradle and the daemon. |
 
 ## Links

--- a/vscode-extension/media/codicon.css
+++ b/vscode-extension/media/codicon.css
@@ -4,22 +4,23 @@
  *--------------------------------------------------------------------------------------------*/
 
 @font-face {
-	font-family: "codicon";
-	font-display: block;
-	src: url("./codicon.ttf?721d4c0a96379d0c13d3d5596893c348") format("truetype");
+    font-family: "codicon";
+    font-display: block;
+    src: url("./codicon.ttf?721d4c0a96379d0c13d3d5596893c348")
+        format("truetype");
 }
 
-.codicon[class*='codicon-'] {
-	font: normal normal normal 16px/1 codicon;
-	display: inline-block;
-	text-decoration: none;
-	text-rendering: auto;
-	text-align: center;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	user-select: none;
-	-webkit-user-select: none;
-	-ms-user-select: none;
+.codicon[class*="codicon-"] {
+    font: normal normal normal 16px/1 codicon;
+    display: inline-block;
+    text-decoration: none;
+    text-rendering: auto;
+    text-align: center;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
 }
 
 /*---------------------
@@ -27,682 +28,1980 @@
  *-------------------*/
 
 @keyframes codicon-spin {
-	100% {
-		transform:rotate(360deg);
-	}
+    100% {
+        transform: rotate(360deg);
+    }
 }
 
 .codicon-sync.codicon-modifier-spin,
 .codicon-loading.codicon-modifier-spin,
 .codicon-gear.codicon-modifier-spin {
-	/* Use steps to throttle FPS to reduce CPU usage */
-	animation: codicon-spin 1.5s steps(30) infinite;
+    /* Use steps to throttle FPS to reduce CPU usage */
+    animation: codicon-spin 1.5s steps(30) infinite;
 }
 
 .codicon-modifier-disabled {
-	opacity: 0.5;
+    opacity: 0.5;
 }
 
 .codicon-modifier-hidden {
-	opacity: 0;
+    opacity: 0;
 }
 
 /* custom speed & easing for loading icon */
 .codicon-loading {
-	animation-duration: 1s !important;
-	animation-timing-function: cubic-bezier(0.53, 0.21, 0.29, 0.67) !important;
+    animation-duration: 1s !important;
+    animation-timing-function: cubic-bezier(0.53, 0.21, 0.29, 0.67) !important;
 }
 
 /*---------------------
  *  Icons
  *-------------------*/
 
-.codicon-add:before { content: "\ea60" }
-.codicon-plus:before { content: "\ea60" }
-.codicon-gist-new:before { content: "\ea60" }
-.codicon-repo-create:before { content: "\ea60" }
-.codicon-lightbulb:before { content: "\ea61" }
-.codicon-light-bulb:before { content: "\ea61" }
-.codicon-repo:before { content: "\ea62" }
-.codicon-repo-delete:before { content: "\ea62" }
-.codicon-gist-fork:before { content: "\ea63" }
-.codicon-repo-forked:before { content: "\ea63" }
-.codicon-git-pull-request:before { content: "\ea64" }
-.codicon-git-pull-request-abandoned:before { content: "\ea64" }
-.codicon-record-keys:before { content: "\ea65" }
-.codicon-keyboard:before { content: "\ea65" }
-.codicon-tag:before { content: "\ea66" }
-.codicon-git-pull-request-label:before { content: "\ea66" }
-.codicon-tag-add:before { content: "\ea66" }
-.codicon-tag-remove:before { content: "\ea66" }
-.codicon-person:before { content: "\ea67" }
-.codicon-person-follow:before { content: "\ea67" }
-.codicon-person-outline:before { content: "\ea67" }
-.codicon-person-filled:before { content: "\ea67" }
-.codicon-source-control:before { content: "\ea68" }
-.codicon-mirror:before { content: "\ea69" }
-.codicon-mirror-public:before { content: "\ea69" }
-.codicon-star:before { content: "\ea6a" }
-.codicon-star-add:before { content: "\ea6a" }
-.codicon-star-delete:before { content: "\ea6a" }
-.codicon-star-empty:before { content: "\ea6a" }
-.codicon-comment:before { content: "\ea6b" }
-.codicon-comment-add:before { content: "\ea6b" }
-.codicon-alert:before { content: "\ea6c" }
-.codicon-warning:before { content: "\ea6c" }
-.codicon-search:before { content: "\ea6d" }
-.codicon-search-save:before { content: "\ea6d" }
-.codicon-log-out:before { content: "\ea6e" }
-.codicon-sign-out:before { content: "\ea6e" }
-.codicon-log-in:before { content: "\ea6f" }
-.codicon-sign-in:before { content: "\ea6f" }
-.codicon-eye:before { content: "\ea70" }
-.codicon-eye-unwatch:before { content: "\ea70" }
-.codicon-eye-watch:before { content: "\ea70" }
-.codicon-circle-filled:before { content: "\ea71" }
-.codicon-primitive-dot:before { content: "\ea71" }
-.codicon-close-dirty:before { content: "\ea71" }
-.codicon-debug-breakpoint:before { content: "\ea71" }
-.codicon-debug-breakpoint-disabled:before { content: "\ea71" }
-.codicon-debug-hint:before { content: "\ea71" }
-.codicon-terminal-decoration-success:before { content: "\ea71" }
-.codicon-primitive-square:before { content: "\ea72" }
-.codicon-edit:before { content: "\ea73" }
-.codicon-pencil:before { content: "\ea73" }
-.codicon-info:before { content: "\ea74" }
-.codicon-issue-opened:before { content: "\ea74" }
-.codicon-gist-private:before { content: "\ea75" }
-.codicon-git-fork-private:before { content: "\ea75" }
-.codicon-lock:before { content: "\ea75" }
-.codicon-mirror-private:before { content: "\ea75" }
-.codicon-close:before { content: "\ea76" }
-.codicon-remove-close:before { content: "\ea76" }
-.codicon-x:before { content: "\ea76" }
-.codicon-repo-sync:before { content: "\ea77" }
-.codicon-sync:before { content: "\ea77" }
-.codicon-clone:before { content: "\ea78" }
-.codicon-desktop-download:before { content: "\ea78" }
-.codicon-beaker:before { content: "\ea79" }
-.codicon-microscope:before { content: "\ea79" }
-.codicon-vm:before { content: "\ea7a" }
-.codicon-device-desktop:before { content: "\ea7a" }
-.codicon-file:before { content: "\ea7b" }
-.codicon-more:before { content: "\ea7c" }
-.codicon-ellipsis:before { content: "\ea7c" }
-.codicon-kebab-horizontal:before { content: "\ea7c" }
-.codicon-mail-reply:before { content: "\ea7d" }
-.codicon-reply:before { content: "\ea7d" }
-.codicon-organization:before { content: "\ea7e" }
-.codicon-organization-filled:before { content: "\ea7e" }
-.codicon-organization-outline:before { content: "\ea7e" }
-.codicon-new-file:before { content: "\ea7f" }
-.codicon-file-add:before { content: "\ea7f" }
-.codicon-new-folder:before { content: "\ea80" }
-.codicon-file-directory-create:before { content: "\ea80" }
-.codicon-trash:before { content: "\ea81" }
-.codicon-trashcan:before { content: "\ea81" }
-.codicon-history:before { content: "\ea82" }
-.codicon-clock:before { content: "\ea82" }
-.codicon-folder:before { content: "\ea83" }
-.codicon-file-directory:before { content: "\ea83" }
-.codicon-symbol-folder:before { content: "\ea83" }
-.codicon-logo-github:before { content: "\ea84" }
-.codicon-mark-github:before { content: "\ea84" }
-.codicon-github:before { content: "\ea84" }
-.codicon-terminal:before { content: "\ea85" }
-.codicon-console:before { content: "\ea85" }
-.codicon-repl:before { content: "\ea85" }
-.codicon-zap:before { content: "\ea86" }
-.codicon-symbol-event:before { content: "\ea86" }
-.codicon-error:before { content: "\ea87" }
-.codicon-stop:before { content: "\ea87" }
-.codicon-variable:before { content: "\ea88" }
-.codicon-symbol-variable:before { content: "\ea88" }
-.codicon-array:before { content: "\ea8a" }
-.codicon-symbol-array:before { content: "\ea8a" }
-.codicon-symbol-module:before { content: "\ea8b" }
-.codicon-symbol-package:before { content: "\ea8b" }
-.codicon-symbol-namespace:before { content: "\ea8b" }
-.codicon-symbol-object:before { content: "\ea8b" }
-.codicon-symbol-method:before { content: "\ea8c" }
-.codicon-symbol-function:before { content: "\ea8c" }
-.codicon-symbol-constructor:before { content: "\ea8c" }
-.codicon-symbol-boolean:before { content: "\ea8f" }
-.codicon-symbol-null:before { content: "\ea8f" }
-.codicon-symbol-numeric:before { content: "\ea90" }
-.codicon-symbol-number:before { content: "\ea90" }
-.codicon-symbol-structure:before { content: "\ea91" }
-.codicon-symbol-struct:before { content: "\ea91" }
-.codicon-symbol-parameter:before { content: "\ea92" }
-.codicon-symbol-type-parameter:before { content: "\ea92" }
-.codicon-symbol-key:before { content: "\ea93" }
-.codicon-symbol-text:before { content: "\ea93" }
-.codicon-symbol-reference:before { content: "\ea94" }
-.codicon-go-to-file:before { content: "\ea94" }
-.codicon-symbol-enum:before { content: "\ea95" }
-.codicon-symbol-value:before { content: "\ea95" }
-.codicon-symbol-ruler:before { content: "\ea96" }
-.codicon-symbol-unit:before { content: "\ea96" }
-.codicon-activate-breakpoints:before { content: "\ea97" }
-.codicon-archive:before { content: "\ea98" }
-.codicon-arrow-both:before { content: "\ea99" }
-.codicon-arrow-down:before { content: "\ea9a" }
-.codicon-arrow-left:before { content: "\ea9b" }
-.codicon-arrow-right:before { content: "\ea9c" }
-.codicon-arrow-small-down:before { content: "\ea9d" }
-.codicon-arrow-small-left:before { content: "\ea9e" }
-.codicon-arrow-small-right:before { content: "\ea9f" }
-.codicon-arrow-small-up:before { content: "\eaa0" }
-.codicon-arrow-up:before { content: "\eaa1" }
-.codicon-bell:before { content: "\eaa2" }
-.codicon-bold:before { content: "\eaa3" }
-.codicon-book:before { content: "\eaa4" }
-.codicon-bookmark:before { content: "\eaa5" }
-.codicon-debug-breakpoint-conditional-unverified:before { content: "\eaa6" }
-.codicon-debug-breakpoint-conditional:before { content: "\eaa7" }
-.codicon-debug-breakpoint-conditional-disabled:before { content: "\eaa7" }
-.codicon-debug-breakpoint-data-unverified:before { content: "\eaa8" }
-.codicon-debug-breakpoint-data:before { content: "\eaa9" }
-.codicon-debug-breakpoint-data-disabled:before { content: "\eaa9" }
-.codicon-debug-breakpoint-log-unverified:before { content: "\eaaa" }
-.codicon-debug-breakpoint-log:before { content: "\eaab" }
-.codicon-debug-breakpoint-log-disabled:before { content: "\eaab" }
-.codicon-briefcase:before { content: "\eaac" }
-.codicon-broadcast:before { content: "\eaad" }
-.codicon-browser:before { content: "\eaae" }
-.codicon-bug:before { content: "\eaaf" }
-.codicon-calendar:before { content: "\eab0" }
-.codicon-case-sensitive:before { content: "\eab1" }
-.codicon-check:before { content: "\eab2" }
-.codicon-checklist:before { content: "\eab3" }
-.codicon-chevron-down:before { content: "\eab4" }
-.codicon-chevron-left:before { content: "\eab5" }
-.codicon-chevron-right:before { content: "\eab6" }
-.codicon-chevron-up:before { content: "\eab7" }
-.codicon-chrome-close:before { content: "\eab8" }
-.codicon-chrome-maximize:before { content: "\eab9" }
-.codicon-chrome-minimize:before { content: "\eaba" }
-.codicon-chrome-restore:before { content: "\eabb" }
-.codicon-circle-outline:before { content: "\eabc" }
-.codicon-circle:before { content: "\eabc" }
-.codicon-debug-breakpoint-unverified:before { content: "\eabc" }
-.codicon-terminal-decoration-incomplete:before { content: "\eabc" }
-.codicon-circle-slash:before { content: "\eabd" }
-.codicon-circuit-board:before { content: "\eabe" }
-.codicon-clear-all:before { content: "\eabf" }
-.codicon-clippy:before { content: "\eac0" }
-.codicon-close-all:before { content: "\eac1" }
-.codicon-cloud-download:before { content: "\eac2" }
-.codicon-cloud-upload:before { content: "\eac3" }
-.codicon-code:before { content: "\eac4" }
-.codicon-collapse-all:before { content: "\eac5" }
-.codicon-color-mode:before { content: "\eac6" }
-.codicon-comment-discussion:before { content: "\eac7" }
-.codicon-credit-card:before { content: "\eac9" }
-.codicon-dash:before { content: "\eacc" }
-.codicon-dashboard:before { content: "\eacd" }
-.codicon-database:before { content: "\eace" }
-.codicon-debug-continue:before { content: "\eacf" }
-.codicon-debug-disconnect:before { content: "\ead0" }
-.codicon-debug-pause:before { content: "\ead1" }
-.codicon-debug-restart:before { content: "\ead2" }
-.codicon-debug-start:before { content: "\ead3" }
-.codicon-debug-step-into:before { content: "\ead4" }
-.codicon-debug-step-out:before { content: "\ead5" }
-.codicon-debug-step-over:before { content: "\ead6" }
-.codicon-debug-stop:before { content: "\ead7" }
-.codicon-debug:before { content: "\ead8" }
-.codicon-device-camera-video:before { content: "\ead9" }
-.codicon-device-camera:before { content: "\eada" }
-.codicon-device-mobile:before { content: "\eadb" }
-.codicon-diff-added:before { content: "\eadc" }
-.codicon-diff-ignored:before { content: "\eadd" }
-.codicon-diff-modified:before { content: "\eade" }
-.codicon-diff-removed:before { content: "\eadf" }
-.codicon-diff-renamed:before { content: "\eae0" }
-.codicon-diff:before { content: "\eae1" }
-.codicon-diff-sidebyside:before { content: "\eae1" }
-.codicon-discard:before { content: "\eae2" }
-.codicon-editor-layout:before { content: "\eae3" }
-.codicon-empty-window:before { content: "\eae4" }
-.codicon-exclude:before { content: "\eae5" }
-.codicon-extensions:before { content: "\eae6" }
-.codicon-eye-closed:before { content: "\eae7" }
-.codicon-file-binary:before { content: "\eae8" }
-.codicon-file-code:before { content: "\eae9" }
-.codicon-file-media:before { content: "\eaea" }
-.codicon-file-pdf:before { content: "\eaeb" }
-.codicon-file-submodule:before { content: "\eaec" }
-.codicon-file-symlink-directory:before { content: "\eaed" }
-.codicon-file-symlink-file:before { content: "\eaee" }
-.codicon-file-zip:before { content: "\eaef" }
-.codicon-files:before { content: "\eaf0" }
-.codicon-filter:before { content: "\eaf1" }
-.codicon-flame:before { content: "\eaf2" }
-.codicon-fold-down:before { content: "\eaf3" }
-.codicon-fold-up:before { content: "\eaf4" }
-.codicon-fold:before { content: "\eaf5" }
-.codicon-folder-active:before { content: "\eaf6" }
-.codicon-folder-opened:before { content: "\eaf7" }
-.codicon-gear:before { content: "\eaf8" }
-.codicon-gift:before { content: "\eaf9" }
-.codicon-gist-secret:before { content: "\eafa" }
-.codicon-gist:before { content: "\eafb" }
-.codicon-git-commit:before { content: "\eafc" }
-.codicon-git-compare:before { content: "\eafd" }
-.codicon-compare-changes:before { content: "\eafd" }
-.codicon-git-merge:before { content: "\eafe" }
-.codicon-github-action:before { content: "\eaff" }
-.codicon-github-alt:before { content: "\eb00" }
-.codicon-globe:before { content: "\eb01" }
-.codicon-grabber:before { content: "\eb02" }
-.codicon-graph:before { content: "\eb03" }
-.codicon-gripper:before { content: "\eb04" }
-.codicon-heart:before { content: "\eb05" }
-.codicon-home:before { content: "\eb06" }
-.codicon-horizontal-rule:before { content: "\eb07" }
-.codicon-hubot:before { content: "\eb08" }
-.codicon-inbox:before { content: "\eb09" }
-.codicon-issue-reopened:before { content: "\eb0b" }
-.codicon-issues:before { content: "\eb0c" }
-.codicon-italic:before { content: "\eb0d" }
-.codicon-jersey:before { content: "\eb0e" }
-.codicon-json:before { content: "\eb0f" }
-.codicon-bracket:before { content: "\eb0f" }
-.codicon-kebab-vertical:before { content: "\eb10" }
-.codicon-key:before { content: "\eb11" }
-.codicon-law:before { content: "\eb12" }
-.codicon-lightbulb-autofix:before { content: "\eb13" }
-.codicon-link-external:before { content: "\eb14" }
-.codicon-link:before { content: "\eb15" }
-.codicon-list-ordered:before { content: "\eb16" }
-.codicon-list-unordered:before { content: "\eb17" }
-.codicon-live-share:before { content: "\eb18" }
-.codicon-loading:before { content: "\eb19" }
-.codicon-location:before { content: "\eb1a" }
-.codicon-mail-read:before { content: "\eb1b" }
-.codicon-mail:before { content: "\eb1c" }
-.codicon-markdown:before { content: "\eb1d" }
-.codicon-megaphone:before { content: "\eb1e" }
-.codicon-mention:before { content: "\eb1f" }
-.codicon-milestone:before { content: "\eb20" }
-.codicon-git-pull-request-milestone:before { content: "\eb20" }
-.codicon-mortar-board:before { content: "\eb21" }
-.codicon-move:before { content: "\eb22" }
-.codicon-multiple-windows:before { content: "\eb23" }
-.codicon-mute:before { content: "\eb24" }
-.codicon-no-newline:before { content: "\eb25" }
-.codicon-note:before { content: "\eb26" }
-.codicon-octoface:before { content: "\eb27" }
-.codicon-open-preview:before { content: "\eb28" }
-.codicon-package:before { content: "\eb29" }
-.codicon-paintcan:before { content: "\eb2a" }
-.codicon-pin:before { content: "\eb2b" }
-.codicon-play:before { content: "\eb2c" }
-.codicon-run:before { content: "\eb2c" }
-.codicon-plug:before { content: "\eb2d" }
-.codicon-preserve-case:before { content: "\eb2e" }
-.codicon-preview:before { content: "\eb2f" }
-.codicon-project:before { content: "\eb30" }
-.codicon-pulse:before { content: "\eb31" }
-.codicon-question:before { content: "\eb32" }
-.codicon-quote:before { content: "\eb33" }
-.codicon-radio-tower:before { content: "\eb34" }
-.codicon-reactions:before { content: "\eb35" }
-.codicon-references:before { content: "\eb36" }
-.codicon-refresh:before { content: "\eb37" }
-.codicon-regex:before { content: "\eb38" }
-.codicon-remote-explorer:before { content: "\eb39" }
-.codicon-remote:before { content: "\eb3a" }
-.codicon-remove:before { content: "\eb3b" }
-.codicon-replace-all:before { content: "\eb3c" }
-.codicon-replace:before { content: "\eb3d" }
-.codicon-repo-clone:before { content: "\eb3e" }
-.codicon-repo-force-push:before { content: "\eb3f" }
-.codicon-repo-pull:before { content: "\eb40" }
-.codicon-repo-push:before { content: "\eb41" }
-.codicon-report:before { content: "\eb42" }
-.codicon-request-changes:before { content: "\eb43" }
-.codicon-rocket:before { content: "\eb44" }
-.codicon-root-folder-opened:before { content: "\eb45" }
-.codicon-root-folder:before { content: "\eb46" }
-.codicon-rss:before { content: "\eb47" }
-.codicon-ruby:before { content: "\eb48" }
-.codicon-save-all:before { content: "\eb49" }
-.codicon-save-as:before { content: "\eb4a" }
-.codicon-save:before { content: "\eb4b" }
-.codicon-screen-full:before { content: "\eb4c" }
-.codicon-screen-normal:before { content: "\eb4d" }
-.codicon-search-stop:before { content: "\eb4e" }
-.codicon-server:before { content: "\eb50" }
-.codicon-settings-gear:before { content: "\eb51" }
-.codicon-settings:before { content: "\eb52" }
-.codicon-shield:before { content: "\eb53" }
-.codicon-smiley:before { content: "\eb54" }
-.codicon-sort-precedence:before { content: "\eb55" }
-.codicon-split-horizontal:before { content: "\eb56" }
-.codicon-split-vertical:before { content: "\eb57" }
-.codicon-squirrel:before { content: "\eb58" }
-.codicon-star-full:before { content: "\eb59" }
-.codicon-star-half:before { content: "\eb5a" }
-.codicon-symbol-class:before { content: "\eb5b" }
-.codicon-symbol-color:before { content: "\eb5c" }
-.codicon-symbol-constant:before { content: "\eb5d" }
-.codicon-symbol-enum-member:before { content: "\eb5e" }
-.codicon-symbol-field:before { content: "\eb5f" }
-.codicon-symbol-file:before { content: "\eb60" }
-.codicon-symbol-interface:before { content: "\eb61" }
-.codicon-symbol-keyword:before { content: "\eb62" }
-.codicon-symbol-misc:before { content: "\eb63" }
-.codicon-symbol-operator:before { content: "\eb64" }
-.codicon-symbol-property:before { content: "\eb65" }
-.codicon-wrench:before { content: "\eb65" }
-.codicon-wrench-subaction:before { content: "\eb65" }
-.codicon-symbol-snippet:before { content: "\eb66" }
-.codicon-tasklist:before { content: "\eb67" }
-.codicon-telescope:before { content: "\eb68" }
-.codicon-text-size:before { content: "\eb69" }
-.codicon-three-bars:before { content: "\eb6a" }
-.codicon-thumbsdown:before { content: "\eb6b" }
-.codicon-thumbsup:before { content: "\eb6c" }
-.codicon-tools:before { content: "\eb6d" }
-.codicon-triangle-down:before { content: "\eb6e" }
-.codicon-triangle-left:before { content: "\eb6f" }
-.codicon-triangle-right:before { content: "\eb70" }
-.codicon-triangle-up:before { content: "\eb71" }
-.codicon-twitter:before { content: "\eb72" }
-.codicon-unfold:before { content: "\eb73" }
-.codicon-unlock:before { content: "\eb74" }
-.codicon-unmute:before { content: "\eb75" }
-.codicon-unverified:before { content: "\eb76" }
-.codicon-verified:before { content: "\eb77" }
-.codicon-versions:before { content: "\eb78" }
-.codicon-vm-active:before { content: "\eb79" }
-.codicon-vm-outline:before { content: "\eb7a" }
-.codicon-vm-running:before { content: "\eb7b" }
-.codicon-watch:before { content: "\eb7c" }
-.codicon-whitespace:before { content: "\eb7d" }
-.codicon-whole-word:before { content: "\eb7e" }
-.codicon-window:before { content: "\eb7f" }
-.codicon-word-wrap:before { content: "\eb80" }
-.codicon-zoom-in:before { content: "\eb81" }
-.codicon-zoom-out:before { content: "\eb82" }
-.codicon-list-filter:before { content: "\eb83" }
-.codicon-list-flat:before { content: "\eb84" }
-.codicon-list-selection:before { content: "\eb85" }
-.codicon-selection:before { content: "\eb85" }
-.codicon-list-tree:before { content: "\eb86" }
-.codicon-debug-breakpoint-function-unverified:before { content: "\eb87" }
-.codicon-debug-breakpoint-function:before { content: "\eb88" }
-.codicon-debug-breakpoint-function-disabled:before { content: "\eb88" }
-.codicon-debug-stackframe-active:before { content: "\eb89" }
-.codicon-circle-small-filled:before { content: "\eb8a" }
-.codicon-debug-stackframe-dot:before { content: "\eb8a" }
-.codicon-terminal-decoration-mark:before { content: "\eb8a" }
-.codicon-debug-stackframe:before { content: "\eb8b" }
-.codicon-debug-stackframe-focused:before { content: "\eb8b" }
-.codicon-debug-breakpoint-unsupported:before { content: "\eb8c" }
-.codicon-symbol-string:before { content: "\eb8d" }
-.codicon-debug-reverse-continue:before { content: "\eb8e" }
-.codicon-debug-step-back:before { content: "\eb8f" }
-.codicon-debug-restart-frame:before { content: "\eb90" }
-.codicon-debug-alt:before { content: "\eb91" }
-.codicon-call-incoming:before { content: "\eb92" }
-.codicon-call-outgoing:before { content: "\eb93" }
-.codicon-menu:before { content: "\eb94" }
-.codicon-expand-all:before { content: "\eb95" }
-.codicon-feedback:before { content: "\eb96" }
-.codicon-git-pull-request-reviewer:before { content: "\eb96" }
-.codicon-group-by-ref-type:before { content: "\eb97" }
-.codicon-ungroup-by-ref-type:before { content: "\eb98" }
-.codicon-account:before { content: "\eb99" }
-.codicon-git-pull-request-assignee:before { content: "\eb99" }
-.codicon-bell-dot:before { content: "\eb9a" }
-.codicon-debug-console:before { content: "\eb9b" }
-.codicon-library:before { content: "\eb9c" }
-.codicon-output:before { content: "\eb9d" }
-.codicon-run-all:before { content: "\eb9e" }
-.codicon-sync-ignored:before { content: "\eb9f" }
-.codicon-pinned:before { content: "\eba0" }
-.codicon-github-inverted:before { content: "\eba1" }
-.codicon-server-process:before { content: "\eba2" }
-.codicon-server-environment:before { content: "\eba3" }
-.codicon-pass:before { content: "\eba4" }
-.codicon-issue-closed:before { content: "\eba4" }
-.codicon-stop-circle:before { content: "\eba5" }
-.codicon-play-circle:before { content: "\eba6" }
-.codicon-record:before { content: "\eba7" }
-.codicon-debug-alt-small:before { content: "\eba8" }
-.codicon-vm-connect:before { content: "\eba9" }
-.codicon-cloud:before { content: "\ebaa" }
-.codicon-merge:before { content: "\ebab" }
-.codicon-export:before { content: "\ebac" }
-.codicon-graph-left:before { content: "\ebad" }
-.codicon-magnet:before { content: "\ebae" }
-.codicon-notebook:before { content: "\ebaf" }
-.codicon-redo:before { content: "\ebb0" }
-.codicon-check-all:before { content: "\ebb1" }
-.codicon-pinned-dirty:before { content: "\ebb2" }
-.codicon-pass-filled:before { content: "\ebb3" }
-.codicon-circle-large-filled:before { content: "\ebb4" }
-.codicon-circle-large:before { content: "\ebb5" }
-.codicon-circle-large-outline:before { content: "\ebb5" }
-.codicon-combine:before { content: "\ebb6" }
-.codicon-gather:before { content: "\ebb6" }
-.codicon-table:before { content: "\ebb7" }
-.codicon-variable-group:before { content: "\ebb8" }
-.codicon-type-hierarchy:before { content: "\ebb9" }
-.codicon-type-hierarchy-sub:before { content: "\ebba" }
-.codicon-type-hierarchy-super:before { content: "\ebbb" }
-.codicon-git-pull-request-create:before { content: "\ebbc" }
-.codicon-run-above:before { content: "\ebbd" }
-.codicon-run-below:before { content: "\ebbe" }
-.codicon-notebook-template:before { content: "\ebbf" }
-.codicon-debug-rerun:before { content: "\ebc0" }
-.codicon-workspace-trusted:before { content: "\ebc1" }
-.codicon-workspace-untrusted:before { content: "\ebc2" }
-.codicon-workspace-unknown:before { content: "\ebc3" }
-.codicon-terminal-cmd:before { content: "\ebc4" }
-.codicon-terminal-debian:before { content: "\ebc5" }
-.codicon-terminal-linux:before { content: "\ebc6" }
-.codicon-terminal-powershell:before { content: "\ebc7" }
-.codicon-terminal-tmux:before { content: "\ebc8" }
-.codicon-terminal-ubuntu:before { content: "\ebc9" }
-.codicon-terminal-bash:before { content: "\ebca" }
-.codicon-arrow-swap:before { content: "\ebcb" }
-.codicon-copy:before { content: "\ebcc" }
-.codicon-person-add:before { content: "\ebcd" }
-.codicon-filter-filled:before { content: "\ebce" }
-.codicon-wand:before { content: "\ebcf" }
-.codicon-debug-line-by-line:before { content: "\ebd0" }
-.codicon-inspect:before { content: "\ebd1" }
-.codicon-layers:before { content: "\ebd2" }
-.codicon-layers-dot:before { content: "\ebd3" }
-.codicon-layers-active:before { content: "\ebd4" }
-.codicon-compass:before { content: "\ebd5" }
-.codicon-compass-dot:before { content: "\ebd6" }
-.codicon-compass-active:before { content: "\ebd7" }
-.codicon-azure:before { content: "\ebd8" }
-.codicon-issue-draft:before { content: "\ebd9" }
-.codicon-git-pull-request-closed:before { content: "\ebda" }
-.codicon-git-pull-request-draft:before { content: "\ebdb" }
-.codicon-debug-all:before { content: "\ebdc" }
-.codicon-debug-coverage:before { content: "\ebdd" }
-.codicon-run-errors:before { content: "\ebde" }
-.codicon-folder-library:before { content: "\ebdf" }
-.codicon-debug-continue-small:before { content: "\ebe0" }
-.codicon-beaker-stop:before { content: "\ebe1" }
-.codicon-graph-line:before { content: "\ebe2" }
-.codicon-graph-scatter:before { content: "\ebe3" }
-.codicon-pie-chart:before { content: "\ebe4" }
-.codicon-bracket-dot:before { content: "\ebe5" }
-.codicon-bracket-error:before { content: "\ebe6" }
-.codicon-lock-small:before { content: "\ebe7" }
-.codicon-azure-devops:before { content: "\ebe8" }
-.codicon-verified-filled:before { content: "\ebe9" }
-.codicon-newline:before { content: "\ebea" }
-.codicon-layout:before { content: "\ebeb" }
-.codicon-layout-activitybar-left:before { content: "\ebec" }
-.codicon-layout-activitybar-right:before { content: "\ebed" }
-.codicon-layout-panel-left:before { content: "\ebee" }
-.codicon-layout-panel-center:before { content: "\ebef" }
-.codicon-layout-panel-justify:before { content: "\ebf0" }
-.codicon-layout-panel-right:before { content: "\ebf1" }
-.codicon-layout-panel:before { content: "\ebf2" }
-.codicon-layout-sidebar-left:before { content: "\ebf3" }
-.codicon-layout-sidebar-right:before { content: "\ebf4" }
-.codicon-layout-statusbar:before { content: "\ebf5" }
-.codicon-layout-menubar:before { content: "\ebf6" }
-.codicon-layout-centered:before { content: "\ebf7" }
-.codicon-target:before { content: "\ebf8" }
-.codicon-indent:before { content: "\ebf9" }
-.codicon-record-small:before { content: "\ebfa" }
-.codicon-error-small:before { content: "\ebfb" }
-.codicon-terminal-decoration-error:before { content: "\ebfb" }
-.codicon-arrow-circle-down:before { content: "\ebfc" }
-.codicon-arrow-circle-left:before { content: "\ebfd" }
-.codicon-arrow-circle-right:before { content: "\ebfe" }
-.codicon-arrow-circle-up:before { content: "\ebff" }
-.codicon-layout-sidebar-right-off:before { content: "\ec00" }
-.codicon-layout-panel-off:before { content: "\ec01" }
-.codicon-layout-sidebar-left-off:before { content: "\ec02" }
-.codicon-blank:before { content: "\ec03" }
-.codicon-heart-filled:before { content: "\ec04" }
-.codicon-map:before { content: "\ec05" }
-.codicon-map-horizontal:before { content: "\ec05" }
-.codicon-fold-horizontal:before { content: "\ec05" }
-.codicon-map-filled:before { content: "\ec06" }
-.codicon-map-horizontal-filled:before { content: "\ec06" }
-.codicon-fold-horizontal-filled:before { content: "\ec06" }
-.codicon-circle-small:before { content: "\ec07" }
-.codicon-bell-slash:before { content: "\ec08" }
-.codicon-bell-slash-dot:before { content: "\ec09" }
-.codicon-comment-unresolved:before { content: "\ec0a" }
-.codicon-git-pull-request-go-to-changes:before { content: "\ec0b" }
-.codicon-git-pull-request-new-changes:before { content: "\ec0c" }
-.codicon-search-fuzzy:before { content: "\ec0d" }
-.codicon-comment-draft:before { content: "\ec0e" }
-.codicon-send:before { content: "\ec0f" }
-.codicon-sparkle:before { content: "\ec10" }
-.codicon-insert:before { content: "\ec11" }
-.codicon-mic:before { content: "\ec12" }
-.codicon-thumbsdown-filled:before { content: "\ec13" }
-.codicon-thumbsup-filled:before { content: "\ec14" }
-.codicon-coffee:before { content: "\ec15" }
-.codicon-snake:before { content: "\ec16" }
-.codicon-game:before { content: "\ec17" }
-.codicon-vr:before { content: "\ec18" }
-.codicon-chip:before { content: "\ec19" }
-.codicon-piano:before { content: "\ec1a" }
-.codicon-music:before { content: "\ec1b" }
-.codicon-mic-filled:before { content: "\ec1c" }
-.codicon-repo-fetch:before { content: "\ec1d" }
-.codicon-copilot:before { content: "\ec1e" }
-.codicon-lightbulb-sparkle:before { content: "\ec1f" }
-.codicon-robot:before { content: "\ec20" }
-.codicon-sparkle-filled:before { content: "\ec21" }
-.codicon-diff-single:before { content: "\ec22" }
-.codicon-diff-multiple:before { content: "\ec23" }
-.codicon-surround-with:before { content: "\ec24" }
-.codicon-share:before { content: "\ec25" }
-.codicon-git-stash:before { content: "\ec26" }
-.codicon-git-stash-apply:before { content: "\ec27" }
-.codicon-git-stash-pop:before { content: "\ec28" }
-.codicon-vscode:before { content: "\ec29" }
-.codicon-vscode-insiders:before { content: "\ec2a" }
-.codicon-code-oss:before { content: "\ec2b" }
-.codicon-run-coverage:before { content: "\ec2c" }
-.codicon-run-all-coverage:before { content: "\ec2d" }
-.codicon-coverage:before { content: "\ec2e" }
-.codicon-github-project:before { content: "\ec2f" }
-.codicon-map-vertical:before { content: "\ec30" }
-.codicon-fold-vertical:before { content: "\ec30" }
-.codicon-map-vertical-filled:before { content: "\ec31" }
-.codicon-fold-vertical-filled:before { content: "\ec31" }
-.codicon-go-to-search:before { content: "\ec32" }
-.codicon-percentage:before { content: "\ec33" }
-.codicon-sort-percentage:before { content: "\ec33" }
-.codicon-attach:before { content: "\ec34" }
-.codicon-go-to-editing-session:before { content: "\ec35" }
-.codicon-edit-session:before { content: "\ec36" }
-.codicon-code-review:before { content: "\ec37" }
-.codicon-copilot-warning:before { content: "\ec38" }
-.codicon-python:before { content: "\ec39" }
-.codicon-copilot-large:before { content: "\ec3a" }
-.codicon-copilot-warning-large:before { content: "\ec3b" }
-.codicon-keyboard-tab:before { content: "\ec3c" }
-.codicon-copilot-blocked:before { content: "\ec3d" }
-.codicon-copilot-not-connected:before { content: "\ec3e" }
-.codicon-flag:before { content: "\ec3f" }
-.codicon-lightbulb-empty:before { content: "\ec40" }
-.codicon-symbol-method-arrow:before { content: "\ec41" }
-.codicon-copilot-unavailable:before { content: "\ec42" }
-.codicon-repo-pinned:before { content: "\ec43" }
-.codicon-keyboard-tab-above:before { content: "\ec44" }
-.codicon-keyboard-tab-below:before { content: "\ec45" }
-.codicon-git-pull-request-done:before { content: "\ec46" }
-.codicon-mcp:before { content: "\ec47" }
-.codicon-extensions-large:before { content: "\ec48" }
-.codicon-layout-panel-dock:before { content: "\ec49" }
-.codicon-layout-sidebar-left-dock:before { content: "\ec4a" }
-.codicon-layout-sidebar-right-dock:before { content: "\ec4b" }
-.codicon-copilot-in-progress:before { content: "\ec4c" }
-.codicon-copilot-error:before { content: "\ec4d" }
-.codicon-copilot-success:before { content: "\ec4e" }
-.codicon-chat-sparkle:before { content: "\ec4f" }
-.codicon-search-sparkle:before { content: "\ec50" }
-.codicon-edit-sparkle:before { content: "\ec51" }
-.codicon-copilot-snooze:before { content: "\ec52" }
-.codicon-send-to-remote-agent:before { content: "\ec53" }
-.codicon-comment-discussion-sparkle:before { content: "\ec54" }
-.codicon-chat-sparkle-warning:before { content: "\ec55" }
-.codicon-chat-sparkle-error:before { content: "\ec56" }
-.codicon-collection:before { content: "\ec57" }
-.codicon-new-collection:before { content: "\ec58" }
-.codicon-thinking:before { content: "\ec59" }
-.codicon-build:before { content: "\ec5a" }
-.codicon-comment-discussion-quote:before { content: "\ec5b" }
-.codicon-cursor:before { content: "\ec5c" }
-.codicon-eraser:before { content: "\ec5d" }
-.codicon-file-text:before { content: "\ec5e" }
-.codicon-quotes:before { content: "\ec60" }
-.codicon-rename:before { content: "\ec61" }
-.codicon-run-with-deps:before { content: "\ec62" }
-.codicon-debug-connected:before { content: "\ec63" }
-.codicon-strikethrough:before { content: "\ec64" }
-.codicon-open-in-product:before { content: "\ec65" }
-.codicon-index-zero:before { content: "\ec66" }
-.codicon-agent:before { content: "\ec67" }
-.codicon-edit-code:before { content: "\ec68" }
-.codicon-repo-selected:before { content: "\ec69" }
-.codicon-skip:before { content: "\ec6a" }
-.codicon-merge-into:before { content: "\ec6b" }
-.codicon-git-branch-changes:before { content: "\ec6c" }
-.codicon-git-branch-staged-changes:before { content: "\ec6d" }
-.codicon-git-branch-conflicts:before { content: "\ec6e" }
-.codicon-git-branch:before { content: "\ec6f" }
-.codicon-git-branch-create:before { content: "\ec6f" }
-.codicon-git-branch-delete:before { content: "\ec6f" }
-.codicon-search-large:before { content: "\ec70" }
-.codicon-terminal-git-bash:before { content: "\ec71" }
-.codicon-window-active:before { content: "\ec72" }
-.codicon-forward:before { content: "\ec73" }
-.codicon-download:before { content: "\ec74" }
-.codicon-clockface:before { content: "\ec75" }
-.codicon-unarchive:before { content: "\ec76" }
-.codicon-session-in-progress:before { content: "\ec77" }
-.codicon-collection-small:before { content: "\ec78" }
-.codicon-vm-small:before { content: "\ec79" }
-.codicon-cloud-small:before { content: "\ec7a" }
-.codicon-add-small:before { content: "\ec7b" }
-.codicon-remove-small:before { content: "\ec7c" }
-.codicon-worktree-small:before { content: "\ec7d" }
-.codicon-worktree:before { content: "\ec7e" }
-.codicon-screen-cut:before { content: "\ec7f" }
-.codicon-ask:before { content: "\ec80" }
-.codicon-openai:before { content: "\ec81" }
-.codicon-claude:before { content: "\ec82" }
-.codicon-open-in-window:before { content: "\ec83" }
-.codicon-new-session:before { content: "\ec84" }
-.codicon-git-fetch:before { content: "\f101" }
-.codicon-vm-pending:before { content: "\f102" }
+.codicon-add:before {
+    content: "\ea60";
+}
+.codicon-plus:before {
+    content: "\ea60";
+}
+.codicon-gist-new:before {
+    content: "\ea60";
+}
+.codicon-repo-create:before {
+    content: "\ea60";
+}
+.codicon-lightbulb:before {
+    content: "\ea61";
+}
+.codicon-light-bulb:before {
+    content: "\ea61";
+}
+.codicon-repo:before {
+    content: "\ea62";
+}
+.codicon-repo-delete:before {
+    content: "\ea62";
+}
+.codicon-gist-fork:before {
+    content: "\ea63";
+}
+.codicon-repo-forked:before {
+    content: "\ea63";
+}
+.codicon-git-pull-request:before {
+    content: "\ea64";
+}
+.codicon-git-pull-request-abandoned:before {
+    content: "\ea64";
+}
+.codicon-record-keys:before {
+    content: "\ea65";
+}
+.codicon-keyboard:before {
+    content: "\ea65";
+}
+.codicon-tag:before {
+    content: "\ea66";
+}
+.codicon-git-pull-request-label:before {
+    content: "\ea66";
+}
+.codicon-tag-add:before {
+    content: "\ea66";
+}
+.codicon-tag-remove:before {
+    content: "\ea66";
+}
+.codicon-person:before {
+    content: "\ea67";
+}
+.codicon-person-follow:before {
+    content: "\ea67";
+}
+.codicon-person-outline:before {
+    content: "\ea67";
+}
+.codicon-person-filled:before {
+    content: "\ea67";
+}
+.codicon-source-control:before {
+    content: "\ea68";
+}
+.codicon-mirror:before {
+    content: "\ea69";
+}
+.codicon-mirror-public:before {
+    content: "\ea69";
+}
+.codicon-star:before {
+    content: "\ea6a";
+}
+.codicon-star-add:before {
+    content: "\ea6a";
+}
+.codicon-star-delete:before {
+    content: "\ea6a";
+}
+.codicon-star-empty:before {
+    content: "\ea6a";
+}
+.codicon-comment:before {
+    content: "\ea6b";
+}
+.codicon-comment-add:before {
+    content: "\ea6b";
+}
+.codicon-alert:before {
+    content: "\ea6c";
+}
+.codicon-warning:before {
+    content: "\ea6c";
+}
+.codicon-search:before {
+    content: "\ea6d";
+}
+.codicon-search-save:before {
+    content: "\ea6d";
+}
+.codicon-log-out:before {
+    content: "\ea6e";
+}
+.codicon-sign-out:before {
+    content: "\ea6e";
+}
+.codicon-log-in:before {
+    content: "\ea6f";
+}
+.codicon-sign-in:before {
+    content: "\ea6f";
+}
+.codicon-eye:before {
+    content: "\ea70";
+}
+.codicon-eye-unwatch:before {
+    content: "\ea70";
+}
+.codicon-eye-watch:before {
+    content: "\ea70";
+}
+.codicon-circle-filled:before {
+    content: "\ea71";
+}
+.codicon-primitive-dot:before {
+    content: "\ea71";
+}
+.codicon-close-dirty:before {
+    content: "\ea71";
+}
+.codicon-debug-breakpoint:before {
+    content: "\ea71";
+}
+.codicon-debug-breakpoint-disabled:before {
+    content: "\ea71";
+}
+.codicon-debug-hint:before {
+    content: "\ea71";
+}
+.codicon-terminal-decoration-success:before {
+    content: "\ea71";
+}
+.codicon-primitive-square:before {
+    content: "\ea72";
+}
+.codicon-edit:before {
+    content: "\ea73";
+}
+.codicon-pencil:before {
+    content: "\ea73";
+}
+.codicon-info:before {
+    content: "\ea74";
+}
+.codicon-issue-opened:before {
+    content: "\ea74";
+}
+.codicon-gist-private:before {
+    content: "\ea75";
+}
+.codicon-git-fork-private:before {
+    content: "\ea75";
+}
+.codicon-lock:before {
+    content: "\ea75";
+}
+.codicon-mirror-private:before {
+    content: "\ea75";
+}
+.codicon-close:before {
+    content: "\ea76";
+}
+.codicon-remove-close:before {
+    content: "\ea76";
+}
+.codicon-x:before {
+    content: "\ea76";
+}
+.codicon-repo-sync:before {
+    content: "\ea77";
+}
+.codicon-sync:before {
+    content: "\ea77";
+}
+.codicon-clone:before {
+    content: "\ea78";
+}
+.codicon-desktop-download:before {
+    content: "\ea78";
+}
+.codicon-beaker:before {
+    content: "\ea79";
+}
+.codicon-microscope:before {
+    content: "\ea79";
+}
+.codicon-vm:before {
+    content: "\ea7a";
+}
+.codicon-device-desktop:before {
+    content: "\ea7a";
+}
+.codicon-file:before {
+    content: "\ea7b";
+}
+.codicon-more:before {
+    content: "\ea7c";
+}
+.codicon-ellipsis:before {
+    content: "\ea7c";
+}
+.codicon-kebab-horizontal:before {
+    content: "\ea7c";
+}
+.codicon-mail-reply:before {
+    content: "\ea7d";
+}
+.codicon-reply:before {
+    content: "\ea7d";
+}
+.codicon-organization:before {
+    content: "\ea7e";
+}
+.codicon-organization-filled:before {
+    content: "\ea7e";
+}
+.codicon-organization-outline:before {
+    content: "\ea7e";
+}
+.codicon-new-file:before {
+    content: "\ea7f";
+}
+.codicon-file-add:before {
+    content: "\ea7f";
+}
+.codicon-new-folder:before {
+    content: "\ea80";
+}
+.codicon-file-directory-create:before {
+    content: "\ea80";
+}
+.codicon-trash:before {
+    content: "\ea81";
+}
+.codicon-trashcan:before {
+    content: "\ea81";
+}
+.codicon-history:before {
+    content: "\ea82";
+}
+.codicon-clock:before {
+    content: "\ea82";
+}
+.codicon-folder:before {
+    content: "\ea83";
+}
+.codicon-file-directory:before {
+    content: "\ea83";
+}
+.codicon-symbol-folder:before {
+    content: "\ea83";
+}
+.codicon-logo-github:before {
+    content: "\ea84";
+}
+.codicon-mark-github:before {
+    content: "\ea84";
+}
+.codicon-github:before {
+    content: "\ea84";
+}
+.codicon-terminal:before {
+    content: "\ea85";
+}
+.codicon-console:before {
+    content: "\ea85";
+}
+.codicon-repl:before {
+    content: "\ea85";
+}
+.codicon-zap:before {
+    content: "\ea86";
+}
+.codicon-symbol-event:before {
+    content: "\ea86";
+}
+.codicon-error:before {
+    content: "\ea87";
+}
+.codicon-stop:before {
+    content: "\ea87";
+}
+.codicon-variable:before {
+    content: "\ea88";
+}
+.codicon-symbol-variable:before {
+    content: "\ea88";
+}
+.codicon-array:before {
+    content: "\ea8a";
+}
+.codicon-symbol-array:before {
+    content: "\ea8a";
+}
+.codicon-symbol-module:before {
+    content: "\ea8b";
+}
+.codicon-symbol-package:before {
+    content: "\ea8b";
+}
+.codicon-symbol-namespace:before {
+    content: "\ea8b";
+}
+.codicon-symbol-object:before {
+    content: "\ea8b";
+}
+.codicon-symbol-method:before {
+    content: "\ea8c";
+}
+.codicon-symbol-function:before {
+    content: "\ea8c";
+}
+.codicon-symbol-constructor:before {
+    content: "\ea8c";
+}
+.codicon-symbol-boolean:before {
+    content: "\ea8f";
+}
+.codicon-symbol-null:before {
+    content: "\ea8f";
+}
+.codicon-symbol-numeric:before {
+    content: "\ea90";
+}
+.codicon-symbol-number:before {
+    content: "\ea90";
+}
+.codicon-symbol-structure:before {
+    content: "\ea91";
+}
+.codicon-symbol-struct:before {
+    content: "\ea91";
+}
+.codicon-symbol-parameter:before {
+    content: "\ea92";
+}
+.codicon-symbol-type-parameter:before {
+    content: "\ea92";
+}
+.codicon-symbol-key:before {
+    content: "\ea93";
+}
+.codicon-symbol-text:before {
+    content: "\ea93";
+}
+.codicon-symbol-reference:before {
+    content: "\ea94";
+}
+.codicon-go-to-file:before {
+    content: "\ea94";
+}
+.codicon-symbol-enum:before {
+    content: "\ea95";
+}
+.codicon-symbol-value:before {
+    content: "\ea95";
+}
+.codicon-symbol-ruler:before {
+    content: "\ea96";
+}
+.codicon-symbol-unit:before {
+    content: "\ea96";
+}
+.codicon-activate-breakpoints:before {
+    content: "\ea97";
+}
+.codicon-archive:before {
+    content: "\ea98";
+}
+.codicon-arrow-both:before {
+    content: "\ea99";
+}
+.codicon-arrow-down:before {
+    content: "\ea9a";
+}
+.codicon-arrow-left:before {
+    content: "\ea9b";
+}
+.codicon-arrow-right:before {
+    content: "\ea9c";
+}
+.codicon-arrow-small-down:before {
+    content: "\ea9d";
+}
+.codicon-arrow-small-left:before {
+    content: "\ea9e";
+}
+.codicon-arrow-small-right:before {
+    content: "\ea9f";
+}
+.codicon-arrow-small-up:before {
+    content: "\eaa0";
+}
+.codicon-arrow-up:before {
+    content: "\eaa1";
+}
+.codicon-bell:before {
+    content: "\eaa2";
+}
+.codicon-bold:before {
+    content: "\eaa3";
+}
+.codicon-book:before {
+    content: "\eaa4";
+}
+.codicon-bookmark:before {
+    content: "\eaa5";
+}
+.codicon-debug-breakpoint-conditional-unverified:before {
+    content: "\eaa6";
+}
+.codicon-debug-breakpoint-conditional:before {
+    content: "\eaa7";
+}
+.codicon-debug-breakpoint-conditional-disabled:before {
+    content: "\eaa7";
+}
+.codicon-debug-breakpoint-data-unverified:before {
+    content: "\eaa8";
+}
+.codicon-debug-breakpoint-data:before {
+    content: "\eaa9";
+}
+.codicon-debug-breakpoint-data-disabled:before {
+    content: "\eaa9";
+}
+.codicon-debug-breakpoint-log-unverified:before {
+    content: "\eaaa";
+}
+.codicon-debug-breakpoint-log:before {
+    content: "\eaab";
+}
+.codicon-debug-breakpoint-log-disabled:before {
+    content: "\eaab";
+}
+.codicon-briefcase:before {
+    content: "\eaac";
+}
+.codicon-broadcast:before {
+    content: "\eaad";
+}
+.codicon-browser:before {
+    content: "\eaae";
+}
+.codicon-bug:before {
+    content: "\eaaf";
+}
+.codicon-calendar:before {
+    content: "\eab0";
+}
+.codicon-case-sensitive:before {
+    content: "\eab1";
+}
+.codicon-check:before {
+    content: "\eab2";
+}
+.codicon-checklist:before {
+    content: "\eab3";
+}
+.codicon-chevron-down:before {
+    content: "\eab4";
+}
+.codicon-chevron-left:before {
+    content: "\eab5";
+}
+.codicon-chevron-right:before {
+    content: "\eab6";
+}
+.codicon-chevron-up:before {
+    content: "\eab7";
+}
+.codicon-chrome-close:before {
+    content: "\eab8";
+}
+.codicon-chrome-maximize:before {
+    content: "\eab9";
+}
+.codicon-chrome-minimize:before {
+    content: "\eaba";
+}
+.codicon-chrome-restore:before {
+    content: "\eabb";
+}
+.codicon-circle-outline:before {
+    content: "\eabc";
+}
+.codicon-circle:before {
+    content: "\eabc";
+}
+.codicon-debug-breakpoint-unverified:before {
+    content: "\eabc";
+}
+.codicon-terminal-decoration-incomplete:before {
+    content: "\eabc";
+}
+.codicon-circle-slash:before {
+    content: "\eabd";
+}
+.codicon-circuit-board:before {
+    content: "\eabe";
+}
+.codicon-clear-all:before {
+    content: "\eabf";
+}
+.codicon-clippy:before {
+    content: "\eac0";
+}
+.codicon-close-all:before {
+    content: "\eac1";
+}
+.codicon-cloud-download:before {
+    content: "\eac2";
+}
+.codicon-cloud-upload:before {
+    content: "\eac3";
+}
+.codicon-code:before {
+    content: "\eac4";
+}
+.codicon-collapse-all:before {
+    content: "\eac5";
+}
+.codicon-color-mode:before {
+    content: "\eac6";
+}
+.codicon-comment-discussion:before {
+    content: "\eac7";
+}
+.codicon-credit-card:before {
+    content: "\eac9";
+}
+.codicon-dash:before {
+    content: "\eacc";
+}
+.codicon-dashboard:before {
+    content: "\eacd";
+}
+.codicon-database:before {
+    content: "\eace";
+}
+.codicon-debug-continue:before {
+    content: "\eacf";
+}
+.codicon-debug-disconnect:before {
+    content: "\ead0";
+}
+.codicon-debug-pause:before {
+    content: "\ead1";
+}
+.codicon-debug-restart:before {
+    content: "\ead2";
+}
+.codicon-debug-start:before {
+    content: "\ead3";
+}
+.codicon-debug-step-into:before {
+    content: "\ead4";
+}
+.codicon-debug-step-out:before {
+    content: "\ead5";
+}
+.codicon-debug-step-over:before {
+    content: "\ead6";
+}
+.codicon-debug-stop:before {
+    content: "\ead7";
+}
+.codicon-debug:before {
+    content: "\ead8";
+}
+.codicon-device-camera-video:before {
+    content: "\ead9";
+}
+.codicon-device-camera:before {
+    content: "\eada";
+}
+.codicon-device-mobile:before {
+    content: "\eadb";
+}
+.codicon-diff-added:before {
+    content: "\eadc";
+}
+.codicon-diff-ignored:before {
+    content: "\eadd";
+}
+.codicon-diff-modified:before {
+    content: "\eade";
+}
+.codicon-diff-removed:before {
+    content: "\eadf";
+}
+.codicon-diff-renamed:before {
+    content: "\eae0";
+}
+.codicon-diff:before {
+    content: "\eae1";
+}
+.codicon-diff-sidebyside:before {
+    content: "\eae1";
+}
+.codicon-discard:before {
+    content: "\eae2";
+}
+.codicon-editor-layout:before {
+    content: "\eae3";
+}
+.codicon-empty-window:before {
+    content: "\eae4";
+}
+.codicon-exclude:before {
+    content: "\eae5";
+}
+.codicon-extensions:before {
+    content: "\eae6";
+}
+.codicon-eye-closed:before {
+    content: "\eae7";
+}
+.codicon-file-binary:before {
+    content: "\eae8";
+}
+.codicon-file-code:before {
+    content: "\eae9";
+}
+.codicon-file-media:before {
+    content: "\eaea";
+}
+.codicon-file-pdf:before {
+    content: "\eaeb";
+}
+.codicon-file-submodule:before {
+    content: "\eaec";
+}
+.codicon-file-symlink-directory:before {
+    content: "\eaed";
+}
+.codicon-file-symlink-file:before {
+    content: "\eaee";
+}
+.codicon-file-zip:before {
+    content: "\eaef";
+}
+.codicon-files:before {
+    content: "\eaf0";
+}
+.codicon-filter:before {
+    content: "\eaf1";
+}
+.codicon-flame:before {
+    content: "\eaf2";
+}
+.codicon-fold-down:before {
+    content: "\eaf3";
+}
+.codicon-fold-up:before {
+    content: "\eaf4";
+}
+.codicon-fold:before {
+    content: "\eaf5";
+}
+.codicon-folder-active:before {
+    content: "\eaf6";
+}
+.codicon-folder-opened:before {
+    content: "\eaf7";
+}
+.codicon-gear:before {
+    content: "\eaf8";
+}
+.codicon-gift:before {
+    content: "\eaf9";
+}
+.codicon-gist-secret:before {
+    content: "\eafa";
+}
+.codicon-gist:before {
+    content: "\eafb";
+}
+.codicon-git-commit:before {
+    content: "\eafc";
+}
+.codicon-git-compare:before {
+    content: "\eafd";
+}
+.codicon-compare-changes:before {
+    content: "\eafd";
+}
+.codicon-git-merge:before {
+    content: "\eafe";
+}
+.codicon-github-action:before {
+    content: "\eaff";
+}
+.codicon-github-alt:before {
+    content: "\eb00";
+}
+.codicon-globe:before {
+    content: "\eb01";
+}
+.codicon-grabber:before {
+    content: "\eb02";
+}
+.codicon-graph:before {
+    content: "\eb03";
+}
+.codicon-gripper:before {
+    content: "\eb04";
+}
+.codicon-heart:before {
+    content: "\eb05";
+}
+.codicon-home:before {
+    content: "\eb06";
+}
+.codicon-horizontal-rule:before {
+    content: "\eb07";
+}
+.codicon-hubot:before {
+    content: "\eb08";
+}
+.codicon-inbox:before {
+    content: "\eb09";
+}
+.codicon-issue-reopened:before {
+    content: "\eb0b";
+}
+.codicon-issues:before {
+    content: "\eb0c";
+}
+.codicon-italic:before {
+    content: "\eb0d";
+}
+.codicon-jersey:before {
+    content: "\eb0e";
+}
+.codicon-json:before {
+    content: "\eb0f";
+}
+.codicon-bracket:before {
+    content: "\eb0f";
+}
+.codicon-kebab-vertical:before {
+    content: "\eb10";
+}
+.codicon-key:before {
+    content: "\eb11";
+}
+.codicon-law:before {
+    content: "\eb12";
+}
+.codicon-lightbulb-autofix:before {
+    content: "\eb13";
+}
+.codicon-link-external:before {
+    content: "\eb14";
+}
+.codicon-link:before {
+    content: "\eb15";
+}
+.codicon-list-ordered:before {
+    content: "\eb16";
+}
+.codicon-list-unordered:before {
+    content: "\eb17";
+}
+.codicon-live-share:before {
+    content: "\eb18";
+}
+.codicon-loading:before {
+    content: "\eb19";
+}
+.codicon-location:before {
+    content: "\eb1a";
+}
+.codicon-mail-read:before {
+    content: "\eb1b";
+}
+.codicon-mail:before {
+    content: "\eb1c";
+}
+.codicon-markdown:before {
+    content: "\eb1d";
+}
+.codicon-megaphone:before {
+    content: "\eb1e";
+}
+.codicon-mention:before {
+    content: "\eb1f";
+}
+.codicon-milestone:before {
+    content: "\eb20";
+}
+.codicon-git-pull-request-milestone:before {
+    content: "\eb20";
+}
+.codicon-mortar-board:before {
+    content: "\eb21";
+}
+.codicon-move:before {
+    content: "\eb22";
+}
+.codicon-multiple-windows:before {
+    content: "\eb23";
+}
+.codicon-mute:before {
+    content: "\eb24";
+}
+.codicon-no-newline:before {
+    content: "\eb25";
+}
+.codicon-note:before {
+    content: "\eb26";
+}
+.codicon-octoface:before {
+    content: "\eb27";
+}
+.codicon-open-preview:before {
+    content: "\eb28";
+}
+.codicon-package:before {
+    content: "\eb29";
+}
+.codicon-paintcan:before {
+    content: "\eb2a";
+}
+.codicon-pin:before {
+    content: "\eb2b";
+}
+.codicon-play:before {
+    content: "\eb2c";
+}
+.codicon-run:before {
+    content: "\eb2c";
+}
+.codicon-plug:before {
+    content: "\eb2d";
+}
+.codicon-preserve-case:before {
+    content: "\eb2e";
+}
+.codicon-preview:before {
+    content: "\eb2f";
+}
+.codicon-project:before {
+    content: "\eb30";
+}
+.codicon-pulse:before {
+    content: "\eb31";
+}
+.codicon-question:before {
+    content: "\eb32";
+}
+.codicon-quote:before {
+    content: "\eb33";
+}
+.codicon-radio-tower:before {
+    content: "\eb34";
+}
+.codicon-reactions:before {
+    content: "\eb35";
+}
+.codicon-references:before {
+    content: "\eb36";
+}
+.codicon-refresh:before {
+    content: "\eb37";
+}
+.codicon-regex:before {
+    content: "\eb38";
+}
+.codicon-remote-explorer:before {
+    content: "\eb39";
+}
+.codicon-remote:before {
+    content: "\eb3a";
+}
+.codicon-remove:before {
+    content: "\eb3b";
+}
+.codicon-replace-all:before {
+    content: "\eb3c";
+}
+.codicon-replace:before {
+    content: "\eb3d";
+}
+.codicon-repo-clone:before {
+    content: "\eb3e";
+}
+.codicon-repo-force-push:before {
+    content: "\eb3f";
+}
+.codicon-repo-pull:before {
+    content: "\eb40";
+}
+.codicon-repo-push:before {
+    content: "\eb41";
+}
+.codicon-report:before {
+    content: "\eb42";
+}
+.codicon-request-changes:before {
+    content: "\eb43";
+}
+.codicon-rocket:before {
+    content: "\eb44";
+}
+.codicon-root-folder-opened:before {
+    content: "\eb45";
+}
+.codicon-root-folder:before {
+    content: "\eb46";
+}
+.codicon-rss:before {
+    content: "\eb47";
+}
+.codicon-ruby:before {
+    content: "\eb48";
+}
+.codicon-save-all:before {
+    content: "\eb49";
+}
+.codicon-save-as:before {
+    content: "\eb4a";
+}
+.codicon-save:before {
+    content: "\eb4b";
+}
+.codicon-screen-full:before {
+    content: "\eb4c";
+}
+.codicon-screen-normal:before {
+    content: "\eb4d";
+}
+.codicon-search-stop:before {
+    content: "\eb4e";
+}
+.codicon-server:before {
+    content: "\eb50";
+}
+.codicon-settings-gear:before {
+    content: "\eb51";
+}
+.codicon-settings:before {
+    content: "\eb52";
+}
+.codicon-shield:before {
+    content: "\eb53";
+}
+.codicon-smiley:before {
+    content: "\eb54";
+}
+.codicon-sort-precedence:before {
+    content: "\eb55";
+}
+.codicon-split-horizontal:before {
+    content: "\eb56";
+}
+.codicon-split-vertical:before {
+    content: "\eb57";
+}
+.codicon-squirrel:before {
+    content: "\eb58";
+}
+.codicon-star-full:before {
+    content: "\eb59";
+}
+.codicon-star-half:before {
+    content: "\eb5a";
+}
+.codicon-symbol-class:before {
+    content: "\eb5b";
+}
+.codicon-symbol-color:before {
+    content: "\eb5c";
+}
+.codicon-symbol-constant:before {
+    content: "\eb5d";
+}
+.codicon-symbol-enum-member:before {
+    content: "\eb5e";
+}
+.codicon-symbol-field:before {
+    content: "\eb5f";
+}
+.codicon-symbol-file:before {
+    content: "\eb60";
+}
+.codicon-symbol-interface:before {
+    content: "\eb61";
+}
+.codicon-symbol-keyword:before {
+    content: "\eb62";
+}
+.codicon-symbol-misc:before {
+    content: "\eb63";
+}
+.codicon-symbol-operator:before {
+    content: "\eb64";
+}
+.codicon-symbol-property:before {
+    content: "\eb65";
+}
+.codicon-wrench:before {
+    content: "\eb65";
+}
+.codicon-wrench-subaction:before {
+    content: "\eb65";
+}
+.codicon-symbol-snippet:before {
+    content: "\eb66";
+}
+.codicon-tasklist:before {
+    content: "\eb67";
+}
+.codicon-telescope:before {
+    content: "\eb68";
+}
+.codicon-text-size:before {
+    content: "\eb69";
+}
+.codicon-three-bars:before {
+    content: "\eb6a";
+}
+.codicon-thumbsdown:before {
+    content: "\eb6b";
+}
+.codicon-thumbsup:before {
+    content: "\eb6c";
+}
+.codicon-tools:before {
+    content: "\eb6d";
+}
+.codicon-triangle-down:before {
+    content: "\eb6e";
+}
+.codicon-triangle-left:before {
+    content: "\eb6f";
+}
+.codicon-triangle-right:before {
+    content: "\eb70";
+}
+.codicon-triangle-up:before {
+    content: "\eb71";
+}
+.codicon-twitter:before {
+    content: "\eb72";
+}
+.codicon-unfold:before {
+    content: "\eb73";
+}
+.codicon-unlock:before {
+    content: "\eb74";
+}
+.codicon-unmute:before {
+    content: "\eb75";
+}
+.codicon-unverified:before {
+    content: "\eb76";
+}
+.codicon-verified:before {
+    content: "\eb77";
+}
+.codicon-versions:before {
+    content: "\eb78";
+}
+.codicon-vm-active:before {
+    content: "\eb79";
+}
+.codicon-vm-outline:before {
+    content: "\eb7a";
+}
+.codicon-vm-running:before {
+    content: "\eb7b";
+}
+.codicon-watch:before {
+    content: "\eb7c";
+}
+.codicon-whitespace:before {
+    content: "\eb7d";
+}
+.codicon-whole-word:before {
+    content: "\eb7e";
+}
+.codicon-window:before {
+    content: "\eb7f";
+}
+.codicon-word-wrap:before {
+    content: "\eb80";
+}
+.codicon-zoom-in:before {
+    content: "\eb81";
+}
+.codicon-zoom-out:before {
+    content: "\eb82";
+}
+.codicon-list-filter:before {
+    content: "\eb83";
+}
+.codicon-list-flat:before {
+    content: "\eb84";
+}
+.codicon-list-selection:before {
+    content: "\eb85";
+}
+.codicon-selection:before {
+    content: "\eb85";
+}
+.codicon-list-tree:before {
+    content: "\eb86";
+}
+.codicon-debug-breakpoint-function-unverified:before {
+    content: "\eb87";
+}
+.codicon-debug-breakpoint-function:before {
+    content: "\eb88";
+}
+.codicon-debug-breakpoint-function-disabled:before {
+    content: "\eb88";
+}
+.codicon-debug-stackframe-active:before {
+    content: "\eb89";
+}
+.codicon-circle-small-filled:before {
+    content: "\eb8a";
+}
+.codicon-debug-stackframe-dot:before {
+    content: "\eb8a";
+}
+.codicon-terminal-decoration-mark:before {
+    content: "\eb8a";
+}
+.codicon-debug-stackframe:before {
+    content: "\eb8b";
+}
+.codicon-debug-stackframe-focused:before {
+    content: "\eb8b";
+}
+.codicon-debug-breakpoint-unsupported:before {
+    content: "\eb8c";
+}
+.codicon-symbol-string:before {
+    content: "\eb8d";
+}
+.codicon-debug-reverse-continue:before {
+    content: "\eb8e";
+}
+.codicon-debug-step-back:before {
+    content: "\eb8f";
+}
+.codicon-debug-restart-frame:before {
+    content: "\eb90";
+}
+.codicon-debug-alt:before {
+    content: "\eb91";
+}
+.codicon-call-incoming:before {
+    content: "\eb92";
+}
+.codicon-call-outgoing:before {
+    content: "\eb93";
+}
+.codicon-menu:before {
+    content: "\eb94";
+}
+.codicon-expand-all:before {
+    content: "\eb95";
+}
+.codicon-feedback:before {
+    content: "\eb96";
+}
+.codicon-git-pull-request-reviewer:before {
+    content: "\eb96";
+}
+.codicon-group-by-ref-type:before {
+    content: "\eb97";
+}
+.codicon-ungroup-by-ref-type:before {
+    content: "\eb98";
+}
+.codicon-account:before {
+    content: "\eb99";
+}
+.codicon-git-pull-request-assignee:before {
+    content: "\eb99";
+}
+.codicon-bell-dot:before {
+    content: "\eb9a";
+}
+.codicon-debug-console:before {
+    content: "\eb9b";
+}
+.codicon-library:before {
+    content: "\eb9c";
+}
+.codicon-output:before {
+    content: "\eb9d";
+}
+.codicon-run-all:before {
+    content: "\eb9e";
+}
+.codicon-sync-ignored:before {
+    content: "\eb9f";
+}
+.codicon-pinned:before {
+    content: "\eba0";
+}
+.codicon-github-inverted:before {
+    content: "\eba1";
+}
+.codicon-server-process:before {
+    content: "\eba2";
+}
+.codicon-server-environment:before {
+    content: "\eba3";
+}
+.codicon-pass:before {
+    content: "\eba4";
+}
+.codicon-issue-closed:before {
+    content: "\eba4";
+}
+.codicon-stop-circle:before {
+    content: "\eba5";
+}
+.codicon-play-circle:before {
+    content: "\eba6";
+}
+.codicon-record:before {
+    content: "\eba7";
+}
+.codicon-debug-alt-small:before {
+    content: "\eba8";
+}
+.codicon-vm-connect:before {
+    content: "\eba9";
+}
+.codicon-cloud:before {
+    content: "\ebaa";
+}
+.codicon-merge:before {
+    content: "\ebab";
+}
+.codicon-export:before {
+    content: "\ebac";
+}
+.codicon-graph-left:before {
+    content: "\ebad";
+}
+.codicon-magnet:before {
+    content: "\ebae";
+}
+.codicon-notebook:before {
+    content: "\ebaf";
+}
+.codicon-redo:before {
+    content: "\ebb0";
+}
+.codicon-check-all:before {
+    content: "\ebb1";
+}
+.codicon-pinned-dirty:before {
+    content: "\ebb2";
+}
+.codicon-pass-filled:before {
+    content: "\ebb3";
+}
+.codicon-circle-large-filled:before {
+    content: "\ebb4";
+}
+.codicon-circle-large:before {
+    content: "\ebb5";
+}
+.codicon-circle-large-outline:before {
+    content: "\ebb5";
+}
+.codicon-combine:before {
+    content: "\ebb6";
+}
+.codicon-gather:before {
+    content: "\ebb6";
+}
+.codicon-table:before {
+    content: "\ebb7";
+}
+.codicon-variable-group:before {
+    content: "\ebb8";
+}
+.codicon-type-hierarchy:before {
+    content: "\ebb9";
+}
+.codicon-type-hierarchy-sub:before {
+    content: "\ebba";
+}
+.codicon-type-hierarchy-super:before {
+    content: "\ebbb";
+}
+.codicon-git-pull-request-create:before {
+    content: "\ebbc";
+}
+.codicon-run-above:before {
+    content: "\ebbd";
+}
+.codicon-run-below:before {
+    content: "\ebbe";
+}
+.codicon-notebook-template:before {
+    content: "\ebbf";
+}
+.codicon-debug-rerun:before {
+    content: "\ebc0";
+}
+.codicon-workspace-trusted:before {
+    content: "\ebc1";
+}
+.codicon-workspace-untrusted:before {
+    content: "\ebc2";
+}
+.codicon-workspace-unknown:before {
+    content: "\ebc3";
+}
+.codicon-terminal-cmd:before {
+    content: "\ebc4";
+}
+.codicon-terminal-debian:before {
+    content: "\ebc5";
+}
+.codicon-terminal-linux:before {
+    content: "\ebc6";
+}
+.codicon-terminal-powershell:before {
+    content: "\ebc7";
+}
+.codicon-terminal-tmux:before {
+    content: "\ebc8";
+}
+.codicon-terminal-ubuntu:before {
+    content: "\ebc9";
+}
+.codicon-terminal-bash:before {
+    content: "\ebca";
+}
+.codicon-arrow-swap:before {
+    content: "\ebcb";
+}
+.codicon-copy:before {
+    content: "\ebcc";
+}
+.codicon-person-add:before {
+    content: "\ebcd";
+}
+.codicon-filter-filled:before {
+    content: "\ebce";
+}
+.codicon-wand:before {
+    content: "\ebcf";
+}
+.codicon-debug-line-by-line:before {
+    content: "\ebd0";
+}
+.codicon-inspect:before {
+    content: "\ebd1";
+}
+.codicon-layers:before {
+    content: "\ebd2";
+}
+.codicon-layers-dot:before {
+    content: "\ebd3";
+}
+.codicon-layers-active:before {
+    content: "\ebd4";
+}
+.codicon-compass:before {
+    content: "\ebd5";
+}
+.codicon-compass-dot:before {
+    content: "\ebd6";
+}
+.codicon-compass-active:before {
+    content: "\ebd7";
+}
+.codicon-azure:before {
+    content: "\ebd8";
+}
+.codicon-issue-draft:before {
+    content: "\ebd9";
+}
+.codicon-git-pull-request-closed:before {
+    content: "\ebda";
+}
+.codicon-git-pull-request-draft:before {
+    content: "\ebdb";
+}
+.codicon-debug-all:before {
+    content: "\ebdc";
+}
+.codicon-debug-coverage:before {
+    content: "\ebdd";
+}
+.codicon-run-errors:before {
+    content: "\ebde";
+}
+.codicon-folder-library:before {
+    content: "\ebdf";
+}
+.codicon-debug-continue-small:before {
+    content: "\ebe0";
+}
+.codicon-beaker-stop:before {
+    content: "\ebe1";
+}
+.codicon-graph-line:before {
+    content: "\ebe2";
+}
+.codicon-graph-scatter:before {
+    content: "\ebe3";
+}
+.codicon-pie-chart:before {
+    content: "\ebe4";
+}
+.codicon-bracket-dot:before {
+    content: "\ebe5";
+}
+.codicon-bracket-error:before {
+    content: "\ebe6";
+}
+.codicon-lock-small:before {
+    content: "\ebe7";
+}
+.codicon-azure-devops:before {
+    content: "\ebe8";
+}
+.codicon-verified-filled:before {
+    content: "\ebe9";
+}
+.codicon-newline:before {
+    content: "\ebea";
+}
+.codicon-layout:before {
+    content: "\ebeb";
+}
+.codicon-layout-activitybar-left:before {
+    content: "\ebec";
+}
+.codicon-layout-activitybar-right:before {
+    content: "\ebed";
+}
+.codicon-layout-panel-left:before {
+    content: "\ebee";
+}
+.codicon-layout-panel-center:before {
+    content: "\ebef";
+}
+.codicon-layout-panel-justify:before {
+    content: "\ebf0";
+}
+.codicon-layout-panel-right:before {
+    content: "\ebf1";
+}
+.codicon-layout-panel:before {
+    content: "\ebf2";
+}
+.codicon-layout-sidebar-left:before {
+    content: "\ebf3";
+}
+.codicon-layout-sidebar-right:before {
+    content: "\ebf4";
+}
+.codicon-layout-statusbar:before {
+    content: "\ebf5";
+}
+.codicon-layout-menubar:before {
+    content: "\ebf6";
+}
+.codicon-layout-centered:before {
+    content: "\ebf7";
+}
+.codicon-target:before {
+    content: "\ebf8";
+}
+.codicon-indent:before {
+    content: "\ebf9";
+}
+.codicon-record-small:before {
+    content: "\ebfa";
+}
+.codicon-error-small:before {
+    content: "\ebfb";
+}
+.codicon-terminal-decoration-error:before {
+    content: "\ebfb";
+}
+.codicon-arrow-circle-down:before {
+    content: "\ebfc";
+}
+.codicon-arrow-circle-left:before {
+    content: "\ebfd";
+}
+.codicon-arrow-circle-right:before {
+    content: "\ebfe";
+}
+.codicon-arrow-circle-up:before {
+    content: "\ebff";
+}
+.codicon-layout-sidebar-right-off:before {
+    content: "\ec00";
+}
+.codicon-layout-panel-off:before {
+    content: "\ec01";
+}
+.codicon-layout-sidebar-left-off:before {
+    content: "\ec02";
+}
+.codicon-blank:before {
+    content: "\ec03";
+}
+.codicon-heart-filled:before {
+    content: "\ec04";
+}
+.codicon-map:before {
+    content: "\ec05";
+}
+.codicon-map-horizontal:before {
+    content: "\ec05";
+}
+.codicon-fold-horizontal:before {
+    content: "\ec05";
+}
+.codicon-map-filled:before {
+    content: "\ec06";
+}
+.codicon-map-horizontal-filled:before {
+    content: "\ec06";
+}
+.codicon-fold-horizontal-filled:before {
+    content: "\ec06";
+}
+.codicon-circle-small:before {
+    content: "\ec07";
+}
+.codicon-bell-slash:before {
+    content: "\ec08";
+}
+.codicon-bell-slash-dot:before {
+    content: "\ec09";
+}
+.codicon-comment-unresolved:before {
+    content: "\ec0a";
+}
+.codicon-git-pull-request-go-to-changes:before {
+    content: "\ec0b";
+}
+.codicon-git-pull-request-new-changes:before {
+    content: "\ec0c";
+}
+.codicon-search-fuzzy:before {
+    content: "\ec0d";
+}
+.codicon-comment-draft:before {
+    content: "\ec0e";
+}
+.codicon-send:before {
+    content: "\ec0f";
+}
+.codicon-sparkle:before {
+    content: "\ec10";
+}
+.codicon-insert:before {
+    content: "\ec11";
+}
+.codicon-mic:before {
+    content: "\ec12";
+}
+.codicon-thumbsdown-filled:before {
+    content: "\ec13";
+}
+.codicon-thumbsup-filled:before {
+    content: "\ec14";
+}
+.codicon-coffee:before {
+    content: "\ec15";
+}
+.codicon-snake:before {
+    content: "\ec16";
+}
+.codicon-game:before {
+    content: "\ec17";
+}
+.codicon-vr:before {
+    content: "\ec18";
+}
+.codicon-chip:before {
+    content: "\ec19";
+}
+.codicon-piano:before {
+    content: "\ec1a";
+}
+.codicon-music:before {
+    content: "\ec1b";
+}
+.codicon-mic-filled:before {
+    content: "\ec1c";
+}
+.codicon-repo-fetch:before {
+    content: "\ec1d";
+}
+.codicon-copilot:before {
+    content: "\ec1e";
+}
+.codicon-lightbulb-sparkle:before {
+    content: "\ec1f";
+}
+.codicon-robot:before {
+    content: "\ec20";
+}
+.codicon-sparkle-filled:before {
+    content: "\ec21";
+}
+.codicon-diff-single:before {
+    content: "\ec22";
+}
+.codicon-diff-multiple:before {
+    content: "\ec23";
+}
+.codicon-surround-with:before {
+    content: "\ec24";
+}
+.codicon-share:before {
+    content: "\ec25";
+}
+.codicon-git-stash:before {
+    content: "\ec26";
+}
+.codicon-git-stash-apply:before {
+    content: "\ec27";
+}
+.codicon-git-stash-pop:before {
+    content: "\ec28";
+}
+.codicon-vscode:before {
+    content: "\ec29";
+}
+.codicon-vscode-insiders:before {
+    content: "\ec2a";
+}
+.codicon-code-oss:before {
+    content: "\ec2b";
+}
+.codicon-run-coverage:before {
+    content: "\ec2c";
+}
+.codicon-run-all-coverage:before {
+    content: "\ec2d";
+}
+.codicon-coverage:before {
+    content: "\ec2e";
+}
+.codicon-github-project:before {
+    content: "\ec2f";
+}
+.codicon-map-vertical:before {
+    content: "\ec30";
+}
+.codicon-fold-vertical:before {
+    content: "\ec30";
+}
+.codicon-map-vertical-filled:before {
+    content: "\ec31";
+}
+.codicon-fold-vertical-filled:before {
+    content: "\ec31";
+}
+.codicon-go-to-search:before {
+    content: "\ec32";
+}
+.codicon-percentage:before {
+    content: "\ec33";
+}
+.codicon-sort-percentage:before {
+    content: "\ec33";
+}
+.codicon-attach:before {
+    content: "\ec34";
+}
+.codicon-go-to-editing-session:before {
+    content: "\ec35";
+}
+.codicon-edit-session:before {
+    content: "\ec36";
+}
+.codicon-code-review:before {
+    content: "\ec37";
+}
+.codicon-copilot-warning:before {
+    content: "\ec38";
+}
+.codicon-python:before {
+    content: "\ec39";
+}
+.codicon-copilot-large:before {
+    content: "\ec3a";
+}
+.codicon-copilot-warning-large:before {
+    content: "\ec3b";
+}
+.codicon-keyboard-tab:before {
+    content: "\ec3c";
+}
+.codicon-copilot-blocked:before {
+    content: "\ec3d";
+}
+.codicon-copilot-not-connected:before {
+    content: "\ec3e";
+}
+.codicon-flag:before {
+    content: "\ec3f";
+}
+.codicon-lightbulb-empty:before {
+    content: "\ec40";
+}
+.codicon-symbol-method-arrow:before {
+    content: "\ec41";
+}
+.codicon-copilot-unavailable:before {
+    content: "\ec42";
+}
+.codicon-repo-pinned:before {
+    content: "\ec43";
+}
+.codicon-keyboard-tab-above:before {
+    content: "\ec44";
+}
+.codicon-keyboard-tab-below:before {
+    content: "\ec45";
+}
+.codicon-git-pull-request-done:before {
+    content: "\ec46";
+}
+.codicon-mcp:before {
+    content: "\ec47";
+}
+.codicon-extensions-large:before {
+    content: "\ec48";
+}
+.codicon-layout-panel-dock:before {
+    content: "\ec49";
+}
+.codicon-layout-sidebar-left-dock:before {
+    content: "\ec4a";
+}
+.codicon-layout-sidebar-right-dock:before {
+    content: "\ec4b";
+}
+.codicon-copilot-in-progress:before {
+    content: "\ec4c";
+}
+.codicon-copilot-error:before {
+    content: "\ec4d";
+}
+.codicon-copilot-success:before {
+    content: "\ec4e";
+}
+.codicon-chat-sparkle:before {
+    content: "\ec4f";
+}
+.codicon-search-sparkle:before {
+    content: "\ec50";
+}
+.codicon-edit-sparkle:before {
+    content: "\ec51";
+}
+.codicon-copilot-snooze:before {
+    content: "\ec52";
+}
+.codicon-send-to-remote-agent:before {
+    content: "\ec53";
+}
+.codicon-comment-discussion-sparkle:before {
+    content: "\ec54";
+}
+.codicon-chat-sparkle-warning:before {
+    content: "\ec55";
+}
+.codicon-chat-sparkle-error:before {
+    content: "\ec56";
+}
+.codicon-collection:before {
+    content: "\ec57";
+}
+.codicon-new-collection:before {
+    content: "\ec58";
+}
+.codicon-thinking:before {
+    content: "\ec59";
+}
+.codicon-build:before {
+    content: "\ec5a";
+}
+.codicon-comment-discussion-quote:before {
+    content: "\ec5b";
+}
+.codicon-cursor:before {
+    content: "\ec5c";
+}
+.codicon-eraser:before {
+    content: "\ec5d";
+}
+.codicon-file-text:before {
+    content: "\ec5e";
+}
+.codicon-quotes:before {
+    content: "\ec60";
+}
+.codicon-rename:before {
+    content: "\ec61";
+}
+.codicon-run-with-deps:before {
+    content: "\ec62";
+}
+.codicon-debug-connected:before {
+    content: "\ec63";
+}
+.codicon-strikethrough:before {
+    content: "\ec64";
+}
+.codicon-open-in-product:before {
+    content: "\ec65";
+}
+.codicon-index-zero:before {
+    content: "\ec66";
+}
+.codicon-agent:before {
+    content: "\ec67";
+}
+.codicon-edit-code:before {
+    content: "\ec68";
+}
+.codicon-repo-selected:before {
+    content: "\ec69";
+}
+.codicon-skip:before {
+    content: "\ec6a";
+}
+.codicon-merge-into:before {
+    content: "\ec6b";
+}
+.codicon-git-branch-changes:before {
+    content: "\ec6c";
+}
+.codicon-git-branch-staged-changes:before {
+    content: "\ec6d";
+}
+.codicon-git-branch-conflicts:before {
+    content: "\ec6e";
+}
+.codicon-git-branch:before {
+    content: "\ec6f";
+}
+.codicon-git-branch-create:before {
+    content: "\ec6f";
+}
+.codicon-git-branch-delete:before {
+    content: "\ec6f";
+}
+.codicon-search-large:before {
+    content: "\ec70";
+}
+.codicon-terminal-git-bash:before {
+    content: "\ec71";
+}
+.codicon-window-active:before {
+    content: "\ec72";
+}
+.codicon-forward:before {
+    content: "\ec73";
+}
+.codicon-download:before {
+    content: "\ec74";
+}
+.codicon-clockface:before {
+    content: "\ec75";
+}
+.codicon-unarchive:before {
+    content: "\ec76";
+}
+.codicon-session-in-progress:before {
+    content: "\ec77";
+}
+.codicon-collection-small:before {
+    content: "\ec78";
+}
+.codicon-vm-small:before {
+    content: "\ec79";
+}
+.codicon-cloud-small:before {
+    content: "\ec7a";
+}
+.codicon-add-small:before {
+    content: "\ec7b";
+}
+.codicon-remove-small:before {
+    content: "\ec7c";
+}
+.codicon-worktree-small:before {
+    content: "\ec7d";
+}
+.codicon-worktree:before {
+    content: "\ec7e";
+}
+.codicon-screen-cut:before {
+    content: "\ec7f";
+}
+.codicon-ask:before {
+    content: "\ec80";
+}
+.codicon-openai:before {
+    content: "\ec81";
+}
+.codicon-claude:before {
+    content: "\ec82";
+}
+.codicon-open-in-window:before {
+    content: "\ec83";
+}
+.codicon-new-session:before {
+    content: "\ec84";
+}
+.codicon-git-fetch:before {
+    content: "\f101";
+}
+.codicon-vm-pending:before {
+    content: "\f102";
+}

--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -7,8 +7,14 @@
     --skeleton-bg: var(--vscode-editor-inactiveSelectionBackground);
     /* Sidebar toolbars in VS Code use a transparent hover tint; fall back to
        list-hover where the token isn't themed. */
-    --toolbar-hover: var(--vscode-toolbar-hoverBackground, var(--vscode-list-hoverBackground));
-    --toolbar-active: var(--vscode-toolbar-activeBackground, var(--toolbar-hover));
+    --toolbar-hover: var(
+        --vscode-toolbar-hoverBackground,
+        var(--vscode-list-hoverBackground)
+    );
+    --toolbar-active: var(
+        --vscode-toolbar-activeBackground,
+        var(--toolbar-hover)
+    );
     --control-height: 22px;
 }
 
@@ -90,7 +96,9 @@ body {
  * up for the brief hide-delay; only the fill and label fade so there's
  * no layout flicker when the strip itself collapses afterwards. */
 .progress-bar.progress-finishing .progress-fill {
-    transition: width 200ms ease-out, opacity 500ms ease-out 100ms;
+    transition:
+        width 200ms ease-out,
+        opacity 500ms ease-out 100ms;
     opacity: 0;
 }
 .progress-bar.progress-finishing .progress-label {
@@ -106,16 +114,21 @@ body {
  * visible without confusing it for the current state.
  */
 .compile-errors {
-    background: var(--vscode-inputValidation-errorBackground,
-        color-mix(in srgb, var(--vscode-errorForeground) 18%, transparent));
-    border: 1px solid var(--vscode-inputValidation-errorBorder, var(--vscode-errorForeground));
+    background: var(
+        --vscode-inputValidation-errorBackground,
+        color-mix(in srgb, var(--vscode-errorForeground) 18%, transparent)
+    );
+    border: 1px solid
+        var(--vscode-inputValidation-errorBorder, var(--vscode-errorForeground));
     border-radius: 4px;
     margin: 6px 8px 0;
     padding: 8px 10px 4px;
     color: var(--vscode-foreground);
     font-size: calc(var(--vscode-font-size) - 1px);
 }
-.compile-errors[hidden] { display: none; }
+.compile-errors[hidden] {
+    display: none;
+}
 
 .compile-errors-header {
     display: flex;
@@ -125,7 +138,9 @@ body {
     color: var(--vscode-errorForeground);
     margin-bottom: 4px;
 }
-.compile-errors-header .codicon { font-size: 14px; }
+.compile-errors-header .codicon {
+    font-size: 14px;
+}
 
 .compile-errors-list {
     display: flex;
@@ -183,7 +198,9 @@ body {
 .preview-grid.compile-stale .preview-card {
     opacity: 0.55;
     filter: saturate(0.7);
-    transition: opacity 0.2s ease, filter 0.2s ease;
+    transition:
+        opacity 0.2s ease,
+        filter 0.2s ease;
 }
 
 /* -- Toolbar ---------------------------------------------------------- */
@@ -217,7 +234,8 @@ body {
     background-color: var(--vscode-dropdown-background);
     background-image: none;
     color: var(--vscode-dropdown-foreground);
-    border: 1px solid var(--vscode-dropdown-border, var(--vscode-dropdown-background));
+    border: 1px solid
+        var(--vscode-dropdown-border, var(--vscode-dropdown-background));
     border-radius: 2px;
     font-family: inherit;
     font-size: var(--vscode-font-size);
@@ -236,7 +254,10 @@ body {
 }
 
 .toolbar select option {
-    background-color: var(--vscode-dropdown-listBackground, var(--vscode-dropdown-background));
+    background-color: var(
+        --vscode-dropdown-listBackground,
+        var(--vscode-dropdown-background)
+    );
     color: var(--vscode-foreground);
 }
 
@@ -389,7 +410,11 @@ body {
 .focus-panel {
     border: 1px solid var(--card-border);
     border-radius: 4px;
-    background: color-mix(in srgb, var(--vscode-editor-background) 94%, var(--text-secondary));
+    background: color-mix(
+        in srgb,
+        var(--vscode-editor-background) 94%,
+        var(--text-secondary)
+    );
     min-width: 0;
 }
 
@@ -517,11 +542,19 @@ body {
 }
 
 .focus-product-option[data-state="ok"] {
-    border-color: color-mix(in srgb, var(--vscode-charts-green, #89d185) 45%, var(--card-border));
+    border-color: color-mix(
+        in srgb,
+        var(--vscode-charts-green, #89d185) 45%,
+        var(--card-border)
+    );
 }
 
 .focus-product-option[data-state="warn"] {
-    border-color: color-mix(in srgb, var(--vscode-editorWarning-foreground, #cca700) 55%, var(--card-border));
+    border-color: color-mix(
+        in srgb,
+        var(--vscode-editorWarning-foreground, #cca700) 55%,
+        var(--card-border)
+    );
 }
 
 .focus-product-option > input {
@@ -571,7 +604,8 @@ body {
 }
 
 .focus-placeholder {
-    border-top: 1px solid color-mix(in srgb, var(--card-border) 70%, transparent);
+    border-top: 1px solid
+        color-mix(in srgb, var(--card-border) 70%, transparent);
 }
 
 .focus-placeholder:first-child {
@@ -617,7 +651,11 @@ body {
     left: 0;
     right: 0;
     padding: 6px 8px;
-    background: color-mix(in srgb, var(--vscode-editor-background) 70%, transparent);
+    background: color-mix(
+        in srgb,
+        var(--vscode-editor-background) 70%,
+        transparent
+    );
     backdrop-filter: blur(6px);
     -webkit-backdrop-filter: blur(6px);
     z-index: 2;
@@ -685,12 +723,16 @@ body {
    - Grid: cards stay uniform (auto-fill columns), so we shrink the image
      container *inside* the card by --size-ratio instead. Smaller previews
      read as smaller, centered within their grid cell. */
-.preview-grid.layout-flow .preview-card[style*="--aspect-ratio"] .image-container {
+.preview-grid.layout-flow
+    .preview-card[style*="--aspect-ratio"]
+    .image-container {
     aspect-ratio: var(--aspect-ratio);
     min-height: 0;
 }
 
-.preview-grid.layout-grid .preview-card[style*="--size-ratio"] .image-container {
+.preview-grid.layout-grid
+    .preview-card[style*="--size-ratio"]
+    .image-container {
     width: calc(100% * var(--size-ratio));
     aspect-ratio: var(--aspect-ratio, auto);
     margin-inline: auto;
@@ -718,8 +760,19 @@ body {
 /* Subtle red border telegraphs that the card is an interactive target. */
 .preview-card.live {
     border-color: var(--vscode-errorForeground, #f55);
-    box-shadow: 0 0 0 1px color-mix(in srgb, var(--vscode-errorForeground, #f55) 30%, transparent),
-                0 0 12px color-mix(in srgb, var(--vscode-errorForeground, #f55) 25%, transparent);
+    box-shadow:
+        0 0 0 1px
+            color-mix(
+                in srgb,
+                var(--vscode-errorForeground, #f55) 30%,
+                transparent
+            ),
+        0 0 12px
+            color-mix(
+                in srgb,
+                var(--vscode-errorForeground, #f55) 25%,
+                transparent
+            );
 }
 .preview-card.live .image-container {
     cursor: crosshair; /* signals "click here to dispatch into the live preview" */
@@ -731,13 +784,25 @@ body {
     right: 6px;
     z-index: 4;
     color: var(--vscode-errorForeground, #f55);
-    background: color-mix(in srgb, var(--vscode-editor-background) 82%, transparent);
-    border-color: color-mix(in srgb, var(--vscode-errorForeground, #f55) 55%, transparent);
+    background: color-mix(
+        in srgb,
+        var(--vscode-editor-background) 82%,
+        transparent
+    );
+    border-color: color-mix(
+        in srgb,
+        var(--vscode-errorForeground, #f55) 55%,
+        transparent
+    );
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.28);
 }
 
 .card-live-stop-btn:hover:not(:disabled) {
-    background: color-mix(in srgb, var(--vscode-errorForeground, #f55) 18%, var(--vscode-editor-background));
+    background: color-mix(
+        in srgb,
+        var(--vscode-errorForeground, #f55) 18%,
+        var(--vscode-editor-background)
+    );
 }
 
 /* Toggle button "live-on" state: red glyph matching the live card outline. */
@@ -779,14 +844,21 @@ body {
     font-size: calc(var(--vscode-font-size) - 1px);
     padding: 12px;
 }
-.preview-diff-error { color: var(--vscode-errorForeground); }
+.preview-diff-error {
+    color: var(--vscode-errorForeground);
+}
 .preview-diff-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 8px;
     min-width: 0;
 }
-.preview-diff-pane { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.preview-diff-pane {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+}
 .preview-diff-pane-label {
     font-size: 90%;
     color: var(--text-secondary);
@@ -852,7 +924,10 @@ body {
     max-width: 100%;
     height: auto;
 }
-.diff-stack .diff-stack-base { position: relative; z-index: 0; }
+.diff-stack .diff-stack-base {
+    position: relative;
+    z-index: 0;
+}
 .diff-stack .diff-stack-top {
     position: absolute;
     inset: 0;
@@ -914,21 +989,34 @@ body {
 }
 
 @keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
 }
 
 .skeleton {
     width: 100%;
     height: 120px;
-    background: linear-gradient(90deg, var(--skeleton-bg) 25%, transparent 50%, var(--skeleton-bg) 75%);
+    background: linear-gradient(
+        90deg,
+        var(--skeleton-bg) 25%,
+        transparent 50%,
+        var(--skeleton-bg) 75%
+    );
     background-size: 200% 100%;
     animation: shimmer 1.5s infinite;
 }
 
 @keyframes shimmer {
-    0% { background-position: 200% 0; }
-    100% { background-position: -200% 0; }
+    0% {
+        background-position: 200% 0;
+    }
+    100% {
+        background-position: -200% 0;
+    }
 }
 
 .loading-overlay {
@@ -965,7 +1053,11 @@ body {
    image and drops a clearly visible spinner in the corner so it reads as
    "updating" at a glance without clobbering the image you're editing. */
 .loading-overlay.subtle {
-    background: color-mix(in srgb, var(--vscode-editor-background) 35%, transparent);
+    background: color-mix(
+        in srgb,
+        var(--vscode-editor-background) 35%,
+        transparent
+    );
     backdrop-filter: blur(1.5px);
     -webkit-backdrop-filter: blur(1.5px);
     justify-content: flex-end;
@@ -993,13 +1085,18 @@ body {
     width: 24px;
     height: 24px;
     border: 3px solid var(--text-secondary);
-    border-top-color: var(--vscode-progressBar-background, var(--vscode-focusBorder));
+    border-top-color: var(
+        --vscode-progressBar-background,
+        var(--vscode-focusBorder)
+    );
     border-radius: 50%;
     animation: spin 0.8s linear infinite;
 }
 
 @keyframes spin {
-    to { transform: rotate(360deg); }
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 .error-message {
@@ -1027,7 +1124,11 @@ body {
 .render-error {
     position: absolute;
     inset: 0;
-    background: color-mix(in srgb, var(--vscode-editor-background) 92%, transparent);
+    background: color-mix(
+        in srgb,
+        var(--vscode-editor-background) 92%,
+        transparent
+    );
     backdrop-filter: blur(2px);
     -webkit-backdrop-filter: blur(2px);
     overflow: auto;
@@ -1067,7 +1168,10 @@ body {
     margin-bottom: 6px;
 }
 .render-error-frame:hover {
-    color: var(--vscode-textLink-activeForeground, var(--vscode-textLink-foreground));
+    color: var(
+        --vscode-textLink-activeForeground,
+        var(--vscode-textLink-foreground)
+    );
 }
 .render-error-frame:focus-visible {
     outline: 1px solid var(--vscode-focusBorder);
@@ -1114,7 +1218,10 @@ body {
 }
 .card-stale-btn:hover {
     color: var(--vscode-editorWarning-foreground, #cca700);
-    background: var(--vscode-toolbar-hoverBackground, rgba(255, 255, 255, 0.08));
+    background: var(
+        --vscode-toolbar-hoverBackground,
+        rgba(255, 255, 255, 0.08)
+    );
 }
 
 /* Persistent variant summary — sits below the preview image so it never
@@ -1153,7 +1260,11 @@ body {
     gap: 4px;
     padding: 2px 6px;
     border-top: 1px solid var(--card-border);
-    background: color-mix(in srgb, var(--vscode-editor-background) 92%, transparent);
+    background: color-mix(
+        in srgb,
+        var(--vscode-editor-background) 92%,
+        transparent
+    );
 }
 
 .frame-controls:focus-visible {
@@ -1208,7 +1319,9 @@ body {
     display: inline-flex;
     align-items: center;
     opacity: 0.7;
-    transition: opacity 0.15s, background 0.15s;
+    transition:
+        opacity 0.15s,
+        background 0.15s;
 }
 .card-focus-btn:hover {
     opacity: 1;
@@ -1273,11 +1386,15 @@ body {
     box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.4);
     border-radius: 2px;
     opacity: 0.5;
-    transition: opacity 120ms ease, box-shadow 120ms ease;
+    transition:
+        opacity 120ms ease,
+        box-shadow 120ms ease;
 }
 .a11y-box.a11y-active {
     opacity: 1;
-    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.6), 0 0 12px var(--a11y-color, #d32f2f);
+    box-shadow:
+        0 0 0 2px rgba(0, 0, 0, 0.6),
+        0 0 12px var(--a11y-color, #d32f2f);
 }
 .a11y-box .a11y-badge {
     position: absolute;
@@ -1314,7 +1431,10 @@ body {
 .a11y-row.a11y-active {
     background: var(--vscode-list-hoverBackground, rgba(128, 128, 128, 0.1));
 }
-.a11y-text { flex: 1; min-width: 0; }
+.a11y-text {
+    flex: 1;
+    min-width: 0;
+}
 .a11y-title {
     font-weight: 600;
     font-size: calc(var(--vscode-font-size));
@@ -1349,6 +1469,12 @@ body {
 }
 
 /* Level → colour. Applied to both overlay boxes and legend rows. */
-.a11y-level-error { --a11y-color: #d32f2f; }
-.a11y-level-warning { --a11y-color: #f57c00; }
-.a11y-level-info { --a11y-color: #1976d2; }
+.a11y-level-error {
+    --a11y-color: #d32f2f;
+}
+.a11y-level-warning {
+    --a11y-color: #f57c00;
+}
+.a11y-level-info {
+    --a11y-color: #1976d2;
+}

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -17,6 +17,7 @@
                 "@vscode/vsce": "^3.0.0",
                 "glob": "^13.0.0",
                 "mocha": "^11.0.0",
+                "prettier": "^3.8.3",
                 "typescript": "^6.0.0"
             },
             "engines": {
@@ -3826,6 +3827,22 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/process-nextick-args": {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -146,7 +146,11 @@
                 },
                 "composePreview.logging.level": {
                     "type": "string",
-                    "enum": ["quiet", "normal", "verbose"],
+                    "enum": [
+                        "quiet",
+                        "normal",
+                        "verbose"
+                    ],
                     "default": "normal",
                     "enumDescriptions": [
                         "Errors and BUILD outcomes only — no per-task progress.",
@@ -161,6 +165,8 @@
     "scripts": {
         "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
+        "format": "prettier --write --tab-width 4 package.json package-lock.json tsconfig.json README.md \"src/**/*.ts\" \"src/**/*.json\" \"media/**/*.css\"",
+        "format:check": "prettier --check --tab-width 4 package.json package-lock.json tsconfig.json README.md \"src/**/*.ts\" \"src/**/*.json\" \"media/**/*.css\"",
         "test": "npm run compile && mocha --exit 'out/test/!(electron)/**/*.test.js' 'out/test/*.test.js'",
         "test:electron": "npm run compile && node ./out/test/electron/runTest.js",
         "lint": "eslint src --ext ts",
@@ -175,6 +181,7 @@
         "@vscode/vsce": "^3.0.0",
         "glob": "^13.0.0",
         "mocha": "^11.0.0",
+        "prettier": "^3.8.3",
         "typescript": "^6.0.0"
     },
     "overrides": {

--- a/vscode-extension/src/androidManifestCodeLensProvider.ts
+++ b/vscode-extension/src/androidManifestCodeLensProvider.ts
@@ -1,8 +1,8 @@
-import * as path from 'path';
-import * as vscode from 'vscode';
-import { GradleService } from './gradleService';
-import { findManifestIconReferences } from './manifestIconReferences';
-import { ResourceManifest, ResourcePreview } from './types';
+import * as path from "path";
+import * as vscode from "vscode";
+import { GradleService } from "./gradleService";
+import { findManifestIconReferences } from "./manifestIconReferences";
+import { ResourceManifest, ResourcePreview } from "./types";
 
 /**
  * Surfaces a "$(file-media) Preview <id>" CodeLens above every `android:icon` / `roundIcon` /
@@ -18,7 +18,9 @@ import { ResourceManifest, ResourcePreview } from './types';
  *   - The lookup we want is "is there a rendered preview for this resource id?" — a direct
  *     `resources[]` scan answers that without a join through `manifestReferences`.
  */
-export class AndroidManifestCodeLensProvider implements vscode.CodeLensProvider {
+export class AndroidManifestCodeLensProvider
+    implements vscode.CodeLensProvider
+{
     private readonly emitter = new vscode.EventEmitter<void>();
     readonly onDidChangeCodeLenses = this.emitter.event;
 
@@ -30,11 +32,17 @@ export class AndroidManifestCodeLensProvider implements vscode.CodeLensProvider 
     }
 
     provideCodeLenses(doc: vscode.TextDocument): vscode.CodeLens[] {
-        if (!doc.fileName.endsWith('AndroidManifest.xml')) { return []; }
+        if (!doc.fileName.endsWith("AndroidManifest.xml")) {
+            return [];
+        }
         const module = this.gradleService.resolveModule(doc.uri.fsPath);
-        if (!module) { return []; }
+        if (!module) {
+            return [];
+        }
         const manifest = this.gradleService.readResourceManifest(module);
-        if (!manifest) { return []; }
+        if (!manifest) {
+            return [];
+        }
 
         const byId = indexResources(manifest);
         const matches = findManifestIconReferences(doc.getText());
@@ -42,14 +50,18 @@ export class AndroidManifestCodeLensProvider implements vscode.CodeLensProvider 
         for (const m of matches) {
             const resourceId = `${m.resourceType}/${m.resourceName}`;
             const resource = byId.get(resourceId);
-            if (!resource) { continue; }
+            if (!resource) {
+                continue;
+            }
             const firstCapture = resource.captures.find((c) => c.renderOutput);
-            if (!firstCapture) { continue; }
+            if (!firstCapture) {
+                continue;
+            }
             const pngPath = path.join(
                 this.gradleService.workspaceRoot,
                 module,
-                'build',
-                'compose-previews',
+                "build",
+                "compose-previews",
                 firstCapture.renderOutput,
             );
             const pos = doc.positionAt(m.offset);
@@ -57,7 +69,7 @@ export class AndroidManifestCodeLensProvider implements vscode.CodeLensProvider 
             lenses.push(
                 new vscode.CodeLens(range, {
                     title: `$(file-media) Preview ${resourceId}`,
-                    command: 'composePreview.previewResource',
+                    command: "composePreview.previewResource",
                     arguments: [pngPath, resourceId],
                 }),
             );
@@ -70,7 +82,9 @@ export class AndroidManifestCodeLensProvider implements vscode.CodeLensProvider 
     }
 }
 
-function indexResources(manifest: ResourceManifest): Map<string, ResourcePreview> {
+function indexResources(
+    manifest: ResourceManifest,
+): Map<string, ResourcePreview> {
     const out = new Map<string, ResourcePreview>();
     for (const r of manifest.resources) {
         out.set(r.id, r);

--- a/vscode-extension/src/buildProgress.ts
+++ b/vscode-extension/src/buildProgress.ts
@@ -16,14 +16,14 @@
  * lap itself or finish early.
  */
 export type PhaseId =
-    | 'starting'
-    | 'configuring'
-    | 'compiling'
-    | 'resolving'
-    | 'discovering'
-    | 'rendering'
-    | 'loading'
-    | 'done';
+    | "starting"
+    | "configuring"
+    | "compiling"
+    | "resolving"
+    | "discovering"
+    | "rendering"
+    | "loading"
+    | "done";
 
 export interface PhaseDescriptor {
     id: PhaseId;
@@ -43,19 +43,46 @@ export interface PhaseDescriptor {
  * line arrives without committing to a percent.
  */
 export const PHASES: readonly PhaseDescriptor[] = [
-    { id: 'starting',    label: 'Starting',          weight: 0,    defaultMs: 200 },
-    { id: 'configuring', label: 'Configuring Gradle', weight: 0.08, defaultMs: 1500 },
-    { id: 'compiling',   label: 'Compiling Kotlin',  weight: 0.30, defaultMs: 4000 },
-    { id: 'resolving',   label: 'Resolving classpath', weight: 0.07, defaultMs: 1000 },
-    { id: 'discovering', label: 'Discovering @Preview', weight: 0.10, defaultMs: 1500 },
-    { id: 'rendering',   label: 'Rendering previews', weight: 0.35, defaultMs: 8000 },
-    { id: 'loading',     label: 'Loading images',    weight: 0.10, defaultMs: 600 },
-    { id: 'done',        label: 'Done',              weight: 0,    defaultMs: 0 },
+    { id: "starting", label: "Starting", weight: 0, defaultMs: 200 },
+    {
+        id: "configuring",
+        label: "Configuring Gradle",
+        weight: 0.08,
+        defaultMs: 1500,
+    },
+    {
+        id: "compiling",
+        label: "Compiling Kotlin",
+        weight: 0.3,
+        defaultMs: 4000,
+    },
+    {
+        id: "resolving",
+        label: "Resolving classpath",
+        weight: 0.07,
+        defaultMs: 1000,
+    },
+    {
+        id: "discovering",
+        label: "Discovering @Preview",
+        weight: 0.1,
+        defaultMs: 1500,
+    },
+    {
+        id: "rendering",
+        label: "Rendering previews",
+        weight: 0.35,
+        defaultMs: 8000,
+    },
+    { id: "loading", label: "Loading images", weight: 0.1, defaultMs: 600 },
+    { id: "done", label: "Done", weight: 0, defaultMs: 0 },
 ];
 
 const PHASE_INDEX: Record<PhaseId, number> = (() => {
     const out: Partial<Record<PhaseId, number>> = {};
-    PHASES.forEach((p, i) => { out[p.id] = i; });
+    PHASES.forEach((p, i) => {
+        out[p.id] = i;
+    });
     return out as Record<PhaseId, number>;
 })();
 
@@ -91,29 +118,43 @@ export type PhaseDurations = Partial<Record<PhaseId, number>>;
  */
 export function classifyTask(taskName: string): PhaseId | null {
     // Strip the leading ':' and any project path, focus on the task segment.
-    const segments = taskName.split(':').filter(s => s.length > 0);
+    const segments = taskName.split(":").filter((s) => s.length > 0);
     const tail = segments[segments.length - 1] ?? taskName;
     const lower = tail.toLowerCase();
 
-    if (lower.includes('renderpreviews') || lower.includes('renderallpreviews')
-        || lower.includes('renderandroidresources')) {
-        return 'rendering';
+    if (
+        lower.includes("renderpreviews") ||
+        lower.includes("renderallpreviews") ||
+        lower.includes("renderandroidresources")
+    ) {
+        return "rendering";
     }
-    if (lower.includes('discoverpreviews') || lower.includes('discoverandroidresources')
-        || lower.includes('collectpreviewinfo')) {
-        return 'discovering';
+    if (
+        lower.includes("discoverpreviews") ||
+        lower.includes("discoverandroidresources") ||
+        lower.includes("collectpreviewinfo")
+    ) {
+        return "discovering";
     }
-    if (lower.startsWith('compile')
-        && (lower.endsWith('kotlin') || lower.endsWith('java') || lower.endsWith('javac')
-            || lower.includes('javawith') || lower.includes('rendershards'))) {
-        return 'compiling';
+    if (
+        lower.startsWith("compile") &&
+        (lower.endsWith("kotlin") ||
+            lower.endsWith("java") ||
+            lower.endsWith("javac") ||
+            lower.includes("javawith") ||
+            lower.includes("rendershards"))
+    ) {
+        return "compiling";
     }
     // AGP task names embed the variant in the middle: `processDebugResources`,
     // `mergeReleaseResources`. Match the verb prefix + the trailing
     // `resources` suffix rather than a literal substring.
-    if (lower.includes('extractpreviewclasses') || lower.includes('generaterendershards')
-        || /^(merge|process)\w*resources$/.test(lower)) {
-        return 'resolving';
+    if (
+        lower.includes("extractpreviewclasses") ||
+        lower.includes("generaterendershards") ||
+        /^(merge|process)\w*resources$/.test(lower)
+    ) {
+        return "resolving";
     }
     return null;
 }
@@ -145,8 +186,8 @@ export interface ProgressTrackerOptions {
  * persist as calibration.
  */
 export class BuildProgressTracker {
-    private buffer = '';
-    private currentPhase: PhaseId = 'starting';
+    private buffer = "";
+    private currentPhase: PhaseId = "starting";
     private phaseEnteredAt = 0;
     private startedAt = 0;
     private lastEmittedPercent = 0;
@@ -170,8 +211,11 @@ export class BuildProgressTracker {
         this.onProgress = opts.onProgress;
         this.calibration = opts.calibration ?? {};
         this.nowFn = opts.now ?? Date.now;
-        this.setIntervalFn = opts.setInterval ?? ((cb, ms) => setInterval(cb, ms));
-        this.clearIntervalFn = opts.clearInterval ?? ((h) => clearInterval(h as ReturnType<typeof setInterval>));
+        this.setIntervalFn =
+            opts.setInterval ?? ((cb, ms) => setInterval(cb, ms));
+        this.clearIntervalFn =
+            opts.clearInterval ??
+            ((h) => clearInterval(h as ReturnType<typeof setInterval>));
         this.tickMs = opts.tickMs ?? 200;
     }
 
@@ -179,7 +223,7 @@ export class BuildProgressTracker {
         const now = this.nowFn();
         this.startedAt = now;
         this.phaseEnteredAt = now;
-        this.currentPhase = 'starting';
+        this.currentPhase = "starting";
         this.lastEmittedPercent = 0;
         this.finished = false;
         this.emit();
@@ -193,7 +237,9 @@ export class BuildProgressTracker {
      * the task returns).
      */
     enterPhase(phase: PhaseId): void {
-        if (this.finished) { return; }
+        if (this.finished) {
+            return;
+        }
         this.transitionTo(phase);
     }
 
@@ -202,29 +248,33 @@ export class BuildProgressTracker {
      * repeatedly with arbitrary chunk boundaries.
      */
     consume(chunk: string): void {
-        if (this.finished) { return; }
+        if (this.finished) {
+            return;
+        }
         this.buffer += chunk;
-        let nl = this.buffer.indexOf('\n');
+        let nl = this.buffer.indexOf("\n");
         while (nl !== -1) {
             const line = this.buffer.slice(0, nl);
             this.buffer = this.buffer.slice(nl + 1);
             this.scanLine(line);
-            nl = this.buffer.indexOf('\n');
+            nl = this.buffer.indexOf("\n");
         }
         // Bound runaway buffering when output arrives without newlines.
         if (this.buffer.length > 16 * 1024) {
             this.scanLine(this.buffer);
-            this.buffer = '';
+            this.buffer = "";
         }
     }
 
     /** Marks the build finished (success or failure). Drives the bar to 100%. */
     finish(): void {
-        if (this.finished) { return; }
+        if (this.finished) {
+            return;
+        }
         // Close out the running phase so its duration lands in phaseDurations.
         this.recordPhaseDuration();
         this.finished = true;
-        this.currentPhase = 'done';
+        this.currentPhase = "done";
         this.lastEmittedPercent = 1;
         this.emit();
         this.stopTicking();
@@ -232,20 +282,24 @@ export class BuildProgressTracker {
 
     /** Cancel without driving to 100% — used when a refresh is superseded. */
     abort(): void {
-        if (this.finished) { return; }
+        if (this.finished) {
+            return;
+        }
         this.finished = true;
         this.stopTicking();
     }
 
     private scanLine(line: string): void {
-        if (CONFIGURE_LINE_RE.test(line) && this.currentPhase === 'starting') {
-            this.transitionTo('configuring');
+        if (CONFIGURE_LINE_RE.test(line) && this.currentPhase === "starting") {
+            this.transitionTo("configuring");
             return;
         }
         const taskMatch = TASK_LINE_RE.exec(line);
         if (taskMatch) {
             const phase = classifyTask(taskMatch[1]);
-            if (phase) { this.transitionTo(phase); }
+            if (phase) {
+                this.transitionTo(phase);
+            }
             return;
         }
         if (BUILD_DONE_RE.test(line)) {
@@ -253,7 +307,7 @@ export class BuildProgressTracker {
             // extension still has post-task work to do (image loading), so we
             // jump to `loading` rather than `done` here. The caller calls
             // finish() once that work is complete.
-            this.transitionTo('loading');
+            this.transitionTo("loading");
         }
     }
 
@@ -263,7 +317,9 @@ export class BuildProgressTracker {
         // Phases are monotonic — a stray `discoverPreviews` line landing in the
         // middle of a render doesn't drag the bar backward. Same-phase
         // signals are no-ops.
-        if (targetIdx <= currentIdx) { return; }
+        if (targetIdx <= currentIdx) {
+            return;
+        }
         this.recordPhaseDuration();
         this.currentPhase = phase;
         this.phaseEnteredAt = this.nowFn();
@@ -273,13 +329,19 @@ export class BuildProgressTracker {
     private recordPhaseDuration(): void {
         const now = this.nowFn();
         const elapsed = now - this.phaseEnteredAt;
-        if (elapsed > 0 && this.currentPhase !== 'starting' && this.currentPhase !== 'done') {
+        if (
+            elapsed > 0 &&
+            this.currentPhase !== "starting" &&
+            this.currentPhase !== "done"
+        ) {
             this.phaseDurations[this.currentPhase] = elapsed;
         }
     }
 
     private tick(): void {
-        if (this.finished) { return; }
+        if (this.finished) {
+            return;
+        }
         this.emit();
     }
 
@@ -287,7 +349,7 @@ export class BuildProgressTracker {
         const state = this.computeState();
         // Don't emit a percent that's lower than what we just sent — the bar
         // is monotonic and going backward looks like a bug.
-        if (state.percent < this.lastEmittedPercent && state.phase !== 'done') {
+        if (state.percent < this.lastEmittedPercent && state.phase !== "done") {
             state.percent = this.lastEmittedPercent;
         }
         this.lastEmittedPercent = state.percent;
@@ -296,22 +358,27 @@ export class BuildProgressTracker {
 
     private computeState(): ProgressState {
         const phase = PHASES[PHASE_INDEX[this.currentPhase]];
-        if (this.currentPhase === 'done') {
-            return { phase: 'done', label: 'Done', percent: 1, slow: false };
+        if (this.currentPhase === "done") {
+            return { phase: "done", label: "Done", percent: 1, slow: false };
         }
-        if (this.currentPhase === 'starting') {
-            return { phase: 'starting', label: phase.label, percent: 0, slow: false };
+        if (this.currentPhase === "starting") {
+            return {
+                phase: "starting",
+                label: phase.label,
+                percent: 0,
+                slow: false,
+            };
         }
-        const { phaseStart, phaseEnd } = this.phaseBoundaries(this.currentPhase);
+        const { phaseStart, phaseEnd } = this.phaseBoundaries(
+            this.currentPhase,
+        );
         const expectedMs = this.expectedPhaseMs(this.currentPhase);
         const elapsed = this.nowFn() - this.phaseEnteredAt;
         // Asymptotic curve: hits ~63% of the phase span at expectedMs, ~95%
         // at 3*expectedMs. Never crosses the next phase boundary unless a
         // task signal explicitly transitions us there. Keeps the bar honest
         // when a phase outruns its estimate (cold Robolectric sandbox).
-        const ratio = expectedMs > 0
-            ? 1 - Math.exp(-elapsed / expectedMs)
-            : 0;
+        const ratio = expectedMs > 0 ? 1 - Math.exp(-elapsed / expectedMs) : 0;
         // Soft cap at 95% of the phase span — leaves visible headroom for the
         // transition into the next phase, so the bar always has somewhere to
         // jump forward to.
@@ -340,7 +407,10 @@ export class BuildProgressTracker {
      * up more of the bar than a fast one. Falls back to the static default
      * weights when no calibration is supplied.
      */
-    private phaseBoundaries(phase: PhaseId): { phaseStart: number; phaseEnd: number } {
+    private phaseBoundaries(phase: PhaseId): {
+        phaseStart: number;
+        phaseEnd: number;
+    } {
         const weights = this.normalisedWeights();
         let acc = 0;
         for (const p of PHASES) {
@@ -361,20 +431,25 @@ export class BuildProgressTracker {
         let total = 0;
         for (const p of PHASES) {
             const fromCalib = this.calibration[p.id];
-            const w = fromCalib != null
-                ? Math.max(50, fromCalib) // ms — clamp so a 0ms phase doesn't vanish
-                : Math.max(50, p.defaultMs * (p.weight > 0 ? 1 : 0));
+            const w =
+                fromCalib != null
+                    ? Math.max(50, fromCalib) // ms — clamp so a 0ms phase doesn't vanish
+                    : Math.max(50, p.defaultMs * (p.weight > 0 ? 1 : 0));
             raw[p.id] = w;
             total += w;
         }
         if (total <= 0) {
             // No data anywhere — fall back to descriptor weights as-is.
             const out: Record<PhaseId, number> = {} as Record<PhaseId, number>;
-            for (const p of PHASES) { out[p.id] = p.weight; }
+            for (const p of PHASES) {
+                out[p.id] = p.weight;
+            }
             return out;
         }
         const out: Record<PhaseId, number> = {} as Record<PhaseId, number>;
-        for (const p of PHASES) { out[p.id] = raw[p.id] / total; }
+        for (const p of PHASES) {
+            out[p.id] = raw[p.id] / total;
+        }
         return out;
     }
 
@@ -392,11 +467,16 @@ export class BuildProgressTracker {
  * on the latest sample (alpha=0.5) so a single fast or slow run is visible
  * on the next refresh, without making estimates pure noise.
  */
-export function mergeCalibration(prior: PhaseDurations, latest: PhaseDurations): PhaseDurations {
+export function mergeCalibration(
+    prior: PhaseDurations,
+    latest: PhaseDurations,
+): PhaseDurations {
     const out: PhaseDurations = { ...prior };
     for (const key of Object.keys(latest) as PhaseId[]) {
         const lv = latest[key];
-        if (lv == null) { continue; }
+        if (lv == null) {
+            continue;
+        }
         const pv = out[key];
         out[key] = pv == null ? lv : Math.round(pv * 0.5 + lv * 0.5);
     }

--- a/vscode-extension/src/captureLabels.ts
+++ b/vscode-extension/src/captureLabels.ts
@@ -1,4 +1,4 @@
-import { Capture, PreviewInfo } from './types';
+import { Capture, PreviewInfo } from "./types";
 
 /**
  * Human-readable label for one capture of a preview, used in the carousel
@@ -23,21 +23,21 @@ export function captureLabel(capture: Capture): string {
     if (capture.scroll) {
         parts.push(scrollLabel(capture.scroll));
     }
-    return parts.join(' \u00B7 ');
+    return parts.join(" \u00B7 ");
 }
 
-function scrollLabel(scroll: NonNullable<Capture['scroll']>): string {
+function scrollLabel(scroll: NonNullable<Capture["scroll"]>): string {
     // Prefer the outcome when the renderer has reported it; fall back to
     // the declared intent. `atEnd` wins over `reachedPx` so "scrolled end"
     // stays stable even when the renderer reports e.g. `reachedPx: 1200`
     // with content actually exhausted at that offset. TOP has no outcome
     // — the renderer doesn't drive any scrollable for it.
-    if (scroll.mode === 'TOP') return 'scroll top';
-    if (scroll.atEnd) return 'scrolled end';
+    if (scroll.mode === "TOP") return "scroll top";
+    if (scroll.atEnd) return "scrolled end";
     if (scroll.reachedPx != null) return `scrolled ${scroll.reachedPx}px`;
-    if (scroll.mode === 'END') return 'scroll end';
-    if (scroll.mode === 'LONG') return 'scroll long';
-    if (scroll.mode === 'GIF') return 'scroll gif';
+    if (scroll.mode === "END") return "scroll end";
+    if (scroll.mode === "LONG") return "scroll long";
+    if (scroll.mode === "GIF") return "scroll gif";
     return `scroll ${scroll.mode.toLowerCase()}`;
 }
 

--- a/vscode-extension/src/compileErrors.ts
+++ b/vscode-extension/src/compileErrors.ts
@@ -68,11 +68,11 @@ export interface CompileError {
  * spelling diagnostic can't accidentally gate a build.
  */
 const TRUSTED_SOURCES = new Set([
-    'kotlin',
-    'kotlin-language-server',
-    'fwcd.kotlin',
-    'gradle',
-    'JetBrains',
+    "kotlin",
+    "kotlin-language-server",
+    "fwcd.kotlin",
+    "gradle",
+    "JetBrains",
 ]);
 
 /**
@@ -89,8 +89,12 @@ export function extractCompileErrors(
     const fileLabel = basename(filePath);
     const errors: CompileError[] = [];
     for (const d of diagnostics) {
-        if (d.severity !== DIAGNOSTIC_SEVERITY.Error) { continue; }
-        if (d.source && !TRUSTED_SOURCES.has(d.source)) { continue; }
+        if (d.severity !== DIAGNOSTIC_SEVERITY.Error) {
+            continue;
+        }
+        if (d.source && !TRUSTED_SOURCES.has(d.source)) {
+            continue;
+        }
         errors.push({
             file: fileLabel,
             path: filePath,
@@ -101,16 +105,19 @@ export function extractCompileErrors(
             message: firstLine(d.message),
         });
     }
-    errors.sort((a, b) => (a.line - b.line) || (a.column - b.column));
+    errors.sort((a, b) => a.line - b.line || a.column - b.column);
     return errors;
 }
 
 function firstLine(message: string): string {
-    const nl = message.indexOf('\n');
+    const nl = message.indexOf("\n");
     return nl >= 0 ? message.slice(0, nl) : message;
 }
 
 function basename(filePath: string): string {
-    const slash = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+    const slash = Math.max(
+        filePath.lastIndexOf("/"),
+        filePath.lastIndexOf("\\"),
+    );
     return slash >= 0 ? filePath.slice(slash + 1) : filePath;
 }

--- a/vscode-extension/src/daemon/currentRendersHistory.ts
+++ b/vscode-extension/src/daemon/currentRendersHistory.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import { HistoryListResult, HistoryReadResult } from './daemonProtocol';
+import * as fs from "fs";
+import * as path from "path";
+import { HistoryListResult, HistoryReadResult } from "./daemonProtocol";
 
 /**
  * UX fallback that surfaces "what's currently on disk under
@@ -31,29 +31,42 @@ export class CurrentRendersHistory {
     list(previewIdFilter?: string): HistoryListResult {
         const manifest = this.readManifest();
         const entries: SyntheticHistoryEntry[] = [];
-        if (!manifest) { return { entries: [], totalCount: 0 }; }
+        if (!manifest) {
+            return { entries: [], totalCount: 0 };
+        }
 
         for (const preview of manifest.previews ?? []) {
-            if (previewIdFilter && preview.id !== previewIdFilter) { continue; }
-            const captures = Array.isArray(preview.captures) ? preview.captures : [];
+            if (previewIdFilter && preview.id !== previewIdFilter) {
+                continue;
+            }
+            const captures = Array.isArray(preview.captures)
+                ? preview.captures
+                : [];
             // Only the representative (first) capture per preview gets a row;
             // the panel doesn't have UI for sibling captures yet, and showing
             // every animation frame as a separate history entry would drown
             // the static previews in the same module.
-            const representative = captures.find(c => c?.renderOutput);
-            if (!representative?.renderOutput) { continue; }
-            const pngPath = path.join(this.opts.buildDir, representative.renderOutput);
+            const representative = captures.find((c) => c?.renderOutput);
+            if (!representative?.renderOutput) {
+                continue;
+            }
+            const pngPath = path.join(
+                this.opts.buildDir,
+                representative.renderOutput,
+            );
             const stat = statOrNull(pngPath);
-            if (!stat) { continue; }
+            if (!stat) {
+                continue;
+            }
             entries.push({
                 id: syntheticId(representative.renderOutput),
                 previewId: preview.id,
                 module: this.opts.moduleId,
                 timestamp: stat.mtime.toISOString(),
                 pngPath: representative.renderOutput,
-                producer: 'gradle',
-                trigger: 'current',
-                source: { kind: 'fs', id: `current:${this.opts.moduleId}` },
+                producer: "gradle",
+                trigger: "current",
+                source: { kind: "fs", id: `current:${this.opts.moduleId}` },
                 previewMetadata: {
                     sourceFile: preview.sourceFile ?? null,
                 },
@@ -70,27 +83,37 @@ export class CurrentRendersHistory {
      * been deleted between list and read (e.g. a `clean` ran).
      */
     read(id: string): HistoryReadResult | null {
-        if (!id.startsWith(SYNTHETIC_ID_PREFIX)) { return null; }
+        if (!id.startsWith(SYNTHETIC_ID_PREFIX)) {
+            return null;
+        }
         const renderOutput = decodeSyntheticId(id);
-        if (!renderOutput) { return null; }
+        if (!renderOutput) {
+            return null;
+        }
         const manifest = this.readManifest();
-        if (!manifest) { return null; }
-        const owner = (manifest.previews ?? []).find(p =>
-            (p.captures ?? []).some(c => c?.renderOutput === renderOutput),
+        if (!manifest) {
+            return null;
+        }
+        const owner = (manifest.previews ?? []).find((p) =>
+            (p.captures ?? []).some((c) => c?.renderOutput === renderOutput),
         );
-        if (!owner) { return null; }
+        if (!owner) {
+            return null;
+        }
         const pngPath = path.join(this.opts.buildDir, renderOutput);
         const stat = statOrNull(pngPath);
-        if (!stat) { return null; }
+        if (!stat) {
+            return null;
+        }
         const entry: SyntheticHistoryEntry = {
             id,
             previewId: owner.id,
             module: this.opts.moduleId,
             timestamp: stat.mtime.toISOString(),
             pngPath: renderOutput,
-            producer: 'gradle',
-            trigger: 'current',
-            source: { kind: 'fs', id: `current:${this.opts.moduleId}` },
+            producer: "gradle",
+            trigger: "current",
+            source: { kind: "fs", id: `current:${this.opts.moduleId}` },
             previewMetadata: {
                 sourceFile: owner.sourceFile ?? null,
             },
@@ -103,12 +126,16 @@ export class CurrentRendersHistory {
     }
 
     private readManifest(): ManifestShape | null {
-        const manifestPath = path.join(this.opts.buildDir, 'previews.json');
-        if (!fs.existsSync(manifestPath)) { return null; }
+        const manifestPath = path.join(this.opts.buildDir, "previews.json");
+        if (!fs.existsSync(manifestPath)) {
+            return null;
+        }
         try {
-            const raw = fs.readFileSync(manifestPath, 'utf-8');
+            const raw = fs.readFileSync(manifestPath, "utf-8");
             const parsed = JSON.parse(raw) as ManifestShape;
-            if (!Array.isArray(parsed.previews)) { return null; }
+            if (!Array.isArray(parsed.previews)) {
+                return null;
+            }
             return parsed;
         } catch {
             return null;
@@ -125,25 +152,35 @@ export interface CurrentRendersOptions {
     moduleId: string;
 }
 
-const SYNTHETIC_ID_PREFIX = 'current:';
+const SYNTHETIC_ID_PREFIX = "current:";
 
 function syntheticId(renderOutput: string): string {
     // Base64url of the renderOutput keeps the id opaque to the panel and
     // round-trippable without a separate index. Path separators and dots
     // would otherwise clash with the panel's CSS-escape attribute selector.
-    return SYNTHETIC_ID_PREFIX + Buffer.from(renderOutput, 'utf-8').toString('base64url');
+    return (
+        SYNTHETIC_ID_PREFIX +
+        Buffer.from(renderOutput, "utf-8").toString("base64url")
+    );
 }
 
 function decodeSyntheticId(id: string): string | null {
     try {
-        return Buffer.from(id.slice(SYNTHETIC_ID_PREFIX.length), 'base64url').toString('utf-8');
+        return Buffer.from(
+            id.slice(SYNTHETIC_ID_PREFIX.length),
+            "base64url",
+        ).toString("utf-8");
     } catch {
         return null;
     }
 }
 
 function statOrNull(p: string): fs.Stats | null {
-    try { return fs.statSync(p); } catch { return null; }
+    try {
+        return fs.statSync(p);
+    } catch {
+        return null;
+    }
 }
 
 interface ManifestShape {

--- a/vscode-extension/src/daemon/daemonClient.ts
+++ b/vscode-extension/src/daemon/daemonClient.ts
@@ -1,5 +1,5 @@
-import { Readable, Writable } from 'stream';
-import { FrameDecoder, encodeFrame } from './daemonFraming';
+import { Readable, Writable } from "stream";
+import { FrameDecoder, encodeFrame } from "./daemonFraming";
 import {
     ClasspathDirtyParams,
     DaemonWarmingParams,
@@ -43,13 +43,17 @@ import {
     SandboxRecycleParams,
     SetFocusParams,
     SetVisibleParams,
-} from './daemonProtocol';
+} from "./daemonProtocol";
 
 export interface DaemonClientLogger {
     appendLine(value: string): void;
 }
 
-const nullLogger: DaemonClientLogger = { appendLine() { /* noop */ } };
+const nullLogger: DaemonClientLogger = {
+    appendLine() {
+        /* noop */
+    },
+};
 
 /**
  * Daemon → client notification handlers. All optional; ignore what you don't
@@ -76,7 +80,7 @@ export interface DaemonClientEvents {
 export class DaemonRpcError extends Error {
     constructor(public readonly rpc: JsonRpcError) {
         super(`${rpc.code} ${rpc.message}`);
-        this.name = 'DaemonRpcError';
+        this.name = "DaemonRpcError";
     }
 }
 
@@ -109,61 +113,63 @@ export class DaemonClient {
             onError: (err) => this.fail(err),
         });
 
-        stdout.on('data', (chunk: Buffer | string) => {
+        stdout.on("data", (chunk: Buffer | string) => {
             const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
             this.decoder.push(buf);
         });
-        stdout.on('end', () => this.fail());
-        stdout.on('error', (err: Error) => this.fail(err));
-        stdin.on('error', (err: Error) => this.fail(err));
+        stdout.on("end", () => this.fail());
+        stdout.on("error", (err: Error) => this.fail(err));
+        stdin.on("error", (err: Error) => this.fail(err));
     }
 
-    initialize(params: Omit<InitializeParams, 'protocolVersion'>): Promise<InitializeResult> {
-        return this.request<InitializeResult>('initialize', {
+    initialize(
+        params: Omit<InitializeParams, "protocolVersion">,
+    ): Promise<InitializeResult> {
+        return this.request<InitializeResult>("initialize", {
             ...params,
             protocolVersion: PROTOCOL_VERSION,
         });
     }
 
     initialized(): void {
-        this.notify('initialized', undefined);
+        this.notify("initialized", undefined);
     }
 
     setVisible(params: SetVisibleParams): void {
-        this.notify('setVisible', params);
+        this.notify("setVisible", params);
     }
 
     setFocus(params: SetFocusParams): void {
-        this.notify('setFocus', params);
+        this.notify("setFocus", params);
     }
 
     fileChanged(params: FileChangedParams): void {
-        this.notify('fileChanged', params);
+        this.notify("fileChanged", params);
     }
 
     renderNow(params: RenderNowParams): Promise<RenderNowResult> {
-        return this.request<RenderNowResult>('renderNow', params);
+        return this.request<RenderNowResult>("renderNow", params);
     }
 
     /** Phase H2. Returns recent history entries newest-first; pass back
      *  `result.nextCursor` as `params.cursor` to paginate. Filter fields are
      *  cumulative (AND semantics). See PROTOCOL.md § 5 (history/list). */
     historyList(params: HistoryListParams = {}): Promise<HistoryListResult> {
-        return this.request<HistoryListResult>('history/list', params);
+        return this.request<HistoryListResult>("history/list", params);
     }
 
     /** Phase H2. `inline: false` (default) returns `pngPath` only —
      *  preferred for local same-host clients; the bytes never traverse the
      *  wire. `inline: true` returns base64 `pngBytes`. See PROTOCOL.md § 5. */
     historyRead(params: HistoryReadParams): Promise<HistoryReadResult> {
-        return this.request<HistoryReadResult>('history/read', params);
+        return this.request<HistoryReadResult>("history/read", params);
     }
 
     /** Phase H3 (metadata mode). `mode: 'pixel'` is reserved for H5 and
      *  rejects with `HistoryPixelNotImplemented` until then. See
      *  PROTOCOL.md § 5 (history/diff). */
     historyDiff(params: HistoryDiffParams): Promise<HistoryDiffResult> {
-        return this.request<HistoryDiffResult>('history/diff', params);
+        return this.request<HistoryDiffResult>("history/diff", params);
     }
 
     /**
@@ -176,7 +182,7 @@ export class DaemonClient {
      * `DataProductUnknown (-32020)`.
      */
     dataFetch(params: DataFetchParams): Promise<DataFetchResult> {
-        return this.request<DataFetchResult>('data/fetch', params);
+        return this.request<DataFetchResult>("data/fetch", params);
     }
 
     /**
@@ -187,13 +193,13 @@ export class DaemonClient {
      * UI is invited to re-subscribe when the preview returns to view.
      */
     dataSubscribe(params: DataSubscribeParams): Promise<DataSubscribeResult> {
-        return this.request<DataSubscribeResult>('data/subscribe', params);
+        return this.request<DataSubscribeResult>("data/subscribe", params);
     }
 
     /** D1 — opposite of {@link dataSubscribe}. Idempotent — unsubscribing
      *  a kind that was never subscribed succeeds silently. */
     dataUnsubscribe(params: DataSubscribeParams): Promise<DataSubscribeResult> {
-        return this.request<DataSubscribeResult>('data/unsubscribe', params);
+        return this.request<DataSubscribeResult>("data/unsubscribe", params);
     }
 
     /**
@@ -206,14 +212,19 @@ export class DaemonClient {
      * `MethodNotFound (-32601)`. The wire shape is locked so a future
      * lockstep landing in `daemon/core` doesn't reshuffle the client.
      */
-    interactiveStart(params: InteractiveStartParams): Promise<InteractiveStartResult> {
-        return this.request<InteractiveStartResult>('interactive/start', params);
+    interactiveStart(
+        params: InteractiveStartParams,
+    ): Promise<InteractiveStartResult> {
+        return this.request<InteractiveStartResult>(
+            "interactive/start",
+            params,
+        );
     }
 
     /** Symmetric to {@link interactiveStart}. Idempotent — extra stops are
      *  no-ops. Notification, not request: drop-and-go semantics. */
     interactiveStop(params: InteractiveStopParams): void {
-        this.notify('interactive/stop', params);
+        this.notify("interactive/stop", params);
     }
 
     /** Notification (drop-and-go). The daemon dispatches the input into the
@@ -221,47 +232,60 @@ export class DaemonClient {
      *  settles. Backpressure is the caller's job — don't issue a new input
      *  before the prior frame arrives. */
     interactiveInput(params: InteractiveInputParams): void {
-        this.notify('interactive/input', params);
+        this.notify("interactive/input", params);
     }
 
-    recordingStart(params: RecordingStartParams): Promise<RecordingStartResult> {
-        return this.request<RecordingStartResult>('recording/start', params);
+    recordingStart(
+        params: RecordingStartParams,
+    ): Promise<RecordingStartResult> {
+        return this.request<RecordingStartResult>("recording/start", params);
     }
 
     recordingInput(params: RecordingInputParams): void {
-        this.notify('recording/input', params);
+        this.notify("recording/input", params);
     }
 
     recordingStop(params: RecordingStopParams): Promise<RecordingStopResult> {
-        return this.request<RecordingStopResult>('recording/stop', params);
+        return this.request<RecordingStopResult>("recording/stop", params);
     }
 
-    recordingEncode(params: RecordingEncodeParams): Promise<RecordingEncodeResult> {
-        return this.request<RecordingEncodeResult>('recording/encode', params);
+    recordingEncode(
+        params: RecordingEncodeParams,
+    ): Promise<RecordingEncodeResult> {
+        return this.request<RecordingEncodeResult>("recording/encode", params);
     }
 
     /** Drains in-flight renders, then resolves. Daemon will not exit until `exit` fires. */
     shutdown(): Promise<null> {
-        return this.request<null>('shutdown', undefined);
+        return this.request<null>("shutdown", undefined);
     }
 
     /** Daemon exits after this. Best-effort; the channel may be closed already. */
     exit(): void {
         try {
-            this.notify('exit', undefined);
+            this.notify("exit", undefined);
         } catch {
             /* channel already gone */
         }
     }
 
-    isClosed(): boolean { return this.closed; }
+    isClosed(): boolean {
+        return this.closed;
+    }
 
     private request<T>(method: string, params: unknown): Promise<T> {
         if (this.closed) {
-            return Promise.reject(new Error(`Daemon channel closed; cannot send ${method}`));
+            return Promise.reject(
+                new Error(`Daemon channel closed; cannot send ${method}`),
+            );
         }
         const id = this.nextId++;
-        const envelope: JsonRpcRequest = { jsonrpc: '2.0', id, method, params: params ?? null };
+        const envelope: JsonRpcRequest = {
+            jsonrpc: "2.0",
+            id,
+            method,
+            params: params ?? null,
+        };
         return new Promise<T>((resolve, reject) => {
             this.pending.set(id, {
                 resolve: (v) => resolve(v as T),
@@ -278,9 +302,11 @@ export class DaemonClient {
     }
 
     private notify(method: string, params: unknown): void {
-        if (this.closed) { return; }
+        if (this.closed) {
+            return;
+        }
         const envelope: JsonRpcNotification = {
-            jsonrpc: '2.0',
+            jsonrpc: "2.0",
             method,
             params: params === undefined ? null : params,
         };
@@ -296,15 +322,19 @@ export class DaemonClient {
         try {
             msg = JSON.parse(json);
         } catch (err) {
-            this.logger.appendLine(`[daemon] dropped non-JSON message: ${(err as Error).message}`);
+            this.logger.appendLine(
+                `[daemon] dropped non-JSON message: ${(err as Error).message}`,
+            );
             return;
         }
 
-        if (typeof (msg as JsonRpcResponse).id === 'number') {
+        if (typeof (msg as JsonRpcResponse).id === "number") {
             const response = msg as JsonRpcResponse;
             const pending = this.pending.get(response.id);
             if (!pending) {
-                this.logger.appendLine(`[daemon] response with no pending request: id=${response.id}`);
+                this.logger.appendLine(
+                    `[daemon] response with no pending request: id=${response.id}`,
+                );
                 return;
             }
             this.pending.delete(response.id);
@@ -322,46 +352,52 @@ export class DaemonClient {
 
     private dispatchNotification(method: string, params: unknown): void {
         switch (method) {
-            case 'discoveryUpdated':
-                this.events.onDiscoveryUpdated?.(params as DiscoveryUpdatedParams);
+            case "discoveryUpdated":
+                this.events.onDiscoveryUpdated?.(
+                    params as DiscoveryUpdatedParams,
+                );
                 break;
-            case 'renderStarted':
+            case "renderStarted":
                 this.events.onRenderStarted?.(params as RenderStartedParams);
                 break;
-            case 'renderFinished':
+            case "renderFinished":
                 this.events.onRenderFinished?.(params as RenderFinishedParams);
                 break;
-            case 'renderFailed':
+            case "renderFailed":
                 this.events.onRenderFailed?.(params as RenderFailedParams);
                 break;
-            case 'classpathDirty':
+            case "classpathDirty":
                 this.events.onClasspathDirty?.(params as ClasspathDirtyParams);
                 break;
-            case 'sandboxRecycle':
+            case "sandboxRecycle":
                 this.events.onSandboxRecycle?.(params as SandboxRecycleParams);
                 break;
-            case 'daemonWarming':
+            case "daemonWarming":
                 this.events.onDaemonWarming?.(params as DaemonWarmingParams);
                 break;
-            case 'daemonReady':
+            case "daemonReady":
                 this.events.onDaemonReady?.();
                 break;
-            case 'log':
+            case "log":
                 this.events.onLog?.(params as LogParams);
                 break;
-            case 'historyAdded':
+            case "historyAdded":
                 this.events.onHistoryAdded?.(params as HistoryAddedParams);
                 break;
             default:
-                this.logger.appendLine(`[daemon] ignoring unknown notification: ${method}`);
+                this.logger.appendLine(
+                    `[daemon] ignoring unknown notification: ${method}`,
+                );
                 break;
         }
     }
 
     private fail(err?: Error): void {
-        if (this.closed) { return; }
+        if (this.closed) {
+            return;
+        }
         this.closed = true;
-        const reason = err ?? new Error('Daemon channel closed');
+        const reason = err ?? new Error("Daemon channel closed");
         for (const [, pending] of this.pending) {
             pending.reject(reason);
         }

--- a/vscode-extension/src/daemon/daemonFraming.ts
+++ b/vscode-extension/src/daemon/daemonFraming.ts
@@ -8,7 +8,7 @@
  * full header + body is in hand.
  */
 
-const HEADER_TERMINATOR = Buffer.from('\r\n\r\n', 'ascii');
+const HEADER_TERMINATOR = Buffer.from("\r\n\r\n", "ascii");
 
 export interface FrameDecoderEvents {
     onMessage: (json: string) => void;
@@ -22,21 +22,32 @@ export class FrameDecoder {
     constructor(private readonly events: FrameDecoderEvents) {}
 
     push(chunk: Buffer): void {
-        this.buffer = this.buffer.length === 0 ? chunk : Buffer.concat([this.buffer, chunk]);
+        this.buffer =
+            this.buffer.length === 0
+                ? chunk
+                : Buffer.concat([this.buffer, chunk]);
 
         // Loop because a single chunk may contain multiple complete frames.
         // eslint-disable-next-line no-constant-condition
         while (true) {
             if (this.expectedBodyLength === null) {
                 const headerEnd = this.buffer.indexOf(HEADER_TERMINATOR);
-                if (headerEnd < 0) { return; }
-                const headerText = this.buffer.subarray(0, headerEnd).toString('ascii');
-                this.buffer = this.buffer.subarray(headerEnd + HEADER_TERMINATOR.length);
+                if (headerEnd < 0) {
+                    return;
+                }
+                const headerText = this.buffer
+                    .subarray(0, headerEnd)
+                    .toString("ascii");
+                this.buffer = this.buffer.subarray(
+                    headerEnd + HEADER_TERMINATOR.length,
+                );
                 const length = parseContentLength(headerText);
                 if (length === null) {
-                    this.events.onError(new Error(
-                        `Daemon framing: missing or invalid Content-Length header: ${headerText.trim()}`,
-                    ));
+                    this.events.onError(
+                        new Error(
+                            `Daemon framing: missing or invalid Content-Length header: ${headerText.trim()}`,
+                        ),
+                    );
                     // Drop the buffer; the channel is unrecoverable from here.
                     this.buffer = Buffer.alloc(0);
                     return;
@@ -44,35 +55,50 @@ export class FrameDecoder {
                 this.expectedBodyLength = length;
             }
 
-            if (this.buffer.length < this.expectedBodyLength) { return; }
-            const body = this.buffer.subarray(0, this.expectedBodyLength).toString('utf-8');
+            if (this.buffer.length < this.expectedBodyLength) {
+                return;
+            }
+            const body = this.buffer
+                .subarray(0, this.expectedBodyLength)
+                .toString("utf-8");
             this.buffer = this.buffer.subarray(this.expectedBodyLength);
             this.expectedBodyLength = null;
             try {
                 this.events.onMessage(body);
             } catch (err) {
-                this.events.onError(err instanceof Error ? err : new Error(String(err)));
+                this.events.onError(
+                    err instanceof Error ? err : new Error(String(err)),
+                );
             }
         }
     }
 }
 
 function parseContentLength(headerText: string): number | null {
-    for (const line of headerText.split('\r\n')) {
-        const colon = line.indexOf(':');
-        if (colon < 0) { continue; }
+    for (const line of headerText.split("\r\n")) {
+        const colon = line.indexOf(":");
+        if (colon < 0) {
+            continue;
+        }
         const name = line.slice(0, colon).trim().toLowerCase();
-        if (name !== 'content-length') { continue; }
+        if (name !== "content-length") {
+            continue;
+        }
         const value = line.slice(colon + 1).trim();
         const n = parseInt(value, 10);
-        if (Number.isFinite(n) && n >= 0) { return n; }
+        if (Number.isFinite(n) && n >= 0) {
+            return n;
+        }
     }
     return null;
 }
 
 /** Encodes a JSON object as a single LSP-framed message (Buffer ready for stdin). */
 export function encodeFrame(obj: unknown): Buffer {
-    const body = Buffer.from(JSON.stringify(obj), 'utf-8');
-    const header = Buffer.from(`Content-Length: ${body.length}\r\n\r\n`, 'ascii');
+    const body = Buffer.from(JSON.stringify(obj), "utf-8");
+    const header = Buffer.from(
+        `Content-Length: ${body.length}\r\n\r\n`,
+        "ascii",
+    );
     return Buffer.concat([header, body]);
 }

--- a/vscode-extension/src/daemon/daemonGate.ts
+++ b/vscode-extension/src/daemon/daemonGate.ts
@@ -1,12 +1,20 @@
-import * as vscode from 'vscode';
-import { GradleService } from '../gradleService';
-import { LogFilter } from '../logFilter';
-import { DaemonClient, DaemonClientEvents, DaemonClientLogger } from './daemonClient';
-import { readLaunchDescriptor, spawnDaemon, SpawnedDaemon } from './daemonProcess';
-import { DaemonLaunchDescriptor } from './daemonProtocol';
+import * as vscode from "vscode";
+import { GradleService } from "../gradleService";
+import { LogFilter } from "../logFilter";
+import {
+    DaemonClient,
+    DaemonClientEvents,
+    DaemonClientLogger,
+} from "./daemonClient";
+import {
+    readLaunchDescriptor,
+    spawnDaemon,
+    SpawnedDaemon,
+} from "./daemonProcess";
+import { DaemonLaunchDescriptor } from "./daemonProtocol";
 
-const SETTING_ENABLED = 'daemon.enabled';
-const LEGACY_SETTING_ENABLED = 'experimental.daemon.enabled';
+const SETTING_ENABLED = "daemon.enabled";
+const LEGACY_SETTING_ENABLED = "experimental.daemon.enabled";
 
 /**
  * Source-of-truth for "is the daemon path live for this user/workspace?"
@@ -35,7 +43,7 @@ export class DaemonGate {
 
     /** Reads the user setting freshly each time so toggles don't need a reload. */
     isEnabled(): boolean {
-        const config = vscode.workspace.getConfiguration('composePreview');
+        const config = vscode.workspace.getConfiguration("composePreview");
         const current = config.inspect<boolean>(SETTING_ENABLED);
         const legacy = config.inspect<boolean>(LEGACY_SETTING_ENABLED);
         const value =
@@ -49,8 +57,8 @@ export class DaemonGate {
         if (!value && !this.warnedUserDisabled) {
             this.warnedUserDisabled = true;
             this.logger.appendLine(
-                '[daemon] WARNING: composePreview.daemon.enabled is false; using the Gradle render path. ' +
-                'The daemon will become required by the VS Code extension in a future release.',
+                "[daemon] WARNING: composePreview.daemon.enabled is false; using the Gradle render path. " +
+                    "The daemon will become required by the VS Code extension in a future release.",
             );
         }
         return value;
@@ -68,21 +76,31 @@ export class DaemonGate {
         moduleId: string,
         events: DaemonClientEvents,
     ): Promise<DaemonClient | null> {
-        if (this.disposed || !this.isEnabled()) { return null; }
+        if (this.disposed || !this.isEnabled()) {
+            return null;
+        }
 
         const existing = this.daemons.get(moduleId);
-        if (existing && !existing.client.isClosed()) { return existing.client; }
+        if (existing && !existing.client.isClosed()) {
+            return existing.client;
+        }
         if (existing && existing.client.isClosed()) {
             this.daemons.delete(moduleId);
         }
         const inFlight = this.spawns.get(moduleId);
-        if (inFlight) { return inFlight; }
+        if (inFlight) {
+            return inFlight;
+        }
 
-        const descriptor = readLaunchDescriptor(this.workspaceRoot, moduleId, this.logger);
+        const descriptor = readLaunchDescriptor(
+            this.workspaceRoot,
+            moduleId,
+            this.logger,
+        );
         if (!descriptor) {
             const message =
                 `[daemon] no launch descriptor for ${moduleId}; ` +
-                `run :${moduleId.replace(/\//g, ':')}:composePreviewDaemonStart first`;
+                `run :${moduleId.replace(/\//g, ":")}:composePreviewDaemonStart first`;
             this.logger.appendLine(message);
             throw new Error(message);
         }
@@ -91,16 +109,17 @@ export class DaemonGate {
                 this.warnedBuildDisabled.add(moduleId);
                 this.logger.appendLine(
                     `[daemon] WARNING: descriptor for ${moduleId} has enabled=false; ` +
-                    'using the Gradle render path for now. The daemon will become required by ' +
-                    'the VS Code extension in a future release. Configure composePreview { daemon { enabled = true } }.',
+                        "using the Gradle render path for now. The daemon will become required by " +
+                        "the VS Code extension in a future release. Configure composePreview { daemon { enabled = true } }.",
                 );
             }
             return null;
         }
 
         try {
-            const spawn = this.spawn(moduleId, descriptor, events)
-                .finally(() => this.spawns.delete(moduleId));
+            const spawn = this.spawn(moduleId, descriptor, events).finally(() =>
+                this.spawns.delete(moduleId),
+            );
             this.spawns.set(moduleId, spawn);
             return await spawn;
         } catch (err) {
@@ -111,14 +130,18 @@ export class DaemonGate {
     }
 
     isBuildDisabled(moduleId: string): boolean {
-        const descriptor = readLaunchDescriptor(this.workspaceRoot, moduleId, this.logger);
+        const descriptor = readLaunchDescriptor(
+            this.workspaceRoot,
+            moduleId,
+            this.logger,
+        );
         if (descriptor?.enabled === false) {
             if (!this.warnedBuildDisabled.has(moduleId)) {
                 this.warnedBuildDisabled.add(moduleId);
                 this.logger.appendLine(
                     `[daemon] WARNING: descriptor for ${moduleId} has enabled=false; ` +
-                    'using the Gradle render path for now. The daemon will become required by ' +
-                    'the VS Code extension in a future release. Configure composePreview { daemon { enabled = true } }.',
+                        "using the Gradle render path for now. The daemon will become required by " +
+                        "the VS Code extension in a future release. Configure composePreview { daemon { enabled = true } }.",
                 );
             }
             return true;
@@ -162,8 +185,13 @@ export class DaemonGate {
      * Gradle bootstrap task once per module. Cheap and cacheable. Propagates failures so callers
      * can surface daemon-enabled bootstrap errors instead of falling back to Gradle.
      */
-    async bootstrap(gradleService: GradleService, moduleId: string): Promise<void> {
-        if (!this.isEnabled()) { return; }
+    async bootstrap(
+        gradleService: GradleService,
+        moduleId: string,
+    ): Promise<void> {
+        if (!this.isEnabled()) {
+            return;
+        }
         await gradleService.runDaemonBootstrap(moduleId);
     }
 
@@ -191,28 +219,38 @@ export class DaemonGate {
      */
     isInteractiveSupported(moduleId: string): boolean {
         const existing = this.daemons.get(moduleId);
-        if (existing == null || existing.client.isClosed()) { return false; }
-        return existing.spawned.initializeResult.capabilities.interactive === true;
+        if (existing == null || existing.client.isClosed()) {
+            return false;
+        }
+        return (
+            existing.spawned.initializeResult.capabilities.interactive === true
+        );
     }
 
     async dispose(): Promise<void> {
         this.disposed = true;
         const entries = [...this.daemons.values()];
         this.daemons.clear();
-        await Promise.all(entries.map(async (entry) => {
-            try {
-                if (!entry.client.isClosed()) {
-                    await Promise.race([
-                        entry.client.shutdown(),
-                        new Promise((resolve) => setTimeout(resolve, 2000)),
-                    ]);
-                    entry.client.exit();
+        await Promise.all(
+            entries.map(async (entry) => {
+                try {
+                    if (!entry.client.isClosed()) {
+                        await Promise.race([
+                            entry.client.shutdown(),
+                            new Promise((resolve) => setTimeout(resolve, 2000)),
+                        ]);
+                        entry.client.exit();
+                    }
+                } catch {
+                    /* best-effort shutdown */
                 }
-            } catch {
-                /* best-effort shutdown */
-            }
-            try { entry.spawned.process.kill('SIGTERM'); } catch { /* ignore */ }
-        }));
+                try {
+                    entry.spawned.process.kill("SIGTERM");
+                } catch {
+                    /* ignore */
+                }
+            }),
+        );
     }
 
     /**
@@ -228,23 +266,31 @@ export class DaemonGate {
      * was spawned with even after the on-disk JAR has been replaced.
      */
     async restartAll(): Promise<string[]> {
-        if (this.disposed) { return []; }
+        if (this.disposed) {
+            return [];
+        }
         const entries = [...this.daemons.entries()];
         this.daemons.clear();
-        await Promise.all(entries.map(async ([_moduleId, entry]) => {
-            try {
-                if (!entry.client.isClosed()) {
-                    await Promise.race([
-                        entry.client.shutdown(),
-                        new Promise((resolve) => setTimeout(resolve, 2000)),
-                    ]);
-                    entry.client.exit();
+        await Promise.all(
+            entries.map(async ([_moduleId, entry]) => {
+                try {
+                    if (!entry.client.isClosed()) {
+                        await Promise.race([
+                            entry.client.shutdown(),
+                            new Promise((resolve) => setTimeout(resolve, 2000)),
+                        ]);
+                        entry.client.exit();
+                    }
+                } catch {
+                    /* best-effort shutdown */
                 }
-            } catch {
-                /* best-effort shutdown */
-            }
-            try { entry.spawned.process.kill('SIGTERM'); } catch { /* ignore */ }
-        }));
+                try {
+                    entry.spawned.process.kill("SIGTERM");
+                } catch {
+                    /* ignore */
+                }
+            }),
+        );
         return entries.map(([moduleId]) => moduleId);
     }
 }
@@ -265,7 +311,11 @@ function composeEvents(
     return {
         ...base,
         onChannelClosed: (err) => {
-            try { base.onChannelClosed?.(err); } finally { onClose(err); }
+            try {
+                base.onChannelClosed?.(err);
+            } finally {
+                onClose(err);
+            }
         },
     };
 }

--- a/vscode-extension/src/daemon/daemonProcess.ts
+++ b/vscode-extension/src/daemon/daemonProcess.ts
@@ -1,13 +1,17 @@
-import { ChildProcess, spawn } from 'child_process';
-import * as fs from 'fs';
-import * as path from 'path';
-import { DaemonClient, DaemonClientEvents, DaemonClientLogger } from './daemonClient';
+import { ChildProcess, spawn } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import {
+    DaemonClient,
+    DaemonClientEvents,
+    DaemonClientLogger,
+} from "./daemonClient";
 import {
     DAEMON_DESCRIPTOR_SCHEMA_VERSION,
     DaemonLaunchDescriptor,
     InitializeResult,
-} from './daemonProtocol';
-import { LogFilter } from '../logFilter';
+} from "./daemonProtocol";
+import { LogFilter } from "../logFilter";
 
 /**
  * Reads `<module>/build/compose-previews/daemon-launch.json` and returns the
@@ -21,22 +25,30 @@ export function readLaunchDescriptor(
     logger?: DaemonClientLogger,
 ): DaemonLaunchDescriptor | null {
     const file = path.join(
-        workspaceRoot, moduleId, 'build', 'compose-previews', 'daemon-launch.json',
+        workspaceRoot,
+        moduleId,
+        "build",
+        "compose-previews",
+        "daemon-launch.json",
     );
-    if (!fs.existsSync(file)) { return null; }
+    if (!fs.existsSync(file)) {
+        return null;
+    }
     try {
-        const raw = fs.readFileSync(file, 'utf-8');
+        const raw = fs.readFileSync(file, "utf-8");
         const parsed = JSON.parse(raw) as DaemonLaunchDescriptor;
         if (parsed.schemaVersion !== DAEMON_DESCRIPTOR_SCHEMA_VERSION) {
             logger?.appendLine(
                 `[daemon] descriptor schema mismatch at ${file}: ` +
-                `got ${parsed.schemaVersion}, expected ${DAEMON_DESCRIPTOR_SCHEMA_VERSION}`,
+                    `got ${parsed.schemaVersion}, expected ${DAEMON_DESCRIPTOR_SCHEMA_VERSION}`,
             );
             return null;
         }
         return parsed;
     } catch (err) {
-        logger?.appendLine(`[daemon] failed to read ${file}: ${(err as Error).message}`);
+        logger?.appendLine(
+            `[daemon] failed to read ${file}: ${(err as Error).message}`,
+        );
         return null;
     }
 }
@@ -78,23 +90,28 @@ export interface SpawnOptions {
 export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
     const { descriptor, clientVersion, events, workspaceRoot } = opts;
     const logger = opts.logger;
-    const logFilter = opts.logFilter ?? new LogFilter(() => 'verbose');
+    const logFilter = opts.logFilter ?? new LogFilter(() => "verbose");
 
     if (!descriptor.enabled) {
-        throw new Error('Daemon disabled in build config: set composePreview.daemon.enabled = true');
+        throw new Error(
+            "Daemon disabled in build config: set composePreview.daemon.enabled = true",
+        );
     }
 
     const javaPath = descriptor.javaLauncher ?? findJavaOnPath();
     if (!javaPath) {
-        throw new Error('No java executable: set javaLauncher via the toolchain or put java on PATH');
+        throw new Error(
+            "No java executable: set javaLauncher via the toolchain or put java on PATH",
+        );
     }
 
-    const sysProps = Object.entries(descriptor.systemProperties)
-        .map(([k, v]) => `-D${k}=${v}`);
+    const sysProps = Object.entries(descriptor.systemProperties).map(
+        ([k, v]) => `-D${k}=${v}`,
+    );
     const args = [
         ...descriptor.jvmArgs,
         ...sysProps,
-        '-cp',
+        "-cp",
         descriptor.classpath.join(path.delimiter),
         descriptor.mainClass,
     ];
@@ -102,34 +119,40 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
     const spawnLine =
         `[daemon] spawning ${descriptor.mainClass} for ${descriptor.modulePath} ` +
         `(${descriptor.classpath.length} classpath entries, java=${javaPath})`;
-    if (logFilter.shouldEmitInformational(spawnLine)) { logger?.appendLine(spawnLine); }
+    if (logFilter.shouldEmitInformational(spawnLine)) {
+        logger?.appendLine(spawnLine);
+    }
 
     const child = spawn(javaPath, args, {
         cwd: descriptor.workingDirectory,
-        stdio: ['pipe', 'pipe', 'pipe'],
+        stdio: ["pipe", "pipe", "pipe"],
         windowsHide: true,
     });
 
     if (!child.stdin || !child.stdout || !child.stderr) {
-        throw new Error('Daemon spawn produced no stdio streams');
+        throw new Error("Daemon spawn produced no stdio streams");
     }
 
     // Stderr is a free-form log channel per PROTOCOL.md § 1 — surface to the
     // logger so daemon `System.err.println` lands in the user's output panel.
     // The filter dedupes the Roborazzi ActionBar banner and drops the boot
     // diagnostics at normal level; verbose passes everything through.
-    child.stderr.setEncoding('utf-8');
-    child.stderr.on('data', (chunk: string) => {
+    child.stderr.setEncoding("utf-8");
+    child.stderr.on("data", (chunk: string) => {
         for (const line of chunk.split(/\r?\n/)) {
-            if (line.length === 0) { continue; }
+            if (line.length === 0) {
+                continue;
+            }
             const filtered = logFilter.filterDaemonStderrLine(line);
-            if (filtered === null) { continue; }
+            if (filtered === null) {
+                continue;
+            }
             logger?.appendLine(`[daemon stderr] ${filtered}`);
         }
     });
 
     const exited = new Promise<number | null>((resolve) => {
-        child.on('exit', (code) => {
+        child.on("exit", (code) => {
             // Exit messages always print — the JVM exiting unexpectedly is
             // never noise. The successful exit case (code=0 on user-driven
             // shutdown) is rare enough that it's still useful at quiet.
@@ -147,10 +170,17 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
             workspaceRoot,
             moduleId: descriptor.modulePath,
             moduleProjectDir: descriptor.workingDirectory,
-            capabilities: opts.capabilities ?? { visibility: true, metrics: true },
+            capabilities: opts.capabilities ?? {
+                visibility: true,
+                metrics: true,
+            },
         });
     } catch (err) {
-        try { child.kill('SIGTERM'); } catch { /* ignore */ }
+        try {
+            child.kill("SIGTERM");
+        } catch {
+            /* ignore */
+        }
         throw err;
     }
 
@@ -164,14 +194,20 @@ export async function spawnDaemon(opts: SpawnOptions): Promise<SpawnedDaemon> {
  * launcher and we never reach this path.
  */
 function findJavaOnPath(): string | null {
-    const exe = process.platform === 'win32' ? 'java.exe' : 'java';
-    const dirs = (process.env.PATH ?? '').split(path.delimiter);
+    const exe = process.platform === "win32" ? "java.exe" : "java";
+    const dirs = (process.env.PATH ?? "").split(path.delimiter);
     for (const dir of dirs) {
-        if (!dir) { continue; }
+        if (!dir) {
+            continue;
+        }
         const candidate = path.join(dir, exe);
         try {
-            if (fs.statSync(candidate).isFile()) { return candidate; }
-        } catch { /* skip */ }
+            if (fs.statSync(candidate).isFile()) {
+                return candidate;
+            }
+        } catch {
+            /* skip */
+        }
     }
     return null;
 }

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -12,21 +12,21 @@ export const PROTOCOL_VERSION = 1;
 // JSON-RPC envelopes (PROTOCOL.md § 2)
 
 export interface JsonRpcRequest<P = unknown> {
-    jsonrpc: '2.0';
+    jsonrpc: "2.0";
     id: number;
     method: string;
     params?: P;
 }
 
 export interface JsonRpcResponse<R = unknown> {
-    jsonrpc: '2.0';
+    jsonrpc: "2.0";
     id: number;
     result?: R;
     error?: JsonRpcError;
 }
 
 export interface JsonRpcNotification<P = unknown> {
-    jsonrpc: '2.0';
+    jsonrpc: "2.0";
     method: string;
     params?: P;
 }
@@ -70,7 +70,7 @@ export interface InitializeParams {
     options?: {
         maxHeapMb?: number;
         warmSpare?: boolean;
-        detectLeaks?: 'off' | 'light' | 'heavy';
+        detectLeaks?: "off" | "light" | "heavy";
         foreground?: boolean;
         /**
          * Data-product kinds the client wants attached to *every* render of
@@ -119,7 +119,7 @@ export interface InitializeParams {
 export interface DataProductCapability {
     kind: string;
     schemaVersion: number;
-    transport: 'inline' | 'path' | 'both';
+    transport: "inline" | "path" | "both";
     attachable: boolean;
     fetchable: boolean;
     requiresRerender: boolean;
@@ -130,23 +130,23 @@ export interface DataProductCapability {
 }
 
 export type DataProductFacet =
-    | 'structured'
-    | 'artifact'
-    | 'image'
-    | 'animation'
-    | 'overlay'
-    | 'check'
-    | 'diagnostic'
-    | 'profile'
-    | 'interactive';
+    | "structured"
+    | "artifact"
+    | "image"
+    | "animation"
+    | "overlay"
+    | "check"
+    | "diagnostic"
+    | "profile"
+    | "interactive";
 
 export type SamplingPolicy =
-    | 'Start'
-    | 'End'
-    | 'EachFrame'
-    | 'OnDemand'
-    | 'Aggregate'
-    | 'Failure';
+    | "Start"
+    | "End"
+    | "EachFrame"
+    | "OnDemand"
+    | "Aggregate"
+    | "Failure";
 
 export interface PreviewExtensionDescriptor {
     id: string;
@@ -183,39 +183,39 @@ export interface PreviewPipelineStep {
 }
 
 export type PreviewExtensionUsageMode =
-    | 'ExplicitEffect'
-    | 'SuggestedExtraPreview';
+    | "ExplicitEffect"
+    | "SuggestedExtraPreview";
 
 export type PipelineStepTrait =
-    | 'ScenarioDriver'
-    | 'InteractiveDriver'
-    | 'AnnotationInspector'
-    | 'ExtraPreviewSuggester'
-    | 'FrameProcessor'
-    | 'FinalArtifactProcessor'
-    | 'DataExtractor'
-    | 'Check'
-    | 'Encoder'
-    | 'Profiler';
+    | "ScenarioDriver"
+    | "InteractiveDriver"
+    | "AnnotationInspector"
+    | "ExtraPreviewSuggester"
+    | "FrameProcessor"
+    | "FinalArtifactProcessor"
+    | "DataExtractor"
+    | "Check"
+    | "Encoder"
+    | "Profiler";
 
 export type PipelineCapability =
-    | 'Frames'
-    | 'SingleFrame'
-    | 'MultipleFrames'
-    | 'PreviewFunctionAnnotations'
-    | 'SuggestedPreviews'
-    | 'DeviceGeometry'
-    | 'DeviceClip'
-    | 'ScrollState'
-    | 'SemanticsSnapshot'
-    | 'AccessibilityNodes'
-    | 'AccessibilityFindings'
-    | 'OverlayAnnotations'
-    | 'ImageArtifact'
-    | 'AnnotatedImageArtifact'
-    | 'AnimatedArtifact'
-    | 'InteractiveSession'
-    | 'TraceEvents';
+    | "Frames"
+    | "SingleFrame"
+    | "MultipleFrames"
+    | "PreviewFunctionAnnotations"
+    | "SuggestedPreviews"
+    | "DeviceGeometry"
+    | "DeviceClip"
+    | "ScrollState"
+    | "SemanticsSnapshot"
+    | "AccessibilityNodes"
+    | "AccessibilityFindings"
+    | "OverlayAnnotations"
+    | "ImageArtifact"
+    | "AnnotatedImageArtifact"
+    | "AnimatedArtifact"
+    | "InteractiveSession"
+    | "TraceEvents";
 
 export interface ExtractionSpec {
     kind: string;
@@ -232,7 +232,7 @@ export interface InitializeResult {
     capabilities: {
         incrementalDiscovery: boolean;
         sandboxRecycle: boolean;
-        leakDetection: ('light' | 'heavy')[];
+        leakDetection: ("light" | "heavy")[];
         /**
          * Phase D1 — kinds the daemon can produce. Empty list means the
          * daemon doesn't speak the data-product surface (pre-D1 daemons).
@@ -281,7 +281,7 @@ export interface InitializeResult {
          * `'android'` for the Robolectric backend. Absent / `null` on hosts that haven't
          * classified themselves (e.g. test fakes); clients should treat both as "unknown".
          */
-        backend?: 'desktop' | 'android' | null;
+        backend?: "desktop" | "android" | null;
         /**
          * Fixed Android SDK level this daemon renders against. Present on Robolectric /
          * Android backends, absent or null on Desktop and other non-Android backends.
@@ -308,11 +308,15 @@ export interface KnownDevice {
 
 // Client → daemon notifications (PROTOCOL.md § 4)
 
-export interface SetVisibleParams { ids: string[] }
-export interface SetFocusParams { ids: string[] }
+export interface SetVisibleParams {
+    ids: string[];
+}
+export interface SetFocusParams {
+    ids: string[];
+}
 
-export type FileKind = 'source' | 'resource' | 'classpath';
-export type FileChangeType = 'modified' | 'created' | 'deleted';
+export type FileKind = "source" | "resource" | "classpath";
+export type FileChangeType = "modified" | "created" | "deleted";
 
 export interface FileChangedParams {
     path: string;
@@ -322,7 +326,7 @@ export interface FileChangedParams {
 
 // Client → daemon requests (PROTOCOL.md § 5)
 
-export type RenderTier = 'fast' | 'full';
+export type RenderTier = "fast" | "full";
 
 /**
  * Per-render display-property overrides — see PROTOCOL.md § 5 (`renderNow.overrides`).
@@ -335,8 +339,8 @@ export interface PreviewOverrides {
     density?: number;
     localeTag?: string;
     fontScale?: number;
-    uiMode?: 'light' | 'dark';
-    orientation?: 'portrait' | 'landscape';
+    uiMode?: "light" | "dark";
+    orientation?: "portrait" | "landscape";
     /**
      * `@Preview(device = ...)` string — `id:pixel_5`, `id:wearos_small_round`, `id:tv_1080p`,
      * or a full `spec:width=400dp,height=800dp,dpi=320` grammar. Resolved by the daemon's
@@ -392,7 +396,10 @@ export interface DiscoveryUpdatedParams {
     totalPreviews: number;
 }
 
-export interface RenderStartedParams { id: string; queuedMs: number }
+export interface RenderStartedParams {
+    id: string;
+    queuedMs: number;
+}
 
 export interface RenderMetrics {
     heapAfterGcMb: number;
@@ -454,31 +461,42 @@ export interface RenderFinishedParams {
 }
 
 export interface RenderError {
-    kind: 'compile' | 'runtime' | 'capture' | 'timeout' | 'internal';
+    kind: "compile" | "runtime" | "capture" | "timeout" | "internal";
     message: string;
     stackTrace?: string;
 }
 
-export interface RenderFailedParams { id: string; error: RenderError }
+export interface RenderFailedParams {
+    id: string;
+    error: RenderError;
+}
 
 export interface ClasspathDirtyParams {
-    reason: 'fingerprintMismatch' | 'fileChanged' | 'manifestMissing';
+    reason: "fingerprintMismatch" | "fileChanged" | "manifestMissing";
     detail: string;
     changedPaths?: string[];
 }
 
 export interface SandboxRecycleParams {
-    reason: 'heapCeiling' | 'heapDrift' | 'renderTimeDrift' | 'histogramDrift'
-          | 'renderCount' | 'leakSuspected' | 'manual';
+    reason:
+        | "heapCeiling"
+        | "heapDrift"
+        | "renderTimeDrift"
+        | "histogramDrift"
+        | "renderCount"
+        | "leakSuspected"
+        | "manual";
     ageMs: number;
     renderCount: number;
     warmSpareReady: boolean;
 }
 
-export interface DaemonWarmingParams { etaMs: number }
+export interface DaemonWarmingParams {
+    etaMs: number;
+}
 
 export interface LogParams {
-    level: 'debug' | 'info' | 'warn' | 'error';
+    level: "debug" | "info" | "warn" | "error";
     message: string;
     category?: string;
     context?: Record<string, unknown>;
@@ -491,17 +509,17 @@ export interface LogParams {
 // onto the dispatch surface; we mirror that with `unknown` here so the
 // types stay schema-agnostic against future additive fields.
 
-export type HistorySourceKind = 'fs' | 'git' | 'http';
+export type HistorySourceKind = "fs" | "git" | "http";
 
 export interface HistoryListParams {
     previewId?: string;
-    since?: string;                   // ISO 8601 lower bound
-    until?: string;                   // ISO 8601 upper bound
-    limit?: number;                   // daemon defaults to 50, max 500
-    cursor?: string;                  // opaque token from a previous response
+    since?: string; // ISO 8601 lower bound
+    until?: string; // ISO 8601 upper bound
+    limit?: number; // daemon defaults to 50, max 500
+    cursor?: string; // opaque token from a previous response
     branch?: string;
-    branchPattern?: string;           // regex
-    commit?: string;                  // long or short SHA
+    branchPattern?: string; // regex
+    commit?: string; // long or short SHA
     worktreePath?: string;
     agentId?: string;
     sourceKind?: HistorySourceKind;
@@ -536,12 +554,12 @@ export interface HistoryReadResult {
     pngBytes?: string;
 }
 
-export type HistoryDiffMode = 'metadata' | 'pixel';
+export type HistoryDiffMode = "metadata" | "pixel";
 
 export interface HistoryDiffParams {
     from: string;
     to: string;
-    mode?: HistoryDiffMode;           // default 'metadata'
+    mode?: HistoryDiffMode; // default 'metadata'
 }
 
 /**
@@ -622,7 +640,10 @@ export interface DataSubscribeResult {
 // lockstep with the daemon work. Adding these methods is additive per
 // PROTOCOL.md § 7 — no `protocolVersion` bump required.
 
-export interface InteractiveStartParams { previewId: string; inspectionMode?: boolean }
+export interface InteractiveStartParams {
+    previewId: string;
+    inspectionMode?: boolean;
+}
 export interface InteractiveStartResult {
     /** Opaque correlation id; the client passes it back on every input
      *  notification so the daemon can route inputs to the right warm
@@ -634,16 +655,18 @@ export interface InteractiveStartResult {
     fallbackReason?: string;
 }
 
-export interface InteractiveStopParams { frameStreamId: string }
+export interface InteractiveStopParams {
+    frameStreamId: string;
+}
 
 export type InteractiveInputKind =
-    | 'click'
-    | 'pointerDown'
-    | 'pointerMove'
-    | 'pointerUp'
-    | 'rotaryScroll'
-    | 'keyDown'
-    | 'keyUp';
+    | "click"
+    | "pointerDown"
+    | "pointerMove"
+    | "pointerUp"
+    | "rotaryScroll"
+    | "keyDown"
+    | "keyUp";
 
 export interface InteractiveInputParams {
     frameStreamId: string;
@@ -658,7 +681,7 @@ export interface InteractiveInputParams {
     keyCode?: string;
 }
 
-export type RecordingFormat = 'apng' | 'mp4' | 'webm';
+export type RecordingFormat = "apng" | "mp4" | "webm";
 
 export interface RecordingStartParams {
     previewId: string;
@@ -668,7 +691,9 @@ export interface RecordingStartParams {
     live?: boolean;
 }
 
-export interface RecordingStartResult { recordingId: string }
+export interface RecordingStartResult {
+    recordingId: string;
+}
 
 export interface RecordingInputParams {
     recordingId: string;
@@ -679,7 +704,9 @@ export interface RecordingInputParams {
     keyCode?: string;
 }
 
-export interface RecordingStopParams { recordingId: string }
+export interface RecordingStopParams {
+    recordingId: string;
+}
 
 export interface RecordingStopResult {
     frameCount: number;

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -1,7 +1,7 @@
-import * as path from 'path';
-import * as fs from 'fs';
-import { GradleService } from '../gradleService';
-import { DaemonGate } from './daemonGate';
+import * as path from "path";
+import * as fs from "fs";
+import { GradleService } from "../gradleService";
+import { DaemonGate } from "./daemonGate";
 import {
     DataProductAttachment,
     DiscoveryUpdatedParams,
@@ -10,10 +10,10 @@ import {
     HistoryAddedParams,
     RenderFinishedParams,
     RenderTier,
-} from './daemonProtocol';
+} from "./daemonProtocol";
 
 export type WarmProgress = (state: WarmState) => void;
-export type WarmState = 'bootstrapping' | 'spawning' | 'ready' | 'fallback';
+export type WarmState = "bootstrapping" | "spawning" | "ready" | "fallback";
 
 export interface SchedulerEvents {
     /**
@@ -41,7 +41,11 @@ export interface SchedulerEvents {
         previewId: string,
         dataProducts: DataProductAttachment[],
     ) => void;
-    onRenderFailed: (moduleId: string, previewId: string, message: string) => void;
+    onRenderFailed: (
+        moduleId: string,
+        previewId: string,
+        message: string,
+    ) => void;
     /**
      * Daemon told us the classpath drifted (e.g. `libs.versions.toml`
      * bumped). The daemon will exit shortly; the scheduler stops issuing
@@ -55,7 +59,10 @@ export interface SchedulerEvents {
      * diff), so receiving this event always means the panel needs to
      * reshape. Optional because tests may not wire it.
      */
-    onDiscoveryUpdated?: (moduleId: string, params: DiscoveryUpdatedParams) => void;
+    onDiscoveryUpdated?: (
+        moduleId: string,
+        params: DiscoveryUpdatedParams,
+    ) => void;
     /** Phase H2 — daemon archived a render. Forwarded to the History
      *  panel; optional because the panel may not exist in test mode. */
     onHistoryAdded?: (moduleId: string, params: HistoryAddedParams) => void;
@@ -71,14 +78,17 @@ export interface SchedulerEvents {
     onChannelClosed?: (moduleId: string) => void;
 }
 
-const HEAVY_TIER_DEFAULT: RenderTier = 'fast';
+const HEAVY_TIER_DEFAULT: RenderTier = "fast";
 
 /**
  * D2 — kinds the focus-mode "Show a11y overlay" button toggles. Pinned to the a11y producer
  * so the local finding + hierarchy overlays light up together; a future panel that wants to
  * subscribe to other kinds (`compose/recomposition`, `layout/inspector`) will export its own list.
  */
-export const A11Y_OVERLAY_KINDS: readonly string[] = ['a11y/atf', 'a11y/hierarchy'];
+export const A11Y_OVERLAY_KINDS: readonly string[] = [
+    "a11y/atf",
+    "a11y/hierarchy",
+];
 /**
  * Cards we'll pre-render ahead of the visible viewport on each scroll-ahead
  * push from the webview. Bounded so a fast scroll past 50 cards doesn't
@@ -127,7 +137,9 @@ export class DaemonScheduler {
     constructor(
         private readonly gate: DaemonGate,
         private readonly events: SchedulerEvents,
-        private readonly logger: { appendLine(s: string): void } = { appendLine() {} },
+        private readonly logger: { appendLine(s: string): void } = {
+            appendLine() {},
+        },
         /**
          * D2 — read freshly per `setVisible` so toggling the user setting
          * `composePreview.a11y.alwaysSubscribe` doesn't need a reload. When `true`,
@@ -147,7 +159,10 @@ export class DaemonScheduler {
      * Enabled-but-broken daemon failures throw so callers do not silently fall back to Gradle.
      */
     async ensureModule(moduleId: string): Promise<boolean> {
-        const client = await this.gate.getOrSpawn(moduleId, this.daemonEvents(moduleId));
+        const client = await this.gate.getOrSpawn(
+            moduleId,
+            this.daemonEvents(moduleId),
+        );
         return client !== null;
     }
 
@@ -170,26 +185,28 @@ export class DaemonScheduler {
         moduleId: string,
         progress?: WarmProgress,
     ): Promise<boolean> {
-        if (!this.gate.isEnabled()) { return false; }
+        if (!this.gate.isEnabled()) {
+            return false;
+        }
         if (this.gate.isDaemonReady(moduleId)) {
-            progress?.('ready');
+            progress?.("ready");
             return true;
         }
-        progress?.('spawning');
+        progress?.("spawning");
         try {
             const ok = await this.ensureModule(moduleId);
             if (ok) {
-                progress?.('ready');
+                progress?.("ready");
                 return true;
             }
         } catch (err) {
             this.logger.appendLine(
                 `[daemon] cached launch failed for ${moduleId}: ${(err as Error).message}; ` +
-                'running composePreviewDaemonStart',
+                    "running composePreviewDaemonStart",
             );
         }
         try {
-            progress?.('bootstrapping');
+            progress?.("bootstrapping");
             await gradleService.runDaemonBootstrap(moduleId);
         } catch (err) {
             this.logger.appendLine(
@@ -197,7 +214,7 @@ export class DaemonScheduler {
             );
             throw err;
         }
-        progress?.('spawning');
+        progress?.("spawning");
         let ok = false;
         try {
             ok = await this.ensureModule(moduleId);
@@ -207,7 +224,7 @@ export class DaemonScheduler {
             );
             throw err;
         }
-        progress?.(ok ? 'ready' : 'fallback');
+        progress?.(ok ? "ready" : "fallback");
         return ok;
     }
 
@@ -218,10 +235,15 @@ export class DaemonScheduler {
     async fileChanged(
         moduleId: string,
         absPath: string,
-        changeType: FileChangeType = 'modified',
+        changeType: FileChangeType = "modified",
     ): Promise<void> {
-        const client = await this.gate.getOrSpawn(moduleId, this.daemonEvents(moduleId));
-        if (!client) { return; }
+        const client = await this.gate.getOrSpawn(
+            moduleId,
+            this.daemonEvents(moduleId),
+        );
+        if (!client) {
+            return;
+        }
         client.fileChanged({
             path: absPath,
             kind: classifyKind(absPath),
@@ -234,10 +256,17 @@ export class DaemonScheduler {
      * IDs. These are rendered first when the queue drains.
      */
     async setFocus(moduleId: string, previewIds: string[]): Promise<void> {
-        if (sameSet(this.lastFocus.get(moduleId), previewIds)) { return; }
+        if (sameSet(this.lastFocus.get(moduleId), previewIds)) {
+            return;
+        }
         this.lastFocus.set(moduleId, [...previewIds]);
-        const client = await this.gate.getOrSpawn(moduleId, this.daemonEvents(moduleId));
-        if (!client) { return; }
+        const client = await this.gate.getOrSpawn(
+            moduleId,
+            this.daemonEvents(moduleId),
+        );
+        if (!client) {
+            return;
+        }
         client.setFocus({ ids: previewIds });
     }
 
@@ -253,12 +282,20 @@ export class DaemonScheduler {
         visible: string[],
         predicted: string[] = [],
     ): Promise<void> {
-        if (sameSet(this.lastVisible.get(moduleId), visible) && predicted.length === 0) {
+        if (
+            sameSet(this.lastVisible.get(moduleId), visible) &&
+            predicted.length === 0
+        ) {
             return;
         }
         this.lastVisible.set(moduleId, [...visible]);
-        const client = await this.gate.getOrSpawn(moduleId, this.daemonEvents(moduleId));
-        if (!client) { return; }
+        const client = await this.gate.getOrSpawn(
+            moduleId,
+            this.daemonEvents(moduleId),
+        );
+        if (!client) {
+            return;
+        }
         client.setVisible({ ids: visible });
 
         // D2 — drop bookkeeping for previews that fell out of view. The daemon already
@@ -269,11 +306,15 @@ export class DaemonScheduler {
         const visibleSetForSub = new Set(visible);
         const modulePrefix = `${moduleId}::`;
         for (const key of [...this.subscribedPairs]) {
-            if (!key.startsWith(modulePrefix)) { continue; }
+            if (!key.startsWith(modulePrefix)) {
+                continue;
+            }
             const rest = key.slice(modulePrefix.length);
-            const sep = rest.indexOf('::');
+            const sep = rest.indexOf("::");
             const id = sep < 0 ? rest : rest.slice(0, sep);
-            if (!visibleSetForSub.has(id)) { this.subscribedPairs.delete(key); }
+            if (!visibleSetForSub.has(id)) {
+                this.subscribedPairs.delete(key);
+            }
         }
 
         // D2 — when the user opted into ambient a11y via
@@ -286,35 +327,45 @@ export class DaemonScheduler {
             for (const id of visible) {
                 for (const kind of A11Y_OVERLAY_KINDS) {
                     const subKey = `${moduleId}::${id}::${kind}`;
-                    if (this.subscribedPairs.has(subKey)) { continue; }
+                    if (this.subscribedPairs.has(subKey)) {
+                        continue;
+                    }
                     this.subscribedPairs.add(subKey);
-                    client.dataSubscribe({ previewId: id, kind }).catch((err) => {
-                        const msg = (err as Error)?.message ?? String(err);
-                        this.logger.appendLine(
-                            `[daemon] alwaysSubscribe dataSubscribe(${id}, ${kind}) failed: ${msg}`,
-                        );
-                        this.subscribedPairs.delete(subKey);
-                    });
+                    client
+                        .dataSubscribe({ previewId: id, kind })
+                        .catch((err) => {
+                            const msg = (err as Error)?.message ?? String(err);
+                            this.logger.appendLine(
+                                `[daemon] alwaysSubscribe dataSubscribe(${id}, ${kind}) failed: ${msg}`,
+                            );
+                            this.subscribedPairs.delete(subKey);
+                        });
                 }
             }
         }
 
-        if (predicted.length === 0) { return; }
+        if (predicted.length === 0) {
+            return;
+        }
         // Bound the speculative request so a flick-scroll past 50 cards
         // doesn't queue 50 renders. Visible IDs trump predicted ones —
         // they're already in the daemon's reactive queue.
         const visibleSet = new Set(visible);
         const fresh = predicted
-            .filter(id => !visibleSet.has(id))
-            .filter(id => !this.speculated.has(specKey(moduleId, id)))
+            .filter((id) => !visibleSet.has(id))
+            .filter((id) => !this.speculated.has(specKey(moduleId, id)))
             .slice(0, SPECULATIVE_BUDGET);
-        if (fresh.length === 0) { return; }
-        for (const id of fresh) { this.speculated.add(specKey(moduleId, id)); }
+        if (fresh.length === 0) {
+            return;
+        }
+        for (const id of fresh) {
+            this.speculated.add(specKey(moduleId, id));
+        }
         try {
             await client.renderNow({
                 previews: fresh,
                 tier: HEAVY_TIER_DEFAULT,
-                reason: 'scroll-ahead',
+                reason: "scroll-ahead",
             });
         } catch (err) {
             this.logger.appendLine(
@@ -339,12 +390,19 @@ export class DaemonScheduler {
         kinds: readonly string[],
         enabled: boolean,
     ): Promise<void> {
-        const client = await this.gate.getOrSpawn(moduleId, this.daemonEvents(moduleId));
-        if (!client) { return; }
+        const client = await this.gate.getOrSpawn(
+            moduleId,
+            this.daemonEvents(moduleId),
+        );
+        if (!client) {
+            return;
+        }
         for (const kind of kinds) {
             const subKey = `${moduleId}::${previewId}::${kind}`;
             const already = this.subscribedPairs.has(subKey);
-            if (enabled === already) { continue; }
+            if (enabled === already) {
+                continue;
+            }
             if (enabled) {
                 this.subscribedPairs.add(subKey);
                 client.dataSubscribe({ previewId, kind }).catch((err) => {
@@ -379,11 +437,16 @@ export class DaemonScheduler {
     async renderNow(
         moduleId: string,
         previewIds: string[],
-        tier: RenderTier = 'fast',
+        tier: RenderTier = "fast",
         reason?: string,
     ): Promise<boolean> {
-        const client = await this.gate.getOrSpawn(moduleId, this.daemonEvents(moduleId));
-        if (!client) { return false; }
+        const client = await this.gate.getOrSpawn(
+            moduleId,
+            this.daemonEvents(moduleId),
+        );
+        if (!client) {
+            return false;
+        }
         try {
             const result = await client.renderNow({
                 previews: previewIds,
@@ -391,7 +454,9 @@ export class DaemonScheduler {
                 reason,
             });
             for (const r of result.rejected) {
-                this.logger.appendLine(`[daemon] renderNow rejected ${r.id}: ${r.reason}`);
+                this.logger.appendLine(
+                    `[daemon] renderNow rejected ${r.id}: ${r.reason}`,
+                );
             }
             return true;
         } catch (err) {
@@ -415,14 +480,23 @@ export class DaemonScheduler {
             onRenderFinished: (params: RenderFinishedParams) => {
                 this.handleRenderFinished(moduleId, params);
             },
-            onRenderFailed: (params: { id: string; error: { message: string } }) => {
-                this.events.onRenderFailed(moduleId, params.id, params.error.message);
+            onRenderFailed: (params: {
+                id: string;
+                error: { message: string };
+            }) => {
+                this.events.onRenderFailed(
+                    moduleId,
+                    params.id,
+                    params.error.message,
+                );
             },
             onClasspathDirty: (params: { detail: string }) => {
                 // Drop the speculative cache for this module so a re-spawned
                 // daemon doesn't think we already pre-warmed those IDs.
                 for (const k of [...this.speculated]) {
-                    if (k.startsWith(`${moduleId}::`)) { this.speculated.delete(k); }
+                    if (k.startsWith(`${moduleId}::`)) {
+                        this.speculated.delete(k);
+                    }
                 }
                 this.events.onClasspathDirty(moduleId, params.detail);
             },
@@ -438,13 +512,17 @@ export class DaemonScheduler {
                 this.lastVisible.delete(moduleId);
                 this.lastFocus.delete(moduleId);
                 for (const k of [...this.speculated]) {
-                    if (k.startsWith(`${moduleId}::`)) { this.speculated.delete(k); }
+                    if (k.startsWith(`${moduleId}::`)) {
+                        this.speculated.delete(k);
+                    }
                 }
                 // D2 — wipe data-product subscription state so the next daemon spawn re-issues
                 // `data/subscribe` against the fresh JVM. Subscriptions don't survive daemon
                 // restarts (PROTOCOL.md / DATA-PRODUCTS.md § "Wire surface").
                 for (const k of [...this.subscribedPairs]) {
-                    if (k.startsWith(`${moduleId}::`)) { this.subscribedPairs.delete(k); }
+                    if (k.startsWith(`${moduleId}::`)) {
+                        this.subscribedPairs.delete(k);
+                    }
                 }
                 // Forward to the extension so it can drop interactive-mode stream state for
                 // this module — frameStreamIds don't survive a daemon restart, and a stale
@@ -455,7 +533,10 @@ export class DaemonScheduler {
         };
     }
 
-    private handleRenderFinished(moduleId: string, params: RenderFinishedParams): void {
+    private handleRenderFinished(
+        moduleId: string,
+        params: RenderFinishedParams,
+    ): void {
         try {
             // Speculative entries graduate to "real" once they actually render —
             // drop them from the dedup set so a subsequent fileChanged for the
@@ -485,8 +566,8 @@ export class DaemonScheduler {
                     this.warnedStubModules.add(moduleId);
                     this.logger.appendLine(
                         `[daemon] ${moduleId} is at stub-render stage (B1.5); ` +
-                        'real renders arrive once :daemon:android ships B1.4 RenderEngine. ' +
-                        'Suppressing per-render ENOENT logs for stub paths.',
+                            "real renders arrive once :daemon:android ships B1.4 RenderEngine. " +
+                            "Suppressing per-render ENOENT logs for stub paths.",
                     );
                 }
                 return;
@@ -496,7 +577,7 @@ export class DaemonScheduler {
             this.events.onPreviewImageReady(
                 moduleId,
                 params.id,
-                buf.toString('base64'),
+                buf.toString("base64"),
                 params.pngPath,
             );
             // D2 — forward attached data products. The dispatcher already filtered to the
@@ -504,7 +585,11 @@ export class DaemonScheduler {
             // payload the panel asked for. Empty / absent → nothing to do; we DON'T fire the
             // event in that case to keep the consumer-side dispatch trivial.
             if (params.dataProducts && params.dataProducts.length > 0) {
-                this.events.onDataProductsAttached?.(moduleId, params.id, params.dataProducts);
+                this.events.onDataProductsAttached?.(
+                    moduleId,
+                    params.id,
+                    params.dataProducts,
+                );
             }
         } catch (err) {
             this.logger.appendLine(
@@ -513,7 +598,7 @@ export class DaemonScheduler {
             this.events.onRenderFailed(
                 moduleId,
                 params.id,
-                'render finished but PNG was unreadable',
+                "render finished but PNG was unreadable",
             );
         }
     }
@@ -522,24 +607,29 @@ export class DaemonScheduler {
 function classifyKind(absPath: string): FileKind {
     const lower = absPath.toLowerCase();
     if (
-        lower.endsWith('libs.versions.toml')
-        || lower.endsWith('.gradle.kts')
-        || lower.endsWith('gradle.properties')
-        || lower.endsWith('local.properties')
-        || lower.endsWith('settings.gradle.kts')
+        lower.endsWith("libs.versions.toml") ||
+        lower.endsWith(".gradle.kts") ||
+        lower.endsWith("gradle.properties") ||
+        lower.endsWith("local.properties") ||
+        lower.endsWith("settings.gradle.kts")
     ) {
-        return 'classpath';
+        return "classpath";
     }
-    if (lower.includes(`${path.sep}res${path.sep}`) || lower.includes('/res/')) {
-        return 'resource';
+    if (
+        lower.includes(`${path.sep}res${path.sep}`) ||
+        lower.includes("/res/")
+    ) {
+        return "resource";
     }
-    return 'source';
+    return "source";
 }
 
 function sameSet(a: string[] | undefined, b: string[]): boolean {
-    if (!a || a.length !== b.length) { return false; }
+    if (!a || a.length !== b.length) {
+        return false;
+    }
     const set = new Set(a);
-    return b.every(id => set.has(id));
+    return b.every((id) => set.has(id));
 }
 
 function specKey(moduleId: string, previewId: string): string {
@@ -556,7 +646,7 @@ function specKey(moduleId: string, previewId: string): string {
  * filename prefix is what's documented as the contract.
  */
 function isDaemonStubPath(pngPath: string): boolean {
-    const slash = Math.max(pngPath.lastIndexOf('/'), pngPath.lastIndexOf('\\'));
+    const slash = Math.max(pngPath.lastIndexOf("/"), pngPath.lastIndexOf("\\"));
     const base = slash >= 0 ? pngPath.slice(slash + 1) : pngPath;
     return /^daemon-stub-.+\.(png|gif)$/.test(base);
 }

--- a/vscode-extension/src/daemon/historyReader.ts
+++ b/vscode-extension/src/daemon/historyReader.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from "fs";
+import * as path from "path";
 import {
     HistoryDiffMode,
     HistoryDiffResult,
@@ -7,7 +7,7 @@ import {
     HistoryListResult,
     HistoryReadResult,
     HistorySourceKind,
-} from './daemonProtocol';
+} from "./daemonProtocol";
 
 /**
  * Filesystem-backed history reader. Used by the Preview History panel when:
@@ -39,7 +39,7 @@ export class HistoryReader {
     /** True iff `<historyDir>/index.jsonl` exists. The panel uses this to
      *  skip rendering when the consumer hasn't enabled history yet. */
     exists(): boolean {
-        return fs.existsSync(path.join(this.historyDir, 'index.jsonl'));
+        return fs.existsSync(path.join(this.historyDir, "index.jsonl"));
     }
 
     /**
@@ -52,13 +52,15 @@ export class HistoryReader {
      * returns an empty list against the FS reader.
      */
     list(params: HistoryListParams = {}): HistoryListResult {
-        const indexPath = path.join(this.historyDir, 'index.jsonl');
+        const indexPath = path.join(this.historyDir, "index.jsonl");
         const entries: HistoryEntryShape[] = [];
         if (fs.existsSync(indexPath)) {
             try {
-                const raw = fs.readFileSync(indexPath, 'utf-8');
-                for (const line of raw.split('\n')) {
-                    if (line.length === 0) { continue; }
+                const raw = fs.readFileSync(indexPath, "utf-8");
+                for (const line of raw.split("\n")) {
+                    if (line.length === 0) {
+                        continue;
+                    }
                     try {
                         entries.push(JSON.parse(line) as HistoryEntryShape);
                     } catch {
@@ -74,15 +76,18 @@ export class HistoryReader {
         }
 
         // Newest first per PROTOCOL.md § "history/list".
-        entries.sort((a, b) => (b.timestamp ?? '').localeCompare(a.timestamp ?? ''));
+        entries.sort((a, b) =>
+            (b.timestamp ?? "").localeCompare(a.timestamp ?? ""),
+        );
 
-        const filtered = entries.filter(e => matchesFilter(e, params));
+        const filtered = entries.filter((e) => matchesFilter(e, params));
         const start = parseCursor(params.cursor);
         const limit = clampLimit(params.limit);
         const page = filtered.slice(start, start + limit);
-        const nextCursor = (start + limit < filtered.length)
-            ? encodeCursor(start + limit)
-            : undefined;
+        const nextCursor =
+            start + limit < filtered.length
+                ? encodeCursor(start + limit)
+                : undefined;
         return {
             entries: page,
             nextCursor,
@@ -98,15 +103,24 @@ export class HistoryReader {
      */
     read(id: string, inline = false): HistoryReadResult | null {
         const sidecar = this.findSidecar(id);
-        if (!sidecar) { return null; }
+        if (!sidecar) {
+            return null;
+        }
         let entry: HistoryEntryShape;
         try {
-            entry = JSON.parse(fs.readFileSync(sidecar.path, 'utf-8')) as HistoryEntryShape;
+            entry = JSON.parse(
+                fs.readFileSync(sidecar.path, "utf-8"),
+            ) as HistoryEntryShape;
         } catch {
             return null;
         }
-        const pngPath = path.join(path.dirname(sidecar.path), entry.pngPath ?? `${id}.png`);
-        if (!fs.existsSync(pngPath)) { return null; }
+        const pngPath = path.join(
+            path.dirname(sidecar.path),
+            entry.pngPath ?? `${id}.png`,
+        );
+        if (!fs.existsSync(pngPath)) {
+            return null;
+        }
         const result: HistoryReadResult = {
             entry,
             previewMetadata: entry.previewMetadata,
@@ -114,7 +128,7 @@ export class HistoryReader {
         };
         if (inline) {
             try {
-                result.pngBytes = fs.readFileSync(pngPath).toString('base64');
+                result.pngBytes = fs.readFileSync(pngPath).toString("base64");
             } catch {
                 /* leave pngBytes undefined — caller falls back to pngPath */
             }
@@ -128,11 +142,19 @@ export class HistoryReader {
      * only — the FS reader returns the metadata fields and leaves the
      * pixel slots undefined.
      */
-    diff(from: string, to: string, mode: HistoryDiffMode = 'metadata'): HistoryDiffResult | null {
-        if (mode === 'pixel') { return null; }
+    diff(
+        from: string,
+        to: string,
+        mode: HistoryDiffMode = "metadata",
+    ): HistoryDiffResult | null {
+        if (mode === "pixel") {
+            return null;
+        }
         const a = this.read(from);
         const b = this.read(to);
-        if (!a || !b) { return null; }
+        if (!a || !b) {
+            return null;
+        }
         const aEntry = a.entry as HistoryEntryShape;
         const bEntry = b.entry as HistoryEntryShape;
         if (aEntry.previewId !== bEntry.previewId) {
@@ -158,7 +180,9 @@ export class HistoryReader {
      * id→folder map keyed off list().
      */
     private findSidecar(id: string): { path: string } | null {
-        if (!fs.existsSync(this.historyDir)) { return null; }
+        if (!fs.existsSync(this.historyDir)) {
+            return null;
+        }
         let entries: fs.Dirent[];
         try {
             entries = fs.readdirSync(this.historyDir, { withFileTypes: true });
@@ -166,9 +190,17 @@ export class HistoryReader {
             return null;
         }
         for (const entry of entries) {
-            if (!entry.isDirectory()) { continue; }
-            const candidate = path.join(this.historyDir, entry.name, `${id}.json`);
-            if (fs.existsSync(candidate)) { return { path: candidate }; }
+            if (!entry.isDirectory()) {
+                continue;
+            }
+            const candidate = path.join(
+                this.historyDir,
+                entry.name,
+                `${id}.json`,
+            );
+            if (fs.existsSync(candidate)) {
+                return { path: candidate };
+            }
         }
         return null;
     }
@@ -199,9 +231,15 @@ const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 500;
 
 function clampLimit(limit: number | undefined): number {
-    if (limit == null) { return DEFAULT_LIMIT; }
-    if (limit < 1) { return 1; }
-    if (limit > MAX_LIMIT) { return MAX_LIMIT; }
+    if (limit == null) {
+        return DEFAULT_LIMIT;
+    }
+    if (limit < 1) {
+        return 1;
+    }
+    if (limit > MAX_LIMIT) {
+        return MAX_LIMIT;
+    }
     return limit;
 }
 
@@ -211,35 +249,62 @@ function clampLimit(limit: number | undefined): number {
  * just feed the value back in — no requirement for cross-source stability.
  */
 function parseCursor(cursor: string | undefined): number {
-    if (!cursor) { return 0; }
+    if (!cursor) {
+        return 0;
+    }
     const n = parseInt(cursor, 10);
     return Number.isFinite(n) && n >= 0 ? n : 0;
 }
 
-function encodeCursor(offset: number): string { return String(offset); }
+function encodeCursor(offset: number): string {
+    return String(offset);
+}
 
-function matchesFilter(entry: HistoryEntryShape, params: HistoryListParams): boolean {
-    if (params.previewId && entry.previewId !== params.previewId) { return false; }
-    if (params.since && (entry.timestamp ?? '') < params.since) { return false; }
-    if (params.until && (entry.timestamp ?? '') > params.until) { return false; }
-    if (params.commit) {
-        const c = entry.git?.commit ?? '';
-        if (!c.startsWith(params.commit)) { return false; }
+function matchesFilter(
+    entry: HistoryEntryShape,
+    params: HistoryListParams,
+): boolean {
+    if (params.previewId && entry.previewId !== params.previewId) {
+        return false;
     }
-    if (params.branch && entry.git?.branch !== params.branch) { return false; }
+    if (params.since && (entry.timestamp ?? "") < params.since) {
+        return false;
+    }
+    if (params.until && (entry.timestamp ?? "") > params.until) {
+        return false;
+    }
+    if (params.commit) {
+        const c = entry.git?.commit ?? "";
+        if (!c.startsWith(params.commit)) {
+            return false;
+        }
+    }
+    if (params.branch && entry.git?.branch !== params.branch) {
+        return false;
+    }
     if (params.branchPattern) {
         try {
             const re = new RegExp(params.branchPattern);
-            if (!re.test(entry.git?.branch ?? '')) { return false; }
+            if (!re.test(entry.git?.branch ?? "")) {
+                return false;
+            }
         } catch {
             // Bad regex from caller — treat as no-match rather than throwing
             // out of the list call. The panel can show "filter invalid".
             return false;
         }
     }
-    if (params.worktreePath && entry.worktree?.path !== params.worktreePath) { return false; }
-    if (params.agentId && entry.worktree?.agentId !== params.agentId) { return false; }
-    if (params.sourceKind && entry.source?.kind !== params.sourceKind) { return false; }
-    if (params.sourceId && entry.source?.id !== params.sourceId) { return false; }
+    if (params.worktreePath && entry.worktree?.path !== params.worktreePath) {
+        return false;
+    }
+    if (params.agentId && entry.worktree?.agentId !== params.agentId) {
+        return false;
+    }
+    if (params.sourceKind && entry.source?.kind !== params.sourceKind) {
+        return false;
+    }
+    if (params.sourceId && entry.source?.id !== params.sourceId) {
+        return false;
+    }
     return true;
 }

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,47 +1,69 @@
-import * as vscode from 'vscode';
-import * as path from 'path';
-import * as fs from 'fs';
-import * as crypto from 'crypto';
-import { GradleService, GradleApi, TaskCancelledError } from './gradleService';
-import { JdkImageError } from './jdkImageErrorDetector';
-import { KotlinCompileError } from './kotlinCompileErrorDetector';
-import { findPluginAppliedAncestor } from './pluginDetection';
-import { PreviewPanel } from './previewPanel';
-import { PreviewRegistry } from './previewRegistry';
-import { PreviewGutterDecorations } from './previewGutterDecorations';
-import { PreviewHoverProvider } from './previewHoverProvider';
-import { PreviewCodeLensProvider } from './previewCodeLensProvider';
-import { AndroidManifestCodeLensProvider } from './androidManifestCodeLensProvider';
-import { PreviewA11yDiagnostics } from './previewA11yDiagnostics';
-import { PreviewDoctorDiagnostics } from './previewDoctorDiagnostics';
-import { packageQualifiedSourcePath } from './sourcePath';
+import * as vscode from "vscode";
+import * as path from "path";
+import * as fs from "fs";
+import * as crypto from "crypto";
+import { GradleService, GradleApi, TaskCancelledError } from "./gradleService";
+import { JdkImageError } from "./jdkImageErrorDetector";
+import { KotlinCompileError } from "./kotlinCompileErrorDetector";
+import { findPluginAppliedAncestor } from "./pluginDetection";
+import { PreviewPanel } from "./previewPanel";
+import { PreviewRegistry } from "./previewRegistry";
+import { PreviewGutterDecorations } from "./previewGutterDecorations";
+import { PreviewHoverProvider } from "./previewHoverProvider";
+import { PreviewCodeLensProvider } from "./previewCodeLensProvider";
+import { AndroidManifestCodeLensProvider } from "./androidManifestCodeLensProvider";
+import { PreviewA11yDiagnostics } from "./previewA11yDiagnostics";
+import { PreviewDoctorDiagnostics } from "./previewDoctorDiagnostics";
+import { packageQualifiedSourcePath } from "./sourcePath";
 import {
     AccessibilityFinding,
     AccessibilityNode,
     HEAVY_COST_THRESHOLD,
     PreviewInfo,
     WebviewToExtension,
-} from './types';
-import { formatRenderErrorMessage } from './renderError';
-import { captureLabel } from './captureLabels';
-import { DaemonGate } from './daemon/daemonGate';
-import { DataProductAttachment } from './daemon/daemonProtocol';
-import { A11Y_OVERLAY_KINDS, DaemonScheduler, WarmState } from './daemon/daemonScheduler';
-import { buildHistorySource, HistoryScope, HistorySource } from './historyPanel';
-import { disposePreviewMainBatches, readPreviewMainPng } from './previewMainSource';
-import { watchPreviewMainRef } from './previewMainWatcher';
-import { LogFilter, parseLogLevel } from './logFilter';
-import { pickRefreshModeFor, RefreshMode } from './refreshMode';
-import { BuildProgressTracker, mergeCalibration, PhaseDurations } from './buildProgress';
-import { CompileError, extractCompileErrors, DiagnosticLike } from './compileErrors';
+} from "./types";
+import { formatRenderErrorMessage } from "./renderError";
+import { captureLabel } from "./captureLabels";
+import { DaemonGate } from "./daemon/daemonGate";
+import { DataProductAttachment } from "./daemon/daemonProtocol";
+import {
+    A11Y_OVERLAY_KINDS,
+    DaemonScheduler,
+    WarmState,
+} from "./daemon/daemonScheduler";
+import {
+    buildHistorySource,
+    HistoryScope,
+    HistorySource,
+} from "./historyPanel";
+import {
+    disposePreviewMainBatches,
+    readPreviewMainPng,
+} from "./previewMainSource";
+import { watchPreviewMainRef } from "./previewMainWatcher";
+import { LogFilter, parseLogLevel } from "./logFilter";
+import { pickRefreshModeFor, RefreshMode } from "./refreshMode";
+import {
+    BuildProgressTracker,
+    mergeCalibration,
+    PhaseDurations,
+} from "./buildProgress";
+import {
+    CompileError,
+    extractCompileErrors,
+    DiagnosticLike,
+} from "./compileErrors";
 import {
     buildPreviewActivityAmStartArgs,
     collectAndroidApplicationModules,
     findAndroidSdkRoot,
     resolveAdbPath,
     runAdb,
-} from './launchOnDevice';
-import { hasFreshRenderStamp, writeRenderFreshnessStamp } from './renderFreshness';
+} from "./launchOnDevice";
+import {
+    hasFreshRenderStamp,
+    writeRenderFreshnessStamp,
+} from "./renderFreshness";
 
 const DEBOUNCE_MS = 1500;
 // Edits to the currently-scoped preview file (e.g. Claude Code's Edit tool
@@ -90,10 +112,19 @@ async function isSourceNewerThanRenders(
     previews: PreviewInfo[],
     modules: string[],
 ): Promise<boolean> {
-    if (!gradleService) { return false; }
+    if (!gradleService) {
+        return false;
+    }
     const module = modules[0];
-    if (!module) { return false; }
-    return !(await hasFreshRenderStamp(gradleService.workspaceRoot, module, activeFile, previews));
+    if (!module) {
+        return false;
+    }
+    return !(await hasFreshRenderStamp(
+        gradleService.workspaceRoot,
+        module,
+        activeFile,
+        previews,
+    ));
 }
 
 const moduleManifestCache = new Map<string, PreviewInfo[]>();
@@ -142,19 +173,21 @@ let refreshInFlight = false;
 const daemonShownPreviewWarmScopes = new Set<string>();
 const daemonStartupProgressTimers = new Map<string, NodeJS.Timeout>();
 /** Workspace-state key that suppresses the "plugin not applied" notification. */
-const DISMISS_KEY = 'composePreview.dismissedMissingPluginWarning';
+const DISMISS_KEY = "composePreview.dismissedMissingPluginWarning";
 /** Workspace-state key for per-module phase-duration calibration. Shape:
  *  `Record<moduleId, PhaseDurations>`. Updated after every successful refresh
  *  so the progress bar's animation rate matches what each module actually
  *  takes (a Wear OS sample with Robolectric is much slower than a CMP one). */
-const PROGRESS_CALIBRATION_KEY = 'composePreview.progressCalibration';
+const PROGRESS_CALIBRATION_KEY = "composePreview.progressCalibration";
 /** Captured in activate() so notification helpers can reach workspaceState. */
 let extensionContext: vscode.ExtensionContext | null = null;
 /** Module-scoped logger wired up in activate() so refresh() can trace state
  *  transitions into the "Compose Preview" output channel. Populate-then-blank
  *  bugs are hard to diagnose from logs unless we explicitly announce each
  *  message we send to the webview. */
-let logLine: (msg: string) => void = () => { /* noop pre-activate */ };
+let logLine: (msg: string) => void = () => {
+    /* noop pre-activate */
+};
 /** Guard against firing the "plugin not applied" notification more than once
  *  per session — users shouldn't see it on every refresh tick. */
 let warnedMissingPluginThisSession = false;
@@ -167,13 +200,15 @@ let warnedJdkImageThisSession = false;
 // custom-multipreview definition sites) and be a Composable file at all.
 // False positives are cheap — an extra informational message. False
 // negatives (silence when the user wanted a nudge) are the worse outcome.
-const SETUP_DOCS_URL = 'https://github.com/yschimke/compose-ai-tools/tree/main/vscode-extension#readme';
-const JDK_DOCS_URL = 'https://github.com/yschimke/compose-ai-tools/blob/main/docs/AGENTS.md#important-constraints';
+const SETUP_DOCS_URL =
+    "https://github.com/yschimke/compose-ai-tools/tree/main/vscode-extension#readme";
+const JDK_DOCS_URL =
+    "https://github.com/yschimke/compose-ai-tools/blob/main/docs/AGENTS.md#important-constraints";
 
 function earlyFeaturesEnabled(): boolean {
     return vscode.workspace
-        .getConfiguration('composePreview')
-        .get<boolean>('earlyFeatures.enabled', false);
+        .getConfiguration("composePreview")
+        .get<boolean>("earlyFeatures.enabled", false);
 }
 
 /**
@@ -183,24 +218,29 @@ function earlyFeaturesEnabled(): boolean {
  * De-duped per session so save-driven rebuilds don't re-open it.
  */
 function showJdkImageRemediation(err: JdkImageError): void {
-    if (warnedJdkImageThisSession) { return; }
+    if (warnedJdkImageThisSession) {
+        return;
+    }
     warnedJdkImageThisSession = true;
-    const reason = err.finding.reason ? ` (${err.finding.reason})` : '';
-    const message = `Compose Preview: Gradle is using a JRE without jlink${reason}. `
-        + 'Point it at a full JDK to build Android modules. '
-        + `Path: ${err.finding.jlinkPath}`;
-    const OPEN_SETTING = 'Open JDK setting';
-    const DOCS = 'Learn more';
-    void vscode.window.showErrorMessage(message, OPEN_SETTING, DOCS).then(action => {
-        if (action === OPEN_SETTING) {
-            void vscode.commands.executeCommand(
-                'workbench.action.openSettings',
-                'java.import.gradle.java.home',
-            );
-        } else if (action === DOCS) {
-            void vscode.env.openExternal(vscode.Uri.parse(JDK_DOCS_URL));
-        }
-    });
+    const reason = err.finding.reason ? ` (${err.finding.reason})` : "";
+    const message =
+        `Compose Preview: Gradle is using a JRE without jlink${reason}. ` +
+        "Point it at a full JDK to build Android modules. " +
+        `Path: ${err.finding.jlinkPath}`;
+    const OPEN_SETTING = "Open JDK setting";
+    const DOCS = "Learn more";
+    void vscode.window
+        .showErrorMessage(message, OPEN_SETTING, DOCS)
+        .then((action) => {
+            if (action === OPEN_SETTING) {
+                void vscode.commands.executeCommand(
+                    "workbench.action.openSettings",
+                    "java.import.gradle.java.home",
+                );
+            } else if (action === DOCS) {
+                void vscode.env.openExternal(vscode.Uri.parse(JDK_DOCS_URL));
+            }
+        });
 }
 
 /**
@@ -218,7 +258,11 @@ export interface ComposePreviewTestApi {
     /** Replace the GradleService with one wired to the supplied stub API. */
     injectGradleApi(api: GradleApi): void;
     /** Drive {@link refresh} synchronously from a test. */
-    triggerRefresh(filePath: string, force?: boolean, tier?: 'fast' | 'full'): Promise<void>;
+    triggerRefresh(
+        filePath: string,
+        force?: boolean,
+        tier?: "fast" | "full",
+    ): Promise<void>;
     /** Snapshot of every panel message posted since [resetMessages]. */
     getPostedMessages(): unknown[];
     /** Drop the captured-messages buffer. */
@@ -251,16 +295,20 @@ export function applyDataProductsToRegistry(
     let nodes: AccessibilityNode[] | undefined;
     for (const dp of dataProducts) {
         try {
-            if (dp.kind === 'a11y/atf') {
+            if (dp.kind === "a11y/atf") {
                 const payload = (dp.payload ?? readJsonPath(dp.path, log)) as
                     | { findings?: AccessibilityFinding[] }
                     | undefined;
-                if (payload?.findings) { findings = payload.findings; }
-            } else if (dp.kind === 'a11y/hierarchy') {
+                if (payload?.findings) {
+                    findings = payload.findings;
+                }
+            } else if (dp.kind === "a11y/hierarchy") {
                 const payload = (dp.payload ?? readJsonPath(dp.path, log)) as
                     | { nodes?: AccessibilityNode[] }
                     | undefined;
-                if (payload?.nodes) { nodes = payload.nodes; }
+                if (payload?.nodes) {
+                    nodes = payload.nodes;
+                }
             }
         } catch (err) {
             log.appendLine(
@@ -275,34 +323,49 @@ export function applyDataProductsToRegistry(
     return null;
 }
 
-function readJsonPath(p: string | undefined, log: { appendLine(value: string): void }): unknown {
-    if (!p) { return undefined; }
+function readJsonPath(
+    p: string | undefined,
+    log: { appendLine(value: string): void },
+): unknown {
+    if (!p) {
+        return undefined;
+    }
     try {
-        return JSON.parse(fs.readFileSync(p, 'utf-8'));
+        return JSON.parse(fs.readFileSync(p, "utf-8"));
     } catch (err) {
-        log.appendLine(`[daemon] could not read data-product JSON at ${p}: ${(err as Error).message}`);
+        log.appendLine(
+            `[daemon] could not read data-product JSON at ${p}: ${(err as Error).message}`,
+        );
         return undefined;
     }
 }
 
-export async function activate(context: vscode.ExtensionContext): Promise<ComposePreviewTestApi | void> {
+export async function activate(
+    context: vscode.ExtensionContext,
+): Promise<ComposePreviewTestApi | void> {
     const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (!workspaceFolders || workspaceFolders.length === 0) { return; }
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+        return;
+    }
 
     extensionContext = context;
     const workspaceRoot = workspaceFolders[0].uri.fsPath;
-    const outputChannel = vscode.window.createOutputChannel('Compose Preview');
+    const outputChannel = vscode.window.createOutputChannel("Compose Preview");
     context.subscriptions.push(outputChannel);
     // `composePreview.logging.level` is read on every emit so a settings.json
     // edit takes effect immediately without a window reload.
     const logFilter = new LogFilter(() =>
         parseLogLevel(
-            vscode.workspace.getConfiguration('composePreview').get<string>('logging.level'),
+            vscode.workspace
+                .getConfiguration("composePreview")
+                .get<string>("logging.level"),
         ),
     );
     logLine = (msg: string) => {
         const line = `[refresh] ${msg}`;
-        if (logFilter.shouldEmitInformational(line)) { outputChannel.appendLine(line); }
+        if (logFilter.shouldEmitInformational(line)) {
+            outputChannel.appendLine(line);
+        }
     };
 
     // Startup fingerprint — answers "is the build I think I installed
@@ -310,21 +373,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     // comes from package.json (bumped by release-please); the path locates
     // the loaded module on disk so an old install lingering from a prior
     // session is obvious.
-    const extId = 'yuri-schimke.compose-preview';
+    const extId = "yuri-schimke.compose-preview";
     const ext = vscode.extensions.getExtension(extId);
-    const extVersion = ext?.packageJSON?.version ?? 'unknown';
-    const extPath = ext?.extensionPath ?? '<unresolved>';
+    const extVersion = ext?.packageJSON?.version ?? "unknown";
+    const extPath = ext?.extensionPath ?? "<unresolved>";
     outputChannel.appendLine(
         `[startup] compose-preview v${extVersion} loaded from ${extPath}`,
     );
 
-    const isTestMode = process.env.COMPOSE_PREVIEW_TEST_MODE === '1';
+    const isTestMode = process.env.COMPOSE_PREVIEW_TEST_MODE === "1";
 
     // vscjava.vscode-gradle is declared as an extensionDependency, so it's
     // guaranteed to be installed in production. Under
     // `COMPOSE_PREVIEW_TEST_MODE=1` we tolerate the dep being a stub (the
     // tests inject their own GradleApi via [ComposePreviewTestApi]).
-    const gradleExt = vscode.extensions.getExtension('vscjava.vscode-gradle');
+    const gradleExt = vscode.extensions.getExtension("vscjava.vscode-gradle");
     if (!gradleExt && !isTestMode) {
         vscode.window.showErrorMessage(
             'Compose Preview requires the "Gradle for Java" extension (vscjava.vscode-gradle).',
@@ -333,146 +396,180 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     }
     const gradleApi: GradleApi = gradleExt
         ? ((await gradleExt.activate()) as GradleApi)
-        : { runTask: async () => { /* test-mode placeholder */ },
-            cancelRunTask: async () => { /* test-mode placeholder */ } };
+        : {
+              runTask: async () => {
+                  /* test-mode placeholder */
+              },
+              cancelRunTask: async () => {
+                  /* test-mode placeholder */
+              },
+          };
 
-    gradleService = new GradleService(workspaceRoot, gradleApi, outputChannel, () => [], logFilter);
+    gradleService = new GradleService(
+        workspaceRoot,
+        gradleApi,
+        outputChannel,
+        () => [],
+        logFilter,
+    );
 
     // Daemon path is controlled by composePreview.daemon.enabled (true by default). When disabled
     // the gate's `isEnabled()` returns false and the scheduler is never asked to spawn anything —
     // the Gradle path is the temporary escape hatch. When enabled, daemon failures surface as
     // errors instead of silently falling back to Gradle.
-    daemonGate = new DaemonGate(workspaceRoot, '0.1.0', outputChannel, logFilter);
-    daemonScheduler = new DaemonScheduler(daemonGate, {
-        onPreviewImageReady: (_moduleId, previewId, imageBase64) => {
-            if (!panel) { return; }
-            if (activeInteractiveStreams.has(previewId) && logFilter.shouldEmitVerbose()) {
-                logLine(`[interactive] frame ${previewId} bytes=${imageBase64.length}`);
-            }
-            // Capture index 0 — the daemon's v1 renderFinished targets the
-            // representative capture only. Multi-capture (animated) renders
-            // still come through the Gradle path; the daemon's predictive
-            // pre-warm focuses on the cheap interactive loop.
-            panel.postMessage({
-                command: 'updateImage',
-                previewId,
-                captureIndex: 0,
-                imageData: imageBase64,
-            });
-        },
-        onRenderFailed: (_moduleId, previewId, message) => {
-            if (!panel) { return; }
-            panel.postMessage({
-                command: 'setImageError',
-                previewId,
-                captureIndex: 0,
-                message,
-                replaceExisting: false,
-            });
-        },
-        onDataProductsAttached: (_moduleId, previewId, dataProducts) => {
-            // D2 — route the data products attached to this render. For path-transport kinds
-            // (`a11y/hierarchy`) we read the JSON off disk; inline kinds (`a11y/atf`) carry
-            // their payload in `dp.payload`. The registry update fires `onDidChange`, which
-            // the diagnostics provider already listens to. The panel receives a targeted
-            // `updateA11y` post so its cached overlays repaint without re-emitting the entire
-            // preview list.
-            const decoded = applyDataProductsToRegistry(
-                registry,
-                previewId,
-                dataProducts,
-                outputChannel,
-            );
-            if (decoded && panel) {
+    daemonGate = new DaemonGate(
+        workspaceRoot,
+        "0.1.0",
+        outputChannel,
+        logFilter,
+    );
+    daemonScheduler = new DaemonScheduler(
+        daemonGate,
+        {
+            onPreviewImageReady: (_moduleId, previewId, imageBase64) => {
+                if (!panel) {
+                    return;
+                }
+                if (
+                    activeInteractiveStreams.has(previewId) &&
+                    logFilter.shouldEmitVerbose()
+                ) {
+                    logLine(
+                        `[interactive] frame ${previewId} bytes=${imageBase64.length}`,
+                    );
+                }
+                // Capture index 0 — the daemon's v1 renderFinished targets the
+                // representative capture only. Multi-capture (animated) renders
+                // still come through the Gradle path; the daemon's predictive
+                // pre-warm focuses on the cheap interactive loop.
                 panel.postMessage({
-                    command: 'updateA11y',
+                    command: "updateImage",
                     previewId,
-                    findings: decoded.findings ?? undefined,
-                    nodes: decoded.nodes ?? undefined,
+                    captureIndex: 0,
+                    imageData: imageBase64,
                 });
-            }
-        },
-        onClasspathDirty: (moduleId, detail) => {
-            outputChannel.appendLine(
-                `[daemon] classpath dirty for ${moduleId}: ${detail} — falling back to Gradle`,
-            );
-            clearDaemonShownPreviewWarmScopes(moduleId);
-            // Daemon will exit on its own (PROTOCOL.md § 6); the channel-
-            // closed handler in DaemonGate evicts the entry. Next save runs
-            // Gradle, which re-bootstraps a fresh daemon when the user
-            // re-enables it via composePreviewDaemonStart.
-            // Drop the interactive-mode availability so any open LIVE chip
-            // disables itself instead of streaming stale frames from a
-            // soon-to-die daemon.
-            publishInteractiveAvailability(moduleId);
-        },
-        onDiscoveryUpdated: (moduleId, params) => {
-            // Daemon emits this only when the in-memory preview index drifted
-            // (added / removed / changed against the snapshot it held before
-            // the save). Identity-only saves are silent. Apply the diff to
-            // the extension-side mirror used for daemon focus computation —
-            // we deliberately don't post a "loading" or progress message;
-            // the user already saw the new PNG arrive via `renderFinished`,
-            // and a webview reshape is only needed when the preview set
-            // actually changed.
-            applyDiscoveryDiff(moduleId, params);
-        },
-        onHistoryAdded: (_moduleId, params) => {
-            // Phase H7 — daemon push: a fresh render landed and was archived. History is
-            // now focus-view-only; the live panel resolves it on demand when the user
-            // asks for a diff from the focused preview.
-            void params;
-        },
-        onChannelClosed: (moduleId) => {
-            clearDaemonShownPreviewWarmScopes(moduleId);
-            // Daemon's stdio channel closed (process exit, classpath dirty,
-            // spawn died). frameStreamIds don't survive a JVM restart, so
-            // drop every entry in `activeInteractiveStreams` whose previewId
-            // belongs to this module. Without this, a click landing after
-            // the daemon respawned would carry a stale streamId the new
-            // JVM never minted, and v2 dispatch would silently drop. The
-            // extension's `previewModuleMap` still resolves correctly post-
-            // respawn so the lookup uses today's mapping.
-            const stale: string[] = [];
-            for (const previewId of activeInteractiveStreams.keys()) {
-                if (previewModuleMap.get(previewId) === moduleId) {
-                    stale.push(previewId);
+            },
+            onRenderFailed: (_moduleId, previewId, message) => {
+                if (!panel) {
+                    return;
                 }
-            }
-            for (const previewId of stale) {
-                activeInteractiveStreams.delete(previewId);
-            }
-            for (const previewId of [...activeRecordingSessions.keys()]) {
-                if (previewModuleMap.get(previewId) === moduleId) {
-                    activeRecordingSessions.delete(previewId);
-                    activeRecordingFormats.delete(previewId);
-                    panel?.postMessage({ command: 'clearRecording', previewId });
-                }
-            }
-            updateInteractiveStatus();
-            if (stale.length > 0) {
-                logLine(
-                    `[interactive] daemon channel closed for ${moduleId}; ` +
-                    `dropped ${stale.length} stale stream(s): ${stale.join(', ')}`,
+                panel.postMessage({
+                    command: "setImageError",
+                    previewId,
+                    captureIndex: 0,
+                    message,
+                    replaceExisting: false,
+                });
+            },
+            onDataProductsAttached: (_moduleId, previewId, dataProducts) => {
+                // D2 — route the data products attached to this render. For path-transport kinds
+                // (`a11y/hierarchy`) we read the JSON off disk; inline kinds (`a11y/atf`) carry
+                // their payload in `dp.payload`. The registry update fires `onDidChange`, which
+                // the diagnostics provider already listens to. The panel receives a targeted
+                // `updateA11y` post so its cached overlays repaint without re-emitting the entire
+                // preview list.
+                const decoded = applyDataProductsToRegistry(
+                    registry,
+                    previewId,
+                    dataProducts,
+                    outputChannel,
                 );
-            }
+                if (decoded && panel) {
+                    panel.postMessage({
+                        command: "updateA11y",
+                        previewId,
+                        findings: decoded.findings ?? undefined,
+                        nodes: decoded.nodes ?? undefined,
+                    });
+                }
+            },
+            onClasspathDirty: (moduleId, detail) => {
+                outputChannel.appendLine(
+                    `[daemon] classpath dirty for ${moduleId}: ${detail} — falling back to Gradle`,
+                );
+                clearDaemonShownPreviewWarmScopes(moduleId);
+                // Daemon will exit on its own (PROTOCOL.md § 6); the channel-
+                // closed handler in DaemonGate evicts the entry. Next save runs
+                // Gradle, which re-bootstraps a fresh daemon when the user
+                // re-enables it via composePreviewDaemonStart.
+                // Drop the interactive-mode availability so any open LIVE chip
+                // disables itself instead of streaming stale frames from a
+                // soon-to-die daemon.
+                publishInteractiveAvailability(moduleId);
+            },
+            onDiscoveryUpdated: (moduleId, params) => {
+                // Daemon emits this only when the in-memory preview index drifted
+                // (added / removed / changed against the snapshot it held before
+                // the save). Identity-only saves are silent. Apply the diff to
+                // the extension-side mirror used for daemon focus computation —
+                // we deliberately don't post a "loading" or progress message;
+                // the user already saw the new PNG arrive via `renderFinished`,
+                // and a webview reshape is only needed when the preview set
+                // actually changed.
+                applyDiscoveryDiff(moduleId, params);
+            },
+            onHistoryAdded: (_moduleId, params) => {
+                // Phase H7 — daemon push: a fresh render landed and was archived. History is
+                // now focus-view-only; the live panel resolves it on demand when the user
+                // asks for a diff from the focused preview.
+                void params;
+            },
+            onChannelClosed: (moduleId) => {
+                clearDaemonShownPreviewWarmScopes(moduleId);
+                // Daemon's stdio channel closed (process exit, classpath dirty,
+                // spawn died). frameStreamIds don't survive a JVM restart, so
+                // drop every entry in `activeInteractiveStreams` whose previewId
+                // belongs to this module. Without this, a click landing after
+                // the daemon respawned would carry a stale streamId the new
+                // JVM never minted, and v2 dispatch would silently drop. The
+                // extension's `previewModuleMap` still resolves correctly post-
+                // respawn so the lookup uses today's mapping.
+                const stale: string[] = [];
+                for (const previewId of activeInteractiveStreams.keys()) {
+                    if (previewModuleMap.get(previewId) === moduleId) {
+                        stale.push(previewId);
+                    }
+                }
+                for (const previewId of stale) {
+                    activeInteractiveStreams.delete(previewId);
+                }
+                for (const previewId of [...activeRecordingSessions.keys()]) {
+                    if (previewModuleMap.get(previewId) === moduleId) {
+                        activeRecordingSessions.delete(previewId);
+                        activeRecordingFormats.delete(previewId);
+                        panel?.postMessage({
+                            command: "clearRecording",
+                            previewId,
+                        });
+                    }
+                }
+                updateInteractiveStatus();
+                if (stale.length > 0) {
+                    logLine(
+                        `[interactive] daemon channel closed for ${moduleId}; ` +
+                            `dropped ${stale.length} stale stream(s): ${stale.join(", ")}`,
+                    );
+                }
+            },
         },
-    }, outputChannel,
+        outputChannel,
         // D2 — read the user setting freshly on each `setVisible` so toggling
         // `composePreview.a11y.alwaysSubscribe` doesn't need a window reload.
         () =>
             vscode.workspace
-                .getConfiguration('composePreview')
-                .get<boolean>('a11y.alwaysSubscribe', false));
+                .getConfiguration("composePreview")
+                .get<boolean>("a11y.alwaysSubscribe", false),
+    );
 
     // Status-bar slot for daemon lifecycle. Hidden when the daemon flag is
     // off or no module is currently warming. Surfacing the cold-bootstrap
     // pause (typically 2-4 s on first scope-in) avoids the "panel is stuck"
     // perception on the daemon flag's first-time UX.
     daemonStatusItem = vscode.window.createStatusBarItem(
-        vscode.StatusBarAlignment.Left, 90,
+        vscode.StatusBarAlignment.Left,
+        90,
     );
-    daemonStatusItem.command = 'workbench.action.output.toggleOutput';
+    daemonStatusItem.command = "workbench.action.output.toggleOutput";
     context.subscriptions.push(daemonStatusItem);
 
     // INTERACTIVE.md § 9 / #425 — status-bar hint surfaced only when the user has LIVE active
@@ -482,15 +579,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     // would otherwise have no signal as to why. Hidden when v2 IS supported (the LIVE chip
     // alone is sufficient feedback) and when no streams are active.
     interactiveStatusItem = vscode.window.createStatusBarItem(
-        vscode.StatusBarAlignment.Left, 89,
+        vscode.StatusBarAlignment.Left,
+        89,
     );
-    interactiveStatusItem.command = 'workbench.action.output.toggleOutput';
+    interactiveStatusItem.command = "workbench.action.output.toggleOutput";
     context.subscriptions.push(interactiveStatusItem);
 
-    panel = new PreviewPanel(
-        context.extensionUri,
-        handleWebviewMessage,
-        () => earlyFeaturesEnabled(),
+    panel = new PreviewPanel(context.extensionUri, handleWebviewMessage, () =>
+        earlyFeaturesEnabled(),
     );
     if (isTestMode) {
         // Tap into every outgoing webview message so the test API can assert
@@ -512,7 +608,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     // internally; we just message the live panel and let it reissue.
     context.subscriptions.push(
         watchPreviewMainRef(workspaceRoot, () => {
-            panel?.postMessage({ command: 'previewMainRefChanged' });
+            panel?.postMessage({ command: "previewMainRefChanged" });
         }),
     );
 
@@ -520,58 +616,93 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     // contributed; history is surfaced from the focus view alongside data products.
     historyScopeRef.current = null;
     historySource = buildHistorySource({
-        isDaemonReady: (moduleId) => daemonGate?.isDaemonReady(moduleId) ?? false,
+        isDaemonReady: (moduleId) =>
+            daemonGate?.isDaemonReady(moduleId) ?? false,
         daemonList: async (scope) => {
             const client = await daemonGate?.getOrSpawn(
-                scope.moduleId, daemonScheduler!.daemonEvents(scope.moduleId),
+                scope.moduleId,
+                daemonScheduler!.daemonEvents(scope.moduleId),
             );
-            if (!client) { throw new Error('daemon unavailable'); }
+            if (!client) {
+                throw new Error("daemon unavailable");
+            }
             return client.historyList({ previewId: scope.previewId });
         },
         daemonRead: async (id) => {
             const moduleId = historyScopeRef.current?.moduleId;
-            if (!moduleId) { throw new Error('no scope'); }
+            if (!moduleId) {
+                throw new Error("no scope");
+            }
             const client = await daemonGate?.getOrSpawn(
-                moduleId, daemonScheduler!.daemonEvents(moduleId),
+                moduleId,
+                daemonScheduler!.daemonEvents(moduleId),
             );
-            if (!client) { throw new Error('daemon unavailable'); }
+            if (!client) {
+                throw new Error("daemon unavailable");
+            }
             return client.historyRead({ id, inline: false });
         },
         daemonDiff: async (fromId, toId) => {
             const moduleId = historyScopeRef.current?.moduleId;
-            if (!moduleId) { throw new Error('no scope'); }
+            if (!moduleId) {
+                throw new Error("no scope");
+            }
             const client = await daemonGate?.getOrSpawn(
-                moduleId, daemonScheduler!.daemonEvents(moduleId),
+                moduleId,
+                daemonScheduler!.daemonEvents(moduleId),
             );
-            if (!client) { throw new Error('daemon unavailable'); }
-            return client.historyDiff({ from: fromId, to: toId, mode: 'metadata' });
+            if (!client) {
+                throw new Error("daemon unavailable");
+            }
+            return client.historyDiff({
+                from: fromId,
+                to: toId,
+                mode: "metadata",
+            });
         },
         getCurrentScope: () => historyScopeRef.current,
         logger: outputChannel,
     });
     context.subscriptions.push(
-        vscode.commands.registerCommand('composePreview.refresh', () =>
-            refresh(true, currentScopeFile ?? undefined)),
-        vscode.commands.registerCommand('composePreview.renderAll', () =>
-            refresh(true, currentScopeFile ?? undefined)),
-        vscode.commands.registerCommand('composePreview.runForFile', (filePath?: string) => {
-            const target = filePath ?? currentScopeFile ?? undefined;
-            if (target) { refresh(true, target); }
-        }),
-        vscode.commands.registerCommand('composePreview.openModuleBuildFile',
-            (filePath?: string) => openModuleBuildFile(workspaceRoot, filePath)),
-        vscode.commands.registerCommand('composePreview.focusPreview',
+        vscode.commands.registerCommand("composePreview.refresh", () =>
+            refresh(true, currentScopeFile ?? undefined),
+        ),
+        vscode.commands.registerCommand("composePreview.renderAll", () =>
+            refresh(true, currentScopeFile ?? undefined),
+        ),
+        vscode.commands.registerCommand(
+            "composePreview.runForFile",
+            (filePath?: string) => {
+                const target = filePath ?? currentScopeFile ?? undefined;
+                if (target) {
+                    refresh(true, target);
+                }
+            },
+        ),
+        vscode.commands.registerCommand(
+            "composePreview.openModuleBuildFile",
+            (filePath?: string) => openModuleBuildFile(workspaceRoot, filePath),
+        ),
+        vscode.commands.registerCommand(
+            "composePreview.focusPreview",
             async (functionName: string, filePath?: string) => {
-                if (!panel) { return; }
+                if (!panel) {
+                    return;
+                }
                 // Reveal the sidebar view. This is the stable command contributed
                 // by VS Code for any registered view (`<viewId>.focus`).
-                await vscode.commands.executeCommand(`${PreviewPanel.viewId}.focus`);
+                await vscode.commands.executeCommand(
+                    `${PreviewPanel.viewId}.focus`,
+                );
                 // If the caller passed a file, scope the panel to it before
                 // filtering — otherwise the currently-scoped module is reused.
                 if (filePath && filePath !== currentScopeFile) {
                     await refresh(false, filePath);
                 }
-                panel.postMessage({ command: 'setFunctionFilter', functionName });
+                panel.postMessage({
+                    command: "setFunctionFilter",
+                    functionName,
+                });
             },
         ),
         // The daemon JVM caches the renderer JAR + sandbox state across every
@@ -582,43 +713,54 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         // never trips it. This command is the explicit escape hatch: shut
         // down every running daemon, clear the bootstrapped-modules memo, and
         // re-run the bootstrap task so the next save picks up the new JAR.
-        vscode.commands.registerCommand('composePreview.restartDaemon', async () => {
-            if (!daemonGate || !daemonScheduler) {
-                vscode.window.showInformationMessage(
-                    'Compose Preview: daemon gate not initialised yet.',
+        vscode.commands.registerCommand(
+            "composePreview.restartDaemon",
+            async () => {
+                if (!daemonGate || !daemonScheduler) {
+                    vscode.window.showInformationMessage(
+                        "Compose Preview: daemon gate not initialised yet.",
+                    );
+                    return;
+                }
+                const restarted = await daemonGate.restartAll();
+                // Clear the per-session bootstrap memo so the next save re-runs
+                // `composePreviewDaemonStart`, which writes a fresh
+                // `daemon-launch.json` pointing at the rebuilt JAR. Without
+                // clearing this the spawn would skip the bootstrap and the
+                // descriptor on disk could still reference the previous build.
+                daemonBootstrappedModules.clear();
+                // Hide the status-bar item — its text references a specific module
+                // that's no longer relevant; the next warmModule call will repopulate
+                // it through its progress callback.
+                daemonStatusItem?.hide();
+                outputChannel.appendLine(
+                    `[daemon] restartDaemon: shut down ${restarted.length} running daemon(s)` +
+                        (restarted.length > 0
+                            ? ` [${restarted.join(", ")}]`
+                            : "") +
+                        ` — next save will respawn from the on-disk JAR`,
                 );
-                return;
-            }
-            const restarted = await daemonGate.restartAll();
-            // Clear the per-session bootstrap memo so the next save re-runs
-            // `composePreviewDaemonStart`, which writes a fresh
-            // `daemon-launch.json` pointing at the rebuilt JAR. Without
-            // clearing this the spawn would skip the bootstrap and the
-            // descriptor on disk could still reference the previous build.
-            daemonBootstrappedModules.clear();
-            // Hide the status-bar item — its text references a specific module
-            // that's no longer relevant; the next warmModule call will repopulate
-            // it through its progress callback.
-            daemonStatusItem?.hide();
-            outputChannel.appendLine(
-                `[daemon] restartDaemon: shut down ${restarted.length} running daemon(s)` +
-                (restarted.length > 0 ? ` [${restarted.join(', ')}]` : '') +
-                ` — next save will respawn from the on-disk JAR`,
-            );
-            vscode.window.showInformationMessage(
-                restarted.length === 0
-                    ? 'Compose Preview: no daemon was running.'
-                    : `Compose Preview: restarted ${restarted.length} daemon(s). ` +
-                      'Next save will respawn from the on-disk JAR.',
-            );
-        }),
+                vscode.window.showInformationMessage(
+                    restarted.length === 0
+                        ? "Compose Preview: no daemon was running."
+                        : `Compose Preview: restarted ${restarted.length} daemon(s). ` +
+                              "Next save will respawn from the on-disk JAR.",
+                );
+            },
+        ),
     );
 
     const detectLog = (msg: string) => {
         const line = `[detect] ${msg}`;
-        if (logFilter.shouldEmitInformational(line)) { outputChannel.appendLine(line); }
+        if (logFilter.shouldEmitInformational(line)) {
+            outputChannel.appendLine(line);
+        }
     };
-    const gutterDecorations = new PreviewGutterDecorations(context.extensionUri, registry, detectLog);
+    const gutterDecorations = new PreviewGutterDecorations(
+        context.extensionUri,
+        registry,
+        detectLog,
+    );
     const hoverProvider = new PreviewHoverProvider(registry, detectLog);
     const codeLensProvider = new PreviewCodeLensProvider(registry, detectLog);
     const a11yDiagnostics = new PreviewA11yDiagnostics(registry, detectLog);
@@ -627,22 +769,32 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         workspaceRoot,
         (msg) => {
             const line = `[doctor] ${msg}`;
-            if (logFilter.shouldEmitInformational(line)) { outputChannel.appendLine(line); }
+            if (logFilter.shouldEmitInformational(line)) {
+                outputChannel.appendLine(line);
+            }
         },
     );
-    const kotlinFiles: vscode.DocumentSelector = { language: 'kotlin', scheme: 'file' };
+    const kotlinFiles: vscode.DocumentSelector = {
+        language: "kotlin",
+        scheme: "file",
+    };
     // AndroidManifest.xml lives at module-root, not under res/, so the existing
     // `**/res/**/*.xml` watcher misses it. Match files by name rather than
     // language id — the language id depends on the user's xml extension setup
     // and isn't a load-bearing signal.
     const androidManifestFiles: vscode.DocumentSelector = {
-        scheme: 'file',
-        pattern: '**/AndroidManifest.xml',
+        scheme: "file",
+        pattern: "**/AndroidManifest.xml",
     };
-    const androidManifestCodeLensProvider = new AndroidManifestCodeLensProvider(gradleService);
+    const androidManifestCodeLensProvider = new AndroidManifestCodeLensProvider(
+        gradleService,
+    );
     context.subscriptions.push(
         vscode.languages.registerHoverProvider(kotlinFiles, hoverProvider),
-        vscode.languages.registerCodeLensProvider(kotlinFiles, codeLensProvider),
+        vscode.languages.registerCodeLensProvider(
+            kotlinFiles,
+            codeLensProvider,
+        ),
         vscode.languages.registerCodeLensProvider(
             androidManifestFiles,
             androidManifestCodeLensProvider,
@@ -662,9 +814,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     // run `:<module>:renderAndroidResources` yet.
     context.subscriptions.push(
         vscode.commands.registerCommand(
-            'composePreview.previewResource',
+            "composePreview.previewResource",
             (pngPath: string, _resourceId: string) => {
-                void vscode.commands.executeCommand('vscode.open', vscode.Uri.file(pngPath));
+                void vscode.commands.executeCommand(
+                    "vscode.open",
+                    vscode.Uri.file(pngPath),
+                );
             },
         ),
     );
@@ -677,19 +832,28 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         // gradleService is non-null inside this activation scope (initialised
         // a few lines up), but the module-scope nullable declaration forces
         // a local alias for the type-checker.
-        if (!gradleService) { return; }
+        if (!gradleService) {
+            return;
+        }
         await doctorDiagnostics.refresh(gradleService.findPreviewModules());
     };
     context.subscriptions.push(
-        vscode.commands.registerCommand('composePreview.runDoctor', () => {
+        vscode.commands.registerCommand("composePreview.runDoctor", () => {
             void vscode.window.withProgress(
-                { location: vscode.ProgressLocation.Window, title: 'Running compose-preview doctor…' },
+                {
+                    location: vscode.ProgressLocation.Window,
+                    title: "Running compose-preview doctor…",
+                },
                 refreshDoctor,
             );
         }),
-        vscode.commands.registerCommand('composePreview.diffAllVsMain', () => diffAllVsMain()),
-        vscode.commands.registerCommand('composePreview.launchOnDevice',
-            (previewId?: string) => launchOnDevice(previewId)),
+        vscode.commands.registerCommand("composePreview.diffAllVsMain", () =>
+            diffAllVsMain(),
+        ),
+        vscode.commands.registerCommand(
+            "composePreview.launchOnDevice",
+            (previewId?: string) => launchOnDevice(previewId),
+        ),
     );
     // Refresh applied-markers in the background so future module resolution can
     // use the authoritative `applied.json` path. Doctor stays explicit via
@@ -698,22 +862,30 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
 
     context.subscriptions.push(
         vscode.workspace.onDidChangeConfiguration((event) => {
-            if (event.affectsConfiguration('composePreview.earlyFeatures.enabled')) {
+            if (
+                event.affectsConfiguration(
+                    "composePreview.earlyFeatures.enabled",
+                )
+            ) {
                 panel?.postMessage({
-                    command: 'setEarlyFeatures',
+                    command: "setEarlyFeatures",
                     enabled: earlyFeaturesEnabled(),
                 });
             }
         }),
-        vscode.window.onDidChangeActiveTextEditor(editor => {
-            if (editor?.document.languageId === 'kotlin') {
+        vscode.window.onDidChangeActiveTextEditor((editor) => {
+            if (editor?.document.languageId === "kotlin") {
                 const filePath = editor.document.uri.fsPath;
-                if (!isPreviewSourceFile(filePath)) { return; }
+                if (!isPreviewSourceFile(filePath)) {
+                    return;
+                }
                 // Focus toggling (editor ↔ webview/terminal ↔ back) fires this
                 // event with the same Kotlin file. Re-running refresh there
                 // just cancels any in-flight render, flashes spinners, and
                 // burns a Gradle invocation — all for a no-op.
-                if (filePath === currentScopeFile) { return; }
+                if (filePath === currentScopeFile) {
+                    return;
+                }
                 // INTERACTIVE.md § 3 — drop active interactive streams when
                 // the user moves focus to a different file. Daemon-side
                 // streams flushed here, panel cleared via clearInteractive
@@ -721,8 +893,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
                 // race this on the new file's manifest arrival.
                 void flushInteractiveStreams();
                 void flushRecordingSessions({ encode: true });
-                panel?.postMessage({ command: 'clearInteractive' });
-                panel?.postMessage({ command: 'clearRecording' });
+                panel?.postMessage({ command: "clearInteractive" });
+                panel?.postMessage({ command: "clearRecording" });
                 clearHeavyRefreshOptIns();
                 // Reconcile the panel first, then pre-warm the daemon for
                 // this file's module. Once daemon startup finishes we run a
@@ -730,7 +902,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
                 // the first edit doesn't have to pay JVM/sandbox startup.
                 void (async () => {
                     await refresh(false, filePath);
-                    await warmDaemonForFile(filePath, { refreshAfterReady: true });
+                    await warmDaemonForFile(filePath, {
+                        refreshAfterReady: true,
+                    });
                 })();
                 return;
             }
@@ -746,8 +920,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
                 // rendering into an invisible panel.
                 void flushInteractiveStreams();
                 void flushRecordingSessions({ encode: true });
-                panel?.postMessage({ command: 'clearInteractive' });
-                panel?.postMessage({ command: 'clearRecording' });
+                panel?.postMessage({ command: "clearInteractive" });
+                panel?.postMessage({ command: "clearRecording" });
                 clearHeavyRefreshOptIns();
                 refresh(false);
             }
@@ -772,13 +946,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     // away; subsequent saves coalesce through a debounced + in-flight-aware
     // queue so we never stack builds on top of each other.
     context.subscriptions.push(
-        vscode.workspace.onDidSaveTextDocument(doc => {
-            if (!isSourceFile(doc.uri.fsPath)) { return; }
+        vscode.workspace.onDidSaveTextDocument((doc) => {
+            if (!isSourceFile(doc.uri.fsPath)) {
+                return;
+            }
             // The daemon-vs-Gradle decision is made inside runRefreshExclusive
             // — either path runs, never both. See `pickRefreshMode` for the
             // health gate. When the daemon flag is off (default) the gate
             // always returns 'gradle' so behaviour is byte-identical to today.
-            if (!firstSaveSeen.has(doc.uri.fsPath) && !refreshInFlight && pendingSavePath === null) {
+            if (
+                !firstSaveSeen.has(doc.uri.fsPath) &&
+                !refreshInFlight &&
+                pendingSavePath === null
+            ) {
                 firstSaveSeen.add(doc.uri.fsPath);
                 invalidateModuleCache(doc.uri.fsPath);
                 void runRefreshExclusive(doc.uri.fsPath);
@@ -795,9 +975,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     // the panel look "jumpy" with spinners reappearing over cards after each
     // build completed.
     const onWatcherEvent = (uri: vscode.Uri) => {
-        if (isSourceFile(uri.fsPath)) { enqueueSaveRefresh(uri.fsPath); }
+        if (isSourceFile(uri.fsPath)) {
+            enqueueSaveRefresh(uri.fsPath);
+        }
     };
-    for (const glob of ['**/*.kt', '**/res/**/*.xml']) {
+    for (const glob of ["**/*.kt", "**/res/**/*.xml"]) {
         const watcher = vscode.workspace.createFileSystemWatcher(glob);
         watcher.onDidChange(onWatcherEvent);
         watcher.onDidCreate(onWatcherEvent);
@@ -821,7 +1003,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     //   4. errors actually clear — the event also fires on diagnostic
     //      content changes, e.g. severity bump from Warning to Error.
     context.subscriptions.push(
-        vscode.languages.onDidChangeDiagnostics(e => onDiagnosticsChanged(e)),
+        vscode.languages.onDidChangeDiagnostics((e) => onDiagnosticsChanged(e)),
     );
 
     context.subscriptions.push({ dispose: () => gradleService?.dispose() });
@@ -832,7 +1014,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
         // API. Tests call triggerRefresh themselves at known points.
         setTimeout(() => {
             const active = vscode.window.activeTextEditor;
-            if (active?.document.languageId === 'kotlin') {
+            if (active?.document.languageId === "kotlin") {
                 void runActivationRefresh(active.document.uri.fsPath);
             } else {
                 // No Kotlin file in focus — let refresh() emit the empty-state
@@ -845,9 +1027,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
     if (isTestMode) {
         const testApi: ComposePreviewTestApi = {
             injectGradleApi(api: GradleApi): void {
-                gradleService = new GradleService(workspaceRoot, api, outputChannel, () => [], logFilter);
+                gradleService = new GradleService(
+                    workspaceRoot,
+                    api,
+                    outputChannel,
+                    () => [],
+                    logFilter,
+                );
             },
-            triggerRefresh(filePath: string, force = false, tier: 'fast' | 'full' = 'full'): Promise<void> {
+            triggerRefresh(
+                filePath: string,
+                force = false,
+                tier: "fast" | "full" = "full",
+            ): Promise<void> {
                 return refresh(force, filePath, tier).then(() => {});
             },
             getPostedMessages(): unknown[] {
@@ -862,7 +1054,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Compos
 }
 
 export function deactivate() {
-    if (debounceTimer) { clearTimeout(debounceTimer); }
+    if (debounceTimer) {
+        clearTimeout(debounceTimer);
+    }
     stopAllDaemonStartupProgress();
     pendingRefresh?.abort();
     // Tell the daemon to release every interactive stream this session opened
@@ -891,77 +1085,107 @@ export function deactivate() {
  * silently swallowed because we're on the way out anyway.
  */
 async function flushInteractiveStreams(): Promise<void> {
-    if (activeInteractiveStreams.size === 0) { return; }
+    if (activeInteractiveStreams.size === 0) {
+        return;
+    }
     const entries = [...activeInteractiveStreams.entries()];
     activeInteractiveStreams.clear();
     updateInteractiveStatus();
-    if (!daemonGate?.isEnabled() || !daemonScheduler) { return; }
-    await Promise.all(entries.map(async ([previewId, streamId]) => {
-        try {
-            const moduleId = previewModuleMap.get(previewId);
-            if (!moduleId) { return; }
-            const client = await daemonGate?.getOrSpawn(
-                moduleId, daemonScheduler!.daemonEvents(moduleId),
-            );
-            client?.interactiveStop({ frameStreamId: streamId });
-        } catch {
-            /* deactivate path — best-effort */
-        }
-    }));
+    if (!daemonGate?.isEnabled() || !daemonScheduler) {
+        return;
+    }
+    await Promise.all(
+        entries.map(async ([previewId, streamId]) => {
+            try {
+                const moduleId = previewModuleMap.get(previewId);
+                if (!moduleId) {
+                    return;
+                }
+                const client = await daemonGate?.getOrSpawn(
+                    moduleId,
+                    daemonScheduler!.daemonEvents(moduleId),
+                );
+                client?.interactiveStop({ frameStreamId: streamId });
+            } catch {
+                /* deactivate path — best-effort */
+            }
+        }),
+    );
 }
 
-async function flushRecordingSessions(options: { encode: boolean }): Promise<void> {
-    if (activeRecordingSessions.size === 0) { return; }
+async function flushRecordingSessions(options: {
+    encode: boolean;
+}): Promise<void> {
+    if (activeRecordingSessions.size === 0) {
+        return;
+    }
     const entries = [...activeRecordingSessions.entries()];
     const formats = new Map(activeRecordingFormats);
     activeRecordingSessions.clear();
     activeRecordingFormats.clear();
-    if (!daemonGate?.isEnabled() || !daemonScheduler) { return; }
-    await Promise.all(entries.map(async ([previewId, recordingId]) => {
-        try {
-            const moduleId = previewModuleMap.get(previewId);
-            if (!moduleId) { return; }
-            const client = await daemonGate?.getOrSpawn(
-                moduleId, daemonScheduler!.daemonEvents(moduleId),
-            );
-            if (!client) { return; }
-            await client.recordingStop({ recordingId });
-            if (options.encode) {
-                const encoded = await client.recordingEncode({
-                    recordingId,
-                    format: formats.get(previewId) ?? 'apng',
-                });
-                void vscode.window.showInformationMessage(
-                    `Compose preview recording saved: ${encoded.videoPath}`,
+    if (!daemonGate?.isEnabled() || !daemonScheduler) {
+        return;
+    }
+    await Promise.all(
+        entries.map(async ([previewId, recordingId]) => {
+            try {
+                const moduleId = previewModuleMap.get(previewId);
+                if (!moduleId) {
+                    return;
+                }
+                const client = await daemonGate?.getOrSpawn(
+                    moduleId,
+                    daemonScheduler!.daemonEvents(moduleId),
+                );
+                if (!client) {
+                    return;
+                }
+                await client.recordingStop({ recordingId });
+                if (options.encode) {
+                    const encoded = await client.recordingEncode({
+                        recordingId,
+                        format: formats.get(previewId) ?? "apng",
+                    });
+                    void vscode.window.showInformationMessage(
+                        `Compose preview recording saved: ${encoded.videoPath}`,
+                    );
+                }
+            } catch (err) {
+                logLine(
+                    `[recording] flush failed for ${previewId}: ${(err as Error).message}`,
                 );
             }
-        } catch (err) {
-            logLine(`[recording] flush failed for ${previewId}: ${(err as Error).message}`);
-        }
-    }));
+        }),
+    );
 }
 
 function sameScope(a: string[], b: string[]): boolean {
-    if (a.length !== b.length) { return false; }
+    if (a.length !== b.length) {
+        return false;
+    }
     const set = new Set(b);
-    return a.every(m => set.has(m));
+    return a.every((m) => set.has(m));
 }
 
 function isSourceFile(filePath: string): boolean {
-    if (isGeneratedOutputPath(filePath)) { return false; }
+    if (isGeneratedOutputPath(filePath)) {
+        return false;
+    }
     return /\.(kt|xml|json|properties)$/i.test(filePath);
 }
 
 function isGeneratedOutputPath(filePath: string): boolean {
     const segments = filePath.split(/[\\/]+/);
-    return segments.includes('build') || segments.includes('bin');
+    return segments.includes("build") || segments.includes("bin");
 }
 
 /** True iff this is a Kotlin source file (.kt), not generated output or a Gradle build script. */
 function isPreviewSourceFile(filePath: string): boolean {
-    return filePath.endsWith('.kt')
-        && !filePath.endsWith('.gradle.kts')
-        && !isGeneratedOutputPath(filePath);
+    return (
+        filePath.endsWith(".kt") &&
+        !filePath.endsWith(".gradle.kts") &&
+        !isGeneratedOutputPath(filePath)
+    );
 }
 
 /**
@@ -979,29 +1203,42 @@ function isPreviewSourceFile(filePath: string): boolean {
  * Returns the resolved path and a short tag describing which fallback was used,
  * for logging.
  */
-function resolveScopeFile(forFilePath?: string): { file?: string; source: string } {
+function resolveScopeFile(forFilePath?: string): {
+    file?: string;
+    source: string;
+} {
     if (forFilePath && isPreviewSourceFile(forFilePath)) {
-        return { file: forFilePath, source: 'caller' };
+        return { file: forFilePath, source: "caller" };
     }
 
     const active = vscode.window.activeTextEditor?.document;
-    if (active && active.languageId === 'kotlin' && isPreviewSourceFile(active.uri.fsPath)) {
-        return { file: active.uri.fsPath, source: 'active' };
+    if (
+        active &&
+        active.languageId === "kotlin" &&
+        isPreviewSourceFile(active.uri.fsPath)
+    ) {
+        return { file: active.uri.fsPath, source: "active" };
     }
 
-    if (currentScopeFile && isPreviewSourceFile(currentScopeFile)
-        && isFileVisibleInEditor(currentScopeFile)) {
-        return { file: currentScopeFile, source: 'sticky' };
+    if (
+        currentScopeFile &&
+        isPreviewSourceFile(currentScopeFile) &&
+        isFileVisibleInEditor(currentScopeFile)
+    ) {
+        return { file: currentScopeFile, source: "sticky" };
     }
 
     for (const editor of vscode.window.visibleTextEditors) {
         const doc = editor.document;
-        if (doc.languageId === 'kotlin' && isPreviewSourceFile(doc.uri.fsPath)) {
-            return { file: doc.uri.fsPath, source: 'visible' };
+        if (
+            doc.languageId === "kotlin" &&
+            isPreviewSourceFile(doc.uri.fsPath)
+        ) {
+            return { file: doc.uri.fsPath, source: "visible" };
         }
     }
 
-    return { source: 'none' };
+    return { source: "none" };
 }
 
 /**
@@ -1012,14 +1249,18 @@ function resolveScopeFile(forFilePath?: string): { file?: string; source: string
  */
 function isFileVisibleInEditor(filePath: string): boolean {
     return vscode.window.visibleTextEditors.some(
-        editor => editor.document.uri.fsPath === filePath,
+        (editor) => editor.document.uri.fsPath === filePath,
     );
 }
 
 function invalidateModuleCache(filePath: string): void {
-    if (!gradleService) { return; }
+    if (!gradleService) {
+        return;
+    }
     const module = gradleService.resolveModule(filePath);
-    if (module) { gradleService.invalidateCache(module); }
+    if (module) {
+        gradleService.invalidateCache(module);
+    }
 }
 
 /**
@@ -1042,8 +1283,18 @@ function invalidateModuleCache(filePath: string): void {
  *
  * Errors are logged and dropped — the next user-driven refresh will reconcile.
  */
-async function applyDiscoveryDiff(moduleId: string, params: { added: unknown[]; removed: string[]; changed: unknown[]; totalPreviews: number }): Promise<void> {
-    if (!gradleService || !panel) { return; }
+async function applyDiscoveryDiff(
+    moduleId: string,
+    params: {
+        added: unknown[];
+        removed: string[];
+        changed: unknown[];
+        totalPreviews: number;
+    },
+): Promise<void> {
+    if (!gradleService || !panel) {
+        return;
+    }
 
     const removedIds = params.removed ?? [];
     const addedCount = params.added?.length ?? 0;
@@ -1055,9 +1306,11 @@ async function applyDiscoveryDiff(moduleId: string, params: { added: unknown[]; 
     // Always reconcile caches, even when no preview editor is visible. Only
     // repaint the panel when its current scope still belongs to this module;
     // daemon save/discovery events can also arrive for background files.
-    const repaintFile = currentScopeFile && gradleService.resolveModule(currentScopeFile) === moduleId
-        ? currentScopeFile
-        : undefined;
+    const repaintFile =
+        currentScopeFile &&
+        gradleService.resolveModule(currentScopeFile) === moduleId
+            ? currentScopeFile
+            : undefined;
     await reconcilePreviewManifest(moduleId, repaintFile);
 }
 
@@ -1066,12 +1319,16 @@ async function applyDiscoveryDiff(moduleId: string, params: { added: unknown[]; 
  * when the daemon path is enabled. Explicit daemon opt-out returns `'disabled'` so the caller can
  * use the Gradle render path; daemon failures return `'failed'` and do not fall back.
  */
-type DaemonSaveResult = 'accepted' | 'disabled' | 'failed';
+type DaemonSaveResult = "accepted" | "disabled" | "failed";
 
 async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler || !gradleService) { return 'disabled'; }
+    if (!daemonGate?.isEnabled() || !daemonScheduler || !gradleService) {
+        return "disabled";
+    }
     const module = gradleService.resolveModule(filePath);
-    if (!module) { return 'failed'; }
+    if (!module) {
+        return "failed";
+    }
 
     // Bootstrap (Gradle task + JVM spawn) happens once per module per
     // session. Normally it has already fired from the active-editor warm
@@ -1081,27 +1338,32 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
         daemonBootstrappedModules.add(module);
         try {
             const warmed = await daemonScheduler.warmModule(
-                gradleService, module,
+                gradleService,
+                module,
                 (state) => updateDaemonStatus(module, state),
             );
             if (!warmed) {
                 daemonBootstrappedModules.delete(module);
-                return daemonGate.isBuildDisabled(module) ? 'disabled' : 'failed';
+                return daemonGate.isBuildDisabled(module)
+                    ? "disabled"
+                    : "failed";
             }
         } catch (err) {
             daemonBootstrappedModules.delete(module);
             logLine(`daemon: ${String((err as Error).message ?? err)}`);
-            return daemonGate.isBuildDisabled(module) ? 'disabled' : 'failed';
+            return daemonGate.isBuildDisabled(module) ? "disabled" : "failed";
         }
     }
 
     try {
         const ok = await daemonScheduler.ensureModule(module);
-        if (!ok) { return daemonGate.isBuildDisabled(module) ? 'disabled' : 'failed'; }
+        if (!ok) {
+            return daemonGate.isBuildDisabled(module) ? "disabled" : "failed";
+        }
         await daemonScheduler.fileChanged(module, filePath);
     } catch (err) {
         logLine(`daemon: ${String((err as Error).message ?? err)}`);
-        return daemonGate.isBuildDisabled(module) ? 'disabled' : 'failed';
+        return daemonGate.isBuildDisabled(module) ? "disabled" : "failed";
     }
 
     // Focus scope = the saved file's previews, derived from the most recent
@@ -1116,36 +1378,58 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
     // discoveryUpdated push).
     const filterFile = packageQualifiedSourcePath(filePath);
     const manifest = moduleManifestCache.get(module) ?? [];
-    let filePreviews = manifest.filter(p => p.sourceFile === filterFile);
+    let filePreviews = manifest.filter((p) => p.sourceFile === filterFile);
     if (await sourceMayHaveDroppedCachedPreviews(filePath, filePreviews)) {
-        logLine(`daemon: preview declarations changed in ${path.basename(filePath)}; reconciling before render`);
-        const repaintFile = currentScopeFile && gradleService.resolveModule(currentScopeFile) === module
-            ? currentScopeFile
-            : undefined;
+        logLine(
+            `daemon: preview declarations changed in ${path.basename(filePath)}; reconciling before render`,
+        );
+        const repaintFile =
+            currentScopeFile &&
+            gradleService.resolveModule(currentScopeFile) === module
+                ? currentScopeFile
+                : undefined;
         const fresh = await reconcilePreviewManifest(module, repaintFile);
-        filePreviews = fresh?.filter(p => p.sourceFile === filterFile) ?? filePreviews;
+        filePreviews =
+            fresh?.filter((p) => p.sourceFile === filterFile) ?? filePreviews;
     }
-    const ids = filePreviews.map(p => p.id);
-    if (ids.length === 0) { return 'accepted'; }
+    const ids = filePreviews.map((p) => p.id);
+    if (ids.length === 0) {
+        return "accepted";
+    }
     try {
         await daemonScheduler.setFocus(module, ids);
         const fullIds = heavyOptInsFor(module, ids);
-        const fastIds = fullIds.length === 0
-            ? ids
-            : ids.filter(id => !fullIds.includes(id));
+        const fastIds =
+            fullIds.length === 0
+                ? ids
+                : ids.filter((id) => !fullIds.includes(id));
 
         if (fastIds.length > 0) {
-            const ok = await daemonScheduler.renderNow(module, fastIds, 'fast', 'save');
-            if (!ok) { return 'failed'; }
+            const ok = await daemonScheduler.renderNow(
+                module,
+                fastIds,
+                "fast",
+                "save",
+            );
+            if (!ok) {
+                return "failed";
+            }
         }
         if (fullIds.length > 0) {
-            const ok = await daemonScheduler.renderNow(module, fullIds, 'full', 'save-heavy-opt-in');
-            if (!ok) { return 'failed'; }
+            const ok = await daemonScheduler.renderNow(
+                module,
+                fullIds,
+                "full",
+                "save-heavy-opt-in",
+            );
+            if (!ok) {
+                return "failed";
+            }
         }
-        return 'accepted';
+        return "accepted";
     } catch (err) {
         logLine(`daemon: ${String((err as Error).message ?? err)}`);
-        return daemonGate.isBuildDisabled(module) ? 'disabled' : 'failed';
+        return daemonGate.isBuildDisabled(module) ? "disabled" : "failed";
     }
 }
 
@@ -1165,16 +1449,28 @@ async function notifyDaemonOfSave(filePath: string): Promise<DaemonSaveResult> {
  * "first launch" empty-state logic), `false` when no usable manifest existed.
  */
 async function preloadCachedPreviews(filePath: string): Promise<boolean> {
-    if (!gradleService || !panel) { return false; }
-    if (!isPreviewSourceFile(filePath)) { return false; }
+    if (!gradleService || !panel) {
+        return false;
+    }
+    if (!isPreviewSourceFile(filePath)) {
+        return false;
+    }
     const module = gradleService.resolveModule(filePath);
-    if (!module) { return false; }
+    if (!module) {
+        return false;
+    }
     const manifest = gradleService.readManifest(module);
-    if (!manifest || manifest.previews.length === 0) { return false; }
+    if (!manifest || manifest.previews.length === 0) {
+        return false;
+    }
 
     const filterFile = packageQualifiedSourcePath(filePath);
-    const visiblePreviews = manifest.previews.filter(p => p.sourceFile === filterFile);
-    if (visiblePreviews.length === 0) { return false; }
+    const visiblePreviews = manifest.previews.filter(
+        (p) => p.sourceFile === filterFile,
+    );
+    if (visiblePreviews.length === 0) {
+        return false;
+    }
 
     for (const p of visiblePreviews) {
         for (const capture of p.captures) {
@@ -1184,7 +1480,7 @@ async function preloadCachedPreviews(filePath: string): Promise<boolean> {
     }
 
     panel.postMessage({
-        command: 'setPreviews',
+        command: "setPreviews",
         previews: visiblePreviews,
         moduleDir: module,
         heavyStaleIds: [],
@@ -1194,22 +1490,30 @@ async function preloadCachedPreviews(filePath: string): Promise<boolean> {
     for (const preview of visiblePreviews) {
         for (let idx = 0; idx < preview.captures.length; idx++) {
             const capture = preview.captures[idx];
-            if (!capture.renderOutput) { continue; }
+            if (!capture.renderOutput) {
+                continue;
+            }
             const captureIndex = idx;
-            imageJobs.push((async () => {
-                const imageData = await gradleService!
-                    .readPreviewImage(module, capture.renderOutput);
-                if (!imageData || !panel) { return; }
-                if (captureIndex === 0) {
-                    registry.setImage(preview.id, imageData);
-                }
-                panel.postMessage({
-                    command: 'updateImage',
-                    previewId: preview.id,
-                    captureIndex,
-                    imageData,
-                });
-            })());
+            imageJobs.push(
+                (async () => {
+                    const imageData = await gradleService!.readPreviewImage(
+                        module,
+                        capture.renderOutput,
+                    );
+                    if (!imageData || !panel) {
+                        return;
+                    }
+                    if (captureIndex === 0) {
+                        registry.setImage(preview.id, imageData);
+                    }
+                    panel.postMessage({
+                        command: "updateImage",
+                        previewId: preview.id,
+                        captureIndex,
+                        imageData,
+                    });
+                })(),
+            );
         }
     }
     await Promise.all(imageJobs);
@@ -1249,11 +1553,15 @@ async function preloadCachedPreviews(filePath: string): Promise<boolean> {
  */
 async function runActivationRefresh(filePath: string): Promise<void> {
     await preloadCachedPreviews(filePath);
-    await refresh(false, filePath, 'full', { showLoadingOverlay: false });
+    await refresh(false, filePath, "full", { showLoadingOverlay: false });
     await warmDaemonForFile(filePath, { refreshAfterReady: true });
-    if (!gradleService || !daemonGate) { return; }
+    if (!gradleService || !daemonGate) {
+        return;
+    }
     const module = gradleService.resolveModule(filePath);
-    if (!module || !daemonGate.isDaemonReady(module)) { return; }
+    if (!module || !daemonGate.isDaemonReady(module)) {
+        return;
+    }
     // Phase 3 — kick off a fresh render through the daemon. Reuses the same
     // notify path the save-driven flow uses; the daemon does the swap +
     // renderNow + the panel updates via the existing onPreviewImageReady
@@ -1273,19 +1581,24 @@ async function warmDaemonForFile(
     filePath: string,
     opts: { refreshAfterReady?: boolean } = {},
 ): Promise<boolean> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler || !gradleService) { return false; }
+    if (!daemonGate?.isEnabled() || !daemonScheduler || !gradleService) {
+        return false;
+    }
     const module = gradleService.resolveModule(filePath);
-    if (!module) { return false; }
+    if (!module) {
+        return false;
+    }
     if (daemonBootstrappedModules.has(module)) {
         if (daemonGate.isDaemonReady(module) && opts.refreshAfterReady) {
-            await refreshAfterDaemonReady(filePath, 'view-open');
+            await refreshAfterDaemonReady(filePath, "view-open");
         }
         return daemonGate.isDaemonReady(module);
     }
     daemonBootstrappedModules.add(module);
     try {
         const warmed = await daemonScheduler.warmModule(
-            gradleService, module,
+            gradleService,
+            module,
             (state) => {
                 updateDaemonStatus(module, state);
                 publishDaemonStartupProgress(module, state);
@@ -1296,16 +1609,18 @@ async function warmDaemonForFile(
         }
         finishDaemonStartupProgress(module, filePath, warmed);
         if (warmed && opts.refreshAfterReady) {
-            await refreshAfterDaemonReady(filePath, 'view-open');
+            await refreshAfterDaemonReady(filePath, "view-open");
         }
         return warmed;
     } catch (err) {
         daemonBootstrappedModules.delete(module);
         stopDaemonStartupProgress(module);
-        panel?.postMessage({ command: 'clearProgress' });
-        logLine(`daemon: warm failed for ${module}: ${String((err as Error).message ?? err)}`);
+        panel?.postMessage({ command: "clearProgress" });
+        logLine(
+            `daemon: warm failed for ${module}: ${String((err as Error).message ?? err)}`,
+        );
         vscode.window.showErrorMessage(
-            'Compose Preview daemon is enabled but failed to start. Preview saves will not fall back to Gradle until the daemon is fixed or disabled.',
+            "Compose Preview daemon is enabled but failed to start. Preview saves will not fall back to Gradle until the daemon is fixed or disabled.",
         );
         return false;
     }
@@ -1319,69 +1634,75 @@ async function warmDaemonForFile(
  * the user can tell the extension is still doing useful work.
  */
 function publishDaemonStartupProgress(module: string, state: WarmState): void {
-    if (!panel) { return; }
+    if (!panel) {
+        return;
+    }
     if (!isDaemonStartupScopeActive(module)) {
         stopDaemonStartupProgress(module);
         return;
     }
     switch (state) {
-        case 'bootstrapping':
+        case "bootstrapping":
             if (!hasPreviewsLoaded) {
                 panel.postMessage({
-                    command: 'showMessage',
+                    command: "showMessage",
                     text: `Preparing Compose Preview daemon for ${module}…`,
                 });
             }
             startDaemonStartupProgress(
                 module,
-                'Preparing preview daemon',
+                "Preparing preview daemon",
                 0.08,
                 0.62,
                 DAEMON_BOOTSTRAP_PROGRESS_MS,
             );
             break;
-        case 'spawning':
+        case "spawning":
             if (!hasPreviewsLoaded) {
                 panel.postMessage({
-                    command: 'showMessage',
+                    command: "showMessage",
                     text: `Starting Compose Preview daemon for ${module}…`,
                 });
             }
             startDaemonStartupProgress(
                 module,
-                'Starting preview daemon',
+                "Starting preview daemon",
                 0.62,
                 0.94,
                 DAEMON_SPAWN_PROGRESS_MS,
             );
             break;
-        case 'ready':
+        case "ready":
             stopDaemonStartupProgress(module);
-            if (!isDaemonStartupScopeActive(module)) { return; }
+            if (!isDaemonStartupScopeActive(module)) {
+                return;
+            }
             if (!hasPreviewsLoaded) {
                 panel.postMessage({
-                    command: 'showMessage',
-                    text: 'Compose Preview daemon is ready. Rendering previews…',
+                    command: "showMessage",
+                    text: "Compose Preview daemon is ready. Rendering previews…",
                 });
             }
             panel.postMessage({
-                command: 'setProgress',
-                phase: 'daemon',
-                label: 'Preview daemon ready',
+                command: "setProgress",
+                phase: "daemon",
+                label: "Preview daemon ready",
                 percent: 1,
                 slow: false,
             });
             break;
-        case 'fallback':
+        case "fallback":
             stopDaemonStartupProgress(module);
-            if (!isDaemonStartupScopeActive(module)) { return; }
+            if (!isDaemonStartupScopeActive(module)) {
+                return;
+            }
             if (!hasPreviewsLoaded) {
                 panel.postMessage({
-                    command: 'showMessage',
+                    command: "showMessage",
                     text: `Compose Preview daemon is disabled for ${module}; using Gradle previews.`,
                 });
             }
-            panel.postMessage({ command: 'clearProgress' });
+            panel.postMessage({ command: "clearProgress" });
             break;
     }
 }
@@ -1396,7 +1717,9 @@ function startDaemonStartupProgress(
     stopDaemonStartupProgress(module);
     const startedAt = Date.now();
     const tick = () => {
-        if (!panel) { return; }
+        if (!panel) {
+            return;
+        }
         if (!isDaemonStartupScopeActive(module)) {
             stopDaemonStartupProgress(module);
             return;
@@ -1404,10 +1727,10 @@ function startDaemonStartupProgress(
         const elapsed = Date.now() - startedAt;
         const ratio = Math.min(0.98, 1 - Math.exp(-elapsed / durationMs));
         panel.postMessage({
-            command: 'setProgress',
-            phase: 'daemon',
+            command: "setProgress",
+            phase: "daemon",
             label,
-            percent: start + ((end - start) * ratio),
+            percent: start + (end - start) * ratio,
             slow: false,
         });
     };
@@ -1419,14 +1742,23 @@ function isDaemonStartupScopeActive(module: string): boolean {
     return currentScopeModule === module;
 }
 
-function setCurrentScopeFile(filePath: string | null, module?: string | null): void {
+function setCurrentScopeFile(
+    filePath: string | null,
+    module?: string | null,
+): void {
     currentScopeFile = filePath;
-    currentScopeModule = module ?? (filePath && gradleService ? gradleService.resolveModule(filePath) : null);
+    currentScopeModule =
+        module ??
+        (filePath && gradleService
+            ? gradleService.resolveModule(filePath)
+            : null);
 }
 
 function stopDaemonStartupProgress(module: string): void {
     const timer = daemonStartupProgressTimers.get(module);
-    if (!timer) { return; }
+    if (!timer) {
+        return;
+    }
     clearInterval(timer);
     daemonStartupProgressTimers.delete(module);
 }
@@ -1437,44 +1769,61 @@ function stopAllDaemonStartupProgress(): void {
     }
 }
 
-function finishDaemonStartupProgress(module: string, filePath: string, warmed: boolean): void {
-    if (!panel || hasPreviewsLoaded || !warmed) { return; }
+function finishDaemonStartupProgress(
+    module: string,
+    filePath: string,
+    warmed: boolean,
+): void {
+    if (!panel || hasPreviewsLoaded || !warmed) {
+        return;
+    }
     const visibleCount = visiblePreviewCount(module, filePath);
-    if (visibleCount > 0) { return; }
-    panel.postMessage({ command: 'clearProgress' });
+    if (visibleCount > 0) {
+        return;
+    }
+    panel.postMessage({ command: "clearProgress" });
     const allPreviews = moduleManifestCache.get(module)?.length ?? 0;
     panel.postMessage({
-        command: 'showMessage',
-        text: allPreviews > 0
-            ? `No @Preview functions in this file (${allPreviews} in other files in this module).`
-            : 'No @Preview functions found in this module',
+        command: "showMessage",
+        text:
+            allPreviews > 0
+                ? `No @Preview functions in this file (${allPreviews} in other files in this module).`
+                : "No @Preview functions found in this module",
     });
 }
 
 function visiblePreviewCount(module: string, filePath: string): number {
     const previews = moduleManifestCache.get(module) ?? [];
     const filterFile = packageQualifiedSourcePath(filePath);
-    return previews.filter(p => p.sourceFile === filterFile).length;
+    return previews.filter((p) => p.sourceFile === filterFile).length;
 }
 
 async function reconcilePreviewManifest(
     module: string,
     repaintFilePath?: string,
 ): Promise<PreviewInfo[] | null> {
-    if (!gradleService) { return null; }
+    if (!gradleService) {
+        return null;
+    }
     gradleService.invalidateCache(module);
     let manifest;
     try {
         manifest = await gradleService.discoverPreviews(module);
     } catch (err) {
-        logLine(`[daemon] silent discover failed for ${module}: ${(err as Error).message}`);
+        logLine(
+            `[daemon] silent discover failed for ${module}: ${(err as Error).message}`,
+        );
         return null;
     }
-    if (!manifest) { return null; }
+    if (!manifest) {
+        return null;
+    }
 
     const fresh = manifest.previews;
     for (const [id, owner] of [...previewModuleMap.entries()]) {
-        if (owner === module) { previewModuleMap.delete(id); }
+        if (owner === module) {
+            previewModuleMap.delete(id);
+        }
     }
     for (const p of fresh) {
         for (const capture of p.captures) {
@@ -1485,17 +1834,17 @@ async function reconcilePreviewManifest(
     moduleManifestCache.set(module, fresh);
     registry.replaceModule(module, fresh);
 
-    if (!panel || !repaintFilePath) { return fresh; }
+    if (!panel || !repaintFilePath) {
+        return fresh;
+    }
 
     const filterFile = packageQualifiedSourcePath(repaintFilePath);
-    const visiblePreviews = fresh.filter(p => p.sourceFile === filterFile);
+    const visiblePreviews = fresh.filter((p) => p.sourceFile === filterFile);
     const heavyStaleIds = fastTierModules.has(module)
-        ? visiblePreviews
-            .filter(hasHeavyCapture)
-            .map(p => p.id)
+        ? visiblePreviews.filter(hasHeavyCapture).map((p) => p.id)
         : [];
     panel.postMessage({
-        command: 'setPreviews',
+        command: "setPreviews",
         previews: visiblePreviews,
         moduleDir: module,
         heavyStaleIds,
@@ -1503,22 +1852,38 @@ async function reconcilePreviewManifest(
     return fresh;
 }
 
-async function refreshAfterDaemonReady(filePath: string, reason: string): Promise<void> {
-    if (!daemonGate || !gradleService || !panel) { return; }
-    const module = gradleService.resolveModule(filePath);
-    if (!module || !daemonGate.isDaemonReady(module)) { return; }
-    if (currentScopeFile && currentScopeFile !== filePath) { return; }
-    if (pendingRefresh || refreshInFlight) {
-        logLine(`daemon: skip post-warm refresh for ${module}; refresh already active`);
+async function refreshAfterDaemonReady(
+    filePath: string,
+    reason: string,
+): Promise<void> {
+    if (!daemonGate || !gradleService || !panel) {
         return;
     }
-    const reconciled = await reconcilePreviewManifestAfterDaemonReady(module, filePath);
-    if (!reconciled) { return; }
+    const module = gradleService.resolveModule(filePath);
+    if (!module || !daemonGate.isDaemonReady(module)) {
+        return;
+    }
+    if (currentScopeFile && currentScopeFile !== filePath) {
+        return;
+    }
+    if (pendingRefresh || refreshInFlight) {
+        logLine(
+            `daemon: skip post-warm refresh for ${module}; refresh already active`,
+        );
+        return;
+    }
+    const reconciled = await reconcilePreviewManifestAfterDaemonReady(
+        module,
+        filePath,
+    );
+    if (!reconciled) {
+        return;
+    }
     await warmShownPreviewsForFile(filePath, reason);
     panel.postMessage({
-        command: 'setProgress',
-        phase: 'daemon',
-        label: 'Preview daemon ready',
+        command: "setProgress",
+        phase: "daemon",
+        label: "Preview daemon ready",
         percent: 1,
         slow: false,
     });
@@ -1528,28 +1893,30 @@ async function reconcilePreviewManifestAfterDaemonReady(
     module: string,
     filePath: string,
 ): Promise<boolean> {
-    if (!gradleService || !panel) { return false; }
+    if (!gradleService || !panel) {
+        return false;
+    }
     try {
         panel.postMessage({
-            command: 'setProgress',
-            phase: 'daemon',
-            label: 'Checking preview list',
+            command: "setProgress",
+            phase: "daemon",
+            label: "Checking preview list",
             percent: 0.86,
             slow: false,
         });
         gradleService.invalidateCache(module);
         const manifest = await gradleService.discoverPreviews(module);
         if (!manifest) {
-            panel.postMessage({ command: 'clearProgress' });
+            panel.postMessage({ command: "clearProgress" });
             return false;
         }
         if (currentScopeFile && currentScopeFile !== filePath) {
-            panel.postMessage({ command: 'clearProgress' });
+            panel.postMessage({ command: "clearProgress" });
             return false;
         }
 
         const fresh = manifest.previews;
-        const freshIds = new Set(fresh.map(p => p.id));
+        const freshIds = new Set(fresh.map((p) => p.id));
         for (const [id, owner] of [...previewModuleMap.entries()]) {
             if (owner === module && !freshIds.has(id)) {
                 previewModuleMap.delete(id);
@@ -1565,64 +1932,80 @@ async function reconcilePreviewManifestAfterDaemonReady(
         registry.replaceModule(module, fresh);
 
         const filterFile = packageQualifiedSourcePath(filePath);
-        const visiblePreviews = fresh.filter(p => p.sourceFile === filterFile);
+        const visiblePreviews = fresh.filter(
+            (p) => p.sourceFile === filterFile,
+        );
         if (visiblePreviews.length === 0) {
             if (!hasPreviewsLoaded) {
                 panel.postMessage({
-                    command: 'showMessage',
-                    text: fresh.length > 0
-                        ? `No @Preview functions in this file (${fresh.length} in other files in this module).`
-                        : 'No @Preview functions found in this module',
+                    command: "showMessage",
+                    text:
+                        fresh.length > 0
+                            ? `No @Preview functions in this file (${fresh.length} in other files in this module).`
+                            : "No @Preview functions found in this module",
                 });
             }
-            panel.postMessage({ command: 'clearProgress' });
+            panel.postMessage({ command: "clearProgress" });
             return false;
         }
 
         const heavyStaleIds = fastTierModules.has(module)
-            ? visiblePreviews
-                .filter(hasHeavyCapture)
-                .map(p => p.id)
+            ? visiblePreviews.filter(hasHeavyCapture).map((p) => p.id)
             : [];
         panel.postMessage({
-            command: 'setPreviews',
+            command: "setPreviews",
             previews: visiblePreviews,
             moduleDir: module,
             heavyStaleIds,
         });
-        panel.postMessage({ command: 'clearCompileErrors' });
+        panel.postMessage({ command: "clearCompileErrors" });
         compileGateActive = false;
         hasPreviewsLoaded = true;
         return true;
     } catch (err) {
-        logLine(`daemon: post-warm discover failed for ${module}: ${(err as Error).message}`);
-        panel.postMessage({ command: 'clearProgress' });
+        logLine(
+            `daemon: post-warm discover failed for ${module}: ${(err as Error).message}`,
+        );
+        panel.postMessage({ command: "clearProgress" });
         return false;
     }
 }
 
-async function warmShownPreviewsForFile(filePath: string, reason: string): Promise<void> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler || !gradleService) { return; }
+async function warmShownPreviewsForFile(
+    filePath: string,
+    reason: string,
+): Promise<void> {
+    if (!daemonGate?.isEnabled() || !daemonScheduler || !gradleService) {
+        return;
+    }
     const module = gradleService.resolveModule(filePath);
-    if (!module || !daemonGate.isDaemonReady(module)) { return; }
+    if (!module || !daemonGate.isDaemonReady(module)) {
+        return;
+    }
 
     const filterFile = packageQualifiedSourcePath(filePath);
     const scopeKey = `${module}::${filterFile}`;
-    if (daemonShownPreviewWarmScopes.has(scopeKey)) { return; }
+    if (daemonShownPreviewWarmScopes.has(scopeKey)) {
+        return;
+    }
 
     const ids = (moduleManifestCache.get(module) ?? [])
-        .filter(p => p.sourceFile === filterFile)
-        .map(p => p.id);
-    if (ids.length === 0) { return; }
+        .filter((p) => p.sourceFile === filterFile)
+        .map((p) => p.id);
+    if (ids.length === 0) {
+        return;
+    }
 
     daemonShownPreviewWarmScopes.add(scopeKey);
     try {
         await daemonScheduler.setFocus(module, ids);
         await daemonScheduler.setVisible(module, ids, []);
-        await daemonScheduler.renderNow(module, ids, 'fast', reason);
+        await daemonScheduler.renderNow(module, ids, "fast", reason);
     } catch (err) {
         daemonShownPreviewWarmScopes.delete(scopeKey);
-        logLine(`daemon: view-open warmup failed for ${module}: ${String((err as Error).message ?? err)}`);
+        logLine(
+            `daemon: view-open warmup failed for ${module}: ${String((err as Error).message ?? err)}`,
+        );
     }
 }
 
@@ -1647,16 +2030,18 @@ function updateDaemonStatus(module: string, state: WarmState): void {
     // state transition. Done outside the !daemonStatusItem early-return so
     // tests that drive activate() without a status bar still see the
     // panel-side state propagate. Cheap: a no-op when panel isn't open.
-    if (state === 'ready' || state === 'fallback') {
+    if (state === "ready" || state === "fallback") {
         publishInteractiveAvailability(module);
     }
-    if (!daemonStatusItem) { return; }
+    if (!daemonStatusItem) {
+        return;
+    }
     if (daemonStatusClearTimer) {
         clearTimeout(daemonStatusClearTimer);
         daemonStatusClearTimer = null;
     }
     switch (state) {
-        case 'bootstrapping':
+        case "bootstrapping":
             daemonStatusItem.text = `$(loading~spin) Daemon: bootstrapping ${module}…`;
             // Cold-build context: composePreviewDaemonStart itself is a
             // small JSON-emit task, but it depends on the consumer's
@@ -1665,29 +2050,39 @@ function updateDaemonStatus(module: string, state: WarmState): void {
             // bump) this can take minutes while Gradle builds the
             // renderer's classpath. Subsequent runs are cacheable and
             // collapse to ~1 s on a warm Gradle daemon.
-            daemonStatusItem.tooltip = 'Running composePreviewDaemonStart. '
-                + 'On a cold build (fresh checkout, after clean, or after a '
-                + 'Compose version bump) this may take a few minutes while '
-                + 'Gradle compiles the renderer classpath. Cacheable on '
-                + 'subsequent runs.';
+            daemonStatusItem.tooltip =
+                "Running composePreviewDaemonStart. " +
+                "On a cold build (fresh checkout, after clean, or after a " +
+                "Compose version bump) this may take a few minutes while " +
+                "Gradle compiles the renderer classpath. Cacheable on " +
+                "subsequent runs.";
             daemonStatusItem.show();
             break;
-        case 'spawning':
+        case "spawning":
             daemonStatusItem.text = `$(loading~spin) Daemon: spawning ${module}…`;
-            daemonStatusItem.tooltip = 'Launching the preview daemon JVM and running initialize';
+            daemonStatusItem.tooltip =
+                "Launching the preview daemon JVM and running initialize";
             daemonStatusItem.show();
             break;
-        case 'ready':
+        case "ready":
             daemonStatusItem.text = `$(check) Daemon: ${module}`;
-            daemonStatusItem.tooltip = 'Preview daemon is up and serving renders';
+            daemonStatusItem.tooltip =
+                "Preview daemon is up and serving renders";
             daemonStatusItem.show();
-            daemonStatusClearTimer = setTimeout(() => daemonStatusItem?.hide(), 4000);
+            daemonStatusClearTimer = setTimeout(
+                () => daemonStatusItem?.hide(),
+                4000,
+            );
             break;
-        case 'fallback':
+        case "fallback":
             daemonStatusItem.text = `$(warning) Daemon: ${module} (using Gradle)`;
-            daemonStatusItem.tooltip = 'Daemon spawn failed — using the Gradle render path. See Output → Compose Preview.';
+            daemonStatusItem.tooltip =
+                "Daemon spawn failed — using the Gradle render path. See Output → Compose Preview.";
             daemonStatusItem.show();
-            daemonStatusClearTimer = setTimeout(() => daemonStatusItem?.hide(), 8000);
+            daemonStatusClearTimer = setTimeout(
+                () => daemonStatusItem?.hide(),
+                8000,
+            );
             break;
     }
 }
@@ -1714,9 +2109,11 @@ function readCompileErrors(filePath: string): CompileError[] {
     // vscode.Diagnostic structurally matches DiagnosticLike — the field
     // names and severity numeric values are the same. Cast through unknown
     // to avoid pulling vscode types into the pure module.
-    return extractCompileErrors(filePath, diagnostics as unknown as readonly DiagnosticLike[]);
+    return extractCompileErrors(
+        filePath,
+        diagnostics as unknown as readonly DiagnosticLike[],
+    );
 }
-
 
 /**
  * Auto-retry the refresh when the LSP republishes diagnostics that
@@ -1730,33 +2127,51 @@ function readCompileErrors(filePath: string): CompileError[] {
  * we don't care.
  */
 function onDiagnosticsChanged(e: vscode.DiagnosticChangeEvent): void {
-    if (!compileGateActive || !currentScopeFile) { return; }
+    if (!compileGateActive || !currentScopeFile) {
+        return;
+    }
     const scopeFile = currentScopeFile;
-    if (!e.uris.some(u => u.fsPath === scopeFile)) { return; }
-    const doc = vscode.workspace.textDocuments.find(d => d.uri.fsPath === scopeFile);
-    if (doc?.isDirty) { return; }
+    if (!e.uris.some((u) => u.fsPath === scopeFile)) {
+        return;
+    }
+    const doc = vscode.workspace.textDocuments.find(
+        (d) => d.uri.fsPath === scopeFile,
+    );
+    if (doc?.isDirty) {
+        return;
+    }
     const errors = readCompileErrors(scopeFile);
-    if (errors.length > 0) { return; }
-    logLine(`auto-retry: LSP diagnostics cleared on ${path.basename(scopeFile)}`);
+    if (errors.length > 0) {
+        return;
+    }
+    logLine(
+        `auto-retry: LSP diagnostics cleared on ${path.basename(scopeFile)}`,
+    );
     compileGateActive = false;
-    void refresh(true, scopeFile, 'fast');
+    void refresh(true, scopeFile, "fast");
 }
 
 /** Read calibrated phase durations for `module` from workspace state. Empty
  *  on first run; the tracker falls back to its built-in phase defaults. */
 function readCalibration(module: string): PhaseDurations {
-    if (!extensionContext) { return {}; }
-    const all = extensionContext.workspaceState.get<Record<string, PhaseDurations>>(
-        PROGRESS_CALIBRATION_KEY, {});
+    if (!extensionContext) {
+        return {};
+    }
+    const all = extensionContext.workspaceState.get<
+        Record<string, PhaseDurations>
+    >(PROGRESS_CALIBRATION_KEY, {});
     return all[module] ?? {};
 }
 
 /** Persist updated calibration for `module`, blending into prior samples via
  *  EMA so a single anomalous run doesn't dominate. */
 function writeCalibration(module: string, latest: PhaseDurations): void {
-    if (!extensionContext) { return; }
-    const all = extensionContext.workspaceState.get<Record<string, PhaseDurations>>(
-        PROGRESS_CALIBRATION_KEY, {});
+    if (!extensionContext) {
+        return;
+    }
+    const all = extensionContext.workspaceState.get<
+        Record<string, PhaseDurations>
+    >(PROGRESS_CALIBRATION_KEY, {});
     all[module] = mergeCalibration(all[module] ?? {}, latest);
     void extensionContext.workspaceState.update(PROGRESS_CALIBRATION_KEY, all);
 }
@@ -1771,16 +2186,18 @@ function writeCalibration(module: string, latest: PhaseDurations): void {
 function enqueueSaveRefresh(filePath: string): void {
     // Prefer the saved file path, but fall back to the active editor when the
     // saved file isn't a Kotlin source (e.g. a resource XML changed).
-    const target = filePath.endsWith('.kt')
+    const target = filePath.endsWith(".kt")
         ? filePath
-        : (vscode.window.activeTextEditor?.document.languageId === 'kotlin'
-            ? vscode.window.activeTextEditor.document.uri.fsPath
-            : filePath);
+        : vscode.window.activeTextEditor?.document.languageId === "kotlin"
+          ? vscode.window.activeTextEditor.document.uri.fsPath
+          : filePath;
     pendingSavePath = target;
     invalidateModuleCache(target);
 
     const delay = target === currentScopeFile ? SCOPE_DEBOUNCE_MS : DEBOUNCE_MS;
-    if (debounceTimer) { clearTimeout(debounceTimer); }
+    if (debounceTimer) {
+        clearTimeout(debounceTimer);
+    }
     debounceElapsed = false;
     debounceTimer = setTimeout(() => {
         debounceTimer = null;
@@ -1793,7 +2210,9 @@ function enqueueSaveRefresh(filePath: string): void {
  *  no other refresh is running. Called from the debounce timer and from the
  *  tail of {@link runRefreshExclusive}. */
 function maybeFirePendingRefresh(): void {
-    if (refreshInFlight || !debounceElapsed || pendingSavePath === null) { return; }
+    if (refreshInFlight || !debounceElapsed || pendingSavePath === null) {
+        return;
+    }
     const target = pendingSavePath;
     pendingSavePath = null;
     void runRefreshExclusive(target);
@@ -1827,28 +2246,28 @@ async function runRefreshExclusive(filePath: string): Promise<void> {
     refreshInFlight = true;
     try {
         const mode = pickRefreshMode(filePath);
-        if (mode === 'daemon') {
+        if (mode === "daemon") {
             const compileOk = await runDaemonCompileOnly(filePath);
             if (!compileOk) {
                 vscode.window.showErrorMessage(
-                    'Compose Preview daemon refresh failed because compile failed. Fix the compile error and save again.',
+                    "Compose Preview daemon refresh failed because compile failed. Fix the compile error and save again.",
                 );
                 return;
             }
             const result = await notifyDaemonOfSave(filePath);
-            if (result === 'accepted') {
+            if (result === "accepted") {
                 return;
             }
-            if (result === 'disabled') {
-                await refresh(true, filePath, 'fast');
+            if (result === "disabled") {
+                await refresh(true, filePath, "fast");
                 return;
             }
             vscode.window.showErrorMessage(
-                'Compose Preview daemon is enabled but unavailable. Restart the preview daemon after fixing the daemon issue.',
+                "Compose Preview daemon is enabled but unavailable. Restart the preview daemon after fixing the daemon issue.",
             );
             return;
         }
-        await refresh(true, filePath, 'fast');
+        await refresh(true, filePath, "fast");
     } finally {
         refreshInFlight = false;
         maybeFirePendingRefresh();
@@ -1867,9 +2286,13 @@ async function runRefreshExclusive(filePath: string): Promise<void> {
  * failures, this just keeps the panel quiet during the happy path.
  */
 async function runDaemonCompileOnly(filePath: string): Promise<boolean> {
-    if (!gradleService) { return false; }
+    if (!gradleService) {
+        return false;
+    }
     const module = gradleService.resolveModule(filePath);
-    if (!module) { return false; }
+    if (!module) {
+        return false;
+    }
 
     // Honour the existing LSP-error gate — same predicate `refresh()` uses to
     // skip Gradle when the active buffer has Error-severity diagnostics. We
@@ -1878,7 +2301,9 @@ async function runDaemonCompileOnly(filePath: string): Promise<boolean> {
     // recompiling a file the LSP already says is broken.
     const compileErrors = readCompileErrors(filePath);
     if (compileErrors.length > 0) {
-        logLine(`daemon: gated — ${compileErrors.length} compile error(s) in ${path.basename(filePath)}`);
+        logLine(
+            `daemon: gated — ${compileErrors.length} compile error(s) in ${path.basename(filePath)}`,
+        );
         return false;
     }
 
@@ -1889,7 +2314,9 @@ async function runDaemonCompileOnly(filePath: string): Promise<boolean> {
         if (err instanceof TaskCancelledError) {
             logLine(`daemon: compileOnly cancelled for ${module}`);
         } else {
-            logLine(`daemon: compileOnly failed for ${module}: ${(err as Error).message}`);
+            logLine(
+                `daemon: compileOnly failed for ${module}: ${(err as Error).message}`,
+            );
         }
         return false;
     }
@@ -1902,7 +2329,9 @@ async function runDaemonCompileOnly(filePath: string): Promise<boolean> {
  * module-level state from the gate / gradle service.
  */
 function pickRefreshMode(filePath: string): RefreshMode {
-    if (!daemonGate || !gradleService) { return 'gradle'; }
+    if (!daemonGate || !gradleService) {
+        return "gradle";
+    }
     return pickRefreshModeFor(
         filePath,
         daemonGate.isEnabled(),
@@ -1911,9 +2340,15 @@ function pickRefreshMode(filePath: string): RefreshMode {
 }
 
 function sendModuleList() {
-    if (!gradleService || !panel) { return; }
+    if (!gradleService || !panel) {
+        return;
+    }
     const modules = gradleService.findPreviewModules();
-    panel.postMessage({ command: 'setModules', modules, selected: selectedModule || '' });
+    panel.postMessage({
+        command: "setModules",
+        modules,
+        selected: selectedModule || "",
+    });
 }
 
 /**
@@ -1926,8 +2361,12 @@ function sendModuleList() {
 const fastTierModules = new Set<string>();
 
 function hasHeavyCapture(preview: PreviewInfo): boolean {
-    return preview.captures.some(c => (c.cost ?? 1) > HEAVY_COST_THRESHOLD)
-        || (preview.dataProducts ?? []).some(p => (p.cost ?? 1) > HEAVY_COST_THRESHOLD);
+    return (
+        preview.captures.some((c) => (c.cost ?? 1) > HEAVY_COST_THRESHOLD) ||
+        (preview.dataProducts ?? []).some(
+            (p) => (p.cost ?? 1) > HEAVY_COST_THRESHOLD,
+        )
+    );
 }
 
 function optInHeavyRefresh(moduleId: string, previewId: string): void {
@@ -1942,44 +2381,63 @@ function clearHeavyRefreshOptIns(): void {
 
 function heavyOptInsFor(moduleId: string, previewIds: string[]): string[] {
     const opted = heavyRefreshOptIns.get(moduleId);
-    if (!opted || opted.size === 0) { return []; }
-    return previewIds.filter(id => opted.has(id));
+    if (!opted || opted.size === 0) {
+        return [];
+    }
+    return previewIds.filter((id) => opted.has(id));
 }
 
 async function sourceMayHaveDroppedCachedPreviews(
     filePath: string,
     previews: PreviewInfo[],
 ): Promise<boolean> {
-    if (previews.length === 0) { return false; }
+    if (previews.length === 0) {
+        return false;
+    }
     let source: string;
     try {
-        source = await fs.promises.readFile(filePath, 'utf-8');
+        source = await fs.promises.readFile(filePath, "utf-8");
     } catch {
         return false;
     }
-    return previews.some(preview => !sourceLooksLikePreviewDeclaration(source, preview.functionName));
+    return previews.some(
+        (preview) =>
+            !sourceLooksLikePreviewDeclaration(source, preview.functionName),
+    );
 }
 
-function sourceLooksLikePreviewDeclaration(source: string, functionName: string): boolean {
-    const escaped = functionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+function sourceLooksLikePreviewDeclaration(
+    source: string,
+    functionName: string,
+): boolean {
+    const escaped = functionName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const match = new RegExp(`\\bfun\\s+${escaped}\\s*\\(`).exec(source);
-    if (!match) { return false; }
+    if (!match) {
+        return false;
+    }
 
     const lines = source.slice(0, match.index).split(/\r?\n/);
     const annotationLines: string[] = [];
     for (let i = lines.length - 1; i >= 0; i--) {
         const line = lines[i].trim();
         if (line.length === 0) {
-            if (annotationLines.length === 0) { continue; }
+            if (annotationLines.length === 0) {
+                continue;
+            }
             break;
         }
-        if (line.startsWith('@') || line.startsWith('//') || line.startsWith('/*') || line.startsWith('*')) {
+        if (
+            line.startsWith("@") ||
+            line.startsWith("//") ||
+            line.startsWith("/*") ||
+            line.startsWith("*")
+        ) {
             annotationLines.unshift(line);
             continue;
         }
         break;
     }
-    return annotationLines.some(line => line.includes('Preview'));
+    return annotationLines.some((line) => line.includes("Preview"));
 }
 
 /**
@@ -2015,15 +2473,22 @@ function sourceLooksLikePreviewDeclaration(source: string, functionName: string)
  *   over the previous (now stale) cards; the next save with a clean buffer
  *   will run a real refresh.
  */
-type RefreshOutcome = 'completed' | 'cancelled' | 'no-module' | 'failed' | 'gated';
+type RefreshOutcome =
+    | "completed"
+    | "cancelled"
+    | "no-module"
+    | "failed"
+    | "gated";
 
 async function refresh(
     forceRender: boolean,
     forFilePath?: string,
-    tier: 'fast' | 'full' = 'full',
+    tier: "fast" | "full" = "full",
     opts: { showLoadingOverlay?: boolean } = {},
 ): Promise<RefreshOutcome> {
-    if (!gradleService || !panel) { return 'no-module'; }
+    if (!gradleService || !panel) {
+        return "no-module";
+    }
 
     // Cancel any in-flight refresh
     pendingRefresh?.abort();
@@ -2036,14 +2501,21 @@ async function refresh(
     // empty state rather than falling through to an ambiguous multi-file view.
     // Picks, in priority: caller > active editor > any visible Kotlin editor >
     // last-scoped file. See resolveScopeFile for the full chain.
-    const { file: activeFile, source: scopeSource } = resolveScopeFile(forFilePath);
-    const module = activeFile && isPreviewSourceFile(activeFile)
-        ? gradleService.resolveModule(activeFile)
-        : null;
+    const { file: activeFile, source: scopeSource } =
+        resolveScopeFile(forFilePath);
+    const module =
+        activeFile && isPreviewSourceFile(activeFile)
+            ? gradleService.resolveModule(activeFile)
+            : null;
     if (!activeFile || !module) {
-        logLine(`no module — activeFile=${activeFile ?? '<none>'} (${scopeSource})`);
-        panel.postMessage({ command: 'clearAll' });
-        panel.postMessage({ command: 'showMessage', text: emptyStateMessage(activeFile) });
+        logLine(
+            `no module — activeFile=${activeFile ?? "<none>"} (${scopeSource})`,
+        );
+        panel.postMessage({ command: "clearAll" });
+        panel.postMessage({
+            command: "showMessage",
+            text: emptyStateMessage(activeFile),
+        });
         lastLoadedModules = [];
         hasPreviewsLoaded = false;
         setCurrentScopeFile(null);
@@ -2052,12 +2524,14 @@ async function refresh(
         if (activeFile && isPreviewSourceFile(activeFile)) {
             maybeShowSetupPrompt(activeFile);
         }
-        return 'no-module';
+        return "no-module";
     }
     if (currentScopeFile && currentScopeFile !== activeFile) {
         clearHeavyRefreshOptIns();
     }
-    logLine(`start forceRender=${forceRender} file=${path.basename(activeFile)} (${scopeSource}) module=${module}`);
+    logLine(
+        `start forceRender=${forceRender} file=${path.basename(activeFile)} (${scopeSource}) module=${module}`,
+    );
 
     // LSP gate. Saves a 5–30 s round-trip through compileKotlin when the
     // user is mid-typo-fix — the active file's diagnostics already tell us
@@ -2076,30 +2550,37 @@ async function refresh(
     // straight to a normal refresh.
     const initialErrors = readCompileErrors(activeFile);
     if (initialErrors.length > 0) {
-        await new Promise(resolve => setTimeout(resolve, GATE_REREAD_DELAY_MS));
-        if (abort.signal.aborted) { return 'cancelled'; }
+        await new Promise((resolve) =>
+            setTimeout(resolve, GATE_REREAD_DELAY_MS),
+        );
+        if (abort.signal.aborted) {
+            return "cancelled";
+        }
     }
-    const compileErrors = initialErrors.length > 0
-        ? readCompileErrors(activeFile)
-        : initialErrors;
+    const compileErrors =
+        initialErrors.length > 0
+            ? readCompileErrors(activeFile)
+            : initialErrors;
     if (compileErrors.length > 0) {
         panel.postMessage({
-            command: 'setCompileErrors',
+            command: "setCompileErrors",
             errors: compileErrors,
         });
         // No build is starting — make sure no stale progress bar lingers
         // from a prior in-flight refresh that was just cancelled by the
         // pendingRefresh.abort() at the top of this function.
-        panel.postMessage({ command: 'clearProgress' });
+        panel.postMessage({ command: "clearProgress" });
         setCurrentScopeFile(activeFile, module);
         compileGateActive = true;
-        logLine(`gated — ${compileErrors.length} compile error(s) in ${path.basename(activeFile)}`);
-        return 'gated';
+        logLine(
+            `gated — ${compileErrors.length} compile error(s) in ${path.basename(activeFile)}`,
+        );
+        return "gated";
     }
     // Errors cleared since the previous gate fire — drop the banner before
     // we begin the actual build so the user sees the panel return to its
     // normal "working" state.
-    panel.postMessage({ command: 'clearCompileErrors' });
+    panel.postMessage({ command: "clearCompileErrors" });
     compileGateActive = false;
 
     setCurrentScopeFile(activeFile, module);
@@ -2114,9 +2595,15 @@ async function refresh(
     // On a module switch the narrow no longer applies — the previewId is
     // owned by the previous module's preview set.
     const prior = historyScopeRef.current;
-    const sameModule = prior?.moduleId === module && prior.projectDir === projectDir;
+    const sameModule =
+        prior?.moduleId === module && prior.projectDir === projectDir;
     const newScope: HistoryScope = sameModule
-        ? { moduleId: module, projectDir, previewId: prior!.previewId, previewLabel: prior!.previewLabel }
+        ? {
+              moduleId: module,
+              projectDir,
+              previewId: prior!.previewId,
+              previewLabel: prior!.previewLabel,
+          }
         : { moduleId: module, projectDir };
     historyScopeRef.current = newScope;
     const modules = [module];
@@ -2132,7 +2619,7 @@ async function refresh(
     // happen if the new refresh cancels before setPreviews.
     const scopeChanged = !sameScope(modules, lastLoadedModules);
     if (scopeChanged) {
-        panel.postMessage({ command: 'clearAll' });
+        panel.postMessage({ command: "clearAll" });
         hasPreviewsLoaded = false;
     }
 
@@ -2141,10 +2628,10 @@ async function refresh(
     // clearing the view. Only show a full "Building..." message on first load.
     const showLoadingOverlay = opts.showLoadingOverlay !== false;
     if (hasPreviewsLoaded && showLoadingOverlay) {
-        panel.postMessage({ command: 'markAllLoading' });
+        panel.postMessage({ command: "markAllLoading" });
     } else {
         if (!hasPreviewsLoaded) {
-            panel.postMessage({ command: 'setLoading' });
+            panel.postMessage({ command: "setLoading" });
         }
     }
     lastLoadedModules = modules;
@@ -2162,9 +2649,11 @@ async function refresh(
     // it last computed (typically "(slow) · 99%").
     const tracker = new BuildProgressTracker({
         onProgress: (state) => {
-            if (abort.signal.aborted) { return; }
+            if (abort.signal.aborted) {
+                return;
+            }
             panel?.postMessage({
-                command: 'setProgress',
+                command: "setProgress",
                 phase: state.phase,
                 label: state.label,
                 percent: state.percent,
@@ -2183,33 +2672,44 @@ async function refresh(
         previewModuleMap.clear();
 
         for (const mod of modules) {
-            if (abort.signal.aborted) { return 'cancelled'; }
+            if (abort.signal.aborted) {
+                return "cancelled";
+            }
 
-            let manifest = !forceRender ? gradleService.readManifest(mod) : null;
+            let manifest = !forceRender
+                ? gradleService.readManifest(mod)
+                : null;
             if (manifest) {
-                const manifestVisiblePreviews = manifest.previews.filter(p => p.sourceFile === filterFile);
-                const fresh = manifestVisiblePreviews.length > 0
-                    && await hasFreshRenderStamp(
+                const manifestVisiblePreviews = manifest.previews.filter(
+                    (p) => p.sourceFile === filterFile,
+                );
+                const fresh =
+                    manifestVisiblePreviews.length > 0 &&
+                    (await hasFreshRenderStamp(
                         gradleService.workspaceRoot,
                         mod,
                         activeFile,
                         manifestVisiblePreviews,
-                    );
+                    ));
                 if (fresh) {
-                    logLine(`cache hit: ${path.basename(activeFile)} render stamp fresh — skipping Gradle`);
+                    logLine(
+                        `cache hit: ${path.basename(activeFile)} render stamp fresh — skipping Gradle`,
+                    );
                 } else {
                     manifest = null;
                 }
             }
-            manifest = manifest ?? (forceRender
-                ? await gradleService.renderPreviews(mod, tier, taskOpts)
-                : await gradleService.discoverPreviews(mod, taskOpts));
+            manifest =
+                manifest ??
+                (forceRender
+                    ? await gradleService.renderPreviews(mod, tier, taskOpts)
+                    : await gradleService.discoverPreviews(mod, taskOpts));
 
             // Track tier so the webview can mark heavy cards as stale after a
             // fast save. A successful full render clears the flag for this
             // module (heavy captures are now fresh on disk).
             if (forceRender && manifest) {
-                if (tier === 'fast') {
+                if (tier === "fast") {
                     fastTierModules.add(mod);
                 } else {
                     fastTierModules.delete(mod);
@@ -2242,61 +2742,77 @@ async function refresh(
             }
         }
 
-        if (abort.signal.aborted) { return 'cancelled'; }
+        if (abort.signal.aborted) {
+            return "cancelled";
+        }
 
         if (allPreviews.length === 0) {
             // Module has no previews at all. Wipe any stale cards so the
             // message isn't overlaid on old content from a prior scope.
-            panel.postMessage({ command: 'clearAll' });
-            panel.postMessage({ command: 'showMessage', text: 'No @Preview functions found in this module' });
-            panel.postMessage({ command: 'clearProgress' });
+            panel.postMessage({ command: "clearAll" });
+            panel.postMessage({
+                command: "showMessage",
+                text: "No @Preview functions found in this module",
+            });
+            panel.postMessage({ command: "clearProgress" });
             hasPreviewsLoaded = false;
-            logLine('done — module has no previews');
-            return 'completed';
+            logLine("done — module has no previews");
+            return "completed";
         }
 
         // Scope strictly to the active file. If the file has no @Preview
         // functions, the panel shows an empty state — never the whole module.
-        const visiblePreviews = allPreviews.filter(p => p.sourceFile === filterFile);
+        const visiblePreviews = allPreviews.filter(
+            (p) => p.sourceFile === filterFile,
+        );
 
         if (visiblePreviews.length === 0) {
             // The module has previews but this file doesn't. An empty
             // setPreviews would get silently wiped by applyFilters in the
             // webview — send an explicit, persistent message instead and
             // clear the grid so the user sees *why* it's blank.
-            panel.postMessage({ command: 'clearAll' });
+            panel.postMessage({ command: "clearAll" });
             const otherFiles = allPreviews.length;
             panel.postMessage({
-                command: 'showMessage',
+                command: "showMessage",
                 text: `No @Preview functions in this file (${otherFiles} in other files in this module).`,
             });
-            panel.postMessage({ command: 'clearProgress' });
+            panel.postMessage({ command: "clearProgress" });
             hasPreviewsLoaded = false;
-            logLine(`done — 0 visible previews in ${path.basename(activeFile)}, module has ${otherFiles}`);
-            return 'completed';
+            logLine(
+                `done — 0 visible previews in ${path.basename(activeFile)}, module has ${otherFiles}`,
+            );
+            return "completed";
         }
 
         // A preview is "heavyStale" when this module's most recent render was
         // tier=fast AND the preview has at least one heavy capture. The
         // webview decorates these cards with a stale badge so the user knows
         // the GIF/long-scroll image is from a previous full render.
-        const moduleIsFastTier = modules.some(mod => fastTierModules.has(mod));
+        const moduleIsFastTier = modules.some((mod) =>
+            fastTierModules.has(mod),
+        );
         const heavyStaleIds = moduleIsFastTier
-            ? visiblePreviews
-                .filter(hasHeavyCapture)
-                .map(p => p.id)
+            ? visiblePreviews.filter(hasHeavyCapture).map((p) => p.id)
             : [];
 
         panel.postMessage({
-            command: 'setPreviews',
+            command: "setPreviews",
             previews: visiblePreviews,
-            moduleDir: modules.join(','),
+            moduleDir: modules.join(","),
             heavyStaleIds,
         });
         hasPreviewsLoaded = true;
-        logLine(`rendered ${visiblePreviews.length} preview(s) for ${path.basename(activeFile)}`);
+        logLine(
+            `rendered ${visiblePreviews.length} preview(s) for ${path.basename(activeFile)}`,
+        );
         if (forceRender && gradleService) {
-            await writeRenderFreshnessStamp(gradleService.workspaceRoot, module, activeFile, visiblePreviews);
+            await writeRenderFreshnessStamp(
+                gradleService.workspaceRoot,
+                module,
+                activeFile,
+                visiblePreviews,
+            );
         }
 
         // Gradle is done; the rest of the work (reading PNGs, base64-encoding,
@@ -2307,7 +2823,7 @@ async function refresh(
         // explicit signal needed from this side. tracker.finish() at the
         // end of the happy path drives the bar to 100% and stops the tick.
         if (!abort.signal.aborted) {
-            tracker.enterPhase('loading');
+            tracker.enterPhase("loading");
         }
 
         // Load images in parallel. Animated previews have multiple captures
@@ -2328,66 +2844,95 @@ async function refresh(
         // it were the current state. Cards keep their cached imageData
         // (last known good) under the loading overlay until the auto-render
         // we kick off below replaces them with fresh bytes.
-        const sourceIsStale = !forceRender
-            && await isSourceNewerThanRenders(activeFile, visiblePreviews, modules);
+        const sourceIsStale =
+            !forceRender &&
+            (await isSourceNewerThanRenders(
+                activeFile,
+                visiblePreviews,
+                modules,
+            ));
         if (!sourceIsStale) {
             const imageJobs: Promise<void>[] = [];
             for (const preview of visiblePreviews) {
                 const captures = preview.captures;
-                if (captures.length === 0) { continue; }
+                if (captures.length === 0) {
+                    continue;
+                }
 
                 const mod = previewModuleMap.get(preview.id);
-                if (!mod) { continue; }
+                if (!mod) {
+                    continue;
+                }
 
-                for (let captureIndex = 0; captureIndex < captures.length; captureIndex++) {
+                for (
+                    let captureIndex = 0;
+                    captureIndex < captures.length;
+                    captureIndex++
+                ) {
                     const capture = captures[captureIndex];
-                    if (!capture.renderOutput) { continue; }
+                    if (!capture.renderOutput) {
+                        continue;
+                    }
                     const idx = captureIndex;
-                    imageJobs.push((async () => {
-                        if (abort.signal.aborted) { return; }
-                        const imageData = await gradleService!.readPreviewImage(mod, capture.renderOutput);
-                        if (abort.signal.aborted || !panel) { return; }
-
-                        if (imageData) {
-                            if (idx === 0) {
-                                registry.setImage(preview.id, imageData);
+                    imageJobs.push(
+                        (async () => {
+                            if (abort.signal.aborted) {
+                                return;
                             }
-                            panel.postMessage({
-                                command: 'updateImage',
-                                previewId: preview.id,
-                                captureIndex: idx,
-                                imageData,
-                            });
-                        } else if (forceRender) {
-                            // Render task completed but produced no PNG for this
-                            // capture. Look for the per-preview error sidecar
-                            // the renderer drops next to the would-be PNG; if
-                            // found, surface the structured exception detail
-                            // (class, message, top app frame). Falls back to
-                            // the generic "see Output" message when the
-                            // sidecar is absent — that's the case for the
-                            // Android Robolectric path which doesn't yet
-                            // write sidecars (planned follow-up).
-                            const renderError = await gradleService!.readPreviewRenderError(
-                                mod, capture.renderOutput,
-                            );
-                            if (abort.signal.aborted || !panel) { return; }
-                            const message = renderError
-                                ? formatRenderErrorMessage(renderError)
-                                : 'Render failed — see Output ▸ Compose Preview';
-                            panel.postMessage({
-                                command: 'setImageError',
-                                previewId: preview.id,
-                                captureIndex: idx,
-                                message,
-                                renderError,
-                                replaceExisting: true,
-                            });
-                        }
-                        // else: discover-only pass, PNG not produced yet. Leave
-                        // the skeleton in place; the next save-triggered render
-                        // will populate it.
-                    })());
+                            const imageData =
+                                await gradleService!.readPreviewImage(
+                                    mod,
+                                    capture.renderOutput,
+                                );
+                            if (abort.signal.aborted || !panel) {
+                                return;
+                            }
+
+                            if (imageData) {
+                                if (idx === 0) {
+                                    registry.setImage(preview.id, imageData);
+                                }
+                                panel.postMessage({
+                                    command: "updateImage",
+                                    previewId: preview.id,
+                                    captureIndex: idx,
+                                    imageData,
+                                });
+                            } else if (forceRender) {
+                                // Render task completed but produced no PNG for this
+                                // capture. Look for the per-preview error sidecar
+                                // the renderer drops next to the would-be PNG; if
+                                // found, surface the structured exception detail
+                                // (class, message, top app frame). Falls back to
+                                // the generic "see Output" message when the
+                                // sidecar is absent — that's the case for the
+                                // Android Robolectric path which doesn't yet
+                                // write sidecars (planned follow-up).
+                                const renderError =
+                                    await gradleService!.readPreviewRenderError(
+                                        mod,
+                                        capture.renderOutput,
+                                    );
+                                if (abort.signal.aborted || !panel) {
+                                    return;
+                                }
+                                const message = renderError
+                                    ? formatRenderErrorMessage(renderError)
+                                    : "Render failed — see Output ▸ Compose Preview";
+                                panel.postMessage({
+                                    command: "setImageError",
+                                    previewId: preview.id,
+                                    captureIndex: idx,
+                                    message,
+                                    renderError,
+                                    replaceExisting: true,
+                                });
+                            }
+                            // else: discover-only pass, PNG not produced yet. Leave
+                            // the skeleton in place; the next save-triggered render
+                            // will populate it.
+                        })(),
+                    );
                 }
             }
             await Promise.all(imageJobs);
@@ -2411,53 +2956,62 @@ async function refresh(
         // just rendered, so PNGs are fresh by definition. Without that
         // gate we'd loop on every save-driven refresh.
         if (sourceIsStale) {
-            logLine(`auto-render: ${path.basename(activeFile)} newer than rendered PNGs — kicking fresh render`);
-            setTimeout(() => { void refresh(true, activeFile, 'fast'); }, 0);
+            logLine(
+                `auto-render: ${path.basename(activeFile)} newer than rendered PNGs — kicking fresh render`,
+            );
+            setTimeout(() => {
+                void refresh(true, activeFile, "fast");
+            }, 0);
         }
-        return abort.signal.aborted ? 'cancelled' : 'completed';
+        return abort.signal.aborted ? "cancelled" : "completed";
     } catch (err: unknown) {
-        if (abort.signal.aborted) { return 'cancelled'; }
+        if (abort.signal.aborted) {
+            return "cancelled";
+        }
         // Cancellation = a follow-up refresh superseded this one. The new
         // refresh owns the panel state from here; surfacing a "FAILED" toast
         // would be misleading and noisy.
         if (err instanceof TaskCancelledError) {
             logLine(`cancelled — superseded by a newer refresh`);
-            panel.postMessage({ command: 'clearProgress' });
-            return 'cancelled';
+            panel.postMessage({ command: "clearProgress" });
+            return "cancelled";
         }
         if (err instanceof JdkImageError) {
             logLine(`FAILED (jlink missing): ${err.finding.jlinkPath}`);
             panel.postMessage({
-                command: 'showMessage',
-                text: 'Gradle is running on a JRE without jlink. Configure a full JDK to render previews.',
+                command: "showMessage",
+                text: "Gradle is running on a JRE without jlink. Configure a full JDK to render previews.",
             });
-            panel.postMessage({ command: 'clearProgress' });
+            panel.postMessage({ command: "clearProgress" });
             showJdkImageRemediation(err);
-            return 'failed';
+            return "failed";
         }
         if (err instanceof KotlinCompileError) {
-            logLine(`FAILED — ${err.errors.length} Kotlin compile error(s) in ${err.task}`);
+            logLine(
+                `FAILED — ${err.errors.length} Kotlin compile error(s) in ${err.task}`,
+            );
             // Reuse the same banner the LSP gate populates — the user
             // sees identical UX whether the gate fired or Gradle's
             // compile actually failed. Cards stay visible and dimmed so
             // the previous successful render is still on screen as a
             // reference while the error gets fixed.
             panel.postMessage({
-                command: 'setCompileErrors',
+                command: "setCompileErrors",
                 errors: err.errors,
             });
-            panel.postMessage({ command: 'clearProgress' });
+            panel.postMessage({ command: "clearProgress" });
             compileGateActive = true;
-            return 'failed';
+            return "failed";
         }
-        const message = err instanceof Error ? err.message.slice(0, 300) : 'Build failed';
+        const message =
+            err instanceof Error ? err.message.slice(0, 300) : "Build failed";
         logLine(`FAILED: ${message}`);
         panel.postMessage({
-            command: 'showMessage',
+            command: "showMessage",
             text: message,
         });
-        panel.postMessage({ command: 'clearProgress' });
-        return 'failed';
+        panel.postMessage({ command: "clearProgress" });
+        return "failed";
     } finally {
         // Idempotent — happy-path tracker.finish() already flipped the
         // tracker's `finished` flag, so this is a no-op there. Failure /
@@ -2465,7 +3019,9 @@ async function refresh(
         // tick interval shut down so the bar doesn't keep emitting after
         // we've moved on.
         tracker.abort();
-        if (pendingRefresh === abort) { pendingRefresh = null; }
+        if (pendingRefresh === abort) {
+            pendingRefresh = null;
+        }
     }
 }
 
@@ -2476,15 +3032,17 @@ function handleWebviewMessage(msg: WebviewToExtension) {
     // webview's untyped postMessage could deliver a structurally-broken
     // payload (e.g. arrays that aren't actually arrays).
     switch (msg.command) {
-        case 'openFile':
+        case "openFile":
             openPreviewSource(msg.className, msg.functionName);
             break;
-        case 'selectModule':
+        case "selectModule":
             selectedModule = msg.value || null;
             sendModuleList();
-            if (selectedModule) { refresh(false); }
+            if (selectedModule) {
+                refresh(false);
+            }
             break;
-        case 'refreshHeavy': {
+        case "refreshHeavy": {
             // Click on a faded heavy card opts it into full-tier renders for
             // this editor focus scope. Future saves keep that preview fresh;
             // changing focus clears the opt-in set.
@@ -2495,16 +3053,16 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                     void daemonScheduler.renderNow(
                         mod,
                         [msg.previewId],
-                        'full',
-                        'heavy-opt-in',
+                        "full",
+                        "heavy-opt-in",
                     );
                 } else {
-                    void refresh(true, currentScopeFile ?? undefined, 'full');
+                    void refresh(true, currentScopeFile ?? undefined, "full");
                 }
             }
             break;
         }
-        case 'viewportUpdated':
+        case "viewportUpdated":
             // Daemon-only: route geometric visibility + scroll-ahead
             // predictions to the scheduler so it can `setVisible` and
             // queue speculative renders. When the daemon is disabled
@@ -2516,17 +3074,23 @@ function handleWebviewMessage(msg: WebviewToExtension) {
                 void notifyDaemonViewport(msg.visible, msg.predicted);
             }
             break;
-        case 'previewScopeChanged': {
+        case "previewScopeChanged": {
             // Live panel has narrowed to a single preview (focus mode, or
             // filters reduced visible cards to one). Re-scope the History
             // panel's previewId filter so it only lists entries for that
             // preview. `previewId` null means widen the scope back to the
             // module — the panel shows every preview's history.
-            if (!historyScopeRef.current) { break; }
+            if (!historyScopeRef.current) {
+                break;
+            }
             const requested = msg.previewId ?? undefined;
-            const requestedLabel = requested ? lookupPreviewLabel(requested) : undefined;
-            if (historyScopeRef.current.previewId === requested
-                && historyScopeRef.current.previewLabel === requestedLabel) {
+            const requestedLabel = requested
+                ? lookupPreviewLabel(requested)
+                : undefined;
+            if (
+                historyScopeRef.current.previewId === requested &&
+                historyScopeRef.current.previewLabel === requestedLabel
+            ) {
                 break;
             }
             const newScope: HistoryScope = {
@@ -2537,40 +3101,46 @@ function handleWebviewMessage(msg: WebviewToExtension) {
             historyScopeRef.current = newScope;
             break;
         }
-        case 'openCompileError':
+        case "openCompileError":
             void openSourcePosition(msg.sourceFile, msg.line, msg.column);
             break;
-        case 'openSourceFile':
+        case "openSourceFile":
             void openSourceByFileName(msg.fileName, msg.line, msg.className);
             break;
-        case 'requestPreviewDiff':
+        case "requestPreviewDiff":
             if (earlyFeaturesEnabled()) {
                 void runLivePreviewDiff(msg.previewId, msg.against);
             }
             break;
-        case 'requestLaunchOnDevice':
+        case "requestLaunchOnDevice":
             if (msg.previewId) {
                 void launchOnDevice(msg.previewId);
             }
             break;
-        case 'setInteractive':
+        case "setInteractive":
             queueInteractiveMutation(msg.previewId, msg.enabled);
             break;
-        case 'setRecording':
+        case "setRecording":
             if (earlyFeaturesEnabled()) {
-                queueRecordingMutation(msg.previewId, msg.enabled, msg.format ?? 'apng');
+                queueRecordingMutation(
+                    msg.previewId,
+                    msg.enabled,
+                    msg.format ?? "apng",
+                );
             }
             break;
-        case 'recordInteractiveInput':
+        case "recordInteractiveInput":
             logLine(
-                `[interactive] ${msg.kind} ${msg.previewId} px=${msg.pixelX},${msg.pixelY} `
-                + `image=${msg.imageWidth}x${msg.imageHeight}`
-                + (msg.scrollDeltaY != null ? ` deltaY=${msg.scrollDeltaY}` : ''),
+                `[interactive] ${msg.kind} ${msg.previewId} px=${msg.pixelX},${msg.pixelY} ` +
+                    `image=${msg.imageWidth}x${msg.imageHeight}` +
+                    (msg.scrollDeltaY != null
+                        ? ` deltaY=${msg.scrollDeltaY}`
+                        : ""),
             );
             void forwardInteractiveInput(msg);
             void forwardRecordingInput(msg);
             break;
-        case 'setA11yOverlay':
+        case "setA11yOverlay":
             if (earlyFeaturesEnabled()) {
                 void handleSetA11yOverlay(msg.previewId, msg.enabled);
             }
@@ -2585,10 +3155,17 @@ function handleWebviewMessage(msg: WebviewToExtension) {
  * even if the next render takes a beat. No-op when the preview's module isn't known yet
  * (panel rebuild race) or when the daemon scheduler isn't wired (Gradle-only mode).
  */
-async function handleSetA11yOverlay(previewId: string, enabled: boolean): Promise<void> {
-    if (!daemonScheduler) { return; }
+async function handleSetA11yOverlay(
+    previewId: string,
+    enabled: boolean,
+): Promise<void> {
+    if (!daemonScheduler) {
+        return;
+    }
     const moduleId = previewModuleMap.get(previewId);
-    if (!moduleId) { return; }
+    if (!moduleId) {
+        return;
+    }
     await daemonScheduler.setDataProductSubscription(
         moduleId,
         previewId,
@@ -2602,7 +3179,7 @@ async function handleSetA11yOverlay(previewId: string, enabled: boolean): Promis
         // daemon overlay subscription and shouldn't disappear when the user hides the
         // visual overlay.
         panel?.postMessage({
-            command: 'updateA11y',
+            command: "updateA11y",
             previewId,
             findings: [],
             nodes: [],
@@ -2616,16 +3193,28 @@ async function handleSetA11yOverlay(previewId: string, enabled: boolean): Promis
  * 1-based input here matches what we render in the banner; vscode's API
  * is 0-based, so we subtract before constructing the Position.
  */
-async function openSourcePosition(filePath: string, line: number, column: number): Promise<void> {
+async function openSourcePosition(
+    filePath: string,
+    line: number,
+    column: number,
+): Promise<void> {
     try {
         const doc = await vscode.workspace.openTextDocument(filePath);
         const editor = await vscode.window.showTextDocument(doc);
-        const pos = new vscode.Position(Math.max(0, line - 1), Math.max(0, column - 1));
+        const pos = new vscode.Position(
+            Math.max(0, line - 1),
+            Math.max(0, column - 1),
+        );
         editor.selection = new vscode.Selection(pos, pos);
-        editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+        editor.revealRange(
+            new vscode.Range(pos, pos),
+            vscode.TextEditorRevealType.InCenter,
+        );
     } catch (e: unknown) {
         const message = e instanceof Error ? e.message : String(e);
-        logLine(`openSourcePosition failed for ${filePath}:${line}:${column} — ${message}`);
+        logLine(
+            `openSourcePosition failed for ${filePath}:${line}:${column} — ${message}`,
+        );
     }
 }
 
@@ -2659,7 +3248,9 @@ async function openSourceByFileName(
     line: number,
     className?: string,
 ): Promise<void> {
-    if (!fileName) { return; }
+    if (!fileName) {
+        return;
+    }
     try {
         // Class-derived path. The Kotlin compiler emits one .class per
         // top-level Kotlin file, named `<File>Kt`; strip the trailing
@@ -2669,9 +3260,14 @@ async function openSourceByFileName(
         // this preview's own file, so the class-derived path would point
         // at the wrong source.
         if (className) {
-            const classFile = className.replace(/Kt$/, '').replace(/\./g, '/') + '.kt';
+            const classFile =
+                className.replace(/Kt$/, "").replace(/\./g, "/") + ".kt";
             if (path.posix.basename(classFile) === fileName) {
-                const exact = await vscode.workspace.findFiles(`**/${classFile}`, '**/build/**', 1);
+                const exact = await vscode.workspace.findFiles(
+                    `**/${classFile}`,
+                    "**/build/**",
+                    1,
+                );
                 if (exact.length > 0) {
                     await openAt(exact[0], line);
                     return;
@@ -2679,7 +3275,11 @@ async function openSourceByFileName(
             }
         }
         // Basename fallback for cross-file throws.
-        const matches = await vscode.workspace.findFiles(`**/${fileName}`, '**/build/**', 1);
+        const matches = await vscode.workspace.findFiles(
+            `**/${fileName}`,
+            "**/build/**",
+            1,
+        );
         if (matches.length === 0) {
             logLine(`openSourceByFileName: no match for ${fileName}`);
             return;
@@ -2687,7 +3287,9 @@ async function openSourceByFileName(
         await openAt(matches[0], line);
     } catch (e: unknown) {
         const message = e instanceof Error ? e.message : String(e);
-        logLine(`openSourceByFileName failed for ${fileName}:${line} — ${message}`);
+        logLine(
+            `openSourceByFileName failed for ${fileName}:${line} — ${message}`,
+        );
     }
 }
 
@@ -2698,30 +3300,41 @@ async function openAt(uri: vscode.Uri, line: number): Promise<void> {
     const editor = await vscode.window.showTextDocument(doc);
     const pos = new vscode.Position(Math.max(0, line - 1), 0);
     editor.selection = new vscode.Selection(pos, pos);
-    editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+    editor.revealRange(
+        new vscode.Range(pos, pos),
+        vscode.TextEditorRevealType.InCenter,
+    );
 }
 
 async function runLivePreviewDiff(
     previewId: string,
-    against: 'head' | 'main',
+    against: "head" | "main",
 ): Promise<void> {
-    if (!earlyFeaturesEnabled()) { return; }
-    if (!panel || !historySource) { return; }
+    if (!earlyFeaturesEnabled()) {
+        return;
+    }
+    if (!panel || !historySource) {
+        return;
+    }
     const moduleId = previewModuleMap.get(previewId);
     const manifest = moduleId ? moduleManifestCache.get(moduleId) : undefined;
-    const info = manifest?.find(p => p.id === previewId);
+    const info = manifest?.find((p) => p.id === previewId);
     if (!moduleId || !info || !gradleService) {
         panel.postMessage({
-            command: 'previewDiffError', previewId, against,
-            message: 'Preview not found in the current scope.',
+            command: "previewDiffError",
+            previewId,
+            against,
+            message: "Preview not found in the current scope.",
         });
         return;
     }
     const capture = info.captures?.[0];
     if (!capture?.renderOutput) {
         panel.postMessage({
-            command: 'previewDiffError', previewId, against,
-            message: 'No live render available for this preview.',
+            command: "previewDiffError",
+            previewId,
+            against,
+            message: "No live render available for this preview.",
         });
         return;
     }
@@ -2730,8 +3343,10 @@ async function runLivePreviewDiff(
     const liveBytes = await fs.promises.readFile(livePath).catch(() => null);
     if (!liveBytes) {
         panel.postMessage({
-            command: 'previewDiffError', previewId, against,
-            message: 'Live render not on disk yet — save the file once first.',
+            command: "previewDiffError",
+            previewId,
+            against,
+            message: "Live render not on disk yet — save the file once first.",
         });
         return;
     }
@@ -2744,20 +3359,24 @@ async function runLivePreviewDiff(
         entries = result.entries ?? [];
     } catch (err) {
         panel.postMessage({
-            command: 'previewDiffError', previewId, against,
+            command: "previewDiffError",
+            previewId,
+            against,
             message: `History unavailable: ${(err as Error).message}`,
         });
         return;
     }
-    const filtered = (against === 'main')
-        ? entries.filter(e => {
-            const branch = (e as { git?: { branch?: string } }).git?.branch;
-            return branch === 'main';
-        })
-        : entries;
+    const filtered =
+        against === "main"
+            ? entries.filter((e) => {
+                  const branch = (e as { git?: { branch?: string } }).git
+                      ?.branch;
+                  return branch === "main";
+              })
+            : entries;
     const sorted = [...filtered].sort((a, b) => {
-        const at = (a as { timestamp?: string }).timestamp ?? '';
-        const bt = (b as { timestamp?: string }).timestamp ?? '';
+        const at = (a as { timestamp?: string }).timestamp ?? "";
+        const bt = (b as { timestamp?: string }).timestamp ?? "";
         return bt.localeCompare(at);
     });
     const target = sorted[0] as { id?: string; timestamp?: string } | undefined;
@@ -2765,20 +3384,23 @@ async function runLivePreviewDiff(
         const right = await historySource.read(target.id);
         if (!right) {
             panel.postMessage({
-                command: 'previewDiffError', previewId, against,
-                message: 'Comparison entry not readable.',
+                command: "previewDiffError",
+                previewId,
+                against,
+                message: "Comparison entry not readable.",
             });
             return;
         }
-        const rightBytes = right.pngBytes
-            ?? (await fs.promises.readFile(right.pngPath)).toString('base64');
+        const rightBytes =
+            right.pngBytes ??
+            (await fs.promises.readFile(right.pngPath)).toString("base64");
         panel.postMessage({
-            command: 'previewDiffReady',
+            command: "previewDiffReady",
             previewId,
             against,
-            leftLabel: 'Live · now',
-            leftImage: liveBytes.toString('base64'),
-            rightLabel: `${against === 'main' ? 'main' : 'HEAD'} · ${formatRelativeShort(target.timestamp)}`,
+            leftLabel: "Live · now",
+            leftImage: liveBytes.toString("base64"),
+            rightLabel: `${against === "main" ? "main" : "HEAD"} · ${formatRelativeShort(target.timestamp)}`,
             rightImage: rightBytes,
         });
         return;
@@ -2788,28 +3410,33 @@ async function runLivePreviewDiff(
     // fallback) — repos using the CI baseline workflow publish every main
     // build's PNGs there. Avoids requiring a daemon or a one-off local
     // archive for the user's first diff against main.
-    if (against === 'main') {
+    if (against === "main") {
         const baseline = await readPreviewMainPng(
-            gradleService.workspaceRoot, moduleId, previewId,
+            gradleService.workspaceRoot,
+            moduleId,
+            previewId,
         );
         if (baseline) {
             panel.postMessage({
-                command: 'previewDiffReady',
+                command: "previewDiffReady",
                 previewId,
                 against,
-                leftLabel: 'Live · now',
-                leftImage: liveBytes.toString('base64'),
+                leftLabel: "Live · now",
+                leftImage: liveBytes.toString("base64"),
                 rightLabel: `main · ${baseline.ref}`,
-                rightImage: baseline.png.toString('base64'),
+                rightImage: baseline.png.toString("base64"),
             });
             return;
         }
     }
     panel.postMessage({
-        command: 'previewDiffError', previewId, against,
-        message: against === 'main'
-            ? 'No archived render on main yet for this preview, and no compose-preview/main baseline.'
-            : 'No archived history yet for this preview.',
+        command: "previewDiffError",
+        previewId,
+        against,
+        message:
+            against === "main"
+                ? "No archived render on main yet for this preview, and no compose-preview/main baseline."
+                : "No archived history yet for this preview.",
     });
 }
 
@@ -2848,23 +3475,28 @@ async function runLivePreviewDiff(
  */
 async function launchOnDevice(focusedPreviewId?: string): Promise<void> {
     if (!gradleService) {
-        vscode.window.showInformationMessage('Compose Preview is not ready yet.');
+        vscode.window.showInformationMessage(
+            "Compose Preview is not ready yet.",
+        );
         return;
     }
     const previewModules = gradleService.findPreviewModules();
     const candidates = collectAndroidApplicationModules(
-        gradleService.workspaceRoot, previewModules,
+        gradleService.workspaceRoot,
+        previewModules,
     );
     if (candidates.length === 0) {
         vscode.window.showInformationMessage(
-            'Compose Preview: no Android application module to launch. '
-            + 'Apply id("com.android.application") with an applicationId to a preview module.',
+            "Compose Preview: no Android application module to launch. " +
+                'Apply id("com.android.application") with an applicationId to a preview module.',
         );
         return;
     }
 
     const preview = await resolveLaunchPreview(focusedPreviewId, candidates);
-    if (!preview) { return; }
+    if (!preview) {
+        return;
+    }
     const { module, applicationId, info } = preview;
     const composableFqn = `${info.className}.${info.functionName}`;
     logLine(`launchOnDevice: ${module} (${applicationId}) → ${composableFqn}`);
@@ -2876,11 +3508,15 @@ async function launchOnDevice(focusedPreviewId?: string): Promise<void> {
             cancellable: false,
         },
         async (progress) => {
-            progress.report({ message: 'Building & installing (installDebug)…' });
+            progress.report({
+                message: "Building & installing (installDebug)…",
+            });
             try {
                 await gradleService!.installDebug(module);
             } catch (e: unknown) {
-                if (e instanceof TaskCancelledError) { return; }
+                if (e instanceof TaskCancelledError) {
+                    return;
+                }
                 const m = e instanceof Error ? e.message : String(e);
                 vscode.window.showErrorMessage(
                     `Compose Preview: installDebug failed — ${m}`,
@@ -2888,24 +3524,33 @@ async function launchOnDevice(focusedPreviewId?: string): Promise<void> {
                 return;
             }
 
-            progress.report({ message: 'Starting PreviewActivity (adb)…' });
+            progress.report({ message: "Starting PreviewActivity (adb)…" });
             const sdkRoot = findAndroidSdkRoot(gradleService!.workspaceRoot);
             const adbPath = resolveAdbPath(sdkRoot);
             const args = buildPreviewActivityAmStartArgs({
                 applicationId,
                 composableFqn,
-                parameterProviderClassName: info.params.previewParameterProviderClassName ?? null,
+                parameterProviderClassName:
+                    info.params.previewParameterProviderClassName ?? null,
             });
             try {
                 const result = await runAdb(adbPath, args);
                 if (result.code !== 0) {
-                    const detail = (result.stderr || result.stdout || '').trim();
-                    const hint = /Activity class .* does not exist|ClassNotFoundException/i.test(detail)
-                        ? ' — add `debugImplementation("androidx.compose.ui:ui-tooling")` so PreviewActivity is on the device.'
-                        : '';
+                    const detail = (
+                        result.stderr ||
+                        result.stdout ||
+                        ""
+                    ).trim();
+                    const hint =
+                        /Activity class .* does not exist|ClassNotFoundException/i.test(
+                            detail,
+                        )
+                            ? ' — add `debugImplementation("androidx.compose.ui:ui-tooling")` so PreviewActivity is on the device.'
+                            : "";
                     vscode.window.showErrorMessage(
                         `Compose Preview: adb failed to start ${applicationId}` +
-                        (detail ? ` — ${detail}` : '') + hint,
+                            (detail ? ` — ${detail}` : "") +
+                            hint,
                     );
                     return;
                 }
@@ -2913,7 +3558,7 @@ async function launchOnDevice(focusedPreviewId?: string): Promise<void> {
                 const m = e instanceof Error ? e.message : String(e);
                 vscode.window.showErrorMessage(
                     `Compose Preview: could not run adb (${adbPath}) — ${m}. ` +
-                    'Set ANDROID_HOME or sdk.dir in local.properties.',
+                        "Set ANDROID_HOME or sdk.dir in local.properties.",
                 );
                 return;
             }
@@ -2946,20 +3591,24 @@ async function resolveLaunchPreview(
     focusedPreviewId: string | undefined,
     candidates: Array<{ module: string; applicationId: string }>,
 ): Promise<ResolvedLaunchPreview | null> {
-    const candidateByModule = new Map(candidates.map(c => [c.module, c]));
+    const candidateByModule = new Map(candidates.map((c) => [c.module, c]));
 
     if (focusedPreviewId) {
         const owner = previewModuleMap.get(focusedPreviewId);
         const candidate = owner ? candidateByModule.get(owner) : undefined;
         const previews = owner ? moduleManifestCache.get(owner) : undefined;
-        const info = previews?.find(p => p.id === focusedPreviewId);
+        const info = previews?.find((p) => p.id === focusedPreviewId);
         if (candidate && info) {
-            return { module: candidate.module, applicationId: candidate.applicationId, info };
+            return {
+                module: candidate.module,
+                applicationId: candidate.applicationId,
+                info,
+            };
         }
         if (owner && !candidate) {
             vscode.window.showInformationMessage(
-                `Compose Preview: ${owner} is not an Android application module — `
-                + 'add id("com.android.application") to deploy a preview from it.',
+                `Compose Preview: ${owner} is not an Android application module — ` +
+                    'add id("com.android.application") to deploy a preview from it.',
             );
             return null;
         }
@@ -2984,200 +3633,261 @@ async function resolveLaunchPreview(
     }
     if (items.length === 0) {
         vscode.window.showInformationMessage(
-            'Compose Preview: no rendered previews yet — render once first '
-            + 'so the @Preview functions show up here.',
+            "Compose Preview: no rendered previews yet — render once first " +
+                "so the @Preview functions show up here.",
         );
         return null;
     }
     if (items.length === 1) {
         const only = items[0];
-        return { module: only.candidate.module, applicationId: only.candidate.applicationId, info: only.info };
+        return {
+            module: only.candidate.module,
+            applicationId: only.candidate.applicationId,
+            info: only.info,
+        };
     }
     const picked = await vscode.window.showQuickPick(items, {
-        placeHolder: 'Pick a @Preview to launch on device',
+        placeHolder: "Pick a @Preview to launch on device",
         matchOnDescription: true,
         matchOnDetail: true,
     });
-    if (!picked) { return null; }
-    return { module: picked.candidate.module, applicationId: picked.candidate.applicationId, info: picked.info };
+    if (!picked) {
+        return null;
+    }
+    return {
+        module: picked.candidate.module,
+        applicationId: picked.candidate.applicationId,
+        info: picked.info,
+    };
 }
 
 async function diffAllVsMain(): Promise<void> {
     if (!earlyFeaturesEnabled()) {
         vscode.window.showInformationMessage(
-            'Compose Preview: enable composePreview.earlyFeatures.enabled to use Diff All vs Main.',
+            "Compose Preview: enable composePreview.earlyFeatures.enabled to use Diff All vs Main.",
         );
         return;
     }
     if (!gradleService || !panel || !historySource) {
-        vscode.window.showInformationMessage('Compose Preview is not ready yet.');
+        vscode.window.showInformationMessage(
+            "Compose Preview is not ready yet.",
+        );
         return;
     }
     if (!currentScopeFile) {
         vscode.window.showInformationMessage(
-            'Open a Kotlin file with @Preview functions before running Diff All vs Main.',
+            "Open a Kotlin file with @Preview functions before running Diff All vs Main.",
         );
         return;
     }
     const moduleId = gradleService.resolveModule(currentScopeFile);
     if (!moduleId) {
-        vscode.window.showInformationMessage('Active file is not part of a Compose Preview module.');
+        vscode.window.showInformationMessage(
+            "Active file is not part of a Compose Preview module.",
+        );
         return;
     }
     const manifest = moduleManifestCache.get(moduleId);
     if (!manifest || manifest.length === 0) {
-        vscode.window.showInformationMessage('No previews discovered yet — render once first.');
+        vscode.window.showInformationMessage(
+            "No previews discovered yet — render once first.",
+        );
         return;
     }
     const projectDir = path.join(gradleService.workspaceRoot, moduleId);
 
     interface DriftItem extends vscode.QuickPickItem {
         previewId: string;
-        driftKind: 'differs' | 'no-baseline' | 'no-live';
+        driftKind: "differs" | "no-baseline" | "no-live";
     }
     const drifted: DriftItem[] = [];
     let identical = 0;
 
-    await vscode.window.withProgress({
-        location: vscode.ProgressLocation.Notification,
-        title: 'Compose Preview — diffing all vs main',
-        cancellable: false,
-    }, async (progress) => {
-        const total = manifest.length;
-        let done = 0;
-        for (const preview of manifest) {
-            done++;
-            progress.report({
-                message: `${done} / ${total} · ${preview.functionName}`,
-                increment: 100 / total,
-            });
-            const cap = preview.captures?.[0];
-            if (!cap?.renderOutput) { continue; }
-            const livePath = path.join(projectDir, cap.renderOutput);
-            const liveBytes = await fs.promises.readFile(livePath).catch(() => null);
-            const label = preview.functionName
-                + (preview.params.name ? ` — ${preview.params.name}` : '');
-            if (!liveBytes) {
-                drifted.push({
-                    label,
-                    description: 'no live render',
-                    detail: preview.id,
-                    previewId: preview.id,
-                    driftKind: 'no-live',
+    await vscode.window.withProgress(
+        {
+            location: vscode.ProgressLocation.Notification,
+            title: "Compose Preview — diffing all vs main",
+            cancellable: false,
+        },
+        async (progress) => {
+            const total = manifest.length;
+            let done = 0;
+            for (const preview of manifest) {
+                done++;
+                progress.report({
+                    message: `${done} / ${total} · ${preview.functionName}`,
+                    increment: 100 / total,
                 });
-                continue;
-            }
-            const liveHash = crypto.createHash('sha256').update(liveBytes).digest('hex');
-            let mainHash: string | null = null;
-            let mainTs = '';
-            try {
-                const list = await historySource!.list({
-                    moduleId, projectDir, previewId: preview.id,
-                });
-                for (const e of list.entries) {
-                    const entry = e as { git?: { branch?: string }; pngHash?: string; timestamp?: string };
-                    if (entry?.git?.branch !== 'main' || !entry.pngHash) { continue; }
-                    const ts = entry.timestamp ?? '';
-                    if (ts > mainTs) { mainTs = ts; mainHash = entry.pngHash; }
+                const cap = preview.captures?.[0];
+                if (!cap?.renderOutput) {
+                    continue;
                 }
-            } catch {
-                // History unavailable for this preview — treat as no baseline.
-            }
-            if (!mainHash) {
-                // Fall back to the compose-preview/main baselines branch
-                // (with legacy preview_main fallback) — repos using the CI
-                // baseline workflow publish PNGs there even when nothing
-                // has been archived locally yet. The lookup also exposes a
-                // sha256 in the manifest, which we compare against the
-                // live hash to skip identical previews.
-                const baseline = await readPreviewMainPng(
-                    gradleService!.workspaceRoot, moduleId, preview.id,
-                );
-                if (!baseline) {
+                const livePath = path.join(projectDir, cap.renderOutput);
+                const liveBytes = await fs.promises
+                    .readFile(livePath)
+                    .catch(() => null);
+                const label =
+                    preview.functionName +
+                    (preview.params.name ? ` — ${preview.params.name}` : "");
+                if (!liveBytes) {
                     drifted.push({
                         label,
-                        description: 'no baseline on main',
+                        description: "no live render",
                         detail: preview.id,
                         previewId: preview.id,
-                        driftKind: 'no-baseline',
+                        driftKind: "no-live",
                     });
                     continue;
                 }
-                const baselineHash = baseline.sha256
-                    ?? crypto.createHash('sha256').update(baseline.png).digest('hex');
-                if (liveHash === baselineHash) {
+                const liveHash = crypto
+                    .createHash("sha256")
+                    .update(liveBytes)
+                    .digest("hex");
+                let mainHash: string | null = null;
+                let mainTs = "";
+                try {
+                    const list = await historySource!.list({
+                        moduleId,
+                        projectDir,
+                        previewId: preview.id,
+                    });
+                    for (const e of list.entries) {
+                        const entry = e as {
+                            git?: { branch?: string };
+                            pngHash?: string;
+                            timestamp?: string;
+                        };
+                        if (entry?.git?.branch !== "main" || !entry.pngHash) {
+                            continue;
+                        }
+                        const ts = entry.timestamp ?? "";
+                        if (ts > mainTs) {
+                            mainTs = ts;
+                            mainHash = entry.pngHash;
+                        }
+                    }
+                } catch {
+                    // History unavailable for this preview — treat as no baseline.
+                }
+                if (!mainHash) {
+                    // Fall back to the compose-preview/main baselines branch
+                    // (with legacy preview_main fallback) — repos using the CI
+                    // baseline workflow publish PNGs there even when nothing
+                    // has been archived locally yet. The lookup also exposes a
+                    // sha256 in the manifest, which we compare against the
+                    // live hash to skip identical previews.
+                    const baseline = await readPreviewMainPng(
+                        gradleService!.workspaceRoot,
+                        moduleId,
+                        preview.id,
+                    );
+                    if (!baseline) {
+                        drifted.push({
+                            label,
+                            description: "no baseline on main",
+                            detail: preview.id,
+                            previewId: preview.id,
+                            driftKind: "no-baseline",
+                        });
+                        continue;
+                    }
+                    const baselineHash =
+                        baseline.sha256 ??
+                        crypto
+                            .createHash("sha256")
+                            .update(baseline.png)
+                            .digest("hex");
+                    if (liveHash === baselineHash) {
+                        identical++;
+                        continue;
+                    }
+                    drifted.push({
+                        label,
+                        description: "differs from main",
+                        detail: preview.id,
+                        previewId: preview.id,
+                        driftKind: "differs",
+                    });
+                    continue;
+                }
+                if (liveHash === mainHash) {
                     identical++;
                     continue;
                 }
                 drifted.push({
                     label,
-                    description: 'differs from main',
+                    description: "differs from main",
                     detail: preview.id,
                     previewId: preview.id,
-                    driftKind: 'differs',
+                    driftKind: "differs",
                 });
-                continue;
             }
-            if (liveHash === mainHash) {
-                identical++;
-                continue;
-            }
-            drifted.push({
-                label,
-                description: 'differs from main',
-                detail: preview.id,
-                previewId: preview.id,
-                driftKind: 'differs',
-            });
-        }
-    });
+        },
+    );
 
     if (drifted.length === 0) {
         vscode.window.showInformationMessage(
-            `All ${identical} preview${identical === 1 ? '' : 's'} match main.`,
+            `All ${identical} preview${identical === 1 ? "" : "s"} match main.`,
         );
         return;
     }
 
-    const driftCount = drifted.filter(i => i.driftKind === 'differs').length;
-    const placeholder = driftCount > 0
-        ? `${driftCount} preview${driftCount === 1 ? '' : 's'} differ from main · ${identical} identical`
-        : `${drifted.length} preview${drifted.length === 1 ? '' : 's'} need attention · ${identical} identical`;
+    const driftCount = drifted.filter((i) => i.driftKind === "differs").length;
+    const placeholder =
+        driftCount > 0
+            ? `${driftCount} preview${driftCount === 1 ? "" : "s"} differ from main · ${identical} identical`
+            : `${drifted.length} preview${drifted.length === 1 ? "" : "s"} need attention · ${identical} identical`;
     const picked = await vscode.window.showQuickPick(drifted, {
         title: `Compose Preview — drift vs main (${moduleId})`,
         placeHolder: placeholder,
         matchOnDescription: true,
     });
-    if (!picked) { return; }
+    if (!picked) {
+        return;
+    }
 
     await vscode.commands.executeCommand(`${PreviewPanel.viewId}.focus`);
     panel.postMessage({
-        command: 'focusAndDiff',
+        command: "focusAndDiff",
         previewId: picked.previewId,
-        against: 'main',
+        against: "main",
     });
 }
 
 function formatRelativeShort(iso: string | undefined): string {
-    if (!iso) { return '(unknown)'; }
+    if (!iso) {
+        return "(unknown)";
+    }
     const t = Date.parse(iso);
-    if (isNaN(t)) { return iso; }
+    if (isNaN(t)) {
+        return iso;
+    }
     const s = Math.round((Date.now() - t) / 1000);
-    if (s < 60) { return s + 's ago'; }
+    if (s < 60) {
+        return s + "s ago";
+    }
     const m = Math.round(s / 60);
-    if (m < 60) { return m + 'm ago'; }
+    if (m < 60) {
+        return m + "m ago";
+    }
     const h = Math.round(m / 60);
-    if (h < 24) { return h + 'h ago'; }
+    if (h < 24) {
+        return h + "h ago";
+    }
     const d = Math.round(h / 24);
-    return d + 'd ago';
+    return d + "d ago";
 }
 
 function lookupPreviewLabel(previewId: string): string | undefined {
     const mod = previewModuleMap.get(previewId);
-    if (!mod) { return undefined; }
+    if (!mod) {
+        return undefined;
+    }
     const manifest = moduleManifestCache.get(mod);
-    const info = manifest?.find(p => p.id === previewId);
-    if (!info) { return undefined; }
+    const info = manifest?.find((p) => p.id === previewId);
+    if (!info) {
+        return undefined;
+    }
     return info.params.name
         ? `${info.functionName} — ${info.params.name}`
         : info.functionName;
@@ -3195,11 +3905,18 @@ function lookupPreviewLabel(previewId: string): string | undefined {
  * Stateless fallback streams are stopped immediately; otherwise the UI would show a LIVE badge
  * while every frame comes from a fresh composition.
  */
-async function handleSetInteractive(previewId: string, enabled: boolean): Promise<void> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler) { return; }
+async function handleSetInteractive(
+    previewId: string,
+    enabled: boolean,
+): Promise<void> {
+    if (!daemonGate?.isEnabled() || !daemonScheduler) {
+        return;
+    }
     const moduleId = previewModuleMap.get(previewId);
     if (!moduleId) {
-        logLine(`[interactive] no module for ${previewId}; ignoring setInteractive`);
+        logLine(
+            `[interactive] no module for ${previewId}; ignoring setInteractive`,
+        );
         return;
     }
     if (!enabled) {
@@ -3208,7 +3925,8 @@ async function handleSetInteractive(previewId: string, enabled: boolean): Promis
             activeInteractiveStreams.delete(previewId);
             updateInteractiveStatus();
             const client = await daemonGate?.getOrSpawn(
-                moduleId, daemonScheduler.daemonEvents(moduleId),
+                moduleId,
+                daemonScheduler.daemonEvents(moduleId),
             );
             client?.interactiveStop({ frameStreamId: stream });
         }
@@ -3216,14 +3934,15 @@ async function handleSetInteractive(previewId: string, enabled: boolean): Promis
         return;
     }
     const client = await daemonGate?.getOrSpawn(
-        moduleId, daemonScheduler.daemonEvents(moduleId),
+        moduleId,
+        daemonScheduler.daemonEvents(moduleId),
     );
     if (!client) {
         // The webview already saw the toggle disabled — but the user could
         // have flipped settings between toggle render and click. Push a
         // fresh availability ping so the chip reverts cleanly.
         panel?.postMessage({
-            command: 'setInteractiveAvailability',
+            command: "setInteractiveAvailability",
             moduleId,
             ready: false,
             interactiveSupported: false,
@@ -3236,10 +3955,12 @@ async function handleSetInteractive(previewId: string, enabled: boolean): Promis
             client.interactiveStop({ frameStreamId: result.frameStreamId });
             logLine(
                 `[interactive] live mode unavailable for ${previewId}: daemon returned ` +
-                `stateless stream ${result.frameStreamId}` +
-                (result.fallbackReason ? ` (${result.fallbackReason})` : ''),
+                    `stateless stream ${result.frameStreamId}` +
+                    (result.fallbackReason
+                        ? ` (${result.fallbackReason})`
+                        : ""),
             );
-            panel?.postMessage({ command: 'clearInteractive', previewId });
+            panel?.postMessage({ command: "clearInteractive", previewId });
             updateInteractiveStatus();
             return;
         }
@@ -3247,8 +3968,8 @@ async function handleSetInteractive(previewId: string, enabled: boolean): Promis
         updateInteractiveStatus();
         logLine(
             `[interactive] live mode on for ${previewId} (module=${moduleId}, ` +
-            `streamId=${result.frameStreamId}, ` +
-            `heldSession=${result.heldSession})`,
+                `streamId=${result.frameStreamId}, ` +
+                `heldSession=${result.heldSession})`,
         );
         await daemonScheduler.setFocus(moduleId, [previewId]);
         return;
@@ -3256,7 +3977,7 @@ async function handleSetInteractive(previewId: string, enabled: boolean): Promis
         logLine(
             `[interactive] live mode failed for ${previewId}: ${(err as Error).message}`,
         );
-        panel?.postMessage({ command: 'clearInteractive', previewId });
+        panel?.postMessage({ command: "clearInteractive", previewId });
         updateInteractiveStatus();
         return;
     }
@@ -3273,7 +3994,7 @@ const activeInteractiveStreams = new Map<string, string>();
 
 const activeRecordingSessions = new Map<string, string>();
 
-const activeRecordingFormats = new Map<string, 'apng' | 'mp4'>();
+const activeRecordingFormats = new Map<string, "apng" | "mp4">();
 
 let interactiveMutationQueue: Promise<void> = Promise.resolve();
 
@@ -3282,8 +4003,10 @@ function queueInteractiveMutation(previewId: string, enabled: boolean): void {
         .catch(() => {})
         .then(() => handleSetInteractive(previewId, enabled))
         .catch((err) => {
-            logLine(`[interactive] setInteractive failed for ${previewId}: ${(err as Error).message}`);
-            panel?.postMessage({ command: 'clearInteractive', previewId });
+            logLine(
+                `[interactive] setInteractive failed for ${previewId}: ${(err as Error).message}`,
+            );
+            panel?.postMessage({ command: "clearInteractive", previewId });
         });
 }
 
@@ -3292,15 +4015,18 @@ const recordingMutationQueues = new Map<string, Promise<void>>();
 function queueRecordingMutation(
     previewId: string,
     enabled: boolean,
-    format: 'apng' | 'mp4',
+    format: "apng" | "mp4",
 ): void {
-    const previous = recordingMutationQueues.get(previewId) ?? Promise.resolve();
+    const previous =
+        recordingMutationQueues.get(previewId) ?? Promise.resolve();
     const next = previous
         .catch(() => {})
         .then(() => handleSetRecording(previewId, enabled, format))
         .catch((err) => {
-            logLine(`[recording] setRecording failed for ${previewId}: ${(err as Error).message}`);
-            panel?.postMessage({ command: 'clearRecording', previewId });
+            logLine(
+                `[recording] setRecording failed for ${previewId}: ${(err as Error).message}`,
+            );
+            panel?.postMessage({ command: "clearRecording", previewId });
         })
         .finally(() => {
             if (recordingMutationQueues.get(previewId) === next) {
@@ -3321,7 +4047,9 @@ function queueRecordingMutation(
  * cleanup, so the indicator reflects the current state without polling.
  */
 function updateInteractiveStatus(): void {
-    if (!interactiveStatusItem) { return; }
+    if (!interactiveStatusItem) {
+        return;
+    }
     if (!daemonGate || activeInteractiveStreams.size === 0) {
         interactiveStatusItem.hide();
         return;
@@ -3329,7 +4057,9 @@ function updateInteractiveStatus(): void {
     const unsupportedModules = new Set<string>();
     for (const previewId of activeInteractiveStreams.keys()) {
         const moduleId = previewModuleMap.get(previewId);
-        if (!moduleId) { continue; }
+        if (!moduleId) {
+            continue;
+        }
         if (!daemonGate.isInteractiveSupported(moduleId)) {
             unsupportedModules.add(moduleId);
         }
@@ -3338,42 +4068,47 @@ function updateInteractiveStatus(): void {
         interactiveStatusItem.hide();
         return;
     }
-    const moduleLabel = unsupportedModules.size === 1
-        ? [...unsupportedModules][0]
-        : `${unsupportedModules.size} modules`;
+    const moduleLabel =
+        unsupportedModules.size === 1
+            ? [...unsupportedModules][0]
+            : `${unsupportedModules.size} modules`;
     interactiveStatusItem.text = `$(warning) Live · v1 fallback`;
-    interactiveStatusItem.tooltip = (
+    interactiveStatusItem.tooltip =
         `Live mode is active on ${moduleLabel}, but this daemon backend doesn't ` +
         `support clicks-into-composition (v2). Inputs trigger a fresh render but ` +
         `state from \`remember { mutableStateOf(...) }\` resets between clicks. ` +
         `Switch to a desktop module for full interactive mode. ` +
-        `See docs/daemon/INTERACTIVE.md § 9.10.`
-    );
+        `See docs/daemon/INTERACTIVE.md § 9.10.`;
     interactiveStatusItem.show();
 }
 
 async function handleSetRecording(
     previewId: string,
     enabled: boolean,
-    format: 'apng' | 'mp4',
+    format: "apng" | "mp4",
 ): Promise<void> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler) { return; }
+    if (!daemonGate?.isEnabled() || !daemonScheduler) {
+        return;
+    }
     const moduleId = previewModuleMap.get(previewId);
     if (!moduleId) {
-        logLine(`[recording] no module for ${previewId}; ignoring setRecording`);
+        logLine(
+            `[recording] no module for ${previewId}; ignoring setRecording`,
+        );
         return;
     }
     const client = await daemonGate?.getOrSpawn(
-        moduleId, daemonScheduler.daemonEvents(moduleId),
+        moduleId,
+        daemonScheduler.daemonEvents(moduleId),
     );
     if (!client) {
-        panel?.postMessage({ command: 'clearRecording', previewId });
+        panel?.postMessage({ command: "clearRecording", previewId });
         return;
     }
     if (!enabled) {
         const recordingId = activeRecordingSessions.get(previewId);
         if (!recordingId) {
-            panel?.postMessage({ command: 'clearRecording', previewId });
+            panel?.postMessage({ command: "clearRecording", previewId });
             return;
         }
         activeRecordingSessions.delete(previewId);
@@ -3381,26 +4116,33 @@ async function handleSetRecording(
         activeRecordingFormats.delete(previewId);
         try {
             const stopped = await client.recordingStop({ recordingId });
-            const encoded = await client.recordingEncode({ recordingId, format: encodeFormat });
+            const encoded = await client.recordingEncode({
+                recordingId,
+                format: encodeFormat,
+            });
             logLine(
                 `[recording] saved ${previewId}: ${encoded.videoPath} ` +
-                `(${stopped.frameCount} frames, ${stopped.durationMs}ms)`,
+                    `(${stopped.frameCount} frames, ${stopped.durationMs}ms)`,
             );
             void vscode.window.showInformationMessage(
                 `Compose preview recording saved: ${encoded.videoPath}`,
             );
         } catch (err) {
-            logLine(`[recording] stop failed for ${previewId}: ${(err as Error).message}`);
+            logLine(
+                `[recording] stop failed for ${previewId}: ${(err as Error).message}`,
+            );
             void vscode.window.showErrorMessage(
                 `Compose preview recording failed: ${(err as Error).message}`,
             );
         } finally {
-            panel?.postMessage({ command: 'clearRecording', previewId });
+            panel?.postMessage({ command: "clearRecording", previewId });
         }
         return;
     }
 
-    if (activeRecordingSessions.has(previewId)) { return; }
+    if (activeRecordingSessions.has(previewId)) {
+        return;
+    }
     try {
         const result = await client.recordingStart({
             previewId,
@@ -3413,11 +4155,13 @@ async function handleSetRecording(
         await daemonScheduler.setFocus(moduleId, [previewId]);
         logLine(
             `[recording] live recording on for ${previewId} ` +
-            `(module=${moduleId}, recordingId=${result.recordingId})`,
+                `(module=${moduleId}, recordingId=${result.recordingId})`,
         );
     } catch (err) {
-        logLine(`[recording] start failed for ${previewId}: ${(err as Error).message}`);
-        panel?.postMessage({ command: 'clearRecording', previewId });
+        logLine(
+            `[recording] start failed for ${previewId}: ${(err as Error).message}`,
+        );
+        panel?.postMessage({ command: "clearRecording", previewId });
         void vscode.window.showErrorMessage(
             `Compose preview recording failed: ${(err as Error).message}`,
         );
@@ -3430,18 +4174,27 @@ async function handleSetRecording(
  * — callers don't need to coordinate with the start/stop dance.
  */
 async function forwardInteractiveInput(
-    input: Extract<WebviewToExtension, { command: 'recordInteractiveInput' }>,
+    input: Extract<WebviewToExtension, { command: "recordInteractiveInput" }>,
 ): Promise<void> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler) { return; }
+    if (!daemonGate?.isEnabled() || !daemonScheduler) {
+        return;
+    }
     const previewId = input.previewId;
     const streamId = activeInteractiveStreams.get(previewId);
-    if (!streamId) { return; }
+    if (!streamId) {
+        return;
+    }
     const moduleId = previewModuleMap.get(previewId);
-    if (!moduleId) { return; }
+    if (!moduleId) {
+        return;
+    }
     const client = await daemonGate?.getOrSpawn(
-        moduleId, daemonScheduler.daemonEvents(moduleId),
+        moduleId,
+        daemonScheduler.daemonEvents(moduleId),
     );
-    if (!client) { return; }
+    if (!client) {
+        return;
+    }
     client.interactiveInput({
         frameStreamId: streamId,
         kind: input.kind,
@@ -3452,18 +4205,27 @@ async function forwardInteractiveInput(
 }
 
 async function forwardRecordingInput(
-    input: Extract<WebviewToExtension, { command: 'recordInteractiveInput' }>,
+    input: Extract<WebviewToExtension, { command: "recordInteractiveInput" }>,
 ): Promise<void> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler) { return; }
+    if (!daemonGate?.isEnabled() || !daemonScheduler) {
+        return;
+    }
     const previewId = input.previewId;
     const recordingId = activeRecordingSessions.get(previewId);
-    if (!recordingId) { return; }
+    if (!recordingId) {
+        return;
+    }
     const moduleId = previewModuleMap.get(previewId);
-    if (!moduleId) { return; }
+    if (!moduleId) {
+        return;
+    }
     const client = await daemonGate?.getOrSpawn(
-        moduleId, daemonScheduler.daemonEvents(moduleId),
+        moduleId,
+        daemonScheduler.daemonEvents(moduleId),
     );
-    if (!client) { return; }
+    if (!client) {
+        return;
+    }
     client.recordingInput({
         recordingId,
         kind: input.kind,
@@ -3480,18 +4242,26 @@ async function forwardRecordingInput(
  * for a module — warm-up completion, channel-close, classpath-dirty.
  */
 function publishInteractiveAvailability(moduleId: string): void {
-    if (!panel) { return; }
+    if (!panel) {
+        return;
+    }
     const ready = daemonGate?.isDaemonReady(moduleId) ?? false;
     panel.postMessage({
-        command: 'setInteractiveAvailability',
+        command: "setInteractiveAvailability",
         moduleId,
         ready,
-        interactiveSupported: ready && (daemonGate?.isInteractiveSupported(moduleId) ?? false),
+        interactiveSupported:
+            ready && (daemonGate?.isInteractiveSupported(moduleId) ?? false),
     });
 }
 
-async function notifyDaemonViewport(visible: string[], predicted: string[]): Promise<void> {
-    if (!daemonGate?.isEnabled() || !daemonScheduler) { return; }
+async function notifyDaemonViewport(
+    visible: string[],
+    predicted: string[],
+): Promise<void> {
+    if (!daemonGate?.isEnabled() || !daemonScheduler) {
+        return;
+    }
     // Group by owning module — viewports cross module boundaries only when
     // the user is paging across the all-modules view (rare today; the
     // panel is module-scoped). Each module's daemon gets its own slice.
@@ -3499,17 +4269,28 @@ async function notifyDaemonViewport(visible: string[], predicted: string[]): Pro
     const predictedByModule = new Map<string, string[]>();
     for (const id of visible) {
         const mod = previewModuleMap.get(id);
-        if (!mod) { continue; }
-        if (!visibleByModule.has(mod)) { visibleByModule.set(mod, []); }
+        if (!mod) {
+            continue;
+        }
+        if (!visibleByModule.has(mod)) {
+            visibleByModule.set(mod, []);
+        }
         visibleByModule.get(mod)!.push(id);
     }
     for (const id of predicted) {
         const mod = previewModuleMap.get(id);
-        if (!mod) { continue; }
-        if (!predictedByModule.has(mod)) { predictedByModule.set(mod, []); }
+        if (!mod) {
+            continue;
+        }
+        if (!predictedByModule.has(mod)) {
+            predictedByModule.set(mod, []);
+        }
         predictedByModule.get(mod)!.push(id);
     }
-    const modules = new Set([...visibleByModule.keys(), ...predictedByModule.keys()]);
+    const modules = new Set([
+        ...visibleByModule.keys(),
+        ...predictedByModule.keys(),
+    ]);
     for (const mod of modules) {
         await daemonScheduler.setVisible(
             mod,
@@ -3535,14 +4316,18 @@ async function notifyDaemonViewport(visible: string[], predicted: string[]): Pro
  *     for case C).
  */
 function emptyStateMessage(activeFile: string | undefined): string {
-    if (!gradleService) { return ''; }
+    if (!gradleService) {
+        return "";
+    }
     if (!activeFile || !isPreviewSourceFile(activeFile)) {
-        return 'Open a Kotlin source file in a module that applies ee.schimke.composeai.preview.';
+        return "Open a Kotlin source file in a module that applies ee.schimke.composeai.preview.";
     }
     const previewModules = gradleService.findPreviewModules();
     if (previewModules.length === 0) {
-        return 'The Compose Preview Gradle plugin isn\'t applied in this workspace. '
-            + 'Add id("ee.schimke.composeai.preview") to a module\'s build.gradle.kts to enable previews.';
+        return (
+            "The Compose Preview Gradle plugin isn't applied in this workspace. " +
+            'Add id("ee.schimke.composeai.preview") to a module\'s build.gradle.kts to enable previews.'
+        );
     }
     if (fileHasPreviewAnnotation(activeFile)) {
         // File is inside a preview-enabled module, but outside this Gradle
@@ -3550,16 +4335,20 @@ function emptyStateMessage(activeFile: string | undefined): string {
         // checkout's workspace. Nothing the user needs to "fix" in the build
         // script; steer them toward opening the right root instead.
         if (findPluginAppliedAncestor(activeFile)) {
-            return 'This file is in a preview-enabled module, but outside this VS Code '
-                + 'workspace root (e.g. a git worktree). Open that project root in VS Code '
-                + 'to see its previews.';
+            return (
+                "This file is in a preview-enabled module, but outside this VS Code " +
+                "workspace root (e.g. a git worktree). Open that project root in VS Code " +
+                "to see its previews."
+            );
         }
-        const topDir = topLevelDirOf(activeFile) ?? '(this module)';
-        return `'${topDir}' doesn't apply ee.schimke.composeai.preview. `
-            + `Modules with previews in this workspace: ${previewModules.join(', ')}.`;
+        const topDir = topLevelDirOf(activeFile) ?? "(this module)";
+        return (
+            `'${topDir}' doesn't apply ee.schimke.composeai.preview. ` +
+            `Modules with previews in this workspace: ${previewModules.join(", ")}.`
+        );
     }
     // No @Preview references in the active file — stay out of the way.
-    return 'No @Preview functions in this file.';
+    return "No @Preview functions in this file.";
 }
 
 /**
@@ -3570,35 +4359,49 @@ function emptyStateMessage(activeFile: string | undefined): string {
  * because that's almost certainly a false alarm.
  */
 function maybeShowSetupPrompt(activeFile: string): void {
-    if (warnedMissingPluginThisSession || !gradleService || !extensionContext) { return; }
-    if (extensionContext.workspaceState.get<boolean>(DISMISS_KEY)) { return; }
+    if (warnedMissingPluginThisSession || !gradleService || !extensionContext) {
+        return;
+    }
+    if (extensionContext.workspaceState.get<boolean>(DISMISS_KEY)) {
+        return;
+    }
 
     const previewModules = gradleService.findPreviewModules();
     const missingAnywhere = previewModules.length === 0;
-    const missingForThisModule = !missingAnywhere && fileHasPreviewAnnotation(activeFile);
-    if (!missingAnywhere && !missingForThisModule) { return; }
+    const missingForThisModule =
+        !missingAnywhere && fileHasPreviewAnnotation(activeFile);
+    if (!missingAnywhere && !missingForThisModule) {
+        return;
+    }
     // The file is already inside a plugin-applied module somewhere up its own
     // path — it just isn't part of *this* Gradle project (e.g. a git worktree
     // nested under the workspace root). No build-script fix is needed; skip
     // the nudge rather than point at a module they'd have to invent.
-    if (findPluginAppliedAncestor(activeFile)) { return; }
+    if (findPluginAppliedAncestor(activeFile)) {
+        return;
+    }
 
     warnedMissingPluginThisSession = true;
     const message = missingAnywhere
-        ? 'Compose Preview: the Gradle plugin isn\'t applied in this workspace yet.'
-        : 'Compose Preview: this module doesn\'t apply the Gradle plugin, but the file uses @Preview.';
-    const OPEN = 'Open build.gradle.kts';
-    const DOCS = 'View setup docs';
-    const NEVER = 'Don\'t show again';
-    void vscode.window.showInformationMessage(message, OPEN, DOCS, NEVER).then(action => {
-        if (action === OPEN) {
-            void vscode.commands.executeCommand('composePreview.openModuleBuildFile', activeFile);
-        } else if (action === DOCS) {
-            void vscode.env.openExternal(vscode.Uri.parse(SETUP_DOCS_URL));
-        } else if (action === NEVER) {
-            void extensionContext?.workspaceState.update(DISMISS_KEY, true);
-        }
-    });
+        ? "Compose Preview: the Gradle plugin isn't applied in this workspace yet."
+        : "Compose Preview: this module doesn't apply the Gradle plugin, but the file uses @Preview.";
+    const OPEN = "Open build.gradle.kts";
+    const DOCS = "View setup docs";
+    const NEVER = "Don't show again";
+    void vscode.window
+        .showInformationMessage(message, OPEN, DOCS, NEVER)
+        .then((action) => {
+            if (action === OPEN) {
+                void vscode.commands.executeCommand(
+                    "composePreview.openModuleBuildFile",
+                    activeFile,
+                );
+            } else if (action === DOCS) {
+                void vscode.env.openExternal(vscode.Uri.parse(SETUP_DOCS_URL));
+            } else if (action === NEVER) {
+                void extensionContext?.workspaceState.update(DISMISS_KEY, true);
+            }
+        });
 }
 
 /**
@@ -3608,51 +4411,75 @@ function maybeShowSetupPrompt(activeFile: string): void {
  * falls back to the root's own build script. This handles both top-level
  * modules (the only kind findPreviewModules scans for) and nested layouts.
  */
-async function openModuleBuildFile(workspaceRoot: string, filePath?: string): Promise<void> {
-    const target = filePath
-        ?? currentScopeFile
-        ?? vscode.window.activeTextEditor?.document.uri.fsPath
-        ?? workspaceRoot;
+async function openModuleBuildFile(
+    workspaceRoot: string,
+    filePath?: string,
+): Promise<void> {
+    const target =
+        filePath ??
+        currentScopeFile ??
+        vscode.window.activeTextEditor?.document.uri.fsPath ??
+        workspaceRoot;
 
     let dir = target === workspaceRoot ? workspaceRoot : path.dirname(target);
     const root = path.resolve(workspaceRoot);
     while (path.resolve(dir).startsWith(root)) {
-        const candidate = path.join(dir, 'build.gradle.kts');
+        const candidate = path.join(dir, "build.gradle.kts");
         if (fs.existsSync(candidate)) {
             const doc = await vscode.workspace.openTextDocument(candidate);
             await vscode.window.showTextDocument(doc);
             return;
         }
         const parent = path.dirname(dir);
-        if (parent === dir) { break; }
+        if (parent === dir) {
+            break;
+        }
         dir = parent;
     }
-    vscode.window.showWarningMessage('No build.gradle.kts found for this file.');
+    vscode.window.showWarningMessage(
+        "No build.gradle.kts found for this file.",
+    );
 }
 
 function fileHasPreviewAnnotation(filePath: string): boolean {
     // Prefer the already-loaded editor buffer over a disk read so unsaved
     // edits (the user just typed `@Preview`) are picked up.
-    const doc = vscode.workspace.textDocuments.find(d => d.uri.fsPath === filePath);
+    const doc = vscode.workspace.textDocuments.find(
+        (d) => d.uri.fsPath === filePath,
+    );
     const text = doc
         ? doc.getText()
-        : (() => { try { return fs.readFileSync(filePath, 'utf-8'); } catch { return ''; } })();
-    return text.includes('Preview') && text.includes('@Composable');
+        : (() => {
+              try {
+                  return fs.readFileSync(filePath, "utf-8");
+              } catch {
+                  return "";
+              }
+          })();
+    return text.includes("Preview") && text.includes("@Composable");
 }
 
 function topLevelDirOf(filePath: string): string | null {
     const folders = vscode.workspace.workspaceFolders;
-    if (!folders || folders.length === 0) { return null; }
+    if (!folders || folders.length === 0) {
+        return null;
+    }
     const rel = path.relative(folders[0].uri.fsPath, filePath);
     const first = rel.split(path.sep)[0];
-    return first && first !== '..' ? first : null;
+    return first && first !== ".." ? first : null;
 }
 
 async function openPreviewSource(className: string, functionName: string) {
-    const classFile = className.replace(/Kt$/, '').replace(/\./g, '/') + '.kt';
-    const files = await vscode.workspace.findFiles(`**/${classFile}`, '**/build/**', 1);
+    const classFile = className.replace(/Kt$/, "").replace(/\./g, "/") + ".kt";
+    const files = await vscode.workspace.findFiles(
+        `**/${classFile}`,
+        "**/build/**",
+        1,
+    );
     if (files.length === 0) {
-        vscode.window.showWarningMessage(`Could not find source for ${className}.${functionName}`);
+        vscode.window.showWarningMessage(
+            `Could not find source for ${className}.${functionName}`,
+        );
         return;
     }
 
@@ -3660,11 +4487,14 @@ async function openPreviewSource(className: string, functionName: string) {
     const editor = await vscode.window.showTextDocument(doc);
 
     const text = doc.getText();
-    const escaped = functionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const escaped = functionName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     const match = new RegExp(`fun\\s+${escaped}\\s*\\(`).exec(text);
     if (match) {
         const pos = doc.positionAt(match.index);
         editor.selection = new vscode.Selection(pos, pos);
-        editor.revealRange(new vscode.Range(pos, pos), vscode.TextEditorRevealType.InCenter);
+        editor.revealRange(
+            new vscode.Range(pos, pos),
+            vscode.TextEditorRevealType.InCenter,
+        );
     }
 }

--- a/vscode-extension/src/gradleService.ts
+++ b/vscode-extension/src/gradleService.ts
@@ -1,10 +1,21 @@
-import * as path from 'path';
-import * as fs from 'fs';
-import { AccessibilityFinding, AccessibilityReport, Capture, DoctorModuleReport, PreviewManifest, PreviewRenderError, ResourceManifest } from './types';
-import { appliesPlugin } from './pluginDetection';
-import { JdkImageError, JdkImageErrorDetector } from './jdkImageErrorDetector';
-import { KotlinCompileError, KotlinCompileErrorDetector } from './kotlinCompileErrorDetector';
-import { LogFilter } from './logFilter';
+import * as path from "path";
+import * as fs from "fs";
+import {
+    AccessibilityFinding,
+    AccessibilityReport,
+    Capture,
+    DoctorModuleReport,
+    PreviewManifest,
+    PreviewRenderError,
+    ResourceManifest,
+} from "./types";
+import { appliesPlugin } from "./pluginDetection";
+import { JdkImageError, JdkImageErrorDetector } from "./jdkImageErrorDetector";
+import {
+    KotlinCompileError,
+    KotlinCompileErrorDetector,
+} from "./kotlinCompileErrorDetector";
+import { LogFilter } from "./logFilter";
 
 /**
  * Expands a parameterized preview's single template capture into N captures
@@ -25,33 +36,62 @@ function expandParamCaptures(
     templates: Capture[],
     siblingRenderOutputs: Set<string>,
 ): Capture[] {
-    if (!fs.existsSync(rendersDir)) { return templates; }
+    if (!fs.existsSync(rendersDir)) {
+        return templates;
+    }
     const expanded: Capture[] = [];
     for (const template of templates) {
-        if (!template.renderOutput) { expanded.push(template); continue; }
+        if (!template.renderOutput) {
+            expanded.push(template);
+            continue;
+        }
         const base = path.basename(template.renderOutput);
-        const dot = base.lastIndexOf('.');
+        const dot = base.lastIndexOf(".");
         const stem = dot > 0 ? base.slice(0, dot) : base;
-        const ext = dot > 0 ? base.slice(dot) : '';
-        const prefix = stem + '_';
+        const ext = dot > 0 ? base.slice(dot) : "";
+        const prefix = stem + "_";
         const templateDir = path.dirname(template.renderOutput);
-        const dirPrefix = templateDir && templateDir !== '.' ? `${templateDir}/` : '';
-        const matches = fs.readdirSync(rendersDir)
-            .filter(name => name.startsWith(prefix) && name.endsWith(ext)
-                && !siblingRenderOutputs.has(dirPrefix + name))
-            .map(name => {
-                const suffix = name.slice(prefix.length, name.length - ext.length);
-                const paramIdxStr = suffix.startsWith('PARAM_') ? suffix.slice('PARAM_'.length) : null;
-                const paramIdx = paramIdxStr !== null ? parseInt(paramIdxStr, 10) : NaN;
-                return { name, suffix, paramIdx: Number.isNaN(paramIdx) ? null : paramIdx };
+        const dirPrefix =
+            templateDir && templateDir !== "." ? `${templateDir}/` : "";
+        const matches = fs
+            .readdirSync(rendersDir)
+            .filter(
+                (name) =>
+                    name.startsWith(prefix) &&
+                    name.endsWith(ext) &&
+                    !siblingRenderOutputs.has(dirPrefix + name),
+            )
+            .map((name) => {
+                const suffix = name.slice(
+                    prefix.length,
+                    name.length - ext.length,
+                );
+                const paramIdxStr = suffix.startsWith("PARAM_")
+                    ? suffix.slice("PARAM_".length)
+                    : null;
+                const paramIdx =
+                    paramIdxStr !== null ? parseInt(paramIdxStr, 10) : NaN;
+                return {
+                    name,
+                    suffix,
+                    paramIdx: Number.isNaN(paramIdx) ? null : paramIdx,
+                };
             })
             .sort((a, b) => {
-                if (a.paramIdx !== null && b.paramIdx !== null) { return a.paramIdx - b.paramIdx; }
-                if (a.paramIdx !== null) { return -1; }
-                if (b.paramIdx !== null) { return 1; }
+                if (a.paramIdx !== null && b.paramIdx !== null) {
+                    return a.paramIdx - b.paramIdx;
+                }
+                if (a.paramIdx !== null) {
+                    return -1;
+                }
+                if (b.paramIdx !== null) {
+                    return 1;
+                }
                 return a.suffix.localeCompare(b.suffix);
             });
-        if (matches.length === 0) { continue; }
+        if (matches.length === 0) {
+            continue;
+        }
         for (const match of matches) {
             expanded.push({
                 advanceTimeMillis: template.advanceTimeMillis,
@@ -78,7 +118,7 @@ const MANIFEST_CACHE_TTL_MS = 30_000;
 export class TaskCancelledError extends Error {
     constructor(public readonly task: string) {
         super(`Gradle task ${task} was cancelled.`);
-        this.name = 'TaskCancelledError';
+        this.name = "TaskCancelledError";
     }
 }
 
@@ -90,12 +130,17 @@ const CANCELLED_RE = /\bCANCELLED\b/i;
 // task names take the colon-separated form (`:samples:wear:foo`) — convert
 // at task-name construction sites only.
 function gradleProjectPath(module: string): string {
-    return ':' + module.split('/').join(':');
+    return ":" + module.split("/").join(":");
 }
 
 const SCAN_SKIP_DIRS = new Set([
-    'node_modules', 'build', 'gradle', 'src', 'out', 'dist',
-    '.compose-preview-history',
+    "node_modules",
+    "build",
+    "gradle",
+    "src",
+    "out",
+    "dist",
+    ".compose-preview-history",
 ]);
 const SCAN_MAX_DEPTH = 4;
 
@@ -136,10 +181,17 @@ export interface GradleApi {
         taskName: string;
         args?: ReadonlyArray<string>;
         showOutputColors: boolean;
-        onOutput?: (output: { getOutputBytes(): Uint8Array; getOutputType(): number }) => void;
+        onOutput?: (output: {
+            getOutputBytes(): Uint8Array;
+            getOutputType(): number;
+        }) => void;
         cancellationKey?: string;
     }): Promise<void>;
-    cancelRunTask(opts: { projectFolder: string; taskName: string; cancellationKey?: string }): Promise<void>;
+    cancelRunTask(opts: {
+        projectFolder: string;
+        taskName: string;
+        cancellationKey?: string;
+    }): Promise<void>;
 }
 
 export class GradleService {
@@ -151,7 +203,10 @@ export class GradleService {
     private gradleApi: GradleApi;
     private argsProvider: () => string[];
     private logFilter: LogFilter;
-    private manifestCache = new Map<string, { manifest: PreviewManifest; timestamp: number }>();
+    private manifestCache = new Map<
+        string,
+        { manifest: PreviewManifest; timestamp: number }
+    >();
     private taskCounter = 0;
     private activeKeys = new Set<string>();
 
@@ -169,12 +224,19 @@ export class GradleService {
         this.logFilter = logFilter ?? new LogFilter();
     }
 
-    async discoverPreviews(module: string, opts?: TaskOptions): Promise<PreviewManifest | null> {
+    async discoverPreviews(
+        module: string,
+        opts?: TaskOptions,
+    ): Promise<PreviewManifest | null> {
         const cached = this.manifestCache.get(module);
         if (cached && Date.now() - cached.timestamp < MANIFEST_CACHE_TTL_MS) {
             return cached.manifest;
         }
-        await this.runTask(`${gradleProjectPath(module)}:discoverPreviews`, [], opts);
+        await this.runTask(
+            `${gradleProjectPath(module)}:discoverPreviews`,
+            [],
+            opts,
+        );
         const manifest = this.readManifest(module);
         if (manifest) {
             this.manifestCache.set(module, { manifest, timestamp: Date.now() });
@@ -197,7 +259,11 @@ export class GradleService {
      */
     async compileOnly(module: string, opts?: TaskOptions): Promise<void> {
         this.manifestCache.delete(module);
-        await this.runTask(`${gradleProjectPath(module)}:composePreviewCompile`, [], opts);
+        await this.runTask(
+            `${gradleProjectPath(module)}:composePreviewCompile`,
+            [],
+            opts,
+        );
     }
 
     /**
@@ -219,7 +285,7 @@ export class GradleService {
      */
     async renderPreviews(
         module: string,
-        tier: 'fast' | 'full' = 'full',
+        tier: "fast" | "full" = "full",
         opts?: TaskOptions,
     ): Promise<PreviewManifest | null> {
         this.manifestCache.delete(module);
@@ -243,7 +309,11 @@ export class GradleService {
      * caller can surface the message to the user.
      */
     async installDebug(module: string, opts?: TaskOptions): Promise<void> {
-        await this.runTask(`${gradleProjectPath(module)}:installDebug`, [], opts);
+        await this.runTask(
+            `${gradleProjectPath(module)}:installDebug`,
+            [],
+            opts,
+        );
     }
 
     /**
@@ -261,30 +331,47 @@ export class GradleService {
         try {
             await this.runTask(task);
         } catch (e) {
-            this.logger.appendLine(`[doctor] ${task} failed: ${(e as Error).message}`);
+            this.logger.appendLine(
+                `[doctor] ${task} failed: ${(e as Error).message}`,
+            );
             return null;
         }
-        const reportPath = path.join(this.workspaceRoot, module, 'build', 'compose-previews', 'doctor.json');
+        const reportPath = path.join(
+            this.workspaceRoot,
+            module,
+            "build",
+            "compose-previews",
+            "doctor.json",
+        );
         if (!fs.existsSync(reportPath)) {
             this.logger.appendLine(`[doctor] ${reportPath} not produced`);
             return null;
         }
         try {
-            const parsed = JSON.parse(fs.readFileSync(reportPath, 'utf-8')) as DoctorModuleReport;
-            if (!parsed.schema?.startsWith('compose-preview-doctor/')) {
-                this.logger.appendLine(`[doctor] unexpected schema in ${reportPath}: ${parsed.schema}`);
+            const parsed = JSON.parse(
+                fs.readFileSync(reportPath, "utf-8"),
+            ) as DoctorModuleReport;
+            if (!parsed.schema?.startsWith("compose-preview-doctor/")) {
+                this.logger.appendLine(
+                    `[doctor] unexpected schema in ${reportPath}: ${parsed.schema}`,
+                );
                 return null;
             }
             return parsed;
         } catch (e) {
-            this.logger.appendLine(`[doctor] parse failed for ${reportPath}: ${(e as Error).message}`);
+            this.logger.appendLine(
+                `[doctor] parse failed for ${reportPath}: ${(e as Error).message}`,
+            );
             return null;
         }
     }
 
     invalidateCache(module?: string): void {
-        if (module) { this.manifestCache.delete(module); }
-        else { this.manifestCache.clear(); }
+        if (module) {
+            this.manifestCache.delete(module);
+        } else {
+            this.manifestCache.clear();
+        }
     }
 
     /**
@@ -299,27 +386,54 @@ export class GradleService {
      * use the raw shape directly.
      */
     readResourceManifest(module: string): ResourceManifest | null {
-        const manifestPath = path.join(this.workspaceRoot, module, 'build', 'compose-previews', 'resources.json');
-        if (!fs.existsSync(manifestPath)) { return null; }
+        const manifestPath = path.join(
+            this.workspaceRoot,
+            module,
+            "build",
+            "compose-previews",
+            "resources.json",
+        );
+        if (!fs.existsSync(manifestPath)) {
+            return null;
+        }
         try {
-            const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as ResourceManifest;
-            if (!Array.isArray(manifest.resources) || !Array.isArray(manifest.manifestReferences)) {
-                this.logger.appendLine(`Malformed resource manifest at ${manifestPath}`);
+            const manifest = JSON.parse(
+                fs.readFileSync(manifestPath, "utf-8"),
+            ) as ResourceManifest;
+            if (
+                !Array.isArray(manifest.resources) ||
+                !Array.isArray(manifest.manifestReferences)
+            ) {
+                this.logger.appendLine(
+                    `Malformed resource manifest at ${manifestPath}`,
+                );
                 return null;
             }
             return manifest;
         } catch (e: unknown) {
             const message = e instanceof Error ? e.message : String(e);
-            this.logger.appendLine(`Failed to parse ${manifestPath}: ${message}`);
+            this.logger.appendLine(
+                `Failed to parse ${manifestPath}: ${message}`,
+            );
             return null;
         }
     }
 
     readManifest(module: string): PreviewManifest | null {
-        const manifestPath = path.join(this.workspaceRoot, module, 'build', 'compose-previews', 'previews.json');
-        if (!fs.existsSync(manifestPath)) { return null; }
+        const manifestPath = path.join(
+            this.workspaceRoot,
+            module,
+            "build",
+            "compose-previews",
+            "previews.json",
+        );
+        if (!fs.existsSync(manifestPath)) {
+            return null;
+        }
         try {
-            const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as PreviewManifest;
+            const manifest = JSON.parse(
+                fs.readFileSync(manifestPath, "utf-8"),
+            ) as PreviewManifest;
             if (!manifest.previews || !Array.isArray(manifest.previews)) {
                 this.logger.appendLine(`Malformed manifest at ${manifestPath}`);
                 return null;
@@ -331,18 +445,30 @@ export class GradleService {
             // before any downstream consumer (carousel, hover, image loader)
             // sees the preview, so the UI walks N files instead of trying to
             // read the template path (which never exists).
-            const rendersDir = path.join(this.workspaceRoot, module, 'build', 'compose-previews', 'renders');
+            const rendersDir = path.join(
+                this.workspaceRoot,
+                module,
+                "build",
+                "compose-previews",
+                "renders",
+            );
             const siblingRenderOutputs = new Set<string>();
             for (const p of manifest.previews) {
                 if (!p.params?.previewParameterProviderClassName) {
                     for (const c of p.captures) {
-                        if (c.renderOutput) { siblingRenderOutputs.add(c.renderOutput); }
+                        if (c.renderOutput) {
+                            siblingRenderOutputs.add(c.renderOutput);
+                        }
                     }
                 }
             }
             for (const p of manifest.previews) {
                 if (p.params?.previewParameterProviderClassName) {
-                    p.captures = expandParamCaptures(rendersDir, p.captures, siblingRenderOutputs);
+                    p.captures = expandParamCaptures(
+                        rendersDir,
+                        p.captures,
+                        siblingRenderOutputs,
+                    );
                 }
             }
             // Enrich each preview with a11y findings when the module has the
@@ -351,7 +477,10 @@ export class GradleService {
             // remove findings from the UI without a stale opt-in run
             // haunting us.
             if (manifest.accessibilityReport) {
-                const byId = this.readA11yById(module, manifest.accessibilityReport);
+                const byId = this.readA11yById(
+                    module,
+                    manifest.accessibilityReport,
+                );
                 for (const p of manifest.previews) {
                     const entry = byId[p.id];
                     p.a11yFindings = entry?.findings ?? [];
@@ -366,7 +495,9 @@ export class GradleService {
             return manifest;
         } catch (e: unknown) {
             const message = e instanceof Error ? e.message : String(e);
-            this.logger.appendLine(`Failed to parse ${manifestPath}: ${message}`);
+            this.logger.appendLine(
+                `Failed to parse ${manifestPath}: ${message}`,
+            );
             return null;
         }
     }
@@ -380,20 +511,40 @@ export class GradleService {
     private readA11yById(
         module: string,
         relativePath: string,
-    ): Record<string, { findings: AccessibilityFinding[]; annotatedPath: string | null }> {
-        const reportPath = path.join(this.workspaceRoot, module, 'build', 'compose-previews', relativePath);
-        if (!fs.existsSync(reportPath)) { return {}; }
+    ): Record<
+        string,
+        { findings: AccessibilityFinding[]; annotatedPath: string | null }
+    > {
+        const reportPath = path.join(
+            this.workspaceRoot,
+            module,
+            "build",
+            "compose-previews",
+            relativePath,
+        );
+        if (!fs.existsSync(reportPath)) {
+            return {};
+        }
         try {
-            const report = JSON.parse(fs.readFileSync(reportPath, 'utf-8')) as AccessibilityReport;
+            const report = JSON.parse(
+                fs.readFileSync(reportPath, "utf-8"),
+            ) as AccessibilityReport;
             const reportDir = path.dirname(reportPath);
-            const out: Record<string, { findings: AccessibilityFinding[]; annotatedPath: string | null }> = {};
+            const out: Record<
+                string,
+                {
+                    findings: AccessibilityFinding[];
+                    annotatedPath: string | null;
+                }
+            > = {};
             for (const entry of report.entries ?? []) {
                 const resolved = entry.annotatedPath
                     ? path.resolve(reportDir, entry.annotatedPath)
                     : null;
                 out[entry.previewId] = {
                     findings: entry.findings ?? [],
-                    annotatedPath: resolved && fs.existsSync(resolved) ? resolved : null,
+                    annotatedPath:
+                        resolved && fs.existsSync(resolved) ? resolved : null,
                 };
             }
             return out;
@@ -404,11 +555,20 @@ export class GradleService {
         }
     }
 
-    async readPreviewImage(module: string, renderOutput: string): Promise<string | null> {
-        const pngPath = path.join(this.workspaceRoot, module, 'build', 'compose-previews', renderOutput);
+    async readPreviewImage(
+        module: string,
+        renderOutput: string,
+    ): Promise<string | null> {
+        const pngPath = path.join(
+            this.workspaceRoot,
+            module,
+            "build",
+            "compose-previews",
+            renderOutput,
+        );
         try {
             const data = await fs.promises.readFile(pngPath);
-            return data.toString('base64');
+            return data.toString("base64");
         } catch {
             return null;
         }
@@ -426,15 +586,24 @@ export class GradleService {
      * extension finds the sidecar by trivial string-concat on the
      * manifest's existing `renderOutput` path.
      */
-    async readPreviewRenderError(module: string, renderOutput: string): Promise<PreviewRenderError | null> {
+    async readPreviewRenderError(
+        module: string,
+        renderOutput: string,
+    ): Promise<PreviewRenderError | null> {
         const sidecarPath = path.join(
-            this.workspaceRoot, module, 'build', 'compose-previews', `${renderOutput}.error.json`,
+            this.workspaceRoot,
+            module,
+            "build",
+            "compose-previews",
+            `${renderOutput}.error.json`,
         );
         try {
-            const text = await fs.promises.readFile(sidecarPath, 'utf-8');
+            const text = await fs.promises.readFile(sidecarPath, "utf-8");
             const parsed = JSON.parse(text) as PreviewRenderError;
-            if (!parsed.schema?.startsWith('compose-preview-error/')) {
-                this.logger.appendLine(`[render-error] unexpected schema in ${sidecarPath}: ${parsed.schema}`);
+            if (!parsed.schema?.startsWith("compose-preview-error/")) {
+                this.logger.appendLine(
+                    `[render-error] unexpected schema in ${sidecarPath}: ${parsed.schema}`,
+                );
                 return null;
             }
             return parsed;
@@ -443,8 +612,10 @@ export class GradleService {
             // Anything else is logged so a malformed file is debuggable
             // without surprising the user with a generic banner.
             const err = e as NodeJS.ErrnoException;
-            if (err && err.code !== 'ENOENT') {
-                this.logger.appendLine(`[render-error] failed to read ${sidecarPath}: ${err.message ?? err}`);
+            if (err && err.code !== "ENOENT") {
+                this.logger.appendLine(
+                    `[render-error] failed to read ${sidecarPath}: ${err.message ?? err}`,
+                );
             }
             return null;
         }
@@ -457,10 +628,12 @@ export class GradleService {
             try {
                 await this.gradleApi.cancelRunTask({
                     projectFolder: this.workspaceRoot,
-                    taskName: key.split('|')[1],
+                    taskName: key.split("|")[1],
                     cancellationKey: key,
                 });
-            } catch { /* ignore */ }
+            } catch {
+                /* ignore */
+            }
         }
     }
 
@@ -493,8 +666,12 @@ export class GradleService {
     findPreviewModules(): string[] {
         const found = new Set<string>();
         const walk = (relDir: string, depth: number): void => {
-            if (depth > SCAN_MAX_DEPTH) { return; }
-            const absDir = relDir ? path.join(this.workspaceRoot, relDir) : this.workspaceRoot;
+            if (depth > SCAN_MAX_DEPTH) {
+                return;
+            }
+            const absDir = relDir
+                ? path.join(this.workspaceRoot, relDir)
+                : this.workspaceRoot;
             let entries: fs.Dirent[];
             try {
                 entries = fs.readdirSync(absDir, { withFileTypes: true });
@@ -502,26 +679,46 @@ export class GradleService {
                 return;
             }
             for (const entry of entries) {
-                if (!entry.isDirectory()) { continue; }
-                if (entry.name.startsWith('.')) { continue; }
-                if (SCAN_SKIP_DIRS.has(entry.name)) { continue; }
-                const childRel = relDir ? `${relDir}/${entry.name}` : entry.name;
+                if (!entry.isDirectory()) {
+                    continue;
+                }
+                if (entry.name.startsWith(".")) {
+                    continue;
+                }
+                if (SCAN_SKIP_DIRS.has(entry.name)) {
+                    continue;
+                }
+                const childRel = relDir
+                    ? `${relDir}/${entry.name}`
+                    : entry.name;
                 const marker = path.join(
-                    this.workspaceRoot, childRel, 'build', 'compose-previews', 'applied.json',
+                    this.workspaceRoot,
+                    childRel,
+                    "build",
+                    "compose-previews",
+                    "applied.json",
                 );
                 if (fs.existsSync(marker)) {
                     found.add(childRel);
                 } else {
-                    const buildFile = path.join(this.workspaceRoot, childRel, 'build.gradle.kts');
+                    const buildFile = path.join(
+                        this.workspaceRoot,
+                        childRel,
+                        "build.gradle.kts",
+                    );
                     try {
-                        const content = fs.readFileSync(buildFile, 'utf-8');
-                        if (appliesPlugin(content)) { found.add(childRel); }
-                    } catch { /* skip */ }
+                        const content = fs.readFileSync(buildFile, "utf-8");
+                        if (appliesPlugin(content)) {
+                            found.add(childRel);
+                        }
+                    } catch {
+                        /* skip */
+                    }
                 }
                 walk(childRel, depth + 1);
             }
         };
-        walk('', 0);
+        walk("", 0);
         return [...found].sort();
     }
 
@@ -540,7 +737,7 @@ export class GradleService {
      */
     async bootstrapAppliedMarkers(): Promise<void> {
         try {
-            await this.runTask('composePreviewApplied');
+            await this.runTask("composePreviewApplied");
         } catch (e) {
             this.logger.appendLine(
                 `[applied] composePreviewApplied bootstrap failed: ${(e as Error).message}`,
@@ -555,24 +752,36 @@ export class GradleService {
      * path is enabled (`composePreview.daemon.enabled`); the caller (DaemonGate) handles errors.
      */
     async runDaemonBootstrap(module: string): Promise<void> {
-        await this.runTask(`${gradleProjectPath(module)}:composePreviewDaemonStart`);
+        await this.runTask(
+            `${gradleProjectPath(module)}:composePreviewDaemonStart`,
+        );
     }
 
     resolveModule(filePath: string): string | null {
         const relative = path.relative(this.workspaceRoot, filePath);
-        if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+        if (
+            !relative ||
+            relative.startsWith("..") ||
+            path.isAbsolute(relative)
+        ) {
             return null;
         }
         // Split on either separator so the same path works on Windows and POSIX.
-        const segments = relative.split(/[\\/]+/).filter((s: string) => s.length > 0);
-        if (segments.length < 2) { return null; }
+        const segments = relative
+            .split(/[\\/]+/)
+            .filter((s: string) => s.length > 0);
+        if (segments.length < 2) {
+            return null;
+        }
         const modules = new Set(this.findPreviewModules());
         // Longest-prefix match: walk from deepest possible module path to
         // shallowest. With nested modules (e.g. `:foo:bar` inside `:foo`)
         // we prefer the more specific match.
         for (let n = segments.length - 1; n >= 1; n--) {
-            const candidate = segments.slice(0, n).join('/');
-            if (modules.has(candidate)) { return candidate; }
+            const candidate = segments.slice(0, n).join("/");
+            if (modules.has(candidate)) {
+                return candidate;
+            }
         }
         return null;
     }
@@ -589,7 +798,9 @@ export class GradleService {
         const cancellationKey = `compose-preview-${++this.taskCounter}|${task}`;
         this.activeKeys.add(cancellationKey);
         const startLine = `> ${task}`;
-        if (this.logFilter.shouldEmitInformational(startLine)) { this.logger.appendLine(startLine); }
+        if (this.logFilter.shouldEmitInformational(startLine)) {
+            this.logger.appendLine(startLine);
+        }
 
         const detector = new JdkImageErrorDetector();
         // Parse `e:` lines from the Kotlin compiler so the panel banner
@@ -600,66 +811,88 @@ export class GradleService {
 
         const timeoutPromise = new Promise<never>((_, reject) => {
             setTimeout(() => {
-                this.gradleApi.cancelRunTask({
-                    projectFolder: this.workspaceRoot,
-                    taskName: task,
-                    cancellationKey,
-                }).catch(() => { /* ignore */ });
-                reject(new Error(`Gradle task ${task} timed out after ${TASK_TIMEOUT_MS / 1000}s`));
+                this.gradleApi
+                    .cancelRunTask({
+                        projectFolder: this.workspaceRoot,
+                        taskName: task,
+                        cancellationKey,
+                    })
+                    .catch(() => {
+                        /* ignore */
+                    });
+                reject(
+                    new Error(
+                        `Gradle task ${task} timed out after ${TASK_TIMEOUT_MS / 1000}s`,
+                    ),
+                );
             }, TASK_TIMEOUT_MS);
         });
 
-        const taskPromise = this.gradleApi.runTask({
-            projectFolder: this.workspaceRoot,
-            taskName: task,
-            args: [...this.argsProvider(), ...extraArgs],
-            showOutputColors: false,
-            cancellationKey,
-            onOutput: (output) => {
-                try {
-                    const decoded = new TextDecoder().decode(output.getOutputBytes());
-                    // Detector still sees the raw stream — it pattern-matches
-                    // on JDK image errors that the filter would suppress at
-                    // normal level (the noisy lines are exactly the ones that
-                    // contain the diagnostic).
-                    detector.consume(decoded);
-                    kotlinDetector.consume(decoded);
-                    const filtered = this.logFilter.filterGradleChunk(decoded);
-                    if (filtered.length > 0) { this.logger.append(filtered); }
-                    opts.onTaskOutput?.(decoded);
-                } catch { /* ignore */ }
-            },
-        }).then(
-            () => {
-                const line = `> ${task} completed`;
-                if (this.logFilter.shouldEmitInformational(line)) { this.logger.appendLine(line); }
-            },
-            (err) => {
-                const message = err?.message ?? String(err);
-                // vscode-gradle reports a superseded task as a gRPC CANCELLED
-                // error — that's the normal "new refresh replaced this one"
-                // path, not a build failure. Log it differently and throw a
-                // typed error so callers can drop it silently.
-                if (CANCELLED_RE.test(message)) {
-                    this.logger.appendLine(`> ${task} cancelled`);
-                    throw new TaskCancelledError(task);
-                }
-                this.logger.appendLine(`> ${task} FAILED: ${message}`);
-                detector.end();
-                kotlinDetector.end();
-                const finding = detector.getFinding();
-                if (finding) {
-                    throw new JdkImageError(finding, task);
-                }
-                const kotlinErrors = kotlinDetector.getErrors();
-                if (kotlinErrors.length > 0) {
-                    throw new KotlinCompileError(kotlinErrors, task);
-                }
-                throw new Error(`Gradle task ${task} failed. See Output > Compose Preview.`);
-            },
-        ).finally(() => {
-            this.activeKeys.delete(cancellationKey);
-        });
+        const taskPromise = this.gradleApi
+            .runTask({
+                projectFolder: this.workspaceRoot,
+                taskName: task,
+                args: [...this.argsProvider(), ...extraArgs],
+                showOutputColors: false,
+                cancellationKey,
+                onOutput: (output) => {
+                    try {
+                        const decoded = new TextDecoder().decode(
+                            output.getOutputBytes(),
+                        );
+                        // Detector still sees the raw stream — it pattern-matches
+                        // on JDK image errors that the filter would suppress at
+                        // normal level (the noisy lines are exactly the ones that
+                        // contain the diagnostic).
+                        detector.consume(decoded);
+                        kotlinDetector.consume(decoded);
+                        const filtered =
+                            this.logFilter.filterGradleChunk(decoded);
+                        if (filtered.length > 0) {
+                            this.logger.append(filtered);
+                        }
+                        opts.onTaskOutput?.(decoded);
+                    } catch {
+                        /* ignore */
+                    }
+                },
+            })
+            .then(
+                () => {
+                    const line = `> ${task} completed`;
+                    if (this.logFilter.shouldEmitInformational(line)) {
+                        this.logger.appendLine(line);
+                    }
+                },
+                (err) => {
+                    const message = err?.message ?? String(err);
+                    // vscode-gradle reports a superseded task as a gRPC CANCELLED
+                    // error — that's the normal "new refresh replaced this one"
+                    // path, not a build failure. Log it differently and throw a
+                    // typed error so callers can drop it silently.
+                    if (CANCELLED_RE.test(message)) {
+                        this.logger.appendLine(`> ${task} cancelled`);
+                        throw new TaskCancelledError(task);
+                    }
+                    this.logger.appendLine(`> ${task} FAILED: ${message}`);
+                    detector.end();
+                    kotlinDetector.end();
+                    const finding = detector.getFinding();
+                    if (finding) {
+                        throw new JdkImageError(finding, task);
+                    }
+                    const kotlinErrors = kotlinDetector.getErrors();
+                    if (kotlinErrors.length > 0) {
+                        throw new KotlinCompileError(kotlinErrors, task);
+                    }
+                    throw new Error(
+                        `Gradle task ${task} failed. See Output > Compose Preview.`,
+                    );
+                },
+            )
+            .finally(() => {
+                this.activeKeys.delete(cancellationKey);
+            });
 
         return Promise.race([taskPromise, timeoutPromise]);
     }

--- a/vscode-extension/src/historyPanel.ts
+++ b/vscode-extension/src/historyPanel.ts
@@ -1,13 +1,13 @@
-import * as fs from 'fs';
-import * as vscode from 'vscode';
-import { HistoryReader } from './daemon/historyReader';
-import { CurrentRendersHistory } from './daemon/currentRendersHistory';
+import * as fs from "fs";
+import * as vscode from "vscode";
+import { HistoryReader } from "./daemon/historyReader";
+import { CurrentRendersHistory } from "./daemon/currentRendersHistory";
 import {
     HistoryAddedParams,
     HistoryListResult,
     HistoryReadResult,
     HistorySourceKind,
-} from './daemon/daemonProtocol';
+} from "./daemon/daemonProtocol";
 
 /**
  * Read-only Preview History panel — HISTORY.md § "VS Code integration".
@@ -32,7 +32,7 @@ import {
  * timeline today; that's H14 (cross-worktree merge in MCP).
  */
 export class HistoryPanel implements vscode.WebviewViewProvider {
-    public static readonly viewId = 'composePreview.historyPanel';
+    public static readonly viewId = "composePreview.historyPanel";
 
     private view?: vscode.WebviewView;
     private currentScope: HistoryScope | null = null;
@@ -53,29 +53,44 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
             localResourceRoots: [this.extensionUri],
         };
         webviewView.webview.html = this.getHtml(webviewView.webview);
-        webviewView.webview.onDidReceiveMessage((msg) => this.handleMessage(msg));
+        webviewView.webview.onDidReceiveMessage((msg) =>
+            this.handleMessage(msg),
+        );
         // Re-list whenever the view becomes visible (lazy panel UX).
         webviewView.onDidChangeVisibility(() => {
-            if (webviewView.visible) { void this.refresh(); }
+            if (webviewView.visible) {
+                void this.refresh();
+            }
         });
-        if (this.currentScope) { void this.refresh(); }
+        if (this.currentScope) {
+            void this.refresh();
+        }
     }
 
     /** Re-scope the panel to a different module's history. Called from
      *  extension.ts when the active editor's module changes. */
     setScope(scope: HistoryScope | null): void {
         this.currentScope = scope;
-        if (this.view?.visible) { void this.refresh(); }
+        if (this.view?.visible) {
+            void this.refresh();
+        }
     }
 
     /** Daemon push: a new render landed. If it belongs to the currently-
      *  scoped module and previewId, prepend it to the visible list and
      *  highlight it briefly. Drops cleanly when the panel isn't open. */
     onHistoryAdded(params: HistoryAddedParams): void {
-        if (!this.view) { return; }
+        if (!this.view) {
+            return;
+        }
         const entry = params.entry as { previewId?: string; module?: string };
-        if (!matchesScope(entry, this.currentScope)) { return; }
-        this.view.webview.postMessage({ command: 'entryAdded', entry: params.entry });
+        if (!matchesScope(entry, this.currentScope)) {
+            return;
+        }
+        this.view.webview.postMessage({
+            command: "entryAdded",
+            entry: params.entry,
+        });
     }
 
     isVisible(): boolean {
@@ -85,8 +100,14 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
     /** Force a re-list against the current scope. */
     async refresh(): Promise<void> {
         if (!this.view || !this.currentScope) {
-            this.view?.webview.postMessage({ command: 'showMessage', text: 'Open a Kotlin file to see its render history.' });
-            this.view?.webview.postMessage({ command: 'setScopeLabel', label: null });
+            this.view?.webview.postMessage({
+                command: "showMessage",
+                text: "Open a Kotlin file to see its render history.",
+            });
+            this.view?.webview.postMessage({
+                command: "setScopeLabel",
+                label: null,
+            });
             return;
         }
         if (!this.currentScope.previewId) {
@@ -95,21 +116,25 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
             // timeline they're looking at. Require a single preview be
             // selected (focus mode, or filters narrowed to one card) and
             // show a hint until then.
-            this.view.webview.postMessage({ command: 'setScopeLabel', label: null });
             this.view.webview.postMessage({
-                command: 'showMessage',
-                text: 'Select a single preview (focus mode, or narrow the filter to one card) to see its render history.',
+                command: "setScopeLabel",
+                label: null,
+            });
+            this.view.webview.postMessage({
+                command: "showMessage",
+                text: "Select a single preview (focus mode, or narrow the filter to one card) to see its render history.",
             });
             return;
         }
-        const label = this.currentScope.previewLabel ?? this.currentScope.previewId;
-        this.view.webview.postMessage({ command: 'setScopeLabel', label });
+        const label =
+            this.currentScope.previewLabel ?? this.currentScope.previewId;
+        this.view.webview.postMessage({ command: "setScopeLabel", label });
         try {
             const result = await this.source.list(this.currentScope);
-            this.view.webview.postMessage({ command: 'setEntries', result });
+            this.view.webview.postMessage({ command: "setEntries", result });
         } catch (err) {
             this.view.webview.postMessage({
-                command: 'showMessage',
+                command: "showMessage",
                 text: `History unavailable: ${(err as Error).message}`,
             });
         }
@@ -117,61 +142,98 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
 
     private async handleMessage(msg: HistoryWebviewMessage): Promise<void> {
         switch (msg.command) {
-            case 'refresh':
+            case "refresh":
                 await this.refresh();
                 break;
-            case 'loadImage':
-                if (msg.id) { await this.sendImage(msg.id, 'expansion'); }
+            case "loadImage":
+                if (msg.id) {
+                    await this.sendImage(msg.id, "expansion");
+                }
                 break;
-            case 'loadThumb':
-                if (msg.id) { await this.sendImage(msg.id, 'thumb'); }
+            case "loadThumb":
+                if (msg.id) {
+                    await this.sendImage(msg.id, "thumb");
+                }
                 break;
-            case 'openSource':
+            case "openSource":
                 if (msg.sourceFile) {
                     const uri = vscode.Uri.file(msg.sourceFile);
                     await vscode.window.showTextDocument(uri);
                 }
                 break;
-            case 'diff':
+            case "diff":
                 if (msg.fromId && msg.toId) {
                     await this.runDiff(msg.fromId, msg.toId);
                 }
                 break;
-            case 'requestDiff':
-                if (msg.id && (msg.against === 'current' || msg.against === 'previous')) {
+            case "requestDiff":
+                if (
+                    msg.id &&
+                    (msg.against === "current" || msg.against === "previous")
+                ) {
                     await this.runPairDiff(msg.id, msg.against);
                 }
                 break;
         }
     }
 
-    private async runPairDiff(id: string, against: 'current' | 'previous'): Promise<void> {
-        if (!this.view) { return; }
+    private async runPairDiff(
+        id: string,
+        against: "current" | "previous",
+    ): Promise<void> {
+        if (!this.view) {
+            return;
+        }
         const scope = this.currentScope;
         if (!scope) {
-            this.view.webview.postMessage({ command: 'diffPairError', id, against, message: 'No active scope.' });
+            this.view.webview.postMessage({
+                command: "diffPairError",
+                id,
+                against,
+                message: "No active scope.",
+            });
             return;
         }
         try {
             const left = await this.source.read(id);
             if (!left) {
-                this.view.webview.postMessage({ command: 'diffPairError', id, against, message: 'Entry not found.' });
+                this.view.webview.postMessage({
+                    command: "diffPairError",
+                    id,
+                    against,
+                    message: "Entry not found.",
+                });
                 return;
             }
-            const leftEntry = left.entry as { previewId?: string; timestamp?: string };
+            const leftEntry = left.entry as {
+                previewId?: string;
+                timestamp?: string;
+            };
             const previewId = leftEntry.previewId ?? scope.previewId;
             if (!previewId) {
-                this.view.webview.postMessage({ command: 'diffPairError', id, against, message: 'Entry has no previewId.' });
+                this.view.webview.postMessage({
+                    command: "diffPairError",
+                    id,
+                    against,
+                    message: "Entry has no previewId.",
+                });
                 return;
             }
 
             let right: HistoryReadResult | null = null;
-            let rightLabel = '';
-            if (against === 'current') {
+            let rightLabel = "";
+            if (against === "current") {
                 const synthList = currentRendersFor(scope).list(previewId);
-                const synth = synthList.entries[0] as { id?: string; timestamp?: string } | undefined;
+                const synth = synthList.entries[0] as
+                    | { id?: string; timestamp?: string }
+                    | undefined;
                 if (!synth?.id) {
-                    this.view.webview.postMessage({ command: 'diffPairError', id, against, message: 'No live render available for this preview.' });
+                    this.view.webview.postMessage({
+                        command: "diffPairError",
+                        id,
+                        against,
+                        message: "No live render available for this preview.",
+                    });
                     return;
                 }
                 right = currentRendersFor(scope).read(synth.id);
@@ -181,29 +243,48 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
                 // Sort newest-first to match the panel; the entry just *after*
                 // the clicked one in this order is the older "previous".
                 const sorted = [...list.entries].sort((a, b) => {
-                    const at = (a as { timestamp?: string }).timestamp ?? '';
-                    const bt = (b as { timestamp?: string }).timestamp ?? '';
+                    const at = (a as { timestamp?: string }).timestamp ?? "";
+                    const bt = (b as { timestamp?: string }).timestamp ?? "";
                     return bt.localeCompare(at);
                 });
-                const idx = sorted.findIndex(e => (e as { id?: string }).id === id);
-                const prev = idx >= 0 ? sorted[idx + 1] as { id?: string; timestamp?: string } | undefined : undefined;
+                const idx = sorted.findIndex(
+                    (e) => (e as { id?: string }).id === id,
+                );
+                const prev =
+                    idx >= 0
+                        ? (sorted[idx + 1] as
+                              | { id?: string; timestamp?: string }
+                              | undefined)
+                        : undefined;
                 if (!prev?.id) {
-                    this.view.webview.postMessage({ command: 'diffPairError', id, against, message: 'No earlier entry for this preview.' });
+                    this.view.webview.postMessage({
+                        command: "diffPairError",
+                        id,
+                        against,
+                        message: "No earlier entry for this preview.",
+                    });
                     return;
                 }
                 right = await this.source.read(prev.id);
                 rightLabel = `Previous · ${formatLabelTime(prev.timestamp)}`;
             }
             if (!right) {
-                this.view.webview.postMessage({ command: 'diffPairError', id, against, message: 'Comparison entry not found.' });
+                this.view.webview.postMessage({
+                    command: "diffPairError",
+                    id,
+                    against,
+                    message: "Comparison entry not found.",
+                });
                 return;
             }
-            const leftBytes = left.pngBytes
-                ?? (await fs.promises.readFile(left.pngPath)).toString('base64');
-            const rightBytes = right.pngBytes
-                ?? (await fs.promises.readFile(right.pngPath)).toString('base64');
+            const leftBytes =
+                left.pngBytes ??
+                (await fs.promises.readFile(left.pngPath)).toString("base64");
+            const rightBytes =
+                right.pngBytes ??
+                (await fs.promises.readFile(right.pngPath)).toString("base64");
             this.view.webview.postMessage({
-                command: 'diffReady',
+                command: "diffReady",
                 id,
                 against,
                 leftLabel: `This entry · ${formatLabelTime(leftEntry.timestamp)}`,
@@ -213,41 +294,69 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
             });
         } catch (err) {
             this.view.webview.postMessage({
-                command: 'diffPairError', id, against, message: (err as Error).message,
+                command: "diffPairError",
+                id,
+                against,
+                message: (err as Error).message,
             });
         }
     }
 
-    private async sendImage(id: string, kind: 'expansion' | 'thumb'): Promise<void> {
-        if (!this.view) { return; }
-        const readyCmd = kind === 'thumb' ? 'thumbReady' : 'imageReady';
-        const errorCmd = kind === 'thumb' ? 'thumbError' : 'imageError';
+    private async sendImage(
+        id: string,
+        kind: "expansion" | "thumb",
+    ): Promise<void> {
+        if (!this.view) {
+            return;
+        }
+        const readyCmd = kind === "thumb" ? "thumbReady" : "imageReady";
+        const errorCmd = kind === "thumb" ? "thumbError" : "imageError";
         try {
             const result = await this.source.read(id);
             if (!result) {
-                this.view.webview.postMessage({ command: errorCmd, id, message: 'Entry not found.' });
+                this.view.webview.postMessage({
+                    command: errorCmd,
+                    id,
+                    message: "Entry not found.",
+                });
                 return;
             }
-            const bytes = result.pngBytes
-                ?? (await fs.promises.readFile(result.pngPath)).toString('base64');
+            const bytes =
+                result.pngBytes ??
+                (await fs.promises.readFile(result.pngPath)).toString("base64");
             this.view.webview.postMessage({
-                command: readyCmd, id, imageData: bytes, entry: result.entry,
+                command: readyCmd,
+                id,
+                imageData: bytes,
+                entry: result.entry,
             });
         } catch (err) {
             this.view.webview.postMessage({
-                command: errorCmd, id, message: (err as Error).message,
+                command: errorCmd,
+                id,
+                message: (err as Error).message,
             });
         }
     }
 
     private async runDiff(fromId: string, toId: string): Promise<void> {
-        if (!this.view) { return; }
+        if (!this.view) {
+            return;
+        }
         try {
             const result = await this.source.diff(fromId, toId);
-            this.view.webview.postMessage({ command: 'diffResult', fromId, toId, result });
+            this.view.webview.postMessage({
+                command: "diffResult",
+                fromId,
+                toId,
+                result,
+            });
         } catch (err) {
             this.view.webview.postMessage({
-                command: 'diffError', fromId, toId, message: (err as Error).message,
+                command: "diffError",
+                fromId,
+                toId,
+                message: (err as Error).message,
             });
         }
     }
@@ -255,10 +364,10 @@ export class HistoryPanel implements vscode.WebviewViewProvider {
     private getHtml(webview: vscode.Webview): string {
         const nonce = getNonce();
         const codiconUri = webview.asWebviewUri(
-            vscode.Uri.joinPath(this.extensionUri, 'media', 'codicon.css'),
+            vscode.Uri.joinPath(this.extensionUri, "media", "codicon.css"),
         );
         const styleUri = webview.asWebviewUri(
-            vscode.Uri.joinPath(this.extensionUri, 'media', 'preview.css'),
+            vscode.Uri.joinPath(this.extensionUri, "media", "preview.css"),
         );
         return /* html */ `<!DOCTYPE html>
 <html lang="en">
@@ -1011,13 +1120,17 @@ export function buildHistorySource(opts: BuildSourceOptions): HistorySource {
             // first render.
             if (result.entries.length === 0) {
                 const synth = currentRendersFor(scope).list(scope.previewId);
-                if (synth.entries.length > 0) { return synth; }
+                if (synth.entries.length > 0) {
+                    return synth;
+                }
             }
             return result;
         },
         read: async (id) => {
             const scope = opts.getCurrentScope();
-            if (!scope) { return null; }
+            if (!scope) {
+                return null;
+            }
             if (CurrentRendersHistory.isSyntheticId(id)) {
                 return currentRendersFor(scope).read(id);
             }
@@ -1034,12 +1147,16 @@ export function buildHistorySource(opts: BuildSourceOptions): HistorySource {
         },
         diff: async (fromId, toId) => {
             const scope = opts.getCurrentScope();
-            if (!scope) { return null; }
+            if (!scope) {
+                return null;
+            }
             // Synthetic "current render" entries don't have a stable prior
             // — diffing them is meaningless. Fall through to null so the
             // panel surfaces "Diff unavailable" instead of crashing.
-            if (CurrentRendersHistory.isSyntheticId(fromId)
-                || CurrentRendersHistory.isSyntheticId(toId)) {
+            if (
+                CurrentRendersHistory.isSyntheticId(fromId) ||
+                CurrentRendersHistory.isSyntheticId(toId)
+            ) {
                 return null;
             }
             if (opts.isDaemonReady(scope.moduleId)) {
@@ -1051,8 +1168,11 @@ export function buildHistorySource(opts: BuildSourceOptions): HistorySource {
                     );
                 }
             }
-            return new HistoryReader(historyDirFor(scope))
-                .diff(fromId, toId, 'metadata');
+            return new HistoryReader(historyDirFor(scope)).diff(
+                fromId,
+                toId,
+                "metadata",
+            );
         },
     };
 }
@@ -1087,15 +1207,22 @@ interface HistoryWebviewMessage {
     sourceFile?: string;
     fromId?: string;
     toId?: string;
-    against?: 'current' | 'previous';
+    against?: "current" | "previous";
 }
 
 function formatLabelTime(iso: string | undefined): string {
-    if (!iso) { return '(unknown time)'; }
+    if (!iso) {
+        return "(unknown time)";
+    }
     const t = Date.parse(iso);
-    if (isNaN(t)) { return iso; }
+    if (isNaN(t)) {
+        return iso;
+    }
     return new Date(t).toLocaleString(undefined, {
-        month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
     });
 }
 
@@ -1103,15 +1230,22 @@ function matchesScope(
     entry: { previewId?: string; module?: string },
     scope: HistoryScope | null,
 ): boolean {
-    if (!scope || !scope.previewId) { return false; }
-    if (entry.module !== scope.moduleId) { return false; }
-    if (entry.previewId !== scope.previewId) { return false; }
+    if (!scope || !scope.previewId) {
+        return false;
+    }
+    if (entry.module !== scope.moduleId) {
+        return false;
+    }
+    if (entry.previewId !== scope.previewId) {
+        return false;
+    }
     return true;
 }
 
 function getNonce(): string {
-    let text = '';
-    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let text = "";
+    const possible =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     for (let i = 0; i < 32; i++) {
         text += possible.charAt(Math.floor(Math.random() * possible.length));
     }

--- a/vscode-extension/src/jdkImageErrorDetector.ts
+++ b/vscode-extension/src/jdkImageErrorDetector.ts
@@ -27,7 +27,8 @@ export interface JdkImageFinding {
     reason: string;
 }
 
-const JLINK_RE = /jlink executable (\S+(?:\/bin\/jlink|\\bin\\jlink(?:\.exe)?))\s+does not exist/;
+const JLINK_RE =
+    /jlink executable (\S+(?:\/bin\/jlink|\\bin\\jlink(?:\.exe)?))\s+does not exist/;
 
 /**
  * Best-effort diagnosis of *why* the path is a JRE and not a JDK. Keyed off
@@ -35,24 +36,24 @@ const JLINK_RE = /jlink executable (\S+(?:\/bin\/jlink|\\bin\\jlink(?:\.exe)?))\
  * vendors match before the generic `/jre/` fallback.
  */
 function diagnose(jlinkPath: string): string {
-    const p = jlinkPath.replace(/\\/g, '/');
+    const p = jlinkPath.replace(/\\/g, "/");
     if (/\/\.antigravity\/extensions\/redhat\.java-/.test(p)) {
-        return 'Red Hat Java extension bundled runtime (Antigravity)';
+        return "Red Hat Java extension bundled runtime (Antigravity)";
     }
     if (/\/\.vscode(?:-server|-insiders)?\/extensions\/redhat\.java-/.test(p)) {
-        return 'Red Hat Java extension bundled runtime (VS Code)';
+        return "Red Hat Java extension bundled runtime (VS Code)";
     }
     if (/\/redhat\.java-[^/]+\/jre\//.test(p)) {
-        return 'Red Hat Java extension bundled runtime';
+        return "Red Hat Java extension bundled runtime";
     }
     if (/\/jre\/|\/jre$/.test(p)) {
-        return 'bundled JRE (no JDK)';
+        return "bundled JRE (no JDK)";
     }
-    return '';
+    return "";
 }
 
 export class JdkImageErrorDetector {
-    private buffer = '';
+    private buffer = "";
     private finding: JdkImageFinding | null = null;
 
     /**
@@ -62,32 +63,36 @@ export class JdkImageErrorDetector {
      * build output).
      */
     consume(chunk: string): void {
-        if (this.finding) { return; }
+        if (this.finding) {
+            return;
+        }
         this.buffer += chunk;
-        let nl = this.buffer.indexOf('\n');
+        let nl = this.buffer.indexOf("\n");
         while (nl !== -1) {
             const line = this.buffer.slice(0, nl);
             this.buffer = this.buffer.slice(nl + 1);
-            if (this.scanLine(line)) { return; }
-            nl = this.buffer.indexOf('\n');
+            if (this.scanLine(line)) {
+                return;
+            }
+            nl = this.buffer.indexOf("\n");
         }
         // Bound the buffer so a pathological producer emitting megabytes
         // without newlines can't grow it without limit. 16 KiB is far
         // larger than any single Gradle log line we care about.
         if (this.buffer.length > 16 * 1024) {
             this.scanLine(this.buffer);
-            this.buffer = '';
+            this.buffer = "";
         }
     }
 
     /** Flush the residual buffer. Call once after the stream ends. */
     end(): void {
         if (this.finding || this.buffer.length === 0) {
-            this.buffer = '';
+            this.buffer = "";
             return;
         }
         this.scanLine(this.buffer);
-        this.buffer = '';
+        this.buffer = "";
     }
 
     getFinding(): JdkImageFinding | null {
@@ -96,7 +101,9 @@ export class JdkImageErrorDetector {
 
     private scanLine(line: string): boolean {
         const m = JLINK_RE.exec(line);
-        if (!m) { return false; }
+        if (!m) {
+            return false;
+        }
         this.finding = { jlinkPath: m[1], reason: diagnose(m[1]) };
         return true;
     }
@@ -109,11 +116,14 @@ export class JdkImageErrorDetector {
  * "Gradle task failed" message.
  */
 export class JdkImageError extends Error {
-    constructor(readonly finding: JdkImageFinding, readonly task: string) {
+    constructor(
+        readonly finding: JdkImageFinding,
+        readonly task: string,
+    ) {
         super(
             `Gradle task ${task} failed: jlink not found at ${finding.jlinkPath}. ` +
-            `Gradle needs a full JDK (with jlink), not a JRE.`,
+                `Gradle needs a full JDK (with jlink), not a JRE.`,
         );
-        this.name = 'JdkImageError';
+        this.name = "JdkImageError";
     }
 }

--- a/vscode-extension/src/kotlinCompileErrorDetector.ts
+++ b/vscode-extension/src/kotlinCompileErrorDetector.ts
@@ -28,7 +28,7 @@
  * the user-visible log via the normal logger path.
  */
 
-import { CompileError } from './compileErrors';
+import { CompileError } from "./compileErrors";
 
 /**
  * Match `e:` lines emitted by `kotlinc`. The path can be either a
@@ -43,10 +43,11 @@ import { CompileError } from './compileErrors';
  * after we've matched the line/column digits, leaving the drive-letter
  * `:` inside the path capture.
  */
-const KOTLIN_ERROR_RE = /^e:\s+(?:file:\/\/)?(.+?):(\d+):(\d+)(?::?\s*(?:error:\s*)?)(.+)$/;
+const KOTLIN_ERROR_RE =
+    /^e:\s+(?:file:\/\/)?(.+?):(\d+):(\d+)(?::?\s*(?:error:\s*)?)(.+)$/;
 
 export class KotlinCompileErrorDetector {
-    private buffer = '';
+    private buffer = "";
     private errors: CompileError[] = [];
     /** Bound the count we hold so a runaway compile (~100s of errors on
      *  a broken refactor) doesn't grow the array without limit. The
@@ -62,16 +63,16 @@ export class KotlinCompileErrorDetector {
      */
     consume(chunk: string): void {
         this.buffer += chunk;
-        let nl = this.buffer.indexOf('\n');
+        let nl = this.buffer.indexOf("\n");
         while (nl !== -1) {
             const line = this.buffer.slice(0, nl);
             this.buffer = this.buffer.slice(nl + 1);
             this.scanLine(line);
-            nl = this.buffer.indexOf('\n');
+            nl = this.buffer.indexOf("\n");
         }
         if (this.buffer.length > 16 * 1024) {
             this.scanLine(this.buffer);
-            this.buffer = '';
+            this.buffer = "";
         }
     }
 
@@ -79,7 +80,7 @@ export class KotlinCompileErrorDetector {
     end(): void {
         if (this.buffer.length > 0) {
             this.scanLine(this.buffer);
-            this.buffer = '';
+            this.buffer = "";
         }
     }
 
@@ -90,15 +91,21 @@ export class KotlinCompileErrorDetector {
     }
 
     private scanLine(line: string): void {
-        if (this.errors.length >= KotlinCompileErrorDetector.MAX_ERRORS) { return; }
-        const trimmed = line.replace(/\r$/, ''); // strip CR from CRLF lines
+        if (this.errors.length >= KotlinCompileErrorDetector.MAX_ERRORS) {
+            return;
+        }
+        const trimmed = line.replace(/\r$/, ""); // strip CR from CRLF lines
         const m = KOTLIN_ERROR_RE.exec(trimmed);
-        if (!m) { return; }
+        if (!m) {
+            return;
+        }
         const path = m[1];
         const lineNum = parseInt(m[2], 10);
         const column = parseInt(m[3], 10);
         const message = m[4].trim();
-        if (!Number.isFinite(lineNum) || !Number.isFinite(column)) { return; }
+        if (!Number.isFinite(lineNum) || !Number.isFinite(column)) {
+            return;
+        }
         this.errors.push({
             file: basename(path),
             path,
@@ -117,15 +124,21 @@ export class KotlinCompileErrorDetector {
  * compile-error banner without re-parsing the log.
  */
 export class KotlinCompileError extends Error {
-    constructor(readonly errors: CompileError[], readonly task: string) {
+    constructor(
+        readonly errors: CompileError[],
+        readonly task: string,
+    ) {
         super(
             `Gradle task ${task} failed: ${errors.length} Kotlin compile error(s).`,
         );
-        this.name = 'KotlinCompileError';
+        this.name = "KotlinCompileError";
     }
 }
 
 function basename(filePath: string): string {
-    const slash = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+    const slash = Math.max(
+        filePath.lastIndexOf("/"),
+        filePath.lastIndexOf("\\"),
+    );
     return slash >= 0 ? filePath.slice(slash + 1) : filePath;
 }

--- a/vscode-extension/src/launchOnDevice.ts
+++ b/vscode-extension/src/launchOnDevice.ts
@@ -1,7 +1,7 @@
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import { spawn } from 'child_process';
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { spawn } from "child_process";
 
 /**
  * Helpers for the "Launch on Device" panel button. This module is
@@ -45,16 +45,24 @@ export function parseAndroidApplicationInfo(
     const lines = buildGradleContent.split(/\r?\n/);
     let isAndroidApp = false;
     for (const line of lines) {
-        if (APPLY_FALSE_RE.test(line)) { continue; }
-        if (ANDROID_APPLICATION_PLUGIN_ID_RE.test(line)
-            || ANDROID_APPLICATION_ALIAS_RE.test(line)) {
+        if (APPLY_FALSE_RE.test(line)) {
+            continue;
+        }
+        if (
+            ANDROID_APPLICATION_PLUGIN_ID_RE.test(line) ||
+            ANDROID_APPLICATION_ALIAS_RE.test(line)
+        ) {
             isAndroidApp = true;
             break;
         }
     }
-    if (!isAndroidApp) { return null; }
+    if (!isAndroidApp) {
+        return null;
+    }
     const m = APPLICATION_ID_RE.exec(buildGradleContent);
-    if (!m) { return null; }
+    if (!m) {
+        return null;
+    }
     return { applicationId: m[1] };
 }
 
@@ -71,25 +79,33 @@ export function parseAndroidApplicationInfo(
  */
 export function findAndroidSdkRoot(workspaceRoot: string): string | null {
     const fromEnv = process.env.ANDROID_HOME || process.env.ANDROID_SDK_ROOT;
-    if (fromEnv && fs.existsSync(fromEnv)) { return fromEnv; }
-    const localProps = path.join(workspaceRoot, 'local.properties');
+    if (fromEnv && fs.existsSync(fromEnv)) {
+        return fromEnv;
+    }
+    const localProps = path.join(workspaceRoot, "local.properties");
     try {
-        const content = fs.readFileSync(localProps, 'utf-8');
+        const content = fs.readFileSync(localProps, "utf-8");
         for (const line of content.split(/\r?\n/)) {
             const m = /^\s*sdk\.dir\s*=\s*(.+?)\s*$/.exec(line);
             if (m) {
                 const dir = m[1].trim();
-                if (fs.existsSync(dir)) { return dir; }
+                if (fs.existsSync(dir)) {
+                    return dir;
+                }
             }
         }
-    } catch { /* no local.properties — fall through */ }
+    } catch {
+        /* no local.properties — fall through */
+    }
     const home = os.homedir();
     const candidates = [
-        path.join(home, 'Library', 'Android', 'sdk'),
-        path.join(home, 'Android', 'Sdk'),
+        path.join(home, "Library", "Android", "sdk"),
+        path.join(home, "Android", "Sdk"),
     ];
     for (const c of candidates) {
-        if (fs.existsSync(c)) { return c; }
+        if (fs.existsSync(c)) {
+            return c;
+        }
     }
     return null;
 }
@@ -100,9 +116,11 @@ export function findAndroidSdkRoot(workspaceRoot: string): string | null {
  * return the bare name and trust the caller's `PATH`.
  */
 export function resolveAdbPath(sdkRoot: string | null): string {
-    if (!sdkRoot) { return 'adb'; }
-    const exe = process.platform === 'win32' ? 'adb.exe' : 'adb';
-    return path.join(sdkRoot, 'platform-tools', exe);
+    if (!sdkRoot) {
+        return "adb";
+    }
+    const exe = process.platform === "win32" ? "adb.exe" : "adb";
+    return path.join(sdkRoot, "platform-tools", exe);
 }
 
 export interface AdbResult {
@@ -122,13 +140,19 @@ export interface AdbResult {
  */
 export function runAdb(adbPath: string, args: string[]): Promise<AdbResult> {
     return new Promise((resolve, reject) => {
-        const proc = spawn(adbPath, args, { stdio: ['ignore', 'pipe', 'pipe'] });
-        let stdout = '';
-        let stderr = '';
-        proc.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
-        proc.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
-        proc.on('error', reject);
-        proc.on('close', (code) => {
+        const proc = spawn(adbPath, args, {
+            stdio: ["ignore", "pipe", "pipe"],
+        });
+        let stdout = "";
+        let stderr = "";
+        proc.stdout.on("data", (chunk) => {
+            stdout += chunk.toString();
+        });
+        proc.stderr.on("data", (chunk) => {
+            stderr += chunk.toString();
+        });
+        proc.on("error", reject);
+        proc.on("close", (code) => {
             resolve({ code: code ?? -1, stdout, stderr });
         });
     });
@@ -159,9 +183,22 @@ export function buildPreviewActivityAmStartArgs(opts: {
     parameterProviderClassName: string | null;
 }): string[] {
     const component = `${opts.applicationId}/androidx.compose.ui.tooling.PreviewActivity`;
-    const args = ['shell', 'am', 'start', '-n', component, '--es', 'composable', opts.composableFqn];
+    const args = [
+        "shell",
+        "am",
+        "start",
+        "-n",
+        component,
+        "--es",
+        "composable",
+        opts.composableFqn,
+    ];
     if (opts.parameterProviderClassName) {
-        args.push('--es', 'parameterProviderClassName', opts.parameterProviderClassName);
+        args.push(
+            "--es",
+            "parameterProviderClassName",
+            opts.parameterProviderClassName,
+        );
     }
     return args;
 }
@@ -178,15 +215,17 @@ export function collectAndroidApplicationModules(
 ): Array<{ module: string; applicationId: string }> {
     const out: Array<{ module: string; applicationId: string }> = [];
     for (const module of modules) {
-        const buildFile = path.join(workspaceRoot, module, 'build.gradle.kts');
+        const buildFile = path.join(workspaceRoot, module, "build.gradle.kts");
         let content: string;
         try {
-            content = fs.readFileSync(buildFile, 'utf-8');
+            content = fs.readFileSync(buildFile, "utf-8");
         } catch {
             continue;
         }
         const info = parseAndroidApplicationInfo(content);
-        if (info) { out.push({ module, applicationId: info.applicationId }); }
+        if (info) {
+            out.push({ module, applicationId: info.applicationId });
+        }
     }
     out.sort((a, b) => a.module.localeCompare(b.module));
     return out;

--- a/vscode-extension/src/logFilter.ts
+++ b/vscode-extension/src/logFilter.ts
@@ -17,12 +17,21 @@
  * a window reload.
  */
 
-export type LogLevel = 'quiet' | 'normal' | 'verbose';
+export type LogLevel = "quiet" | "normal" | "verbose";
 
-const KNOWN_LEVELS: ReadonlySet<string> = new Set(['quiet', 'normal', 'verbose']);
+const KNOWN_LEVELS: ReadonlySet<string> = new Set([
+    "quiet",
+    "normal",
+    "verbose",
+]);
 
-export function parseLogLevel(raw: string | undefined | null, fallback: LogLevel = 'normal'): LogLevel {
-    if (raw && KNOWN_LEVELS.has(raw)) { return raw as LogLevel; }
+export function parseLogLevel(
+    raw: string | undefined | null,
+    fallback: LogLevel = "normal",
+): LogLevel {
+    if (raw && KNOWN_LEVELS.has(raw)) {
+        return raw as LogLevel;
+    }
     return fallback;
 }
 
@@ -63,7 +72,7 @@ const DAEMON_TIMING_RE =
 
 // Robolectric's "you don't have Java 21" warning fires on every daemon spawn.
 // Show it once per session.
-const ROBOLECTRIC_SDK_WARN_PREFIX = '[Robolectric] WARN:';
+const ROBOLECTRIC_SDK_WARN_PREFIX = "[Robolectric] WARN:";
 
 // Roborazzi prints a 6-line ActionBar overlap workaround block on every
 // captured preview — 17 captures × 6 lines = 102 lines per refresh. We dedupe
@@ -72,13 +81,15 @@ const ROBOLECTRIC_SDK_WARN_PREFIX = '[Robolectric] WARN:';
 const ROBORAZZI_ACTIONBAR_FIRST_LINE_RE =
     /^Roborazzi: Hiding the ActionBar to avoid content overlap issues during capture\.$/;
 const ROBORAZZI_ACTIONBAR_FOLLOWUP_RE = new RegExp(
-    '^(' + [
-        'This workaround is used when an ActionBar is present and the SDK version is 35 or higher\\.',
-        'Hiding the ActionBar might cause slight performance overhead due to layout invalidation\\.',
-        'We recommend setting the theme using <application android:theme="@android:style/Theme\\.Material\\.NoActionBar" /> in your test/AndroidManifest\\.xml to avoid this workaround\\.',
-        'If you are intentionally using an ActionBar, you can disable this workaround by setting the gradle property \'roborazzi\\.compose\\.actionbar\\.overlap\\.fix\' to false\\.',
-        'This problem is tracked in https://issuetracker\\.google\\.com/issues/383368165',
-    ].join('|') + ')$',
+    "^(" +
+        [
+            "This workaround is used when an ActionBar is present and the SDK version is 35 or higher\\.",
+            "Hiding the ActionBar might cause slight performance overhead due to layout invalidation\\.",
+            'We recommend setting the theme using <application android:theme="@android:style/Theme\\.Material\\.NoActionBar" /> in your test/AndroidManifest\\.xml to avoid this workaround\\.',
+            "If you are intentionally using an ActionBar, you can disable this workaround by setting the gradle property 'roborazzi\\.compose\\.actionbar\\.overlap\\.fix' to false\\.",
+            "This problem is tracked in https://issuetracker\\.google\\.com/issues/383368165",
+        ].join("|") +
+        ")$",
 );
 
 const BUILD_SUCCESS_FAIL_RE = /^BUILD (SUCCESSFUL|FAILED) /;
@@ -88,12 +99,12 @@ const BUILD_SUCCESS_FAIL_RE = /^BUILD (SUCCESSFUL|FAILED) /;
 // normal but redundant at quiet — quiet keeps only error lines and the BUILD
 // outcome.
 const EXTENSION_INFO_PREFIXES = [
-    '[refresh] start ',
-    '[refresh] rendered ',
-    '[doctor] doctor diagnostics refreshed ',
-    '[daemon] spawning ',
-    '[daemon] ready for ',
-    '[detect] ',
+    "[refresh] start ",
+    "[refresh] rendered ",
+    "[doctor] doctor diagnostics refreshed ",
+    "[daemon] spawning ",
+    "[daemon] ready for ",
+    "[detect] ",
 ];
 
 // `> :module:task` and `> :module:task completed` are progress markers we
@@ -106,9 +117,13 @@ export class LogFilter {
     private inConfigureBlock = false;
     private inRoborazziBlock = false;
 
-    constructor(private readonly levelProvider: () => LogLevel = () => 'normal') {}
+    constructor(
+        private readonly levelProvider: () => LogLevel = () => "normal",
+    ) {}
 
-    private level(): LogLevel { return this.levelProvider(); }
+    private level(): LogLevel {
+        return this.levelProvider();
+    }
 
     /**
      * Splits [chunk] on newlines, drops lines that are noise at the current
@@ -117,7 +132,9 @@ export class LogFilter {
      * appending an empty `\n` to the output channel.
      */
     filterGradleChunk(chunk: string): string {
-        if (this.level() === 'verbose') { return chunk; }
+        if (this.level() === "verbose") {
+            return chunk;
+        }
         // Preserve trailing newlines so partial chunks reassemble correctly.
         const lines = chunk.split(/\r?\n/);
         const out: string[] = [];
@@ -125,52 +142,89 @@ export class LogFilter {
             const line = lines[i];
             const isLast = i === lines.length - 1;
             const decision = this.classifyGradleLine(line);
-            if (decision === 'keep') { out.push(line); continue; }
-            if (decision === 'drop') {
+            if (decision === "keep") {
+                out.push(line);
+                continue;
+            }
+            if (decision === "drop") {
                 // For non-last lines we still need to consume the newline; for
                 // the trailing partial we drop nothing so downstream
                 // line-buffering keeps working.
-                if (!isLast) { /* swallow the line + its newline */ }
-                else { out.push(''); }
+                if (!isLast) {
+                    /* swallow the line + its newline */
+                } else {
+                    out.push("");
+                }
             }
         }
-        return out.join('\n');
+        return out.join("\n");
     }
 
-    private classifyGradleLine(line: string): 'keep' | 'drop' {
+    private classifyGradleLine(line: string): "keep" | "drop" {
         // Configure-project block runs until a blank line. The block's body is
         // continuation text we also want to drop.
         if (this.inConfigureBlock) {
-            if (line.length === 0) { this.inConfigureBlock = false; }
-            return 'drop';
+            if (line.length === 0) {
+                this.inConfigureBlock = false;
+            }
+            return "drop";
         }
         if (CONFIGURE_PROJECT_RE.test(line)) {
             this.inConfigureBlock = true;
-            return 'drop';
+            return "drop";
         }
 
         const trimmed = line.trimEnd();
-        if (trimmed.length === 0) { return 'keep'; }
+        if (trimmed.length === 0) {
+            return "keep";
+        }
 
-        if (this.level() === 'quiet') {
+        if (this.level() === "quiet") {
             // Quiet keeps only outcome lines and FAILED/error-shaped lines.
-            if (BUILD_SUCCESS_FAIL_RE.test(trimmed)) { return 'keep'; }
-            if (/^FAILURE: /.test(trimmed)) { return 'keep'; }
-            if (/^\* What went wrong:/.test(trimmed)) { return 'keep'; }
-            if (/(^|\s)FAILED(\s|$)/.test(trimmed)) { return 'keep'; }
-            if (/^Caused by: /.test(trimmed)) { return 'keep'; }
-            if (/^[ \t]+at .+\(/.test(line)) { return 'keep'; }
-            if (/^e: /.test(trimmed)) { return 'keep'; } // kotlinc errors
-            if (/^w: /.test(trimmed)) { return 'keep'; } // kotlinc warnings
-            return 'drop';
+            if (BUILD_SUCCESS_FAIL_RE.test(trimmed)) {
+                return "keep";
+            }
+            if (/^FAILURE: /.test(trimmed)) {
+                return "keep";
+            }
+            if (/^\* What went wrong:/.test(trimmed)) {
+                return "keep";
+            }
+            if (/(^|\s)FAILED(\s|$)/.test(trimmed)) {
+                return "keep";
+            }
+            if (/^Caused by: /.test(trimmed)) {
+                return "keep";
+            }
+            if (/^[ \t]+at .+\(/.test(line)) {
+                return "keep";
+            }
+            if (/^e: /.test(trimmed)) {
+                return "keep";
+            } // kotlinc errors
+            if (/^w: /.test(trimmed)) {
+                return "keep";
+            } // kotlinc warnings
+            return "drop";
         }
 
         // normal level
-        if (trimmed.startsWith('> Task ') && NOOP_TASK_SUFFIX_RE.test(trimmed)) { return 'drop'; }
-        if (CONFIG_CACHE_RE.test(trimmed)) { return 'drop'; }
-        if (ACTIONABLE_FOOTER_RE.test(trimmed)) { return 'drop'; }
-        if (INCUBATING_RE.test(trimmed)) { return 'drop'; }
-        return 'keep';
+        if (
+            trimmed.startsWith("> Task ") &&
+            NOOP_TASK_SUFFIX_RE.test(trimmed)
+        ) {
+            return "drop";
+        }
+        if (CONFIG_CACHE_RE.test(trimmed)) {
+            return "drop";
+        }
+        if (ACTIONABLE_FOOTER_RE.test(trimmed)) {
+            return "drop";
+        }
+        if (INCUBATING_RE.test(trimmed)) {
+            return "drop";
+        }
+        return "keep";
     }
 
     /**
@@ -178,46 +232,69 @@ export class LogFilter {
      * current level. The line is passed without the `[daemon stderr] ` prefix.
      */
     filterDaemonStderrLine(line: string): string | null {
-        if (this.level() === 'verbose') { return line; }
+        if (this.level() === "verbose") {
+            return line;
+        }
 
         // Roborazzi ActionBar block — first line shows once, follow-ups are
         // always suppressed at normal/quiet. The block is line-by-line so we
         // track our way through it with a flag.
         if (ROBORAZZI_ACTIONBAR_FIRST_LINE_RE.test(line)) {
             this.inRoborazziBlock = true;
-            if (this.warnedOnce.has('roborazzi-actionbar')) { return null; }
-            this.warnedOnce.add('roborazzi-actionbar');
+            if (this.warnedOnce.has("roborazzi-actionbar")) {
+                return null;
+            }
+            this.warnedOnce.add("roborazzi-actionbar");
             return line;
         }
         if (this.inRoborazziBlock) {
-            if (ROBORAZZI_ACTIONBAR_FOLLOWUP_RE.test(line)) { return null; }
+            if (ROBORAZZI_ACTIONBAR_FOLLOWUP_RE.test(line)) {
+                return null;
+            }
             // The block is exactly 6 lines (1 header + 5 follow-ups); anything
             // else means the block ended.
             this.inRoborazziBlock = false;
         }
 
-        if (line.startsWith(ROBOLECTRIC_SDK_WARN_PREFIX) ||
-            line.startsWith('Android SDK 36 requires Java 21')) {
-            const key = 'robolectric-sdk-java';
-            if (this.warnedOnce.has(key)) { return null; }
+        if (
+            line.startsWith(ROBOLECTRIC_SDK_WARN_PREFIX) ||
+            line.startsWith("Android SDK 36 requires Java 21")
+        ) {
+            const key = "robolectric-sdk-java";
+            if (this.warnedOnce.has(key)) {
+                return null;
+            }
             this.warnedOnce.add(key);
             return line;
         }
 
-        if (this.level() === 'quiet') {
+        if (this.level() === "quiet") {
             // Drop everything that isn't an exception or stack frame.
-            if (line.startsWith('Exception ') || line.startsWith('Caused by: ')) { return line; }
-            if (/^\s+at .+\(/.test(line)) { return line; }
-            if (line.startsWith('compose-ai-daemon: fatal') ||
-                line.startsWith('compose-ai-daemon: dispatch error')) {
+            if (
+                line.startsWith("Exception ") ||
+                line.startsWith("Caused by: ")
+            ) {
+                return line;
+            }
+            if (/^\s+at .+\(/.test(line)) {
+                return line;
+            }
+            if (
+                line.startsWith("compose-ai-daemon: fatal") ||
+                line.startsWith("compose-ai-daemon: dispatch error")
+            ) {
                 return line;
             }
             return null;
         }
 
         // normal level
-        if (DAEMON_BOOT_BANNER_RE.test(line)) { return null; }
-        if (DAEMON_TIMING_RE.test(line)) { return null; }
+        if (DAEMON_BOOT_BANNER_RE.test(line)) {
+            return null;
+        }
+        if (DAEMON_TIMING_RE.test(line)) {
+            return null;
+        }
         return line;
     }
 
@@ -227,17 +304,23 @@ export class LogFilter {
      * Errors and `FAILED` lines should bypass this and emit unconditionally.
      */
     shouldEmitInformational(line: string): boolean {
-        if (this.level() !== 'quiet') { return true; }
-        for (const prefix of EXTENSION_INFO_PREFIXES) {
-            if (line.startsWith(prefix)) { return false; }
+        if (this.level() !== "quiet") {
+            return true;
         }
-        if (TASK_PROGRESS_RE.test(line)) { return false; }
+        for (const prefix of EXTENSION_INFO_PREFIXES) {
+            if (line.startsWith(prefix)) {
+                return false;
+            }
+        }
+        if (TASK_PROGRESS_RE.test(line)) {
+            return false;
+        }
         return true;
     }
 
     /** Returns true only when verbose logging is enabled. */
     shouldEmitVerbose(): boolean {
-        return this.level() === 'verbose';
+        return this.level() === "verbose";
     }
 
     /** Resets dedupe state — call at session boundaries (extension activation in tests). */

--- a/vscode-extension/src/manifestIconReferences.ts
+++ b/vscode-extension/src/manifestIconReferences.ts
@@ -8,9 +8,9 @@ export interface ManifestIconMatch {
     /** Byte offset of the matched attribute within the document text. */
     offset: number;
     /** Local attribute name without the `android:` prefix — `icon` / `roundIcon` / `logo` / `banner`. */
-    attribute: 'icon' | 'roundIcon' | 'logo' | 'banner';
+    attribute: "icon" | "roundIcon" | "logo" | "banner";
     /** `drawable` or `mipmap`. */
-    resourceType: 'drawable' | 'mipmap';
+    resourceType: "drawable" | "mipmap";
     /** Resource name without the `@type/` prefix. */
     resourceName: string;
 }
@@ -27,13 +27,14 @@ export interface ManifestIconMatch {
  */
 export function findManifestIconReferences(text: string): ManifestIconMatch[] {
     const out: ManifestIconMatch[] = [];
-    const re = /android:(icon|roundIcon|logo|banner)\s*=\s*["'](@(?:\+)?(drawable|mipmap)\/([A-Za-z0-9_]+))["']/g;
+    const re =
+        /android:(icon|roundIcon|logo|banner)\s*=\s*["'](@(?:\+)?(drawable|mipmap)\/([A-Za-z0-9_]+))["']/g;
     let match: RegExpExecArray | null;
     while ((match = re.exec(text)) !== null) {
         out.push({
             offset: match.index,
-            attribute: match[1] as ManifestIconMatch['attribute'],
-            resourceType: match[3] as ManifestIconMatch['resourceType'],
+            attribute: match[1] as ManifestIconMatch["attribute"],
+            resourceType: match[3] as ManifestIconMatch["resourceType"],
             resourceName: match[4],
         });
     }

--- a/vscode-extension/src/pluginDetection.ts
+++ b/vscode-extension/src/pluginDetection.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from "fs";
+import * as path from "path";
 
 /**
  * Pure filesystem helpers for detecting where the Compose Preview Gradle
@@ -18,7 +18,7 @@ import * as path from 'path';
  *      the current Gradle project or a nested worktree's sibling layout.
  */
 
-export const PLUGIN_ID = 'ee.schimke.composeai.preview';
+export const PLUGIN_ID = "ee.schimke.composeai.preview";
 
 // Matches the plugin being *applied* literally (`id("ee.schimke.composeai.preview")`
 // or `id "ee.schimke.composeai.preview"`), not the plugin's own declaration in
@@ -47,8 +47,12 @@ const APPLY_FALSE_RE = /\bapply\s+false\b/;
 export function appliesPlugin(content: string): boolean {
     const lines = content.split(/\r?\n/);
     for (const line of lines) {
-        if (!APPLIES_PLUGIN_RE.test(line)) { continue; }
-        if (APPLY_FALSE_RE.test(line)) { continue; }
+        if (!APPLIES_PLUGIN_RE.test(line)) {
+            continue;
+        }
+        if (APPLY_FALSE_RE.test(line)) {
+            continue;
+        }
         return true;
     }
     return false;
@@ -76,15 +80,19 @@ export function appliesPlugin(content: string): boolean {
 export function findPluginAppliedAncestor(filePath: string): string | null {
     let dir = path.dirname(filePath);
     while (true) {
-        const candidate = path.join(dir, 'build.gradle.kts');
+        const candidate = path.join(dir, "build.gradle.kts");
         try {
-            const content = fs.readFileSync(candidate, 'utf-8');
+            const content = fs.readFileSync(candidate, "utf-8");
             if (appliesPlugin(content)) {
                 return dir;
             }
-        } catch { /* no build file here, keep walking */ }
+        } catch {
+            /* no build file here, keep walking */
+        }
         const parent = path.dirname(dir);
-        if (parent === dir) { return null; }
+        if (parent === dir) {
+            return null;
+        }
         dir = parent;
     }
 }

--- a/vscode-extension/src/previewA11yDiagnostics.ts
+++ b/vscode-extension/src/previewA11yDiagnostics.ts
@@ -1,6 +1,6 @@
-import * as vscode from 'vscode';
-import { PreviewRegistry } from './previewRegistry';
-import { detectPreviews } from './previewDetection';
+import * as vscode from "vscode";
+import { PreviewRegistry } from "./previewRegistry";
+import { detectPreviews } from "./previewDetection";
 
 /**
  * Publishes ATF findings collected in the [PreviewRegistry] as VS Code
@@ -27,17 +27,25 @@ export class PreviewA11yDiagnostics implements vscode.Disposable {
         private readonly registry: PreviewRegistry,
         private readonly log?: (msg: string) => void,
     ) {
-        this.collection = vscode.languages.createDiagnosticCollection('compose-preview-a11y');
+        this.collection = vscode.languages.createDiagnosticCollection(
+            "compose-preview-a11y",
+        );
         this.disposables.push(this.collection);
         this.disposables.push(registry.onDidChange(() => this.refreshAll()));
         this.disposables.push(
-            vscode.workspace.onDidOpenTextDocument((doc) => this.scheduleRefresh(doc)),
+            vscode.workspace.onDidOpenTextDocument((doc) =>
+                this.scheduleRefresh(doc),
+            ),
         );
         this.disposables.push(
-            vscode.workspace.onDidChangeTextDocument((e) => this.scheduleRefresh(e.document)),
+            vscode.workspace.onDidChangeTextDocument((e) =>
+                this.scheduleRefresh(e.document),
+            ),
         );
         this.disposables.push(
-            vscode.workspace.onDidCloseTextDocument((doc) => this.collection.delete(doc.uri)),
+            vscode.workspace.onDidCloseTextDocument((doc) =>
+                this.collection.delete(doc.uri),
+            ),
         );
         // Seed currently-open documents so findings render on first load
         // without the user having to re-open anything.
@@ -47,9 +55,13 @@ export class PreviewA11yDiagnostics implements vscode.Disposable {
     }
 
     dispose(): void {
-        for (const t of this.pending.values()) { clearTimeout(t); }
+        for (const t of this.pending.values()) {
+            clearTimeout(t);
+        }
         this.pending.clear();
-        for (const d of this.disposables) { d.dispose(); }
+        for (const d of this.disposables) {
+            d.dispose();
+        }
     }
 
     private refreshAll(): void {
@@ -59,18 +71,25 @@ export class PreviewA11yDiagnostics implements vscode.Disposable {
     }
 
     private scheduleRefresh(doc: vscode.TextDocument): void {
-        if (doc.languageId !== 'kotlin') { return; }
+        if (doc.languageId !== "kotlin") {
+            return;
+        }
         const key = doc.uri.toString();
         const existing = this.pending.get(key);
-        if (existing) { clearTimeout(existing); }
-        this.pending.set(key, setTimeout(() => {
-            this.pending.delete(key);
-            void this.refreshDocument(doc);
-        }, 200));
+        if (existing) {
+            clearTimeout(existing);
+        }
+        this.pending.set(
+            key,
+            setTimeout(() => {
+                this.pending.delete(key);
+                void this.refreshDocument(doc);
+            }, 200),
+        );
     }
 
     private async refreshDocument(doc: vscode.TextDocument): Promise<void> {
-        if (doc.languageId !== 'kotlin') {
+        if (doc.languageId !== "kotlin") {
             this.collection.delete(doc.uri);
             return;
         }
@@ -79,17 +98,28 @@ export class PreviewA11yDiagnostics implements vscode.Disposable {
         for (const det of detected) {
             const entry = this.registry.find(doc.uri.fsPath, det.functionName);
             const findings = entry?.preview.a11yFindings;
-            if (!findings || findings.length === 0) { continue; }
+            if (!findings || findings.length === 0) {
+                continue;
+            }
             const line = det.funLineNumber;
-            const range = new vscode.Range(line, 0, line, doc.lineAt(line).text.length);
+            const range = new vscode.Range(
+                line,
+                0,
+                line,
+                doc.lineAt(line).text.length,
+            );
             for (const f of findings) {
-                if (f.level === 'INFO') { continue; }
+                if (f.level === "INFO") {
+                    continue;
+                }
                 const diag = new vscode.Diagnostic(
                     range,
                     `${f.type}: ${f.message}`,
-                    f.level === 'ERROR' ? vscode.DiagnosticSeverity.Error : vscode.DiagnosticSeverity.Warning,
+                    f.level === "ERROR"
+                        ? vscode.DiagnosticSeverity.Error
+                        : vscode.DiagnosticSeverity.Warning,
                 );
-                diag.source = 'compose-preview-a11y';
+                diag.source = "compose-preview-a11y";
                 diag.code = f.type;
                 diagnostics.push(diag);
             }

--- a/vscode-extension/src/previewCodeLensProvider.ts
+++ b/vscode-extension/src/previewCodeLensProvider.ts
@@ -1,6 +1,6 @@
-import * as vscode from 'vscode';
-import { detectPreviews } from './previewDetection';
-import { PreviewRegistry } from './previewRegistry';
+import * as vscode from "vscode";
+import { detectPreviews } from "./previewDetection";
+import { PreviewRegistry } from "./previewRegistry";
 
 /**
  * Renders a clickable "Focus in Preview panel" lens above every detected
@@ -22,17 +22,27 @@ export class PreviewCodeLensProvider implements vscode.CodeLensProvider {
     async provideCodeLenses(
         doc: vscode.TextDocument,
     ): Promise<vscode.CodeLens[]> {
-        if (doc.languageId !== 'kotlin') { return []; }
+        if (doc.languageId !== "kotlin") {
+            return [];
+        }
         const detected = await detectPreviews(doc, this.registry, this.log);
         const filePath = doc.uri.fsPath;
-        return detected.map(det => new vscode.CodeLens(
-            new vscode.Range(det.funLineNumber, 0, det.funLineNumber, 0),
-            {
-                title: '$(eye) Focus in Preview panel',
-                command: 'composePreview.focusPreview',
-                arguments: [det.functionName, filePath],
-            },
-        ));
+        return detected.map(
+            (det) =>
+                new vscode.CodeLens(
+                    new vscode.Range(
+                        det.funLineNumber,
+                        0,
+                        det.funLineNumber,
+                        0,
+                    ),
+                    {
+                        title: "$(eye) Focus in Preview panel",
+                        command: "composePreview.focusPreview",
+                        arguments: [det.functionName, filePath],
+                    },
+                ),
+        );
     }
 
     dispose(): void {

--- a/vscode-extension/src/previewDetection.ts
+++ b/vscode-extension/src/previewDetection.ts
@@ -1,5 +1,5 @@
-import * as vscode from 'vscode';
-import { PreviewRegistry } from './previewRegistry';
+import * as vscode from "vscode";
+import { PreviewRegistry } from "./previewRegistry";
 
 export interface DetectedPreview {
     functionName: string;
@@ -34,13 +34,17 @@ export async function detectPreviews(
     log?: (msg: string) => void,
 ): Promise<DetectedPreview[]> {
     const symbols = await fetchSymbols(doc, log);
-    if (!symbols) { return []; }
+    if (!symbols) {
+        return [];
+    }
 
     const out: DetectedPreview[] = [];
     const visit = (s: FnLike) => {
-        const isFn = s.kind === vscode.SymbolKind.Function || s.kind === vscode.SymbolKind.Method;
+        const isFn =
+            s.kind === vscode.SymbolKind.Function ||
+            s.kind === vscode.SymbolKind.Method;
         if (isFn) {
-            const name = s.name.replace(/\(.*$/, '').trim();
+            const name = s.name.replace(/\(.*$/, "").trim();
             if (registry.find(doc.uri.fsPath, name)) {
                 out.push({
                     functionName: name,
@@ -61,14 +65,22 @@ async function fetchSymbols(
 ): Promise<FnLike[] | undefined> {
     try {
         const result = await vscode.commands.executeCommand<unknown>(
-            'vscode.executeDocumentSymbolProvider',
+            "vscode.executeDocumentSymbolProvider",
             doc.uri,
         );
-        if (!Array.isArray(result) || result.length === 0) { return undefined; }
+        if (!Array.isArray(result) || result.length === 0) {
+            return undefined;
+        }
         const first = result[0] as { children?: unknown; location?: unknown };
-        if ('children' in first) { return (result as vscode.DocumentSymbol[]).map(toFnLike); }
-        if ('location' in first) { return (result as vscode.SymbolInformation[]).map(siToFnLike); }
-        log?.(`executeDocumentSymbolProvider returned unknown shape: ${JSON.stringify(first).slice(0, 200)}`);
+        if ("children" in first) {
+            return (result as vscode.DocumentSymbol[]).map(toFnLike);
+        }
+        if ("location" in first) {
+            return (result as vscode.SymbolInformation[]).map(siToFnLike);
+        }
+        log?.(
+            `executeDocumentSymbolProvider returned unknown shape: ${JSON.stringify(first).slice(0, 200)}`,
+        );
         return undefined;
     } catch (e) {
         log?.(`executeDocumentSymbolProvider threw: ${(e as Error).message}`);

--- a/vscode-extension/src/previewDoctorDiagnostics.ts
+++ b/vscode-extension/src/previewDoctorDiagnostics.ts
@@ -1,8 +1,8 @@
-import * as vscode from 'vscode';
-import * as path from 'node:path';
-import * as fs from 'node:fs';
-import { GradleService } from './gradleService';
-import { DoctorFinding } from './types';
+import * as vscode from "vscode";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { GradleService } from "./gradleService";
+import { DoctorFinding } from "./types";
 
 /**
  * Runs `:<module>:composePreviewDoctor` on each applied-plugin module and
@@ -23,7 +23,9 @@ export class PreviewDoctorDiagnostics implements vscode.Disposable {
         private readonly workspaceRoot: string,
         private readonly log?: (msg: string) => void,
     ) {
-        this.collection = vscode.languages.createDiagnosticCollection('compose-preview-doctor');
+        this.collection = vscode.languages.createDiagnosticCollection(
+            "compose-preview-doctor",
+        );
     }
 
     dispose(): void {
@@ -39,9 +41,13 @@ export class PreviewDoctorDiagnostics implements vscode.Disposable {
         const next = new Map<string, vscode.Diagnostic[]>();
         for (const module of modules) {
             const report = await this.gradleService.runDoctor(module);
-            if (!report) { continue; }
+            if (!report) {
+                continue;
+            }
             const targetFile = this.resolveBuildFile(module);
-            if (!targetFile) { continue; }
+            if (!targetFile) {
+                continue;
+            }
             const diags: vscode.Diagnostic[] = [];
             for (const finding of report.findings) {
                 diags.push(this.toDiagnostic(module, finding));
@@ -56,16 +62,25 @@ export class PreviewDoctorDiagnostics implements vscode.Disposable {
         for (const [file, diags] of next) {
             this.collection.set(vscode.Uri.file(file), diags);
         }
-        this.log?.(`doctor diagnostics refreshed across ${modules.length} module(s)`);
+        this.log?.(
+            `doctor diagnostics refreshed across ${modules.length} module(s)`,
+        );
     }
 
-    private toDiagnostic(module: string, finding: DoctorFinding): vscode.Diagnostic {
+    private toDiagnostic(
+        module: string,
+        finding: DoctorFinding,
+    ): vscode.Diagnostic {
         const severity =
-            finding.severity === 'error' ? vscode.DiagnosticSeverity.Error :
-            finding.severity === 'warning' ? vscode.DiagnosticSeverity.Warning :
-            vscode.DiagnosticSeverity.Information;
+            finding.severity === "error"
+                ? vscode.DiagnosticSeverity.Error
+                : finding.severity === "warning"
+                  ? vscode.DiagnosticSeverity.Warning
+                  : vscode.DiagnosticSeverity.Information;
         const parts = [finding.message];
-        if (finding.detail) { parts.push(finding.detail); }
+        if (finding.detail) {
+            parts.push(finding.detail);
+        }
         if (finding.remediationSummary) {
             parts.push(`→ ${finding.remediationSummary}`);
             for (const cmd of finding.remediationCommands ?? []) {
@@ -79,17 +94,19 @@ export class PreviewDoctorDiagnostics implements vscode.Disposable {
         // at the top of the build file. VS Code still threads the finding
         // into the Problems panel with the file name as location.
         const range = new vscode.Range(0, 0, 0, 0);
-        const diag = new vscode.Diagnostic(range, parts.join('\n'), severity);
-        diag.source = 'compose-preview-doctor';
+        const diag = new vscode.Diagnostic(range, parts.join("\n"), severity);
+        diag.source = "compose-preview-doctor";
         diag.code = `${module}:${finding.id}`;
         return diag;
     }
 
     /** Locate the module's build.gradle[.kts] relative to the workspace root. */
     private resolveBuildFile(module: string): string | undefined {
-        for (const name of ['build.gradle.kts', 'build.gradle']) {
+        for (const name of ["build.gradle.kts", "build.gradle"]) {
             const candidate = path.join(this.workspaceRoot, module, name);
-            if (fs.existsSync(candidate)) { return candidate; }
+            if (fs.existsSync(candidate)) {
+                return candidate;
+            }
         }
         return undefined;
     }

--- a/vscode-extension/src/previewFilter.ts
+++ b/vscode-extension/src/previewFilter.ts
@@ -1,4 +1,4 @@
-import { PreviewInfo } from './types';
+import { PreviewInfo } from "./types";
 
 export interface FilterState {
     sourceFile: string | null;
@@ -7,12 +7,23 @@ export interface FilterState {
     group: string | null;
 }
 
-export function filterPreviews(previews: PreviewInfo[], filter: FilterState): PreviewInfo[] {
-    return previews.filter(p => {
-        if (filter.sourceFile && p.sourceFile !== filter.sourceFile) { return false; }
-        if (filter.functionName && p.functionName !== filter.functionName) { return false; }
-        if (filter.label && (p.params.name ?? '') !== filter.label) { return false; }
-        if (filter.group && (p.params.group ?? '') !== filter.group) { return false; }
+export function filterPreviews(
+    previews: PreviewInfo[],
+    filter: FilterState,
+): PreviewInfo[] {
+    return previews.filter((p) => {
+        if (filter.sourceFile && p.sourceFile !== filter.sourceFile) {
+            return false;
+        }
+        if (filter.functionName && p.functionName !== filter.functionName) {
+            return false;
+        }
+        if (filter.label && (p.params.name ?? "") !== filter.label) {
+            return false;
+        }
+        if (filter.group && (p.params.group ?? "") !== filter.group) {
+            return false;
+        }
         return true;
     });
 }
@@ -31,10 +42,16 @@ export function extractFilterOptions(previews: PreviewInfo[]): FilterOptions {
     const groups = new Set<string>();
 
     for (const p of previews) {
-        if (p.sourceFile) { sourceFiles.add(p.sourceFile); }
+        if (p.sourceFile) {
+            sourceFiles.add(p.sourceFile);
+        }
         functionNames.add(p.functionName);
-        if (p.params.name) { labels.add(p.params.name); }
-        if (p.params.group) { groups.add(p.params.group); }
+        if (p.params.name) {
+            labels.add(p.params.name);
+        }
+        if (p.params.group) {
+            groups.add(p.params.group);
+        }
     }
 
     return {

--- a/vscode-extension/src/previewGutterDecorations.ts
+++ b/vscode-extension/src/previewGutterDecorations.ts
@@ -1,6 +1,6 @@
-import * as vscode from 'vscode';
-import { detectPreviews } from './previewDetection';
-import { PreviewRegistry } from './previewRegistry';
+import * as vscode from "vscode";
+import { detectPreviews } from "./previewDetection";
+import { PreviewRegistry } from "./previewRegistry";
 
 /**
  * Paints a gutter marker next to every function the plugin recognised as a
@@ -20,57 +20,87 @@ export class PreviewGutterDecorations implements vscode.Disposable {
         private log?: (msg: string) => void,
     ) {
         this.decoration = vscode.window.createTextEditorDecorationType({
-            gutterIconPath: vscode.Uri.joinPath(extensionUri, 'media', 'preview-gutter.svg'),
-            gutterIconSize: 'contain',
+            gutterIconPath: vscode.Uri.joinPath(
+                extensionUri,
+                "media",
+                "preview-gutter.svg",
+            ),
+            gutterIconSize: "contain",
             isWholeLine: false,
         });
 
         this.disposables.push(
             this.decoration,
-            vscode.window.onDidChangeVisibleTextEditors(editors =>
-                editors.forEach(ed => this.scheduleUpdate(ed))),
-            vscode.workspace.onDidChangeTextDocument(e => {
+            vscode.window.onDidChangeVisibleTextEditors((editors) =>
+                editors.forEach((ed) => this.scheduleUpdate(ed)),
+            ),
+            vscode.workspace.onDidChangeTextDocument((e) => {
                 for (const ed of vscode.window.visibleTextEditors) {
-                    if (ed.document === e.document) { this.scheduleUpdate(ed); }
+                    if (ed.document === e.document) {
+                        this.scheduleUpdate(ed);
+                    }
                 }
             }),
             registry.onDidChange(() =>
-                vscode.window.visibleTextEditors.forEach(ed => this.scheduleUpdate(ed))),
+                vscode.window.visibleTextEditors.forEach((ed) =>
+                    this.scheduleUpdate(ed),
+                ),
+            ),
         );
 
-        vscode.window.visibleTextEditors.forEach(ed => this.scheduleUpdate(ed));
+        vscode.window.visibleTextEditors.forEach((ed) =>
+            this.scheduleUpdate(ed),
+        );
     }
 
     private scheduleUpdate(editor: vscode.TextEditor): void {
-        if (editor.document.languageId !== 'kotlin') { return; }
+        if (editor.document.languageId !== "kotlin") {
+            return;
+        }
         const key = editor.document.uri.toString();
         const existing = this.pending.get(key);
-        if (existing) { clearTimeout(existing); }
-        this.pending.set(key, setTimeout(() => {
-            this.pending.delete(key);
-            void this.update(editor);
-        }, 150));
+        if (existing) {
+            clearTimeout(existing);
+        }
+        this.pending.set(
+            key,
+            setTimeout(() => {
+                this.pending.delete(key);
+                void this.update(editor);
+            }, 150),
+        );
     }
 
     private async update(editor: vscode.TextEditor): Promise<void> {
-        if (editor.document.languageId !== 'kotlin') {
+        if (editor.document.languageId !== "kotlin") {
             editor.setDecorations(this.decoration, []);
             return;
         }
-        const detected = await detectPreviews(editor.document, this.registry, this.log);
+        const detected = await detectPreviews(
+            editor.document,
+            this.registry,
+            this.log,
+        );
         const filePath = editor.document.uri.fsPath;
-        const options: vscode.DecorationOptions[] = detected.map(det => {
+        const options: vscode.DecorationOptions[] = detected.map((det) => {
             // Decoration gutter icons can't receive click events, so the
             // CodeLens above the function is the actual click target. The
             // hover here is a fallback affordance — hovering the gutter icon
             // also exposes the same focus command.
-            const args = encodeURIComponent(JSON.stringify([det.functionName, filePath]));
+            const args = encodeURIComponent(
+                JSON.stringify([det.functionName, filePath]),
+            );
             const hover = new vscode.MarkdownString(
                 `[Focus \`${det.functionName}\` in Preview panel](command:composePreview.focusPreview?${args})`,
             );
             hover.isTrusted = true;
             return {
-                range: new vscode.Range(det.funLineNumber, 0, det.funLineNumber, 0),
+                range: new vscode.Range(
+                    det.funLineNumber,
+                    0,
+                    det.funLineNumber,
+                    0,
+                ),
                 hoverMessage: hover,
             };
         });
@@ -78,8 +108,8 @@ export class PreviewGutterDecorations implements vscode.Disposable {
     }
 
     dispose(): void {
-        this.pending.forEach(t => clearTimeout(t));
+        this.pending.forEach((t) => clearTimeout(t));
         this.pending.clear();
-        this.disposables.forEach(d => d.dispose());
+        this.disposables.forEach((d) => d.dispose());
     }
 }

--- a/vscode-extension/src/previewHoverProvider.ts
+++ b/vscode-extension/src/previewHoverProvider.ts
@@ -1,6 +1,6 @@
-import * as vscode from 'vscode';
-import { detectPreviews } from './previewDetection';
-import { PreviewRegistry } from './previewRegistry';
+import * as vscode from "vscode";
+import { detectPreviews } from "./previewDetection";
+import { PreviewRegistry } from "./previewRegistry";
 
 // Hover image is a peek of the rendered preview. VS Code's hover markdown
 // doesn't reliably honor inline `max-width`/`max-height` on images (the
@@ -15,11 +15,18 @@ export class PreviewHoverProvider implements vscode.HoverProvider {
         private log?: (msg: string) => void,
     ) {}
 
-    async provideHover(doc: vscode.TextDocument, position: vscode.Position): Promise<vscode.Hover | undefined> {
-        if (doc.languageId !== 'kotlin') { return; }
+    async provideHover(
+        doc: vscode.TextDocument,
+        position: vscode.Position,
+    ): Promise<vscode.Hover | undefined> {
+        if (doc.languageId !== "kotlin") {
+            return;
+        }
         const detected = await detectPreviews(doc, this.registry, this.log);
         for (const det of detected) {
-            if (!det.nameRange.contains(position)) { continue; }
+            if (!det.nameRange.contains(position)) {
+                continue;
+            }
             const entry = this.registry.find(doc.uri.fsPath, det.functionName);
 
             const md = new vscode.MarkdownString();
@@ -31,18 +38,24 @@ export class PreviewHoverProvider implements vscode.HoverProvider {
                 // Derive MIME from the primary capture's renderOutput so
                 // GIF-mode previews hover as animated GIFs instead of a
                 // static first frame interpreted as PNG.
-                const primary = entry.preview.captures?.[0]?.renderOutput ?? '';
-                const mime = typeof primary === 'string' && primary.toLowerCase().endsWith('.gif')
-                    ? 'image/gif'
-                    : 'image/png';
+                const primary = entry.preview.captures?.[0]?.renderOutput ?? "";
+                const mime =
+                    typeof primary === "string" &&
+                    primary.toLowerCase().endsWith(".gif")
+                        ? "image/gif"
+                        : "image/png";
                 md.appendMarkdown(
-                    `<img src="data:${mime};base64,${entry.imageBase64}" `
-                    + `width="${HOVER_IMG_MAX}" height="${HOVER_IMG_MAX}" />`,
+                    `<img src="data:${mime};base64,${entry.imageBase64}" ` +
+                        `width="${HOVER_IMG_MAX}" height="${HOVER_IMG_MAX}" />`,
                 );
             } else {
-                md.appendMarkdown('_No render yet._ ');
-                const args = encodeURIComponent(JSON.stringify([doc.uri.fsPath]));
-                md.appendMarkdown(`[Run Preview](command:composePreview.runForFile?${args})`);
+                md.appendMarkdown("_No render yet._ ");
+                const args = encodeURIComponent(
+                    JSON.stringify([doc.uri.fsPath]),
+                );
+                md.appendMarkdown(
+                    `[Run Preview](command:composePreview.runForFile?${args})`,
+                );
             }
             return new vscode.Hover(md, det.nameRange);
         }

--- a/vscode-extension/src/previewMainSource.ts
+++ b/vscode-extension/src/previewMainSource.ts
@@ -1,5 +1,5 @@
-import { ChildProcessByStdio, spawn } from 'child_process';
-import type { Readable, Writable } from 'stream';
+import { ChildProcessByStdio, spawn } from "child_process";
+import type { Readable, Writable } from "stream";
 
 /**
  * Read PNG bytes for a preview's `main` baseline directly from the
@@ -29,21 +29,31 @@ export async function readPreviewMainPng(
 ): Promise<PreviewMainResult | null> {
     const batch = getBatch(workspaceRoot);
     const candidateRefs = [
-        'origin/compose-preview/main',
-        'compose-preview/main',
-        'origin/preview_main',
-        'preview_main',
+        "origin/compose-preview/main",
+        "compose-preview/main",
+        "origin/preview_main",
+        "preview_main",
     ];
     for (const ref of candidateRefs) {
         const baselineBuf = await batch.read(`${ref}:baselines.json`);
-        if (!baselineBuf) { continue; }
-        const baselines = parseBaselines(baselineBuf.toString('utf8'));
-        if (!baselines) { continue; }
+        if (!baselineBuf) {
+            continue;
+        }
+        const baselines = parseBaselines(baselineBuf.toString("utf8"));
+        if (!baselines) {
+            continue;
+        }
         const entry = lookupBaselineEntry(baselines, moduleId, previewId);
-        if (!entry) { continue; }
+        if (!entry) {
+            continue;
+        }
         const basename = entry.renderBasename || `${previewId}.png`;
-        const png = await batch.read(`${ref}:renders/${entry.module ?? moduleId}/${basename}`);
-        if (!png) { continue; }
+        const png = await batch.read(
+            `${ref}:renders/${entry.module ?? moduleId}/${basename}`,
+        );
+        if (!png) {
+            continue;
+        }
         return { ref, baselineKey: entry.key, sha256: entry.sha256, png };
     }
     return null;
@@ -64,7 +74,9 @@ export interface PreviewMainResult {
  *  into the extension's `context.subscriptions` so an extension reload
  *  doesn't leak children. */
 export function disposePreviewMainBatches(): void {
-    for (const b of batches.values()) { b.dispose(); }
+    for (const b of batches.values()) {
+        b.dispose();
+    }
     batches.clear();
 }
 
@@ -81,8 +93,11 @@ function lookupBaselineEntry(
     previewId: string,
 ): BaselineEntry | null {
     const direct = baselines[`${moduleId}/${previewId}`];
-    if (direct && typeof direct === 'object') {
-        return makeEntry(`${moduleId}/${previewId}`, direct as Record<string, unknown>);
+    if (direct && typeof direct === "object") {
+        return makeEntry(
+            `${moduleId}/${previewId}`,
+            direct as Record<string, unknown>,
+        );
     }
     // Fall back to endswith match. Different module-key encodings (with /
     // without leading colon) shouldn't drop a hit for an unambiguous
@@ -91,9 +106,11 @@ function lookupBaselineEntry(
     // meant from previewId alone.
     const suffix = `/${previewId}`;
     for (const k of Object.keys(baselines)) {
-        if (!k.endsWith(suffix)) { continue; }
+        if (!k.endsWith(suffix)) {
+            continue;
+        }
         const v = baselines[k];
-        if (v && typeof v === 'object') {
+        if (v && typeof v === "object") {
             return makeEntry(k, v as Record<string, unknown>);
         }
     }
@@ -103,16 +120,21 @@ function lookupBaselineEntry(
 function makeEntry(key: string, raw: Record<string, unknown>): BaselineEntry {
     return {
         key,
-        module: typeof raw.module === 'string' ? raw.module : undefined,
-        sha256: typeof raw.sha256 === 'string' ? raw.sha256 : undefined,
-        renderBasename: typeof raw.renderBasename === 'string' ? raw.renderBasename : undefined,
+        module: typeof raw.module === "string" ? raw.module : undefined,
+        sha256: typeof raw.sha256 === "string" ? raw.sha256 : undefined,
+        renderBasename:
+            typeof raw.renderBasename === "string"
+                ? raw.renderBasename
+                : undefined,
     };
 }
 
 function parseBaselines(text: string): Record<string, unknown> | null {
     try {
         const parsed = JSON.parse(text);
-        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) { return null; }
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+            return null;
+        }
         return parsed as Record<string, unknown>;
     } catch {
         return null;
@@ -143,7 +165,7 @@ function getBatch(cwd: string): GitCatFileBatch {
  */
 export class CatFileBatchParser {
     private buffer: Buffer = Buffer.alloc(0);
-    private state: 'header' | 'body' = 'header';
+    private state: "header" | "body" = "header";
     private bodyRemaining = 0;
     private bodyChunks: Buffer[] = [];
 
@@ -153,16 +175,18 @@ export class CatFileBatchParser {
         this.buffer = Buffer.concat([this.buffer, chunk]);
         const out: Array<Buffer | null> = [];
         while (true) {
-            if (this.state === 'header') {
+            if (this.state === "header") {
                 const nl = this.buffer.indexOf(0x0a);
-                if (nl === -1) { return out; }
-                const line = this.buffer.slice(0, nl).toString('utf8');
+                if (nl === -1) {
+                    return out;
+                }
+                const line = this.buffer.slice(0, nl).toString("utf8");
                 this.buffer = this.buffer.slice(nl + 1);
-                if (line.endsWith(' missing')) {
+                if (line.endsWith(" missing")) {
                     out.push(null);
                     continue;
                 }
-                const parts = line.split(' ');
+                const parts = line.split(" ");
                 const size = parts.length === 3 ? parseInt(parts[2], 10) : NaN;
                 if (isNaN(size) || size < 0) {
                     // Unparseable header — fail the request and try to
@@ -171,17 +195,19 @@ export class CatFileBatchParser {
                     out.push(null);
                     continue;
                 }
-                this.state = 'body';
+                this.state = "body";
                 this.bodyRemaining = size;
                 this.bodyChunks = [];
             }
-            if (this.state === 'body') {
+            if (this.state === "body") {
                 // Body is exactly `bodyRemaining` bytes followed by '\n'.
-                if (this.buffer.length < this.bodyRemaining + 1) { return out; }
+                if (this.buffer.length < this.bodyRemaining + 1) {
+                    return out;
+                }
                 this.bodyChunks.push(this.buffer.slice(0, this.bodyRemaining));
                 this.buffer = this.buffer.slice(this.bodyRemaining + 1);
                 this.bodyRemaining = 0;
-                this.state = 'header';
+                this.state = "header";
                 out.push(Buffer.concat(this.bodyChunks));
                 this.bodyChunks = [];
             }
@@ -190,7 +216,7 @@ export class CatFileBatchParser {
 
     reset(): void {
         this.buffer = Buffer.alloc(0);
-        this.state = 'header';
+        this.state = "header";
         this.bodyRemaining = 0;
         this.bodyChunks = [];
     }
@@ -215,12 +241,16 @@ class GitCatFileBatch {
     constructor(private readonly cwd: string) {}
 
     read(rev: string): Promise<Buffer | null> {
-        if (this.disposed) { return Promise.resolve(null); }
-        if (!this.ensure()) { return Promise.resolve(null); }
+        if (this.disposed) {
+            return Promise.resolve(null);
+        }
+        if (!this.ensure()) {
+            return Promise.resolve(null);
+        }
         return new Promise((resolve) => {
             this.queue.push(resolve);
             try {
-                this.child!.stdin.write(rev + '\n');
+                this.child!.stdin.write(rev + "\n");
             } catch {
                 this.handleExit();
                 resolve(null);
@@ -229,24 +259,28 @@ class GitCatFileBatch {
     }
 
     private ensure(): boolean {
-        if (this.child) { return true; }
+        if (this.child) {
+            return true;
+        }
         try {
-            this.child = spawn(
-                'git', ['cat-file', '--batch'],
-                { cwd: this.cwd, stdio: ['pipe', 'pipe', 'ignore'] },
-            ) as ChildProcessByStdio<Writable, Readable, null>;
+            this.child = spawn("git", ["cat-file", "--batch"], {
+                cwd: this.cwd,
+                stdio: ["pipe", "pipe", "ignore"],
+            }) as ChildProcessByStdio<Writable, Readable, null>;
         } catch {
             this.child = null;
             return false;
         }
-        this.child.stdout.on('data', (c: Buffer) => {
+        this.child.stdout.on("data", (c: Buffer) => {
             for (const result of this.parser.feed(c)) {
                 const cb = this.queue.shift();
-                if (cb) { cb(result); }
+                if (cb) {
+                    cb(result);
+                }
             }
         });
-        this.child.on('exit', () => this.handleExit());
-        this.child.on('error', () => this.handleExit());
+        this.child.on("exit", () => this.handleExit());
+        this.child.on("error", () => this.handleExit());
         return true;
     }
 
@@ -255,7 +289,9 @@ class GitCatFileBatch {
         this.parser.reset();
         const drained = this.queue;
         this.queue = [];
-        for (const cb of drained) { cb(null); }
+        for (const cb of drained) {
+            cb(null);
+        }
     }
 
     dispose(): void {
@@ -263,8 +299,16 @@ class GitCatFileBatch {
         const child = this.child;
         this.handleExit();
         if (child) {
-            try { child.stdin.end(); } catch { /* already closed */ }
-            try { child.kill(); } catch { /* already gone */ }
+            try {
+                child.stdin.end();
+            } catch {
+                /* already closed */
+            }
+            try {
+                child.kill();
+            } catch {
+                /* already gone */
+            }
         }
     }
 }

--- a/vscode-extension/src/previewMainWatcher.ts
+++ b/vscode-extension/src/previewMainWatcher.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from "fs";
+import * as path from "path";
 
 /**
  * Watch the git refs that back the "Diff vs main" anchor and fire a single
@@ -27,17 +27,23 @@ export function watchPreviewMainRef(
     workspaceRoot: string,
     onChange: () => void,
 ): { dispose(): void } {
-    const gitDir = path.join(workspaceRoot, '.git');
+    const gitDir = path.join(workspaceRoot, ".git");
     if (!fs.existsSync(gitDir) || !fs.statSync(gitDir).isDirectory()) {
         // Worktree (`.git` is a file pointing elsewhere) or non-git
         // workspace. Fall through to a no-op; callers don't gain
         // automatic refresh, but explicit Diff vs main still works.
-        return { dispose: () => { /* nothing to clean up */ } };
+        return {
+            dispose: () => {
+                /* nothing to clean up */
+            },
+        };
     }
 
     let debounce: NodeJS.Timeout | null = null;
     const fire = () => {
-        if (debounce) { return; }
+        if (debounce) {
+            return;
+        }
         debounce = setTimeout(() => {
             debounce = null;
             onChange();
@@ -53,12 +59,30 @@ export function watchPreviewMainRef(
         // dir for `main` filename — the parent itself may not exist yet on
         // first checkout, in which case the existsSync check below skips
         // until the first fetch creates it.
-        { dir: path.join(gitDir, 'refs', 'remotes', 'origin', 'compose-preview'), filenames: new Set(['main']) },
-        { dir: path.join(gitDir, 'refs', 'heads', 'compose-preview'), filenames: new Set(['main']) },
+        {
+            dir: path.join(
+                gitDir,
+                "refs",
+                "remotes",
+                "origin",
+                "compose-preview",
+            ),
+            filenames: new Set(["main"]),
+        },
+        {
+            dir: path.join(gitDir, "refs", "heads", "compose-preview"),
+            filenames: new Set(["main"]),
+        },
         // Legacy flat refs — kept so repos that haven't migrated keep working.
-        { dir: path.join(gitDir, 'refs', 'remotes', 'origin'), filenames: new Set(['preview_main']) },
-        { dir: path.join(gitDir, 'refs', 'heads'), filenames: new Set(['preview_main']) },
-        { dir: gitDir, filenames: new Set(['packed-refs']) },
+        {
+            dir: path.join(gitDir, "refs", "remotes", "origin"),
+            filenames: new Set(["preview_main"]),
+        },
+        {
+            dir: path.join(gitDir, "refs", "heads"),
+            filenames: new Set(["preview_main"]),
+        },
+        { dir: gitDir, filenames: new Set(["packed-refs"]) },
     ];
 
     const watchers: fs.FSWatcher[] = [];
@@ -67,13 +91,17 @@ export function watchPreviewMainRef(
             // The dir might not exist yet (e.g. no remotes configured).
             // We tolerate ENOENT silently — the user just doesn't get
             // automatic refresh for that path until it appears.
-            if (!fs.existsSync(dir)) { continue; }
+            if (!fs.existsSync(dir)) {
+                continue;
+            }
             const watcher = fs.watch(dir, (_eventType, filename) => {
                 if (filename && filenames.has(filename.toString())) {
                     fire();
                 }
             });
-            watcher.on('error', () => { /* ignore — best-effort watcher */ });
+            watcher.on("error", () => {
+                /* ignore — best-effort watcher */
+            });
             watchers.push(watcher);
         } catch {
             // Platform-specific watcher failures (EMFILE on busy
@@ -83,9 +111,16 @@ export function watchPreviewMainRef(
 
     return {
         dispose() {
-            if (debounce) { clearTimeout(debounce); debounce = null; }
+            if (debounce) {
+                clearTimeout(debounce);
+                debounce = null;
+            }
             for (const w of watchers) {
-                try { w.close(); } catch { /* already closed */ }
+                try {
+                    w.close();
+                } catch {
+                    /* already closed */
+                }
             }
             watchers.length = 0;
         },

--- a/vscode-extension/src/previewPanel.ts
+++ b/vscode-extension/src/previewPanel.ts
@@ -1,8 +1,8 @@
-import * as vscode from 'vscode';
-import { ExtensionToWebview, WebviewToExtension } from './types';
+import * as vscode from "vscode";
+import { ExtensionToWebview, WebviewToExtension } from "./types";
 
 export class PreviewPanel implements vscode.WebviewViewProvider {
-    public static readonly viewId = 'composePreview.panel';
+    public static readonly viewId = "composePreview.panel";
 
     private view?: vscode.WebviewView;
     private extensionUri: vscode.Uri;
@@ -37,7 +37,9 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
             this.onMessage(msg);
         });
         webviewView.onDidChangeVisibility(() => {
-            if (webviewView.visible || !this.shouldRestoreVisibility()) { return; }
+            if (webviewView.visible || !this.shouldRestoreVisibility()) {
+                return;
+            }
             void vscode.commands.executeCommand(`${PreviewPanel.viewId}.focus`);
         });
     }
@@ -50,10 +52,10 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
         const nonce = getNonce();
         const earlyFeaturesEnabled = this.earlyFeaturesEnabled();
         const styleUri = webview.asWebviewUri(
-            vscode.Uri.joinPath(this.extensionUri, 'media', 'preview.css'),
+            vscode.Uri.joinPath(this.extensionUri, "media", "preview.css"),
         );
         const codiconUri = webview.asWebviewUri(
-            vscode.Uri.joinPath(this.extensionUri, 'media', 'codicon.css'),
+            vscode.Uri.joinPath(this.extensionUri, "media", "codicon.css"),
         );
 
         return /* html */ `<!DOCTYPE html>
@@ -155,7 +157,7 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
     (function() {
         const vscode = acquireVsCodeApi();
         const state = vscode.getState() || { filters: {} };
-        let earlyFeaturesEnabled = ${earlyFeaturesEnabled ? 'true' : 'false'};
+        let earlyFeaturesEnabled = ${earlyFeaturesEnabled ? "true" : "false"};
 
         const grid = document.getElementById('preview-grid');
         const focusInspector = document.getElementById('focus-inspector');
@@ -3110,8 +3112,9 @@ export class PreviewPanel implements vscode.WebviewViewProvider {
 }
 
 function getNonce(): string {
-    let text = '';
-    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let text = "";
+    const possible =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     for (let i = 0; i < 32; i++) {
         text += possible.charAt(Math.floor(Math.random() * possible.length));
     }

--- a/vscode-extension/src/previewRegistry.ts
+++ b/vscode-extension/src/previewRegistry.ts
@@ -1,6 +1,6 @@
-import * as vscode from 'vscode';
-import { packageQualifiedSourcePath } from './sourcePath';
-import { AccessibilityFinding, AccessibilityNode, PreviewInfo } from './types';
+import * as vscode from "vscode";
+import { packageQualifiedSourcePath } from "./sourcePath";
+import { AccessibilityFinding, AccessibilityNode, PreviewInfo } from "./types";
 
 export interface RegistryEntry {
     preview: PreviewInfo;
@@ -25,15 +25,24 @@ export class PreviewRegistry {
 
     replaceModule(module: string, previews: PreviewInfo[]): void {
         for (const [k, v] of this.bySourceAndName) {
-            if (v.module === module) { this.bySourceAndName.delete(k); }
+            if (v.module === module) {
+                this.bySourceAndName.delete(k);
+            }
         }
         for (const [k, v] of this.byId) {
-            if (v.module === module) { this.byId.delete(k); }
+            if (v.module === module) {
+                this.byId.delete(k);
+            }
         }
         for (const p of previews) {
-            if (!p.sourceFile) { continue; }
+            if (!p.sourceFile) {
+                continue;
+            }
             const entry: RegistryEntry = { preview: p, module };
-            this.bySourceAndName.set(keyOf(p.sourceFile, p.functionName), entry);
+            this.bySourceAndName.set(
+                keyOf(p.sourceFile, p.functionName),
+                entry,
+            );
             this.byId.set(p.id, entry);
         }
         this._onDidChange.fire();
@@ -41,7 +50,9 @@ export class PreviewRegistry {
 
     setImage(previewId: string, imageBase64: string): void {
         const entry = this.byId.get(previewId);
-        if (!entry) { return; }
+        if (!entry) {
+            return;
+        }
         entry.imageBase64 = imageBase64;
         this._onDidChange.fire();
     }
@@ -53,17 +64,28 @@ export class PreviewRegistry {
      */
     setA11y(
         previewId: string,
-        opts: { findings?: AccessibilityFinding[]; nodes?: AccessibilityNode[] },
+        opts: {
+            findings?: AccessibilityFinding[];
+            nodes?: AccessibilityNode[];
+        },
     ): void {
         const entry = this.byId.get(previewId);
-        if (!entry) { return; }
-        if (opts.findings !== undefined) { entry.preview.a11yFindings = opts.findings; }
-        if (opts.nodes !== undefined) { entry.preview.a11yNodes = opts.nodes; }
+        if (!entry) {
+            return;
+        }
+        if (opts.findings !== undefined) {
+            entry.preview.a11yFindings = opts.findings;
+        }
+        if (opts.nodes !== undefined) {
+            entry.preview.a11yNodes = opts.nodes;
+        }
         this._onDidChange.fire();
     }
 
     find(filePath: string, functionName: string): RegistryEntry | undefined {
-        return this.bySourceAndName.get(keyOf(packageQualifiedSourcePath(filePath), functionName));
+        return this.bySourceAndName.get(
+            keyOf(packageQualifiedSourcePath(filePath), functionName),
+        );
     }
 
     dispose(): void {

--- a/vscode-extension/src/refreshMode.ts
+++ b/vscode-extension/src/refreshMode.ts
@@ -7,7 +7,7 @@
  * `daemonGate` / `gradleService` state and forwards into here.
  */
 
-export type RefreshMode = 'daemon' | 'gradle';
+export type RefreshMode = "daemon" | "gradle";
 
 /**
  * - `'daemon'` — the daemon flag is on and the file resolves to a module. The save path skips
@@ -22,7 +22,11 @@ export function pickRefreshModeFor(
     daemonEnabled: boolean,
     moduleId: string | null,
 ): RefreshMode {
-    if (!daemonEnabled) { return 'gradle'; }
-    if (!moduleId) { return 'gradle'; }
-    return 'daemon';
+    if (!daemonEnabled) {
+        return "gradle";
+    }
+    if (!moduleId) {
+        return "gradle";
+    }
+    return "daemon";
 }

--- a/vscode-extension/src/renderError.ts
+++ b/vscode-extension/src/renderError.ts
@@ -12,7 +12,7 @@
  * that lands on the failing card via `setImageError.message`.
  */
 
-import { PreviewRenderError } from './types';
+import { PreviewRenderError } from "./types";
 
 /**
  * Render the structured renderer error into a single-line message for
@@ -27,12 +27,12 @@ import { PreviewRenderError } from './types';
  * already available in `renderError.exception` for tooling that wants it.
  */
 export function formatRenderErrorMessage(err: PreviewRenderError): string {
-    const cls = err.exception.split('.').pop() ?? err.exception;
+    const cls = err.exception.split(".").pop() ?? err.exception;
     const head = err.message ? `${cls}: ${err.message}` : cls;
     const frame = err.topAppFrame;
     if (frame && frame.file) {
-        const lineSuffix = frame.line > 0 ? `:${frame.line}` : '';
-        const fnSuffix = frame.function ? ` in ${frame.function}` : '';
+        const lineSuffix = frame.line > 0 ? `:${frame.line}` : "";
+        const fnSuffix = frame.function ? ` in ${frame.function}` : "";
         return `${head} (at ${frame.file}${lineSuffix}${fnSuffix})`;
     }
     return head;

--- a/vscode-extension/src/renderFreshness.ts
+++ b/vscode-extension/src/renderFreshness.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import { PreviewInfo } from './types';
+import * as fs from "fs";
+import * as path from "path";
+import { PreviewInfo } from "./types";
 
 const STAMP_SCHEMA_VERSION = 1;
 const MTIME_EPSILON_MS = 1;
@@ -14,7 +14,9 @@ interface RenderFreshnessStamp {
     previewIds: string[];
 }
 
-export async function sourceFileMtime(filePath: string): Promise<number | null> {
+export async function sourceFileMtime(
+    filePath: string,
+): Promise<number | null> {
     try {
         const stat = await fs.promises.stat(filePath);
         return stat.mtimeMs;
@@ -28,13 +30,13 @@ export function renderFreshnessStampPath(
     module: string,
     sourceFile: string,
 ): string {
-    const encoded = Buffer.from(sourceFile).toString('base64url');
+    const encoded = Buffer.from(sourceFile).toString("base64url");
     return path.join(
         workspaceRoot,
         module,
-        'build',
-        'compose-previews',
-        'render-freshness',
+        "build",
+        "compose-previews",
+        "render-freshness",
         `${encoded}.json`,
     );
 }
@@ -46,7 +48,9 @@ export async function writeRenderFreshnessStamp(
     previews: PreviewInfo[],
 ): Promise<void> {
     const sourceMtime = await sourceFileMtime(sourceFile);
-    if (sourceMtime == null) { return; }
+    if (sourceMtime == null) {
+        return;
+    }
 
     const stamp: RenderFreshnessStamp = {
         schemaVersion: STAMP_SCHEMA_VERSION,
@@ -54,9 +58,13 @@ export async function writeRenderFreshnessStamp(
         sourceFile,
         sourceMtimeMs: sourceMtime,
         renderedAtMs: Date.now(),
-        previewIds: previews.map(p => p.id).sort(),
+        previewIds: previews.map((p) => p.id).sort(),
     };
-    const stampPath = renderFreshnessStampPath(workspaceRoot, module, sourceFile);
+    const stampPath = renderFreshnessStampPath(
+        workspaceRoot,
+        module,
+        sourceFile,
+    );
     await fs.promises.mkdir(path.dirname(stampPath), { recursive: true });
     await fs.promises.writeFile(stampPath, JSON.stringify(stamp, null, 2));
 }
@@ -68,28 +76,34 @@ export async function hasFreshRenderStamp(
     previews: PreviewInfo[],
 ): Promise<boolean> {
     const sourceMtime = await sourceFileMtime(sourceFile);
-    if (sourceMtime == null) { return false; }
+    if (sourceMtime == null) {
+        return false;
+    }
 
     try {
         const raw = await fs.promises.readFile(
             renderFreshnessStampPath(workspaceRoot, module, sourceFile),
-            'utf8',
+            "utf8",
         );
         const stamp = JSON.parse(raw) as Partial<RenderFreshnessStamp>;
         if (
-            stamp.schemaVersion !== STAMP_SCHEMA_VERSION
-            || stamp.module !== module
-            || stamp.sourceFile !== sourceFile
-            || typeof stamp.sourceMtimeMs !== 'number'
-            || !Array.isArray(stamp.previewIds)
+            stamp.schemaVersion !== STAMP_SCHEMA_VERSION ||
+            stamp.module !== module ||
+            stamp.sourceFile !== sourceFile ||
+            typeof stamp.sourceMtimeMs !== "number" ||
+            !Array.isArray(stamp.previewIds)
         ) {
             return false;
         }
         if (sourceMtime > stamp.sourceMtimeMs + MTIME_EPSILON_MS) {
             return false;
         }
-        const stampedIds = new Set(stamp.previewIds.filter((id): id is string => typeof id === 'string'));
-        return previews.every(p => stampedIds.has(p.id));
+        const stampedIds = new Set(
+            stamp.previewIds.filter(
+                (id): id is string => typeof id === "string",
+            ),
+        );
+        return previews.every((p) => stampedIds.has(p.id));
     } catch {
         return false;
     }

--- a/vscode-extension/src/sourcePath.ts
+++ b/vscode-extension/src/sourcePath.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from "fs";
+import * as path from "path";
 
 // Matches a top-level Kotlin package declaration. Tolerates optional trailing
 // semicolon and leading whitespace (annotations/comments above `package` are
@@ -17,11 +17,13 @@ const PACKAGE_RE = /^\s*package\s+([a-zA-Z_][\w.]*)\s*;?\s*$/m;
 export function packageQualifiedSourcePath(filePath: string): string {
     const basename = path.basename(filePath);
     try {
-        const content = fs.readFileSync(filePath, 'utf-8');
+        const content = fs.readFileSync(filePath, "utf-8");
         const m = PACKAGE_RE.exec(content);
         if (m) {
-            return m[1].replace(/\./g, '/') + '/' + basename;
+            return m[1].replace(/\./g, "/") + "/" + basename;
         }
-    } catch { /* fall through to basename */ }
+    } catch {
+        /* fall through to basename */
+    }
     return basename;
 }

--- a/vscode-extension/src/test/androidManifestCodeLensProvider.test.ts
+++ b/vscode-extension/src/test/androidManifestCodeLensProvider.test.ts
@@ -1,8 +1,8 @@
-import * as assert from 'assert';
-import { findManifestIconReferences } from '../manifestIconReferences';
+import * as assert from "assert";
+import { findManifestIconReferences } from "../manifestIconReferences";
 
-describe('findManifestIconReferences', () => {
-    it('extracts icon and roundIcon from <application>', () => {
+describe("findManifestIconReferences", () => {
+    it("extracts icon and roundIcon from <application>", () => {
         const xml = `
             <manifest xmlns:android="http://schemas.android.com/apk/res/android">
                 <application
@@ -12,12 +12,21 @@ describe('findManifestIconReferences', () => {
         `;
         const matches = findManifestIconReferences(xml);
         assert.strictEqual(matches.length, 2);
-        assert.deepStrictEqual(matches.map((m) => m.attribute), ['icon', 'roundIcon']);
-        assert.deepStrictEqual(matches.map((m) => m.resourceType), ['mipmap', 'mipmap']);
-        assert.deepStrictEqual(matches.map((m) => m.resourceName), ['ic_launcher', 'ic_launcher_round']);
+        assert.deepStrictEqual(
+            matches.map((m) => m.attribute),
+            ["icon", "roundIcon"],
+        );
+        assert.deepStrictEqual(
+            matches.map((m) => m.resourceType),
+            ["mipmap", "mipmap"],
+        );
+        assert.deepStrictEqual(
+            matches.map((m) => m.resourceName),
+            ["ic_launcher", "ic_launcher_round"],
+        );
     });
 
-    it('extracts an activity-level icon override', () => {
+    it("extracts an activity-level icon override", () => {
         const xml = `
             <activity android:name=".MainActivity" android:icon="@drawable/ic_settings"/>
         `;
@@ -25,13 +34,13 @@ describe('findManifestIconReferences', () => {
         assert.strictEqual(matches.length, 1);
         assert.deepStrictEqual(matches[0], {
             offset: matches[0].offset,
-            attribute: 'icon',
-            resourceType: 'drawable',
-            resourceName: 'ic_settings',
+            attribute: "icon",
+            resourceType: "drawable",
+            resourceName: "ic_settings",
         });
     });
 
-    it('handles attributes split across lines with single quotes', () => {
+    it("handles attributes split across lines with single quotes", () => {
         const xml = `
             <activity
                 android:name='.Foo'
@@ -39,20 +48,20 @@ describe('findManifestIconReferences', () => {
         `;
         const matches = findManifestIconReferences(xml);
         assert.strictEqual(matches.length, 1);
-        assert.strictEqual(matches[0].resourceName, 'foo_icon');
+        assert.strictEqual(matches[0].resourceName, "foo_icon");
     });
 
-    it('skips framework drawable references (@android:drawable/...)', () => {
+    it("skips framework drawable references (@android:drawable/...)", () => {
         const xml = `<application android:icon="@android:drawable/sym_def_app_icon" />`;
         assert.deepStrictEqual(findManifestIconReferences(xml), []);
     });
 
-    it('skips theme attribute references (?attr/...)', () => {
+    it("skips theme attribute references (?attr/...)", () => {
         const xml = `<activity android:icon="?attr/iconResource" />`;
         assert.deepStrictEqual(findManifestIconReferences(xml), []);
     });
 
-    it('skips non-icon attributes carrying drawable refs', () => {
+    it("skips non-icon attributes carrying drawable refs", () => {
         const xml = `
             <application android:theme="@style/AppTheme">
                 <activity android:label="@string/title" />
@@ -61,33 +70,42 @@ describe('findManifestIconReferences', () => {
         assert.deepStrictEqual(findManifestIconReferences(xml), []);
     });
 
-    it('records the offset of each match for CodeLens range positioning', () => {
+    it("records the offset of each match for CodeLens range positioning", () => {
         const xml = 'before <activity android:icon="@drawable/foo" /> after';
         const matches = findManifestIconReferences(xml);
         assert.strictEqual(matches.length, 1);
         // Offset should land on the `android:` prefix, not the start of the document.
-        assert.strictEqual(xml.slice(matches[0].offset, matches[0].offset + 'android:icon'.length), 'android:icon');
+        assert.strictEqual(
+            xml.slice(
+                matches[0].offset,
+                matches[0].offset + "android:icon".length,
+            ),
+            "android:icon",
+        );
     });
 
-    it('handles logo and banner attributes', () => {
+    it("handles logo and banner attributes", () => {
         const xml = `
             <application android:logo="@drawable/app_logo">
                 <activity android:banner="@drawable/tv_banner" />
             </application>
         `;
         const matches = findManifestIconReferences(xml);
-        assert.deepStrictEqual(matches.map((m) => m.attribute).sort(), ['banner', 'logo']);
+        assert.deepStrictEqual(matches.map((m) => m.attribute).sort(), [
+            "banner",
+            "logo",
+        ]);
     });
 
-    it('returns empty for a manifest with no icon attributes', () => {
+    it("returns empty for a manifest with no icon attributes", () => {
         const xml = `<manifest xmlns:android="http://schemas.android.com/apk/res/android"><application /></manifest>`;
         assert.deepStrictEqual(findManifestIconReferences(xml), []);
     });
 
-    it('accepts the @+drawable/ resource-id form', () => {
+    it("accepts the @+drawable/ resource-id form", () => {
         const xml = `<application android:icon="@+drawable/new_icon" />`;
         const matches = findManifestIconReferences(xml);
         assert.strictEqual(matches.length, 1);
-        assert.strictEqual(matches[0].resourceName, 'new_icon');
+        assert.strictEqual(matches[0].resourceName, "new_icon");
     });
 });

--- a/vscode-extension/src/test/buildProgress.test.ts
+++ b/vscode-extension/src/test/buildProgress.test.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import * as assert from "assert";
 import {
     BuildProgressTracker,
     PHASES,
@@ -6,7 +6,7 @@ import {
     PhaseId,
     classifyTask,
     mergeCalibration,
-} from '../buildProgress';
+} from "../buildProgress";
 
 /**
  * Deterministic clock + tick scheduler so the tracker's behaviour is fully
@@ -23,7 +23,7 @@ class FakeClock {
         return handle;
     };
     clearInterval = (handle: unknown): void => {
-        this.timers = this.timers.filter(h => h !== handle);
+        this.timers = this.timers.filter((h) => h !== handle);
     };
     advance(ms: number): void {
         const target = this.t + ms;
@@ -31,9 +31,11 @@ class FakeClock {
         // eslint-disable-next-line no-constant-condition
         while (true) {
             const next = this.timers
-                .filter(h => h.nextAt <= target)
+                .filter((h) => h.nextAt <= target)
                 .sort((a, b) => a.nextAt - b.nextAt)[0];
-            if (!next) { break; }
+            if (!next) {
+                break;
+            }
             this.t = next.nextAt;
             next.nextAt += next.interval;
             next.cb();
@@ -65,112 +67,152 @@ function makeTracker(opts: {
     return { tracker, states };
 }
 
-describe('classifyTask', () => {
-    it('routes render tasks to the rendering phase', () => {
-        assert.strictEqual(classifyTask(':samples:android:renderPreviews'), 'rendering');
-        assert.strictEqual(classifyTask(':app:renderAllPreviews'), 'rendering');
-        assert.strictEqual(classifyTask(':app:renderAndroidResources'), 'rendering');
+describe("classifyTask", () => {
+    it("routes render tasks to the rendering phase", () => {
+        assert.strictEqual(
+            classifyTask(":samples:android:renderPreviews"),
+            "rendering",
+        );
+        assert.strictEqual(classifyTask(":app:renderAllPreviews"), "rendering");
+        assert.strictEqual(
+            classifyTask(":app:renderAndroidResources"),
+            "rendering",
+        );
     });
 
-    it('routes discover tasks to the discovering phase', () => {
-        assert.strictEqual(classifyTask(':samples:cmp:discoverPreviews'), 'discovering');
-        assert.strictEqual(classifyTask(':app:discoverAndroidResources'), 'discovering');
+    it("routes discover tasks to the discovering phase", () => {
+        assert.strictEqual(
+            classifyTask(":samples:cmp:discoverPreviews"),
+            "discovering",
+        );
+        assert.strictEqual(
+            classifyTask(":app:discoverAndroidResources"),
+            "discovering",
+        );
     });
 
-    it('routes Kotlin/Java compile tasks to the compiling phase', () => {
-        assert.strictEqual(classifyTask(':app:compileDebugKotlin'), 'compiling');
-        assert.strictEqual(classifyTask(':app:compileDebugUnitTestKotlin'), 'compiling');
-        assert.strictEqual(classifyTask(':app:compileDebugJavaWithJavac'), 'compiling');
-        assert.strictEqual(classifyTask(':app:compileRenderShards'), 'compiling');
+    it("routes Kotlin/Java compile tasks to the compiling phase", () => {
+        assert.strictEqual(
+            classifyTask(":app:compileDebugKotlin"),
+            "compiling",
+        );
+        assert.strictEqual(
+            classifyTask(":app:compileDebugUnitTestKotlin"),
+            "compiling",
+        );
+        assert.strictEqual(
+            classifyTask(":app:compileDebugJavaWithJavac"),
+            "compiling",
+        );
+        assert.strictEqual(
+            classifyTask(":app:compileRenderShards"),
+            "compiling",
+        );
     });
 
-    it('routes resource / classpath staging to resolving', () => {
-        assert.strictEqual(classifyTask(':app:extractPreviewClasses'), 'resolving');
-        assert.strictEqual(classifyTask(':app:generateRenderShards'), 'resolving');
-        assert.strictEqual(classifyTask(':app:processDebugResources'), 'resolving');
+    it("routes resource / classpath staging to resolving", () => {
+        assert.strictEqual(
+            classifyTask(":app:extractPreviewClasses"),
+            "resolving",
+        );
+        assert.strictEqual(
+            classifyTask(":app:generateRenderShards"),
+            "resolving",
+        );
+        assert.strictEqual(
+            classifyTask(":app:processDebugResources"),
+            "resolving",
+        );
     });
 
-    it('returns null for uninteresting tasks', () => {
-        assert.strictEqual(classifyTask(':composePreviewApplied'), null);
-        assert.strictEqual(classifyTask(':app:composePreviewDoctor'), null);
+    it("returns null for uninteresting tasks", () => {
+        assert.strictEqual(classifyTask(":composePreviewApplied"), null);
+        assert.strictEqual(classifyTask(":app:composePreviewDoctor"), null);
     });
 });
 
-describe('BuildProgressTracker', () => {
-    it('starts at zero and advances through phases on task signals', () => {
+describe("BuildProgressTracker", () => {
+    it("starts at zero and advances through phases on task signals", () => {
         const clock = new FakeClock();
         const { tracker, states } = makeTracker({ clock });
         tracker.start();
         const initial = states[states.length - 1];
-        assert.strictEqual(initial.phase, 'starting');
+        assert.strictEqual(initial.phase, "starting");
         assert.strictEqual(initial.percent, 0);
 
-        tracker.consume('> Configure project :samples:android\n');
-        assert.strictEqual(states[states.length - 1].phase, 'configuring');
+        tracker.consume("> Configure project :samples:android\n");
+        assert.strictEqual(states[states.length - 1].phase, "configuring");
 
-        tracker.consume('> Task :samples:android:compileDebugKotlin\n');
-        assert.strictEqual(states[states.length - 1].phase, 'compiling');
+        tracker.consume("> Task :samples:android:compileDebugKotlin\n");
+        assert.strictEqual(states[states.length - 1].phase, "compiling");
 
-        tracker.consume('> Task :samples:android:discoverPreviews\n');
-        assert.strictEqual(states[states.length - 1].phase, 'discovering');
+        tracker.consume("> Task :samples:android:discoverPreviews\n");
+        assert.strictEqual(states[states.length - 1].phase, "discovering");
 
-        tracker.consume('> Task :samples:android:renderPreviews\n');
-        assert.strictEqual(states[states.length - 1].phase, 'rendering');
+        tracker.consume("> Task :samples:android:renderPreviews\n");
+        assert.strictEqual(states[states.length - 1].phase, "rendering");
 
         tracker.finish();
         const last = states[states.length - 1];
-        assert.strictEqual(last.phase, 'done');
+        assert.strictEqual(last.phase, "done");
         assert.strictEqual(last.percent, 1);
     });
 
-    it('is monotonic — late stray signals do not move the bar backward', () => {
+    it("is monotonic — late stray signals do not move the bar backward", () => {
         const clock = new FakeClock();
         const { tracker, states } = makeTracker({ clock });
         tracker.start();
-        tracker.consume('> Task :a:renderPreviews\n');
+        tracker.consume("> Task :a:renderPreviews\n");
         const renderingPct = states[states.length - 1].percent;
         // A stray discoverPreviews line after rendering started must not
         // drag the bar backward — phase index is lower but tracker ignores
         // it.
-        tracker.consume('> Task :a:discoverPreviews\n');
+        tracker.consume("> Task :a:discoverPreviews\n");
         const afterStray = states[states.length - 1].percent;
-        assert.ok(afterStray >= renderingPct,
-            `expected ${afterStray} >= ${renderingPct} (no rewind on out-of-order signal)`);
-        assert.strictEqual(states[states.length - 1].phase, 'rendering');
+        assert.ok(
+            afterStray >= renderingPct,
+            `expected ${afterStray} >= ${renderingPct} (no rewind on out-of-order signal)`,
+        );
+        assert.strictEqual(states[states.length - 1].phase, "rendering");
     });
 
-    it('animates within a phase via the tick timer without crossing phase boundary', () => {
+    it("animates within a phase via the tick timer without crossing phase boundary", () => {
         const clock = new FakeClock();
         const { tracker, states } = makeTracker({ clock });
         tracker.start();
-        tracker.consume('> Task :a:compileDebugKotlin\n');
+        tracker.consume("> Task :a:compileDebugKotlin\n");
         const compileStart = states[states.length - 1].percent;
 
         // Advance well past the default compile duration. The bar should
         // approach but not exceed the compile phase's upper boundary.
         clock.advance(60_000);
         const long = states[states.length - 1].percent;
-        assert.ok(long > compileStart, `expected progress to advance during ticks: ${long} > ${compileStart}`);
+        assert.ok(
+            long > compileStart,
+            `expected progress to advance during ticks: ${long} > ${compileStart}`,
+        );
 
-        tracker.consume('> Task :a:renderPreviews\n');
+        tracker.consume("> Task :a:renderPreviews\n");
         const renderStart = states[states.length - 1].percent;
-        assert.ok(renderStart >= long,
-            `entering render must not rewind: ${renderStart} >= ${long}`);
+        assert.ok(
+            renderStart >= long,
+            `entering render must not rewind: ${renderStart} >= ${long}`,
+        );
         tracker.finish();
     });
 
-    it('records phase durations for caller-side calibration', () => {
+    it("records phase durations for caller-side calibration", () => {
         const clock = new FakeClock();
         const { tracker } = makeTracker({ clock });
         tracker.start();
         clock.advance(200);
-        tracker.consume('> Configure project :a\n');
+        tracker.consume("> Configure project :a\n");
         clock.advance(800);
-        tracker.consume('> Task :a:compileDebugKotlin\n');
+        tracker.consume("> Task :a:compileDebugKotlin\n");
         clock.advance(3500);
-        tracker.consume('> Task :a:discoverPreviews\n');
+        tracker.consume("> Task :a:discoverPreviews\n");
         clock.advance(400);
-        tracker.consume('> Task :a:renderPreviews\n');
+        tracker.consume("> Task :a:renderPreviews\n");
         clock.advance(7000);
         tracker.finish();
         const d = tracker.phaseDurations;
@@ -180,7 +222,7 @@ describe('BuildProgressTracker', () => {
         assert.strictEqual(d.rendering, 7000);
     });
 
-    it('jumps to 100% on finish() and stays there', () => {
+    it("jumps to 100% on finish() and stays there", () => {
         const clock = new FakeClock();
         const { tracker, states } = makeTracker({ clock });
         tracker.start();
@@ -190,38 +232,44 @@ describe('BuildProgressTracker', () => {
         // No ticks should fire after finish — the timer is cleared.
         const stateCount = states.length;
         clock.advance(5_000);
-        assert.strictEqual(states.length, stateCount,
-            'no progress events should fire after finish()');
+        assert.strictEqual(
+            states.length,
+            stateCount,
+            "no progress events should fire after finish()",
+        );
     });
 
-    it('abort() stops emitting without driving to 100%', () => {
+    it("abort() stops emitting without driving to 100%", () => {
         const clock = new FakeClock();
         const { tracker, states } = makeTracker({ clock });
         tracker.start();
-        tracker.consume('> Task :a:renderPreviews\n');
+        tracker.consume("> Task :a:renderPreviews\n");
         const beforeAbort = states[states.length - 1].percent;
         tracker.abort();
         clock.advance(5_000);
         const last = states[states.length - 1];
         // We never emitted a synthetic 100% — the last percent we sent is
         // whatever the renderer phase had reached.
-        assert.ok(last.percent < 1, `aborted progress should not reach 1: ${last.percent}`);
+        assert.ok(
+            last.percent < 1,
+            `aborted progress should not reach 1: ${last.percent}`,
+        );
         assert.ok(last.percent >= beforeAbort);
     });
 
-    it('handles split chunks across newline boundaries', () => {
+    it("handles split chunks across newline boundaries", () => {
         const clock = new FakeClock();
         const { tracker, states } = makeTracker({ clock });
         tracker.start();
         // Split the same task line over four chunks — must still classify.
-        tracker.consume('> Task ');
-        tracker.consume(':app:co');
-        tracker.consume('mpileDebugKotlin');
-        tracker.consume('\n');
-        assert.strictEqual(states[states.length - 1].phase, 'compiling');
+        tracker.consume("> Task ");
+        tracker.consume(":app:co");
+        tracker.consume("mpileDebugKotlin");
+        tracker.consume("\n");
+        assert.strictEqual(states[states.length - 1].phase, "compiling");
     });
 
-    it('uses calibration data to expand slow phases on the bar', () => {
+    it("uses calibration data to expand slow phases on the bar", () => {
         const clock = new FakeClock();
         const calibration: PhaseDurations = {
             configuring: 500,
@@ -232,67 +280,81 @@ describe('BuildProgressTracker', () => {
         };
         const { tracker, states } = makeTracker({ clock, calibration });
         tracker.start();
-        tracker.consume('> Task :a:compileDebugKotlin\n');
+        tracker.consume("> Task :a:compileDebugKotlin\n");
         const compileStart = states[states.length - 1].percent;
-        tracker.consume('> Task :a:renderPreviews\n');
+        tracker.consume("> Task :a:renderPreviews\n");
         const renderStart = states[states.length - 1].percent;
         const compileSpan = renderStart - compileStart;
         // Compile owns ~50/51.8 of the bar after configure, so its span
         // should dominate (>50% of the [compileStart, 1] tail).
-        assert.ok(compileSpan > 0.5,
-            `compile span should be large with this calibration, got ${compileSpan}`);
+        assert.ok(
+            compileSpan > 0.5,
+            `compile span should be large with this calibration, got ${compileSpan}`,
+        );
         tracker.finish();
     });
 
-    it('every phase descriptor has a non-empty label', () => {
+    it("every phase descriptor has a non-empty label", () => {
         for (const p of PHASES) {
             assert.ok(p.label.length > 0, `phase ${p.id} missing label`);
         }
     });
 
-    it('flags slow=true once elapsed exceeds 2x the phase estimate', () => {
+    it("flags slow=true once elapsed exceeds 2x the phase estimate", () => {
         const clock = new FakeClock();
         // Calibrate compile to 1000ms — so any tick after 2000ms in compile
         // counts as slow.
         const calibration: PhaseDurations = { compiling: 1000 };
         const { tracker, states } = makeTracker({ clock, calibration });
         tracker.start();
-        tracker.consume('> Task :a:compileDebugKotlin\n');
+        tracker.consume("> Task :a:compileDebugKotlin\n");
         const enteredCompile = states[states.length - 1];
-        assert.strictEqual(enteredCompile.slow, false,
-            'just-entered phase should not be slow');
+        assert.strictEqual(
+            enteredCompile.slow,
+            false,
+            "just-entered phase should not be slow",
+        );
 
         clock.advance(1500);
         const halfwayOver = states[states.length - 1];
-        assert.strictEqual(halfwayOver.slow, false,
-            '1.5x expected is not yet slow');
+        assert.strictEqual(
+            halfwayOver.slow,
+            false,
+            "1.5x expected is not yet slow",
+        );
 
         clock.advance(1000); // total 2500ms — past the 2x threshold
         const slow = states[states.length - 1];
-        assert.strictEqual(slow.slow, true, '>2x expected should flag slow');
+        assert.strictEqual(slow.slow, true, ">2x expected should flag slow");
 
         // Transition out of the slow phase — slow flag resets for the next.
-        tracker.consume('> Task :a:renderPreviews\n');
+        tracker.consume("> Task :a:renderPreviews\n");
         const renderJustStarted = states[states.length - 1];
-        assert.strictEqual(renderJustStarted.slow, false,
-            'fresh phase should reset the slow flag');
+        assert.strictEqual(
+            renderJustStarted.slow,
+            false,
+            "fresh phase should reset the slow flag",
+        );
         tracker.finish();
     });
 });
 
-describe('mergeCalibration', () => {
-    it('returns the latest sample when no prior exists', () => {
+describe("mergeCalibration", () => {
+    it("returns the latest sample when no prior exists", () => {
         const merged = mergeCalibration({}, { compiling: 4000 });
         assert.strictEqual(merged.compiling, 4000);
     });
 
-    it('blends prior and latest with EMA', () => {
-        const merged = mergeCalibration({ compiling: 1000 }, { compiling: 3000 });
+    it("blends prior and latest with EMA", () => {
+        const merged = mergeCalibration(
+            { compiling: 1000 },
+            { compiling: 3000 },
+        );
         // 0.5 * 1000 + 0.5 * 3000 = 2000
         assert.strictEqual(merged.compiling, 2000);
     });
 
-    it('preserves prior samples for phases not seen this run', () => {
+    it("preserves prior samples for phases not seen this run", () => {
         const merged = mergeCalibration(
             { compiling: 1000, rendering: 5000 },
             { compiling: 2000 },

--- a/vscode-extension/src/test/compileErrors.test.ts
+++ b/vscode-extension/src/test/compileErrors.test.ts
@@ -1,9 +1,9 @@
-import * as assert from 'assert';
+import * as assert from "assert";
 import {
     DIAGNOSTIC_SEVERITY,
     DiagnosticLike,
     extractCompileErrors,
-} from '../compileErrors';
+} from "../compileErrors";
 
 /** Minimal diagnostic builder mirroring the bits we use from vscode.Diagnostic. */
 function diag(opts: {
@@ -21,114 +21,189 @@ function diag(opts: {
     };
 }
 
-describe('extractCompileErrors', () => {
-    it('returns an empty array when no diagnostics are present', () => {
-        const out = extractCompileErrors('/ws/Foo.kt', []);
+describe("extractCompileErrors", () => {
+    it("returns an empty array when no diagnostics are present", () => {
+        const out = extractCompileErrors("/ws/Foo.kt", []);
         assert.deepStrictEqual(out, []);
     });
 
-    it('returns an empty array when all diagnostics are warnings/hints', () => {
-        const out = extractCompileErrors('/ws/Foo.kt', [
-            diag({ severity: DIAGNOSTIC_SEVERITY.Warning, line: 0, message: 'unused import', source: 'kotlin' }),
-            diag({ severity: DIAGNOSTIC_SEVERITY.Hint, line: 1, message: 'spell', source: 'kotlin' }),
+    it("returns an empty array when all diagnostics are warnings/hints", () => {
+        const out = extractCompileErrors("/ws/Foo.kt", [
+            diag({
+                severity: DIAGNOSTIC_SEVERITY.Warning,
+                line: 0,
+                message: "unused import",
+                source: "kotlin",
+            }),
+            diag({
+                severity: DIAGNOSTIC_SEVERITY.Hint,
+                line: 1,
+                message: "spell",
+                source: "kotlin",
+            }),
         ]);
         assert.deepStrictEqual(out, []);
     });
 
-    it('extracts an Error diagnostic with 1-based line/column', () => {
-        const out = extractCompileErrors('/ws/Foo.kt', [
+    it("extracts an Error diagnostic with 1-based line/column", () => {
+        const out = extractCompileErrors("/ws/Foo.kt", [
             diag({
                 severity: DIAGNOSTIC_SEVERITY.Error,
-                line: 41,        // 0-based
-                column: 4,       // 0-based
-                message: 'Unresolved reference: Modfier',
-                source: 'kotlin',
+                line: 41, // 0-based
+                column: 4, // 0-based
+                message: "Unresolved reference: Modfier",
+                source: "kotlin",
             }),
         ]);
         assert.strictEqual(out.length, 1);
-        assert.strictEqual(out[0].file, 'Foo.kt');
-        assert.strictEqual(out[0].line, 42);     // 1-based for display
-        assert.strictEqual(out[0].column, 5);    // 1-based for display
-        assert.strictEqual(out[0].message, 'Unresolved reference: Modfier');
+        assert.strictEqual(out[0].file, "Foo.kt");
+        assert.strictEqual(out[0].line, 42); // 1-based for display
+        assert.strictEqual(out[0].column, 5); // 1-based for display
+        assert.strictEqual(out[0].message, "Unresolved reference: Modfier");
     });
 
-    it('mixes errors and warnings — only errors are returned', () => {
-        const out = extractCompileErrors('/ws/Foo.kt', [
-            diag({ severity: DIAGNOSTIC_SEVERITY.Warning, line: 5, message: 'shadows outer', source: 'kotlin' }),
-            diag({ severity: DIAGNOSTIC_SEVERITY.Error, line: 10, message: 'expected }', source: 'kotlin' }),
-            diag({ severity: DIAGNOSTIC_SEVERITY.Hint, line: 12, message: 'redundant', source: 'kotlin' }),
+    it("mixes errors and warnings — only errors are returned", () => {
+        const out = extractCompileErrors("/ws/Foo.kt", [
+            diag({
+                severity: DIAGNOSTIC_SEVERITY.Warning,
+                line: 5,
+                message: "shadows outer",
+                source: "kotlin",
+            }),
+            diag({
+                severity: DIAGNOSTIC_SEVERITY.Error,
+                line: 10,
+                message: "expected }",
+                source: "kotlin",
+            }),
+            diag({
+                severity: DIAGNOSTIC_SEVERITY.Hint,
+                line: 12,
+                message: "redundant",
+                source: "kotlin",
+            }),
         ]);
         assert.strictEqual(out.length, 1);
         assert.strictEqual(out[0].line, 11);
     });
 
-    it('rejects errors from untrusted sources', () => {
+    it("rejects errors from untrusted sources", () => {
         // A markdown linter or a custom checker shouldn't be able to gate a
         // Kotlin build — only diagnostics from known compile sources count.
-        const out = extractCompileErrors('/ws/Foo.kt', [
+        const out = extractCompileErrors("/ws/Foo.kt", [
             diag({
                 severity: DIAGNOSTIC_SEVERITY.Error,
                 line: 0,
-                message: 'spelling: Composble',
-                source: 'cspell',
+                message: "spelling: Composble",
+                source: "cspell",
             }),
         ]);
         assert.deepStrictEqual(out, []);
     });
 
-    it('accepts errors from trusted Kotlin LSP sources', () => {
-        for (const src of ['kotlin', 'kotlin-language-server', 'fwcd.kotlin', 'gradle', 'JetBrains']) {
-            const out = extractCompileErrors('/ws/Foo.kt', [
-                diag({ severity: DIAGNOSTIC_SEVERITY.Error, line: 0, message: 'x', source: src }),
+    it("accepts errors from trusted Kotlin LSP sources", () => {
+        for (const src of [
+            "kotlin",
+            "kotlin-language-server",
+            "fwcd.kotlin",
+            "gradle",
+            "JetBrains",
+        ]) {
+            const out = extractCompileErrors("/ws/Foo.kt", [
+                diag({
+                    severity: DIAGNOSTIC_SEVERITY.Error,
+                    line: 0,
+                    message: "x",
+                    source: src,
+                }),
             ]);
-            assert.strictEqual(out.length, 1, `expected source "${src}" to be trusted`);
+            assert.strictEqual(
+                out.length,
+                1,
+                `expected source "${src}" to be trusted`,
+            );
         }
     });
 
-    it('accepts errors with no source field set', () => {
+    it("accepts errors with no source field set", () => {
         // Some servers don't populate `source`. Default-trust those rather
         // than silently swallowing the gate.
-        const out = extractCompileErrors('/ws/Foo.kt', [
-            diag({ severity: DIAGNOSTIC_SEVERITY.Error, line: 0, message: 'oops' }),
+        const out = extractCompileErrors("/ws/Foo.kt", [
+            diag({
+                severity: DIAGNOSTIC_SEVERITY.Error,
+                line: 0,
+                message: "oops",
+            }),
         ]);
         assert.strictEqual(out.length, 1);
     });
 
-    it('returns errors sorted by line then column', () => {
-        const out = extractCompileErrors('/ws/Foo.kt', [
-            diag({ severity: DIAGNOSTIC_SEVERITY.Error, line: 50, column: 0, message: 'late', source: 'kotlin' }),
-            diag({ severity: DIAGNOSTIC_SEVERITY.Error, line: 10, column: 5, message: 'early B', source: 'kotlin' }),
-            diag({ severity: DIAGNOSTIC_SEVERITY.Error, line: 10, column: 1, message: 'early A', source: 'kotlin' }),
+    it("returns errors sorted by line then column", () => {
+        const out = extractCompileErrors("/ws/Foo.kt", [
+            diag({
+                severity: DIAGNOSTIC_SEVERITY.Error,
+                line: 50,
+                column: 0,
+                message: "late",
+                source: "kotlin",
+            }),
+            diag({
+                severity: DIAGNOSTIC_SEVERITY.Error,
+                line: 10,
+                column: 5,
+                message: "early B",
+                source: "kotlin",
+            }),
+            diag({
+                severity: DIAGNOSTIC_SEVERITY.Error,
+                line: 10,
+                column: 1,
+                message: "early A",
+                source: "kotlin",
+            }),
         ]);
-        assert.deepStrictEqual(out.map(e => e.message), ['early A', 'early B', 'late']);
+        assert.deepStrictEqual(
+            out.map((e) => e.message),
+            ["early A", "early B", "late"],
+        );
     });
 
-    it('uses only the first line of multi-line diagnostic messages', () => {
+    it("uses only the first line of multi-line diagnostic messages", () => {
         // A long Kotlin error message with type-inference detail can run
         // many lines. Banner rows are one line each so we trim — full
         // detail still in the LSP hover / Problems panel.
-        const out = extractCompileErrors('/ws/Foo.kt', [
+        const out = extractCompileErrors("/ws/Foo.kt", [
             diag({
                 severity: DIAGNOSTIC_SEVERITY.Error,
                 line: 0,
-                message: 'Type mismatch.\nRequired: String\nFound: Int',
-                source: 'kotlin',
+                message: "Type mismatch.\nRequired: String\nFound: Int",
+                source: "kotlin",
             }),
         ]);
-        assert.strictEqual(out[0].message, 'Type mismatch.');
+        assert.strictEqual(out[0].message, "Type mismatch.");
     });
 
-    it('extracts the file basename for display, even from absolute paths', () => {
-        const out = extractCompileErrors('/long/abs/path/to/Previews.kt', [
-            diag({ severity: DIAGNOSTIC_SEVERITY.Error, line: 0, message: 'x', source: 'kotlin' }),
+    it("extracts the file basename for display, even from absolute paths", () => {
+        const out = extractCompileErrors("/long/abs/path/to/Previews.kt", [
+            diag({
+                severity: DIAGNOSTIC_SEVERITY.Error,
+                line: 0,
+                message: "x",
+                source: "kotlin",
+            }),
         ]);
-        assert.strictEqual(out[0].file, 'Previews.kt');
+        assert.strictEqual(out[0].file, "Previews.kt");
     });
 
-    it('handles Windows-style paths', () => {
-        const out = extractCompileErrors('C:\\workspace\\src\\Previews.kt', [
-            diag({ severity: DIAGNOSTIC_SEVERITY.Error, line: 0, message: 'x', source: 'kotlin' }),
+    it("handles Windows-style paths", () => {
+        const out = extractCompileErrors("C:\\workspace\\src\\Previews.kt", [
+            diag({
+                severity: DIAGNOSTIC_SEVERITY.Error,
+                line: 0,
+                message: "x",
+                source: "kotlin",
+            }),
         ]);
-        assert.strictEqual(out[0].file, 'Previews.kt');
+        assert.strictEqual(out[0].file, "Previews.kt");
     });
 });

--- a/vscode-extension/src/test/currentRendersHistory.test.ts
+++ b/vscode-extension/src/test/currentRendersHistory.test.ts
@@ -1,8 +1,8 @@
-import * as assert from 'assert';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import { CurrentRendersHistory } from '../daemon/currentRendersHistory';
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { CurrentRendersHistory } from "../daemon/currentRendersHistory";
 
 interface ManifestPreview {
     id: string;
@@ -16,13 +16,13 @@ function withFixture<T>(
     fn: (buildDir: string) => T | Promise<T>,
 ): () => Promise<T> {
     return async () => {
-        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'current-renders-'));
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), "current-renders-"));
         try {
-            const buildDir = path.join(root, 'build', 'compose-previews');
-            fs.mkdirSync(path.join(buildDir, 'renders'), { recursive: true });
+            const buildDir = path.join(root, "build", "compose-previews");
+            fs.mkdirSync(path.join(buildDir, "renders"), { recursive: true });
             fs.writeFileSync(
-                path.join(buildDir, 'previews.json'),
-                JSON.stringify({ module: 'test', variant: 'debug', previews }),
+                path.join(buildDir, "previews.json"),
+                JSON.stringify({ module: "test", variant: "debug", previews }),
             );
             for (const [rel, body] of Object.entries(pngFiles)) {
                 const full = path.join(buildDir, rel);
@@ -38,55 +38,86 @@ function withFixture<T>(
 
 const PREVIEWS: ManifestPreview[] = [
     {
-        id: 'com.example.A',
-        sourceFile: 'com/example/Previews.kt',
-        captures: [{ renderOutput: 'renders/com.example.A.png' }],
+        id: "com.example.A",
+        sourceFile: "com/example/Previews.kt",
+        captures: [{ renderOutput: "renders/com.example.A.png" }],
     },
     {
-        id: 'com.example.B',
-        sourceFile: 'com/example/Previews.kt',
-        captures: [{ renderOutput: 'renders/com.example.B.png' }],
+        id: "com.example.B",
+        sourceFile: "com/example/Previews.kt",
+        captures: [{ renderOutput: "renders/com.example.B.png" }],
     },
 ];
 
 const PNGS = {
-    'renders/com.example.A.png': 'png-A',
-    'renders/com.example.B.png': 'png-B',
+    "renders/com.example.A.png": "png-A",
+    "renders/com.example.B.png": "png-B",
 };
 
-describe('CurrentRendersHistory', () => {
-    it('returns one synthetic entry per preview with a render on disk',
+describe("CurrentRendersHistory", () => {
+    it(
+        "returns one synthetic entry per preview with a render on disk",
         withFixture(PREVIEWS, PNGS, (buildDir) => {
-            const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample' });
+            const reader = new CurrentRendersHistory({
+                buildDir,
+                moduleId: "sample",
+            });
             const result = reader.list();
             assert.strictEqual(result.totalCount, 2);
-            const ids = result.entries.map(e => (e as { previewId: string }).previewId).sort();
-            assert.deepStrictEqual(ids, ['com.example.A', 'com.example.B']);
+            const ids = result.entries
+                .map((e) => (e as { previewId: string }).previewId)
+                .sort();
+            assert.deepStrictEqual(ids, ["com.example.A", "com.example.B"]);
         }),
     );
 
-    it('honours the previewId filter', withFixture(PREVIEWS, PNGS, (buildDir) => {
-        const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample' });
-        const result = reader.list('com.example.A');
-        assert.strictEqual(result.totalCount, 1);
-        assert.strictEqual((result.entries[0] as { previewId: string }).previewId, 'com.example.A');
-    }));
-
-    it('skips previews whose render file is missing on disk',
-        withFixture(PREVIEWS, { 'renders/com.example.A.png': 'p' }, (buildDir) => {
-            const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample' });
-            const result = reader.list();
+    it(
+        "honours the previewId filter",
+        withFixture(PREVIEWS, PNGS, (buildDir) => {
+            const reader = new CurrentRendersHistory({
+                buildDir,
+                moduleId: "sample",
+            });
+            const result = reader.list("com.example.A");
             assert.strictEqual(result.totalCount, 1);
-            assert.strictEqual((result.entries[0] as { previewId: string }).previewId, 'com.example.A');
+            assert.strictEqual(
+                (result.entries[0] as { previewId: string }).previewId,
+                "com.example.A",
+            );
         }),
     );
 
-    it('returns empty list when previews.json is missing', async () => {
-        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'current-renders-empty-'));
+    it(
+        "skips previews whose render file is missing on disk",
+        withFixture(
+            PREVIEWS,
+            { "renders/com.example.A.png": "p" },
+            (buildDir) => {
+                const reader = new CurrentRendersHistory({
+                    buildDir,
+                    moduleId: "sample",
+                });
+                const result = reader.list();
+                assert.strictEqual(result.totalCount, 1);
+                assert.strictEqual(
+                    (result.entries[0] as { previewId: string }).previewId,
+                    "com.example.A",
+                );
+            },
+        ),
+    );
+
+    it("returns empty list when previews.json is missing", async () => {
+        const root = fs.mkdtempSync(
+            path.join(os.tmpdir(), "current-renders-empty-"),
+        );
         try {
-            const buildDir = path.join(root, 'build', 'compose-previews');
+            const buildDir = path.join(root, "build", "compose-previews");
             fs.mkdirSync(buildDir, { recursive: true });
-            const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample' });
+            const reader = new CurrentRendersHistory({
+                buildDir,
+                moduleId: "sample",
+            });
             const result = reader.list();
             assert.strictEqual(result.totalCount, 0);
             assert.strictEqual(result.entries.length, 0);
@@ -95,44 +126,87 @@ describe('CurrentRendersHistory', () => {
         }
     });
 
-    it('round-trips list ids through read', withFixture(PREVIEWS, PNGS, (buildDir) => {
-        const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample' });
-        const list = reader.list();
-        const id = (list.entries[0] as { id: string }).id;
-        assert.ok(CurrentRendersHistory.isSyntheticId(id),
-            `expected synthetic id, got ${id}`);
-        const read = reader.read(id);
-        assert.notStrictEqual(read, null);
-        assert.ok(fs.existsSync(read!.pngPath), `png missing: ${read!.pngPath}`);
-    }));
-
-    it('read returns null for non-synthetic ids', withFixture(PREVIEWS, PNGS, (buildDir) => {
-        const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample' });
-        assert.strictEqual(reader.read('20260430-aaaaaaaa'), null);
-    }));
-
-    it('read returns null for malformed synthetic ids',
+    it(
+        "round-trips list ids through read",
         withFixture(PREVIEWS, PNGS, (buildDir) => {
-            const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample' });
-            assert.strictEqual(reader.read('current:not-base64-of-anything-known'), null);
+            const reader = new CurrentRendersHistory({
+                buildDir,
+                moduleId: "sample",
+            });
+            const list = reader.list();
+            const id = (list.entries[0] as { id: string }).id;
+            assert.ok(
+                CurrentRendersHistory.isSyntheticId(id),
+                `expected synthetic id, got ${id}`,
+            );
+            const read = reader.read(id);
+            assert.notStrictEqual(read, null);
+            assert.ok(
+                fs.existsSync(read!.pngPath),
+                `png missing: ${read!.pngPath}`,
+            );
         }),
     );
 
-    it('orders entries newest-first by mtime', withFixture(PREVIEWS, PNGS, async (buildDir) => {
-        // Backdate B so A is newer.
-        const past = new Date(Date.now() - 60_000);
-        fs.utimesSync(path.join(buildDir, 'renders/com.example.B.png'), past, past);
-        const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample' });
-        const ids = reader.list().entries.map(e => (e as { previewId: string }).previewId);
-        assert.deepStrictEqual(ids, ['com.example.A', 'com.example.B']);
-    }));
-
-    it('tags entries with the moduleId so the panel scope filter matches',
+    it(
+        "read returns null for non-synthetic ids",
         withFixture(PREVIEWS, PNGS, (buildDir) => {
-            const reader = new CurrentRendersHistory({ buildDir, moduleId: 'sample/wear' });
+            const reader = new CurrentRendersHistory({
+                buildDir,
+                moduleId: "sample",
+            });
+            assert.strictEqual(reader.read("20260430-aaaaaaaa"), null);
+        }),
+    );
+
+    it(
+        "read returns null for malformed synthetic ids",
+        withFixture(PREVIEWS, PNGS, (buildDir) => {
+            const reader = new CurrentRendersHistory({
+                buildDir,
+                moduleId: "sample",
+            });
+            assert.strictEqual(
+                reader.read("current:not-base64-of-anything-known"),
+                null,
+            );
+        }),
+    );
+
+    it(
+        "orders entries newest-first by mtime",
+        withFixture(PREVIEWS, PNGS, async (buildDir) => {
+            // Backdate B so A is newer.
+            const past = new Date(Date.now() - 60_000);
+            fs.utimesSync(
+                path.join(buildDir, "renders/com.example.B.png"),
+                past,
+                past,
+            );
+            const reader = new CurrentRendersHistory({
+                buildDir,
+                moduleId: "sample",
+            });
+            const ids = reader
+                .list()
+                .entries.map((e) => (e as { previewId: string }).previewId);
+            assert.deepStrictEqual(ids, ["com.example.A", "com.example.B"]);
+        }),
+    );
+
+    it(
+        "tags entries with the moduleId so the panel scope filter matches",
+        withFixture(PREVIEWS, PNGS, (buildDir) => {
+            const reader = new CurrentRendersHistory({
+                buildDir,
+                moduleId: "sample/wear",
+            });
             const result = reader.list();
             for (const entry of result.entries) {
-                assert.strictEqual((entry as { module: string }).module, 'sample/wear');
+                assert.strictEqual(
+                    (entry as { module: string }).module,
+                    "sample/wear",
+                );
             }
         }),
     );

--- a/vscode-extension/src/test/daemonClient.test.ts
+++ b/vscode-extension/src/test/daemonClient.test.ts
@@ -1,11 +1,8 @@
-import * as assert from 'assert';
-import { PassThrough } from 'stream';
-import { DaemonClient, DaemonRpcError } from '../daemon/daemonClient';
-import { encodeFrame, FrameDecoder } from '../daemon/daemonFraming';
-import {
-    JsonRpcRequest,
-    PROTOCOL_VERSION,
-} from '../daemon/daemonProtocol';
+import * as assert from "assert";
+import { PassThrough } from "stream";
+import { DaemonClient, DaemonRpcError } from "../daemon/daemonClient";
+import { encodeFrame, FrameDecoder } from "../daemon/daemonFraming";
+import { JsonRpcRequest, PROTOCOL_VERSION } from "../daemon/daemonProtocol";
 
 /**
  * A lightweight bidirectional pair: client.stdin → toServer; toClient → client.stdout.
@@ -25,108 +22,130 @@ function captureFrames(stream: PassThrough): { take(): Promise<unknown> } {
     const decoder = new FrameDecoder({
         onMessage: (json) => {
             const parsed = JSON.parse(json);
-            if (waiters.length > 0) { waiters.shift()!(parsed); }
-            else { queue.push(parsed); }
+            if (waiters.length > 0) {
+                waiters.shift()!(parsed);
+            } else {
+                queue.push(parsed);
+            }
         },
         onError: (err) => assert.fail(err.message),
     });
-    stream.on('data', (chunk: Buffer) => decoder.push(chunk));
+    stream.on("data", (chunk: Buffer) => decoder.push(chunk));
     return {
         take(): Promise<unknown> {
-            if (queue.length > 0) { return Promise.resolve(queue.shift()!); }
+            if (queue.length > 0) {
+                return Promise.resolve(queue.shift()!);
+            }
             return new Promise((resolve) => waiters.push(resolve));
         },
     };
 }
 
-describe('DaemonClient', () => {
-    it('sends initialize and resolves on response', async () => {
+describe("DaemonClient", () => {
+    it("sends initialize and resolves on response", async () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);
         const client = new DaemonClient(toServer, toClient, {});
 
         const promise = client.initialize({
-            clientVersion: '0.0.0',
-            workspaceRoot: '/work',
-            moduleId: ':samples:android',
-            moduleProjectDir: '/work/samples/android',
+            clientVersion: "0.0.0",
+            workspaceRoot: "/work",
+            moduleId: ":samples:android",
+            moduleProjectDir: "/work/samples/android",
             capabilities: { visibility: true, metrics: true },
         });
 
         const sent = (await frames.take()) as JsonRpcRequest;
-        assert.strictEqual(sent.method, 'initialize');
-        assert.strictEqual((sent.params as { protocolVersion: number }).protocolVersion, PROTOCOL_VERSION);
+        assert.strictEqual(sent.method, "initialize");
+        assert.strictEqual(
+            (sent.params as { protocolVersion: number }).protocolVersion,
+            PROTOCOL_VERSION,
+        );
 
         // Server responds with an InitializeResult shaped object.
-        toClient.write(encodeFrame({
-            jsonrpc: '2.0',
-            id: sent.id,
-            result: {
-                protocolVersion: PROTOCOL_VERSION,
-                daemonVersion: '0.1.0',
-                pid: 4321,
-                capabilities: {
-                    incrementalDiscovery: false,
-                    sandboxRecycle: true,
-                    leakDetection: [],
+        toClient.write(
+            encodeFrame({
+                jsonrpc: "2.0",
+                id: sent.id,
+                result: {
+                    protocolVersion: PROTOCOL_VERSION,
+                    daemonVersion: "0.1.0",
+                    pid: 4321,
+                    capabilities: {
+                        incrementalDiscovery: false,
+                        sandboxRecycle: true,
+                        leakDetection: [],
+                    },
+                    classpathFingerprint: "a".repeat(64),
+                    manifest: { path: "/m", previewCount: 0 },
                 },
-                classpathFingerprint: 'a'.repeat(64),
-                manifest: { path: '/m', previewCount: 0 },
-            },
-        }));
+            }),
+        );
 
         const result = await promise;
-        assert.strictEqual(result.daemonVersion, '0.1.0');
+        assert.strictEqual(result.daemonVersion, "0.1.0");
         assert.strictEqual(result.pid, 4321);
     });
 
-    it('rejects pending request with DaemonRpcError on error response', async () => {
+    it("rejects pending request with DaemonRpcError on error response", async () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);
         const client = new DaemonClient(toServer, toClient, {});
 
-        const p = client.renderNow({ previews: ['foo'], tier: 'fast' });
+        const p = client.renderNow({ previews: ["foo"], tier: "fast" });
         const req = (await frames.take()) as JsonRpcRequest;
-        toClient.write(encodeFrame({
-            jsonrpc: '2.0',
-            id: req.id,
-            error: { code: -32002, message: 'classpath dirty', data: { kind: 'ClasspathDirty' } },
-        }));
+        toClient.write(
+            encodeFrame({
+                jsonrpc: "2.0",
+                id: req.id,
+                error: {
+                    code: -32002,
+                    message: "classpath dirty",
+                    data: { kind: "ClasspathDirty" },
+                },
+            }),
+        );
 
         await assert.rejects(p, (err: Error) => {
-            return err instanceof DaemonRpcError
-                && err.message.includes('classpath dirty')
-                && (err as DaemonRpcError).rpc.code === -32002;
+            return (
+                err instanceof DaemonRpcError &&
+                err.message.includes("classpath dirty") &&
+                (err as DaemonRpcError).rpc.code === -32002
+            );
         });
     });
 
-    it('dispatches notifications to the right handler', async () => {
+    it("dispatches notifications to the right handler", async () => {
         const { toServer, toClient } = bidiPair();
         let renderFinishedCount = 0;
-        let lastPng = '';
+        let lastPng = "";
         const client = new DaemonClient(toServer, toClient, {
             onRenderFinished: (params) => {
                 renderFinishedCount++;
                 lastPng = params.pngPath;
             },
         });
-        toClient.write(encodeFrame({
-            jsonrpc: '2.0',
-            method: 'renderFinished',
-            params: { id: 'p1', pngPath: '/tmp/a.png', tookMs: 42 },
-        }));
+        toClient.write(
+            encodeFrame({
+                jsonrpc: "2.0",
+                method: "renderFinished",
+                params: { id: "p1", pngPath: "/tmp/a.png", tookMs: 42 },
+            }),
+        );
         // Drain the writer queue + decoder microtasks before asserting.
         await new Promise((r) => setImmediate(r));
         assert.strictEqual(renderFinishedCount, 1);
-        assert.strictEqual(lastPng, '/tmp/a.png');
+        assert.strictEqual(lastPng, "/tmp/a.png");
         client.exit();
     });
 
-    it('rejects in-flight requests when the channel closes', async () => {
+    it("rejects in-flight requests when the channel closes", async () => {
         const { toServer, toClient } = bidiPair();
         let closedErr: Error | undefined;
         const client = new DaemonClient(toServer, toClient, {
-            onChannelClosed: (err) => { closedErr = err; },
+            onChannelClosed: (err) => {
+                closedErr = err;
+            },
         });
         const p = client.shutdown();
         toClient.end();
@@ -136,44 +155,53 @@ describe('DaemonClient', () => {
         assert.strictEqual(client.isClosed(), true);
     });
 
-    it('encodes a notification with no result tracking', async () => {
+    it("encodes a notification with no result tracking", async () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);
         const client = new DaemonClient(toServer, toClient, {});
-        client.setFocus({ ids: ['a', 'b'] });
+        client.setFocus({ ids: ["a", "b"] });
         const sent = (await frames.take()) as JsonRpcRequest;
-        assert.strictEqual(sent.method, 'setFocus');
+        assert.strictEqual(sent.method, "setFocus");
         assert.strictEqual((sent as unknown as { id?: number }).id, undefined);
-        assert.deepStrictEqual((sent.params as { ids: string[] }).ids, ['a', 'b']);
+        assert.deepStrictEqual((sent.params as { ids: string[] }).ids, [
+            "a",
+            "b",
+        ]);
     });
 
-    it('correlates out-of-order responses to the right pending request', async () => {
+    it("correlates out-of-order responses to the right pending request", async () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);
         const client = new DaemonClient(toServer, toClient, {});
 
         // Two concurrent renderNow requests. Server responds to the
         // SECOND one first to verify id-based correlation.
-        const p1 = client.renderNow({ previews: ['first'], tier: 'fast' });
-        const p2 = client.renderNow({ previews: ['second'], tier: 'fast' });
+        const p1 = client.renderNow({ previews: ["first"], tier: "fast" });
+        const p2 = client.renderNow({ previews: ["second"], tier: "fast" });
         const r1 = (await frames.take()) as JsonRpcRequest;
         const r2 = (await frames.take()) as JsonRpcRequest;
 
-        toClient.write(encodeFrame({
-            jsonrpc: '2.0', id: r2.id,
-            result: { queued: ['second'], rejected: [] },
-        }));
-        toClient.write(encodeFrame({
-            jsonrpc: '2.0', id: r1.id,
-            result: { queued: ['first'], rejected: [] },
-        }));
+        toClient.write(
+            encodeFrame({
+                jsonrpc: "2.0",
+                id: r2.id,
+                result: { queued: ["second"], rejected: [] },
+            }),
+        );
+        toClient.write(
+            encodeFrame({
+                jsonrpc: "2.0",
+                id: r1.id,
+                result: { queued: ["first"], rejected: [] },
+            }),
+        );
 
         const [a, b] = await Promise.all([p1, p2]);
-        assert.deepStrictEqual(a.queued, ['first']);
-        assert.deepStrictEqual(b.queued, ['second']);
+        assert.deepStrictEqual(a.queued, ["first"]);
+        assert.deepStrictEqual(b.queued, ["second"]);
     });
 
-    it('interactiveStart sends a request with previewId and awaits a frameStreamId result', async () => {
+    it("interactiveStart sends a request with previewId and awaits a frameStreamId result", async () => {
         // Reserved per docs/daemon/INTERACTIVE.md § 7. v0 daemons reject
         // with MethodNotFound, but the wire shape is locked here so the
         // caller-side machinery is ready when the daemon implementation
@@ -181,279 +209,343 @@ describe('DaemonClient', () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);
         const client = new DaemonClient(toServer, toClient, {});
-        const promise = client.interactiveStart({ previewId: 'com.example.PreviewA' });
+        const promise = client.interactiveStart({
+            previewId: "com.example.PreviewA",
+        });
         const sent = (await frames.take()) as JsonRpcRequest;
-        assert.strictEqual(sent.method, 'interactive/start');
-        assert.deepStrictEqual(sent.params, { previewId: 'com.example.PreviewA' });
-        toClient.write(encodeFrame({
-            jsonrpc: '2.0',
-            id: sent.id,
-            result: { frameStreamId: 'stream-42' },
-        }));
+        assert.strictEqual(sent.method, "interactive/start");
+        assert.deepStrictEqual(sent.params, {
+            previewId: "com.example.PreviewA",
+        });
+        toClient.write(
+            encodeFrame({
+                jsonrpc: "2.0",
+                id: sent.id,
+                result: { frameStreamId: "stream-42" },
+            }),
+        );
         const result = await promise;
-        assert.strictEqual(result.frameStreamId, 'stream-42');
+        assert.strictEqual(result.frameStreamId, "stream-42");
         client.exit();
     });
 
-    it('interactiveStop emits a notification (no id) carrying the stream id', async () => {
+    it("interactiveStop emits a notification (no id) carrying the stream id", async () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);
         const client = new DaemonClient(toServer, toClient, {});
-        client.interactiveStop({ frameStreamId: 'stream-42' });
+        client.interactiveStop({ frameStreamId: "stream-42" });
         const sent = (await frames.take()) as JsonRpcRequest;
-        assert.strictEqual(sent.method, 'interactive/stop');
+        assert.strictEqual(sent.method, "interactive/stop");
         assert.strictEqual((sent as unknown as { id?: number }).id, undefined);
-        assert.deepStrictEqual(sent.params, { frameStreamId: 'stream-42' });
+        assert.deepStrictEqual(sent.params, { frameStreamId: "stream-42" });
         client.exit();
     });
 
-    it('interactiveInput emits a notification carrying click coordinates', async () => {
+    it("interactiveInput emits a notification carrying click coordinates", async () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);
         const client = new DaemonClient(toServer, toClient, {});
         client.interactiveInput({
-            frameStreamId: 'stream-42',
-            kind: 'click',
+            frameStreamId: "stream-42",
+            kind: "click",
             pixelX: 120,
             pixelY: 64,
         });
         const sent = (await frames.take()) as JsonRpcRequest;
-        assert.strictEqual(sent.method, 'interactive/input');
+        assert.strictEqual(sent.method, "interactive/input");
         assert.strictEqual((sent as unknown as { id?: number }).id, undefined);
         assert.deepStrictEqual(sent.params, {
-            frameStreamId: 'stream-42',
-            kind: 'click',
+            frameStreamId: "stream-42",
+            kind: "click",
             pixelX: 120,
             pixelY: 64,
         });
         client.exit();
     });
 
-    it('issues monotonically increasing ids', async () => {
+    it("issues monotonically increasing ids", async () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);
         const client = new DaemonClient(toServer, toClient, {});
         // Send three requests, never resolve them, just inspect the ids.
-        client.renderNow({ previews: [], tier: 'fast' });
-        client.renderNow({ previews: [], tier: 'fast' });
-        client.renderNow({ previews: [], tier: 'fast' });
+        client.renderNow({ previews: [], tier: "fast" });
+        client.renderNow({ previews: [], tier: "fast" });
+        client.renderNow({ previews: [], tier: "fast" });
         const ids = [
             ((await frames.take()) as JsonRpcRequest).id,
             ((await frames.take()) as JsonRpcRequest).id,
             ((await frames.take()) as JsonRpcRequest).id,
         ];
-        assert.ok(ids[0] < ids[1] && ids[1] < ids[2], `ids not monotonic: ${ids.join(',')}`);
+        assert.ok(
+            ids[0] < ids[1] && ids[1] < ids[2],
+            `ids not monotonic: ${ids.join(",")}`,
+        );
     });
 
-    it('rejects new requests issued after the channel is closed', async () => {
+    it("rejects new requests issued after the channel is closed", async () => {
         const { toServer, toClient } = bidiPair();
         const client = new DaemonClient(toServer, toClient, {});
         toClient.end();
         // Give Node a tick to propagate the 'end' event into the client.
         await new Promise((r) => setImmediate(r));
         await assert.rejects(
-            client.renderNow({ previews: [], tier: 'fast' }),
+            client.renderNow({ previews: [], tier: "fast" }),
             /closed/i,
         );
     });
 
-    it('silently drops notifications sent after the channel is closed', async () => {
+    it("silently drops notifications sent after the channel is closed", async () => {
         const { toServer, toClient } = bidiPair();
         const client = new DaemonClient(toServer, toClient, {});
         toClient.end();
         await new Promise((r) => setImmediate(r));
         // Should not throw; no test assertion needed beyond "no exception."
-        client.setFocus({ ids: ['a'] });
-        client.fileChanged({ path: '/x.kt', kind: 'source', changeType: 'modified' });
+        client.setFocus({ ids: ["a"] });
+        client.fileChanged({
+            path: "/x.kt",
+            kind: "source",
+            changeType: "modified",
+        });
         client.exit();
     });
 
-    it('drops unknown daemon notifications without erroring', async () => {
+    it("drops unknown daemon notifications without erroring", async () => {
         // PROTOCOL.md § 7: additive notifications must not break old clients.
         // The dispatcher logs and continues — verifying via no exception
         // and no handler invocation.
         const { toServer, toClient } = bidiPair();
         let sawAnyKnownEvent = false;
         const client = new DaemonClient(toServer, toClient, {
-            onRenderFinished: () => { sawAnyKnownEvent = true; },
+            onRenderFinished: () => {
+                sawAnyKnownEvent = true;
+            },
         });
-        toClient.write(encodeFrame({
-            jsonrpc: '2.0',
-            method: 'futureMessage_v2',
-            params: { whatever: true },
-        }));
+        toClient.write(
+            encodeFrame({
+                jsonrpc: "2.0",
+                method: "futureMessage_v2",
+                params: { whatever: true },
+            }),
+        );
         await new Promise((r) => setImmediate(r));
         assert.strictEqual(sawAnyKnownEvent, false);
         assert.strictEqual(client.isClosed(), false);
         client.exit();
     });
 
-    it('survives non-JSON garbage on the wire by dropping the message', async () => {
+    it("survives non-JSON garbage on the wire by dropping the message", async () => {
         // The daemon SHOULDN'T emit invalid JSON, but if it does (e.g. a
         // stray println from an undisciplined library) the client logs and
         // keeps going — channel stays open.
         const logs: string[] = [];
         const { toServer, toClient } = bidiPair();
-        const client = new DaemonClient(toServer, toClient, {}, { appendLine: (s) => logs.push(s) });
+        const client = new DaemonClient(
+            toServer,
+            toClient,
+            {},
+            { appendLine: (s) => logs.push(s) },
+        );
         // Send a syntactically valid LSP frame whose body is invalid JSON.
-        const body = Buffer.from('not-json-at-all', 'utf-8');
-        const header = Buffer.from(`Content-Length: ${body.length}\r\n\r\n`, 'ascii');
+        const body = Buffer.from("not-json-at-all", "utf-8");
+        const header = Buffer.from(
+            `Content-Length: ${body.length}\r\n\r\n`,
+            "ascii",
+        );
         toClient.write(Buffer.concat([header, body]));
         await new Promise((r) => setImmediate(r));
         assert.strictEqual(client.isClosed(), false);
-        assert.ok(logs.some(l => l.includes('non-JSON')), `expected non-JSON log, got: ${logs.join(' / ')}`);
+        assert.ok(
+            logs.some((l) => l.includes("non-JSON")),
+            `expected non-JSON log, got: ${logs.join(" / ")}`,
+        );
         client.exit();
     });
 
-    it('surfaces stray responses (no pending request) without crashing', async () => {
+    it("surfaces stray responses (no pending request) without crashing", async () => {
         // Late or duplicate response after the request was already
         // resolved. Logged and dropped.
         const logs: string[] = [];
         const { toServer, toClient } = bidiPair();
-        const client = new DaemonClient(toServer, toClient, {}, { appendLine: (s) => logs.push(s) });
-        toClient.write(encodeFrame({ jsonrpc: '2.0', id: 9999, result: null }));
+        const client = new DaemonClient(
+            toServer,
+            toClient,
+            {},
+            { appendLine: (s) => logs.push(s) },
+        );
+        toClient.write(encodeFrame({ jsonrpc: "2.0", id: 9999, result: null }));
         await new Promise((r) => setImmediate(r));
-        assert.ok(logs.some(l => l.includes('no pending request')));
+        assert.ok(logs.some((l) => l.includes("no pending request")));
         client.exit();
     });
 
-    it('rejects all in-flight requests when stdout closes mid-flight', async () => {
+    it("rejects all in-flight requests when stdout closes mid-flight", async () => {
         const { toServer, toClient } = bidiPair();
         const client = new DaemonClient(toServer, toClient, {});
-        const p1 = client.renderNow({ previews: ['a'], tier: 'fast' });
+        const p1 = client.renderNow({ previews: ["a"], tier: "fast" });
         const p2 = client.shutdown();
-        toClient.destroy(new Error('pipe broken'));
+        toClient.destroy(new Error("pipe broken"));
         await assert.rejects(p1, /pipe broken/);
         await assert.rejects(p2, /pipe broken/);
         assert.strictEqual(client.isClosed(), true);
     });
 
-    it('dispatches historyAdded notifications to the right handler', async () => {
+    it("dispatches historyAdded notifications to the right handler", async () => {
         const { toServer, toClient } = bidiPair();
         const seen: unknown[] = [];
         const client = new DaemonClient(toServer, toClient, {
             onHistoryAdded: (params) => seen.push(params.entry),
         });
-        toClient.write(encodeFrame({
-            jsonrpc: '2.0',
-            method: 'historyAdded',
-            params: {
-                entry: {
-                    id: '20260430-101234-a1b2c3d4',
-                    previewId: 'com.example.X',
-                    pngHash: 'abcdef',
+        toClient.write(
+            encodeFrame({
+                jsonrpc: "2.0",
+                method: "historyAdded",
+                params: {
+                    entry: {
+                        id: "20260430-101234-a1b2c3d4",
+                        previewId: "com.example.X",
+                        pngHash: "abcdef",
+                    },
                 },
-            },
-        }));
+            }),
+        );
         await new Promise((r) => setImmediate(r));
         assert.strictEqual(seen.length, 1);
-        assert.strictEqual((seen[0] as { previewId: string }).previewId, 'com.example.X');
+        assert.strictEqual(
+            (seen[0] as { previewId: string }).previewId,
+            "com.example.X",
+        );
         client.exit();
     });
 
-    it('history/list passes every filter through verbatim', async () => {
+    it("history/list passes every filter through verbatim", async () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);
         const client = new DaemonClient(toServer, toClient, {});
         const filters = {
-            previewId: 'com.example.X',
-            since: '2026-04-30T00:00:00Z',
+            previewId: "com.example.X",
+            since: "2026-04-30T00:00:00Z",
             limit: 10,
-            branch: 'main',
-            sourceKind: 'fs' as const,
+            branch: "main",
+            sourceKind: "fs" as const,
         };
         const p = client.historyList(filters);
         const sent = (await frames.take()) as JsonRpcRequest;
-        assert.strictEqual(sent.method, 'history/list');
+        assert.strictEqual(sent.method, "history/list");
         assert.deepStrictEqual(sent.params, filters);
-        toClient.write(encodeFrame({
-            jsonrpc: '2.0', id: sent.id,
-            result: { entries: [], totalCount: 0 },
-        }));
+        toClient.write(
+            encodeFrame({
+                jsonrpc: "2.0",
+                id: sent.id,
+                result: { entries: [], totalCount: 0 },
+            }),
+        );
         const res = await p;
         assert.strictEqual(res.totalCount, 0);
     });
 
-    it('history/read default omits inline and reads pngPath from disk', async () => {
+    it("history/read default omits inline and reads pngPath from disk", async () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);
         const client = new DaemonClient(toServer, toClient, {});
-        const p = client.historyRead({ id: 'a1' });
+        const p = client.historyRead({ id: "a1" });
         const sent = (await frames.take()) as JsonRpcRequest;
-        assert.strictEqual(sent.method, 'history/read');
-        assert.deepStrictEqual(sent.params, { id: 'a1' });
-        toClient.write(encodeFrame({
-            jsonrpc: '2.0', id: sent.id,
-            result: { entry: { id: 'a1' }, pngPath: '/abs/a1.png' },
-        }));
+        assert.strictEqual(sent.method, "history/read");
+        assert.deepStrictEqual(sent.params, { id: "a1" });
+        toClient.write(
+            encodeFrame({
+                jsonrpc: "2.0",
+                id: sent.id,
+                result: { entry: { id: "a1" }, pngPath: "/abs/a1.png" },
+            }),
+        );
         const res = await p;
-        assert.strictEqual(res.pngPath, '/abs/a1.png');
+        assert.strictEqual(res.pngPath, "/abs/a1.png");
         assert.strictEqual(res.pngBytes, undefined);
     });
 
-    it('history/diff defaults to metadata mode and tolerates null pixel fields', async () => {
+    it("history/diff defaults to metadata mode and tolerates null pixel fields", async () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);
         const client = new DaemonClient(toServer, toClient, {});
-        const p = client.historyDiff({ from: 'a1', to: 'a2' });
+        const p = client.historyDiff({ from: "a1", to: "a2" });
         const sent = (await frames.take()) as JsonRpcRequest;
-        assert.strictEqual(sent.method, 'history/diff');
-        assert.deepStrictEqual(sent.params, { from: 'a1', to: 'a2' });
-        toClient.write(encodeFrame({
-            jsonrpc: '2.0', id: sent.id,
-            result: {
-                pngHashChanged: true,
-                fromMetadata: { id: 'a1' },
-                toMetadata: { id: 'a2' },
-            },
-        }));
+        assert.strictEqual(sent.method, "history/diff");
+        assert.deepStrictEqual(sent.params, { from: "a1", to: "a2" });
+        toClient.write(
+            encodeFrame({
+                jsonrpc: "2.0",
+                id: sent.id,
+                result: {
+                    pngHashChanged: true,
+                    fromMetadata: { id: "a1" },
+                    toMetadata: { id: "a2" },
+                },
+            }),
+        );
         const res = await p;
         assert.strictEqual(res.pngHashChanged, true);
         assert.strictEqual(res.diffPx, undefined);
     });
 
-    it('history/diff with mode=pixel surfaces the reserved-for-H5 error', async () => {
+    it("history/diff with mode=pixel surfaces the reserved-for-H5 error", async () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);
         const client = new DaemonClient(toServer, toClient, {});
-        const p = client.historyDiff({ from: 'a1', to: 'a2', mode: 'pixel' });
+        const p = client.historyDiff({ from: "a1", to: "a2", mode: "pixel" });
         const sent = (await frames.take()) as JsonRpcRequest;
-        toClient.write(encodeFrame({
-            jsonrpc: '2.0', id: sent.id,
-            error: { code: -32012, message: 'pixel mode reserved for H5' },
-        }));
-        await assert.rejects(p, (err: Error) =>
-            err instanceof DaemonRpcError && (err as DaemonRpcError).rpc.code === -32012);
+        toClient.write(
+            encodeFrame({
+                jsonrpc: "2.0",
+                id: sent.id,
+                error: { code: -32012, message: "pixel mode reserved for H5" },
+            }),
+        );
+        await assert.rejects(
+            p,
+            (err: Error) =>
+                err instanceof DaemonRpcError &&
+                (err as DaemonRpcError).rpc.code === -32012,
+        );
     });
 
-    it('initialize stamps protocolVersion = 1 and sends initialized after', async () => {
+    it("initialize stamps protocolVersion = 1 and sends initialized after", async () => {
         const { toServer, toClient } = bidiPair();
         const frames = captureFrames(toServer);
         const client = new DaemonClient(toServer, toClient, {});
         const p = client.initialize({
-            clientVersion: '0.0.0',
-            workspaceRoot: '/w',
-            moduleId: ':m',
-            moduleProjectDir: '/w/m',
+            clientVersion: "0.0.0",
+            workspaceRoot: "/w",
+            moduleId: ":m",
+            moduleProjectDir: "/w/m",
             capabilities: { visibility: true, metrics: true },
         });
         const init = (await frames.take()) as JsonRpcRequest;
-        assert.strictEqual((init.params as { protocolVersion: number }).protocolVersion, PROTOCOL_VERSION);
-        toClient.write(encodeFrame({
-            jsonrpc: '2.0', id: init.id,
-            result: {
-                protocolVersion: PROTOCOL_VERSION,
-                daemonVersion: '0.1.0',
-                pid: 1,
-                capabilities: { incrementalDiscovery: false, sandboxRecycle: true, leakDetection: [] },
-                classpathFingerprint: '0'.repeat(64),
-                manifest: { path: '/m', previewCount: 0 },
-            },
-        }));
+        assert.strictEqual(
+            (init.params as { protocolVersion: number }).protocolVersion,
+            PROTOCOL_VERSION,
+        );
+        toClient.write(
+            encodeFrame({
+                jsonrpc: "2.0",
+                id: init.id,
+                result: {
+                    protocolVersion: PROTOCOL_VERSION,
+                    daemonVersion: "0.1.0",
+                    pid: 1,
+                    capabilities: {
+                        incrementalDiscovery: false,
+                        sandboxRecycle: true,
+                        leakDetection: [],
+                    },
+                    classpathFingerprint: "0".repeat(64),
+                    manifest: { path: "/m", previewCount: 0 },
+                },
+            }),
+        );
         await p;
         client.initialized();
         const initd = (await frames.take()) as JsonRpcRequest;
-        assert.strictEqual(initd.method, 'initialized');
+        assert.strictEqual(initd.method, "initialized");
         assert.strictEqual((initd as unknown as { id?: number }).id, undefined);
     });
 });

--- a/vscode-extension/src/test/daemonFraming.test.ts
+++ b/vscode-extension/src/test/daemonFraming.test.ts
@@ -1,77 +1,80 @@
-import * as assert from 'assert';
-import * as fs from 'fs';
-import * as path from 'path';
-import { FrameDecoder, encodeFrame } from '../daemon/daemonFraming';
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import { FrameDecoder, encodeFrame } from "../daemon/daemonFraming";
 
-describe('daemon framing', () => {
-    it('round-trips a single message', () => {
+describe("daemon framing", () => {
+    it("round-trips a single message", () => {
         const messages: string[] = [];
         const errors: Error[] = [];
         const decoder = new FrameDecoder({
             onMessage: (json) => messages.push(json),
             onError: (err) => errors.push(err),
         });
-        const payload = { jsonrpc: '2.0', method: 'hello', params: { x: 1 } };
+        const payload = { jsonrpc: "2.0", method: "hello", params: { x: 1 } };
         decoder.push(encodeFrame(payload));
         assert.strictEqual(errors.length, 0);
         assert.deepStrictEqual(JSON.parse(messages[0]), payload);
     });
 
-    it('parses multiple messages in one chunk', () => {
+    it("parses multiple messages in one chunk", () => {
         const messages: string[] = [];
         const decoder = new FrameDecoder({
             onMessage: (json) => messages.push(json),
-            onError: () => assert.fail('no error expected'),
+            onError: () => assert.fail("no error expected"),
         });
-        const a = encodeFrame({ method: 'a' });
-        const b = encodeFrame({ method: 'b' });
-        const c = encodeFrame({ method: 'c' });
+        const a = encodeFrame({ method: "a" });
+        const b = encodeFrame({ method: "b" });
+        const c = encodeFrame({ method: "c" });
         decoder.push(Buffer.concat([a, b, c]));
-        const methods = messages.map(m => JSON.parse(m).method);
-        assert.deepStrictEqual(methods, ['a', 'b', 'c']);
+        const methods = messages.map((m) => JSON.parse(m).method);
+        assert.deepStrictEqual(methods, ["a", "b", "c"]);
     });
 
-    it('reassembles a message split across chunks', () => {
+    it("reassembles a message split across chunks", () => {
         const messages: string[] = [];
         const decoder = new FrameDecoder({
             onMessage: (json) => messages.push(json),
-            onError: () => assert.fail('no error expected'),
+            onError: () => assert.fail("no error expected"),
         });
-        const full = encodeFrame({ method: 'split', params: { value: 'abcdef' } });
+        const full = encodeFrame({
+            method: "split",
+            params: { value: "abcdef" },
+        });
         // Split mid-header, mid-body — both transition points.
         for (let i = 0; i < full.length; i += 5) {
             decoder.push(full.subarray(i, Math.min(i + 5, full.length)));
         }
         assert.strictEqual(messages.length, 1);
-        assert.strictEqual(JSON.parse(messages[0]).method, 'split');
+        assert.strictEqual(JSON.parse(messages[0]).method, "split");
     });
 
-    it('counts UTF-8 bytes (not characters) in Content-Length', () => {
+    it("counts UTF-8 bytes (not characters) in Content-Length", () => {
         const messages: string[] = [];
         const decoder = new FrameDecoder({
             onMessage: (json) => messages.push(json),
-            onError: () => assert.fail('no error expected'),
+            onError: () => assert.fail("no error expected"),
         });
         // Multi-byte UTF-8 — emoji = 4 bytes, kanji = 3 bytes per character.
-        const payload = { method: 'i18n', text: '日本語🎉' };
+        const payload = { method: "i18n", text: "日本語🎉" };
         decoder.push(encodeFrame(payload));
-        assert.strictEqual(JSON.parse(messages[0]).text, '日本語🎉');
+        assert.strictEqual(JSON.parse(messages[0]).text, "日本語🎉");
     });
 
-    it('reports a clear error on malformed header', () => {
+    it("reports a clear error on malformed header", () => {
         const messages: string[] = [];
         const errors: Error[] = [];
         const decoder = new FrameDecoder({
             onMessage: (json) => messages.push(json),
             onError: (err) => errors.push(err),
         });
-        decoder.push(Buffer.from('No-Length: bogus\r\n\r\nbody', 'ascii'));
+        decoder.push(Buffer.from("No-Length: bogus\r\n\r\nbody", "ascii"));
         assert.strictEqual(messages.length, 0);
         assert.strictEqual(errors.length, 1);
         assert.match(errors[0].message, /Content-Length/);
     });
 
-    it('handles a body that contains the header terminator literally', () => {
+    it("handles a body that contains the header terminator literally", () => {
         // The header terminator is `\r\n\r\n`. If a JSON body contains the
         // same byte sequence (e.g. inside a string) the decoder MUST NOT
         // treat it as the start of the next frame — Content-Length is the
@@ -79,76 +82,99 @@ describe('daemon framing', () => {
         const messages: string[] = [];
         const decoder = new FrameDecoder({
             onMessage: (json) => messages.push(json),
-            onError: () => assert.fail('no error expected'),
+            onError: () => assert.fail("no error expected"),
         });
-        const payload = { method: 'embed', text: 'line1\r\n\r\nline2' };
+        const payload = { method: "embed", text: "line1\r\n\r\nline2" };
         decoder.push(encodeFrame(payload));
         assert.strictEqual(messages.length, 1);
         assert.deepStrictEqual(JSON.parse(messages[0]), payload);
     });
 
-    it('accepts case-insensitive Content-Length header', () => {
+    it("accepts case-insensitive Content-Length header", () => {
         // LSP framing canonicalises the header name as `Content-Length`, but
         // RFC 7230 § 3.2 says HTTP headers are case-insensitive. Tolerate
         // a daemon that emits it as `content-length:`.
         const messages: string[] = [];
         const decoder = new FrameDecoder({
             onMessage: (json) => messages.push(json),
-            onError: () => assert.fail('no error expected'),
+            onError: () => assert.fail("no error expected"),
         });
-        const body = Buffer.from('{"method":"x"}', 'utf-8');
-        const header = Buffer.from(`content-length: ${body.length}\r\n\r\n`, 'ascii');
+        const body = Buffer.from('{"method":"x"}', "utf-8");
+        const header = Buffer.from(
+            `content-length: ${body.length}\r\n\r\n`,
+            "ascii",
+        );
         decoder.push(Buffer.concat([header, body]));
-        assert.strictEqual(JSON.parse(messages[0]).method, 'x');
+        assert.strictEqual(JSON.parse(messages[0]).method, "x");
     });
 
-    it('ignores an optional Content-Type header alongside Content-Length', () => {
+    it("ignores an optional Content-Type header alongside Content-Length", () => {
         // PROTOCOL.md § 1: Content-Type is optional and ignored by the reader.
         const messages: string[] = [];
         const decoder = new FrameDecoder({
             onMessage: (json) => messages.push(json),
-            onError: () => assert.fail('no error expected'),
+            onError: () => assert.fail("no error expected"),
         });
-        const body = Buffer.from('{"method":"y"}', 'utf-8');
+        const body = Buffer.from('{"method":"y"}', "utf-8");
         const header = Buffer.from(
             `Content-Length: ${body.length}\r\n` +
-            `Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n\r\n`,
-            'ascii',
+                `Content-Type: application/vscode-jsonrpc; charset=utf-8\r\n\r\n`,
+            "ascii",
         );
         decoder.push(Buffer.concat([header, body]));
-        assert.strictEqual(JSON.parse(messages[0]).method, 'y');
+        assert.strictEqual(JSON.parse(messages[0]).method, "y");
     });
 
-    it('round-trips every shipped protocol fixture', () => {
+    it("round-trips every shipped protocol fixture", () => {
         // Encode each fixture, push the encoded bytes through the decoder,
         // assert the decoded JSON matches. Catches regressions in encode
         // (length miscounts) and decode (boundary mishandling) against the
         // exact shapes the daemon uses on the wire.
-        const fixturesDir = path.resolve(__dirname, '..', '..', '..', 'docs', 'daemon', 'protocol-fixtures');
-        const files = fs.readdirSync(fixturesDir).filter(f => f.endsWith('.json') && !f.startsWith('README'));
-        assert.ok(files.length > 0, 'no fixtures found');
+        const fixturesDir = path.resolve(
+            __dirname,
+            "..",
+            "..",
+            "..",
+            "docs",
+            "daemon",
+            "protocol-fixtures",
+        );
+        const files = fs
+            .readdirSync(fixturesDir)
+            .filter((f) => f.endsWith(".json") && !f.startsWith("README"));
+        assert.ok(files.length > 0, "no fixtures found");
 
         for (const file of files) {
-            const original = JSON.parse(fs.readFileSync(path.join(fixturesDir, file), 'utf-8'));
+            const original = JSON.parse(
+                fs.readFileSync(path.join(fixturesDir, file), "utf-8"),
+            );
             const messages: string[] = [];
             const decoder = new FrameDecoder({
                 onMessage: (json) => messages.push(json),
                 onError: () => assert.fail(`framing error on fixture ${file}`),
             });
             decoder.push(encodeFrame(original));
-            assert.strictEqual(messages.length, 1, `fixture ${file} did not round-trip`);
-            assert.deepStrictEqual(JSON.parse(messages[0]), original, `fixture ${file} mutated`);
+            assert.strictEqual(
+                messages.length,
+                1,
+                `fixture ${file} did not round-trip`,
+            );
+            assert.deepStrictEqual(
+                JSON.parse(messages[0]),
+                original,
+                `fixture ${file} mutated`,
+            );
         }
     });
 
-    it('handles an empty-object payload (Content-Length: 2)', () => {
+    it("handles an empty-object payload (Content-Length: 2)", () => {
         // The `daemonReady` notification carries `{}` as params — minimum
         // legal body length. Make sure the decoder doesn't get stuck on
         // sub-byte tracking.
         const messages: string[] = [];
         const decoder = new FrameDecoder({
             onMessage: (json) => messages.push(json),
-            onError: () => assert.fail('no error expected'),
+            onError: () => assert.fail("no error expected"),
         });
         decoder.push(encodeFrame({}));
         assert.strictEqual(messages.length, 1);

--- a/vscode-extension/src/test/daemonIntegration.test.ts
+++ b/vscode-extension/src/test/daemonIntegration.test.ts
@@ -1,16 +1,16 @@
-import * as assert from 'assert';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import { PassThrough } from 'stream';
-import { DaemonClient } from '../daemon/daemonClient';
-import { encodeFrame, FrameDecoder } from '../daemon/daemonFraming';
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { PassThrough } from "stream";
+import { DaemonClient } from "../daemon/daemonClient";
+import { encodeFrame, FrameDecoder } from "../daemon/daemonFraming";
 import {
     InitializeParams,
     JsonRpcRequest,
     PROTOCOL_VERSION,
     RenderNowParams,
-} from '../daemon/daemonProtocol';
+} from "../daemon/daemonProtocol";
 
 /**
  * Tiny in-process fake daemon. Speaks the v1 wire format over the same kind
@@ -22,33 +22,41 @@ class FakeDaemon {
     public readonly toClient: PassThrough;
     public readonly fromClient: PassThrough;
     public readonly seenRequests: JsonRpcRequest[] = [];
-    public readonly seenNotifications: { method: string; params: unknown }[] = [];
+    public readonly seenNotifications: { method: string; params: unknown }[] =
+        [];
 
     private readonly decoder: FrameDecoder;
     private onInitialize: ((req: JsonRpcRequest) => void) | null = null;
-    private onRenderNow: ((req: JsonRpcRequest, params: RenderNowParams) => void) | null = null;
+    private onRenderNow:
+        | ((req: JsonRpcRequest, params: RenderNowParams) => void)
+        | null = null;
 
     constructor() {
         this.toClient = new PassThrough();
         this.fromClient = new PassThrough();
         this.decoder = new FrameDecoder({
             onMessage: (json) => this.handle(JSON.parse(json)),
-            onError: (err) => assert.fail(`fake daemon framing: ${err.message}`),
+            onError: (err) =>
+                assert.fail(`fake daemon framing: ${err.message}`),
         });
-        this.fromClient.on('data', (chunk: Buffer) => this.decoder.push(chunk));
+        this.fromClient.on("data", (chunk: Buffer) => this.decoder.push(chunk));
     }
 
-    onInit(handler: (req: JsonRpcRequest) => void): void { this.onInitialize = handler; }
-    onRender(handler: (req: JsonRpcRequest, params: RenderNowParams) => void): void {
+    onInit(handler: (req: JsonRpcRequest) => void): void {
+        this.onInitialize = handler;
+    }
+    onRender(
+        handler: (req: JsonRpcRequest, params: RenderNowParams) => void,
+    ): void {
         this.onRenderNow = handler;
     }
 
     sendNotification(method: string, params: unknown): void {
-        this.toClient.write(encodeFrame({ jsonrpc: '2.0', method, params }));
+        this.toClient.write(encodeFrame({ jsonrpc: "2.0", method, params }));
     }
 
     sendResult(id: number, result: unknown): void {
-        this.toClient.write(encodeFrame({ jsonrpc: '2.0', id, result }));
+        this.toClient.write(encodeFrame({ jsonrpc: "2.0", id, result }));
     }
 
     close(): void {
@@ -56,14 +64,19 @@ class FakeDaemon {
         this.fromClient.end();
     }
 
-    private handle(msg: JsonRpcRequest | { jsonrpc: '2.0'; method: string; params: unknown }): void {
+    private handle(
+        msg:
+            | JsonRpcRequest
+            | { jsonrpc: "2.0"; method: string; params: unknown },
+    ): void {
         const m = msg as JsonRpcRequest;
-        if (typeof m.id === 'number') {
+        if (typeof m.id === "number") {
             this.seenRequests.push(m);
-            if (m.method === 'initialize' && this.onInitialize) { this.onInitialize(m); }
-            else if (m.method === 'renderNow' && this.onRenderNow) {
+            if (m.method === "initialize" && this.onInitialize) {
+                this.onInitialize(m);
+            } else if (m.method === "renderNow" && this.onRenderNow) {
                 this.onRenderNow(m, m.params as RenderNowParams);
-            } else if (m.method === 'shutdown') {
+            } else if (m.method === "shutdown") {
                 this.sendResult(m.id, null);
             }
         } else {
@@ -75,91 +88,111 @@ class FakeDaemon {
 function defaultInitResult(): unknown {
     return {
         protocolVersion: PROTOCOL_VERSION,
-        daemonVersion: '0.0.0-fake',
+        daemonVersion: "0.0.0-fake",
         pid: 4321,
         capabilities: {
             incrementalDiscovery: false,
             sandboxRecycle: true,
-            leakDetection: ['light'],
+            leakDetection: ["light"],
         },
-        classpathFingerprint: 'a'.repeat(64),
-        manifest: { path: '/m', previewCount: 5 },
+        classpathFingerprint: "a".repeat(64),
+        manifest: { path: "/m", previewCount: 5 },
     };
 }
 
-describe('daemon integration — fake daemon round trip', () => {
-    it('initialize → setVisible → renderNow → renderFinished → close', async () => {
+describe("daemon integration — fake daemon round trip", () => {
+    it("initialize → setVisible → renderNow → renderFinished → close", async () => {
         const daemon = new FakeDaemon();
         daemon.onInit((req) => daemon.sendResult(req.id, defaultInitResult()));
 
-        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'daemon-int-'));
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "daemon-int-"));
         try {
-            const pngPath = path.join(tmpDir, 'render.png');
-            const pngBytes = Buffer.from('PNG-bytes-stand-in', 'utf-8');
+            const pngPath = path.join(tmpDir, "render.png");
+            const pngBytes = Buffer.from("PNG-bytes-stand-in", "utf-8");
             fs.writeFileSync(pngPath, pngBytes);
 
             const finishedSeen: { id: string; pngPath: string }[] = [];
             const startedSeen: string[] = [];
-            const client = new DaemonClient(daemon.fromClient, daemon.toClient, {
-                onRenderStarted: (p) => startedSeen.push(p.id),
-                onRenderFinished: (p) => finishedSeen.push({ id: p.id, pngPath: p.pngPath }),
-            });
+            const client = new DaemonClient(
+                daemon.fromClient,
+                daemon.toClient,
+                {
+                    onRenderStarted: (p) => startedSeen.push(p.id),
+                    onRenderFinished: (p) =>
+                        finishedSeen.push({ id: p.id, pngPath: p.pngPath }),
+                },
+            );
 
             // 1. initialize handshake
-            const initParams: Omit<InitializeParams, 'protocolVersion'> = {
-                clientVersion: '0.0.0',
-                workspaceRoot: '/w',
-                moduleId: ':m',
-                moduleProjectDir: '/w/m',
+            const initParams: Omit<InitializeParams, "protocolVersion"> = {
+                clientVersion: "0.0.0",
+                workspaceRoot: "/w",
+                moduleId: ":m",
+                moduleProjectDir: "/w/m",
                 capabilities: { visibility: true, metrics: true },
             };
             const init = await client.initialize(initParams);
-            assert.strictEqual(init.daemonVersion, '0.0.0-fake');
+            assert.strictEqual(init.daemonVersion, "0.0.0-fake");
             client.initialized();
 
             // 2. setVisible / setFocus notifications — verified by side
             //    inspection in daemon.seenNotifications.
-            client.setVisible({ ids: ['p1', 'p2'] });
-            client.setFocus({ ids: ['p1'] });
+            client.setVisible({ ids: ["p1", "p2"] });
+            client.setFocus({ ids: ["p1"] });
 
             // 3. renderNow → daemon responds with queued result, then
             //    pushes renderStarted + renderFinished as a side-effect.
             daemon.onRender((req, params) => {
-                daemon.sendResult(req.id, { queued: params.previews, rejected: [] });
-                daemon.sendNotification('renderStarted', { id: 'p1', queuedMs: 1 });
-                daemon.sendNotification('renderFinished', {
-                    id: 'p1',
+                daemon.sendResult(req.id, {
+                    queued: params.previews,
+                    rejected: [],
+                });
+                daemon.sendNotification("renderStarted", {
+                    id: "p1",
+                    queuedMs: 1,
+                });
+                daemon.sendNotification("renderFinished", {
+                    id: "p1",
                     pngPath,
                     tookMs: 99,
                 });
             });
-            const result = await client.renderNow({ previews: ['p1'], tier: 'fast' });
-            assert.deepStrictEqual(result.queued, ['p1']);
+            const result = await client.renderNow({
+                previews: ["p1"],
+                tier: "fast",
+            });
+            assert.deepStrictEqual(result.queued, ["p1"]);
 
             // Microtask drain so the notifications dispatched on the
             // toClient stream reach our handlers.
             await new Promise((r) => setImmediate(r));
-            assert.deepStrictEqual(startedSeen, ['p1']);
-            assert.deepStrictEqual(finishedSeen, [{ id: 'p1', pngPath }]);
+            assert.deepStrictEqual(startedSeen, ["p1"]);
+            assert.deepStrictEqual(finishedSeen, [{ id: "p1", pngPath }]);
 
             // 4. Wire-side assertions on what the daemon saw.
             const methods = daemon.seenRequests.map((r) => r.method);
-            assert.deepStrictEqual(methods, ['initialize', 'renderNow']);
+            assert.deepStrictEqual(methods, ["initialize", "renderNow"]);
             const notifMethods = daemon.seenNotifications.map((n) => n.method);
-            assert.deepStrictEqual(notifMethods, ['initialized', 'setVisible', 'setFocus']);
+            assert.deepStrictEqual(notifMethods, [
+                "initialized",
+                "setVisible",
+                "setFocus",
+            ]);
 
             // 5. Clean shutdown — daemon resolves the request, client is
             //    free to call exit() (a notification with no response).
             await client.shutdown();
             client.exit();
-            assert.ok(daemon.seenNotifications.some((n) => n.method === 'exit'));
+            assert.ok(
+                daemon.seenNotifications.some((n) => n.method === "exit"),
+            );
         } finally {
             daemon.close();
             fs.rmSync(tmpDir, { recursive: true });
         }
     });
 
-    it('survives the daemon emitting renderFailed instead of renderFinished', async () => {
+    it("survives the daemon emitting renderFailed instead of renderFinished", async () => {
         const daemon = new FakeDaemon();
         daemon.onInit((req) => daemon.sendResult(req.id, defaultInitResult()));
         const failures: string[] = [];
@@ -168,29 +201,29 @@ describe('daemon integration — fake daemon round trip', () => {
         });
         try {
             await client.initialize({
-                clientVersion: '0.0.0',
-                workspaceRoot: '/w',
-                moduleId: ':m',
-                moduleProjectDir: '/w/m',
+                clientVersion: "0.0.0",
+                workspaceRoot: "/w",
+                moduleId: ":m",
+                moduleProjectDir: "/w/m",
                 capabilities: { visibility: true, metrics: true },
             });
             client.initialized();
             daemon.onRender((req) => {
-                daemon.sendResult(req.id, { queued: ['p1'], rejected: [] });
-                daemon.sendNotification('renderFailed', {
-                    id: 'p1',
-                    error: { kind: 'runtime', message: 'NPE in composable' },
+                daemon.sendResult(req.id, { queued: ["p1"], rejected: [] });
+                daemon.sendNotification("renderFailed", {
+                    id: "p1",
+                    error: { kind: "runtime", message: "NPE in composable" },
                 });
             });
-            await client.renderNow({ previews: ['p1'], tier: 'fast' });
+            await client.renderNow({ previews: ["p1"], tier: "fast" });
             await new Promise((r) => setImmediate(r));
-            assert.deepStrictEqual(failures, ['NPE in composable']);
+            assert.deepStrictEqual(failures, ["NPE in composable"]);
         } finally {
             daemon.close();
         }
     });
 
-    it('classpathDirty notification reaches the client and the channel stays open', async () => {
+    it("classpathDirty notification reaches the client and the channel stays open", async () => {
         // PROTOCOL.md § 6: classpathDirty is delivered before the daemon
         // exits within classpathDirtyGraceMs. Until the stream closes the
         // client should still process notifications — for example, it's
@@ -205,30 +238,32 @@ describe('daemon integration — fake daemon round trip', () => {
         });
         try {
             await client.initialize({
-                clientVersion: '0.0.0',
-                workspaceRoot: '/w',
-                moduleId: ':m',
-                moduleProjectDir: '/w/m',
+                clientVersion: "0.0.0",
+                workspaceRoot: "/w",
+                moduleId: ":m",
+                moduleProjectDir: "/w/m",
                 capabilities: { visibility: true, metrics: true },
             });
             client.initialized();
-            daemon.sendNotification('classpathDirty', {
-                reason: 'fingerprintMismatch',
-                detail: 'libs.versions.toml SHA changed',
+            daemon.sendNotification("classpathDirty", {
+                reason: "fingerprintMismatch",
+                detail: "libs.versions.toml SHA changed",
             });
-            daemon.sendNotification('log', {
-                level: 'info',
-                message: 'exiting in 2s',
+            daemon.sendNotification("log", {
+                level: "info",
+                message: "exiting in 2s",
             });
             await new Promise((r) => setImmediate(r));
-            assert.deepStrictEqual(dirtySeen, ['libs.versions.toml SHA changed']);
-            assert.deepStrictEqual(logsSeen, ['exiting in 2s']);
+            assert.deepStrictEqual(dirtySeen, [
+                "libs.versions.toml SHA changed",
+            ]);
+            assert.deepStrictEqual(logsSeen, ["exiting in 2s"]);
         } finally {
             daemon.close();
         }
     });
 
-    it('handles a rapid burst of renderFinished notifications without losing any', async () => {
+    it("handles a rapid burst of renderFinished notifications without losing any", async () => {
         // The render-watcher thread on the daemon side can emit notifications
         // back-to-back; the framing layer must not coalesce or lose any.
         const daemon = new FakeDaemon();
@@ -239,16 +274,20 @@ describe('daemon integration — fake daemon round trip', () => {
         });
         try {
             await client.initialize({
-                clientVersion: '0.0.0',
-                workspaceRoot: '/w',
-                moduleId: ':m',
-                moduleProjectDir: '/w/m',
+                clientVersion: "0.0.0",
+                workspaceRoot: "/w",
+                moduleId: ":m",
+                moduleProjectDir: "/w/m",
                 capabilities: { visibility: true, metrics: true },
             });
             client.initialized();
             const ids = Array.from({ length: 20 }, (_, i) => `p${i}`);
             for (const id of ids) {
-                daemon.sendNotification('renderFinished', { id, pngPath: '/x.png', tookMs: 1 });
+                daemon.sendNotification("renderFinished", {
+                    id,
+                    pngPath: "/x.png",
+                    tookMs: 1,
+                });
             }
             await new Promise((r) => setImmediate(r));
             assert.deepStrictEqual(seen, ids);

--- a/vscode-extension/src/test/daemonProcess.test.ts
+++ b/vscode-extension/src/test/daemonProcess.test.ts
@@ -1,16 +1,18 @@
-import * as assert from 'assert';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import { readLaunchDescriptor } from '../daemon/daemonProcess';
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { readLaunchDescriptor } from "../daemon/daemonProcess";
 import {
     DAEMON_DESCRIPTOR_SCHEMA_VERSION,
     DaemonLaunchDescriptor,
-} from '../daemon/daemonProtocol';
+} from "../daemon/daemonProtocol";
 
-function withTempWorkspace<T>(fn: (workspaceRoot: string) => T | Promise<T>): () => Promise<T> {
+function withTempWorkspace<T>(
+    fn: (workspaceRoot: string) => T | Promise<T>,
+): () => Promise<T> {
     return async () => {
-        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'daemon-launch-'));
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "daemon-launch-"));
         try {
             return await fn(dir);
         } finally {
@@ -19,10 +21,14 @@ function withTempWorkspace<T>(fn: (workspaceRoot: string) => T | Promise<T>): ()
     };
 }
 
-function writeDescriptor(workspaceRoot: string, moduleId: string, descriptor: object): string {
-    const dir = path.join(workspaceRoot, moduleId, 'build', 'compose-previews');
+function writeDescriptor(
+    workspaceRoot: string,
+    moduleId: string,
+    descriptor: object,
+): string {
+    const dir = path.join(workspaceRoot, moduleId, "build", "compose-previews");
     fs.mkdirSync(dir, { recursive: true });
-    const file = path.join(dir, 'daemon-launch.json');
+    const file = path.join(dir, "daemon-launch.json");
     fs.writeFileSync(file, JSON.stringify(descriptor));
     return file;
 }
@@ -30,74 +36,104 @@ function writeDescriptor(workspaceRoot: string, moduleId: string, descriptor: ob
 function validDescriptor(): DaemonLaunchDescriptor {
     return {
         schemaVersion: DAEMON_DESCRIPTOR_SCHEMA_VERSION,
-        modulePath: ':samples:android',
-        variant: 'debug',
+        modulePath: ":samples:android",
+        variant: "debug",
         enabled: true,
-        mainClass: 'ee.schimke.composeai.daemon.DaemonMain',
-        javaLauncher: '/opt/jdk/bin/java',
-        classpath: ['/lib/a.jar'],
-        jvmArgs: ['-Xmx1024m'],
+        mainClass: "ee.schimke.composeai.daemon.DaemonMain",
+        javaLauncher: "/opt/jdk/bin/java",
+        classpath: ["/lib/a.jar"],
+        jvmArgs: ["-Xmx1024m"],
         systemProperties: {},
-        workingDirectory: '/work',
-        manifestPath: '/work/build/compose-previews/previews.json',
+        workingDirectory: "/work",
+        manifestPath: "/work/build/compose-previews/previews.json",
     };
 }
 
-describe('readLaunchDescriptor', () => {
-    it('returns null when the descriptor file does not exist', withTempWorkspace((dir) => {
-        const result = readLaunchDescriptor(dir, 'samples/android');
-        assert.strictEqual(result, null);
-    }));
+describe("readLaunchDescriptor", () => {
+    it(
+        "returns null when the descriptor file does not exist",
+        withTempWorkspace((dir) => {
+            const result = readLaunchDescriptor(dir, "samples/android");
+            assert.strictEqual(result, null);
+        }),
+    );
 
-    it('parses a valid descriptor', withTempWorkspace((dir) => {
-        const descriptor = validDescriptor();
-        writeDescriptor(dir, 'samples/android', descriptor);
-        const result = readLaunchDescriptor(dir, 'samples/android');
-        assert.notStrictEqual(result, null);
-        assert.strictEqual(result!.modulePath, ':samples:android');
-        assert.strictEqual(result!.enabled, true);
-        assert.deepStrictEqual(result!.classpath, ['/lib/a.jar']);
-    }));
+    it(
+        "parses a valid descriptor",
+        withTempWorkspace((dir) => {
+            const descriptor = validDescriptor();
+            writeDescriptor(dir, "samples/android", descriptor);
+            const result = readLaunchDescriptor(dir, "samples/android");
+            assert.notStrictEqual(result, null);
+            assert.strictEqual(result!.modulePath, ":samples:android");
+            assert.strictEqual(result!.enabled, true);
+            assert.deepStrictEqual(result!.classpath, ["/lib/a.jar"]);
+        }),
+    );
 
-    it('returns null on schema-version mismatch and logs the reason', withTempWorkspace((dir) => {
-        const logs: string[] = [];
-        const descriptor = { ...validDescriptor(), schemaVersion: 999 };
-        writeDescriptor(dir, 'samples/android', descriptor);
-        const result = readLaunchDescriptor(dir, 'samples/android', { appendLine: (s) => logs.push(s) });
-        assert.strictEqual(result, null);
-        assert.ok(
-            logs.some(l => l.includes('schema mismatch')),
-            `expected schema mismatch log, got: ${logs.join(' / ')}`,
-        );
-    }));
+    it(
+        "returns null on schema-version mismatch and logs the reason",
+        withTempWorkspace((dir) => {
+            const logs: string[] = [];
+            const descriptor = { ...validDescriptor(), schemaVersion: 999 };
+            writeDescriptor(dir, "samples/android", descriptor);
+            const result = readLaunchDescriptor(dir, "samples/android", {
+                appendLine: (s) => logs.push(s),
+            });
+            assert.strictEqual(result, null);
+            assert.ok(
+                logs.some((l) => l.includes("schema mismatch")),
+                `expected schema mismatch log, got: ${logs.join(" / ")}`,
+            );
+        }),
+    );
 
-    it('returns null on malformed JSON', withTempWorkspace((dir) => {
-        const logs: string[] = [];
-        const descriptorDir = path.join(dir, 'samples/android', 'build', 'compose-previews');
-        fs.mkdirSync(descriptorDir, { recursive: true });
-        fs.writeFileSync(path.join(descriptorDir, 'daemon-launch.json'), '{ not json');
-        const result = readLaunchDescriptor(dir, 'samples/android', { appendLine: (s) => logs.push(s) });
-        assert.strictEqual(result, null);
-        assert.ok(
-            logs.some(l => l.includes('failed to read')),
-            `expected parse failure log, got: ${logs.join(' / ')}`,
-        );
-    }));
+    it(
+        "returns null on malformed JSON",
+        withTempWorkspace((dir) => {
+            const logs: string[] = [];
+            const descriptorDir = path.join(
+                dir,
+                "samples/android",
+                "build",
+                "compose-previews",
+            );
+            fs.mkdirSync(descriptorDir, { recursive: true });
+            fs.writeFileSync(
+                path.join(descriptorDir, "daemon-launch.json"),
+                "{ not json",
+            );
+            const result = readLaunchDescriptor(dir, "samples/android", {
+                appendLine: (s) => logs.push(s),
+            });
+            assert.strictEqual(result, null);
+            assert.ok(
+                logs.some((l) => l.includes("failed to read")),
+                `expected parse failure log, got: ${logs.join(" / ")}`,
+            );
+        }),
+    );
 
-    it('preserves an explicit enabled=false flag without mutating it', withTempWorkspace((dir) => {
-        // The build can opt out via composePreview.daemon.enabled = false
-        // even with the VS Code setting on. Reader must return the descriptor
-        // honestly; the gate decides what to do with it.
-        const descriptor = { ...validDescriptor(), enabled: false };
-        writeDescriptor(dir, 'samples/android', descriptor);
-        const result = readLaunchDescriptor(dir, 'samples/android');
-        assert.strictEqual(result?.enabled, false);
-    }));
+    it(
+        "preserves an explicit enabled=false flag without mutating it",
+        withTempWorkspace((dir) => {
+            // The build can opt out via composePreview.daemon.enabled = false
+            // even with the VS Code setting on. Reader must return the descriptor
+            // honestly; the gate decides what to do with it.
+            const descriptor = { ...validDescriptor(), enabled: false };
+            writeDescriptor(dir, "samples/android", descriptor);
+            const result = readLaunchDescriptor(dir, "samples/android");
+            assert.strictEqual(result?.enabled, false);
+        }),
+    );
 
-    it('preserves a null javaLauncher (toolchain absent)', withTempWorkspace((dir) => {
-        const descriptor = { ...validDescriptor(), javaLauncher: null };
-        writeDescriptor(dir, 'samples/android', descriptor);
-        const result = readLaunchDescriptor(dir, 'samples/android');
-        assert.strictEqual(result?.javaLauncher, null);
-    }));
+    it(
+        "preserves a null javaLauncher (toolchain absent)",
+        withTempWorkspace((dir) => {
+            const descriptor = { ...validDescriptor(), javaLauncher: null };
+            writeDescriptor(dir, "samples/android", descriptor);
+            const result = readLaunchDescriptor(dir, "samples/android");
+            assert.strictEqual(result?.javaLauncher, null);
+        }),
+    );
 });

--- a/vscode-extension/src/test/daemonProtocol.test.ts
+++ b/vscode-extension/src/test/daemonProtocol.test.ts
@@ -1,6 +1,6 @@
-import * as assert from 'assert';
-import * as fs from 'fs';
-import * as path from 'path';
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
 import {
     DAEMON_DESCRIPTOR_SCHEMA_VERSION,
     DaemonLaunchDescriptor,
@@ -30,7 +30,7 @@ import {
     RenderNowParams,
     RenderNowResult,
     SetVisibleParams,
-} from '../daemon/daemonProtocol';
+} from "../daemon/daemonProtocol";
 
 /**
  * Shared protocol fixtures live under `docs/daemon/protocol-fixtures/`. Both
@@ -39,104 +39,150 @@ import {
  * we want to catch (PROTOCOL.md § 9). Workspace layout: vscode-extension is
  * at <repo>/vscode-extension, fixtures at <repo>/docs/daemon/protocol-fixtures.
  */
-const FIXTURES_DIR = path.resolve(__dirname, '..', '..', '..', 'docs', 'daemon', 'protocol-fixtures');
+const FIXTURES_DIR = path.resolve(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "docs",
+    "daemon",
+    "protocol-fixtures",
+);
 
 function readFixture<T>(name: string): T {
-    return JSON.parse(fs.readFileSync(path.join(FIXTURES_DIR, name), 'utf-8')) as T;
+    return JSON.parse(
+        fs.readFileSync(path.join(FIXTURES_DIR, name), "utf-8"),
+    ) as T;
 }
 
-describe('daemon protocol — golden fixtures', () => {
-    it('parses client-initialize.json into InitializeParams shape', () => {
-        const params = readFixture<InitializeParams>('client-initialize.json');
+describe("daemon protocol — golden fixtures", () => {
+    it("parses client-initialize.json into InitializeParams shape", () => {
+        const params = readFixture<InitializeParams>("client-initialize.json");
         assert.strictEqual(params.protocolVersion, PROTOCOL_VERSION);
-        assert.strictEqual(params.moduleId, ':samples:android');
+        assert.strictEqual(params.moduleId, ":samples:android");
         assert.strictEqual(params.capabilities.visibility, true);
         assert.strictEqual(params.capabilities.metrics, true);
-        assert.strictEqual(params.options?.detectLeaks, 'light');
+        assert.strictEqual(params.options?.detectLeaks, "light");
     });
 
-    it('parses daemon-initializeResult.json into InitializeResult shape', () => {
-        const result = readFixture<InitializeResult>('daemon-initializeResult.json');
+    it("parses daemon-initializeResult.json into InitializeResult shape", () => {
+        const result = readFixture<InitializeResult>(
+            "daemon-initializeResult.json",
+        );
         assert.strictEqual(result.protocolVersion, PROTOCOL_VERSION);
         assert.strictEqual(result.capabilities.sandboxRecycle, true);
         assert.strictEqual(result.classpathFingerprint.length, 64);
-        assert.deepStrictEqual(result.capabilities.leakDetection, ['light', 'heavy']);
+        assert.deepStrictEqual(result.capabilities.leakDetection, [
+            "light",
+            "heavy",
+        ]);
         // PROTOCOL.md § 3 — `knownDevices` is the daemon's catalog of `@Preview(device = ...)`
         // ids, projected to wire shape so panels can build a picker without re-bundling.
         const known = result.capabilities.knownDevices ?? [];
-        assert.ok(known.length >= 1, 'fixture should advertise at least one known device');
-        const pixel5 = known.find(d => d.id === 'id:pixel_5');
-        assert.ok(pixel5, 'fixture should include id:pixel_5');
+        assert.ok(
+            known.length >= 1,
+            "fixture should advertise at least one known device",
+        );
+        const pixel5 = known.find((d) => d.id === "id:pixel_5");
+        assert.ok(pixel5, "fixture should include id:pixel_5");
         assert.strictEqual(pixel5!.widthDp, 393);
         assert.strictEqual(pixel5!.density, 2.75);
-        const wear = known.find(d => d.id === 'id:wearos_small_round');
-        assert.ok(wear, 'fixture should include id:wearos_small_round');
+        const wear = known.find((d) => d.id === "id:wearos_small_round");
+        assert.ok(wear, "fixture should include id:wearos_small_round");
         assert.strictEqual(wear!.isRound, true);
         // PROTOCOL.md § 3 — supportedOverrides advertises which `PreviewOverrides` fields
         // this host actually applies. Desktop omits `localeTag` and `orientation`; the
         // fixture mirrors a desktop daemon so those should be absent.
         const supported = result.capabilities.supportedOverrides ?? [];
-        assert.ok(supported.includes('widthPx'), 'desktop should advertise widthPx');
-        assert.ok(supported.includes('uiMode'), 'desktop should advertise uiMode');
-        assert.ok(supported.includes('device'), 'desktop should advertise device');
-        assert.ok(supported.includes('inspectionMode'), 'desktop should advertise inspectionMode');
-        assert.ok(!supported.includes('localeTag'), 'desktop should NOT advertise localeTag');
-        assert.ok(!supported.includes('orientation'), 'desktop should NOT advertise orientation');
+        assert.ok(
+            supported.includes("widthPx"),
+            "desktop should advertise widthPx",
+        );
+        assert.ok(
+            supported.includes("uiMode"),
+            "desktop should advertise uiMode",
+        );
+        assert.ok(
+            supported.includes("device"),
+            "desktop should advertise device",
+        );
+        assert.ok(
+            supported.includes("inspectionMode"),
+            "desktop should advertise inspectionMode",
+        );
+        assert.ok(
+            !supported.includes("localeTag"),
+            "desktop should NOT advertise localeTag",
+        );
+        assert.ok(
+            !supported.includes("orientation"),
+            "desktop should NOT advertise orientation",
+        );
         // PROTOCOL.md § 3 — backend identifies the renderer; fixture mirrors a desktop daemon.
-        assert.strictEqual(result.capabilities.backend, 'desktop');
+        assert.strictEqual(result.capabilities.backend, "desktop");
     });
 
-    it('parses client-fileChanged.json with all required fields', () => {
-        const params = readFixture<FileChangedParams>('client-fileChanged.json');
-        assert.strictEqual(params.kind, 'source');
-        assert.strictEqual(params.changeType, 'modified');
+    it("parses client-fileChanged.json with all required fields", () => {
+        const params = readFixture<FileChangedParams>(
+            "client-fileChanged.json",
+        );
+        assert.strictEqual(params.kind, "source");
+        assert.strictEqual(params.changeType, "modified");
         assert.match(params.path, /\.kt$/);
     });
 
-    it('parses client-setVisible.json into a string-array shape', () => {
-        const params = readFixture<SetVisibleParams>('client-setVisible.json');
+    it("parses client-setVisible.json into a string-array shape", () => {
+        const params = readFixture<SetVisibleParams>("client-setVisible.json");
         assert.ok(Array.isArray(params.ids));
         assert.ok(params.ids.length > 0);
-        for (const id of params.ids) { assert.strictEqual(typeof id, 'string'); }
+        for (const id of params.ids) {
+            assert.strictEqual(typeof id, "string");
+        }
     });
 
-    it('parses daemon-renderFinished.json with metrics', () => {
-        const params = readFixture<RenderFinishedParams>('daemon-renderFinished.json');
+    it("parses daemon-renderFinished.json with metrics", () => {
+        const params = readFixture<RenderFinishedParams>(
+            "daemon-renderFinished.json",
+        );
         assert.match(params.pngPath, /\.png$/);
         assert.ok(params.tookMs > 0);
         assert.ok(params.metrics);
-        assert.strictEqual(typeof params.metrics!.heapAfterGcMb, 'number');
+        assert.strictEqual(typeof params.metrics!.heapAfterGcMb, "number");
     });
 
-    it('parses daemon-renderNowResult.json — queued + rejected lists', () => {
-        const result = readFixture<RenderNowResult>('daemon-renderNowResult.json');
+    it("parses daemon-renderNowResult.json — queued + rejected lists", () => {
+        const result = readFixture<RenderNowResult>(
+            "daemon-renderNowResult.json",
+        );
         assert.ok(Array.isArray(result.queued));
         assert.ok(Array.isArray(result.rejected));
-        assert.strictEqual(result.rejected[0].reason, 'unknown preview ID');
+        assert.strictEqual(result.rejected[0].reason, "unknown preview ID");
     });
 
-    it('parses client-renderNow.json with tier=fast', () => {
-        const params = readFixture<RenderNowParams>('client-renderNow.json');
-        assert.strictEqual(params.tier, 'fast');
+    it("parses client-renderNow.json with tier=fast", () => {
+        const params = readFixture<RenderNowParams>("client-renderNow.json");
+        assert.strictEqual(params.tier, "fast");
         assert.ok(params.previews.length >= 1);
     });
 
-    it('parses client-renderNow-overrides.json with display-property overrides', () => {
+    it("parses client-renderNow-overrides.json with display-property overrides", () => {
         // PROTOCOL.md § 5 — `renderNow.overrides` extends the request shape with optional
         // per-call display overrides. The Kotlin counterpart round-trips the same fixture in
         // MessagesTest, which is the cross-language source of truth for this feature.
-        const params = readFixture<RenderNowParams>('client-renderNow-overrides.json');
-        assert.strictEqual(params.tier, 'fast');
+        const params = readFixture<RenderNowParams>(
+            "client-renderNow-overrides.json",
+        );
+        assert.strictEqual(params.tier, "fast");
         assert.ok(params.overrides);
         assert.strictEqual(params.overrides!.widthPx, 600);
-        assert.strictEqual(params.overrides!.uiMode, 'dark');
-        assert.strictEqual(params.overrides!.localeTag, 'fr-FR');
+        assert.strictEqual(params.overrides!.uiMode, "dark");
+        assert.strictEqual(params.overrides!.localeTag, "fr-FR");
         assert.strictEqual(params.overrides!.inspectionMode, false);
     });
 });
 
-describe('daemon launch descriptor', () => {
-    it('rejects descriptors with mismatched schemaVersion', () => {
+describe("daemon launch descriptor", () => {
+    it("rejects descriptors with mismatched schemaVersion", () => {
         // The reader in daemonProcess.ts gates on DAEMON_DESCRIPTOR_SCHEMA_VERSION;
         // the constant exists so callers can hard-fail rather than silently
         // accept an incompatible JVM spec. The contract test here just pins
@@ -145,25 +191,27 @@ describe('daemon launch descriptor', () => {
         assert.strictEqual(DAEMON_DESCRIPTOR_SCHEMA_VERSION, 1);
     });
 
-    it('round-trips a synthetic descriptor', () => {
+    it("round-trips a synthetic descriptor", () => {
         // Smoke test: TypeScript shape stays in sync with the Kotlin
         // DaemonClasspathDescriptor data class. No tooling enforces this at
         // compile time, so a trivial shape exercise here catches the most
         // common drift (renamed field).
         const desc: DaemonLaunchDescriptor = {
             schemaVersion: DAEMON_DESCRIPTOR_SCHEMA_VERSION,
-            modulePath: ':samples:android',
-            variant: 'debug',
+            modulePath: ":samples:android",
+            variant: "debug",
             enabled: true,
-            mainClass: 'ee.schimke.composeai.daemon.DaemonMain',
-            javaLauncher: '/opt/jdk/bin/java',
-            classpath: ['/lib/a.jar', '/lib/b.jar'],
-            jvmArgs: ['-Xmx1024m'],
-            systemProperties: { 'composeai.history': '/tmp/history' },
-            workingDirectory: '/work',
-            manifestPath: '/work/build/compose-previews/previews.json',
+            mainClass: "ee.schimke.composeai.daemon.DaemonMain",
+            javaLauncher: "/opt/jdk/bin/java",
+            classpath: ["/lib/a.jar", "/lib/b.jar"],
+            jvmArgs: ["-Xmx1024m"],
+            systemProperties: { "composeai.history": "/tmp/history" },
+            workingDirectory: "/work",
+            manifestPath: "/work/build/compose-previews/previews.json",
         };
-        const round = JSON.parse(JSON.stringify(desc)) as DaemonLaunchDescriptor;
+        const round = JSON.parse(
+            JSON.stringify(desc),
+        ) as DaemonLaunchDescriptor;
         assert.deepStrictEqual(round, desc);
     });
 });
@@ -176,8 +224,8 @@ describe('daemon launch descriptor', () => {
  * HISTORY.md § "Sidecar metadata schema" so any drift on the doc surface is
  * a test failure here.
  */
-describe('history protocol shapes', () => {
-    it('error codes match PROTOCOL.md § 5', () => {
+describe("history protocol shapes", () => {
+    it("error codes match PROTOCOL.md § 5", () => {
         // Pinned constants — change in lockstep with the Kotlin side. The
         // daemon's `JsonRpcServer` returns these literal codes from
         // history/list / history/read / history/diff dispatch.
@@ -186,76 +234,89 @@ describe('history protocol shapes', () => {
         assert.strictEqual(ERROR_HISTORY_PIXEL_NOT_IMPLEMENTED, -32012);
     });
 
-    it('history/list params accept every documented filter', () => {
+    it("history/list params accept every documented filter", () => {
         // Compile-time + runtime check: every filter listed in PROTOCOL.md
         // § 5 ("history/list") must be assignable to HistoryListParams.
         const params: HistoryListParams = {
-            previewId: 'com.example.RedSquare',
-            since: '2026-04-29T00:00:00Z',
-            until: '2026-04-30T23:59:59Z',
+            previewId: "com.example.RedSquare",
+            since: "2026-04-29T00:00:00Z",
+            until: "2026-04-30T23:59:59Z",
             limit: 50,
-            cursor: 'opaque-token',
-            branch: 'main',
-            branchPattern: '^agent/.*',
-            commit: '6af6b8c',
-            worktreePath: '/home/yuri/workspace/compose-ai-tools',
-            agentId: 'claude-code',
-            sourceKind: 'git',
-            sourceId: 'git:preview/main@abc123',
+            cursor: "opaque-token",
+            branch: "main",
+            branchPattern: "^agent/.*",
+            commit: "6af6b8c",
+            worktreePath: "/home/yuri/workspace/compose-ai-tools",
+            agentId: "claude-code",
+            sourceKind: "git",
+            sourceId: "git:preview/main@abc123",
         };
         const round = JSON.parse(JSON.stringify(params));
         assert.deepStrictEqual(round, params);
     });
 
-    it('history/list result mirrors the documented field set', () => {
+    it("history/list result mirrors the documented field set", () => {
         const result: HistoryListResult = {
-            entries: [{ id: '20260430-101234-a1b2c3d4', previewId: 'com.example.X' }],
-            nextCursor: 'next-page',
+            entries: [
+                { id: "20260430-101234-a1b2c3d4", previewId: "com.example.X" },
+            ],
+            nextCursor: "next-page",
             totalCount: 142,
         };
         assert.strictEqual(result.entries.length, 1);
         assert.strictEqual(result.totalCount, 142);
     });
 
-    it('history/read params + result round-trip', () => {
-        const params: HistoryReadParams = { id: '20260430-101234-a1b2c3d4', inline: false };
-        const result: HistoryReadResult = {
-            entry: { id: params.id, previewId: 'com.example.X' },
-            previewMetadata: { displayName: 'X', sourceFile: '/abs/X.kt' },
-            pngPath: '/abs/.compose-preview-history/com.example.X/20260430-101234-a1b2c3d4.png',
+    it("history/read params + result round-trip", () => {
+        const params: HistoryReadParams = {
+            id: "20260430-101234-a1b2c3d4",
+            inline: false,
         };
-        assert.strictEqual(result.pngPath.endsWith('.png'), true);
-        assert.strictEqual(result.pngBytes, undefined,
-            'inline=false omits pngBytes; the client reads from disk');
+        const result: HistoryReadResult = {
+            entry: { id: params.id, previewId: "com.example.X" },
+            previewMetadata: { displayName: "X", sourceFile: "/abs/X.kt" },
+            pngPath:
+                "/abs/.compose-preview-history/com.example.X/20260430-101234-a1b2c3d4.png",
+        };
+        assert.strictEqual(result.pngPath.endsWith(".png"), true);
+        assert.strictEqual(
+            result.pngBytes,
+            undefined,
+            "inline=false omits pngBytes; the client reads from disk",
+        );
         assert.deepStrictEqual(JSON.parse(JSON.stringify(params)), params);
     });
 
-    it('history/diff metadata-mode result keeps pixel fields nullable', () => {
+    it("history/diff metadata-mode result keeps pixel fields nullable", () => {
         // Per PROTOCOL.md § 5: `diffPx` / `ssim` / `diffPngPath` are reserved
         // for phase H5; in metadata mode they are always undefined or null.
         // A result asserting them as required would lock us into H5 prematurely.
-        const params: HistoryDiffParams = { from: 'a1', to: 'a2', mode: 'metadata' };
+        const params: HistoryDiffParams = {
+            from: "a1",
+            to: "a2",
+            mode: "metadata",
+        };
         const result: HistoryDiffResult = {
             pngHashChanged: true,
-            fromMetadata: { id: 'a1' },
-            toMetadata: { id: 'a2' },
+            fromMetadata: { id: "a1" },
+            toMetadata: { id: "a2" },
         };
-        assert.strictEqual(params.mode, 'metadata');
+        assert.strictEqual(params.mode, "metadata");
         assert.strictEqual(result.diffPx, undefined);
         assert.strictEqual(result.ssim, undefined);
         assert.strictEqual(result.diffPngPath, undefined);
     });
 
-    it('historyAdded notification carries an entry payload', () => {
+    it("historyAdded notification carries an entry payload", () => {
         // The wire shape from PROTOCOL.md § 6 ("historyAdded"): a single
         // `entry` field whose value is the sidecar JSON. We don't pin the
         // sidecar's full shape here — that lives in HISTORY.md and changes
         // additively — but we do pin the envelope.
         const params: HistoryAddedParams = {
             entry: {
-                id: '20260430-101234-a1b2c3d4',
-                previewId: 'com.example.RedSquare',
-                pngHash: 'a1b2c3d4e5f6789',
+                id: "20260430-101234-a1b2c3d4",
+                previewId: "com.example.RedSquare",
+                pngHash: "a1b2c3d4e5f6789",
             },
         };
         const round = JSON.parse(JSON.stringify(params)) as HistoryAddedParams;
@@ -267,7 +328,7 @@ describe('history protocol shapes', () => {
  * D1 — data product wire shapes. See `docs/daemon/DATA-PRODUCTS.md` and
  * the round-trip golden fixtures under `docs/daemon/protocol-fixtures/`.
  */
-describe('data product protocol shapes', () => {
+describe("data product protocol shapes", () => {
     it('error codes match DATA-PRODUCTS.md § "Error codes"', () => {
         assert.strictEqual(ERROR_DATA_PRODUCT_UNKNOWN, -32020);
         assert.strictEqual(ERROR_DATA_PRODUCT_NOT_AVAILABLE, -32021);
@@ -275,49 +336,59 @@ describe('data product protocol shapes', () => {
         assert.strictEqual(ERROR_DATA_PRODUCT_BUDGET_EXCEEDED, -32023);
     });
 
-    it('parses client-dataFetch.json into DataFetchParams shape', () => {
-        const params = readFixture<DataFetchParams>('client-dataFetch.json');
-        assert.strictEqual(params.kind, 'a11y/hierarchy');
-        assert.strictEqual(params.previewId, 'com.example.HomeKt#HomePreview');
+    it("parses client-dataFetch.json into DataFetchParams shape", () => {
+        const params = readFixture<DataFetchParams>("client-dataFetch.json");
+        assert.strictEqual(params.kind, "a11y/hierarchy");
+        assert.strictEqual(params.previewId, "com.example.HomeKt#HomePreview");
         // `inline` defaults to false on the wire; the fixture omits it so the
         // Kotlin round-trip with `encodeDefaults = false` stays clean.
         assert.strictEqual(params.inline, undefined);
     });
 
-    it('parses daemon-dataFetchResult.json into DataFetchResult shape', () => {
-        const result = readFixture<DataFetchResult>('daemon-dataFetchResult.json');
-        assert.strictEqual(result.kind, 'a11y/hierarchy');
+    it("parses daemon-dataFetchResult.json into DataFetchResult shape", () => {
+        const result = readFixture<DataFetchResult>(
+            "daemon-dataFetchResult.json",
+        );
+        assert.strictEqual(result.kind, "a11y/hierarchy");
         assert.strictEqual(result.schemaVersion, 1);
-        assert.ok(result.path && result.path.endsWith('a11y-hierarchy.json'));
+        assert.ok(result.path && result.path.endsWith("a11y-hierarchy.json"));
         assert.strictEqual(result.payload, undefined);
         assert.strictEqual(result.bytes, undefined);
     });
 
-    it('subscribe / unsubscribe share params shape', () => {
-        const params = readFixture<DataSubscribeParams>('client-dataSubscribe.json');
-        assert.strictEqual(params.kind, 'a11y/hierarchy');
-        assert.strictEqual(params.previewId, 'com.example.HomeKt#HomePreview');
-        const result = readFixture<DataSubscribeResult>('daemon-dataSubscribeResult.json');
+    it("subscribe / unsubscribe share params shape", () => {
+        const params = readFixture<DataSubscribeParams>(
+            "client-dataSubscribe.json",
+        );
+        assert.strictEqual(params.kind, "a11y/hierarchy");
+        assert.strictEqual(params.previewId, "com.example.HomeKt#HomePreview");
+        const result = readFixture<DataSubscribeResult>(
+            "daemon-dataSubscribeResult.json",
+        );
         assert.strictEqual(result.ok, true);
     });
 
-    it('initialize result advertises data product capabilities', () => {
+    it("initialize result advertises data product capabilities", () => {
         // Lock the field's wire spelling — the renderFinished attach path
         // depends on the daemon listing each kind it can produce here.
-        const result = readFixture<InitializeResult>('daemon-initializeResult.json');
+        const result = readFixture<InitializeResult>(
+            "daemon-initializeResult.json",
+        );
         assert.ok(Array.isArray(result.capabilities.dataProducts));
         const kinds = result.capabilities.dataProducts.map((c) => c.kind);
-        assert.ok(kinds.includes('a11y/atf'));
-        assert.ok(kinds.includes('a11y/hierarchy'));
+        assert.ok(kinds.includes("a11y/atf"));
+        assert.ok(kinds.includes("a11y/hierarchy"));
     });
 
-    it('renderFinished can carry per-kind data product attachments', () => {
+    it("renderFinished can carry per-kind data product attachments", () => {
         const params = readFixture<RenderFinishedParams>(
-            'daemon-renderFinished-withDataProducts.json',
+            "daemon-renderFinished-withDataProducts.json",
         );
         assert.ok(Array.isArray(params.dataProducts));
-        const atf = params.dataProducts!.find((p) => p.kind === 'a11y/atf');
-        const hierarchy = params.dataProducts!.find((p) => p.kind === 'a11y/hierarchy');
+        const atf = params.dataProducts!.find((p) => p.kind === "a11y/atf");
+        const hierarchy = params.dataProducts!.find(
+            (p) => p.kind === "a11y/hierarchy",
+        );
         // Inline payload for atf, path for hierarchy — exercises both transports.
         assert.ok(atf?.payload);
         assert.ok(hierarchy?.path);

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -1,50 +1,60 @@
-import * as assert from 'assert';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import { DaemonScheduler } from '../daemon/daemonScheduler';
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { DaemonScheduler } from "../daemon/daemonScheduler";
 
 interface RecordedCall {
     method:
-        | 'fileChanged'
-        | 'setFocus'
-        | 'setVisible'
-        | 'renderNow'
-        | 'dataSubscribe'
-        | 'dataUnsubscribe';
+        | "fileChanged"
+        | "setFocus"
+        | "setVisible"
+        | "renderNow"
+        | "dataSubscribe"
+        | "dataUnsubscribe";
     args: unknown;
 }
 
 class FakeClient {
     public calls: RecordedCall[] = [];
     public closed = false;
-    public renderNowResult: { queued: string[]; rejected: { id: string; reason: string }[] } =
-        { queued: ['x'], rejected: [] };
+    public renderNowResult: {
+        queued: string[];
+        rejected: { id: string; reason: string }[];
+    } = { queued: ["x"], rejected: [] };
     /**
      * D2 — when true, `dataSubscribe` rejects with `DataProductUnknown`-shaped error,
      * mimicking a pre-D2 daemon. Tests that don't set this get a successful resolution.
      */
     public dataSubscribeRejects = false;
 
-    fileChanged(args: unknown): void { this.calls.push({ method: 'fileChanged', args }); }
-    setFocus(args: unknown): void { this.calls.push({ method: 'setFocus', args }); }
-    setVisible(args: unknown): void { this.calls.push({ method: 'setVisible', args }); }
+    fileChanged(args: unknown): void {
+        this.calls.push({ method: "fileChanged", args });
+    }
+    setFocus(args: unknown): void {
+        this.calls.push({ method: "setFocus", args });
+    }
+    setVisible(args: unknown): void {
+        this.calls.push({ method: "setVisible", args });
+    }
     renderNow(args: unknown): Promise<unknown> {
-        this.calls.push({ method: 'renderNow', args });
+        this.calls.push({ method: "renderNow", args });
         return Promise.resolve(this.renderNowResult);
     }
     dataSubscribe(args: unknown): Promise<unknown> {
-        this.calls.push({ method: 'dataSubscribe', args });
+        this.calls.push({ method: "dataSubscribe", args });
         if (this.dataSubscribeRejects) {
-            return Promise.reject(new Error('-32020 DataProductUnknown'));
+            return Promise.reject(new Error("-32020 DataProductUnknown"));
         }
         return Promise.resolve({ ok: true });
     }
     dataUnsubscribe(args: unknown): Promise<unknown> {
-        this.calls.push({ method: 'dataUnsubscribe', args });
+        this.calls.push({ method: "dataUnsubscribe", args });
         return Promise.resolve({ ok: true });
     }
-    isClosed(): boolean { return this.closed; }
+    isClosed(): boolean {
+        return this.closed;
+    }
 }
 
 /**
@@ -60,20 +70,41 @@ class FakeGate {
     public ready = false;
     public getOrSpawnCalls: string[] = [];
     public getOrSpawnErrors: Error[] = [];
-    public capturedEvents = new Map<string, {
-        onRenderFinished?: (p: { id: string; pngPath: string; tookMs: number }) => void;
-        onRenderFailed?: (p: { id: string; error: { message: string } }) => void;
-        onClasspathDirty?: (p: { detail: string }) => void;
-        onDiscoveryUpdated?: (p: { added: unknown[]; removed: string[]; changed: unknown[]; totalPreviews: number }) => void;
-        onChannelClosed?: () => void;
-    }>();
+    public capturedEvents = new Map<
+        string,
+        {
+            onRenderFinished?: (p: {
+                id: string;
+                pngPath: string;
+                tookMs: number;
+            }) => void;
+            onRenderFailed?: (p: {
+                id: string;
+                error: { message: string };
+            }) => void;
+            onClasspathDirty?: (p: { detail: string }) => void;
+            onDiscoveryUpdated?: (p: {
+                added: unknown[];
+                removed: string[];
+                changed: unknown[];
+                totalPreviews: number;
+            }) => void;
+            onChannelClosed?: () => void;
+        }
+    >();
 
-    isEnabled(): boolean { return this.enabled; }
-    isDaemonReady(_moduleId: string): boolean { return this.ready; }
+    isEnabled(): boolean {
+        return this.enabled;
+    }
+    isDaemonReady(_moduleId: string): boolean {
+        return this.ready;
+    }
     getOrSpawn(moduleId: string, events: unknown): Promise<FakeClient | null> {
         this.getOrSpawnCalls.push(moduleId);
         const err = this.getOrSpawnErrors.shift();
-        if (err) { return Promise.reject(err); }
+        if (err) {
+            return Promise.reject(err);
+        }
         this.capturedEvents.set(moduleId, events as never);
         return Promise.resolve(this.client);
     }
@@ -84,7 +115,9 @@ class FakeGradleService {
     public bootstrapShouldThrow: Error | null = null;
     async runDaemonBootstrap(moduleId: string): Promise<void> {
         this.bootstrapCalls.push(moduleId);
-        if (this.bootstrapShouldThrow) { throw this.bootstrapShouldThrow; }
+        if (this.bootstrapShouldThrow) {
+            throw this.bootstrapShouldThrow;
+        }
     }
 }
 
@@ -104,9 +137,18 @@ function build(opts: BuildOptions = {}) {
     const gate = new FakeGate();
     const log: string[] = [];
     const images: CapturedImage[] = [];
-    const failures: { moduleId: string; previewId: string; message: string }[] = [];
+    const failures: { moduleId: string; previewId: string; message: string }[] =
+        [];
     const dirty: { moduleId: string; detail: string }[] = [];
-    const discovery: { moduleId: string; params: { added: unknown[]; removed: string[]; changed: unknown[]; totalPreviews: number } }[] = [];
+    const discovery: {
+        moduleId: string;
+        params: {
+            added: unknown[];
+            removed: string[];
+            changed: unknown[];
+            totalPreviews: number;
+        };
+    }[] = [];
     const dataProducts: {
         moduleId: string;
         previewId: string;
@@ -114,7 +156,12 @@ function build(opts: BuildOptions = {}) {
     }[] = [];
     const channelClosed: string[] = [];
     const events = {
-        onPreviewImageReady: (moduleId: string, previewId: string, base64: string, pngPath: string) => {
+        onPreviewImageReady: (
+            moduleId: string,
+            previewId: string,
+            base64: string,
+            pngPath: string,
+        ) => {
             images.push({ moduleId, previewId, base64, pngPath });
         },
         onDataProductsAttached: (
@@ -124,13 +171,25 @@ function build(opts: BuildOptions = {}) {
         ) => {
             dataProducts.push({ moduleId, previewId, attachments });
         },
-        onRenderFailed: (moduleId: string, previewId: string, message: string) => {
+        onRenderFailed: (
+            moduleId: string,
+            previewId: string,
+            message: string,
+        ) => {
             failures.push({ moduleId, previewId, message });
         },
         onClasspathDirty: (moduleId: string, detail: string) => {
             dirty.push({ moduleId, detail });
         },
-        onDiscoveryUpdated: (moduleId: string, params: { added: unknown[]; removed: string[]; changed: unknown[]; totalPreviews: number }) => {
+        onDiscoveryUpdated: (
+            moduleId: string,
+            params: {
+                added: unknown[];
+                removed: string[];
+                changed: unknown[];
+                totalPreviews: number;
+            },
+        ) => {
             discovery.push({ moduleId, params });
         },
         onChannelClosed: (moduleId: string) => {
@@ -143,160 +202,210 @@ function build(opts: BuildOptions = {}) {
         { appendLine: (s) => log.push(s) },
         opts.a11yAlwaysSubscribe ?? (() => false),
     );
-    return { gate, scheduler, log, images, failures, dirty, discovery, dataProducts, channelClosed };
+    return {
+        gate,
+        scheduler,
+        log,
+        images,
+        failures,
+        dirty,
+        discovery,
+        dataProducts,
+        channelClosed,
+    };
 }
 
-describe('DaemonScheduler', () => {
-    it('dedupes setVisible when the visible set is unchanged', async () => {
+describe("DaemonScheduler", () => {
+    it("dedupes setVisible when the visible set is unchanged", async () => {
         const { gate, scheduler } = build();
-        await scheduler.setVisible('mod', ['a', 'b'], []);
-        await scheduler.setVisible('mod', ['a', 'b'], []); // no-op
-        await scheduler.setVisible('mod', ['b', 'a'], []); // same set, different order — still no-op
-        const visibleCalls = gate.client!.calls.filter(c => c.method === 'setVisible');
+        await scheduler.setVisible("mod", ["a", "b"], []);
+        await scheduler.setVisible("mod", ["a", "b"], []); // no-op
+        await scheduler.setVisible("mod", ["b", "a"], []); // same set, different order — still no-op
+        const visibleCalls = gate.client!.calls.filter(
+            (c) => c.method === "setVisible",
+        );
         assert.strictEqual(visibleCalls.length, 1);
     });
 
-    it('caps speculative renderNow at the budget', async () => {
+    it("caps speculative renderNow at the budget", async () => {
         const { gate, scheduler } = build();
-        const predicted = ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'];
-        await scheduler.setVisible('mod', ['v1'], predicted);
-        const renderCalls = gate.client!.calls.filter(c => c.method === 'renderNow');
+        const predicted = ["p1", "p2", "p3", "p4", "p5", "p6", "p7", "p8"];
+        await scheduler.setVisible("mod", ["v1"], predicted);
+        const renderCalls = gate.client!.calls.filter(
+            (c) => c.method === "renderNow",
+        );
         assert.strictEqual(renderCalls.length, 1);
-        const params = renderCalls[0].args as { previews: string[]; tier: string };
+        const params = renderCalls[0].args as {
+            previews: string[];
+            tier: string;
+        };
         assert.strictEqual(params.previews.length, 4);
-        assert.strictEqual(params.tier, 'fast');
+        assert.strictEqual(params.tier, "fast");
         // The four selected must be a prefix of `predicted` (preserves the
         // webview's ranked-by-velocity order — see PREDICTIVE.md § 2).
         assert.deepStrictEqual(params.previews, predicted.slice(0, 4));
     });
 
-    it('does not re-speculate IDs already in the visible set', async () => {
+    it("does not re-speculate IDs already in the visible set", async () => {
         const { gate, scheduler } = build();
-        await scheduler.setVisible('mod', ['a', 'b'], ['b', 'c', 'd']);
-        const renderCalls = gate.client!.calls.filter(c => c.method === 'renderNow');
+        await scheduler.setVisible("mod", ["a", "b"], ["b", "c", "d"]);
+        const renderCalls = gate.client!.calls.filter(
+            (c) => c.method === "renderNow",
+        );
         assert.strictEqual(renderCalls.length, 1);
         const params = renderCalls[0].args as { previews: string[] };
         // 'b' is currently visible — daemon's reactive queue handles it. We
         // only speculate 'c' and 'd'.
-        assert.deepStrictEqual(params.previews, ['c', 'd']);
+        assert.deepStrictEqual(params.previews, ["c", "d"]);
     });
 
-    it('does not re-speculate IDs already speculated in this session', async () => {
+    it("does not re-speculate IDs already speculated in this session", async () => {
         // Scrolling back over cards we already pre-warmed shouldn't re-queue
         // identical work; the daemon's reactive queue still handles them on
         // actual focus.
         const { gate, scheduler } = build();
-        await scheduler.setVisible('mod', ['v1'], ['p1', 'p2']);
-        await scheduler.setVisible('mod', ['v2'], ['p1', 'p2']); // same predictions
-        const renderCalls = gate.client!.calls.filter(c => c.method === 'renderNow');
+        await scheduler.setVisible("mod", ["v1"], ["p1", "p2"]);
+        await scheduler.setVisible("mod", ["v2"], ["p1", "p2"]); // same predictions
+        const renderCalls = gate.client!.calls.filter(
+            (c) => c.method === "renderNow",
+        );
         // Only the first push generated a renderNow; the second was deduped.
         assert.strictEqual(renderCalls.length, 1);
     });
 
-    it('emits a renderNow even when visible is unchanged but predicted is fresh', async () => {
+    it("emits a renderNow even when visible is unchanged but predicted is fresh", async () => {
         // The dedup check on `setVisible` fires only when there's no fresh
         // predicted set; with predictions, the scheduler still considers
         // them and may issue speculative renders even if visibility is the
         // same set as last time.
         const { gate, scheduler } = build();
-        await scheduler.setVisible('mod', ['v1'], []);
-        await scheduler.setVisible('mod', ['v1'], ['fresh1', 'fresh2']);
-        const renderCalls = gate.client!.calls.filter(c => c.method === 'renderNow');
+        await scheduler.setVisible("mod", ["v1"], []);
+        await scheduler.setVisible("mod", ["v1"], ["fresh1", "fresh2"]);
+        const renderCalls = gate.client!.calls.filter(
+            (c) => c.method === "renderNow",
+        );
         assert.strictEqual(renderCalls.length, 1);
         const params = renderCalls[0].args as { previews: string[] };
-        assert.deepStrictEqual(params.previews, ['fresh1', 'fresh2']);
+        assert.deepStrictEqual(params.previews, ["fresh1", "fresh2"]);
     });
 
-    it('skips daemon traffic entirely when the gate is disabled', async () => {
+    it("skips daemon traffic entirely when the gate is disabled", async () => {
         const { gate, scheduler } = build();
         gate.enabled = false;
         gate.client = null;
-        await scheduler.fileChanged('mod', '/x.kt');
-        await scheduler.setFocus('mod', ['a']);
-        await scheduler.setVisible('mod', ['a'], ['b']);
-        const ok = await scheduler.ensureModule('mod');
+        await scheduler.fileChanged("mod", "/x.kt");
+        await scheduler.setFocus("mod", ["a"]);
+        await scheduler.setVisible("mod", ["a"], ["b"]);
+        const ok = await scheduler.ensureModule("mod");
         assert.strictEqual(ok, false);
     });
 
-    it('classifies file kinds for fileChanged', async () => {
+    it("classifies file kinds for fileChanged", async () => {
         const { gate, scheduler } = build();
-        await scheduler.fileChanged('mod', '/proj/src/main/kotlin/Foo.kt');
-        await scheduler.fileChanged('mod', '/proj/src/main/res/values/strings.xml');
-        await scheduler.fileChanged('mod', '/proj/gradle/libs.versions.toml');
-        await scheduler.fileChanged('mod', '/proj/build.gradle.kts');
-        await scheduler.fileChanged('mod', '/proj/gradle.properties');
-        const kinds = gate.client!.calls
-            .filter(c => c.method === 'fileChanged')
-            .map(c => (c.args as { kind: string }).kind);
-        assert.deepStrictEqual(kinds, ['source', 'resource', 'classpath', 'classpath', 'classpath']);
+        await scheduler.fileChanged("mod", "/proj/src/main/kotlin/Foo.kt");
+        await scheduler.fileChanged(
+            "mod",
+            "/proj/src/main/res/values/strings.xml",
+        );
+        await scheduler.fileChanged("mod", "/proj/gradle/libs.versions.toml");
+        await scheduler.fileChanged("mod", "/proj/build.gradle.kts");
+        await scheduler.fileChanged("mod", "/proj/gradle.properties");
+        const kinds = gate
+            .client!.calls.filter((c) => c.method === "fileChanged")
+            .map((c) => (c.args as { kind: string }).kind);
+        assert.deepStrictEqual(kinds, [
+            "source",
+            "resource",
+            "classpath",
+            "classpath",
+            "classpath",
+        ]);
     });
 
-    it('dedupes setFocus when ids are unchanged regardless of order', async () => {
+    it("dedupes setFocus when ids are unchanged regardless of order", async () => {
         const { gate, scheduler } = build();
-        await scheduler.setFocus('mod', ['a', 'b']);
-        await scheduler.setFocus('mod', ['b', 'a']);
-        const focusCalls = gate.client!.calls.filter(c => c.method === 'setFocus');
+        await scheduler.setFocus("mod", ["a", "b"]);
+        await scheduler.setFocus("mod", ["b", "a"]);
+        const focusCalls = gate.client!.calls.filter(
+            (c) => c.method === "setFocus",
+        );
         assert.strictEqual(focusCalls.length, 1);
     });
 
-    it('reads the rendered PNG and forwards bytes via onPreviewImageReady', async () => {
+    it("reads the rendered PNG and forwards bytes via onPreviewImageReady", async () => {
         const { gate, scheduler, images } = build();
-        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sched-'));
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sched-"));
         try {
-            const pngPath = path.join(tmpDir, 'preview.png');
-            const bytes = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]); // PNG magic
+            const pngPath = path.join(tmpDir, "preview.png");
+            const bytes = Buffer.from([
+                0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+            ]); // PNG magic
             fs.writeFileSync(pngPath, bytes);
 
-            await scheduler.ensureModule('mod');
-            const evts = gate.capturedEvents.get('mod')!;
-            evts.onRenderFinished!({ id: 'p1', pngPath, tookMs: 200 });
+            await scheduler.ensureModule("mod");
+            const evts = gate.capturedEvents.get("mod")!;
+            evts.onRenderFinished!({ id: "p1", pngPath, tookMs: 200 });
 
             assert.strictEqual(images.length, 1);
-            assert.strictEqual(images[0].previewId, 'p1');
+            assert.strictEqual(images[0].previewId, "p1");
             assert.strictEqual(images[0].pngPath, pngPath);
-            assert.strictEqual(images[0].base64, bytes.toString('base64'));
+            assert.strictEqual(images[0].base64, bytes.toString("base64"));
         } finally {
             fs.rmSync(tmpDir, { recursive: true });
         }
     });
 
-    it('short-circuits when renderFinished carries unchanged=true (frame dedup)', async () => {
+    it("short-circuits when renderFinished carries unchanged=true (frame dedup)", async () => {
         // INTERACTIVE.md § 5 — the daemon already determined the bytes are byte-identical
         // to the last frame for this preview id. The scheduler must skip the disk read +
         // base64 + onPreviewImageReady hop so the panel doesn't repaint identical bytes.
         const { gate, scheduler, images, failures } = build();
-        await scheduler.ensureModule('mod');
-        const evts = gate.capturedEvents.get('mod')!;
+        await scheduler.ensureModule("mod");
+        const evts = gate.capturedEvents.get("mod")!;
         // Use a path that doesn't exist on disk — if the scheduler even tries to read it,
         // it would emit onRenderFailed. The dedup short-circuit means it does neither:
         // no image, no failure.
         evts.onRenderFinished!({
-            id: 'p1', pngPath: '/no/such/dedup.png', tookMs: 5,
+            id: "p1",
+            pngPath: "/no/such/dedup.png",
+            tookMs: 5,
             unchanged: true,
         } as never);
-        assert.strictEqual(images.length, 0, 'unchanged=true must not emit onPreviewImageReady');
-        assert.strictEqual(failures.length, 0, 'unchanged=true must not trigger an unreadable-PNG failure path');
+        assert.strictEqual(
+            images.length,
+            0,
+            "unchanged=true must not emit onPreviewImageReady",
+        );
+        assert.strictEqual(
+            failures.length,
+            0,
+            "unchanged=true must not trigger an unreadable-PNG failure path",
+        );
     });
 
-    it('reports onRenderFailed when the renderFinished PNG path is unreadable', async () => {
+    it("reports onRenderFailed when the renderFinished PNG path is unreadable", async () => {
         const { gate, scheduler, failures } = build();
-        await scheduler.ensureModule('mod');
-        const evts = gate.capturedEvents.get('mod')!;
-        evts.onRenderFinished!({ id: 'pZ', pngPath: '/no/such/file.png', tookMs: 1 });
+        await scheduler.ensureModule("mod");
+        const evts = gate.capturedEvents.get("mod")!;
+        evts.onRenderFinished!({
+            id: "pZ",
+            pngPath: "/no/such/file.png",
+            tookMs: 1,
+        });
         assert.strictEqual(failures.length, 1);
-        assert.strictEqual(failures[0].previewId, 'pZ');
+        assert.strictEqual(failures[0].previewId, "pZ");
         assert.match(failures[0].message, /unreadable/i);
     });
 
-    it('silently no-ops on daemon stub paths — once-per-module info log only', async () => {
+    it("silently no-ops on daemon stub paths — once-per-module info log only", async () => {
         // Until :daemon:android ships B1.4, every "successful" render
         // returns `<historyDir>/daemon-stub-<id>.{png,gif}` with nothing
         // on disk. Logging ENOENT per render drowns the output channel;
         // the panel is already populated by the Gradle fallback. We
         // detect the documented stub-filename shape and skip.
         const { gate, scheduler, log, failures, images } = build();
-        await scheduler.ensureModule('mod');
-        const evts = gate.capturedEvents.get('mod')!;
+        await scheduler.ensureModule("mod");
+        const evts = gate.capturedEvents.get("mod")!;
         for (let i = 1; i <= 5; i++) {
             evts.onRenderFinished!({
                 id: `p${i}`,
@@ -308,52 +417,54 @@ describe('DaemonScheduler', () => {
         assert.strictEqual(images.length, 0);
         assert.strictEqual(failures.length, 0);
         // One info log per module (rate-limited), not five.
-        const stubLogs = log.filter(l => l.includes('stub-render stage'));
+        const stubLogs = log.filter((l) => l.includes("stub-render stage"));
         assert.strictEqual(stubLogs.length, 1);
     });
 
-    it('detects gif stub paths the same way as png stubs', async () => {
+    it("detects gif stub paths the same way as png stubs", async () => {
         const { gate, scheduler, failures, images } = build();
-        await scheduler.ensureModule('mod');
-        const evts = gate.capturedEvents.get('mod')!;
+        await scheduler.ensureModule("mod");
+        const evts = gate.capturedEvents.get("mod")!;
         evts.onRenderFinished!({
-            id: 'p1',
-            pngPath: '.compose-preview-history/daemon-stub-1.gif',
+            id: "p1",
+            pngPath: ".compose-preview-history/daemon-stub-1.gif",
             tookMs: 1,
         });
         assert.strictEqual(images.length, 0);
         assert.strictEqual(failures.length, 0);
     });
 
-    it('still surfaces ENOENT for non-stub paths (real-render misconfig)', async () => {
+    it("still surfaces ENOENT for non-stub paths (real-render misconfig)", async () => {
         // The stub filter is precisely scoped — real-render paths that
         // happen to be missing must still surface as a failure so the
         // daemon's render bug is visible rather than silently swallowed.
         const { gate, scheduler, failures } = build();
-        await scheduler.ensureModule('mod');
-        const evts = gate.capturedEvents.get('mod')!;
+        await scheduler.ensureModule("mod");
+        const evts = gate.capturedEvents.get("mod")!;
         evts.onRenderFinished!({
-            id: 'pY',
-            pngPath: '/abs/build/compose-previews/renders/com.example.X.png',
+            id: "pY",
+            pngPath: "/abs/build/compose-previews/renders/com.example.X.png",
             tookMs: 1,
         });
         assert.strictEqual(failures.length, 1);
         assert.match(failures[0].message, /unreadable/i);
     });
 
-    it('forwards onRenderFailed from the daemon directly to the caller', async () => {
+    it("forwards onRenderFailed from the daemon directly to the caller", async () => {
         const { gate, scheduler, failures } = build();
-        await scheduler.ensureModule('mod');
-        const evts = gate.capturedEvents.get('mod')!;
-        evts.onRenderFailed!({ id: 'pX', error: { message: 'compile error' } });
-        assert.deepStrictEqual(failures, [{ moduleId: 'mod', previewId: 'pX', message: 'compile error' }]);
+        await scheduler.ensureModule("mod");
+        const evts = gate.capturedEvents.get("mod")!;
+        evts.onRenderFailed!({ id: "pX", error: { message: "compile error" } });
+        assert.deepStrictEqual(failures, [
+            { moduleId: "mod", previewId: "pX", message: "compile error" },
+        ]);
     });
 
-    it('clears the speculation cache and visibility memo when the channel closes', async () => {
+    it("clears the speculation cache and visibility memo when the channel closes", async () => {
         const { gate, scheduler } = build();
         // Speculate first so the cache is populated.
-        await scheduler.setVisible('mod', ['v1'], ['p1', 'p2']);
-        const evts = gate.capturedEvents.get('mod')!;
+        await scheduler.setVisible("mod", ["v1"], ["p1", "p2"]);
+        const evts = gate.capturedEvents.get("mod")!;
 
         // Channel close → the gate registry will replace the client. Pretend
         // a fresh daemon spawned with a new client object.
@@ -362,160 +473,198 @@ describe('DaemonScheduler', () => {
         evts.onChannelClosed!();
 
         // Same predictions on a fresh daemon should re-issue, not dedup.
-        await scheduler.setVisible('mod', ['v1'], ['p1', 'p2']);
-        const renderCalls = fresh.calls.filter(c => c.method === 'renderNow');
-        assert.strictEqual(renderCalls.length, 1, 'speculation cache survived channel close');
+        await scheduler.setVisible("mod", ["v1"], ["p1", "p2"]);
+        const renderCalls = fresh.calls.filter((c) => c.method === "renderNow");
+        assert.strictEqual(
+            renderCalls.length,
+            1,
+            "speculation cache survived channel close",
+        );
     });
 
-    it('forwards onChannelClosed to the caller with the moduleId attached', async () => {
+    it("forwards onChannelClosed to the caller with the moduleId attached", async () => {
         // The extension uses this hook to drop interactive-mode stream state for the dead
         // daemon — frameStreamIds don't survive a JVM restart, so a stale entry would route
         // future clicks to a stream id the new daemon never minted.
         const { gate, scheduler, channelClosed } = build();
-        await scheduler.ensureModule('alpha');
-        await scheduler.ensureModule('beta');
-        gate.capturedEvents.get('alpha')!.onChannelClosed!();
-        assert.deepStrictEqual(channelClosed, ['alpha']);
-        gate.capturedEvents.get('beta')!.onChannelClosed!();
-        assert.deepStrictEqual(channelClosed, ['alpha', 'beta']);
+        await scheduler.ensureModule("alpha");
+        await scheduler.ensureModule("beta");
+        gate.capturedEvents.get("alpha")!.onChannelClosed!();
+        assert.deepStrictEqual(channelClosed, ["alpha"]);
+        gate.capturedEvents.get("beta")!.onChannelClosed!();
+        assert.deepStrictEqual(channelClosed, ["alpha", "beta"]);
     });
 
-    it('routes classpathDirty to the caller and drops the module speculation cache', async () => {
+    it("routes classpathDirty to the caller and drops the module speculation cache", async () => {
         const { gate, scheduler, dirty } = build();
-        await scheduler.setVisible('mod', ['v1'], ['p1', 'p2']);
-        const evts = gate.capturedEvents.get('mod')!;
-        evts.onClasspathDirty!({ detail: 'libs.versions.toml SHA changed' });
+        await scheduler.setVisible("mod", ["v1"], ["p1", "p2"]);
+        const evts = gate.capturedEvents.get("mod")!;
+        evts.onClasspathDirty!({ detail: "libs.versions.toml SHA changed" });
         assert.strictEqual(dirty.length, 1);
-        assert.strictEqual(dirty[0].moduleId, 'mod');
+        assert.strictEqual(dirty[0].moduleId, "mod");
     });
 
-    it('forwards discoveryUpdated to the caller with the moduleId attached', async () => {
+    it("forwards discoveryUpdated to the caller with the moduleId attached", async () => {
         const { gate, scheduler, discovery } = build();
         // First call any scheduler method that goes through getOrSpawn so the
         // events bag for `mod` is registered; setFocus is the cheapest.
-        await scheduler.setFocus('mod', ['p1']);
-        const evts = gate.capturedEvents.get('mod')!;
+        await scheduler.setFocus("mod", ["p1"]);
+        const evts = gate.capturedEvents.get("mod")!;
         evts.onDiscoveryUpdated!({
             added: [],
-            removed: ['p1'],
+            removed: ["p1"],
             changed: [],
             totalPreviews: 0,
         });
         assert.strictEqual(discovery.length, 1);
-        assert.strictEqual(discovery[0].moduleId, 'mod');
-        assert.deepStrictEqual(discovery[0].params.removed, ['p1']);
+        assert.strictEqual(discovery[0].moduleId, "mod");
+        assert.deepStrictEqual(discovery[0].params.removed, ["p1"]);
     });
 
-    it('renderNow returns true on accept and false when no daemon is available', async () => {
+    it("renderNow returns true on accept and false when no daemon is available", async () => {
         const { gate, scheduler } = build();
-        const ok = await scheduler.renderNow('mod', ['p1'], 'fast');
+        const ok = await scheduler.renderNow("mod", ["p1"], "fast");
         assert.strictEqual(ok, true);
 
         gate.enabled = false;
         gate.client = null;
-        const fail = await scheduler.renderNow('mod2', ['p1'], 'fast');
+        const fail = await scheduler.renderNow("mod2", ["p1"], "fast");
         assert.strictEqual(fail, false);
     });
 
-    it('logs rejected previews from renderNow without throwing', async () => {
+    it("logs rejected previews from renderNow without throwing", async () => {
         const { gate, scheduler, log } = build();
         gate.client!.renderNowResult = {
-            queued: ['p1'],
-            rejected: [{ id: 'pBad', reason: 'unknown preview ID' }],
+            queued: ["p1"],
+            rejected: [{ id: "pBad", reason: "unknown preview ID" }],
         };
-        const ok = await scheduler.renderNow('mod', ['p1', 'pBad'], 'fast');
+        const ok = await scheduler.renderNow("mod", ["p1", "pBad"], "fast");
         assert.strictEqual(ok, true);
-        assert.ok(log.some(l => l.includes('rejected pBad')), `expected rejected log, got: ${log.join(' / ')}`);
+        assert.ok(
+            log.some((l) => l.includes("rejected pBad")),
+            `expected rejected log, got: ${log.join(" / ")}`,
+        );
     });
 
-    describe('warmModule', () => {
-        it('uses an existing daemon descriptor before running bootstrap', async () => {
+    describe("warmModule", () => {
+        it("uses an existing daemon descriptor before running bootstrap", async () => {
             const { gate, scheduler } = build();
             const gradle = new FakeGradleService();
             const states: string[] = [];
             const ok = await scheduler.warmModule(
                 gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
-                'mod',
+                "mod",
                 (s) => states.push(s),
             );
             assert.strictEqual(ok, true);
-            assert.deepStrictEqual(states, ['spawning', 'ready']);
-            assert.deepStrictEqual(gate.getOrSpawnCalls, ['mod']);
-            assert.deepStrictEqual(gradle.bootstrapCalls, [], 'cached descriptor should start without blocking on Gradle');
+            assert.deepStrictEqual(states, ["spawning", "ready"]);
+            assert.deepStrictEqual(gate.getOrSpawnCalls, ["mod"]);
+            assert.deepStrictEqual(
+                gradle.bootstrapCalls,
+                [],
+                "cached descriptor should start without blocking on Gradle",
+            );
         });
 
-        it('drives progress through bootstrap fallback when the cached descriptor is missing', async () => {
+        it("drives progress through bootstrap fallback when the cached descriptor is missing", async () => {
             const { gate, scheduler, log } = build();
-            gate.getOrSpawnErrors.push(new Error('[daemon] no launch descriptor for mod'));
+            gate.getOrSpawnErrors.push(
+                new Error("[daemon] no launch descriptor for mod"),
+            );
             const gradle = new FakeGradleService();
             const states: string[] = [];
             const ok = await scheduler.warmModule(
                 gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
-                'mod',
+                "mod",
                 (s) => states.push(s),
             );
             assert.strictEqual(ok, true);
-            assert.deepStrictEqual(states, ['spawning', 'bootstrapping', 'spawning', 'ready']);
-            assert.deepStrictEqual(gate.getOrSpawnCalls, ['mod', 'mod']);
-            assert.deepStrictEqual(gradle.bootstrapCalls, ['mod']);
-            assert.ok(log.some(l => l.includes('cached launch failed')), `expected cached failure log, got: ${log.join(' / ')}`);
+            assert.deepStrictEqual(states, [
+                "spawning",
+                "bootstrapping",
+                "spawning",
+                "ready",
+            ]);
+            assert.deepStrictEqual(gate.getOrSpawnCalls, ["mod", "mod"]);
+            assert.deepStrictEqual(gradle.bootstrapCalls, ["mod"]);
+            assert.ok(
+                log.some((l) => l.includes("cached launch failed")),
+                `expected cached failure log, got: ${log.join(" / ")}`,
+            );
         });
 
-        it('short-circuits to ready without re-bootstrapping when the daemon is already up', async () => {
+        it("short-circuits to ready without re-bootstrapping when the daemon is already up", async () => {
             const { gate, scheduler } = build();
             gate.ready = true;
             const gradle = new FakeGradleService();
             const states: string[] = [];
             const ok = await scheduler.warmModule(
                 gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
-                'mod',
+                "mod",
                 (s) => states.push(s),
             );
             assert.strictEqual(ok, true);
-            assert.deepStrictEqual(states, ['ready']);
-            assert.deepStrictEqual(gradle.bootstrapCalls, [], 'bootstrap should not run when daemon is ready');
+            assert.deepStrictEqual(states, ["ready"]);
+            assert.deepStrictEqual(
+                gradle.bootstrapCalls,
+                [],
+                "bootstrap should not run when daemon is ready",
+            );
         });
 
-        it('throws when the bootstrap task fails while the daemon is enabled', async () => {
+        it("throws when the bootstrap task fails while the daemon is enabled", async () => {
             const { gate, scheduler } = build();
-            gate.getOrSpawnErrors.push(new Error('[daemon] no launch descriptor for mod'));
+            gate.getOrSpawnErrors.push(
+                new Error("[daemon] no launch descriptor for mod"),
+            );
             const gradle = new FakeGradleService();
-            gradle.bootstrapShouldThrow = new Error('Gradle config-cache rejected');
+            gradle.bootstrapShouldThrow = new Error(
+                "Gradle config-cache rejected",
+            );
             const states: string[] = [];
             await assert.rejects(
                 scheduler.warmModule(
-                    gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
-                    'mod',
+                    gradle as unknown as Parameters<
+                        typeof scheduler.warmModule
+                    >[0],
+                    "mod",
                     (s) => states.push(s),
                 ),
                 /Gradle config-cache rejected/,
             );
-            assert.deepStrictEqual(states, ['spawning', 'bootstrapping']);
+            assert.deepStrictEqual(states, ["spawning", "bootstrapping"]);
         });
 
-        it('reports fallback only when the daemon is explicitly unavailable after bootstrap', async () => {
+        it("reports fallback only when the daemon is explicitly unavailable after bootstrap", async () => {
             const { gate, scheduler } = build();
             const gradle = new FakeGradleService();
             const states: string[] = [];
-            gate.getOrSpawnErrors.push(new Error('[daemon] no launch descriptor for mod'));
+            gate.getOrSpawnErrors.push(
+                new Error("[daemon] no launch descriptor for mod"),
+            );
             gate.client = null;
             const ok = await scheduler.warmModule(
                 gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
-                'mod',
+                "mod",
                 (s) => states.push(s),
             );
             assert.strictEqual(ok, false);
-            assert.deepStrictEqual(states, ['spawning', 'bootstrapping', 'spawning', 'fallback']);
+            assert.deepStrictEqual(states, [
+                "spawning",
+                "bootstrapping",
+                "spawning",
+                "fallback",
+            ]);
         });
 
-        it('returns false without progress events when the gate is disabled', async () => {
+        it("returns false without progress events when the gate is disabled", async () => {
             const { gate, scheduler } = build();
             gate.enabled = false;
             const gradle = new FakeGradleService();
             const states: string[] = [];
             const ok = await scheduler.warmModule(
                 gradle as unknown as Parameters<typeof scheduler.warmModule>[0],
-                'mod',
+                "mod",
                 (s) => states.push(s),
             );
             assert.strictEqual(ok, false);
@@ -524,38 +673,46 @@ describe('DaemonScheduler', () => {
         });
     });
 
-    describe('onHistoryAdded forwarding (Phase H7)', () => {
-        it('passes the daemon notification through with the right moduleId', async () => {
+    describe("onHistoryAdded forwarding (Phase H7)", () => {
+        it("passes the daemon notification through with the right moduleId", async () => {
             const gate = new FakeGate();
             const log: string[] = [];
             const seen: { moduleId: string; entry: unknown }[] = [];
             const scheduler = new DaemonScheduler(
-                gate as unknown as ConstructorParameters<typeof DaemonScheduler>[0],
+                gate as unknown as ConstructorParameters<
+                    typeof DaemonScheduler
+                >[0],
                 {
                     onPreviewImageReady: () => {},
                     onRenderFailed: () => {},
                     onClasspathDirty: () => {},
-                    onHistoryAdded: (moduleId, params) => seen.push({ moduleId, entry: params.entry }),
+                    onHistoryAdded: (moduleId, params) =>
+                        seen.push({ moduleId, entry: params.entry }),
                 },
                 { appendLine: (s) => log.push(s) },
             );
-            await scheduler.ensureModule('mod');
-            const evts = gate.capturedEvents.get('mod')! as unknown as {
+            await scheduler.ensureModule("mod");
+            const evts = gate.capturedEvents.get("mod")! as unknown as {
                 onHistoryAdded?: (params: { entry: unknown }) => void;
             };
-            evts.onHistoryAdded!({ entry: { id: 'abc', previewId: 'X' } });
+            evts.onHistoryAdded!({ entry: { id: "abc", previewId: "X" } });
             assert.strictEqual(seen.length, 1);
-            assert.strictEqual(seen[0].moduleId, 'mod');
-            assert.deepStrictEqual(seen[0].entry, { id: 'abc', previewId: 'X' });
+            assert.strictEqual(seen[0].moduleId, "mod");
+            assert.deepStrictEqual(seen[0].entry, {
+                id: "abc",
+                previewId: "X",
+            });
         });
 
-        it('is a no-op when the caller didn\'t register an onHistoryAdded handler', async () => {
+        it("is a no-op when the caller didn't register an onHistoryAdded handler", async () => {
             // No `onHistoryAdded` on SchedulerEvents (it's optional). The
             // scheduler must tolerate that — daemon pushes still arrive,
             // they just go nowhere.
             const gate = new FakeGate();
             const scheduler = new DaemonScheduler(
-                gate as unknown as ConstructorParameters<typeof DaemonScheduler>[0],
+                gate as unknown as ConstructorParameters<
+                    typeof DaemonScheduler
+                >[0],
                 {
                     onPreviewImageReady: () => {},
                     onRenderFailed: () => {},
@@ -563,12 +720,12 @@ describe('DaemonScheduler', () => {
                     // no onHistoryAdded
                 },
             );
-            await scheduler.ensureModule('mod');
-            const evts = gate.capturedEvents.get('mod')! as unknown as {
+            await scheduler.ensureModule("mod");
+            const evts = gate.capturedEvents.get("mod")! as unknown as {
                 onHistoryAdded?: (params: { entry: unknown }) => void;
             };
             // Doesn't throw.
-            evts.onHistoryAdded!({ entry: { id: 'abc' } });
+            evts.onHistoryAdded!({ entry: { id: "abc" } });
         });
     });
 
@@ -577,166 +734,277 @@ describe('DaemonScheduler', () => {
      * focus-mode "Show a11y overlay" toggle drives them) — `setVisible` itself does NOT
      * subscribe, only prunes stale bookkeeping. `renderFinished` forwards attachments.
      */
-    describe('data products', () => {
-        it('does not auto-subscribe on setVisible by default — subscriptions are explicit', async () => {
+    describe("data products", () => {
+        it("does not auto-subscribe on setVisible by default — subscriptions are explicit", async () => {
             const { gate, scheduler } = build();
-            await scheduler.setVisible('mod', ['a', 'b'], []);
-            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            await scheduler.setVisible("mod", ["a", "b"], []);
+            const subs = gate.client!.calls.filter(
+                (c) => c.method === "dataSubscribe",
+            );
             assert.strictEqual(subs.length, 0);
         });
 
-        it('auto-subscribes both a11y kinds for newly-visible previews when alwaysSubscribe is on', async () => {
-            const { gate, scheduler } = build({ a11yAlwaysSubscribe: () => true });
-            await scheduler.setVisible('mod', ['a', 'b'], []);
-            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+        it("auto-subscribes both a11y kinds for newly-visible previews when alwaysSubscribe is on", async () => {
+            const { gate, scheduler } = build({
+                a11yAlwaysSubscribe: () => true,
+            });
+            await scheduler.setVisible("mod", ["a", "b"], []);
+            const subs = gate.client!.calls.filter(
+                (c) => c.method === "dataSubscribe",
+            );
             // 2 kinds × 2 previews = 4 subscribes.
             assert.strictEqual(subs.length, 4);
-            const kinds = new Set(subs.map(c => (c.args as { kind: string }).kind));
-            assert.deepStrictEqual([...kinds].sort(), ['a11y/atf', 'a11y/hierarchy']);
-            const ids = new Set(subs.map(c => (c.args as { previewId: string }).previewId));
-            assert.deepStrictEqual([...ids].sort(), ['a', 'b']);
+            const kinds = new Set(
+                subs.map((c) => (c.args as { kind: string }).kind),
+            );
+            assert.deepStrictEqual([...kinds].sort(), [
+                "a11y/atf",
+                "a11y/hierarchy",
+            ]);
+            const ids = new Set(
+                subs.map((c) => (c.args as { previewId: string }).previewId),
+            );
+            assert.deepStrictEqual([...ids].sort(), ["a", "b"]);
         });
 
-        it('alwaysSubscribe re-reads on every setVisible — flipping the setting takes effect immediately', async () => {
+        it("alwaysSubscribe re-reads on every setVisible — flipping the setting takes effect immediately", async () => {
             let alwaysOn = false;
-            const { gate, scheduler } = build({ a11yAlwaysSubscribe: () => alwaysOn });
-            await scheduler.setVisible('mod', ['a'], []);
-            const initial = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            const { gate, scheduler } = build({
+                a11yAlwaysSubscribe: () => alwaysOn,
+            });
+            await scheduler.setVisible("mod", ["a"], []);
+            const initial = gate.client!.calls.filter(
+                (c) => c.method === "dataSubscribe",
+            );
             assert.strictEqual(initial.length, 0);
             // User flips the setting on between setVisible calls.
             alwaysOn = true;
-            await scheduler.setVisible('mod', ['a', 'b'], []);
+            await scheduler.setVisible("mod", ["a", "b"], []);
             // 'a' was previously visible but skipped under the off setting; 'b' is new.
             // With alwaysOn now true, both get subscribed (we haven't seen them yet under
             // the on setting, so subscribedPairs is empty for them).
-            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            const subs = gate.client!.calls.filter(
+                (c) => c.method === "dataSubscribe",
+            );
             assert.strictEqual(subs.length, 4);
         });
 
-        it('alwaysSubscribe does not re-subscribe (previewId, kind) pairs already in flight', async () => {
-            const { gate, scheduler } = build({ a11yAlwaysSubscribe: () => true });
-            await scheduler.setVisible('mod', ['a'], []);
-            await scheduler.setVisible('mod', ['a', 'b'], []); // 'a' already subscribed
-            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+        it("alwaysSubscribe does not re-subscribe (previewId, kind) pairs already in flight", async () => {
+            const { gate, scheduler } = build({
+                a11yAlwaysSubscribe: () => true,
+            });
+            await scheduler.setVisible("mod", ["a"], []);
+            await scheduler.setVisible("mod", ["a", "b"], []); // 'a' already subscribed
+            const subs = gate.client!.calls.filter(
+                (c) => c.method === "dataSubscribe",
+            );
             // 'a': 2 kinds (round 1) + 'b': 2 kinds (round 2) = 4. 'a' is NOT re-subscribed.
             assert.strictEqual(subs.length, 4);
         });
 
-        it('setDataProductSubscription(true) issues data/subscribe per kind', async () => {
+        it("setDataProductSubscription(true) issues data/subscribe per kind", async () => {
             const { gate, scheduler } = build();
             await scheduler.setDataProductSubscription(
-                'mod',
-                'a',
-                ['a11y/atf', 'a11y/hierarchy'],
+                "mod",
+                "a",
+                ["a11y/atf", "a11y/hierarchy"],
                 true,
             );
-            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            const subs = gate.client!.calls.filter(
+                (c) => c.method === "dataSubscribe",
+            );
             assert.strictEqual(subs.length, 2);
-            const kinds = subs.map(c => (c.args as { kind: string }).kind).sort();
-            assert.deepStrictEqual(kinds, ['a11y/atf', 'a11y/hierarchy']);
+            const kinds = subs
+                .map((c) => (c.args as { kind: string }).kind)
+                .sort();
+            assert.deepStrictEqual(kinds, ["a11y/atf", "a11y/hierarchy"]);
         });
 
-        it('setDataProductSubscription(true) twice is idempotent', async () => {
+        it("setDataProductSubscription(true) twice is idempotent", async () => {
             const { gate, scheduler } = build();
-            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
-            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
-            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            await scheduler.setDataProductSubscription(
+                "mod",
+                "a",
+                ["a11y/atf"],
+                true,
+            );
+            await scheduler.setDataProductSubscription(
+                "mod",
+                "a",
+                ["a11y/atf"],
+                true,
+            );
+            const subs = gate.client!.calls.filter(
+                (c) => c.method === "dataSubscribe",
+            );
             assert.strictEqual(subs.length, 1);
         });
 
-        it('setDataProductSubscription(false) issues data/unsubscribe and forgets the pair', async () => {
+        it("setDataProductSubscription(false) issues data/unsubscribe and forgets the pair", async () => {
             const { gate, scheduler } = build();
-            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
-            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], false);
-            const unsubs = gate.client!.calls.filter(c => c.method === 'dataUnsubscribe');
+            await scheduler.setDataProductSubscription(
+                "mod",
+                "a",
+                ["a11y/atf"],
+                true,
+            );
+            await scheduler.setDataProductSubscription(
+                "mod",
+                "a",
+                ["a11y/atf"],
+                false,
+            );
+            const unsubs = gate.client!.calls.filter(
+                (c) => c.method === "dataUnsubscribe",
+            );
             assert.strictEqual(unsubs.length, 1);
             // Re-enabling re-issues subscribe (bookkeeping was cleared).
-            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
-            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            await scheduler.setDataProductSubscription(
+                "mod",
+                "a",
+                ["a11y/atf"],
+                true,
+            );
+            const subs = gate.client!.calls.filter(
+                (c) => c.method === "dataSubscribe",
+            );
             assert.strictEqual(subs.length, 2);
         });
 
-        it('setDataProductSubscription(false) on an unknown pair is a no-op', async () => {
+        it("setDataProductSubscription(false) on an unknown pair is a no-op", async () => {
             const { gate, scheduler } = build();
-            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], false);
+            await scheduler.setDataProductSubscription(
+                "mod",
+                "a",
+                ["a11y/atf"],
+                false,
+            );
             const calls = gate.client!.calls.filter(
-                c => c.method === 'dataSubscribe' || c.method === 'dataUnsubscribe',
+                (c) =>
+                    c.method === "dataSubscribe" ||
+                    c.method === "dataUnsubscribe",
             );
             assert.strictEqual(calls.length, 0);
         });
 
-        it('setVisible drops bookkeeping for previews that left view', async () => {
+        it("setVisible drops bookkeeping for previews that left view", async () => {
             const { gate, scheduler } = build();
-            await scheduler.setVisible('mod', ['a', 'b'], []);
-            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
-            await scheduler.setVisible('mod', ['b'], []); // 'a' fell out
+            await scheduler.setVisible("mod", ["a", "b"], []);
+            await scheduler.setDataProductSubscription(
+                "mod",
+                "a",
+                ["a11y/atf"],
+                true,
+            );
+            await scheduler.setVisible("mod", ["b"], []); // 'a' fell out
             // Re-subscribing 'a' should issue another subscribe (bookkeeping was cleared by
             // the visibility prune even though the daemon never received our explicit call).
-            await scheduler.setVisible('mod', ['a', 'b'], []);
-            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
-            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            await scheduler.setVisible("mod", ["a", "b"], []);
+            await scheduler.setDataProductSubscription(
+                "mod",
+                "a",
+                ["a11y/atf"],
+                true,
+            );
+            const subs = gate.client!.calls.filter(
+                (c) => c.method === "dataSubscribe",
+            );
             assert.strictEqual(subs.length, 2);
         });
 
-        it('forwards renderFinished.dataProducts via onDataProductsAttached', async () => {
+        it("forwards renderFinished.dataProducts via onDataProductsAttached", async () => {
             const { gate, scheduler, dataProducts } = build();
-            await scheduler.ensureModule('mod');
-            const evts = gate.capturedEvents.get('mod')! as unknown as {
+            await scheduler.ensureModule("mod");
+            const evts = gate.capturedEvents.get("mod")! as unknown as {
                 onRenderFinished: (p: {
                     id: string;
                     pngPath: string;
                     tookMs: number;
-                    dataProducts?: { kind: string; payload?: unknown; path?: string }[];
+                    dataProducts?: {
+                        kind: string;
+                        payload?: unknown;
+                        path?: string;
+                    }[];
                 }) => void;
             };
             // Stage a real PNG so the scheduler doesn't bail on ENOENT.
-            const tmp = path.join(os.tmpdir(), `data-products-${Date.now()}.png`);
-            fs.writeFileSync(tmp, Buffer.from('\x89PNG\r\n\x1a\n', 'binary'));
+            const tmp = path.join(
+                os.tmpdir(),
+                `data-products-${Date.now()}.png`,
+            );
+            fs.writeFileSync(tmp, Buffer.from("\x89PNG\r\n\x1a\n", "binary"));
             evts.onRenderFinished({
-                id: 'a',
+                id: "a",
                 pngPath: tmp,
                 tookMs: 10,
                 dataProducts: [
-                    { kind: 'a11y/atf', payload: { findings: [] } },
-                    { kind: 'a11y/hierarchy', path: '/abs/a11y-hierarchy.json' },
+                    { kind: "a11y/atf", payload: { findings: [] } },
+                    {
+                        kind: "a11y/hierarchy",
+                        path: "/abs/a11y-hierarchy.json",
+                    },
                 ],
             });
             assert.strictEqual(dataProducts.length, 1);
-            assert.strictEqual(dataProducts[0].previewId, 'a');
+            assert.strictEqual(dataProducts[0].previewId, "a");
             assert.strictEqual(dataProducts[0].attachments.length, 2);
             fs.unlinkSync(tmp);
         });
 
-        it('does not fire onDataProductsAttached when renderFinished carries no products', async () => {
+        it("does not fire onDataProductsAttached when renderFinished carries no products", async () => {
             const { gate, scheduler, dataProducts } = build();
-            await scheduler.ensureModule('mod');
-            const evts = gate.capturedEvents.get('mod')! as unknown as {
-                onRenderFinished: (p: { id: string; pngPath: string; tookMs: number }) => void;
+            await scheduler.ensureModule("mod");
+            const evts = gate.capturedEvents.get("mod")! as unknown as {
+                onRenderFinished: (p: {
+                    id: string;
+                    pngPath: string;
+                    tookMs: number;
+                }) => void;
             };
-            const tmp = path.join(os.tmpdir(), `data-products-empty-${Date.now()}.png`);
-            fs.writeFileSync(tmp, Buffer.from('\x89PNG\r\n\x1a\n', 'binary'));
-            evts.onRenderFinished({ id: 'a', pngPath: tmp, tookMs: 10 });
+            const tmp = path.join(
+                os.tmpdir(),
+                `data-products-empty-${Date.now()}.png`,
+            );
+            fs.writeFileSync(tmp, Buffer.from("\x89PNG\r\n\x1a\n", "binary"));
+            evts.onRenderFinished({ id: "a", pngPath: tmp, tookMs: 10 });
             assert.strictEqual(dataProducts.length, 0);
             fs.unlinkSync(tmp);
         });
 
-        it('survives a pre-D2 daemon that rejects dataSubscribe with DataProductUnknown', async () => {
+        it("survives a pre-D2 daemon that rejects dataSubscribe with DataProductUnknown", async () => {
             const { gate, scheduler, log } = build();
             gate.client!.dataSubscribeRejects = true;
-            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
+            await scheduler.setDataProductSubscription(
+                "mod",
+                "a",
+                ["a11y/atf"],
+                true,
+            );
             // Wait one microtask cycle so the rejected promise settles.
             await Promise.resolve();
             await Promise.resolve();
             // Subscribe was attempted; the rejection is absorbed and the bookkeeping rolls
             // back so a future re-attempt re-issues.
-            const subs = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            const subs = gate.client!.calls.filter(
+                (c) => c.method === "dataSubscribe",
+            );
             assert.strictEqual(subs.length, 1);
-            const subFailures = log.filter(l => l.includes('dataSubscribe'));
-            assert.ok(subFailures.length >= 1, 'expected log entry for failed dataSubscribe');
+            const subFailures = log.filter((l) => l.includes("dataSubscribe"));
+            assert.ok(
+                subFailures.length >= 1,
+                "expected log entry for failed dataSubscribe",
+            );
             // Retry succeeds (the rollback dropped the bookkeeping).
             gate.client!.dataSubscribeRejects = false;
-            await scheduler.setDataProductSubscription('mod', 'a', ['a11y/atf'], true);
-            const subsAfter = gate.client!.calls.filter(c => c.method === 'dataSubscribe');
+            await scheduler.setDataProductSubscription(
+                "mod",
+                "a",
+                ["a11y/atf"],
+                true,
+            );
+            const subsAfter = gate.client!.calls.filter(
+                (c) => c.method === "dataSubscribe",
+            );
             assert.strictEqual(subsAfter.length, 2);
         });
     });

--- a/vscode-extension/src/test/electron/fixtures/workspace/sample-module/build/compose-previews/previews.json
+++ b/vscode-extension/src/test/electron/fixtures/workspace/sample-module/build/compose-previews/previews.json
@@ -51,7 +51,11 @@
                 {
                     "advanceTimeMillis": null,
                     "scroll": null,
-                    "animation": { "durationMs": 1500, "frameIntervalMs": 33, "showCurves": true },
+                    "animation": {
+                        "durationMs": 1500,
+                        "frameIntervalMs": 33,
+                        "showCurves": true
+                    },
                     "renderOutput": "renders/com.example.sample.PreviewsKt.AnimatedPreview.gif",
                     "cost": 50.0
                 }

--- a/vscode-extension/src/test/electron/runTest.ts
+++ b/vscode-extension/src/test/electron/runTest.ts
@@ -1,5 +1,5 @@
-import * as path from 'path';
-import { downloadAndUnzipVSCode, runTests } from '@vscode/test-electron';
+import * as path from "path";
+import { downloadAndUnzipVSCode, runTests } from "@vscode/test-electron";
 
 /**
  * Entry point for `npm run test:electron`.
@@ -16,22 +16,30 @@ import { downloadAndUnzipVSCode, runTests } from '@vscode/test-electron';
  * `vscode.extensions.getExtension('yuri-schimke.compose-preview').exports`.
  */
 async function main(): Promise<void> {
-    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
-    const extensionTestsPath = path.resolve(__dirname, './suite/index');
+    const extensionDevelopmentPath = path.resolve(__dirname, "../../..");
+    const extensionTestsPath = path.resolve(__dirname, "./suite/index");
     // Fixtures live in `src/` (raw assets — JSON manifest + PNG/GIF + a
     // build.gradle.kts), not `out/`, so resolve relative to the source tree.
     // `__dirname` here is `out/test/electron/`, hence the `../../../src/...`
     // walk-back to land in `src/test/electron/fixtures/`.
-    const fixturesRoot = path.resolve(__dirname, '../../../src/test/electron/fixtures');
-    const workspacePath = path.join(fixturesRoot, 'workspace');
-    const fakeGradleExtensionPath = path.join(fixturesRoot, 'fake-vscode-gradle');
+    const fixturesRoot = path.resolve(
+        __dirname,
+        "../../../src/test/electron/fixtures",
+    );
+    const workspacePath = path.join(fixturesRoot, "workspace");
+    const fakeGradleExtensionPath = path.join(
+        fixturesRoot,
+        "fake-vscode-gradle",
+    );
 
-    console.log(`[runTest] extensionDevelopmentPath=${extensionDevelopmentPath}`);
+    console.log(
+        `[runTest] extensionDevelopmentPath=${extensionDevelopmentPath}`,
+    );
     console.log(`[runTest] extensionTestsPath=${extensionTestsPath}`);
     console.log(`[runTest] workspacePath=${workspacePath}`);
     console.log(`[runTest] fakeGradleExtensionPath=${fakeGradleExtensionPath}`);
 
-    const vscodeExecutablePath = await downloadAndUnzipVSCode('stable');
+    const vscodeExecutablePath = await downloadAndUnzipVSCode("stable");
     console.log(`[runTest] vscodeExecutablePath=${vscodeExecutablePath}`);
 
     // Load the fake `vscjava.vscode-gradle` stub alongside our extension by
@@ -44,7 +52,10 @@ async function main(): Promise<void> {
     console.log(`[runTest] launching tests…`);
     await runTests({
         vscodeExecutablePath,
-        extensionDevelopmentPath: [extensionDevelopmentPath, fakeGradleExtensionPath],
+        extensionDevelopmentPath: [
+            extensionDevelopmentPath,
+            fakeGradleExtensionPath,
+        ],
         extensionTestsPath,
         // CI-friendly launch args:
         //  - `--disable-workspace-trust` skips the trust modal that would
@@ -57,19 +68,19 @@ async function main(): Promise<void> {
         //    check during a 30s test window.
         launchArgs: [
             workspacePath,
-            '--disable-workspace-trust',
-            '--no-sandbox',
-            '--disable-gpu',
-            '--disable-updates',
+            "--disable-workspace-trust",
+            "--no-sandbox",
+            "--disable-gpu",
+            "--disable-updates",
         ],
         extensionTestsEnv: {
-            COMPOSE_PREVIEW_TEST_MODE: '1',
+            COMPOSE_PREVIEW_TEST_MODE: "1",
         },
     });
     console.log(`[runTest] tests complete`);
 }
 
-main().catch(err => {
-    console.error('Failed to run tests:', err);
+main().catch((err) => {
+    console.error("Failed to run tests:", err);
     process.exit(1);
 });

--- a/vscode-extension/src/test/electron/suite/index.ts
+++ b/vscode-extension/src/test/electron/suite/index.ts
@@ -1,6 +1,6 @@
-import * as path from 'path';
-import Mocha from 'mocha';
-import { glob } from 'glob';
+import * as path from "path";
+import Mocha from "mocha";
+import { glob } from "glob";
 
 /**
  * Mocha entry point loaded by `@vscode/test-electron` inside the spawned
@@ -12,7 +12,7 @@ import { glob } from 'glob';
  */
 export async function run(): Promise<void> {
     const mocha = new Mocha({
-        ui: 'bdd',
+        ui: "bdd",
         color: true,
         // Generous default — VS Code activation + view focus + a stub
         // Gradle round-trip lands well under this on a warm host, but a
@@ -22,12 +22,14 @@ export async function run(): Promise<void> {
         // bookkeeping (extension-host event-loop spinup) before the
         // assertions run.
         timeout: 60_000,
-        reporter: 'spec',
+        reporter: "spec",
     });
 
     const testsRoot = __dirname;
-    const files = await glob('**/*.test.js', { cwd: testsRoot });
-    console.log(`[suite] discovered ${files.length} test file(s) in ${testsRoot}`);
+    const files = await glob("**/*.test.js", { cwd: testsRoot });
+    console.log(
+        `[suite] discovered ${files.length} test file(s) in ${testsRoot}`,
+    );
     for (const f of files) {
         const abs = path.resolve(testsRoot, f);
         console.log(`[suite] add ${abs}`);
@@ -36,7 +38,7 @@ export async function run(): Promise<void> {
 
     return new Promise((resolve, reject) => {
         try {
-            mocha.run(failures => {
+            mocha.run((failures) => {
                 if (failures > 0) {
                     reject(new Error(`${failures} test(s) failed`));
                 } else {

--- a/vscode-extension/src/test/electron/suite/lifecycle.test.ts
+++ b/vscode-extension/src/test/electron/suite/lifecycle.test.ts
@@ -1,8 +1,8 @@
-import * as assert from 'assert';
-import * as path from 'path';
-import * as vscode from 'vscode';
-import type { ComposePreviewTestApi } from '../../../extension';
-import type { GradleApi } from '../../../gradleService';
+import * as assert from "assert";
+import * as path from "path";
+import * as vscode from "vscode";
+import type { ComposePreviewTestApi } from "../../../extension";
+import type { GradleApi } from "../../../gradleService";
 
 /** Stub GradleApi that records every runTask invocation (task + args). */
 class RecordingGradleApi implements GradleApi {
@@ -16,7 +16,10 @@ class RecordingGradleApi implements GradleApi {
         taskName: string;
         args?: ReadonlyArray<string>;
         showOutputColors: boolean;
-        onOutput?: (output: { getOutputBytes(): Uint8Array; getOutputType(): number }) => void;
+        onOutput?: (output: {
+            getOutputBytes(): Uint8Array;
+            getOutputType(): number;
+        }) => void;
         cancellationKey?: string;
     }): Promise<void> {
         this.invocations.push({
@@ -33,18 +36,35 @@ class RecordingGradleApi implements GradleApi {
 /** Helper that yields control to the event loop so any awaited postMessage
  *  callbacks land in `getPostedMessages()` before the assertion. */
 function flushMicrotasks(): Promise<void> {
-    return new Promise(resolve => setImmediate(resolve));
+    return new Promise((resolve) => setImmediate(resolve));
 }
 
 async function getApi(): Promise<ComposePreviewTestApi> {
-    console.log('[lifecycle] env COMPOSE_PREVIEW_TEST_MODE=' + process.env.COMPOSE_PREVIEW_TEST_MODE);
-    console.log('[lifecycle] all extensions: ' + vscode.extensions.all.map(e => e.id).join(', '));
-    const ext = vscode.extensions.getExtension<ComposePreviewTestApi>('yuri-schimke.compose-preview');
-    assert.ok(ext, 'compose-preview extension must be present in the test host');
-    console.log('[lifecycle] extension found, activating…');
+    console.log(
+        "[lifecycle] env COMPOSE_PREVIEW_TEST_MODE=" +
+            process.env.COMPOSE_PREVIEW_TEST_MODE,
+    );
+    console.log(
+        "[lifecycle] all extensions: " +
+            vscode.extensions.all.map((e) => e.id).join(", "),
+    );
+    const ext = vscode.extensions.getExtension<ComposePreviewTestApi>(
+        "yuri-schimke.compose-preview",
+    );
+    assert.ok(
+        ext,
+        "compose-preview extension must be present in the test host",
+    );
+    console.log("[lifecycle] extension found, activating…");
     const api = await ext.activate();
-    console.log('[lifecycle] activate() returned: ' + (api ? 'ComposePreviewTestApi' : 'void'));
-    assert.ok(api, 'activate() must return ComposePreviewTestApi under COMPOSE_PREVIEW_TEST_MODE=1');
+    console.log(
+        "[lifecycle] activate() returned: " +
+            (api ? "ComposePreviewTestApi" : "void"),
+    );
+    assert.ok(
+        api,
+        "activate() must return ComposePreviewTestApi under COMPOSE_PREVIEW_TEST_MODE=1",
+    );
     return api;
 }
 
@@ -54,14 +74,19 @@ interface PostedMessage {
 }
 
 function commandsOf(messages: unknown[]): string[] {
-    return messages.map(m => (m as PostedMessage).command);
+    return messages.map((m) => (m as PostedMessage).command);
 }
 
-function findMessage(messages: unknown[], command: string): PostedMessage | undefined {
-    return messages.find(m => (m as PostedMessage).command === command) as PostedMessage | undefined;
+function findMessage(
+    messages: unknown[],
+    command: string,
+): PostedMessage | undefined {
+    return messages.find((m) => (m as PostedMessage).command === command) as
+        | PostedMessage
+        | undefined;
 }
 
-describe('Compose Preview lifecycle', () => {
+describe("Compose Preview lifecycle", () => {
     let api: ComposePreviewTestApi;
     let gradle: RecordingGradleApi;
     let kotlinFile: string;
@@ -69,11 +94,20 @@ describe('Compose Preview lifecycle', () => {
     before(async () => {
         api = await getApi();
         const folders = vscode.workspace.workspaceFolders;
-        assert.ok(folders && folders.length > 0, 'fixture workspace must be open');
+        assert.ok(
+            folders && folders.length > 0,
+            "fixture workspace must be open",
+        );
         kotlinFile = path.join(
             folders[0].uri.fsPath,
-            'sample-module', 'src', 'main', 'kotlin',
-            'com', 'example', 'sample', 'Previews.kt',
+            "sample-module",
+            "src",
+            "main",
+            "kotlin",
+            "com",
+            "example",
+            "sample",
+            "Previews.kt",
         );
     });
 
@@ -83,8 +117,8 @@ describe('Compose Preview lifecycle', () => {
         api.resetMessages();
     });
 
-    it('save-driven refresh sends setLoading then setPreviews and clears the Building banner', async () => {
-        await api.triggerRefresh(kotlinFile, /* force */ true, 'fast');
+    it("save-driven refresh sends setLoading then setPreviews and clears the Building banner", async () => {
+        await api.triggerRefresh(kotlinFile, /* force */ true, "fast");
         await flushMicrotasks();
 
         const messages = api.getPostedMessages();
@@ -95,65 +129,86 @@ describe('Compose Preview lifecycle', () => {
         // clears the 'loading' banner the moment cards land — exercised in
         // the webview unit test; here we verify the extension at least
         // emits the right sequence.
-        const loadingIdx = cmds.indexOf('setLoading');
-        const setPreviewsIdx = cmds.indexOf('setPreviews');
-        assert.notStrictEqual(loadingIdx, -1, `expected setLoading, got: ${cmds.join(', ')}`);
-        assert.notStrictEqual(setPreviewsIdx, -1, `expected setPreviews, got: ${cmds.join(', ')}`);
-        assert.ok(loadingIdx < setPreviewsIdx, 'setLoading must precede setPreviews');
+        const loadingIdx = cmds.indexOf("setLoading");
+        const setPreviewsIdx = cmds.indexOf("setPreviews");
+        assert.notStrictEqual(
+            loadingIdx,
+            -1,
+            `expected setLoading, got: ${cmds.join(", ")}`,
+        );
+        assert.notStrictEqual(
+            setPreviewsIdx,
+            -1,
+            `expected setPreviews, got: ${cmds.join(", ")}`,
+        );
+        assert.ok(
+            loadingIdx < setPreviewsIdx,
+            "setLoading must precede setPreviews",
+        );
 
-        const previewsMsg = findMessage(messages, 'setPreviews');
+        const previewsMsg = findMessage(messages, "setPreviews");
         const previews = previewsMsg!.previews as Array<{ id: string }>;
-        assert.strictEqual(previews.length, 2, 'fixture has two previews in this file');
+        assert.strictEqual(
+            previews.length,
+            2,
+            "fixture has two previews in this file",
+        );
     });
 
-    it('tier=fast on save passes -PcomposePreview.tier=fast to renderAllPreviews', async () => {
-        await api.triggerRefresh(kotlinFile, /* force */ true, 'fast');
+    it("tier=fast on save passes -PcomposePreview.tier=fast to renderAllPreviews", async () => {
+        await api.triggerRefresh(kotlinFile, /* force */ true, "fast");
         await flushMicrotasks();
 
         const renderCall = gradle.invocations.find(
-            i => i.taskName === ':sample-module:renderAllPreviews',
+            (i) => i.taskName === ":sample-module:renderAllPreviews",
         );
-        assert.ok(renderCall, 'expected a renderAllPreviews invocation');
+        assert.ok(renderCall, "expected a renderAllPreviews invocation");
         assert.ok(
-            renderCall.args.includes('-PcomposePreview.tier=fast'),
-            `expected tier=fast in args; got: ${renderCall.args.join(' ')}`,
+            renderCall.args.includes("-PcomposePreview.tier=fast"),
+            `expected tier=fast in args; got: ${renderCall.args.join(" ")}`,
         );
     });
 
-    it('tier=full on explicit refresh passes -PcomposePreview.tier=full', async () => {
-        await api.triggerRefresh(kotlinFile, /* force */ true, 'full');
+    it("tier=full on explicit refresh passes -PcomposePreview.tier=full", async () => {
+        await api.triggerRefresh(kotlinFile, /* force */ true, "full");
         await flushMicrotasks();
 
         const renderCall = gradle.invocations.find(
-            i => i.taskName === ':sample-module:renderAllPreviews',
+            (i) => i.taskName === ":sample-module:renderAllPreviews",
         );
-        assert.ok(renderCall, 'expected a renderAllPreviews invocation');
+        assert.ok(renderCall, "expected a renderAllPreviews invocation");
         assert.ok(
-            renderCall.args.includes('-PcomposePreview.tier=full'),
-            `expected tier=full in args; got: ${renderCall.args.join(' ')}`,
+            renderCall.args.includes("-PcomposePreview.tier=full"),
+            `expected tier=full in args; got: ${renderCall.args.join(" ")}`,
         );
     });
 
-    it('heavyStaleIds populated after a fast render; cleared after a full render', async () => {
+    it("heavyStaleIds populated after a fast render; cleared after a full render", async () => {
         // Fast first — heavy preview should be marked stale.
-        await api.triggerRefresh(kotlinFile, /* force */ true, 'fast');
+        await api.triggerRefresh(kotlinFile, /* force */ true, "fast");
         await flushMicrotasks();
-        const fastSetPreviews = findMessage(api.getPostedMessages(), 'setPreviews');
+        const fastSetPreviews = findMessage(
+            api.getPostedMessages(),
+            "setPreviews",
+        );
         assert.deepStrictEqual(
             fastSetPreviews!.heavyStaleIds,
-            ['com.example.sample.PreviewsKt.AnimatedPreview'],
-            'after a fast render the animated preview should be flagged stale',
+            ["com.example.sample.PreviewsKt.AnimatedPreview"],
+            "after a fast render the animated preview should be flagged stale",
         );
 
         // Full render clears the flag.
         api.resetMessages();
-        await api.triggerRefresh(kotlinFile, /* force */ true, 'full');
+        await api.triggerRefresh(kotlinFile, /* force */ true, "full");
         await flushMicrotasks();
-        const fullSetPreviews = findMessage(api.getPostedMessages(), 'setPreviews');
+        const fullSetPreviews = findMessage(
+            api.getPostedMessages(),
+            "setPreviews",
+        );
         assert.deepStrictEqual(
             fullSetPreviews!.heavyStaleIds,
             [],
-            'after a full render the stale list should be empty',
+            "after a full render the stale list should be empty",
         );
     });
 });

--- a/vscode-extension/src/test/fixtures/resources.json
+++ b/vscode-extension/src/test/fixtures/resources.json
@@ -11,12 +11,20 @@
             },
             "captures": [
                 {
-                    "variant": { "qualifiers": "xhdpi", "shape": null, "style": null },
+                    "variant": {
+                        "qualifiers": "xhdpi",
+                        "shape": null,
+                        "style": null
+                    },
                     "renderOutput": "renders/resources/drawable/ic_compose_logo_xhdpi.png",
                     "cost": 1.0
                 },
                 {
-                    "variant": { "qualifiers": "night-xhdpi", "shape": null, "style": null },
+                    "variant": {
+                        "qualifiers": "night-xhdpi",
+                        "shape": null,
+                        "style": null
+                    },
                     "renderOutput": "renders/resources/drawable/ic_compose_logo_night-xhdpi.png",
                     "cost": 1.0
                 }
@@ -30,22 +38,38 @@
             },
             "captures": [
                 {
-                    "variant": { "qualifiers": "xhdpi", "shape": "CIRCLE", "style": "FULL_COLOR" },
+                    "variant": {
+                        "qualifiers": "xhdpi",
+                        "shape": "CIRCLE",
+                        "style": "FULL_COLOR"
+                    },
                     "renderOutput": "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_circle.png",
                     "cost": 4.0
                 },
                 {
-                    "variant": { "qualifiers": "xhdpi", "shape": "SQUIRCLE", "style": "THEMED_LIGHT" },
+                    "variant": {
+                        "qualifiers": "xhdpi",
+                        "shape": "SQUIRCLE",
+                        "style": "THEMED_LIGHT"
+                    },
                     "renderOutput": "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_squircle_themed-light.png",
                     "cost": 4.0
                 },
                 {
-                    "variant": { "qualifiers": "xhdpi", "shape": "SQUIRCLE", "style": "THEMED_DARK" },
+                    "variant": {
+                        "qualifiers": "xhdpi",
+                        "shape": "SQUIRCLE",
+                        "style": "THEMED_DARK"
+                    },
                     "renderOutput": "renders/resources/mipmap/ic_launcher_xhdpi_SHAPE_squircle_themed-dark.png",
                     "cost": 4.0
                 },
                 {
-                    "variant": { "qualifiers": "xhdpi", "shape": null, "style": "LEGACY" },
+                    "variant": {
+                        "qualifiers": "xhdpi",
+                        "shape": null,
+                        "style": "LEGACY"
+                    },
                     "renderOutput": "renders/resources/mipmap/ic_launcher_xhdpi_LEGACY.png",
                     "cost": 4.0
                 }
@@ -59,7 +83,11 @@
             },
             "captures": [
                 {
-                    "variant": { "qualifiers": "xhdpi", "shape": null, "style": null },
+                    "variant": {
+                        "qualifiers": "xhdpi",
+                        "shape": null,
+                        "style": null
+                    },
                     "renderOutput": "renders/resources/drawable/avd_pulse_xhdpi.gif",
                     "cost": 35.0
                 }

--- a/vscode-extension/src/test/gradleService.test.ts
+++ b/vscode-extension/src/test/gradleService.test.ts
@@ -1,30 +1,40 @@
-import * as assert from 'assert';
-import * as path from 'path';
-import * as fs from 'fs';
-import * as os from 'os';
-import { GradleService, GradleApi, TaskCancelledError } from '../gradleService';
-import { JdkImageError } from '../jdkImageErrorDetector';
+import * as assert from "assert";
+import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
+import { GradleService, GradleApi, TaskCancelledError } from "../gradleService";
+import { JdkImageError } from "../jdkImageErrorDetector";
 
 /** Stub GradleApi that records invocations and allows test control. */
 class StubGradleApi implements GradleApi {
     public runCalls: Array<{ taskName: string; cancellationKey?: string }> = [];
-    public cancelCalls: Array<{ taskName: string; cancellationKey?: string }> = [];
-    public nextRunResult: 'success' | Error = 'success';
+    public cancelCalls: Array<{ taskName: string; cancellationKey?: string }> =
+        [];
+    public nextRunResult: "success" | Error = "success";
     /** Bytes to feed through onOutput before resolving/rejecting. */
-    public nextRunOutput: string = '';
+    public nextRunOutput: string = "";
 
     async runTask(opts: {
         projectFolder: string;
         taskName: string;
         cancellationKey?: string;
-        onOutput?: (output: { getOutputBytes(): Uint8Array; getOutputType(): number }) => void;
+        onOutput?: (output: {
+            getOutputBytes(): Uint8Array;
+            getOutputType(): number;
+        }) => void;
     }): Promise<void> {
-        this.runCalls.push({ taskName: opts.taskName, cancellationKey: opts.cancellationKey });
+        this.runCalls.push({
+            taskName: opts.taskName,
+            cancellationKey: opts.cancellationKey,
+        });
         if (this.nextRunOutput && opts.onOutput) {
             const bytes = new TextEncoder().encode(this.nextRunOutput);
-            opts.onOutput({ getOutputBytes: () => bytes, getOutputType: () => 0 });
+            opts.onOutput({
+                getOutputBytes: () => bytes,
+                getOutputType: () => 0,
+            });
         }
-        if (this.nextRunResult !== 'success') {
+        if (this.nextRunResult !== "success") {
             throw this.nextRunResult;
         }
     }
@@ -34,13 +44,20 @@ class StubGradleApi implements GradleApi {
         taskName: string;
         cancellationKey?: string;
     }): Promise<void> {
-        this.cancelCalls.push({ taskName: opts.taskName, cancellationKey: opts.cancellationKey });
+        this.cancelCalls.push({
+            taskName: opts.taskName,
+            cancellationKey: opts.cancellationKey,
+        });
     }
 }
 
-function withTempDir(fn: (dir: string, api: StubGradleApi) => void | Promise<void>): () => Promise<void> {
+function withTempDir(
+    fn: (dir: string, api: StubGradleApi) => void | Promise<void>,
+): () => Promise<void> {
     return async () => {
-        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'compose-preview-test-'));
+        const dir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "compose-preview-test-"),
+        );
         try {
             await fn(dir, new StubGradleApi());
         } finally {
@@ -49,154 +66,296 @@ function withTempDir(fn: (dir: string, api: StubGradleApi) => void | Promise<voi
     };
 }
 
-describe('GradleService', () => {
-    describe('readManifest', () => {
-        it('reads and parses a valid manifest', withTempDir((dir, api) => {
-            const manifestDir = path.join(dir, 'testmodule', 'build', 'compose-previews');
-            fs.mkdirSync(manifestDir, { recursive: true });
-            fs.copyFileSync(
-                path.join(__dirname, '..', '..', 'src', 'test', 'fixtures', 'previews.json'),
-                path.join(manifestDir, 'previews.json'),
-            );
+describe("GradleService", () => {
+    describe("readManifest", () => {
+        it(
+            "reads and parses a valid manifest",
+            withTempDir((dir, api) => {
+                const manifestDir = path.join(
+                    dir,
+                    "testmodule",
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(manifestDir, { recursive: true });
+                fs.copyFileSync(
+                    path.join(
+                        __dirname,
+                        "..",
+                        "..",
+                        "src",
+                        "test",
+                        "fixtures",
+                        "previews.json",
+                    ),
+                    path.join(manifestDir, "previews.json"),
+                );
 
-            const service = new GradleService(dir, api);
-            const manifest = service.readManifest('testmodule');
+                const service = new GradleService(dir, api);
+                const manifest = service.readManifest("testmodule");
 
-            assert.notStrictEqual(manifest, null);
-            assert.strictEqual(manifest!.module, 'sample-android');
-            assert.strictEqual(manifest!.previews.length, 4);
-        }));
+                assert.notStrictEqual(manifest, null);
+                assert.strictEqual(manifest!.module, "sample-android");
+                assert.strictEqual(manifest!.previews.length, 4);
+            }),
+        );
 
-        it('returns null for missing manifest', withTempDir((dir, api) => {
-            const service = new GradleService(dir, api);
-            assert.strictEqual(service.readManifest('nonexistent'), null);
-        }));
+        it(
+            "returns null for missing manifest",
+            withTempDir((dir, api) => {
+                const service = new GradleService(dir, api);
+                assert.strictEqual(service.readManifest("nonexistent"), null);
+            }),
+        );
 
-        it('returns null for malformed JSON', withTempDir((dir, api) => {
-            const manifestDir = path.join(dir, 'bad', 'build', 'compose-previews');
-            fs.mkdirSync(manifestDir, { recursive: true });
-            fs.writeFileSync(path.join(manifestDir, 'previews.json'), '{ broken');
+        it(
+            "returns null for malformed JSON",
+            withTempDir((dir, api) => {
+                const manifestDir = path.join(
+                    dir,
+                    "bad",
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(manifestDir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(manifestDir, "previews.json"),
+                    "{ broken",
+                );
 
-            const service = new GradleService(dir, api);
-            assert.strictEqual(service.readManifest('bad'), null);
-        }));
+                const service = new GradleService(dir, api);
+                assert.strictEqual(service.readManifest("bad"), null);
+            }),
+        );
 
-        it('returns null for manifest without previews array', withTempDir((dir, api) => {
-            const manifestDir = path.join(dir, 'empty', 'build', 'compose-previews');
-            fs.mkdirSync(manifestDir, { recursive: true });
-            fs.writeFileSync(path.join(manifestDir, 'previews.json'), '{"module":"x"}');
+        it(
+            "returns null for manifest without previews array",
+            withTempDir((dir, api) => {
+                const manifestDir = path.join(
+                    dir,
+                    "empty",
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(manifestDir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(manifestDir, "previews.json"),
+                    '{"module":"x"}',
+                );
 
-            const service = new GradleService(dir, api);
-            assert.strictEqual(service.readManifest('empty'), null);
-        }));
+                const service = new GradleService(dir, api);
+                assert.strictEqual(service.readManifest("empty"), null);
+            }),
+        );
     });
 
-    describe('readResourceManifest', () => {
-        it('reads and parses a valid resource manifest', withTempDir((dir, api) => {
-            const manifestDir = path.join(dir, 'testmodule', 'build', 'compose-previews');
-            fs.mkdirSync(manifestDir, { recursive: true });
-            fs.copyFileSync(
-                path.join(__dirname, '..', '..', 'src', 'test', 'fixtures', 'resources.json'),
-                path.join(manifestDir, 'resources.json'),
-            );
+    describe("readResourceManifest", () => {
+        it(
+            "reads and parses a valid resource manifest",
+            withTempDir((dir, api) => {
+                const manifestDir = path.join(
+                    dir,
+                    "testmodule",
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(manifestDir, { recursive: true });
+                fs.copyFileSync(
+                    path.join(
+                        __dirname,
+                        "..",
+                        "..",
+                        "src",
+                        "test",
+                        "fixtures",
+                        "resources.json",
+                    ),
+                    path.join(manifestDir, "resources.json"),
+                );
 
-            const service = new GradleService(dir, api);
-            const manifest = service.readResourceManifest('testmodule');
+                const service = new GradleService(dir, api);
+                const manifest = service.readResourceManifest("testmodule");
 
-            assert.notStrictEqual(manifest, null);
-            assert.strictEqual(manifest!.module, 'sample-android');
-            assert.strictEqual(manifest!.resources.length, 3);
-            assert.strictEqual(manifest!.manifestReferences.length, 2);
+                assert.notStrictEqual(manifest, null);
+                assert.strictEqual(manifest!.module, "sample-android");
+                assert.strictEqual(manifest!.resources.length, 3);
+                assert.strictEqual(manifest!.manifestReferences.length, 2);
 
-            // The empty-string convention for default-qualifier source files should round-trip
-            // through JSON.parse — guards the regression where `Map<String?, String>` emitted
-            // bare `null:` keys.
-            const compose = manifest!.resources.find((r) => r.id === 'drawable/ic_compose_logo')!;
-            assert.deepStrictEqual(Object.keys(compose.sourceFiles).sort(), ['', 'night']);
+                // The empty-string convention for default-qualifier source files should round-trip
+                // through JSON.parse — guards the regression where `Map<String?, String>` emitted
+                // bare `null:` keys.
+                const compose = manifest!.resources.find(
+                    (r) => r.id === "drawable/ic_compose_logo",
+                )!;
+                assert.deepStrictEqual(
+                    Object.keys(compose.sourceFiles).sort(),
+                    ["", "night"],
+                );
 
-            // Adaptive-icon captures should carry their shape and style; vector captures
-            // should carry neither. LEGACY captures carry style but no shape.
-            const launcher = manifest!.resources.find((r) => r.id === 'mipmap/ic_launcher')!;
-            assert.strictEqual(launcher.captures[0].variant?.shape, 'CIRCLE');
-            assert.strictEqual(launcher.captures[0].variant?.style, 'FULL_COLOR');
-            const themedLight = launcher.captures.find((c) => c.variant?.style === 'THEMED_LIGHT')!;
-            assert.strictEqual(themedLight.variant?.shape, 'SQUIRCLE');
-            const legacy = launcher.captures.find((c) => c.variant?.style === 'LEGACY')!;
-            assert.strictEqual(legacy.variant?.shape, null);
-            assert.strictEqual(compose.captures[0].variant?.shape, null);
+                // Adaptive-icon captures should carry their shape and style; vector captures
+                // should carry neither. LEGACY captures carry style but no shape.
+                const launcher = manifest!.resources.find(
+                    (r) => r.id === "mipmap/ic_launcher",
+                )!;
+                assert.strictEqual(
+                    launcher.captures[0].variant?.shape,
+                    "CIRCLE",
+                );
+                assert.strictEqual(
+                    launcher.captures[0].variant?.style,
+                    "FULL_COLOR",
+                );
+                const themedLight = launcher.captures.find(
+                    (c) => c.variant?.style === "THEMED_LIGHT",
+                )!;
+                assert.strictEqual(themedLight.variant?.shape, "SQUIRCLE");
+                const legacy = launcher.captures.find(
+                    (c) => c.variant?.style === "LEGACY",
+                )!;
+                assert.strictEqual(legacy.variant?.shape, null);
+                assert.strictEqual(compose.captures[0].variant?.shape, null);
 
-            // Manifest references resolve activity short-form names against the package.
-            const activityRef = manifest!.manifestReferences.find((r) => r.componentKind === 'activity')!;
-            assert.strictEqual(activityRef.componentName, 'com.example.sampleandroid.MainActivity');
-            assert.strictEqual(activityRef.resourceType, 'drawable');
-            assert.strictEqual(activityRef.resourceName, 'ic_settings');
-        }));
+                // Manifest references resolve activity short-form names against the package.
+                const activityRef = manifest!.manifestReferences.find(
+                    (r) => r.componentKind === "activity",
+                )!;
+                assert.strictEqual(
+                    activityRef.componentName,
+                    "com.example.sampleandroid.MainActivity",
+                );
+                assert.strictEqual(activityRef.resourceType, "drawable");
+                assert.strictEqual(activityRef.resourceName, "ic_settings");
+            }),
+        );
 
-        it('returns null when resources.json is missing', withTempDir((dir, api) => {
-            const service = new GradleService(dir, api);
-            assert.strictEqual(service.readResourceManifest('nonexistent'), null);
-        }));
+        it(
+            "returns null when resources.json is missing",
+            withTempDir((dir, api) => {
+                const service = new GradleService(dir, api);
+                assert.strictEqual(
+                    service.readResourceManifest("nonexistent"),
+                    null,
+                );
+            }),
+        );
 
-        it('returns null for malformed JSON', withTempDir((dir, api) => {
-            const manifestDir = path.join(dir, 'bad', 'build', 'compose-previews');
-            fs.mkdirSync(manifestDir, { recursive: true });
-            fs.writeFileSync(path.join(manifestDir, 'resources.json'), '{ broken');
+        it(
+            "returns null for malformed JSON",
+            withTempDir((dir, api) => {
+                const manifestDir = path.join(
+                    dir,
+                    "bad",
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(manifestDir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(manifestDir, "resources.json"),
+                    "{ broken",
+                );
 
-            const service = new GradleService(dir, api);
-            assert.strictEqual(service.readResourceManifest('bad'), null);
-        }));
+                const service = new GradleService(dir, api);
+                assert.strictEqual(service.readResourceManifest("bad"), null);
+            }),
+        );
 
-        it('returns null when resources / manifestReferences arrays are missing', withTempDir((dir, api) => {
-            const manifestDir = path.join(dir, 'empty', 'build', 'compose-previews');
-            fs.mkdirSync(manifestDir, { recursive: true });
-            fs.writeFileSync(path.join(manifestDir, 'resources.json'), '{"module":"x","variant":"debug"}');
+        it(
+            "returns null when resources / manifestReferences arrays are missing",
+            withTempDir((dir, api) => {
+                const manifestDir = path.join(
+                    dir,
+                    "empty",
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(manifestDir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(manifestDir, "resources.json"),
+                    '{"module":"x","variant":"debug"}',
+                );
 
-            const service = new GradleService(dir, api);
-            assert.strictEqual(service.readResourceManifest('empty'), null);
-        }));
+                const service = new GradleService(dir, api);
+                assert.strictEqual(service.readResourceManifest("empty"), null);
+            }),
+        );
     });
 
-    describe('readPreviewImage', () => {
-        it('reads a PNG as base64', withTempDir(async (dir, api) => {
-            const renderDir = path.join(dir, 'mod', 'build', 'compose-previews', 'renders');
-            fs.mkdirSync(renderDir, { recursive: true });
-            fs.writeFileSync(path.join(renderDir, 'test.png'), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+    describe("readPreviewImage", () => {
+        it(
+            "reads a PNG as base64",
+            withTempDir(async (dir, api) => {
+                const renderDir = path.join(
+                    dir,
+                    "mod",
+                    "build",
+                    "compose-previews",
+                    "renders",
+                );
+                fs.mkdirSync(renderDir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(renderDir, "test.png"),
+                    Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+                );
 
-            const service = new GradleService(dir, api);
-            const base64 = await service.readPreviewImage('mod', 'renders/test.png');
+                const service = new GradleService(dir, api);
+                const base64 = await service.readPreviewImage(
+                    "mod",
+                    "renders/test.png",
+                );
 
-            assert.notStrictEqual(base64, null);
-            assert.strictEqual(Buffer.from(base64!, 'base64')[0], 0x89);
-        }));
+                assert.notStrictEqual(base64, null);
+                assert.strictEqual(Buffer.from(base64!, "base64")[0], 0x89);
+            }),
+        );
 
-        it('returns null for missing image', withTempDir(async (dir, api) => {
-            const service = new GradleService(dir, api);
-            assert.strictEqual(await service.readPreviewImage('mod', 'missing.png'), null);
-        }));
+        it(
+            "returns null for missing image",
+            withTempDir(async (dir, api) => {
+                const service = new GradleService(dir, api);
+                assert.strictEqual(
+                    await service.readPreviewImage("mod", "missing.png"),
+                    null,
+                );
+            }),
+        );
     });
 
-    describe('findPreviewModules', () => {
-        it('finds modules with the plugin applied', withTempDir((dir, api) => {
-            fs.mkdirSync(path.join(dir, 'app'));
-            fs.writeFileSync(path.join(dir, 'app', 'build.gradle.kts'),
-                'id("ee.schimke.composeai.preview")');
+    describe("findPreviewModules", () => {
+        it(
+            "finds modules with the plugin applied",
+            withTempDir((dir, api) => {
+                fs.mkdirSync(path.join(dir, "app"));
+                fs.writeFileSync(
+                    path.join(dir, "app", "build.gradle.kts"),
+                    'id("ee.schimke.composeai.preview")',
+                );
 
-            fs.mkdirSync(path.join(dir, 'lib'));
-            fs.writeFileSync(path.join(dir, 'lib', 'build.gradle.kts'),
-                'id("org.jetbrains.kotlin.jvm")');
+                fs.mkdirSync(path.join(dir, "lib"));
+                fs.writeFileSync(
+                    path.join(dir, "lib", "build.gradle.kts"),
+                    'id("org.jetbrains.kotlin.jvm")',
+                );
 
-            const service = new GradleService(dir, api);
-            assert.deepStrictEqual(service.findPreviewModules(), ['app']);
-        }));
+                const service = new GradleService(dir, api);
+                assert.deepStrictEqual(service.findPreviewModules(), ["app"]);
+            }),
+        );
 
-        it('returns empty for workspace with no modules', withTempDir((dir, api) => {
-            const service = new GradleService(dir, api);
-            assert.deepStrictEqual(service.findPreviewModules(), []);
-        }));
+        it(
+            "returns empty for workspace with no modules",
+            withTempDir((dir, api) => {
+                const service = new GradleService(dir, api);
+                assert.deepStrictEqual(service.findPreviewModules(), []);
+            }),
+        );
 
-        it('ignores the plugin module itself (declares but does not apply)', withTempDir((dir, api) => {
-            fs.mkdirSync(path.join(dir, 'gradle-plugin'));
-            fs.writeFileSync(path.join(dir, 'gradle-plugin', 'build.gradle.kts'), `
+        it(
+            "ignores the plugin module itself (declares but does not apply)",
+            withTempDir((dir, api) => {
+                fs.mkdirSync(path.join(dir, "gradle-plugin"));
+                fs.writeFileSync(
+                    path.join(dir, "gradle-plugin", "build.gradle.kts"),
+                    `
                 gradlePlugin {
                     plugins {
                         create("composePreview") {
@@ -204,297 +363,503 @@ describe('GradleService', () => {
                         }
                     }
                 }
-            `);
-            fs.mkdirSync(path.join(dir, 'app'));
-            fs.writeFileSync(path.join(dir, 'app', 'build.gradle.kts'),
-                'plugins { id("ee.schimke.composeai.preview") }');
+            `,
+                );
+                fs.mkdirSync(path.join(dir, "app"));
+                fs.writeFileSync(
+                    path.join(dir, "app", "build.gradle.kts"),
+                    'plugins { id("ee.schimke.composeai.preview") }',
+                );
 
-            const service = new GradleService(dir, api);
-            assert.deepStrictEqual(service.findPreviewModules(), ['app']);
-        }));
+                const service = new GradleService(dir, api);
+                assert.deepStrictEqual(service.findPreviewModules(), ["app"]);
+            }),
+        );
 
-        it('excludes literal `apply false` declarations', withTempDir((dir, api) => {
-            fs.mkdirSync(path.join(dir, 'lib'));
-            fs.writeFileSync(path.join(dir, 'lib', 'build.gradle.kts'),
-                'plugins { id("ee.schimke.composeai.preview") apply false }');
+        it(
+            "excludes literal `apply false` declarations",
+            withTempDir((dir, api) => {
+                fs.mkdirSync(path.join(dir, "lib"));
+                fs.writeFileSync(
+                    path.join(dir, "lib", "build.gradle.kts"),
+                    'plugins { id("ee.schimke.composeai.preview") apply false }',
+                );
 
-            const service = new GradleService(dir, api);
-            assert.deepStrictEqual(service.findPreviewModules(), []);
-        }));
+                const service = new GradleService(dir, api);
+                assert.deepStrictEqual(service.findPreviewModules(), []);
+            }),
+        );
 
-        it('finds modules via applied.json markers even when build script does not mention the plugin',
+        it(
+            "finds modules via applied.json markers even when build script does not mention the plugin",
             withTempDir((dir, api) => {
                 // E.g. the module applies the plugin from a convention plugin
                 // in `buildSrc/` — neither the literal-id nor alias regex
                 // catches it, but the Gradle-written marker does.
-                fs.mkdirSync(path.join(dir, 'mod'));
-                fs.writeFileSync(path.join(dir, 'mod', 'build.gradle.kts'),
-                    'plugins { id("my-convention-plugin") }');
-                const markerDir = path.join(dir, 'mod', 'build', 'compose-previews');
+                fs.mkdirSync(path.join(dir, "mod"));
+                fs.writeFileSync(
+                    path.join(dir, "mod", "build.gradle.kts"),
+                    'plugins { id("my-convention-plugin") }',
+                );
+                const markerDir = path.join(
+                    dir,
+                    "mod",
+                    "build",
+                    "compose-previews",
+                );
                 fs.mkdirSync(markerDir, { recursive: true });
-                fs.writeFileSync(path.join(markerDir, 'applied.json'),
-                    '{"schema":"compose-preview-applied/v1","modulePath":":mod","moduleName":"mod","pluginVersion":"0.7.2"}');
+                fs.writeFileSync(
+                    path.join(markerDir, "applied.json"),
+                    '{"schema":"compose-preview-applied/v1","modulePath":":mod","moduleName":"mod","pluginVersion":"0.7.2"}',
+                );
 
                 const service = new GradleService(dir, api);
-                assert.deepStrictEqual(service.findPreviewModules(), ['mod']);
-            }));
+                assert.deepStrictEqual(service.findPreviewModules(), ["mod"]);
+            }),
+        );
 
-        it('unions marker-detected and scan-detected modules', withTempDir((dir, api) => {
-            fs.mkdirSync(path.join(dir, 'app'));
-            fs.writeFileSync(path.join(dir, 'app', 'build.gradle.kts'),
-                'id("ee.schimke.composeai.preview")');
+        it(
+            "unions marker-detected and scan-detected modules",
+            withTempDir((dir, api) => {
+                fs.mkdirSync(path.join(dir, "app"));
+                fs.writeFileSync(
+                    path.join(dir, "app", "build.gradle.kts"),
+                    'id("ee.schimke.composeai.preview")',
+                );
 
-            // A second module with only the marker (e.g. discovered earlier
-            // and since rewritten to a convention plugin that the regex
-            // doesn't recognise).
-            fs.mkdirSync(path.join(dir, 'lib'));
-            fs.writeFileSync(path.join(dir, 'lib', 'build.gradle.kts'),
-                'plugins { id("some-convention") }');
-            const markerDir = path.join(dir, 'lib', 'build', 'compose-previews');
-            fs.mkdirSync(markerDir, { recursive: true });
-            fs.writeFileSync(path.join(markerDir, 'applied.json'),
-                '{"schema":"compose-preview-applied/v1","modulePath":":lib","moduleName":"lib","pluginVersion":"0.7.2"}');
+                // A second module with only the marker (e.g. discovered earlier
+                // and since rewritten to a convention plugin that the regex
+                // doesn't recognise).
+                fs.mkdirSync(path.join(dir, "lib"));
+                fs.writeFileSync(
+                    path.join(dir, "lib", "build.gradle.kts"),
+                    'plugins { id("some-convention") }',
+                );
+                const markerDir = path.join(
+                    dir,
+                    "lib",
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(markerDir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(markerDir, "applied.json"),
+                    '{"schema":"compose-preview-applied/v1","modulePath":":lib","moduleName":"lib","pluginVersion":"0.7.2"}',
+                );
 
-            const service = new GradleService(dir, api);
-            assert.deepStrictEqual(service.findPreviewModules(), ['app', 'lib']);
-        }));
+                const service = new GradleService(dir, api);
+                assert.deepStrictEqual(service.findPreviewModules(), [
+                    "app",
+                    "lib",
+                ]);
+            }),
+        );
 
-        it('finds nested modules (e.g. samples/wear)', withTempDir((dir, api) => {
-            // Multi-project layouts where modules live under an organising
-            // parent directory (`samples/wear`, `features/login`) — the
-            // parent itself has no build file.
-            fs.mkdirSync(path.join(dir, 'samples', 'wear'), { recursive: true });
-            fs.writeFileSync(path.join(dir, 'samples', 'wear', 'build.gradle.kts'),
-                'plugins { id("ee.schimke.composeai.preview") }');
-            fs.mkdirSync(path.join(dir, 'samples', 'cmp'));
-            const markerDir = path.join(dir, 'samples', 'cmp', 'build', 'compose-previews');
-            fs.mkdirSync(markerDir, { recursive: true });
-            fs.writeFileSync(path.join(markerDir, 'applied.json'),
-                '{"schema":"compose-preview-applied/v1","modulePath":":samples:cmp","moduleName":"cmp","pluginVersion":"0.8.0"}');
+        it(
+            "finds nested modules (e.g. samples/wear)",
+            withTempDir((dir, api) => {
+                // Multi-project layouts where modules live under an organising
+                // parent directory (`samples/wear`, `features/login`) — the
+                // parent itself has no build file.
+                fs.mkdirSync(path.join(dir, "samples", "wear"), {
+                    recursive: true,
+                });
+                fs.writeFileSync(
+                    path.join(dir, "samples", "wear", "build.gradle.kts"),
+                    'plugins { id("ee.schimke.composeai.preview") }',
+                );
+                fs.mkdirSync(path.join(dir, "samples", "cmp"));
+                const markerDir = path.join(
+                    dir,
+                    "samples",
+                    "cmp",
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(markerDir, { recursive: true });
+                fs.writeFileSync(
+                    path.join(markerDir, "applied.json"),
+                    '{"schema":"compose-preview-applied/v1","modulePath":":samples:cmp","moduleName":"cmp","pluginVersion":"0.8.0"}',
+                );
 
-            const service = new GradleService(dir, api);
-            assert.deepStrictEqual(
-                service.findPreviewModules(),
-                ['samples/cmp', 'samples/wear'],
-            );
-        }));
+                const service = new GradleService(dir, api);
+                assert.deepStrictEqual(service.findPreviewModules(), [
+                    "samples/cmp",
+                    "samples/wear",
+                ]);
+            }),
+        );
     });
 
-    describe('resolveModule', () => {
-        it('resolves file path to module name', withTempDir((dir, api) => {
-            fs.mkdirSync(path.join(dir, 'sample-android'));
-            fs.writeFileSync(path.join(dir, 'sample-android', 'build.gradle.kts'),
-                'id("ee.schimke.composeai.preview")');
+    describe("resolveModule", () => {
+        it(
+            "resolves file path to module name",
+            withTempDir((dir, api) => {
+                fs.mkdirSync(path.join(dir, "sample-android"));
+                fs.writeFileSync(
+                    path.join(dir, "sample-android", "build.gradle.kts"),
+                    'id("ee.schimke.composeai.preview")',
+                );
 
-            const service = new GradleService(dir, api);
-            assert.strictEqual(
-                service.resolveModule(path.join(dir, 'sample-android', 'src', 'Foo.kt')),
-                'sample-android',
-            );
-        }));
+                const service = new GradleService(dir, api);
+                assert.strictEqual(
+                    service.resolveModule(
+                        path.join(dir, "sample-android", "src", "Foo.kt"),
+                    ),
+                    "sample-android",
+                );
+            }),
+        );
 
-        it('returns null for file outside any module', withTempDir((dir, api) => {
-            const service = new GradleService(dir, api);
-            assert.strictEqual(service.resolveModule(path.join(dir, 'unknown', 'Foo.kt')), null);
-        }));
+        it(
+            "returns null for file outside any module",
+            withTempDir((dir, api) => {
+                const service = new GradleService(dir, api);
+                assert.strictEqual(
+                    service.resolveModule(path.join(dir, "unknown", "Foo.kt")),
+                    null,
+                );
+            }),
+        );
 
-        it('resolves nested module paths', withTempDir((dir, api) => {
-            fs.mkdirSync(path.join(dir, 'samples', 'wear'), { recursive: true });
-            fs.writeFileSync(path.join(dir, 'samples', 'wear', 'build.gradle.kts'),
-                'plugins { id("ee.schimke.composeai.preview") }');
+        it(
+            "resolves nested module paths",
+            withTempDir((dir, api) => {
+                fs.mkdirSync(path.join(dir, "samples", "wear"), {
+                    recursive: true,
+                });
+                fs.writeFileSync(
+                    path.join(dir, "samples", "wear", "build.gradle.kts"),
+                    'plugins { id("ee.schimke.composeai.preview") }',
+                );
 
-            const service = new GradleService(dir, api);
-            assert.strictEqual(
-                service.resolveModule(path.join(
-                    dir, 'samples', 'wear',
-                    'src', 'main', 'kotlin', 'com', 'example', 'Foo.kt',
-                )),
-                'samples/wear',
-            );
-        }));
+                const service = new GradleService(dir, api);
+                assert.strictEqual(
+                    service.resolveModule(
+                        path.join(
+                            dir,
+                            "samples",
+                            "wear",
+                            "src",
+                            "main",
+                            "kotlin",
+                            "com",
+                            "example",
+                            "Foo.kt",
+                        ),
+                    ),
+                    "samples/wear",
+                );
+            }),
+        );
 
-        it('prefers the deepest matching module (longest-prefix match)', withTempDir((dir, api) => {
-            // Gradle allows `:foo:bar` to nest inside `:foo`. A file under
-            // `foo/bar/...` belongs to `foo/bar`, not `foo`.
-            fs.mkdirSync(path.join(dir, 'foo', 'bar'), { recursive: true });
-            fs.writeFileSync(path.join(dir, 'foo', 'build.gradle.kts'),
-                'plugins { id("ee.schimke.composeai.preview") }');
-            fs.writeFileSync(path.join(dir, 'foo', 'bar', 'build.gradle.kts'),
-                'plugins { id("ee.schimke.composeai.preview") }');
+        it(
+            "prefers the deepest matching module (longest-prefix match)",
+            withTempDir((dir, api) => {
+                // Gradle allows `:foo:bar` to nest inside `:foo`. A file under
+                // `foo/bar/...` belongs to `foo/bar`, not `foo`.
+                fs.mkdirSync(path.join(dir, "foo", "bar"), { recursive: true });
+                fs.writeFileSync(
+                    path.join(dir, "foo", "build.gradle.kts"),
+                    'plugins { id("ee.schimke.composeai.preview") }',
+                );
+                fs.writeFileSync(
+                    path.join(dir, "foo", "bar", "build.gradle.kts"),
+                    'plugins { id("ee.schimke.composeai.preview") }',
+                );
 
-            const service = new GradleService(dir, api);
-            assert.strictEqual(
-                service.resolveModule(path.join(dir, 'foo', 'bar', 'src', 'Foo.kt')),
-                'foo/bar',
-            );
-            assert.strictEqual(
-                service.resolveModule(path.join(dir, 'foo', 'src', 'Foo.kt')),
-                'foo',
-            );
-        }));
+                const service = new GradleService(dir, api);
+                assert.strictEqual(
+                    service.resolveModule(
+                        path.join(dir, "foo", "bar", "src", "Foo.kt"),
+                    ),
+                    "foo/bar",
+                );
+                assert.strictEqual(
+                    service.resolveModule(
+                        path.join(dir, "foo", "src", "Foo.kt"),
+                    ),
+                    "foo",
+                );
+            }),
+        );
     });
 
-    describe('discoverPreviews', () => {
-        it('invokes gradleApi with correct task name', withTempDir(async (dir, api) => {
-            fs.mkdirSync(path.join(dir, 'mod'));
-            fs.writeFileSync(path.join(dir, 'mod', 'build.gradle.kts'),
-                'id("ee.schimke.composeai.preview")');
-
-            const manifestDir = path.join(dir, 'mod', 'build', 'compose-previews');
-            fs.mkdirSync(manifestDir, { recursive: true });
-            fs.copyFileSync(
-                path.join(__dirname, '..', '..', 'src', 'test', 'fixtures', 'previews.json'),
-                path.join(manifestDir, 'previews.json'),
-            );
-
-            const service = new GradleService(dir, api);
-            await service.discoverPreviews('mod');
-
-            assert.strictEqual(api.runCalls.length, 1);
-            assert.strictEqual(api.runCalls[0].taskName, ':mod:discoverPreviews');
-        }));
-
-        it('translates nested module path to colon-separated Gradle task name',
+    describe("discoverPreviews", () => {
+        it(
+            "invokes gradleApi with correct task name",
             withTempDir(async (dir, api) => {
-                fs.mkdirSync(path.join(dir, 'samples', 'wear'), { recursive: true });
-                fs.writeFileSync(path.join(dir, 'samples', 'wear', 'build.gradle.kts'),
-                    'plugins { id("ee.schimke.composeai.preview") }');
+                fs.mkdirSync(path.join(dir, "mod"));
+                fs.writeFileSync(
+                    path.join(dir, "mod", "build.gradle.kts"),
+                    'id("ee.schimke.composeai.preview")',
+                );
+
                 const manifestDir = path.join(
-                    dir, 'samples', 'wear', 'build', 'compose-previews',
+                    dir,
+                    "mod",
+                    "build",
+                    "compose-previews",
                 );
                 fs.mkdirSync(manifestDir, { recursive: true });
                 fs.copyFileSync(
-                    path.join(__dirname, '..', '..', 'src', 'test', 'fixtures', 'previews.json'),
-                    path.join(manifestDir, 'previews.json'),
+                    path.join(
+                        __dirname,
+                        "..",
+                        "..",
+                        "src",
+                        "test",
+                        "fixtures",
+                        "previews.json",
+                    ),
+                    path.join(manifestDir, "previews.json"),
                 );
 
                 const service = new GradleService(dir, api);
-                await service.discoverPreviews('samples/wear');
+                await service.discoverPreviews("mod");
 
                 assert.strictEqual(api.runCalls.length, 1);
                 assert.strictEqual(
                     api.runCalls[0].taskName,
-                    ':samples:wear:discoverPreviews',
+                    ":mod:discoverPreviews",
                 );
-            }));
+            }),
+        );
 
-        it('uses cache for repeated calls within TTL', withTempDir(async (dir, api) => {
-            fs.mkdirSync(path.join(dir, 'mod'));
-            const manifestDir = path.join(dir, 'mod', 'build', 'compose-previews');
-            fs.mkdirSync(manifestDir, { recursive: true });
-            fs.copyFileSync(
-                path.join(__dirname, '..', '..', 'src', 'test', 'fixtures', 'previews.json'),
-                path.join(manifestDir, 'previews.json'),
-            );
-
-            const service = new GradleService(dir, api);
-            await service.discoverPreviews('mod');
-            await service.discoverPreviews('mod');
-
-            // Second call hit cache — only one Gradle invocation
-            assert.strictEqual(api.runCalls.length, 1);
-        }));
-
-        it('compileOnly invokes :module:composePreviewCompile and drops the manifest cache',
+        it(
+            "translates nested module path to colon-separated Gradle task name",
             withTempDir(async (dir, api) => {
-                fs.mkdirSync(path.join(dir, 'mod'));
-                const manifestDir = path.join(dir, 'mod', 'build', 'compose-previews');
+                fs.mkdirSync(path.join(dir, "samples", "wear"), {
+                    recursive: true,
+                });
+                fs.writeFileSync(
+                    path.join(dir, "samples", "wear", "build.gradle.kts"),
+                    'plugins { id("ee.schimke.composeai.preview") }',
+                );
+                const manifestDir = path.join(
+                    dir,
+                    "samples",
+                    "wear",
+                    "build",
+                    "compose-previews",
+                );
                 fs.mkdirSync(manifestDir, { recursive: true });
                 fs.copyFileSync(
-                    path.join(__dirname, '..', '..', 'src', 'test', 'fixtures', 'previews.json'),
-                    path.join(manifestDir, 'previews.json'),
+                    path.join(
+                        __dirname,
+                        "..",
+                        "..",
+                        "src",
+                        "test",
+                        "fixtures",
+                        "previews.json",
+                    ),
+                    path.join(manifestDir, "previews.json"),
+                );
+
+                const service = new GradleService(dir, api);
+                await service.discoverPreviews("samples/wear");
+
+                assert.strictEqual(api.runCalls.length, 1);
+                assert.strictEqual(
+                    api.runCalls[0].taskName,
+                    ":samples:wear:discoverPreviews",
+                );
+            }),
+        );
+
+        it(
+            "uses cache for repeated calls within TTL",
+            withTempDir(async (dir, api) => {
+                fs.mkdirSync(path.join(dir, "mod"));
+                const manifestDir = path.join(
+                    dir,
+                    "mod",
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(manifestDir, { recursive: true });
+                fs.copyFileSync(
+                    path.join(
+                        __dirname,
+                        "..",
+                        "..",
+                        "src",
+                        "test",
+                        "fixtures",
+                        "previews.json",
+                    ),
+                    path.join(manifestDir, "previews.json"),
+                );
+
+                const service = new GradleService(dir, api);
+                await service.discoverPreviews("mod");
+                await service.discoverPreviews("mod");
+
+                // Second call hit cache — only one Gradle invocation
+                assert.strictEqual(api.runCalls.length, 1);
+            }),
+        );
+
+        it(
+            "compileOnly invokes :module:composePreviewCompile and drops the manifest cache",
+            withTempDir(async (dir, api) => {
+                fs.mkdirSync(path.join(dir, "mod"));
+                const manifestDir = path.join(
+                    dir,
+                    "mod",
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(manifestDir, { recursive: true });
+                fs.copyFileSync(
+                    path.join(
+                        __dirname,
+                        "..",
+                        "..",
+                        "src",
+                        "test",
+                        "fixtures",
+                        "previews.json",
+                    ),
+                    path.join(manifestDir, "previews.json"),
                 );
 
                 const service = new GradleService(dir, api);
                 // Prime the cache via a discoverPreviews invocation.
-                await service.discoverPreviews('mod');
+                await service.discoverPreviews("mod");
                 assert.strictEqual(api.runCalls.length, 1);
-                assert.strictEqual(api.runCalls[0].taskName, ':mod:discoverPreviews');
+                assert.strictEqual(
+                    api.runCalls[0].taskName,
+                    ":mod:discoverPreviews",
+                );
 
                 // compileOnly runs a different task and invalidates the cache.
-                await service.compileOnly('mod');
+                await service.compileOnly("mod");
                 assert.strictEqual(api.runCalls.length, 2);
-                assert.strictEqual(api.runCalls[1].taskName, ':mod:composePreviewCompile');
+                assert.strictEqual(
+                    api.runCalls[1].taskName,
+                    ":mod:composePreviewCompile",
+                );
 
                 // Cache was dropped, so the next discoverPreviews calls Gradle again.
-                await service.discoverPreviews('mod');
+                await service.discoverPreviews("mod");
                 assert.strictEqual(api.runCalls.length, 3);
-                assert.strictEqual(api.runCalls[2].taskName, ':mod:discoverPreviews');
-            }));
+                assert.strictEqual(
+                    api.runCalls[2].taskName,
+                    ":mod:discoverPreviews",
+                );
+            }),
+        );
 
-        it('bypasses cache after invalidateCache', withTempDir(async (dir, api) => {
-            fs.mkdirSync(path.join(dir, 'mod'));
-            const manifestDir = path.join(dir, 'mod', 'build', 'compose-previews');
-            fs.mkdirSync(manifestDir, { recursive: true });
-            fs.copyFileSync(
-                path.join(__dirname, '..', '..', 'src', 'test', 'fixtures', 'previews.json'),
-                path.join(manifestDir, 'previews.json'),
-            );
+        it(
+            "bypasses cache after invalidateCache",
+            withTempDir(async (dir, api) => {
+                fs.mkdirSync(path.join(dir, "mod"));
+                const manifestDir = path.join(
+                    dir,
+                    "mod",
+                    "build",
+                    "compose-previews",
+                );
+                fs.mkdirSync(manifestDir, { recursive: true });
+                fs.copyFileSync(
+                    path.join(
+                        __dirname,
+                        "..",
+                        "..",
+                        "src",
+                        "test",
+                        "fixtures",
+                        "previews.json",
+                    ),
+                    path.join(manifestDir, "previews.json"),
+                );
 
-            const service = new GradleService(dir, api);
-            await service.discoverPreviews('mod');
-            service.invalidateCache('mod');
-            await service.discoverPreviews('mod');
+                const service = new GradleService(dir, api);
+                await service.discoverPreviews("mod");
+                service.invalidateCache("mod");
+                await service.discoverPreviews("mod");
 
-            assert.strictEqual(api.runCalls.length, 2);
-        }));
+                assert.strictEqual(api.runCalls.length, 2);
+            }),
+        );
 
-        it('wraps Gradle failures in readable error', withTempDir(async (dir, api) => {
-            api.nextRunResult = new Error('compilation failed');
+        it(
+            "wraps Gradle failures in readable error",
+            withTempDir(async (dir, api) => {
+                api.nextRunResult = new Error("compilation failed");
 
-            const service = new GradleService(dir, api);
-            await assert.rejects(
-                service.discoverPreviews('mod'),
-                /Gradle task .* failed/,
-            );
-        }));
+                const service = new GradleService(dir, api);
+                await assert.rejects(
+                    service.discoverPreviews("mod"),
+                    /Gradle task .* failed/,
+                );
+            }),
+        );
 
-        it('throws TaskCancelledError (not generic failure) when vscode-gradle reports a cancelled task',
+        it(
+            "throws TaskCancelledError (not generic failure) when vscode-gradle reports a cancelled task",
             withTempDir(async (dir, api) => {
                 // vscode-gradle's gRPC layer rejects superseded tasks with
                 // a Status.CANCELLED error. That's a normal lifecycle event
                 // (a follow-up refresh replaced this one), not a build
                 // failure — callers need to be able to drop it silently.
-                api.nextRunResult = new Error('1 CANCELLED: Call cancelled');
+                api.nextRunResult = new Error("1 CANCELLED: Call cancelled");
 
                 const service = new GradleService(dir, api);
                 await assert.rejects(
-                    service.discoverPreviews('mod'),
+                    service.discoverPreviews("mod"),
                     (err: unknown) => {
-                        assert.ok(err instanceof TaskCancelledError, 'expected TaskCancelledError');
+                        assert.ok(
+                            err instanceof TaskCancelledError,
+                            "expected TaskCancelledError",
+                        );
                         return true;
                     },
                 );
-            }));
+            }),
+        );
 
-        it('throws JdkImageError when the failure output contains the jlink signature',
+        it(
+            "throws JdkImageError when the failure output contains the jlink signature",
             withTempDir(async (dir, api) => {
                 api.nextRunOutput =
-                    '> jlink executable /home/u/.antigravity/extensions/redhat.java-1.54.0-linux-x64'
-                    + '/jre/21.0.10-linux-x86_64/bin/jlink does not exist.\n';
-                api.nextRunResult = new Error('build failed');
+                    "> jlink executable /home/u/.antigravity/extensions/redhat.java-1.54.0-linux-x64" +
+                    "/jre/21.0.10-linux-x86_64/bin/jlink does not exist.\n";
+                api.nextRunResult = new Error("build failed");
 
                 const service = new GradleService(dir, api);
                 await assert.rejects(
-                    service.discoverPreviews('mod'),
+                    service.discoverPreviews("mod"),
                     (err: unknown) => {
-                        assert.ok(err instanceof JdkImageError, 'expected JdkImageError');
-                        assert.match((err as JdkImageError).finding.jlinkPath, /\/bin\/jlink$/);
+                        assert.ok(
+                            err instanceof JdkImageError,
+                            "expected JdkImageError",
+                        );
+                        assert.match(
+                            (err as JdkImageError).finding.jlinkPath,
+                            /\/bin\/jlink$/,
+                        );
                         return true;
                     },
                 );
-            }));
+            }),
+        );
     });
 
-    describe('cancel', () => {
-        it('cancels in-flight tasks via API', withTempDir(async (dir, api) => {
-            const service = new GradleService(dir, api);
-            // Start a task but don't await — simulate running
-            service.discoverPreviews('mod').catch(() => {}); // swallow error
-            await new Promise(resolve => setTimeout(resolve, 10));
+    describe("cancel", () => {
+        it(
+            "cancels in-flight tasks via API",
+            withTempDir(async (dir, api) => {
+                const service = new GradleService(dir, api);
+                // Start a task but don't await — simulate running
+                service.discoverPreviews("mod").catch(() => {}); // swallow error
+                await new Promise((resolve) => setTimeout(resolve, 10));
 
-            await service.cancel();
-            assert.strictEqual(api.cancelCalls.length >= 0, true); // at least attempted
-        }));
+                await service.cancel();
+                assert.strictEqual(api.cancelCalls.length >= 0, true); // at least attempted
+            }),
+        );
     });
 });

--- a/vscode-extension/src/test/historyReader.test.ts
+++ b/vscode-extension/src/test/historyReader.test.ts
@@ -1,8 +1,8 @@
-import * as assert from 'assert';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
-import { HistoryReader } from '../daemon/historyReader';
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { HistoryReader } from "../daemon/historyReader";
 
 interface SidecarFields {
     id: string;
@@ -24,22 +24,28 @@ function withFixture<T>(
     fn: (historyDir: string) => T | Promise<T>,
 ): () => Promise<T> {
     return async () => {
-        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'history-reader-'));
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), "history-reader-"));
         try {
             const indexLines: string[] = [];
             for (const sidecar of sidecars) {
-                const folder = sidecar.previewId.replace(/[^a-zA-Z0-9._-]/g, '_');
+                const folder = sidecar.previewId.replace(
+                    /[^a-zA-Z0-9._-]/g,
+                    "_",
+                );
                 const dir = path.join(root, folder);
                 fs.mkdirSync(dir, { recursive: true });
                 const pngName = sidecar.pngPath ?? `${sidecar.id}.png`;
-                fs.writeFileSync(path.join(dir, pngName), 'png-bytes');
+                fs.writeFileSync(path.join(dir, pngName), "png-bytes");
                 fs.writeFileSync(
                     path.join(dir, `${sidecar.id}.json`),
                     JSON.stringify({ ...sidecar, pngPath: pngName }),
                 );
                 indexLines.push(JSON.stringify(sidecar));
             }
-            fs.writeFileSync(path.join(root, 'index.jsonl'), indexLines.join('\n') + '\n');
+            fs.writeFileSync(
+                path.join(root, "index.jsonl"),
+                indexLines.join("\n") + "\n",
+            );
             return await fn(root);
         } finally {
             fs.rmSync(root, { recursive: true });
@@ -47,34 +53,43 @@ function withFixture<T>(
     };
 }
 
-describe('HistoryReader', () => {
+describe("HistoryReader", () => {
     const sidecars: SidecarFields[] = [
         {
-            id: '20260430-101234-aaaaaaaa', previewId: 'com.example.A', timestamp: '2026-04-30T10:12:34Z',
-            pngHash: 'aaa', trigger: 'fileChanged',
-            source: { kind: 'fs', id: 'fs:/h' },
-            git: { branch: 'main', commit: '6af6b8c1' },
-            worktree: { path: '/work', agentId: null },
+            id: "20260430-101234-aaaaaaaa",
+            previewId: "com.example.A",
+            timestamp: "2026-04-30T10:12:34Z",
+            pngHash: "aaa",
+            trigger: "fileChanged",
+            source: { kind: "fs", id: "fs:/h" },
+            git: { branch: "main", commit: "6af6b8c1" },
+            worktree: { path: "/work", agentId: null },
         },
         {
-            id: '20260430-110000-bbbbbbbb', previewId: 'com.example.A', timestamp: '2026-04-30T11:00:00Z',
-            pngHash: 'aaa', trigger: 'fileChanged',
-            source: { kind: 'fs', id: 'fs:/h' },
-            git: { branch: 'main', commit: '6af6b8c1' },
-            worktree: { path: '/work' },
+            id: "20260430-110000-bbbbbbbb",
+            previewId: "com.example.A",
+            timestamp: "2026-04-30T11:00:00Z",
+            pngHash: "aaa",
+            trigger: "fileChanged",
+            source: { kind: "fs", id: "fs:/h" },
+            git: { branch: "main", commit: "6af6b8c1" },
+            worktree: { path: "/work" },
             deltaFromPrevious: { pngHashChanged: false },
         },
         {
-            id: '20260430-120000-cccccccc', previewId: 'com.example.B', timestamp: '2026-04-30T12:00:00Z',
-            pngHash: 'ccc', trigger: 'renderNow',
-            source: { kind: 'git', id: 'git:preview/agent/foo' },
-            git: { branch: 'agent/foo', commit: 'deadbeef' },
-            worktree: { path: '/work', agentId: 'claude-code' },
+            id: "20260430-120000-cccccccc",
+            previewId: "com.example.B",
+            timestamp: "2026-04-30T12:00:00Z",
+            pngHash: "ccc",
+            trigger: "renderNow",
+            source: { kind: "git", id: "git:preview/agent/foo" },
+            git: { branch: "agent/foo", commit: "deadbeef" },
+            worktree: { path: "/work", agentId: "claude-code" },
         },
     ];
 
-    it('exists() reports false when index.jsonl is missing', () => {
-        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'history-empty-'));
+    it("exists() reports false when index.jsonl is missing", () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "history-empty-"));
         try {
             const reader = new HistoryReader(dir);
             assert.strictEqual(reader.exists(), false);
@@ -83,167 +98,272 @@ describe('HistoryReader', () => {
         }
     });
 
-    it('lists entries newest-first', withFixture(sidecars, (dir) => {
-        const reader = new HistoryReader(dir);
-        assert.strictEqual(reader.exists(), true);
-        const result = reader.list();
-        assert.strictEqual(result.totalCount, 3);
-        const ids = result.entries.map(e => (e as { id: string }).id);
-        assert.deepStrictEqual(ids, [
-            '20260430-120000-cccccccc',
-            '20260430-110000-bbbbbbbb',
-            '20260430-101234-aaaaaaaa',
-        ]);
-    }));
+    it(
+        "lists entries newest-first",
+        withFixture(sidecars, (dir) => {
+            const reader = new HistoryReader(dir);
+            assert.strictEqual(reader.exists(), true);
+            const result = reader.list();
+            assert.strictEqual(result.totalCount, 3);
+            const ids = result.entries.map((e) => (e as { id: string }).id);
+            assert.deepStrictEqual(ids, [
+                "20260430-120000-cccccccc",
+                "20260430-110000-bbbbbbbb",
+                "20260430-101234-aaaaaaaa",
+            ]);
+        }),
+    );
 
-    it('filters by previewId', withFixture(sidecars, (dir) => {
-        const r = new HistoryReader(dir).list({ previewId: 'com.example.A' });
-        assert.strictEqual(r.totalCount, 2);
-        for (const e of r.entries) {
-            assert.strictEqual((e as { previewId: string }).previewId, 'com.example.A');
-        }
-    }));
+    it(
+        "filters by previewId",
+        withFixture(sidecars, (dir) => {
+            const r = new HistoryReader(dir).list({
+                previewId: "com.example.A",
+            });
+            assert.strictEqual(r.totalCount, 2);
+            for (const e of r.entries) {
+                assert.strictEqual(
+                    (e as { previewId: string }).previewId,
+                    "com.example.A",
+                );
+            }
+        }),
+    );
 
-    it('filters by branch', withFixture(sidecars, (dir) => {
-        const r = new HistoryReader(dir).list({ branch: 'agent/foo' });
-        assert.strictEqual(r.totalCount, 1);
-        assert.strictEqual((r.entries[0] as { id: string }).id, '20260430-120000-cccccccc');
-    }));
+    it(
+        "filters by branch",
+        withFixture(sidecars, (dir) => {
+            const r = new HistoryReader(dir).list({ branch: "agent/foo" });
+            assert.strictEqual(r.totalCount, 1);
+            assert.strictEqual(
+                (r.entries[0] as { id: string }).id,
+                "20260430-120000-cccccccc",
+            );
+        }),
+    );
 
-    it('filters by branchPattern regex', withFixture(sidecars, (dir) => {
-        const r = new HistoryReader(dir).list({ branchPattern: '^agent/' });
-        assert.strictEqual(r.totalCount, 1);
-    }));
+    it(
+        "filters by branchPattern regex",
+        withFixture(sidecars, (dir) => {
+            const r = new HistoryReader(dir).list({ branchPattern: "^agent/" });
+            assert.strictEqual(r.totalCount, 1);
+        }),
+    );
 
-    it('treats invalid branchPattern regex as no-match (does not throw)', withFixture(sidecars, (dir) => {
-        const r = new HistoryReader(dir).list({ branchPattern: '[invalid' });
-        assert.strictEqual(r.totalCount, 0);
-    }));
+    it(
+        "treats invalid branchPattern regex as no-match (does not throw)",
+        withFixture(sidecars, (dir) => {
+            const r = new HistoryReader(dir).list({
+                branchPattern: "[invalid",
+            });
+            assert.strictEqual(r.totalCount, 0);
+        }),
+    );
 
-    it('filters by sourceKind = fs', withFixture(sidecars, (dir) => {
-        const r = new HistoryReader(dir).list({ sourceKind: 'fs' });
-        assert.strictEqual(r.totalCount, 2);
-    }));
+    it(
+        "filters by sourceKind = fs",
+        withFixture(sidecars, (dir) => {
+            const r = new HistoryReader(dir).list({ sourceKind: "fs" });
+            assert.strictEqual(r.totalCount, 2);
+        }),
+    );
 
-    it('filters by agentId', withFixture(sidecars, (dir) => {
-        const r = new HistoryReader(dir).list({ agentId: 'claude-code' });
-        assert.strictEqual(r.totalCount, 1);
-    }));
+    it(
+        "filters by agentId",
+        withFixture(sidecars, (dir) => {
+            const r = new HistoryReader(dir).list({ agentId: "claude-code" });
+            assert.strictEqual(r.totalCount, 1);
+        }),
+    );
 
-    it('filters by since lower-bound', withFixture(sidecars, (dir) => {
-        const r = new HistoryReader(dir).list({ since: '2026-04-30T11:00:00Z' });
-        assert.strictEqual(r.totalCount, 2);
-    }));
+    it(
+        "filters by since lower-bound",
+        withFixture(sidecars, (dir) => {
+            const r = new HistoryReader(dir).list({
+                since: "2026-04-30T11:00:00Z",
+            });
+            assert.strictEqual(r.totalCount, 2);
+        }),
+    );
 
-    it('filters by until upper-bound', withFixture(sidecars, (dir) => {
-        const r = new HistoryReader(dir).list({ until: '2026-04-30T11:00:00Z' });
-        assert.strictEqual(r.totalCount, 2);
-    }));
+    it(
+        "filters by until upper-bound",
+        withFixture(sidecars, (dir) => {
+            const r = new HistoryReader(dir).list({
+                until: "2026-04-30T11:00:00Z",
+            });
+            assert.strictEqual(r.totalCount, 2);
+        }),
+    );
 
-    it('honours commit prefix matching', withFixture(sidecars, (dir) => {
-        const r = new HistoryReader(dir).list({ commit: '6af6b8c' });
-        assert.strictEqual(r.totalCount, 2);
-    }));
+    it(
+        "honours commit prefix matching",
+        withFixture(sidecars, (dir) => {
+            const r = new HistoryReader(dir).list({ commit: "6af6b8c" });
+            assert.strictEqual(r.totalCount, 2);
+        }),
+    );
 
-    it('paginates via opaque cursor', withFixture(sidecars, (dir) => {
-        const reader = new HistoryReader(dir);
-        const first = reader.list({ limit: 2 });
-        assert.strictEqual(first.entries.length, 2);
-        assert.ok(first.nextCursor);
-        const second = reader.list({ limit: 2, cursor: first.nextCursor });
-        assert.strictEqual(second.entries.length, 1);
-        assert.strictEqual(second.nextCursor, undefined);
-    }));
+    it(
+        "paginates via opaque cursor",
+        withFixture(sidecars, (dir) => {
+            const reader = new HistoryReader(dir);
+            const first = reader.list({ limit: 2 });
+            assert.strictEqual(first.entries.length, 2);
+            assert.ok(first.nextCursor);
+            const second = reader.list({ limit: 2, cursor: first.nextCursor });
+            assert.strictEqual(second.entries.length, 1);
+            assert.strictEqual(second.nextCursor, undefined);
+        }),
+    );
 
-    it('clamps limit to MAX', withFixture(sidecars, (dir) => {
-        const r = new HistoryReader(dir).list({ limit: 5_000_000 });
-        assert.strictEqual(r.entries.length, 3); // bounded by content, not limit
-    }));
+    it(
+        "clamps limit to MAX",
+        withFixture(sidecars, (dir) => {
+            const r = new HistoryReader(dir).list({ limit: 5_000_000 });
+            assert.strictEqual(r.entries.length, 3); // bounded by content, not limit
+        }),
+    );
 
-    it('skips torn lines in index.jsonl per HISTORY.md § Concurrency', () => {
-        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'history-torn-'));
+    it("skips torn lines in index.jsonl per HISTORY.md § Concurrency", () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "history-torn-"));
         try {
             // Write a valid preview folder + sidecar so the reader can
             // resolve at least one entry.
-            const folder = path.join(dir, 'X');
+            const folder = path.join(dir, "X");
             fs.mkdirSync(folder);
-            fs.writeFileSync(path.join(folder, 'a.json'), JSON.stringify({
-                id: 'a', previewId: 'X', timestamp: 't', pngHash: 'h', pngPath: 'a.png',
-            }));
-            fs.writeFileSync(path.join(folder, 'a.png'), 'p');
+            fs.writeFileSync(
+                path.join(folder, "a.json"),
+                JSON.stringify({
+                    id: "a",
+                    previewId: "X",
+                    timestamp: "t",
+                    pngHash: "h",
+                    pngPath: "a.png",
+                }),
+            );
+            fs.writeFileSync(path.join(folder, "a.png"), "p");
             // Index has the good entry plus a half-line.
-            fs.writeFileSync(path.join(dir, 'index.jsonl'),
+            fs.writeFileSync(
+                path.join(dir, "index.jsonl"),
                 '{"id":"a","previewId":"X","timestamp":"t","pngHash":"h"}\n' +
-                '{"id":"b","previewId":"X","timestamp":"t","pngHash":\n');
+                    '{"id":"b","previewId":"X","timestamp":"t","pngHash":\n',
+            );
             const reader = new HistoryReader(dir);
             const r = reader.list();
             assert.strictEqual(r.totalCount, 1);
-            assert.strictEqual((r.entries[0] as { id: string }).id, 'a');
+            assert.strictEqual((r.entries[0] as { id: string }).id, "a");
         } finally {
             fs.rmSync(dir, { recursive: true });
         }
     });
 
-    it('reads an entry with pngPath resolved against the sidecar dir', withFixture(sidecars, (dir) => {
-        const reader = new HistoryReader(dir);
-        const result = reader.read('20260430-101234-aaaaaaaa');
-        assert.notStrictEqual(result, null);
-        assert.ok(fs.existsSync(result!.pngPath));
-        assert.strictEqual((result!.entry as { id: string }).id, '20260430-101234-aaaaaaaa');
-        assert.strictEqual(result!.pngBytes, undefined,
-            'inline=false (default) omits pngBytes');
-    }));
+    it(
+        "reads an entry with pngPath resolved against the sidecar dir",
+        withFixture(sidecars, (dir) => {
+            const reader = new HistoryReader(dir);
+            const result = reader.read("20260430-101234-aaaaaaaa");
+            assert.notStrictEqual(result, null);
+            assert.ok(fs.existsSync(result!.pngPath));
+            assert.strictEqual(
+                (result!.entry as { id: string }).id,
+                "20260430-101234-aaaaaaaa",
+            );
+            assert.strictEqual(
+                result!.pngBytes,
+                undefined,
+                "inline=false (default) omits pngBytes",
+            );
+        }),
+    );
 
-    it('inline=true returns base64 PNG bytes', withFixture(sidecars, (dir) => {
-        const reader = new HistoryReader(dir);
-        const result = reader.read('20260430-101234-aaaaaaaa', true);
-        assert.ok(result?.pngBytes);
-        assert.strictEqual(Buffer.from(result!.pngBytes!, 'base64').toString('utf-8'), 'png-bytes');
-    }));
+    it(
+        "inline=true returns base64 PNG bytes",
+        withFixture(sidecars, (dir) => {
+            const reader = new HistoryReader(dir);
+            const result = reader.read("20260430-101234-aaaaaaaa", true);
+            assert.ok(result?.pngBytes);
+            assert.strictEqual(
+                Buffer.from(result!.pngBytes!, "base64").toString("utf-8"),
+                "png-bytes",
+            );
+        }),
+    );
 
-    it('returns null for missing entry id', withFixture(sidecars, (dir) => {
-        const reader = new HistoryReader(dir);
-        assert.strictEqual(reader.read('does-not-exist'), null);
-    }));
+    it(
+        "returns null for missing entry id",
+        withFixture(sidecars, (dir) => {
+            const reader = new HistoryReader(dir);
+            assert.strictEqual(reader.read("does-not-exist"), null);
+        }),
+    );
 
-    it('diff metadata-mode reports byte-identical when pngHash matches', withFixture(sidecars, (dir) => {
-        const reader = new HistoryReader(dir);
-        const r = reader.diff('20260430-101234-aaaaaaaa', '20260430-110000-bbbbbbbb');
-        assert.notStrictEqual(r, null);
-        assert.strictEqual(r!.pngHashChanged, false);
-    }));
+    it(
+        "diff metadata-mode reports byte-identical when pngHash matches",
+        withFixture(sidecars, (dir) => {
+            const reader = new HistoryReader(dir);
+            const r = reader.diff(
+                "20260430-101234-aaaaaaaa",
+                "20260430-110000-bbbbbbbb",
+            );
+            assert.notStrictEqual(r, null);
+            assert.strictEqual(r!.pngHashChanged, false);
+        }),
+    );
 
-    it('diff metadata-mode reports change when pngHash differs', withFixture(sidecars, (dir) => {
-        // Same folder, different hashes — skip via cross-preview combo
-        // since the fixture's same-preview pair has identical hashes.
-        // We extend the fixture inline.
-        const folder = path.join(dir, 'com.example.A');
-        fs.writeFileSync(path.join(folder, 'changed.json'), JSON.stringify({
-            id: 'changed', previewId: 'com.example.A', timestamp: 't', pngHash: 'zzz',
-            pngPath: 'changed.png',
-        }));
-        fs.writeFileSync(path.join(folder, 'changed.png'), 'p');
-        const reader = new HistoryReader(dir);
-        const r = reader.diff('20260430-101234-aaaaaaaa', 'changed');
-        assert.notStrictEqual(r, null);
-        assert.strictEqual(r!.pngHashChanged, true);
-    }));
+    it(
+        "diff metadata-mode reports change when pngHash differs",
+        withFixture(sidecars, (dir) => {
+            // Same folder, different hashes — skip via cross-preview combo
+            // since the fixture's same-preview pair has identical hashes.
+            // We extend the fixture inline.
+            const folder = path.join(dir, "com.example.A");
+            fs.writeFileSync(
+                path.join(folder, "changed.json"),
+                JSON.stringify({
+                    id: "changed",
+                    previewId: "com.example.A",
+                    timestamp: "t",
+                    pngHash: "zzz",
+                    pngPath: "changed.png",
+                }),
+            );
+            fs.writeFileSync(path.join(folder, "changed.png"), "p");
+            const reader = new HistoryReader(dir);
+            const r = reader.diff("20260430-101234-aaaaaaaa", "changed");
+            assert.notStrictEqual(r, null);
+            assert.strictEqual(r!.pngHashChanged, true);
+        }),
+    );
 
-    it('diff returns null for cross-preview entries (HistoryDiffMismatch on the wire)', withFixture(sidecars, (dir) => {
-        const reader = new HistoryReader(dir);
-        // A vs B → different previewId. The daemon would surface -32011;
-        // the FS reader returns null per its KDoc.
-        assert.strictEqual(
-            reader.diff('20260430-101234-aaaaaaaa', '20260430-120000-cccccccc'),
-            null,
-        );
-    }));
+    it(
+        "diff returns null for cross-preview entries (HistoryDiffMismatch on the wire)",
+        withFixture(sidecars, (dir) => {
+            const reader = new HistoryReader(dir);
+            // A vs B → different previewId. The daemon would surface -32011;
+            // the FS reader returns null per its KDoc.
+            assert.strictEqual(
+                reader.diff(
+                    "20260430-101234-aaaaaaaa",
+                    "20260430-120000-cccccccc",
+                ),
+                null,
+            );
+        }),
+    );
 
-    it('diff pixel-mode is daemon-only (FS reader returns null)', withFixture(sidecars, (dir) => {
-        const reader = new HistoryReader(dir);
-        assert.strictEqual(
-            reader.diff('20260430-101234-aaaaaaaa', '20260430-110000-bbbbbbbb', 'pixel'),
-            null,
-        );
-    }));
+    it(
+        "diff pixel-mode is daemon-only (FS reader returns null)",
+        withFixture(sidecars, (dir) => {
+            const reader = new HistoryReader(dir);
+            assert.strictEqual(
+                reader.diff(
+                    "20260430-101234-aaaaaaaa",
+                    "20260430-110000-bbbbbbbb",
+                    "pixel",
+                ),
+                null,
+            );
+        }),
+    );
 });

--- a/vscode-extension/src/test/jdkImageErrorDetector.test.ts
+++ b/vscode-extension/src/test/jdkImageErrorDetector.test.ts
@@ -1,22 +1,22 @@
-import * as assert from 'assert';
-import { JdkImageErrorDetector } from '../jdkImageErrorDetector';
+import * as assert from "assert";
+import { JdkImageErrorDetector } from "../jdkImageErrorDetector";
 
 const ANTIGRAVITY_FIXTURE = [
-    '[Incubating] Problems report is available at: file:///tmp/problems-report.html',
-    '',
-    'FAILURE: Build failed with an exception.',
-    '',
-    '* What went wrong:',
-    'Configuration cache state could not be cached: field `generatedModuleFile` of `com.android.build.gradle.tasks.JdkImageInput` bean [...]',
-    '> Could not resolve all files for configuration \':app:androidJdkImage\'.',
-    '   > Failed to transform core-for-system-modules.jar to match attributes {artifactType=_internal_android_jdk_image, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}.',
-    '      > Execution failed for JdkImageTransform: /home/yuri/Android/Sdk/platforms/android-36/core-for-system-modules.jar.',
-    '         > jlink executable /home/yuri/.antigravity/extensions/redhat.java-1.54.0-linux-x64/jre/21.0.10-linux-x86_64/bin/jlink does not exist.',
-    '',
-].join('\n');
+    "[Incubating] Problems report is available at: file:///tmp/problems-report.html",
+    "",
+    "FAILURE: Build failed with an exception.",
+    "",
+    "* What went wrong:",
+    "Configuration cache state could not be cached: field `generatedModuleFile` of `com.android.build.gradle.tasks.JdkImageInput` bean [...]",
+    "> Could not resolve all files for configuration ':app:androidJdkImage'.",
+    "   > Failed to transform core-for-system-modules.jar to match attributes {artifactType=_internal_android_jdk_image, org.gradle.libraryelements=jar, org.gradle.usage=java-runtime}.",
+    "      > Execution failed for JdkImageTransform: /home/yuri/Android/Sdk/platforms/android-36/core-for-system-modules.jar.",
+    "         > jlink executable /home/yuri/.antigravity/extensions/redhat.java-1.54.0-linux-x64/jre/21.0.10-linux-x86_64/bin/jlink does not exist.",
+    "",
+].join("\n");
 
-describe('JdkImageErrorDetector', () => {
-    it('detects the jlink-missing signature from the Antigravity fixture', () => {
+describe("JdkImageErrorDetector", () => {
+    it("detects the jlink-missing signature from the Antigravity fixture", () => {
         const d = new JdkImageErrorDetector();
         d.consume(ANTIGRAVITY_FIXTURE);
         d.end();
@@ -24,82 +24,96 @@ describe('JdkImageErrorDetector', () => {
         assert.notStrictEqual(f, null);
         assert.strictEqual(
             f!.jlinkPath,
-            '/home/yuri/.antigravity/extensions/redhat.java-1.54.0-linux-x64/jre/21.0.10-linux-x86_64/bin/jlink',
+            "/home/yuri/.antigravity/extensions/redhat.java-1.54.0-linux-x64/jre/21.0.10-linux-x86_64/bin/jlink",
         );
-        assert.strictEqual(f!.reason, 'Red Hat Java extension bundled runtime (Antigravity)');
+        assert.strictEqual(
+            f!.reason,
+            "Red Hat Java extension bundled runtime (Antigravity)",
+        );
     });
 
-    it('detects the VS Code Red Hat Java bundled runtime', () => {
+    it("detects the VS Code Red Hat Java bundled runtime", () => {
         const d = new JdkImageErrorDetector();
         d.consume(
-            '> jlink executable /home/user/.vscode/extensions/redhat.java-1.54.0-linux-x64/jre/21.0.10/bin/jlink does not exist.\n',
+            "> jlink executable /home/user/.vscode/extensions/redhat.java-1.54.0-linux-x64/jre/21.0.10/bin/jlink does not exist.\n",
         );
         const f = d.getFinding();
-        assert.strictEqual(f!.reason, 'Red Hat Java extension bundled runtime (VS Code)');
+        assert.strictEqual(
+            f!.reason,
+            "Red Hat Java extension bundled runtime (VS Code)",
+        );
     });
 
     it('falls back to "bundled JRE" for generic /jre/ paths', () => {
         const d = new JdkImageErrorDetector();
-        d.consume('> jlink executable /opt/runtime/jre/bin/jlink does not exist.\n');
-        assert.strictEqual(d.getFinding()!.reason, 'bundled JRE (no JDK)');
+        d.consume(
+            "> jlink executable /opt/runtime/jre/bin/jlink does not exist.\n",
+        );
+        assert.strictEqual(d.getFinding()!.reason, "bundled JRE (no JDK)");
     });
 
-    it('returns empty reason for unrecognised paths', () => {
+    it("returns empty reason for unrecognised paths", () => {
         const d = new JdkImageErrorDetector();
-        d.consume('> jlink executable /custom/path/bin/jlink does not exist.\n');
+        d.consume(
+            "> jlink executable /custom/path/bin/jlink does not exist.\n",
+        );
         const f = d.getFinding()!;
-        assert.strictEqual(f.jlinkPath, '/custom/path/bin/jlink');
-        assert.strictEqual(f.reason, '');
+        assert.strictEqual(f.jlinkPath, "/custom/path/bin/jlink");
+        assert.strictEqual(f.reason, "");
     });
 
-    it('handles Windows-style paths', () => {
+    it("handles Windows-style paths", () => {
         const d = new JdkImageErrorDetector();
-        d.consume('> jlink executable C:\\Users\\x\\jre\\bin\\jlink.exe does not exist.\n');
+        d.consume(
+            "> jlink executable C:\\Users\\x\\jre\\bin\\jlink.exe does not exist.\n",
+        );
         const f = d.getFinding();
-        assert.strictEqual(f!.jlinkPath, 'C:\\Users\\x\\jre\\bin\\jlink.exe');
+        assert.strictEqual(f!.jlinkPath, "C:\\Users\\x\\jre\\bin\\jlink.exe");
         // `/jre/` normalisation kicks in after backslash->slash replacement.
-        assert.strictEqual(f!.reason, 'bundled JRE (no JDK)');
+        assert.strictEqual(f!.reason, "bundled JRE (no JDK)");
     });
 
-    it('survives chunks that split mid-line', () => {
+    it("survives chunks that split mid-line", () => {
         const d = new JdkImageErrorDetector();
-        d.consume('> jlink executable /opt/jre/bin/jlink');
+        d.consume("> jlink executable /opt/jre/bin/jlink");
         assert.strictEqual(d.getFinding(), null);
-        d.consume(' does not exist.\n');
+        d.consume(" does not exist.\n");
         assert.notStrictEqual(d.getFinding(), null);
     });
 
-    it('catches the line at end-of-stream without a trailing newline', () => {
+    it("catches the line at end-of-stream without a trailing newline", () => {
         const d = new JdkImageErrorDetector();
-        d.consume('> jlink executable /opt/jre/bin/jlink does not exist.');
+        d.consume("> jlink executable /opt/jre/bin/jlink does not exist.");
         assert.strictEqual(d.getFinding(), null);
         d.end();
         assert.notStrictEqual(d.getFinding(), null);
     });
 
-    it('returns null when the output is unrelated', () => {
+    it("returns null when the output is unrelated", () => {
         const d = new JdkImageErrorDetector();
-        d.consume('FAILURE: compilation failed\n> error: cannot find symbol\n');
+        d.consume("FAILURE: compilation failed\n> error: cannot find symbol\n");
         d.end();
         assert.strictEqual(d.getFinding(), null);
     });
 
-    it('returns null for the corroborating messages alone (no jlink line)', () => {
+    it("returns null for the corroborating messages alone (no jlink line)", () => {
         const d = new JdkImageErrorDetector();
-        d.consume([
-            '> Failed to transform core-for-system-modules.jar to match attributes {...}',
-            '> Execution failed for JdkImageTransform: /path/to/core.jar',
-            '',
-        ].join('\n'));
+        d.consume(
+            [
+                "> Failed to transform core-for-system-modules.jar to match attributes {...}",
+                "> Execution failed for JdkImageTransform: /path/to/core.jar",
+                "",
+            ].join("\n"),
+        );
         d.end();
         assert.strictEqual(d.getFinding(), null);
     });
 
-    it('is idempotent after the first match', () => {
+    it("is idempotent after the first match", () => {
         const d = new JdkImageErrorDetector();
-        d.consume('> jlink executable /a/jre/bin/jlink does not exist.\n');
+        d.consume("> jlink executable /a/jre/bin/jlink does not exist.\n");
         const first = d.getFinding();
-        d.consume('> jlink executable /b/jre/bin/jlink does not exist.\n');
+        d.consume("> jlink executable /b/jre/bin/jlink does not exist.\n");
         const second = d.getFinding();
         assert.strictEqual(second!.jlinkPath, first!.jlinkPath);
     });

--- a/vscode-extension/src/test/kotlinCompileErrorDetector.test.ts
+++ b/vscode-extension/src/test/kotlinCompileErrorDetector.test.ts
@@ -1,8 +1,8 @@
-import * as assert from 'assert';
+import * as assert from "assert";
 import {
     KotlinCompileError,
     KotlinCompileErrorDetector,
-} from '../kotlinCompileErrorDetector';
+} from "../kotlinCompileErrorDetector";
 
 /**
  * Fixture mirroring `compileDebugKotlin` output on a typo —
@@ -11,14 +11,14 @@ import {
  * so the detector has to actually anchor on `e:`.
  */
 const FIXTURE_SINGLE_ERROR = [
-    '> Task :samples:android:compileDebugKotlin',
-    'w: file:///home/user/proj/Other.kt:5:1 Variable \'x\' is never used',
-    'e: file:///home/user/proj/samples/android/src/main/kotlin/Previews.kt:42:5 Unresolved reference: Modfier',
-    '',
-    '> Task :samples:android:compileDebugKotlin FAILED',
-    '',
-    'FAILURE: Build failed with an exception.',
-].join('\n');
+    "> Task :samples:android:compileDebugKotlin",
+    "w: file:///home/user/proj/Other.kt:5:1 Variable 'x' is never used",
+    "e: file:///home/user/proj/samples/android/src/main/kotlin/Previews.kt:42:5 Unresolved reference: Modfier",
+    "",
+    "> Task :samples:android:compileDebugKotlin FAILED",
+    "",
+    "FAILURE: Build failed with an exception.",
+].join("\n");
 
 /**
  * Two errors across two files — the cross-file case the LSP-gate misses
@@ -26,70 +26,72 @@ const FIXTURE_SINGLE_ERROR = [
  * editor's file. Detector must produce both, each with its own path.
  */
 const FIXTURE_CROSS_FILE = [
-    '> Task :app:compileDebugKotlin',
-    'e: file:///proj/app/src/main/kotlin/Theme.kt:18:12 Type mismatch: inferred type is String but Int was expected',
-    'e: file:///proj/app/src/main/kotlin/Previews.kt:8:1 Expecting }',
-    '> Task :app:compileDebugKotlin FAILED',
-].join('\n');
+    "> Task :app:compileDebugKotlin",
+    "e: file:///proj/app/src/main/kotlin/Theme.kt:18:12 Type mismatch: inferred type is String but Int was expected",
+    "e: file:///proj/app/src/main/kotlin/Previews.kt:8:1 Expecting }",
+    "> Task :app:compileDebugKotlin FAILED",
+].join("\n");
 
 /** Kotlin 2.0+ form with an `: error:` segment between the position and message. */
 const FIXTURE_K2_FORMAT =
-    'e: file:///proj/Foo.kt:42:5: error: Unresolved reference: Modfier\n';
+    "e: file:///proj/Foo.kt:42:5: error: Unresolved reference: Modfier\n";
 
 /** Bare-path form (no file:// prefix) — seen on some Kotlin versions / shells. */
 const FIXTURE_BARE_PATH =
-    'e: /proj/Foo.kt:42:5 Unresolved reference: Modfier\n';
+    "e: /proj/Foo.kt:42:5 Unresolved reference: Modfier\n";
 
-describe('KotlinCompileErrorDetector', () => {
-    it('returns no errors for an empty stream', () => {
+describe("KotlinCompileErrorDetector", () => {
+    it("returns no errors for an empty stream", () => {
         const d = new KotlinCompileErrorDetector();
         d.end();
         assert.deepStrictEqual(d.getErrors(), []);
     });
 
-    it('extracts a single error from realistic compile output', () => {
+    it("extracts a single error from realistic compile output", () => {
         const d = new KotlinCompileErrorDetector();
         d.consume(FIXTURE_SINGLE_ERROR);
         d.end();
         const errors = d.getErrors();
-        assert.strictEqual(errors.length, 1, 'should capture one e: line');
-        assert.strictEqual(errors[0].file, 'Previews.kt');
+        assert.strictEqual(errors.length, 1, "should capture one e: line");
+        assert.strictEqual(errors[0].file, "Previews.kt");
         assert.strictEqual(
             errors[0].path,
-            '/home/user/proj/samples/android/src/main/kotlin/Previews.kt',
+            "/home/user/proj/samples/android/src/main/kotlin/Previews.kt",
         );
         assert.strictEqual(errors[0].line, 42);
         assert.strictEqual(errors[0].column, 5);
-        assert.strictEqual(errors[0].message, 'Unresolved reference: Modfier');
+        assert.strictEqual(errors[0].message, "Unresolved reference: Modfier");
     });
 
-    it('ignores w: warning lines', () => {
+    it("ignores w: warning lines", () => {
         const d = new KotlinCompileErrorDetector();
         d.consume(FIXTURE_SINGLE_ERROR);
         d.end();
         // The fixture has one warning + one error. Detector should
         // only surface the error — warnings flow through the log
         // channel but don't gate the build banner.
-        const messages = d.getErrors().map(e => e.message);
-        assert.ok(!messages.some(m => m.includes('never used')),
-            'warnings must not appear in error list');
+        const messages = d.getErrors().map((e) => e.message);
+        assert.ok(
+            !messages.some((m) => m.includes("never used")),
+            "warnings must not appear in error list",
+        );
     });
 
-    it('captures cross-file errors with distinct paths', () => {
+    it("captures cross-file errors with distinct paths", () => {
         const d = new KotlinCompileErrorDetector();
         d.consume(FIXTURE_CROSS_FILE);
         d.end();
         const errors = d.getErrors();
         assert.strictEqual(errors.length, 2);
-        const files = errors.map(e => e.file).sort();
-        assert.deepStrictEqual(files, ['Previews.kt', 'Theme.kt']);
+        const files = errors.map((e) => e.file).sort();
+        assert.deepStrictEqual(files, ["Previews.kt", "Theme.kt"]);
         // Each error must carry its own path so the click handler
         // routes to the right file.
-        const themePath = errors.find(e => e.file === 'Theme.kt')!.path;
-        const previewsPath = errors.find(e => e.file === 'Previews.kt')!.path;
+        const themePath = errors.find((e) => e.file === "Theme.kt")!.path;
+        const previewsPath = errors.find((e) => e.file === "Previews.kt")!.path;
         assert.notStrictEqual(themePath, previewsPath);
-        assert.ok(themePath.endsWith('Theme.kt'));
-        assert.ok(previewsPath.endsWith('Previews.kt'));
+        assert.ok(themePath.endsWith("Theme.kt"));
+        assert.ok(previewsPath.endsWith("Previews.kt"));
     });
 
     it('parses the Kotlin 2.0+ "error:" segment between position and message', () => {
@@ -98,108 +100,120 @@ describe('KotlinCompileErrorDetector', () => {
         d.end();
         const errors = d.getErrors();
         assert.strictEqual(errors.length, 1);
-        assert.strictEqual(errors[0].message, 'Unresolved reference: Modfier');
+        assert.strictEqual(errors[0].message, "Unresolved reference: Modfier");
         // The "error:" prefix should NOT leak into the message.
-        assert.ok(!errors[0].message.startsWith('error:'));
+        assert.ok(!errors[0].message.startsWith("error:"));
     });
 
-    it('parses bare-path form (no file:// prefix)', () => {
+    it("parses bare-path form (no file:// prefix)", () => {
         const d = new KotlinCompileErrorDetector();
         d.consume(FIXTURE_BARE_PATH);
         d.end();
         const errors = d.getErrors();
         assert.strictEqual(errors.length, 1);
-        assert.strictEqual(errors[0].path, '/proj/Foo.kt');
+        assert.strictEqual(errors[0].path, "/proj/Foo.kt");
         assert.strictEqual(errors[0].line, 42);
         assert.strictEqual(errors[0].column, 5);
     });
 
-    it('handles partial chunks split mid-line', () => {
+    it("handles partial chunks split mid-line", () => {
         const d = new KotlinCompileErrorDetector();
         // Split a single error across four reads to exercise buffering.
-        d.consume('e: file:///proj/Foo.kt:42:5 ');
-        d.consume('Unresolved');
-        d.consume(' reference: ');
-        d.consume('Modfier\n');
+        d.consume("e: file:///proj/Foo.kt:42:5 ");
+        d.consume("Unresolved");
+        d.consume(" reference: ");
+        d.consume("Modfier\n");
         d.end();
         const errors = d.getErrors();
         assert.strictEqual(errors.length, 1);
-        assert.strictEqual(errors[0].message, 'Unresolved reference: Modfier');
+        assert.strictEqual(errors[0].message, "Unresolved reference: Modfier");
     });
 
-    it('catches a final line that lacks a trailing newline', () => {
+    it("catches a final line that lacks a trailing newline", () => {
         const d = new KotlinCompileErrorDetector();
-        d.consume('e: file:///proj/Foo.kt:42:5 Unresolved reference: Modfier');
+        d.consume("e: file:///proj/Foo.kt:42:5 Unresolved reference: Modfier");
         // No newline before end() — flush must scan the residual buffer.
         d.end();
         const errors = d.getErrors();
         assert.strictEqual(errors.length, 1);
     });
 
-    it('strips CR from CRLF-terminated lines', () => {
+    it("strips CR from CRLF-terminated lines", () => {
         const d = new KotlinCompileErrorDetector();
-        d.consume('e: file:///proj/Foo.kt:42:5 Unresolved reference: Modfier\r\n');
+        d.consume(
+            "e: file:///proj/Foo.kt:42:5 Unresolved reference: Modfier\r\n",
+        );
         d.end();
         const errors = d.getErrors();
         assert.strictEqual(errors.length, 1);
         // Trailing CR must not leak into the message — would print as a
         // mojibake glyph in the banner.
-        assert.ok(!errors[0].message.endsWith('\r'));
+        assert.ok(!errors[0].message.endsWith("\r"));
     });
 
-    it('skips lines that have e: somewhere but not at the start', () => {
+    it("skips lines that have e: somewhere but not at the start", () => {
         // A literal "see e: line" elsewhere in stdout shouldn't be
         // mistaken for a kotlin error. The ^ anchor enforces this.
         const d = new KotlinCompileErrorDetector();
-        d.consume('see e: file:///proj/Foo.kt:42:5 nope\n');
+        d.consume("see e: file:///proj/Foo.kt:42:5 nope\n");
         d.end();
         assert.deepStrictEqual(d.getErrors(), []);
     });
 
-    it('caps captures at MAX_ERRORS so a runaway compile cannot grow the buffer', () => {
+    it("caps captures at MAX_ERRORS so a runaway compile cannot grow the buffer", () => {
         const d = new KotlinCompileErrorDetector();
         const lines = [];
         for (let i = 0; i < 200; i++) {
             lines.push(`e: file:///proj/Foo.kt:${i}:1 oops`);
         }
-        d.consume(lines.join('\n') + '\n');
+        d.consume(lines.join("\n") + "\n");
         d.end();
         const errors = d.getErrors();
-        assert.ok(errors.length <= 50,
-            `should cap at MAX_ERRORS, got ${errors.length}`);
+        assert.ok(
+            errors.length <= 50,
+            `should cap at MAX_ERRORS, got ${errors.length}`,
+        );
     });
 
-    it('extracts the basename from absolute Linux-style paths', () => {
+    it("extracts the basename from absolute Linux-style paths", () => {
         const d = new KotlinCompileErrorDetector();
-        d.consume('e: file:///long/abs/path/to/Previews.kt:1:1 oops\n');
+        d.consume("e: file:///long/abs/path/to/Previews.kt:1:1 oops\n");
         d.end();
-        assert.strictEqual(d.getErrors()[0].file, 'Previews.kt');
+        assert.strictEqual(d.getErrors()[0].file, "Previews.kt");
     });
 
-    it('extracts the basename from Windows-style paths in a file URL', () => {
+    it("extracts the basename from Windows-style paths in a file URL", () => {
         const d = new KotlinCompileErrorDetector();
-        d.consume('e: file:///C:/work/Previews.kt:1:1 oops\n');
+        d.consume("e: file:///C:/work/Previews.kt:1:1 oops\n");
         d.end();
-        assert.strictEqual(d.getErrors()[0].file, 'Previews.kt');
+        assert.strictEqual(d.getErrors()[0].file, "Previews.kt");
     });
 
-    it('extracts the basename from bare Windows paths', () => {
+    it("extracts the basename from bare Windows paths", () => {
         const d = new KotlinCompileErrorDetector();
-        d.consume('e: C:\\work\\Previews.kt:1:1 oops\n');
+        d.consume("e: C:\\work\\Previews.kt:1:1 oops\n");
         d.end();
-        assert.strictEqual(d.getErrors()[0].file, 'Previews.kt');
+        assert.strictEqual(d.getErrors()[0].file, "Previews.kt");
     });
 });
 
-describe('KotlinCompileError', () => {
-    it('carries the parsed errors plus the failing task', () => {
+describe("KotlinCompileError", () => {
+    it("carries the parsed errors plus the failing task", () => {
         const e = new KotlinCompileError(
-            [{ file: 'Foo.kt', path: '/p/Foo.kt', line: 1, column: 1, message: 'x' }],
-            ':app:compileDebugKotlin',
+            [
+                {
+                    file: "Foo.kt",
+                    path: "/p/Foo.kt",
+                    line: 1,
+                    column: 1,
+                    message: "x",
+                },
+            ],
+            ":app:compileDebugKotlin",
         );
         assert.strictEqual(e.errors.length, 1);
-        assert.strictEqual(e.task, ':app:compileDebugKotlin');
+        assert.strictEqual(e.task, ":app:compileDebugKotlin");
         assert.ok(e instanceof Error);
-        assert.strictEqual(e.name, 'KotlinCompileError');
+        assert.strictEqual(e.name, "KotlinCompileError");
     });
 });

--- a/vscode-extension/src/test/launchOnDevice.test.ts
+++ b/vscode-extension/src/test/launchOnDevice.test.ts
@@ -1,18 +1,22 @@
-import * as assert from 'assert';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 import {
     buildPreviewActivityAmStartArgs,
     collectAndroidApplicationModules,
     findAndroidSdkRoot,
     parseAndroidApplicationInfo,
     resolveAdbPath,
-} from '../launchOnDevice';
+} from "../launchOnDevice";
 
-function withTempDir(fn: (dir: string) => void | Promise<void>): () => Promise<void> {
+function withTempDir(
+    fn: (dir: string) => void | Promise<void>,
+): () => Promise<void> {
     return async () => {
-        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'compose-preview-launch-'));
+        const dir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "compose-preview-launch-"),
+        );
         try {
             await fn(dir);
         } finally {
@@ -21,8 +25,8 @@ function withTempDir(fn: (dir: string) => void | Promise<void>): () => Promise<v
     };
 }
 
-describe('parseAndroidApplicationInfo', () => {
-    it('extracts applicationId when literal id() is used', () => {
+describe("parseAndroidApplicationInfo", () => {
+    it("extracts applicationId when literal id() is used", () => {
         const content = `
             plugins {
                 id("com.android.application")
@@ -35,13 +39,12 @@ describe('parseAndroidApplicationInfo', () => {
                 }
             }
         `;
-        assert.deepStrictEqual(
-            parseAndroidApplicationInfo(content),
-            { applicationId: 'com.example.foo' },
-        );
+        assert.deepStrictEqual(parseAndroidApplicationInfo(content), {
+            applicationId: "com.example.foo",
+        });
     });
 
-    it('extracts applicationId when version-catalog alias is used', () => {
+    it("extracts applicationId when version-catalog alias is used", () => {
         const content = `
             plugins {
                 alias(libs.plugins.android.application)
@@ -50,13 +53,12 @@ describe('parseAndroidApplicationInfo', () => {
                 defaultConfig { applicationId = "com.example.bar" }
             }
         `;
-        assert.deepStrictEqual(
-            parseAndroidApplicationInfo(content),
-            { applicationId: 'com.example.bar' },
-        );
+        assert.deepStrictEqual(parseAndroidApplicationInfo(content), {
+            applicationId: "com.example.bar",
+        });
     });
 
-    it('returns null for an Android library', () => {
+    it("returns null for an Android library", () => {
         const content = `
             plugins {
                 id("com.android.library")
@@ -68,7 +70,7 @@ describe('parseAndroidApplicationInfo', () => {
         assert.strictEqual(parseAndroidApplicationInfo(content), null);
     });
 
-    it('returns null when applicationId is missing', () => {
+    it("returns null when applicationId is missing", () => {
         const content = `
             plugins { id("com.android.application") }
             android { defaultConfig { } }
@@ -76,7 +78,7 @@ describe('parseAndroidApplicationInfo', () => {
         assert.strictEqual(parseAndroidApplicationInfo(content), null);
     });
 
-    it('skips apply-false declarations (root build pattern)', () => {
+    it("skips apply-false declarations (root build pattern)", () => {
         const content = `
             plugins {
                 id("com.android.application") apply false
@@ -86,141 +88,203 @@ describe('parseAndroidApplicationInfo', () => {
         assert.strictEqual(parseAndroidApplicationInfo(content), null);
     });
 
-    it('handles single-quoted id()', () => {
+    it("handles single-quoted id()", () => {
         const content = `
             plugins { id 'com.android.application' }
             applicationId = "com.example.sq"
         `;
-        assert.deepStrictEqual(
-            parseAndroidApplicationInfo(content),
-            { applicationId: 'com.example.sq' },
-        );
+        assert.deepStrictEqual(parseAndroidApplicationInfo(content), {
+            applicationId: "com.example.sq",
+        });
     });
 });
 
-describe('resolveAdbPath', () => {
-    it('returns the bare name when no sdk root is given', () => {
-        assert.strictEqual(resolveAdbPath(null), 'adb');
+describe("resolveAdbPath", () => {
+    it("returns the bare name when no sdk root is given", () => {
+        assert.strictEqual(resolveAdbPath(null), "adb");
     });
 
-    it('joins platform-tools when sdk root is given', () => {
-        const sdk = path.join(os.tmpdir(), 'fake-sdk');
+    it("joins platform-tools when sdk root is given", () => {
+        const sdk = path.join(os.tmpdir(), "fake-sdk");
         const got = resolveAdbPath(sdk);
         const expected = path.join(
             sdk,
-            'platform-tools',
-            process.platform === 'win32' ? 'adb.exe' : 'adb',
+            "platform-tools",
+            process.platform === "win32" ? "adb.exe" : "adb",
         );
         assert.strictEqual(got, expected);
     });
 });
 
-describe('findAndroidSdkRoot', () => {
-    it('reads sdk.dir from local.properties', withTempDir((dir) => {
-        const fakeSdk = fs.mkdtempSync(path.join(os.tmpdir(), 'fake-sdk-'));
-        try {
-            fs.writeFileSync(path.join(dir, 'local.properties'), `sdk.dir=${fakeSdk}\n`);
-            const original = { home: process.env.ANDROID_HOME, root: process.env.ANDROID_SDK_ROOT };
-            delete process.env.ANDROID_HOME;
-            delete process.env.ANDROID_SDK_ROOT;
+describe("findAndroidSdkRoot", () => {
+    it(
+        "reads sdk.dir from local.properties",
+        withTempDir((dir) => {
+            const fakeSdk = fs.mkdtempSync(path.join(os.tmpdir(), "fake-sdk-"));
             try {
-                assert.strictEqual(findAndroidSdkRoot(dir), fakeSdk);
-            } finally {
-                if (original.home !== undefined) { process.env.ANDROID_HOME = original.home; }
-                if (original.root !== undefined) { process.env.ANDROID_SDK_ROOT = original.root; }
-            }
-        } finally {
-            fs.rmSync(fakeSdk, { recursive: true, force: true });
-        }
-    }));
-
-    it('prefers ANDROID_HOME over local.properties when both are set', withTempDir((dir) => {
-        const fakeEnvSdk = fs.mkdtempSync(path.join(os.tmpdir(), 'env-sdk-'));
-        const fakePropsSdk = fs.mkdtempSync(path.join(os.tmpdir(), 'props-sdk-'));
-        try {
-            fs.writeFileSync(path.join(dir, 'local.properties'), `sdk.dir=${fakePropsSdk}\n`);
-            const originalHome = process.env.ANDROID_HOME;
-            process.env.ANDROID_HOME = fakeEnvSdk;
-            try {
-                assert.strictEqual(findAndroidSdkRoot(dir), fakeEnvSdk);
-            } finally {
-                if (originalHome !== undefined) {
-                    process.env.ANDROID_HOME = originalHome;
-                } else {
-                    delete process.env.ANDROID_HOME;
+                fs.writeFileSync(
+                    path.join(dir, "local.properties"),
+                    `sdk.dir=${fakeSdk}\n`,
+                );
+                const original = {
+                    home: process.env.ANDROID_HOME,
+                    root: process.env.ANDROID_SDK_ROOT,
+                };
+                delete process.env.ANDROID_HOME;
+                delete process.env.ANDROID_SDK_ROOT;
+                try {
+                    assert.strictEqual(findAndroidSdkRoot(dir), fakeSdk);
+                } finally {
+                    if (original.home !== undefined) {
+                        process.env.ANDROID_HOME = original.home;
+                    }
+                    if (original.root !== undefined) {
+                        process.env.ANDROID_SDK_ROOT = original.root;
+                    }
                 }
+            } finally {
+                fs.rmSync(fakeSdk, { recursive: true, force: true });
             }
-        } finally {
-            fs.rmSync(fakeEnvSdk, { recursive: true, force: true });
-            fs.rmSync(fakePropsSdk, { recursive: true, force: true });
-        }
-    }));
+        }),
+    );
+
+    it(
+        "prefers ANDROID_HOME over local.properties when both are set",
+        withTempDir((dir) => {
+            const fakeEnvSdk = fs.mkdtempSync(
+                path.join(os.tmpdir(), "env-sdk-"),
+            );
+            const fakePropsSdk = fs.mkdtempSync(
+                path.join(os.tmpdir(), "props-sdk-"),
+            );
+            try {
+                fs.writeFileSync(
+                    path.join(dir, "local.properties"),
+                    `sdk.dir=${fakePropsSdk}\n`,
+                );
+                const originalHome = process.env.ANDROID_HOME;
+                process.env.ANDROID_HOME = fakeEnvSdk;
+                try {
+                    assert.strictEqual(findAndroidSdkRoot(dir), fakeEnvSdk);
+                } finally {
+                    if (originalHome !== undefined) {
+                        process.env.ANDROID_HOME = originalHome;
+                    } else {
+                        delete process.env.ANDROID_HOME;
+                    }
+                }
+            } finally {
+                fs.rmSync(fakeEnvSdk, { recursive: true, force: true });
+                fs.rmSync(fakePropsSdk, { recursive: true, force: true });
+            }
+        }),
+    );
 });
 
-describe('buildPreviewActivityAmStartArgs', () => {
-    it('targets PreviewActivity with the composable FQN', () => {
+describe("buildPreviewActivityAmStartArgs", () => {
+    it("targets PreviewActivity with the composable FQN", () => {
         const args = buildPreviewActivityAmStartArgs({
-            applicationId: 'com.example.app',
-            composableFqn: 'com.example.PreviewsKt.MyPreview',
+            applicationId: "com.example.app",
+            composableFqn: "com.example.PreviewsKt.MyPreview",
             parameterProviderClassName: null,
         });
         assert.deepStrictEqual(args, [
-            'shell', 'am', 'start',
-            '-n', 'com.example.app/androidx.compose.ui.tooling.PreviewActivity',
-            '--es', 'composable', 'com.example.PreviewsKt.MyPreview',
+            "shell",
+            "am",
+            "start",
+            "-n",
+            "com.example.app/androidx.compose.ui.tooling.PreviewActivity",
+            "--es",
+            "composable",
+            "com.example.PreviewsKt.MyPreview",
         ]);
     });
 
-    it('forwards parameterProviderClassName when present', () => {
+    it("forwards parameterProviderClassName when present", () => {
         const args = buildPreviewActivityAmStartArgs({
-            applicationId: 'com.example.app',
-            composableFqn: 'com.example.PreviewsKt.ParamPreview',
-            parameterProviderClassName: 'com.example.PreviewsKt$ToggleProvider',
+            applicationId: "com.example.app",
+            composableFqn: "com.example.PreviewsKt.ParamPreview",
+            parameterProviderClassName: "com.example.PreviewsKt$ToggleProvider",
         });
         assert.deepStrictEqual(args, [
-            'shell', 'am', 'start',
-            '-n', 'com.example.app/androidx.compose.ui.tooling.PreviewActivity',
-            '--es', 'composable', 'com.example.PreviewsKt.ParamPreview',
-            '--es', 'parameterProviderClassName', 'com.example.PreviewsKt$ToggleProvider',
+            "shell",
+            "am",
+            "start",
+            "-n",
+            "com.example.app/androidx.compose.ui.tooling.PreviewActivity",
+            "--es",
+            "composable",
+            "com.example.PreviewsKt.ParamPreview",
+            "--es",
+            "parameterProviderClassName",
+            "com.example.PreviewsKt$ToggleProvider",
         ]);
     });
 });
 
-describe('collectAndroidApplicationModules', () => {
-    it('keeps only modules with com.android.application + applicationId', withTempDir((dir) => {
-        const app = path.join(dir, 'samples', 'app');
-        const lib = path.join(dir, 'samples', 'lib');
-        const cmp = path.join(dir, 'samples', 'cmp');
-        for (const d of [app, lib, cmp]) { fs.mkdirSync(d, { recursive: true }); }
-        fs.writeFileSync(path.join(app, 'build.gradle.kts'), `
+describe("collectAndroidApplicationModules", () => {
+    it(
+        "keeps only modules with com.android.application + applicationId",
+        withTempDir((dir) => {
+            const app = path.join(dir, "samples", "app");
+            const lib = path.join(dir, "samples", "lib");
+            const cmp = path.join(dir, "samples", "cmp");
+            for (const d of [app, lib, cmp]) {
+                fs.mkdirSync(d, { recursive: true });
+            }
+            fs.writeFileSync(
+                path.join(app, "build.gradle.kts"),
+                `
             plugins { id("com.android.application") }
             android { defaultConfig { applicationId = "com.example.app" } }
-        `);
-        fs.writeFileSync(path.join(lib, 'build.gradle.kts'), `
+        `,
+            );
+            fs.writeFileSync(
+                path.join(lib, "build.gradle.kts"),
+                `
             plugins { id("com.android.library") }
-        `);
-        fs.writeFileSync(path.join(cmp, 'build.gradle.kts'), `
+        `,
+            );
+            fs.writeFileSync(
+                path.join(cmp, "build.gradle.kts"),
+                `
             plugins { kotlin("multiplatform") }
-        `);
+        `,
+            );
 
-        const got = collectAndroidApplicationModules(dir, [
-            'samples/app', 'samples/lib', 'samples/cmp',
-        ]);
-        assert.deepStrictEqual(got, [
-            { module: 'samples/app', applicationId: 'com.example.app' },
-        ]);
-    }));
+            const got = collectAndroidApplicationModules(dir, [
+                "samples/app",
+                "samples/lib",
+                "samples/cmp",
+            ]);
+            assert.deepStrictEqual(got, [
+                { module: "samples/app", applicationId: "com.example.app" },
+            ]);
+        }),
+    );
 
-    it('returns sorted output', withTempDir((dir) => {
-        for (const name of ['z-app', 'a-app']) {
-            const m = path.join(dir, name);
-            fs.mkdirSync(m, { recursive: true });
-            fs.writeFileSync(path.join(m, 'build.gradle.kts'), `
+    it(
+        "returns sorted output",
+        withTempDir((dir) => {
+            for (const name of ["z-app", "a-app"]) {
+                const m = path.join(dir, name);
+                fs.mkdirSync(m, { recursive: true });
+                fs.writeFileSync(
+                    path.join(m, "build.gradle.kts"),
+                    `
                 plugins { id("com.android.application") }
-                android { defaultConfig { applicationId = "com.example.${name.replace('-', '')}" } }
-            `);
-        }
-        const got = collectAndroidApplicationModules(dir, ['z-app', 'a-app']);
-        assert.deepStrictEqual(got.map(x => x.module), ['a-app', 'z-app']);
-    }));
+                android { defaultConfig { applicationId = "com.example.${name.replace("-", "")}" } }
+            `,
+                );
+            }
+            const got = collectAndroidApplicationModules(dir, [
+                "z-app",
+                "a-app",
+            ]);
+            assert.deepStrictEqual(
+                got.map((x) => x.module),
+                ["a-app", "z-app"],
+            );
+        }),
+    );
 });

--- a/vscode-extension/src/test/logFilter.test.ts
+++ b/vscode-extension/src/test/logFilter.test.ts
@@ -1,240 +1,270 @@
-import * as assert from 'assert';
-import { LogFilter, LogLevel, parseLogLevel } from '../logFilter';
+import * as assert from "assert";
+import { LogFilter, LogLevel, parseLogLevel } from "../logFilter";
 
 function withLevel(level: LogLevel): LogFilter {
     return new LogFilter(() => level);
 }
 
-describe('LogFilter', () => {
-    describe('parseLogLevel', () => {
-        it('returns the value when known', () => {
-            assert.strictEqual(parseLogLevel('quiet'), 'quiet');
-            assert.strictEqual(parseLogLevel('normal'), 'normal');
-            assert.strictEqual(parseLogLevel('verbose'), 'verbose');
+describe("LogFilter", () => {
+    describe("parseLogLevel", () => {
+        it("returns the value when known", () => {
+            assert.strictEqual(parseLogLevel("quiet"), "quiet");
+            assert.strictEqual(parseLogLevel("normal"), "normal");
+            assert.strictEqual(parseLogLevel("verbose"), "verbose");
         });
 
-        it('falls back to normal on unknown / undefined', () => {
-            assert.strictEqual(parseLogLevel(undefined), 'normal');
-            assert.strictEqual(parseLogLevel(null), 'normal');
-            assert.strictEqual(parseLogLevel(''), 'normal');
-            assert.strictEqual(parseLogLevel('debug'), 'normal');
+        it("falls back to normal on unknown / undefined", () => {
+            assert.strictEqual(parseLogLevel(undefined), "normal");
+            assert.strictEqual(parseLogLevel(null), "normal");
+            assert.strictEqual(parseLogLevel(""), "normal");
+            assert.strictEqual(parseLogLevel("debug"), "normal");
         });
     });
 
-    describe('filterGradleChunk at normal', () => {
-        it('drops UP-TO-DATE / NO-SOURCE / SKIPPED / FROM-CACHE task lines', () => {
-            const f = withLevel('normal');
+    describe("filterGradleChunk at normal", () => {
+        it("drops UP-TO-DATE / NO-SOURCE / SKIPPED / FROM-CACHE task lines", () => {
+            const f = withLevel("normal");
             const out = f.filterGradleChunk(
-                '> Task :samples:wear:preBuild UP-TO-DATE\n' +
-                '> Task :samples:wear:processDebugManifest UP-TO-DATE\n' +
-                '> Task :preview-annotations:processResources NO-SOURCE\n' +
-                '> Task :daemon:core:checkKotlinGradlePluginConfigurationErrors SKIPPED\n' +
-                '> Task :samples:wear:compileDebugKotlin FROM-CACHE\n',
+                "> Task :samples:wear:preBuild UP-TO-DATE\n" +
+                    "> Task :samples:wear:processDebugManifest UP-TO-DATE\n" +
+                    "> Task :preview-annotations:processResources NO-SOURCE\n" +
+                    "> Task :daemon:core:checkKotlinGradlePluginConfigurationErrors SKIPPED\n" +
+                    "> Task :samples:wear:compileDebugKotlin FROM-CACHE\n",
             );
-            assert.strictEqual(out, '');
+            assert.strictEqual(out, "");
         });
 
-        it('keeps non-noop task headers', () => {
-            const f = withLevel('normal');
+        it("keeps non-noop task headers", () => {
+            const f = withLevel("normal");
             const out = f.filterGradleChunk(
-                '> Task :samples:wear:compileDebugKotlin\n' +
-                '> Task :samples:wear:discoverPreviews\n',
+                "> Task :samples:wear:compileDebugKotlin\n" +
+                    "> Task :samples:wear:discoverPreviews\n",
             );
-            assert.strictEqual(out, '> Task :samples:wear:compileDebugKotlin\n> Task :samples:wear:discoverPreviews\n');
+            assert.strictEqual(
+                out,
+                "> Task :samples:wear:compileDebugKotlin\n> Task :samples:wear:discoverPreviews\n",
+            );
         });
 
-        it('drops configuration-cache and incubating bookkeeping', () => {
-            const f = withLevel('normal');
+        it("drops configuration-cache and incubating bookkeeping", () => {
+            const f = withLevel("normal");
             const out = f.filterGradleChunk(
-                'Reusing configuration cache.\n' +
-                'Configuration cache entry reused.\n' +
-                'Configuration cache entry stored.\n' +
-                'Calculating task graph as configuration cache cannot be reused because an input changed.\n' +
-                '[Incubating] Problems report is available at: file:///foo/problems-report.html\n',
+                "Reusing configuration cache.\n" +
+                    "Configuration cache entry reused.\n" +
+                    "Configuration cache entry stored.\n" +
+                    "Calculating task graph as configuration cache cannot be reused because an input changed.\n" +
+                    "[Incubating] Problems report is available at: file:///foo/problems-report.html\n",
             );
-            assert.strictEqual(out, '');
+            assert.strictEqual(out, "");
         });
 
-        it('drops the actionable-tasks footer', () => {
-            const f = withLevel('normal');
+        it("drops the actionable-tasks footer", () => {
+            const f = withLevel("normal");
             const out = f.filterGradleChunk(
-                '1 actionable task: 1 up-to-date\n' +
-                '9 actionable tasks: 2 executed, 7 up-to-date\n',
+                "1 actionable task: 1 up-to-date\n" +
+                    "9 actionable tasks: 2 executed, 7 up-to-date\n",
             );
-            assert.strictEqual(out, '');
+            assert.strictEqual(out, "");
         });
 
-        it('keeps BUILD SUCCESSFUL / BUILD FAILED lines', () => {
-            const f = withLevel('normal');
-            const out = f.filterGradleChunk('BUILD SUCCESSFUL in 16s\nBUILD FAILED in 1s\n');
-            assert.strictEqual(out, 'BUILD SUCCESSFUL in 16s\nBUILD FAILED in 1s\n');
-        });
-
-        it('drops the multi-line configure-project warning block', () => {
-            const f = withLevel('normal');
+        it("keeps BUILD SUCCESSFUL / BUILD FAILED lines", () => {
+            const f = withLevel("normal");
             const out = f.filterGradleChunk(
-                '> Configure project :gradle-plugin\n' +
-                'WARNING: Unsupported Kotlin plugin version.\n' +
-                'The `embedded-kotlin` and `kotlin-dsl` plugins rely on features...\n' +
-                'Using the `kotlin-dsl` plugin together with a different Kotlin version...\n' +
-                'See https://docs.gradle.org/9.4.1/userguide/kotlin_dsl.html#sec:kotlin\n' +
-                '\n' +
-                '> Task :gradle-plugin:checkKotlinGradlePluginConfigurationErrors SKIPPED\n',
+                "BUILD SUCCESSFUL in 16s\nBUILD FAILED in 1s\n",
             );
-            assert.strictEqual(out, '');
+            assert.strictEqual(
+                out,
+                "BUILD SUCCESSFUL in 16s\nBUILD FAILED in 1s\n",
+            );
         });
 
-        it('drops the experimental-screenshot-test configure block too', () => {
-            const f = withLevel('normal');
+        it("drops the multi-line configure-project warning block", () => {
+            const f = withLevel("normal");
             const out = f.filterGradleChunk(
-                '> Configure project :renderer-android\n' +
-                "WARNING: The option setting 'android.experimental.enableScreenshotTest=true' is experimental.\n" +
-                "The current default is 'false'.\n" +
-                '\n',
+                "> Configure project :gradle-plugin\n" +
+                    "WARNING: Unsupported Kotlin plugin version.\n" +
+                    "The `embedded-kotlin` and `kotlin-dsl` plugins rely on features...\n" +
+                    "Using the `kotlin-dsl` plugin together with a different Kotlin version...\n" +
+                    "See https://docs.gradle.org/9.4.1/userguide/kotlin_dsl.html#sec:kotlin\n" +
+                    "\n" +
+                    "> Task :gradle-plugin:checkKotlinGradlePluginConfigurationErrors SKIPPED\n",
             );
-            assert.strictEqual(out, '');
+            assert.strictEqual(out, "");
         });
 
-        it('keeps lines after the configure block ends', () => {
-            const f = withLevel('normal');
+        it("drops the experimental-screenshot-test configure block too", () => {
+            const f = withLevel("normal");
             const out = f.filterGradleChunk(
-                '> Configure project :gradle-plugin\n' +
-                'WARNING: Unsupported Kotlin plugin version.\n' +
-                '\n' +
-                'BUILD SUCCESSFUL in 1s\n',
+                "> Configure project :renderer-android\n" +
+                    "WARNING: The option setting 'android.experimental.enableScreenshotTest=true' is experimental.\n" +
+                    "The current default is 'false'.\n" +
+                    "\n",
             );
-            assert.strictEqual(out, 'BUILD SUCCESSFUL in 1s\n');
+            assert.strictEqual(out, "");
         });
 
-        it('keeps the discoverPreviews bullet list at normal', () => {
-            const f = withLevel('normal');
+        it("keeps lines after the configure block ends", () => {
+            const f = withLevel("normal");
+            const out = f.filterGradleChunk(
+                "> Configure project :gradle-plugin\n" +
+                    "WARNING: Unsupported Kotlin plugin version.\n" +
+                    "\n" +
+                    "BUILD SUCCESSFUL in 1s\n",
+            );
+            assert.strictEqual(out, "BUILD SUCCESSFUL in 1s\n");
+        });
+
+        it("keeps the discoverPreviews bullet list at normal", () => {
+            const f = withLevel("normal");
             const out = f.filterGradleChunk(
                 "Discovered 17 preview(s) in module 'wear':\n" +
-                '  com.example.samplewear.PreviewsKt.ButtonPreview  [id:wearos_large_round]\n',
+                    "  com.example.samplewear.PreviewsKt.ButtonPreview  [id:wearos_large_round]\n",
             );
             assert.strictEqual(
                 out,
                 "Discovered 17 preview(s) in module 'wear':\n" +
-                '  com.example.samplewear.PreviewsKt.ButtonPreview  [id:wearos_large_round]\n',
+                    "  com.example.samplewear.PreviewsKt.ButtonPreview  [id:wearos_large_round]\n",
             );
         });
 
         it('keeps FAILURE / "What went wrong" / "Try" sections', () => {
-            const f = withLevel('normal');
+            const f = withLevel("normal");
             const block =
-                'FAILURE: Build failed with an exception.\n' +
-                '\n' +
-                '* What went wrong:\n' +
+                "FAILURE: Build failed with an exception.\n" +
+                "\n" +
+                "* What went wrong:\n" +
                 "Cannot locate tasks that match ':samples:cmp:composePreviewDoctor'.\n" +
-                '\n' +
-                '* Try:\n' +
-                '> Run gradle tasks to get a list of available tasks.\n';
+                "\n" +
+                "* Try:\n" +
+                "> Run gradle tasks to get a list of available tasks.\n";
             assert.strictEqual(f.filterGradleChunk(block), block);
         });
     });
 
-    describe('filterGradleChunk at quiet', () => {
-        it('drops everything except errors and BUILD outcomes', () => {
-            const f = withLevel('quiet');
+    describe("filterGradleChunk at quiet", () => {
+        it("drops everything except errors and BUILD outcomes", () => {
+            const f = withLevel("quiet");
             const out = f.filterGradleChunk(
-                '> Task :samples:wear:compileDebugKotlin\n' +
-                '> Task :samples:wear:preBuild UP-TO-DATE\n' +
-                'BUILD SUCCESSFUL in 16s\n',
+                "> Task :samples:wear:compileDebugKotlin\n" +
+                    "> Task :samples:wear:preBuild UP-TO-DATE\n" +
+                    "BUILD SUCCESSFUL in 16s\n",
             );
-            assert.strictEqual(out, 'BUILD SUCCESSFUL in 16s\n');
+            assert.strictEqual(out, "BUILD SUCCESSFUL in 16s\n");
         });
 
-        it('keeps FAILED, FAILURE, and stack frames', () => {
-            const f = withLevel('quiet');
+        it("keeps FAILED, FAILURE, and stack frames", () => {
+            const f = withLevel("quiet");
             const block =
-                '> Task :samples:wear:compileDebugKotlin FAILED\n' +
-                'FAILURE: Build failed with an exception.\n' +
-                'Caused by: java.lang.RuntimeException: boom\n' +
-                '\tat java.base/java.io.FileInputStream.open0(Native Method)\n';
+                "> Task :samples:wear:compileDebugKotlin FAILED\n" +
+                "FAILURE: Build failed with an exception.\n" +
+                "Caused by: java.lang.RuntimeException: boom\n" +
+                "\tat java.base/java.io.FileInputStream.open0(Native Method)\n";
             assert.strictEqual(f.filterGradleChunk(block), block);
         });
 
-        it('keeps kotlinc e: / w: lines', () => {
-            const f = withLevel('quiet');
+        it("keeps kotlinc e: / w: lines", () => {
+            const f = withLevel("quiet");
             const out = f.filterGradleChunk(
-                'e: Incremental compilation failed: foo.bin (No such file)\n' +
-                'w: Some warning\n',
+                "e: Incremental compilation failed: foo.bin (No such file)\n" +
+                    "w: Some warning\n",
             );
             assert.strictEqual(
                 out,
-                'e: Incremental compilation failed: foo.bin (No such file)\nw: Some warning\n',
+                "e: Incremental compilation failed: foo.bin (No such file)\nw: Some warning\n",
             );
         });
     });
 
-    describe('filterGradleChunk at verbose', () => {
-        it('passes everything through unchanged', () => {
-            const f = withLevel('verbose');
+    describe("filterGradleChunk at verbose", () => {
+        it("passes everything through unchanged", () => {
+            const f = withLevel("verbose");
             const block =
-                '> Task :samples:wear:preBuild UP-TO-DATE\n' +
-                'Reusing configuration cache.\n' +
-                '> Configure project :gradle-plugin\n' +
-                'WARNING: Unsupported Kotlin plugin version.\n' +
-                'BUILD SUCCESSFUL in 16s\n';
+                "> Task :samples:wear:preBuild UP-TO-DATE\n" +
+                "Reusing configuration cache.\n" +
+                "> Configure project :gradle-plugin\n" +
+                "WARNING: Unsupported Kotlin plugin version.\n" +
+                "BUILD SUCCESSFUL in 16s\n";
             assert.strictEqual(f.filterGradleChunk(block), block);
         });
     });
 
-    describe('filterDaemonStderrLine at normal', () => {
-        it('drops the boot banner', () => {
-            const f = withLevel('normal');
-            assert.strictEqual(f.filterDaemonStderrLine('compose-ai-tools daemon: hello (args=[])'), null);
+    describe("filterDaemonStderrLine at normal", () => {
+        it("drops the boot banner", () => {
+            const f = withLevel("normal");
             assert.strictEqual(
-                f.filterDaemonStderrLine('compose-ai-tools daemon: UserClassLoaderHolder active (urls=7, dirs=[/foo])'),
+                f.filterDaemonStderrLine(
+                    "compose-ai-tools daemon: hello (args=[])",
+                ),
                 null,
             );
             assert.strictEqual(
-                f.filterDaemonStderrLine('compose-ai-tools daemon: PreviewIndex loaded (path=/foo, previewCount=17)'),
+                f.filterDaemonStderrLine(
+                    "compose-ai-tools daemon: UserClassLoaderHolder active (urls=7, dirs=[/foo])",
+                ),
                 null,
             );
             assert.strictEqual(
-                f.filterDaemonStderrLine('compose-ai-tools daemon: HistoryManager active (dir=/foo)'),
-                null,
-            );
-        });
-
-        it('drops startup-timing markers', () => {
-            const f = withLevel('normal');
-            assert.strictEqual(
-                f.filterDaemonStderrLine('compose-ai-daemon: [+271ms] JsonRpcServer.run() entered'),
+                f.filterDaemonStderrLine(
+                    "compose-ai-tools daemon: PreviewIndex loaded (path=/foo, previewCount=17)",
+                ),
                 null,
             );
             assert.strictEqual(
-                f.filterDaemonStderrLine('compose-ai-daemon: startup timeline:'),
-                null,
-            );
-            assert.strictEqual(
-                f.filterDaemonStderrLine('  [  271ms]   +271ms  JsonRpcServer.run() entered  (main)'),
+                f.filterDaemonStderrLine(
+                    "compose-ai-tools daemon: HistoryManager active (dir=/foo)",
+                ),
                 null,
             );
         });
 
-        it('keeps fatal/dispatch errors and arbitrary daemon output', () => {
-            const f = withLevel('normal');
+        it("drops startup-timing markers", () => {
+            const f = withLevel("normal");
             assert.strictEqual(
-                f.filterDaemonStderrLine('compose-ai-daemon: fatal in JsonRpcServer.run: boom'),
-                'compose-ai-daemon: fatal in JsonRpcServer.run: boom',
+                f.filterDaemonStderrLine(
+                    "compose-ai-daemon: [+271ms] JsonRpcServer.run() entered",
+                ),
+                null,
             );
             assert.strictEqual(
-                f.filterDaemonStderrLine('Exception in thread "main" java.lang.NoSuchMethodError'),
+                f.filterDaemonStderrLine(
+                    "compose-ai-daemon: startup timeline:",
+                ),
+                null,
+            );
+            assert.strictEqual(
+                f.filterDaemonStderrLine(
+                    "  [  271ms]   +271ms  JsonRpcServer.run() entered  (main)",
+                ),
+                null,
+            );
+        });
+
+        it("keeps fatal/dispatch errors and arbitrary daemon output", () => {
+            const f = withLevel("normal");
+            assert.strictEqual(
+                f.filterDaemonStderrLine(
+                    "compose-ai-daemon: fatal in JsonRpcServer.run: boom",
+                ),
+                "compose-ai-daemon: fatal in JsonRpcServer.run: boom",
+            );
+            assert.strictEqual(
+                f.filterDaemonStderrLine(
+                    'Exception in thread "main" java.lang.NoSuchMethodError',
+                ),
                 'Exception in thread "main" java.lang.NoSuchMethodError',
             );
         });
 
-        it('shows the Roborazzi ActionBar block once and suppresses the rest', () => {
-            const f = withLevel('normal');
-            const header = 'Roborazzi: Hiding the ActionBar to avoid content overlap issues during capture.';
+        it("shows the Roborazzi ActionBar block once and suppresses the rest", () => {
+            const f = withLevel("normal");
+            const header =
+                "Roborazzi: Hiding the ActionBar to avoid content overlap issues during capture.";
             const followups = [
-                'This workaround is used when an ActionBar is present and the SDK version is 35 or higher.',
-                'Hiding the ActionBar might cause slight performance overhead due to layout invalidation.',
+                "This workaround is used when an ActionBar is present and the SDK version is 35 or higher.",
+                "Hiding the ActionBar might cause slight performance overhead due to layout invalidation.",
                 'We recommend setting the theme using <application android:theme="@android:style/Theme.Material.NoActionBar" /> in your test/AndroidManifest.xml to avoid this workaround.',
                 "If you are intentionally using an ActionBar, you can disable this workaround by setting the gradle property 'roborazzi.compose.actionbar.overlap.fix' to false.",
-                'This problem is tracked in https://issuetracker.google.com/issues/383368165',
+                "This problem is tracked in https://issuetracker.google.com/issues/383368165",
             ];
 
             // First occurrence: header survives, followups are dropped.
@@ -250,90 +280,170 @@ describe('LogFilter', () => {
             }
         });
 
-        it('shows Robolectric SDK warning once per session', () => {
-            const f = withLevel('normal');
-            const warn = '[Robolectric] WARN: ';
+        it("shows Robolectric SDK warning once per session", () => {
+            const f = withLevel("normal");
+            const warn = "[Robolectric] WARN: ";
             assert.strictEqual(f.filterDaemonStderrLine(warn), warn);
             assert.strictEqual(f.filterDaemonStderrLine(warn), null);
             assert.strictEqual(
-                f.filterDaemonStderrLine('Android SDK 36 requires Java 21 (have Java 17). Tests won\'t be run on SDK 36 unless explicitly requested.'),
+                f.filterDaemonStderrLine(
+                    "Android SDK 36 requires Java 21 (have Java 17). Tests won't be run on SDK 36 unless explicitly requested.",
+                ),
                 null,
             );
         });
     });
 
-    describe('filterDaemonStderrLine at quiet', () => {
-        it('drops startup chatter and keeps stack frames', () => {
-            const f = withLevel('quiet');
-            assert.strictEqual(f.filterDaemonStderrLine('compose-ai-tools daemon: hello (args=[])'), null);
+    describe("filterDaemonStderrLine at quiet", () => {
+        it("drops startup chatter and keeps stack frames", () => {
+            const f = withLevel("quiet");
             assert.strictEqual(
-                f.filterDaemonStderrLine('Exception in thread "main" java.lang.NoSuchMethodError: foo'),
+                f.filterDaemonStderrLine(
+                    "compose-ai-tools daemon: hello (args=[])",
+                ),
+                null,
+            );
+            assert.strictEqual(
+                f.filterDaemonStderrLine(
+                    'Exception in thread "main" java.lang.NoSuchMethodError: foo',
+                ),
                 'Exception in thread "main" java.lang.NoSuchMethodError: foo',
             );
             assert.strictEqual(
-                f.filterDaemonStderrLine('\tat ee.schimke.composeai.daemon.DaemonMain.main(DaemonMain.kt:180)'),
-                '\tat ee.schimke.composeai.daemon.DaemonMain.main(DaemonMain.kt:180)',
+                f.filterDaemonStderrLine(
+                    "\tat ee.schimke.composeai.daemon.DaemonMain.main(DaemonMain.kt:180)",
+                ),
+                "\tat ee.schimke.composeai.daemon.DaemonMain.main(DaemonMain.kt:180)",
             );
         });
     });
 
-    describe('filterDaemonStderrLine at verbose', () => {
-        it('passes everything through', () => {
-            const f = withLevel('verbose');
+    describe("filterDaemonStderrLine at verbose", () => {
+        it("passes everything through", () => {
+            const f = withLevel("verbose");
             assert.strictEqual(
-                f.filterDaemonStderrLine('compose-ai-tools daemon: hello (args=[])'),
-                'compose-ai-tools daemon: hello (args=[])',
+                f.filterDaemonStderrLine(
+                    "compose-ai-tools daemon: hello (args=[])",
+                ),
+                "compose-ai-tools daemon: hello (args=[])",
             );
-            const header = 'Roborazzi: Hiding the ActionBar to avoid content overlap issues during capture.';
+            const header =
+                "Roborazzi: Hiding the ActionBar to avoid content overlap issues during capture.";
             assert.strictEqual(f.filterDaemonStderrLine(header), header);
             assert.strictEqual(f.filterDaemonStderrLine(header), header);
         });
     });
 
-    describe('shouldEmitInformational', () => {
-        it('always emits at normal/verbose', () => {
-            for (const level of ['normal', 'verbose'] as const) {
+    describe("shouldEmitInformational", () => {
+        it("always emits at normal/verbose", () => {
+            for (const level of ["normal", "verbose"] as const) {
                 const f = withLevel(level);
-                assert.strictEqual(f.shouldEmitInformational('[refresh] start foo'), true);
-                assert.strictEqual(f.shouldEmitInformational('[doctor] doctor diagnostics refreshed across 9'), true);
-                assert.strictEqual(f.shouldEmitInformational('[detect] something'), true);
-                assert.strictEqual(f.shouldEmitInformational('> :samples:wear:discoverPreviews'), true);
-                assert.strictEqual(f.shouldEmitInformational('> :samples:wear:discoverPreviews completed'), true);
-                assert.strictEqual(f.shouldEmitInformational('[daemon] ready for samples/wear'), true);
+                assert.strictEqual(
+                    f.shouldEmitInformational("[refresh] start foo"),
+                    true,
+                );
+                assert.strictEqual(
+                    f.shouldEmitInformational(
+                        "[doctor] doctor diagnostics refreshed across 9",
+                    ),
+                    true,
+                );
+                assert.strictEqual(
+                    f.shouldEmitInformational("[detect] something"),
+                    true,
+                );
+                assert.strictEqual(
+                    f.shouldEmitInformational(
+                        "> :samples:wear:discoverPreviews",
+                    ),
+                    true,
+                );
+                assert.strictEqual(
+                    f.shouldEmitInformational(
+                        "> :samples:wear:discoverPreviews completed",
+                    ),
+                    true,
+                );
+                assert.strictEqual(
+                    f.shouldEmitInformational(
+                        "[daemon] ready for samples/wear",
+                    ),
+                    true,
+                );
             }
         });
 
-        it('drops chatter at quiet but keeps unknown / error-shaped lines', () => {
-            const f = withLevel('quiet');
-            assert.strictEqual(f.shouldEmitInformational('[refresh] start foo'), false);
-            assert.strictEqual(f.shouldEmitInformational('[refresh] rendered 13 preview(s)'), false);
-            assert.strictEqual(f.shouldEmitInformational('[doctor] doctor diagnostics refreshed across 9'), false);
-            assert.strictEqual(f.shouldEmitInformational('[detect] something'), false);
-            assert.strictEqual(f.shouldEmitInformational('> :samples:wear:discoverPreviews'), false);
-            assert.strictEqual(f.shouldEmitInformational('> :samples:wear:discoverPreviews completed'), false);
-            assert.strictEqual(f.shouldEmitInformational('[daemon] ready for samples/wear'), false);
-            assert.strictEqual(f.shouldEmitInformational('[daemon] spawning foo'), false);
+        it("drops chatter at quiet but keeps unknown / error-shaped lines", () => {
+            const f = withLevel("quiet");
+            assert.strictEqual(
+                f.shouldEmitInformational("[refresh] start foo"),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("[refresh] rendered 13 preview(s)"),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "[doctor] doctor diagnostics refreshed across 9",
+                ),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("[detect] something"),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("> :samples:wear:discoverPreviews"),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "> :samples:wear:discoverPreviews completed",
+                ),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("[daemon] ready for samples/wear"),
+                false,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational("[daemon] spawning foo"),
+                false,
+            );
 
             // Error / failure shaped lines pass through.
-            assert.strictEqual(f.shouldEmitInformational('> :samples:wear:foo FAILED: ...'), true);
-            assert.strictEqual(f.shouldEmitInformational('[doctor] :samples:cmp:composePreviewDoctor failed: ...'), true);
+            assert.strictEqual(
+                f.shouldEmitInformational("> :samples:wear:foo FAILED: ..."),
+                true,
+            );
+            assert.strictEqual(
+                f.shouldEmitInformational(
+                    "[doctor] :samples:cmp:composePreviewDoctor failed: ...",
+                ),
+                true,
+            );
         });
     });
 
-    it('reset() clears dedupe state', () => {
-        const f = withLevel('normal');
-        const header = 'Roborazzi: Hiding the ActionBar to avoid content overlap issues during capture.';
+    it("reset() clears dedupe state", () => {
+        const f = withLevel("normal");
+        const header =
+            "Roborazzi: Hiding the ActionBar to avoid content overlap issues during capture.";
         assert.strictEqual(f.filterDaemonStderrLine(header), header);
         assert.strictEqual(f.filterDaemonStderrLine(header), null);
         f.reset();
         assert.strictEqual(f.filterDaemonStderrLine(header), header);
     });
 
-    it('observes level changes between calls', () => {
-        let level: LogLevel = 'normal';
+    it("observes level changes between calls", () => {
+        let level: LogLevel = "normal";
         const f = new LogFilter(() => level);
-        assert.strictEqual(f.filterGradleChunk('> Task :foo UP-TO-DATE\n'), '');
-        level = 'verbose';
-        assert.strictEqual(f.filterGradleChunk('> Task :foo UP-TO-DATE\n'), '> Task :foo UP-TO-DATE\n');
+        assert.strictEqual(f.filterGradleChunk("> Task :foo UP-TO-DATE\n"), "");
+        level = "verbose";
+        assert.strictEqual(
+            f.filterGradleChunk("> Task :foo UP-TO-DATE\n"),
+            "> Task :foo UP-TO-DATE\n",
+        );
     });
 });

--- a/vscode-extension/src/test/pluginDetection.test.ts
+++ b/vscode-extension/src/test/pluginDetection.test.ts
@@ -1,16 +1,20 @@
-import * as assert from 'assert';
-import * as path from 'path';
-import * as fs from 'fs';
-import * as os from 'os';
+import * as assert from "assert";
+import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
 import {
     APPLIES_PLUGIN_RE,
     appliesPlugin,
     findPluginAppliedAncestor,
-} from '../pluginDetection';
+} from "../pluginDetection";
 
-function withTempDir(fn: (dir: string) => void | Promise<void>): () => Promise<void> {
+function withTempDir(
+    fn: (dir: string) => void | Promise<void>,
+): () => Promise<void> {
     return async () => {
-        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'compose-preview-test-'));
+        const dir = fs.mkdtempSync(
+            path.join(os.tmpdir(), "compose-preview-test-"),
+        );
         try {
             await fn(dir);
         } finally {
@@ -19,96 +23,154 @@ function withTempDir(fn: (dir: string) => void | Promise<void>): () => Promise<v
     };
 }
 
-describe('findPluginAppliedAncestor', () => {
-    it('finds a direct ancestor that applies the plugin', withTempDir((dir) => {
-        fs.mkdirSync(path.join(dir, 'app', 'src'), { recursive: true });
-        fs.writeFileSync(path.join(dir, 'app', 'build.gradle.kts'),
-            'id("ee.schimke.composeai.preview")');
-        assert.strictEqual(
-            findPluginAppliedAncestor(path.join(dir, 'app', 'src', 'Foo.kt')),
-            path.join(dir, 'app'),
-        );
-    }));
+describe("findPluginAppliedAncestor", () => {
+    it(
+        "finds a direct ancestor that applies the plugin",
+        withTempDir((dir) => {
+            fs.mkdirSync(path.join(dir, "app", "src"), { recursive: true });
+            fs.writeFileSync(
+                path.join(dir, "app", "build.gradle.kts"),
+                'id("ee.schimke.composeai.preview")',
+            );
+            assert.strictEqual(
+                findPluginAppliedAncestor(
+                    path.join(dir, "app", "src", "Foo.kt"),
+                ),
+                path.join(dir, "app"),
+            );
+        }),
+    );
 
-    it('finds a deeply-nested (worktree-like) ancestor', withTempDir((dir) => {
-        const wt = path.join(dir, '.claude', 'worktrees', 'wt1', 'sample-android');
-        fs.mkdirSync(path.join(wt, 'src', 'main', 'kotlin'), { recursive: true });
-        fs.writeFileSync(path.join(wt, 'build.gradle.kts'),
-            'plugins { id("ee.schimke.composeai.preview") }');
-        assert.strictEqual(
-            findPluginAppliedAncestor(path.join(wt, 'src', 'main', 'kotlin', 'Foo.kt')),
-            wt,
-        );
-    }));
+    it(
+        "finds a deeply-nested (worktree-like) ancestor",
+        withTempDir((dir) => {
+            const wt = path.join(
+                dir,
+                ".claude",
+                "worktrees",
+                "wt1",
+                "sample-android",
+            );
+            fs.mkdirSync(path.join(wt, "src", "main", "kotlin"), {
+                recursive: true,
+            });
+            fs.writeFileSync(
+                path.join(wt, "build.gradle.kts"),
+                'plugins { id("ee.schimke.composeai.preview") }',
+            );
+            assert.strictEqual(
+                findPluginAppliedAncestor(
+                    path.join(wt, "src", "main", "kotlin", "Foo.kt"),
+                ),
+                wt,
+            );
+        }),
+    );
 
-    it('returns null when no ancestor applies the plugin', withTempDir((dir) => {
-        fs.mkdirSync(path.join(dir, 'lib', 'src'), { recursive: true });
-        fs.writeFileSync(path.join(dir, 'lib', 'build.gradle.kts'),
-            'id("org.jetbrains.kotlin.jvm")');
-        assert.strictEqual(
-            findPluginAppliedAncestor(path.join(dir, 'lib', 'src', 'Foo.kt')),
-            null,
-        );
-    }));
+    it(
+        "returns null when no ancestor applies the plugin",
+        withTempDir((dir) => {
+            fs.mkdirSync(path.join(dir, "lib", "src"), { recursive: true });
+            fs.writeFileSync(
+                path.join(dir, "lib", "build.gradle.kts"),
+                'id("org.jetbrains.kotlin.jvm")',
+            );
+            assert.strictEqual(
+                findPluginAppliedAncestor(
+                    path.join(dir, "lib", "src", "Foo.kt"),
+                ),
+                null,
+            );
+        }),
+    );
 
-    it('skips build scripts that only declare the plugin', withTempDir((dir) => {
-        fs.mkdirSync(path.join(dir, 'gradle-plugin', 'src'), { recursive: true });
-        fs.writeFileSync(path.join(dir, 'gradle-plugin', 'build.gradle.kts'), `
+    it(
+        "skips build scripts that only declare the plugin",
+        withTempDir((dir) => {
+            fs.mkdirSync(path.join(dir, "gradle-plugin", "src"), {
+                recursive: true,
+            });
+            fs.writeFileSync(
+                path.join(dir, "gradle-plugin", "build.gradle.kts"),
+                `
             gradlePlugin { plugins { create("p") { id = "ee.schimke.composeai.preview" } } }
-        `);
-        assert.strictEqual(
-            findPluginAppliedAncestor(path.join(dir, 'gradle-plugin', 'src', 'Foo.kt')),
-            null,
-        );
-    }));
+        `,
+            );
+            assert.strictEqual(
+                findPluginAppliedAncestor(
+                    path.join(dir, "gradle-plugin", "src", "Foo.kt"),
+                ),
+                null,
+            );
+        }),
+    );
 
-    it('skips literal applications trailing `apply false`', withTempDir((dir) => {
-        fs.mkdirSync(path.join(dir, 'wearApp', 'src'), { recursive: true });
-        // Root-level declaration-only: module pulls the plugin in for
-        // subprojects but does not apply it here.
-        fs.writeFileSync(path.join(dir, 'build.gradle.kts'),
-            'plugins { id("ee.schimke.composeai.preview") apply false }');
-        fs.writeFileSync(path.join(dir, 'wearApp', 'build.gradle.kts'),
-            'plugins { id("org.jetbrains.kotlin.jvm") }');
-        assert.strictEqual(
-            findPluginAppliedAncestor(path.join(dir, 'wearApp', 'src', 'Foo.kt')),
-            null,
-        );
-    }));
+    it(
+        "skips literal applications trailing `apply false`",
+        withTempDir((dir) => {
+            fs.mkdirSync(path.join(dir, "wearApp", "src"), { recursive: true });
+            // Root-level declaration-only: module pulls the plugin in for
+            // subprojects but does not apply it here.
+            fs.writeFileSync(
+                path.join(dir, "build.gradle.kts"),
+                'plugins { id("ee.schimke.composeai.preview") apply false }',
+            );
+            fs.writeFileSync(
+                path.join(dir, "wearApp", "build.gradle.kts"),
+                'plugins { id("org.jetbrains.kotlin.jvm") }',
+            );
+            assert.strictEqual(
+                findPluginAppliedAncestor(
+                    path.join(dir, "wearApp", "src", "Foo.kt"),
+                ),
+                null,
+            );
+        }),
+    );
 });
 
-describe('appliesPlugin', () => {
-    it('matches the literal id form', () => {
+describe("appliesPlugin", () => {
+    it("matches the literal id form", () => {
         assert.ok(appliesPlugin('id("ee.schimke.composeai.preview")'));
-        assert.ok(appliesPlugin('plugins { id("ee.schimke.composeai.preview") }'));
+        assert.ok(
+            appliesPlugin('plugins { id("ee.schimke.composeai.preview") }'),
+        );
         assert.ok(appliesPlugin("id 'ee.schimke.composeai.preview'"));
     });
 
-    it('rejects a declaration-only snippet', () => {
+    it("rejects a declaration-only snippet", () => {
         assert.ok(!appliesPlugin('id = "ee.schimke.composeai.preview"'));
     });
 
-    it('rejects literal `apply false` on the same line', () => {
-        assert.ok(!appliesPlugin('id("ee.schimke.composeai.preview") apply false'));
+    it("rejects literal `apply false` on the same line", () => {
+        assert.ok(
+            !appliesPlugin('id("ee.schimke.composeai.preview") apply false'),
+        );
     });
 
-    it('does NOT match the version-catalog alias form — handled via marker', () => {
+    it("does NOT match the version-catalog alias form — handled via marker", () => {
         // Intentional: alias detection would require parsing
         // `libs.versions.toml`. The `applied.json` marker written by
         // `composePreviewApplied` covers this case authoritatively.
-        assert.ok(!appliesPlugin('alias(libs.plugins.composeai.preview)'));
+        assert.ok(!appliesPlugin("alias(libs.plugins.composeai.preview)"));
     });
 });
 
-describe('APPLIES_PLUGIN_RE', () => {
-    it('matches the literal application forms', () => {
+describe("APPLIES_PLUGIN_RE", () => {
+    it("matches the literal application forms", () => {
         assert.ok(APPLIES_PLUGIN_RE.test('id("ee.schimke.composeai.preview")'));
-        assert.ok(APPLIES_PLUGIN_RE.test('plugins { id("ee.schimke.composeai.preview") }'));
+        assert.ok(
+            APPLIES_PLUGIN_RE.test(
+                'plugins { id("ee.schimke.composeai.preview") }',
+            ),
+        );
         assert.ok(APPLIES_PLUGIN_RE.test("id 'ee.schimke.composeai.preview'"));
     });
 
-    it('rejects declaration-only usage', () => {
-        assert.ok(!APPLIES_PLUGIN_RE.test('id = "ee.schimke.composeai.preview"'));
+    it("rejects declaration-only usage", () => {
+        assert.ok(
+            !APPLIES_PLUGIN_RE.test('id = "ee.schimke.composeai.preview"'),
+        );
     });
 
     // Note: the raw regex is just the plugin-reference matcher. The `apply

--- a/vscode-extension/src/test/previewFilter.test.ts
+++ b/vscode-extension/src/test/previewFilter.test.ts
@@ -1,111 +1,162 @@
-import * as assert from 'assert';
-import * as fs from 'fs';
-import * as path from 'path';
-import { filterPreviews, extractFilterOptions, FilterState } from '../previewFilter';
-import { PreviewManifest } from '../types';
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import {
+    filterPreviews,
+    extractFilterOptions,
+    FilterState,
+} from "../previewFilter";
+import { PreviewManifest } from "../types";
 
 const fixtureManifest: PreviewManifest = JSON.parse(
-    fs.readFileSync(path.join(__dirname, '..', '..', 'src', 'test', 'fixtures', 'previews.json'), 'utf-8'),
+    fs.readFileSync(
+        path.join(
+            __dirname,
+            "..",
+            "..",
+            "src",
+            "test",
+            "fixtures",
+            "previews.json",
+        ),
+        "utf-8",
+    ),
 );
 const previews = fixtureManifest.previews;
 
-describe('extractFilterOptions', () => {
-    it('extracts unique source files', () => {
+describe("extractFilterOptions", () => {
+    it("extracts unique source files", () => {
         const opts = extractFilterOptions(previews);
-        assert.deepStrictEqual(opts.sourceFiles, ['Main.kt', 'Previews.kt']);
+        assert.deepStrictEqual(opts.sourceFiles, ["Main.kt", "Previews.kt"]);
     });
 
-    it('extracts unique function names', () => {
+    it("extracts unique function names", () => {
         const opts = extractFilterOptions(previews);
-        assert.deepStrictEqual(opts.functionNames, ['BlueBoxPreview', 'GreetingPreview', 'RedBoxPreview']);
+        assert.deepStrictEqual(opts.functionNames, [
+            "BlueBoxPreview",
+            "GreetingPreview",
+            "RedBoxPreview",
+        ]);
     });
 
-    it('extracts unique labels (preview names)', () => {
+    it("extracts unique labels (preview names)", () => {
         const opts = extractFilterOptions(previews);
-        assert.deepStrictEqual(opts.labels, ['Blue Box', 'Dark Mode', 'Red Box']);
+        assert.deepStrictEqual(opts.labels, [
+            "Blue Box",
+            "Dark Mode",
+            "Red Box",
+        ]);
     });
 
-    it('extracts unique groups', () => {
+    it("extracts unique groups", () => {
         const opts = extractFilterOptions(previews);
-        assert.deepStrictEqual(opts.groups, ['colors']);
+        assert.deepStrictEqual(opts.groups, ["colors"]);
     });
 });
 
-describe('filterPreviews', () => {
-    const noFilter: FilterState = { sourceFile: null, functionName: null, label: null, group: null };
+describe("filterPreviews", () => {
+    const noFilter: FilterState = {
+        sourceFile: null,
+        functionName: null,
+        label: null,
+        group: null,
+    };
 
-    it('returns all previews with no filters', () => {
+    it("returns all previews with no filters", () => {
         const result = filterPreviews(previews, noFilter);
         assert.strictEqual(result.length, 4);
     });
 
-    it('filters by source file', () => {
-        const result = filterPreviews(previews, { ...noFilter, sourceFile: 'Main.kt' });
+    it("filters by source file", () => {
+        const result = filterPreviews(previews, {
+            ...noFilter,
+            sourceFile: "Main.kt",
+        });
         assert.strictEqual(result.length, 1);
-        assert.strictEqual(result[0].functionName, 'GreetingPreview');
+        assert.strictEqual(result[0].functionName, "GreetingPreview");
     });
 
-    it('filters by source file — Previews.kt has 3 previews', () => {
-        const result = filterPreviews(previews, { ...noFilter, sourceFile: 'Previews.kt' });
+    it("filters by source file — Previews.kt has 3 previews", () => {
+        const result = filterPreviews(previews, {
+            ...noFilter,
+            sourceFile: "Previews.kt",
+        });
         assert.strictEqual(result.length, 3);
     });
 
-    it('filters by function name', () => {
-        const result = filterPreviews(previews, { ...noFilter, functionName: 'RedBoxPreview' });
+    it("filters by function name", () => {
+        const result = filterPreviews(previews, {
+            ...noFilter,
+            functionName: "RedBoxPreview",
+        });
         assert.strictEqual(result.length, 2); // Red Box + Dark Mode (same function, different labels)
     });
 
-    it('filters by label (multi-preview variant name)', () => {
-        const result = filterPreviews(previews, { ...noFilter, label: 'Dark Mode' });
+    it("filters by label (multi-preview variant name)", () => {
+        const result = filterPreviews(previews, {
+            ...noFilter,
+            label: "Dark Mode",
+        });
         assert.strictEqual(result.length, 1);
-        assert.strictEqual(result[0].id, 'com.example.PreviewsKt.RedBoxPreview_Dark Mode');
+        assert.strictEqual(
+            result[0].id,
+            "com.example.PreviewsKt.RedBoxPreview_Dark Mode",
+        );
     });
 
-    it('filters by group', () => {
-        const result = filterPreviews(previews, { ...noFilter, group: 'colors' });
+    it("filters by group", () => {
+        const result = filterPreviews(previews, {
+            ...noFilter,
+            group: "colors",
+        });
         assert.strictEqual(result.length, 3); // Red, Blue, Dark Mode — all in "colors" group
     });
 
-    it('combines file + function filter', () => {
+    it("combines file + function filter", () => {
         const result = filterPreviews(previews, {
             ...noFilter,
-            sourceFile: 'Previews.kt',
-            functionName: 'BlueBoxPreview',
+            sourceFile: "Previews.kt",
+            functionName: "BlueBoxPreview",
         });
         assert.strictEqual(result.length, 1);
-        assert.strictEqual(result[0].params.name, 'Blue Box');
+        assert.strictEqual(result[0].params.name, "Blue Box");
     });
 
-    it('combines function + label filter', () => {
+    it("combines function + label filter", () => {
         const result = filterPreviews(previews, {
             ...noFilter,
-            functionName: 'RedBoxPreview',
-            label: 'Red Box',
+            functionName: "RedBoxPreview",
+            label: "Red Box",
         });
         assert.strictEqual(result.length, 1);
         assert.strictEqual(result[0].params.backgroundColor, 4294901760);
     });
 
-    it('returns empty when no match', () => {
-        const result = filterPreviews(previews, { ...noFilter, sourceFile: 'Nonexistent.kt' });
+    it("returns empty when no match", () => {
+        const result = filterPreviews(previews, {
+            ...noFilter,
+            sourceFile: "Nonexistent.kt",
+        });
         assert.strictEqual(result.length, 0);
     });
 });
 
-describe('manifest parsing', () => {
-    it('parses fixture manifest', () => {
-        assert.strictEqual(fixtureManifest.module, 'sample-android');
-        assert.strictEqual(fixtureManifest.variant, 'debug');
+describe("manifest parsing", () => {
+    it("parses fixture manifest", () => {
+        assert.strictEqual(fixtureManifest.module, "sample-android");
+        assert.strictEqual(fixtureManifest.variant, "debug");
         assert.strictEqual(fixtureManifest.previews.length, 4);
     });
 
-    it('preserves backgroundColor as number', () => {
-        const red = previews.find(p => p.params.name === 'Red Box')!;
+    it("preserves backgroundColor as number", () => {
+        const red = previews.find((p) => p.params.name === "Red Box")!;
         assert.strictEqual(red.params.backgroundColor, 4294901760); // 0xFFFF0000
     });
 
-    it('handles null fields', () => {
-        const greeting = previews.find(p => p.functionName === 'GreetingPreview')!;
+    it("handles null fields", () => {
+        const greeting = previews.find(
+            (p) => p.functionName === "GreetingPreview",
+        )!;
         assert.strictEqual(greeting.params.name, null);
         assert.strictEqual(greeting.params.group, null);
         assert.strictEqual(greeting.params.device, null);

--- a/vscode-extension/src/test/previewMainBatchParser.test.ts
+++ b/vscode-extension/src/test/previewMainBatchParser.test.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert';
-import { CatFileBatchParser } from '../previewMainSource';
+import * as assert from "assert";
+import { CatFileBatchParser } from "../previewMainSource";
 
 // Wire format: `<sha> <type> <size>\n<bytes>\n` for hits, `<rev> missing\n`
 // for misses. Tests cover the common shapes plus a few hostile inputs
@@ -15,40 +15,46 @@ function missing(rev: string): Buffer {
 }
 
 function hit(sha: string, type: string, body: Buffer): Buffer {
-    return Buffer.concat([header(sha, type, body.length), body, Buffer.from('\n')]);
+    return Buffer.concat([
+        header(sha, type, body.length),
+        body,
+        Buffer.from("\n"),
+    ]);
 }
 
-const SHA = 'a1b2c3d4e5f6789012345678901234567890abcd';
+const SHA = "a1b2c3d4e5f6789012345678901234567890abcd";
 
-describe('CatFileBatchParser', () => {
-    it('parses a single hit delivered as one chunk', () => {
+describe("CatFileBatchParser", () => {
+    it("parses a single hit delivered as one chunk", () => {
         const parser = new CatFileBatchParser();
-        const body = Buffer.from('hello world');
-        const out = parser.feed(hit(SHA, 'blob', body));
+        const body = Buffer.from("hello world");
+        const out = parser.feed(hit(SHA, "blob", body));
         assert.strictEqual(out.length, 1);
         assert.deepStrictEqual(out[0], body);
     });
 
-    it('parses a missing response', () => {
+    it("parses a missing response", () => {
         const parser = new CatFileBatchParser();
-        const out = parser.feed(missing('origin/compose-preview/main:no/such/path'));
+        const out = parser.feed(
+            missing("origin/compose-preview/main:no/such/path"),
+        );
         assert.deepStrictEqual(out, [null]);
     });
 
-    it('preserves bodies that contain newlines', () => {
+    it("preserves bodies that contain newlines", () => {
         // PNG / JSON with embedded newlines exercises the byte-counted
         // body parser. A naive line-based reader would split this.
         const parser = new CatFileBatchParser();
-        const body = Buffer.from('line one\nline two\n\nline four');
-        const out = parser.feed(hit(SHA, 'blob', body));
+        const body = Buffer.from("line one\nline two\n\nline four");
+        const out = parser.feed(hit(SHA, "blob", body));
         assert.strictEqual(out.length, 1);
         assert.deepStrictEqual(out[0], body);
     });
 
-    it('reassembles a response split across multiple chunks', () => {
+    it("reassembles a response split across multiple chunks", () => {
         const parser = new CatFileBatchParser();
-        const body = Buffer.from('xy'.repeat(50));
-        const full = hit(SHA, 'blob', body);
+        const body = Buffer.from("xy".repeat(50));
+        const full = hit(SHA, "blob", body);
         // Feed one byte at a time — the parser must not emit until the
         // whole response (header + body + trailing newline) is in.
         let collected: Array<Buffer | null> = [];
@@ -59,14 +65,14 @@ describe('CatFileBatchParser', () => {
         assert.deepStrictEqual(collected[0], body);
     });
 
-    it('emits multiple responses from one chunk', () => {
+    it("emits multiple responses from one chunk", () => {
         const parser = new CatFileBatchParser();
-        const a = Buffer.from('alpha');
-        const b = Buffer.from('beta');
+        const a = Buffer.from("alpha");
+        const b = Buffer.from("beta");
         const combined = Buffer.concat([
-            hit(SHA, 'blob', a),
-            missing('foo'),
-            hit(SHA, 'blob', b),
+            hit(SHA, "blob", a),
+            missing("foo"),
+            hit(SHA, "blob", b),
         ]);
         const out = parser.feed(combined);
         assert.strictEqual(out.length, 3);
@@ -75,32 +81,32 @@ describe('CatFileBatchParser', () => {
         assert.deepStrictEqual(out[2], b);
     });
 
-    it('handles a zero-byte blob (empty file checked into git)', () => {
+    it("handles a zero-byte blob (empty file checked into git)", () => {
         const parser = new CatFileBatchParser();
         const body = Buffer.alloc(0);
-        const out = parser.feed(hit(SHA, 'blob', body));
+        const out = parser.feed(hit(SHA, "blob", body));
         assert.strictEqual(out.length, 1);
         assert.deepStrictEqual(out[0], body);
     });
 
-    it('recovers when feed contains a malformed header', () => {
+    it("recovers when feed contains a malformed header", () => {
         const parser = new CatFileBatchParser();
-        const malformed = Buffer.from('garbage that pretends to be a header\n');
-        const good = hit(SHA, 'blob', Buffer.from('ok'));
+        const malformed = Buffer.from("garbage that pretends to be a header\n");
+        const good = hit(SHA, "blob", Buffer.from("ok"));
         const out = parser.feed(Buffer.concat([malformed, good]));
         assert.strictEqual(out.length, 2);
         assert.strictEqual(out[0], null);
-        assert.deepStrictEqual(out[1], Buffer.from('ok'));
+        assert.deepStrictEqual(out[1], Buffer.from("ok"));
     });
 
-    it('reset() drops mid-message state', () => {
+    it("reset() drops mid-message state", () => {
         const parser = new CatFileBatchParser();
         // Feed only the header — body is incomplete.
-        parser.feed(header(SHA, 'blob', 10));
+        parser.feed(header(SHA, "blob", 10));
         parser.reset();
         // Subsequent feed of a fresh, well-formed message should parse.
-        const body = Buffer.from('reset-ok');
-        const out = parser.feed(hit(SHA, 'blob', body));
+        const body = Buffer.from("reset-ok");
+        const out = parser.feed(hit(SHA, "blob", body));
         assert.strictEqual(out.length, 1);
         assert.deepStrictEqual(out[0], body);
     });

--- a/vscode-extension/src/test/refreshMode.test.ts
+++ b/vscode-extension/src/test/refreshMode.test.ts
@@ -1,5 +1,5 @@
-import * as assert from 'assert';
-import { pickRefreshModeFor } from '../refreshMode';
+import * as assert from "assert";
+import { pickRefreshModeFor } from "../refreshMode";
 
 /**
  * Pure predicate test — the production wrapper {@link pickRefreshMode}
@@ -7,25 +7,22 @@ import { pickRefreshModeFor } from '../refreshMode';
  * decision logic is in {@link pickRefreshModeFor} so we can exercise
  * every branch without stubbing the VS Code API.
  */
-describe('pickRefreshModeFor', () => {
-    it('returns gradle when the daemon flag is off', () => {
+describe("pickRefreshModeFor", () => {
+    it("returns gradle when the daemon flag is off", () => {
         assert.strictEqual(
-            pickRefreshModeFor('/x.kt', /* enabled */ false, 'mod'),
-            'gradle',
+            pickRefreshModeFor("/x.kt", /* enabled */ false, "mod"),
+            "gradle",
         );
     });
 
-    it('returns gradle when the file resolves to no module', () => {
+    it("returns gradle when the file resolves to no module", () => {
         assert.strictEqual(
-            pickRefreshModeFor('/outside.kt', true, null),
-            'gradle',
+            pickRefreshModeFor("/outside.kt", true, null),
+            "gradle",
         );
     });
 
-    it('returns daemon when enabled and the file resolves to a module', () => {
-        assert.strictEqual(
-            pickRefreshModeFor('/x.kt', true, 'mod'),
-            'daemon',
-        );
+    it("returns daemon when enabled and the file resolves to a module", () => {
+        assert.strictEqual(pickRefreshModeFor("/x.kt", true, "mod"), "daemon");
     });
 });

--- a/vscode-extension/src/test/renderError.test.ts
+++ b/vscode-extension/src/test/renderError.test.ts
@@ -1,96 +1,126 @@
-import * as assert from 'assert';
-import { formatRenderErrorMessage } from '../renderError';
-import { PreviewRenderError } from '../types';
+import * as assert from "assert";
+import { formatRenderErrorMessage } from "../renderError";
+import { PreviewRenderError } from "../types";
 
 function err(overrides: Partial<PreviewRenderError>): PreviewRenderError {
     return {
-        schema: 'compose-preview-error/v1',
-        exception: 'java.lang.RuntimeException',
-        message: '',
+        schema: "compose-preview-error/v1",
+        exception: "java.lang.RuntimeException",
+        message: "",
         topAppFrame: null,
-        stackTrace: '',
+        stackTrace: "",
         ...overrides,
     };
 }
 
-describe('formatRenderErrorMessage', () => {
-    it('strips the FQN prefix from the exception class', () => {
-        const out = formatRenderErrorMessage(err({ exception: 'java.lang.NullPointerException' }));
-        assert.strictEqual(out, 'NullPointerException');
+describe("formatRenderErrorMessage", () => {
+    it("strips the FQN prefix from the exception class", () => {
+        const out = formatRenderErrorMessage(
+            err({ exception: "java.lang.NullPointerException" }),
+        );
+        assert.strictEqual(out, "NullPointerException");
     });
 
-    it('keeps the simple-name when the exception has no package', () => {
-        const out = formatRenderErrorMessage(err({ exception: 'CustomError' }));
-        assert.strictEqual(out, 'CustomError');
+    it("keeps the simple-name when the exception has no package", () => {
+        const out = formatRenderErrorMessage(err({ exception: "CustomError" }));
+        assert.strictEqual(out, "CustomError");
     });
 
-    it('appends the message when one is present', () => {
-        const out = formatRenderErrorMessage(err({
-            exception: 'java.lang.NullPointerException',
-            message: 'LocalContext was null',
-        }));
-        assert.strictEqual(out, 'NullPointerException: LocalContext was null');
+    it("appends the message when one is present", () => {
+        const out = formatRenderErrorMessage(
+            err({
+                exception: "java.lang.NullPointerException",
+                message: "LocalContext was null",
+            }),
+        );
+        assert.strictEqual(out, "NullPointerException: LocalContext was null");
     });
 
-    it('omits the message segment when it is the empty string', () => {
-        const out = formatRenderErrorMessage(err({
-            exception: 'kotlin.NotImplementedError',
-            message: '',
-        }));
+    it("omits the message segment when it is the empty string", () => {
+        const out = formatRenderErrorMessage(
+            err({
+                exception: "kotlin.NotImplementedError",
+                message: "",
+            }),
+        );
         // No "ClassName: " prefix when message is empty — empty message
         // would render as a confusing dangling colon.
-        assert.strictEqual(out, 'NotImplementedError');
+        assert.strictEqual(out, "NotImplementedError");
     });
 
-    it('appends the top app frame when both file and line are known', () => {
-        const out = formatRenderErrorMessage(err({
-            exception: 'java.lang.NullPointerException',
-            message: 'LocalContext was null',
-            topAppFrame: { file: 'Previews.kt', line: 47, function: 'HomeScreen' },
-        }));
+    it("appends the top app frame when both file and line are known", () => {
+        const out = formatRenderErrorMessage(
+            err({
+                exception: "java.lang.NullPointerException",
+                message: "LocalContext was null",
+                topAppFrame: {
+                    file: "Previews.kt",
+                    line: 47,
+                    function: "HomeScreen",
+                },
+            }),
+        );
         assert.strictEqual(
             out,
-            'NullPointerException: LocalContext was null (at Previews.kt:47 in HomeScreen)',
+            "NullPointerException: LocalContext was null (at Previews.kt:47 in HomeScreen)",
         );
     });
 
-    it('omits the line when line is 0 (frame missing line info)', () => {
+    it("omits the line when line is 0 (frame missing line info)", () => {
         // Native frames or anonymous classes can have line=0; we still
         // surface the file + function but drop the line: prefix so the
         // message doesn't read as "Previews.kt:0".
-        const out = formatRenderErrorMessage(err({
-            exception: 'java.lang.IllegalStateException',
-            message: 'oops',
-            topAppFrame: { file: 'Previews.kt', line: 0, function: 'lambda$0' },
-        }));
-        assert.strictEqual(out, 'IllegalStateException: oops (at Previews.kt in lambda$0)');
+        const out = formatRenderErrorMessage(
+            err({
+                exception: "java.lang.IllegalStateException",
+                message: "oops",
+                topAppFrame: {
+                    file: "Previews.kt",
+                    line: 0,
+                    function: "lambda$0",
+                },
+            }),
+        );
+        assert.strictEqual(
+            out,
+            "IllegalStateException: oops (at Previews.kt in lambda$0)",
+        );
     });
 
-    it('omits the function suffix when function is empty', () => {
-        const out = formatRenderErrorMessage(err({
-            exception: 'java.lang.IllegalArgumentException',
-            message: 'bad arg',
-            topAppFrame: { file: 'Previews.kt', line: 12, function: '' },
-        }));
-        assert.strictEqual(out, 'IllegalArgumentException: bad arg (at Previews.kt:12)');
+    it("omits the function suffix when function is empty", () => {
+        const out = formatRenderErrorMessage(
+            err({
+                exception: "java.lang.IllegalArgumentException",
+                message: "bad arg",
+                topAppFrame: { file: "Previews.kt", line: 12, function: "" },
+            }),
+        );
+        assert.strictEqual(
+            out,
+            "IllegalArgumentException: bad arg (at Previews.kt:12)",
+        );
     });
 
-    it('drops the topAppFrame block entirely when file is empty', () => {
+    it("drops the topAppFrame block entirely when file is empty", () => {
         // Renderer returns frame.file='' when the StackTraceElement
         // didn't carry a fileName (e.g. native methods). Don't render
         // a useless "(at )" suffix.
-        const out = formatRenderErrorMessage(err({
-            exception: 'java.lang.RuntimeException',
-            message: 'kaboom',
-            topAppFrame: { file: '', line: 5, function: 'unknown' },
-        }));
-        assert.strictEqual(out, 'RuntimeException: kaboom');
+        const out = formatRenderErrorMessage(
+            err({
+                exception: "java.lang.RuntimeException",
+                message: "kaboom",
+                topAppFrame: { file: "", line: 5, function: "unknown" },
+            }),
+        );
+        assert.strictEqual(out, "RuntimeException: kaboom");
     });
 
-    it('handles the no-message + no-frame case', () => {
-        const out = formatRenderErrorMessage(err({
-            exception: 'java.lang.RuntimeException',
-        }));
-        assert.strictEqual(out, 'RuntimeException');
+    it("handles the no-message + no-frame case", () => {
+        const out = formatRenderErrorMessage(
+            err({
+                exception: "java.lang.RuntimeException",
+            }),
+        );
+        assert.strictEqual(out, "RuntimeException");
     });
 });

--- a/vscode-extension/src/test/renderFreshness.test.ts
+++ b/vscode-extension/src/test/renderFreshness.test.ts
@@ -1,20 +1,20 @@
-import * as assert from 'assert';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import * as assert from "assert";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 import {
     hasFreshRenderStamp,
     renderFreshnessStampPath,
     writeRenderFreshnessStamp,
-} from '../renderFreshness';
-import { PreviewInfo } from '../types';
+} from "../renderFreshness";
+import { PreviewInfo } from "../types";
 
 function preview(id: string): PreviewInfo {
     return {
         id,
-        functionName: 'Preview',
-        className: 'com.example.PreviewsKt',
-        sourceFile: 'com/example/Previews.kt',
+        functionName: "Preview",
+        className: "com.example.PreviewsKt",
+        sourceFile: "com/example/Previews.kt",
         params: {
             name: null,
             device: null,
@@ -28,12 +28,20 @@ function preview(id: string): PreviewInfo {
             locale: null,
             group: null,
         },
-        captures: [{ advanceTimeMillis: null, scroll: null, renderOutput: `renders/${id}.png` }],
+        captures: [
+            {
+                advanceTimeMillis: null,
+                scroll: null,
+                renderOutput: `renders/${id}.png`,
+            },
+        ],
     };
 }
 
 async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'compose-preview-freshness-'));
+    const dir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "compose-preview-freshness-"),
+    );
     try {
         await fn(dir);
     } finally {
@@ -41,60 +49,99 @@ async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
     }
 }
 
-describe('renderFreshness', () => {
-    it('treats a stamped render as fresh even when PNG mtimes are older than the source', async () => {
-        await withTempDir(async dir => {
-            const module = 'app';
-            const source = path.join(dir, module, 'src/main/kotlin/com/example/Previews.kt');
-            const png = path.join(dir, module, 'build/compose-previews/renders/p1.png');
+describe("renderFreshness", () => {
+    it("treats a stamped render as fresh even when PNG mtimes are older than the source", async () => {
+        await withTempDir(async (dir) => {
+            const module = "app";
+            const source = path.join(
+                dir,
+                module,
+                "src/main/kotlin/com/example/Previews.kt",
+            );
+            const png = path.join(
+                dir,
+                module,
+                "build/compose-previews/renders/p1.png",
+            );
             fs.mkdirSync(path.dirname(source), { recursive: true });
             fs.mkdirSync(path.dirname(png), { recursive: true });
-            fs.writeFileSync(source, '@Preview fun P() {}');
-            fs.writeFileSync(png, 'png');
+            fs.writeFileSync(source, "@Preview fun P() {}");
+            fs.writeFileSync(png, "png");
 
             const old = new Date(Date.now() - 60_000);
             fs.utimesSync(png, old, old);
-            await writeRenderFreshnessStamp(dir, module, source, [preview('p1')]);
+            await writeRenderFreshnessStamp(dir, module, source, [
+                preview("p1"),
+            ]);
 
-            assert.strictEqual(await hasFreshRenderStamp(dir, module, source, [preview('p1')]), true);
+            assert.strictEqual(
+                await hasFreshRenderStamp(dir, module, source, [preview("p1")]),
+                true,
+            );
         });
     });
 
-    it('marks the render stale when the source changes after the stamp', async () => {
-        await withTempDir(async dir => {
-            const module = 'app';
-            const source = path.join(dir, module, 'src/main/kotlin/com/example/Previews.kt');
+    it("marks the render stale when the source changes after the stamp", async () => {
+        await withTempDir(async (dir) => {
+            const module = "app";
+            const source = path.join(
+                dir,
+                module,
+                "src/main/kotlin/com/example/Previews.kt",
+            );
             fs.mkdirSync(path.dirname(source), { recursive: true });
-            fs.writeFileSync(source, '@Preview fun P() {}');
-            await writeRenderFreshnessStamp(dir, module, source, [preview('p1')]);
+            fs.writeFileSync(source, "@Preview fun P() {}");
+            await writeRenderFreshnessStamp(dir, module, source, [
+                preview("p1"),
+            ]);
 
             const newer = new Date(Date.now() + 5_000);
             fs.utimesSync(source, newer, newer);
 
-            assert.strictEqual(await hasFreshRenderStamp(dir, module, source, [preview('p1')]), false);
-        });
-    });
-
-    it('marks the render stale when the visible preview set is not covered by the stamp', async () => {
-        await withTempDir(async dir => {
-            const module = 'app';
-            const source = path.join(dir, module, 'src/main/kotlin/com/example/Previews.kt');
-            fs.mkdirSync(path.dirname(source), { recursive: true });
-            fs.writeFileSync(source, '@Preview fun P() {}');
-            await writeRenderFreshnessStamp(dir, module, source, [preview('p1')]);
-
             assert.strictEqual(
-                await hasFreshRenderStamp(dir, module, source, [preview('p1'), preview('p2')]),
+                await hasFreshRenderStamp(dir, module, source, [preview("p1")]),
                 false,
             );
         });
     });
 
-    it('stores source-specific stamps under the module build directory', async () => {
-        await withTempDir(async dir => {
-            const stampPath = renderFreshnessStampPath(dir, 'app', path.join(dir, 'app/src/Previews.kt'));
-            assert.ok(stampPath.startsWith(path.join(dir, 'app', 'build', 'compose-previews')));
-            assert.ok(stampPath.endsWith('.json'));
+    it("marks the render stale when the visible preview set is not covered by the stamp", async () => {
+        await withTempDir(async (dir) => {
+            const module = "app";
+            const source = path.join(
+                dir,
+                module,
+                "src/main/kotlin/com/example/Previews.kt",
+            );
+            fs.mkdirSync(path.dirname(source), { recursive: true });
+            fs.writeFileSync(source, "@Preview fun P() {}");
+            await writeRenderFreshnessStamp(dir, module, source, [
+                preview("p1"),
+            ]);
+
+            assert.strictEqual(
+                await hasFreshRenderStamp(dir, module, source, [
+                    preview("p1"),
+                    preview("p2"),
+                ]),
+                false,
+            );
+        });
+    });
+
+    it("stores source-specific stamps under the module build directory", async () => {
+        await withTempDir(async (dir) => {
+            const stampPath = renderFreshnessStampPath(
+                dir,
+                "app",
+                path.join(dir, "app/src/Previews.kt"),
+            );
+            assert.ok(
+                stampPath.startsWith(
+                    path.join(dir, "app", "build", "compose-previews"),
+                ),
+            );
+            assert.ok(stampPath.endsWith(".json"));
         });
     });
 });

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -29,8 +29,8 @@ export interface PreviewParams {
  * reachedPx) are populated by the renderer post-capture.
  */
 export interface ScrollCapture {
-    mode: 'TOP' | 'END' | 'LONG' | string;
-    axis: 'VERTICAL' | 'HORIZONTAL' | string;
+    mode: "TOP" | "END" | "LONG" | string;
+    axis: "VERTICAL" | "HORIZONTAL" | string;
     maxScrollPx: number;
     reduceMotion: boolean;
     /** Scrollable reached the end of its content before the renderer stopped.
@@ -93,27 +93,27 @@ export interface PreviewDataProduct {
 }
 
 export type PreviewDataProductFacet =
-    | 'STRUCTURED'
-    | 'ARTIFACT'
-    | 'IMAGE'
-    | 'ANIMATION'
-    | 'OVERLAY'
-    | 'CHECK'
-    | 'DIAGNOSTIC'
-    | 'PROFILE'
-    | 'INTERACTIVE';
+    | "STRUCTURED"
+    | "ARTIFACT"
+    | "IMAGE"
+    | "ANIMATION"
+    | "OVERLAY"
+    | "CHECK"
+    | "DIAGNOSTIC"
+    | "PROFILE"
+    | "INTERACTIVE";
 
 export type PreviewDataProductSampling =
-    | 'START'
-    | 'END'
-    | 'EACH_FRAME'
-    | 'ON_DEMAND'
-    | 'AGGREGATE'
-    | 'FAILURE';
+    | "START"
+    | "END"
+    | "EACH_FRAME"
+    | "ON_DEMAND"
+    | "AGGREGATE"
+    | "FAILURE";
 
 export type PreviewExtensionUsageMode =
-    | 'EXPLICIT_EFFECT'
-    | 'SUGGESTED_EXTRA_PREVIEW';
+    | "EXPLICIT_EFFECT"
+    | "SUGGESTED_EXTRA_PREVIEW";
 
 export interface PreviewInfo {
     id: string;
@@ -166,7 +166,7 @@ export interface PreviewManifest {
 }
 
 export interface AccessibilityFinding {
-    level: 'ERROR' | 'WARNING' | 'INFO' | string;
+    level: "ERROR" | "WARNING" | "INFO" | string;
     type: string;
     message: string;
     viewDescription?: string | null;
@@ -225,11 +225,25 @@ export interface PreviewRenderErrorTopFrame {
 // See `docs/ANDROID_RESOURCE_PREVIEWS.md` for the data model.
 // -------------------------------------------------------------------------
 
-export type ResourceType = 'VECTOR' | 'ANIMATED_VECTOR' | 'ADAPTIVE_ICON' | string;
+export type ResourceType =
+    | "VECTOR"
+    | "ANIMATED_VECTOR"
+    | "ADAPTIVE_ICON"
+    | string;
 
-export type AdaptiveShape = 'CIRCLE' | 'SQUIRCLE' | 'ROUNDED_SQUARE' | 'SQUARE' | string;
+export type AdaptiveShape =
+    | "CIRCLE"
+    | "SQUIRCLE"
+    | "ROUNDED_SQUARE"
+    | "SQUARE"
+    | string;
 
-export type AdaptiveStyle = 'FULL_COLOR' | 'THEMED_LIGHT' | 'THEMED_DARK' | 'LEGACY' | string;
+export type AdaptiveStyle =
+    | "FULL_COLOR"
+    | "THEMED_LIGHT"
+    | "THEMED_DARK"
+    | "LEGACY"
+    | string;
 
 export interface ResourceVariant {
     /**
@@ -324,7 +338,7 @@ export interface DoctorModuleReport {
 
 export interface DoctorFinding {
     id: string;
-    severity: 'error' | 'warning' | 'info' | string;
+    severity: "error" | "warning" | "info" | string;
     message: string;
     detail?: string | null;
     remediationSummary?: string | null;
@@ -335,7 +349,7 @@ export interface DoctorFinding {
 /** Messages from extension to webview */
 export type ExtensionToWebview =
     | {
-          command: 'setPreviews';
+          command: "setPreviews";
           previews: PreviewInfo[];
           moduleDir: string;
           /**
@@ -348,7 +362,12 @@ export type ExtensionToWebview =
       }
     /** `captureIndex` addresses which capture within an animated preview the
      *  image belongs to. Static previews have a single capture at index 0. */
-    | { command: 'updateImage'; previewId: string; captureIndex: number; imageData: string }
+    | {
+          command: "updateImage";
+          previewId: string;
+          captureIndex: number;
+          imageData: string;
+      }
     /**
      * D2 — daemon-attached `a11y/atf` (findings) and/or `a11y/hierarchy` (nodes) for one
      * preview. The webview updates its in-memory caches and re-applies the existing finding
@@ -356,13 +375,13 @@ export type ExtensionToWebview =
      * node when present. Either field may be undefined to leave the current state untouched.
      */
     | {
-          command: 'updateA11y';
+          command: "updateA11y";
           previewId: string;
           findings?: AccessibilityFinding[] | null;
           nodes?: AccessibilityNode[] | null;
       }
     | {
-          command: 'setImageError';
+          command: "setImageError";
           previewId: string;
           captureIndex: number;
           message: string;
@@ -383,13 +402,13 @@ export type ExtensionToWebview =
            */
           replaceExisting?: boolean;
       }
-    | { command: 'setLoading'; previewId?: string }
-    | { command: 'markAllLoading' }
-    | { command: 'setError'; previewId: string; message: string }
-    | { command: 'showMessage'; text: string }
-    | { command: 'clearAll' }
-    | { command: 'setModules'; modules: string[]; selected: string }
-    | { command: 'setFunctionFilter'; functionName: string }
+    | { command: "setLoading"; previewId?: string }
+    | { command: "markAllLoading" }
+    | { command: "setError"; previewId: string; message: string }
+    | { command: "showMessage"; text: string }
+    | { command: "clearAll" }
+    | { command: "setModules"; modules: string[]; selected: string }
+    | { command: "setFunctionFilter"; functionName: string }
     /**
      * Drives the slim progress bar at the top of the panel. `percent` is
      * monotonic within a refresh and clamped to [0, 1]; `label` is the
@@ -398,9 +417,15 @@ export type ExtensionToWebview =
      * estimate — the webview tints the bar and appends "(slow)" to the
      * label. The webview hides the bar on its own when `percent` reaches 1.
      */
-    | { command: 'setProgress'; phase: string; label: string; percent: number; slow?: boolean }
+    | {
+          command: "setProgress";
+          phase: string;
+          label: string;
+          percent: number;
+          slow?: boolean;
+      }
     /** Force-clear the progress bar (e.g. on cancellation or fatal error). */
-    | { command: 'clearProgress' }
+    | { command: "clearProgress" }
     /**
      * Replace the compile-error banner. Each entry carries its own
      * absolute `path` so the click handler can deep-link to whatever
@@ -409,27 +434,35 @@ export type ExtensionToWebview =
      * but get a "compile-stale" decoration so the user keeps the last
      * successful render visible alongside the error list.
      */
-    | { command: 'setCompileErrors'; errors: import('./compileErrors').CompileError[] }
+    | {
+          command: "setCompileErrors";
+          errors: import("./compileErrors").CompileError[];
+      }
     /** Remove the compile-error banner and the compile-stale dim on cards. */
-    | { command: 'clearCompileErrors' }
+    | { command: "clearCompileErrors" }
     /** Side-by-side diff result for a focused live preview. The webview
      *  swaps in an overlay over the focused image with two labelled images. */
     | {
-          command: 'previewDiffReady';
+          command: "previewDiffReady";
           previewId: string;
-          against: 'head' | 'main';
+          against: "head" | "main";
           leftLabel: string;
           leftImage: string;
           rightLabel: string;
           rightImage: string;
       }
-    | { command: 'previewDiffError'; previewId: string; against: 'head' | 'main'; message: string }
+    | {
+          command: "previewDiffError";
+          previewId: string;
+          against: "head" | "main";
+          message: string;
+      }
     /**
      * Programmatic open of a preview in focus mode + immediate diff
      * request. Used by the "Diff All vs Main" command so picking an item
      * from its quick-pick lands the user directly on the diff result.
      */
-    | { command: 'focusAndDiff'; previewId: string; against: 'head' | 'main' }
+    | { command: "focusAndDiff"; previewId: string; against: "head" | "main" }
     /**
      * `origin/compose-preview/main` (or the local `compose-preview/main`
      * branch, the legacy `preview_main` flat refs, or `packed-refs`) just
@@ -437,7 +470,7 @@ export type ExtensionToWebview =
      * baseline. The live panel re-issues any open "Diff vs main" overlay
      * so the user sees the new bytes without manually clicking.
      */
-    | { command: 'previewMainRefChanged' }
+    | { command: "previewMainRefChanged" }
     /**
      * Interactive (live-stream) mode availability for a given module.
      * Posted by the extension whenever the daemon for [moduleId] becomes
@@ -449,7 +482,7 @@ export type ExtensionToWebview =
      * fallback; see #422).
      */
     | {
-          command: 'setInteractiveAvailability';
+          command: "setInteractiveAvailability";
           moduleId: string;
           ready: boolean;
           interactiveSupported?: boolean;
@@ -463,20 +496,20 @@ export type ExtensionToWebview =
      * without sending its own `setInteractive` messages back (those would
      * race the extension's flush). See INTERACTIVE.md § 3.
      */
-    | { command: 'clearInteractive'; previewId?: string }
-    | { command: 'clearRecording'; previewId?: string }
-    | { command: 'setEarlyFeatures'; enabled: boolean };
+    | { command: "clearInteractive"; previewId?: string }
+    | { command: "clearRecording"; previewId?: string }
+    | { command: "setEarlyFeatures"; enabled: boolean };
 
 /** Messages from webview to extension */
 export type WebviewToExtension =
-    | { command: 'openFile'; className: string; functionName: string }
-    | { command: 'selectModule'; value: string }
+    | { command: "openFile"; className: string; functionName: string }
+    | { command: "selectModule"; value: string }
     /**
      * User clicked a faded heavy card. The extension opts that preview into
      * full-tier refreshes until focus moves to another source scope, and
      * triggers an immediate full-tier render for the selected preview.
      */
-    | { command: 'refreshHeavy'; previewId: string }
+    | { command: "refreshHeavy"; previewId: string }
     /**
      * Webview reports current geometric visibility of preview cards plus
      * cards it predicts will scroll into view next based on scroll velocity
@@ -488,7 +521,7 @@ export type WebviewToExtension =
      * previous send. `predicted` excludes IDs already in `visible` because
      * those are reactively rendered by the visible queue.
      */
-    | { command: 'viewportUpdated'; visible: string[]; predicted: string[] }
+    | { command: "viewportUpdated"; visible: string[]; predicted: string[] }
     /**
      * Webview reports which preview the user has narrowed the live panel to.
      * Drives the History panel's `previewId` filter so it shows only entries
@@ -497,14 +530,19 @@ export type WebviewToExtension =
      * full module view — extension clears the previewId filter on the
      * History panel scope.
      */
-    | { command: 'previewScopeChanged'; previewId: string | null }
+    | { command: "previewScopeChanged"; previewId: string | null }
     /**
      * Click on a compile-error banner row. Extension responds by opening the
      * source file and revealing the position. `sourceFile` is the same
      * absolute path the extension passed in `setCompileErrors`; the line /
      * column come from the LSP diagnostic (1-based).
      */
-    | { command: 'openCompileError'; sourceFile: string; line: number; column: number }
+    | {
+          command: "openCompileError";
+          sourceFile: string;
+          line: number;
+          column: number;
+      }
     /**
      * Click on a runtime-error card's "top app frame" link. Unlike the
      * compile-error path, runtime errors only carry the source-file
@@ -519,14 +557,23 @@ export type WebviewToExtension =
      * for that exact path first; on no hit (or no `className`) we fall
      * back to the basename glob.
      */
-    | { command: 'openSourceFile'; fileName: string; line: number; className?: string }
+    | {
+          command: "openSourceFile";
+          fileName: string;
+          line: number;
+          className?: string;
+      }
     /**
      * Live panel asks the extension to compute a diff for the focused
      * preview against an anchor. `head` = latest archived render in
      * `.compose-preview-history/` for this preview; `main` = same, filtered
      * to entries whose `git.branch` is `main`.
      */
-    | { command: 'requestPreviewDiff'; previewId: string; against: 'head' | 'main' }
+    | {
+          command: "requestPreviewDiff";
+          previewId: string;
+          against: "head" | "main";
+      }
     /**
      * Click on the "Launch on Device" button in the focus-mode toolbar.
      * The extension uses [previewId] to bias module selection (the owner
@@ -535,7 +582,7 @@ export type WebviewToExtension =
      * Falls back to a quick-pick when more than one Android-application
      * module applies the plugin.
      */
-    | { command: 'requestLaunchOnDevice'; previewId: string }
+    | { command: "requestLaunchOnDevice"; previewId: string }
     /**
      * Toggle interactive (live-stream) mode for [previewId]. Daemon-only —
      * the extension routes this into a `setFocus` + `renderNow(tier='fast')`
@@ -544,17 +591,27 @@ export type WebviewToExtension =
      * save/focus-change publishes a fresh focus set on its own. See
      * docs/daemon/INTERACTIVE.md § 4 for the lifecycle.
      */
-    | { command: 'setInteractive'; previewId: string; enabled: boolean }
-    | { command: 'setRecording'; previewId: string; enabled: boolean; format?: 'apng' | 'mp4' }
+    | { command: "setInteractive"; previewId: string; enabled: boolean }
+    | {
+          command: "setRecording";
+          previewId: string;
+          enabled: boolean;
+          format?: "apng" | "mp4";
+      }
     /**
      * Pointer/rotary input on the focused image while interactive mode is on.
      * Coordinates are in IMAGE-NATURAL pixel space — the same coordinate
      * system the renderer thinks in. See docs/daemon/INTERACTIVE.md § 6/§ 7.
      */
     | {
-          command: 'recordInteractiveInput';
+          command: "recordInteractiveInput";
           previewId: string;
-          kind: 'click' | 'pointerDown' | 'pointerMove' | 'pointerUp' | 'rotaryScroll';
+          kind:
+              | "click"
+              | "pointerDown"
+              | "pointerMove"
+              | "pointerUp"
+              | "rotaryScroll";
           pixelX: number;
           pixelY: number;
           imageWidth: number;
@@ -569,4 +626,4 @@ export type WebviewToExtension =
      * and tells the webview to drop the cached nodes/findings. Idempotent on
      * both sides.
      */
-    | { command: 'setA11yOverlay'; previewId: string; enabled: boolean };
+    | { command: "setA11yOverlay"; previewId: string; enabled: boolean };


### PR DESCRIPTION
## Summary

- Add Prettier as a VS Code extension dev dependency.
- Add `format` and `format:check` npm scripts for extension TypeScript, JSON, Markdown, and CSS files.
- Run the first Prettier formatting pass across the matched extension files.
- Update the shared pre-commit hook to run `npm --prefix vscode-extension run format:check` when staged extension files are present.

## Validation

- `npm run format:check`
- `npm run compile`
- `git diff --check`
- Pre-commit hook ran `format:check` during commit creation

## Notes

This PR is mostly mechanical formatting noise from introducing Prettier. SVG files are not included in the Prettier script because this installed Prettier version did not infer a parser for them in this project.