### PR TITLE
test(vscode): real-Gradle e2e prototype gated on main CI

### DIFF
--- a/.github/workflows/vscode-extension-e2e.yml
+++ b/.github/workflows/vscode-extension-e2e.yml
@@ -1,0 +1,146 @@
+name: VS Code Extension E2E
+
+# End-to-end test that drives the VS Code extension against a real Gradle
+# build of `:samples:cmp` (locally-built plugin via `includeBuild`). The
+# fast `vscode-extension-tests` job in ci.yml stubs Gradle out with a
+# RecordingGradleApi; this job swaps in a real one (`RealGradleApi`) so
+# the loop is exercised plugin-end-to-extension-end.
+#
+# Not on every PR: cold renderAllPreviews on `:samples:cmp` is multi-minute
+# and the prototype is more flake-prone than the stub-driven path.
+#
+# Triggers:
+#   workflow_dispatch — manual one-off runs (any branch).
+#   workflow_run      — fires after CI or Integration finish on `main`. Each
+#                       completion fires this workflow once, so the `gate`
+#                       job below short-circuits unless the *other* upstream
+#                       has also already succeeded on the same head_sha.
+#                       Net effect: e2e runs once per main push, after both
+#                       gating workflows are green.
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["CI", "Integration"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  # Group on the head SHA so the CI-completion run and the
+  # Integration-completion run for the same commit dedupe to a single
+  # attempt. Manual dispatches get their own slot via run_id.
+  group: vscode-extension-e2e-${{ github.event.workflow_run.head_sha || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    name: Gate on upstream workflows
+    runs-on: ubuntu-latest
+    # workflow_run can fire after a *failed* upstream too; `if` weeds those
+    # out so the gate job itself only runs in the proceed-eligible cases.
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success')
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          TRIGGERING_WORKFLOW: ${{ github.event.workflow_run.name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Manual dispatch — proceeding."
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Sibling gating workflows beyond the one that triggered us.
+          REQUIRED=(CI Integration)
+          for wf in "${REQUIRED[@]}"; do
+            if [ "$wf" = "$TRIGGERING_WORKFLOW" ]; then
+              continue
+            fi
+            echo "Checking '$wf' status for $HEAD_SHA"
+            STATE=$(gh run list \
+              --workflow "$wf" \
+              --commit "$HEAD_SHA" \
+              --limit 1 \
+              --json conclusion,status \
+              --jq '.[0] | "\(.status):\(.conclusion // "")"' \
+              || true)
+            echo "  $wf -> ${STATE:-(no run found)}"
+            if [ "$STATE" != "completed:success" ]; then
+              echo "::notice::Skipping e2e — '$wf' is '${STATE:-missing}' on $HEAD_SHA. Re-runs once it goes green."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          echo "All required upstream workflows are green for $HEAD_SHA."
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+  e2e:
+    name: VS Code Extension E2E (real Gradle)
+    needs: gate
+    if: needs.gate.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    # 60 minutes ceiling — local cold runs land closer to 5-10 min, but a
+    # CI runner with no Gradle/Compose caches warm and a fresh
+    # @vscode/test-electron download can stretch.
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          # workflow_run sets github.sha to the workflow file's own commit,
+          # not the head_sha that fired it. Pin to head_sha so we test the
+          # same tree CI / Integration just verified.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - uses: ./.github/actions/setup
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+
+      # Cache the @vscode/test-electron VS Code download so subsequent runs
+      # don't re-fetch the ~150MB stable build.
+      - name: Cache VS Code download
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: vscode-extension/.vscode-test
+          key: vscode-test-electron-${{ runner.os }}
+
+      - name: Install extension dependencies
+        working-directory: vscode-extension
+        run: npm ci
+
+      # Compile up front so the e2e launcher (which also runs `npm run
+      # compile`) finds an already-warm tsc and so any compile failures
+      # surface before xvfb spins up.
+      - name: Compile extension
+        working-directory: vscode-extension
+        run: npm run compile
+
+      - name: Run e2e tests under xvfb
+        working-directory: vscode-extension
+        run: xvfb-run -a npm run test:e2e
+
+      - name: Upload renders on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-renders
+          path: |
+            samples/cmp/build/compose-previews/
+            vscode-extension/.vscode-test/user-data/logs/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/samples/desktop-daemon-bench/build.gradle.kts
+++ b/samples/desktop-daemon-bench/build.gradle.kts
@@ -1,4 +1,3 @@
-// Desktop latency baseline harness for the preview daemon work — see
 // Desktop latency baseline harness for the preview daemon work — see docs/daemon/DESIGN.md § 13.
 //
 // Mirrors :samples:android-daemon-bench (P0.1) but renders through the

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -158,6 +158,7 @@
         "format:check": "prettier --check --tab-width 4 package.json package-lock.json tsconfig.json README.md \"src/**/*.ts\" \"src/**/*.json\" \"media/**/*.css\"",
         "test": "npm run compile && mocha --exit 'out/test/!(electron)/**/*.test.js' 'out/test/*.test.js'",
         "test:electron": "npm run compile && node ./out/test/electron/runTest.js",
+        "test:e2e": "npm run compile && COMPOSE_PREVIEW_E2E=1 node ./out/test/electron/runTest.js",
         "lint": "eslint src --ext ts",
         "package": "npm run compile && vsce package --no-dependencies"
     },

--- a/vscode-extension/src/test/electron/realGradleApi.ts
+++ b/vscode-extension/src/test/electron/realGradleApi.ts
@@ -1,0 +1,85 @@
+import { spawn } from "child_process";
+import * as path from "path";
+import type { GradleApi } from "../../gradleService";
+
+/**
+ * Real {@link GradleApi} that shells out to the repo's `./gradlew` wrapper.
+ * Used by the daily/manual e2e suite to drive the *actual* Gradle plugin
+ * end-to-end, instead of the recording stub the fast suite uses.
+ *
+ * Stays out of `src/main/` because it pulls `child_process` and resolves
+ * paths assuming the test layout — production extension code reaches
+ * Gradle through the official `vscjava.vscode-gradle` API, never directly.
+ */
+export class RealGradleApi implements GradleApi {
+    /**
+     * @param gradlewDir Absolute path to the directory containing the
+     *                   `gradlew` script (the repo root).
+     * @param onLog Optional sink for human-readable progress lines.
+     */
+    constructor(
+        private readonly gradlewDir: string,
+        private readonly onLog: (line: string) => void = () => {},
+    ) {}
+
+    runTask(opts: {
+        projectFolder: string;
+        taskName: string;
+        args?: ReadonlyArray<string>;
+        showOutputColors: boolean;
+        onOutput?: (output: {
+            getOutputBytes(): Uint8Array;
+            getOutputType(): number;
+        }) => void;
+        cancellationKey?: string;
+    }): Promise<void> {
+        const gradlewPath =
+            process.platform === "win32"
+                ? path.join(this.gradlewDir, "gradlew.bat")
+                : path.join(this.gradlewDir, "gradlew");
+        const gradleArgs = [opts.taskName, ...(opts.args ?? [])];
+        this.onLog(
+            `[realGradleApi] ${gradlewPath} ${gradleArgs.join(" ")} (cwd=${opts.projectFolder})`,
+        );
+
+        return new Promise((resolve, reject) => {
+            const child = spawn(gradlewPath, gradleArgs, {
+                cwd: opts.projectFolder,
+                env: { ...process.env },
+                stdio: ["ignore", "pipe", "pipe"],
+            });
+            child.stdout.on("data", (chunk: Buffer) => {
+                opts.onOutput?.({
+                    getOutputBytes: () => new Uint8Array(chunk),
+                    // 0 = stdout, matches the bytes-shaped contract the
+                    // production GradleApi consumer (gradleService.ts) uses.
+                    getOutputType: () => 0,
+                });
+            });
+            child.stderr.on("data", (chunk: Buffer) => {
+                opts.onOutput?.({
+                    getOutputBytes: () => new Uint8Array(chunk),
+                    getOutputType: () => 1,
+                });
+            });
+            child.once("error", reject);
+            child.once("close", (code) => {
+                if (code === 0) {
+                    resolve();
+                } else {
+                    reject(
+                        new Error(
+                            `gradlew ${gradleArgs.join(" ")} exited with ${code}`,
+                        ),
+                    );
+                }
+            });
+        });
+    }
+
+    async cancelRunTask(): Promise<void> {
+        // The e2e suite runs each gradle invocation to completion; the
+        // extension never cancels mid-run in this harness. If we ever want
+        // to exercise cancellation we'd track the live child here.
+    }
+}

--- a/vscode-extension/src/test/electron/runTest.ts
+++ b/vscode-extension/src/test/electron/runTest.ts
@@ -26,7 +26,16 @@ async function main(): Promise<void> {
         __dirname,
         "../../../src/test/electron/fixtures",
     );
-    const workspacePath = path.join(fixturesRoot, "workspace");
+    // E2E mode (COMPOSE_PREVIEW_E2E=1, set by `npm run test:e2e` and the
+    // daily/manual GitHub Actions workflow) opens the *repo root* as the
+    // workspace. That gives the test a working `:samples:cmp` module wired
+    // into the local plugin via `includeBuild("gradle-plugin")`, without
+    // duplicating fixture build files. The fast suite keeps its tiny
+    // pre-baked workspace.
+    const e2eMode = process.env.COMPOSE_PREVIEW_E2E === "1";
+    const workspacePath = e2eMode
+        ? path.resolve(extensionDevelopmentPath, "..")
+        : path.join(fixturesRoot, "workspace");
     const fakeGradleExtensionPath = path.join(
         fixturesRoot,
         "fake-vscode-gradle",
@@ -75,6 +84,7 @@ async function main(): Promise<void> {
         ],
         extensionTestsEnv: {
             COMPOSE_PREVIEW_TEST_MODE: "1",
+            ...(e2eMode ? { COMPOSE_PREVIEW_E2E: "1" } : {}),
         },
     });
     console.log(`[runTest] tests complete`);

--- a/vscode-extension/src/test/electron/suite/e2e.test.ts
+++ b/vscode-extension/src/test/electron/suite/e2e.test.ts
@@ -1,0 +1,175 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import * as vscode from "vscode";
+import type { ComposePreviewTestApi } from "../../../extension";
+import { RealGradleApi } from "../realGradleApi";
+
+/**
+ * End-to-end test. Drives the extension against a real Gradle build of
+ * `:samples:cmp` so the *full* loop is exercised: `renderAllPreviews`
+ * runs through the locally-built plugin, the renderer subprocesses fork,
+ * PNGs land under `samples/cmp/build/compose-previews/renders/`, and the
+ * extension panel receives the populated `setPreviews` message.
+ *
+ * Gated on `COMPOSE_PREVIEW_E2E=1`. Skipped silently in the fast suite
+ * because (a) cold Gradle + Compose Multiplatform setup is multi-minute,
+ * (b) flake potential is non-trivial. The CI workflow at
+ * `.github/workflows/vscode-extension-e2e.yml` runs it on `main` after
+ * CI + Integration both pass, plus on `workflow_dispatch`.
+ *
+ * Why the existing `samples/cmp` module rather than a fresh fixture: the
+ * repo's settings.gradle.kts already wires `includeBuild("gradle-plugin")`,
+ * so the test exercises the locally-built plugin without any version-
+ * pinning or `publishToMavenLocal` setup. This is the prototype shape;
+ * a self-contained fixture is a follow-up if/when we want to insulate
+ * the test from sample evolution.
+ */
+
+const E2E = process.env.COMPOSE_PREVIEW_E2E === "1";
+const describeE2E = E2E ? describe : describe.skip;
+
+interface PostedMessage {
+    command: string;
+    [key: string]: unknown;
+}
+
+function findMessage(
+    messages: unknown[],
+    command: string,
+): PostedMessage | undefined {
+    return messages.find((m) => (m as PostedMessage).command === command) as
+        | PostedMessage
+        | undefined;
+}
+
+async function waitFor<T>(
+    description: string,
+    timeoutMs: number,
+    pollMs: number,
+    probe: () => T | undefined,
+): Promise<T> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const value = probe();
+        if (value !== undefined) {
+            return value;
+        }
+        await new Promise((r) => setTimeout(r, pollMs));
+    }
+    throw new Error(
+        `Timed out after ${timeoutMs}ms waiting for: ${description}`,
+    );
+}
+
+describeE2E("Compose Preview e2e (real Gradle)", function () {
+    // Cold renderAllPreviews on `:samples:cmp` is ~30-90s on a warm machine
+    // and can spike higher on a fresh CI runner. 10 minutes is the same
+    // ceiling the gradle-plugin functional tests use.
+    this.timeout(10 * 60_000);
+
+    let api: ComposePreviewTestApi;
+    let kotlinFile: string;
+    let repoRoot: string;
+    let renderDir: string;
+
+    before(async () => {
+        const folders = vscode.workspace.workspaceFolders;
+        assert.ok(folders && folders.length > 0, "workspace must be open");
+        repoRoot = folders[0].uri.fsPath;
+        kotlinFile = path.join(
+            repoRoot,
+            "samples",
+            "cmp",
+            "src",
+            "main",
+            "kotlin",
+            "com",
+            "example",
+            "samplecmp",
+            "Previews.kt",
+        );
+        assert.ok(
+            fs.existsSync(kotlinFile),
+            `expected fixture file at ${kotlinFile}`,
+        );
+        renderDir = path.join(
+            repoRoot,
+            "samples",
+            "cmp",
+            "build",
+            "compose-previews",
+            "renders",
+        );
+        // Clean previous renders so the assertion below verifies *this* run
+        // produced PNGs, not a stale artifact from a developer's last build.
+        if (fs.existsSync(renderDir)) {
+            for (const entry of fs.readdirSync(renderDir)) {
+                fs.rmSync(path.join(renderDir, entry), {
+                    recursive: true,
+                    force: true,
+                });
+            }
+        }
+
+        const ext = vscode.extensions.getExtension<ComposePreviewTestApi>(
+            "yuri-schimke.compose-preview",
+        );
+        assert.ok(ext, "compose-preview extension must be present");
+        const exported = await ext.activate();
+        assert.ok(
+            exported,
+            "activate() must return ComposePreviewTestApi under COMPOSE_PREVIEW_TEST_MODE=1",
+        );
+        api = exported;
+        api.injectGradleApi(
+            new RealGradleApi(repoRoot, (line) => console.log(line)),
+        );
+    });
+
+    it("renders previews for samples/cmp through the real Gradle plugin", async () => {
+        api.resetMessages();
+        await api.triggerRefresh(kotlinFile, /* force */ true, "full");
+
+        // The panel may emit several setPreviews on its way through the
+        // refresh flow; the last one is the one carrying the rendered
+        // metadata, so wait for any non-empty message.
+        const previewsMessage = await waitFor(
+            "non-empty setPreviews from real renderAllPreviews",
+            this.timeout(),
+            500,
+            () => {
+                const msgs = api.getPostedMessages();
+                const m = findMessage(msgs, "setPreviews");
+                if (!m) return undefined;
+                const previews = m.previews as Array<unknown> | undefined;
+                if (!previews || previews.length === 0) return undefined;
+                return m;
+            },
+        );
+
+        const previews = previewsMessage.previews as Array<{
+            id: string;
+            renderPath?: string;
+        }>;
+        console.log(
+            `[e2e] received ${previews.length} previews: ` +
+                previews.map((p) => p.id).join(", "),
+        );
+        assert.ok(
+            previews.length >= 2,
+            `expected at least 2 previews, got ${previews.length}`,
+        );
+
+        // Confirm the renders actually landed on disk — the panel-message
+        // path could in theory be satisfied by a cached previews.json
+        // without fresh PNGs, and we want to catch that regression here.
+        const pngs = fs.existsSync(renderDir)
+            ? fs.readdirSync(renderDir).filter((n) => n.endsWith(".png"))
+            : [];
+        assert.ok(
+            pngs.length >= 2,
+            `expected at least 2 rendered PNGs in ${renderDir}, found ${pngs.length}`,
+        );
+    });
+});

--- a/vscode-extension/src/test/electron/suite/index.ts
+++ b/vscode-extension/src/test/electron/suite/index.ts
@@ -26,9 +26,16 @@ export async function run(): Promise<void> {
     });
 
     const testsRoot = __dirname;
-    const files = await glob("**/*.test.js", { cwd: testsRoot });
+    // E2E mode (COMPOSE_PREVIEW_E2E=1, set by runTest.ts when launched via
+    // `npm run test:e2e`) runs only the slow real-Gradle suite; the fast
+    // suite excludes it. Pattern selection here so each mode's run output
+    // doesn't list "skipped" entries for the other mode's tests.
+    const e2eMode = process.env.COMPOSE_PREVIEW_E2E === "1";
+    const pattern = e2eMode ? "**/e2e.test.js" : "**/*.test.js";
+    const ignore = e2eMode ? [] : ["**/e2e.test.js"];
+    const files = await glob(pattern, { cwd: testsRoot, ignore });
     console.log(
-        `[suite] discovered ${files.length} test file(s) in ${testsRoot}`,
+        `[suite] discovered ${files.length} test file(s) in ${testsRoot} (e2e=${e2eMode})`,
     );
     for (const f of files) {
         const abs = path.resolve(testsRoot, f);


### PR DESCRIPTION
## Summary

- New end-to-end VS Code extension test that drives `:samples:cmp:renderAllPreviews` through the locally-built plugin (no recording stub), asserts `setPreviews` lands on the panel, and confirms PNGs hit disk under `samples/cmp/build/compose-previews/renders/`.
- `RealGradleApi` adapter spawns the repo's `gradlew`; `COMPOSE_PREVIEW_E2E=1` flips the launcher onto the repo root as the workspace and the suite filter onto `e2e.test.js` only — the fast suite is untouched (320 tests still pass).
- New `vscode-extension-e2e.yml` workflow runs on `workflow_dispatch` and after **both** `CI` and `Integration` succeed on `main`. A small `gate` job uses `gh run list` to verify the sibling upstream is also green on the same `head_sha`, so we run once per main push instead of twice (once per upstream completion).
- Drive-by: drop a stray duplicated header line in `samples/desktop-daemon-bench/build.gradle.kts` (line 1 was a truncated stutter of line 2).

## Why this shape

The existing `lifecycle.test.ts` already runs inside a real VS Code via `@vscode/test-electron`, but it stubs Gradle out with a `RecordingGradleApi` and ships pre-baked PNGs. This prototype swaps in a real adapter and reuses `samples/cmp` rather than introducing a new fixture, because the repo's `includeBuild("gradle-plugin")` already wires the locally-built plugin without any version-pinning or `publishToMavenLocal` setup. A self-contained fixture is a sensible follow-up if/when the test starts being sensitive to sample evolution.

## Test plan

- [x] `npm --prefix vscode-extension run compile` — clean
- [x] `npm --prefix vscode-extension run test` — 320 passing, fast suite untouched
- [x] `npm --prefix vscode-extension run format:check` — all files match Prettier
- [x] `./gradlew :samples:desktop-daemon-bench:ktfmtCheckMain` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/vscode-extension-e2e.yml'))"` — workflow YAML parses
- [ ] Local `xvfb-run -a npm run test:e2e` — sandbox blocks `update.code.visualstudio.com`, so the VS Code download fails locally; up to and including the workspacePath/env wiring is verified, real Gradle round-trip will only execute on a CI runner with network access
- [ ] After merge: `workflow_dispatch` from the Actions tab once, then watch the next push to main fire the gated path


---
_Generated by [Claude Code](https://claude.ai/code/session_01JE5XpePuMenwGX8LvVeJW7)_