### PR TITLE
Add theme capture data extension hook

### DIFF
--- a/data/theme/connector/build.gradle.kts
+++ b/data/theme/connector/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 dependencies {
   api(project(":daemon:core"))
+  api(project(":data-render-compose"))
   implementation(compose.runtime)
   implementation(compose.ui)
   implementation(compose.material3)

--- a/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
+++ b/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
@@ -1,8 +1,11 @@
 package ee.schimke.composeai.daemon
 
 import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
 import androidx.compose.material3.Typography
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.tooling.CompositionData
 import androidx.compose.runtime.tooling.CompositionGroup
 import androidx.compose.ui.graphics.Color
@@ -14,6 +17,12 @@ import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.ComposableExtractorExtension
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionCompositionSink
 import java.lang.reflect.Method
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.Serializable
@@ -124,6 +133,42 @@ class ThemeDataProductRegistry : DataProductRegistry {
       encodeDefaults = true
       prettyPrint = false
     }
+  }
+}
+
+/**
+ * Clean Compose-facing connector for `compose/theme` capture.
+ *
+ * This is the preferred implementation shape for theme data extensions: read public Material
+ * CompositionLocals, build the product payload, and emit it through the extension sink. Slot-table
+ * inspection remains only as a fallback facade for hosts that have not installed this extractor
+ * yet.
+ */
+class ThemeCaptureExtension :
+  ComposableExtractorExtension(
+    id = DataExtensionId(ThemeDataProductRegistry.KIND),
+    constraints =
+      DataExtensionConstraints(
+        phase = DataExtensionPhase.Capture,
+        provides = setOf(DataExtensionCapability(ThemeDataProductRegistry.KIND)),
+      ),
+  ) {
+  @Composable
+  override fun Extract(sink: ExtensionCompositionSink) {
+    val colorScheme = MaterialTheme.colorScheme
+    val typography = MaterialTheme.typography
+    val shapes = MaterialTheme.shapes
+    SideEffect {
+      sink.put(
+        extensionId = id,
+        key = PAYLOAD_KEY,
+        value = themePayloadFromMaterialTheme(colorScheme, typography, shapes),
+      )
+    }
+  }
+
+  companion object {
+    const val PAYLOAD_KEY: String = MATERIAL3_THEME_PAYLOAD_CONTEXT_KEY
   }
 }
 

--- a/data/theme/connector/src/test/kotlin/ee/schimke/composeai/daemon/MaterialThemeTokensTest.kt
+++ b/data/theme/connector/src/test/kotlin/ee/schimke/composeai/daemon/MaterialThemeTokensTest.kt
@@ -4,11 +4,29 @@ import androidx.compose.material3.ShapeDefaults
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.sp
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.ComposableExtractorHook
+import ee.schimke.composeai.data.render.extensions.compose.hasComposableExtractorHook
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MaterialThemeTokensTest {
+  @Test
+  fun themeCaptureExtensionDeclaresComposableExtractorHook() {
+    val extension = ThemeCaptureExtension()
+    val hook: ComposableExtractorHook = extension
+
+    assertEquals(DataExtensionId(ThemeDataProductRegistry.KIND), extension.id)
+    assertEquals(setOf(DataExtensionHookKind.ComposableExtractor), extension.hooks)
+    assertEquals(DataExtensionPhase.Capture, extension.constraints.phase)
+    assertTrue(extension.hasComposableExtractorHook)
+    assertEquals(extension, hook)
+  }
+
   @Test
   fun readsColorSchemeFromTokenObject() {
     val source = ReflectedThemeTokens()


### PR DESCRIPTION
## Summary

Adds a focused theme data-extension connector hook as the first one-extension migration from the ugly-list follow-ups.

## What changed

- Added `ThemeCaptureExtension`, a `ComposableExtractorExtension` for `compose/theme`.
- The extension reads public Material3 `MaterialTheme` composition locals and emits the existing typed `ThemePayload` through `ExtensionCompositionSink`.
- Kept slot-table inspection as the fallback facade for hosts that have not installed the extractor yet.
- Added the `:data-render-compose` dependency to the theme connector.
- Added focused test coverage for the extension hook declaration and capture phase metadata.

## Notes

This PR intentionally does not rewire Android/Desktop render engines yet. It creates the clean connector API for theme first; renderer integration can follow as a separate focused change.

Refs #690.

## Validation

```bash
./gradlew :data-theme-connector:ktfmtCheck :data-theme-connector:test --tests ee.schimke.composeai.daemon.MaterialThemeTokensTest
```