### PR TITLE
feat: add layout inspector capture context

### DIFF
--- a/data/layoutinspector/connector/build.gradle.kts
+++ b/data/layoutinspector/connector/build.gradle.kts
@@ -11,6 +11,7 @@ android { namespace = "ee.schimke.composeai.data.layoutinspector.connector" }
 
 dependencies {
   api(project(":data-layoutinspector-core"))
+  api(project(":data-render-compose"))
   api(project(":daemon:core"))
   compileOnly(platform(libs.compose.bom.compat))
   compileOnly(libs.compose.ui)

--- a/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
+++ b/data/layoutinspector/connector/src/main/kotlin/ee/schimke/composeai/daemon/ComposeSemanticsDataProduct.kt
@@ -21,6 +21,7 @@ import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.data.layoutinspector.ComposeSemanticsProduct
 import ee.schimke.composeai.data.layoutinspector.LayoutInspectorProduct
 import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.extensions.compose.ExtensionSlotTables
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import java.io.File
 import java.lang.reflect.Method
@@ -185,17 +186,29 @@ object LayoutInspectorDataProducer {
     previewId: String,
     previewContext: PreviewContext,
   ) {
-    val root = previewContext.inspection.rootForTest as? RootForTest ?: return
-    val layoutRoot =
-      ComposeLayoutInspector.inspect(
-        rootSemanticsNode = root.semanticsOwner.unmergedRootSemanticsNode,
-        slotTables = previewContext.inspection.slotTables,
-      ) ?: return
+    val capture = LayoutInspectorCaptureContext.from(previewContext) ?: return
+    val layoutRoot = ComposeLayoutInspector.inspect(capture) ?: return
     val previewDir = rootDir.resolve(previewId).also { it.mkdirs() }
     val payload = LayoutInspectorPayload(root = layoutRoot)
     previewDir.resolve(FILE).writeText(
       json.encodeToString(LayoutInspectorPayload.serializer(), payload)
     )
+  }
+}
+
+internal data class LayoutInspectorCaptureContext(
+  val rootSemanticsNode: Any,
+  val slotTables: ExtensionSlotTables = ExtensionSlotTables.Empty,
+) {
+  companion object {
+    fun from(previewContext: PreviewContext): LayoutInspectorCaptureContext? {
+      val root = previewContext.inspection.rootForTest as? RootForTest ?: return null
+      return LayoutInspectorCaptureContext(
+        rootSemanticsNode = root.semanticsOwner.unmergedRootSemanticsNode,
+        slotTables =
+          ExtensionSlotTables.of(previewContext.inspection.slotTables.filterIsInstance<CompositionData>()),
+      )
+    }
   }
 }
 
@@ -208,9 +221,9 @@ object LayoutInspectorDataProducer {
  * context, get a [LayoutInspectorNode].
  */
 internal object ComposeLayoutInspector {
-  fun inspect(rootSemanticsNode: Any, slotTables: List<Any>): LayoutInspectorNode? {
-    val root = LayoutTreeAccess.rootLayoutNode(rootSemanticsNode) ?: return null
-    val sources = LayoutSourceIndex(slotTables)
+  fun inspect(context: LayoutInspectorCaptureContext): LayoutInspectorNode? {
+    val root = LayoutTreeAccess.rootLayoutNode(context.rootSemanticsNode) ?: return null
+    val sources = LayoutSourceIndex(context.slotTables)
     return root.toWireNode(rootCoordinates = null, sources = sources)
   }
 
@@ -290,13 +303,13 @@ internal object ComposeLayoutInspector {
     val sourceInfo: String?,
   )
 
-  private class LayoutSourceIndex(slotTables: List<Any>) {
+  private class LayoutSourceIndex(slotTables: ExtensionSlotTables) {
     private val byNode = java.util.IdentityHashMap<Any, LayoutSource>()
 
     init {
       slotTables
+        .snapshot()
         .asSequence()
-        .filterIsInstance<CompositionData>()
         .flatMap { it.compositionGroups.asSequence() }
         .flatMap { it.flattenGroups().asSequence() }
         .forEach { group ->

--- a/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeLayoutInspectorTest.kt
+++ b/data/layoutinspector/connector/src/test/kotlin/ee/schimke/composeai/daemon/ComposeLayoutInspectorTest.kt
@@ -12,7 +12,8 @@ class ComposeLayoutInspectorTest {
     val root = LayoutNodeLike(id = 42, width = 100, height = 50, children = listOf(child))
     val semanticsRoot = SemanticsNodeLike(layoutNode = root)
 
-    val node = ComposeLayoutInspector.inspect(semanticsRoot, slotTables = emptyList())
+    val node =
+      ComposeLayoutInspector.inspect(LayoutInspectorCaptureContext(rootSemanticsNode = semanticsRoot))
 
     requireNotNull(node)
     assertEquals("42", node.nodeId)
@@ -29,14 +30,15 @@ class ComposeLayoutInspectorTest {
     val layout = LayoutNodeLike(id = 9, width = 24, height = 16)
     val semanticsRoot = SemanticsInfoLike(layoutInfo = layout)
 
-    val node = ComposeLayoutInspector.inspect(semanticsRoot, slotTables = emptyList())
+    val node =
+      ComposeLayoutInspector.inspect(LayoutInspectorCaptureContext(rootSemanticsNode = semanticsRoot))
 
     assertEquals("9", node?.nodeId)
   }
 
   @Test
   fun returnsNullWhenNoLayoutRootIsAvailable() {
-    val node = ComposeLayoutInspector.inspect(Any(), slotTables = emptyList())
+    val node = ComposeLayoutInspector.inspect(LayoutInspectorCaptureContext(rootSemanticsNode = Any()))
 
     assertNull(node)
   }


### PR DESCRIPTION
## Summary

Continues the one-extension ugly-list cleanup for the layout inspector extension.

## What changed

- Added `LayoutInspectorCaptureContext` as the clean handoff API for layout-inspector capture data.
- Moved `PreviewContext` extraction of `RootForTest` and slot tables into that capture context.
- Changed `ComposeLayoutInspector.inspect(...)` to consume the capture context instead of raw `Any` root + raw slot-table list parameters.
- Routed slot tables through the shared `ExtensionSlotTables` API from `:data-render-compose`.
- Updated layout-inspector tests to use the capture context API.

## Why

This keeps the layout inspector call site shaped around the data the extension actually wants, while the Compose/RootForTest and slot-table details stay in one connector-owned adapter. The reflection and Compose-internal access remain hidden behind the layout inspector facade.

## Validation

```bash
./gradlew :data-layoutinspector-connector:ktfmtFormat :data-layoutinspector-connector:ktfmtCheck :data-layoutinspector-connector:testDebugUnitTest --tests ee.schimke.composeai.daemon.ComposeLayoutInspectorTest --tests ee.schimke.composeai.daemon.ComposeSemanticsDataProductRegistryTest :data-layoutinspector-connector:compileDebugKotlin
```