### PR TITLE
refactor(daemon): host-derive supported recording-script descriptors

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -337,12 +337,14 @@ fun main(args: Array<String>) {
       incrementalDiscovery = incrementalDiscovery,
       historyManager = historyManager,
       dataProducts = dataProducts,
-      // Base recording-script descriptors are renderer-agnostic; the a11y action descriptors are
-      // Android-only and only meaningful when the a11y preview extension is enabled. They ship as
-      // `supported = false` until the recording-script handler registry refactor lands the actual
-      // dispatch — `record_preview` rejects them up front via `validateRecordingScriptKinds`.
+      // dataExtensions = host's supported descriptors + renderer-agnostic roadmap +
+      // (when the a11y preview extension is enabled) the Android-only a11y action roadmap. The
+      // host method tracks what `RobolectricHost`'s recording sessions actually dispatch
+      // (`recording.probe` today). The two roadmap lists carry `supported = false` until the
+      // handlers ship; `record_preview` rejects them up front via `validateRecordingScriptKinds`.
       dataExtensions =
-        RecordingScriptDataExtensions.descriptors +
+        host.recordingScriptEventDescriptors() +
+          RecordingScriptDataExtensions.roadmapDescriptors +
           (if (a11yPreviewExtensionEnabled) AccessibilityRecordingScriptEvents.descriptors
           else emptyList()),
       previewExtensions = previewExtensions,

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -13,6 +13,8 @@ import com.github.takahirom.roborazzi.captureRoboImage
 import ee.schimke.composeai.data.render.PreviewContext
 import ee.schimke.composeai.data.render.PreviewDeviceContext
 import ee.schimke.composeai.data.render.PreviewDeviceSpec
+import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
+import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
 import ee.schimke.composeai.daemon.bridge.DaemonHostBridge
 import ee.schimke.composeai.daemon.bridge.InteractiveCommand
 import ee.schimke.composeai.daemon.bridge.SandboxSlot
@@ -187,6 +189,18 @@ open class RobolectricHost(
             add("webm")
           }
         }
+
+  /**
+   * `recording.probe` is the only extension event [AndroidRecordingSession] dispatches today. The
+   * a11y action descriptors live in `:data-a11y-connector` and are concatenated into
+   * `dataExtensions` by `DaemonMain` only when the a11y preview extension is enabled, so this host
+   * method stays scoped to the renderer-agnostic probe extension. Empty when the host can't
+   * actually allocate a session ([supportsRecording] = false) so agents don't see supported = true
+   * on a daemon that would reject `recording/start` anyway.
+   */
+  override fun recordingScriptEventDescriptors(): List<DataExtensionDescriptor> =
+    if (supportsRecording) listOf(RecordingScriptDataExtensions.recordingDescriptor)
+    else emptyList()
 
   /**
    * Identifier of the currently-held interactive session, or `null` when no session is active.

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RenderHost.kt
@@ -1,6 +1,7 @@
 package ee.schimke.composeai.daemon
 
 import ee.schimke.composeai.data.render.PreviewContext
+import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -229,6 +230,23 @@ interface RenderHost {
     throw UnsupportedOperationException(
       "recording unsupported by ${this::class.simpleName ?: this::class.java.name}"
     )
+
+  /**
+   * Recording-script extension events this host's [RecordingSession]s actually dispatch — surfaced
+   * in `InitializeResult.capabilities.dataExtensions` alongside any roadmap descriptors the daemon
+   * advertises.
+   *
+   * Each entry's `recordingScriptEvents[*]` MUST flag `supported = true` and MUST be registered in
+   * the [RecordingScriptHandlerRegistry] the host's recording sessions build — agents take
+   * `supported = true` as a contract that `record_preview` will accept and the daemon will
+   * dispatch. Hosts without a recording session (FakeHost) inherit the default empty list.
+   *
+   * Roadmap items (`supported = false`) DO NOT belong here — they're advertised separately by
+   * `DaemonMain` (see `RecordingScriptDataExtensions.roadmapDescriptors`) so a host that wires real
+   * dispatch for one of them can flip just its own contribution to `supported = true` without
+   * editing the global roadmap list.
+   */
+  fun recordingScriptEventDescriptors(): List<DataExtensionDescriptor> = emptyList()
 
   companion object {
     /**

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -263,7 +263,12 @@ fun main(args: Array<String>) {
       // path as a future Compose API rename. Wiring is intentionally global — kinds advertised
       // in `initialize.capabilities.dataProducts` reflect the daemon's whole surface.
       dataProducts = dataProducts,
-      dataExtensions = RecordingScriptDataExtensions.descriptors,
+      // dataExtensions = host's supported recording-script extensions + renderer-agnostic roadmap
+      // descriptors. The host's contribution flips supported flags as new handlers land in its
+      // session registry; the roadmap list is the global "advertised but not yet implemented" set
+      // (state.save / state.restore / lifecycle.event / preview.reload).
+      dataExtensions =
+        host.recordingScriptEventDescriptors() + RecordingScriptDataExtensions.roadmapDescriptors,
       previewExtensions =
         buildList {
           add(RenderPreviewExtension.deviceClipDescriptor)

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -1,5 +1,7 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
+import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingQueue
@@ -149,6 +151,16 @@ open class DesktopHost(
             add("webm")
           }
         }
+
+  /**
+   * `recording.probe` is the only extension event [DesktopRecordingSession] dispatches today; click
+   * / pointer kinds are built-in inputs, not extensions. The descriptor is empty when the host
+   * can't actually allocate a session ([supportsRecording] = false) so agents don't see
+   * supported = true on a daemon that would reject `recording/start` anyway.
+   */
+  override fun recordingScriptEventDescriptors(): List<DataExtensionDescriptor> =
+    if (supportsRecording) listOf(RecordingScriptDataExtensions.recordingDescriptor)
+    else emptyList()
 
   /**
    * PROTOCOL.md § 3 (`InitializeResult.capabilities.supportedOverrides`) — the desktop renderer

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
@@ -94,4 +94,33 @@ class DesktopHostTest {
 
     assertEquals(RenderEngine.supportsLocaleTagOverride(), "localeTag" in supported)
   }
+
+  /**
+   * `recordingScriptEventDescriptors()` is the seam DaemonMain reads to assemble the daemon's
+   * `dataExtensions` capability. Without a resolver the host can't allocate a recording session,
+   * so it must NOT advertise `recording.probe` as `supported = true` — otherwise an agent
+   * trusting `list_data_products` would see a green probe and watch its `record_preview` calls
+   * fail with `MethodNotFound`.
+   */
+  @Test
+  fun recordingScriptEventDescriptorsAreEmptyWithoutResolver() {
+    assertEquals(emptyList<Any>(), DesktopHost().recordingScriptEventDescriptors())
+  }
+
+  /**
+   * With a resolver wired, `recordingScriptEventDescriptors()` advertises only
+   * `recording.probe` (supported = true). Roadmap descriptors stay out of the host contribution —
+   * they're appended separately by DaemonMain.
+   */
+  @Test
+  fun recordingScriptEventDescriptorsAdvertiseProbeWhenResolverPresent() {
+    val descriptors = DesktopHost(previewSpecResolver = { null }).recordingScriptEventDescriptors()
+    assertEquals(1, descriptors.size)
+    val recording = descriptors.single()
+    assertEquals("recording", recording.id.value)
+    assertEquals(1, recording.recordingScriptEvents.size)
+    val probe = recording.recordingScriptEvents.single()
+    assertEquals("recording.probe", probe.id)
+    assertTrue("desktop must advertise recording.probe as supported", probe.supported)
+  }
 }

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
@@ -232,6 +232,22 @@ data class RecordingScriptEventDescriptor(
   }
 }
 
+/**
+ * Built-in recording-script descriptor namespace. Splits cleanly between two halves:
+ *
+ * - [recordingDescriptor] — the `recording` extension, advertising `recording.probe` as
+ *   `supported = true`. Each [ee.schimke.composeai.daemon.RenderHost] returns this from its
+ *   `recordingScriptEventDescriptors()` override, alongside any host-specific extensions, so the
+ *   daemon's `dataExtensions` capability set tracks what the host actually dispatches.
+ * - [roadmapDescriptors] — `state` / `lifecycle` / `preview`, all `supported = false`. Advertised
+ *   by `DaemonMain` regardless of host so agents can see what's planned via `list_data_products`.
+ *   `record_preview` rejects them up front (see compose-ai-tools#714); the descriptors flip to
+ *   `supported = true` only when a real handler lands in the host's session registry, at which
+ *   point the descriptor moves out of `roadmapDescriptors` and into the host's own contribution.
+ *
+ * The legacy aggregate [descriptors] (probe + roadmap) is retained for callers that haven't
+ * migrated yet — see the deprecation note.
+ */
 object RecordingScriptDataExtensions {
   const val PROBE_EVENT: String = "recording.probe"
   const val STATE_SAVE_EVENT: String = "state.save"
@@ -239,21 +255,34 @@ object RecordingScriptDataExtensions {
   const val PREVIEW_RELOAD_EVENT: String = "preview.reload"
   const val LIFECYCLE_EVENT: String = "lifecycle.event"
 
-  val descriptors: List<DataExtensionDescriptor> =
+  /**
+   * `recording.probe` descriptor with `supported = true`. Returned from each
+   * `RenderHost.recordingScriptEventDescriptors()` that wires a real probe handler in its
+   * recording-session registry (today: both desktop and android backends).
+   */
+  val recordingDescriptor: DataExtensionDescriptor =
+    DataExtensionDescriptor(
+      id = DataExtensionId("recording"),
+      displayName = "Recording script markers",
+      recordingScriptEvents =
+        listOf(
+          RecordingScriptEventDescriptor(
+            id = PROBE_EVENT,
+            displayName = "Probe marker",
+            summary = "Records a named point in the recording timeline.",
+            supported = true,
+          )
+        ),
+    )
+
+  /**
+   * Renderer-agnostic roadmap descriptors. Advertised by every daemon so `list_data_products`
+   * surfaces the planned surface area, but `supported = false` everywhere — `record_preview`
+   * rejects up front. When a host wires real dispatch for one of these, advertise the upgraded
+   * descriptor from the host's `recordingScriptEventDescriptors()` and remove it from this list.
+   */
+  val roadmapDescriptors: List<DataExtensionDescriptor> =
     listOf(
-      DataExtensionDescriptor(
-        id = DataExtensionId("recording"),
-        displayName = "Recording script markers",
-        recordingScriptEvents =
-          listOf(
-            RecordingScriptEventDescriptor(
-              id = PROBE_EVENT,
-              displayName = "Probe marker",
-              summary = "Records a named point in the recording timeline.",
-              supported = true,
-            )
-          ),
-      ),
       DataExtensionDescriptor(
         id = DataExtensionId("state"),
         displayName = "State restoration script markers",
@@ -296,6 +325,14 @@ object RecordingScriptDataExtensions {
           ),
       ),
     )
+
+  /**
+   * Combined list of [recordingDescriptor] + [roadmapDescriptors]. Retained for callers that build
+   * their `dataExtensions` from a single source; new code should prefer
+   * `host.recordingScriptEventDescriptors() + roadmapDescriptors` so the host can opt in / out of
+   * the supported half independently.
+   */
+  val descriptors: List<DataExtensionDescriptor> = listOf(recordingDescriptor) + roadmapDescriptors
 }
 
 data class SimplePlannedDataExtension(

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/extensions/RecordingScriptDataExtensionsTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/extensions/RecordingScriptDataExtensionsTest.kt
@@ -1,0 +1,60 @@
+package ee.schimke.composeai.data.render.extensions
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the supported/roadmap split of [RecordingScriptDataExtensions] — `record_preview`'s
+ * `validateRecordingScriptKinds` filters by descriptor `supported` flag, and the daemon's
+ * `dataExtensions` capability is composed from `RenderHost.recordingScriptEventDescriptors()` plus
+ * [RecordingScriptDataExtensions.roadmapDescriptors]. The split has to stay honest: the host
+ * contribution carries the `supported = true` halves; the roadmap list is `supported = false`
+ * everywhere.
+ */
+class RecordingScriptDataExtensionsTest {
+
+  @Test
+  fun `recordingDescriptor is the supported probe descriptor`() {
+    val descriptor = RecordingScriptDataExtensions.recordingDescriptor
+    assertEquals(DataExtensionId("recording"), descriptor.id)
+    assertEquals(1, descriptor.recordingScriptEvents.size)
+    val probe = descriptor.recordingScriptEvents.single()
+    assertEquals(RecordingScriptDataExtensions.PROBE_EVENT, probe.id)
+    assertTrue(
+      "recording.probe must advertise supported = true so record_preview accepts it",
+      probe.supported,
+    )
+  }
+
+  @Test
+  fun `roadmapDescriptors carry only unsupported events`() {
+    val roadmap = RecordingScriptDataExtensions.roadmapDescriptors
+    val ids = roadmap.flatMap { it.recordingScriptEvents }.map { it.id }.toSet()
+    assertEquals(
+      setOf(
+        RecordingScriptDataExtensions.STATE_SAVE_EVENT,
+        RecordingScriptDataExtensions.STATE_RESTORE_EVENT,
+        RecordingScriptDataExtensions.LIFECYCLE_EVENT,
+        RecordingScriptDataExtensions.PREVIEW_RELOAD_EVENT,
+      ),
+      ids,
+    )
+    val anySupported = roadmap.flatMap { it.recordingScriptEvents }.any { it.supported }
+    assertFalse(
+      "roadmap descriptors must all be supported = false; flip them in the host's contribution " +
+        "when real dispatch lands",
+      anySupported,
+    )
+  }
+
+  @Test
+  fun `legacy descriptors aggregate is recordingDescriptor plus roadmap`() {
+    assertEquals(
+      listOf(RecordingScriptDataExtensions.recordingDescriptor) +
+        RecordingScriptDataExtensions.roadmapDescriptors,
+      RecordingScriptDataExtensions.descriptors,
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Follows the registry refactor in #720. `DaemonMain` previously hand-rolled `dataExtensions = RecordingScriptDataExtensions.descriptors` regardless of what its host actually dispatched. A host without a held-scene resolver still advertised `recording.probe` as `supported = true`, so an agent that called `record_preview` would see `MethodNotFound` after trusting `list_data_products`. Move the supported half to the host so the descriptor tracks the registry automatically.

- **New `RenderHost.recordingScriptEventDescriptors()`** (default empty) returns the descriptors whose events the host's `RecordingSession`s actually dispatch. `DesktopHost` and `RobolectricHost` both override it to return `[RecordingScriptDataExtensions.recordingDescriptor]` — but **only when `supportsRecording = true`**, so a host that can't allocate a session doesn't advertise a green probe.
- **Split `RecordingScriptDataExtensions`** into `recordingDescriptor` (single, `supported = true`) and `roadmapDescriptors` (state.save / state.restore / lifecycle.event / preview.reload, all `supported = false`). The legacy `descriptors` aggregate is retained as `[recordingDescriptor] + roadmapDescriptors` for callers (MCP test fixtures) that haven't migrated yet.
- **Both `DaemonMain` entry points** now compose `host.recordingScriptEventDescriptors() + RecordingScriptDataExtensions.roadmapDescriptors`; Android also adds `AccessibilityRecordingScriptEvents.descriptors` when a11y is enabled. Roadmap stays hand-curated; the supported half tracks per-host.

The migration story for landing a real handler for a roadmap event is now local: add the handler to the host's session registry, advertise an upgraded descriptor (`supported = true`) from the host's `recordingScriptEventDescriptors()`, and remove that entry from `roadmapDescriptors`. No more "edit a global list and hope every backend agrees".

Tests:
- `RecordingScriptDataExtensionsTest` (new, in `:data-render-core`) pins the supported/roadmap split — `recordingDescriptor` has `supported = true`, `roadmapDescriptors` are all `supported = false`, legacy `descriptors` = the concatenation.
- `DesktopHostTest` gains two cases: empty descriptors when no resolver (so a daemon that can't record doesn't advertise probe), probe-only with `supported = true` when a resolver is wired.

## Test plan

- [ ] `./gradlew :daemon:core:check :daemon:desktop:check :daemon:android:check` (couldn't run locally — same JDK-17-install network gap as #718/#720; CI is the source of truth)
- [ ] `./gradlew :data-render-core:check :mcp:check` (downstream)
- [ ] CI: `format`, `test` jobs green
- [ ] Manual: `compose-preview mcp doctor` against a daemon WITHOUT a resolver shows `dataExtensions[].recordingScriptEvents[].supported` for `recording.probe` as **absent** (only roadmap items appear). With a resolver, probe shows `supported: true`.

## Follow-ups

Same list as #720, minus this one:
- Migrate live mode through the same registry (requires a small wire shape adjustment).
- Wire real handlers for the `a11y.action.*` events advertised in `AccessibilityRecordingScriptEvents` (#718) — each becomes a registered handler on the Robolectric host that calls `AccessibilityNodeInfo.performAction(...)`. With this PR, flipping one of those to `supported = true` is now a one-place edit on the Android host.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8qJtJESJvS4yoTB9PKtRF)_