### PR TITLE
feat(a11y): wire AccessibilityHierarchyExtension on both render paths

### DIFF
--- a/daemon/android/build.gradle.kts
+++ b/daemon/android/build.gradle.kts
@@ -73,6 +73,12 @@ dependencies {
   // `AccessibilityFinding` / `AccessibilityNode` without adding their own project dep.
   api(project(":data-a11y-connector"))
 
+  // Android-platform-specific hierarchy producer — `RenderEngine.kt` installs
+  // `AccessibilityHierarchyExtension` and runs the typed extension contract instead of calling
+  // `AccessibilityChecker.analyze` directly. Pairs with `:data-a11y-core`'s consumers
+  // (TouchTargetsExtension, OverlayExtension) and any future `:data-a11y-hierarchy-desktop`.
+  implementation(project(":data-a11y-hierarchy-android"))
+
   // The daemon process holds a Robolectric sandbox open via a dummy @Test
   // (DESIGN.md § 9), so JUnit + Robolectric must be on the *main* classpath,
   // not just test. DaemonHost in src/main runs the JUnit core programmatically.

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RenderEngine.kt
@@ -35,7 +35,13 @@ import ee.schimke.composeai.data.render.extensions.compose.ComposeDataExtensionP
 import ee.schimke.composeai.data.render.extensions.compose.RecordingExtensionCompositionSink
 import ee.schimke.composeai.daemon.devices.DeviceDimensions
 import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
-import ee.schimke.composeai.renderer.AccessibilityChecker
+import ee.schimke.composeai.data.render.extensions.ExtensionContextData
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import ee.schimke.composeai.data.render.extensions.provides
+import ee.schimke.composeai.renderer.AccessibilityDataProducts
+import ee.schimke.composeai.renderer.AccessibilityHierarchyContextKeys
+import ee.schimke.composeai.renderer.AccessibilityHierarchyExtension
 import java.io.File
 import java.util.Base64
 import kotlinx.serialization.decodeFromString
@@ -393,12 +399,33 @@ class RenderEngine(
               try {
                 trace.section("a11y:dataProducts") {
                   val view = (rule.onRoot().fetchSemanticsNode().root as ViewRootForTest).view
-                  val a11yResult = AccessibilityChecker.analyze(spec.outputBaseName, view)
+                  // Hierarchy + ATF come from a typed extension instead of a direct
+                  // AccessibilityChecker.analyze call. The extension owns the platform-specific
+                  // ATF walk; downstream consumers (TouchTargets, Overlay) read declared inputs
+                  // without re-walking the View. A future :data-a11y-hierarchy-desktop (CMP
+                  // semantics walk) would target {Desktop} and emit the same product keys; the
+                  // planner's target filter selects exactly one provider per platform.
+                  val hierarchyExtension = AccessibilityHierarchyExtension()
+                  val store = RecordingDataProductStore()
+                  hierarchyExtension.process(
+                    ExtensionPostCaptureContext(
+                      extensionId = hierarchyExtension.id,
+                      previewId = spec.outputBaseName,
+                      renderMode = spec.renderMode,
+                      products = store.scopedFor(hierarchyExtension),
+                      data =
+                        ExtensionContextData.of(
+                          AccessibilityHierarchyContextKeys.ViewRoot provides view
+                        ),
+                    )
+                  )
+                  val hierarchy = store.require(AccessibilityDataProducts.Hierarchy)
+                  val findings = store.require(AccessibilityDataProducts.Atf)
                   AccessibilityDataProducer.writeArtifacts(
                     rootDir = dataDir,
                     previewId = spec.outputBaseName,
-                    findings = a11yResult.findings,
-                    nodes = a11yResult.nodes,
+                    findings = findings.findings,
+                    nodes = hierarchy.nodes,
                     density = spec.density,
                     pngFile = outputFile,
                     isRound = isRound,

--- a/renderer-android/build.gradle.kts
+++ b/renderer-android/build.gradle.kts
@@ -28,6 +28,11 @@ dependencies {
   // `ee.schimke.composeai.renderer.AccessibilityChecker` etc. still resolve and downstream
   // consumers (`RobolectricRenderTest`) compile unchanged.
   api(project(":data-a11y-core"))
+  // Android-platform-specific hierarchy producer — RobolectricRenderTest installs
+  // AccessibilityHierarchyExtension and runs the typed extension contract for the per-preview
+  // ATF + hierarchy walk, mirroring `:daemon:android`'s RenderEngine. Pairs with
+  // `:data-a11y-core`'s consumers (TouchTargetsExtension, OverlayExtension).
+  implementation(project(":data-a11y-hierarchy-android"))
   implementation(project(":data-render-core"))
   implementation(project(":data-scroll-core"))
 

--- a/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
+++ b/renderer-android/src/main/kotlin/ee/schimke/composeai/renderer/RobolectricRenderTest.kt
@@ -28,6 +28,10 @@ import com.github.takahirom.roborazzi.locale
 import com.github.takahirom.roborazzi.size
 import com.github.takahirom.roborazzi.uiMode
 import ee.schimke.composeai.data.render.PreviewAnimationContext
+import ee.schimke.composeai.data.render.extensions.ExtensionContextData
+import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
+import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
+import ee.schimke.composeai.data.render.extensions.provides
 import ee.schimke.composeai.scroll.FLING_DECAY
 import ee.schimke.composeai.scroll.FLING_MAX_DISTANCE_VIEWPORTS
 import ee.schimke.composeai.scroll.FLING_MIN_STEP_DP
@@ -847,10 +851,29 @@ abstract class RobolectricRenderTestBase(
                         // produces populated AccessibilityNodeInfo. DecorView
                         // here returns all NOT_RUN.
                         val view = (onRoot.fetchSemanticsNode().root as ViewRootForTest).view
-                        // analyze() runs ATF and walks the hierarchy in one
-                        // pass — the overlay needs both findings (red badge
-                        // layer) and ANI nodes (the colour-swatched legend).
-                        val result = AccessibilityChecker.analyze(preview.id, view)
+                        // Hierarchy + ATF come from a typed extension instead of a direct
+                        // AccessibilityChecker.analyze call. Symmetric with `:daemon:android`'s
+                        // RenderEngine. The extension owns the platform-specific walk;
+                        // downstream consumers in `:data-a11y-core` (TouchTargets, Overlay)
+                        // read declared inputs without re-walking the View. A future
+                        // `:data-a11y-hierarchy-desktop` (CMP semantics walk) drops in with
+                        // `targets = {Desktop}` and the same product keys.
+                        val hierarchyExtension = AccessibilityHierarchyExtension()
+                        val store = RecordingDataProductStore()
+                        hierarchyExtension.process(
+                            ExtensionPostCaptureContext(
+                                extensionId = hierarchyExtension.id,
+                                previewId = preview.id,
+                                renderMode = null,
+                                products = store.scopedFor(hierarchyExtension),
+                                data =
+                                    ExtensionContextData.of(
+                                        AccessibilityHierarchyContextKeys.ViewRoot provides view,
+                                    ),
+                            ),
+                        )
+                        val hierarchy = store.require(AccessibilityDataProducts.Hierarchy)
+                        val findings = store.require(AccessibilityDataProducts.Atf)
                         val a11yDir = File(
                             System.getProperty("composeai.a11y.outputDir")
                                 ?: "build/compose-previews/accessibility-per-preview",
@@ -858,8 +881,8 @@ abstract class RobolectricRenderTestBase(
                         AccessibilityChecker.writePerPreviewReport(
                             outputDir = a11yDir,
                             previewId = preview.id,
-                            findings = result.findings,
-                            nodes = result.nodes,
+                            findings = findings.findings,
+                            nodes = hierarchy.nodes,
                             screenshot = outputFile.takeIf { annotate },
                             isRound = isRoundDevice(preview.params.device) &&
                                 (preview.params.showSystemUi ||


### PR DESCRIPTION
Stacked on #739 (typed context keys). Once #739 lands, base auto-rebases to `main`.

Replaces both #730 (daemon `RenderEngine` wiring; not in main as of this commit) and #737 (renderer-android `RobolectricRenderTest` wiring; was failing CI on a stale base).

## Summary

Symmetric wiring of `AccessibilityHierarchyExtension` on both Android render paths. After this lands, **no production caller invokes `AccessibilityChecker.analyze` directly** — the platform-specific ATF walk is fully behind the typed extension binding on both render paths (`:daemon:android` for the daemon, `:renderer-android` for the Gradle plugin's `:renderAllPreviews`).

Both callers populate `ExtensionContextData` via the typed `AccessibilityHierarchyContextKeys.ViewRoot` key (introduced in #739):

```kotlin
val hierarchyExtension = AccessibilityHierarchyExtension()
val store = RecordingDataProductStore()
hierarchyExtension.process(
  ExtensionPostCaptureContext(
    extensionId = hierarchyExtension.id,
    previewId = preview.id,
    products = store.scopedFor(hierarchyExtension),
    data = ExtensionContextData.of(
      AccessibilityHierarchyContextKeys.ViewRoot provides view,
    ),
  ),
)
val hierarchy = store.require(AccessibilityDataProducts.Hierarchy)
val findings = store.require(AccessibilityDataProducts.Atf)
```

A future `:data-a11y-hierarchy-desktop` (Compose Multiplatform semantics walk, `targets = {Desktop}`) drops in alongside the Android variant — neither `RenderEngine` nor `RobolectricRenderTest` needs to know about it; the planner's target filter selects the right provider per platform.

Pulls in `:data-a11y-hierarchy-android` via `implementation` deps on both `:daemon:android` and `:renderer-android`.

## Test plan

- [x] `./gradlew :daemon:android:compileDebugKotlin :daemon:android:test` — green.
- [x] `./gradlew :renderer-android:compileDebugKotlin` — green.
- [x] `./gradlew ktfmtCheckAll` — green.
- [x] End-to-end ATF + hierarchy walk already covered by `RobolectricRenderTest` (renderer path) and the daemon's `RenderEngineTest`. Same path as before, just now through the typed extension binding.

## Follow-ups

- Migrate `OverlayExtension`'s `OUTPUT_DIRECTORY_ATTRIBUTE` and `IS_ROUND_ATTRIBUTE` to typed context keys or — better — typed `RenderDataDirectory` / `RenderDeviceShape` products.
- Once those migrate, the legacy `attributes: Map<String, Any?>` field on `ExtensionPostCaptureContext` can be deleted.