### PR TITLE
docs: make agent audit recipes actionable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,23 @@ jobs:
       - name: Build CLI
         run: ./gradlew :cli:build
 
+  agent-audit-samples:
+    name: Agent Audit Samples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Run agent audit sample scripts
+        run: python3 skills/compose-preview-review/scripts/run-agent-audit-samples.py
+      - name: Upload agent audit outputs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: agent-audit-sample-outputs
+          path: build/agent-audit-samples/
+
   # Pure-stdlib unittest for the script that drives `preview-baselines` and
   # `preview-comment` actions. Lives here because the script is JSON-shape-
   # coupled to the CLI — running it on every PR catches contract breaks

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,6 +18,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "skills/**"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/integration.yml"
+      - ".github/workflows/preview-comment.yml"
   workflow_dispatch:
   schedule:
     # Weekly — catches drift when consumer repos bump AGP/Kotlin without us.
@@ -326,6 +331,11 @@ jobs:
           mapfile -t pngs < <(find . -path '*/build/compose-previews/renders/*.png' -not -path '*/external/build/*' 2>/dev/null)
           if [ "${#pngs[@]}" -eq 0 ]; then
             echo "::error::renderPreviews ran but no PNG files were produced."
+            mapfile -t sidecars < <(find . -path '*/build/compose-previews/renders/*.error.json' -not -path '*/external/build/*' 2>/dev/null)
+            if [ "${#sidecars[@]}" -gt 0 ]; then
+              echo "Render error sidecars:"
+              printf '  %s\n' "${sidecars[@]}"
+            fi
             exit 1
           fi
           echo "Rendered ${#pngs[@]} PNG file(s):"
@@ -468,7 +478,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: renders-${{ matrix.slug }}
-          path: external/**/build/compose-previews/renders/*.png
+          path: |
+            external/**/build/compose-previews/renders/*.png
+            external/**/build/compose-previews/renders/*.error.json
           if-no-files-found: warn
           retention-days: 7
 

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize]
+    paths-ignore:
+      - "skills/**"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/integration.yml"
+      - ".github/workflows/preview-comment.yml"
 
 # Workflow-level: read only. Jobs that need to push renders or comment on
 # the PR widen below.

--- a/skills/compose-preview-review/design/AGENT_AUDITS.md
+++ b/skills/compose-preview-review/design/AGENT_AUDITS.md
@@ -5,9 +5,54 @@ focused audit is needed beyond the basic before/after screenshot diff. Keep
 comments evidence-based: cite the preview, locale/device when relevant, and the
 data product or screenshot that supports the finding.
 
+The examples below are exercised by
+[`../scripts/run-agent-audit-samples.py`](../scripts/run-agent-audit-samples.py):
+the script writes temporary Kotlin/resource fixtures, runs the documented
+CLI/MCP commands, and asserts the expected data-product output shapes.
+
 ### Accessibility audit
 
-Sample command: `compose-preview a11y --filter <screen> --json --fail-on warnings`
+Use this when a PR changes tappable controls, icon-only actions, semantics,
+contrast, or screen state. Run ATF first, then inspect the annotated PNG path
+from the JSON output.
+
+Example problem:
+
+```kotlin
+@Preview(showBackground = true)
+@Composable
+fun SaveToolbarPreview() {
+  IconButton(onClick = {}) {
+    Icon(Icons.Default.Save, contentDescription = null)
+  }
+}
+```
+
+Command:
+
+```sh
+compose-preview a11y --filter SaveToolbar --json --fail-on warnings
+```
+
+Issue-identifying output:
+
+```json
+{
+  "previewId": "com.example.SaveToolbarPreview",
+  "a11yFindings": [
+    {
+      "level": "WARNING",
+      "type": "SpeakableTextPresentCheck",
+      "message": "This item may not have a label readable by screen readers.",
+      "viewDescription": "IconButton"
+    }
+  ],
+  "a11yAnnotatedPath": "build/compose-previews/renders/com.example.SaveToolbarPreview.a11y.png"
+}
+```
+
+Action: ask for a meaningful `contentDescription` or a parent semantics label,
+then rerun the same command and cite the cleared finding or remaining warning.
 
 Check:
 
@@ -19,7 +64,105 @@ Check:
 
 ### Localisation audit
 
-Sample command: `render_preview uri=<preview-uri> overrides.localeTag=fr-FR`
+Use this when copy, string resources, date/number formatting, or row layout
+changed. Test at least one longer locale and one RTL locale for user-facing
+screens.
+
+Example problem:
+
+```kotlin
+// res/values/strings.xml
+// <string name="done">Done</string>
+//
+// res/values-de/strings.xml
+// <string name="done">Vollstaendig und unwiderruflich abgeschlossen</string>
+
+@Preview(name = "English", showBackground = true)
+@Composable
+fun DoneButtonPreview() {
+  Button(onClick = {}, modifier = Modifier.width(96.dp)) {
+    Text(stringResource(R.string.done), maxLines = 1)
+  }
+}
+```
+
+Commands:
+
+```json
+{
+  "tool": "render_preview",
+  "arguments": {
+    "uri": "compose-preview://workspace/_app/com.example.DoneButtonPreview",
+    "overrides": { "localeTag": "de-DE" }
+  }
+}
+```
+
+```json
+{
+  "tool": "get_preview_data",
+  "arguments": {
+    "uri": "compose-preview://workspace/_app/com.example.DoneButtonPreview",
+    "kind": "text/strings"
+  }
+}
+```
+
+```json
+{
+  "tool": "get_preview_data",
+  "arguments": {
+    "uri": "compose-preview://workspace/_app/com.example.DoneButtonPreview",
+    "kind": "resources/used"
+  }
+}
+```
+
+Issue-identifying output:
+
+```json
+{
+  "kind": "text/strings",
+  "payload": {
+    "texts": [
+      {
+        "text": "Vollstaendig und unwiderruflich abgeschlossen",
+        "textSource": "layout",
+        "nodeId": "7",
+        "boundsInScreen": "16,10,96,34",
+        "localeTag": "de-DE",
+        "fontScale": 1.0
+      }
+    ]
+  }
+}
+```
+
+```json
+{
+  "kind": "resources/used",
+  "payload": {
+    "references": [
+      {
+        "resourceType": "string",
+        "resourceName": "done",
+        "packageName": "com.example",
+        "resolvedValue": "Vollstaendig und unwiderruflich abgeschlossen",
+        "resolvedFile": "/workspace/app/src/main/res/values-de/strings.xml",
+        "consumers": []
+      }
+    ]
+  }
+}
+```
+
+Action: cite both products: `resources/used` proves the German resource was
+selected, and `text/strings` proves the German text is what was laid out in
+the 96 dp button. Open the rendered PNG to confirm visible truncation; explicit
+`truncated` / `clipBounds` fields are not exposed yet (tracked in
+compose-ai-tools#705). Ask for flexible width, wrapping, shorter localized
+copy, or an alternate compact layout. Then rerender with the same `localeTag`
+override.
 
 Check:
 
@@ -30,7 +173,58 @@ Check:
 
 ### Wear and round-device audit
 
-Sample command: `get_preview_data uri=<wear-preview-uri> kind=render/deviceClip`
+Use this when Wear UI, round-device previews, edge buttons, or scrolling lists
+changed. Fetch the device clip metadata and compare it with the rendered PNG.
+
+Example problem:
+
+```kotlin
+@WearPreviewLargeRound
+@Composable
+fun AlertRoundPreview() {
+  Box(Modifier.fillMaxSize()) {
+    Text(
+      "High priority alert",
+      modifier = Modifier.align(Alignment.TopCenter).padding(top = 2.dp),
+    )
+  }
+}
+```
+
+Command:
+
+```json
+{
+  "tool": "get_preview_data",
+  "arguments": {
+    "uri": "compose-preview://workspace/_wear/com.example.AlertRoundPreview",
+    "kind": "render/deviceClip"
+  }
+}
+```
+
+Issue-identifying output:
+
+```json
+{
+  "kind": "render/deviceClip",
+  "payload": {
+    "clip": {
+      "shape": "circle",
+      "centerXDp": 113.5,
+      "centerYDp": 113.5,
+      "radiusDp": 113.5
+    }
+  }
+}
+```
+
+Action: cite `render/deviceClip` to prove this preview is captured under a
+round mask, then inspect the PNG or a11y overlay for actual clipping. The data
+product does not yet report safe bounds or content intersections (tracked in
+compose-ai-tools#704). If content is clipped, ask for `ScreenScaffold`, list
+`contentPadding`, or a lower top alignment. Then rerun the fetch and inspect
+the PNG to confirm the text is no longer hidden by the round edge.
 
 Check:
 
@@ -43,7 +237,67 @@ Check:
 
 ### Text overflow and readability audit
 
-Sample command: `get_preview_data uri=<preview-uri> kind=text/strings`
+Use this when a PR changes text, badges, counters, font sizes, density, or
+container widths. Prefer a font-scale preview variant when available.
+
+Example problem:
+
+```kotlin
+@Preview(name = "fontScale 1.3", fontScale = 1.3f, showBackground = true)
+@Composable
+fun AccountLimitPreview() {
+  Row(Modifier.width(180.dp), horizontalArrangement = Arrangement.SpaceBetween) {
+    Text("Available balance")
+    Text("$12,450.00")
+  }
+}
+```
+
+Command:
+
+```json
+{
+  "tool": "get_preview_data",
+  "arguments": {
+    "uri": "compose-preview://workspace/_app/com.example.AccountLimitPreview",
+    "kind": "text/strings"
+  }
+}
+```
+
+Issue-identifying output:
+
+```json
+{
+  "kind": "text/strings",
+  "payload": {
+    "texts": [
+      {
+        "text": "Available balance",
+        "textSource": "layout",
+        "nodeId": "4",
+        "boundsInScreen": "0,8,146,32",
+        "localeTag": "en-US",
+        "fontScale": 1.3
+      },
+      {
+        "text": "$12,450.00",
+        "textSource": "layout",
+        "nodeId": "5",
+        "boundsInScreen": "92,8,180,32",
+        "localeTag": "en-US",
+        "fontScale": 1.3
+      }
+    ]
+  }
+}
+```
+
+Action: ask for wrapping, a vertical layout at larger font scales, constrained
+number formatting, or `TextOverflow.Ellipsis` only when truncation is accepted
+by product. `text/strings` does not yet report overlap or truncation directly
+(tracked in compose-ai-tools#705), so confirm with the same data product and
+the rendered PNG.
 
 Check:
 
@@ -54,7 +308,69 @@ Check:
 
 ### Resource and theme provenance audit
 
-Sample command: `get_preview_data uri=<preview-uri> kind=resources/used`
+Use this when a PR changes resources, themes, dynamic colors, typography,
+icons, drawables, or preview overrides. Fetch provenance and verify the
+visible preview matches the intended token/resource.
+
+Example problem:
+
+```kotlin
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES, showBackground = true)
+@Composable
+fun WarningBannerDarkPreview() {
+  Text(
+    "Payment failed",
+    color = Color(0xFFB00020),
+    modifier = Modifier.background(MaterialTheme.colorScheme.background),
+  )
+}
+```
+
+Command:
+
+```json
+{
+  "tool": "get_preview_data",
+  "arguments": {
+    "uri": "compose-preview://workspace/_app/com.example.WarningBannerDarkPreview",
+    "kind": "resources/used"
+  }
+}
+```
+
+Issue-identifying output:
+
+```json
+{
+  "kind": "resources/used",
+  "payload": {
+    "references": [
+      {
+        "resourceType": "color",
+        "resourceName": "warning_red",
+        "packageName": "com.example",
+        "resolvedValue": "#FFB00020",
+        "resolvedFile": "/workspace/app/src/main/res/values/colors.xml",
+        "consumers": []
+      },
+      {
+        "resourceType": "string",
+        "resourceName": "payment_failed",
+        "packageName": "com.example",
+        "resolvedValue": "Payment failed",
+        "resolvedFile": "/workspace/app/src/main/res/values/strings.xml",
+        "consumers": []
+      }
+    ]
+  }
+}
+```
+
+Action: cite `references[]` to prove which resources resolved. If an expected
+theme token or resource is absent, ask for the design-system token
+(`MaterialTheme.colorScheme.error`, `onError`, etc.) or a named resource
+instead of a literal. If the visual diff is intentionally unchanged, the PR
+should explain why the provenance changed.
 
 Check:
 
@@ -67,7 +383,49 @@ Check:
 
 ### Visual regression and changed-region audit
 
-Sample command: `compose-preview show --filter <screen> --json --changed-only`
+Use this as the default PR audit once previews have been rendered on base and
+head. Start from `changed: true` entries, then inspect only the named PNGs and
+diffs.
+
+Example problem:
+
+```kotlin
+@Preview(showBackground = true)
+@Composable
+fun ProfileHeaderPreview() {
+  Row(verticalAlignment = Alignment.CenterVertically) {
+    Avatar()
+    Text("Jordan Lee", modifier = Modifier.padding(start = 4.dp))
+  }
+}
+```
+
+Command:
+
+```sh
+compose-preview show --filter ProfileHeader --json --changed-only
+```
+
+Issue-identifying output:
+
+```json
+{
+  "previews": [
+    {
+      "id": "com.example.ProfileHeaderPreview",
+      "changed": true,
+      "pngPath": "build/compose-previews/renders/com.example.ProfileHeaderPreview.png",
+      "diffPath": "build/compose-previews/diffs/com.example.ProfileHeaderPreview.diff.png",
+      "changedPixels": 18420
+    }
+  ],
+  "counts": { "changed": 1, "unchanged": 0, "missing": 0 }
+}
+```
+
+Action: open `diffPath` first. If pixels changed outside the intended header
+area, ask for the layout cause or fix. If the change is expected, cite the
+preview id and diff path in the PR review summary.
 
 Check:
 
@@ -89,7 +447,66 @@ Check:
 
 ### Failure triage audit
 
-Sample command: `get_preview_data uri=<preview-uri> kind=test/failure`
+Use this when a preview fails to render or a daemon/CI report says a data
+product is unavailable. Fetch the failure payload before guessing from the
+Gradle log.
+
+Example problem:
+
+```kotlin
+@Preview
+@Composable
+fun DetailPreview() {
+  DetailScreen(id = checkNotNull(null))
+}
+```
+
+Command:
+
+```json
+{
+  "tool": "get_preview_data",
+  "arguments": {
+    "uri": "compose-preview://workspace/_app/com.example.DetailPreview",
+    "kind": "test/failure"
+  }
+}
+```
+
+Issue-identifying output:
+
+```json
+{
+  "kind": "test/failure",
+  "payload": {
+    "status": "failed",
+    "phase": "unknown",
+    "error": {
+      "type": "IllegalStateException",
+      "message": "Required value was null.",
+      "topFrame": "DetailPreview.kt:42",
+      "stackTrace": [
+        "com.example.DetailPreviewKt.DetailPreview(DetailPreview.kt:42)"
+      ]
+    },
+    "partialScreenshot": null,
+    "partialScreenshotAvailable": false,
+    "pendingEffects": [],
+    "runningAnimations": [],
+    "frameClockState": { "status": "unknown" },
+    "lastSnapshotSummary": {
+      "stateObjects": null,
+      "valuesCaptured": false,
+      "redaction": "state values are not captured in schema v1"
+    }
+  }
+}
+```
+
+Action: ask for deterministic preview state or fake data at
+`payload.error.topFrame`. If the payload says `DataProductUnknown`, switch to
+`list_data_products` and verify the producer is enabled before filing a
+renderer bug.
 
 Check:
 

--- a/skills/compose-preview-review/scripts/run-agent-audit-samples.py
+++ b/skills/compose-preview-review/scripts/run-agent-audit-samples.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python3
+"""Exercise the agent audit recipes against generated Compose previews.
+
+The script writes a small Kotlin fixture into ``samples/android``, runs the
+same CLI/MCP commands that the audit guide recommends, and asserts the result
+shapes agents are expected to consume. It is intentionally end-to-end: if a
+documented command, preview id, override, or data-product schema drifts, this
+script should fail before the skill bundle ships.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SAMPLE = ROOT / "samples/android"
+OUT = ROOT / "build/agent-audit-samples"
+CLI = ROOT / "cli/build/install/compose-preview/bin/compose-preview"
+FIXTURE_KT = SAMPLE / "src/main/kotlin/com/example/sampleandroid/AgentAuditSamples.kt"
+FAILURE_KT = SAMPLE / "src/main/kotlin/com/example/sampleandroid/AgentAuditFailureSample.kt"
+VALUES = SAMPLE / "src/main/res/values/agent_audit.xml"
+VALUES_DE = SAMPLE / "src/main/res/values-de/agent_audit.xml"
+BUILD_GRADLE = SAMPLE / "build.gradle.kts"
+MODULE = "samples:android"
+
+
+KOTLIN_FIXTURE = """\
+package com.example.sampleandroid
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Preview(name = "Agent Audit Save Toolbar", showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+fun AgentAuditSaveToolbarPreview() {
+    Button(
+        onClick = {},
+        modifier = Modifier.size(width = 20.dp, height = 20.dp),
+    ) {}
+}
+
+@Preview(name = "Agent Audit Done English", showBackground = true)
+@Composable
+fun AgentAuditDoneButtonPreview() {
+    Button(onClick = {}, modifier = Modifier.width(96.dp)) {
+        Text(stringResource(R.string.agent_audit_done), maxLines = 1)
+    }
+}
+
+@Preview(name = "Agent Audit Account Limit", fontScale = 1.3f, showBackground = true)
+@Composable
+fun AgentAuditAccountLimitPreview() {
+    Row(Modifier.width(180.dp)) {
+        Text("Available balance")
+        Text("$12,450.00")
+    }
+}
+
+@Preview(
+    name = "Agent Audit Warning Dark",
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    showBackground = true,
+)
+@Composable
+fun AgentAuditWarningBannerPreview() {
+    Text(
+        text = stringResource(R.string.agent_audit_payment_failed),
+        color = colorResource(R.color.agent_audit_warning_red),
+        modifier = Modifier.background(MaterialTheme.colorScheme.background),
+    )
+}
+
+@Preview(name = "Agent Audit Round Clip", device = "id:wearos_large_round", showBackground = true)
+@Composable
+fun AgentAuditRoundClipPreview() {
+    Box(Modifier.fillMaxSize()) {
+        Text(
+            "High priority alert",
+            modifier = Modifier.align(Alignment.TopCenter).padding(top = 2.dp),
+        )
+    }
+}
+
+@Preview(name = "Agent Audit Profile Header", showBackground = true)
+@Composable
+fun AgentAuditProfileHeaderPreview() {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(Modifier.size(40.dp).background(MaterialTheme.colorScheme.primary))
+        Text("Jordan Lee", modifier = Modifier.padding(start = 4.dp))
+    }
+}
+"""
+
+
+FAILURE_FIXTURE = """\
+package com.example.sampleandroid
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(name = "Agent Audit Failure")
+@Composable
+fun AgentAuditFailurePreview() {
+    error("Required value was null.")
+}
+"""
+
+
+VALUES_XML = """\
+<resources>
+    <string name="agent_audit_done">Done</string>
+    <string name="agent_audit_payment_failed">Payment failed</string>
+    <color name="agent_audit_warning_red">#B00020</color>
+</resources>
+"""
+
+
+VALUES_DE_XML = """\
+<resources>
+    <string name="agent_audit_done">Vollstaendig und unwiderruflich abgeschlossen</string>
+</resources>
+"""
+
+
+def run(args: list[str], *, check: bool = True, timeout: int = 300) -> subprocess.CompletedProcess:
+    print("$ " + " ".join(args), flush=True)
+    result = subprocess.run(
+        args,
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+    )
+    if result.stdout:
+        (OUT / "last-stdout.txt").write_text(result.stdout)
+    if result.stderr:
+        (OUT / "last-stderr.txt").write_text(result.stderr)
+    if check and result.returncode != 0:
+        sys.stderr.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        raise AssertionError(f"command failed with {result.returncode}: {' '.join(args)}")
+    return result
+
+
+def write_fixture_files(include_failure: bool = False) -> None:
+    FIXTURE_KT.parent.mkdir(parents=True, exist_ok=True)
+    VALUES.parent.mkdir(parents=True, exist_ok=True)
+    VALUES_DE.parent.mkdir(parents=True, exist_ok=True)
+    FIXTURE_KT.write_text(KOTLIN_FIXTURE)
+    VALUES.write_text(VALUES_XML)
+    VALUES_DE.write_text(VALUES_DE_XML)
+    if include_failure:
+        FAILURE_KT.write_text(FAILURE_FIXTURE)
+    elif FAILURE_KT.exists():
+        FAILURE_KT.unlink()
+
+
+def enable_a11y_checks() -> str:
+    original = BUILD_GRADLE.read_text()
+    updated = original.replace("// enableAllChecks()", "enableAllChecks()")
+    if updated == original:
+        raise AssertionError("could not enable sample a11y checks in samples/android/build.gradle.kts")
+    BUILD_GRADLE.write_text(updated)
+    return original
+
+
+def clean_fixture_files() -> None:
+    for file in (FIXTURE_KT, FAILURE_KT, VALUES, VALUES_DE):
+        try:
+            file.unlink()
+        except FileNotFoundError:
+            pass
+    try:
+        VALUES_DE.parent.rmdir()
+    except OSError:
+        pass
+
+
+def json_from_stdout(result: subprocess.CompletedProcess) -> dict[str, Any]:
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(f"stdout was not JSON: {exc}\n{result.stdout[:400]}") from exc
+
+
+def assert_any(items: list[dict[str, Any]], predicate, message: str) -> dict[str, Any]:
+    for item in items:
+        if predicate(item):
+            return item
+    raise AssertionError(message)
+
+
+def preview_id(method_name: str) -> str:
+    manifest = json.loads((SAMPLE / "build/compose-previews/previews.json").read_text())
+    for preview in manifest["previews"]:
+        if preview.get("functionName") == method_name:
+            return preview["id"]
+    raise AssertionError(f"preview method not discovered: {method_name}")
+
+
+def encoded_module(module: str) -> str:
+    return "_" + module.strip(":").replace(":", "_")
+
+
+def stdio_message(body: dict[str, Any]) -> bytes:
+    return (json.dumps(body, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+class McpClient:
+    def __init__(self):
+        self.proc = subprocess.Popen(
+            [str(CLI), "mcp", "serve", "--project", str(ROOT)],
+            cwd=ROOT,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            bufsize=0,
+        )
+        self.next_id = 1
+        self.responses: dict[int, dict[str, Any]] = {}
+        self.cv = threading.Condition()
+        threading.Thread(target=self._reader, daemon=True).start()
+        threading.Thread(target=self._stderr, daemon=True).start()
+
+    def _reader(self) -> None:
+        assert self.proc.stdout is not None
+        for line in self.proc.stdout:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                obj = json.loads(stripped.decode("utf-8"))
+            except json.JSONDecodeError as exc:
+                raise AssertionError(f"bad MCP JSON line: {stripped[:160]!r}: {exc}") from exc
+            else:
+                with self.cv:
+                    if "id" in obj:
+                        self.responses[obj["id"]] = obj
+                        self.cv.notify_all()
+
+    def _stderr(self) -> None:
+        assert self.proc.stderr is not None
+        log = OUT / "mcp-stderr.log"
+        with log.open("ab") as fh:
+            for line in self.proc.stderr:
+                fh.write(line)
+                fh.flush()
+
+    def request(self, method: str, params: dict[str, Any] | None = None, timeout: int = 180):
+        req_id = self.next_id
+        self.next_id += 1
+        body: dict[str, Any] = {"jsonrpc": "2.0", "id": req_id, "method": method}
+        if params is not None:
+            body["params"] = params
+        assert self.proc.stdin is not None
+        self.proc.stdin.write(stdio_message(body))
+        self.proc.stdin.flush()
+        deadline = time.time() + timeout
+        with self.cv:
+            while req_id not in self.responses:
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    raise TimeoutError(f"{method} timed out")
+                self.cv.wait(remaining)
+            response = self.responses.pop(req_id)
+        if "error" in response:
+            raise AssertionError(f"{method} failed: {response['error']}")
+        return response["result"]
+
+    def notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        body: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            body["params"] = params
+        assert self.proc.stdin is not None
+        self.proc.stdin.write(stdio_message(body))
+        self.proc.stdin.flush()
+
+    def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+        *,
+        allow_error: bool = False,
+        timeout: int = 180,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {"name": name}
+        if arguments is not None:
+            params["arguments"] = arguments
+        result = self.request("tools/call", params, timeout=timeout)
+        if result.get("isError") and not allow_error:
+            raise AssertionError(f"tool {name} failed: {result}")
+        return result
+
+    def first_text(self, tool_result: dict[str, Any]) -> dict[str, Any]:
+        return json.loads(tool_result["content"][0]["text"])
+
+    def shutdown(self) -> None:
+        try:
+            if self.proc.stdin:
+                self.proc.stdin.close()
+        except BrokenPipeError:
+            pass
+        try:
+            self.proc.wait(timeout=20)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+
+
+def workspace_id_from_register(client: McpClient) -> str:
+    result = client.call_tool(
+        "register_project",
+        {
+            "path": str(ROOT),
+            "rootProjectName": "compose-ai-tools",
+            "modules": [":samples:android"],
+        },
+        timeout=240,
+    )
+    return client.first_text(result)["workspaceId"]
+
+
+def preview_uri(workspace_id: str, method_name: str) -> str:
+    return f"compose-preview://{workspace_id}/{encoded_module(MODULE)}/{preview_id(method_name)}"
+
+
+def setup_mcp() -> tuple[McpClient, str]:
+    client = McpClient()
+    client.request(
+        "initialize",
+        {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "agent-audit-samples", "version": "0"},
+        },
+    )
+    client.notify("notifications/initialized")
+    workspace_id = workspace_id_from_register(client)
+    client.call_tool("watch", {"workspaceId": workspace_id, "module": ":samples:android"})
+    return client, workspace_id
+
+
+def install_and_discover() -> None:
+    run([str(CLI), "mcp", "install", "--project", str(ROOT), "--module", "samples:android"], timeout=600)
+
+
+def test_accessibility_cli() -> None:
+    result = run(
+        [
+            str(CLI),
+            "a11y",
+            "--module",
+            MODULE,
+            "--filter",
+            "AgentAuditSaveToolbar",
+            "--json",
+            "--fail-on",
+            "warnings",
+        ],
+        check=False,
+        timeout=600,
+    )
+    if result.returncode == 0:
+        raise AssertionError("a11y sample should fail on warning-level findings")
+    payload = json_from_stdout(result)
+    OUT.joinpath("a11y.json").write_text(json.dumps(payload, indent=2))
+    preview = assert_any(
+        payload["previews"],
+        lambda item: "AgentAuditSaveToolbarPreview" in item["id"],
+        "a11y output did not include AgentAuditSaveToolbarPreview",
+    )
+    findings = preview.get("a11yFindings") or []
+    assert findings, "expected ATF findings for the deliberately tiny unlabelled button"
+
+
+def test_visual_regression_cli() -> None:
+    state = SAMPLE / "build/compose-previews/.cli-state.json"
+    state.unlink(missing_ok=True)
+    result = run(
+        [
+            str(CLI),
+            "show",
+            "--module",
+            MODULE,
+            "--filter",
+            "AgentAuditProfileHeader",
+            "--json",
+            "--changed-only",
+        ],
+        timeout=600,
+    )
+    payload = json_from_stdout(result)
+    OUT.joinpath("profile-header-show.json").write_text(json.dumps(payload, indent=2))
+    preview = assert_any(
+        payload["previews"],
+        lambda item: "AgentAuditProfileHeaderPreview" in item["id"],
+        "show output did not include AgentAuditProfileHeaderPreview",
+    )
+    png = Path(preview["pngPath"])
+    if not png.is_file():
+        raise AssertionError(f"expected rendered PNG to exist: {png}")
+
+
+def test_mcp_data_products() -> None:
+    install_and_discover()
+    client, workspace_id = setup_mcp()
+    try:
+        done_uri = preview_uri(workspace_id, "AgentAuditDoneButtonPreview")
+        client.call_tool("render_preview", {"uri": done_uri, "overrides": {"localeTag": "de-DE"}})
+        text_payload = client.first_text(
+            client.call_tool("get_preview_data", {"uri": done_uri, "kind": "text/strings"})
+        )
+        OUT.joinpath("done-text-strings.json").write_text(json.dumps(text_payload, indent=2))
+        texts = text_payload["payload"]["texts"]
+        assert_any(
+            texts,
+            lambda item: item.get("text") == "Vollstaendig und unwiderruflich abgeschlossen"
+            and item.get("localeTag") == "de-DE",
+            "locale override did not render the long German string in text/strings",
+        )
+        resources_payload = client.first_text(
+            client.call_tool("get_preview_data", {"uri": done_uri, "kind": "resources/used"})
+        )
+        OUT.joinpath("done-resources-used.json").write_text(json.dumps(resources_payload, indent=2))
+        refs = resources_payload["payload"]["references"]
+        assert_any(
+            refs,
+            lambda item: item.get("resourceType") == "string"
+            and item.get("resourceName") == "agent_audit_done"
+            and item.get("resolvedValue") == "Vollstaendig und unwiderruflich abgeschlossen",
+            "resources/used did not record the German string resource",
+        )
+
+        account_uri = preview_uri(workspace_id, "AgentAuditAccountLimitPreview")
+        client.call_tool("render_preview", {"uri": account_uri})
+        account_text = client.first_text(
+            client.call_tool("get_preview_data", {"uri": account_uri, "kind": "text/strings"})
+        )
+        OUT.joinpath("account-text-strings.json").write_text(json.dumps(account_text, indent=2))
+        account_texts = account_text["payload"]["texts"]
+        assert_any(
+            account_texts,
+            lambda item: item.get("text") == "Available balance" and item.get("fontScale") == 1.3,
+            "text/strings did not report the font-scale text sample",
+        )
+
+        clip_uri = preview_uri(workspace_id, "AgentAuditRoundClipPreview")
+        client.call_tool("render_preview", {"uri": clip_uri})
+        clip_payload = client.first_text(
+            client.call_tool("get_preview_data", {"uri": clip_uri, "kind": "render/deviceClip"})
+        )
+        OUT.joinpath("round-device-clip.json").write_text(json.dumps(clip_payload, indent=2))
+        clip = clip_payload["payload"]["clip"]
+        if clip.get("shape") != "circle" or "radiusDp" not in clip:
+            raise AssertionError(f"unexpected render/deviceClip payload: {clip_payload}")
+
+        warning_uri = preview_uri(workspace_id, "AgentAuditWarningBannerPreview")
+        client.call_tool("render_preview", {"uri": warning_uri})
+        warning_resources = client.first_text(
+            client.call_tool("get_preview_data", {"uri": warning_uri, "kind": "resources/used"})
+        )
+        OUT.joinpath("warning-resources-used.json").write_text(
+            json.dumps(warning_resources, indent=2)
+        )
+        warning_refs = warning_resources["payload"]["references"]
+        assert_any(
+            warning_refs,
+            lambda item: item.get("resourceType") == "color"
+            and item.get("resourceName") == "agent_audit_warning_red"
+            and item.get("resolvedValue", "").upper() == "#FFB00020",
+            "resources/used did not record the warning color resource",
+        )
+    finally:
+        client.shutdown()
+
+
+def test_failure_payload() -> None:
+    write_fixture_files(include_failure=True)
+    install_and_discover()
+    client, workspace_id = setup_mcp()
+    try:
+        uri = preview_uri(workspace_id, "AgentAuditFailurePreview")
+        client.call_tool("render_preview", {"uri": uri}, allow_error=True, timeout=240)
+        failure = client.first_text(
+            client.call_tool("get_preview_data", {"uri": uri, "kind": "test/failure"})
+        )
+        OUT.joinpath("test-failure.json").write_text(json.dumps(failure, indent=2))
+        payload = failure["payload"]
+        if payload.get("status") != "failed" or "error" not in payload:
+            raise AssertionError(f"unexpected test/failure payload: {failure}")
+        error = payload["error"]
+        if error.get("type") != "IllegalStateException":
+            raise AssertionError(f"unexpected failure type: {error}")
+        if "Required value was null." not in error.get("message", ""):
+            raise AssertionError(f"unexpected failure message: {error}")
+    finally:
+        client.shutdown()
+
+
+def main() -> int:
+    OUT.mkdir(parents=True, exist_ok=True)
+    if not shutil.which("java"):
+        raise AssertionError("java must be on PATH")
+    keep = os.environ.get("KEEP_AGENT_AUDIT_FIXTURES") == "1"
+    original_build_gradle: str | None = None
+    try:
+        write_fixture_files(include_failure=False)
+        original_build_gradle = enable_a11y_checks()
+        run(["./gradlew", ":cli:installDist"], timeout=600)
+        test_accessibility_cli()
+        test_visual_regression_cli()
+        test_mcp_data_products()
+        test_failure_payload()
+        print("Agent audit sample scripts passed.")
+        return 0
+    finally:
+        if original_build_gradle is not None:
+            BUILD_GRADLE.write_text(original_build_gradle)
+        if not keep:
+            clean_fixture_files()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Expand the agent PR audit reference with concrete bad composable examples.
- Add the command an agent should run for each non-recomposition audit.
- Include representative issue-identifying output and explicit follow-up actions.
- Leave the runtime/recomposition audit guidance unchanged.
- Add an executable agent audit sample script that writes temporary Kotlin/resource fixtures, runs the documented CLI/MCP commands, and validates the expected output shapes.
- Wire the script into CI as an `Agent Audit Samples` job.

## Follow-ups Logged

- #704 tracks richer `render/deviceClip` bounds/intersection data for round-device clipping audits.
- #705 tracks explicit `text/strings` truncation / clip-bounds data for localisation and font-scale audits.

## Validation

- `git diff --check`
- `python3 -m py_compile skills/compose-preview-review/scripts/run-agent-audit-samples.py`
- `python3 skills/compose-preview-review/scripts/run-agent-audit-samples.py`