### PR TITLE
refactor(mcp): make recording-script kind validation honest

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -337,7 +337,14 @@ fun main(args: Array<String>) {
       incrementalDiscovery = incrementalDiscovery,
       historyManager = historyManager,
       dataProducts = dataProducts,
-      dataExtensions = RecordingScriptDataExtensions.descriptors,
+      // Base recording-script descriptors are renderer-agnostic; the a11y action descriptors are
+      // Android-only and only meaningful when the a11y preview extension is enabled. They ship as
+      // `supported = false` until the recording-script handler registry refactor lands the actual
+      // dispatch — `record_preview` rejects them up front via `validateRecordingScriptKinds`.
+      dataExtensions =
+        RecordingScriptDataExtensions.descriptors +
+          (if (a11yPreviewExtensionEnabled) AccessibilityRecordingScriptEvents.descriptors
+          else emptyList()),
       previewExtensions = previewExtensions,
     )
   server.run()

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
@@ -128,13 +128,24 @@ data class RecordingResult(
 data class EncodedRecording(val videoPath: String, val mimeType: String, val sizeBytes: Long)
 
 fun String.toInteractiveInputKindOrNull(): InteractiveInputKind? =
-  when (this) {
-    "click" -> InteractiveInputKind.CLICK
-    "pointerDown" -> InteractiveInputKind.POINTER_DOWN
-    "pointerMove" -> InteractiveInputKind.POINTER_MOVE
-    "pointerUp" -> InteractiveInputKind.POINTER_UP
-    "rotaryScroll" -> InteractiveInputKind.ROTARY_SCROLL
-    "keyDown" -> InteractiveInputKind.KEY_DOWN
-    "keyUp" -> InteractiveInputKind.KEY_UP
-    else -> null
-  }
+  INTERACTIVE_INPUT_KIND_BY_WIRE_NAME[this]
+
+/**
+ * Wire-name table for [InteractiveInputKind]. Single source of truth shared by the daemon's
+ * recording sessions ([toInteractiveInputKindOrNull]) and the MCP server's `record_preview`
+ * validator. Adding a new enum constant + wire name extends both call sites automatically — there's
+ * no separate hard-coded set to keep in sync.
+ */
+val INTERACTIVE_INPUT_KIND_BY_WIRE_NAME: Map<String, InteractiveInputKind> =
+  mapOf(
+    "click" to InteractiveInputKind.CLICK,
+    "pointerDown" to InteractiveInputKind.POINTER_DOWN,
+    "pointerMove" to InteractiveInputKind.POINTER_MOVE,
+    "pointerUp" to InteractiveInputKind.POINTER_UP,
+    "rotaryScroll" to InteractiveInputKind.ROTARY_SCROLL,
+    "keyDown" to InteractiveInputKind.KEY_DOWN,
+    "keyUp" to InteractiveInputKind.KEY_UP,
+  )
+
+/** Wire-name set derived from [INTERACTIVE_INPUT_KIND_BY_WIRE_NAME]. */
+val INTERACTIVE_INPUT_KIND_WIRE_NAMES: Set<String> = INTERACTIVE_INPUT_KIND_BY_WIRE_NAME.keys

--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEvents.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEvents.kt
@@ -1,0 +1,152 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescriptor
+
+/**
+ * Accessibility-driven `record_preview` script events — see
+ * [`compose-preview-review/design/AGENT_AUDITS.md`](../../../../../../skills/compose-preview-review/design/AGENT_AUDITS.md)
+ * § "Accessibility-driven interaction audit" (planned).
+ *
+ * Each id maps to one [`AccessibilityNodeInfo`](https://developer.android.com/reference/android/view/accessibility/AccessibilityNodeInfo)
+ * action constant. An `a11y.action.<name>` event in a recording script means "find the node
+ * identified by `params` (today: `nodeId` from the most recent `a11y/hierarchy` payload — content-
+ * description / semantics-tag matching is a follow-up) and dispatch the corresponding accessibility
+ * action through `AccessibilityNodeInfo.performAction(...)`."
+ *
+ * Why these belong on a separate descriptor and not on `RecordingScriptDataExtensions` in
+ * `:data-render-core`: a11y dispatch is Android-only (TalkBack-equivalent semantics drive these
+ * actions) and lives in the a11y module pair. Desktop daemons don't advertise this descriptor at
+ * all. The wiring point is `:daemon:android`'s [DaemonMain], which concatenates this list onto the
+ * base recording-script descriptors when `a11y` is enabled — same gate as the a11y preview-
+ * extension publishers.
+ *
+ * **Status:** all entries ship with `supported = false` for now. The MCP layer
+ * (`record_preview`'s `validateRecordingScriptKinds`) rejects them up front so an agent that picks
+ * one up from `list_data_products` doesn't watch a quiet `unsupported` evidence trail come back.
+ * The actual dispatch path lands once the recording-script handler registry refactor consolidates
+ * input + extension dispatch under one interface (compose-ai-tools#714 follow-up).
+ */
+object AccessibilityRecordingScriptEvents {
+
+  /** Namespaced ids match `AccessibilityAction`'s short names. */
+  const val ACTION_CLICK: String = "a11y.action.click"
+  const val ACTION_LONG_CLICK: String = "a11y.action.longClick"
+  const val ACTION_FOCUS: String = "a11y.action.focus"
+  const val ACTION_CLEAR_FOCUS: String = "a11y.action.clearFocus"
+  const val ACTION_ACCESSIBILITY_FOCUS: String = "a11y.action.accessibilityFocus"
+  const val ACTION_CLEAR_ACCESSIBILITY_FOCUS: String = "a11y.action.clearAccessibilityFocus"
+  const val ACTION_SELECT: String = "a11y.action.select"
+  const val ACTION_CLEAR_SELECTION: String = "a11y.action.clearSelection"
+  const val ACTION_SCROLL_FORWARD: String = "a11y.action.scrollForward"
+  const val ACTION_SCROLL_BACKWARD: String = "a11y.action.scrollBackward"
+  const val ACTION_SCROLL_UP: String = "a11y.action.scrollUp"
+  const val ACTION_SCROLL_DOWN: String = "a11y.action.scrollDown"
+  const val ACTION_SCROLL_LEFT: String = "a11y.action.scrollLeft"
+  const val ACTION_SCROLL_RIGHT: String = "a11y.action.scrollRight"
+  const val ACTION_EXPAND: String = "a11y.action.expand"
+  const val ACTION_COLLAPSE: String = "a11y.action.collapse"
+  const val ACTION_DISMISS: String = "a11y.action.dismiss"
+  const val ACTION_NEXT_AT_GRANULARITY: String = "a11y.action.nextAtGranularity"
+  const val ACTION_PREVIOUS_AT_GRANULARITY: String = "a11y.action.previousAtGranularity"
+
+  val descriptor: DataExtensionDescriptor =
+    DataExtensionDescriptor(
+      id = DataExtensionId("a11y"),
+      displayName = "Accessibility script actions",
+      recordingScriptEvents =
+        listOf(
+          event(ACTION_CLICK, "Click", "Performs ACTION_CLICK on the targeted accessibility node."),
+          event(
+            ACTION_LONG_CLICK,
+            "Long click",
+            "Performs ACTION_LONG_CLICK on the targeted accessibility node.",
+          ),
+          event(ACTION_FOCUS, "Focus", "Performs ACTION_FOCUS on the targeted node."),
+          event(
+            ACTION_CLEAR_FOCUS,
+            "Clear focus",
+            "Performs ACTION_CLEAR_FOCUS on the targeted node.",
+          ),
+          event(
+            ACTION_ACCESSIBILITY_FOCUS,
+            "Accessibility focus",
+            "Performs ACTION_ACCESSIBILITY_FOCUS — the action a screen reader emits when the user " +
+              "swipes onto a node.",
+          ),
+          event(
+            ACTION_CLEAR_ACCESSIBILITY_FOCUS,
+            "Clear accessibility focus",
+            "Performs ACTION_CLEAR_ACCESSIBILITY_FOCUS, the screen-reader counterpart to " +
+              "swiping off a node.",
+          ),
+          event(ACTION_SELECT, "Select", "Performs ACTION_SELECT on the targeted node."),
+          event(
+            ACTION_CLEAR_SELECTION,
+            "Clear selection",
+            "Performs ACTION_CLEAR_SELECTION on the targeted node.",
+          ),
+          event(
+            ACTION_SCROLL_FORWARD,
+            "Scroll forward",
+            "Performs ACTION_SCROLL_FORWARD on the targeted scrollable node.",
+          ),
+          event(
+            ACTION_SCROLL_BACKWARD,
+            "Scroll backward",
+            "Performs ACTION_SCROLL_BACKWARD on the targeted scrollable node.",
+          ),
+          event(
+            ACTION_SCROLL_UP,
+            "Scroll up",
+            "Performs ACTION_SCROLL_UP on the targeted scrollable node.",
+          ),
+          event(
+            ACTION_SCROLL_DOWN,
+            "Scroll down",
+            "Performs ACTION_SCROLL_DOWN on the targeted scrollable node.",
+          ),
+          event(
+            ACTION_SCROLL_LEFT,
+            "Scroll left",
+            "Performs ACTION_SCROLL_LEFT on the targeted scrollable node.",
+          ),
+          event(
+            ACTION_SCROLL_RIGHT,
+            "Scroll right",
+            "Performs ACTION_SCROLL_RIGHT on the targeted scrollable node.",
+          ),
+          event(ACTION_EXPAND, "Expand", "Performs ACTION_EXPAND on the targeted node."),
+          event(ACTION_COLLAPSE, "Collapse", "Performs ACTION_COLLAPSE on the targeted node."),
+          event(ACTION_DISMISS, "Dismiss", "Performs ACTION_DISMISS on the targeted node."),
+          event(
+            ACTION_NEXT_AT_GRANULARITY,
+            "Next at movement granularity",
+            "Performs ACTION_NEXT_AT_MOVEMENT_GRANULARITY on the targeted text node.",
+          ),
+          event(
+            ACTION_PREVIOUS_AT_GRANULARITY,
+            "Previous at movement granularity",
+            "Performs ACTION_PREVIOUS_AT_MOVEMENT_GRANULARITY on the targeted text node.",
+          ),
+        ),
+    )
+
+  /** Convenience for the daemon's wiring code that takes a list of descriptors. */
+  val descriptors: List<DataExtensionDescriptor> = listOf(descriptor)
+
+  private fun event(
+    id: String,
+    displayName: String,
+    summary: String,
+  ): RecordingScriptEventDescriptor =
+    RecordingScriptEventDescriptor(
+      id = id,
+      displayName = displayName,
+      summary = summary,
+      // Dispatch lands with the recording-script handler registry refactor; until then the
+      // descriptor advertises the surface area as roadmap and `record_preview` rejects up front.
+      supported = false,
+    )
+}

--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -188,10 +188,19 @@ Typical agent flow:
   "events": [
     { "tMs": 0, "kind": "click", "pixelX": 120, "pixelY": 80 },
     { "tMs": 200, "kind": "state.save", "checkpointId": "before-second-click" },
-    { "tMs": 400, "kind": "click", "pixelX": 120, "pixelY": 80 }
+    { "tMs": 400, "kind": "lifecycle.event", "lifecycleEvent": "resume" },
+    { "tMs": 400, "kind": "state.restore", "checkpointId": "before-second-click" },
+    { "tMs": 400, "kind": "recording.probe", "label": "after-restore" },
+    { "tMs": 600, "kind": "click", "pixelX": 120, "pixelY": 80 }
   ]
 }
 ```
+
+Events sharing a `tMs` are treated as one script step. Control/state markers in
+the step are applied before the frame for that timestamp is captured, so agents
+should put `lifecycle.event`, `state.restore`, and a verification
+`recording.probe` at the same `tMs` when they need the preview to observe
+restored state immediately.
 
 On success the tool returns an inline media block plus a JSON metadata text
 block containing `recordingId`, `videoPath`, `mimeType`, `sizeBytes`,

--- a/docs/daemon/MCP.md
+++ b/docs/daemon/MCP.md
@@ -187,32 +187,42 @@ Typical agent flow:
   "format": "apng",
   "events": [
     { "tMs": 0, "kind": "click", "pixelX": 120, "pixelY": 80 },
-    { "tMs": 200, "kind": "state.save", "checkpointId": "before-second-click" },
-    { "tMs": 400, "kind": "lifecycle.event", "lifecycleEvent": "resume" },
-    { "tMs": 400, "kind": "state.restore", "checkpointId": "before-second-click" },
-    { "tMs": 400, "kind": "recording.probe", "label": "after-restore" },
+    { "tMs": 400, "kind": "recording.probe", "label": "after-first-click" },
     { "tMs": 600, "kind": "click", "pixelX": 120, "pixelY": 80 }
   ]
 }
 ```
 
-Events sharing a `tMs` are treated as one script step. Control/state markers in
-the step are applied before the frame for that timestamp is captured, so agents
-should put `lifecycle.event`, `state.restore`, and a verification
-`recording.probe` at the same `tMs` when they need the preview to observe
-restored state immediately.
+Events sharing a `tMs` are treated as one script step. Control markers in the
+step are applied before the frame for that timestamp is captured, so agents
+should colocate a verification `recording.probe` with the input that should
+change state.
+
+`record_preview` accepts two kinds of events:
+
+1. **Built-in input kinds** — `click`, `pointerDown`, `pointerMove`, `pointerUp`,
+   `rotaryScroll`, `keyDown`, `keyUp`. Sourced from `InteractiveInputKind`; what
+   each backend actually dispatches depends on the host (e.g. desktop reports
+   `unsupported` for `keyDown` until key dispatch lands).
+2. **Namespaced data-extension events** — advertised by the daemon via
+   `capabilities.dataExtensions[].recordingScriptEvents[]`. Only entries with
+   `supported = true` are accepted; entries advertised with `supported = false`
+   are roadmap signals (visible via `list_data_products`) and are rejected up
+   front by `record_preview`. Today the only `supported = true` extension event
+   is `recording.probe`; `state.save`, `state.restore`, `lifecycle.event`, and
+   `preview.reload` are advertised as roadmap (compose-ai-tools#714).
 
 On success the tool returns an inline media block plus a JSON metadata text
 block containing `recordingId`, `videoPath`, `mimeType`, `sizeBytes`,
 `frameCount`, `durationMs`, `framesDir`, `frameWidthPx`, and
 `frameHeightPx`. It also includes `scriptEvents[]`, a per-event evidence list
-with `applied` or `unsupported` status for input, probe, state, and lifecycle
-script events. Non-input script events are namespaced ids advertised by
-`capabilities.dataExtensions[].recordingScriptEvents[]`. Treat `unsupported` as
-a compose-ai-tools capability gap, not as an app regression. The raw PNG frames live at
-`<framesDir>/frame-00000.png`, `<framesDir>/frame-00001.png`, and so on, which
-is useful when a client cannot display APNG or wants to inspect individual
-frames.
+with `applied` or `unsupported` status for input and probe events. Non-input
+events that reach the daemon (i.e. ones MCP didn't reject) get the same
+evidence treatment — `unsupported` here is the daemon's defense-in-depth path
+for older MCP servers or direct daemon clients; standard MCP usage will only
+see `applied`. The raw PNG frames live at `<framesDir>/frame-00000.png`,
+`<framesDir>/frame-00001.png`, and so on, which is useful when a client cannot
+display APNG or wants to inspect individual frames.
 
 Sandbox note: Android recordings run through Robolectric. Restricted agent
 sandboxes must allow Robolectric to create its host cache/lock files, including

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.mcp
 
+import ee.schimke.composeai.daemon.INTERACTIVE_INPUT_KIND_WIRE_NAMES
 import ee.schimke.composeai.daemon.protocol.ChangeType
 import ee.schimke.composeai.daemon.protocol.FileKind
 import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
@@ -1127,7 +1128,7 @@ class DaemonMcpServer(
                     "type":"object",
                     "properties":{
                       "tMs":{"type":"integer","description":"Virtual time offset from recording/start, in milliseconds. Must be ≥ 0."},
-                      "kind":{"type":"string","description":"Input event kind (`click`, `pointerDown`, `pointerMove`, `pointerUp`, `rotaryScroll`, `keyDown`, `keyUp`) or a namespaced data-extension script event id advertised by the daemon, for example `recording.probe` or `state.save`."},
+                      "kind":{"type":"string","description":"Input event kind (`click`, `pointerDown`, `pointerMove`, `pointerUp`, `rotaryScroll`, `keyDown`, `keyUp`) or a namespaced data-extension script event id the daemon advertises with `supported = true` — `recording.probe` is the only one wired today; `state.save`, `state.restore`, `lifecycle.event`, and `preview.reload` appear in `list_data_products` as roadmap entries (`supported = false`) and are rejected up front by record_preview."},
                       "pixelX":{"type":"integer","description":"X coord in image-natural pixel space (the preview's own widthPx)."},
                       "pixelY":{"type":"integer","description":"Y coord in image-natural pixel space."},
                       "scrollDeltaY":{"type":"number","description":"For 'rotaryScroll'."},
@@ -2590,10 +2591,12 @@ class DaemonMcpServer(
 
   /**
    * Translate the MCP `record_preview.events` JSON array into typed [RecordingScriptEvent]s.
-   * Validates each entry has a non-negative `tMs` and a known `kind`; throws on malformed input so
-   * the wrapper surfaces "invalid events: …" rather than dying inside the daemon's notification
+   * Validates each entry has a non-negative `tMs` and a non-blank `kind`; throws on malformed input
+   * so the wrapper surfaces "invalid events: …" rather than dying inside the daemon's notification
    * decoder. Unknown extra keys are tolerated for forward compatibility (same shape rule the
-   * `decodePreviewOverrides` helper uses).
+   * `decodePreviewOverrides` helper uses). Closed-set validation against the daemon's advertised
+   * input + extension kinds happens later in [validateRecordingScriptKinds] once the daemon has been
+   * resolved.
    */
   private fun decodeRecordingEvents(arr: JsonArray): List<RecordingScriptEvent> {
     return arr.mapIndexed { idx, elem ->
@@ -2604,11 +2607,6 @@ class DaemonMcpServer(
       require(tMs >= 0) { "event[$idx] tMs must be ≥ 0; got $tMs" }
       val kindStr = obj["kind"]?.jsonPrimitive?.contentOrNull ?: error("event[$idx] missing 'kind'")
       require(kindStr.isNotBlank()) { "event[$idx] kind must not be blank" }
-      if (kindStr !in RECORDING_INPUT_KINDS && !kindStr.contains('.')) {
-        error(
-          "event[$idx] unknown input kind '$kindStr' and extension event ids must be namespaced"
-        )
-      }
       RecordingScriptEvent(
         tMs = tMs,
         kind = kindStr,
@@ -2632,18 +2630,50 @@ class DaemonMcpServer(
       RecordingScriptEventStatus.UNSUPPORTED -> "unsupported"
     }
 
+  /**
+   * Per-event closed-set validation against the resolved daemon's advertised capabilities.
+   *
+   * Events fall into two buckets:
+   * 1. **Input kinds** — `click`, `pointerDown`, `pointerMove`, `pointerUp`, `rotaryScroll`,
+   *    `keyDown`, `keyUp`. Sourced from [INTERACTIVE_INPUT_KIND_WIRE_NAMES] (the same enum
+   *    [InteractiveInputKind] the daemon dispatches against). Always accepted at the MCP layer; the
+   *    daemon's recording session decides what to actually do with each (e.g. desktop returns
+   *    `unsupported` for `keyDown` until key dispatch lands).
+   * 2. **Extension events** — namespaced ids advertised in
+   *    `ServerCapabilities.dataExtensions[].recordingScriptEvents[]`. We accept only those flagged
+   *    `supported = true` by the daemon. Advertising an event with `supported = false` is the
+   *    daemon's roadmap signal — agents see it via `list_data_products` so they know what's planned,
+   *    but the script wrapper rejects it up front rather than letting the agent watch a quiet
+   *    `unsupported` evidence trail come back. (The daemon-side fallback that emits `unsupported`
+   *    evidence stays in place as defense-in-depth for older MCP servers + direct daemon clients.)
+   */
   private fun validateRecordingScriptKinds(
     events: List<RecordingScriptEvent>,
     daemon: SupervisedDaemon,
   ): List<String> {
-    val extensionEventIds =
-      daemon.dataExtensionDescriptors.flatMap { it.recordingScriptEvents }.map { it.id }.toSet()
+    val supportedExtensionEventIds =
+      daemon.dataExtensionDescriptors
+        .flatMap { it.recordingScriptEvents }
+        .filter { it.supported }
+        .map { it.id }
+        .toSet()
+    val advertisedButUnsupported =
+      daemon.dataExtensionDescriptors
+        .flatMap { it.recordingScriptEvents }
+        .filterNot { it.supported }
+        .map { it.id }
+        .toSet()
     return events.mapIndexedNotNull { index, event ->
       when {
-        event.kind in RECORDING_INPUT_KINDS -> null
-        event.kind in extensionEventIds -> null
+        event.kind in INTERACTIVE_INPUT_KIND_WIRE_NAMES -> null
+        event.kind in supportedExtensionEventIds -> null
+        event.kind in advertisedButUnsupported ->
+          "event[$index] extension script event '${event.kind}' is advertised by this daemon but " +
+            "not yet implemented (supported=false); list_data_products to inspect the roadmap"
         else ->
-          "event[$index] extension script event '${event.kind}' is not advertised by this daemon"
+          "event[$index] kind '${event.kind}' is not a recognised input event " +
+            "(${INTERACTIVE_INPUT_KIND_WIRE_NAMES.sorted()}) and not advertised by this daemon as " +
+            "an extension event"
       }
     }
   }
@@ -3201,8 +3231,5 @@ class DaemonMcpServer(
      * valid arguments without code changes here.
      */
     private const val DEFAULT_OVERLAY_KIND: String = "a11y/overlay"
-
-    private val RECORDING_INPUT_KINDS =
-      setOf("click", "pointerDown", "pointerMove", "pointerUp", "rotaryScroll", "keyDown", "keyUp")
   }
 }

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -907,12 +907,12 @@ class DaemonMcpServerTest {
             listOf(
               ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence(
                 tMs = 250L,
-                kind = "state.save",
+                kind = "recording.probe",
                 status =
-                  ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.UNSUPPORTED,
+                  ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.APPLIED,
                 label = "before-rotate",
                 checkpointId = "checkpoint-1",
-                message = "state checkpoints are not implemented by this daemon",
+                message = "probe marker reached",
               )
             ),
         )
@@ -954,7 +954,7 @@ class DaemonMcpServerTest {
             add(
               buildJsonObject {
                 put("tMs", 250)
-                put("kind", "state.save")
+                put("kind", "recording.probe")
                 put("label", "before-rotate")
                 put("checkpointId", "checkpoint-1")
                 putJsonArray("tags") { add(JsonPrimitive("state-restoration")) }
@@ -988,7 +988,7 @@ class DaemonMcpServerTest {
     assertThat(scriptCall.events[0].pixelX).isEqualTo(120)
     assertThat(scriptCall.events[0].pixelY).isEqualTo(40)
     assertThat(scriptCall.events[1].tMs).isEqualTo(500L)
-    assertThat(scriptCall.events[2].kind).isEqualTo("state.save")
+    assertThat(scriptCall.events[2].kind).isEqualTo("recording.probe")
     assertThat(scriptCall.events[2].label).isEqualTo("before-rotate")
     assertThat(scriptCall.events[2].checkpointId).isEqualTo("checkpoint-1")
     assertThat(scriptCall.events[2].tags).containsExactly("state-restoration")
@@ -1052,9 +1052,9 @@ class DaemonMcpServerTest {
     val scriptEvents = metadata["scriptEvents"]!!.jsonArray
     assertThat(scriptEvents).hasSize(1)
     assertThat(scriptEvents[0].jsonObject["kind"]?.jsonPrimitive?.contentOrNull)
-      .isEqualTo("state.save")
+      .isEqualTo("recording.probe")
     assertThat(scriptEvents[0].jsonObject["status"]?.jsonPrimitive?.contentOrNull)
-      .isEqualTo("unsupported")
+      .isEqualTo("applied")
     assertThat(scriptEvents[0].jsonObject["checkpointId"]?.jsonPrimitive?.contentOrNull)
       .isEqualTo("checkpoint-1")
     assertThat(
@@ -1099,7 +1099,9 @@ class DaemonMcpServerTest {
         },
       )
     assertThat(resp.isError()).isTrue()
-    assertThat(resp.firstTextContent()).contains("invalid events")
+    val msg = resp.firstTextContent()
+    assertThat(msg).contains("kind 'scroll' is not a recognised input event")
+    assertThat(msg).contains("not advertised by this daemon")
     // No daemon-side recording session should have been allocated when validation fails.
     assertThat(daemon.recordingStarts).isEmpty()
   }
@@ -1134,6 +1136,52 @@ class DaemonMcpServerTest {
 
     assertThat(resp.isError()).isTrue()
     assertThat(resp.firstTextContent()).contains("not advertised by this daemon")
+    assertThat(daemon.recordingStarts).isEmpty()
+  }
+
+  @Test
+  fun `record_preview rejects extension events advertised but not yet implemented`() {
+    // The daemon advertises `state.save` in `dataExtensions[].recordingScriptEvents` with
+    // `supported = false` to signal a planned-but-unwired roadmap item. MCP rejects up front so the
+    // agent doesn't watch a quiet `unsupported` evidence trail come back from a recording that
+    // otherwise looks healthy. The daemon-side fallback (returning `unsupported` evidence) stays as
+    // defense-in-depth for direct daemon clients.
+    factory.daemonConfigurer = { d ->
+      d.advertisedDataExtensions =
+        ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions.descriptors
+    }
+    client.initialize()
+    val projectDir = tmp.newFolder("workspace")
+    tmp.newFolder("workspace", "module")
+    val workspaceId = registerWorkspace(projectDir, "demo")
+    val daemon = warmDaemonFor(workspaceId, ":module")
+    val previewId = "com.example.Red"
+    daemon.emitDiscovery(previewId)
+    client.expectNotification("notifications/resources/list_changed", 2_000)
+
+    val uri = PreviewUri(workspaceId, ":module", previewId).toUri()
+    val resp =
+      client.callTool(
+        "record_preview",
+        buildJsonObject {
+          put("uri", uri)
+          putJsonArray("events") {
+            add(
+              buildJsonObject {
+                put("tMs", 0)
+                put("kind", "state.save")
+                put("checkpointId", "before")
+              }
+            )
+          }
+        },
+      )
+
+    assertThat(resp.isError()).isTrue()
+    val msg = resp.firstTextContent()
+    assertThat(msg).contains("'state.save'")
+    assertThat(msg).contains("not yet implemented")
+    assertThat(msg).contains("supported=false")
     assertThat(daemon.recordingStarts).isEmpty()
   }
 

--- a/skills/compose-preview-review/design/AGENT_AUDITS.md
+++ b/skills/compose-preview-review/design/AGENT_AUDITS.md
@@ -516,7 +516,29 @@ payload evidence and the state/parameter path you found in code.
 
 ### State restoration and lifecycle audit
 
-Sample MCP call: `record_preview uri=<preview-uri> events='[{"tMs":0,"kind":"click","pixelX":120,"pixelY":40},{"tMs":200,"kind":"state.save","checkpointId":"before"},{"tMs":250,"kind":"lifecycle.event","lifecycleEvent":"resume"},{"tMs":300,"kind":"state.restore","checkpointId":"before"}]'`
+Sample MCP call:
+
+```json
+{
+  "tool": "record_preview",
+  "arguments": {
+    "uri": "compose-preview://workspace/_app/com.example.StatefulPreview",
+    "events": [
+      { "tMs": 0, "kind": "click", "pixelX": 120, "pixelY": 40 },
+      { "tMs": 0, "kind": "state.save", "checkpointId": "before" },
+      { "tMs": 200, "kind": "lifecycle.event", "lifecycleEvent": "resume" },
+      { "tMs": 200, "kind": "state.restore", "checkpointId": "before" },
+      { "tMs": 200, "kind": "recording.probe", "label": "after-restore" }
+    ]
+  }
+}
+```
+
+Events with the same `tMs` are one script step: lifecycle, saved-state, and
+probe markers at `tMs: 200` are expected to happen together before the frame for
+that tick is captured. Do not add fake delays between `resume` and
+`state.restore`; that would test timing luck instead of restored-state
+semantics.
 
 Check:
 
@@ -526,7 +548,7 @@ Check:
 - `unsupported` script events are reported as tool capability gaps, not app
   regressions.
 - Do not claim state restoration passed unless the evidence shows applied
-  save/restore lifecycle events and stable restored UI.
+  save/restore lifecycle events in the same script step and stable restored UI.
 
 ### Failure triage audit
 

--- a/skills/compose-preview-review/design/AGENT_AUDITS.md
+++ b/skills/compose-preview-review/design/AGENT_AUDITS.md
@@ -516,7 +516,28 @@ payload evidence and the state/parameter path you found in code.
 
 ### State restoration and lifecycle audit
 
-Sample MCP call:
+> **Capability gap.** As of 0.9.x the only `dataExtensions[].recordingScriptEvents`
+> entry the daemon dispatches is `recording.probe`. `state.save`, `state.restore`,
+> `lifecycle.event`, and `preview.reload` are advertised as `supported = false` —
+> they appear in `list_data_products` so agents can see what's planned, but
+> `record_preview` rejects them up front (see compose-ai-tools#714). Until that
+> lands, the audit below uses only `recording.probe` to mark the verification
+> tick; do not synthesise lifecycle/state markers in the script — they will be
+> rejected before any recording is started.
+
+First check the daemon's advertised extension events:
+
+```json
+{ "tool": "list_data_products", "arguments": { "workspaceId": "<workspace>" } }
+```
+
+Inspect `dataExtensions[].recordingScriptEvents[]`: only entries with
+`supported: true` may appear in a `record_preview` script. If the audit needs an
+event that's still `supported: false`, name the gap in the review and stop —
+this is a tooling roadmap item, not a PR-level finding.
+
+Then drive the click flow that should change state, with a probe tick to
+ground the verification:
 
 ```json
 {
@@ -525,30 +546,72 @@ Sample MCP call:
     "uri": "compose-preview://workspace/_app/com.example.StatefulPreview",
     "events": [
       { "tMs": 0, "kind": "click", "pixelX": 120, "pixelY": 40 },
-      { "tMs": 0, "kind": "state.save", "checkpointId": "before" },
-      { "tMs": 200, "kind": "lifecycle.event", "lifecycleEvent": "resume" },
-      { "tMs": 200, "kind": "state.restore", "checkpointId": "before" },
-      { "tMs": 200, "kind": "recording.probe", "label": "after-restore" }
+      { "tMs": 200, "kind": "recording.probe", "label": "after-click" }
     ]
   }
 }
 ```
 
-Events with the same `tMs` are one script step: lifecycle, saved-state, and
-probe markers at `tMs: 200` are expected to happen together before the frame for
-that tick is captured. Do not add fake delays between `resume` and
-`state.restore`; that would test timing luck instead of restored-state
-semantics.
+Events with the same `tMs` are one script step: any control markers at the
+probe's tick are applied before the frame for that tick is captured. Do not
+add fake delays around the probe; that would test timing luck instead of
+restored-state semantics.
 
 Check:
 
-- The recording metadata includes `scriptEvents` for every state/lifecycle
-  marker.
-- Input events that should change state produce changed frames.
-- `unsupported` script events are reported as tool capability gaps, not app
-  regressions.
-- Do not claim state restoration passed unless the evidence shows applied
-  save/restore lifecycle events in the same script step and stable restored UI.
+- `list_data_products` advertises `recording.probe` with `supported: true` —
+  otherwise the daemon doesn't ship probe markers and this audit can't be run.
+- The recording metadata includes `scriptEvents` for the probe with
+  `status: "applied"`.
+- Input events that should change state produce changed frames
+  (`changedFromPrevious: true` on the post-click frame).
+- Once `state.save` / `state.restore` / `lifecycle.event` ship as
+  `supported: true`, extend this audit to assert `applied` status on the
+  matching markers in the same `tMs` group.
+
+### Accessibility-driven interaction audit (planned)
+
+> **Capability gap.** Roadmap. The a11y connector module advertises an `a11y` data extension
+> with `recordingScriptEvents` for each `AccessibilityNodeInfo` action — `a11y.action.click`,
+> `a11y.action.longClick`, `a11y.action.scrollForward`, `a11y.action.focus`,
+> `a11y.action.accessibilityFocus`, etc. Today they all carry `supported = false` and
+> `record_preview` rejects them up front (compose-ai-tools#714 follow-up). This stub describes
+> the audit pattern so the next pass drops in the dispatch and updates the example.
+
+Use this when a PR changes a screen reader–facing flow: clickable nodes, `Modifier.semantics`
+handlers, scrollable containers consumed by a screen reader, or anything that should be reachable
+without a pointer event. The intent is to drive the preview the way assistive technology does
+rather than by pixel coordinates.
+
+Planned MCP shape (subject to revision when dispatch lands):
+
+```json
+{
+  "tool": "record_preview",
+  "arguments": {
+    "uri": "compose-preview://workspace/_app/com.example.SettingsRowPreview",
+    "events": [
+      { "tMs": 0,   "kind": "a11y.action.accessibilityFocus", "params": { "nodeId": "row-mute" } },
+      { "tMs": 100, "kind": "a11y.action.click", "params": { "nodeId": "row-mute" } },
+      { "tMs": 250, "kind": "recording.probe", "label": "after-a11y-click" }
+    ]
+  }
+}
+```
+
+`params.nodeId` references a node from the preview's most recent `a11y/hierarchy` payload —
+fetch via `get_preview_data uri=<…> kind=a11y/hierarchy` and pick the node by content
+description, role, or semantics tag. Content-description / semantics-tag matching parameters
+will land alongside the dispatch.
+
+Check (once dispatch lands):
+
+- `list_data_products` advertises the relevant `a11y.action.*` ids with `supported: true`.
+- `recording.probe` evidence at the verification tick reports `applied`.
+- `a11y/hierarchy` after the click reflects the expected state mutation (selected, expanded,
+  focused).
+- The screen-reader-driven sequence produces the same UI changes a pointer-driven sequence
+  would, modulo intentional differences (e.g. focus-only flows that bypass the click).
 
 ### Failure triage audit
 

--- a/skills/compose-preview-review/scripts/run-agent-audit-samples.py
+++ b/skills/compose-preview-review/scripts/run-agent-audit-samples.py
@@ -514,6 +514,12 @@ def test_mcp_data_products() -> None:
             "resources/used did not record the warning color resource",
         )
 
+        # State-restoration audit: today only `recording.probe` is wired as a script event
+        # (the other extension events are advertised with `supported = false` and rejected by
+        # record_preview up front — see compose-ai-tools#714). Drive the click that should
+        # change state and a same-tick probe to ground the verification; once state/lifecycle
+        # extensions ship as `supported = true`, extend the script with the matching markers in
+        # the same `tMs` group.
         recording = client.call_tool(
             "record_preview",
             {
@@ -528,24 +534,9 @@ def test_mcp_data_products() -> None:
                         "pixelY": 24,
                     },
                     {
-                        "tMs": 0,
-                        "kind": "state.save",
-                        "checkpointId": "before-resume",
-                    },
-                    {
-                        "tMs": 250,
-                        "kind": "lifecycle.event",
-                        "lifecycleEvent": "resume",
-                    },
-                    {
-                        "tMs": 250,
-                        "kind": "state.restore",
-                        "checkpointId": "before-resume",
-                    },
-                    {
                         "tMs": 250,
                         "kind": "recording.probe",
-                        "label": "after-restore-same-tick",
+                        "label": "after-click-same-tick",
                     },
                 ],
             },
@@ -557,34 +548,13 @@ def test_mcp_data_products() -> None:
         recording_meta = recording_payloads[-1]
         OUT.joinpath("same-tick-recording.json").write_text(json.dumps(recording_meta, indent=2))
         script_events = recording_meta["scriptEvents"]
-        same_tick = [
-            event
-            for event in script_events
-            if event.get("tMs") == 250
-            and event.get("kind") in {"lifecycle.event", "state.restore", "recording.probe"}
-        ]
-        if [event.get("kind") for event in same_tick] != [
-            "lifecycle.event",
-            "state.restore",
-            "recording.probe",
-        ]:
-            raise AssertionError(
-                "record_preview did not preserve the expected same-tick lifecycle/restore/probe "
-                f"group: {script_events}"
-            )
         assert_any(
-            same_tick,
-            lambda item: item.get("kind") == "recording.probe"
-            and item.get("label") == "after-restore-same-tick"
+            script_events,
+            lambda item: item.get("tMs") == 250
+            and item.get("kind") == "recording.probe"
+            and item.get("label") == "after-click-same-tick"
             and item.get("status") == "applied",
-            "recording.probe at the restore tick was not applied",
-        )
-        assert_any(
-            same_tick,
-            lambda item: item.get("kind") == "state.restore"
-            and item.get("checkpointId") == "before-resume"
-            and item.get("status") in {"applied", "unsupported"},
-            "state.restore at the resume tick did not produce script evidence",
+            "recording.probe at the verification tick was not applied",
         )
     finally:
         client.shutdown()

--- a/skills/compose-preview-review/scripts/run-agent-audit-samples.py
+++ b/skills/compose-preview-review/scripts/run-agent-audit-samples.py
@@ -322,6 +322,13 @@ class McpClient:
     def first_text(self, tool_result: dict[str, Any]) -> dict[str, Any]:
         return json.loads(tool_result["content"][0]["text"])
 
+    def text_blocks(self, tool_result: dict[str, Any]) -> list[dict[str, Any]]:
+        return [
+            json.loads(block["text"])
+            for block in tool_result["content"]
+            if block.get("type") == "text" and "text" in block
+        ]
+
     def shutdown(self) -> None:
         try:
             if self.proc.stdin:
@@ -363,7 +370,16 @@ def setup_mcp() -> tuple[McpClient, str]:
     )
     client.notify("notifications/initialized")
     workspace_id = workspace_id_from_register(client)
-    client.call_tool("watch", {"workspaceId": workspace_id, "module": ":samples:android"})
+    client.call_tool(
+        "watch",
+        {
+            "workspaceId": workspace_id,
+            "module": ":samples:android",
+            "awaitDiscovery": True,
+            "awaitTimeoutMs": 240_000,
+        },
+        timeout=300,
+    )
     return client, workspace_id
 
 
@@ -496,6 +512,79 @@ def test_mcp_data_products() -> None:
             and item.get("resourceName") == "agent_audit_warning_red"
             and item.get("resolvedValue", "").upper() == "#FFB00020",
             "resources/used did not record the warning color resource",
+        )
+
+        recording = client.call_tool(
+            "record_preview",
+            {
+                "uri": done_uri,
+                "fps": 4,
+                "format": "apng",
+                "events": [
+                    {
+                        "tMs": 0,
+                        "kind": "click",
+                        "pixelX": 48,
+                        "pixelY": 24,
+                    },
+                    {
+                        "tMs": 0,
+                        "kind": "state.save",
+                        "checkpointId": "before-resume",
+                    },
+                    {
+                        "tMs": 250,
+                        "kind": "lifecycle.event",
+                        "lifecycleEvent": "resume",
+                    },
+                    {
+                        "tMs": 250,
+                        "kind": "state.restore",
+                        "checkpointId": "before-resume",
+                    },
+                    {
+                        "tMs": 250,
+                        "kind": "recording.probe",
+                        "label": "after-restore-same-tick",
+                    },
+                ],
+            },
+            timeout=600,
+        )
+        recording_payloads = client.text_blocks(recording)
+        if not recording_payloads:
+            raise AssertionError(f"record_preview returned no metadata text block: {recording}")
+        recording_meta = recording_payloads[-1]
+        OUT.joinpath("same-tick-recording.json").write_text(json.dumps(recording_meta, indent=2))
+        script_events = recording_meta["scriptEvents"]
+        same_tick = [
+            event
+            for event in script_events
+            if event.get("tMs") == 250
+            and event.get("kind") in {"lifecycle.event", "state.restore", "recording.probe"}
+        ]
+        if [event.get("kind") for event in same_tick] != [
+            "lifecycle.event",
+            "state.restore",
+            "recording.probe",
+        ]:
+            raise AssertionError(
+                "record_preview did not preserve the expected same-tick lifecycle/restore/probe "
+                f"group: {script_events}"
+            )
+        assert_any(
+            same_tick,
+            lambda item: item.get("kind") == "recording.probe"
+            and item.get("label") == "after-restore-same-tick"
+            and item.get("status") == "applied",
+            "recording.probe at the restore tick was not applied",
+        )
+        assert_any(
+            same_tick,
+            lambda item: item.get("kind") == "state.restore"
+            and item.get("checkpointId") == "before-resume"
+            and item.get("status") in {"applied", "unsupported"},
+            "state.restore at the resume tick did not produce script evidence",
         )
     finally:
         client.shutdown()

--- a/skills/compose-preview/design/CAPTURE_MODES.md
+++ b/skills/compose-preview/design/CAPTURE_MODES.md
@@ -135,31 +135,32 @@ enough to define the recording duration:
 }
 ```
 
-Scripts can also include audit/control markers:
+Scripts can also include audit/control markers. Today only `recording.probe`
+is dispatched; `state.save`, `state.restore`, `lifecycle.event`, and
+`preview.reload` are advertised on the daemon's `dataExtensions` as
+`supported = false` roadmap entries, and `record_preview` rejects them up
+front (compose-ai-tools#714).
 
 ```json
 {
   "uri": "compose-preview://<workspace>/<module>/<preview>",
   "events": [
     { "tMs": 0, "kind": "click", "pixelX": 120, "pixelY": 40 },
-    { "tMs": 0, "kind": "state.save", "checkpointId": "before" },
-    { "tMs": 200, "kind": "lifecycle.event", "lifecycleEvent": "resume" },
-    { "tMs": 200, "kind": "state.restore", "checkpointId": "before" },
-    { "tMs": 200, "kind": "recording.probe", "label": "after-restore" }
+    { "tMs": 200, "kind": "recording.probe", "label": "after-click" }
   ]
 }
 ```
 
-Events with the same `tMs` form a single script step. Control/state events in
-that step are applied before the frame for that timestamp is captured, so a
-preview should observe restored state immediately on the `tMs: 200` frame above
-rather than after an artificial delay.
+Events with the same `tMs` form a single script step. Control events in that
+step are applied before the frame for that timestamp is captured, so colocate
+a verification `recording.probe` with the input that should change state.
 
 Always inspect `scriptEvents` in the metadata. Input and `recording.probe`
-events may be `applied`; state/lifecycle markers can be `unsupported` on
-daemons that do not yet drive real saved-state or activity lifecycle
-transitions. Non-input script event ids are namespaced and must be advertised
-under `capabilities.dataExtensions[].recordingScriptEvents[]`.
+events may be `applied` or `unsupported` (the daemon's defense-in-depth path
+for events MCP didn't reject — older MCP servers or direct daemon clients).
+Non-input script event ids are namespaced and must be advertised under
+`capabilities.dataExtensions[].recordingScriptEvents[]` with
+`supported = true`.
 
 The response includes `recordingId`, `mimeType`, `sizeBytes`, `frameCount`,
 `durationMs`, `frameWidthPx`, `frameHeightPx`, `frames[]`, and `scriptEvents[]`.

--- a/skills/compose-preview/design/CAPTURE_MODES.md
+++ b/skills/compose-preview/design/CAPTURE_MODES.md
@@ -142,12 +142,18 @@ Scripts can also include audit/control markers:
   "uri": "compose-preview://<workspace>/<module>/<preview>",
   "events": [
     { "tMs": 0, "kind": "click", "pixelX": 120, "pixelY": 40 },
-    { "tMs": 200, "kind": "state.save", "checkpointId": "before" },
-    { "tMs": 250, "kind": "lifecycle.event", "lifecycleEvent": "resume" },
-    { "tMs": 300, "kind": "state.restore", "checkpointId": "before" }
+    { "tMs": 0, "kind": "state.save", "checkpointId": "before" },
+    { "tMs": 200, "kind": "lifecycle.event", "lifecycleEvent": "resume" },
+    { "tMs": 200, "kind": "state.restore", "checkpointId": "before" },
+    { "tMs": 200, "kind": "recording.probe", "label": "after-restore" }
   ]
 }
 ```
+
+Events with the same `tMs` form a single script step. Control/state events in
+that step are applied before the frame for that timestamp is captured, so a
+preview should observe restored state immediately on the `tMs: 200` frame above
+rather than after an artificial delay.
 
 Always inspect `scriptEvents` in the metadata. Input and `recording.probe`
 events may be `applied`; state/lifecycle markers can be `unsupported` on


### PR DESCRIPTION
## Summary

`record_preview` previously used a hand-rolled `RECORDING_INPUT_KINDS` set duplicated against `InteractiveInputKind`, and its validator accepted any extension-event id the daemon advertised — including ones flagged `supported = false`. Agents could submit `state.save` / `lifecycle.event` scripts and watch a quiet `unsupported` evidence trail come back from a recording that otherwise looked healthy. This tightens the contract end-to-end and lays groundwork for a future registry-based redesign.

- **Single source of truth for input wire names.** New `INTERACTIVE_INPUT_KIND_BY_WIRE_NAME` map (and derived `INTERACTIVE_INPUT_KIND_WIRE_NAMES` set) in `:daemon:core` so the enum and the MCP validator can't drift; `RECORDING_INPUT_KINDS` deleted from `DaemonMcpServer`.
- **Honest extension validation.** `validateRecordingScriptKinds` accepts only extension events flagged `supported = true`. Unsupported-but-advertised ids return `"advertised by this daemon but not yet implemented (supported=false); list_data_products to inspect the roadmap"`. Truly unknown ids get the recognised-input list in the error so typos like `"scroll"` are obvious. The daemon-side `unsupported` evidence path stays as defense in depth for older MCP servers and direct daemon clients.
- **A11y action descriptors (roadmap).** New `AccessibilityRecordingScriptEvents` advertises 19 `AccessibilityNodeInfo` actions (`a11y.action.click`, `a11y.action.scrollForward`, `a11y.action.accessibilityFocus`, …) under a namespaced `a11y` data extension, all `supported = false` for now. Wired into `:daemon:android`'s `dataExtensions` only when a11y is enabled, so desktop daemons don't see Android-only actions in their capability set.
- **Docs aligned with reality.** `AGENT_AUDITS.md` state-restoration example now uses only `recording.probe` (the only `supported = true` extension event today) plus a new "Accessibility-driven interaction audit (planned)" section describing the a11y-action roadmap. `docs/daemon/MCP.md` and `skills/compose-preview/design/CAPTURE_MODES.md` updated to match. `run-agent-audit-samples.py` reworked to assert on the supported flow end-to-end.

This is the cleanup pass that makes the existing surface coherent. The bigger registry refactor (each event kind — including built-in inputs — becomes a contributed extension with its own dispatch handler) is the natural follow-up but not in this PR.

## Test plan

- [ ] `./gradlew ktfmtCheckAll` (couldn't run locally — sandbox network blocked JDK 17 install; CI's format job is the source of truth)
- [ ] `./gradlew :daemon:core:check :mcp:check :data-a11y-connector:check`
- [ ] `./gradlew :daemon:android:check`
- [ ] CI: `format`, `test` jobs green
- [ ] Manual: `record_preview` with `kind: "state.save"` against an a11y-enabled Android daemon returns the new "supported=false; list_data_products to inspect the roadmap" diagnostic without spawning a recording session
- [ ] Manual: `list_data_products` shows the new `a11y.action.*` ids alongside `recording.probe`, all with `supported: false` (a11y) or `true` (probe)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8qJtJESJvS4yoTB9PKtRF)_