### PR TITLE
feat(a11y): route TouchTargets through typed pipeline at runtime

### DIFF
--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
@@ -9,9 +9,10 @@ import ee.schimke.composeai.daemon.protocol.DataProductTransport
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import ee.schimke.composeai.renderer.AccessibilityDataProducts
 import ee.schimke.composeai.renderer.AccessibilityFinding
+import ee.schimke.composeai.renderer.AccessibilityFindingsPayload
+import ee.schimke.composeai.renderer.AccessibilityHierarchyPayload
 import ee.schimke.composeai.renderer.AccessibilityNode
 import ee.schimke.composeai.renderer.AccessibilityTouchTargetsPayload
-import ee.schimke.composeai.renderer.buildTouchTargets
 import java.io.File
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -98,14 +99,23 @@ object AccessibilityDataProducer {
     previewDir
       .resolve(FILE_HIERARCHY)
       .writeText(json.encodeToString(HierarchyPayload.serializer(), HierarchyPayload(nodes)))
-    previewDir
-      .resolve(FILE_TOUCH_TARGETS)
-      .writeText(
-        json.encodeToString(
-          AccessibilityTouchTargetsPayload.serializer(),
-          AccessibilityTouchTargetsPayload(buildTouchTargets(nodes, density)),
-        )
+
+    // Touch targets ride through the typed extension graph so the consumer side stays exercised
+    // on real production data. JSON shape is byte-identical to the previous inline call —
+    // TouchTargetsExtension wraps the same buildTouchTargets math.
+    val store =
+      runAccessibilityPostCapturePipeline(
+        previewId = previewId,
+        hierarchy = AccessibilityHierarchyPayload(nodes),
+        findings = AccessibilityFindingsPayload(findings),
+        density = density,
       )
+    store.get(AccessibilityDataProducts.TouchTargets)?.let { touchTargets ->
+      previewDir
+        .resolve(FILE_TOUCH_TARGETS)
+        .writeText(json.encodeToString(AccessibilityTouchTargetsPayload.serializer(), touchTargets))
+    }
+
     if (pngFile == null || imageProcessors.isEmpty()) return
     val input =
       ImageProcessorInput(

--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityPostCapturePipeline.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityPostCapturePipeline.kt
@@ -1,0 +1,109 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.CommonDataProducts
+import ee.schimke.composeai.data.render.extensions.DataExtensionPlanner
+import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
+import ee.schimke.composeai.data.render.extensions.DataProductKey
+import ee.schimke.composeai.data.render.extensions.DataProductStore
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
+import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
+import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import ee.schimke.composeai.data.render.extensions.RenderDensity
+import ee.schimke.composeai.data.render.extensions.RenderImageArtifact
+import ee.schimke.composeai.renderer.AccessibilityDataProducts
+import ee.schimke.composeai.renderer.AccessibilityFindingsPayload
+import ee.schimke.composeai.renderer.AccessibilityHierarchyPayload
+import ee.schimke.composeai.renderer.TouchTargetsExtension
+
+/**
+ * Seeds a [DataProductStore] with hierarchy + ATF + density (and image artifact when present),
+ * plans the registered post-capture extensions, runs each [PostCaptureProcessor] in planner-
+ * determined order, and returns the populated store. Each extension's view is `scopedFor(it)` so
+ * undeclared `put`/`get` fail loudly.
+ *
+ * Failures from individual extensions are logged and skipped — one bad extension shouldn't strand
+ * the typed products earlier extensions already produced. Mirrors the existing
+ * [AccessibilityImageProcessor] error policy in [AccessibilityDataProducer.writeArtifacts].
+ *
+ * Caller-supplied [extensions] lets test code inject custom processors; production wiring passes
+ * the default consumer set ([AccessibilityPostCaptureExtensions.defaults]).
+ */
+fun runAccessibilityPostCapturePipeline(
+  previewId: String,
+  hierarchy: AccessibilityHierarchyPayload,
+  findings: AccessibilityFindingsPayload,
+  density: Float,
+  imageArtifact: RenderImageArtifact? = null,
+  attributes: Map<String, Any?> = emptyMap(),
+  extensions: List<PlannedDataExtension> = AccessibilityPostCaptureExtensions.defaults,
+  target: DataExtensionTarget? = DataExtensionTarget.Android,
+): DataProductStore {
+  val store = RecordingDataProductStore()
+  store.put(AccessibilityDataProducts.Hierarchy, hierarchy)
+  store.put(AccessibilityDataProducts.Atf, findings)
+  store.put(CommonDataProducts.Density, RenderDensity(density))
+  imageArtifact?.let { store.put(CommonDataProducts.ImageArtifact, it) }
+
+  val initialProducts =
+    buildSet<DataProductKey<*>> {
+      add(AccessibilityDataProducts.Hierarchy)
+      add(AccessibilityDataProducts.Atf)
+      add(CommonDataProducts.Density)
+      if (imageArtifact != null) add(CommonDataProducts.ImageArtifact)
+    }
+
+  val requestedOutputs =
+    extensions
+      .filter { ext -> imageArtifact != null || CommonDataProducts.ImageArtifact !in ext.inputs }
+      .flatMap { it.outputs }
+      .toSet()
+
+  if (requestedOutputs.isEmpty()) return store
+
+  val plan =
+    DataExtensionPlanner.planOutputs(
+      extensions = extensions,
+      requestedOutputs = requestedOutputs,
+      initialProducts = initialProducts,
+      target = target,
+    )
+
+  if (!plan.isValid) {
+    System.err.println(
+      "AccessibilityPostCapturePipeline: planning failed for $previewId — ${plan.errors}"
+    )
+    return store
+  }
+
+  for (ext in plan.orderedExtensions) {
+    if (ext !is PostCaptureProcessor) continue
+    try {
+      ext.process(
+        ExtensionPostCaptureContext(
+          extensionId = ext.id,
+          previewId = previewId,
+          renderMode = null,
+          products = store.scopedFor(ext),
+          attributes = attributes,
+        )
+      )
+    } catch (t: Throwable) {
+      System.err.println(
+        "AccessibilityPostCapturePipeline: extension '${ext.id}' failed for " +
+          "$previewId: ${t.javaClass.simpleName}: ${t.message}"
+      )
+    }
+  }
+  return store
+}
+
+/**
+ * Default consumer set for [runAccessibilityPostCapturePipeline]. Currently just
+ * [TouchTargetsExtension] — overlay generation still goes through the legacy
+ * [AccessibilityImageProcessor] hook on [AccessibilityDataProducer.writeArtifacts] until that path
+ * gets folded into the typed graph in a follow-up.
+ */
+object AccessibilityPostCaptureExtensions {
+  val defaults: List<PlannedDataExtension> = listOf(TouchTargetsExtension())
+}

--- a/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityPostCapturePipelineTest.kt
+++ b/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityPostCapturePipelineTest.kt
@@ -1,0 +1,190 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.CommonDataProducts
+import ee.schimke.composeai.data.render.extensions.DataExtensionConstraints
+import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.DataProductKey
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
+import ee.schimke.composeai.data.render.extensions.RenderImageArtifact
+import ee.schimke.composeai.renderer.AccessibilityDataProducts
+import ee.schimke.composeai.renderer.AccessibilityFindingsPayload
+import ee.schimke.composeai.renderer.AccessibilityHierarchyPayload
+import ee.schimke.composeai.renderer.AccessibilityNode
+import ee.schimke.composeai.renderer.TouchTargetsExtension
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class AccessibilityPostCapturePipelineTest {
+  @Test
+  fun seedsHierarchyAtfDensityAndRunsTouchTargetsByDefault() {
+    val store =
+      runAccessibilityPostCapturePipeline(
+        previewId = "preview",
+        hierarchy =
+          AccessibilityHierarchyPayload(
+            nodes =
+              listOf(
+                AccessibilityNode(
+                  label = "Tiny",
+                  role = "Button",
+                  states = listOf("clickable"),
+                  boundsInScreen = "0,0,80,80",
+                )
+              )
+          ),
+        findings = AccessibilityFindingsPayload(emptyList()),
+        density = 2f,
+      )
+
+    val touchTargets = store.get(AccessibilityDataProducts.TouchTargets)
+    assertNotNull("touch-targets must be populated by the default pipeline", touchTargets)
+    assertEquals(1, touchTargets!!.targets.size)
+    assertEquals(40f, touchTargets.targets.single().widthDp)
+    assertEquals(listOf("belowMinimum"), touchTargets.targets.single().findings)
+  }
+
+  @Test
+  fun returnsSeededProductsEvenWhenNoExtensionsPlanned() {
+    val hierarchy = AccessibilityHierarchyPayload(emptyList())
+    val findings = AccessibilityFindingsPayload(emptyList())
+
+    val store =
+      runAccessibilityPostCapturePipeline(
+        previewId = "preview",
+        hierarchy = hierarchy,
+        findings = findings,
+        density = 1f,
+        extensions = emptyList(),
+      )
+
+    assertSame(hierarchy, store.get(AccessibilityDataProducts.Hierarchy))
+    assertSame(findings, store.get(AccessibilityDataProducts.Atf))
+    assertEquals(1f, store.get(CommonDataProducts.Density)!!.density)
+    assertNull(store.get(AccessibilityDataProducts.TouchTargets))
+  }
+
+  @Test
+  fun skipsImageDependentExtensionsWhenNoImageArtifact() {
+    val invocations = mutableListOf<String>()
+    val imageRequiringExtension = recordingProcessor(
+      id = "image-requiring",
+      inputs = setOf(CommonDataProducts.ImageArtifact),
+      outputs = setOf(StringProductKey),
+      invocations = invocations,
+    )
+
+    runAccessibilityPostCapturePipeline(
+      previewId = "preview",
+      hierarchy = AccessibilityHierarchyPayload(emptyList()),
+      findings = AccessibilityFindingsPayload(emptyList()),
+      density = 1f,
+      imageArtifact = null,
+      extensions = listOf(imageRequiringExtension),
+    )
+
+    assertEquals(emptyList<String>(), invocations)
+  }
+
+  @Test
+  fun runsImageDependentExtensionsWhenImageArtifactSeeded() {
+    val invocations = mutableListOf<String>()
+    val imageRequiringExtension = recordingProcessor(
+      id = "image-requiring",
+      inputs = setOf(CommonDataProducts.ImageArtifact),
+      outputs = setOf(StringProductKey),
+      invocations = invocations,
+    )
+
+    runAccessibilityPostCapturePipeline(
+      previewId = "preview",
+      hierarchy = AccessibilityHierarchyPayload(emptyList()),
+      findings = AccessibilityFindingsPayload(emptyList()),
+      density = 1f,
+      imageArtifact = RenderImageArtifact(path = "/tmp/preview.png"),
+      extensions = listOf(imageRequiringExtension),
+    )
+
+    assertEquals(listOf("image-requiring"), invocations)
+  }
+
+  @Test
+  fun extensionFailureIsLoggedAndDoesNotStrandLaterProducts() {
+    val failingExtension =
+      object : PostCaptureProcessor {
+        override val id: DataExtensionId = DataExtensionId("failing")
+        override val hooks: Set<DataExtensionHookKind> =
+          setOf(DataExtensionHookKind.AfterCapture)
+        override val constraints: DataExtensionConstraints =
+          DataExtensionConstraints(phase = DataExtensionPhase.PostProcess)
+        override val outputs: Set<DataProductKey<*>> = setOf(FailingOutput)
+
+        override fun process(context: ExtensionPostCaptureContext) {
+          throw IllegalStateException("boom")
+        }
+      }
+
+    val store =
+      runAccessibilityPostCapturePipeline(
+        previewId = "preview",
+        hierarchy =
+          AccessibilityHierarchyPayload(
+            nodes =
+              listOf(
+                AccessibilityNode(
+                  label = "Tiny",
+                  states = listOf("clickable"),
+                  boundsInScreen = "0,0,80,80",
+                )
+              )
+          ),
+        findings = AccessibilityFindingsPayload(emptyList()),
+        density = 2f,
+        extensions = listOf(failingExtension, TouchTargetsExtension()),
+      )
+
+    assertNull(store.get(FailingOutput))
+    assertNotNull(
+      "TouchTargetsExtension still ran after the unrelated failing extension",
+      store.get(AccessibilityDataProducts.TouchTargets),
+    )
+  }
+
+  private fun recordingProcessor(
+    id: String,
+    inputs: Set<DataProductKey<*>>,
+    outputs: Set<DataProductKey<*>>,
+    invocations: MutableList<String>,
+  ): PostCaptureProcessor =
+    object : PostCaptureProcessor {
+      override val id: DataExtensionId = DataExtensionId(id)
+      override val hooks: Set<DataExtensionHookKind> = setOf(DataExtensionHookKind.AfterCapture)
+      override val constraints: DataExtensionConstraints =
+        DataExtensionConstraints(phase = DataExtensionPhase.PostProcess)
+      override val inputs: Set<DataProductKey<*>> = inputs
+      override val outputs: Set<DataProductKey<*>> = outputs
+
+      override fun process(context: ExtensionPostCaptureContext) {
+        invocations += id
+        outputs.forEach { key ->
+          if (key.type == String::class.java) {
+            @Suppress("UNCHECKED_CAST")
+            context.products.put(key as DataProductKey<String>, "ok")
+          }
+        }
+      }
+    }
+
+  companion object {
+    private val StringProductKey: DataProductKey<String> =
+      DataProductKey("test/string", schemaVersion = 1, String::class.java)
+
+    private val FailingOutput: DataProductKey<String> =
+      DataProductKey("test/failing", schemaVersion = 1, String::class.java)
+  }
+}


### PR DESCRIPTION
## Summary

First runtime use of the typed extension pipeline on real production data.

- New `runAccessibilityPostCapturePipeline(...)` helper in `:data-a11y-connector` — seeds a `DataProductStore` with hierarchy + ATF + density (and optionally `ImageArtifact`), plans the registered extensions via `DataExtensionPlanner.planOutputs`, runs each `PostCaptureProcessor` against `scopedFor(extension)`, and returns the populated store.
- `AccessibilityDataProducer.writeArtifacts` now delegates touch-targets generation to the pipeline instead of calling `buildTouchTargets` inline. JSON shape on disk is byte-identical — `TouchTargetsExtension` wraps the same math — but the typed graph now runs end-to-end.
- Overlay generation still goes through the legacy `AccessibilityImageProcessor` for backward compat. Folding overlay into the pipeline (and deprecating the legacy hook) is a follow-up that needs a story for the double-write collision.

Failures from individual extensions are logged and skipped — one bad extension can't strand the typed products earlier extensions already produced. Mirrors the existing `imageProcessors` error policy.

## Test plan

- [x] `./gradlew :data-a11y-connector:check` — green (existing `AccessibilityDataProductRegistryTest` passes unchanged → on-disk JSON contract preserved)
- [x] `./gradlew ktfmtCheckAll` — clean
- [x] New `AccessibilityPostCapturePipelineTest`:
  - `seedsHierarchyAtfDensityAndRunsTouchTargetsByDefault`
  - `returnsSeededProductsEvenWhenNoExtensionsPlanned`
  - `skipsImageDependentExtensionsWhenNoImageArtifact`
  - `runsImageDependentExtensionsWhenImageArtifactSeeded`
  - `extensionFailureIsLoggedAndDoesNotStrandLaterProducts`

## Follow-ups

- Fold `OverlayExtension` into the pipeline once the daemon's legacy `AccessibilityImageProcessor` hook is deprecated (avoid the double-write to `a11y-overlay.png`).
- Move pipeline seeding upward into `daemon/android/RenderEngine` so `AccessibilityHierarchyExtension` (the producer in `:data-a11y-hierarchy-android`) drives the analyze step from inside the typed graph.
- Generic `DataProductTransport` registry so connector publish serializes by `DataProductKey<*>` instead of bespoke per-product JSON writes.