### PR TITLE
feat(a11y): wire a11y.action.click end-to-end through SemanticsActions.OnClick

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -10,6 +10,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
@@ -228,6 +229,46 @@ internal constructor(
       )
     }
     replyError.get()?.let { throw it }
+  }
+
+  /**
+   * Override of [InteractiveSession.dispatchSemanticsAction]. Enqueues a
+   * [InteractiveCommand.DispatchSemanticsAction] envelope through the bridge; the sandbox-side
+   * loop in [RobolectricHost.SandboxRunner.runHeldInteractiveSession] resolves the matching node
+   * by `hasContentDescription(...)` and invokes the corresponding `SemanticsActions` action.
+   *
+   * Returns `true` when the action fired against a matched node; `false` when no node matched
+   * (caller surfaces unsupported evidence). Throws when the action body itself failed — same
+   * propagation path as [dispatch].
+   */
+  override fun dispatchSemanticsAction(
+    actionKind: String,
+    nodeContentDescription: String,
+  ): Boolean {
+    if (closed) return false
+    lastUsedAtMs.set(System.currentTimeMillis())
+    val replyLatch = CountDownLatch(1)
+    val replyError = AtomicReference<Throwable?>(null)
+    val replyMatched = AtomicBoolean(false)
+    slot.interactiveCommands.put(
+      InteractiveCommand.DispatchSemanticsAction(
+        streamId = streamId,
+        actionKind = actionKind,
+        nodeContentDescription = nodeContentDescription,
+        replyLatch = replyLatch,
+        replyError = replyError,
+        replyMatched = replyMatched,
+      )
+    )
+    if (!replyLatch.await(DISPATCH_TIMEOUT_SEC, TimeUnit.SECONDS)) {
+      error(
+        "AndroidInteractiveSession.dispatchSemanticsAction timed out after " +
+          "${DISPATCH_TIMEOUT_SEC}s for stream '$streamId' (action=$actionKind, " +
+          "contentDescription='$nodeContentDescription'). Held-rule loop may be stuck."
+      )
+    }
+    replyError.get()?.let { throw it }
+    return replyMatched.get()
   }
 
   override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult {

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -256,6 +256,11 @@ class AndroidRecordingSession(
         put(RecordingScriptDataExtensions.PROBE_EVENT, RecordingScriptEventHandler { e, _ ->
           appliedEvidence(e, "probe marker reached")
         })
+        // Accessibility-driven dispatch — wire `a11y.action.click` end-to-end. Other
+        // `a11y.action.*` ids stay roadmap (`supported = false`) until their handler lands; each
+        // is a tiny extension to this registry plus a `when` arm in
+        // [RobolectricHost.performSemanticsActionByContentDescription].
+        put("a11y.action.click", a11ySemanticsClickHandler())
       }
     )
 
@@ -282,6 +287,40 @@ class AndroidRecordingSession(
   private fun androidUnsupported(label: String): RecordingScriptEventHandler =
     RecordingScriptEventHandler { event, _ ->
       unsupportedEvidence(event, "$label dispatch is not implemented for Android recording")
+    }
+
+  /**
+   * Handler for `a11y.action.click` — resolves a node by its visible content description and
+   * invokes `SemanticsActions.OnClick` against it. Same semantic path a screen reader would walk
+   * via `AccessibilityNodeInfo.performAction(ACTION_CLICK)`. The match is exact + uses the
+   * unmerged tree, so a clickable parent's merged children remain reachable.
+   *
+   * Reports `unsupported` (with a specific reason) when the agent didn't supply
+   * `nodeContentDescription`, when no node matched, or when the matched node didn't expose an
+   * `OnClick` semantic. Throws (propagating into stop()) only when the action body itself fails
+   * — same shape as a regular `click` handler under a Compose runtime error.
+   */
+  private fun a11ySemanticsClickHandler(): RecordingScriptEventHandler =
+    RecordingScriptEventHandler { event, _ ->
+      val description = event.nodeContentDescription
+      if (description.isNullOrBlank()) {
+        return@RecordingScriptEventHandler unsupportedEvidence(
+          event,
+          "${event.kind} requires a non-blank 'nodeContentDescription' to resolve the target node",
+        )
+      }
+      val matched = interactive.dispatchSemanticsAction("click", description)
+      if (matched) {
+        appliedEvidence(
+          event,
+          "a11y action 'click' fired against contentDescription='$description'",
+        )
+      } else {
+        unsupportedEvidence(
+          event,
+          "no node with contentDescription='$description' exposes an OnClick semantic",
+        )
+      }
     }
 
   private fun runLiveTickLoop() {

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -337,15 +337,23 @@ fun main(args: Array<String>) {
       incrementalDiscovery = incrementalDiscovery,
       historyManager = historyManager,
       dataProducts = dataProducts,
-      // dataExtensions = host's supported descriptors + renderer-agnostic roadmap +
-      // (when the a11y preview extension is enabled) the Android-only a11y action roadmap. The
-      // host method tracks what `RobolectricHost`'s recording sessions actually dispatch
-      // (`recording.probe` today). The two roadmap lists carry `supported = false` until the
-      // handlers ship; `record_preview` rejects them up front via `validateRecordingScriptKinds`.
+      // dataExtensions composition (per-extension halves):
+      //   - host.recordingScriptEventDescriptors()  → supported, renderer-agnostic (probe)
+      //   - AccessibilityRecordingScriptEvents.supportedDescriptors  → supported, a11y-only
+      //     (today: a11y.action.click). Wired only when the a11y preview extension is enabled
+      //     so a non-a11y daemon doesn't advertise an action it can't dispatch.
+      //   - RecordingScriptDataExtensions.roadmapDescriptors  → roadmap, renderer-agnostic
+      //     (state.save / state.restore / lifecycle.event / preview.reload, all supported = false)
+      //   - AccessibilityRecordingScriptEvents.roadmapDescriptors  → roadmap, a11y-only
+      //     (the other 18 a11y.action.* ids, supported = false)
+      // `record_preview` rejects roadmap kinds up front via `validateRecordingScriptKinds`.
       dataExtensions =
         host.recordingScriptEventDescriptors() +
+          (if (a11yPreviewExtensionEnabled)
+            AccessibilityRecordingScriptEvents.supportedDescriptors
+          else emptyList()) +
           RecordingScriptDataExtensions.roadmapDescriptors +
-          (if (a11yPreviewExtensionEnabled) AccessibilityRecordingScriptEvents.descriptors
+          (if (a11yPreviewExtensionEnabled) AccessibilityRecordingScriptEvents.roadmapDescriptors
           else emptyList()),
       previewExtensions = previewExtensions,
     )

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasRequestFocusAction
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performTouchInput
@@ -1613,6 +1614,22 @@ open class RobolectricHost(
                     .computeIfAbsent(cmd.requestId) { LinkedBlockingQueue() }
                     .put(resultOrError)
                 }
+                is InteractiveCommand.DispatchSemanticsAction -> {
+                  try {
+                    val matched = performSemanticsActionByContentDescription(rule, cmd)
+                    cmd.replyMatched.set(matched)
+                    if (matched) {
+                      // Match the input-dispatch settle pattern so a screen-reader-driven click
+                      // observes the same recomposition window a pixel click does.
+                      rule.mainClock.advanceTimeBy(POINTER_MOVE_MS)
+                      rule.waitForIdle()
+                    }
+                  } catch (t: Throwable) {
+                    cmd.replyError.set(t)
+                  } finally {
+                    cmd.replyLatch.countDown()
+                  }
+                }
                 is InteractiveCommand.Close -> {
                   cmd.replyLatch.countDown()
                   return
@@ -1729,6 +1746,49 @@ open class RobolectricHost(
       rule.mainClock.advanceTimeBy(POINTER_MOVE_MS)
       rule.waitForIdle()
       return true
+    }
+
+    /**
+     * Resolve a node by its `SemanticsProperties.ContentDescription` and invoke the named
+     * `SemanticsActions` action against it — the screen-reader path. Used by
+     * [InteractiveCommand.DispatchSemanticsAction] for `record_preview`'s `a11y.action.*` script
+     * events. Returns `true` when a node matched the description AND the matched node exposed the
+     * requested action; `false` otherwise (caller surfaces unsupported evidence with a specific
+     * reason).
+     *
+     * Matching uses `useUnmergedTree = true` so a node merged into a parent (the inner `Icon` of
+     * an `IconButton` carrying the contentDescription) remains reachable. When multiple nodes
+     * match (e.g. two buttons with the same contentDescription), we pick the smallest by area —
+     * same heuristic as [performClickActionAt] uses for overlapping pixel hits — to bias toward
+     * the most-specific match. Note: a future iteration could surface "ambiguous match" as a
+     * distinct evidence message rather than silently picking one.
+     *
+     * Today only `actionKind = "click"` is wired; other action kinds return `false` so the
+     * registry handler reports unsupported. New action kinds extend the `when` here without
+     * changing the bridge shape.
+     */
+    private fun performSemanticsActionByContentDescription(
+      rule:
+        androidx.compose.ui.test.junit4.AndroidComposeTestRule<
+          *,
+          androidx.activity.ComponentActivity,
+        >,
+      cmd: InteractiveCommand.DispatchSemanticsAction,
+    ): Boolean {
+      val matchers =
+        rule.onAllNodes(hasContentDescription(cmd.nodeContentDescription), useUnmergedTree = true)
+      val nodes = matchers.fetchSemanticsNodes(atLeastOneRootRequired = false)
+      if (nodes.isEmpty()) return false
+      val target =
+        nodes.minByOrNull { node -> node.boundsInRoot.width * node.boundsInRoot.height } ?: nodes[0]
+      return when (cmd.actionKind) {
+        "click" -> {
+          val onClick = target.config.getOrNull(SemanticsActions.OnClick) ?: return false
+          rule.runOnUiThread { onClick.action?.invoke() }
+          true
+        }
+        else -> false
+      }
     }
 
     private fun performRequestFocusAt(

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -441,4 +441,32 @@ sealed interface InteractiveCommand {
    */
   data class Close(override val streamId: String, val replyLatch: CountDownLatch) :
     InteractiveCommand
+
+  /**
+   * Accessibility-driven dispatch: invoke a `SemanticsActions` action against the node whose
+   * content description matches [nodeContentDescription]. The sandbox-side handler resolves the
+   * node via `rule.onAllNodes(hasContentDescription(...), useUnmergedTree = true)` and invokes the
+   * matching action — same path a screen reader would walk in `AccessibilityNodeInfo.performAction`.
+   *
+   * [actionKind] is a short wire name (`"click"`, `"longClick"`, …); the sandbox maps it to the
+   * corresponding `SemanticsActions` constant. New actions extend this list; the bridge shape
+   * doesn't need to change per action.
+   *
+   * [replyMatched] is set by the sandbox before [replyLatch] counts down: `true` when a node
+   * matched and the action fired, `false` when no node matched (caller surfaces unsupported
+   * evidence). Throwables from the action body land in [replyError]; the host's
+   * `dispatchSemanticsAction` rethrows on the caller thread so the recording session sees the
+   * failure rather than a silently-truncated playback.
+   *
+   * Strings travel as `java.lang.String` (do-not-acquire). No Compose types cross the bridge —
+   * the sandbox does the matcher resolution itself.
+   */
+  data class DispatchSemanticsAction(
+    override val streamId: String,
+    val actionKind: String,
+    val nodeContentDescription: String,
+    val replyLatch: CountDownLatch,
+    val replyError: AtomicReference<Throwable?>,
+    val replyMatched: AtomicBoolean,
+  ) : InteractiveCommand
 }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
@@ -270,6 +270,166 @@ class AndroidRecordingSessionTest {
   }
 
   @Test
+  fun a11yActionClickRoutesThroughDispatchSemanticsAction() {
+    // Happy path for the new `a11y.action.click` registry entry: the handler reads
+    // `nodeContentDescription`, calls `interactive.dispatchSemanticsAction("click", description)`,
+    // and reports `applied` evidence with a message naming the description it matched.
+    val framesDir = tempFolder.newFolder("a11y-click-frames")
+    val encodedDir = tempFolder.newFolder("a11y-click-encoded")
+    val sourcePng = File(tempFolder.newFolder("a11y-click-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    val interactive = RecordingDeltaSession(sourcePng).apply { semanticsActionResult = true }
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-a11y-click",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    try {
+      session.postScript(
+        listOf(
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = "a11y.action.click",
+            nodeContentDescription = "Save",
+          )
+        )
+      )
+      val result = session.stop()
+
+      assertEquals(
+        "the registry must route a11y.action.click through dispatchSemanticsAction, not dispatch",
+        0,
+        interactive.dispatchCount,
+      )
+      assertEquals(listOf("click" to "Save"), interactive.semanticsActionCalls)
+      assertEquals(1, result.scriptEvents.size)
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.APPLIED,
+        result.scriptEvents[0].status,
+      )
+      val message = result.scriptEvents[0].message ?: ""
+      assertTrue(
+        "evidence must name the matched contentDescription; got '$message'",
+        message.contains("'Save'"),
+      )
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
+  fun a11yActionClickReportsUnsupportedWhenNoNodeMatches() {
+    // When `dispatchSemanticsAction` returns false (no matching node, or matched node didn't
+    // expose OnClick), the handler must surface a specific unsupported reason — not let the agent
+    // think the click landed.
+    val framesDir = tempFolder.newFolder("a11y-click-miss-frames")
+    val encodedDir = tempFolder.newFolder("a11y-click-miss-encoded")
+    val sourcePng = File(tempFolder.newFolder("a11y-click-miss-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    val interactive = RecordingDeltaSession(sourcePng).apply { semanticsActionResult = false }
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-a11y-click-miss",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    try {
+      session.postScript(
+        listOf(
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = "a11y.action.click",
+            nodeContentDescription = "Nonexistent",
+          )
+        )
+      )
+      val result = session.stop()
+
+      assertEquals(1, result.scriptEvents.size)
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.UNSUPPORTED,
+        result.scriptEvents[0].status,
+      )
+      val message = result.scriptEvents[0].message ?: ""
+      assertTrue(
+        "miss diagnostic must mention the contentDescription so the agent can debug; got '$message'",
+        message.contains("'Nonexistent'"),
+      )
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
+  fun a11yActionClickRequiresNodeContentDescription() {
+    // Bare `kind = "a11y.action.click"` with no contentDescription is meaningless — the registry
+    // handler short-circuits to unsupported BEFORE touching `interactive.dispatchSemanticsAction`,
+    // so we know at most we waste an empty-string lookup.
+    val framesDir = tempFolder.newFolder("a11y-click-blank-frames")
+    val encodedDir = tempFolder.newFolder("a11y-click-blank-encoded")
+    val sourcePng = File(tempFolder.newFolder("a11y-click-blank-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    val interactive = RecordingDeltaSession(sourcePng)
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-a11y-click-blank",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    try {
+      session.postScript(
+        listOf(RecordingScriptEvent(tMs = 0L, kind = "a11y.action.click"))
+      )
+      val result = session.stop()
+
+      assertTrue(
+        "handler must short-circuit before calling interactive.dispatchSemanticsAction",
+        interactive.semanticsActionCalls.isEmpty(),
+      )
+      assertEquals(1, result.scriptEvents.size)
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.UNSUPPORTED,
+        result.scriptEvents[0].status,
+      )
+      val message = result.scriptEvents[0].message ?: ""
+      assertTrue(
+        "diagnostic must call out the missing nodeContentDescription; got '$message'",
+        message.contains("nodeContentDescription"),
+      )
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
   fun scriptedClickFlipsStateAndProducesFrames() {
     val outputDir = tempFolder.newFolder("recording-renders")
     val recordingsRoot = tempFolder.newFolder("recordings-root")
@@ -514,9 +674,26 @@ class AndroidRecordingSessionTest {
     val renderAdvances = mutableListOf<Long?>()
     var dispatchCount = 0
     var closed = false
+    val semanticsActionCalls = mutableListOf<Pair<String, String>>()
+
+    /**
+     * When non-null, [dispatchSemanticsAction] returns this value verbatim and records the call
+     * into [semanticsActionCalls]. When null (the default), the inherited interface-level default
+     * (`return false`) is used so existing tests don't have to opt in.
+     */
+    var semanticsActionResult: Boolean? = null
 
     override fun dispatch(input: ee.schimke.composeai.daemon.protocol.InteractiveInputParams) {
       dispatchCount++
+    }
+
+    override fun dispatchSemanticsAction(
+      actionKind: String,
+      nodeContentDescription: String,
+    ): Boolean {
+      semanticsActionCalls += actionKind to nodeContentDescription
+      val override = semanticsActionResult
+      return override ?: super.dispatchSemanticsAction(actionKind, nodeContentDescription)
     }
 
     override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult {

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/InteractiveCommandTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/InteractiveCommandTest.kt
@@ -2,9 +2,11 @@ package ee.schimke.composeai.daemon.bridge
 
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
@@ -146,5 +148,37 @@ class InteractiveCommandTest {
       slot0.interactiveCommands.isEmpty(),
     )
     assertEquals(cmd, slot1.interactiveCommands.poll(1, TimeUnit.SECONDS))
+  }
+
+  @Test
+  fun dispatchSemanticsActionRoundTripsThroughTheBridge() {
+    // Pin the cross-classloader contract for the new variant: only `java.*` types in the payload,
+    // round-trips through `interactiveCommands` by reference (so the host's latch / atomic refs
+    // come back out unchanged for the await pattern). Mirrors the assertion shape the input
+    // `Dispatch` variant gets in `queueRoundTripsEveryVariantInFifoOrder`.
+    DaemonHostBridge.reset()
+    val slot = DaemonHostBridge.slot(0)
+    val replyLatch = CountDownLatch(1)
+    val replyError = AtomicReference<Throwable?>(null)
+    val replyMatched = AtomicBoolean(false)
+    val cmd =
+      InteractiveCommand.DispatchSemanticsAction(
+        streamId = "stream-A",
+        actionKind = "click",
+        nodeContentDescription = "Save",
+        replyLatch = replyLatch,
+        replyError = replyError,
+        replyMatched = replyMatched,
+      )
+    slot.interactiveCommands.put(cmd)
+
+    val drained = slot.interactiveCommands.poll(1, TimeUnit.SECONDS)
+    assertSame("queue must round-trip the same instance, not a copy", cmd, drained)
+    val asAction = drained as InteractiveCommand.DispatchSemanticsAction
+    assertSame(replyLatch, asAction.replyLatch)
+    assertSame(replyError, asAction.replyError)
+    assertSame(replyMatched, asAction.replyMatched)
+    assertNull("replyError defaults to null", asAction.replyError.get())
+    assertFalse("replyMatched defaults to false", asAction.replyMatched.get())
   }
 }

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
@@ -50,6 +50,30 @@ interface InteractiveSession : AutoCloseable {
   fun dispatch(input: InteractiveInputParams)
 
   /**
+   * Accessibility-driven dispatch: resolve a node by its visible content description and invoke
+   * the named [`SemanticsActions`](https://developer.android.com/reference/kotlin/androidx/compose/ui/semantics/SemanticsActions)
+   * action against it — same path a screen reader would walk. Used by `record_preview`'s
+   * `a11y.action.*` script events.
+   *
+   * Returns `true` when a node matched [nodeContentDescription] and the action fired; `false` when
+   * no node matched or the matched node didn't expose [actionKind] (caller surfaces unsupported
+   * evidence). Throws when the action ran but failed mid-flight (Compose runtime error,
+   * cross-classloader marshalling failure) — same semantics as [dispatch].
+   *
+   * Default returns `false` so hosts without semantics-driven dispatch (DesktopHost today) cleanly
+   * surface "no a11y dispatch available" via [false] without blowing up the session.
+   *
+   * @param actionKind short name of the semantics action — `"click"`, `"longClick"`, `"focus"`,
+   *   `"scrollForward"`, etc. The implementation maps each name to the matching
+   *   [`androidx.compose.ui.semantics.SemanticsActions`] constant.
+   * @param nodeContentDescription content-description string the agent already saw in the latest
+   *   `a11y/hierarchy` payload (or that they know from the source). Matched against the node's
+   *   `SemanticsProperties.ContentDescription` — exact match, useUnmergedTree = true so merged
+   *   children remain reachable.
+   */
+  fun dispatchSemanticsAction(actionKind: String, nodeContentDescription: String): Boolean = false
+
+  /**
    * Render the current composition to a PNG and return the result. The implementation runs the
    * scene through enough frames to settle (typically two `scene.render()` calls — same heuristic as
    * the one-shot path) and encodes to disk at a stable path the daemon can publish via

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1027,6 +1027,16 @@ data class RecordingScriptEvent(
   val lifecycleEvent: String? = null,
   /** Optional free-form tags copied into script evidence. */
   val tags: List<String> = emptyList(),
+  /**
+   * Accessibility-node identifier for `kind = a11y.action.*` events: the visible content
+   * description of the target node (`Modifier.semantics { contentDescription = "Save" }` /
+   * `Icon(contentDescription = "Save")`). The handler resolves this against the held composition's
+   * semantics tree and dispatches the corresponding `SemanticsActions` action — same lookup a
+   * screen reader would perform. Ignored for input/probe/state/lifecycle events. Future a11y
+   * matchers (visible text, role, tag) will land as sibling fields rather than a generic params
+   * map so per-action validation stays typed end-to-end.
+   */
+  val nodeContentDescription: String? = null,
 )
 
 @Serializable

--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEvents.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEvents.kt
@@ -22,11 +22,12 @@ import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescripto
  * base recording-script descriptors when `a11y` is enabled — same gate as the a11y preview-
  * extension publishers.
  *
- * **Status:** all entries ship with `supported = false` for now. The MCP layer
- * (`record_preview`'s `validateRecordingScriptKinds`) rejects them up front so an agent that picks
- * one up from `list_data_products` doesn't watch a quiet `unsupported` evidence trail come back.
- * The actual dispatch path lands once the recording-script handler registry refactor consolidates
- * input + extension dispatch under one interface (compose-ai-tools#714 follow-up).
+ * **Status:** [supportedDescriptors] today carries `a11y.action.click` only — wired end-to-end
+ * through `AndroidInteractiveSession.dispatchSemanticsAction` →
+ * `RobolectricHost.performSemanticsActionByContentDescription` →
+ * `SemanticsActions.OnClick.action.invoke()`. [roadmapDescriptors] carries the other 18 actions
+ * with `supported = false`; the MCP layer rejects them up front, and each lands one-by-one as
+ * its sandbox-side `when` arm + handler factory ships.
  */
 object AccessibilityRecordingScriptEvents {
 
@@ -51,90 +52,130 @@ object AccessibilityRecordingScriptEvents {
   const val ACTION_NEXT_AT_GRANULARITY: String = "a11y.action.nextAtGranularity"
   const val ACTION_PREVIOUS_AT_GRANULARITY: String = "a11y.action.previousAtGranularity"
 
-  val descriptor: DataExtensionDescriptor =
-    DataExtensionDescriptor(
-      id = DataExtensionId("a11y"),
-      displayName = "Accessibility script actions",
-      recordingScriptEvents =
-        listOf(
-          event(ACTION_CLICK, "Click", "Performs ACTION_CLICK on the targeted accessibility node."),
-          event(
-            ACTION_LONG_CLICK,
-            "Long click",
-            "Performs ACTION_LONG_CLICK on the targeted accessibility node.",
+  /**
+   * `a11y.action.click` is the only a11y action wired today. `RobolectricHost`'s sandbox-side
+   * loop resolves the matching node by `hasContentDescription(...)` and invokes
+   * `SemanticsActions.OnClick.action.invoke()` — same semantic path
+   * `AccessibilityNodeInfo.performAction(ACTION_CLICK)` walks. The descriptor advertises
+   * `supported = true` so `record_preview` accepts it; the rest of the action ids appear in
+   * [roadmapDescriptors] until their handler ships.
+   */
+  val supportedDescriptors: List<DataExtensionDescriptor> =
+    listOf(
+      DataExtensionDescriptor(
+        id = DataExtensionId("a11y"),
+        displayName = "Accessibility script actions",
+        recordingScriptEvents =
+          listOf(
+            RecordingScriptEventDescriptor(
+              id = ACTION_CLICK,
+              displayName = "Click",
+              summary =
+                "Performs ACTION_CLICK on the accessibility node identified by " +
+                  "`nodeContentDescription`. Same path a screen reader walks via " +
+                  "AccessibilityNodeInfo.performAction(ACTION_CLICK).",
+              supported = true,
+            )
           ),
-          event(ACTION_FOCUS, "Focus", "Performs ACTION_FOCUS on the targeted node."),
-          event(
-            ACTION_CLEAR_FOCUS,
-            "Clear focus",
-            "Performs ACTION_CLEAR_FOCUS on the targeted node.",
-          ),
-          event(
-            ACTION_ACCESSIBILITY_FOCUS,
-            "Accessibility focus",
-            "Performs ACTION_ACCESSIBILITY_FOCUS — the action a screen reader emits when the user " +
-              "swipes onto a node.",
-          ),
-          event(
-            ACTION_CLEAR_ACCESSIBILITY_FOCUS,
-            "Clear accessibility focus",
-            "Performs ACTION_CLEAR_ACCESSIBILITY_FOCUS, the screen-reader counterpart to " +
-              "swiping off a node.",
-          ),
-          event(ACTION_SELECT, "Select", "Performs ACTION_SELECT on the targeted node."),
-          event(
-            ACTION_CLEAR_SELECTION,
-            "Clear selection",
-            "Performs ACTION_CLEAR_SELECTION on the targeted node.",
-          ),
-          event(
-            ACTION_SCROLL_FORWARD,
-            "Scroll forward",
-            "Performs ACTION_SCROLL_FORWARD on the targeted scrollable node.",
-          ),
-          event(
-            ACTION_SCROLL_BACKWARD,
-            "Scroll backward",
-            "Performs ACTION_SCROLL_BACKWARD on the targeted scrollable node.",
-          ),
-          event(
-            ACTION_SCROLL_UP,
-            "Scroll up",
-            "Performs ACTION_SCROLL_UP on the targeted scrollable node.",
-          ),
-          event(
-            ACTION_SCROLL_DOWN,
-            "Scroll down",
-            "Performs ACTION_SCROLL_DOWN on the targeted scrollable node.",
-          ),
-          event(
-            ACTION_SCROLL_LEFT,
-            "Scroll left",
-            "Performs ACTION_SCROLL_LEFT on the targeted scrollable node.",
-          ),
-          event(
-            ACTION_SCROLL_RIGHT,
-            "Scroll right",
-            "Performs ACTION_SCROLL_RIGHT on the targeted scrollable node.",
-          ),
-          event(ACTION_EXPAND, "Expand", "Performs ACTION_EXPAND on the targeted node."),
-          event(ACTION_COLLAPSE, "Collapse", "Performs ACTION_COLLAPSE on the targeted node."),
-          event(ACTION_DISMISS, "Dismiss", "Performs ACTION_DISMISS on the targeted node."),
-          event(
-            ACTION_NEXT_AT_GRANULARITY,
-            "Next at movement granularity",
-            "Performs ACTION_NEXT_AT_MOVEMENT_GRANULARITY on the targeted text node.",
-          ),
-          event(
-            ACTION_PREVIOUS_AT_GRANULARITY,
-            "Previous at movement granularity",
-            "Performs ACTION_PREVIOUS_AT_MOVEMENT_GRANULARITY on the targeted text node.",
-          ),
-        ),
+      )
     )
 
-  /** Convenience for the daemon's wiring code that takes a list of descriptors. */
-  val descriptors: List<DataExtensionDescriptor> = listOf(descriptor)
+  /**
+   * Roadmap a11y action descriptors — `supported = false`. Each one ships individually as a
+   * `RobolectricHost.performSemanticsActionByContentDescription` arm + a registry entry in
+   * `AndroidRecordingSession`. When that lands, move the matching `RecordingScriptEventDescriptor`
+   * into the `supportedDescriptors` `a11y` extension above.
+   */
+  val roadmapDescriptors: List<DataExtensionDescriptor> =
+    listOf(
+      DataExtensionDescriptor(
+        id = DataExtensionId("a11y.roadmap"),
+        displayName = "Accessibility script actions (roadmap)",
+        recordingScriptEvents =
+          listOf(
+            event(
+              ACTION_LONG_CLICK,
+              "Long click",
+              "Performs ACTION_LONG_CLICK on the targeted accessibility node.",
+            ),
+            event(ACTION_FOCUS, "Focus", "Performs ACTION_FOCUS on the targeted node."),
+            event(
+              ACTION_CLEAR_FOCUS,
+              "Clear focus",
+              "Performs ACTION_CLEAR_FOCUS on the targeted node.",
+            ),
+            event(
+              ACTION_ACCESSIBILITY_FOCUS,
+              "Accessibility focus",
+              "Performs ACTION_ACCESSIBILITY_FOCUS — the action a screen reader emits when the " +
+                "user swipes onto a node.",
+            ),
+            event(
+              ACTION_CLEAR_ACCESSIBILITY_FOCUS,
+              "Clear accessibility focus",
+              "Performs ACTION_CLEAR_ACCESSIBILITY_FOCUS, the screen-reader counterpart to " +
+                "swiping off a node.",
+            ),
+            event(ACTION_SELECT, "Select", "Performs ACTION_SELECT on the targeted node."),
+            event(
+              ACTION_CLEAR_SELECTION,
+              "Clear selection",
+              "Performs ACTION_CLEAR_SELECTION on the targeted node.",
+            ),
+            event(
+              ACTION_SCROLL_FORWARD,
+              "Scroll forward",
+              "Performs ACTION_SCROLL_FORWARD on the targeted scrollable node.",
+            ),
+            event(
+              ACTION_SCROLL_BACKWARD,
+              "Scroll backward",
+              "Performs ACTION_SCROLL_BACKWARD on the targeted scrollable node.",
+            ),
+            event(
+              ACTION_SCROLL_UP,
+              "Scroll up",
+              "Performs ACTION_SCROLL_UP on the targeted scrollable node.",
+            ),
+            event(
+              ACTION_SCROLL_DOWN,
+              "Scroll down",
+              "Performs ACTION_SCROLL_DOWN on the targeted scrollable node.",
+            ),
+            event(
+              ACTION_SCROLL_LEFT,
+              "Scroll left",
+              "Performs ACTION_SCROLL_LEFT on the targeted scrollable node.",
+            ),
+            event(
+              ACTION_SCROLL_RIGHT,
+              "Scroll right",
+              "Performs ACTION_SCROLL_RIGHT on the targeted scrollable node.",
+            ),
+            event(ACTION_EXPAND, "Expand", "Performs ACTION_EXPAND on the targeted node."),
+            event(ACTION_COLLAPSE, "Collapse", "Performs ACTION_COLLAPSE on the targeted node."),
+            event(ACTION_DISMISS, "Dismiss", "Performs ACTION_DISMISS on the targeted node."),
+            event(
+              ACTION_NEXT_AT_GRANULARITY,
+              "Next at movement granularity",
+              "Performs ACTION_NEXT_AT_MOVEMENT_GRANULARITY on the targeted text node.",
+            ),
+            event(
+              ACTION_PREVIOUS_AT_GRANULARITY,
+              "Previous at movement granularity",
+              "Performs ACTION_PREVIOUS_AT_MOVEMENT_GRANULARITY on the targeted text node.",
+            ),
+          ),
+      )
+    )
+
+  /**
+   * Combined list ([supportedDescriptors] + [roadmapDescriptors]) for callers that want to
+   * advertise the full a11y action surface in one go. New code should prefer the split lists so
+   * supported / roadmap halves can flow through the host-derived dataExtensions composition
+   * without re-flagging supported flags.
+   */
+  val descriptors: List<DataExtensionDescriptor> = supportedDescriptors + roadmapDescriptors
 
   private fun event(
     id: String,

--- a/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEventsTest.kt
+++ b/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEventsTest.kt
@@ -1,0 +1,72 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the supported/roadmap split of [AccessibilityRecordingScriptEvents] — Android `DaemonMain`
+ * composes the daemon's `dataExtensions` capability from these two halves, and `record_preview`'s
+ * `validateRecordingScriptKinds` filters by the `supported` flag. The split must stay honest:
+ * supported descriptors carry the kinds wired to a real `RobolectricHost.performSemanticsAction*`
+ * arm, roadmap descriptors are everything else.
+ */
+class AccessibilityRecordingScriptEventsTest {
+
+  @Test
+  fun `supportedDescriptors expose only a11y action click as supported`() {
+    val supported = AccessibilityRecordingScriptEvents.supportedDescriptors
+    val supportedEvents = supported.flatMap { it.recordingScriptEvents }
+    assertEquals(1, supportedEvents.size)
+    val click = supportedEvents.single()
+    assertEquals(AccessibilityRecordingScriptEvents.ACTION_CLICK, click.id)
+    assertTrue(
+      "a11y.action.click must advertise supported = true so record_preview accepts it",
+      click.supported,
+    )
+  }
+
+  @Test
+  fun `roadmapDescriptors carry the unwired a11y action ids`() {
+    val roadmap = AccessibilityRecordingScriptEvents.roadmapDescriptors
+    val roadmapIds = roadmap.flatMap { it.recordingScriptEvents }.map { it.id }.toSet()
+    val expectedRoadmapIds =
+      setOf(
+        AccessibilityRecordingScriptEvents.ACTION_LONG_CLICK,
+        AccessibilityRecordingScriptEvents.ACTION_FOCUS,
+        AccessibilityRecordingScriptEvents.ACTION_CLEAR_FOCUS,
+        AccessibilityRecordingScriptEvents.ACTION_ACCESSIBILITY_FOCUS,
+        AccessibilityRecordingScriptEvents.ACTION_CLEAR_ACCESSIBILITY_FOCUS,
+        AccessibilityRecordingScriptEvents.ACTION_SELECT,
+        AccessibilityRecordingScriptEvents.ACTION_CLEAR_SELECTION,
+        AccessibilityRecordingScriptEvents.ACTION_SCROLL_FORWARD,
+        AccessibilityRecordingScriptEvents.ACTION_SCROLL_BACKWARD,
+        AccessibilityRecordingScriptEvents.ACTION_SCROLL_UP,
+        AccessibilityRecordingScriptEvents.ACTION_SCROLL_DOWN,
+        AccessibilityRecordingScriptEvents.ACTION_SCROLL_LEFT,
+        AccessibilityRecordingScriptEvents.ACTION_SCROLL_RIGHT,
+        AccessibilityRecordingScriptEvents.ACTION_EXPAND,
+        AccessibilityRecordingScriptEvents.ACTION_COLLAPSE,
+        AccessibilityRecordingScriptEvents.ACTION_DISMISS,
+        AccessibilityRecordingScriptEvents.ACTION_NEXT_AT_GRANULARITY,
+        AccessibilityRecordingScriptEvents.ACTION_PREVIOUS_AT_GRANULARITY,
+      )
+    assertEquals(expectedRoadmapIds, roadmapIds)
+    val anySupported = roadmap.flatMap { it.recordingScriptEvents }.any { it.supported }
+    assertFalse(
+      "roadmap descriptors must all be supported = false; flip them into the supportedDescriptors " +
+        "list when a real handler arm lands",
+      anySupported,
+    )
+  }
+
+  @Test
+  fun `legacy descriptors aggregate is supportedDescriptors plus roadmap`() {
+    assertEquals(
+      AccessibilityRecordingScriptEvents.supportedDescriptors +
+        AccessibilityRecordingScriptEvents.roadmapDescriptors,
+      AccessibilityRecordingScriptEvents.descriptors,
+    )
+  }
+}

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -1136,7 +1136,8 @@ class DaemonMcpServer(
                       "label":{"type":"string","description":"Agent label copied into scriptEvents evidence for probes/checkpoints."},
                       "checkpointId":{"type":"string","description":"Checkpoint id for state save/restore audit events."},
                       "lifecycleEvent":{"type":"string","description":"Lifecycle transition for lifecycle script events, e.g. resume, pause, destroy."},
-                      "tags":{"type":"array","items":{"type":"string"},"description":"Optional agent tags copied into scriptEvents evidence."}
+                      "tags":{"type":"array","items":{"type":"string"},"description":"Optional agent tags copied into scriptEvents evidence."},
+                      "nodeContentDescription":{"type":"string","description":"For `a11y.action.*` kinds — visible content description of the target accessibility node (`Modifier.semantics { contentDescription = ... }` / `Icon(contentDescription = ...)`). The daemon resolves this against the held composition's semantics tree and dispatches the corresponding SemanticsActions action — same lookup a screen reader walks via AccessibilityNodeInfo.performAction. Ignored for input/probe/state/lifecycle events."}
                     },
                     "required":["tMs","kind"]
                   }
@@ -2620,6 +2621,7 @@ class DaemonMcpServer(
         tags =
           (obj["tags"] as? JsonArray)?.mapNotNull { tag -> tag.jsonPrimitive.contentOrNull }
             ?: emptyList(),
+        nodeContentDescription = obj["nodeContentDescription"]?.jsonPrimitive?.contentOrNull,
       )
     }
   }

--- a/skills/compose-preview-review/design/AGENT_AUDITS.md
+++ b/skills/compose-preview-review/design/AGENT_AUDITS.md
@@ -569,21 +569,21 @@ Check:
   `supported: true`, extend this audit to assert `applied` status on the
   matching markers in the same `tMs` group.
 
-### Accessibility-driven interaction audit (planned)
+### Accessibility-driven interaction audit
 
-> **Capability gap.** Roadmap. The a11y connector module advertises an `a11y` data extension
-> with `recordingScriptEvents` for each `AccessibilityNodeInfo` action — `a11y.action.click`,
-> `a11y.action.longClick`, `a11y.action.scrollForward`, `a11y.action.focus`,
-> `a11y.action.accessibilityFocus`, etc. Today they all carry `supported = false` and
-> `record_preview` rejects them up front (compose-ai-tools#714 follow-up). This stub describes
-> the audit pattern so the next pass drops in the dispatch and updates the example.
+> **Capability split.** `a11y.action.click` is wired end-to-end on the Android backend (resolves
+> the target node by content description, invokes `SemanticsActions.OnClick` — same path
+> `AccessibilityNodeInfo.performAction(ACTION_CLICK)` walks). The other `a11y.action.*` ids
+> (`longClick`, `focus`, `scrollForward`, `expand`, `dismiss`, …) appear in `list_data_products`
+> as `supported = false` roadmap entries and are rejected up front by `record_preview`; they
+> land one-by-one as their handler factory ships.
 
 Use this when a PR changes a screen reader–facing flow: clickable nodes, `Modifier.semantics`
 handlers, scrollable containers consumed by a screen reader, or anything that should be reachable
 without a pointer event. The intent is to drive the preview the way assistive technology does
 rather than by pixel coordinates.
 
-Planned MCP shape (subject to revision when dispatch lands):
+Driving sequence:
 
 ```json
 {
@@ -591,27 +591,29 @@ Planned MCP shape (subject to revision when dispatch lands):
   "arguments": {
     "uri": "compose-preview://workspace/_app/com.example.SettingsRowPreview",
     "events": [
-      { "tMs": 0,   "kind": "a11y.action.accessibilityFocus", "params": { "nodeId": "row-mute" } },
-      { "tMs": 100, "kind": "a11y.action.click", "params": { "nodeId": "row-mute" } },
-      { "tMs": 250, "kind": "recording.probe", "label": "after-a11y-click" }
+      { "tMs": 0,   "kind": "a11y.action.click", "nodeContentDescription": "Mute notifications" },
+      { "tMs": 250, "kind": "recording.probe",   "label": "after-a11y-click" }
     ]
   }
 }
 ```
 
-`params.nodeId` references a node from the preview's most recent `a11y/hierarchy` payload —
-fetch via `get_preview_data uri=<…> kind=a11y/hierarchy` and pick the node by content
-description, role, or semantics tag. Content-description / semantics-tag matching parameters
-will land alongside the dispatch.
+`nodeContentDescription` is matched exactly against the node's `SemanticsProperties.ContentDescription`
+(useUnmergedTree = true) — fetch a fresh `a11y/hierarchy` to look up the canonical strings.
+When multiple nodes share the same description, the smallest by area wins. If no node matches,
+`scriptEvents[*].status = "unsupported"` with a specific reason.
 
-Check (once dispatch lands):
+Check:
 
-- `list_data_products` advertises the relevant `a11y.action.*` ids with `supported: true`.
+- `list_data_products` advertises `a11y.action.click` with `supported: true` on the daemon under
+  test (Android with the a11y preview extension enabled).
 - `recording.probe` evidence at the verification tick reports `applied`.
-- `a11y/hierarchy` after the click reflects the expected state mutation (selected, expanded,
-  focused).
+- The post-click frame's `a11y/hierarchy` reflects the expected state mutation (selected,
+  expanded, focused).
 - The screen-reader-driven sequence produces the same UI changes a pointer-driven sequence
   would, modulo intentional differences (e.g. focus-only flows that bypass the click).
+- Roadmap actions (`a11y.action.longClick`, etc.) come back as MCP-level rejections rather than
+  daemon evidence — that's a tooling gap, not an app regression.
 
 ### Failure triage audit
 


### PR DESCRIPTION
## Summary

`AccessibilityRecordingScriptEvents` advertised 19 `a11y.action.*` ids back in #718, all flagged `supported = false`. This wires the most useful one — `a11y.action.click` — end-to-end on the Android backend. The script event resolves a node by its visible content description and invokes `SemanticsActions.OnClick` against it: same path `AccessibilityNodeInfo.performAction(ACTION_CLICK)` walks via TalkBack, exercising the screen-reader entry point an app actually has to support.

End-to-end shape:

- **Wire** (`RecordingScriptEvent`): new `nodeContentDescription: String?` field (additive, default `null`). MCP decodes it; the `record_preview` tool schema documents it. Other a11y matchers (visible text, role, semantics tag) will land as sibling fields rather than a generic params map so per-action validation stays typed.
- **`InteractiveSession`**: new `dispatchSemanticsAction(actionKind, contentDescription): Boolean` with default `false` — `DesktopHost` inherits the no-op (caller surfaces unsupported); `AndroidInteractiveSession` overrides to enqueue a new `InteractiveCommand.DispatchSemanticsAction` through `DaemonHostBridge`.
- **Sandbox dispatch** (`RobolectricHost.performSemanticsActionByContentDescription`): resolves the matching node via `rule.onAllNodes(hasContentDescription(...), useUnmergedTree = true)` and invokes `target.config.getOrNull(SemanticsActions.OnClick)?.action?.invoke()`. Returns whether a matching node carried the requested action; the host translates that to applied / unsupported evidence. Smallest-by-area heuristic for the multi-match case mirrors `performClickActionAt`.
- **Recording session** (`AndroidRecordingSession.buildScriptHandlers`): registers `"a11y.action.click"` → handler that requires a non-blank `nodeContentDescription`, calls `interactive.dispatchSemanticsAction("click", description)`, and returns specific evidence (applied with the matched description, or unsupported with the failure reason — three distinct: blank field, no node match, no OnClick on matched node).
- **Descriptor split**: `AccessibilityRecordingScriptEvents.supportedDescriptors` carries just `a11y.action.click` (`supported = true`); `roadmapDescriptors` carries the other 18. Android `DaemonMain` composes `host.recordingScriptEventDescriptors() + supportedDescriptors + roadmapDescriptors` (gated on the a11y preview extension being enabled). Each future a11y action lands as one `performSemanticsActionByContentDescription` arm + one descriptor moved from `roadmapDescriptors` into `supportedDescriptors` — no other surface changes.

Builds on:
- #720 (registry-based dispatch — this PR plugs the new handler into that registry)
- #722 (host-derived supported descriptors — this PR's `supportedDescriptors` flow into the same composition)

## Test plan

- [ ] `./gradlew :daemon:core:check :daemon:android:check :data-a11y-connector:check :mcp:check` (couldn't run locally — JDK 17 install still blocked by sandbox network policy; CI is the verification path)
- [ ] CI: `format`, `test` jobs green
- [ ] `AccessibilityRecordingScriptEventsTest` (new): supported/roadmap split is honest — only `a11y.action.click` is `supported = true`; the other 18 are in roadmap; legacy `descriptors` aggregate = `supportedDescriptors + roadmapDescriptors`.
- [ ] `AndroidRecordingSessionTest`: three new cases pin the registry handler — happy path, miss, blank-field rejection.
- [ ] `InteractiveCommandTest`: cross-classloader contract for `DispatchSemanticsAction` (latch / atomic refs round-trip by reference, no Compose types in the payload).
- [ ] Manual smoke (post-merge, on an a11y-enabled Android daemon): `record_preview` with a single `a11y.action.click` event against a fixture preview that has a clickable button with `Modifier.semantics { contentDescription = "Save" }` produces `applied` evidence and a frame difference between pre/post.
- [ ] Manual: `list_data_products` shows `a11y.action.click` with `supported: true` only when a11y is enabled; the other 18 ids stay `supported: false`.

## Follow-ups

Now down to one item from the original chain:
- Migrate live mode through the same registry — straightforward but needs a wire-shape adjustment so live's typed `InteractiveInputKind` lands as a wire-string kind.

Plus the next a11y action to wire (probably `a11y.action.longClick` first — same shape as click but `SemanticsActions.OnLongClick`; or `a11y.action.scrollForward` because it's the screen-reader-driven scroll path Wear PRs lean on).

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8qJtJESJvS4yoTB9PKtRF)_