### PR TITLE
feat: add device clip around composable hook

### DIFF
--- a/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProduct.kt
+++ b/data/render/connector/src/main/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProduct.kt
@@ -1,5 +1,10 @@
 package ee.schimke.composeai.daemon
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
 import ee.schimke.composeai.daemon.protocol.DataFetchResult
 import ee.schimke.composeai.daemon.protocol.DataProductAttachment
@@ -9,6 +14,11 @@ import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.PreviewDeviceContext
 import ee.schimke.composeai.data.render.PreviewDeviceSpec
+import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.json.JsonElement
@@ -103,6 +113,37 @@ class DeviceClipDataProductRegistry(previewIndex: PreviewIndex) : DataProductReg
     const val KIND: String = "render/deviceClip"
     const val SCHEMA_VERSION: Int = 1
   }
+}
+
+/**
+ * Clean Compose-facing connector for applying the selected device-frame clip.
+ *
+ * The metadata product still owns device discovery and payload shape. Hosts that want the clip
+ * applied in composition can plan this extension instead of hardcoding a renderer-side round-device
+ * wrapper.
+ */
+class DeviceClipExtension(private val shape: DeviceClipShape?) :
+  AroundComposableExtension(
+    id = DataExtensionId(DeviceClipDataProductRegistry.KIND),
+    constraints =
+      DataExtensionConstraints(
+        phase = DataExtensionPhase.OuterEnvironment,
+        before = setOf(DataExtensionId(DeviceBackgroundDataProductRegistry.KIND)),
+        provides = setOf(DataExtensionCapability(DeviceClipDataProductRegistry.KIND)),
+      ),
+  ) {
+  @Composable
+  override fun AroundComposable(content: @Composable () -> Unit) {
+    when (shape) {
+      is DeviceClipShape.Circle -> Box(modifier = Modifier.clip(CircleShape)) { content() }
+      null -> content()
+    }
+  }
+}
+
+sealed interface DeviceClipShape {
+  data class Circle(val centerXDp: Double, val centerYDp: Double, val radiusDp: Double) :
+    DeviceClipShape
 }
 
 private fun PreviewInfoDto.previewDeviceContext(): PreviewDeviceContext {

--- a/data/render/connector/src/test/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProductRegistryTest.kt
+++ b/data/render/connector/src/test/kotlin/ee/schimke/composeai/daemon/DeviceClipDataProductRegistryTest.kt
@@ -3,6 +3,11 @@ package ee.schimke.composeai.daemon
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.PreviewDeviceSpec
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.AroundComposableHook
+import ee.schimke.composeai.data.render.extensions.compose.hasAroundComposableHook
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -12,6 +17,22 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class DeviceClipDataProductRegistryTest {
+  @Test
+  fun `device clip extension declares around composable hook before background`() {
+    val extension = DeviceClipExtension(DeviceClipShape.Circle(50.0, 50.0, 50.0))
+    val hook: AroundComposableHook = extension
+
+    assertEquals(DataExtensionId(DeviceClipDataProductRegistry.KIND), extension.id)
+    assertEquals(setOf(DataExtensionHookKind.AroundComposable), extension.hooks)
+    assertEquals(DataExtensionPhase.OuterEnvironment, extension.constraints.phase)
+    assertEquals(
+      setOf(DataExtensionId(DeviceBackgroundDataProductRegistry.KIND)),
+      extension.constraints.before,
+    )
+    assertTrue(extension.hasAroundComposableHook)
+    assertEquals(extension, hook)
+  }
+
   @Test
   fun `capability advertises inline fetchable attachable device clip`() {
     val registry = DeviceClipDataProductRegistry(PreviewIndex.empty())


### PR DESCRIPTION
## Summary

Adds a focused device-clip data-extension connector hook as the next one-extension migration from the ugly-list follow-ups.

## What changed

- Added `DeviceClipExtension`, an `AroundComposableExtension` for `render/deviceClip`.
- Added typed `DeviceClipShape` API so hosts pass a domain shape instead of renderer-specific or JSON payload details.
- The extension applies the round-device clip using normal Compose code: `Box(Modifier.clip(CircleShape)) { content() }`.
- Declared an ordering constraint so device clip wraps device background when both extensions are planned.
- Added focused test coverage for hook declaration, phase, ordering, and hook detection.

## In-flight PRs checked

- #697 theme hook: merged.
- #698 recomposition hook: merged.
- #699 device background hook: merged.
- #683 Material theme overrides: still open and intentionally not touched here.

## Notes

This PR intentionally does not rewire Android/Desktop renderers yet. It provides the clean extension implementation that future host integration can plan instead of hardcoding renderer-side round-device wrappers.

## Validation

```bash
./gradlew :data-render-connector:ktfmtFormat :data-render-connector:ktfmtCheck :data-render-connector:test --tests ee.schimke.composeai.daemon.DeviceClipDataProductRegistryTest
```