### PR TITLE
feat: add device background around composable hook

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -71,6 +71,7 @@ jobs:
             :data-history-connector:publishToMavenLocal \
             :data-layoutinspector-core:publishToMavenLocal \
             :data-layoutinspector-connector:publishToMavenLocal \
+            :data-render-compose:publishToMavenLocal \
             :data-render-core:publishToMavenLocal \
             :data-render-connector:publishToMavenLocal \
             :data-resources-core:publishToMavenLocal \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
             :data-layoutinspector-core:publishAllPublicationsToGitHubPackagesRepository \
             :data-layoutinspector-connector:publishAllPublicationsToGitHubPackagesRepository \
             :data-recomposition-connector:publishAllPublicationsToGitHubPackagesRepository \
+            :data-render-compose:publishAllPublicationsToGitHubPackagesRepository \
             :data-render-core:publishAllPublicationsToGitHubPackagesRepository \
             :data-render-connector:publishAllPublicationsToGitHubPackagesRepository \
             :data-resources-core:publishAllPublicationsToGitHubPackagesRepository \
@@ -133,6 +134,7 @@ jobs:
             :data-layoutinspector-core:publishAndReleaseToMavenCentral \
             :data-layoutinspector-connector:publishAndReleaseToMavenCentral \
             :data-recomposition-connector:publishAndReleaseToMavenCentral \
+            :data-render-compose:publishAndReleaseToMavenCentral \
             :data-render-core:publishAndReleaseToMavenCentral \
             :data-render-connector:publishAndReleaseToMavenCentral \
             :data-resources-core:publishAndReleaseToMavenCentral \

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -95,6 +95,7 @@ jobs:
             :data-layoutinspector-core:publishToMavenCentral \
             :data-layoutinspector-connector:publishToMavenCentral \
             :data-recomposition-connector:publishToMavenCentral \
+            :data-render-compose:publishToMavenCentral \
             :data-render-core:publishToMavenCentral \
             :data-render-connector:publishToMavenCentral \
             :data-resources-core:publishToMavenCentral \

--- a/data/render/compose/build.gradle.kts
+++ b/data/render/compose/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
   api(project(":data-render-core"))
   api(platform(libs.compose.bom.compat))
   api(libs.compose.runtime)
+  api(libs.compose.ui)
 
   testImplementation(libs.junit)
 }

--- a/data/render/compose/src/main/kotlin/ee/schimke/composeai/data/render/extensions/compose/ComposeColorSpec.kt
+++ b/data/render/compose/src/main/kotlin/ee/schimke/composeai/data/render/extensions/compose/ComposeColorSpec.kt
@@ -1,0 +1,55 @@
+package ee.schimke.composeai.data.render.extensions.compose
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Shared parser for user/config supplied Compose colors.
+ *
+ * Keep color strings consistent across data extensions. This intentionally supports only stable,
+ * host-independent values: ARGB/RGB hex and common Compose color constants. Theme-relative colors
+ * require composition context and should be resolved by a product-specific extension before calling
+ * this utility.
+ */
+object ComposeColorSpec {
+  fun resolve(value: String): Color {
+    val spec = value.trim()
+    namedColor(spec)?.let {
+      return it
+    }
+    return parseHex(spec)
+  }
+
+  private fun namedColor(spec: String): Color? =
+    when (spec.removePrefix("Color.").lowercase()) {
+      "black" -> Color.Black
+      "white" -> Color.White
+      "transparent" -> Color.Transparent
+      "red" -> Color.Red
+      "green" -> Color.Green
+      "blue" -> Color.Blue
+      "yellow" -> Color.Yellow
+      "cyan" -> Color.Cyan
+      "magenta" -> Color.Magenta
+      "gray",
+      "grey" -> Color.Gray
+      else -> null
+    }
+
+  private fun parseHex(spec: String): Color {
+    val raw = spec.removePrefix("#")
+    val argb =
+      when (raw.length) {
+        6 -> "FF$raw"
+        8 -> raw
+        else ->
+          error("Expected color as #RRGGBB, #AARRGGBB, or a known color constant; got '$spec'.")
+      }
+    val value = argb.toLong(16)
+    return Color(
+      red = ((value shr 16) and 0xFF).toInt(),
+      green = ((value shr 8) and 0xFF).toInt(),
+      blue = (value and 0xFF).toInt(),
+      alpha = ((value shr 24) and 0xFF).toInt(),
+    )
+  }
+}

--- a/data/render/compose/src/test/kotlin/ee/schimke/composeai/data/render/extensions/compose/ComposeColorSpecTest.kt
+++ b/data/render/compose/src/test/kotlin/ee/schimke/composeai/data/render/extensions/compose/ComposeColorSpecTest.kt
@@ -1,0 +1,24 @@
+package ee.schimke.composeai.data.render.extensions.compose
+
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ComposeColorSpecTest {
+  @Test
+  fun resolvesRgbHexAsOpaqueColor() {
+    assertEquals(Color(0xFF112233), ComposeColorSpec.resolve("#112233"))
+  }
+
+  @Test
+  fun resolvesArgbHex() {
+    assertEquals(Color(0x80112233), ComposeColorSpec.resolve("#80112233"))
+  }
+
+  @Test
+  fun resolvesKnownComposeColorConstants() {
+    assertEquals(Color.Black, ComposeColorSpec.resolve("Black"))
+    assertEquals(Color.White, ComposeColorSpec.resolve("Color.White"))
+    assertEquals(Color.Transparent, ComposeColorSpec.resolve("transparent"))
+  }
+}

--- a/data/render/connector/build.gradle.kts
+++ b/data/render/connector/build.gradle.kts
@@ -1,12 +1,18 @@
 plugins {
   id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.compose.compiler)
   alias(libs.plugins.kotlin.serialization)
 }
 
 dependencies {
   api(project(":data-render-core"))
+  api(project(":data-render-compose"))
   api(project(":daemon:core"))
+  implementation(platform(libs.compose.bom.compat))
+  implementation(libs.compose.foundation)
+  implementation(libs.compose.runtime)
+  implementation(libs.compose.ui)
   testImplementation(libs.junit)
 }
 

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceBackgroundDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceBackgroundDataProduct.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
@@ -16,6 +15,7 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
 import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
 import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
+import ee.schimke.composeai.data.render.extensions.compose.ComposeColorSpec
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.JsonElement
@@ -123,7 +123,7 @@ class DeviceBackgroundExtension(private val color: String) :
   ) {
   @Composable
   override fun AroundComposable(content: @Composable () -> Unit) {
-    Box(modifier = Modifier.background(color.toComposeColor())) { content() }
+    Box(modifier = Modifier.background(ComposeColorSpec.resolve(color))) { content() }
   }
 }
 
@@ -199,17 +199,6 @@ private fun fallbackBackground(): DeviceBackground =
   DeviceBackground("#FFFFFBFE", "material3.lightBackgroundFallback")
 
 private fun Long.hexArgb(): String = "#%08X".format(this and 0xFFFFFFFFL)
-
-private fun String.toComposeColor(): Color {
-  val raw = removePrefix("#")
-  val argb =
-    when (raw.length) {
-      6 -> "FF$raw"
-      8 -> raw
-      else -> error("Expected #RRGGBB or #AARRGGBB device background color, got '$this'.")
-    }
-  return Color(argb.toULong(16))
-}
 
 private fun isTransparentColor(color: String): Boolean =
   color.length == 9 && color.startsWith("#") && color.substring(1, 3).equals("00", true)

--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceBackgroundDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceBackgroundDataProduct.kt
@@ -1,11 +1,21 @@
 package ee.schimke.composeai.daemon
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
 import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.JsonElement
@@ -96,6 +106,27 @@ class DeviceBackgroundDataProductRegistry(previewIndex: PreviewIndex) : DataProd
   }
 }
 
+/**
+ * Clean Compose-facing connector for applying the selected device background.
+ *
+ * The metadata product still decides which color wins. Hosts that want the background applied in
+ * composition can plan this extension instead of hardcoding a renderer-side `Box` wrapper.
+ */
+class DeviceBackgroundExtension(private val color: String) :
+  AroundComposableExtension(
+    id = DataExtensionId(DeviceBackgroundDataProductRegistry.KIND),
+    constraints =
+      DataExtensionConstraints(
+        phase = DataExtensionPhase.OuterEnvironment,
+        provides = setOf(DataExtensionCapability(DeviceBackgroundDataProductRegistry.KIND)),
+      ),
+  ) {
+  @Composable
+  override fun AroundComposable(content: @Composable () -> Unit) {
+    Box(modifier = Modifier.background(color.toComposeColor())) { content() }
+  }
+}
+
 private data class DeviceBackground(
   val color: String,
   val source: String,
@@ -168,6 +199,17 @@ private fun fallbackBackground(): DeviceBackground =
   DeviceBackground("#FFFFFBFE", "material3.lightBackgroundFallback")
 
 private fun Long.hexArgb(): String = "#%08X".format(this and 0xFFFFFFFFL)
+
+private fun String.toComposeColor(): Color {
+  val raw = removePrefix("#")
+  val argb =
+    when (raw.length) {
+      6 -> "FF$raw"
+      8 -> raw
+      else -> error("Expected #RRGGBB or #AARRGGBB device background color, got '$this'.")
+    }
+  return Color(argb.toULong(16))
+}
 
 private fun isTransparentColor(color: String): Boolean =
   color.length == 9 && color.startsWith("#") && color.substring(1, 3).equals("00", true)

--- a/data/render/connector/src/test/kotlin/ee/schimke/composeai/daemon/DeviceBackgroundDataProductRegistryTest.kt
+++ b/data/render/connector/src/test/kotlin/ee/schimke/composeai/daemon/DeviceBackgroundDataProductRegistryTest.kt
@@ -2,6 +2,11 @@ package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
+import ee.schimke.composeai.data.render.extensions.compose.hasAroundComposableHook
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
@@ -9,6 +14,18 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DeviceBackgroundDataProductRegistryTest {
+  @Test
+  fun `device background extension declares around composable hook`() {
+    val extension = DeviceBackgroundExtension("#FFFFFBFE")
+    val hook: AroundComposableHook = extension
+
+    assertEquals(DataExtensionId(DeviceBackgroundDataProductRegistry.KIND), extension.id)
+    assertEquals(setOf(DataExtensionHookKind.AroundComposable), extension.hooks)
+    assertEquals(DataExtensionPhase.OuterEnvironment, extension.constraints.phase)
+    assertTrue(extension.hasAroundComposableHook)
+    assertEquals(extension, hook)
+  }
+
   @Test
   fun `capability advertises inline fetchable attachable device background`() {
     val registry = DeviceBackgroundDataProductRegistry(PreviewIndex.empty())


### PR DESCRIPTION
## Summary

Adds a focused device-background data-extension connector hook as the next one-extension migration from the ugly-list follow-ups.

## What changed

- Added `DeviceBackgroundExtension`, an `AroundComposableExtension` for `render/deviceBackground`.
- The extension applies the selected color using normal Compose code: `Box(Modifier.background(...)) { content() }`.
- Kept `DeviceBackgroundDataProductRegistry` responsible for choosing the winning background source.
- Added Compose dependencies to `:data-render-connector` for this connector hook.
- Added focused test coverage for hook declaration, phase, and hook detection.

## Notes

This PR intentionally does not rewire Android/Desktop renderers yet. It provides the clean extension implementation that future host integration can plan instead of hardcoding renderer-side background wrappers.

## Validation

```bash
./gradlew :data-render-connector:ktfmtFormat :data-render-connector:ktfmtCheck :data-render-connector:test --tests ee.schimke.composeai.daemon.DeviceBackgroundDataProductRegistryTest
```