### PR TITLE
Document recomposition audit counts

### DIFF
--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopComposeClasspathTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopComposeClasspathTest.kt
@@ -1,0 +1,31 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DesktopComposeClasspathTest {
+
+  @Test
+  fun desktopClasspathDoesNotContainAndroidxComposeUiArtifacts() {
+    val offenders =
+      System.getProperty("java.class.path")
+        .split(java.io.File.pathSeparatorChar)
+        .filter { path ->
+          val normalized = path.replace('\\', '/')
+          val filename = normalized.substringAfterLast('/')
+          normalized.contains("/androidx.compose.ui/") ||
+            normalized.contains("/androidx/compose/ui/") ||
+            filename.startsWith("androidx.compose.ui.") ||
+            (normalized.contains("/androidx.compose.") && filename.contains("jvmstubs"))
+        }
+        .distinct()
+        .sorted()
+
+    assertTrue(
+      "Desktop daemon test classpath contains AndroidX Compose UI artifacts. " +
+        "Use org.jetbrains.compose UI artifacts for Compose Multiplatform desktop.\n" +
+        offenders.joinToString(separator = "\n") { " - $it" },
+      offenders.isEmpty(),
+    )
+  }
+}

--- a/data/render/compose/build.gradle.kts
+++ b/data/render/compose/build.gradle.kts
@@ -1,14 +1,14 @@
 plugins {
   id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.compose.multiplatform)
   alias(libs.plugins.compose.compiler)
 }
 
 dependencies {
   api(project(":data-render-core"))
-  api(platform(libs.compose.bom.compat))
-  api(libs.compose.runtime)
-  api(libs.compose.ui)
+  api(libs.jetbrains.compose.runtime)
+  api(libs.jetbrains.compose.ui)
 
   testImplementation(libs.junit)
 }

--- a/data/render/connector/build.gradle.kts
+++ b/data/render/connector/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id("composeai.maven-publishing")
   alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.compose.multiplatform)
   alias(libs.plugins.compose.compiler)
   alias(libs.plugins.kotlin.serialization)
 }
@@ -9,10 +10,9 @@ dependencies {
   api(project(":data-render-core"))
   api(project(":data-render-compose"))
   api(project(":daemon:core"))
-  implementation(platform(libs.compose.bom.compat))
-  implementation(libs.compose.foundation)
-  implementation(libs.compose.runtime)
-  implementation(libs.compose.ui)
+  implementation(libs.jetbrains.compose.foundation)
+  implementation(libs.jetbrains.compose.runtime)
+  implementation(libs.jetbrains.compose.ui)
   testImplementation(libs.junit)
 }
 

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ComposePreviewTasks.kt
@@ -99,6 +99,13 @@ internal object ComposePreviewTasks {
       }
 
     if (hasDesktopRenderer) {
+      val renderClasspathGuard =
+        registerDesktopClasspathGuard(
+          project = project,
+          taskName = "validateComposePreviewDesktopRenderClasspath",
+          dependencyConfigName = dependencyConfigName,
+          toolClasspath = rendererConfig,
+        )
       val renderTask =
         project.tasks.register("renderPreviews", RenderPreviewsTask::class.java) {
           onlyIf { extension.enabled.get() }
@@ -113,6 +120,7 @@ internal object ComposePreviewTasks {
           group = "compose preview"
           description = "Render all previews to PNG"
           dependsOn(discoverTask)
+          dependsOn(renderClasspathGuard)
         }
       registerRenderAllPreviews(
         project,
@@ -194,6 +202,14 @@ internal object ComposePreviewTasks {
         "ee.schimke.composeai:daemon-desktop:${PluginVersion.value}",
       )
     }
+
+    val daemonClasspathGuard =
+      registerDesktopClasspathGuard(
+        project = project,
+        taskName = "validateComposePreviewDesktopDaemonClasspath",
+        dependencyConfigName = dependencyConfigName,
+        toolClasspath = daemonRendererConfig,
+      )
 
     // Mirror the Android registration's eager-resolved values (see
     // AndroidPreviewSupport.kt) so each MapProperty / ListProperty entry's Provider chain
@@ -320,11 +336,24 @@ internal object ComposePreviewTasks {
       workingDirectory.set(project.projectDir.absolutePath)
       manifestPath.set(previewsJsonProvider)
       outputFile.set(outputFileProvider)
+      dependsOn(daemonClasspathGuard)
       group = "compose preview"
       description =
         "Emit build/compose-previews/daemon-launch.json so VS Code can spawn the desktop preview daemon JVM"
     }
   }
+
+  private fun registerDesktopClasspathGuard(
+    project: Project,
+    taskName: String,
+    dependencyConfigName: String,
+    toolClasspath: org.gradle.api.artifacts.Configuration,
+  ): TaskProvider<ValidateComposePreviewClasspathTask> =
+    project.tasks.register(taskName, ValidateComposePreviewClasspathTask::class.java) {
+      platform.set("desktop")
+      classpath.from(toolClasspath)
+      project.configurations.findByName(dependencyConfigName)?.let { classpath.from(it) }
+    }
 
   /**
    * Tier-1 cheap-signal file set for the desktop daemon's [ClasspathFingerprint][

--- a/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ValidateComposePreviewClasspathTask.kt
+++ b/gradle-plugin/src/main/kotlin/ee/schimke/composeai/plugin/ValidateComposePreviewClasspathTask.kt
@@ -1,0 +1,68 @@
+package ee.schimke.composeai.plugin
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Fails desktop preview tasks before launch when their JVM classpath contains AndroidX Compose
+ * artifacts. Compose Multiplatform desktop uses JetBrains Compose artifacts with the same
+ * `androidx.compose.*` packages; AndroidX JVM stubs can resolve first and throw
+ * `NotImplementedError: Implemented only in JetBrains fork` from `ImageComposeScene`.
+ */
+@CacheableTask
+abstract class ValidateComposePreviewClasspathTask : DefaultTask() {
+
+  @get:Input abstract val platform: Property<String>
+
+  @get:Internal abstract val classpath: ConfigurableFileCollection
+
+  @get:Input
+  val classpathPaths: List<String>
+    get() = classpath.files.map { it.absolutePath }
+
+  init {
+    group = "compose preview"
+    description = "Validate the compose-preview runtime classpath for platform-specific artifacts"
+    dependsOn(classpath)
+  }
+
+  @TaskAction
+  fun validate() {
+    if (platform.get() != "desktop") return
+
+    val offenders = androidxComposeArtifactsOnDesktopClasspath(classpathPaths)
+    if (offenders.isEmpty()) return
+
+    throw GradleException(
+      buildString {
+        appendLine(
+          "Compose Preview desktop classpath contains AndroidX Compose UI artifacts. " +
+            "Use org.jetbrains.compose UI artifacts for Compose Multiplatform desktop classpaths."
+        )
+        offenders.take(8).forEach { appendLine(" - $it") }
+        if (offenders.size > 8) appendLine(" - (+${offenders.size - 8} more)")
+      }
+    )
+  }
+
+  internal companion object {
+    fun androidxComposeArtifactsOnDesktopClasspath(paths: Iterable<String>): List<String> =
+      paths
+        .filter { path ->
+          val normalized = path.replace('\\', '/')
+          val filename = normalized.substringAfterLast('/')
+          normalized.contains("/androidx.compose.ui/") ||
+            normalized.contains("/androidx/compose/ui/") ||
+            filename.startsWith("androidx.compose.ui.") ||
+            (normalized.contains("/androidx.compose.") && filename.contains("jvmstubs"))
+        }
+        .distinct()
+        .sorted()
+  }
+}

--- a/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ValidateComposePreviewClasspathTaskTest.kt
+++ b/gradle-plugin/src/test/kotlin/ee/schimke/composeai/plugin/ValidateComposePreviewClasspathTaskTest.kt
@@ -1,0 +1,75 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import org.gradle.api.GradleException
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+
+class ValidateComposePreviewClasspathTaskTest {
+
+  @Test
+  fun `desktop validator flags androidx compose maven cache paths`() {
+    val offenders =
+      ValidateComposePreviewClasspathTask.androidxComposeArtifactsOnDesktopClasspath(
+        listOf(
+          "/home/user/.gradle/caches/modules-2/files-2.1/androidx.compose.ui/ui-jvmstubs/1.9.5/ui-jvmstubs-1.9.5.jar",
+          "/home/user/.gradle/caches/modules-2/files-2.1/org.jetbrains.compose.ui/ui-desktop/1.10.3/ui-desktop-1.10.3.jar",
+        )
+      )
+
+    assertThat(offenders)
+      .containsExactly(
+        "/home/user/.gradle/caches/modules-2/files-2.1/androidx.compose.ui/ui-jvmstubs/1.9.5/ui-jvmstubs-1.9.5.jar"
+      )
+  }
+
+  @Test
+  fun `desktop validator fails before emitting mixed compose classpath`() {
+    val project = ProjectBuilder.builder().build()
+    val badJar =
+      project.layout.buildDirectory
+        .file("fake-cache/androidx.compose.ui/ui-jvmstubs/1.9.5/ui-jvmstubs-1.9.5.jar")
+        .get()
+        .asFile
+    badJar.parentFile.mkdirs()
+    badJar.writeText("not a real jar")
+
+    val task =
+      project.tasks.register(
+        "validateComposePreviewDesktopClasspath",
+        ValidateComposePreviewClasspathTask::class.java,
+      ) {
+        platform.set("desktop")
+        classpath.from(badJar)
+      }
+
+    val thrown = runCatching { task.get().validate() }.exceptionOrNull()
+
+    assertThat(thrown).isInstanceOf(GradleException::class.java)
+    assertThat(thrown!!.message).contains("AndroidX Compose UI artifacts")
+    assertThat(thrown.message).contains("ui-jvmstubs-1.9.5.jar")
+  }
+
+  @Test
+  fun `android validator allows androidx compose artifacts`() {
+    val project = ProjectBuilder.builder().build()
+    val badJar =
+      project.layout.buildDirectory
+        .file("fake-cache/androidx.compose.ui/ui/1.9.5/ui-1.9.5.jar")
+        .get()
+        .asFile
+    badJar.parentFile.mkdirs()
+    badJar.writeText("not a real jar")
+
+    val task =
+      project.tasks.register(
+        "validateComposePreviewAndroidClasspath",
+        ValidateComposePreviewClasspathTask::class.java,
+      ) {
+        platform.set("android")
+        classpath.from(badJar)
+      }
+
+    task.get().validate()
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -99,6 +99,9 @@ compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-foundation = { module = "androidx.compose.foundation:foundation" }
 compose-runtime = { module = "androidx.compose.runtime:runtime" }
 compose-runtime-tracing = { module = "androidx.compose.runtime:runtime-tracing" }
+jetbrains-compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "compose-multiplatform" }
+jetbrains-compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "compose-multiplatform" }
+jetbrains-compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-multiplatform" }
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 wear-compose-material3 = { module = "androidx.wear.compose:compose-material3", version.ref = "wear-compose" }
 wear-compose-foundation = { module = "androidx.wear.compose:compose-foundation", version.ref = "wear-compose" }

--- a/skills/compose-preview-review/design/AGENT_AUDITS.md
+++ b/skills/compose-preview-review/design/AGENT_AUDITS.md
@@ -87,6 +87,75 @@ Check:
 - Trace output is treated as triage evidence unless the PR explicitly targets
   runtime behavior.
 
+Use the recomposition data extension directly. In delta mode it observes the
+held interactive composition, resets counters on each flush, and returns the
+scopes that recomposed after the last input. A useful bad example is a parent
+passing `count` into static children that do not use it, so one click can make
+the header, value, and footer all recompose.
+
+```kotlin
+@Preview
+@Composable
+fun BadCounterPreview() {
+  var count by remember { mutableIntStateOf(0) }
+
+  Column(Modifier.clickable { count++ }.padding(16.dp)) {
+    BadCounterHeader(count)
+    Text("Count: $count")
+    BadCounterFooter(count)
+  }
+}
+
+@Composable
+private fun BadCounterHeader(count: Int) {
+  Text("Checkout")
+}
+
+@Composable
+private fun BadCounterFooter(count: Int) {
+  Text("Tap anywhere to increment")
+}
+```
+
+Agent flow:
+
+```text
+list_data_products workspaceId=<workspace>
+get_preview_data uri=<preview-uri> kind=compose/recomposition \
+  params='{"mode":"delta","frameStreamId":"<stream-id>"}'
+```
+
+The payload to inspect has this shape:
+
+```json
+{
+  "mode": "delta",
+  "sinceFrameStreamId": "agent-run-1",
+  "inputSeq": 1,
+  "nodes": [
+    { "nodeId": "header-scope", "count": 1 },
+    { "nodeId": "counter-value-scope", "count": 1 },
+    { "nodeId": "footer-scope", "count": 1 }
+  ]
+}
+```
+
+This is a bad signal for the example above because one click changed three
+scopes. The counter text is expected to recompose; the header and footer are
+not, because they display static copy. The agent should infer that only the
+counter value needed `count`, narrow the child parameters, rerun the
+interaction, and confirm the next delta only reports the counter-related
+scope. A follow-up flush without another input should return `nodes: []`,
+which confirms the extension reset the delta counters.
+
+Use DejaVu-style reasoning for this audit: a recomposition count is evidence,
+not the finding by itself. Matt McKenna's DejaVu library formalizes this as
+test assertions with `createRecompositionTrackingRule()`,
+`assertRecompositions(...)`, and `assertStable()`, plus causality diagnostics
+from snapshot-state writes and dirty parameter slots. compose-preview does not
+yet expose DejaVu's `testTag`/source/dirty-bit causality, so name the scoped
+payload evidence and the state/parameter path you found in code.
+
 ### Failure triage audit
 
 Sample command: `get_preview_data uri=<preview-uri> kind=test/failure`

--- a/skills/compose-preview/design/DATA_PRODUCTS.md
+++ b/skills/compose-preview/design/DATA_PRODUCTS.md
@@ -140,6 +140,11 @@ from `compose/semantics` and
 `a11y/hierarchy`; fetch those when the question is semantic intent or
 assistive-technology output.
 
+`compose/recomposition` is the agent-facing performance signal for
+unnecessary recomposition. For review guidance, bad examples, and direct
+composition-counter probes, use
+[`compose-preview-review/design/AGENT_AUDITS.md`](../../compose-preview-review/design/AGENT_AUDITS.md).
+
 `test/failure` is daemon fetch-only. After a `renderFailed`
 notification, call `get_preview_data(..., kind = "test/failure")` to
 retrieve the latest failed-render postmortem for that preview: error


### PR DESCRIPTION
## Summary

Updates the compose-preview review audit docs with an agent-facing recomposition audit example that uses the existing `compose/recomposition` data extension directly.

Adds guidance in `skills/compose-preview-review/design/AGENT_AUDITS.md` for:

- using `compose/recomposition` delta payloads as audit evidence
- confirming a bad composable where static header/footer children recompose after a counter click
- inspecting `nodes[].count`, `inputSeq`, and the empty follow-up `nodes: []` reset signal
- applying DejaVu-style reasoning while noting that compose-preview does not yet expose DejaVu's `testTag`/source/dirty-bit causality

Also updates `skills/compose-preview/design/DATA_PRODUCTS.md` to point recomposition review guidance at the audit checklist.

No helper script or manual `CountCompositions` wrapper is included; the docs rely on the recomposition data extension and leave the decision to the agent.

This also fixes the local CMP desktop test classpath issue found while validating the recomposition extension:

- `data-render-compose` and `data-render-connector` now use JetBrains Compose Multiplatform artifacts instead of exporting AndroidX Compose UI JVM stubs into `:daemon:desktop`
- `:daemon:desktop` has a classpath regression test that fails if AndroidX Compose UI/stub jars reappear
- the Gradle plugin now wires desktop render and desktop daemon descriptor tasks through a classpath guard, so consuming apps fail early if our desktop preview classpath would include AndroidX Compose UI/stub artifacts

## Validation

- `./gradlew :daemon:desktop:test --tests ee.schimke.composeai.daemon.RecompositionDataProductRegistryTest.capabilities_advertise_compose_recomposition_with_requires_rerender`
- `./gradlew :daemon:desktop:test --tests ee.schimke.composeai.daemon.DesktopComposeClasspathTest --tests ee.schimke.composeai.daemon.RecompositionDataProductRegistryTest.delta_subscribe_then_click_attaches_non_empty_payload_and_resets_between_flushes --stacktrace`
- `./gradlew :daemon:desktop:dependencyInsight --configuration testRuntimeClasspath --dependency androidx.compose.ui`
- `./gradlew :gradle-plugin:test --tests ee.schimke.composeai.plugin.ValidateComposePreviewClasspathTaskTest --tests ee.schimke.composeai.plugin.KmpAndroidDesktopRoutingTest`
- `./gradlew :gradle-plugin:ktfmtCheck :daemon:desktop:ktfmtCheck`
- `./gradlew :daemon:android:compileDebugKotlin`
- `git diff --check`