### PR TITLE
feat(daemon-android): RenderEngine uses AccessibilityHierarchyExtension

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -73,6 +73,13 @@ dependencies {
   // `AccessibilityFinding` / `AccessibilityNode` without adding their own project dep.
   api(project(":data-a11y-connector"))
 
+  // Android-platform-specific hierarchy producer — `RenderEngine.kt` installs
+  // `AccessibilityHierarchyExtension` and runs the typed extension graph instead of calling
+  // `AccessibilityChecker.analyze` directly. Pairs with `:data-a11y-core`'s consumers
+  // (TouchTargetsExtension, OverlayExtension) and any future
+  // `:data-a11y-hierarchy-desktop` (CMP semantics walk).
+  implementation(project(":data-a11y-hierarchy-android"))
+
   // The daemon process holds a Robolectric sandbox open via a dummy @Test
   // (DESIGN.md § 9), so JUnit + Robolectric must be on the *main* classpath,
   // not just test. DaemonHost in src/main runs the JUnit core programmatically.

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -35,7 +35,10 @@ import ee.schimke.composeai.data.render.extensions.compose.ComposeDataExtensionP
 import ee.schimke.composeai.data.render.extensions.compose.RecordingExtensionCompositionSink
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
 import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
-import ee.schimke.composeai.renderer.AccessibilityChecker
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import ee.schimke.composeai.renderer.AccessibilityDataProducts
+import ee.schimke.composeai.renderer.AccessibilityHierarchyExtension
 import java.io.File
 import java.util.Base64
 import kotlinx.serialization.decodeFromString
@@ -393,12 +396,30 @@ class RenderEngine(
               try {
                 trace.section("a11y:dataProducts") {
                   val view = (rule.onRoot().fetchSemanticsNode().root as ViewRootForTest).view
-                  val a11yResult = AccessibilityChecker.analyze(spec.outputBaseName, view)
+                  // Hierarchy + ATF now come from a typed extension instead of a direct
+                  // AccessibilityChecker.analyze call. RenderEngine no longer needs to know
+                  // about ATF — the extension owns the platform-specific walk and emits typed
+                  // payloads into the store; downstream consumers (TouchTargets, future
+                  // Overlay) read those declared inputs without re-walking the View.
+                  val hierarchyExtension = AccessibilityHierarchyExtension()
+                  val store = RecordingDataProductStore()
+                  hierarchyExtension.process(
+                    ExtensionPostCaptureContext(
+                      extensionId = hierarchyExtension.id,
+                      previewId = spec.outputBaseName,
+                      renderMode = spec.renderMode,
+                      products = store.scopedFor(hierarchyExtension),
+                      attributes =
+                        mapOf(AccessibilityHierarchyExtension.VIEW_ROOT_ATTRIBUTE to view),
+                    )
+                  )
+                  val hierarchy = store.require(AccessibilityDataProducts.Hierarchy)
+                  val findings = store.require(AccessibilityDataProducts.Atf)
                   AccessibilityDataProducer.writeArtifacts(
                     rootDir = dataDir,
                     previewId = spec.outputBaseName,
-                    findings = a11yResult.findings,
-                    nodes = a11yResult.nodes,
+                    findings = findings.findings,
+                    nodes = hierarchy.nodes,
                     density = spec.density,
                     pngFile = outputFile,
                     isRound = isRound,


### PR DESCRIPTION
Stacked on #728. When that lands, this PR's base auto-rebases to `main` and only the wiring commit remains.

## Summary

Replaces `RenderEngine`'s direct `AccessibilityChecker.analyze` call with `AccessibilityHierarchyExtension` running through the typed extension contract. The platform-specific ATF walk is now owned by the extension instead of being inlined in `RenderEngine`.

```kotlin
// Before
val a11yResult = AccessibilityChecker.analyze(spec.outputBaseName, view)
AccessibilityDataProducer.writeArtifacts(... findings = a11yResult.findings, nodes = a11yResult.nodes ...)

// After
val store = RecordingDataProductStore()
hierarchyExtension.process(
  ExtensionPostCaptureContext(
    products = store.scopedFor(hierarchyExtension),
    attributes = mapOf(VIEW_ROOT_ATTRIBUTE to view),
  )
)
val hierarchy = store.require(AccessibilityDataProducts.Hierarchy)
val findings = store.require(AccessibilityDataProducts.Atf)
AccessibilityDataProducer.writeArtifacts(... findings = findings.findings, nodes = hierarchy.nodes ...)
```

A future `:data-a11y-hierarchy-desktop` (Compose Multiplatform semantics walk, `targets = {Desktop}`) can drop in alongside the Android variant — `RenderEngine` won't need to know about it, the planner's target filter selects the right provider.

Pulls in `:data-a11y-hierarchy-android` via `implementation` dep on `:daemon:android`.

## Test coverage caveat

The transitive path the CLI hits (`compose-preview a11y` → Gradle Tooling API → `:module:renderAllPreviews` → renderer-android Robolectric → `AccessibilityChecker.analyze` → `writeArtifacts` → JSON files → CLI reads) has no integration test today. Inventory:

- ✅ `runAccessibilityPostCapturePipeline` unit tests in `:data-a11y-connector` (#726, #728)
- ✅ `AccessibilityDataProducer.writeArtifacts` covered by `AccessibilityDataProductRegistryTest` (synthetic findings/nodes in, JSON shape out)
- ⚠️ `AccessibilityChecker.analyze` no direct test — exercised in passing by `RobolectricRenderTest`
- ❌ Zero Gradle functional tests touch the a11y branch
- ❌ Zero CLI tests for `A11yCommand`

This PR's wiring inherits that gap — adding `A11yCommandTest` and a Gradle functional test that wires `previewExtensions { a11y { enableAllChecks() } }` against a synthetic project + asserts JSON files would catch the whole pipeline. Worth doing as a separate PR; flagged but not blocking this one.

## Test plan

- [x] `./gradlew :daemon:android:test` — green (existing tests cover the render path)
- [x] `./gradlew ktfmtCheckAll` — green