### PR TITLE
Use basic Gradle Actions cache provider

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,6 +5,12 @@ description: >
   dependabot only has to bump these in one place.
 
 inputs:
+  cache-provider:
+    description: >
+      Cache provider for gradle/actions/setup-gradle. Keep the default on the
+      MIT-licensed basic provider rather than Gradle Actions v6's enhanced
+      provider.
+    default: 'basic'
   cache-read-only:
     description: >
       Pass 'true' in release/publish jobs to prevent Gradle cache writes —
@@ -21,4 +27,5 @@ runs:
         java-version: 17
     - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       with:
+        cache-provider: ${{ inputs.cache-provider }}
         cache-read-only: ${{ inputs.cache-read-only }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -224,6 +224,8 @@ jobs:
           java-version: 17
 
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-provider: basic
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -495,6 +497,8 @@ jobs:
           java-version: 17
 
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-provider: basic
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:


### PR DESCRIPTION
## Summary
- Keep the shared setup action on Gradle Actions v6.1.0 but explicitly select `cache-provider: basic`.
- Apply the same basic cache provider to the integration workflow's direct `setup-gradle` uses.

## Why
Gradle Actions v6 defaults to the enhanced caching provider backed by `gradle-actions-caching`. The v6 release notes describe that caching component as separately licensed/proprietary, while v6.1.0 adds the MIT-licensed `basic` provider. This makes the workflow choice explicit and avoids accidentally opting into the enhanced provider.

## Validation
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml", ".github/actions/*/action.yml"].each { |f| YAML.load_file(f); puts f }'`
- `git diff --check`
- `python3 .github/actions/lib/test_compare_previews.py -v`
- `python3 .github/actions/lib/test_a11y_report.py -v`
- `ANDROID_HOME=/opt/homebrew/share/android-commandlinetools ./gradlew :data-render-compose:ktfmtCheck :data-scroll-core:ktfmtCheck :renderer-android:ktfmtCheck :data-render-compose:test --tests ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtensionTest :data-scroll-core:testDebugUnitTest --tests ee.schimke.composeai.scroll.ScrollPreviewExtensionTest --tests ee.schimke.composeai.scroll.GifScrollScriptTest :renderer-android:compileDebugKotlin`