### PR TITLE
feat(a11y): TouchTargetsExtension via new PostCaptureProcessor hook

### DIFF
--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
@@ -10,6 +10,8 @@ import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import ee.schimke.composeai.renderer.AccessibilityDataProducts
 import ee.schimke.composeai.renderer.AccessibilityFinding
 import ee.schimke.composeai.renderer.AccessibilityNode
+import ee.schimke.composeai.renderer.AccessibilityTouchTargetsPayload
+import ee.schimke.composeai.renderer.buildTouchTargets
 import java.io.File
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -68,18 +70,6 @@ object AccessibilityDataProducer {
 
   @Serializable internal data class HierarchyPayload(val nodes: List<AccessibilityNode>)
 
-  @Serializable internal data class TouchTargetsPayload(val targets: List<TouchTarget>)
-
-  @Serializable
-  internal data class TouchTarget(
-    val nodeId: String,
-    val boundsInScreen: String,
-    val widthDp: Float,
-    val heightDp: Float,
-    val findings: List<String>,
-    val overlappingNodeIds: List<String>? = null,
-  )
-
   /**
    * Writes both JSON files to `<rootDir>/<previewId>/` (creating the directory tree if needed).
    * Idempotent — overwrites prior files. Called from [RenderEngine.render]'s a11y branch with
@@ -112,8 +102,8 @@ object AccessibilityDataProducer {
       .resolve(FILE_TOUCH_TARGETS)
       .writeText(
         json.encodeToString(
-          TouchTargetsPayload.serializer(),
-          TouchTargetsPayload(buildTouchTargets(nodes, density)),
+          AccessibilityTouchTargetsPayload.serializer(),
+          AccessibilityTouchTargetsPayload(buildTouchTargets(nodes, density)),
         )
       )
     if (pngFile == null || imageProcessors.isEmpty()) return
@@ -136,80 +126,6 @@ object AccessibilityDataProducer {
       }
     }
   }
-
-  private fun buildTouchTargets(nodes: List<AccessibilityNode>, density: Float): List<TouchTarget> {
-    val scale = density.takeIf { it > 0f } ?: 1f
-    val candidates =
-      nodes.mapIndexedNotNull { index, node ->
-        if (!node.states.any { it == "clickable" || it == "long-clickable" }) return@mapIndexedNotNull null
-        val rect = parseBounds(node.boundsInScreen) ?: return@mapIndexedNotNull null
-        Candidate(
-          nodeId = "node-$index",
-          boundsInScreen = node.boundsInScreen,
-          rect = rect,
-          widthDp = rect.widthPx / scale,
-          heightDp = rect.heightPx / scale,
-        )
-      }
-
-    for (i in candidates.indices) {
-      for (j in i + 1 until candidates.size) {
-        val a = candidates[i]
-        val b = candidates[j]
-        if (a.rect.overlaps(b.rect) && !a.rect.contains(b.rect) && !b.rect.contains(a.rect)) {
-          a.overlappingNodeIds += b.nodeId
-          b.overlappingNodeIds += a.nodeId
-        }
-      }
-    }
-
-    return candidates.map { candidate ->
-      val findings = mutableListOf<String>()
-      if (candidate.widthDp < MIN_TOUCH_TARGET_DP || candidate.heightDp < MIN_TOUCH_TARGET_DP) {
-        findings += FINDING_BELOW_MINIMUM
-      }
-      if (candidate.overlappingNodeIds.isNotEmpty()) findings += FINDING_OVERLAPPING
-      TouchTarget(
-        nodeId = candidate.nodeId,
-        boundsInScreen = candidate.boundsInScreen,
-        widthDp = candidate.widthDp,
-        heightDp = candidate.heightDp,
-        findings = findings,
-        overlappingNodeIds = candidate.overlappingNodeIds.takeIf { it.isNotEmpty() },
-      )
-    }
-  }
-
-  private data class Candidate(
-    val nodeId: String,
-    val boundsInScreen: String,
-    val rect: BoundsRect,
-    val widthDp: Float,
-    val heightDp: Float,
-    val overlappingNodeIds: MutableList<String> = mutableListOf(),
-  )
-
-  private data class BoundsRect(val left: Int, val top: Int, val right: Int, val bottom: Int) {
-    val widthPx: Int = (right - left).coerceAtLeast(0)
-    val heightPx: Int = (bottom - top).coerceAtLeast(0)
-
-    fun overlaps(other: BoundsRect): Boolean =
-      left < other.right && right > other.left && top < other.bottom && bottom > other.top
-
-    fun contains(other: BoundsRect): Boolean =
-      left <= other.left && top <= other.top && right >= other.right && bottom >= other.bottom
-  }
-
-  private fun parseBounds(bounds: String): BoundsRect? {
-    val parts = bounds.split(',')
-    if (parts.size != 4) return null
-    val values = parts.map { it.trim().toIntOrNull() ?: return null }
-    return BoundsRect(values[0], values[1], values[2], values[3])
-  }
-
-  private const val MIN_TOUCH_TARGET_DP = 48f
-  private const val FINDING_BELOW_MINIMUM = "belowMinimum"
-  private const val FINDING_OVERLAPPING = "overlapping"
 }
 
 /**

--- a/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProductRegistryTest.kt
+++ b/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProductRegistryTest.kt
@@ -3,6 +3,7 @@ package ee.schimke.composeai.daemon
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.renderer.AccessibilityFinding
 import ee.schimke.composeai.renderer.AccessibilityNode
+import ee.schimke.composeai.renderer.AccessibilityTouchTargetsPayload
 import java.io.File
 import java.nio.file.Files
 import kotlinx.serialization.json.Json
@@ -141,7 +142,7 @@ class AccessibilityDataProductRegistryTest {
     val touchFile = File(rootDir, "$previewId/${AccessibilityDataProducer.FILE_TOUCH_TARGETS}")
     val payload =
       Json.decodeFromString(
-        AccessibilityDataProducer.TouchTargetsPayload.serializer(),
+        AccessibilityTouchTargetsPayload.serializer(),
         touchFile.readText(),
       )
     assertEquals(3, payload.targets.size)

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/TouchTargetsExtension.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/TouchTargetsExtension.kt
@@ -1,0 +1,123 @@
+package ee.schimke.composeai.renderer
+
+import ee.schimke.composeai.data.render.extensions.CommonDataProducts
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataProductKey
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
+
+/**
+ * Derives clickable target sizes + overlap findings from an [AccessibilityHierarchyPayload]
+ * snapshot. Pure platform-agnostic transformation — Android and Desktop hierarchy producers can
+ * both feed this without duplicating the math.
+ *
+ * Inputs: [AccessibilityDataProducts.Hierarchy] (nodes), [CommonDataProducts.Density] (dp scale).
+ * Output: [AccessibilityDataProducts.TouchTargets].
+ */
+class TouchTargetsExtension : PostCaptureProcessor {
+  override val id: DataExtensionId = DataExtensionId(EXTENSION_ID)
+  override val hooks: Set<DataExtensionHookKind> = setOf(DataExtensionHookKind.AfterCapture)
+  override val constraints: DataExtensionConstraints =
+    DataExtensionConstraints(phase = DataExtensionPhase.PostProcess)
+  override val inputs: Set<DataProductKey<*>> =
+    setOf(AccessibilityDataProducts.Hierarchy, CommonDataProducts.Density)
+  override val outputs: Set<DataProductKey<*>> = setOf(AccessibilityDataProducts.TouchTargets)
+
+  override fun process(context: ExtensionPostCaptureContext) {
+    val hierarchy = context.products.require(AccessibilityDataProducts.Hierarchy)
+    val density = context.products.require(CommonDataProducts.Density)
+    context.products.put(
+      AccessibilityDataProducts.TouchTargets,
+      AccessibilityTouchTargetsPayload(buildTouchTargets(hierarchy.nodes, density.density)),
+    )
+  }
+
+  companion object {
+    const val EXTENSION_ID: String = "a11y-touch-targets"
+  }
+}
+
+/**
+ * Public counterpart to the previously-internal `AccessibilityDataProducer.buildTouchTargets`.
+ * Kept here so both the extension and the on-disk producer call into the same logic until the
+ * connector layer migrates to consuming the typed product directly.
+ */
+fun buildTouchTargets(
+  nodes: List<AccessibilityNode>,
+  density: Float,
+): List<AccessibilityTouchTarget> {
+  val scale = density.takeIf { it > 0f } ?: 1f
+  val candidates =
+    nodes.mapIndexedNotNull { index, node ->
+      if (!node.states.any { it == "clickable" || it == "long-clickable" }) return@mapIndexedNotNull null
+      val rect = parseBounds(node.boundsInScreen) ?: return@mapIndexedNotNull null
+      TouchTargetCandidate(
+        nodeId = "node-$index",
+        boundsInScreen = node.boundsInScreen,
+        rect = rect,
+        widthDp = rect.widthPx / scale,
+        heightDp = rect.heightPx / scale,
+      )
+    }
+
+  for (i in candidates.indices) {
+    for (j in i + 1 until candidates.size) {
+      val a = candidates[i]
+      val b = candidates[j]
+      if (a.rect.overlaps(b.rect) && !a.rect.contains(b.rect) && !b.rect.contains(a.rect)) {
+        a.overlappingNodeIds += b.nodeId
+        b.overlappingNodeIds += a.nodeId
+      }
+    }
+  }
+
+  return candidates.map { candidate ->
+    val findings = mutableListOf<String>()
+    if (candidate.widthDp < MIN_TOUCH_TARGET_DP || candidate.heightDp < MIN_TOUCH_TARGET_DP) {
+      findings += FINDING_BELOW_MINIMUM
+    }
+    if (candidate.overlappingNodeIds.isNotEmpty()) findings += FINDING_OVERLAPPING
+    AccessibilityTouchTarget(
+      nodeId = candidate.nodeId,
+      boundsInScreen = candidate.boundsInScreen,
+      widthDp = candidate.widthDp,
+      heightDp = candidate.heightDp,
+      findings = findings,
+      overlappingNodeIds = candidate.overlappingNodeIds.takeIf { it.isNotEmpty() },
+    )
+  }
+}
+
+private data class TouchTargetCandidate(
+  val nodeId: String,
+  val boundsInScreen: String,
+  val rect: BoundsRect,
+  val widthDp: Float,
+  val heightDp: Float,
+  val overlappingNodeIds: MutableList<String> = mutableListOf(),
+)
+
+private data class BoundsRect(val left: Int, val top: Int, val right: Int, val bottom: Int) {
+  val widthPx: Int = (right - left).coerceAtLeast(0)
+  val heightPx: Int = (bottom - top).coerceAtLeast(0)
+
+  fun overlaps(other: BoundsRect): Boolean =
+    left < other.right && right > other.left && top < other.bottom && bottom > other.top
+
+  fun contains(other: BoundsRect): Boolean =
+    left <= other.left && top <= other.top && right >= other.right && bottom >= other.bottom
+}
+
+private fun parseBounds(bounds: String): BoundsRect? {
+  val parts = bounds.split(',')
+  if (parts.size != 4) return null
+  val values = parts.map { it.trim().toIntOrNull() ?: return null }
+  return BoundsRect(values[0], values[1], values[2], values[3])
+}
+
+private const val MIN_TOUCH_TARGET_DP = 48f
+private const val FINDING_BELOW_MINIMUM = "belowMinimum"
+private const val FINDING_OVERLAPPING = "overlapping"

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/TouchTargetsExtensionTest.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/TouchTargetsExtensionTest.kt
@@ -1,0 +1,94 @@
+package ee.schimke.composeai.renderer
+
+import ee.schimke.composeai.data.render.extensions.CommonDataProducts
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPlanner
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import ee.schimke.composeai.data.render.extensions.RenderDensity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TouchTargetsExtensionTest {
+  private val extension = TouchTargetsExtension()
+
+  @Test
+  fun emitsTouchTargetsPayloadFromHierarchyAndDensity() {
+    val hierarchy =
+      AccessibilityHierarchyPayload(
+        nodes =
+          listOf(
+            AccessibilityNode(
+              label = "Small",
+              role = "Button",
+              states = listOf("clickable"),
+              boundsInScreen = "0,0,80,80",
+            ),
+            AccessibilityNode(
+              label = "Static text",
+              boundsInScreen = "100,0,200,80",
+            ),
+          )
+      )
+
+    val store = RecordingDataProductStore()
+    store.put(AccessibilityDataProducts.Hierarchy, hierarchy)
+    store.put(CommonDataProducts.Density, RenderDensity(2f))
+    val scoped = store.scopedFor(extension)
+
+    extension.process(
+      ExtensionPostCaptureContext(
+        extensionId = extension.id,
+        previewId = "preview",
+        renderMode = null,
+        products = scoped,
+      )
+    )
+
+    val emitted = store.require(AccessibilityDataProducts.TouchTargets)
+    assertEquals(1, emitted.targets.size)
+    val target = emitted.targets.single()
+    assertEquals("node-0", target.nodeId)
+    assertEquals(40f, target.widthDp)
+    assertEquals(40f, target.heightDp)
+    assertEquals(listOf("belowMinimum"), target.findings)
+  }
+
+  @Test
+  fun scopedStoreRefusesToReadUndeclaredProduct() {
+    val foreignProduct =
+      ee.schimke.composeai.data.render.extensions.DataProductKey(
+        "foreign/key",
+        schemaVersion = 1,
+        AccessibilityHierarchyPayload::class.java,
+      )
+    val scoped = RecordingDataProductStore().scopedFor(extension)
+
+    val ex = assertThrows(IllegalArgumentException::class.java) { scoped.get(foreignProduct) }
+    assertTrue(ex.message!!.contains("undeclared product"))
+  }
+
+  @Test
+  fun plannerOrdersTouchTargetsAfterHierarchyProducer() {
+    val hierarchyProducer =
+      ee.schimke.composeai.data.render.extensions.SimplePlannedDataExtension(
+        id = DataExtensionId("a11y"),
+        outputs = setOf(AccessibilityDataProducts.Hierarchy),
+      )
+
+    val result =
+      DataExtensionPlanner.planOutputs(
+        extensions = listOf(extension, hierarchyProducer),
+        requestedOutputs = setOf(AccessibilityDataProducts.TouchTargets),
+        initialProducts = setOf(CommonDataProducts.Density),
+      )
+
+    assertTrue(result.errors.toString(), result.isValid)
+    assertEquals(
+      listOf("a11y", TouchTargetsExtension.EXTENSION_ID),
+      result.orderedExtensions.map { it.id.value },
+    )
+  }
+}

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/PostCaptureProcessor.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/PostCaptureProcessor.kt
@@ -1,0 +1,29 @@
+package ee.schimke.composeai.data.render.extensions
+
+/**
+ * Pure-data context passed to [PostCaptureProcessor.process] after a render's bitmap has been
+ * captured. No Compose runtime, no platform-specific types — extensions read declared inputs and
+ * write declared outputs through [products], which the executor scopes to the extension's
+ * `inputs`/`outputs` set so contract violations fail loudly at runtime.
+ */
+data class ExtensionPostCaptureContext(
+  val extensionId: DataExtensionId,
+  val previewId: String?,
+  val renderMode: String?,
+  val products: DataProductStore,
+  val attributes: Map<String, Any?> = emptyMap(),
+)
+
+/**
+ * Hook for extensions that run once after a render's bitmap is captured. Distinct from
+ * [ee.schimke.composeai.data.render.extensions.compose.ImageFrameTransformHook]: post-capture
+ * processors don't transform the image directly — they read/write typed data products such as
+ * accessibility hierarchies, ATF findings, derived touch targets, or annotated overlay artifacts.
+ *
+ * The executor invokes [process] in planner-determined order with a [DataProductStore] already
+ * populated by upstream producers. Implementations should fail fast on missing required inputs via
+ * `context.products.require(...)` and emit outputs with `context.products.put(key, value)`.
+ */
+interface PostCaptureProcessor : PlannedDataExtension {
+  fun process(context: ExtensionPostCaptureContext)
+}


### PR DESCRIPTION
First concrete consumer of the typed product graph from #716.

## Summary

- **`PostCaptureProcessor` hook** in `data-render-core`: pure-data context (`ExtensionPostCaptureContext`) and a single-method interface (`process(context)`) for extensions that read declared inputs and write declared outputs through the typed product store after the bitmap is captured. No Compose dependency, so a11y-core can implement it directly.
- **`TouchTargetsExtension : PostCaptureProcessor`** in `data-a11y-core` — first concrete impl. Consumes `AccessibilityHierarchyPayload + RenderDensity`, emits `AccessibilityTouchTargetsPayload`. Platform-agnostic: any hierarchy producer (Android ATF, future Desktop semantics walk) can feed it without duplicating the math.
- **`buildTouchTargets` promoted** from a private helper in `AccessibilityDataProducer` to a public function in a11y-core. The connector and the extension now share a single source of truth, and the on-disk JSON shape is unified on the public `AccessibilityTouchTarget` type (the previous internal `TouchTarget` type was structurally identical — just deleted).

## Not in this PR

- Wiring the extension into `RenderEngine.render`'s post-capture loop. Requires defining when post-capture extensions run relative to `AccessibilityDataProducer.writeArtifacts` and how the store gets seeded with `Hierarchy` (currently produced by `AccessibilityChecker.analyze`). Separate refactor.
- `AtfExtension` / `OverlayExtension` siblings — same shape, different inputs/outputs.

## Test plan

- [x] `./gradlew :data-render-core:test :data-a11y-core:check :data-a11y-connector:check` — green
- [x] `./gradlew :daemon:desktop:compileKotlin :daemon:android:compileDebugKotlin` — downstream still compiles
- [x] `./gradlew ktfmtCheckAll` — clean
- [x] New tests: `emitsTouchTargetsPayloadFromHierarchyAndDensity`, `scopedStoreRefusesToReadUndeclaredProduct`, `plannerOrdersTouchTargetsAfterHierarchyProducer`
- [x] Existing connector test (`AccessibilityDataProductRegistryTest`) updated to consume the unified `AccessibilityTouchTargetsPayload` and still passes — JSON shape unchanged on disk.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHbVixJqqQvGdBGbHeuJpJ)_