### PR TITLE
[codex] Contribute recording script events via data extensions

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -5,6 +5,9 @@ import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingInputParams
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence
+import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
 import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.io.File
@@ -152,6 +155,7 @@ class AndroidRecordingSession(
     var lastFrameTimeMs = 0L
     var frameWidthPx = 0
     var frameHeightPx = 0
+    val evidence = mutableListOf<RecordingScriptEvidence>()
     for (frameIndex in 0 until totalFrames) {
       val tMs: Long = frameIndex.toLong() * 1000L / fps.toLong()
 
@@ -161,16 +165,27 @@ class AndroidRecordingSession(
       // doesn't matter on the host side (the underlying session has its own streamId).
       while (nextEventIdx < sortedEvents.size && sortedEvents[nextEventIdx].tMs <= tMs) {
         val e = sortedEvents[nextEventIdx]
-        if (e.kind != InteractiveInputKind.KEY_DOWN && e.kind != InteractiveInputKind.KEY_UP) {
+        val inputKind = e.kind.toInteractiveInputKindOrNull()
+        if (e.kind == RecordingScriptDataExtensions.PROBE_EVENT) {
+          evidence.add(e.appliedEvidence("probe marker reached"))
+        } else if (inputKind == null) {
+          evidence.add(e.unsupportedEvidence("script event kind '${e.kind}' is not implemented"))
+        } else if (
+          inputKind == InteractiveInputKind.KEY_DOWN || inputKind == InteractiveInputKind.KEY_UP
+        ) {
+          evidence.add(e.unsupportedEvidence("key dispatch is not implemented for Android recording"))
+        } else {
           interactive.dispatch(
             InteractiveInputParams(
               frameStreamId = "android-recording-internal",
-              kind = e.kind,
+              kind = inputKind,
               pixelX = e.pixelX,
               pixelY = e.pixelY,
+              scrollDeltaY = e.scrollDeltaY,
               keyCode = e.keyCode,
             )
           )
+          evidence.add(e.appliedEvidence())
         }
         nextEventIdx++
       }
@@ -206,6 +221,7 @@ class AndroidRecordingSession(
       framesDir = framesDir.absolutePath,
       frameWidthPx = frameWidthPx,
       frameHeightPx = frameHeightPx,
+      scriptEvents = evidence,
     )
   }
 
@@ -235,6 +251,30 @@ class AndroidRecordingSession(
       frameHeightPx = liveFrameHeightPx,
     )
   }
+
+  private fun RecordingScriptEvent.appliedEvidence(message: String? = null): RecordingScriptEvidence =
+    RecordingScriptEvidence(
+      tMs = tMs,
+      kind = kind,
+      status = RecordingScriptEventStatus.APPLIED,
+      label = label,
+      checkpointId = checkpointId,
+      lifecycleEvent = lifecycleEvent,
+      tags = tags,
+      message = message,
+    )
+
+  private fun RecordingScriptEvent.unsupportedEvidence(message: String): RecordingScriptEvidence =
+    RecordingScriptEvidence(
+      tMs = tMs,
+      kind = kind,
+      status = RecordingScriptEventStatus.UNSUPPORTED,
+      label = label,
+      checkpointId = checkpointId,
+      lifecycleEvent = lifecycleEvent,
+      tags = tags,
+      message = message,
+    )
 
   private fun runLiveTickLoop() {
     val startNs = System.nanoTime()

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -8,6 +8,7 @@ import ee.schimke.composeai.daemon.history.GitRefHistorySource
 import ee.schimke.composeai.daemon.history.HistoryManager
 import ee.schimke.composeai.daemon.history.HistoryPruneConfig
 import ee.schimke.composeai.data.render.RenderPreviewExtension
+import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
 import ee.schimke.composeai.renderer.AccessibilityAnnotatedPreviewExtension
 import ee.schimke.composeai.renderer.AccessibilityOverlayPreviewExtension
 import ee.schimke.composeai.renderer.AccessibilitySemanticsPreviewExtension
@@ -336,6 +337,7 @@ fun main(args: Array<String>) {
       incrementalDiscovery = incrementalDiscovery,
       historyManager = historyManager,
       dataProducts = dataProducts,
+      dataExtensions = RecordingScriptDataExtensions.descriptors,
       previewExtensions = previewExtensions,
     )
   server.run()

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
@@ -4,6 +4,7 @@ import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
 import java.io.ByteArrayInputStream
 import java.io.File
 import javax.imageio.ImageIO
@@ -67,7 +68,7 @@ class AndroidRecordingSessionTest {
       listOf(
         RecordingScriptEvent(
           tMs = 67L,
-          kind = InteractiveInputKind.CLICK,
+          kind = "click",
           pixelX = 4,
           pixelY = 4,
         )
@@ -145,7 +146,14 @@ class AndroidRecordingSessionTest {
     try {
       try {
         session.postScript(
-          listOf(RecordingScriptEvent(tMs = 0L, kind = InteractiveInputKind.CLICK, pixelX = 1, pixelY = 1))
+          listOf(
+            RecordingScriptEvent(
+              tMs = 0L,
+              kind = "click",
+              pixelX = 1,
+              pixelY = 1,
+            )
+          )
         )
         fail("expected live recording to reject postScript")
       } catch (expected: IllegalStateException) {
@@ -195,6 +203,73 @@ class AndroidRecordingSessionTest {
   }
 
   @Test
+  fun scriptedRecordingReportsUnsupportedStateEventsWithoutDispatchingThem() {
+    val framesDir = tempFolder.newFolder("scripted-state-events-frames")
+    val encodedDir = tempFolder.newFolder("scripted-state-events-encoded")
+    val sourcePng = File(tempFolder.newFolder("scripted-state-events-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    val interactive = RecordingDeltaSession(sourcePng)
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-scripted-state-events",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    try {
+      session.postScript(
+        listOf(
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = "click",
+            pixelX = 1,
+            pixelY = 1,
+          ),
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = RecordingScriptDataExtensions.STATE_SAVE_EVENT,
+            label = "before",
+            checkpointId = "c1",
+          ),
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = RecordingScriptDataExtensions.PROBE_EVENT,
+            label = "after-save-marker",
+          ),
+        )
+      )
+      val result = session.stop()
+
+      assertEquals("only the click should dispatch through interactive input", 1, interactive.dispatchCount)
+      assertEquals(3, result.scriptEvents.size)
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.APPLIED,
+        result.scriptEvents[0].status,
+      )
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.UNSUPPORTED,
+        result.scriptEvents[1].status,
+      )
+      assertEquals("c1", result.scriptEvents[1].checkpointId)
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.APPLIED,
+        result.scriptEvents[2].status,
+      )
+      assertEquals("after-save-marker", result.scriptEvents[2].label)
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
   fun scriptedClickFlipsStateAndProducesFrames() {
     val outputDir = tempFolder.newFolder("recording-renders")
     val recordingsRoot = tempFolder.newFolder("recordings-root")
@@ -231,7 +306,7 @@ class AndroidRecordingSessionTest {
           listOf(
             RecordingScriptEvent(
               tMs = 67L,
-              kind = InteractiveInputKind.CLICK,
+              kind = "click",
               pixelX = INTERACTIVE_WIDTH_PX / 2,
               pixelY = INTERACTIVE_HEIGHT_PX / 2,
             )

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/JsonRpcServer.kt
@@ -51,6 +51,7 @@ import ee.schimke.composeai.daemon.protocol.ServerCapabilities
 import ee.schimke.composeai.daemon.protocol.SetFocusParams
 import ee.schimke.composeai.daemon.protocol.SetVisibleParams
 import ee.schimke.composeai.daemon.protocol.UiMode
+import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
 import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
 import java.io.ByteArrayOutputStream
 import java.io.EOFException
@@ -184,6 +185,7 @@ class JsonRpcServer(
    * in `renderer-android`) is the first concrete implementation that gets wired in by `DaemonMain`.
    */
   private val dataProducts: DataProductRegistry = DataProductRegistry.Empty,
+  private val dataExtensions: List<DataExtensionDescriptor> = emptyList(),
   private val previewExtensions: List<PreviewExtensionDescriptor> = emptyList(),
   /**
    * D3 — per-request budget for `data/fetch` re-render-on-demand (DATA-PRODUCTS.md § "Re-render
@@ -640,6 +642,7 @@ class JsonRpcServer(
             leakDetection = emptyList<LeakDetectionMode>(),
             // D1 — advertised kinds. Empty when no producer was wired (pre-D2 default).
             dataProducts = dataProducts.capabilities,
+            dataExtensions = dataExtensions,
             previewExtensions = previewExtensions,
             // INTERACTIVE.md § 9 — `true` when the host's `acquireInteractiveSession` returns a
             // real held-scene session (DesktopHost). `false` for hosts that inherit the throwing
@@ -2270,6 +2273,7 @@ class JsonRpcServer(
                   framesDir = r.framesDir,
                   frameWidthPx = r.frameWidthPx,
                   frameHeightPx = r.frameHeightPx,
+                  scriptEvents = r.scriptEvents,
                 ),
               ),
             )

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
@@ -1,8 +1,10 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingInputParams
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence
 
 /**
  * Held-scene recording session for one `recordingId` — see
@@ -119,7 +121,20 @@ data class RecordingResult(
   val framesDir: String,
   val frameWidthPx: Int,
   val frameHeightPx: Int,
+  val scriptEvents: List<RecordingScriptEvidence> = emptyList(),
 )
 
 /** Metadata returned by [RecordingSession.encode]. */
 data class EncodedRecording(val videoPath: String, val mimeType: String, val sizeBytes: Long)
+
+fun String.toInteractiveInputKindOrNull(): InteractiveInputKind? =
+  when (this) {
+    "click" -> InteractiveInputKind.CLICK
+    "pointerDown" -> InteractiveInputKind.POINTER_DOWN
+    "pointerMove" -> InteractiveInputKind.POINTER_MOVE
+    "pointerUp" -> InteractiveInputKind.POINTER_UP
+    "rotaryScroll" -> InteractiveInputKind.ROTARY_SCROLL
+    "keyDown" -> InteractiveInputKind.KEY_DOWN
+    "keyUp" -> InteractiveInputKind.KEY_UP
+    else -> null
+  }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon.protocol
 
+import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
 import ee.schimke.composeai.data.render.pipeline.PreviewExtensionDescriptor
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import kotlinx.serialization.EncodeDefault
@@ -140,6 +141,8 @@ data class ServerCapabilities(
   // client side treats absent and `[]` identically). See
   // docs/daemon/DATA-PRODUCTS.md § "Wire surface".
   val dataProducts: List<DataProductCapability> = emptyList(),
+  /** Metadata for registered data extensions, including namespaced recording script events. */
+  val dataExtensions: List<DataExtensionDescriptor> = emptyList(),
   /**
    * Metadata for extension steps the daemon can plan into a render pipeline. Clients should use
    * this for generic UI affordances and validation instead of keying behavior off product strings.
@@ -993,23 +996,55 @@ data class RecordingInputParams(
  */
 @Serializable data class RecordingStartResult(val recordingId: String)
 
-/** One scripted input event on the virtual timeline. */
+@Serializable
+enum class RecordingScriptEventStatus {
+  @SerialName("applied") APPLIED,
+  @SerialName("unsupported") UNSUPPORTED,
+}
+
+/** One scripted input/control event on the virtual timeline. */
 @Serializable
 data class RecordingScriptEvent(
   /** Virtual time offset from `recording/start`, in milliseconds. Must be ≥ 0. */
   val tMs: Long,
-  val kind: InteractiveInputKind,
+  /**
+   * Input event wire value (`click`, `pointerDown`, …) or a namespaced data-extension script event
+   * id advertised in `ServerCapabilities.dataExtensions[].recordingScriptEvents[]`.
+   */
+  val kind: String,
   /** Image-natural pixel coordinates. Same coordinate system as `interactive/input`. */
   val pixelX: Int? = null,
   val pixelY: Int? = null,
   /** For `keyDown` / `keyUp` (no-op in v1; reserved for v2 key dispatch). */
   val keyCode: String? = null,
+  /** Browser wheel delta for `rotaryScroll`; positive means wheel-down. */
+  val scrollDeltaY: Float? = null,
+  /** Agent-supplied label for probes and state checkpoints. */
+  val label: String? = null,
+  /** Agent-supplied checkpoint id for save/restore state markers. */
+  val checkpointId: String? = null,
+  /** Lifecycle transition name for `kind = lifecycle`, e.g. `resume`, `pause`, or `destroy`. */
+  val lifecycleEvent: String? = null,
+  /** Optional free-form tags copied into script evidence. */
+  val tags: List<String> = emptyList(),
 )
 
 @Serializable
 data class RecordingScriptParams(val recordingId: String, val events: List<RecordingScriptEvent>)
 
 @Serializable data class RecordingStopParams(val recordingId: String)
+
+@Serializable
+data class RecordingScriptEvidence(
+  val tMs: Long,
+  val kind: String,
+  val status: RecordingScriptEventStatus,
+  val label: String? = null,
+  val checkpointId: String? = null,
+  val lifecycleEvent: String? = null,
+  val tags: List<String> = emptyList(),
+  val message: String? = null,
+)
 
 /**
  * Result of `recording/stop`. The daemon has played the script back in virtual time, written one
@@ -1029,6 +1064,8 @@ data class RecordingStopResult(
   val frameWidthPx: Int,
   /** Frame height in pixels, after `scale`. */
   val frameHeightPx: Int,
+  /** Per-script-event execution evidence for input, lifecycle, state, and probe events. */
+  val scriptEvents: List<RecordingScriptEvidence> = emptyList(),
 )
 
 /**

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -7,6 +7,7 @@ import ee.schimke.composeai.daemon.history.GitRefHistorySource
 import ee.schimke.composeai.daemon.history.HistoryManager
 import ee.schimke.composeai.daemon.history.HistoryPruneConfig
 import ee.schimke.composeai.data.render.RenderPreviewExtension
+import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
 import java.io.File
 import java.nio.file.Path
 
@@ -262,6 +263,7 @@ fun main(args: Array<String>) {
       // path as a future Compose API rename. Wiring is intentionally global — kinds advertised
       // in `initialize.capabilities.dataProducts` reflect the daemon's whole surface.
       dataProducts = dataProducts,
+      dataExtensions = RecordingScriptDataExtensions.descriptors,
       previewExtensions =
         buildList {
           add(RenderPreviewExtension.deviceClipDescriptor)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -7,6 +7,9 @@ import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingInputParams
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence
+import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
 import java.io.File
 import java.util.concurrent.ConcurrentLinkedQueue
 import org.jetbrains.skia.EncodedImageFormat
@@ -171,20 +174,39 @@ class DesktopRecordingSession(
     val durationMs: Long = sortedEvents.maxOfOrNull { it.tMs } ?: 0L
     // Frames are paced as `frameIndex * 1000 / fps` (integer division on the ms side keeps the
     // virtual cadence stable across long timelines; nanoTime stays exact via the 1e9/fps split
-    // below). We always render frame 0 plus one frame per `frameStep` covering the timeline up
-    // to and including `durationMs`. So a 500ms timeline at 30fps produces frames 0..15 (16
-    // frames in total — t = 0, 33, 66, ..., 500ms).
-    val totalFrames = (durationMs * fps / 1000).toInt() + 1
+    // below). We always render frame 0 plus enough frames to drain every event in the timeline.
+    // So a 67ms timeline at 30fps produces frames 0..3 (t = 0, 33, 66, 100ms), and the 67ms event
+    // is dispatched before the final frame instead of silently missing both input and evidence.
+    val totalFrames = ((durationMs * fps + 999L) / 1000L).toInt() + 1
 
     val startNs = System.nanoTime()
     var nextEventIdx = 0
+    val evidence = mutableListOf<RecordingScriptEvidence>()
     for (frameIndex in 0 until totalFrames) {
       val tNanos: Long = frameIndex.toLong() * 1_000_000_000L / fps.toLong()
       val tMs: Long = tNanos / 1_000_000L
 
       while (nextEventIdx < sortedEvents.size && sortedEvents[nextEventIdx].tMs <= tMs) {
         val e = sortedEvents[nextEventIdx]
-        dispatchInput(e.kind, e.pixelX, e.pixelY, tNanos, tMs)
+        val inputKind = e.kind.toInteractiveInputKindOrNull()
+        if (e.kind == RecordingScriptDataExtensions.PROBE_EVENT) {
+          evidence.add(e.appliedEvidence("probe marker reached"))
+        } else if (inputKind == null) {
+          evidence.add(e.unsupportedEvidence("script event kind '${e.kind}' is not implemented"))
+        } else if (
+          inputKind == InteractiveInputKind.KEY_DOWN ||
+            inputKind == InteractiveInputKind.KEY_UP ||
+            inputKind == InteractiveInputKind.ROTARY_SCROLL
+        ) {
+          evidence.add(
+            e.unsupportedEvidence(
+              "key and rotary dispatch are not implemented for desktop recording"
+            )
+          )
+        } else {
+          dispatchInput(inputKind, e.pixelX, e.pixelY, tNanos, tMs)
+          evidence.add(e.appliedEvidence())
+        }
         nextEventIdx++
       }
 
@@ -203,6 +225,7 @@ class DesktopRecordingSession(
       framesDir = framesDir.absolutePath,
       frameWidthPx = frameWidthPx,
       frameHeightPx = frameHeightPx,
+      scriptEvents = evidence,
     )
   }
 
@@ -253,6 +276,32 @@ class DesktopRecordingSession(
       frameHeightPx = frameHeightPx,
     )
   }
+
+  private fun RecordingScriptEvent.appliedEvidence(
+    message: String? = null
+  ): RecordingScriptEvidence =
+    RecordingScriptEvidence(
+      tMs = tMs,
+      kind = kind,
+      status = RecordingScriptEventStatus.APPLIED,
+      label = label,
+      checkpointId = checkpointId,
+      lifecycleEvent = lifecycleEvent,
+      tags = tags,
+      message = message,
+    )
+
+  private fun RecordingScriptEvent.unsupportedEvidence(message: String): RecordingScriptEvidence =
+    RecordingScriptEvidence(
+      tMs = tMs,
+      kind = kind,
+      status = RecordingScriptEventStatus.UNSUPPORTED,
+      label = label,
+      checkpointId = checkpointId,
+      lifecycleEvent = lifecycleEvent,
+      tags = tags,
+      message = message,
+    )
 
   /**
    * Live tick loop body. Runs on the dedicated `compose-ai-daemon-recording-live-<id>` thread.

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
@@ -95,13 +95,13 @@ class DesktopRecordingSessionTest {
           listOf(
             RecordingScriptEvent(
               tMs = 0L,
-              kind = InteractiveInputKind.CLICK,
+              kind = "click",
               pixelX = COMPONENT_WIDTH_PX / 2,
               pixelY = COMPONENT_HEIGHT_PX / 2,
             ),
             RecordingScriptEvent(
               tMs = 500L,
-              kind = InteractiveInputKind.CLICK,
+              kind = "click",
               pixelX = COMPONENT_WIDTH_PX / 2,
               pixelY = COMPONENT_HEIGHT_PX / 2,
             ),
@@ -226,7 +226,7 @@ class DesktopRecordingSessionTest {
           listOf(
             RecordingScriptEvent(
               tMs = 0L,
-              kind = InteractiveInputKind.CLICK,
+              kind = "click",
               pixelX = COMPONENT_WIDTH_PX / 2,
               pixelY = COMPONENT_HEIGHT_PX / 2,
             )
@@ -315,13 +315,13 @@ class DesktopRecordingSessionTest {
           listOf(
             RecordingScriptEvent(
               tMs = 0L,
-              kind = InteractiveInputKind.CLICK,
+              kind = "click",
               pixelX = COMPONENT_WIDTH_PX / 2,
               pixelY = COMPONENT_HEIGHT_PX / 2,
             ),
             RecordingScriptEvent(
               tMs = 200L,
-              kind = InteractiveInputKind.CLICK,
+              kind = "click",
               pixelX = COMPONENT_WIDTH_PX / 2,
               pixelY = COMPONENT_HEIGHT_PX / 2,
             ),
@@ -525,16 +525,7 @@ class DesktopRecordingSessionTest {
         )
       try {
         val thrown =
-          runCatching {
-              session.postScript(
-                listOf(
-                  RecordingScriptEvent(
-                    tMs = 0L,
-                    kind = ee.schimke.composeai.daemon.protocol.InteractiveInputKind.CLICK,
-                  )
-                )
-              )
-            }
+          runCatching { session.postScript(listOf(RecordingScriptEvent(tMs = 0L, kind = "click"))) }
             .exceptionOrNull()
         assertTrue(
           "postScript on a live session must throw IllegalStateException; got ${thrown?.javaClass}",

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
@@ -97,6 +97,94 @@ interface DataExtension<in Request> {
   fun plan(request: Request): PlannedDataExtension?
 }
 
+@Serializable
+data class DataExtensionDescriptor(
+  val id: DataExtensionId,
+  val displayName: String = id.value,
+  val recordingScriptEvents: List<RecordingScriptEventDescriptor> = emptyList(),
+)
+
+@Serializable
+data class RecordingScriptEventDescriptor(
+  val id: String,
+  val displayName: String = id,
+  val summary: String = "",
+  val supported: Boolean = false,
+) {
+  init {
+    require(id.contains('.')) {
+      "Recording script event id '$id' must be namespaced, e.g. '${id}.event'."
+    }
+    require(id.isNotBlank()) { "Recording script event id must not be blank." }
+  }
+}
+
+object RecordingScriptDataExtensions {
+  const val PROBE_EVENT: String = "recording.probe"
+  const val STATE_SAVE_EVENT: String = "state.save"
+  const val STATE_RESTORE_EVENT: String = "state.restore"
+  const val PREVIEW_RELOAD_EVENT: String = "preview.reload"
+  const val LIFECYCLE_EVENT: String = "lifecycle.event"
+
+  val descriptors: List<DataExtensionDescriptor> =
+    listOf(
+      DataExtensionDescriptor(
+        id = DataExtensionId("recording"),
+        displayName = "Recording script markers",
+        recordingScriptEvents =
+          listOf(
+            RecordingScriptEventDescriptor(
+              id = PROBE_EVENT,
+              displayName = "Probe marker",
+              summary = "Records a named point in the recording timeline.",
+              supported = true,
+            )
+          ),
+      ),
+      DataExtensionDescriptor(
+        id = DataExtensionId("state"),
+        displayName = "State restoration script markers",
+        recordingScriptEvents =
+          listOf(
+            RecordingScriptEventDescriptor(
+              id = STATE_SAVE_EVENT,
+              displayName = "Save state checkpoint",
+              summary = "Requests a saved-state checkpoint in a recording script.",
+            ),
+            RecordingScriptEventDescriptor(
+              id = STATE_RESTORE_EVENT,
+              displayName = "Restore state checkpoint",
+              summary = "Requests restoration from a saved-state checkpoint.",
+            ),
+          ),
+      ),
+      DataExtensionDescriptor(
+        id = DataExtensionId("preview"),
+        displayName = "Preview script controls",
+        recordingScriptEvents =
+          listOf(
+            RecordingScriptEventDescriptor(
+              id = PREVIEW_RELOAD_EVENT,
+              displayName = "Reload preview",
+              summary = "Requests preview reload during a recording script.",
+            )
+          ),
+      ),
+      DataExtensionDescriptor(
+        id = DataExtensionId("lifecycle"),
+        displayName = "Lifecycle script controls",
+        recordingScriptEvents =
+          listOf(
+            RecordingScriptEventDescriptor(
+              id = LIFECYCLE_EVENT,
+              displayName = "Lifecycle event",
+              summary = "Requests a lifecycle transition during a recording script.",
+            )
+          ),
+      ),
+    )
+}
+
 data class SimplePlannedDataExtension(
   override val id: DataExtensionId,
   override val hooks: Set<DataExtensionHookKind> = emptySet(),

--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -187,6 +187,7 @@ Typical agent flow:
   "format": "apng",
   "events": [
     { "tMs": 0, "kind": "click", "pixelX": 120, "pixelY": 80 },
+    { "tMs": 200, "kind": "state.save", "checkpointId": "before-second-click" },
     { "tMs": 400, "kind": "click", "pixelX": 120, "pixelY": 80 }
   ]
 }
@@ -195,7 +196,11 @@ Typical agent flow:
 On success the tool returns an inline media block plus a JSON metadata text
 block containing `recordingId`, `videoPath`, `mimeType`, `sizeBytes`,
 `frameCount`, `durationMs`, `framesDir`, `frameWidthPx`, and
-`frameHeightPx`. The raw PNG frames live at
+`frameHeightPx`. It also includes `scriptEvents[]`, a per-event evidence list
+with `applied` or `unsupported` status for input, probe, state, and lifecycle
+script events. Non-input script events are namespaced ids advertised by
+`capabilities.dataExtensions[].recordingScriptEvents[]`. Treat `unsupported` as
+a compose-ai-tools capability gap, not as an app regression. The raw PNG frames live at
 `<framesDir>/frame-00000.png`, `<framesDir>/frame-00001.png`, and so on, which
 is useful when a client cannot display APNG or wants to inspect individual
 frames.

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -2,12 +2,12 @@ package ee.schimke.composeai.mcp
 
 import ee.schimke.composeai.daemon.protocol.ChangeType
 import ee.schimke.composeai.daemon.protocol.FileKind
-import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
 import ee.schimke.composeai.daemon.protocol.Orientation
 import ee.schimke.composeai.daemon.protocol.PreviewOverrides
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus
 import ee.schimke.composeai.daemon.protocol.RenderTier
 import ee.schimke.composeai.daemon.protocol.UiMode
 import ee.schimke.composeai.data.render.pipeline.PreviewExtensionCommandCatalog
@@ -1127,10 +1127,15 @@ class DaemonMcpServer(
                     "type":"object",
                     "properties":{
                       "tMs":{"type":"integer","description":"Virtual time offset from recording/start, in milliseconds. Must be ≥ 0."},
-                      "kind":{"type":"string","enum":["click","pointerDown","pointerUp","keyDown","keyUp"],"description":"Input event kind. 'click' is Press+Release at the same virtual tMs."},
+                      "kind":{"type":"string","description":"Input event kind (`click`, `pointerDown`, `pointerMove`, `pointerUp`, `rotaryScroll`, `keyDown`, `keyUp`) or a namespaced data-extension script event id advertised by the daemon, for example `recording.probe` or `state.save`."},
                       "pixelX":{"type":"integer","description":"X coord in image-natural pixel space (the preview's own widthPx)."},
                       "pixelY":{"type":"integer","description":"Y coord in image-natural pixel space."},
-                      "keyCode":{"type":"string","description":"For 'keyDown'/'keyUp' (reserved; v1 dispatch is a no-op)."}
+                      "scrollDeltaY":{"type":"number","description":"For 'rotaryScroll'."},
+                      "keyCode":{"type":"string","description":"For 'keyDown'/'keyUp' (reserved; v1 dispatch is a no-op)."},
+                      "label":{"type":"string","description":"Agent label copied into scriptEvents evidence for probes/checkpoints."},
+                      "checkpointId":{"type":"string","description":"Checkpoint id for state save/restore audit events."},
+                      "lifecycleEvent":{"type":"string","description":"Lifecycle transition for lifecycle script events, e.g. resume, pause, destroy."},
+                      "tags":{"type":"array","items":{"type":"string"},"description":"Optional agent tags copied into scriptEvents evidence."}
                     },
                     "required":["tMs","kind"]
                   }
@@ -1846,6 +1851,17 @@ class DaemonMcpServer(
                     )
                   }
                 }
+                putJsonArray("dataExtensions") {
+                  daemon.dataExtensionDescriptors.forEach { extension ->
+                    add(
+                      json.encodeToJsonElement(
+                        ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
+                          .serializer(),
+                        extension,
+                      )
+                    )
+                  }
+                }
               }
             )
           }
@@ -2344,6 +2360,10 @@ class DaemonMcpServer(
         return errorCallToolResult("record_preview: ${violations.joinToString("; ")}")
       }
     }
+    val scriptKindViolations = validateRecordingScriptKinds(events, daemon)
+    if (scriptKindViolations.isNotEmpty()) {
+      return errorCallToolResult("record_preview: ${scriptKindViolations.joinToString("; ")}")
+    }
     // RECORDING.md § "encoded formats" — when the daemon advertises a non-empty `recordingFormats`
     // capability, reject formats outside the advertised set up front so the agent sees a clean
     // diagnostic instead of waiting on a `recording/encode` round-trip that would only fail.
@@ -2423,6 +2443,24 @@ class DaemonMcpServer(
                   frame.dimensionChangedFromPrevious?.let {
                     put("dimensionChangedFromPrevious", it)
                   }
+                }
+              )
+            }
+          }
+          putJsonArray("scriptEvents") {
+            for (event in stopResult.scriptEvents) {
+              add(
+                buildJsonObject {
+                  put("tMs", event.tMs)
+                  put("kind", event.kind)
+                  put("status", event.status.wireName())
+                  event.label?.let { put("label", it) }
+                  event.checkpointId?.let { put("checkpointId", it) }
+                  event.lifecycleEvent?.let { put("lifecycleEvent", it) }
+                  if (event.tags.isNotEmpty()) {
+                    putJsonArray("tags") { for (tag in event.tags) add(JsonPrimitive(tag)) }
+                  }
+                  event.message?.let { put("message", it) }
                 }
               )
             }
@@ -2565,22 +2603,48 @@ class DaemonMcpServer(
           ?: error("event[$idx] missing or invalid 'tMs'")
       require(tMs >= 0) { "event[$idx] tMs must be ≥ 0; got $tMs" }
       val kindStr = obj["kind"]?.jsonPrimitive?.contentOrNull ?: error("event[$idx] missing 'kind'")
-      val kind =
-        when (kindStr) {
-          "click" -> InteractiveInputKind.CLICK
-          "pointerDown" -> InteractiveInputKind.POINTER_DOWN
-          "pointerUp" -> InteractiveInputKind.POINTER_UP
-          "keyDown" -> InteractiveInputKind.KEY_DOWN
-          "keyUp" -> InteractiveInputKind.KEY_UP
-          else -> error("event[$idx] unknown kind '$kindStr'")
-        }
+      require(kindStr.isNotBlank()) { "event[$idx] kind must not be blank" }
+      if (kindStr !in RECORDING_INPUT_KINDS && !kindStr.contains('.')) {
+        error(
+          "event[$idx] unknown input kind '$kindStr' and extension event ids must be namespaced"
+        )
+      }
       RecordingScriptEvent(
         tMs = tMs,
-        kind = kind,
+        kind = kindStr,
         pixelX = obj["pixelX"]?.jsonPrimitive?.contentOrNull?.toIntOrNull(),
         pixelY = obj["pixelY"]?.jsonPrimitive?.contentOrNull?.toIntOrNull(),
+        scrollDeltaY = obj["scrollDeltaY"]?.jsonPrimitive?.contentOrNull?.toFloatOrNull(),
         keyCode = obj["keyCode"]?.jsonPrimitive?.contentOrNull,
+        label = obj["label"]?.jsonPrimitive?.contentOrNull,
+        checkpointId = obj["checkpointId"]?.jsonPrimitive?.contentOrNull,
+        lifecycleEvent = obj["lifecycleEvent"]?.jsonPrimitive?.contentOrNull,
+        tags =
+          (obj["tags"] as? JsonArray)?.mapNotNull { tag -> tag.jsonPrimitive.contentOrNull }
+            ?: emptyList(),
       )
+    }
+  }
+
+  private fun RecordingScriptEventStatus.wireName(): String =
+    when (this) {
+      RecordingScriptEventStatus.APPLIED -> "applied"
+      RecordingScriptEventStatus.UNSUPPORTED -> "unsupported"
+    }
+
+  private fun validateRecordingScriptKinds(
+    events: List<RecordingScriptEvent>,
+    daemon: SupervisedDaemon,
+  ): List<String> {
+    val extensionEventIds =
+      daemon.dataExtensionDescriptors.flatMap { it.recordingScriptEvents }.map { it.id }.toSet()
+    return events.mapIndexedNotNull { index, event ->
+      when {
+        event.kind in RECORDING_INPUT_KINDS -> null
+        event.kind in extensionEventIds -> null
+        else ->
+          "event[$index] extension script event '${event.kind}' is not advertised by this daemon"
+      }
     }
   }
 
@@ -3137,5 +3201,8 @@ class DaemonMcpServer(
      * valid arguments without code changes here.
      */
     private const val DEFAULT_OVERLAY_KIND: String = "a11y/overlay"
+
+    private val RECORDING_INPUT_KINDS =
+      setOf("click", "pointerDown", "pointerMove", "pointerUp", "rotaryScroll", "keyDown", "keyUp")
   }
 }

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonSupervisor.kt
@@ -211,6 +211,7 @@ class DaemonSupervisor(
         // daemons; the field is also `emptyList()` by default in [ServerCapabilities] so absent
         // and `[]` collapse the same way client-side.
         supervised.dataProductCapabilities = result.capabilities.dataProducts
+        supervised.dataExtensionDescriptors = result.capabilities.dataExtensions
         // PROTOCOL.md § 3 — cache the daemon's advertised supportedOverrides + knownDevice ids so
         // `DaemonMcpServer.toolRenderPreview` can validate inbound `overrides` against what this
         // backend will actually apply (instead of silently no-op'ing fields the backend ignores)
@@ -359,6 +360,12 @@ class SupervisedDaemon(val workspaceId: WorkspaceId, val modulePath: String) {
    */
   @Volatile
   var backendKind: BackendKind? = null
+    internal set
+
+  @Volatile
+  var dataExtensionDescriptors:
+    List<ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor> =
+    emptyList()
     internal set
 
   /**

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -894,6 +894,8 @@ class DaemonMcpServerTest {
     factory.daemonConfigurer = { d ->
       d.recordingEncodedBytes = cannedApngBytes
       d.recordingEncodeDir = recordingsDir
+      d.advertisedDataExtensions =
+        ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions.descriptors
       d.recordingStopResult =
         ee.schimke.composeai.daemon.protocol.RecordingStopResult(
           frameCount = 16,
@@ -901,6 +903,18 @@ class DaemonMcpServerTest {
           framesDir = framesDir.absolutePath,
           frameWidthPx = 240,
           frameHeightPx = 80,
+          scriptEvents =
+            listOf(
+              ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence(
+                tMs = 250L,
+                kind = "state.save",
+                status =
+                  ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.UNSUPPORTED,
+                label = "before-rotate",
+                checkpointId = "checkpoint-1",
+                message = "state checkpoints are not implemented by this daemon",
+              )
+            ),
         )
     }
     client.initialize()
@@ -937,6 +951,15 @@ class DaemonMcpServerTest {
                 put("pixelY", 40)
               }
             )
+            add(
+              buildJsonObject {
+                put("tMs", 250)
+                put("kind", "state.save")
+                put("label", "before-rotate")
+                put("checkpointId", "checkpoint-1")
+                putJsonArray("tags") { add(JsonPrimitive("state-restoration")) }
+              }
+            )
           }
           putJsonObject("overrides") {
             put("widthPx", 240)
@@ -959,13 +982,16 @@ class DaemonMcpServerTest {
 
     val scriptCall = daemon.recordingScripts.poll(2_000, TimeUnit.MILLISECONDS)
     assertThat(scriptCall).isNotNull()
-    assertThat(scriptCall!!.events).hasSize(2)
+    assertThat(scriptCall!!.events).hasSize(3)
     assertThat(scriptCall.events[0].tMs).isEqualTo(0L)
-    assertThat(scriptCall.events[0].kind)
-      .isEqualTo(ee.schimke.composeai.daemon.protocol.InteractiveInputKind.CLICK)
+    assertThat(scriptCall.events[0].kind).isEqualTo("click")
     assertThat(scriptCall.events[0].pixelX).isEqualTo(120)
     assertThat(scriptCall.events[0].pixelY).isEqualTo(40)
     assertThat(scriptCall.events[1].tMs).isEqualTo(500L)
+    assertThat(scriptCall.events[2].kind).isEqualTo("state.save")
+    assertThat(scriptCall.events[2].label).isEqualTo("before-rotate")
+    assertThat(scriptCall.events[2].checkpointId).isEqualTo("checkpoint-1")
+    assertThat(scriptCall.events[2].tags).containsExactly("state-restoration")
 
     val stopCall = daemon.recordingStops.poll(2_000, TimeUnit.MILLISECONDS)
     assertThat(stopCall).isNotNull()
@@ -1023,6 +1049,14 @@ class DaemonMcpServerTest {
       .isEqualTo(4)
     assertThat(frames[2].jsonObject["changedFromPrevious"]?.jsonPrimitive?.contentOrNull)
       .isEqualTo("false")
+    val scriptEvents = metadata["scriptEvents"]!!.jsonArray
+    assertThat(scriptEvents).hasSize(1)
+    assertThat(scriptEvents[0].jsonObject["kind"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("state.save")
+    assertThat(scriptEvents[0].jsonObject["status"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("unsupported")
+    assertThat(scriptEvents[0].jsonObject["checkpointId"]?.jsonPrimitive?.contentOrNull)
+      .isEqualTo("checkpoint-1")
     assertThat(
         frames[2]
           .jsonObject["changedPixelsFromPrevious"]
@@ -1067,6 +1101,39 @@ class DaemonMcpServerTest {
     assertThat(resp.isError()).isTrue()
     assertThat(resp.firstTextContent()).contains("invalid events")
     // No daemon-side recording session should have been allocated when validation fails.
+    assertThat(daemon.recordingStarts).isEmpty()
+  }
+
+  @Test
+  fun `record_preview rejects unadvertised extension event without starting recording`() {
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "record_preview",
+        buildJsonObject {
+          put("uri", uri)
+          putJsonArray("events") {
+            add(
+              buildJsonObject {
+                put("tMs", 0)
+                put("kind", "unknown.event")
+              }
+            )
+          }
+        },
+      )
+
+    assertThat(resp.isError()).isTrue()
+    assertThat(resp.firstTextContent()).contains("not advertised by this daemon")
     assertThat(daemon.recordingStarts).isEmpty()
   }
 

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/FakeDaemon.kt
@@ -94,6 +94,12 @@ class FakeDaemon : DaemonSpawn {
    */
   @Volatile var advertisedRecordingFormats: List<String> = emptyList()
 
+  /** Data extensions advertised in `initialize.capabilities.dataExtensions`. */
+  @Volatile
+  var advertisedDataExtensions:
+    List<ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor> =
+    emptyList()
+
   /**
    * D1 — fake handler for `data/fetch`. When set, the lambda receives `(previewId, kind, params,
    * inline)` and returns either the [DataFetchOutcome] the daemon should respond with. Default
@@ -361,6 +367,7 @@ class FakeDaemon : DaemonSpawn {
                 sandboxRecycle = false,
                 leakDetection = emptyList(),
                 dataProducts = advertisedDataProducts,
+                dataExtensions = advertisedDataExtensions,
                 knownDevices = advertisedKnownDevices,
                 supportedOverrides = advertisedSupportedOverrides,
                 recordingFormats = advertisedRecordingFormats,

--- a/skills/compose-preview-review/design/AGENT_AUDITS.md
+++ b/skills/compose-preview-review/design/AGENT_AUDITS.md
@@ -514,6 +514,20 @@ from snapshot-state writes and dirty parameter slots. compose-preview does not
 yet expose DejaVu's `testTag`/source/dirty-bit causality, so name the scoped
 payload evidence and the state/parameter path you found in code.
 
+### State restoration and lifecycle audit
+
+Sample MCP call: `record_preview uri=<preview-uri> events='[{"tMs":0,"kind":"click","pixelX":120,"pixelY":40},{"tMs":200,"kind":"state.save","checkpointId":"before"},{"tMs":250,"kind":"lifecycle.event","lifecycleEvent":"resume"},{"tMs":300,"kind":"state.restore","checkpointId":"before"}]'`
+
+Check:
+
+- The recording metadata includes `scriptEvents` for every state/lifecycle
+  marker.
+- Input events that should change state produce changed frames.
+- `unsupported` script events are reported as tool capability gaps, not app
+  regressions.
+- Do not claim state restoration passed unless the evidence shows applied
+  save/restore lifecycle events and stable restored UI.
+
 ### Failure triage audit
 
 Use this when a preview fails to render or a daemon/CI report says a data

--- a/skills/compose-preview/design/CAPTURE_MODES.md
+++ b/skills/compose-preview/design/CAPTURE_MODES.md
@@ -135,9 +135,29 @@ enough to define the recording duration:
 }
 ```
 
+Scripts can also include audit/control markers:
+
+```json
+{
+  "uri": "compose-preview://<workspace>/<module>/<preview>",
+  "events": [
+    { "tMs": 0, "kind": "click", "pixelX": 120, "pixelY": 40 },
+    { "tMs": 200, "kind": "state.save", "checkpointId": "before" },
+    { "tMs": 250, "kind": "lifecycle.event", "lifecycleEvent": "resume" },
+    { "tMs": 300, "kind": "state.restore", "checkpointId": "before" }
+  ]
+}
+```
+
+Always inspect `scriptEvents` in the metadata. Input and `recording.probe`
+events may be `applied`; state/lifecycle markers can be `unsupported` on
+daemons that do not yet drive real saved-state or activity lifecycle
+transitions. Non-input script event ids are namespaced and must be advertised
+under `capabilities.dataExtensions[].recordingScriptEvents[]`.
+
 The response includes `recordingId`, `mimeType`, `sizeBytes`, `frameCount`,
-`durationMs`, `frameWidthPx`, and `frameHeightPx`. Raw frames are also written
-under:
+`durationMs`, `frameWidthPx`, `frameHeightPx`, `frames[]`, and `scriptEvents[]`.
+Raw frames are also written under:
 
 ```text
 <module>/build/compose-previews/daemon-recordings/frames/<recordingId>/frame-00000.png

--- a/vscode-extension/src/daemon/daemonProtocol.ts
+++ b/vscode-extension/src/daemon/daemonProtocol.ts
@@ -168,6 +168,19 @@ export interface PreviewExtensionCliCommand {
     productKinds?: string[];
 }
 
+export interface DataExtensionDescriptor {
+    id: string;
+    displayName?: string;
+    recordingScriptEvents?: RecordingScriptEventDescriptor[];
+}
+
+export interface RecordingScriptEventDescriptor {
+    id: string;
+    displayName?: string;
+    summary?: string;
+    supported?: boolean;
+}
+
 export interface PreviewPipelineStep {
     id: string;
     displayName?: string;
@@ -240,6 +253,7 @@ export interface InitializeResult {
          * kinds in subscribe/fetch with `DataProductUnknown` (-32020).
          */
         dataProducts: DataProductCapability[];
+        dataExtensions?: DataExtensionDescriptor[];
         previewExtensions?: PreviewExtensionDescriptor[];
         /**
          * INTERACTIVE.md § 9 — `true` when the daemon's host can dispatch
@@ -683,6 +697,8 @@ export interface InteractiveInputParams {
 
 export type RecordingFormat = "apng" | "mp4" | "webm";
 
+export type RecordingScriptEventStatus = "applied" | "unsupported";
+
 export interface RecordingStartParams {
     previewId: string;
     fps?: number;
@@ -704,6 +720,30 @@ export interface RecordingInputParams {
     keyCode?: string;
 }
 
+export interface RecordingScriptEvent {
+    tMs: number;
+    kind: string;
+    pixelX?: number;
+    pixelY?: number;
+    scrollDeltaY?: number;
+    keyCode?: string;
+    label?: string;
+    checkpointId?: string;
+    lifecycleEvent?: string;
+    tags?: string[];
+}
+
+export interface RecordingScriptEvidence {
+    tMs: number;
+    kind: string;
+    status: RecordingScriptEventStatus;
+    label?: string;
+    checkpointId?: string;
+    lifecycleEvent?: string;
+    tags?: string[];
+    message?: string;
+}
+
 export interface RecordingStopParams {
     recordingId: string;
 }
@@ -714,6 +754,7 @@ export interface RecordingStopResult {
     framesDir: string;
     frameWidthPx: number;
     frameHeightPx: number;
+    scriptEvents?: RecordingScriptEvidence[];
 }
 
 export interface RecordingEncodeParams {


### PR DESCRIPTION
## Summary

- adds data extension descriptors for recording script events so agents can discover supported events dynamically
- exposes daemon data extension capabilities through MCP data product listing
- validates non-input recording script events against the daemon-advertised descriptors before starting a recording
- keeps unsupported lifecycle/state/reload events honest while recording probe events are applied and returned as evidence
- updates the state restoration and lifecycle audit guidance with namespaced script-mode examples

## Validation

- `./gradlew ktfmtCheck :daemon:android:testDebugUnitTest --tests ee.schimke.composeai.daemon.AndroidRecordingSessionTest :mcp:test --tests ee.schimke.composeai.mcp.DaemonMcpServerTest :daemon:desktop:compileKotlin`

Build result: `BUILD SUCCESSFUL`.