### PR TITLE
feat(daemon): wire lifecycle.event as a host-owned recording-script extension

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -271,6 +271,41 @@ internal constructor(
     return replyMatched.get()
   }
 
+  /**
+   * Override of [InteractiveSession.dispatchLifecycle]. Enqueues a
+   * [InteractiveCommand.DispatchLifecycle] envelope through the bridge; the sandbox-side loop in
+   * [RobolectricHost.SandboxRunner.runHeldInteractiveSession] resolves the wire-name string to a
+   * `Lifecycle.State` and calls `ActivityScenario.moveToState(...)`.
+   *
+   * Returns `true` when the lifecycle transition fired; `false` when the named event isn't
+   * recognised. Throws when the transition itself failed — same propagation path as [dispatch].
+   */
+  override fun dispatchLifecycle(lifecycleEvent: String): Boolean {
+    if (closed) return false
+    lastUsedAtMs.set(System.currentTimeMillis())
+    val replyLatch = CountDownLatch(1)
+    val replyError = AtomicReference<Throwable?>(null)
+    val replyApplied = AtomicBoolean(false)
+    slot.interactiveCommands.put(
+      InteractiveCommand.DispatchLifecycle(
+        streamId = streamId,
+        lifecycleEvent = lifecycleEvent,
+        replyLatch = replyLatch,
+        replyError = replyError,
+        replyApplied = replyApplied,
+      )
+    )
+    if (!replyLatch.await(DISPATCH_TIMEOUT_SEC, TimeUnit.SECONDS)) {
+      error(
+        "AndroidInteractiveSession.dispatchLifecycle timed out after " +
+          "${DISPATCH_TIMEOUT_SEC}s for stream '$streamId' (lifecycleEvent=$lifecycleEvent). " +
+          "Held-rule loop may be stuck."
+      )
+    }
+    replyError.get()?.let { throw it }
+    return replyApplied.get()
+  }
+
   override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult {
     check(!closed) { "AndroidInteractiveSession.render() called after close()" }
     lastUsedAtMs.set(System.currentTimeMillis())

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -268,6 +268,10 @@ class AndroidRecordingSession(
         for (action in A11Y_SEMANTIC_ACTIONS) {
           put("a11y.action.$action", a11ySemanticsActionHandler(action))
         }
+        // Lifecycle dispatch — `lifecycle.event` reads `lifecycleEvent` payload and routes
+        // through `interactive.dispatchLifecycle(...)` → `ActivityScenario.moveToState(...)`.
+        // See [LifecycleRecordingScriptEvents] for the descriptor + state mapping.
+        put(LifecycleRecordingScriptEvents.LIFECYCLE_EVENT, lifecycleEventHandler())
       }
     )
 
@@ -327,6 +331,45 @@ class AndroidRecordingSession(
         unsupportedEvidence(
           event,
           "no node with contentDescription='$description' exposes the '$actionKind' semantic",
+        )
+      }
+    }
+
+  /**
+   * Handler for `lifecycle.event` — reads `event.lifecycleEvent` (the wire-name string) and
+   * forwards to `interactive.dispatchLifecycle(...)`. The Robolectric sandbox maps the string to
+   * a `Lifecycle.State` and calls `ActivityScenario.moveToState(...)`.
+   *
+   * Reports `unsupported` (with a specific reason) when the event payload omits the
+   * `lifecycleEvent` field, when the named transition isn't in the v1 supported set
+   * ([LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS]), or when the host can't
+   * dispatch lifecycle (interactive returned `false`).
+   */
+  private fun lifecycleEventHandler(): RecordingScriptEventHandler =
+    RecordingScriptEventHandler { event, _ ->
+      val lifecycleEvent = event.lifecycleEvent
+      if (lifecycleEvent.isNullOrBlank()) {
+        return@RecordingScriptEventHandler unsupportedEvidence(
+          event,
+          "${event.kind} requires a non-blank 'lifecycleEvent' (one of " +
+            "${LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS.sorted()})",
+        )
+      }
+      if (lifecycleEvent !in LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS) {
+        return@RecordingScriptEventHandler unsupportedEvidence(
+          event,
+          "lifecycleEvent '$lifecycleEvent' is not supported (one of " +
+            "${LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS.sorted()})",
+        )
+      }
+      val applied = interactive.dispatchLifecycle(lifecycleEvent)
+      if (applied) {
+        appliedEvidence(event, "lifecycle transition '$lifecycleEvent' fired on the held activity")
+      } else {
+        unsupportedEvidence(
+          event,
+          "host did not apply lifecycle transition '$lifecycleEvent'; held composition may be " +
+            "missing an ActivityScenario",
         )
       }
     }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/LifecycleRecordingScriptEvents.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/LifecycleRecordingScriptEvents.kt
@@ -1,0 +1,59 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescriptor
+
+/**
+ * Lifecycle-driven `record_preview` script events — see
+ * [`compose-preview-review/design/AGENT_AUDITS.md`](../../../../../../skills/compose-preview-review/design/AGENT_AUDITS.md)
+ * § "State restoration and lifecycle audit".
+ *
+ * One descriptor — `lifecycle.event` — that drives `ActivityScenario.moveToState(...)` on the
+ * held rule's activity. The wire payload's `lifecycleEvent` field selects the target state:
+ * `"pause"` → STARTED, `"resume"` → RESUMED, `"stop"` → CREATED. `"destroy"` is intentionally
+ * not part of v1 — moving to DESTROYED mid-recording would tear down the scenario and break
+ * subsequent renders.
+ *
+ * Why this lives in `:daemon:android` and not in a `:data-lifecycle-connector` module like the
+ * a11y descriptors do: lifecycle has no data products (no per-render JSON / overlay PNG), so
+ * there's no separate Android-only data module to colocate with. The dispatch end is in
+ * [RobolectricHost.SandboxRunner.performLifecycleTransition]; the descriptor end lives next to
+ * it.
+ *
+ * **Status:** the single descriptor ships with `supported = true`. Hosts that can dispatch
+ * lifecycle (today: only [RobolectricHost]) advertise it from `recordingScriptEventDescriptors()`;
+ * hosts without an Android lifecycle owner (DesktopHost) skip it entirely. The roadmap entries
+ * (`state.save` / `state.restore` / `preview.reload`) stay in
+ * `RecordingScriptDataExtensions.roadmapDescriptors` until their dispatch lands.
+ */
+object LifecycleRecordingScriptEvents {
+
+  /** Wire-name id matching `RecordingScriptDataExtensions.LIFECYCLE_EVENT`. */
+  const val LIFECYCLE_EVENT: String = "lifecycle.event"
+
+  /** Recognised values for [RecordingScriptEvent.lifecycleEvent]. `"destroy"` deliberately not in v1. */
+  val SUPPORTED_LIFECYCLE_EVENTS: Set<String> = setOf("pause", "resume", "stop")
+
+  val descriptor: DataExtensionDescriptor =
+    DataExtensionDescriptor(
+      id = DataExtensionId("lifecycle"),
+      displayName = "Lifecycle script controls",
+      recordingScriptEvents =
+        listOf(
+          RecordingScriptEventDescriptor(
+            id = LIFECYCLE_EVENT,
+            displayName = "Lifecycle event",
+            summary =
+              "Drives the held activity through the named lifecycle transition via " +
+                "ActivityScenario.moveToState. `lifecycleEvent` payload selects the target: " +
+                "'pause' → STARTED, 'resume' → RESUMED, 'stop' → CREATED. " +
+                "'destroy' is rejected (would break subsequent renders).",
+            supported = true,
+          )
+        ),
+    )
+
+  /** Convenience for the host's `recordingScriptEventDescriptors()` override. */
+  val descriptors: List<DataExtensionDescriptor> = listOf(descriptor)
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -192,15 +192,25 @@ open class RobolectricHost(
         }
 
   /**
-   * `recording.probe` is the only extension event [AndroidRecordingSession] dispatches today. The
-   * a11y action descriptors live in `:data-a11y-connector` and are concatenated into
-   * `dataExtensions` by `DaemonMain` only when the a11y preview extension is enabled, so this host
-   * method stays scoped to the renderer-agnostic probe extension. Empty when the host can't
-   * actually allocate a session ([supportsRecording] = false) so agents don't see supported = true
-   * on a daemon that would reject `recording/start` anyway.
+   * Recording-script extension descriptors this host's [AndroidRecordingSession]s actually
+   * dispatch:
+   *
+   * - `recording.probe` (renderer-agnostic) — the in-script timeline marker.
+   * - `lifecycle.event` (Android-only) — drives `ActivityScenario.moveToState(...)` against the
+   *   held rule's activity.
+   *
+   * The a11y action descriptors live in `:data-a11y-connector` and are concatenated into
+   * `dataExtensions` by `DaemonMain` only when the a11y preview extension is enabled, so they
+   * stay out of this host method. Empty when the host can't actually allocate a session
+   * ([supportsRecording] = false) so agents don't see supported = true on a daemon that would
+   * reject `recording/start` anyway.
    */
   override fun recordingScriptEventDescriptors(): List<DataExtensionDescriptor> =
-    if (supportsRecording) listOf(RecordingScriptDataExtensions.recordingDescriptor)
+    if (supportsRecording)
+      listOf(
+        RecordingScriptDataExtensions.recordingDescriptor,
+        LifecycleRecordingScriptEvents.descriptor,
+      )
     else emptyList()
 
   /**
@@ -1630,6 +1640,24 @@ open class RobolectricHost(
                     cmd.replyLatch.countDown()
                   }
                 }
+                is InteractiveCommand.DispatchLifecycle -> {
+                  try {
+                    val applied = performLifecycleTransition(rule, cmd)
+                    cmd.replyApplied.set(applied)
+                    if (applied) {
+                      // Settle window — onPause / onResume / onStop run as part of the
+                      // moveToState call, but composition recompositions triggered by lifecycle
+                      // observers (e.g. `LocalLifecycleOwner` watchers) need a clock tick to
+                      // flush before subsequent inputs / renders observe the new state.
+                      rule.mainClock.advanceTimeBy(POINTER_MOVE_MS)
+                      rule.waitForIdle()
+                    }
+                  } catch (t: Throwable) {
+                    cmd.replyError.set(t)
+                  } finally {
+                    cmd.replyLatch.countDown()
+                  }
+                }
                 is InteractiveCommand.Close -> {
                   cmd.replyLatch.countDown()
                   return
@@ -1825,6 +1853,42 @@ open class RobolectricHost(
       val accessibilityAction = target.config.getOrNull(key) ?: return false
       val lambda = accessibilityAction.action ?: return false
       rule.runOnUiThread { lambda.invoke() }
+      return true
+    }
+
+    /**
+     * Dispatch a `lifecycle.event` script event by mapping the wire-name string to a
+     * `Lifecycle.State` and calling `ActivityScenario.moveToState(...)` on the held rule's
+     * activity scenario. Returns `true` when the transition fired, `false` when [cmd.lifecycleEvent]
+     * isn't a recognised name (caller surfaces unsupported evidence with a specific reason).
+     *
+     * `"destroy"` is intentionally rejected — moving to `DESTROYED` mid-recording would tear
+     * down the scenario and break subsequent renders. Document as a follow-up if a use case for
+     * post-destroy recording surfaces.
+     */
+    private fun performLifecycleTransition(
+      rule:
+        androidx.compose.ui.test.junit4.AndroidComposeTestRule<
+          *,
+          androidx.activity.ComponentActivity,
+        >,
+      cmd: InteractiveCommand.DispatchLifecycle,
+    ): Boolean {
+      val target =
+        when (cmd.lifecycleEvent) {
+          "pause" -> androidx.lifecycle.Lifecycle.State.STARTED
+          "resume" -> androidx.lifecycle.Lifecycle.State.RESUMED
+          "stop" -> androidx.lifecycle.Lifecycle.State.CREATED
+          else -> return false
+        }
+      // `createAndroidComposeRule<A>()` always produces a rule whose activityRule is an
+      // ActivityScenarioRule<A>; the Compose API just types it as `R : TestRule` to support a
+      // hypothetical custom scaffolder. The cast is safe under Robolectric's runtime.
+      @Suppress("UNCHECKED_CAST")
+      val activityRule =
+        rule.activityRule
+          as androidx.test.ext.junit.rules.ActivityScenarioRule<androidx.activity.ComponentActivity>
+      activityRule.scenario.moveToState(target)
       return true
     }
 

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -469,4 +469,26 @@ sealed interface InteractiveCommand {
     val replyError: AtomicReference<Throwable?>,
     val replyMatched: AtomicBoolean,
   ) : InteractiveCommand
+
+  /**
+   * Lifecycle dispatch: move the held activity to the named lifecycle state via
+   * `ActivityScenario.moveToState(...)`. Used by `record_preview`'s `lifecycle.event` script
+   * events to drive `onPause` / `onResume` / `onStop` on the held composition.
+   *
+   * [lifecycleEvent] is a wire-level string the sandbox maps to the matching
+   * `Lifecycle.State` value (`"pause"` → STARTED, `"resume"` → RESUMED, `"stop"` → CREATED).
+   * Unknown names set [replyApplied] to `false` so the caller can emit a precise unsupported
+   * reason. `"destroy"` is intentionally rejected — moving to DESTROYED mid-recording would tear
+   * down the scenario and break subsequent renders.
+   *
+   * Strings travel as `java.lang.String` (do-not-acquire). No `Lifecycle.State` types cross the
+   * bridge — the sandbox owns the mapping internally.
+   */
+  data class DispatchLifecycle(
+    override val streamId: String,
+    val lifecycleEvent: String,
+    val replyLatch: CountDownLatch,
+    val replyError: AtomicReference<Throwable?>,
+    val replyApplied: AtomicBoolean,
+  ) : InteractiveCommand
 }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
@@ -555,6 +555,179 @@ class AndroidRecordingSessionTest {
   }
 
   @Test
+  fun lifecycleEventRoutesThroughDispatchLifecycle() {
+    // Happy path for the new `lifecycle.event` registry entry: the handler reads
+    // `event.lifecycleEvent`, calls `interactive.dispatchLifecycle(...)`, and reports `applied`
+    // evidence with a message naming the transition. Pin every supported transition in one go so
+    // adding a new entry to `LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS` without
+    // updating the handler short-circuit is caught here.
+    val framesDir = tempFolder.newFolder("lifecycle-frames")
+    val encodedDir = tempFolder.newFolder("lifecycle-encoded")
+    val sourcePng = File(tempFolder.newFolder("lifecycle-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    val interactive = RecordingDeltaSession(sourcePng).apply { lifecycleResult = true }
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-lifecycle",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    try {
+      session.postScript(
+        LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS.sorted().map { transition ->
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = LifecycleRecordingScriptEvents.LIFECYCLE_EVENT,
+            lifecycleEvent = transition,
+          )
+        }
+      )
+      val result = session.stop()
+
+      // Every transition in the supported set routed through dispatchLifecycle in order.
+      assertEquals(
+        LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS.sorted(),
+        interactive.lifecycleCalls,
+      )
+      // None went through pointer or semantics dispatch.
+      assertEquals(0, interactive.dispatchCount)
+      assertTrue(interactive.semanticsActionCalls.isEmpty())
+      // Every event reported applied with the transition named in the message.
+      val supported = LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS.sorted()
+      supported.forEachIndexed { index, transition ->
+        val evidence = result.scriptEvents[index]
+        assertEquals(
+          "evidence for lifecycle.event '$transition' must be applied",
+          ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.APPLIED,
+          evidence.status,
+        )
+        val message = evidence.message ?: ""
+        assertTrue(
+          "evidence message must name the lifecycle transition '$transition'; got '$message'",
+          message.contains("'$transition'"),
+        )
+      }
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
+  fun lifecycleEventReportsUnsupportedForBlankPayload() {
+    // `kind = "lifecycle.event"` without a `lifecycleEvent` payload short-circuits BEFORE
+    // touching `interactive.dispatchLifecycle` — we know the agent has nothing meaningful for the
+    // host to do, so we surface a precise unsupported reason naming the supported set.
+    val framesDir = tempFolder.newFolder("lifecycle-blank-frames")
+    val encodedDir = tempFolder.newFolder("lifecycle-blank-encoded")
+    val sourcePng = File(tempFolder.newFolder("lifecycle-blank-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    val interactive = RecordingDeltaSession(sourcePng)
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-lifecycle-blank",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    try {
+      session.postScript(
+        listOf(
+          RecordingScriptEvent(tMs = 0L, kind = LifecycleRecordingScriptEvents.LIFECYCLE_EVENT)
+        )
+      )
+      val result = session.stop()
+
+      assertTrue(
+        "blank payload must short-circuit before dispatchLifecycle",
+        interactive.lifecycleCalls.isEmpty(),
+      )
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.UNSUPPORTED,
+        result.scriptEvents[0].status,
+      )
+      val message = result.scriptEvents[0].message ?: ""
+      assertTrue(
+        "diagnostic must list the supported transitions; got '$message'",
+        message.contains("pause") && message.contains("resume") && message.contains("stop"),
+      )
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
+  fun lifecycleEventReportsUnsupportedForUnknownTransition() {
+    // `lifecycleEvent: "destroy"` (and any other string outside the supported set) is rejected up
+    // front — destroy specifically is documented as v2 because it would tear down the scenario
+    // and break subsequent renders.
+    val framesDir = tempFolder.newFolder("lifecycle-destroy-frames")
+    val encodedDir = tempFolder.newFolder("lifecycle-destroy-encoded")
+    val sourcePng = File(tempFolder.newFolder("lifecycle-destroy-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    val interactive = RecordingDeltaSession(sourcePng)
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-lifecycle-destroy",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    try {
+      session.postScript(
+        listOf(
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = LifecycleRecordingScriptEvents.LIFECYCLE_EVENT,
+            lifecycleEvent = "destroy",
+          )
+        )
+      )
+      val result = session.stop()
+
+      assertTrue(
+        "unsupported transition must short-circuit before dispatchLifecycle",
+        interactive.lifecycleCalls.isEmpty(),
+      )
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.UNSUPPORTED,
+        result.scriptEvents[0].status,
+      )
+      val message = result.scriptEvents[0].message ?: ""
+      assertTrue(
+        "diagnostic must mention the rejected transition name; got '$message'",
+        message.contains("'destroy'"),
+      )
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
   fun scriptedClickFlipsStateAndProducesFrames() {
     val outputDir = tempFolder.newFolder("recording-renders")
     val recordingsRoot = tempFolder.newFolder("recordings-root")
@@ -800,6 +973,7 @@ class AndroidRecordingSessionTest {
     var dispatchCount = 0
     var closed = false
     val semanticsActionCalls = mutableListOf<Pair<String, String>>()
+    val lifecycleCalls = mutableListOf<String>()
 
     /**
      * When non-null, [dispatchSemanticsAction] returns this value verbatim and records the call
@@ -807,6 +981,13 @@ class AndroidRecordingSessionTest {
      * (`return false`) is used so existing tests don't have to opt in.
      */
     var semanticsActionResult: Boolean? = null
+
+    /**
+     * When non-null, [dispatchLifecycle] returns this value verbatim and records the call into
+     * [lifecycleCalls]. When null (the default), the inherited interface-level default (`return
+     * false`) is used so existing tests don't have to opt in.
+     */
+    var lifecycleResult: Boolean? = null
 
     override fun dispatch(input: ee.schimke.composeai.daemon.protocol.InteractiveInputParams) {
       dispatchCount++
@@ -819,6 +1000,12 @@ class AndroidRecordingSessionTest {
       semanticsActionCalls += actionKind to nodeContentDescription
       val override = semanticsActionResult
       return override ?: super.dispatchSemanticsAction(actionKind, nodeContentDescription)
+    }
+
+    override fun dispatchLifecycle(lifecycleEvent: String): Boolean {
+      lifecycleCalls += lifecycleEvent
+      val override = lifecycleResult
+      return override ?: super.dispatchLifecycle(lifecycleEvent)
     }
 
     override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult {

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/LifecycleRecordingScriptEventsTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/LifecycleRecordingScriptEventsTest.kt
@@ -1,0 +1,49 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [LifecycleRecordingScriptEvents] — the Android-only lifecycle-driven script-event
+ * descriptor that `RobolectricHost` advertises from `recordingScriptEventDescriptors()`.
+ *
+ * The split between supported transitions and roadmap (`destroy`) is also pinned in
+ * [AndroidRecordingSessionTest] via `lifecycleEventReportsUnsupportedForUnknownTransition`; this
+ * test keeps the descriptor side honest.
+ */
+class LifecycleRecordingScriptEventsTest {
+
+  @Test
+  fun `descriptor advertises lifecycle event with supported = true`() {
+    val descriptor = LifecycleRecordingScriptEvents.descriptor
+    assertEquals("lifecycle", descriptor.id.value)
+    val events = descriptor.recordingScriptEvents
+    assertEquals(1, events.size)
+    val lifecycleEvent = events.single()
+    assertEquals(LifecycleRecordingScriptEvents.LIFECYCLE_EVENT, lifecycleEvent.id)
+    assertTrue(
+      "lifecycle.event must advertise supported = true so record_preview accepts it on Android",
+      lifecycleEvent.supported,
+    )
+  }
+
+  @Test
+  fun `supported transitions cover pause resume stop without destroy`() {
+    val supported = LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS
+    assertEquals(setOf("pause", "resume", "stop"), supported)
+    assertFalse(
+      "destroy must stay out of v1 — moving the scenario to DESTROYED breaks subsequent renders",
+      "destroy" in supported,
+    )
+  }
+
+  @Test
+  fun `descriptors convenience list wraps the single descriptor`() {
+    assertEquals(
+      listOf(LifecycleRecordingScriptEvents.descriptor),
+      LifecycleRecordingScriptEvents.descriptors,
+    )
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/InteractiveCommandTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/InteractiveCommandTest.kt
@@ -151,6 +151,37 @@ class InteractiveCommandTest {
   }
 
   @Test
+  fun dispatchLifecycleRoundTripsThroughTheBridge() {
+    // Pin the cross-classloader contract for the new variant: only `java.*` types in the
+    // payload, round-trips through `interactiveCommands` by reference (so the host's latch /
+    // atomic refs come back out unchanged for the await pattern). Mirrors
+    // `dispatchSemanticsActionRoundTripsThroughTheBridge` for the lifecycle variant.
+    DaemonHostBridge.reset()
+    val slot = DaemonHostBridge.slot(0)
+    val replyLatch = CountDownLatch(1)
+    val replyError = AtomicReference<Throwable?>(null)
+    val replyApplied = AtomicBoolean(false)
+    val cmd =
+      InteractiveCommand.DispatchLifecycle(
+        streamId = "stream-A",
+        lifecycleEvent = "pause",
+        replyLatch = replyLatch,
+        replyError = replyError,
+        replyApplied = replyApplied,
+      )
+    slot.interactiveCommands.put(cmd)
+
+    val drained = slot.interactiveCommands.poll(1, TimeUnit.SECONDS)
+    assertSame("queue must round-trip the same instance, not a copy", cmd, drained)
+    val asLifecycle = drained as InteractiveCommand.DispatchLifecycle
+    assertSame(replyLatch, asLifecycle.replyLatch)
+    assertSame(replyError, asLifecycle.replyError)
+    assertSame(replyApplied, asLifecycle.replyApplied)
+    assertNull("replyError defaults to null", asLifecycle.replyError.get())
+    assertFalse("replyApplied defaults to false", asLifecycle.replyApplied.get())
+  }
+
+  @Test
   fun dispatchSemanticsActionRoundTripsThroughTheBridge() {
     // Pin the cross-classloader contract for the new variant: only `java.*` types in the payload,
     // round-trips through `interactiveCommands` by reference (so the host's latch / atomic refs

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
@@ -74,6 +74,28 @@ interface InteractiveSession : AutoCloseable {
   fun dispatchSemanticsAction(actionKind: String, nodeContentDescription: String): Boolean = false
 
   /**
+   * Lifecycle dispatch: move the held activity (or per-host equivalent) to the named lifecycle
+   * state, exercising `onPause` / `onResume` / `onStop` etc. on the way. Used by `record_preview`'s
+   * `lifecycle.event` script events to verify that a preview survives a pause-resume cycle or a
+   * stop-restart.
+   *
+   * Returns `true` when the lifecycle transition fired; `false` when the host doesn't support
+   * lifecycle dispatch (e.g. desktop's `ImageComposeScene` has no Android lifecycle) or the named
+   * event isn't one the host recognises (caller surfaces unsupported evidence with a specific
+   * reason). Throws when the transition itself failed — same propagation shape as [dispatch].
+   *
+   * Default returns `false` so hosts without an Android lifecycle owner cleanly surface
+   * "no lifecycle dispatch available" without blowing up the session.
+   *
+   * @param lifecycleEvent transition name on the wire — `"pause"`, `"resume"`, `"stop"`. The
+   *   implementation maps each to the matching `Lifecycle.State` and calls
+   *   `ActivityScenario.moveToState(...)`. Unknown names yield `false`. `"destroy"` is
+   *   intentionally not part of v1 — moving to `DESTROYED` mid-recording would tear down the
+   *   scenario and break subsequent renders; document it as a follow-up if a use case lands.
+   */
+  fun dispatchLifecycle(lifecycleEvent: String): Boolean = false
+
+  /**
    * Render the current composition to a PNG and return the result. The implementation runs the
    * scene through enough frames to settle (typically two `scene.render()` calls — same heuristic as
    * the one-shot path) and encodes to disk at a stable path the daemon can publish via

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
@@ -312,18 +312,10 @@ object RecordingScriptDataExtensions {
             )
           ),
       ),
-      DataExtensionDescriptor(
-        id = DataExtensionId("lifecycle"),
-        displayName = "Lifecycle script controls",
-        recordingScriptEvents =
-          listOf(
-            RecordingScriptEventDescriptor(
-              id = LIFECYCLE_EVENT,
-              displayName = "Lifecycle event",
-              summary = "Requests a lifecycle transition during a recording script.",
-            )
-          ),
-      ),
+      // `lifecycle.event` moved out — the Android backend wires `ActivityScenario.moveToState` via
+      // `LifecycleRecordingScriptEvents.descriptor` (advertised by `RobolectricHost`'s
+      // `recordingScriptEventDescriptors()`). Renderer-agnostic descriptors only carry roadmap
+      // entries that no host has wired yet.
     )
 
   /**

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/extensions/RecordingScriptDataExtensionsTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/extensions/RecordingScriptDataExtensionsTest.kt
@@ -29,14 +29,17 @@ class RecordingScriptDataExtensionsTest {
   }
 
   @Test
-  fun `roadmapDescriptors carry only unsupported events`() {
+  fun `roadmapDescriptors carry only the still-unwired script events`() {
     val roadmap = RecordingScriptDataExtensions.roadmapDescriptors
     val ids = roadmap.flatMap { it.recordingScriptEvents }.map { it.id }.toSet()
+    // `lifecycle.event` left this list when the Android backend wired
+    // `ActivityScenario.moveToState` — `RobolectricHost.recordingScriptEventDescriptors()` now
+    // advertises `LifecycleRecordingScriptEvents.descriptor` directly. The remaining entries
+    // (state save/restore, preview reload) wait for their dispatch.
     assertEquals(
       setOf(
         RecordingScriptDataExtensions.STATE_SAVE_EVENT,
         RecordingScriptDataExtensions.STATE_RESTORE_EVENT,
-        RecordingScriptDataExtensions.LIFECYCLE_EVENT,
         RecordingScriptDataExtensions.PREVIEW_RELOAD_EVENT,
       ),
       ids,

--- a/skills/compose-preview-review/design/AGENT_AUDITS.md
+++ b/skills/compose-preview-review/design/AGENT_AUDITS.md
@@ -516,14 +516,12 @@ payload evidence and the state/parameter path you found in code.
 
 ### State restoration and lifecycle audit
 
-> **Capability gap.** As of 0.9.x the only `dataExtensions[].recordingScriptEvents`
-> entry the daemon dispatches is `recording.probe`. `state.save`, `state.restore`,
-> `lifecycle.event`, and `preview.reload` are advertised as `supported = false` —
-> they appear in `list_data_products` so agents can see what's planned, but
-> `record_preview` rejects them up front (see compose-ai-tools#714). Until that
-> lands, the audit below uses only `recording.probe` to mark the verification
-> tick; do not synthesise lifecycle/state markers in the script — they will be
-> rejected before any recording is started.
+> **Capability split.** `recording.probe` and `lifecycle.event` (Android-only — drives
+> `ActivityScenario.moveToState(...)` against the held rule's activity) are wired and
+> `record_preview` accepts them. `state.save` / `state.restore` and `preview.reload` are still
+> advertised as `supported = false` roadmap and rejected up front. The lifecycle event accepts
+> `pause` / `resume` / `stop` in v1 — `destroy` is rejected because moving the scenario to
+> DESTROYED would break subsequent renders.
 
 First check the daemon's advertised extension events:
 
@@ -531,13 +529,13 @@ First check the daemon's advertised extension events:
 { "tool": "list_data_products", "arguments": { "workspaceId": "<workspace>" } }
 ```
 
-Inspect `dataExtensions[].recordingScriptEvents[]`: only entries with
-`supported: true` may appear in a `record_preview` script. If the audit needs an
-event that's still `supported: false`, name the gap in the review and stop —
-this is a tooling roadmap item, not a PR-level finding.
+Inspect `dataExtensions[].recordingScriptEvents[]`: only entries with `supported: true` may
+appear in a `record_preview` script. If the audit needs an event that's still
+`supported: false`, name the gap in the review and stop — this is a tooling roadmap item, not a
+PR-level finding.
 
-Then drive the click flow that should change state, with a probe tick to
-ground the verification:
+Then drive the click flow plus a pause-resume cycle to verify state survives an Android
+lifecycle round-trip:
 
 ```json
 {
@@ -545,29 +543,31 @@ ground the verification:
   "arguments": {
     "uri": "compose-preview://workspace/_app/com.example.StatefulPreview",
     "events": [
-      { "tMs": 0, "kind": "click", "pixelX": 120, "pixelY": 40 },
-      { "tMs": 200, "kind": "recording.probe", "label": "after-click" }
+      { "tMs": 0,   "kind": "click", "pixelX": 120, "pixelY": 40 },
+      { "tMs": 200, "kind": "lifecycle.event", "lifecycleEvent": "pause" },
+      { "tMs": 200, "kind": "lifecycle.event", "lifecycleEvent": "resume" },
+      { "tMs": 200, "kind": "recording.probe", "label": "after-resume" }
     ]
   }
 }
 ```
 
-Events with the same `tMs` are one script step: any control markers at the
-probe's tick are applied before the frame for that tick is captured. Do not
-add fake delays around the probe; that would test timing luck instead of
-restored-state semantics.
+Events with the same `tMs` are one script step — the `pause` + `resume` + verification probe at
+`tMs: 200` happen before the frame for that tick is captured, so the rendered frame at 200ms
+already reflects the post-resume composition. Do not add fake delays around the lifecycle
+events; that tests timing luck instead of state-survival semantics.
 
 Check:
 
-- `list_data_products` advertises `recording.probe` with `supported: true` —
-  otherwise the daemon doesn't ship probe markers and this audit can't be run.
-- The recording metadata includes `scriptEvents` for the probe with
-  `status: "applied"`.
-- Input events that should change state produce changed frames
-  (`changedFromPrevious: true` on the post-click frame).
-- Once `state.save` / `state.restore` / `lifecycle.event` ship as
-  `supported: true`, extend this audit to assert `applied` status on the
-  matching markers in the same `tMs` group.
+- `list_data_products` advertises `recording.probe` and `lifecycle.event` with `supported: true`
+  on the daemon under test.
+- The recording metadata's `scriptEvents` for both lifecycle events report `status: "applied"`
+  (each handler emits a message naming the transition).
+- Input events that should change state produce changed frames before the lifecycle round-trip
+  AND survive the round-trip (`changedFromPrevious: false` on the post-resume frame would mean
+  the click state was lost across pause-resume).
+- Once `state.save` / `state.restore` ship as `supported: true`, extend this audit with named
+  checkpoint pairs for explicit save/restore verification.
 
 ### Accessibility-driven interaction audit
 


### PR DESCRIPTION
## Summary

Recording scripts can now drive `ActivityScenario.moveToState(...)` against the held rule's activity, so audits of "screen state survives a pause-resume cycle" run end-to-end on the Android backend. Modeled as a self-contained extension parallel to the a11y pattern, with its own descriptor object and host-derived advertisement.

- **`LifecycleRecordingScriptEvents`** (new, `:daemon:android`) — owns the `lifecycle` data-extension descriptor with one `RecordingScriptEventDescriptor` (`lifecycle.event`, `supported = true`). Lives in `:daemon:android` rather than a separate `:data-lifecycle-connector` module because lifecycle has no data products to colocate with — the dispatch end is a few lines in `RobolectricHost`, not a producer + image processor pair.
- **`InteractiveSession.dispatchLifecycle(lifecycleEvent)`** — new method with default `false`. `DesktopHost` inherits the no-op (no `ActivityScenario` against `ImageComposeScene`); `AndroidInteractiveSession` overrides to enqueue a new `InteractiveCommand.DispatchLifecycle` envelope through `DaemonHostBridge`.
- **Sandbox dispatch** (`RobolectricHost.performLifecycleTransition`) — maps the wire string to `Lifecycle.State` (`pause` → STARTED, `resume` → RESUMED, `stop` → CREATED) and calls `rule.activityRule.scenario.moveToState(...)`. `destroy` is intentionally rejected — moving the scenario to DESTROYED would tear it down and break subsequent renders.
- **Recording session** (`AndroidRecordingSession.buildScriptHandlers`) — registers the `lifecycle.event` handler that reads `event.lifecycleEvent`, validates against `LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS`, and routes through `interactive.dispatchLifecycle(...)`. Three distinct unsupported diagnostics: blank payload, unrecognised transition (e.g. `destroy`), host couldn't apply.
- **Host-derived advertisement** — `RobolectricHost.recordingScriptEventDescriptors()` now returns `[recordingDescriptor, LifecycleRecordingScriptEvents.descriptor]`. `lifecycle.event` is removed from `RecordingScriptDataExtensions.roadmapDescriptors` since it's no longer unwired anywhere.

Builds on:
- #720 (registry-based dispatch)
- #722 (host-derived supported descriptors)
- #734 (`a11y.action.click` end-to-end — same shape as this PR)
- #738 (the rest of the a11y actions — same shape)

## Test plan

- [ ] `./gradlew :daemon:core:check :daemon:android:check :data-render-core:check` (couldn't run locally — sandbox network blocks JDK 17 install; CI is the verification path)
- [ ] CI: `format`, `test` jobs green
- [ ] `LifecycleRecordingScriptEventsTest` (new) pins the descriptor shape and the supported-set invariant (`destroy` stays out).
- [ ] `AndroidRecordingSessionTest` (new cases): happy path looping every entry in `SUPPORTED_LIFECYCLE_EVENTS`, blank-payload rejection, unsupported-transition rejection (specifically asserts `destroy` is rejected before touching `dispatchLifecycle`).
- [ ] `InteractiveCommandTest` (new case): cross-classloader contract for `DispatchLifecycle`.
- [ ] `RecordingScriptDataExtensionsTest` (updated): asserts `lifecycle.event` left the renderer-agnostic roadmap.
- [ ] Manual smoke (post-merge, on an a11y-enabled Android daemon): a `record_preview` script with `click → lifecycle.event:pause → lifecycle.event:resume → recording.probe` against a `rememberSaveable`-backed counter shows the count survives the pause-resume cycle.

## Follow-ups

The remaining roadmap entries:
- `state.save` / `state.restore` — needs a multi-checkpoint `Bundle` stash. The pragmatic alternative is a single `state.recreate` event that calls `scenario.recreate()` (Android's automatic save+restore round-trip via configuration change) — collapses save+restore into one event but exercises the actual save/restore code path. Decide which model when audits start asking for it.
- `preview.reload` — re-invoke the composable. Tear down + re-setContent on the held rule. Useful for "verify the screen recovers from a recompose-from-scratch."
- The 7 a11y actions without a clean `SemanticsActions` equivalent (`clearFocus`, `accessibilityFocus`, `clearAccessibilityFocus`, `select`, `clearSelection`, `nextAtGranularity`, `previousAtGranularity`) — land if/when Compose grows the matching semantic, or via a direct `AccessibilityNodeInfo` fallback path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8qJtJESJvS4yoTB9PKtRF)_