### PR TITLE
feat(a11y): OverlayExtension as 3-input PostCaptureProcessor

### DIFF
--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/OverlayExtension.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/OverlayExtension.kt
@@ -1,0 +1,69 @@
+package ee.schimke.composeai.renderer
+
+import ee.schimke.composeai.data.render.extensions.CommonDataProducts
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.DataProductKey
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
+import java.io.File
+
+/**
+ * Renders the Paparazzi-style annotated PNG overlay from a hierarchy + ATF findings + the captured
+ * image. Android-only today (the [AccessibilityOverlay] generator uses Android `Bitmap`/`Canvas`);
+ * a Desktop variant would target [DataExtensionTarget.Desktop] without conflicting because the
+ * planner's target filter selects exactly one provider per platform.
+ *
+ * Inputs: hierarchy, ATF findings, captured image. Output: [AccessibilityOverlayArtifact] pointing
+ * at the written PNG. The output directory and round-clip flag are passed via `attributes` (see
+ * [OUTPUT_DIRECTORY_ATTRIBUTE], [IS_ROUND_ATTRIBUTE]) — those are render-host-controlled paths
+ * rather than typed products so the extension itself stays a pure consumer of the typed graph.
+ */
+class OverlayExtension : PostCaptureProcessor {
+  override val id: DataExtensionId = DataExtensionId(EXTENSION_ID)
+  override val hooks: Set<DataExtensionHookKind> = setOf(DataExtensionHookKind.AfterRender)
+  override val constraints: DataExtensionConstraints =
+    DataExtensionConstraints(phase = DataExtensionPhase.Publish)
+  override val inputs: Set<DataProductKey<*>> =
+    setOf(
+      AccessibilityDataProducts.Hierarchy,
+      AccessibilityDataProducts.Atf,
+      CommonDataProducts.ImageArtifact,
+    )
+  override val outputs: Set<DataProductKey<*>> = setOf(AccessibilityDataProducts.Overlay)
+  override val targets: Set<DataExtensionTarget> = setOf(DataExtensionTarget.Android)
+
+  override fun process(context: ExtensionPostCaptureContext) {
+    val hierarchy = context.products.require(AccessibilityDataProducts.Hierarchy)
+    val findings = context.products.require(AccessibilityDataProducts.Atf)
+    val image = context.products.require(CommonDataProducts.ImageArtifact)
+    val outputDir =
+      context.attributes[OUTPUT_DIRECTORY_ATTRIBUTE] as? File
+        ?: error("OverlayExtension requires '$OUTPUT_DIRECTORY_ATTRIBUTE' in attributes.")
+    val isRound = context.attributes[IS_ROUND_ATTRIBUTE] as? Boolean ?: false
+    val sourcePng = File(image.path)
+    val destPng = outputDir.resolve(OVERLAY_FILE_NAME)
+    val written =
+      AccessibilityOverlay.generate(
+        sourcePng = sourcePng,
+        findings = findings.findings,
+        nodes = hierarchy.nodes,
+        destPng = destPng,
+        isRound = isRound,
+      ) ?: return
+    context.products.put(
+      AccessibilityDataProducts.Overlay,
+      AccessibilityOverlayArtifact(path = written.absolutePath),
+    )
+  }
+
+  companion object {
+    const val EXTENSION_ID: String = "a11y-overlay"
+    const val OUTPUT_DIRECTORY_ATTRIBUTE: String = "a11y-overlay.outputDirectory"
+    const val IS_ROUND_ATTRIBUTE: String = "a11y-overlay.isRound"
+    const val OVERLAY_FILE_NAME: String = "a11y-overlay.png"
+  }
+}

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/OverlayExtensionTest.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/OverlayExtensionTest.kt
@@ -1,0 +1,105 @@
+package ee.schimke.composeai.renderer
+
+import ee.schimke.composeai.data.render.extensions.CommonDataProducts
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPlanner
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import ee.schimke.composeai.data.render.extensions.RenderImageArtifact
+import ee.schimke.composeai.data.render.extensions.SimplePlannedDataExtension
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OverlayExtensionTest {
+  private val extension = OverlayExtension()
+
+  @Test
+  fun declaresExpectedInputsOutputsAndTarget() {
+    assertEquals(
+      setOf(
+        AccessibilityDataProducts.Hierarchy,
+        AccessibilityDataProducts.Atf,
+        CommonDataProducts.ImageArtifact,
+      ),
+      extension.inputs,
+    )
+    assertEquals(setOf(AccessibilityDataProducts.Overlay), extension.outputs)
+    assertEquals(setOf(DataExtensionTarget.Android), extension.targets)
+  }
+
+  @Test
+  fun failsLoudlyWhenOutputDirectoryAttributeMissing() {
+    val store = RecordingDataProductStore()
+    store.put(AccessibilityDataProducts.Hierarchy, AccessibilityHierarchyPayload(emptyList()))
+    store.put(AccessibilityDataProducts.Atf, AccessibilityFindingsPayload(emptyList()))
+    store.put(CommonDataProducts.ImageArtifact, RenderImageArtifact("/tmp/preview.png"))
+
+    val ex =
+      assertThrows(IllegalStateException::class.java) {
+        extension.process(
+          ExtensionPostCaptureContext(
+            extensionId = extension.id,
+            previewId = "preview",
+            renderMode = null,
+            products = store.scopedFor(extension),
+          )
+        )
+      }
+    assertTrue(
+      ex.message!!,
+      ex.message!!.contains(OverlayExtension.OUTPUT_DIRECTORY_ATTRIBUTE),
+    )
+  }
+
+  @Test
+  fun plannerOrdersOverlayAfterHierarchyAndAtfProducers() {
+    val hierarchyAtfProducer =
+      SimplePlannedDataExtension(
+        id = DataExtensionId("a11y"),
+        outputs = setOf(AccessibilityDataProducts.Hierarchy, AccessibilityDataProducts.Atf),
+      )
+
+    val result =
+      DataExtensionPlanner.planOutputs(
+        extensions = listOf(extension, hierarchyAtfProducer),
+        requestedOutputs = setOf(AccessibilityDataProducts.Overlay),
+        initialProducts = setOf(CommonDataProducts.ImageArtifact),
+        target = DataExtensionTarget.Android,
+      )
+
+    assertTrue(result.errors.toString(), result.isValid)
+    assertEquals(
+      listOf("a11y", OverlayExtension.EXTENSION_ID),
+      result.orderedExtensions.map { it.id.value },
+    )
+  }
+
+  @Test
+  fun plannerSchedulesOverlayAndTouchTargetsTogetherAfterHierarchy() {
+    val hierarchyAtfProducer =
+      SimplePlannedDataExtension(
+        id = DataExtensionId("a11y"),
+        outputs = setOf(AccessibilityDataProducts.Hierarchy, AccessibilityDataProducts.Atf),
+      )
+
+    val result =
+      DataExtensionPlanner.planOutputs(
+        extensions = listOf(extension, TouchTargetsExtension(), hierarchyAtfProducer),
+        requestedOutputs =
+          setOf(AccessibilityDataProducts.Overlay, AccessibilityDataProducts.TouchTargets),
+        initialProducts = setOf(CommonDataProducts.ImageArtifact, CommonDataProducts.Density),
+        target = DataExtensionTarget.Android,
+      )
+
+    assertTrue(result.errors.toString(), result.isValid)
+    val ordered = result.orderedExtensions.map { it.id.value }
+    assertEquals("a11y", ordered.first())
+    assertTrue(
+      "expected both consumers after the hierarchy producer, got $ordered",
+      ordered.containsAll(listOf(OverlayExtension.EXTENSION_ID, TouchTargetsExtension.EXTENSION_ID)),
+    )
+  }
+}


### PR DESCRIPTION
## Summary

`OverlayExtension : PostCaptureProcessor` — second concrete consumer of the typed graph and the first 3-input extension. Wraps the existing `AccessibilityOverlay.generate(...)` to render the Paparazzi-style annotated PNG.

- Inputs: `AccessibilityHierarchyPayload`, `AccessibilityFindingsPayload`, `RenderImageArtifact`.
- Output: `AccessibilityOverlayArtifact`.
- `targets = setOf(Android)` — the planner's target filter lets a future Desktop variant share the same `Overlay` output key without conflicting.

The output directory and round-clip flag come in via `attributes` (`a11y-overlay.outputDirectory`, `a11y-overlay.isRound`). Those are render-host paths rather than extension-emitted products, so the extension stays a pure consumer of the typed product graph. Folding them into typed `RenderDataDirectory` / `RenderDeviceShape` products is a separate cleanup worth doing once we have more extensions that need the same data.

End-to-end overlay rendering is already covered by `AccessibilityOverlayMergedTest` against `AccessibilityOverlay` directly; the extension is a thin wrapper, so the new tests focus on the contract (declared shape, fail-loud on missing attributes, planner ordering).

## Test plan

- [x] `./gradlew :data-a11y-core:check` — green
- [x] `./gradlew ktfmtCheckAll` — clean
- [x] New tests: `declaresExpectedInputsOutputsAndTarget`, `failsLoudlyWhenOutputDirectoryAttributeMissing`, `plannerOrdersOverlayAfterHierarchyAndAtfProducers`, `plannerSchedulesOverlayAndTouchTargetsTogetherAfterHierarchy`

## Follow-ups

- Wire `RenderEngine.render` to seed the store with `Hierarchy + Atf` from `AccessibilityChecker.analyze`, plan post-capture extensions, run them, then publish from the store. Bigger refactor; deserves its own session.
- Promote `outputDirectory` / `isRound` from `attributes` to typed `RenderDataDirectory` / `RenderDeviceShape` products.
- Generic `DataProductTransport` registry so connector publish serializes by `DataProductKey<*>`.