### PR TITLE
feat: add theme token capture facade

### DIFF
--- a/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
+++ b/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
@@ -249,15 +249,7 @@ fun themePayloadFromMaterialTheme(
   typography: Typography,
   shapes: Shapes,
 ): ThemePayload =
-  ThemePayload(
-    resolvedTokens =
-      ResolvedThemeTokens(
-        colorScheme = colorTokens(colorScheme),
-        typography = typographyTokens(typography),
-        shapes = shapeTokens(shapes),
-      ),
-    consumers = emptyList(),
-  )
+  MaterialThemeTokenCapture.fromMaterialTheme(colorScheme, typography, shapes).payload()
 
 fun themePayloadFromThemeObjects(
   colorSource: Any,
@@ -266,20 +258,14 @@ fun themePayloadFromThemeObjects(
   fallbackTypography: Typography?,
   fallbackShapes: Shapes?,
 ): ThemePayload? {
-  val colorScheme = colorTokens(colorSource).takeIf { it.isNotEmpty() } ?: return null
-  val typography =
-    typographyTokens(typographySource).takeIf { it.isNotEmpty() }
-      ?: fallbackTypography?.let(::typographyTokens)
-      ?: emptyMap()
-  val shapes =
-    shapeTokens(shapesSource).takeIf { it.isNotEmpty() }
-      ?: fallbackShapes?.let(::shapeTokens)
-      ?: emptyMap()
-  return ThemePayload(
-    resolvedTokens =
-      ResolvedThemeTokens(colorScheme = colorScheme, typography = typography, shapes = shapes),
-    consumers = emptyList(),
-  )
+  return MaterialThemeTokenCapture.fromInspectionSources(
+      colorSource = colorSource,
+      typographySource = typographySource,
+      shapesSource = shapesSource,
+      fallbackTypography = fallbackTypography,
+      fallbackShapes = fallbackShapes,
+    )
+    ?.payload()
 }
 
 fun themePayloadFromPreviewContext(
@@ -301,21 +287,72 @@ fun themePayloadFromPreviewContext(
 fun themePayloadFromPreviewContext(context: PreviewContext): ThemePayload? =
   themePayloadFromPreviewContext(context, fallbackTypography = null, fallbackShapes = null)
 
-fun colorTokens(source: Any?): Map<String, String> = MaterialThemeTokens.colorScheme(source)
-
-fun typographyTokens(source: Any?): Map<String, TypographyToken> =
-  MaterialThemeTokens.typography(source)
-
-fun shapeTokens(source: Any?): Map<String, String> = MaterialThemeTokens.shapes(source)
-
 /**
  * Domain API for reading Material theme tokens from either public Material3 objects or backend
  * token objects captured from Compose inspection.
  *
  * The API intentionally returns stable token maps. If a backend object needs reflective access,
- * that implementation detail stays behind [TokenObjectAccess].
+ * that implementation detail stays behind this facade.
  */
-internal object MaterialThemeTokens {
+internal data class MaterialThemeTokenCapture(
+  val colorScheme: Map<String, String>,
+  val typography: Map<String, TypographyToken>,
+  val shapes: Map<String, String>,
+) {
+  fun payload(): ThemePayload =
+    ThemePayload(
+      resolvedTokens =
+        ResolvedThemeTokens(colorScheme = colorScheme, typography = typography, shapes = shapes),
+      consumers = emptyList(),
+    )
+
+  companion object {
+    fun fromMaterialTheme(
+      colorScheme: ColorScheme,
+      typography: Typography,
+      shapes: Shapes,
+    ): MaterialThemeTokenCapture =
+      MaterialThemeTokenCapture(
+        colorScheme = MaterialThemeTokenReader.colorScheme(colorScheme),
+        typography = MaterialThemeTokenReader.typography(typography),
+        shapes = MaterialThemeTokenReader.shapes(shapes),
+      )
+
+    fun fromInspectionSources(
+      colorSource: Any,
+      typographySource: Any?,
+      shapesSource: Any?,
+      fallbackTypography: Typography?,
+      fallbackShapes: Shapes?,
+    ): MaterialThemeTokenCapture? {
+      val colorScheme =
+        MaterialThemeTokenReader.colorScheme(colorSource).takeIf { it.isNotEmpty() } ?: return null
+      val typography =
+        MaterialThemeTokenReader.typography(typographySource).takeIf { it.isNotEmpty() }
+          ?: fallbackTypography?.let(MaterialThemeTokenReader::typography)
+          ?: emptyMap()
+      val shapes =
+        MaterialThemeTokenReader.shapes(shapesSource).takeIf { it.isNotEmpty() }
+          ?: fallbackShapes?.let(MaterialThemeTokenReader::shapes)
+          ?: emptyMap()
+      return MaterialThemeTokenCapture(
+        colorScheme = colorScheme,
+        typography = typography,
+        shapes = shapes,
+      )
+    }
+
+    fun hasColorScheme(source: Any?): Boolean =
+      MaterialThemeTokenReader.colorScheme(source).isNotEmpty()
+
+    fun hasTypography(source: Any?): Boolean =
+      MaterialThemeTokenReader.typography(source).isNotEmpty()
+
+    fun hasShapes(source: Any?): Boolean = MaterialThemeTokenReader.shapes(source).isNotEmpty()
+  }
+}
+
+private object MaterialThemeTokenReader {
   fun colorScheme(source: Any?): Map<String, String> =
     when (source) {
       null -> emptyMap()
@@ -399,55 +436,55 @@ internal object MaterialThemeTokens {
         )
       else -> TokenObjectAccess.shapeProperties(source).mapValues { (_, value) -> value.toString() }
     }
+}
 
-  private object TokenObjectAccess {
-    fun colorProperties(source: Any): Map<String, Any> =
-      linkedMapOf<String, Any>().also { tokens ->
-        for (method in source.javaClass.readableNoArgMethods()) {
-          val name = method.propertyName()
-          val value = method.invokeOrNull(source)
-          when (value) {
-            is Color -> tokens[name] = value
-            is Long -> if (method.returnType == java.lang.Long.TYPE) tokens[name] = value
-          }
+private object TokenObjectAccess {
+  fun colorProperties(source: Any): Map<String, Any> =
+    linkedMapOf<String, Any>().also { tokens ->
+      for (method in source.javaClass.readableNoArgMethods()) {
+        val name = method.propertyName()
+        val value = method.invokeOrNull(source)
+        when (value) {
+          is Color -> tokens[name] = value
+          is Long -> if (method.returnType == java.lang.Long.TYPE) tokens[name] = value
         }
       }
-
-    fun textStyleProperties(source: Any): Map<String, TextStyle> =
-      linkedMapOf<String, TextStyle>().also { tokens ->
-        for (method in source.javaClass.readableNoArgMethods()) {
-          val value = method.invokeOrNull(source)
-          if (value is TextStyle) tokens[method.propertyName()] = value
-        }
-      }
-
-    fun shapeProperties(source: Any): Map<String, Any> =
-      linkedMapOf<String, Any>().also { tokens ->
-        for (method in source.javaClass.readableNoArgMethods()) {
-          val value = method.invokeOrNull(source) ?: continue
-          if (value.javaClass.name.contains("Shape", ignoreCase = true)) {
-            tokens[method.propertyName()] = value
-          }
-        }
-      }
-
-    private fun Class<*>.readableNoArgMethods(): List<Method> = methods.filter { method ->
-      method.parameterCount == 0 &&
-        method.name.startsWith("get") &&
-        method.name != "getClass" &&
-        method.returnType != java.lang.Void.TYPE
     }
 
-    private fun Method.invokeOrNull(receiver: Any): Any? =
-      runCatching {
-          isAccessible = true
-          invoke(receiver)
-        }
-        .getOrNull()
+  fun textStyleProperties(source: Any): Map<String, TextStyle> =
+    linkedMapOf<String, TextStyle>().also { tokens ->
+      for (method in source.javaClass.readableNoArgMethods()) {
+        val value = method.invokeOrNull(source)
+        if (value is TextStyle) tokens[method.propertyName()] = value
+      }
+    }
 
-    private fun Method.propertyName(): String =
-      name.removePrefix("get").substringBefore("-").replaceFirstChar { it.lowercase() }
+  fun shapeProperties(source: Any): Map<String, Any> =
+    linkedMapOf<String, Any>().also { tokens ->
+      for (method in source.javaClass.readableNoArgMethods()) {
+        val value = method.invokeOrNull(source) ?: continue
+        if (value.javaClass.name.contains("Shape", ignoreCase = true)) {
+          tokens[method.propertyName()] = value
+        }
+      }
+    }
+
+  private fun Class<*>.readableNoArgMethods(): List<Method> = methods.filter { method ->
+    method.parameterCount == 0 &&
+      method.name.startsWith("get") &&
+      method.name != "getClass" &&
+      method.returnType != java.lang.Void.TYPE
   }
+
+  private fun Method.invokeOrNull(receiver: Any): Any? =
+    runCatching {
+        isAccessible = true
+        invoke(receiver)
+      }
+      .getOrNull()
+
+  private fun Method.propertyName(): String =
+    name.removePrefix("get").substringBefore("-").replaceFirstChar { it.lowercase() }
 }
 
 /**
@@ -492,16 +529,17 @@ internal object MaterialThemeInspectionSnapshot {
   ): ThemePayload? {
     for (group in groups.asReversed()) {
       val values = group.data.toList()
-      val colorSource = values.lastOrNull { colorTokens(it).isNotEmpty() } ?: continue
-      val typographySource = values.lastOrNull { typographyTokens(it).isNotEmpty() }
-      val shapesSource = values.lastOrNull { shapeTokens(it).isNotEmpty() }
-      return themePayloadFromThemeObjects(
-        colorSource = colorSource,
-        typographySource = typographySource,
-        shapesSource = shapesSource,
-        fallbackTypography = fallbackTypography,
-        fallbackShapes = fallbackShapes,
-      )
+      val colorSource = values.lastOrNull(MaterialThemeTokenCapture::hasColorScheme) ?: continue
+      val typographySource = values.lastOrNull(MaterialThemeTokenCapture::hasTypography)
+      val shapesSource = values.lastOrNull(MaterialThemeTokenCapture::hasShapes)
+      return MaterialThemeTokenCapture.fromInspectionSources(
+          colorSource = colorSource,
+          typographySource = typographySource,
+          shapesSource = shapesSource,
+          fallbackTypography = fallbackTypography,
+          fallbackShapes = fallbackShapes,
+        )
+        ?.payload()
     }
     return null
   }

--- a/data/theme/connector/src/test/kotlin/ee/schimke/composeai/daemon/MaterialThemeTokenCaptureTest.kt
+++ b/data/theme/connector/src/test/kotlin/ee/schimke/composeai/daemon/MaterialThemeTokenCaptureTest.kt
@@ -14,7 +14,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-class MaterialThemeTokensTest {
+class MaterialThemeTokenCaptureTest {
   @Test
   fun themeCaptureExtensionDeclaresComposableExtractorHook() {
     val extension = ThemeCaptureExtension()
@@ -28,10 +28,18 @@ class MaterialThemeTokensTest {
   }
 
   @Test
-  fun readsColorSchemeFromTokenObject() {
+  fun capturesColorSchemeFromInspectionTokenObject() {
     val source = ReflectedThemeTokens()
 
-    val tokens = MaterialThemeTokens.colorScheme(source)
+    val capture =
+      MaterialThemeTokenCapture.fromInspectionSources(
+        colorSource = source,
+        typographySource = null,
+        shapesSource = null,
+        fallbackTypography = null,
+        fallbackShapes = null,
+      )
+    val tokens = requireNotNull(capture).colorScheme
 
     assertEquals(Color.Red.hexArgb(), tokens["primary"])
     assertEquals(Color(0xFF00FF00u).hexArgb(), tokens["secondary"])
@@ -39,23 +47,53 @@ class MaterialThemeTokensTest {
   }
 
   @Test
-  fun readsTypographyFromTokenObject() {
+  fun capturesTypographyFromInspectionTokenObject() {
     val source = ReflectedThemeTokens()
 
-    val tokens = MaterialThemeTokens.typography(source)
+    val capture =
+      MaterialThemeTokenCapture.fromInspectionSources(
+        colorSource = source,
+        typographySource = source,
+        shapesSource = null,
+        fallbackTypography = null,
+        fallbackShapes = null,
+      )
+    val tokens = requireNotNull(capture).typography
 
     assertEquals(16f, tokens.getValue("bodyLarge").fontSize)
     assertFalse(tokens.containsKey("primary"))
   }
 
   @Test
-  fun readsShapesFromTokenObject() {
+  fun capturesShapesFromInspectionTokenObject() {
     val source = ReflectedThemeTokens()
 
-    val tokens = MaterialThemeTokens.shapes(source)
+    val capture =
+      MaterialThemeTokenCapture.fromInspectionSources(
+        colorSource = source,
+        typographySource = null,
+        shapesSource = source,
+        fallbackTypography = null,
+        fallbackShapes = null,
+      )
+    val tokens = requireNotNull(capture).shapes
 
     assertEquals(ShapeDefaults.Small.toString(), tokens["small"])
     assertFalse(tokens.containsKey("bodyLarge"))
+  }
+
+  @Test
+  fun returnsNullWhenInspectionTokenObjectHasNoColorScheme() {
+    val capture =
+      MaterialThemeTokenCapture.fromInspectionSources(
+        colorSource = Any(),
+        typographySource = ReflectedThemeTokens(),
+        shapesSource = ReflectedThemeTokens(),
+        fallbackTypography = null,
+        fallbackShapes = null,
+      )
+
+    assertEquals(null, capture)
   }
 
   @Suppress("unused")


### PR DESCRIPTION
## Summary

Continues the one-extension ugly-list cleanup for the theme extension.

## What changed

- Replaced the old token helper surface (`colorTokens`, `typographyTokens`, `shapeTokens`, `MaterialThemeTokens`) with `MaterialThemeTokenCapture`.
- `themePayloadFromMaterialTheme(...)` now builds a capture from public Material3 objects and converts it to a payload.
- Slot-table fallback now asks `MaterialThemeTokenCapture` whether a group value can provide color, typography, or shape tokens.
- Reflection over backend token objects is private behind `MaterialThemeTokenReader` / `TokenObjectAccess`.
- Renamed and updated the focused tests to exercise the capture facade rather than raw token readers.

## Why

This keeps extension code calling the API we want: capture Material theme tokens and turn them into the product payload. Reflection remains an internal adapter detail for inspection fallback objects, not the API extension authors or product code consume.

## Validation

```bash
./gradlew :data-theme-connector:ktfmtCheck :data-theme-connector:test --tests ee.schimke.composeai.daemon.MaterialThemeTokenCaptureTest --tests ee.schimke.composeai.daemon.ThemeDataProductTest :data-theme-connector:compileKotlin
```