### PR TITLE
feat(extensions): typed context keys for non-product hook inputs

### DIFF
--- a/data/a11y/hierarchy-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityHierarchyExtension.kt
+++ b/data/a11y/hierarchy-android/src/main/kotlin/ee/schimke/composeai/renderer/AccessibilityHierarchyExtension.kt
@@ -7,6 +7,7 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
 import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
 import ee.schimke.composeai.data.render.extensions.DataProductKey
+import ee.schimke.composeai.data.render.extensions.ExtensionContextKey
 import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
 import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
 
@@ -39,8 +40,9 @@ data class AccessibilityAnalysis(
 /**
  * Default binding for [AccessibilityHierarchyExtractor]: invokes it after the bitmap is captured
  * and emits the typed products into the store. Reads the captured `View` root from
- * `attributes[VIEW_ROOT_ATTRIBUTE]`, which the host populates from its own platform handle (the
- * daemon's RenderEngine has the View, the Robolectric Test runner has it via `ViewRootForTest`).
+ * [AccessibilityHierarchyContextKeys.ViewRoot] — the host populates it from its own platform
+ * handle (the daemon's RenderEngine has the View directly; the Robolectric test runner gets it
+ * via `ViewRootForTest`).
  *
  * `targets = {Android}` — a future Compose Multiplatform Desktop hierarchy producer would target
  * `{Desktop}` and emit the same product keys; the planner's target filter selects exactly one.
@@ -55,9 +57,7 @@ class AccessibilityHierarchyExtension : PostCaptureProcessor {
   override val targets: Set<DataExtensionTarget> = setOf(DataExtensionTarget.Android)
 
   override fun process(context: ExtensionPostCaptureContext) {
-    val view =
-      context.attributes[VIEW_ROOT_ATTRIBUTE] as? View
-        ?: error("AccessibilityHierarchyExtension requires '$VIEW_ROOT_ATTRIBUTE' in attributes.")
+    val view = context.require(AccessibilityHierarchyContextKeys.ViewRoot)
     val analysis = AccessibilityHierarchyExtractor.extract(context.previewId, view)
     context.products.put(AccessibilityDataProducts.Hierarchy, analysis.hierarchy)
     context.products.put(AccessibilityDataProducts.Atf, analysis.findings)
@@ -65,6 +65,15 @@ class AccessibilityHierarchyExtension : PostCaptureProcessor {
 
   companion object {
     const val EXTENSION_ID: String = "a11y"
-    const val VIEW_ROOT_ATTRIBUTE: String = "a11y-hierarchy.viewRoot"
   }
+}
+
+/**
+ * Typed keys this extension reads from [ExtensionPostCaptureContext.data]. The Android-platform
+ * binding lives here (where [View] is in scope); a future `:data-a11y-hierarchy-desktop` would
+ * declare its own `ViewRoot` key with the Desktop equivalent type.
+ */
+object AccessibilityHierarchyContextKeys {
+  val ViewRoot: ExtensionContextKey<View> =
+    ExtensionContextKey(name = "a11y-hierarchy.viewRoot", type = View::class.java)
 }

--- a/data/a11y/hierarchy-android/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityHierarchyExtensionTest.kt
+++ b/data/a11y/hierarchy-android/src/test/kotlin/ee/schimke/composeai/renderer/AccessibilityHierarchyExtensionTest.kt
@@ -23,7 +23,7 @@ class AccessibilityHierarchyExtensionTest {
   }
 
   @Test
-  fun failsLoudlyWhenViewRootAttributeMissing() {
+  fun failsLoudlyWhenViewRootContextKeyMissing() {
     val store = RecordingDataProductStore()
 
     val ex =
@@ -39,7 +39,7 @@ class AccessibilityHierarchyExtensionTest {
       }
     assertTrue(
       ex.message!!,
-      ex.message!!.contains(AccessibilityHierarchyExtension.VIEW_ROOT_ATTRIBUTE),
+      ex.message!!.contains(AccessibilityHierarchyContextKeys.ViewRoot.name),
     )
   }
 

--- a/data/recomposition/connector/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
+++ b/data/recomposition/connector/src/main/kotlin/ee/schimke/composeai/daemon/RecompositionDataProducer.kt
@@ -22,10 +22,10 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionHookKind
 import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionLifecycle
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
+import ee.schimke.composeai.data.render.extensions.ExtensionContextKey
 import ee.schimke.composeai.data.render.extensions.compose.CompositionObserverHook
 import ee.schimke.composeai.data.render.extensions.compose.ExtensionComposeContext
 import ee.schimke.composeai.data.render.extensions.compose.ExtensionCompositionSink
-import ee.schimke.composeai.data.render.extensions.compose.ExtensionContextKey
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json

--- a/data/render/compose/src/main/kotlin/ee/schimke/composeai/data/render/extensions/compose/ComposeDataExtensionHooks.kt
+++ b/data/render/compose/src/main/kotlin/ee/schimke/composeai/data/render/extensions/compose/ComposeDataExtensionHooks.kt
@@ -12,6 +12,8 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionLifecycle
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
 import ee.schimke.composeai.data.render.extensions.DataProductSink
 import ee.schimke.composeai.data.render.extensions.DataProductStore
+import ee.schimke.composeai.data.render.extensions.ExtensionContextData
+import ee.schimke.composeai.data.render.extensions.ExtensionContextKey
 import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
 import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
 
@@ -46,37 +48,6 @@ data class ExtensionComposeContext(
   fun <T : Any> state(key: ExtensionStateKey<T>): State<T>? = states.state(key)
 
   fun <T : Any> value(key: ExtensionStateKey<T>): T? = states.value(key)
-}
-
-data class ExtensionContextKey<T : Any>(val name: String, val type: Class<T>) {
-  init {
-    require(name.isNotBlank()) { "Extension context key name must not be blank." }
-  }
-}
-
-data class ExtensionContextValue<T : Any>(val key: ExtensionContextKey<T>, val value: T)
-
-infix fun <T : Any> ExtensionContextKey<T>.provides(value: T): ExtensionContextValue<T> =
-  ExtensionContextValue(this, value)
-
-class ExtensionContextData
-private constructor(private val values: Map<ExtensionContextKey<*>, Any>) {
-  fun <T : Any> get(key: ExtensionContextKey<T>): T? {
-    val value = values[key] ?: return null
-    return key.type.cast(value)
-  }
-
-  fun <T : Any> require(key: ExtensionContextKey<T>): T =
-    get(key) ?: error("Extension context value '${key.name}' is not available.")
-
-  fun contains(key: ExtensionContextKey<*>): Boolean = key in values
-
-  companion object {
-    val Empty: ExtensionContextData = ExtensionContextData(emptyMap())
-
-    fun of(vararg values: ExtensionContextValue<*>): ExtensionContextData =
-      ExtensionContextData(values.associate { it.key to it.value })
-  }
 }
 
 fun interface ExtensionSlotTables {

--- a/data/render/compose/src/test/kotlin/ee/schimke/composeai/data/render/extensions/compose/AroundComposableExtensionTest.kt
+++ b/data/render/compose/src/test/kotlin/ee/schimke/composeai/data/render/extensions/compose/AroundComposableExtensionTest.kt
@@ -6,6 +6,9 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionLifecycle
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
 import ee.schimke.composeai.data.render.extensions.DataProductSink
+import ee.schimke.composeai.data.render.extensions.ExtensionContextData
+import ee.schimke.composeai.data.render.extensions.ExtensionContextKey
+import ee.schimke.composeai.data.render.extensions.provides
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/ExtensionContextData.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/ExtensionContextData.kt
@@ -1,0 +1,44 @@
+package ee.schimke.composeai.data.render.extensions
+
+/**
+ * Typed key for a non-product context value handed to an extension hook (e.g. the captured Android
+ * `View` root, a coroutine scope, an inspectable composition table). Distinct from
+ * [DataProductKey]: products are emitted by an extension and consumed by another via the planner
+ * graph; context values are render-host-controlled inputs the host hands to extensions when it
+ * invokes them. Both use a string [name] + payload [type] for the same compile-time-typed-but-
+ * stringly-keyed lookup pattern.
+ *
+ * Lives in :data-render-core so non-Compose hook contexts (e.g. [ExtensionPostCaptureContext]) can
+ * use the same typed-key shape the Compose-side hooks already rely on.
+ */
+data class ExtensionContextKey<T : Any>(val name: String, val type: Class<T>) {
+  init {
+    require(name.isNotBlank()) { "Extension context key name must not be blank." }
+  }
+}
+
+data class ExtensionContextValue<T : Any>(val key: ExtensionContextKey<T>, val value: T)
+
+infix fun <T : Any> ExtensionContextKey<T>.provides(value: T): ExtensionContextValue<T> =
+  ExtensionContextValue(this, value)
+
+/** Read-only typed container for [ExtensionContextKey] entries. */
+class ExtensionContextData
+private constructor(private val values: Map<ExtensionContextKey<*>, Any>) {
+  fun <T : Any> get(key: ExtensionContextKey<T>): T? {
+    val value = values[key] ?: return null
+    return key.type.cast(value)
+  }
+
+  fun <T : Any> require(key: ExtensionContextKey<T>): T =
+    get(key) ?: error("Extension context value '${key.name}' is not available.")
+
+  fun contains(key: ExtensionContextKey<*>): Boolean = key in values
+
+  companion object {
+    val Empty: ExtensionContextData = ExtensionContextData(emptyMap())
+
+    fun of(vararg values: ExtensionContextValue<*>): ExtensionContextData =
+      ExtensionContextData(values.associate { it.key to it.value })
+  }
+}

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/PostCaptureProcessor.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/PostCaptureProcessor.kt
@@ -5,14 +5,24 @@ package ee.schimke.composeai.data.render.extensions
  * captured. No Compose runtime, no platform-specific types — extensions read declared inputs and
  * write declared outputs through [products], which the executor scopes to the extension's
  * `inputs`/`outputs` set so contract violations fail loudly at runtime.
+ *
+ * Non-product context inputs the host hands to extensions go through [data] (typed
+ * [ExtensionContextKey] entries) for new extensions. The legacy [attributes] map is kept for
+ * back-compat with extensions that haven't migrated to typed keys yet (overlay attribute slots in
+ * particular); prefer [data] in new code.
  */
 data class ExtensionPostCaptureContext(
   val extensionId: DataExtensionId,
   val previewId: String?,
   val renderMode: String?,
   val products: DataProductStore,
+  val data: ExtensionContextData = ExtensionContextData.Empty,
   val attributes: Map<String, Any?> = emptyMap(),
-)
+) {
+  fun <T : Any> get(key: ExtensionContextKey<T>): T? = data.get(key)
+
+  fun <T : Any> require(key: ExtensionContextKey<T>): T = data.require(key)
+}
 
 /**
  * Hook for extensions that run once after a render's bitmap is captured. Distinct from


### PR DESCRIPTION
Promotes the View handoff (and any future non-product hook input) from the string-keyed `attributes: Map<String, Any?>` escape hatch to typed `ExtensionContextKey<T>` keys.

## Summary

- `ExtensionContextKey<T>`, `ExtensionContextData`, `ExtensionContextValue`, and the `provides` infix move from `:data-render-compose` to `:data-render-core`. They have no Compose deps; they were originally added for the Compose-side hook contexts but the same shape is exactly what `:data-render-core`'s `ExtensionPostCaptureContext` needs.
- `ExtensionPostCaptureContext` gains a `data: ExtensionContextData` field alongside the legacy `attributes` map. Convenience `get`/`require` shorthands mirror the Compose-side `ExtensionComposeContext`.
- `AccessibilityHierarchyExtension` switches over: declares `AccessibilityHierarchyContextKeys.ViewRoot: ExtensionContextKey<View>` and reads it via `context.require(...)`. The string `VIEW_ROOT_ATTRIBUTE` constant is gone.
- The Android-platform binding (`View` as payload type) lives in `:data-a11y-hierarchy-android` — a future `:data-a11y-hierarchy-desktop` would declare its own `ViewRoot` key with the Desktop equivalent type, and downstream consumers stay type-safe within the platform variant they're paired with.

## Cross-module impact

Two callers outside `:data-render-compose` imported the types from the old package:

- `:data-recomposition-connector` — `RecompositionDataProducer`. Import updated.
- `:data-render-compose`'s own test (`AroundComposableExtensionTest`) — same package, imports updated.

The Compose hook surface (`ExtensionComposeContext` et al.) keeps its existing API by importing from the new render-core location.

## Test plan

- [x] `./gradlew :data-render-core:check :data-render-compose:check :data-recomposition-connector:check :data-a11y-hierarchy-android:check :data-a11y-connector:check :daemon:android:compileDebugKotlin :renderer-android:compileDebugKotlin :data-theme-connector:compileKotlin` — green.
- [x] `./gradlew ktfmtCheckAll` — green.
- [x] `failsLoudlyWhenViewRootContextKeyMissing` (renamed from `failsLoudlyWhenViewRootAttributeMissing`) now asserts on the typed key's `name` instead of the deprecated attribute constant.

## Follow-ups

- Migrate `OverlayExtension`'s `OUTPUT_DIRECTORY_ATTRIBUTE` and `IS_ROUND_ATTRIBUTE` from `attributes` to either typed `ExtensionContextKey`s or — better — typed `RenderDataDirectory` / `RenderDeviceShape` products. Output dir + isRound are render-host-controlled values that would slot well as products.
- Once both `attributes` callers (overlay slots above) migrate, the legacy `attributes: Map<String, Any?>` field on `ExtensionPostCaptureContext` can be deleted.
- Re-apply the `AccessibilityHierarchyExtension` wiring in `:daemon:android`'s `RenderEngine` and `:renderer-android`'s `RobolectricRenderTest` (PRs #730 and #737 — neither is in main as of the current commit). Those callers now populate `data = ExtensionContextData.of(AccessibilityHierarchyContextKeys.ViewRoot provides view)` instead of the string-keyed attribute.