### PR TITLE
feat(a11y): hierarchy-android producer in its own small module

### DIFF
--- a/data/a11y/hierarchy-android/build.gradle.kts
+++ b/data/a11y/hierarchy-android/build.gradle.kts
@@ -1,0 +1,51 @@
+@file:Suppress(
+  "DEPRECATION"
+) // AndroidSingleVariantLibrary(Boolean, Boolean) is deprecated; the replacement
+
+// types (SourcesJar/JavadocJar) vary between plugin versions. Re-visit when bumping.
+
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+
+// `:data-a11y-hierarchy-android` — the Android-platform-specific producer for
+// `a11y/hierarchy` and `a11y/atf`. Wraps `AccessibilityChecker.analyze` (ATF +
+// Robolectric) into a `PostCaptureProcessor` so the typed product graph stays
+// platform-agnostic downstream — `:data-a11y-core` consumers like
+// `TouchTargetsExtension` and `OverlayExtension` only see typed payloads, not
+// `View`s or ATF types. A future Compose-Multiplatform Desktop variant lands as
+// `:data-a11y-hierarchy-desktop` with the same outputs and `targets = {Desktop}`;
+// the planner's target filter selects exactly one provider per platform.
+
+plugins {
+  id("composeai.maven-publishing")
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.tapmoc)
+}
+
+android { namespace = "ee.schimke.composeai.data.a11y.hierarchy.android" }
+
+dependencies {
+  api(project(":data-a11y-core"))
+
+  testImplementation(libs.junit)
+  testImplementation(libs.robolectric)
+}
+
+mavenPublishing {
+  configure(
+    com.vanniktech.maven.publish.AndroidSingleVariantLibrary(
+      javadocJar = com.vanniktech.maven.publish.JavadocJar.Empty(),
+      sourcesJar = com.vanniktech.maven.publish.SourcesJar.Sources(),
+      variant = "release",
+    )
+  )
+}
+
+composeAiMavenPublishing {
+  coordinates(
+    artifactId = "data-a11y-hierarchy-android",
+    displayName = "Compose Preview — Accessibility Hierarchy Producer (Android)",
+    description =
+      "Android-platform-specific producer that runs ATF over a captured View tree and emits typed AccessibilityHierarchyPayload + AccessibilityFindingsPayload products. Pairs with `:data-a11y-core`'s platform-agnostic consumers (touch targets, overlay).",
+  )
+  inceptionYear.set("2026")
+}

--- a/data/a11y/hierarchy-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityHierarchyExtension.kt
+++ b/data/a11y/hierarchy-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityHierarchyExtension.kt
@@ -1,0 +1,70 @@
+package ee.schimke.composeai.renderer
+
+import android.view.View
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.DataProductKey
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
+
+/**
+ * Pure extractor — runs ATF over a View tree and returns the typed payloads. No invocation point
+ * baked in; any binding (post-capture today, around-script-event tomorrow, frame driver later) can
+ * call this directly.
+ */
+object AccessibilityHierarchyExtractor {
+  fun extract(previewId: String?, root: View): AccessibilityAnalysis {
+    val result = AccessibilityChecker.analyze(previewId ?: "preview", root)
+    return AccessibilityAnalysis(
+      hierarchy = AccessibilityHierarchyPayload(result.nodes),
+      findings = AccessibilityFindingsPayload(result.findings),
+    )
+  }
+}
+
+/**
+ * Bundled output of one ATF + hierarchy walk. Today the ATF library produces both findings and
+ * nodes from the same `AccessibilityHierarchyAndroid` build, so they ship as a pair to avoid two
+ * walks of the same View tree. Consumers that only want one product still benefit — the planner
+ * pulls in this single producer once and routes both products to whoever declared them as inputs.
+ */
+data class AccessibilityAnalysis(
+  val hierarchy: AccessibilityHierarchyPayload,
+  val findings: AccessibilityFindingsPayload,
+)
+
+/**
+ * Default binding for [AccessibilityHierarchyExtractor]: invokes it after the bitmap is captured
+ * and emits the typed products into the store. Reads the captured `View` root from
+ * `attributes[VIEW_ROOT_ATTRIBUTE]`, which the host populates from its own platform handle (the
+ * daemon's RenderEngine has the View, the Robolectric Test runner has it via `ViewRootForTest`).
+ *
+ * `targets = {Android}` — a future Compose Multiplatform Desktop hierarchy producer would target
+ * `{Desktop}` and emit the same product keys; the planner's target filter selects exactly one.
+ */
+class AccessibilityHierarchyExtension : PostCaptureProcessor {
+  override val id: DataExtensionId = DataExtensionId(EXTENSION_ID)
+  override val hooks: Set<DataExtensionHookKind> = setOf(DataExtensionHookKind.AfterCapture)
+  override val constraints: DataExtensionConstraints =
+    DataExtensionConstraints(phase = DataExtensionPhase.Capture)
+  override val outputs: Set<DataProductKey<*>> =
+    setOf(AccessibilityDataProducts.Hierarchy, AccessibilityDataProducts.Atf)
+  override val targets: Set<DataExtensionTarget> = setOf(DataExtensionTarget.Android)
+
+  override fun process(context: ExtensionPostCaptureContext) {
+    val view =
+      context.attributes[VIEW_ROOT_ATTRIBUTE] as? View
+        ?: error("AccessibilityHierarchyExtension requires '$VIEW_ROOT_ATTRIBUTE' in attributes.")
+    val analysis = AccessibilityHierarchyExtractor.extract(context.previewId, view)
+    context.products.put(AccessibilityDataProducts.Hierarchy, analysis.hierarchy)
+    context.products.put(AccessibilityDataProducts.Atf, analysis.findings)
+  }
+
+  companion object {
+    const val EXTENSION_ID: String = "a11y"
+    const val VIEW_ROOT_ATTRIBUTE: String = "a11y-hierarchy.viewRoot"
+  }
+}

--- a/data/a11y/hierarchy-android/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityHierarchyExtensionTest.kt
+++ b/data/a11y/hierarchy-android/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityHierarchyExtensionTest.kt
@@ -1,0 +1,110 @@
+package ee.schimke.composeai.renderer
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionPlanner
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AccessibilityHierarchyExtensionTest {
+  private val extension = AccessibilityHierarchyExtension()
+
+  @Test
+  fun declaresExpectedOutputsAndTarget() {
+    assertTrue(extension.inputs.isEmpty())
+    assertEquals(
+      setOf(AccessibilityDataProducts.Hierarchy, AccessibilityDataProducts.Atf),
+      extension.outputs,
+    )
+    assertEquals(setOf(DataExtensionTarget.Android), extension.targets)
+  }
+
+  @Test
+  fun failsLoudlyWhenViewRootAttributeMissing() {
+    val store = RecordingDataProductStore()
+
+    val ex =
+      assertThrows(IllegalStateException::class.java) {
+        extension.process(
+          ExtensionPostCaptureContext(
+            extensionId = extension.id,
+            previewId = "preview",
+            renderMode = null,
+            products = store.scopedFor(extension),
+          )
+        )
+      }
+    assertTrue(
+      ex.message!!,
+      ex.message!!.contains(AccessibilityHierarchyExtension.VIEW_ROOT_ATTRIBUTE),
+    )
+  }
+
+  @Test
+  fun plannerSchedulesHierarchyBeforeTouchTargets() {
+    val result =
+      DataExtensionPlanner.planOutputs(
+        extensions = listOf(TouchTargetsExtension(), extension),
+        requestedOutputs = setOf(AccessibilityDataProducts.TouchTargets),
+        initialProducts =
+          setOf(ee.schimke.composeai.data.render.extensions.CommonDataProducts.Density),
+        target = DataExtensionTarget.Android,
+      )
+
+    assertTrue(result.errors.toString(), result.isValid)
+    assertEquals(
+      listOf(AccessibilityHierarchyExtension.EXTENSION_ID, TouchTargetsExtension.EXTENSION_ID),
+      result.orderedExtensions.map { it.id.value },
+    )
+  }
+
+  @Test
+  fun plannerSchedulesHierarchyBeforeOverlay() {
+    val result =
+      DataExtensionPlanner.planOutputs(
+        extensions = listOf(OverlayExtension(), extension),
+        requestedOutputs = setOf(AccessibilityDataProducts.Overlay),
+        initialProducts =
+          setOf(ee.schimke.composeai.data.render.extensions.CommonDataProducts.ImageArtifact),
+        target = DataExtensionTarget.Android,
+      )
+
+    assertTrue(result.errors.toString(), result.isValid)
+    assertEquals(
+      listOf(AccessibilityHierarchyExtension.EXTENSION_ID, OverlayExtension.EXTENSION_ID),
+      result.orderedExtensions.map { it.id.value },
+    )
+  }
+
+  @Test
+  fun plannerCoSchedulesAllConsumersAfterSingleHierarchyProducer() {
+    val result =
+      DataExtensionPlanner.planOutputs(
+        extensions = listOf(OverlayExtension(), TouchTargetsExtension(), extension),
+        requestedOutputs =
+          setOf(AccessibilityDataProducts.Overlay, AccessibilityDataProducts.TouchTargets),
+        initialProducts =
+          setOf(
+            ee.schimke.composeai.data.render.extensions.CommonDataProducts.ImageArtifact,
+            ee.schimke.composeai.data.render.extensions.CommonDataProducts.Density,
+          ),
+        target = DataExtensionTarget.Android,
+      )
+
+    assertTrue(result.errors.toString(), result.isValid)
+    assertEquals(
+      AccessibilityHierarchyExtension.EXTENSION_ID,
+      result.orderedExtensions.first().id.value,
+    )
+    val tail = result.orderedExtensions.drop(1).map { it.id.value }
+    assertTrue(
+      "expected overlay + touchTargets after hierarchy, got $tail",
+      tail.containsAll(
+        listOf(OverlayExtension.EXTENSION_ID, TouchTargetsExtension.EXTENSION_ID)
+      ),
+    )
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -62,6 +62,10 @@ include(":data-a11y-core")
 
 project(":data-a11y-core").projectDir = file("data/a11y/core")
 
+include(":data-a11y-hierarchy-android")
+
+project(":data-a11y-hierarchy-android").projectDir = file("data/a11y/hierarchy-android")
+
 include(":data-a11y-connector")
 
 project(":data-a11y-connector").projectDir = file("data/a11y/connector")


### PR DESCRIPTION
## Summary

New `:data-a11y-hierarchy-android` module — Android-platform-specific producer for `AccessibilityHierarchyPayload + AccessibilityFindingsPayload`. Wraps `AccessibilityChecker.analyze` (ATF + Robolectric) into a `PostCaptureProcessor` with `targets = {Android}`. The typed product graph stays platform-agnostic downstream — `TouchTargetsExtension` and `OverlayExtension` only see typed payloads, not `View`s or ATF types.

**Module split** — per architectural guidance, the platform-specific bit lives in a small focused module while the common payload types stay in `:data-a11y-core`. A future `:data-a11y-hierarchy-desktop` (Compose semantics walk via Multiplatform) targets `{Desktop}` and emits the same product keys without conflict — the planner's target filter selects exactly one provider per platform.

**Extractor / binding split** — `AccessibilityHierarchyExtractor` is a pure `object` with a single `extract(previewId, root)` function. Invocation point isn't baked in. `AccessibilityHierarchyExtension` is the default binding (post-capture). When `BeforeScriptEvent` / `AfterScriptEvent` hooks land later, a second binding instance can call the same extractor without rewriting the producer.

The View root passes through `attributes[a11y-hierarchy.viewRoot]` — captured Views are render-host-controlled, not extension-emitted products. Folding into a typed `RenderViewRoot` product is a future cleanup.

## Test plan

- [x] `./gradlew :data-a11y-hierarchy-android:check` — green
- [x] New tests: `declaresExpectedOutputsAndTarget`, `failsLoudlyWhenViewRootAttributeMissing`, `plannerSchedulesHierarchyBeforeTouchTargets`, `plannerSchedulesHierarchyBeforeOverlay`, `plannerCoSchedulesAllConsumersAfterSingleHierarchyProducer`
- End-to-end ATF + hierarchy walk already covered by `RobolectricRenderTest` against `AccessibilityChecker` directly — the extension is a thin binding.

## Follow-ups

- Wire `daemon/android/RenderEngine` to install `AccessibilityHierarchyExtension`, populate the View attribute, and run the post-capture pipeline end-to-end.
- Promote `viewRoot` from `attributes` to a typed product or extension-context-key.
- Generic `DataProductTransport` registry so connector publish serializes by `DataProductKey<*>`.