### PR TITLE
feat: add device background preview extension

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -252,6 +252,8 @@ fun main(args: Array<String>) {
     buildList {
         System.err.println("compose-ai-tools daemon: DeviceClipDataProductRegistry active")
         add(DeviceClipDataProductRegistry(previewIndex = previewIndex))
+        System.err.println("compose-ai-tools daemon: DeviceBackgroundDataProductRegistry active")
+        add(DeviceBackgroundDataProductRegistry(previewIndex = previewIndex))
         System.err.println("compose-ai-tools daemon: RenderTraceDataProductRegistry active")
         add(RenderTraceDataProductRegistry())
         System.err.println("compose-ai-tools daemon: TestFailureDataProductRegistry active")
@@ -310,6 +312,7 @@ fun main(args: Array<String>) {
   val previewExtensions =
     buildList {
       add(RenderPreviewExtension.deviceClipDescriptor)
+      add(RenderPreviewExtension.deviceBackgroundDescriptor)
       add(RenderPreviewExtension.renderTraceDescriptor)
       if (composeTraceEnabled) {
         add(RenderPreviewExtension.composeTraceDescriptor)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -222,6 +222,7 @@ fun main(args: Array<String>) {
     CompositeDataProductRegistry(
       buildList {
         add(DeviceClipDataProductRegistry(previewIndex = previewIndex))
+        add(DeviceBackgroundDataProductRegistry(previewIndex = previewIndex))
         add(RenderTraceDataProductRegistry())
         add(TestFailureDataProductRegistry())
         add(themeRegistry)
@@ -264,6 +265,7 @@ fun main(args: Array<String>) {
       previewExtensions =
         buildList {
           add(RenderPreviewExtension.deviceClipDescriptor)
+          add(RenderPreviewExtension.deviceBackgroundDescriptor)
           add(RenderPreviewExtension.renderTraceDescriptor)
           if (composeTraceEnabled) {
             add(RenderPreviewExtension.composeTraceDescriptor)

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceBackgroundDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceBackgroundDataProduct.kt
@@ -1,0 +1,145 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataFetchResult
+import ee.schimke.composeai.daemon.protocol.DataProductAttachment
+import ee.schimke.composeai.daemon.protocol.DataProductCapability
+import ee.schimke.composeai.daemon.protocol.DataProductFacet
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Metadata product describing the background a client should place behind a rendered device frame.
+ *
+ * Preview annotation settings win because they are an explicit author signal. Otherwise, a render
+ * can provide captured Material3 theme colors through [PreviewContext.inspection]; when no render
+ * has happened yet, the product falls back to Material3's light background color so transparent
+ * component previews remain readable.
+ */
+class DeviceBackgroundDataProductRegistry(previewIndex: PreviewIndex) : DataProductRegistry {
+  private val backgrounds: ConcurrentHashMap<String, DeviceBackground> =
+    ConcurrentHashMap(previewIndex.snapshot().mapValues { (_, preview) -> preview.background() })
+
+  override val capabilities: List<DataProductCapability> =
+    listOf(
+      DataProductCapability(
+        kind = KIND,
+        schemaVersion = SCHEMA_VERSION,
+        transport = DataProductTransport.INLINE,
+        attachable = true,
+        fetchable = true,
+        requiresRerender = false,
+        displayName = "Device background",
+        facets = listOf(DataProductFacet.STRUCTURED),
+        sampling = SamplingPolicy.End,
+      )
+    )
+
+  override fun fetch(
+    previewId: String,
+    kind: String,
+    params: JsonElement?,
+    inline: Boolean,
+  ): DataProductRegistry.Outcome {
+    if (kind != KIND) return DataProductRegistry.Outcome.Unknown
+    val payload = payloadFor(previewId) ?: return DataProductRegistry.Outcome.NotAvailable
+    return DataProductRegistry.Outcome.Ok(
+      DataFetchResult(kind = KIND, schemaVersion = SCHEMA_VERSION, payload = payload)
+    )
+  }
+
+  override fun attachmentsFor(previewId: String, kinds: Set<String>): List<DataProductAttachment> {
+    if (KIND !in kinds) return emptyList()
+    val payload = payloadFor(previewId) ?: return emptyList()
+    return listOf(
+      DataProductAttachment(kind = KIND, schemaVersion = SCHEMA_VERSION, payload = payload)
+    )
+  }
+
+  override fun onRender(previewId: String, result: RenderResult) {
+    result.previewContext?.let { context ->
+      val current = backgrounds[previewId]
+      backgrounds[previewId] = context.material3Background() ?: current ?: fallbackBackground()
+    }
+  }
+
+  private fun payloadFor(previewId: String): JsonElement? =
+    backgrounds[previewId]?.let { background ->
+      buildJsonObject {
+        putJsonBackground("background", background)
+        put("color", background.color)
+        put("source", background.source)
+      }
+    }
+
+  private fun kotlinx.serialization.json.JsonObjectBuilder.putJsonBackground(
+    name: String,
+    background: DeviceBackground,
+  ) {
+    put(
+      name,
+      buildJsonObject {
+        put("color", background.color)
+        put("source", background.source)
+      },
+    )
+  }
+
+  companion object {
+    const val KIND: String = "render/deviceBackground"
+    const val SCHEMA_VERSION: Int = 1
+  }
+}
+
+private data class DeviceBackground(val color: String, val source: String)
+
+private fun PreviewInfoDto.background(): DeviceBackground {
+  val previewParams = params
+  val backgroundColor = previewParams?.backgroundColor
+  return when {
+    backgroundColor != null && backgroundColor != 0L ->
+      DeviceBackground(backgroundColor.hexArgb(), "preview.backgroundColor")
+    previewParams?.showBackground == true -> DeviceBackground("#FFFFFFFF", "preview.showBackground")
+    else -> fallbackBackground()
+  }
+}
+
+private fun PreviewContext.material3Background(): DeviceBackground? {
+  val colorScheme = material3ColorScheme() ?: return null
+  val background =
+    colorScheme["background"]?.takeUnless(::isTransparentColor)
+      ?: colorScheme["surface"]?.takeUnless(::isTransparentColor)
+      ?: return null
+  val source =
+    if (colorScheme["background"]?.equals(background, ignoreCase = true) == true) {
+      "material3.background"
+    } else {
+      "material3.surface"
+    }
+  return DeviceBackground(background.uppercase(), source)
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun PreviewContext.material3ColorScheme(): Map<String, String>? {
+  val payload = inspection.values["compose.material3.themePayload"] ?: return null
+  val resolvedTokens =
+    runCatching { payload.javaClass.getMethod("getResolvedTokens").invoke(payload) }.getOrNull()
+      ?: return null
+  return runCatching {
+      resolvedTokens.javaClass.getMethod("getColorScheme").invoke(resolvedTokens)
+        as? Map<String, String>
+    }
+    .getOrNull()
+}
+
+private fun fallbackBackground(): DeviceBackground =
+  DeviceBackground("#FFFFFBFE", "material3.lightBackgroundFallback")
+
+private fun Long.hexArgb(): String = "#%08X".format(this and 0xFFFFFFFFL)
+
+private fun isTransparentColor(color: String): Boolean =
+  color.length == 9 && color.startsWith("#") && color.substring(1, 3).equals("00", true)

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceBackgroundDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceBackgroundDataProduct.kt
@@ -63,6 +63,7 @@ class DeviceBackgroundDataProductRegistry(previewIndex: PreviewIndex) : DataProd
   override fun onRender(previewId: String, result: RenderResult) {
     result.previewContext?.let { context ->
       val current = backgrounds[previewId]
+      if (current?.previewExplicit == true) return
       backgrounds[previewId] = context.material3Background() ?: current ?: fallbackBackground()
     }
   }
@@ -95,15 +96,28 @@ class DeviceBackgroundDataProductRegistry(previewIndex: PreviewIndex) : DataProd
   }
 }
 
-private data class DeviceBackground(val color: String, val source: String)
+private data class DeviceBackground(
+  val color: String,
+  val source: String,
+  val previewExplicit: Boolean = false,
+)
 
 private fun PreviewInfoDto.background(): DeviceBackground {
   val previewParams = params
   val backgroundColor = previewParams?.backgroundColor
   return when {
     backgroundColor != null && backgroundColor != 0L ->
-      DeviceBackground(backgroundColor.hexArgb(), "preview.backgroundColor")
-    previewParams?.showBackground == true -> DeviceBackground("#FFFFFFFF", "preview.showBackground")
+      DeviceBackground(
+        color = backgroundColor.hexArgb(),
+        source = "preview.backgroundColor",
+        previewExplicit = true,
+      )
+    previewParams?.showBackground == true ->
+      DeviceBackground(
+        color = "#FFFFFFFF",
+        source = "preview.showBackground",
+        previewExplicit = true,
+      )
     else -> fallbackBackground()
   }
 }

--- a/data/render/connector/src/test/kotlin/ee/schimke/composeai/daemon/DeviceBackgroundDataProductRegistryTest.kt
+++ b/data/render/connector/src/test/kotlin/ee/schimke/composeai/daemon/DeviceBackgroundDataProductRegistryTest.kt
@@ -144,6 +144,74 @@ class DeviceBackgroundDataProductRegistryTest {
   }
 
   @Test
+  fun `render context preserves explicit preview background color`() {
+    val registry =
+      DeviceBackgroundDataProductRegistry(
+        PreviewIndex.fromMap(
+          path = null,
+          byId =
+            mapOf(
+              "explicit" to
+                PreviewInfoDto(
+                  id = "explicit",
+                  className = "com.example.PreviewKt",
+                  methodName = "Explicit",
+                  params = PreviewParamsDto(backgroundColor = 0xFF112233),
+                )
+            ),
+        )
+      )
+    registry.onRender(
+      "explicit",
+      RenderResult(
+        id = 1,
+        classLoaderHashCode = 1,
+        classLoaderName = "loader",
+        previewContext = themeContext("explicit", mapOf("background" to "#FFABCDEF")),
+      ),
+    )
+
+    val payload = fetchPayload(registry, "explicit")
+
+    assertEquals("#FF112233", payload["color"]!!.jsonPrimitive.content)
+    assertEquals("preview.backgroundColor", payload["source"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `render context preserves showBackground preview background`() {
+    val registry =
+      DeviceBackgroundDataProductRegistry(
+        PreviewIndex.fromMap(
+          path = null,
+          byId =
+            mapOf(
+              "show-background" to
+                PreviewInfoDto(
+                  id = "show-background",
+                  className = "com.example.PreviewKt",
+                  methodName = "ShowBackground",
+                  params = PreviewParamsDto(showBackground = true),
+                )
+            ),
+        )
+      )
+    registry.onRender(
+      "show-background",
+      RenderResult(
+        id = 1,
+        classLoaderHashCode = 1,
+        classLoaderName = "loader",
+        previewContext = themeContext("show-background", mapOf("background" to "#FFABCDEF")),
+      ),
+    )
+
+    val payload = fetchPayload(registry, "show-background")
+
+    assertEquals("#FFFFFFFF", payload["color"]!!.jsonPrimitive.content)
+    assertEquals("preview.showBackground", payload["source"]!!.jsonPrimitive.content)
+  }
+
+  @Test
   fun `render context falls back to material surface when background is transparent`() {
     val registry =
       DeviceBackgroundDataProductRegistry(
@@ -218,6 +286,19 @@ class DeviceBackgroundDataProductRegistryTest {
     assertTrue(outcome is DataProductRegistry.Outcome.Ok)
     return (outcome as DataProductRegistry.Outcome.Ok).result.payload!!.jsonObject
   }
+
+  private fun themeContext(previewId: String, colors: Map<String, String>): PreviewContext =
+    PreviewContext.Builder(
+        previewId = previewId,
+        backend = null,
+        renderMode = null,
+        outputBaseName = null,
+      )
+      .putInspectionValue(
+        "compose.material3.themePayload",
+        FakeThemePayload(FakeResolvedTokens(colors)),
+      )
+      .build()
 
   private data class FakeThemePayload(val resolvedTokens: FakeResolvedTokens)
 

--- a/data/render/connector/src/test/kotlin/ee/schimke/composeai/daemon/DeviceBackgroundDataProductRegistryTest.kt
+++ b/data/render/connector/src/test/kotlin/ee/schimke/composeai/daemon/DeviceBackgroundDataProductRegistryTest.kt
@@ -1,0 +1,225 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.render.PreviewContext
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DeviceBackgroundDataProductRegistryTest {
+  @Test
+  fun `capability advertises inline fetchable attachable device background`() {
+    val registry = DeviceBackgroundDataProductRegistry(PreviewIndex.empty())
+
+    val cap = registry.capabilities.single()
+    assertEquals(DeviceBackgroundDataProductRegistry.KIND, cap.kind)
+    assertEquals(1, cap.schemaVersion)
+    assertEquals(DataProductTransport.INLINE, cap.transport)
+    assertTrue(cap.attachable)
+    assertTrue(cap.fetchable)
+    assertTrue(!cap.requiresRerender)
+  }
+
+  @Test
+  fun `fetch prefers preview background color`() {
+    val registry =
+      DeviceBackgroundDataProductRegistry(
+        PreviewIndex.fromMap(
+          path = null,
+          byId =
+            mapOf(
+              "explicit" to
+                PreviewInfoDto(
+                  id = "explicit",
+                  className = "com.example.PreviewKt",
+                  methodName = "Explicit",
+                  params = PreviewParamsDto(backgroundColor = 0xFF112233),
+                )
+            ),
+        )
+      )
+
+    val payload = fetchPayload(registry, "explicit")
+
+    assertEquals("#FF112233", payload["color"]!!.jsonPrimitive.content)
+    assertEquals("preview.backgroundColor", payload["source"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `fetch uses white for showBackground preview`() {
+    val registry =
+      DeviceBackgroundDataProductRegistry(
+        PreviewIndex.fromMap(
+          path = null,
+          byId =
+            mapOf(
+              "show-background" to
+                PreviewInfoDto(
+                  id = "show-background",
+                  className = "com.example.PreviewKt",
+                  methodName = "ShowBackground",
+                  params = PreviewParamsDto(showBackground = true),
+                )
+            ),
+        )
+      )
+
+    val payload = fetchPayload(registry, "show-background")
+
+    assertEquals("#FFFFFFFF", payload["background"]!!.jsonObject["color"]!!.jsonPrimitive.content)
+    assertEquals("preview.showBackground", payload["source"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `fetch falls back to material light background for transparent preview`() {
+    val registry =
+      DeviceBackgroundDataProductRegistry(
+        PreviewIndex.fromMap(
+          path = null,
+          byId =
+            mapOf(
+              "plain" to
+                PreviewInfoDto(
+                  id = "plain",
+                  className = "com.example.PreviewKt",
+                  methodName = "Plain",
+                )
+            ),
+        )
+      )
+
+    val payload = fetchPayload(registry, "plain")
+
+    assertEquals("#FFFFFBFE", payload["color"]!!.jsonPrimitive.content)
+    assertEquals("material3.lightBackgroundFallback", payload["source"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `render context replaces fallback with captured Material3 background`() {
+    val registry =
+      DeviceBackgroundDataProductRegistry(
+        PreviewIndex.fromMap(
+          path = null,
+          byId =
+            mapOf(
+              "themed" to
+                PreviewInfoDto(
+                  id = "themed",
+                  className = "com.example.PreviewKt",
+                  methodName = "Themed",
+                )
+            ),
+        )
+      )
+    val context =
+      PreviewContext.Builder(
+          previewId = "themed",
+          backend = null,
+          renderMode = null,
+          outputBaseName = null,
+        )
+        .putInspectionValue(
+          "compose.material3.themePayload",
+          FakeThemePayload(
+            FakeResolvedTokens(mapOf("background" to "#FFABCDEF", "surface" to "#FF111111"))
+          ),
+        )
+        .build()
+    registry.onRender(
+      "themed",
+      RenderResult(
+        id = 1,
+        classLoaderHashCode = 1,
+        classLoaderName = "loader",
+        previewContext = context,
+      ),
+    )
+
+    val payload = fetchPayload(registry, "themed")
+
+    assertEquals("#FFABCDEF", payload["color"]!!.jsonPrimitive.content)
+    assertEquals("material3.background", payload["source"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `render context falls back to material surface when background is transparent`() {
+    val registry =
+      DeviceBackgroundDataProductRegistry(
+        PreviewIndex.fromMap(
+          path = null,
+          byId =
+            mapOf(
+              "themed" to
+                PreviewInfoDto(
+                  id = "themed",
+                  className = "com.example.PreviewKt",
+                  methodName = "Themed",
+                )
+            ),
+        )
+      )
+    registry.onRender(
+      "themed",
+      RenderResult(
+        id = 1,
+        classLoaderHashCode = 1,
+        classLoaderName = "loader",
+        previewContext =
+          PreviewContext.Builder(
+              previewId = "themed",
+              backend = null,
+              renderMode = null,
+              outputBaseName = null,
+            )
+            .putInspectionValue(
+              "compose.material3.themePayload",
+              FakeThemePayload(
+                FakeResolvedTokens(mapOf("background" to "#00123456", "surface" to "#FF654321"))
+              ),
+            )
+            .build(),
+      ),
+    )
+
+    val payload = fetchPayload(registry, "themed")
+
+    assertEquals("#FF654321", payload["color"]!!.jsonPrimitive.content)
+    assertEquals("material3.surface", payload["source"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `unknown preview is not available`() {
+    val registry = DeviceBackgroundDataProductRegistry(PreviewIndex.empty())
+
+    assertEquals(
+      DataProductRegistry.Outcome.NotAvailable,
+      registry.fetch(
+        previewId = "missing",
+        kind = DeviceBackgroundDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      ),
+    )
+  }
+
+  private fun fetchPayload(
+    registry: DeviceBackgroundDataProductRegistry,
+    previewId: String,
+  ): kotlinx.serialization.json.JsonObject {
+    val outcome =
+      registry.fetch(
+        previewId = previewId,
+        kind = DeviceBackgroundDataProductRegistry.KIND,
+        params = null,
+        inline = true,
+      )
+    assertTrue(outcome is DataProductRegistry.Outcome.Ok)
+    return (outcome as DataProductRegistry.Outcome.Ok).result.payload!!.jsonObject
+  }
+
+  private data class FakeThemePayload(val resolvedTokens: FakeResolvedTokens)
+
+  private data class FakeResolvedTokens(val colorScheme: Map<String, String>)
+}

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderPreviewExtension.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/RenderPreviewExtension.kt
@@ -11,6 +11,7 @@ import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 object RenderPreviewExtension {
   const val ID: String = "render"
   const val KIND_DEVICE_CLIP: String = "render/deviceClip"
+  const val KIND_DEVICE_BACKGROUND: String = "render/deviceBackground"
   const val KIND_TRACE: String = "render/trace"
   const val KIND_COMPOSE_AI_TRACE: String = "render/composeAiTrace"
   const val KIND_TEST_FAILURE: String = "test/failure"
@@ -23,6 +24,16 @@ object RenderPreviewExtension {
       traits = setOf(PipelineStepTrait.FrameProcessor),
       requires = setOf(PipelineCapability.DeviceGeometry, PipelineCapability.ImageArtifact),
       provides = setOf(PipelineCapability.DeviceClip, PipelineCapability.ImageArtifact),
+    )
+
+  val deviceBackgroundProcessor: PreviewPipelineStep =
+    PreviewPipelineStep(
+      id = "render.deviceBackground",
+      displayName = "Device background",
+      productKinds = listOf(KIND_DEVICE_BACKGROUND),
+      traits = setOf(PipelineStepTrait.FrameProcessor),
+      requires = setOf(PipelineCapability.ImageArtifact),
+      provides = setOf(PipelineCapability.DeviceBackground, PipelineCapability.ImageArtifact),
     )
 
   val renderTraceProfiler: PreviewPipelineStep =
@@ -79,6 +90,33 @@ object RenderPreviewExtension {
           )
         ),
       steps = listOf(deviceClipProcessor),
+    )
+
+  val deviceBackgroundDescriptor: PreviewExtensionDescriptor =
+    PreviewExtensionDescriptor(
+      id = "render-device-background",
+      displayName = "Device background",
+      cliCommands =
+        listOf(
+          PreviewExtensionCliCommand(
+            id = "render-device-background.get",
+            displayName = "Fetch device background",
+            summary = "Reads the background color that should be applied behind one preview.",
+            command =
+              listOf(
+                "compose-preview",
+                "extensions",
+                "run",
+                "render-device-background.get",
+                "--id",
+                "<preview-id>",
+                "--json",
+              ),
+            requiresDaemon = true,
+            productKinds = listOf(KIND_DEVICE_BACKGROUND),
+          )
+        ),
+      steps = listOf(deviceBackgroundProcessor),
     )
 
   val renderTraceDescriptor: PreviewExtensionDescriptor =

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewExtensionCommandCatalog.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewExtensionCommandCatalog.kt
@@ -14,6 +14,7 @@ object PreviewExtensionCommandCatalog {
   val extensions: List<PreviewExtensionDescriptor> =
     listOf(
       RenderPreviewExtension.deviceClipDescriptor,
+      RenderPreviewExtension.deviceBackgroundDescriptor,
       RenderPreviewExtension.renderTraceDescriptor,
       RenderPreviewExtension.composeTraceDescriptor,
       RenderPreviewExtension.overlayLegendDescriptor,

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewPipeline.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewPipeline.kt
@@ -75,6 +75,7 @@ enum class PipelineCapability {
   SuggestedPreviews,
   DeviceGeometry,
   DeviceClip,
+  DeviceBackground,
   ScrollState,
   SemanticsSnapshot,
   AccessibilityNodes,

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewExtensionCommandCatalogTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/pipeline/PreviewExtensionCommandCatalogTest.kt
@@ -18,4 +18,18 @@ class PreviewExtensionCommandCatalogTest {
     assertEquals(listOf("a11y/overlay"), command.productKinds)
     assertEquals(command, PreviewExtensionCommandCatalog.commandById("a11y-overlay.get"))
   }
+
+  @Test
+  fun deviceBackgroundCommandIsCataloged() {
+    val descriptor =
+      PreviewExtensionCommandCatalog.extensions.single { it.id == "render-device-background" }
+
+    val command = descriptor.cliCommands.single()
+    assertEquals("render-device-background.get", command.id)
+    assertEquals(listOf("render/deviceBackground"), command.productKinds)
+    assertEquals(
+      command,
+      PreviewExtensionCommandCatalog.commandById("render-device-background.get"),
+    )
+  }
 }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -1903,6 +1903,7 @@ class DaemonMcpServer(
     }
     return when (commandId) {
       "render-device-clip.get" -> data("render/deviceClip")
+      "render-device-background.get" -> data("render/deviceBackground")
       "render-trace.get" -> data("render/trace")
       "compose-trace.get" -> data("render/composeAiTrace")
       "a11y.hierarchy.get" -> data("a11y/hierarchy")


### PR DESCRIPTION
## Summary

Closes #664 by adding a `render/deviceBackground` preview extension and data product.

## Details

- Adds `render-device-background` extension metadata and a daemon-free command catalog entry.
- Adds a fetchable/attachable `DeviceBackgroundDataProductRegistry` advertised by Android and desktop daemons.
- Routes `render-device-background.get` through MCP `run_extension_command` to `get_preview_data`.
- Background selection order:
  - explicit `@Preview(backgroundColor = ...)`
  - `@Preview(showBackground = true)` white background
  - captured Material3 `background`, then `surface` when background is transparent
  - Material3 light background fallback `#FFFFFBFE`

## Validation

- `./gradlew :data-render-connector:test :data-render-core:test`
- `./gradlew ktfmtCheckAll :daemon:android:compileDebugKotlin :daemon:desktop:compileKotlin :mcp:test`