### PR TITLE
Validate preview data product outputs

### DIFF
--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/RenderFunctionalTest.kt
@@ -4,6 +4,8 @@ import com.google.common.truth.Truth.assertThat
 import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
@@ -15,7 +17,10 @@ class RenderFunctionalTest {
 
   @get:Rule val tempDir = TemporaryFolder()
 
-  private val json = Json { ignoreUnknownKeys = true }
+  private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+  }
 
   private fun createTestProject(): File {
     val projectDir = tempDir.root
@@ -171,8 +176,57 @@ class RenderFunctionalTest {
         .withPluginClasspath()
         .buildAndFail()
 
-    assertThat(result.output).contains("render produced no PNG")
+    assertThat(result.output).contains("render produced no output file")
     assertThat(result.output).contains("NO-SOURCE")
+  }
+
+  @Test
+  fun `renderAllPreviews fails loudly when render produces no data product output`() {
+    val projectDir = createTestProject()
+
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withArguments("discoverPreviews")
+      .withPluginClasspath()
+      .build()
+
+    val manifestFile = File(projectDir, "build/compose-previews/previews.json")
+    val manifest = json.decodeFromString<PreviewManifest>(manifestFile.readText())
+    val preview = manifest.previews.single()
+    val captureOutput = preview.captures.single().renderOutput
+    File(projectDir, "build/compose-previews/$captureOutput").also {
+      it.parentFile.mkdirs()
+      it.writeBytes(byteArrayOf(1, 2, 3))
+    }
+    manifestFile.writeText(
+      json.encodeToString(
+        manifest.copy(
+          previews =
+            listOf(
+              preview.copy(
+                dataProducts =
+                  listOf(
+                    PreviewDataProduct(
+                      kind = "render/scroll/long",
+                      output = "data/render-scroll-long/${preview.id}.png",
+                      cost = SCROLL_LONG_COST,
+                    )
+                  )
+              )
+            )
+        )
+      )
+    )
+
+    val result =
+      GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withArguments("renderAllPreviews", "-x", "renderPreviews", "--stacktrace")
+        .withPluginClasspath()
+        .buildAndFail()
+
+    assertThat(result.output).contains("render produced no output file")
+    assertThat(result.output).contains(preview.id)
   }
 
   @Test

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -554,52 +554,12 @@ internal object ComposePreviewTasks {
         // from the `<stem>_*` glob so a `Foo_header.png` that
         // belongs to a different preview never gets treated as
         // part of `Foo`'s fan-out.
-        val siblingNames =
-          manifest.previews
-            .filter { it.params.previewParameterProviderClassName == null }
-            .flatMap { it.captures.map { c -> c.renderOutput } }
-            .filter { it.isNotEmpty() }
-            .map { java.io.File(outDir, it).name }
-            .toSet()
-        val missing =
-          manifest.previews
-            .filter { p ->
-              p.captures.any { c ->
-                // `tier=fast` legitimately skips heavy captures —
-                // their PNG/GIF either still exists on disk from a
-                // prior full run (and stays usable as the "stale"
-                // image) or hasn't been produced yet. Either way,
-                // it isn't a wiring bug worth failing the build
-                // over, so exclude them from the must-exist check.
-                if (isFastTier && isHeavyCost(c.cost)) return@any false
-                val rel = c.renderOutput.ifEmpty { "renders/${p.id}.png" }
-                // `@PreviewParameter` previews fan out at render
-                // time: manifest carries a `<stem>.png` template,
-                // but the actual files live at
-                // `<stem>_<label>.png` (one per provider value,
-                // or `_PARAM_<idx>` when the label can't be
-                // derived). Check that at least ONE matching
-                // fan-out file exists instead of demanding the
-                // template itself.
-                if (p.params.previewParameterProviderClassName != null) {
-                  val file = outDir.resolve(rel)
-                  val dir = file.parentFile ?: outDir
-                  val prefix = file.nameWithoutExtension + "_"
-                  val ext = ".${file.extension}"
-                  !(dir.listFiles()?.any { f ->
-                    f.name.startsWith(prefix) && f.name.endsWith(ext) && f.name !in siblingNames
-                  } ?: false)
-                } else {
-                  !outDir.resolve(rel).exists()
-                }
-              }
-            }
-            .map { it.id }
+        val missing = missingPreviewOutputIds(manifest, outDir, isFastTier)
         if (missing.isNotEmpty()) {
           val preview = missing.take(3).joinToString(", ")
           val andMore = if (missing.size > 3) " (+${missing.size - 3} more)" else ""
           throw GradleException(
-            "renderAllPreviews: render produced no PNG for ${missing.size} of " +
+            "renderAllPreviews: render produced no output file for ${missing.size} of " +
               "${manifest.previews.size} preview(s): $preview$andMore. This means " +
               "`renderPreviews` was skipped or silently did nothing — on Android " +
               "that usually means it reported NO-SOURCE because " +
@@ -612,6 +572,67 @@ internal object ComposePreviewTasks {
         marker.writeText("validated\n")
       }
     }
+  }
+
+  internal fun missingPreviewOutputIds(
+    manifest: PreviewManifest,
+    outDir: java.io.File,
+    isFastTier: Boolean,
+  ): List<String> {
+    val siblingNames =
+      manifest.previews
+        .filter { it.params.previewParameterProviderClassName == null }
+        .flatMap { p ->
+          p.captures.map { c -> c.renderOutput } + p.dataProducts.map { product -> product.output }
+        }
+        .filter { it.isNotEmpty() }
+        .map { java.io.File(outDir, it).name }
+        .toSet()
+
+    return manifest.previews
+      .filter { p ->
+        val captureMissing =
+          p.captures.any { c ->
+            if (isFastTier && isHeavyCost(c.cost)) return@any false
+            val rel = c.renderOutput.ifEmpty { "renders/${p.id}.png" }
+            outputMissing(
+              outDir,
+              rel,
+              p.params.previewParameterProviderClassName != null,
+              siblingNames,
+            )
+          }
+        val productMissing =
+          p.dataProducts.any { product ->
+            if (isFastTier && isHeavyCost(product.cost)) return@any false
+            outputMissing(
+              outDir,
+              product.output,
+              p.params.previewParameterProviderClassName != null,
+              siblingNames,
+            )
+          }
+        captureMissing || productMissing
+      }
+      .map { it.id }
+  }
+
+  private fun outputMissing(
+    outDir: java.io.File,
+    rel: String,
+    isPreviewParameter: Boolean,
+    siblingNames: Set<String>,
+  ): Boolean {
+    if (isPreviewParameter) {
+      val file = outDir.resolve(rel)
+      val dir = file.parentFile ?: outDir
+      val prefix = file.nameWithoutExtension + "_"
+      val ext = ".${file.extension}"
+      return !(dir.listFiles()?.any { f ->
+        f.name.startsWith(prefix) && f.name.endsWith(ext) && f.name !in siblingNames
+      } ?: false)
+    }
+    return !outDir.resolve(rel).exists()
   }
 
   /**

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/CleanStaleRendersTest.kt
@@ -1,9 +1,13 @@
 package ee.schimke.composeai.plugin
 
 import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 
 class CleanStaleRendersTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
 
   private val expected = setOf("Foo.png", "sub/Bar.png", "Baz_TIME_500ms.png")
 
@@ -33,5 +37,81 @@ class CleanStaleRendersTest {
     // so the caller decides.
     assertThat(ComposePreviewTasks.isA11ySiblingOfExpected("Foo.png", expected)).isFalse()
     assertThat(ComposePreviewTasks.isA11ySiblingOfExpected("Foo.gif", expected)).isFalse()
+  }
+
+  @Test
+  fun `missing output check includes scroll data products`() {
+    val outDir = tempDir.root.resolve("build/compose-previews")
+    outDir.resolve("renders/Foo.png").also {
+      it.parentFile.mkdirs()
+      it.writeBytes(byteArrayOf(1))
+    }
+    val manifest =
+      PreviewManifest(
+        module = "app",
+        variant = "debug",
+        previews =
+          listOf(
+            PreviewInfo(
+              id = "Foo",
+              functionName = "Foo",
+              className = "com.example.PreviewsKt",
+              captures = listOf(Capture(renderOutput = "renders/Foo.png")),
+              dataProducts =
+                listOf(
+                  PreviewDataProduct(
+                    kind = "render/scroll/long",
+                    output = "data/render-scroll-long/Foo.png",
+                    cost = SCROLL_LONG_COST,
+                  )
+                ),
+            )
+          ),
+      )
+
+    assertThat(ComposePreviewTasks.missingPreviewOutputIds(manifest, outDir, isFastTier = false))
+      .containsExactly("Foo")
+
+    outDir.resolve("data/render-scroll-long/Foo.png").also {
+      it.parentFile.mkdirs()
+      it.writeBytes(byteArrayOf(2))
+    }
+
+    assertThat(ComposePreviewTasks.missingPreviewOutputIds(manifest, outDir, isFastTier = false))
+      .isEmpty()
+  }
+
+  @Test
+  fun `fast tier tolerates missing heavy data products`() {
+    val outDir = tempDir.root.resolve("build/compose-previews")
+    outDir.resolve("renders/Foo.png").also {
+      it.parentFile.mkdirs()
+      it.writeBytes(byteArrayOf(1))
+    }
+    val manifest =
+      PreviewManifest(
+        module = "app",
+        variant = "debug",
+        previews =
+          listOf(
+            PreviewInfo(
+              id = "Foo",
+              functionName = "Foo",
+              className = "com.example.PreviewsKt",
+              captures = listOf(Capture(renderOutput = "renders/Foo.png")),
+              dataProducts =
+                listOf(
+                  PreviewDataProduct(
+                    kind = "render/scroll/long",
+                    output = "data/render-scroll-long/Foo.png",
+                    cost = SCROLL_LONG_COST,
+                  )
+                ),
+            )
+          ),
+      )
+
+    assertThat(ComposePreviewTasks.missingPreviewOutputIds(manifest, outDir, isFastTier = true))
+      .isEmpty()
   }
 }


### PR DESCRIPTION
## Summary

Investigates #679 and tightens the missing test coverage around the 0.9.x scroll data-product migration.

The existing Wear pixel regression test does run in CI and passes on the in-repo sample, but `renderAllPreviews` still only validated `captures[].renderOutput`. After LONG/GIF scroll renders moved into `dataProducts`, a missing or skipped scroll product could escape the aggregate render post-condition as long as the normal static capture existed.

This PR:

- extends `renderAllPreviews` post-condition validation to include `PreviewDataProduct.output`
- preserves the fast-tier behavior that tolerates intentionally skipped heavy products
- adds unit coverage for missing scroll data-product outputs
- adds a functional regression where the static PNG exists but the scroll data-product is missing

## Validation

- `./gradlew :samples:wear:testDebugUnitTest --tests com.example.samplewear.LongScrollPreviewPixelTest --stacktrace`
- `./gradlew :gradle-plugin:test --tests ee.schimke.composeai.plugin.CleanStaleRendersTest --stacktrace`
- `./gradlew :gradle-plugin:functionalTest --tests ee.schimke.composeai.plugin.RenderFunctionalTest --stacktrace`
- `./gradlew :gradle-plugin:ktfmtCheckMain :gradle-plugin:ktfmtCheckTest :gradle-plugin:ktfmtCheckFunctionalTest`
- `git diff --check`

Fixes #679