### PR TITLE
feat: add material theme preview overrides

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -127,6 +127,7 @@ class PreviewManifestRouter(
         append("captureAdvanceMs=").append(it).append(';')
       }
       inbound["inspectionMode"]?.let { append("inspectionMode=").append(it).append(';') }
+      inbound["material3Theme"]?.let { append("material3Theme=").append(it).append(';') }
       inbound["mode"]?.let { append("mode=").append(it).append(';') }
       append("outputBaseName=").append(resolved.outputBaseName)
     }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -31,9 +31,15 @@ import com.github.takahirom.roborazzi.captureRoboImage
 import ee.schimke.composeai.data.render.PreviewBackends
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.PreviewDeviceSpec
+import ee.schimke.composeai.data.render.extensions.compose.ComposeDataExtensionPipeline
+import ee.schimke.composeai.data.render.extensions.compose.RecordingExtensionCompositionSink
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
+import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
 import ee.schimke.composeai.renderer.AccessibilityChecker
 import java.io.File
+import java.util.Base64
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 
 /**
  * Robolectric/Compose render body for the preview daemon — the per-preview inner loop that turns a
@@ -254,7 +260,15 @@ class RenderEngine(
                     themeFallbackCapture.capture(payload)
                   }
                   val content: @Composable () -> Unit = {
-                    Box(modifier = Modifier.fillMaxSize()) { InvokeComposable(composableMethod) }
+                    ComposeDataExtensionPipeline.Apply(
+                      extensions =
+                        listOfNotNull(spec.material3Theme?.let(::Material3ThemeOverrideExtension)),
+                      previewId = spec.previewId,
+                      renderMode = spec.renderMode,
+                      sink = RecordingExtensionCompositionSink(),
+                    ) {
+                      Box(modifier = Modifier.fillMaxSize()) { InvokeComposable(composableMethod) }
+                    }
                   }
                   InspectablePreviewContent(slotTableCapture, content)
                 }
@@ -732,6 +746,8 @@ data class RenderSpec(
    * semantics (`true`); a11y mode still forces `false` so accessibility semantics are populated.
    */
   val inspectionMode: Boolean? = null,
+  /** Optional Material 3 token overrides applied as a `MaterialTheme` composable wrapper. */
+  val material3Theme: Material3ThemeOverrides? = null,
 ) {
 
   enum class SpecUiMode {
@@ -797,7 +813,20 @@ data class RenderSpec(
           },
         captureAdvanceMs = map["captureAdvanceMs"]?.toLongOrNull()?.takeIf { it > 0L },
         inspectionMode = map["inspectionMode"]?.toBooleanStrictOrNull(),
+        material3Theme = map["material3Theme"]?.decodeMaterial3ThemeOverrides(),
       )
     }
+
+    private val json = Json {
+      ignoreUnknownKeys = true
+      encodeDefaults = false
+    }
+
+    private fun String.decodeMaterial3ThemeOverrides(): Material3ThemeOverrides? =
+      runCatching {
+          val bytes = Base64.getUrlDecoder().decode(this)
+          json.decodeFromString(Material3ThemeOverrides.serializer(), bytes.toString(Charsets.UTF_8))
+        }
+        .getOrNull()
   }
 }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -242,6 +242,7 @@ open class RobolectricHost(
       "device",
       "captureAdvanceMs",
       "inspectionMode",
+      "material3Theme",
     )
 
   /** PROTOCOL.md § 3 — android backend identifier surfaced via `capabilities.backend`. */
@@ -914,6 +915,7 @@ open class RobolectricHost(
                 null -> null
               },
             inspectionMode = base.inspectionMode,
+            material3Theme = base.material3Theme,
           ),
         overrides = overrides,
       )
@@ -939,6 +941,7 @@ open class RobolectricHost(
           null -> null
         },
       inspectionMode = merged.inspectionMode,
+      material3Theme = merged.material3Theme,
       outputBaseName = "recording-$recordingId",
     )
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -37,6 +37,7 @@ import ee.schimke.composeai.daemon.protocol.JsonRpcResponse
 import ee.schimke.composeai.daemon.protocol.KnownDevice
 import ee.schimke.composeai.daemon.protocol.LeakDetectionMode
 import ee.schimke.composeai.daemon.protocol.Manifest
+import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
 import ee.schimke.composeai.daemon.protocol.Orientation
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.PruneReasonWire
@@ -907,6 +908,19 @@ class JsonRpcServer(
       overrides.inspectionMode?.let {
         if (isNotEmpty()) append(';')
         append("inspectionMode=").append(it)
+      }
+      overrides.material3Theme?.let {
+        if (isNotEmpty()) append(';')
+        append("material3Theme=")
+        append(
+          Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(
+              json
+                .encodeToString(Material3ThemeOverrides.serializer(), it)
+                .toByteArray(Charsets.UTF_8)
+            )
+        )
       }
     }
   }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/PreviewOverrideMerge.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
+import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
 import ee.schimke.composeai.daemon.protocol.Orientation
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.UiMode
@@ -22,6 +23,7 @@ data class PreviewOverrideBaseSpec(
   val uiMode: UiMode?,
   val orientation: Orientation?,
   val inspectionMode: Boolean?,
+  val material3Theme: Material3ThemeOverrides? = null,
 )
 
 data class MergedPreviewOverrides(
@@ -34,6 +36,7 @@ data class MergedPreviewOverrides(
   val uiMode: UiMode?,
   val orientation: Orientation?,
   val inspectionMode: Boolean?,
+  val material3Theme: Material3ThemeOverrides?,
 )
 
 /**
@@ -59,6 +62,7 @@ fun mergePreviewOverrides(
       uiMode = base.uiMode,
       orientation = base.orientation,
       inspectionMode = base.inspectionMode,
+      material3Theme = base.material3Theme,
     )
   }
   val deviceOverride = overrides.device?.takeIf { it.isNotBlank() }
@@ -80,5 +84,6 @@ fun mergePreviewOverrides(
     uiMode = overrides.uiMode ?: base.uiMode,
     orientation = overrides.orientation ?: base.orientation,
     inspectionMode = overrides.inspectionMode ?: base.inspectionMode,
+    material3Theme = overrides.material3Theme ?: base.material3Theme,
   )
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -372,6 +372,31 @@ data class PreviewOverrides(
    * without allocating a held interactive session.
    */
   val inspectionMode: Boolean? = null,
+  /**
+   * Optional Material 3 theme token overrides applied by the renderer as a normal
+   * `MaterialTheme(...) { preview() }` wrapper around the invoked preview. This lets callers test
+   * components under alternate color, shape, or typography tokens without editing source previews.
+   */
+  val material3Theme: Material3ThemeOverrides? = null,
+)
+
+@Serializable
+data class Material3ThemeOverrides(
+  /** Material 3 color role -> `#RRGGBB` or `#AARRGGBB`. */
+  val colorScheme: Map<String, String> = emptyMap(),
+  /** Material 3 text style name -> partial text-style override. */
+  val typography: Map<String, Material3TypographyOverride> = emptyMap(),
+  /** Material 3 shape token name -> rounded corner size in dp. */
+  val shapes: Map<String, Float> = emptyMap(),
+)
+
+@Serializable
+data class Material3TypographyOverride(
+  val fontSizeSp: Float? = null,
+  val lineHeightSp: Float? = null,
+  val letterSpacingSp: Float? = null,
+  val fontWeight: Int? = null,
+  val italic: Boolean? = null,
 )
 
 @Serializable

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -170,6 +170,7 @@ open class DesktopHost(
     add("uiMode")
     add("device")
     add("inspectionMode")
+    add("material3Theme")
   }
 
   /** PROTOCOL.md § 3 — desktop backend identifier surfaced via `capabilities.backend`. */
@@ -432,6 +433,7 @@ open class DesktopHost(
                 null -> null
               },
             inspectionMode = base.inspectionMode,
+            material3Theme = base.material3Theme,
           ),
         overrides = overrides,
       )
@@ -459,6 +461,7 @@ open class DesktopHost(
       uiMode = uiMode,
       orientation = orientation,
       inspectionMode = merged.inspectionMode,
+      material3Theme = merged.material3Theme,
       outputBaseName = "recording-$recordingId",
     )
   }

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/PreviewManifestRouter.kt
@@ -102,6 +102,7 @@ class PreviewManifestRouter(
             inbound["orientation"]?.let { append("orientation=").append(it).append(';') }
             inbound["captureAdvanceMs"]?.let { append("captureAdvanceMs=").append(it).append(';') }
             inbound["inspectionMode"]?.let { append("inspectionMode=").append(it).append(';') }
+            inbound["material3Theme"]?.let { append("material3Theme=").append(it).append(';') }
             append("outputBaseName=").append(resolved.outputBaseName)
           },
       )

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -27,12 +27,18 @@ import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.intl.LocaleList
 import androidx.compose.ui.unit.Density
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
+import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
 import ee.schimke.composeai.data.render.PreviewBackends
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.PreviewDeviceSpec
+import ee.schimke.composeai.data.render.extensions.compose.ComposeDataExtensionPipeline
+import ee.schimke.composeai.data.render.extensions.compose.RecordingExtensionCompositionSink
 import java.io.File
+import java.util.Base64
 import java.util.Collections
 import java.util.WeakHashMap
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import org.jetbrains.skia.EncodedImageFormat
 
 /**
@@ -246,9 +252,17 @@ class RenderEngine(
                   else -> Color.Transparent
                 }
               Box(modifier = Modifier.fillMaxSize().background(bgColor)) {
-                // Trampoline through a @Composable so the reflective invocation lands inside the
-                // running composition. Mirrors `:renderer-desktop`'s InvokeComposable.
-                InvokeComposable(composableMethod)
+                ComposeDataExtensionPipeline.Apply(
+                  extensions =
+                    listOfNotNull(spec.material3Theme?.let(::Material3ThemeOverrideExtension)),
+                  previewId = spec.previewId,
+                  renderMode = spec.renderMode,
+                  sink = RecordingExtensionCompositionSink(),
+                ) {
+                  // Trampoline through a @Composable so the reflective invocation lands inside the
+                  // running composition. Mirrors `:renderer-desktop`'s InvokeComposable.
+                  InvokeComposable(composableMethod)
+                }
               }
             }
             if (slotTableCapture != null) {
@@ -512,6 +526,8 @@ data class RenderSpec(
    * semantics (`true`); held interactive/recording sessions pass their own runtime-like `false`.
    */
   val inspectionMode: Boolean? = null,
+  /** Optional Material 3 token overrides applied as a `MaterialTheme` composable wrapper. */
+  val material3Theme: Material3ThemeOverrides? = null,
 ) {
 
   enum class SpecUiMode {
@@ -581,8 +597,24 @@ data class RenderSpec(
             else -> null
           },
         inspectionMode = map["inspectionMode"]?.toBooleanStrictOrNull(),
+        material3Theme = map["material3Theme"]?.decodeMaterial3ThemeOverrides(),
       )
     }
+
+    private val json = Json {
+      ignoreUnknownKeys = true
+      encodeDefaults = false
+    }
+
+    private fun String.decodeMaterial3ThemeOverrides(): Material3ThemeOverrides? =
+      runCatching {
+          val bytes = Base64.getUrlDecoder().decode(this)
+          json.decodeFromString(
+            Material3ThemeOverrides.serializer(),
+            bytes.toString(Charsets.UTF_8),
+          )
+        }
+        .getOrNull()
   }
 }
 

--- a/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
+++ b/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
@@ -11,17 +12,25 @@ import androidx.compose.runtime.tooling.CompositionGroup
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isSpecified
+import androidx.compose.ui.unit.sp
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
+import ee.schimke.composeai.daemon.protocol.Material3TypographyOverride
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
 import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
 import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
 import ee.schimke.composeai.data.render.extensions.compose.ComposableExtractorExtension
+import ee.schimke.composeai.data.render.extensions.compose.ComposeColorSpec
 import ee.schimke.composeai.data.render.extensions.compose.ExtensionCompositionSink
 import java.lang.reflect.Method
 import java.util.concurrent.ConcurrentHashMap
@@ -30,6 +39,41 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
 const val MATERIAL3_THEME_PAYLOAD_CONTEXT_KEY: String = "compose.material3.themePayload"
+
+@Composable
+fun Material3ThemeOverride(overrides: Material3ThemeOverrides?, content: @Composable () -> Unit) {
+  if (overrides == null || overrides.isEmpty()) {
+    content()
+    return
+  }
+  MaterialTheme(
+    colorScheme = MaterialTheme.colorScheme.withOverrides(overrides.colorScheme),
+    typography = MaterialTheme.typography.withOverrides(overrides.typography),
+    shapes = MaterialTheme.shapes.withOverrides(overrides.shapes),
+    content = content,
+  )
+}
+
+/**
+ * Clean Compose-facing connector for applying Material3 theme overrides.
+ *
+ * Hosts should plan this extension when a request carries Material3 override tokens instead of
+ * hardcoding a renderer-side `MaterialTheme` wrapper.
+ */
+class Material3ThemeOverrideExtension(private val overrides: Material3ThemeOverrides?) :
+  AroundComposableExtension(
+    id = DataExtensionId("compose/material3ThemeOverride"),
+    constraints =
+      DataExtensionConstraints(
+        phase = DataExtensionPhase.UserEnvironment,
+        provides = setOf(DataExtensionCapability("compose/material3ThemeOverride")),
+      ),
+  ) {
+  @Composable
+  override fun AroundComposable(content: @Composable () -> Unit) {
+    Material3ThemeOverride(overrides, content)
+  }
+}
 
 /**
  * Compose daemon producer for `compose/theme`.
@@ -464,6 +508,98 @@ internal object MaterialThemeInspectionSnapshot {
 
   private fun CompositionGroup.flattenGroups(): List<CompositionGroup> =
     listOf(this) + compositionGroups.flatMap { it.flattenGroups() }
+}
+
+private fun Material3ThemeOverrides.isEmpty(): Boolean =
+  colorScheme.isEmpty() && typography.isEmpty() && shapes.isEmpty()
+
+private fun ColorScheme.withOverrides(overrides: Map<String, String>): ColorScheme {
+  if (overrides.isEmpty()) return this
+  fun color(name: String): Color? = overrides[name]?.parseComposeColor()
+  return copy(
+    primary = color("primary") ?: primary,
+    onPrimary = color("onPrimary") ?: onPrimary,
+    primaryContainer = color("primaryContainer") ?: primaryContainer,
+    onPrimaryContainer = color("onPrimaryContainer") ?: onPrimaryContainer,
+    inversePrimary = color("inversePrimary") ?: inversePrimary,
+    secondary = color("secondary") ?: secondary,
+    onSecondary = color("onSecondary") ?: onSecondary,
+    secondaryContainer = color("secondaryContainer") ?: secondaryContainer,
+    onSecondaryContainer = color("onSecondaryContainer") ?: onSecondaryContainer,
+    tertiary = color("tertiary") ?: tertiary,
+    onTertiary = color("onTertiary") ?: onTertiary,
+    tertiaryContainer = color("tertiaryContainer") ?: tertiaryContainer,
+    onTertiaryContainer = color("onTertiaryContainer") ?: onTertiaryContainer,
+    background = color("background") ?: background,
+    onBackground = color("onBackground") ?: onBackground,
+    surface = color("surface") ?: surface,
+    onSurface = color("onSurface") ?: onSurface,
+    surfaceVariant = color("surfaceVariant") ?: surfaceVariant,
+    onSurfaceVariant = color("onSurfaceVariant") ?: onSurfaceVariant,
+    surfaceTint = color("surfaceTint") ?: surfaceTint,
+    inverseSurface = color("inverseSurface") ?: inverseSurface,
+    inverseOnSurface = color("inverseOnSurface") ?: inverseOnSurface,
+    error = color("error") ?: error,
+    onError = color("onError") ?: onError,
+    errorContainer = color("errorContainer") ?: errorContainer,
+    onErrorContainer = color("onErrorContainer") ?: onErrorContainer,
+    outline = color("outline") ?: outline,
+    outlineVariant = color("outlineVariant") ?: outlineVariant,
+    scrim = color("scrim") ?: scrim,
+  )
+}
+
+private fun Typography.withOverrides(
+  overrides: Map<String, Material3TypographyOverride>
+): Typography {
+  if (overrides.isEmpty()) return this
+  fun TextStyle.override(name: String): TextStyle =
+    overrides[name]?.let { token ->
+      copy(
+        fontSize = token.fontSizeSp?.sp ?: fontSize,
+        lineHeight = token.lineHeightSp?.sp ?: lineHeight,
+        letterSpacing = token.letterSpacingSp?.sp ?: letterSpacing,
+        fontWeight = material3FontWeightOverride(token.fontWeight) ?: fontWeight,
+        fontStyle =
+          token.italic?.let { if (it) FontStyle.Italic else FontStyle.Normal } ?: fontStyle,
+      )
+    } ?: this
+  return copy(
+    displayLarge = displayLarge.override("displayLarge"),
+    displayMedium = displayMedium.override("displayMedium"),
+    displaySmall = displaySmall.override("displaySmall"),
+    headlineLarge = headlineLarge.override("headlineLarge"),
+    headlineMedium = headlineMedium.override("headlineMedium"),
+    headlineSmall = headlineSmall.override("headlineSmall"),
+    titleLarge = titleLarge.override("titleLarge"),
+    titleMedium = titleMedium.override("titleMedium"),
+    titleSmall = titleSmall.override("titleSmall"),
+    bodyLarge = bodyLarge.override("bodyLarge"),
+    bodyMedium = bodyMedium.override("bodyMedium"),
+    bodySmall = bodySmall.override("bodySmall"),
+    labelLarge = labelLarge.override("labelLarge"),
+    labelMedium = labelMedium.override("labelMedium"),
+    labelSmall = labelSmall.override("labelSmall"),
+  )
+}
+
+internal fun material3FontWeightOverride(weight: Int?): FontWeight? =
+  weight?.takeIf { it in 1..1000 }?.let(::FontWeight)
+
+private fun Shapes.withOverrides(overrides: Map<String, Float>): Shapes {
+  if (overrides.isEmpty()) return this
+  fun rounded(name: String) = overrides[name]?.let { RoundedCornerShape(it.dp) }
+  return copy(
+    extraSmall = rounded("extraSmall") ?: extraSmall,
+    small = rounded("small") ?: small,
+    medium = rounded("medium") ?: medium,
+    large = rounded("large") ?: large,
+    extraLarge = rounded("extraLarge") ?: extraLarge,
+  )
+}
+
+private fun String.parseComposeColor(): Color? {
+  return runCatching { ComposeColorSpec.resolve(this) }.getOrNull()
 }
 
 fun Color.hexArgb(): String = "#%08X".format(toArgb())

--- a/data/theme/connector/src/test/kotlin/ee/schimke/composeai/daemon/ThemeDataProductTest.kt
+++ b/data/theme/connector/src/test/kotlin/ee/schimke/composeai/daemon/ThemeDataProductTest.kt
@@ -1,0 +1,44 @@
+package ee.schimke.composeai.daemon
+
+import androidx.compose.ui.text.font.FontWeight
+import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
+import ee.schimke.composeai.data.render.extensions.compose.hasAroundComposableHook
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ThemeDataProductTest {
+  @Test
+  fun `material theme override extension declares around composable hook`() {
+    val extension =
+      Material3ThemeOverrideExtension(
+        Material3ThemeOverrides(colorScheme = mapOf("primary" to "#FF336699"))
+      )
+    val hook: AroundComposableHook = extension
+
+    assertEquals(DataExtensionId("compose/material3ThemeOverride"), extension.id)
+    assertEquals(setOf(DataExtensionHookKind.AroundComposable), extension.hooks)
+    assertEquals(DataExtensionPhase.UserEnvironment, extension.constraints.phase)
+    assertTrue(extension.hasAroundComposableHook)
+    assertEquals(extension, hook)
+  }
+
+  @Test
+  fun `material font weight override accepts compose range`() {
+    assertEquals(FontWeight(1), material3FontWeightOverride(1))
+    assertEquals(FontWeight(700), material3FontWeightOverride(700))
+    assertEquals(FontWeight(1000), material3FontWeightOverride(1000))
+  }
+
+  @Test
+  fun `material font weight override ignores invalid values`() {
+    assertNull(material3FontWeightOverride(null))
+    assertNull(material3FontWeightOverride(0))
+    assertNull(material3FontWeightOverride(1001))
+  }
+}

--- a/docs/daemon/INTERACTIVE.md
+++ b/docs/daemon/INTERACTIVE.md
@@ -298,8 +298,8 @@ multiple concurrent streams coexist. The dispatch flow inside `JsonRpcServer`:
 ## 8a. Display overrides
 
 Per-render display properties — **size**, **density**, **locale**,
-**fontScale**, **uiMode** (light/dark), **orientation**, **device** — ride
-on the existing `renderNow` request via the optional `overrides` field
+**fontScale**, **uiMode** (light/dark), **orientation**, **device**, and
+**Material 3 theme tokens** — ride on the existing `renderNow` request via the optional `overrides` field
 documented in [PROTOCOL.md § 5](PROTOCOL.md#renderNow). They are not
 interactive-only: any caller (panel, MCP, future RPC) can attach overrides
 to a single `renderNow` to get a one-off render with a different qualifier
@@ -317,6 +317,23 @@ widthPx: 600` to force a wider window on the Pixel 5's density, or
 device frame (the Android backend's `isRoundDevice` round-detection picks
 up the override). Unknown ids fall back to the daemon's default
 (400×800dp at xxhdpi).
+
+**Material 3 theme override.** `material3Theme` lets callers test components
+against alternate Material 3 color, typography, and shape tokens without
+editing the preview. The renderer applies the override through the normal
+composition path as `MaterialTheme(...) { InvokeComposable(...) }`, so regular
+Material components and `MaterialTheme.colorScheme` / `typography` / `shapes`
+reads see the supplied values. Example:
+
+```json
+{
+  "material3Theme": {
+    "colorScheme": { "primary": "#FF336699", "onPrimary": "#FFFFFFFF" },
+    "typography": { "bodyLarge": { "fontSizeSp": 18.0, "fontWeight": 700 } },
+    "shapes": { "medium": 16.0 }
+  }
+}
+```
 
 **Why not interactive-only.** Size/density/locale/fontScale/uiMode/orientation
 are all the same Robolectric qualifier knob (`setQualifiers` +

--- a/docs/daemon/PROTOCOL.md
+++ b/docs/daemon/PROTOCOL.md
@@ -142,7 +142,8 @@ Result:
   //
   // supportedOverrides — the `PreviewOverrides` field names this daemon's host actually applies
   // (subset of {"widthPx","heightPx","density","localeTag","fontScale","uiMode","orientation",
-  // "device","captureAdvanceMs","inspectionMode"}). Lets clients grey out unsupported sliders.
+  // "device","captureAdvanceMs","inspectionMode","material3Theme"}). Lets clients grey out
+  // unsupported sliders.
   // Empty list = pre-feature daemon;
   // treat absent and `[]` identically and assume any field might be ignored.
   // Today: Robolectric advertises every field; Desktop omits "orientation" (no rotation concept
@@ -241,6 +242,17 @@ A `classpath` event triggers Tier-1 fingerprint recomputation; on mismatch the d
                                      // default ≈ 32ms. Bump for animation-heavy previews.
   inspectionMode?: boolean;          // Override LocalInspectionMode for this one-shot render.
                                      // Null/absent keeps normal preview semantics.
+  material3Theme?: {                 // Material 3 tokens applied as MaterialTheme { preview() }.
+    colorScheme?: Record<string, string>; // Role -> "#RRGGBB" or "#AARRGGBB".
+    typography?: Record<string, {    // Text style name -> partial override.
+      fontSizeSp?: number;
+      lineHeightSp?: number;
+      letterSpacingSp?: number;
+      fontWeight?: number;
+      italic?: boolean;
+    }>;
+    shapes?: Record<string, number>; // Shape token name -> rounded corner size in dp.
+  };
 }
 
 // result
@@ -252,7 +264,7 @@ A `classpath` event triggers Tier-1 fingerprint recomputation; on mismatch the d
 
 The result resolves as soon as the request is queued, **not** when rendering completes. Per-render progress arrives as `renderStarted` / `renderFinished` / `renderFailed` notifications keyed by ID.
 
-`overrides` are merged onto the discovery-time `RenderSpec` per-call. A subsequent `renderNow` for the same preview **without** `overrides` reverts to the discovery-time defaults — overrides are not sticky across calls. Backends that don't model a particular field ignore it (e.g. desktop has no display rotation concept, so `orientation` is a no-op on the desktop render path today; desktop `localeTag` requires a Compose UI runtime that exposes a providable locale list). `inspectionMode` controls the `LocalInspectionMode` value for this one-shot render; absent/null preserves preview behaviour (`true`).
+`overrides` are merged onto the discovery-time `RenderSpec` per-call. A subsequent `renderNow` for the same preview **without** `overrides` reverts to the discovery-time defaults — overrides are not sticky across calls. Backends that don't model a particular field ignore it (e.g. desktop has no display rotation concept, so `orientation` is a no-op on the desktop render path today; desktop `localeTag` requires a Compose UI runtime that exposes a providable locale list). `inspectionMode` controls the `LocalInspectionMode` value for this one-shot render; absent/null preserves preview behaviour (`true`). `material3Theme` is applied in the renderer's normal Compose tree as a `MaterialTheme(...) { preview() }` wrapper, so it affects components that read Material 3 locals without requiring the preview source to declare its own theme.
 
 **Coalescing.** When `overrides` is non-null and a prior override-bearing render is still in-flight for the same `previewId`, the new request is rejected with `reason = "coalesced: …"` rather than queued. The client (panel, MCP, etc.) is responsible for resubmitting on the next `renderFinished` if the latest override values still differ from what was rendered. Plain (no-overrides) `renderNow` is unaffected — the existing save-debounce loop continues to coalesce upstream.
 

--- a/docs/daemon/protocol-fixtures/client-renderNow-overrides.json
+++ b/docs/daemon/protocol-fixtures/client-renderNow-overrides.json
@@ -12,6 +12,22 @@
     "orientation": "portrait",
     "device": "id:pixel_5",
     "captureAdvanceMs": 250,
-    "inspectionMode": false
+    "inspectionMode": false,
+    "material3Theme": {
+      "colorScheme": {
+        "primary": "#FF336699",
+        "onPrimary": "#FFFFFFFF"
+      },
+      "typography": {
+        "bodyLarge": {
+          "fontSizeSp": 18.0,
+          "lineHeightSp": 24.0,
+          "fontWeight": 700
+        }
+      },
+      "shapes": {
+        "medium": 16.0
+      }
+    }
   }
 }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.mcp
 import ee.schimke.composeai.daemon.protocol.ChangeType
 import ee.schimke.composeai.daemon.protocol.FileKind
 import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
+import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
 import ee.schimke.composeai.daemon.protocol.Orientation
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
@@ -36,6 +37,7 @@ import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
@@ -713,7 +715,16 @@ class DaemonMcpServer(
                     "orientation":{"type":"string","enum":["portrait","landscape"],"description":"Portrait/landscape override. Android-only today."},
                     "device":{"type":"string","description":"@Preview(device=...) string — 'id:pixel_5', 'id:wearos_small_round', 'id:tv_1080p', or full 'spec:width=400dp,height=800dp,dpi=320'. Resolved by the daemon's catalog into widthPx/heightPx/density; explicit width/height/density overrides on this same object take precedence."},
                     "captureAdvanceMs":{"type":"integer","description":"Paused-clock advance before capture. Android-only today."},
-                    "inspectionMode":{"type":"boolean","description":"Override LocalInspectionMode for this one-shot render. Null/default keeps preview semantics."}
+                    "inspectionMode":{"type":"boolean","description":"Override LocalInspectionMode for this one-shot render. Null/default keeps preview semantics."},
+                    "material3Theme":{
+                      "type":"object",
+                      "description":"Material 3 theme token overrides applied as a normal MaterialTheme wrapper around the preview.",
+                      "properties":{
+                        "colorScheme":{"type":"object","additionalProperties":{"type":"string"},"description":"Color role names to #RRGGBB or #AARRGGBB, e.g. primary, onPrimary, surface."},
+                        "typography":{"type":"object","additionalProperties":{"type":"object","properties":{"fontSizeSp":{"type":"number"},"lineHeightSp":{"type":"number"},"letterSpacingSp":{"type":"number"},"fontWeight":{"type":"integer"},"italic":{"type":"boolean"}}},"description":"Text style names to partial overrides, e.g. bodyLarge, titleMedium, labelSmall."},
+                        "shapes":{"type":"object","additionalProperties":{"type":"number"},"description":"Shape token names to rounded corner size in dp, e.g. small, medium, extraLarge."}
+                      }
+                    }
                   }
                 }
               },
@@ -1393,6 +1404,7 @@ class DaemonMcpServer(
       check("device", overrides.device != null)
       check("captureAdvanceMs", overrides.captureAdvanceMs != null)
       check("inspectionMode", overrides.inspectionMode != null)
+      check("material3Theme", overrides.material3Theme != null)
     }
     val deviceOverride = overrides.device
     val knownIds = daemon.knownDeviceIds
@@ -1468,6 +1480,10 @@ class DaemonMcpServer(
       device = str("device"),
       captureAdvanceMs = int("captureAdvanceMs")?.toLong(),
       inspectionMode = bool("inspectionMode"),
+      material3Theme =
+        obj["material3Theme"]
+          ?.takeUnless { it is kotlinx.serialization.json.JsonNull }
+          ?.let { json.decodeFromJsonElement(Material3ThemeOverrides.serializer(), it) },
     )
   }
 

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -694,6 +694,20 @@ class DaemonMcpServerTest {
             put("device", "id:pixel_5")
             put("captureAdvanceMs", 250)
             put("inspectionMode", false)
+            putJsonObject("material3Theme") {
+              putJsonObject("colorScheme") {
+                put("primary", "#FF336699")
+                put("onPrimary", "#FFFFFFFF")
+              }
+              putJsonObject("typography") {
+                putJsonObject("bodyLarge") {
+                  put("fontSizeSp", 18)
+                  put("lineHeightSp", 24)
+                  put("fontWeight", 700)
+                }
+              }
+              putJsonObject("shapes") { put("medium", 16) }
+            }
           },
         )
       },
@@ -712,6 +726,10 @@ class DaemonMcpServerTest {
     assertThat(firstOverrides.device).isEqualTo("id:pixel_5")
     assertThat(firstOverrides.captureAdvanceMs).isEqualTo(250L)
     assertThat(firstOverrides.inspectionMode).isFalse()
+    val material3Theme = firstOverrides.material3Theme!!
+    assertThat(material3Theme.colorScheme["primary"]).isEqualTo("#FF336699")
+    assertThat(material3Theme.typography["bodyLarge"]!!.fontWeight).isEqualTo(700)
+    assertThat(material3Theme.shapes["medium"]).isEqualTo(16.0f)
 
     // A second render_preview call WITHOUT overrides now uses a different RenderKey and triggers
     // a fresh renderNow rather than dedup'ing onto the first. Pre-fix, the now-stale shared key


### PR DESCRIPTION
## Summary

Adds a `material3Theme` preview override so callers can test components under alternate Material 3 color, typography, and shape tokens without editing preview source.

The override is threaded through the daemon protocol, MCP `render_preview` input, JSON-RPC render payloads, and both Android/Desktop manifest routers. The renderers now apply the override by planning a `Material3ThemeOverrideExtension` and running it through `ComposeDataExtensionPipeline`, so the actual Compose wrapper stays in the theme connector instead of being hardcoded as renderer-specific `MaterialTheme(...)` logic.

This also declares `build/compose-previews/data` as an Android `renderPreviews` output so build-cache restores include scroll/GIF data products before `renderAllPreviews` validates `@ScrollingPreview` entries.

## Validation

```bash
./gradlew :data-theme-connector:ktfmtFormat :daemon:android:ktfmtFormat :daemon:desktop:ktfmtFormat :mcp:ktfmtFormat :data-theme-connector:ktfmtCheck :daemon:core:compileKotlin :data-theme-connector:compileKotlin :daemon:desktop:compileKotlin :daemon:android:compileDebugKotlin :mcp:compileKotlin :data-theme-connector:test --tests ee.schimke.composeai.daemon.ThemeDataProductTest
```