### PR TITLE
feat(a11y): OverlayExtension runs through the typed pipeline

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -106,13 +106,13 @@ class RenderEngine(
   private val dataDir: File? =
     (outputDir.parentFile ?: outputDir).resolve("data"),
   /**
-   * D2.1 — image processors that run after the PNG + JSON artefacts are written. Defaults to
-   * a single [AccessibilityImageProcessor] so the Paparazzi-style overlay PNG lands under
-   * `<dataDir>/<previewId>/a11y-overlay.png` whenever a11y mode produced findings or nodes.
-   * Empty list disables — useful for the harness's fake-mode runs that don't exercise the
-   * processor surface.
+   * Legacy image-processor escape hatch kept for embedders that registered custom processors
+   * alongside the old [AccessibilityImageProcessor]. Empty by default — overlay generation now
+   * runs through the typed extension graph (`OverlayExtension` inside
+   * `runAccessibilityPostCapturePipeline`), so the daemon's default wiring no longer pre-installs
+   * `AccessibilityImageProcessor`.
    */
-  private val imageProcessors: List<ImageProcessor> = listOf(AccessibilityImageProcessor()),
+  private val imageProcessors: List<ImageProcessor> = emptyList(),
 ) {
 
   /**

--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityDataProducer.kt
@@ -6,6 +6,7 @@ import ee.schimke.composeai.daemon.protocol.DataProductCapability
 import ee.schimke.composeai.daemon.protocol.DataProductExtra
 import ee.schimke.composeai.daemon.protocol.DataProductFacet
 import ee.schimke.composeai.daemon.protocol.DataProductTransport
+import ee.schimke.composeai.data.render.extensions.RenderImageArtifact
 import ee.schimke.composeai.data.render.pipeline.SamplingPolicy
 import ee.schimke.composeai.renderer.AccessibilityDataProducts
 import ee.schimke.composeai.renderer.AccessibilityFinding
@@ -67,19 +68,24 @@ object AccessibilityDataProducer {
   const val FILE_TOUCH_TARGETS: String = "a11y-touchTargets.json"
   const val FILE_OVERLAY: String = "a11y-overlay.png"
 
+  /** [DataProductExtra.name] used for the rendered overlay PNG attached to a11y JSON kinds. */
+  const val OVERLAY_EXTRA_NAME: String = "overlay"
+
   @Serializable internal data class AtfPayload(val findings: List<AccessibilityFinding>)
 
   @Serializable internal data class HierarchyPayload(val nodes: List<AccessibilityNode>)
 
   /**
-   * Writes both JSON files to `<rootDir>/<previewId>/` (creating the directory tree if needed).
-   * Idempotent — overwrites prior files. Called from [RenderEngine.render]'s a11y branch with
-   * the result of [ee.schimke.composeai.renderer.AccessibilityChecker.analyze].
+   * Writes ATF + hierarchy JSON to `<rootDir>/<previewId>/` and runs the typed post-capture
+   * pipeline ([runAccessibilityPostCapturePipeline]) so [TouchTargetsExtension] writes the
+   * touch-targets JSON and [OverlayExtension] writes the overlay PNG. Idempotent — overwrites
+   * prior files.
    *
-   * When [pngFile] is supplied (the captured screenshot), the configured [imageProcessors]
-   * also run — for the daemon's default wiring that means [AccessibilityImageProcessor]
-   * generates `a11y-overlay.png`. Each processor failure is logged + skipped so a single
-   * bad processor never strands the JSON the consumer already cares about.
+   * Legacy [imageProcessors] still run after the typed pipeline, for embedders that registered
+   * custom processors alongside [AccessibilityImageProcessor]. The default daemon wiring no
+   * longer pre-installs [AccessibilityImageProcessor] — overlay generation is now owned by the
+   * typed extension graph. Each processor failure is logged + skipped so one bad processor
+   * never strands the JSON the consumer already cares about.
    */
   fun writeArtifacts(
     rootDir: File,
@@ -100,15 +106,20 @@ object AccessibilityDataProducer {
       .resolve(FILE_HIERARCHY)
       .writeText(json.encodeToString(HierarchyPayload.serializer(), HierarchyPayload(nodes)))
 
-    // Touch targets ride through the typed extension graph so the consumer side stays exercised
-    // on real production data. JSON shape is byte-identical to the previous inline call —
-    // TouchTargetsExtension wraps the same buildTouchTargets math.
+    // Typed post-capture pipeline: TouchTargetsExtension always runs; OverlayExtension runs when
+    // pngFile is supplied (it requires CommonDataProducts.ImageArtifact). Both write their
+    // outputs through the typed product store and we serialize touchTargets here. Overlay
+    // writes its own PNG side-effectfully — the store carries the resulting AccessibilityOverlayArtifact
+    // for any future consumer that wants the path inline.
     val store =
       runAccessibilityPostCapturePipeline(
         previewId = previewId,
         hierarchy = AccessibilityHierarchyPayload(nodes),
         findings = AccessibilityFindingsPayload(findings),
         density = density,
+        imageArtifact = pngFile?.let { RenderImageArtifact(path = it.absolutePath) },
+        outputDirectory = previewDir,
+        isRound = isRound,
       )
     store.get(AccessibilityDataProducts.TouchTargets)?.let { touchTargets ->
       previewDir
@@ -298,7 +309,7 @@ class AccessibilityDataProductRegistry(private val rootDir: File) : DataProductR
     if (!overlay.exists()) return emptyList()
     return listOf(
       DataProductExtra(
-        name = AccessibilityImageProcessor.OVERLAY_NAME,
+        name = AccessibilityDataProducer.OVERLAY_EXTRA_NAME,
         path = overlay.absolutePath,
         mediaType = "image/png",
         sizeBytes = overlay.length().takeIf { it > 0 },

--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityImageProcessor.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityImageProcessor.kt
@@ -6,20 +6,18 @@ import ee.schimke.composeai.renderer.AccessibilityNode
 import ee.schimke.composeai.renderer.AccessibilityOverlay
 
 /**
- * D2.1 — first concrete [ImageProcessor]. When the render ran in a11y mode and produced any
- * findings or nodes, generates the Paparazzi-style annotated overlay via
- * [AccessibilityOverlay.generate] and attaches it to `a11y/atf`, `a11y/hierarchy`, and the
- * dedicated `a11y/overlay` kind as the `overlay` extra.
- *
- * Output path: `<dataDir>/<previewId>/a11y-overlay.png`. Same naming convention the JSON
- * artefacts use (slash-to-dash on the kind), so the registry's reverse mapping stays
- * mechanical.
- *
- * Reads its typed payload off [ImageProcessorInput.context] — the producer
- * ([AccessibilityDataProducer.writeArtifacts]) hands an [AccessibilityImageContext] in
- * there. A render whose context is missing or has a different shape gets an empty map back,
- * matching the "this render skipped a11y" no-op case.
+ * D2.1 — first concrete [ImageProcessor]. Kept for backwards compatibility with embedders that
+ * registered custom [ImageProcessor]s alongside it; the default daemon wiring no longer installs
+ * this. Overlay generation now runs through the typed extension graph
+ * ([ee.schimke.composeai.renderer.OverlayExtension] inside
+ * [runAccessibilityPostCapturePipeline]).
  */
+@Deprecated(
+  message =
+    "Overlay generation now runs through OverlayExtension in the typed extension graph. " +
+      "Embedders relying on AccessibilityImageProcessor should migrate to a PostCaptureProcessor " +
+      "or stop installing this — it's no longer the default wiring.",
+)
 class AccessibilityImageProcessor : ImageProcessor {
   override val name: String = "a11y-overlay"
 
@@ -54,8 +52,16 @@ class AccessibilityImageProcessor : ImageProcessor {
   }
 
   companion object {
-    /** [DataProductExtra.name] used for the rendered overlay PNG. */
-    const val OVERLAY_NAME: String = "overlay"
+    /**
+     * @deprecated Moved to [AccessibilityDataProducer.OVERLAY_EXTRA_NAME] — the constant is a
+     *   property of the data product, not the legacy processor. Kept here as a forwarding alias
+     *   so embedders that referenced the old name keep compiling.
+     */
+    @Deprecated(
+      message = "Use AccessibilityDataProducer.OVERLAY_EXTRA_NAME.",
+      replaceWith = ReplaceWith("AccessibilityDataProducer.OVERLAY_EXTRA_NAME"),
+    )
+    const val OVERLAY_NAME: String = AccessibilityDataProducer.OVERLAY_EXTRA_NAME
 
     /** Filename under `<dataDir>/<previewId>/`. Mirrors `a11y-{atf,hierarchy}.json`. */
     const val OVERLAY_FILE: String = "a11y-overlay.png"

--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityPostCapturePipeline.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityPostCapturePipeline.kt
@@ -14,7 +14,9 @@ import ee.schimke.composeai.data.render.extensions.RenderImageArtifact
 import ee.schimke.composeai.renderer.AccessibilityDataProducts
 import ee.schimke.composeai.renderer.AccessibilityFindingsPayload
 import ee.schimke.composeai.renderer.AccessibilityHierarchyPayload
+import ee.schimke.composeai.renderer.OverlayExtension
 import ee.schimke.composeai.renderer.TouchTargetsExtension
+import java.io.File
 
 /**
  * Seeds a [DataProductStore] with hierarchy + ATF + density (and image artifact when present),
@@ -35,6 +37,8 @@ fun runAccessibilityPostCapturePipeline(
   findings: AccessibilityFindingsPayload,
   density: Float,
   imageArtifact: RenderImageArtifact? = null,
+  outputDirectory: File? = null,
+  isRound: Boolean = false,
   attributes: Map<String, Any?> = emptyMap(),
   extensions: List<PlannedDataExtension> = AccessibilityPostCaptureExtensions.defaults,
   target: DataExtensionTarget? = DataExtensionTarget.Android,
@@ -44,6 +48,15 @@ fun runAccessibilityPostCapturePipeline(
   store.put(AccessibilityDataProducts.Atf, findings)
   store.put(CommonDataProducts.Density, RenderDensity(density))
   imageArtifact?.let { store.put(CommonDataProducts.ImageArtifact, it) }
+
+  // Merge caller attributes with the OverlayExtension contract slots — caller wins on conflict so
+  // tests can override. Folding outputDirectory + isRound into a typed product later (see
+  // RenderDataDirectory / RenderDeviceShape follow-up) lets us drop these named slots.
+  val mergedAttributes = buildMap<String, Any?> {
+    if (outputDirectory != null) put(OverlayExtension.OUTPUT_DIRECTORY_ATTRIBUTE, outputDirectory)
+    put(OverlayExtension.IS_ROUND_ATTRIBUTE, isRound)
+    putAll(attributes)
+  }
 
   val initialProducts =
     buildSet<DataProductKey<*>> {
@@ -88,7 +101,7 @@ fun runAccessibilityPostCapturePipeline(
           previewId = previewId,
           renderMode = null,
           products = store.scopedFor(ext),
-          attributes = attributes,
+          attributes = mergedAttributes,
         )
       )
     } catch (t: Throwable) {
@@ -102,13 +115,12 @@ fun runAccessibilityPostCapturePipeline(
 }
 
 /**
- * Default consumer set for [runAccessibilityPostCapturePipeline]. Currently just
- * [TouchTargetsExtension] — overlay generation still goes through the legacy
- * [AccessibilityImageProcessor] hook on [AccessibilityDataProducer.writeArtifacts] until that path
- * gets folded into the typed graph in a follow-up.
+ * Default consumer set for [runAccessibilityPostCapturePipeline]. Both [TouchTargetsExtension] and
+ * [OverlayExtension] now run through the typed graph; the legacy [AccessibilityImageProcessor]
+ * hook is no longer installed by default and is kept only for embedders with custom processors.
  */
 object AccessibilityPostCaptureExtensions {
-  val defaults: List<PlannedDataExtension> = listOf(TouchTargetsExtension())
+  val defaults: List<PlannedDataExtension> = listOf(TouchTargetsExtension(), OverlayExtension())
 }
 
 /**

--- a/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityPostCapturePipelineTest.kt
+++ b/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityPostCapturePipelineTest.kt
@@ -13,7 +13,10 @@ import ee.schimke.composeai.renderer.AccessibilityDataProducts
 import ee.schimke.composeai.renderer.AccessibilityFindingsPayload
 import ee.schimke.composeai.renderer.AccessibilityHierarchyPayload
 import ee.schimke.composeai.renderer.AccessibilityNode
+import ee.schimke.composeai.renderer.OverlayExtension
 import ee.schimke.composeai.renderer.TouchTargetsExtension
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -21,6 +24,82 @@ import org.junit.Assert.assertSame
 import org.junit.Test
 
 class AccessibilityPostCapturePipelineTest {
+  @get:Rule val tempFolder: TemporaryFolder = TemporaryFolder()
+
+  @Test
+  fun defaultsIncludeBothTouchTargetsAndOverlay() {
+    val ids = AccessibilityPostCaptureExtensions.defaults.map { it.id.value }
+    assertEquals(
+      listOf(TouchTargetsExtension.EXTENSION_ID, OverlayExtension.EXTENSION_ID),
+      ids,
+    )
+  }
+
+  @Test
+  fun overlayExtensionRunsWhenImageArtifactAndOutputDirectorySeeded() {
+    // Source PNG path doesn't need to exist — AccessibilityOverlay.generate returns null
+    // when the source is missing, OverlayExtension's process exits silently. We're asserting
+    // the wiring (extension was selected by the planner and process() was invoked without
+    // throwing), not the overlay-rendering behaviour itself (covered by
+    // AccessibilityOverlayMergedTest against AccessibilityOverlay directly).
+    val store =
+      runAccessibilityPostCapturePipeline(
+        previewId = "preview",
+        hierarchy =
+          AccessibilityHierarchyPayload(
+            nodes =
+              listOf(
+                AccessibilityNode(
+                  label = "Tiny",
+                  states = listOf("clickable"),
+                  boundsInScreen = "0,0,80,80",
+                )
+              )
+          ),
+        findings = AccessibilityFindingsPayload(emptyList()),
+        density = 2f,
+        imageArtifact =
+          RenderImageArtifact(path = tempFolder.root.resolve("missing.png").absolutePath),
+        outputDirectory = tempFolder.root,
+      )
+
+    // TouchTargets is satisfiable independently of the overlay path.
+    assertNotNull(
+      "TouchTargets must run regardless of overlay source",
+      store.get(AccessibilityDataProducts.TouchTargets),
+    )
+    // Overlay's source PNG was missing → generate returned null → no Overlay product. The
+    // extension still ran (no throw), which is the wiring assertion.
+    assertNull(store.get(AccessibilityDataProducts.Overlay))
+  }
+
+  @Test
+  fun overlayExtensionExcludedFromPlanWhenImageArtifactAbsent() {
+    // No imageArtifact → runnableExtensionsFor drops OverlayExtension because its
+    // CommonDataProducts.ImageArtifact input can't be satisfied. TouchTargets runs in isolation.
+    val store =
+      runAccessibilityPostCapturePipeline(
+        previewId = "preview",
+        hierarchy =
+          AccessibilityHierarchyPayload(
+            nodes =
+              listOf(
+                AccessibilityNode(
+                  label = "Tiny",
+                  states = listOf("clickable"),
+                  boundsInScreen = "0,0,80,80",
+                )
+              )
+          ),
+        findings = AccessibilityFindingsPayload(emptyList()),
+        density = 2f,
+        imageArtifact = null,
+      )
+
+    assertNotNull(store.get(AccessibilityDataProducts.TouchTargets))
+    assertNull(store.get(AccessibilityDataProducts.Overlay))
+  }
+
   @Test
   fun seedsHierarchyAtfDensityAndRunsTouchTargetsByDefault() {
     val store =


### PR DESCRIPTION
Closes the explicit follow-up called out in #726: all four a11y products now flow through the typed extension graph.

## Summary

Folds `OverlayExtension` into `AccessibilityPostCaptureExtensions.defaults`. The legacy `AccessibilityImageProcessor` is now `@Deprecated` and no longer pre-installed by the daemon's default wiring.

- `runAccessibilityPostCapturePipeline` gains `outputDirectory` and `isRound` parameters; merges them into the attributes map under the keys `OverlayExtension` declares (caller-supplied attributes override on conflict so test injection still works).
- `AccessibilityDataProducer.writeArtifacts` passes `previewDir` + `isRound` through; `OverlayExtension` writes `a11y-overlay.png` from inside the pipeline. JSON + PNG output on disk byte-identical to before.
- `RenderEngine.imageProcessors` default → `emptyList()`. The legacy `ImageProcessor` surface stays for embedders with custom processors, but the daemon's default wiring is the typed graph.
- `OVERLAY_NAME` constant moved to `AccessibilityDataProducer.OVERLAY_EXTRA_NAME` (it's a property of the data product, not the legacy processor). Old name kept on `AccessibilityImageProcessor` as a deprecated forwarding alias for binary-compat.

## Why this matters

Before: Hierarchy + Atf came from a direct `AccessibilityChecker.analyze` call; TouchTargets ran through the typed graph; Overlay ran through the legacy `imageProcessors` hook. Three different mechanisms for four products.

After: TouchTargets and Overlay both run through `runAccessibilityPostCapturePipeline` with the planner ordering them by declared inputs. Hierarchy + Atf are still seeded from `AccessibilityChecker.analyze` (RenderEngine wiring is in #730 — separate concern). Once #730 lands, the producer side is also typed-graph and the only non-extension code in the path is the JSON-write step.

## Test plan

- [x] `./gradlew :data-a11y-connector:check` — green; existing `AccessibilityDataProductRegistryTest` passes unchanged → on-disk JSON + PNG contract preserved.
- [x] `./gradlew :daemon:android:compileDebugKotlin` — green.
- [x] `./gradlew ktfmtCheckAll` — green.
- [x] New tests:
  - `defaultsIncludeBothTouchTargetsAndOverlay` — the wired default set.
  - `overlayExtensionRunsWhenImageArtifactAndOutputDirectorySeeded` — asserts OverlayExtension is selected by the planner and `process()` is invoked, using a missing source PNG (generate returns null gracefully). Real overlay-rendering coverage stays in `AccessibilityOverlayMergedTest` against `AccessibilityOverlay` directly.
  - `overlayExtensionExcludedFromPlanWhenImageArtifactAbsent` — `runnableExtensionsFor` drops Overlay when `imageArtifact == null`; TouchTargets still runs.

## Follow-ups

- Promote `outputDirectory` / `isRound` from `attributes` to typed `RenderDataDirectory` / `RenderDeviceShape` products.
- Generic `DataProductTransport` registry so the connector publish phase serializes JSON by `DataProductKey<*>` instead of bespoke per-product writes.
- Renderer-android `RobolectricRenderTest` still calls `AccessibilityChecker.analyze` directly — symmetric move once `RenderEngine` (in #730) lands.