### PR TITLE
Clean up redundant comment in desktop-daemon-bench build file

### DIFF
--- a/samples/desktop-daemon-bench/build.gradle.kts
+++ b/samples/desktop-daemon-bench/build.gradle.kts
@@ -1,4 +1,3 @@
-// Desktop latency baseline harness for the preview daemon work — see
 // Desktop latency baseline harness for the preview daemon work — see docs/daemon/DESIGN.md § 13.
 //
 // Mirrors :samples:android-daemon-bench (P0.1) but renders through the


### PR DESCRIPTION
## Summary
Removed a redundant comment line from the desktop-daemon-bench build configuration file.

## Changes
- Removed duplicate comment header that was partially repeated on the following line
- The full comment referencing `docs/daemon/DESIGN.md § 13` is retained as the complete documentation reference

## Details
The first line of the build.gradle.kts file contained an incomplete comment that was superseded by the more complete comment on the next line. This cleanup removes the redundant text while preserving the full documentation reference.

https://claude.ai/code/session_01JE5XpePuMenwGX8LvVeJW7