### PR TITLE
feat(extensions): typed runtime contract for data extensions

### DIFF
--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
@@ -7,6 +7,7 @@ import ee.schimke.composeai.daemon.protocol.DataProductExtra
 import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
+import ee.schimke.composeai.renderer.AccessibilityDataProducts
 import ee.schimke.composeai.renderer.AccessibilityFinding
 import ee.schimke.composeai.renderer.AccessibilityNode
 import java.io.File
@@ -38,16 +39,16 @@ object AccessibilityDataProducer {
   }
 
   /** Schema version pinned alongside the on-disk shape. Bumped when the shape changes. */
-  const val SCHEMA_VERSION: Int = 1
+  const val SCHEMA_VERSION: Int = AccessibilityDataProducts.SCHEMA_VERSION
 
   /** `a11y/atf` — findings array. */
-  const val KIND_ATF: String = "a11y/atf"
+  const val KIND_ATF: String = AccessibilityDataProducts.KIND_ATF
 
   /** `a11y/hierarchy` — accessibility-relevant nodes with bounds + label + states. */
-  const val KIND_HIERARCHY: String = "a11y/hierarchy"
+  const val KIND_HIERARCHY: String = AccessibilityDataProducts.KIND_HIERARCHY
 
   /** `a11y/touchTargets` — clickable node sizes and overlap findings derived from hierarchy. */
-  const val KIND_TOUCH_TARGETS: String = "a11y/touchTargets"
+  const val KIND_TOUCH_TARGETS: String = AccessibilityDataProducts.KIND_TOUCH_TARGETS
 
   /**
    * D2.1 — `a11y/overlay`. Path-transport kind whose only content is the Paparazzi-style
@@ -55,7 +56,7 @@ object AccessibilityDataProducer {
    * directly without first asking for the JSON kinds. Also surfaces as an `overlay` extra on
    * the JSON kinds, so a panel that subscribed to `a11y/atf` still has the PNG path handy.
    */
-  const val KIND_OVERLAY: String = "a11y/overlay"
+  const val KIND_OVERLAY: String = AccessibilityDataProducts.KIND_OVERLAY
 
   /** File names under `<rootDir>/<previewId>/`. */
   const val FILE_ATF: String = "a11y-atf.json"

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityModels.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityModels.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.renderer
 
+import ee.schimke.composeai.data.render.extensions.DataProductKey
 import kotlinx.serialization.Serializable
 
 // ---------------------------------------------------------------------------
@@ -104,3 +105,49 @@ data class AccessibilityFinding(
     /** `left,top,right,bottom` in the preview's pixel space — agents can highlight on the PNG. */
     val boundsInScreen: String? = null,
 )
+
+@Serializable data class AccessibilityHierarchyPayload(val nodes: List<AccessibilityNode>)
+
+@Serializable data class AccessibilityFindingsPayload(val findings: List<AccessibilityFinding>)
+
+@Serializable
+data class AccessibilityTouchTarget(
+    val nodeId: String,
+    val boundsInScreen: String,
+    val widthDp: Float,
+    val heightDp: Float,
+    val findings: List<String>,
+    val overlappingNodeIds: List<String>? = null,
+)
+
+@Serializable data class AccessibilityTouchTargetsPayload(val targets: List<AccessibilityTouchTarget>)
+
+@Serializable
+data class AccessibilityOverlayArtifact(
+    val path: String,
+    val mediaType: String = "image/png",
+)
+
+object AccessibilityDataProducts {
+    const val SCHEMA_VERSION: Int = 1
+    const val KIND_HIERARCHY: String = "a11y/hierarchy"
+    const val KIND_ATF: String = "a11y/atf"
+    const val KIND_TOUCH_TARGETS: String = "a11y/touchTargets"
+    const val KIND_OVERLAY: String = "a11y/overlay"
+
+    val Hierarchy: DataProductKey<AccessibilityHierarchyPayload> =
+        DataProductKey(KIND_HIERARCHY, SCHEMA_VERSION, AccessibilityHierarchyPayload::class.java)
+
+    val Atf: DataProductKey<AccessibilityFindingsPayload> =
+        DataProductKey(KIND_ATF, SCHEMA_VERSION, AccessibilityFindingsPayload::class.java)
+
+    val TouchTargets: DataProductKey<AccessibilityTouchTargetsPayload> =
+        DataProductKey(
+            KIND_TOUCH_TARGETS,
+            SCHEMA_VERSION,
+            AccessibilityTouchTargetsPayload::class.java,
+        )
+
+    val Overlay: DataProductKey<AccessibilityOverlayArtifact> =
+        DataProductKey(KIND_OVERLAY, SCHEMA_VERSION, AccessibilityOverlayArtifact::class.java)
+}

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtension.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtension.kt
@@ -1,6 +1,13 @@
 package ee.schimke.composeai.renderer
 
 import ee.schimke.composeai.data.render.RenderPreviewExtension
+import ee.schimke.composeai.data.render.extensions.CommonDataProducts
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import ee.schimke.composeai.data.render.extensions.SimplePlannedDataExtension
 import ee.schimke.composeai.data.render.pipeline.ExtractionSpec
 import ee.schimke.composeai.data.render.pipeline.PipelineCapability
 import ee.schimke.composeai.data.render.pipeline.PipelineStepTrait
@@ -221,4 +228,66 @@ object AccessibilityAnnotatedPreviewExtension {
           ),
         ),
     )
+}
+
+/** Typed data-product graph for the split a11y extension stack. */
+object AccessibilityDataProductExtensions {
+  val hierarchy: PlannedDataExtension =
+    SimplePlannedDataExtension(
+      id = DataExtensionId(AccessibilitySemanticsPreviewExtension.ID),
+      hooks = setOf(DataExtensionHookKind.AfterCapture),
+      constraints = DataExtensionConstraints(phase = DataExtensionPhase.Capture),
+      inputs = setOf(CommonDataProducts.SemanticsSnapshot),
+      outputs = setOf(AccessibilityDataProducts.Hierarchy),
+    )
+
+  val atf: PlannedDataExtension =
+    SimplePlannedDataExtension(
+      id = DataExtensionId(AtfChecksPreviewExtension.ID),
+      hooks = setOf(DataExtensionHookKind.AfterCapture),
+      constraints =
+        DataExtensionConstraints(
+          phase = DataExtensionPhase.PostProcess,
+          after = setOf(DataExtensionId(AccessibilitySemanticsPreviewExtension.ID)),
+        ),
+      inputs = setOf(AccessibilityDataProducts.Hierarchy),
+      outputs = setOf(AccessibilityDataProducts.Atf),
+    )
+
+  val touchTargets: PlannedDataExtension =
+    SimplePlannedDataExtension(
+      id = DataExtensionId("a11y-touch-targets"),
+      hooks = setOf(DataExtensionHookKind.AfterCapture),
+      constraints =
+        DataExtensionConstraints(
+          phase = DataExtensionPhase.PostProcess,
+          after = setOf(DataExtensionId(AccessibilitySemanticsPreviewExtension.ID)),
+        ),
+      inputs = setOf(AccessibilityDataProducts.Hierarchy, CommonDataProducts.Density),
+      outputs = setOf(AccessibilityDataProducts.TouchTargets),
+    )
+
+  val overlay: PlannedDataExtension =
+    SimplePlannedDataExtension(
+      id = DataExtensionId(AccessibilityOverlayPreviewExtension.ID),
+      hooks = setOf(DataExtensionHookKind.AfterRender),
+      constraints =
+        DataExtensionConstraints(
+          phase = DataExtensionPhase.Publish,
+          after =
+            setOf(
+              DataExtensionId(AccessibilitySemanticsPreviewExtension.ID),
+              DataExtensionId(AtfChecksPreviewExtension.ID),
+            ),
+        ),
+      inputs =
+        setOf(
+          CommonDataProducts.ImageArtifact,
+          AccessibilityDataProducts.Hierarchy,
+          AccessibilityDataProducts.Atf,
+        ),
+      outputs = setOf(AccessibilityDataProducts.Overlay),
+    )
+
+  val all: List<PlannedDataExtension> = listOf(hierarchy, atf, touchTargets, overlay)
 }

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtension.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtension.kt
@@ -1,13 +1,6 @@
 package ee.schimke.composeai.renderer
 
 import ee.schimke.composeai.data.render.RenderPreviewExtension
-import ee.schimke.composeai.data.render.extensions.CommonDataProducts
-import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
-import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
-import ee.schimke.composeai.data.render.extensions.DataExtensionId
-import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
-import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
-import ee.schimke.composeai.data.render.extensions.SimplePlannedDataExtension
 import ee.schimke.composeai.data.render.pipeline.ExtractionSpec
 import ee.schimke.composeai.data.render.pipeline.PipelineCapability
 import ee.schimke.composeai.data.render.pipeline.PipelineStepTrait
@@ -230,64 +223,3 @@ object AccessibilityAnnotatedPreviewExtension {
     )
 }
 
-/** Typed data-product graph for the split a11y extension stack. */
-object AccessibilityDataProductExtensions {
-  val hierarchy: PlannedDataExtension =
-    SimplePlannedDataExtension(
-      id = DataExtensionId(AccessibilitySemanticsPreviewExtension.ID),
-      hooks = setOf(DataExtensionHookKind.AfterCapture),
-      constraints = DataExtensionConstraints(phase = DataExtensionPhase.Capture),
-      inputs = setOf(CommonDataProducts.SemanticsSnapshot),
-      outputs = setOf(AccessibilityDataProducts.Hierarchy),
-    )
-
-  val atf: PlannedDataExtension =
-    SimplePlannedDataExtension(
-      id = DataExtensionId(AtfChecksPreviewExtension.ID),
-      hooks = setOf(DataExtensionHookKind.AfterCapture),
-      constraints =
-        DataExtensionConstraints(
-          phase = DataExtensionPhase.PostProcess,
-          after = setOf(DataExtensionId(AccessibilitySemanticsPreviewExtension.ID)),
-        ),
-      inputs = setOf(AccessibilityDataProducts.Hierarchy),
-      outputs = setOf(AccessibilityDataProducts.Atf),
-    )
-
-  val touchTargets: PlannedDataExtension =
-    SimplePlannedDataExtension(
-      id = DataExtensionId("a11y-touch-targets"),
-      hooks = setOf(DataExtensionHookKind.AfterCapture),
-      constraints =
-        DataExtensionConstraints(
-          phase = DataExtensionPhase.PostProcess,
-          after = setOf(DataExtensionId(AccessibilitySemanticsPreviewExtension.ID)),
-        ),
-      inputs = setOf(AccessibilityDataProducts.Hierarchy, CommonDataProducts.Density),
-      outputs = setOf(AccessibilityDataProducts.TouchTargets),
-    )
-
-  val overlay: PlannedDataExtension =
-    SimplePlannedDataExtension(
-      id = DataExtensionId(AccessibilityOverlayPreviewExtension.ID),
-      hooks = setOf(DataExtensionHookKind.AfterRender),
-      constraints =
-        DataExtensionConstraints(
-          phase = DataExtensionPhase.Publish,
-          after =
-            setOf(
-              DataExtensionId(AccessibilitySemanticsPreviewExtension.ID),
-              DataExtensionId(AtfChecksPreviewExtension.ID),
-            ),
-        ),
-      inputs =
-        setOf(
-          CommonDataProducts.ImageArtifact,
-          AccessibilityDataProducts.Hierarchy,
-          AccessibilityDataProducts.Atf,
-        ),
-      outputs = setOf(AccessibilityDataProducts.Overlay),
-    )
-
-  val all: List<PlannedDataExtension> = listOf(hierarchy, atf, touchTargets, overlay)
-}

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtensionTest.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtensionTest.kt
@@ -1,6 +1,8 @@
 package ee.schimke.composeai.renderer
 
 import ee.schimke.composeai.data.render.RenderPreviewExtension
+import ee.schimke.composeai.data.render.extensions.CommonDataProducts
+import ee.schimke.composeai.data.render.extensions.DataExtensionPlanner
 import ee.schimke.composeai.data.render.pipeline.PipelineCapability
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelinePlan
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelineValidator
@@ -119,5 +121,41 @@ class AccessibilityPreviewExtensionTest {
     val command =
       AccessibilityAnnotatedPreviewExtension.descriptor.cliCommands.single { it.id == "a11y-overlay.get" }
     assertEquals(listOf(AccessibilityOverlayPreviewExtension.KIND_OVERLAY), command.productKinds)
+  }
+
+  @Test
+  fun typedOverlayRequestPlansHierarchyAndAtfDependencies() {
+    val result =
+      DataExtensionPlanner.planOutputs(
+        extensions = AccessibilityDataProductExtensions.all,
+        requestedOutputs = setOf(AccessibilityDataProducts.Overlay),
+        initialProducts = setOf(CommonDataProducts.SemanticsSnapshot, CommonDataProducts.ImageArtifact),
+      )
+
+    assertTrue(result.errors.toString(), result.isValid)
+    assertEquals(
+      listOf(
+        AccessibilitySemanticsPreviewExtension.ID,
+        AtfChecksPreviewExtension.ID,
+        AccessibilityOverlayPreviewExtension.ID,
+      ),
+      result.orderedExtensions.map { it.id.value },
+    )
+  }
+
+  @Test
+  fun typedTouchTargetsReuseHierarchyWithoutAtf() {
+    val result =
+      DataExtensionPlanner.planOutputs(
+        extensions = AccessibilityDataProductExtensions.all,
+        requestedOutputs = setOf(AccessibilityDataProducts.TouchTargets),
+        initialProducts = setOf(CommonDataProducts.SemanticsSnapshot, CommonDataProducts.Density),
+      )
+
+    assertTrue(result.errors.toString(), result.isValid)
+    assertEquals(
+      listOf(AccessibilitySemanticsPreviewExtension.ID, "a11y-touch-targets"),
+      result.orderedExtensions.map { it.id.value },
+    )
   }
 }

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtensionTest.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityPreviewExtensionTest.kt
@@ -1,8 +1,6 @@
 package ee.schimke.composeai.renderer
 
 import ee.schimke.composeai.data.render.RenderPreviewExtension
-import ee.schimke.composeai.data.render.extensions.CommonDataProducts
-import ee.schimke.composeai.data.render.extensions.DataExtensionPlanner
 import ee.schimke.composeai.data.render.pipeline.PipelineCapability
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelinePlan
 import ee.schimke.composeai.data.render.pipeline.PreviewPipelineValidator
@@ -123,39 +121,4 @@ class AccessibilityPreviewExtensionTest {
     assertEquals(listOf(AccessibilityOverlayPreviewExtension.KIND_OVERLAY), command.productKinds)
   }
 
-  @Test
-  fun typedOverlayRequestPlansHierarchyAndAtfDependencies() {
-    val result =
-      DataExtensionPlanner.planOutputs(
-        extensions = AccessibilityDataProductExtensions.all,
-        requestedOutputs = setOf(AccessibilityDataProducts.Overlay),
-        initialProducts = setOf(CommonDataProducts.SemanticsSnapshot, CommonDataProducts.ImageArtifact),
-      )
-
-    assertTrue(result.errors.toString(), result.isValid)
-    assertEquals(
-      listOf(
-        AccessibilitySemanticsPreviewExtension.ID,
-        AtfChecksPreviewExtension.ID,
-        AccessibilityOverlayPreviewExtension.ID,
-      ),
-      result.orderedExtensions.map { it.id.value },
-    )
-  }
-
-  @Test
-  fun typedTouchTargetsReuseHierarchyWithoutAtf() {
-    val result =
-      DataExtensionPlanner.planOutputs(
-        extensions = AccessibilityDataProductExtensions.all,
-        requestedOutputs = setOf(AccessibilityDataProducts.TouchTargets),
-        initialProducts = setOf(CommonDataProducts.SemanticsSnapshot, CommonDataProducts.Density),
-      )
-
-    assertTrue(result.errors.toString(), result.isValid)
-    assertEquals(
-      listOf(AccessibilitySemanticsPreviewExtension.ID, "a11y-touch-targets"),
-      result.orderedExtensions.map { it.id.value },
-    )
-  }
 }

--- a/data/render/compose/src/main/kotlin/ee/schimke/composeai/data/render/extensions/compose/ComposeDataExtensionHooks.kt
+++ b/data/render/compose/src/main/kotlin/ee/schimke/composeai/data/render/extensions/compose/ComposeDataExtensionHooks.kt
@@ -10,7 +10,10 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
 import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionLifecycle
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataProductSink
+import ee.schimke.composeai.data.render.extensions.DataProductStore
 import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
 
 /**
  * Compose-facing data-extension hook surface.
@@ -27,6 +30,7 @@ data class ExtensionComposeContext(
   val attributes: Map<String, Any?> = emptyMap(),
   val extraction: ExtensionExtractionContext = ExtensionExtractionContext.Empty,
   val states: ExtensionStateRegistry = RecordingExtensionStateRegistry(),
+  val products: DataProductStore = RecordingDataProductStore(),
 ) {
   val slotTables: ExtensionSlotTables
     get() = extraction.slotTables
@@ -228,10 +232,10 @@ abstract class ComposableExtractorExtension(
 
   @Composable
   final override fun Extract(context: ExtensionComposeContext, sink: ExtensionCompositionSink) {
-    Extract(sink)
+    Extract(sink, context.products)
   }
 
-  @Composable abstract fun Extract(sink: ExtensionCompositionSink)
+  @Composable abstract fun Extract(sink: ExtensionCompositionSink, products: DataProductSink)
 }
 
 interface CompositionObserverHook : PlannedDataExtension {
@@ -253,10 +257,10 @@ abstract class CompositionObserverExtension(
 
   @Composable
   final override fun Observe(context: ExtensionComposeContext, sink: ExtensionCompositionSink) {
-    Observe(sink)
+    Observe(sink, context.products)
   }
 
-  @Composable abstract fun Observe(sink: ExtensionCompositionSink)
+  @Composable abstract fun Observe(sink: ExtensionCompositionSink, products: DataProductSink)
 }
 
 data class ExtensionFrameContext(
@@ -266,6 +270,7 @@ data class ExtensionFrameContext(
   val attributes: Map<String, Any?> = emptyMap(),
   val extraction: ExtensionExtractionContext = ExtensionExtractionContext.Empty,
   val states: ExtensionStateRegistry = RecordingExtensionStateRegistry(),
+  val products: DataProductStore = RecordingDataProductStore(),
 ) {
   fun <T : Any> exportState(key: ExtensionStateKey<T>, state: State<T>) {
     states.export(key, state)
@@ -362,9 +367,11 @@ object ComposeDataExtensionPipeline {
     attributes: Map<String, Any?> = emptyMap(),
     extraction: ExtensionExtractionContext = ExtensionExtractionContext.Empty,
     states: ExtensionStateRegistry? = null,
+    products: DataProductStore? = null,
     content: @Composable () -> Unit,
   ) {
     val extensionStates = states ?: remember { RecordingExtensionStateRegistry() }
+    val extensionProducts = products ?: remember { RecordingDataProductStore() }
     Observe(
       extensions = extensions,
       previewId = previewId,
@@ -373,6 +380,7 @@ object ComposeDataExtensionPipeline {
       attributes = attributes,
       extraction = extraction,
       states = extensionStates,
+      products = extensionProducts,
     )
     Extract(
       extensions = extensions,
@@ -382,6 +390,7 @@ object ComposeDataExtensionPipeline {
       attributes = attributes,
       extraction = extraction,
       states = extensionStates,
+      products = extensionProducts,
     )
     Around(
       hooks = extensions.filterIsInstance<AroundComposableHook>(),
@@ -391,6 +400,7 @@ object ComposeDataExtensionPipeline {
       attributes = attributes,
       extraction = extraction,
       states = extensionStates,
+      products = extensionProducts,
       content = content,
     )
   }
@@ -404,8 +414,10 @@ object ComposeDataExtensionPipeline {
     attributes: Map<String, Any?> = emptyMap(),
     extraction: ExtensionExtractionContext = ExtensionExtractionContext.Empty,
     states: ExtensionStateRegistry? = null,
+    products: DataProductStore? = null,
   ) {
     val extensionStates = states ?: remember { RecordingExtensionStateRegistry() }
+    val extensionProducts = products ?: remember { RecordingDataProductStore() }
     for (hook in extensions.filterIsInstance<ComposableExtractorHook>()) {
       hook.Extract(
         context =
@@ -416,6 +428,7 @@ object ComposeDataExtensionPipeline {
             attributes = attributes,
             extraction = extraction,
             states = extensionStates,
+            products = extensionProducts.scopedFor(hook),
           ),
         sink = sink,
       )
@@ -431,8 +444,10 @@ object ComposeDataExtensionPipeline {
     attributes: Map<String, Any?> = emptyMap(),
     extraction: ExtensionExtractionContext = ExtensionExtractionContext.Empty,
     states: ExtensionStateRegistry? = null,
+    products: DataProductStore? = null,
   ) {
     val extensionStates = states ?: remember { RecordingExtensionStateRegistry() }
+    val extensionProducts = products ?: remember { RecordingDataProductStore() }
     for (hook in extensions.filterIsInstance<CompositionObserverHook>()) {
       hook.Observe(
         context =
@@ -443,6 +458,7 @@ object ComposeDataExtensionPipeline {
             attributes = attributes,
             extraction = extraction,
             states = extensionStates,
+            products = extensionProducts.scopedFor(hook),
           ),
         sink = sink,
       )
@@ -458,6 +474,7 @@ object ComposeDataExtensionPipeline {
     attributes: Map<String, Any?>,
     extraction: ExtensionExtractionContext,
     states: ExtensionStateRegistry,
+    products: DataProductStore,
     content: @Composable () -> Unit,
   ) {
     val hook = hooks.getOrNull(index)
@@ -475,6 +492,7 @@ object ComposeDataExtensionPipeline {
           attributes = attributes,
           extraction = extraction,
           states = states,
+          products = products.scopedFor(hook),
         )
     ) {
       Around(
@@ -485,6 +503,7 @@ object ComposeDataExtensionPipeline {
         attributes = attributes,
         extraction = extraction,
         states = states,
+        products = products,
         content = content,
       )
     }

--- a/data/render/compose/src/test/kotlin/ee/schimke/composeai/data/render/extensions/compose/AroundComposableExtensionTest.kt
+++ b/data/render/compose/src/test/kotlin/ee/schimke/composeai/data/render/extensions/compose/AroundComposableExtensionTest.kt
@@ -5,6 +5,7 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
 import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionLifecycle
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataProductSink
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -137,7 +138,7 @@ class AroundComposableExtensionTest {
   private class SimpleThemeExtractorExtension :
     ComposableExtractorExtension(DataExtensionId("compose-theme")) {
     @Composable
-    override fun Extract(sink: ExtensionCompositionSink) {
+    override fun Extract(sink: ExtensionCompositionSink, products: DataProductSink) {
       sink.put(id, "theme", "material")
     }
   }
@@ -145,7 +146,7 @@ class AroundComposableExtensionTest {
   private class SimpleRecompositionObserverExtension :
     CompositionObserverExtension(DataExtensionId("compose-recomposition")) {
     @Composable
-    override fun Observe(sink: ExtensionCompositionSink) {
+    override fun Observe(sink: ExtensionCompositionSink, products: DataProductSink) {
       sink.put(id, "observer", "installed")
     }
   }

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
@@ -3,6 +3,76 @@ package ee.schimke.composeai.data.render.extensions
 import kotlinx.serialization.Serializable
 
 /**
+ * Stable, typed identity for one data product emitted by the extension graph.
+ *
+ * [kind] is the protocol/on-disk name clients already know (`"a11y/hierarchy"`). [type] is the
+ * in-process payload shape extension authors consume from [DataProductStore]. Keeping both on the
+ * same key lets planner code stay protocol-compatible while extension implementations depend on
+ * compile-time payload types instead of string joins.
+ */
+data class DataProductKey<T : Any>(val kind: String, val schemaVersion: Int, val type: Class<T>) :
+  Comparable<DataProductKey<*>> {
+  init {
+    require(kind.isNotBlank()) { "Data product kind must not be blank." }
+    require(schemaVersion > 0) { "Data product schema version must be positive." }
+  }
+
+  override fun compareTo(other: DataProductKey<*>): Int =
+    compareValuesBy(this, other, DataProductKey<*>::kind, DataProductKey<*>::schemaVersion)
+
+  override fun toString(): String = "$kind@v$schemaVersion"
+}
+
+/** A small in-process product store used by downstream extensions to consume declared inputs. */
+interface DataProductStore {
+  fun <T : Any> get(key: DataProductKey<T>): T?
+
+  fun <T : Any> require(key: DataProductKey<T>): T =
+    get(key) ?: error("Data product '$key' is not available.")
+
+  fun <T : Any> put(key: DataProductKey<T>, value: T)
+}
+
+class RecordingDataProductStore : DataProductStore {
+  private val values: MutableMap<DataProductKey<*>, Any> = linkedMapOf()
+
+  override fun <T : Any> get(key: DataProductKey<T>): T? {
+    val value = values[key] ?: return null
+    return key.type.cast(value)
+  }
+
+  override fun <T : Any> put(key: DataProductKey<T>, value: T) {
+    values[key] = key.type.cast(value)
+  }
+}
+
+data class RenderImageArtifact(val path: String, val mediaType: String = "image/png")
+
+data class RenderSemanticsSnapshot(val handle: String)
+
+data class RenderDensity(val density: Float)
+
+object CommonDataProducts {
+  val ImageArtifact: DataProductKey<RenderImageArtifact> =
+    DataProductKey("render/image", schemaVersion = 1, RenderImageArtifact::class.java)
+
+  val SemanticsSnapshot: DataProductKey<RenderSemanticsSnapshot> =
+    DataProductKey(
+      "render/semanticsSnapshot",
+      schemaVersion = 1,
+      RenderSemanticsSnapshot::class.java,
+    )
+
+  val Density: DataProductKey<RenderDensity> =
+    DataProductKey("render/density", schemaVersion = 1, RenderDensity::class.java)
+}
+
+enum class DataExtensionTarget {
+  Android,
+  Desktop,
+}
+
+/**
  * Renderer-agnostic identity for a data extension.
  *
  * Extension ids are stable protocol/configuration names, not Kotlin class names. They are used in
@@ -87,6 +157,14 @@ interface PlannedDataExtension {
   val id: DataExtensionId
   val hooks: Set<DataExtensionHookKind>
   val constraints: DataExtensionConstraints
+  val inputs: Set<DataProductKey<*>>
+    get() = emptySet()
+
+  val outputs: Set<DataProductKey<*>>
+    get() = emptySet()
+
+  val targets: Set<DataExtensionTarget>
+    get() = emptySet()
 }
 
 interface DataExtension<in Request> {
@@ -189,6 +267,9 @@ data class SimplePlannedDataExtension(
   override val id: DataExtensionId,
   override val hooks: Set<DataExtensionHookKind> = emptySet(),
   override val constraints: DataExtensionConstraints = DataExtensionConstraints(),
+  override val inputs: Set<DataProductKey<*>> = emptySet(),
+  override val outputs: Set<DataProductKey<*>> = emptySet(),
+  override val targets: Set<DataExtensionTarget> = emptySet(),
 ) : PlannedDataExtension
 
 data class OrderedDataExtensionPlan(
@@ -216,6 +297,71 @@ data class DataExtensionPlanningResult(
 }
 
 object DataExtensionPlanner {
+  fun planOutputs(
+    extensions: List<PlannedDataExtension>,
+    requestedOutputs: Set<DataProductKey<*>>,
+    initialProducts: Set<DataProductKey<*>> = emptySet(),
+    initialCapabilities: Set<DataExtensionCapability> = emptySet(),
+    target: DataExtensionTarget? = null,
+  ): DataExtensionPlanningResult {
+    val eligibleExtensions =
+      if (target == null) extensions
+      else
+        extensions.filter { extension ->
+          extension.targets.isEmpty() || target in extension.targets
+        }
+    val duplicateErrors =
+      duplicateIdErrors(eligibleExtensions) + duplicateOutputErrors(eligibleExtensions)
+    if (duplicateErrors.isNotEmpty()) {
+      return DataExtensionPlanningResult(emptyList(), duplicateErrors)
+    }
+
+    val byOutput =
+      eligibleExtensions
+        .flatMap { extension -> extension.outputs.map { output -> output to extension } }
+        .associate { it.first to it.second }
+    val selected = linkedMapOf<DataExtensionId, PlannedDataExtension>()
+    val visiting = linkedSetOf<DataProductKey<*>>()
+    val errors = mutableListOf<DataExtensionPlanningError>()
+
+    fun resolve(product: DataProductKey<*>) {
+      if (product in initialProducts) return
+      val provider = byOutput[product]
+      if (provider == null) {
+        errors +=
+          DataExtensionPlanningError(
+            code = "MissingProductProvider",
+            message = "No data extension provides requested product '$product'.",
+          )
+        return
+      }
+      if (provider.id in selected) return
+      if (!visiting.add(product)) {
+        errors +=
+          DataExtensionPlanningError(
+            code = "ProductDependencyCycle",
+            message = "Data product dependency graph contains a cycle at '$product'.",
+            extensions = listOf(provider.id),
+          )
+        return
+      }
+      provider.inputs.sorted().forEach(::resolve)
+      visiting.remove(product)
+      selected[provider.id] = provider
+    }
+
+    requestedOutputs.sorted().forEach(::resolve)
+    if (errors.isNotEmpty()) {
+      return DataExtensionPlanningResult(emptyList(), errors)
+    }
+
+    val sorted = plan(selected.values.toList(), initialCapabilities = initialCapabilities)
+    return DataExtensionPlanningResult(
+      orderedExtensions = sorted.orderedExtensions,
+      errors = sorted.errors + validateProducts(sorted.orderedExtensions, initialProducts),
+    )
+  }
+
   fun <Request> planRequest(
     extensions: List<DataExtension<Request>>,
     request: Request,
@@ -251,6 +397,24 @@ object DataExtensionPlanner {
           code = "DuplicateExtensionId",
           message = "Data extension '$id' is planned ${matches.size} times.",
           extensions = listOf(id),
+        )
+      }
+
+  private fun duplicateOutputErrors(
+    extensions: List<PlannedDataExtension>
+  ): List<DataExtensionPlanningError> =
+    extensions
+      .flatMap { extension -> extension.outputs.map { output -> output to extension.id } }
+      .groupBy { it.first }
+      .filterValues { it.size > 1 }
+      .map { (output, matches) ->
+        DataExtensionPlanningError(
+          code = "DuplicateProductProvider",
+          message =
+            "Data product '$output' is provided by multiple extensions: " +
+              matches.joinToString { it.second.value } +
+              ".",
+          extensions = matches.map { it.second },
         )
       }
 
@@ -421,6 +585,28 @@ object DataExtensionPlanner {
       }
 
       provided += extension.constraints.provides
+    }
+  }
+
+  private fun validateProducts(
+    ordered: List<PlannedDataExtension>,
+    initialProducts: Set<DataProductKey<*>>,
+  ): List<DataExtensionPlanningError> = buildList {
+    var provided = initialProducts
+    for (extension in ordered) {
+      val missing = extension.inputs - provided
+      if (missing.isNotEmpty()) {
+        add(
+          DataExtensionPlanningError(
+            code = "MissingProductInput",
+            message =
+              "Data extension '${extension.id}' requires data products that are not " +
+                "available yet: ${missing.joinToString()}.",
+            extensions = listOf(extension.id),
+          )
+        )
+      }
+      provided += extension.outputs
     }
   }
 }

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
@@ -23,14 +23,29 @@ data class DataProductKey<T : Any>(val kind: String, val schemaVersion: Int, val
   override fun toString(): String = "$kind@v$schemaVersion"
 }
 
-/** A small in-process product store used by downstream extensions to consume declared inputs. */
-interface DataProductStore {
+/** Read-only view of declared inputs for an extension. */
+interface DataProductSource {
   fun <T : Any> get(key: DataProductKey<T>): T?
 
   fun <T : Any> require(key: DataProductKey<T>): T =
     get(key) ?: error("Data product '$key' is not available.")
+}
 
+/** Write-only view for emitting an extension's declared outputs. */
+interface DataProductSink {
   fun <T : Any> put(key: DataProductKey<T>, value: T)
+}
+
+/** A small in-process product store used by downstream extensions to consume declared inputs. */
+interface DataProductStore : DataProductSource, DataProductSink {
+  /**
+   * Returns a per-extension view that enforces the declared `inputs`/`outputs` contract: `get` only
+   * succeeds for keys in [PlannedDataExtension.inputs] (or already produced), `put` only for keys
+   * in [PlannedDataExtension.outputs]. Use this to wrap the shared store before handing it to a
+   * hook so contract drift is caught at runtime, not days later in a downstream consumer.
+   */
+  fun scopedFor(extension: PlannedDataExtension): DataProductStore =
+    ScopedDataProductStore(this, extension)
 }
 
 class RecordingDataProductStore : DataProductStore {
@@ -43,6 +58,26 @@ class RecordingDataProductStore : DataProductStore {
 
   override fun <T : Any> put(key: DataProductKey<T>, value: T) {
     values[key] = key.type.cast(value)
+  }
+}
+
+private class ScopedDataProductStore(
+  private val delegate: DataProductStore,
+  private val extension: PlannedDataExtension,
+) : DataProductStore {
+  override fun <T : Any> get(key: DataProductKey<T>): T? {
+    require(key in extension.inputs) {
+      "Data extension '${extension.id}' read undeclared product '$key'; " + "declare it in inputs."
+    }
+    return delegate.get(key)
+  }
+
+  override fun <T : Any> put(key: DataProductKey<T>, value: T) {
+    require(key in extension.outputs) {
+      "Data extension '${extension.id}' wrote undeclared product '$key'; " +
+        "declare it in outputs."
+    }
+    delegate.put(key, value)
   }
 }
 

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlannerTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlannerTest.kt
@@ -117,6 +117,107 @@ class DataExtensionPlannerTest {
     assertEquals(listOf("fonts", "theme"), result.orderedIds())
   }
 
+  @Test
+  fun expandsRequestedOutputsThroughTypedProductDependencies() {
+    val semantics = product("render/semantics")
+    val hierarchy = product("a11y/hierarchy")
+    val atf = product("a11y/atf")
+    val overlay = product("a11y/overlay")
+
+    val hierarchyExtension =
+      extension(
+        id = "a11y",
+        phase = DataExtensionPhase.Capture,
+        inputs = setOf(semantics),
+        outputs = setOf(hierarchy),
+      )
+    val atfExtension =
+      extension(
+        id = "atf",
+        phase = DataExtensionPhase.PostProcess,
+        inputs = setOf(hierarchy),
+        outputs = setOf(atf),
+      )
+    val overlayExtension =
+      extension(
+        id = "overlay",
+        phase = DataExtensionPhase.Publish,
+        inputs = setOf(hierarchy, atf),
+        outputs = setOf(overlay),
+      )
+
+    val result =
+      DataExtensionPlanner.planOutputs(
+        extensions = listOf(overlayExtension, atfExtension, hierarchyExtension),
+        requestedOutputs = setOf(overlay),
+        initialProducts = setOf(semantics),
+      )
+
+    assertTrue(result.errors.toString(), result.isValid)
+    assertEquals(listOf("a11y", "atf", "overlay"), result.orderedIds())
+  }
+
+  @Test
+  fun reportsMissingProviderForRequestedTypedProduct() {
+    val result =
+      DataExtensionPlanner.planOutputs(
+        extensions = emptyList(),
+        requestedOutputs = setOf(product("a11y/overlay")),
+      )
+
+    assertFalse(result.isValid)
+    assertEquals(listOf("MissingProductProvider"), result.errors.map { it.code })
+  }
+
+  @Test
+  fun reportsDuplicateTypedProductProviders() {
+    val hierarchy = product("a11y/hierarchy")
+
+    val result =
+      DataExtensionPlanner.planOutputs(
+        extensions =
+          listOf(
+            extension("android-hierarchy", outputs = setOf(hierarchy)),
+            extension("desktop-hierarchy", outputs = setOf(hierarchy)),
+          ),
+        requestedOutputs = setOf(hierarchy),
+      )
+
+    assertFalse(result.isValid)
+    assertEquals(listOf("DuplicateProductProvider"), result.errors.map { it.code })
+  }
+
+  @Test
+  fun filtersTypedProductProvidersByTargetBeforeResolvingGraph() {
+    val semantics = product("render/semantics")
+    val hierarchy = product("a11y/hierarchy")
+
+    val result =
+      DataExtensionPlanner.planOutputs(
+        extensions =
+          listOf(
+            extension(
+              "android-hierarchy",
+              inputs = setOf(semantics),
+              outputs = setOf(hierarchy),
+              targets = setOf(DataExtensionTarget.Android),
+            ),
+            extension(
+              "desktop-hierarchy",
+              inputs = setOf(semantics),
+              outputs = setOf(hierarchy),
+              targets = setOf(DataExtensionTarget.Desktop),
+            ),
+          ),
+        requestedOutputs = setOf(hierarchy),
+        initialProducts = setOf(semantics),
+        target = DataExtensionTarget.Desktop,
+      )
+
+    assertTrue(result.errors.toString(), result.isValid)
+    assertEquals(listOf("desktop-hierarchy"), result.orderedIds())
+  }
+
   private fun DataExtensionPlanningResult.orderedIds(): List<String> = orderedExtensions.map {
     it.id.value
   }
@@ -129,6 +230,9 @@ class DataExtensionPlannerTest {
     requires: Set<String> = emptySet(),
     provides: Set<String> = emptySet(),
     conflictsWith: Set<String> = emptySet(),
+    inputs: Set<DataProductKey<*>> = emptySet(),
+    outputs: Set<DataProductKey<*>> = emptySet(),
+    targets: Set<DataExtensionTarget> = emptySet(),
   ): SimplePlannedDataExtension =
     SimplePlannedDataExtension(
       id = DataExtensionId(id),
@@ -141,7 +245,13 @@ class DataExtensionPlannerTest {
           provides = provides.map(::cap).toSet(),
           conflictsWith = conflictsWith.map(::cap).toSet(),
         ),
+      inputs = inputs,
+      outputs = outputs,
+      targets = targets,
     )
 
   private fun cap(value: String): DataExtensionCapability = DataExtensionCapability(value)
+
+  private fun product(kind: String): DataProductKey<String> =
+    DataProductKey(kind, schemaVersion = 1, String::class.java)
 }

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlannerTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlannerTest.kt
@@ -2,6 +2,8 @@ package ee.schimke.composeai.data.render.extensions
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -216,6 +218,53 @@ class DataExtensionPlannerTest {
 
     assertTrue(result.errors.toString(), result.isValid)
     assertEquals(listOf("desktop-hierarchy"), result.orderedIds())
+  }
+
+  @Test
+  fun scopedStoreAllowsDeclaredPutAndGet() {
+    val hierarchy = product("a11y/hierarchy")
+    val atf = product("a11y/atf")
+    val producer = extension("a11y", outputs = setOf(hierarchy))
+    val consumer = extension("atf", inputs = setOf(hierarchy), outputs = setOf(atf))
+
+    val store = RecordingDataProductStore()
+    store.scopedFor(producer).put(hierarchy, "nodes")
+    val view = store.scopedFor(consumer)
+
+    assertEquals("nodes", view.get(hierarchy))
+    assertEquals("nodes", view.require(hierarchy))
+  }
+
+  @Test
+  fun scopedStoreRejectsUndeclaredPut() {
+    val hierarchy = product("a11y/hierarchy")
+    val producer = extension("hierarchy")
+
+    val ex =
+      assertThrows(IllegalArgumentException::class.java) {
+        RecordingDataProductStore().scopedFor(producer).put(hierarchy, "nodes")
+      }
+    assertTrue(ex.message!!.contains("undeclared product"))
+  }
+
+  @Test
+  fun scopedStoreRejectsUndeclaredGet() {
+    val hierarchy = product("a11y/hierarchy")
+    val consumer = extension("atf")
+
+    val ex =
+      assertThrows(IllegalArgumentException::class.java) {
+        RecordingDataProductStore().scopedFor(consumer).get(hierarchy)
+      }
+    assertTrue(ex.message!!.contains("undeclared product"))
+  }
+
+  @Test
+  fun scopedStoreReturnsNullForDeclaredButMissingInput() {
+    val hierarchy = product("a11y/hierarchy")
+    val consumer = extension("atf", inputs = setOf(hierarchy))
+
+    assertNull(RecordingDataProductStore().scopedFor(consumer).get(hierarchy))
   }
 
   private fun DataExtensionPlanningResult.orderedIds(): List<String> = orderedExtensions.map {

--- a/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
+++ b/data/theme/connector/src/main/kotlin/ee/schimke/composeai/daemon/ThemeDataProduct.kt
@@ -28,6 +28,8 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionCapability
 import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
 import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataProductKey
+import ee.schimke.composeai.data.render.extensions.DataProductSink
 import ee.schimke.composeai.data.render.extensions.compose.AroundComposableExtension
 import ee.schimke.composeai.data.render.extensions.compose.ComposableExtractorExtension
 import ee.schimke.composeai.data.render.extensions.compose.ComposeColorSpec
@@ -197,22 +199,31 @@ class ThemeCaptureExtension :
         provides = setOf(DataExtensionCapability(ThemeDataProductRegistry.KIND)),
       ),
   ) {
+  override val outputs: Set<DataProductKey<*>> = setOf(ThemeProduct)
+
   @Composable
-  override fun Extract(sink: ExtensionCompositionSink) {
+  override fun Extract(sink: ExtensionCompositionSink, products: DataProductSink) {
     val colorScheme = MaterialTheme.colorScheme
     val typography = MaterialTheme.typography
     val shapes = MaterialTheme.shapes
     SideEffect {
-      sink.put(
-        extensionId = id,
-        key = PAYLOAD_KEY,
-        value = themePayloadFromMaterialTheme(colorScheme, typography, shapes),
-      )
+      val payload = themePayloadFromMaterialTheme(colorScheme, typography, shapes)
+      products.put(ThemeProduct, payload)
+      // String-keyed sink kept for hosts that read from PreviewContext.inspection.values until
+      // they migrate to the typed product channel.
+      sink.put(extensionId = id, key = PAYLOAD_KEY, value = payload)
     }
   }
 
   companion object {
     const val PAYLOAD_KEY: String = MATERIAL3_THEME_PAYLOAD_CONTEXT_KEY
+
+    val ThemeProduct: DataProductKey<ThemePayload> =
+      DataProductKey(
+        ThemeDataProductRegistry.KIND,
+        ThemeDataProductRegistry.SCHEMA_VERSION,
+        ThemePayload::class.java,
+      )
   }
 }
 


### PR DESCRIPTION
## Summary

Three-step cleanup of the data-extension graph so producer/consumer wiring is real at runtime, not just planner metadata.

- **Drop the dead `AccessibilityDataProductExtensions` metadata object.** Four `SimplePlannedDataExtension` declarations with `before/after`-vs-`inputs/outputs` redundancy and no impls behind them. Planner-coverage already exists in `DataExtensionPlannerTest.expandsRequestedOutputsThroughTypedProductDependencies`.
- **Typed runtime contract through hook contexts.** `DataProductStore` splits into read-only `DataProductSource` and write-only `DataProductSink`. `ExtensionComposeContext` / `ExtensionFrameContext` now carry a `products: DataProductStore`. The pipeline wraps each per-extension view with `scopedFor(extension)`, which throws at runtime if an extension `put`s a key not in `outputs` or `get`s a key not in `inputs`. Closes the loop between planner declaration and emission/consumption.
- **Theme as the proof point.** `ThemeCaptureExtension` declares `outputs = setOf(ThemeProduct)` and emits `ThemePayload` via the typed sink. Legacy string-keyed `ExtensionCompositionSink` emission stays for hosts still reading from `PreviewContext.inspection.values`.

## Follow-ups (not in this PR)

- Real per-platform a11y impls (`AccessibilityHierarchyExtension : ComposableExtractorExtension` for Android + Desktop, then `Atf` / `TouchTargets` / `Overlay` consuming `AccessibilityDataProducts.Hierarchy`). Requires breaking apart `AccessibilityDataProducer.writeArtifacts` and threading the store through `RenderEngine`.
- Generic `DataProductTransport` registry so connector publish serializes by `DataProductKey<*>` instead of bespoke per-product write paths.
- Drop `PipelineCapability` strings + `provides`/`requires` redundancy on `PreviewPipelineStep` once typed graph fully owns dependency expression.

## Test plan

- [x] `./gradlew :data-render-core:check :data-render-compose:check :data-theme-connector:check :data-recomposition-connector:check :data-fonts-connector:check :data-a11y-core:check` — all green
- [x] `./gradlew :daemon:desktop:compileKotlin :daemon:android:compileDebugKotlin :data-scroll-core:compileDebugKotlin :data-resources-connector:compileDebugKotlin` — all downstream callers still compile
- [x] `./gradlew ktfmtCheckAll` — clean
- [x] New tests in `DataExtensionPlannerTest`: `scopedStoreAllowsDeclaredPutAndGet`, `scopedStoreRejectsUndeclaredPut`, `scopedStoreRejectsUndeclaredGet`, `scopedStoreReturnsNullForDeclaredButMissingInput`

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHbVixJqqQvGdBGbHeuJpJ)_