### PR TITLE
feat: add scroll gif frame driver hook

### DIFF
--- a/data/render/compose/src/main/kotlin/ee/schimke/composeai/data/render/extensions/compose/ComposeDataExtensionHooks.kt
+++ b/data/render/compose/src/main/kotlin/ee/schimke/composeai/data/render/extensions/compose/ComposeDataExtensionHooks.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.data.render.extensions.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.tooling.CompositionData
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
@@ -24,6 +26,7 @@ data class ExtensionComposeContext(
   val renderMode: String?,
   val attributes: Map<String, Any?> = emptyMap(),
   val extraction: ExtensionExtractionContext = ExtensionExtractionContext.Empty,
+  val states: ExtensionStateRegistry = RecordingExtensionStateRegistry(),
 ) {
   val slotTables: ExtensionSlotTables
     get() = extraction.slotTables
@@ -31,6 +34,14 @@ data class ExtensionComposeContext(
   fun <T : Any> get(key: ExtensionContextKey<T>): T? = extraction.get(key)
 
   fun <T : Any> require(key: ExtensionContextKey<T>): T = extraction.require(key)
+
+  fun <T : Any> exportState(key: ExtensionStateKey<T>, state: State<T>) {
+    states.export(key, state)
+  }
+
+  fun <T : Any> state(key: ExtensionStateKey<T>): State<T>? = states.state(key)
+
+  fun <T : Any> value(key: ExtensionStateKey<T>): T? = states.value(key)
 }
 
 data class ExtensionContextKey<T : Any>(val name: String, val type: Class<T>) {
@@ -93,6 +104,49 @@ object CommonExtensionContextKeys {
   val RenderPreviewContext: ExtensionContextKey<PreviewContext> =
     ExtensionContextKey("preview-context", PreviewContext::class.java)
 }
+
+data class ExtensionStateKey<T : Any>(
+  val owner: DataExtensionId,
+  val name: String,
+  val type: Class<T>,
+) {
+  init {
+    require(name.isNotBlank()) { "Extension state key name must not be blank." }
+  }
+}
+
+interface ExtensionStateRegistry {
+  fun <T : Any> export(key: ExtensionStateKey<T>, state: State<T>)
+
+  fun <T : Any> state(key: ExtensionStateKey<T>): State<T>?
+
+  fun <T : Any> value(key: ExtensionStateKey<T>): T? = state(key)?.value
+
+  fun <T : Any> requireState(key: ExtensionStateKey<T>): State<T> =
+    state(key) ?: error("Extension state '${key.owner.value}/${key.name}' is not available.")
+
+  fun <T : Any> requireValue(key: ExtensionStateKey<T>): T = requireState(key).value
+}
+
+class RecordingExtensionStateRegistry : ExtensionStateRegistry {
+  private val values: MutableMap<ExtensionStateKey<*>, State<*>> = linkedMapOf()
+
+  override fun <T : Any> export(key: ExtensionStateKey<T>, state: State<T>) {
+    key.type.cast(state.value)
+    values[key] = state
+  }
+
+  override fun <T : Any> state(key: ExtensionStateKey<T>): State<T>? {
+    val state = values[key] ?: return null
+    key.type.cast(state.value)
+    @Suppress("UNCHECKED_CAST")
+    return state as State<T>
+  }
+}
+
+class StaticExtensionState<T : Any>(override val value: T) : State<T>
+
+fun <T : Any> staticExtensionState(value: T): State<T> = StaticExtensionState(value)
 
 interface ExtensionCompositionSink {
   fun put(extensionId: DataExtensionId, key: String, value: Any?)
@@ -211,7 +265,16 @@ data class ExtensionFrameContext(
   val renderMode: String?,
   val attributes: Map<String, Any?> = emptyMap(),
   val extraction: ExtensionExtractionContext = ExtensionExtractionContext.Empty,
-)
+  val states: ExtensionStateRegistry = RecordingExtensionStateRegistry(),
+) {
+  fun <T : Any> exportState(key: ExtensionStateKey<T>, state: State<T>) {
+    states.export(key, state)
+  }
+
+  fun <T : Any> state(key: ExtensionStateKey<T>): State<T>? = states.state(key)
+
+  fun <T : Any> value(key: ExtensionStateKey<T>): T? = states.value(key)
+}
 
 data class ExtensionFrame(
   val index: Int,
@@ -298,8 +361,10 @@ object ComposeDataExtensionPipeline {
     sink: ExtensionCompositionSink,
     attributes: Map<String, Any?> = emptyMap(),
     extraction: ExtensionExtractionContext = ExtensionExtractionContext.Empty,
+    states: ExtensionStateRegistry? = null,
     content: @Composable () -> Unit,
   ) {
+    val extensionStates = states ?: remember { RecordingExtensionStateRegistry() }
     Observe(
       extensions = extensions,
       previewId = previewId,
@@ -307,6 +372,7 @@ object ComposeDataExtensionPipeline {
       sink = sink,
       attributes = attributes,
       extraction = extraction,
+      states = extensionStates,
     )
     Extract(
       extensions = extensions,
@@ -315,6 +381,7 @@ object ComposeDataExtensionPipeline {
       sink = sink,
       attributes = attributes,
       extraction = extraction,
+      states = extensionStates,
     )
     Around(
       hooks = extensions.filterIsInstance<AroundComposableHook>(),
@@ -323,6 +390,7 @@ object ComposeDataExtensionPipeline {
       renderMode = renderMode,
       attributes = attributes,
       extraction = extraction,
+      states = extensionStates,
       content = content,
     )
   }
@@ -335,7 +403,9 @@ object ComposeDataExtensionPipeline {
     sink: ExtensionCompositionSink,
     attributes: Map<String, Any?> = emptyMap(),
     extraction: ExtensionExtractionContext = ExtensionExtractionContext.Empty,
+    states: ExtensionStateRegistry? = null,
   ) {
+    val extensionStates = states ?: remember { RecordingExtensionStateRegistry() }
     for (hook in extensions.filterIsInstance<ComposableExtractorHook>()) {
       hook.Extract(
         context =
@@ -345,6 +415,7 @@ object ComposeDataExtensionPipeline {
             renderMode = renderMode,
             attributes = attributes,
             extraction = extraction,
+            states = extensionStates,
           ),
         sink = sink,
       )
@@ -359,7 +430,9 @@ object ComposeDataExtensionPipeline {
     sink: ExtensionCompositionSink,
     attributes: Map<String, Any?> = emptyMap(),
     extraction: ExtensionExtractionContext = ExtensionExtractionContext.Empty,
+    states: ExtensionStateRegistry? = null,
   ) {
+    val extensionStates = states ?: remember { RecordingExtensionStateRegistry() }
     for (hook in extensions.filterIsInstance<CompositionObserverHook>()) {
       hook.Observe(
         context =
@@ -369,6 +442,7 @@ object ComposeDataExtensionPipeline {
             renderMode = renderMode,
             attributes = attributes,
             extraction = extraction,
+            states = extensionStates,
           ),
         sink = sink,
       )
@@ -383,6 +457,7 @@ object ComposeDataExtensionPipeline {
     renderMode: String?,
     attributes: Map<String, Any?>,
     extraction: ExtensionExtractionContext,
+    states: ExtensionStateRegistry,
     content: @Composable () -> Unit,
   ) {
     val hook = hooks.getOrNull(index)
@@ -399,6 +474,7 @@ object ComposeDataExtensionPipeline {
           renderMode = renderMode,
           attributes = attributes,
           extraction = extraction,
+          states = states,
         )
     ) {
       Around(
@@ -408,6 +484,7 @@ object ComposeDataExtensionPipeline {
         renderMode = renderMode,
         attributes = attributes,
         extraction = extraction,
+        states = states,
         content = content,
       )
     }

--- a/data/render/compose/src/test/kotlin/ee/schimke/composeai/data/render/extensions/compose/AroundComposableExtensionTest.kt
+++ b/data/render/compose/src/test/kotlin/ee/schimke/composeai/data/render/extensions/compose/AroundComposableExtensionTest.kt
@@ -103,6 +103,29 @@ class AroundComposableExtensionTest {
     assertNull(context.get(ExtensionContextKey("missing", String::class.java)))
   }
 
+  @Test
+  fun extensionContextExposesTypedStateExports() {
+    val owner = DataExtensionId("scroll-gif")
+    val framesKey = ExtensionStateKey(owner = owner, name = "frames", type = String::class.java)
+    val registry = RecordingExtensionStateRegistry()
+    val context =
+      ExtensionComposeContext(
+        extensionId = owner,
+        previewId = "preview",
+        renderMode = "gif",
+        states = registry,
+      )
+
+    context.exportState(framesKey, staticExtensionState("planned"))
+
+    assertEquals("planned", context.value(framesKey))
+    assertEquals("planned", context.state(framesKey)?.value)
+    assertEquals("planned", registry.requireValue(framesKey))
+    assertNull(
+      context.state(ExtensionStateKey(owner = owner, name = "missing", String::class.java))
+    )
+  }
+
   private class SimpleBackgroundExtension :
     AroundComposableExtension(DataExtensionId("render-device-background")) {
     @Composable

--- a/data/scroll/core/build.gradle.kts
+++ b/data/scroll/core/build.gradle.kts
@@ -16,6 +16,7 @@ android { namespace = "ee.schimke.composeai.data.scroll.core" }
 
 dependencies {
   api(project(":data-render-core"))
+  api(project(":data-render-compose"))
 
   compileOnly(platform(libs.compose.bom.compat))
   compileOnly(libs.compose.ui)

--- a/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollGifFrameDriverExtension.kt
+++ b/data/scroll/core/src/main/kotlin/ee/schimke/composeai/scroll/ScrollGifFrameDriverExtension.kt
@@ -1,0 +1,179 @@
+package ee.schimke.composeai.scroll
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionLifecycle
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionFrame
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionFrameContext
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionFrameSequence
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionStateKey
+import ee.schimke.composeai.data.render.extensions.compose.NormalizedFrameDriverExtension
+import ee.schimke.composeai.data.render.extensions.compose.staticExtensionState
+
+data class ScrollGifFramePlan(
+  val contentExtentPxHint: Float,
+  val viewportPx: Float,
+  val density: Float,
+  val frameIntervalMs: Int = DEFAULT_SCROLL_GIF_FRAME_INTERVAL_MS,
+) {
+  init {
+    require(contentExtentPxHint >= 0f) { "Content extent must be non-negative." }
+    require(viewportPx >= 0f) { "Viewport size must be non-negative." }
+    require(density >= 0f) { "Density must be non-negative." }
+    require(frameIntervalMs >= 0) { "Frame interval must be non-negative." }
+  }
+
+  val effectiveFrameIntervalMs: Int
+    get() =
+      if (frameIntervalMs == 0) {
+        DEFAULT_SCROLL_GIF_FRAME_INTERVAL_MS
+      } else {
+        frameIntervalMs
+      }
+}
+
+data class ScrollGifFrame(
+  val frame: ExtensionFrame,
+  val scrollDeltaPx: Float,
+) {
+  init {
+    require(scrollDeltaPx >= 0f) { "Scroll delta must be non-negative." }
+  }
+}
+
+data class ScrollGifFrameSequence(
+  val frames: List<ScrollGifFrame>,
+  val contentExtentPxHint: Float,
+  val viewportPx: Float,
+  val density: Float,
+) {
+  val scrollDeltasPx: List<Float>
+    get() = frames.map { it.scrollDeltaPx }
+
+  fun asExtensionFrameSequence(): ExtensionFrameSequence =
+    ExtensionFrameSequence(
+      frames = frames.map { it.frame },
+      extras =
+        mapOf(
+          "axis" to "vertical",
+          "scrollDeltasPx" to scrollDeltasPx,
+          "frameDelaysMs" to frames.map { it.frame.delayMillis },
+          "contentExtentPxHint" to contentExtentPxHint,
+          "viewportPx" to viewportPx,
+          "density" to density,
+        ),
+    )
+}
+
+object ScrollGifExtensionStateKeys {
+  val Frames: ExtensionStateKey<ScrollGifFrameSequence> =
+    ExtensionStateKey(
+      owner = DataExtensionId(ScrollPreviewExtension.KIND_GIF),
+      name = "frames",
+      type = ScrollGifFrameSequence::class.java,
+    )
+}
+
+/**
+ * Clean data-extension hook for planning animated scroll-GIF frames.
+ *
+ * The extension owns the calibrated scroll deltas and their normalized frame projection. Hosts can
+ * bind [scrollFrames] to their own scroll/capture implementation without hardcoding scroll-GIF
+ * timing rules in the daemon or renderer.
+ */
+class ScrollGifFrameDriverExtension(private val plan: ScrollGifFramePlan) :
+  NormalizedFrameDriverExtension(
+    id = DataExtensionId(ScrollPreviewExtension.KIND_GIF),
+    constraints =
+      DataExtensionConstraints(
+        phase = DataExtensionPhase.Scenario,
+        lifecycle = DataExtensionLifecycle.MultiFrame,
+        provides =
+          setOf(
+            DataExtensionCapability(ScrollPreviewExtension.KIND_GIF),
+            DataExtensionCapability("scroll/frames"),
+          ),
+      ),
+  ) {
+  fun scrollFrames(context: ExtensionFrameContext): ScrollGifFrameSequence {
+    val steps =
+      buildGifScrollScript(
+        contentExtentPxHint = plan.contentExtentPxHint,
+        viewportPx = plan.viewportPx,
+        density = plan.density,
+        frameIntervalMs = plan.effectiveFrameIntervalMs,
+      )
+    if (steps.isEmpty()) {
+      return exportFrames(
+        context,
+        ScrollGifFrameSequence(
+          frames =
+            listOf(
+              ScrollGifFrame(
+                frame = ExtensionFrame(index = 0, fraction = 0f, timeMillis = 0L, delayMillis = 0),
+                scrollDeltaPx = 0f,
+              )
+            ),
+          contentExtentPxHint = plan.contentExtentPxHint,
+          viewportPx = plan.viewportPx,
+          density = plan.density,
+        ),
+      )
+    }
+
+    val frames = mutableListOf<ScrollGifFrame>()
+    var timeMillis = 0L
+    var scrolledPx = 0f
+    frames +=
+      ScrollGifFrame(
+        frame =
+          ExtensionFrame(
+            index = 0,
+            fraction = 0f,
+            timeMillis = timeMillis,
+            delayMillis = HOLD_START_MS,
+          ),
+        scrollDeltaPx = 0f,
+      )
+    steps.forEachIndexed { index, step ->
+      timeMillis += frames.last().frame.delayMillis
+      scrolledPx = (scrolledPx + step.scrollPx).coerceAtMost(plan.contentExtentPxHint)
+      frames +=
+        ScrollGifFrame(
+          frame =
+            ExtensionFrame(
+              index = index + 1,
+              fraction = (scrolledPx / plan.contentExtentPxHint).coerceIn(0f, 1f),
+              timeMillis = timeMillis,
+              delayMillis = step.delayMs,
+            ),
+          scrollDeltaPx = step.scrollPx,
+        )
+    }
+
+    return exportFrames(
+      context,
+      ScrollGifFrameSequence(
+        frames = frames,
+        contentExtentPxHint = plan.contentExtentPxHint,
+        viewportPx = plan.viewportPx,
+        density = plan.density,
+      ),
+    )
+  }
+
+  override fun frames(context: ExtensionFrameContext): ExtensionFrameSequence =
+    scrollFrames(context).asExtensionFrameSequence()
+
+  private fun exportFrames(
+    context: ExtensionFrameContext,
+    frames: ScrollGifFrameSequence,
+  ): ScrollGifFrameSequence {
+    context.exportState(ScrollGifExtensionStateKeys.Frames, staticExtensionState(frames))
+    return frames
+  }
+}
+
+const val DEFAULT_SCROLL_GIF_FRAME_INTERVAL_MS: Int = 80

--- a/data/scroll/core/src/test/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtensionTest.kt
+++ b/data/scroll/core/src/test/kotlin/ee/schimke/composeai/scroll/ScrollPreviewExtensionTest.kt
@@ -1,13 +1,82 @@
 package ee.schimke.composeai.scroll
 
 import ee.schimke.composeai.data.render.RenderPreviewExtension
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionLifecycle
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionFrameContext
+import ee.schimke.composeai.data.render.extensions.compose.FrameDriverHook
+import ee.schimke.composeai.data.render.extensions.compose.RecordingExtensionStateRegistry
+import ee.schimke.composeai.data.render.extensions.compose.hasFrameDriverHook
 import ee.schimke.composeai.data.render.pipeline.PipelineCapability
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelinePlan
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelineValidator
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ScrollPreviewExtensionTest {
+  @Test
+  fun gifFrameDriverDeclaresScenarioHookAndNormalizesFrames() {
+    val extension =
+      ScrollGifFrameDriverExtension(
+        ScrollGifFramePlan(
+          contentExtentPxHint = 600f,
+          viewportPx = 400f,
+          density = 1f,
+          frameIntervalMs = 80,
+        )
+      )
+    val hook: FrameDriverHook = extension
+    val states = RecordingExtensionStateRegistry()
+    val context =
+      ExtensionFrameContext(
+        extensionId = extension.id,
+        previewId = "preview",
+        renderMode = "gif",
+        states = states,
+      )
+
+    val sequence = hook.frames(context)
+    val scrollSequence = states.requireValue(ScrollGifExtensionStateKeys.Frames)
+
+    assertEquals(DataExtensionId(ScrollPreviewExtension.KIND_GIF), extension.id)
+    assertEquals(setOf(DataExtensionHookKind.ScenarioDriver), extension.hooks)
+    assertEquals(DataExtensionPhase.Scenario, extension.constraints.phase)
+    assertEquals(DataExtensionLifecycle.MultiFrame, extension.constraints.lifecycle)
+    assertTrue(extension.hasFrameDriverHook)
+    assertEquals(0f, sequence.frames.first().fraction)
+    assertEquals(1f, sequence.frames.last().fraction)
+    assertTrue(sequence.frames.zipWithNext().all { (a, b) -> b.timeMillis >= a.timeMillis })
+    assertEquals("vertical", sequence.extras["axis"])
+    assertTrue((sequence.extras["scrollDeltasPx"] as List<*>).isNotEmpty())
+    assertEquals(sequence.frames, scrollSequence.frames.map { it.frame })
+    assertTrue(scrollSequence.frames.any { it.scrollDeltaPx > 0f })
+  }
+
+  @Test
+  fun gifFrameDriverTreatsZeroFrameIntervalAsDefaultCadence() {
+    val extension =
+      ScrollGifFrameDriverExtension(
+        ScrollGifFramePlan(
+          contentExtentPxHint = 600f,
+          viewportPx = 400f,
+          density = 1f,
+          frameIntervalMs = 0,
+        )
+      )
+
+    val sequence =
+      extension.scrollFrames(
+        ExtensionFrameContext(extensionId = extension.id, previewId = "preview", renderMode = "gif")
+      )
+
+    assertEquals(DEFAULT_SCROLL_GIF_FRAME_INTERVAL_MS, sequence.frames[1].frame.delayMillis)
+    assertEquals(HOLD_START_MS.toLong(), sequence.frames[1].frame.timeMillis)
+    assertTrue(sequence.frames.zipWithNext().all { (a, b) -> b.frame.timeMillis > a.frame.timeMillis })
+  }
+
   @Test
   fun gifScenarioCanBeClippedBeforeEncoding() {
     val plan =

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -37,16 +37,19 @@ import ee.schimke.composeai.scroll.HOLD_START_MS
 import ee.schimke.composeai.scroll.INTER_FLING_HOLD_MS
 import ee.schimke.composeai.scroll.ScrollAxis as ProductScrollAxis
 import ee.schimke.composeai.scroll.ScrollDriveResult
+import ee.schimke.composeai.scroll.ScrollGifFrameDriverExtension
+import ee.schimke.composeai.scroll.ScrollGifFramePlan
 import ee.schimke.composeai.scroll.ScrollGifEncoder
 import ee.schimke.composeai.scroll.SliceCapture
 import ee.schimke.composeai.scroll.applyWearPillClip
-import ee.schimke.composeai.scroll.buildGifScrollScript
 import ee.schimke.composeai.scroll.driveScrollBy
 import ee.schimke.composeai.scroll.driveScrollByViewport
 import ee.schimke.composeai.scroll.driveScrollToEnd
 import ee.schimke.composeai.scroll.driveScrollToStart
 import ee.schimke.composeai.scroll.remainingScrollPx
 import ee.schimke.composeai.scroll.stitchSlicesWithFinalFrame
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionFrameContext
 import java.awt.image.BufferedImage
 import java.io.File
 import kotlinx.serialization.json.Json
@@ -1239,19 +1242,29 @@ private fun handleGifCapture(
         val cap = if (scroll.maxScrollPx > 0) scroll.maxScrollPx.toFloat() else Float.POSITIVE_INFINITY
         val extentHint = minOf(liveRemaining, cap)
 
-        val script = buildGifScrollScript(
-            contentExtentPxHint = extentHint,
-            viewportPx = viewportLayoutPx.toFloat(),
-            density = density,
-            frameIntervalMs = frameIntervalMs,
-        )
+        val scrollFrames =
+            ScrollGifFrameDriverExtension(
+                    ScrollGifFramePlan(
+                        contentExtentPxHint = extentHint,
+                        viewportPx = viewportLayoutPx.toFloat(),
+                        density = density,
+                        frameIntervalMs = frameIntervalMs,
+                    ),
+                )
+                .scrollFrames(
+                    ExtensionFrameContext(
+                        extensionId = DataExtensionId("render/scroll/gif"),
+                        previewId = previewId,
+                        renderMode = "scroll-gif",
+                    ),
+                )
 
         var scrolledPx = 0f
         var scriptHitEnd = false
-        for (step in script) {
-            if (step.scrollPx > 0f) {
+        for (scrollFrame in scrollFrames.frames.drop(1)) {
+            if (scrollFrame.scrollDeltaPx > 0f) {
                 val headroom = (cap - scrolledPx).coerceAtLeast(0f)
-                val target = minOf(step.scrollPx, headroom)
+                val target = minOf(scrollFrame.scrollDeltaPx, headroom)
                 if (target <= 0f) {
                     scriptHitEnd = true
                     break
@@ -1268,7 +1281,7 @@ private fun handleGifCapture(
                 // ticking honestly across the hold.
                 rule.mainClock.advanceTimeBy(frameIntervalMs.toLong())
             }
-            captureFrame(step.delayMs)
+            captureFrame(scrollFrame.frame.delayMillis)
         }
 
         // Tail flings: LazyList reports `maxValue` progressively, so the


### PR DESCRIPTION
## Summary

Adds a focused scroll-GIF data-extension hook as the next one-extension migration from the ugly-list follow-ups, and wires the existing Android scroll-GIF renderer path to consume it. It also adds a typed exported `State<>` channel to the Compose extension context so extensions can communicate without daemon-specific hardcoding.

## What changed

- Added `ExtensionStateKey`, `ExtensionStateRegistry`, and context helpers like `exportState(...)` / `state(...)` on the Compose extension hook surface.
- `ComposeDataExtensionPipeline.Apply` now shares one state registry across observer, extractor, and around-composable hooks for a render pass.
- Added `ScrollGifFrameDriverExtension`, a `NormalizedFrameDriverExtension` for `render/scroll/gif`.
- Added typed `ScrollGifFramePlan`, `ScrollGifFrame`, and `ScrollGifFrameSequence` so hosts can consume scroll deltas and delays directly instead of unpacking generic `extras` arrays.
- `ScrollGifFrameDriverExtension` now exports its planned `State<ScrollGifFrameSequence>` via `ScrollGifExtensionStateKeys.Frames` for other extensions to consume.
- The extension still projects to generic `ExtensionFrame`s from `0..1`, but Android now uses the typed `scrollFrames(...)` API to drive the real GIF capture loop.
- Replaced Android `buildGifScrollScript(...)` usage in `RobolectricRenderTest.handleGifCapture` with the new hook.
- Added `:data-render-compose` as an API dependency of `:data-scroll-core` for the shared hook surface.
- Added focused test coverage for hook declaration, lifecycle, normalized frames, typed scroll deltas, exported state, and extras.

## Applying to Android/Desktop

Android exposed a bad assumption in the first version: a generic normalized frame is not enough to execute a scroll scenario. The host needs a typed per-frame `scrollDeltaPx`, so the API now exposes `ScrollGifFrameSequence` and treats the generic `ExtensionFrameSequence` as a projection.

Desktop exposed a different gap: there is no existing desktop `@ScrollingPreview(GIF)` capture path equivalent to Android's `RobolectricRenderTest.handleGifCapture`. This PR does not invent that renderer path; it leaves the reusable hook ready for a future desktop host binding once desktop scroll capture exists.

## In-flight PRs checked

- #683 Material theme overrides: open and updated first; renderers now route the override through `Material3ThemeOverrideExtension` + `ComposeDataExtensionPipeline`.
- #700 device clip hook: merged.

## Validation

```bash
./gradlew :data-render-compose:ktfmtFormat :data-scroll-core:ktfmtFormat :renderer-android:ktfmtFormat :data-render-compose:ktfmtCheck :data-scroll-core:ktfmtCheck :renderer-android:ktfmtCheck :data-render-compose:test --tests ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtensionTest :data-scroll-core:testDebugUnitTest --tests ee.schimke.composeai.scroll.ScrollPreviewExtensionTest --tests ee.schimke.composeai.scroll.GifScrollScriptTest :renderer-android:compileDebugKotlin
```