### PR TITLE
refactor(daemon): unify recording-script dispatch through a per-session registry

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -5,7 +5,6 @@ import ee.schimke.composeai.daemon.protocol.InteractiveInputParams
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingInputParams
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
-import ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence
 import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
 import java.awt.RenderingHints
@@ -165,28 +164,8 @@ class AndroidRecordingSession(
       // doesn't matter on the host side (the underlying session has its own streamId).
       while (nextEventIdx < sortedEvents.size && sortedEvents[nextEventIdx].tMs <= tMs) {
         val e = sortedEvents[nextEventIdx]
-        val inputKind = e.kind.toInteractiveInputKindOrNull()
-        if (e.kind == RecordingScriptDataExtensions.PROBE_EVENT) {
-          evidence.add(e.appliedEvidence("probe marker reached"))
-        } else if (inputKind == null) {
-          evidence.add(e.unsupportedEvidence("script event kind '${e.kind}' is not implemented"))
-        } else if (
-          inputKind == InteractiveInputKind.KEY_DOWN || inputKind == InteractiveInputKind.KEY_UP
-        ) {
-          evidence.add(e.unsupportedEvidence("key dispatch is not implemented for Android recording"))
-        } else {
-          interactive.dispatch(
-            InteractiveInputParams(
-              frameStreamId = "android-recording-internal",
-              kind = inputKind,
-              pixelX = e.pixelX,
-              pixelY = e.pixelY,
-              scrollDeltaY = e.scrollDeltaY,
-              keyCode = e.keyCode,
-            )
-          )
-          evidence.add(e.appliedEvidence())
-        }
+        val ctx = SimpleRecordingDispatchContext(tNanos = tMs * 1_000_000L, tMs = tMs)
+        evidence.add(scriptHandlers.dispatch(e, ctx))
         nextEventIdx++
       }
 
@@ -252,29 +231,58 @@ class AndroidRecordingSession(
     )
   }
 
-  private fun RecordingScriptEvent.appliedEvidence(message: String? = null): RecordingScriptEvidence =
-    RecordingScriptEvidence(
-      tMs = tMs,
-      kind = kind,
-      status = RecordingScriptEventStatus.APPLIED,
-      label = label,
-      checkpointId = checkpointId,
-      lifecycleEvent = lifecycleEvent,
-      tags = tags,
-      message = message,
+  /**
+   * Per-session script-event handler registry. Built once so each handler closes over [interactive];
+   * [stopScripted]'s loop just calls `scriptHandlers.dispatch(...)` and never branches on event
+   * kind directly.
+   *
+   * Built-in input kinds (`click`, `pointerDown`, `pointerMove`, `pointerUp`, `rotaryScroll`) all
+   * route through the held-rule loop's [InteractiveSession.dispatch] — same path the live tick loop
+   * uses. `keyDown` / `keyUp` register as unsupported (Robolectric key dispatch is a follow-up).
+   * The probe extension handler appears once, here, instead of as a dispatch-loop special case.
+   */
+  private val scriptHandlers: RecordingScriptHandlerRegistry = buildScriptHandlers()
+
+  private fun buildScriptHandlers(): RecordingScriptHandlerRegistry =
+    RecordingScriptHandlerRegistry(
+      buildMap {
+        put("click", interactiveDispatchHandler(InteractiveInputKind.CLICK))
+        put("pointerDown", interactiveDispatchHandler(InteractiveInputKind.POINTER_DOWN))
+        put("pointerMove", interactiveDispatchHandler(InteractiveInputKind.POINTER_MOVE))
+        put("pointerUp", interactiveDispatchHandler(InteractiveInputKind.POINTER_UP))
+        put("rotaryScroll", interactiveDispatchHandler(InteractiveInputKind.ROTARY_SCROLL))
+        put("keyDown", androidUnsupported("keyDown"))
+        put("keyUp", androidUnsupported("keyUp"))
+        put(RecordingScriptDataExtensions.PROBE_EVENT, RecordingScriptEventHandler { e, _ ->
+          appliedEvidence(e, "probe marker reached")
+        })
+      }
     )
 
-  private fun RecordingScriptEvent.unsupportedEvidence(message: String): RecordingScriptEvidence =
-    RecordingScriptEvidence(
-      tMs = tMs,
-      kind = kind,
-      status = RecordingScriptEventStatus.UNSUPPORTED,
-      label = label,
-      checkpointId = checkpointId,
-      lifecycleEvent = lifecycleEvent,
-      tags = tags,
-      message = message,
-    )
+  /**
+   * Forward an input event through the held-rule loop. Mirrors the live tick path's
+   * [dispatchLiveInput]; the wire-string kind translates to the typed [InteractiveInputKind]
+   * once at registration time so the handler body doesn't repeat the lookup.
+   */
+  private fun interactiveDispatchHandler(kind: InteractiveInputKind): RecordingScriptEventHandler =
+    RecordingScriptEventHandler { event, _ ->
+      interactive.dispatch(
+        InteractiveInputParams(
+          frameStreamId = "android-recording-internal",
+          kind = kind,
+          pixelX = event.pixelX,
+          pixelY = event.pixelY,
+          scrollDeltaY = event.scrollDeltaY,
+          keyCode = event.keyCode,
+        )
+      )
+      appliedEvidence(event)
+    }
+
+  private fun androidUnsupported(label: String): RecordingScriptEventHandler =
+    RecordingScriptEventHandler { event, _ ->
+      unsupportedEvidence(event, "$label dispatch is not implemented for Android recording")
+    }
 
   private fun runLiveTickLoop() {
     val startNs = System.nanoTime()

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistry.kt
@@ -1,0 +1,106 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence
+
+/**
+ * Per-event dispatch context passed to each [RecordingScriptEventHandler] invocation.
+ *
+ * Carries the virtual-clock stamps the handler needs when driving the held scene/rule.
+ * `tNanos` and `tMs` are the **frame's** virtual time, not the event's `tMs` — events whose
+ * `event.tMs <= frame.tMs` are dispatched against the upcoming frame, so handlers should send
+ * pointer events at the frame's nanoTime so `scene.render(nanoTime)` and `sendPointerEvent` agree.
+ *
+ * Live tick-loop callers reuse the same shape with the wall-clock-anchored virtual nanoTime.
+ */
+interface RecordingDispatchContext {
+  /** Virtual nanoTime of the frame this event is dispatched at. */
+  val tNanos: Long
+
+  /** Virtual milliseconds (`tNanos / 1_000_000`). */
+  val tMs: Long
+}
+
+/** Default value-class implementation — backends can pass an instance per event. */
+data class SimpleRecordingDispatchContext(override val tNanos: Long, override val tMs: Long) :
+  RecordingDispatchContext
+
+/**
+ * Single-event dispatch interface. One implementation per `(host, event-kind)` pair. The session
+ * owns a [RecordingScriptHandlerRegistry] mapping kind → handler and looks up by `event.kind`.
+ *
+ * Implementations close over host-specific scene/rule state (Skiko `ImageComposeScene` on desktop,
+ * `AndroidInteractiveSession` on Android). They MUST return well-formed [RecordingScriptEvidence]
+ * — never throw — so a malformed event aborts at most a single dispatch slot, not the whole
+ * recording. Use [appliedEvidence] / [unsupportedEvidence] to build the result.
+ */
+fun interface RecordingScriptEventHandler {
+  fun apply(event: RecordingScriptEvent, ctx: RecordingDispatchContext): RecordingScriptEvidence
+}
+
+/**
+ * Map from event-kind wire string to its [RecordingScriptEventHandler]. Built by each
+ * [RenderHost.acquireRecordingSession] call so handlers can close over the per-session held
+ * scene/rule. The registry shape itself is renderer-agnostic — desktop and Android both build one,
+ * registering whichever input + extension kinds the host actually dispatches.
+ *
+ * Lookup is by `event.kind` (the wire string the agent sent). Kinds with no registered handler
+ * yield [unsupportedEvidence] — defense in depth for events the MCP layer didn't filter (older MCP
+ * servers, direct daemon clients).
+ */
+class RecordingScriptHandlerRegistry(
+  private val handlers: Map<String, RecordingScriptEventHandler>
+) {
+
+  fun dispatch(
+    event: RecordingScriptEvent,
+    ctx: RecordingDispatchContext,
+  ): RecordingScriptEvidence {
+    val handler = handlers[event.kind]
+    return if (handler == null) {
+      unsupportedEvidence(event, "no recording-script handler registered for kind '${event.kind}'")
+    } else {
+      handler.apply(event, ctx)
+    }
+  }
+
+  /** Wire-string keys this registry knows about. Useful for tests + capability derivation. */
+  fun knownKinds(): Set<String> = handlers.keys
+}
+
+/**
+ * Build an [RecordingScriptEvidence] for an applied event. Optional [message] is forwarded as the
+ * `message` field for human-readable trace context.
+ */
+fun appliedEvidence(
+  event: RecordingScriptEvent,
+  message: String? = null,
+): RecordingScriptEvidence =
+  RecordingScriptEvidence(
+    tMs = event.tMs,
+    kind = event.kind,
+    status = RecordingScriptEventStatus.APPLIED,
+    label = event.label,
+    checkpointId = event.checkpointId,
+    lifecycleEvent = event.lifecycleEvent,
+    tags = event.tags,
+    message = message,
+  )
+
+/**
+ * Build an [RecordingScriptEvidence] for an unsupported event. The [message] is required so the
+ * agent always has a concrete reason for the unsupported status (which kind, on which backend, why
+ * — e.g. "key dispatch is not implemented for desktop recording").
+ */
+fun unsupportedEvidence(event: RecordingScriptEvent, message: String): RecordingScriptEvidence =
+  RecordingScriptEvidence(
+    tMs = event.tMs,
+    kind = event.kind,
+    status = RecordingScriptEventStatus.UNSUPPORTED,
+    label = event.label,
+    checkpointId = event.checkpointId,
+    lifecycleEvent = event.lifecycleEvent,
+    tags = event.tags,
+    message = message,
+  )

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistryTest.kt
@@ -1,0 +1,128 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
+import ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [RecordingScriptHandlerRegistry] — the renderer-agnostic dispatch hub the desktop
+ * and Android recording sessions both build from. Pins:
+ *
+ * - Registered handlers receive the event verbatim and their evidence is returned unchanged.
+ * - Unregistered kinds yield well-formed `unsupportedEvidence` (defense in depth — the MCP layer
+ *   filters most unknown kinds, but a direct daemon client could still send one).
+ * - The dispatch context (`tNanos` / `tMs`) reaches the handler so it can drive virtual time.
+ * - `appliedEvidence` / `unsupportedEvidence` copy the agent's `label`, `checkpointId`,
+ *   `lifecycleEvent`, and `tags` onto the evidence so trace context survives.
+ */
+class RecordingScriptHandlerRegistryTest {
+
+  @Test
+  fun `dispatch routes to the registered handler and forwards context`() {
+    var observedTNanos = -1L
+    var observedTMs = -1L
+    val registry =
+      RecordingScriptHandlerRegistry(
+        mapOf(
+          "click" to
+            RecordingScriptEventHandler { event, ctx ->
+              observedTNanos = ctx.tNanos
+              observedTMs = ctx.tMs
+              appliedEvidence(event, "click handled")
+            }
+        )
+      )
+
+    val event = RecordingScriptEvent(tMs = 33L, kind = "click", pixelX = 10, pixelY = 20)
+    val ctx = SimpleRecordingDispatchContext(tNanos = 33_000_000L, tMs = 33L)
+    val evidence = registry.dispatch(event, ctx)
+
+    assertEquals(33_000_000L, observedTNanos)
+    assertEquals(33L, observedTMs)
+    assertEquals(RecordingScriptEventStatus.APPLIED, evidence.status)
+    assertEquals("click handled", evidence.message)
+    assertEquals("click", evidence.kind)
+    assertEquals(33L, evidence.tMs)
+  }
+
+  @Test
+  fun `dispatch returns unsupported for unregistered kinds`() {
+    val registry = RecordingScriptHandlerRegistry(emptyMap())
+    val event = RecordingScriptEvent(tMs = 0L, kind = "unknown.kind", label = "L")
+
+    val evidence = registry.dispatch(event, SimpleRecordingDispatchContext(0L, 0L))
+
+    assertEquals(RecordingScriptEventStatus.UNSUPPORTED, evidence.status)
+    assertEquals("unknown.kind", evidence.kind)
+    assertEquals("L", evidence.label)
+    assertTrue(
+      "diagnostic must mention the kind so an agent can locate the offending event; " +
+        "got '${evidence.message}'",
+      evidence.message?.contains("unknown.kind") == true,
+    )
+  }
+
+  @Test
+  fun `appliedEvidence copies the agent's trace metadata onto the evidence`() {
+    val event =
+      RecordingScriptEvent(
+        tMs = 7L,
+        kind = "recording.probe",
+        label = "after-restore",
+        checkpointId = "c1",
+        lifecycleEvent = "resume",
+        tags = listOf("audit", "state-restoration"),
+      )
+
+    val evidence = appliedEvidence(event, "probe marker reached")
+
+    assertEquals("after-restore", evidence.label)
+    assertEquals("c1", evidence.checkpointId)
+    assertEquals("resume", evidence.lifecycleEvent)
+    assertEquals(listOf("audit", "state-restoration"), evidence.tags)
+    assertEquals("probe marker reached", evidence.message)
+    assertEquals(RecordingScriptEventStatus.APPLIED, evidence.status)
+  }
+
+  @Test
+  fun `unsupportedEvidence copies trace metadata and forces a message`() {
+    val event = RecordingScriptEvent(tMs = 12L, kind = "keyDown", keyCode = "Enter", label = "L")
+
+    val evidence = unsupportedEvidence(event, "key dispatch is not implemented")
+
+    assertEquals(RecordingScriptEventStatus.UNSUPPORTED, evidence.status)
+    assertEquals("key dispatch is not implemented", evidence.message)
+    assertEquals("L", evidence.label)
+    assertEquals("keyDown", evidence.kind)
+  }
+
+  @Test
+  fun `knownKinds reflects the registered handler set`() {
+    val sentinel =
+      RecordingScriptEventHandler { event, _ -> appliedEvidence(event, "noop") }
+    val registry =
+      RecordingScriptHandlerRegistry(mapOf("click" to sentinel, "recording.probe" to sentinel))
+
+    assertEquals(setOf("click", "recording.probe"), registry.knownKinds())
+  }
+
+  @Test
+  fun `dispatch returns the handler's own evidence object verbatim`() {
+    val sentinelEvidence = appliedEvidence(RecordingScriptEvent(tMs = 0L, kind = "click"))
+    val registry =
+      RecordingScriptHandlerRegistry(
+        mapOf("click" to RecordingScriptEventHandler { _, _ -> sentinelEvidence })
+      )
+
+    val returned =
+      registry.dispatch(
+        RecordingScriptEvent(tMs = 0L, kind = "click"),
+        SimpleRecordingDispatchContext(0L, 0L),
+      )
+
+    assertSame("registry must not re-wrap the handler's evidence", sentinelEvidence, returned)
+  }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -7,7 +7,6 @@ import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingInputParams
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
-import ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence
 import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
 import java.io.File
@@ -188,25 +187,8 @@ class DesktopRecordingSession(
 
       while (nextEventIdx < sortedEvents.size && sortedEvents[nextEventIdx].tMs <= tMs) {
         val e = sortedEvents[nextEventIdx]
-        val inputKind = e.kind.toInteractiveInputKindOrNull()
-        if (e.kind == RecordingScriptDataExtensions.PROBE_EVENT) {
-          evidence.add(e.appliedEvidence("probe marker reached"))
-        } else if (inputKind == null) {
-          evidence.add(e.unsupportedEvidence("script event kind '${e.kind}' is not implemented"))
-        } else if (
-          inputKind == InteractiveInputKind.KEY_DOWN ||
-            inputKind == InteractiveInputKind.KEY_UP ||
-            inputKind == InteractiveInputKind.ROTARY_SCROLL
-        ) {
-          evidence.add(
-            e.unsupportedEvidence(
-              "key and rotary dispatch are not implemented for desktop recording"
-            )
-          )
-        } else {
-          dispatchInput(inputKind, e.pixelX, e.pixelY, tNanos, tMs)
-          evidence.add(e.appliedEvidence())
-        }
+        val ctx = SimpleRecordingDispatchContext(tNanos = tNanos, tMs = tMs)
+        evidence.add(scriptHandlers.dispatch(e, ctx))
         nextEventIdx++
       }
 
@@ -277,31 +259,95 @@ class DesktopRecordingSession(
     )
   }
 
-  private fun RecordingScriptEvent.appliedEvidence(
-    message: String? = null
-  ): RecordingScriptEvidence =
-    RecordingScriptEvidence(
-      tMs = tMs,
-      kind = kind,
-      status = RecordingScriptEventStatus.APPLIED,
-      label = label,
-      checkpointId = checkpointId,
-      lifecycleEvent = lifecycleEvent,
-      tags = tags,
-      message = message,
+  /**
+   * Per-session script-event handler registry. Built once per session so each handler closes over
+   * the held [state.scene]; the dispatch loop in [stopScripted] just calls
+   * [scriptHandlers.dispatch] and never branches on event kind directly.
+   *
+   * Built-in input kinds (`click`, `pointerDown`, `pointerMove`, `pointerUp`) are registered as
+   * real Skiko `sendPointerEvent` calls. `rotaryScroll`, `keyDown`, and `keyUp` register as
+   * unsupported handlers so the agent gets a specific reason rather than the generic "no handler"
+   * message. The probe extension handler appears once, here, instead of leaking into the dispatch
+   * loop's special-case branch.
+   */
+  private val scriptHandlers: RecordingScriptHandlerRegistry = buildScriptHandlers()
+
+  private fun buildScriptHandlers(): RecordingScriptHandlerRegistry =
+    RecordingScriptHandlerRegistry(
+      buildMap {
+        put("click", clickHandler())
+        put("pointerDown", pointerHandler(PointerEventType.Press))
+        put("pointerMove", pointerHandler(PointerEventType.Move))
+        put("pointerUp", pointerHandler(PointerEventType.Release))
+        put("rotaryScroll", desktopUnsupported("rotary scroll"))
+        put("keyDown", desktopUnsupported("keyDown"))
+        put("keyUp", desktopUnsupported("keyUp"))
+        put(RecordingScriptDataExtensions.PROBE_EVENT, RecordingScriptEventHandler { e, _ ->
+          appliedEvidence(e, "probe marker reached")
+        })
+      }
     )
 
-  private fun RecordingScriptEvent.unsupportedEvidence(message: String): RecordingScriptEvidence =
-    RecordingScriptEvidence(
-      tMs = tMs,
-      kind = kind,
-      status = RecordingScriptEventStatus.UNSUPPORTED,
-      label = label,
-      checkpointId = checkpointId,
-      lifecycleEvent = lifecycleEvent,
-      tags = tags,
-      message = message,
-    )
+  private fun clickHandler(): RecordingScriptEventHandler =
+    RecordingScriptEventHandler { event, ctx ->
+      val px = event.pixelX
+      val py = event.pixelY
+      if (px == null || py == null) {
+        return@RecordingScriptEventHandler unsupportedEvidence(
+          event,
+          "${event.kind} requires both pixelX and pixelY",
+        )
+      }
+      val offset = sceneOffset(px, py)
+      state.scene.sendPointerEvent(
+        eventType = PointerEventType.Press,
+        position = offset,
+        timeMillis = ctx.tMs,
+        button = PointerButton.Primary,
+        buttons = PointerButtons(isPrimaryPressed = true),
+      )
+      state.scene.render(nanoTime = ctx.tNanos)
+      state.scene.sendPointerEvent(
+        eventType = PointerEventType.Release,
+        position = offset,
+        timeMillis = ctx.tMs,
+        button = PointerButton.Primary,
+        buttons = PointerButtons(),
+      )
+      appliedEvidence(event)
+    }
+
+  /**
+   * Single-event pointer dispatch. `Press` carries the primary-button-pressed buttons mask;
+   * `Move` keeps the primary button held (a drag); `Release` clears the mask. Matches the
+   * pattern [DesktopInteractiveSession] uses so `Modifier.clickable {}` and other tap-gesture
+   * detectors see consistent down→up sequences regardless of mode.
+   */
+  private fun pointerHandler(eventType: PointerEventType): RecordingScriptEventHandler =
+    RecordingScriptEventHandler { event, ctx ->
+      val px = event.pixelX
+      val py = event.pixelY
+      if (px == null || py == null) {
+        return@RecordingScriptEventHandler unsupportedEvidence(
+          event,
+          "${event.kind} requires both pixelX and pixelY",
+        )
+      }
+      val pressed = eventType != PointerEventType.Release
+      state.scene.sendPointerEvent(
+        eventType = eventType,
+        position = sceneOffset(px, py),
+        timeMillis = ctx.tMs,
+        button = PointerButton.Primary,
+        buttons = PointerButtons(isPrimaryPressed = pressed),
+      )
+      appliedEvidence(event)
+    }
+
+  private fun desktopUnsupported(label: String): RecordingScriptEventHandler =
+    RecordingScriptEventHandler { event, _ ->
+      unsupportedEvidence(event, "$label dispatch is not implemented for desktop recording")
+    }
 
   /**
    * Live tick loop body. Runs on the dedicated `compose-ai-daemon-recording-live-<id>` thread.


### PR DESCRIPTION
## Summary

Both `DesktopRecordingSession.stopScripted` and `AndroidRecordingSession.stopScripted` carried parallel `if/else` ladders over event kinds — special-casing `RecordingScriptDataExtensions.PROBE_EVENT`, falling back to `toInteractiveInputKindOrNull`, then dispatching against an inline pointer or held-rule path. Each backend also re-defined its own private `appliedEvidence` / `unsupportedEvidence` extension helpers. Adding a new event kind (a11y action handlers from #718, eventual state/lifecycle handlers) meant editing every backend.

This replaces both ladders with a single dispatch through a per-session `RecordingScriptHandlerRegistry`. Step toward the registry-based design discussed in #718: the dispatch surface is now extension-shaped, even if the dataExtension descriptors aren't yet derived from it.

- **New `:daemon:core` types**: `RecordingScriptEventHandler` (functional interface), `RecordingScriptHandlerRegistry` (kind → handler map with a single `dispatch` entry point that returns well-formed evidence on every input — never throws), `RecordingDispatchContext` + `SimpleRecordingDispatchContext` (per-event virtual-time stamps), and shared `appliedEvidence` / `unsupportedEvidence` builders.
- **Desktop**: registers Skiko `sendPointerEvent` handlers for `click` / `pointerDown` / `pointerMove` / `pointerUp`; `rotaryScroll` / `keyDown` / `keyUp` register as unsupported with backend-specific diagnostics. Probe handler appears once, in the registry, instead of as a dispatch-loop special case.
- **Android**: routes input kinds through `InteractiveSession.dispatch` (same path the live tick loop uses), registers the same probe handler. `keyDown` / `keyUp` register as unsupported.
- **Both** sessions' dispatch loops collapse to `evidence.add(scriptHandlers.dispatch(event, ctx))`. The kind→handler map is the only thing that changes when we add new event kinds.

**Live mode kept on the existing `dispatchInput` / `dispatchLiveInput` path** because it consumes typed `InteractiveInputKind` from `RecordingInputParams`, not wire-string kinds. A follow-up PR can migrate that once the live-mode wire carries script-event kinds (or by translating at the boundary).

`RecordingScriptHandlerRegistryTest` (new) pins the contract: registered handlers receive the event verbatim, unregistered kinds yield well-formed `unsupportedEvidence`, the dispatch context carries through, and the trace-metadata fields (`label`, `checkpointId`, `lifecycleEvent`, `tags`) survive the evidence builders.

Behaviour-preserving — `AndroidRecordingSessionTest`'s "click/state.save/probe" mixed-event test still passes (state.save → unsupported, click + probe → applied) because the registry's default unsupported evidence message changed in wording but tests only assert on `status`.

## Test plan

- [ ] `./gradlew :daemon:core:check :daemon:desktop:check :daemon:android:check` (couldn't run locally — sandbox network blocked JDK 17 install; CI is the source of truth)
- [ ] `./gradlew :mcp:check` (downstream of the daemon changes)
- [ ] CI: `format`, `test` jobs green
- [ ] `RecordingScriptHandlerRegistryTest` covers: registered-kind dispatch with context forwarded, unregistered-kind unsupported evidence, applied/unsupported metadata copy, knownKinds, evidence pass-through identity
- [ ] Manual smoke: `record_preview` with a click + `recording.probe` script (the `run-agent-audit-samples.py` driver from #718) still produces `APPLIED` evidence for both events

## Follow-ups

- Move the registry up to `RenderHost.recordingScriptHandlers()` so the daemon's `dataExtensions` capability set can be derived from `registry.knownKinds()` instead of hand-curated `RecordingScriptDataExtensions.descriptors`.
- Migrate live mode to dispatch through the same registry (requires a small wire shape adjustment so live's typed `InteractiveInputKind` lands as a wire-string kind first).
- Wire real handlers for the a11y action events advertised in `AccessibilityRecordingScriptEvents` (#718) — each becomes a `RecordingScriptEventHandler` that calls `AccessibilityNodeInfo.performAction(...)` against the resolved node.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8qJtJESJvS4yoTB9PKtRF)_