### PR TITLE
fix: handle MCP serve without project

### DIFF
--- a/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
+++ b/cli/src/main/kotlin/ee/schimke/composeai/cli/McpCommand.kt
@@ -59,7 +59,8 @@ internal class McpCommand(args: List<String>) {
 
       Subcommands:
         serve    Start the MCP server on stdio. Forwards remaining flags to DaemonMcpMain
-                 (--project <path>[:<rootName>], --replicas-per-daemon N).
+                 (--project <path>[:<rootName>] is optional; projects can also be registered
+                 later with the register_project MCP tool).
         install  Bootstrap daemon descriptors for every module with the plugin applied,
                  flip each descriptor's enabled flag, print a `claude mcp add` line,
                  and optionally write Antigravity's MCP config.
@@ -84,10 +85,9 @@ internal class McpCommand(args: List<String>) {
 
   private fun serve(args: List<String>) {
     // Pure delegation — the MCP server owns System.in / System.out for JSON-RPC framing. Anything
-    // we print to stdout would corrupt the wire protocol; status goes to stderr.
-    val forwarded =
-      if (hasProjectArg(args)) args else args + "--project=${resolveProjectDir(args).absolutePath}"
-    DaemonMcpMain.main(forwarded.toTypedArray())
+    // we print to stdout would corrupt the wire protocol; status goes to stderr. Do not infer a
+    // default project from cwd: MCP hosts may launch from "/" and projects can be registered later.
+    DaemonMcpMain.main(args.toTypedArray())
   }
 
   // -- install -----------------------------------------------------------------------------------
@@ -306,10 +306,6 @@ internal class McpCommand(args: List<String>) {
     val cwd = explicit ?: File(".").canonicalFile
     val resolved = findGradleRoot(cwd) ?: cwd
     return resolved
-  }
-
-  private fun hasProjectArg(args: List<String>): Boolean = args.any {
-    it == "--project" || it.startsWith("--project=")
   }
 
   private fun findGradleRoot(from: File): File? {

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -392,6 +392,7 @@ internal object ComposePreviewTasks {
       }
       moduleName.set(project.name)
       variantName.set(extension.variant)
+      projectDirectory.set(project.layout.projectDirectory.asFile.absolutePath)
       // Generic data-product override:
       // `-PcomposePreview.previewExtensions.a11y.allChecks=true` wins over the
       // extension. Lets VSCode / CLI flip the feature on for a run without

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/DiscoverPreviewsTask.kt
@@ -7,6 +7,7 @@ import io.github.classgraph.ClassGraph
 import io.github.classgraph.ClassInfo
 import io.github.classgraph.MethodInfo
 import io.github.classgraph.ScanResult
+import java.io.File
 import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
@@ -38,6 +39,12 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
   @get:Input abstract val moduleName: Property<String>
 
   @get:Input abstract val variantName: Property<String>
+
+  /**
+   * Project root path used to render module-relative source paths in the manifest. Captured at
+   * configuration time so the task action stays configuration-cache-safe.
+   */
+  @get:Input abstract val projectDirectory: Property<String>
 
   /**
    * When `true`, [outputFile] is written with a populated [PreviewManifest.accessibilityReport]
@@ -902,9 +909,15 @@ abstract class DiscoverPreviewsTask : DefaultTask() {
       sourceFiles.files.firstOrNull { file ->
         file.isFile && file.invariantSeparatorsPath.endsWith(packageQualified)
       }
-    return source
-      ?.let { project.projectDir.toPath().relativize(it.toPath()).toString() }
-      ?.replace(java.io.File.separatorChar, '/') ?: packageQualified
+    return source?.let { it.toRelativeStringSafe(File(projectDirectory.get())) } ?: packageQualified
+  }
+
+  private fun File.toRelativeStringSafe(root: File): String {
+    return try {
+      relativeTo(root).path.replace(File.separatorChar, '/')
+    } catch (_: IllegalArgumentException) {
+      absolutePath.replace(File.separatorChar, '/')
+    }
   }
 
   // Package-qualified source path, e.g. "com/example/samplewear/Previews.kt".

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpMain.kt
@@ -33,6 +33,7 @@ object DaemonMcpMain {
 
   @JvmStatic
   fun main(args: Array<String>) {
+    disableKotlinLoggingStartupMessage()
     val replicasPerDaemon = parseReplicasPerDaemon(args)
     val supervisor =
       DaemonSupervisor(
@@ -57,6 +58,17 @@ object DaemonMcpMain {
     // thread so the JVM would otherwise terminate immediately; awaitClose pins main here.
     session.awaitClose()
     runCatching { supervisor.shutdown() }
+  }
+
+  private fun disableKotlinLoggingStartupMessage() {
+    runCatching {
+      val configurationClass =
+        Class.forName("io.github.oshai.kotlinlogging.KotlinLoggingConfiguration")
+      val instance = configurationClass.getField("INSTANCE").get(null)
+      configurationClass
+        .getMethod("setLogStartupMessage", java.lang.Boolean.TYPE)
+        .invoke(instance, false)
+    }
   }
 
   private fun parseProjects(args: Array<String>): List<Pair<String, String?>> {

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -90,7 +90,10 @@ class DaemonSupervisor(
     }
     val canonical =
       runCatching { absolutePath.canonicalFile }.getOrDefault(absolutePath.absoluteFile)
-    val name = rootProjectName ?: canonical.name
+    val name =
+      rootProjectName?.takeIf { it.isNotBlank() }
+        ?: canonical.name.takeIf { it.isNotBlank() }
+        ?: "workspace"
     val workspaceId = WorkspaceId.derive(name, canonical)
     val project =
       projects.computeIfAbsent(workspaceId) {

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonSupervisorTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonSupervisorTest.kt
@@ -1,0 +1,21 @@
+package ee.schimke.composeai.mcp
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.Test
+
+class DaemonSupervisorTest {
+  @Test
+  fun `registerProject tolerates root directory without explicit project name`() {
+    val supervisor =
+      DaemonSupervisor(
+        descriptorProvider = FakeDescriptorProvider(),
+        clientFactory = FakeDaemonClientFactory(),
+      )
+
+    val project = supervisor.registerProject(File("/"))
+
+    assertThat(project.rootProjectName).isEqualTo("workspace")
+    assertThat(project.workspaceId.value).startsWith("workspace-")
+  }
+}


### PR DESCRIPTION
## Summary

Fixes `compose-preview mcp serve` when an MCP host launches the command without an explicit project and with `/` as the working directory. Also fixes the CI configuration-cache failure in `discoverPreviews` that surfaced after this PR was opened.

## Root Cause

The CLI wrapper still inferred a default `--project=<cwd>` for `mcp serve`. Hosts may launch MCP servers from `/`, which caused the server to try registering `/` and fail with a blank root project name. Separately, kotlin-logging's startup banner could print to stdout before the MCP JSON-RPC response, corrupting stdio transport with `invalid character 'k'`.

CI also exposed that `DiscoverPreviewsTask` used `Task.project` at execution time while resolving source file paths, which is unsupported with Gradle configuration cache.

## Changes

- Keep `mcp serve` as pure delegation and do not infer a project from cwd.
- Disable kotlin-logging's startup banner before the Kotlin MCP SDK initializes.
- Make workspace registration tolerate root paths by falling back to `workspace` as the generated root name.
- Add a regression test for registering `/` without an explicit root project name.
- Capture the Gradle project directory as a `DiscoverPreviewsTask` input during configuration, then use that input during execution.

## Validation

- `./gradlew :mcp:test :cli:test`
- `./gradlew :mcp:test --tests ee.schimke.composeai.mcp.DaemonSupervisorTest :cli:installDist`
- `./gradlew :samples:cmp:discoverPreviews`
- `./gradlew :gradle-plugin:functionalTest`
- `./gradlew ktfmtCheckAll :mcp:test :cli:test`
- `./gradlew :samples:android-daemon-bench:discoverPreviews :samples:cmp:discoverPreviews`
- Manually launched the installed CLI from `/` and verified the first stdout line is the MCP initialize JSON response with empty stderr.