### PR TITLE
Refresh previews when source mtime changes

### DIFF
--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -371,6 +371,12 @@ internal object ComposePreviewTasks {
 
     return project.tasks.register("discoverPreviews", DiscoverPreviewsTask::class.java) {
       classDirs.from(sourceClassDirs)
+      sourceFiles.from(
+        project.fileTree("src") {
+          include("**/*.kt")
+          include("**/*.java")
+        }
+      )
       project.configurations.findByName(dependencyConfigName)?.let { config ->
         // For Android projects, dependencies resolve as AARs. Use artifact view
         // filtering to request the extracted classes.jar (AGP registers the

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -31,6 +31,10 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
   @get:PathSensitive(PathSensitivity.NONE)
   abstract val dependencyJars: ConfigurableFileCollection
 
+  @get:InputFiles
+  @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val sourceFiles: ConfigurableFileCollection
+
   @get:Input abstract val moduleName: Property<String>
 
   @get:Input abstract val variantName: Property<String>
@@ -883,11 +887,24 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
       id = id,
       functionName = method.name,
       className = classInfo.name,
-      sourceFile = packageQualifiedSourcePath(classInfo),
+      sourceFile = sourceFilePath(classInfo),
       params = params,
       captures = outputPlan.captures,
       dataProducts = outputPlan.dataProducts,
     )
+  }
+
+  // Module-relative source path, e.g. "src/main/kotlin/com/example/samplewear/Previews.kt".
+  // Fall back to the old package-qualified path when source files were not wired into the task.
+  private fun sourceFilePath(classInfo: ClassInfo): String? {
+    val packageQualified = packageQualifiedSourcePath(classInfo) ?: return null
+    val source =
+      sourceFiles.files.firstOrNull { file ->
+        file.isFile && file.invariantSeparatorsPath.endsWith(packageQualified)
+      }
+    return source
+      ?.let { project.projectDir.toPath().relativize(it.toPath()).toString() }
+      ?.replace(java.io.File.separatorChar, '/') ?: packageQualified
   }
 
   // Package-qualified source path, e.g. "com/example/samplewear/Previews.kt".

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -364,6 +364,7 @@ class DaemonMcpServer(
     overrides: PreviewOverrides? = null,
   ): RenderOutcome.Finished {
     val daemon = supervisor.daemonFor(uri.workspaceId, uri.modulePath)
+    ensureSourceFreshBeforeRender(uri, daemon)
     val key = PreviewIdKey(uri.workspaceId, uri.modulePath, uri.previewFqn)
     val future = java.util.concurrent.CompletableFuture<RenderOutcome>()
     // Atomically join the right group. `becameFront` (captured outside the compute lambda)
@@ -430,6 +431,52 @@ class DaemonMcpServer(
         error("awaitNextRender failed for $uri: ${outcome.kind} ${outcome.message}")
       is RenderOutcome.Finished -> outcome
     }
+  }
+
+  private fun ensureSourceFreshBeforeRender(uri: PreviewUri, daemon: SupervisedDaemon) {
+    val addr = DaemonAddr(uri.workspaceId, uri.modulePath)
+    val entry = catalog[addr]?.get(uri.previewFqn) ?: return
+    val sourceFile = resolvePreviewSourceFile(uri, entry.sourceFile) ?: return
+    val currentModifiedMs = sourceFile.lastModified().takeIf { it > 0L } ?: return
+    val knownModifiedMs =
+      entry.sourceLastModifiedMs
+        ?: run {
+          catalog[addr]?.computeIfPresent(uri.previewFqn) { _, current ->
+            current.copy(sourceLastModifiedMs = currentModifiedMs)
+          }
+          return
+        }
+    if (currentModifiedMs <= knownModifiedMs) return
+
+    daemon.allClients().forEach { client ->
+      runCatching {
+        client.fileChanged(
+          path = sourceFile.absolutePath,
+          kind = FileKind.SOURCE,
+          changeType = ChangeType.MODIFIED,
+        )
+      }
+    }
+    catalog[addr]?.computeIfPresent(uri.previewFqn) { _, current ->
+      current.copy(sourceLastModifiedMs = currentModifiedMs)
+    }
+  }
+
+  private fun resolvePreviewSourceFile(uri: PreviewUri, sourceFile: String?): File? {
+    if (sourceFile.isNullOrBlank()) return null
+    val direct = File(sourceFile)
+    if (direct.isFile) return direct
+    val project = supervisor.project(uri.workspaceId) ?: return null
+    val moduleDir = moduleDir(project.path, uri.modulePath)
+    val fromModule = File(moduleDir, sourceFile)
+    if (fromModule.isFile) return fromModule
+    return null
+  }
+
+  private fun moduleDir(projectRoot: File, modulePath: String): File {
+    val trimmed = modulePath.trimStart(':')
+    if (trimmed.isEmpty()) return projectRoot
+    return File(projectRoot, trimmed.replace(':', File.separatorChar))
   }
 
   /**
@@ -2666,11 +2713,26 @@ class DaemonMcpServer(
         .orEmpty()
     for (entry in added + changed) {
       val id = entry["id"]?.jsonPrimitive?.contentOrNull ?: continue
+      val sourceFile = entry["sourceFile"]?.jsonPrimitive?.contentOrNull
+      val sourceLastModifiedMs =
+        resolvePreviewSourceFile(
+            PreviewUri(
+              workspaceId = daemon.workspaceId,
+              modulePath = daemon.modulePath,
+              previewFqn = id,
+              config = entry["config"]?.jsonPrimitive?.contentOrNull,
+            ),
+            sourceFile,
+          )
+          ?.lastModified()
+          ?.takeIf { it > 0L }
       byId[id] =
         PreviewEntry(
           fqn = id,
           displayName = entry["displayName"]?.jsonPrimitive?.contentOrNull,
           config = entry["config"]?.jsonPrimitive?.contentOrNull,
+          sourceFile = sourceFile,
+          sourceLastModifiedMs = sourceLastModifiedMs,
         )
     }
     removed.forEach { byId.remove(it) }
@@ -2900,7 +2962,13 @@ class DaemonMcpServer(
 
   private data class DaemonAddr(val workspaceId: WorkspaceId, val modulePath: String)
 
-  private data class PreviewEntry(val fqn: String, val displayName: String?, val config: String?)
+  private data class PreviewEntry(
+    val fqn: String,
+    val displayName: String?,
+    val config: String?,
+    val sourceFile: String?,
+    val sourceLastModifiedMs: Long? = null,
+  )
 
   /**
    * Per-previewId queue key for [previewQueues]. `(workspace, module, previewId)` identifies the

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -1338,6 +1338,42 @@ class DaemonMcpServerTest {
     assertThat(blob.mimeType).isEqualTo("image/png")
   }
 
+  @Test
+  fun `resources read forwards fileChanged when preview source mtime moved since discovery`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    val moduleDir = tmp.newFolder("workspace", "module")
+    val sourceFile = moduleDir.resolve("src/main/kotlin/com/example/Preview.kt")
+    sourceFile.parentFile.mkdirs()
+    sourceFile.writeText("@Preview fun Red() {}")
+    val initialMtime = System.currentTimeMillis() - 10_000
+    assertThat(sourceFile.setLastModified(initialMtime)).isTrue()
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId, sourceFile = "src/main/kotlin/com/example/Preview.kt")
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    sourceFile.writeText("@Preview fun Red() { /* changed */ }")
+    assertThat(sourceFile.setLastModified(initialMtime + 5_000)).isTrue()
+
+    val pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4e, 0x47)
+    val pngFile = tmp.newFile("fresh-render.png")
+    Files.write(pngFile.toPath(), pngBytes)
+    daemon.autoRenderPngPath = { id -> if (id == previewId) pngFile.absolutePath else null }
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    client.request("resources/read", buildJsonObject { put("uri", uri) }, timeoutMs = 10_000)
+
+    val fileChanged = daemon.fileChanges.poll(2_000, TimeUnit.MILLISECONDS)
+    assertThat(fileChanged).isNotNull()
+    assertThat(fileChanged!!["path"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo(sourceFile.canonicalPath)
+    assertThat(fileChanged["kind"]?.jsonPrimitive?.contentOrNull).isEqualTo("source")
+    assertThat(daemon.renderRequests.poll(2_000, TimeUnit.MILLISECONDS))
+      .isEqualTo(listOf(previewId))
+  }
+
   // -------------------------------------------------------------------------
   // D1 — data product tools
   // -------------------------------------------------------------------------

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
@@ -55,6 +55,8 @@ class FakeDaemon : DaemonSpawn {
   val focusSets = java.util.concurrent.LinkedBlockingQueue<List<String>>()
   /** `renderNow` invocations the fake observed. */
   val renderRequests = java.util.concurrent.LinkedBlockingQueue<List<String>>()
+  /** `fileChanged` notifications the fake observed. */
+  val fileChanges = java.util.concurrent.LinkedBlockingQueue<JsonObject>()
   /**
    * `renderNow.overrides` payloads the fake observed (in lockstep with [renderRequests]).
    * `LinkedBlockingQueue` rejects null elements, so we use `CopyOnWriteArrayList` and tests poll by
@@ -249,7 +251,11 @@ class FakeDaemon : DaemonSpawn {
   }
 
   /** Pushes a `discoveryUpdated` notification with one preview added. Test helper. */
-  fun emitDiscovery(previewId: String, displayName: String = previewId) {
+  fun emitDiscovery(
+    previewId: String,
+    displayName: String = previewId,
+    sourceFile: String? = null,
+  ) {
     val params = buildJsonObject {
       putJsonArray("added") {
         add(
@@ -258,6 +264,7 @@ class FakeDaemon : DaemonSpawn {
             put("className", previewId.substringBeforeLast('.'))
             put("methodName", previewId.substringAfterLast('.'))
             put("displayName", displayName)
+            if (sourceFile != null) put("sourceFile", sourceFile)
           }
         )
       }
@@ -604,6 +611,9 @@ class FakeDaemon : DaemonSpawn {
   private fun handleNotification(method: String, params: JsonObject?) {
     when (method) {
       "initialized" -> {}
+      "fileChanged" -> {
+        if (params != null) fileChanges.offer(params)
+      }
       "setVisible" -> {
         val ids =
           (params?.get("ids") as? kotlinx.serialization.json.JsonArray)?.mapNotNull {


### PR DESCRIPTION
## Summary

- Add source files as an input to `discoverPreviews` and emit module-relative `sourceFile` metadata when possible.
- Preserve preview `sourceFile` and discovery-time mtime in the MCP catalog.
- Before serving a preview resource, check the preview source file mtime and forward `fileChanged(kind=source)` to the daemon before `renderNow` when it moved.
- Cover the MCP behavior with a regression test using the fake daemon.

## Notes

This avoids searching the source tree during MCP reads. New manifests point directly at paths like `src/main/kotlin/com/example/Preview.kt`; older package-qualified metadata simply skips the mtime guard.

Fixes #672.

## Validation

- `./gradlew ktfmtFormatAll`
- `./gradlew :mcp:test :gradle-plugin:test`
- `git diff --check`