### PR TITLE
refactor(daemon): live-mode recording dispatch funnels through the script-handler registry

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -332,9 +332,14 @@ class AndroidRecordingSession(
         val frameIndex = liveFrameCount
         val tNanos = System.nanoTime() - startNs
         val tMs = tNanos / 1_000_000L
+        // Same registry the scripted path uses — typed RecordingInputParams translates to a
+        // synthetic RecordingScriptEvent keyed by `kind.wireName()`. Live mode discards the
+        // per-event evidence (only the scripted [stop] result carries `scriptEvents`); the
+        // dispatch's effect on the held interactive composition is what matters here.
+        val ctx = SimpleRecordingDispatchContext(tNanos = tNanos, tMs = tMs)
         while (true) {
           val next = liveInputs.poll() ?: break
-          dispatchLiveInput(next)
+          scriptHandlers.dispatch(next.toScriptEvent(tMs), ctx)
         }
 
         val advanceTimeMs = if (frameIndex == 0) 0L else (tMs - lastFrameTimeMs).coerceAtLeast(0L)
@@ -379,20 +384,24 @@ class AndroidRecordingSession(
     }
   }
 
-  private fun dispatchLiveInput(input: RecordingInputParams) {
-    if (input.kind == InteractiveInputKind.KEY_DOWN || input.kind == InteractiveInputKind.KEY_UP) {
-      return
-    }
-    interactive.dispatch(
-      InteractiveInputParams(
-        frameStreamId = "android-recording-live",
-        kind = input.kind,
-        pixelX = input.pixelX,
-        pixelY = input.pixelY,
-        keyCode = input.keyCode,
-      )
+  /**
+   * Translate a typed live-mode [RecordingInputParams] into a synthetic [RecordingScriptEvent]
+   * keyed by the same wire-name string the scripted path emits — so [scriptHandlers] dispatches
+   * both modes through one registry. `tMs` is the **frame's** virtual time (live mode stamps the
+   * input at the current frame boundary, same convention scripted playback uses).
+   *
+   * `RecordingInputParams` doesn't carry `scrollDeltaY` today (the wire shape is set by
+   * `JsonRpcServer.handleRecordingInput`); future rotary-aware live drivers can extend this
+   * synthesisation when the new payload field is wired through.
+   */
+  private fun RecordingInputParams.toScriptEvent(tMs: Long): RecordingScriptEvent =
+    RecordingScriptEvent(
+      tMs = tMs,
+      kind = kind.wireName(),
+      pixelX = pixelX,
+      pixelY = pixelY,
+      keyCode = keyCode,
     )
-  }
 
   override fun encode(format: RecordingFormat): EncodedRecording {
     val r =

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
@@ -83,6 +83,57 @@ class AndroidRecordingSessionTest {
   }
 
   @Test
+  fun liveRecordingRoutesQueuedInputThroughTheSameRegistryAsScripted() {
+    // Live mode used to call a separate `dispatchLiveInput` ladder; now both paths funnel through
+    // `scriptHandlers.dispatch(...)`. Pin that the click in `liveInputs` reaches the same
+    // `interactive.dispatch(InteractiveInputParams)` call the scripted `kind = "click"` handler
+    // makes — verifying the wireName translation + registry routing without standing up a real
+    // Robolectric sandbox.
+    val framesDir = tempFolder.newFolder("live-registry-frames")
+    val encodedDir = tempFolder.newFolder("live-registry-encoded")
+    val sourcePng = File(tempFolder.newFolder("live-registry-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    val interactive = RecordingDeltaSession(sourcePng)
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-live-registry",
+        fps = FPS,
+        scale = 1.0f,
+        live = true,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    session.postInput(
+      ee.schimke.composeai.daemon.protocol.RecordingInputParams(
+        recordingId = "test-rec-live-registry",
+        kind = InteractiveInputKind.CLICK,
+        pixelX = 4,
+        pixelY = 4,
+      )
+    )
+    Thread.sleep(90)
+    val result = session.stop()
+
+    assertTrue("live recording should capture at least one frame", result.frameCount >= 1)
+    assertEquals(
+      "the queued click must route through the registry's `click` handler",
+      1,
+      interactive.dispatchCount,
+    )
+    assertTrue(
+      "live mode must not emit script-event evidence — only scripted [stop] populates it",
+      result.scriptEvents.isEmpty(),
+    )
+  }
+
+  @Test
   fun liveRecordingCapturesFramesAndDispatchesQueuedInput() {
     val framesDir = tempFolder.newFolder("live-frames")
     val encodedDir = tempFolder.newFolder("live-encoded")

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
@@ -149,3 +149,17 @@ val INTERACTIVE_INPUT_KIND_BY_WIRE_NAME: Map<String, InteractiveInputKind> =
 
 /** Wire-name set derived from [INTERACTIVE_INPUT_KIND_BY_WIRE_NAME]. */
 val INTERACTIVE_INPUT_KIND_WIRE_NAMES: Set<String> = INTERACTIVE_INPUT_KIND_BY_WIRE_NAME.keys
+
+/**
+ * Reverse lookup — typed [InteractiveInputKind] back to its wire-name string. Used by live-mode
+ * recording sessions to translate a typed `RecordingInputParams` into a synthetic
+ * [RecordingScriptEvent] for dispatch through the same [RecordingScriptHandlerRegistry] scripted
+ * playback uses. Derived from [INTERACTIVE_INPUT_KIND_BY_WIRE_NAME] so the round-trip stays in
+ * lockstep — adding a new enum constant + wire name extends both directions automatically.
+ */
+private val INTERACTIVE_INPUT_KIND_TO_WIRE_NAME: Map<InteractiveInputKind, String> =
+  INTERACTIVE_INPUT_KIND_BY_WIRE_NAME.entries.associate { (wire, kind) -> kind to wire }
+
+/** Wire-name string for an [InteractiveInputKind] (the reverse of [toInteractiveInputKindOrNull]). */
+fun InteractiveInputKind.wireName(): String =
+  INTERACTIVE_INPUT_KIND_TO_WIRE_NAME.getValue(this)

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistryTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/RecordingScriptHandlerRegistryTest.kt
@@ -1,5 +1,6 @@
 package ee.schimke.composeai.daemon
 
+import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus
 import org.junit.Assert.assertEquals
@@ -106,6 +107,23 @@ class RecordingScriptHandlerRegistryTest {
       RecordingScriptHandlerRegistry(mapOf("click" to sentinel, "recording.probe" to sentinel))
 
     assertEquals(setOf("click", "recording.probe"), registry.knownKinds())
+  }
+
+  @Test
+  fun `wireName round-trips with toInteractiveInputKindOrNull for every enum value`() {
+    // Live mode synthesises a RecordingScriptEvent from a typed RecordingInputParams via
+    // `kind.wireName()`; the scripted path resolves the same wire name back to the enum via
+    // `toInteractiveInputKindOrNull`. Pin that the round-trip is bijective for every enum value
+    // so adding a new InteractiveInputKind keeps both directions wired (the reverse map is
+    // derived, so this test catches "added the enum, forgot the wire-name entry").
+    for (kind in InteractiveInputKind.entries) {
+      val wire = kind.wireName()
+      assertEquals(
+        "wireName -> toInteractiveInputKindOrNull must be the identity on enum '$kind'",
+        kind,
+        wire.toInteractiveInputKindOrNull(),
+      )
+    }
   }
 
   @Test

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -3,7 +3,6 @@ package ee.schimke.composeai.daemon
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
-import ee.schimke.composeai.daemon.protocol.InteractiveInputKind
 import ee.schimke.composeai.daemon.protocol.RecordingFormat
 import ee.schimke.composeai.daemon.protocol.RecordingInputParams
 import ee.schimke.composeai.daemon.protocol.RecordingScriptEvent
@@ -388,10 +387,15 @@ class DesktopRecordingSession(
 
         // Drain inputs accumulated since the last tick; dispatch each at the current virtual
         // nanoTime. Inputs that arrive *during* the dispatch+render below are picked up next
-        // tick.
+        // tick. Routes through the same [scriptHandlers] registry the scripted path uses — the
+        // typed `RecordingInputParams` translates to a synthetic [RecordingScriptEvent] keyed by
+        // `kind.wireName()`. Live mode discards the per-event evidence (only the scripted
+        // [stop] result carries `scriptEvents`); the dispatch's side effects on the held scene
+        // are what live mode cares about.
+        val ctx = SimpleRecordingDispatchContext(tNanos = tNanos, tMs = tMs)
         while (true) {
           val next = liveInputs.poll() ?: break
-          dispatchInput(next.kind, next.pixelX, next.pixelY, tNanos, tMs)
+          scriptHandlers.dispatch(next.toScriptEvent(tMs), ctx)
         }
 
         val image = state.scene.render(nanoTime = tNanos)
@@ -508,78 +512,22 @@ class DesktopRecordingSession(
   }
 
   /**
-   * Common pointer-input dispatch shared by scripted ([stopScripted]) and live ([runLiveTickLoop])
-   * paths. Translates protocol [InteractiveInputKind] into Skiko `sendPointerEvent` calls at the
-   * supplied virtual `tNanos` / `tMs`. Same Press → render-tick → Release pattern for CLICK as
-   * [DesktopInteractiveSession] uses, so `Modifier.clickable {}` and other tap-gesture detectors
-   * see a clean down→up sequence regardless of mode.
+   * Translate a typed live-mode [RecordingInputParams] into a synthetic [RecordingScriptEvent]
+   * keyed by the same wire-name string the scripted path emits — so [scriptHandlers] dispatches
+   * both modes through one registry. `tMs` is the **frame's** virtual time (live mode stamps the
+   * input at the current frame boundary, same convention scripted playback uses).
    */
-  private fun dispatchInput(
-    kind: InteractiveInputKind,
-    pixelX: Int?,
-    pixelY: Int?,
-    tNanos: Long,
-    tMs: Long,
-  ) {
-    val px = pixelX
-    val py = pixelY
-    when (kind) {
-      InteractiveInputKind.CLICK -> {
-        if (px == null || py == null) return
-        val offset = sceneOffset(px, py)
-        state.scene.sendPointerEvent(
-          eventType = PointerEventType.Press,
-          position = offset,
-          timeMillis = tMs,
-          button = PointerButton.Primary,
-          buttons = PointerButtons(isPrimaryPressed = true),
-        )
-        state.scene.render(nanoTime = tNanos)
-        state.scene.sendPointerEvent(
-          eventType = PointerEventType.Release,
-          position = offset,
-          timeMillis = tMs,
-          button = PointerButton.Primary,
-          buttons = PointerButtons(),
-        )
-      }
-      InteractiveInputKind.POINTER_DOWN -> {
-        if (px == null || py == null) return
-        state.scene.sendPointerEvent(
-          eventType = PointerEventType.Press,
-          position = sceneOffset(px, py),
-          timeMillis = tMs,
-          button = PointerButton.Primary,
-          buttons = PointerButtons(isPrimaryPressed = true),
-        )
-      }
-      InteractiveInputKind.POINTER_MOVE -> {
-        if (px == null || py == null) return
-        state.scene.sendPointerEvent(
-          eventType = PointerEventType.Move,
-          position = sceneOffset(px, py),
-          timeMillis = tMs,
-          button = PointerButton.Primary,
-          buttons = PointerButtons(isPrimaryPressed = true),
-        )
-      }
-      InteractiveInputKind.POINTER_UP -> {
-        if (px == null || py == null) return
-        state.scene.sendPointerEvent(
-          eventType = PointerEventType.Release,
-          position = sceneOffset(px, py),
-          timeMillis = tMs,
-          button = PointerButton.Primary,
-          buttons = PointerButtons(),
-        )
-      }
-      InteractiveInputKind.ROTARY_SCROLL,
-      InteractiveInputKind.KEY_DOWN,
-      InteractiveInputKind.KEY_UP -> {
-        // Reserved for v2 key dispatch; same no-op as DesktopInteractiveSession.
-      }
-    }
-  }
+  private fun RecordingInputParams.toScriptEvent(tMs: Long): RecordingScriptEvent =
+    RecordingScriptEvent(
+      tMs = tMs,
+      kind = kind.wireName(),
+      pixelX = pixelX,
+      pixelY = pixelY,
+      keyCode = keyCode,
+      // RecordingInputParams doesn't carry scrollDeltaY today (the wire shape is set by the
+      // panel-side recording/input notification handler in JsonRpcServer); future rotary-aware
+      // live drivers can extend this synthesisation when they wire the new payload field.
+    )
 
   private fun writeFramePng(image: Image, frameIndex: Int) {
     val outFile = File(framesDir, "frame-${"%05d".format(frameIndex)}.png")


### PR DESCRIPTION
## Summary

Closes the last item in the registry-consolidation chain. Live recording mode (background tick loop driven by `recording/input` notifications) used a parallel `dispatchInput` / `dispatchLiveInput` ladder over `InteractiveInputKind` — separate from the scripted-mode `scriptHandlers.dispatch(...)` registry shipped in #720. Adding any new event kind (the `a11y.action.click` from #734, future RSB scrolls, eventual key dispatch) had to be wired into both paths.

Funnel both onto the registry:

- **New `InteractiveInputKind.wireName()`** extension in `:daemon:core` — reverse of `toInteractiveInputKindOrNull`, derived from `INTERACTIVE_INPUT_KIND_BY_WIRE_NAME` so the round-trip stays bijective. Adding a new enum constant + wire-name entry extends both directions automatically.
- **Each live tick loop** now calls `scriptHandlers.dispatch(next.toScriptEvent(tMs), ctx)` after draining `liveInputs`. The synthetic `RecordingScriptEvent` carries `kind = wireName()` plus the typed payload (pixelX/Y, keyCode); evidence is discarded since live mode doesn't track scripted-style script events.
- **Desktop's `dispatchInput`** (~70 lines of `when (InteractiveInputKind) { ... sendPointerEvent }`) collapses out — every branch was already mirrored by an entry in the registry's `buildScriptHandlers()`. Android's `dispatchLiveInput` collapses similarly. Net diff: −53 lines of parallel dispatch with no behaviour change for the live path.

Tests:

- `RecordingScriptHandlerRegistryTest` (new case): pins the wire-name round-trip across every `InteractiveInputKind` enum value — adding a new constant without a wire-name entry now fails the test instead of silently routing to the unsupported branch.
- `AndroidRecordingSessionTest` (new case): asserts that a queued live click reaches the same `interactive.dispatch(InteractiveInputParams)` call the scripted `kind = "click"` handler makes — verifying the wireName translation + registry routing without standing up Robolectric. Also pins that live mode produces no `scriptEvents` (only scripted `[stop]` populates them).

After this PR every recording-script kind — input, probe, `a11y.action.click`, and future a11y / state / lifecycle handlers — flows through one dispatch path on each backend. The registry's `knownKinds()` is the single source of truth for "what does this session dispatch"; the host's `recordingScriptEventDescriptors()` (#722) and the daemon's `dataExtensions` capability are both derivable from it.

Builds on:
- #720 (registry-based scripted dispatch — this PR plugs live mode into the same registry)
- #722 (host-derived supported descriptors)
- #734 (`a11y.action.click` end-to-end via `SemanticsActions.OnClick`)

## Test plan

- [ ] `./gradlew :daemon:core:check :daemon:android:check :daemon:desktop:check` (couldn't run locally — JDK 17 install still blocked by sandbox network policy; CI is the verification path)
- [ ] CI: `format`, `test` jobs green
- [ ] `RecordingScriptHandlerRegistryTest.wireName round-trips with toInteractiveInputKindOrNull for every enum value` covers the bijection
- [ ] `AndroidRecordingSessionTest.liveRecordingRoutesQueuedInputThroughTheSameRegistryAsScripted` covers the live-tick dispatch path
- [ ] Existing `liveRecordingCapturesFramesAndDispatchesQueuedInput` continues to pass (behaviour-preserving for the live capture surface)
- [ ] Manual smoke (post-merge, on a desktop daemon): a focus-mode live recording with several clicks against a stateful preview produces the same frame deltas as the same clicks via a scripted recording

## Follow-ups

The original chain is now done — every recording-script kind dispatches through one path on each backend.

Adjacent work that's now straightforward:
- Wire a second `a11y.action.*` (longClick / scrollForward / accessibilityFocus) — each is one new arm in `RobolectricHost.performSemanticsActionByContentDescription` plus one descriptor moved from `roadmapDescriptors` to `supportedDescriptors`.
- Wire `state.save` / `state.restore` against `SavedStateRegistry` — needs a held-rule integration but the registry pattern handles the dispatch surface.
- Wire `lifecycle.event` against `LifecycleRegistry` — same shape.
- Lift the registry up to `RenderHost.recordingScriptHandlers()` (a step beyond #722) so `dataExtensions` is fully derived from the host's actual handlers rather than partially-derived + roadmap-curated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8qJtJESJvS4yoTB9PKtRF)_