### PR TITLE
Add recomposition observer data extension hook

### DIFF
--- a/data/recomposition/connector/build.gradle.kts
+++ b/data/recomposition/connector/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 dependencies {
   api(project(":daemon:core"))
+  api(project(":data-render-compose"))
   implementation(compose.runtime)
   implementation(compose.ui)
   testImplementation(libs.junit)

--- a/data/recomposition/connector/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
+++ b/data/recomposition/connector/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
@@ -2,6 +2,8 @@
 
 package ee.schimke.composeai.daemon
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.ExperimentalComposeRuntimeApi
 import androidx.compose.runtime.RecomposeScope
 import androidx.compose.runtime.tooling.CompositionObserver
@@ -14,6 +16,16 @@ import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionLifecycle
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.CompositionObserverHook
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionComposeContext
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionCompositionSink
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionContextKey
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -460,6 +472,56 @@ open class RecompositionDataProductRegistry : DataProductRegistry {
       encodeDefaults = true
       prettyPrint = false
     }
+  }
+}
+
+fun interface RecompositionObservationHandle {
+  fun dispose()
+}
+
+fun interface RecompositionObservationSession {
+  fun observe(onPayload: (RecompositionPayload) -> Unit): RecompositionObservationHandle
+}
+
+object RecompositionExtensionContextKeys {
+  val ObservationSession: ExtensionContextKey<RecompositionObservationSession> =
+    ExtensionContextKey(
+      "compose.recomposition.observationSession",
+      RecompositionObservationSession::class.java,
+    )
+}
+
+/**
+ * Clean Compose-facing connector for recomposition observation.
+ *
+ * Hosts provide a typed [RecompositionObservationSession] through [ExtensionComposeContext]. This
+ * keeps scene/recomposer access, including any reflection needed by a specific host, behind a
+ * product-owned facade while the extension itself stays shaped like a normal Compose lifecycle
+ * hook.
+ */
+class RecompositionObserverExtension : CompositionObserverHook {
+  override val id: DataExtensionId = DataExtensionId(RecompositionDataProductRegistry.KIND)
+  override val hooks: Set<DataExtensionHookKind> = setOf(DataExtensionHookKind.CompositionObserver)
+  override val constraints: DataExtensionConstraints =
+    DataExtensionConstraints(
+      phase = DataExtensionPhase.Instrumentation,
+      provides = setOf(DataExtensionCapability(RecompositionDataProductRegistry.KIND)),
+      lifecycle = DataExtensionLifecycle.Subscribed,
+    )
+
+  @Composable
+  override fun Observe(context: ExtensionComposeContext, sink: ExtensionCompositionSink) {
+    val session = context.get(RecompositionExtensionContextKeys.ObservationSession) ?: return
+    DisposableEffect(session, sink) {
+      val handle = session.observe { payload ->
+        sink.put(extensionId = id, key = PAYLOAD_KEY, value = payload)
+      }
+      onDispose { handle.dispose() }
+    }
+  }
+
+  companion object {
+    const val PAYLOAD_KEY: String = "payload"
   }
 }
 

--- a/data/recomposition/connector/src/test/kotlin/ee/schimke/composeai/daemon/DesktopSceneRecomposerTest.kt
+++ b/data/recomposition/connector/src/test/kotlin/ee/schimke/composeai/daemon/DesktopSceneRecomposerTest.kt
@@ -1,9 +1,30 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionLifecycle
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.CompositionObserverHook
+import ee.schimke.composeai.data.render.extensions.compose.hasCompositionObserverHook
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DesktopSceneRecomposerTest {
+  @Test
+  fun recompositionObserverExtensionDeclaresCompositionObserverHook() {
+    val extension = RecompositionObserverExtension()
+    val hook: CompositionObserverHook = extension
+
+    assertEquals(DataExtensionId(RecompositionDataProductRegistry.KIND), extension.id)
+    assertEquals(setOf(DataExtensionHookKind.CompositionObserver), extension.hooks)
+    assertEquals(DataExtensionPhase.Instrumentation, extension.constraints.phase)
+    assertEquals(DataExtensionLifecycle.Subscribed, extension.constraints.lifecycle)
+    assertTrue(extension.hasCompositionObserverHook)
+    assertEquals(extension, hook)
+  }
+
   @Test
   fun readsCurrentRecomposerFromSceneHandle() {
     val recomposer = Any()


### PR DESCRIPTION
## Summary

Adds a focused recomposition data-extension connector hook as the next one-extension migration from the ugly-list follow-ups.

## What changed

- Added `RecompositionObserverExtension`, a `CompositionObserverHook` for `compose/recomposition`.
- Added typed `RecompositionObservationSession` / `RecompositionObservationHandle` facades so host-specific scene/recomposer access stays outside the extension hook.
- Added `RecompositionExtensionContextKeys.ObservationSession` for hosts to provide observation capability through `ExtensionContext`.
- The hook installs observation with `DisposableEffect` and emits typed `RecompositionPayload` values through `ExtensionCompositionSink`.
- Added the `:data-render-compose` dependency to the recomposition connector.
- Added focused test coverage for hook declaration, phase, lifecycle, and hook detection.

## Notes

This PR intentionally does not rewire the desktop interactive registry yet. It creates the clean connector shape first; host integration can follow in a separate focused change.

Refs #695.

## Validation

```bash
./gradlew :data-recomposition-connector:ktfmtCheck :data-recomposition-connector:test --tests ee.schimke.composeai.daemon.DesktopSceneRecomposerTest
```