### PR TITLE
Remove VS Code a11y always subscribe setting

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -128,11 +128,6 @@
                     "default": true,
                     "description": "Use the persistent preview daemon for refresh on saves to files the user has open, plus scroll-ahead speculative renders. When on, daemon failures are shown as errors instead of silently falling back to the Gradle `renderPreviews` task. Turning this off temporarily uses the Gradle path, but the daemon will become required by the extension in a future release."
                 },
-                "composePreview.a11y.alwaysSubscribe": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "When on, the panel auto-subscribes to a11y data products (`a11y/atf` for diagnostic squigglies, `a11y/hierarchy` for the local overlay) for every visible preview in daemon mode — diagnostics fire ambient without entering focus mode. Off (the default) keeps the focus-mode 'Show accessibility overlay' button as the only opt-in. The producer side must also be enabled with the Gradle preview extension (`composePreview { previewExtensions { a11y { enableAllChecks() } } }` or the matching `-PcomposePreview.previewExtensions.a11y.*` properties); when the daemon advertises no a11y kinds this setting has no effect."
-                },
                 "composePreview.earlyFeatures.enabled": {
                     "type": "boolean",
                     "default": false,

--- a/vscode-extension/src/daemon/daemonScheduler.ts
+++ b/vscode-extension/src/daemon/daemonScheduler.ts
@@ -140,16 +140,6 @@ export class DaemonScheduler {
         private readonly logger: { appendLine(s: string): void } = {
             appendLine() {},
         },
-        /**
-         * D2 — read freshly per `setVisible` so toggling the user setting
-         * `composePreview.a11y.alwaysSubscribe` doesn't need a reload. When `true`,
-         * newly-visible previews are auto-subscribed to a11y data products
-         * ([A11Y_OVERLAY_KINDS] + the ambient atf kind); when `false` (the default),
-         * the focus-mode toggle is the only path — no wire traffic for unfocused
-         * cards. Tests pass a constant lambda; production wires
-         * `vscode.workspace.getConfiguration('composePreview').get('a11y.alwaysSubscribe')`.
-         */
-        private readonly isA11yAlwaysSubscribed: () => boolean = () => false,
     ) {}
 
     /**
@@ -314,33 +304,6 @@ export class DaemonScheduler {
             const id = sep < 0 ? rest : rest.slice(0, sep);
             if (!visibleSetForSub.has(id)) {
                 this.subscribedPairs.delete(key);
-            }
-        }
-
-        // D2 — when the user opted into ambient a11y via
-        // `composePreview.a11y.alwaysSubscribe`, subscribe every newly-visible preview to
-        // [A11Y_OVERLAY_KINDS] so diagnostics + the hierarchy overlay fire without entering
-        // focus mode. dataSubscribe rejects gracefully (DataProductUnknown) when the daemon
-        // was not built with the a11y data plugin enabled; that path absorbs the
-        // rejection and rolls back the bookkeeping (matching `setDataProductSubscription`).
-        if (this.isA11yAlwaysSubscribed()) {
-            for (const id of visible) {
-                for (const kind of A11Y_OVERLAY_KINDS) {
-                    const subKey = `${moduleId}::${id}::${kind}`;
-                    if (this.subscribedPairs.has(subKey)) {
-                        continue;
-                    }
-                    this.subscribedPairs.add(subKey);
-                    client
-                        .dataSubscribe({ previewId: id, kind })
-                        .catch((err) => {
-                            const msg = (err as Error)?.message ?? String(err);
-                            this.logger.appendLine(
-                                `[daemon] alwaysSubscribe dataSubscribe(${id}, ${kind}) failed: ${msg}`,
-                            );
-                            this.subscribedPairs.delete(subKey);
-                        });
-                }
             }
         }
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -553,12 +553,6 @@ export async function activate(
             },
         },
         outputChannel,
-        // D2 — read the user setting freshly on each `setVisible` so toggling
-        // `composePreview.a11y.alwaysSubscribe` doesn't need a window reload.
-        () =>
-            vscode.workspace
-                .getConfiguration("composePreview")
-                .get<boolean>("a11y.alwaysSubscribe", false),
     );
 
     // Status-bar slot for daemon lifecycle. Hidden when the daemon flag is

--- a/vscode-extension/src/test/daemonScheduler.test.ts
+++ b/vscode-extension/src/test/daemonScheduler.test.ts
@@ -128,12 +128,7 @@ interface CapturedImage {
     pngPath: string;
 }
 
-interface BuildOptions {
-    /** D2 — drives `composePreview.a11y.alwaysSubscribe`. Defaults to false to mirror prod. */
-    a11yAlwaysSubscribe?: () => boolean;
-}
-
-function build(opts: BuildOptions = {}) {
+function build() {
     const gate = new FakeGate();
     const log: string[] = [];
     const images: CapturedImage[] = [];
@@ -200,7 +195,6 @@ function build(opts: BuildOptions = {}) {
         gate as unknown as ConstructorParameters<typeof DaemonScheduler>[0],
         events,
         { appendLine: (s) => log.push(s) },
-        opts.a11yAlwaysSubscribe ?? (() => false),
     );
     return {
         gate,
@@ -742,64 +736,6 @@ describe("DaemonScheduler", () => {
                 (c) => c.method === "dataSubscribe",
             );
             assert.strictEqual(subs.length, 0);
-        });
-
-        it("auto-subscribes both a11y kinds for newly-visible previews when alwaysSubscribe is on", async () => {
-            const { gate, scheduler } = build({
-                a11yAlwaysSubscribe: () => true,
-            });
-            await scheduler.setVisible("mod", ["a", "b"], []);
-            const subs = gate.client!.calls.filter(
-                (c) => c.method === "dataSubscribe",
-            );
-            // 2 kinds × 2 previews = 4 subscribes.
-            assert.strictEqual(subs.length, 4);
-            const kinds = new Set(
-                subs.map((c) => (c.args as { kind: string }).kind),
-            );
-            assert.deepStrictEqual([...kinds].sort(), [
-                "a11y/atf",
-                "a11y/hierarchy",
-            ]);
-            const ids = new Set(
-                subs.map((c) => (c.args as { previewId: string }).previewId),
-            );
-            assert.deepStrictEqual([...ids].sort(), ["a", "b"]);
-        });
-
-        it("alwaysSubscribe re-reads on every setVisible — flipping the setting takes effect immediately", async () => {
-            let alwaysOn = false;
-            const { gate, scheduler } = build({
-                a11yAlwaysSubscribe: () => alwaysOn,
-            });
-            await scheduler.setVisible("mod", ["a"], []);
-            const initial = gate.client!.calls.filter(
-                (c) => c.method === "dataSubscribe",
-            );
-            assert.strictEqual(initial.length, 0);
-            // User flips the setting on between setVisible calls.
-            alwaysOn = true;
-            await scheduler.setVisible("mod", ["a", "b"], []);
-            // 'a' was previously visible but skipped under the off setting; 'b' is new.
-            // With alwaysOn now true, both get subscribed (we haven't seen them yet under
-            // the on setting, so subscribedPairs is empty for them).
-            const subs = gate.client!.calls.filter(
-                (c) => c.method === "dataSubscribe",
-            );
-            assert.strictEqual(subs.length, 4);
-        });
-
-        it("alwaysSubscribe does not re-subscribe (previewId, kind) pairs already in flight", async () => {
-            const { gate, scheduler } = build({
-                a11yAlwaysSubscribe: () => true,
-            });
-            await scheduler.setVisible("mod", ["a"], []);
-            await scheduler.setVisible("mod", ["a", "b"], []); // 'a' already subscribed
-            const subs = gate.client!.calls.filter(
-                (c) => c.method === "dataSubscribe",
-            );
-            // 'a': 2 kinds (round 1) + 'b': 2 kinds (round 2) = 4. 'a' is NOT re-subscribed.
-            assert.strictEqual(subs.length, 4);
         });
 
         it("setDataProductSubscription(true) issues data/subscribe per kind", async () => {


### PR DESCRIPTION
## Summary

- Remove the `composePreview.a11y.alwaysSubscribe` VS Code configuration.
- Remove the ambient visible-preview a11y subscription path from `DaemonScheduler`.
- Keep a11y data subscriptions explicit through the focus-mode overlay path.

## Validation

- `npm run format:check` in `vscode-extension/`
- `npm run compile` in `vscode-extension/`
- `npm test -- --grep "data products"` in `vscode-extension/`
- `git diff --check`