### PR TITLE
Add typed extension extraction context APIs

### DIFF
--- a/data/render/compose/src/main/kotlin/ee/schimke/composeai/data/render/extensions/compose/ComposeDataExtensionHooks.kt
+++ b/data/render/compose/src/main/kotlin/ee/schimke/composeai/data/render/extensions/compose/ComposeDataExtensionHooks.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.data.render.extensions.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.tooling.CompositionData
+import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
 import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
 import ee.schimke.composeai.data.render.extensions.DataExtensionId
@@ -21,7 +23,76 @@ data class ExtensionComposeContext(
   val previewId: String?,
   val renderMode: String?,
   val attributes: Map<String, Any?> = emptyMap(),
-)
+  val extraction: ExtensionExtractionContext = ExtensionExtractionContext.Empty,
+) {
+  val slotTables: ExtensionSlotTables
+    get() = extraction.slotTables
+
+  fun <T : Any> get(key: ExtensionContextKey<T>): T? = extraction.get(key)
+
+  fun <T : Any> require(key: ExtensionContextKey<T>): T = extraction.require(key)
+}
+
+data class ExtensionContextKey<T : Any>(val name: String, val type: Class<T>) {
+  init {
+    require(name.isNotBlank()) { "Extension context key name must not be blank." }
+  }
+}
+
+data class ExtensionContextValue<T : Any>(val key: ExtensionContextKey<T>, val value: T)
+
+infix fun <T : Any> ExtensionContextKey<T>.provides(value: T): ExtensionContextValue<T> =
+  ExtensionContextValue(this, value)
+
+class ExtensionContextData
+private constructor(private val values: Map<ExtensionContextKey<*>, Any>) {
+  fun <T : Any> get(key: ExtensionContextKey<T>): T? {
+    val value = values[key] ?: return null
+    return key.type.cast(value)
+  }
+
+  fun <T : Any> require(key: ExtensionContextKey<T>): T =
+    get(key) ?: error("Extension context value '${key.name}' is not available.")
+
+  fun contains(key: ExtensionContextKey<*>): Boolean = key in values
+
+  companion object {
+    val Empty: ExtensionContextData = ExtensionContextData(emptyMap())
+
+    fun of(vararg values: ExtensionContextValue<*>): ExtensionContextData =
+      ExtensionContextData(values.associate { it.key to it.value })
+  }
+}
+
+fun interface ExtensionSlotTables {
+  fun snapshot(): List<CompositionData>
+
+  companion object {
+    val Empty: ExtensionSlotTables = ExtensionSlotTables { emptyList() }
+
+    fun of(tables: List<CompositionData>): ExtensionSlotTables = ExtensionSlotTables {
+      tables.toList()
+    }
+  }
+}
+
+data class ExtensionExtractionContext(
+  val slotTables: ExtensionSlotTables = ExtensionSlotTables.Empty,
+  val data: ExtensionContextData = ExtensionContextData.Empty,
+) {
+  fun <T : Any> get(key: ExtensionContextKey<T>): T? = data.get(key)
+
+  fun <T : Any> require(key: ExtensionContextKey<T>): T = data.require(key)
+
+  companion object {
+    val Empty: ExtensionExtractionContext = ExtensionExtractionContext()
+  }
+}
+
+object CommonExtensionContextKeys {
+  val RenderPreviewContext: ExtensionContextKey<PreviewContext> =
+    ExtensionContextKey("preview-context", PreviewContext::class.java)
+}
 
 interface ExtensionCompositionSink {
   fun put(extensionId: DataExtensionId, key: String, value: Any?)
@@ -139,6 +210,7 @@ data class ExtensionFrameContext(
   val previewId: String?,
   val renderMode: String?,
   val attributes: Map<String, Any?> = emptyMap(),
+  val extraction: ExtensionExtractionContext = ExtensionExtractionContext.Empty,
 )
 
 data class ExtensionFrame(
@@ -225,6 +297,7 @@ object ComposeDataExtensionPipeline {
     renderMode: String?,
     sink: ExtensionCompositionSink,
     attributes: Map<String, Any?> = emptyMap(),
+    extraction: ExtensionExtractionContext = ExtensionExtractionContext.Empty,
     content: @Composable () -> Unit,
   ) {
     Observe(
@@ -233,6 +306,7 @@ object ComposeDataExtensionPipeline {
       renderMode = renderMode,
       sink = sink,
       attributes = attributes,
+      extraction = extraction,
     )
     Extract(
       extensions = extensions,
@@ -240,6 +314,7 @@ object ComposeDataExtensionPipeline {
       renderMode = renderMode,
       sink = sink,
       attributes = attributes,
+      extraction = extraction,
     )
     Around(
       hooks = extensions.filterIsInstance<AroundComposableHook>(),
@@ -247,6 +322,7 @@ object ComposeDataExtensionPipeline {
       previewId = previewId,
       renderMode = renderMode,
       attributes = attributes,
+      extraction = extraction,
       content = content,
     )
   }
@@ -258,6 +334,7 @@ object ComposeDataExtensionPipeline {
     renderMode: String?,
     sink: ExtensionCompositionSink,
     attributes: Map<String, Any?> = emptyMap(),
+    extraction: ExtensionExtractionContext = ExtensionExtractionContext.Empty,
   ) {
     for (hook in extensions.filterIsInstance<ComposableExtractorHook>()) {
       hook.Extract(
@@ -267,6 +344,7 @@ object ComposeDataExtensionPipeline {
             previewId = previewId,
             renderMode = renderMode,
             attributes = attributes,
+            extraction = extraction,
           ),
         sink = sink,
       )
@@ -280,6 +358,7 @@ object ComposeDataExtensionPipeline {
     renderMode: String?,
     sink: ExtensionCompositionSink,
     attributes: Map<String, Any?> = emptyMap(),
+    extraction: ExtensionExtractionContext = ExtensionExtractionContext.Empty,
   ) {
     for (hook in extensions.filterIsInstance<CompositionObserverHook>()) {
       hook.Observe(
@@ -289,6 +368,7 @@ object ComposeDataExtensionPipeline {
             previewId = previewId,
             renderMode = renderMode,
             attributes = attributes,
+            extraction = extraction,
           ),
         sink = sink,
       )
@@ -302,6 +382,7 @@ object ComposeDataExtensionPipeline {
     previewId: String?,
     renderMode: String?,
     attributes: Map<String, Any?>,
+    extraction: ExtensionExtractionContext,
     content: @Composable () -> Unit,
   ) {
     val hook = hooks.getOrNull(index)
@@ -317,6 +398,7 @@ object ComposeDataExtensionPipeline {
           previewId = previewId,
           renderMode = renderMode,
           attributes = attributes,
+          extraction = extraction,
         )
     ) {
       Around(
@@ -325,6 +407,7 @@ object ComposeDataExtensionPipeline {
         previewId = previewId,
         renderMode = renderMode,
         attributes = attributes,
+        extraction = extraction,
         content = content,
       )
     }

--- a/data/render/compose/src/test/kotlin/ee/schimke/composeai/data/render/extensions/compose/AroundComposableExtensionTest.kt
+++ b/data/render/compose/src/test/kotlin/ee/schimke/composeai/data/render/extensions/compose/AroundComposableExtensionTest.kt
@@ -6,6 +6,8 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionLifecycle
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AroundComposableExtensionTest {
@@ -76,6 +78,29 @@ class AroundComposableExtensionTest {
     assertEquals(DataExtensionPhase.PostProcess, extension.constraints.phase)
     assertEquals(true, extension.hasImageFrameTransformHook)
     assertEquals("frame@0.5", transformed)
+  }
+
+  @Test
+  fun extensionContextExposesTypedExtractionDataAndSlotTables() {
+    val scrollAxisKey = ExtensionContextKey("scroll-axis", String::class.java)
+    val extraction =
+      ExtensionExtractionContext(
+        slotTables = ExtensionSlotTables.Empty,
+        data = ExtensionContextData.of(scrollAxisKey provides "vertical"),
+      )
+    val context =
+      ExtensionComposeContext(
+        extensionId = DataExtensionId("scroll"),
+        previewId = "preview",
+        renderMode = "gif",
+        extraction = extraction,
+      )
+
+    assertEquals(emptyList<Any>(), context.slotTables.snapshot())
+    assertEquals("vertical", context.get(scrollAxisKey))
+    assertEquals("vertical", context.require(scrollAxisKey))
+    assertTrue(extraction.data.contains(scrollAxisKey))
+    assertNull(context.get(ExtensionContextKey("missing", String::class.java)))
   }
 
   private class SimpleBackgroundExtension :

--- a/docs/daemon/DATA-PRODUCTS.md
+++ b/docs/daemon/DATA-PRODUCTS.md
@@ -47,10 +47,11 @@ kinds are silently ignored both ways.
      everywhere" cases (cheap, always-relevant data like `a11y/atf`
      findings that drive diagnostic squigglies). Most clients leave it
      empty.
-4. Layering ([LAYERING.md](LAYERING.md)) preserved: data products are a
-   Layer 2 (daemon) surface. Renderer-side production sits in
-   `renderer-{android,desktop}` and is reused by the CLI; the daemon is
-   thin glue that surfaces what the renderer already produces.
+4. Layering ([LAYERING.md](LAYERING.md)) preserved: data products are
+   reusable extension functionality first, daemon protocol surface second.
+   Renderer-side production sits in reusable modules and is reused by the
+   CLI, embedded engines, and the daemon; the daemon is thin glue that
+   surfaces what an extension engine already knows how to produce.
 5. **No `protocolVersion` bump.** Adding a kind, adding a field to a
    payload, adding a new method in the `data/*` family — all additive
    per PROTOCOL.md § 7. Both sides ignore unknowns.
@@ -68,6 +69,58 @@ kinds are silently ignored both ways.
    surface — `data/fetch` re-render, `data/subscribe` priming, kind
    discovery — live in the daemon protocol and its MCP front-end, not
    the CLI.
+
+## Direction: embeddable data-extension engine
+
+The data-product implementation should not grow into a daemon-only feature
+set. The daemon is one host for data extensions, not the architecture
+boundary. Future refactors should head toward an embeddable extension engine
+that can be used as a library inside another Compose tooling surface.
+
+The target module split for each product is:
+
+- **`core`** — the clean product implementation, based on AndroidX Compose,
+  Compose Multiplatform, platform SDKs, or other public APIs. This is where
+  typed facades live when a product needs lower-level runtime access. A
+  `core` module does not have to exist when the product truly cannot be
+  expressed cleanly outside a specific host.
+- **connector** — binds the product implementation to the data-extension API:
+  declares ids, capabilities, constraints, hooks, lifecycle, transports, and
+  schema metadata.
+- **host integration** — daemon, CLI, tests, playgrounds, or other tooling
+  choose a set of extensions and wire them into an engine. Host integration
+  should not contain product-specific composition wrappers, extractor rules,
+  frame drivers, or image overlay logic except as glue to platform services.
+
+This keeps the same extensions usable in several contexts:
+
+- the compose-preview daemon, with rich JSON-RPC fetch/subscribe behavior;
+- Gradle/CLI rendering, with on-disk artifacts;
+- an embedded engine in another IDE, test harness, or build tool;
+- a future web playground that compiles/loads Kotlin code, renders it, and
+  enables a selected subset of extensions for insight into the running UI;
+- a future web-based player for interactive UI simulation, where frame
+  driving, animation state, and overlays are extension-provided rather than
+  daemon-special-cased.
+
+Concrete rules for future PRs:
+
+- Prefer Compose Multiplatform and AndroidX public APIs when they can also
+  support Android. Platform-specific code is fine at the edge, but the
+  extension-facing API should stay Compose-shaped.
+- Favor Compose abstractions and implementations: `AroundComposable`,
+  composable extractors, lifecycle/effect hooks, normalized frame drivers,
+  and typed image transforms. Avoid daemon-specific hooks in product code.
+- Put reflection or runtime internals behind typed facades owned by the
+  product. Calling code should look like normal Compose or domain code.
+- Avoid hardcoded assumptions about which features combine. Extensions should
+  declare constraints, capabilities, lifecycle, and ordering; hosts should
+  plan a requested set instead of branching on concrete product names.
+- Keep connector modules thin. If a connector starts knowing how to inspect
+  slot tables, drive scroll, render overlays, or parse product payloads, move
+  that behavior into `core` or a typed facade.
+- Keep hosts replaceable. An embedded engine should be able to run a chosen
+  set of data extensions without starting the external daemon process.
 
 Gradle-side selection is preview-extension-scoped:
 


### PR DESCRIPTION
## Summary

Adds typed extraction/context APIs to the Compose data-extension hook surface so extensions can access shared renderer extraction data without raw attribute maps or renderer-private plumbing.

## What changed

- Added `ExtensionExtractionContext` to carry common extraction capabilities.
- Added `ExtensionSlotTables` so extensions can call `context.slotTables.snapshot()` instead of directly owning slot-table plumbing.
- Added typed context keys and values via `ExtensionContextKey<T>`, `ExtensionContextData`, and `key provides value`.
- Added `CommonExtensionContextKeys.RenderPreviewContext` for passing a typed `PreviewContext` when renderers have one.
- Threaded extraction context through `ComposeDataExtensionPipeline.Apply`, `Extract`, `Observe`, and around hooks.
- Extended focused tests for typed extraction data and slot-table access.

## Validation

```bash
./gradlew :data-render-compose:ktfmtFormat :data-render-compose:ktfmtCheck :data-render-compose:test --tests ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtensionTest
```