### PR TITLE
fix(a11y): plan only transitively-runnable extensions per render

### DIFF
--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -155,8 +155,8 @@ open class DesktopHost(
   /**
    * `recording.probe` is the only extension event [DesktopRecordingSession] dispatches today; click
    * / pointer kinds are built-in inputs, not extensions. The descriptor is empty when the host
-   * can't actually allocate a session ([supportsRecording] = false) so agents don't see
-   * supported = true on a daemon that would reject `recording/start` anyway.
+   * can't actually allocate a session ([supportsRecording] = false) so agents don't see supported =
+   * true on a daemon that would reject `recording/start` anyway.
    */
   override fun recordingScriptEventDescriptors(): List<DataExtensionDescriptor> =
     if (supportsRecording) listOf(RecordingScriptDataExtensions.recordingDescriptor)

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
@@ -97,10 +97,10 @@ class DesktopHostTest {
 
   /**
    * `recordingScriptEventDescriptors()` is the seam DaemonMain reads to assemble the daemon's
-   * `dataExtensions` capability. Without a resolver the host can't allocate a recording session,
-   * so it must NOT advertise `recording.probe` as `supported = true` — otherwise an agent
-   * trusting `list_data_products` would see a green probe and watch its `record_preview` calls
-   * fail with `MethodNotFound`.
+   * `dataExtensions` capability. Without a resolver the host can't allocate a recording session, so
+   * it must NOT advertise `recording.probe` as `supported = true` — otherwise an agent trusting
+   * `list_data_products` would see a green probe and watch its `record_preview` calls fail with
+   * `MethodNotFound`.
    */
   @Test
   fun recordingScriptEventDescriptorsAreEmptyWithoutResolver() {
@@ -108,9 +108,9 @@ class DesktopHostTest {
   }
 
   /**
-   * With a resolver wired, `recordingScriptEventDescriptors()` advertises only
-   * `recording.probe` (supported = true). Roadmap descriptors stay out of the host contribution —
-   * they're appended separately by DaemonMain.
+   * With a resolver wired, `recordingScriptEventDescriptors()` advertises only `recording.probe`
+   * (supported = true). Roadmap descriptors stay out of the host contribution — they're appended
+   * separately by DaemonMain.
    */
   @Test
   fun recordingScriptEventDescriptorsAdvertiseProbeWhenResolverPresent() {

--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityPostCapturePipeline.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityPostCapturePipeline.kt
@@ -53,17 +53,20 @@ fun runAccessibilityPostCapturePipeline(
       if (imageArtifact != null) add(CommonDataProducts.ImageArtifact)
     }
 
-  val requestedOutputs =
-    extensions
-      .filter { ext -> imageArtifact != null || CommonDataProducts.ImageArtifact !in ext.inputs }
-      .flatMap { it.outputs }
-      .toSet()
+  // Only request outputs whose full dependency chain can be satisfied from initialProducts +
+  // extensions on this render. Direct-input filtering isn't enough — an extension with no direct
+  // image dependency may still transitively depend on one through another extension's output, in
+  // which case planOutputs would error on the missing ImageArtifact and strand every output for
+  // this render. Computing the runnable closure first lets unaffected outputs (e.g. touch-targets)
+  // still run.
+  val runnableExtensions = runnableExtensionsFor(extensions, initialProducts)
+  val requestedOutputs = runnableExtensions.flatMap { it.outputs }.toSet()
 
   if (requestedOutputs.isEmpty()) return store
 
   val plan =
     DataExtensionPlanner.planOutputs(
-      extensions = extensions,
+      extensions = runnableExtensions,
       requestedOutputs = requestedOutputs,
       initialProducts = initialProducts,
       target = target,
@@ -106,4 +109,32 @@ fun runAccessibilityPostCapturePipeline(
  */
 object AccessibilityPostCaptureExtensions {
   val defaults: List<PlannedDataExtension> = listOf(TouchTargetsExtension())
+}
+
+/**
+ * Walks the dependency closure forward from [initialProducts] and returns the subset of
+ * [extensions] whose full input chain is ultimately satisfied. Used to drop extensions whose
+ * declared inputs (or transitive inputs through other extensions in the list) can't be produced
+ * on this render so their unsatisfiable outputs don't poison [DataExtensionPlanner.planOutputs]
+ * for the rest.
+ *
+ * Fixpoint iteration over the producer map. O(n²) in the worst case for n extensions; n is small
+ * (single-digit) for any realistic registered set, so the simple shape stays cheaper than a
+ * topological sort with cycle handling.
+ */
+internal fun runnableExtensionsFor(
+  extensions: List<PlannedDataExtension>,
+  initialProducts: Set<DataProductKey<*>>,
+): List<PlannedDataExtension> {
+  val producible = initialProducts.toMutableSet()
+  val runnable = mutableListOf<PlannedDataExtension>()
+  val pending = extensions.toMutableList()
+  do {
+    val newlyRunnable = pending.filter { ext -> ext.inputs.all { it in producible } }
+    if (newlyRunnable.isEmpty()) break
+    runnable += newlyRunnable
+    newlyRunnable.forEach { producible += it.outputs }
+    pending.removeAll(newlyRunnable)
+  } while (pending.isNotEmpty())
+  return runnable
 }

--- a/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityPostCapturePipelineTest.kt
+++ b/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityPostCapturePipelineTest.kt
@@ -114,6 +114,55 @@ class AccessibilityPostCapturePipelineTest {
   }
 
   @Test
+  fun transitiveImageDependencyDoesNotStrandUnrelatedConsumers() {
+    // Chain: chained ← intermediate ← ImageArtifact. When ImageArtifact isn't seeded, neither
+    // of those should run, but TouchTargetsExtension (no image dep, anywhere in its chain) must
+    // still run — the previous direct-input filter would let `chained` slip through and the
+    // planner would then error on the missing ImageArtifact for the whole render.
+    val intermediate =
+      recordingProcessor(
+        id = "intermediate",
+        inputs = setOf(CommonDataProducts.ImageArtifact),
+        outputs = setOf(IntermediateProduct),
+        invocations = mutableListOf(),
+      )
+    val chained =
+      recordingProcessor(
+        id = "chained",
+        inputs = setOf(IntermediateProduct),
+        outputs = setOf(ChainedProduct),
+        invocations = mutableListOf(),
+      )
+
+    val store =
+      runAccessibilityPostCapturePipeline(
+        previewId = "preview",
+        hierarchy =
+          AccessibilityHierarchyPayload(
+            nodes =
+              listOf(
+                AccessibilityNode(
+                  label = "Tiny",
+                  states = listOf("clickable"),
+                  boundsInScreen = "0,0,80,80",
+                )
+              )
+          ),
+        findings = AccessibilityFindingsPayload(emptyList()),
+        density = 2f,
+        imageArtifact = null,
+        extensions = listOf(intermediate, chained, TouchTargetsExtension()),
+      )
+
+    assertNull(store.get(IntermediateProduct))
+    assertNull(store.get(ChainedProduct))
+    assertNotNull(
+      "TouchTargetsExtension must still run when an unrelated chain is unsatisfiable",
+      store.get(AccessibilityDataProducts.TouchTargets),
+    )
+  }
+
+  @Test
   fun extensionFailureIsLoggedAndDoesNotStrandLaterProducts() {
     val failingExtension =
       object : PostCaptureProcessor {
@@ -186,5 +235,11 @@ class AccessibilityPostCapturePipelineTest {
 
     private val FailingOutput: DataProductKey<String> =
       DataProductKey("test/failing", schemaVersion = 1, String::class.java)
+
+    private val IntermediateProduct: DataProductKey<String> =
+      DataProductKey("test/intermediate", schemaVersion = 1, String::class.java)
+
+    private val ChainedProduct: DataProductKey<String> =
+      DataProductKey("test/chained", schemaVersion = 1, String::class.java)
   }
 }

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
@@ -235,8 +235,8 @@ data class RecordingScriptEventDescriptor(
 /**
  * Built-in recording-script descriptor namespace. Splits cleanly between two halves:
  *
- * - [recordingDescriptor] — the `recording` extension, advertising `recording.probe` as
- *   `supported = true`. Each [ee.schimke.composeai.daemon.RenderHost] returns this from its
+ * - [recordingDescriptor] — the `recording` extension, advertising `recording.probe` as `supported
+ *   = true`. Each [ee.schimke.composeai.daemon.RenderHost] returns this from its
  *   `recordingScriptEventDescriptors()` override, alongside any host-specific extensions, so the
  *   daemon's `dataExtensions` capability set tracks what the host actually dispatches.
  * - [roadmapDescriptors] — `state` / `lifecycle` / `preview`, all `supported = false`. Advertised


### PR DESCRIPTION
## Summary

Addresses [PR #726 review feedback](https://github.com/yschimke/compose-ai-tools/pull/726): the post-capture pipeline's direct-input filter for `ImageArtifact` only handled the trivial case. An extension chained through another extension's output (`Z ← Y ← ImageArtifact`) would slip through, get added to `requestedOutputs`, and `planOutputs` would then error on the missing `ImageArtifact` for the whole render — stranding unrelated outputs (touch-targets included).

**Fix:** compute the runnable closure first. Walk forward from `initialProducts`, mark each extension whose inputs are satisfied, repeat until fixpoint. Pass the runnable subset (plus its corresponding requested outputs) to the planner — unaffected outputs still produce when an unrelated chain isn't satisfiable on this render.

Two commits:

- `9d363f4 chore: ktfmtFormatAll across daemon-desktop and data-render-core` — three more upstream files that landed unformatted (`DesktopHost.kt`, `DesktopHostTest.kt`, `DataExtensionPlan.kt`). Same pattern as #723. Pure formatter output.
- `f0deede fix(a11y): plan only transitively-runnable extensions per render` — the actual fix + regression test.

## Test plan

- [x] `./gradlew :data-a11y-connector:check` — green
- [x] `./gradlew ktfmtCheckAll` — clean
- [x] New `transitiveImageDependencyDoesNotStrandUnrelatedConsumers` regression covers exactly the chained case from the review comment.