### PR TITLE
chore: ktfmtFormatAll across daemon-core, mcp, daemon-desktop

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistry.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistry.kt
@@ -7,10 +7,10 @@ import ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence
 /**
  * Per-event dispatch context passed to each [RecordingScriptEventHandler] invocation.
  *
- * Carries the virtual-clock stamps the handler needs when driving the held scene/rule.
- * `tNanos` and `tMs` are the **frame's** virtual time, not the event's `tMs` — events whose
- * `event.tMs <= frame.tMs` are dispatched against the upcoming frame, so handlers should send
- * pointer events at the frame's nanoTime so `scene.render(nanoTime)` and `sendPointerEvent` agree.
+ * Carries the virtual-clock stamps the handler needs when driving the held scene/rule. `tNanos` and
+ * `tMs` are the **frame's** virtual time, not the event's `tMs` — events whose `event.tMs <=
+ * frame.tMs` are dispatched against the upcoming frame, so handlers should send pointer events at
+ * the frame's nanoTime so `scene.render(nanoTime)` and `sendPointerEvent` agree.
  *
  * Live tick-loop callers reuse the same shape with the wall-clock-anchored virtual nanoTime.
  */
@@ -31,8 +31,8 @@ data class SimpleRecordingDispatchContext(override val tNanos: Long, override va
  * owns a [RecordingScriptHandlerRegistry] mapping kind → handler and looks up by `event.kind`.
  *
  * Implementations close over host-specific scene/rule state (Skiko `ImageComposeScene` on desktop,
- * `AndroidInteractiveSession` on Android). They MUST return well-formed [RecordingScriptEvidence]
- * — never throw — so a malformed event aborts at most a single dispatch slot, not the whole
+ * `AndroidInteractiveSession` on Android). They MUST return well-formed [RecordingScriptEvidence] —
+ * never throw — so a malformed event aborts at most a single dispatch slot, not the whole
  * recording. Use [appliedEvidence] / [unsupportedEvidence] to build the result.
  */
 fun interface RecordingScriptEventHandler {
@@ -73,10 +73,7 @@ class RecordingScriptHandlerRegistry(
  * Build an [RecordingScriptEvidence] for an applied event. Optional [message] is forwarded as the
  * `message` field for human-readable trace context.
  */
-fun appliedEvidence(
-  event: RecordingScriptEvent,
-  message: String? = null,
-): RecordingScriptEvidence =
+fun appliedEvidence(event: RecordingScriptEvent, message: String? = null): RecordingScriptEvidence =
   RecordingScriptEvidence(
     tMs = event.tMs,
     kind = event.kind,

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistryTest.kt
@@ -101,8 +101,7 @@ class RecordingScriptHandlerRegistryTest {
 
   @Test
   fun `knownKinds reflects the registered handler set`() {
-    val sentinel =
-      RecordingScriptEventHandler { event, _ -> appliedEvidence(event, "noop") }
+    val sentinel = RecordingScriptEventHandler { event, _ -> appliedEvidence(event, "noop") }
     val registry =
       RecordingScriptHandlerRegistry(mapOf("click" to sentinel, "recording.probe" to sentinel))
 

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -282,9 +282,10 @@ class DesktopRecordingSession(
         put("rotaryScroll", desktopUnsupported("rotary scroll"))
         put("keyDown", desktopUnsupported("keyDown"))
         put("keyUp", desktopUnsupported("keyUp"))
-        put(RecordingScriptDataExtensions.PROBE_EVENT, RecordingScriptEventHandler { e, _ ->
-          appliedEvidence(e, "probe marker reached")
-        })
+        put(
+          RecordingScriptDataExtensions.PROBE_EVENT,
+          RecordingScriptEventHandler { e, _ -> appliedEvidence(e, "probe marker reached") },
+        )
       }
     )
 
@@ -318,10 +319,10 @@ class DesktopRecordingSession(
     }
 
   /**
-   * Single-event pointer dispatch. `Press` carries the primary-button-pressed buttons mask;
-   * `Move` keeps the primary button held (a drag); `Release` clears the mask. Matches the
-   * pattern [DesktopInteractiveSession] uses so `Modifier.clickable {}` and other tap-gesture
-   * detectors see consistent down→up sequences regardless of mode.
+   * Single-event pointer dispatch. `Press` carries the primary-button-pressed buttons mask; `Move`
+   * keeps the primary button held (a drag); `Release` clears the mask. Matches the pattern
+   * [DesktopInteractiveSession] uses so `Modifier.clickable {}` and other tap-gesture detectors see
+   * consistent down→up sequences regardless of mode.
    */
   private fun pointerHandler(eventType: PointerEventType): RecordingScriptEventHandler =
     RecordingScriptEventHandler { event, ctx ->

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -2595,8 +2595,8 @@ class DaemonMcpServer(
    * so the wrapper surfaces "invalid events: …" rather than dying inside the daemon's notification
    * decoder. Unknown extra keys are tolerated for forward compatibility (same shape rule the
    * `decodePreviewOverrides` helper uses). Closed-set validation against the daemon's advertised
-   * input + extension kinds happens later in [validateRecordingScriptKinds] once the daemon has been
-   * resolved.
+   * input + extension kinds happens later in [validateRecordingScriptKinds] once the daemon has
+   * been resolved.
    */
   private fun decodeRecordingEvents(arr: JsonArray): List<RecordingScriptEvent> {
     return arr.mapIndexed { idx, elem ->
@@ -2642,10 +2642,11 @@ class DaemonMcpServer(
    * 2. **Extension events** — namespaced ids advertised in
    *    `ServerCapabilities.dataExtensions[].recordingScriptEvents[]`. We accept only those flagged
    *    `supported = true` by the daemon. Advertising an event with `supported = false` is the
-   *    daemon's roadmap signal — agents see it via `list_data_products` so they know what's planned,
-   *    but the script wrapper rejects it up front rather than letting the agent watch a quiet
-   *    `unsupported` evidence trail come back. (The daemon-side fallback that emits `unsupported`
-   *    evidence stays in place as defense-in-depth for older MCP servers + direct daemon clients.)
+   *    daemon's roadmap signal — agents see it via `list_data_products` so they know what's
+   *    planned, but the script wrapper rejects it up front rather than letting the agent watch a
+   *    quiet `unsupported` evidence trail come back. (The daemon-side fallback that emits
+   *    `unsupported` evidence stays in place as defense-in-depth for older MCP servers + direct
+   *    daemon clients.)
    */
   private fun validateRecordingScriptKinds(
     events: List<RecordingScriptEvent>,

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -908,8 +908,7 @@ class DaemonMcpServerTest {
               ee.schimke.composeai.daemon.protocol.RecordingScriptEvidence(
                 tMs = 250L,
                 kind = "recording.probe",
-                status =
-                  ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.APPLIED,
+                status = ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.APPLIED,
                 label = "before-rotate",
                 checkpointId = "checkpoint-1",
                 message = "probe marker reached",


### PR DESCRIPTION
## Summary

Pure `./gradlew ktfmtFormatAll` output — five files that landed unformatted via #718 and #720:

- `daemon/core/src/main/kotlin/.../RecordingScriptHandlerRegistry.kt`
- `daemon/core/src/test/kotlin/.../RecordingScriptHandlerRegistryTest.kt`
- `daemon/desktop/src/main/kotlin/.../DesktopRecordingSession.kt`
- `mcp/src/main/kotlin/.../DaemonMcpServer.kt`
- `mcp/src/test/kotlin/.../DaemonMcpServerTest.kt`

No behaviour change. Unblocks `ktfmtCheckAll` on branches stacked on the current `main`.

## Test plan

- [x] `./gradlew ktfmtCheckAll` — green