### PR TITLE
feat(daemon): wire preview.reload via key(...) invalidation

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -306,6 +306,37 @@ internal constructor(
     return replyApplied.get()
   }
 
+  /**
+   * Override of [InteractiveSession.dispatchPreviewReload]. Enqueues a
+   * [InteractiveCommand.DispatchPreviewReload] envelope through the bridge; the sandbox-side
+   * loop in [RobolectricHost.SandboxRunner.runHeldInteractiveSession] increments the held
+   * `key(...)` reload counter, which Compose detects as a key change and rebuilds the
+   * composition slot table from scratch.
+   */
+  override fun dispatchPreviewReload(): Boolean {
+    if (closed) return false
+    lastUsedAtMs.set(System.currentTimeMillis())
+    val replyLatch = CountDownLatch(1)
+    val replyError = AtomicReference<Throwable?>(null)
+    val replyApplied = AtomicBoolean(false)
+    slot.interactiveCommands.put(
+      InteractiveCommand.DispatchPreviewReload(
+        streamId = streamId,
+        replyLatch = replyLatch,
+        replyError = replyError,
+        replyApplied = replyApplied,
+      )
+    )
+    if (!replyLatch.await(DISPATCH_TIMEOUT_SEC, TimeUnit.SECONDS)) {
+      error(
+        "AndroidInteractiveSession.dispatchPreviewReload timed out after " +
+          "${DISPATCH_TIMEOUT_SEC}s for stream '$streamId'. Held-rule loop may be stuck."
+      )
+    }
+    replyError.get()?.let { throw it }
+    return replyApplied.get()
+  }
+
   override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult {
     check(!closed) { "AndroidInteractiveSession.render() called after close()" }
     lastUsedAtMs.set(System.currentTimeMillis())

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -272,6 +272,9 @@ class AndroidRecordingSession(
         // through `interactive.dispatchLifecycle(...)` → `ActivityScenario.moveToState(...)`.
         // See [LifecycleRecordingScriptEvents] for the descriptor + state mapping.
         put(LifecycleRecordingScriptEvents.LIFECYCLE_EVENT, lifecycleEventHandler())
+        // Preview reload — `preview.reload` forces a fresh composition via the held rule's
+        // `key(...)` reload counter. See [PreviewReloadRecordingScriptEvents].
+        put(PreviewReloadRecordingScriptEvents.PREVIEW_RELOAD_EVENT, previewReloadHandler())
       }
     )
 
@@ -331,6 +334,28 @@ class AndroidRecordingSession(
         unsupportedEvidence(
           event,
           "no node with contentDescription='$description' exposes the '$actionKind' semantic",
+        )
+      }
+    }
+
+  /**
+   * Handler for `preview.reload` — forces a fresh composition by routing through
+   * `interactive.dispatchPreviewReload()`. The Robolectric sandbox increments a `key(...)` reload
+   * counter, which Compose detects as a key change and rebuilds the slot table from scratch.
+   *
+   * Reports `unsupported` when the host can't dispatch reload (interactive returned `false`,
+   * e.g. on a backend without a held rule). No payload validation needed — the kind alone is
+   * sufficient.
+   */
+  private fun previewReloadHandler(): RecordingScriptEventHandler =
+    RecordingScriptEventHandler { event, _ ->
+      val applied = interactive.dispatchPreviewReload()
+      if (applied) {
+        appliedEvidence(event, "composition rebuilt from a fresh `key(...)` boundary")
+      } else {
+        unsupportedEvidence(
+          event,
+          "host did not apply preview reload; held composition may be missing a reload counter",
         )
       }
     }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewReloadRecordingScriptEvents.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/PreviewReloadRecordingScriptEvents.kt
@@ -1,0 +1,57 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
+import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescriptor
+
+/**
+ * Preview-reload `record_preview` script event. One descriptor — `preview.reload` — that forces a
+ * fresh composition by tearing down the held content under its current `key(...)` boundary and
+ * rebuilding from scratch. Used by audits that want to verify a screen recovers cleanly from a
+ * recompose-from-zero (`remember`, `rememberSaveable`, `LaunchedEffect`-keyed work all reset).
+ *
+ * Why this lives in `:daemon:android` (mirroring [LifecycleRecordingScriptEvents]) and not in a
+ * separate connector module: there's no data-product side, just a single dispatch arm in
+ * [RobolectricHost.SandboxRunner] that increments a `mutableIntStateOf` counter the wrapping
+ * `key(...)` block reads.
+ *
+ * **Distinct from `lifecycle.event`.** Lifecycle drives `ActivityScenario.moveToState(...)` which
+ * preserves `rememberSaveable` state across `pause` / `resume`. `preview.reload` invalidates the
+ * Compose slot table entirely — `rememberSaveable` state is lost too because the `key(...)`
+ * boundary changes its call-site path. Use `lifecycle.event` to verify state survives a
+ * configuration change; use `preview.reload` to verify the screen handles a cold composition.
+ *
+ * **Status:** the descriptor ships with `supported = true`. Hosts that wire reload (today: only
+ * [RobolectricHost]) advertise it from `recordingScriptEventDescriptors()`. The renderer-agnostic
+ * `RecordingScriptDataExtensions.PREVIEW_RELOAD_EVENT` constant is reused for the wire-name id;
+ * `RecordingScriptDataExtensions.roadmapDescriptors` no longer carries the `preview` extension
+ * since it's now wired here.
+ */
+object PreviewReloadRecordingScriptEvents {
+
+  /** Wire-name id matching `RecordingScriptDataExtensions.PREVIEW_RELOAD_EVENT`. */
+  const val PREVIEW_RELOAD_EVENT: String = RecordingScriptDataExtensions.PREVIEW_RELOAD_EVENT
+
+  val descriptor: DataExtensionDescriptor =
+    DataExtensionDescriptor(
+      id = DataExtensionId("preview"),
+      displayName = "Preview script controls",
+      recordingScriptEvents =
+        listOf(
+          RecordingScriptEventDescriptor(
+            id = PREVIEW_RELOAD_EVENT,
+            displayName = "Reload preview",
+            summary =
+              "Forces a fresh composition: tears down the current slot table under its " +
+                "`key(...)` boundary and rebuilds against the same composable. `remember` and " +
+                "`rememberSaveable` state both reset. Use `lifecycle.event` (pause/resume) for " +
+                "config-change-style audits where rememberSaveable state should survive.",
+            supported = true,
+          )
+        ),
+    )
+
+  /** Convenience for the host's `recordingScriptEventDescriptors()` override. */
+  val descriptors: List<DataExtensionDescriptor> = listOf(descriptor)
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -198,6 +198,8 @@ open class RobolectricHost(
    * - `recording.probe` (renderer-agnostic) — the in-script timeline marker.
    * - `lifecycle.event` (Android-only) — drives `ActivityScenario.moveToState(...)` against the
    *   held rule's activity.
+   * - `preview.reload` (Android-only today) — forces a fresh composition via the held rule's
+   *   `key(...)` reload counter.
    *
    * The a11y action descriptors live in `:data-a11y-connector` and are concatenated into
    * `dataExtensions` by `DaemonMain` only when the a11y preview extension is enabled, so they
@@ -210,6 +212,7 @@ open class RobolectricHost(
       listOf(
         RecordingScriptDataExtensions.recordingDescriptor,
         LifecycleRecordingScriptEvents.descriptor,
+        PreviewReloadRecordingScriptEvents.descriptor,
       )
     else emptyList()
 
@@ -1538,16 +1541,24 @@ open class RobolectricHost(
             rule.runOnUiThread { rule.activity.window.decorView.setBackgroundColor(backgroundArgb) }
             val setupTrace =
               PerfettoTraceDataProducer.recorder(start.outputBaseName, backend = "android-live")
+            // `preview.reload` reload counter — wrapping `key(...)` reads `intValue`, so
+            // incrementing it from the command handler tears down the slot table inside the
+            // boundary and rebuilds against a fresh `remember` / `rememberSaveable` slot map.
+            // Lives here (not as a class-level field) because the held composition is local to
+            // this `evaluate()` invocation; one reload counter per stream.
+            val reloadCounter = androidx.compose.runtime.mutableIntStateOf(0)
             setupTrace.section("compose:setContent") {
               rule.setContent {
-                androidx.compose.runtime.CompositionLocalProvider(
-                  androidx.compose.ui.platform.LocalInspectionMode provides
-                    (start.inspectionMode ?: false)
-                ) {
-                  androidx.compose.foundation.layout.Box(
-                    modifier = androidx.compose.ui.Modifier.fillMaxSize()
+                androidx.compose.runtime.key(reloadCounter.intValue) {
+                  androidx.compose.runtime.CompositionLocalProvider(
+                    androidx.compose.ui.platform.LocalInspectionMode provides
+                      (start.inspectionMode ?: false)
                   ) {
-                    InvokeHeldComposable(composableMethod)
+                    androidx.compose.foundation.layout.Box(
+                      modifier = androidx.compose.ui.Modifier.fillMaxSize()
+                    ) {
+                      InvokeHeldComposable(composableMethod)
+                    }
                   }
                 }
               }
@@ -1652,6 +1663,21 @@ open class RobolectricHost(
                       rule.mainClock.advanceTimeBy(POINTER_MOVE_MS)
                       rule.waitForIdle()
                     }
+                  } catch (t: Throwable) {
+                    cmd.replyError.set(t)
+                  } finally {
+                    cmd.replyLatch.countDown()
+                  }
+                }
+                is InteractiveCommand.DispatchPreviewReload -> {
+                  try {
+                    rule.runOnUiThread { reloadCounter.intValue++ }
+                    // Settle window — Compose has to detect the key change, dispose the old
+                    // slot table, and run the new composition's first frame before subsequent
+                    // inputs / renders observe the rebuilt state.
+                    rule.mainClock.advanceTimeBy(HELD_CAPTURE_ADVANCE_MS)
+                    rule.waitForIdle()
+                    cmd.replyApplied.set(true)
                   } catch (t: Throwable) {
                     cmd.replyError.set(t)
                   } finally {

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -491,4 +491,24 @@ sealed interface InteractiveCommand {
     val replyError: AtomicReference<Throwable?>,
     val replyApplied: AtomicBoolean,
   ) : InteractiveCommand
+
+  /**
+   * Force a fresh composition by tearing down the held content under its current `key(...)`
+   * boundary and rebuilding. Used by `record_preview`'s `preview.reload` script event to verify
+   * a screen recovers from a recompose-from-zero. The sandbox-side handler increments a
+   * `mutableIntStateOf` reload counter that the wrapping `key(...)` block reads, which Compose
+   * detects as a key change and rebuilds the slot table fresh.
+   *
+   * No payload — the reload target is implicit (the held composition this stream is driving).
+   * `replyApplied` is set by the sandbox before [replyLatch] counts down: `true` on success,
+   * `false` if the host doesn't carry a reload counter (defensive — the production held-rule
+   * loop always wires one). Throwables from the rebuild ride [replyError] for the host's
+   * dispatch path to rethrow.
+   */
+  data class DispatchPreviewReload(
+    override val streamId: String,
+    val replyLatch: CountDownLatch,
+    val replyError: AtomicReference<Throwable?>,
+    val replyApplied: AtomicBoolean,
+  ) : InteractiveCommand
 }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
@@ -728,6 +728,114 @@ class AndroidRecordingSessionTest {
   }
 
   @Test
+  fun previewReloadRoutesThroughDispatchPreviewReload() {
+    // Happy path for the new `preview.reload` registry entry: handler calls
+    // `interactive.dispatchPreviewReload()` and reports `applied` evidence with a message
+    // describing the rebuild. No payload validation needed — the kind alone is sufficient.
+    val framesDir = tempFolder.newFolder("preview-reload-frames")
+    val encodedDir = tempFolder.newFolder("preview-reload-encoded")
+    val sourcePng = File(tempFolder.newFolder("preview-reload-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    val interactive = RecordingDeltaSession(sourcePng).apply { previewReloadResult = true }
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-preview-reload",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    try {
+      session.postScript(
+        listOf(
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = PreviewReloadRecordingScriptEvents.PREVIEW_RELOAD_EVENT,
+          )
+        )
+      )
+      val result = session.stop()
+
+      assertEquals(
+        "the registry must route preview.reload through dispatchPreviewReload, not pointer dispatch",
+        0,
+        interactive.dispatchCount,
+      )
+      assertEquals(1, interactive.previewReloadCount)
+      assertEquals(1, result.scriptEvents.size)
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.APPLIED,
+        result.scriptEvents[0].status,
+      )
+      val message = result.scriptEvents[0].message ?: ""
+      assertTrue(
+        "evidence must mention the composition rebuild; got '$message'",
+        message.contains("composition") && message.contains("rebuilt"),
+      )
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
+  fun previewReloadReportsUnsupportedWhenHostCannotReload() {
+    // When `dispatchPreviewReload` returns false (no held rule, or reload counter wasn't wired),
+    // the handler must surface a specific unsupported reason — not let the agent think the
+    // reload landed.
+    val framesDir = tempFolder.newFolder("preview-reload-miss-frames")
+    val encodedDir = tempFolder.newFolder("preview-reload-miss-encoded")
+    val sourcePng = File(tempFolder.newFolder("preview-reload-miss-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    val interactive = RecordingDeltaSession(sourcePng).apply { previewReloadResult = false }
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-preview-reload-miss",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    try {
+      session.postScript(
+        listOf(
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = PreviewReloadRecordingScriptEvents.PREVIEW_RELOAD_EVENT,
+          )
+        )
+      )
+      val result = session.stop()
+
+      assertEquals(1, interactive.previewReloadCount)
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.UNSUPPORTED,
+        result.scriptEvents[0].status,
+      )
+      val message = result.scriptEvents[0].message ?: ""
+      assertTrue(
+        "miss diagnostic must mention reload counter wiring; got '$message'",
+        message.contains("reload counter"),
+      )
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
   fun scriptedClickFlipsStateAndProducesFrames() {
     val outputDir = tempFolder.newFolder("recording-renders")
     val recordingsRoot = tempFolder.newFolder("recordings-root")
@@ -1006,6 +1114,21 @@ class AndroidRecordingSessionTest {
       lifecycleCalls += lifecycleEvent
       val override = lifecycleResult
       return override ?: super.dispatchLifecycle(lifecycleEvent)
+    }
+
+    var previewReloadCount: Int = 0
+
+    /**
+     * When non-null, [dispatchPreviewReload] returns this value verbatim and increments
+     * [previewReloadCount]. When null (the default), the inherited interface-level default
+     * (`return false`) is used so existing tests don't have to opt in.
+     */
+    var previewReloadResult: Boolean? = null
+
+    override fun dispatchPreviewReload(): Boolean {
+      previewReloadCount++
+      val override = previewReloadResult
+      return override ?: super.dispatchPreviewReload()
     }
 
     override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult {

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewReloadRecordingScriptEventsTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/PreviewReloadRecordingScriptEventsTest.kt
@@ -1,0 +1,47 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [PreviewReloadRecordingScriptEvents] — the host-owned descriptor that
+ * `RobolectricHost.recordingScriptEventDescriptors()` advertises as `supported = true` for the
+ * `preview.reload` script event.
+ */
+class PreviewReloadRecordingScriptEventsTest {
+
+  @Test
+  fun `descriptor advertises preview reload with supported = true`() {
+    val descriptor = PreviewReloadRecordingScriptEvents.descriptor
+    assertEquals("preview", descriptor.id.value)
+    val events = descriptor.recordingScriptEvents
+    assertEquals(1, events.size)
+    val reload = events.single()
+    assertEquals(PreviewReloadRecordingScriptEvents.PREVIEW_RELOAD_EVENT, reload.id)
+    assertTrue(
+      "preview.reload must advertise supported = true so record_preview accepts it on Android",
+      reload.supported,
+    )
+  }
+
+  @Test
+  fun `wire-name id matches the renderer-agnostic constant`() {
+    // The wire-name string is shared with `RecordingScriptDataExtensions.PREVIEW_RELOAD_EVENT`
+    // so older clients (pre-this-PR) and newer clients hit the same id. Drift would silently
+    // route to the registry's "no handler" branch.
+    assertEquals(
+      RecordingScriptDataExtensions.PREVIEW_RELOAD_EVENT,
+      PreviewReloadRecordingScriptEvents.PREVIEW_RELOAD_EVENT,
+    )
+  }
+
+  @Test
+  fun `descriptors convenience list wraps the single descriptor`() {
+    assertEquals(
+      listOf(PreviewReloadRecordingScriptEvents.descriptor),
+      PreviewReloadRecordingScriptEvents.descriptors,
+    )
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/InteractiveCommandTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/InteractiveCommandTest.kt
@@ -151,6 +151,35 @@ class InteractiveCommandTest {
   }
 
   @Test
+  fun dispatchPreviewReloadRoundTripsThroughTheBridge() {
+    // Pin the cross-classloader contract for the new variant: only `java.*` types in the
+    // payload, round-trips through `interactiveCommands` by reference. No event-specific fields
+    // — reload is parameterless; the held composition is implicit.
+    DaemonHostBridge.reset()
+    val slot = DaemonHostBridge.slot(0)
+    val replyLatch = CountDownLatch(1)
+    val replyError = AtomicReference<Throwable?>(null)
+    val replyApplied = AtomicBoolean(false)
+    val cmd =
+      InteractiveCommand.DispatchPreviewReload(
+        streamId = "stream-A",
+        replyLatch = replyLatch,
+        replyError = replyError,
+        replyApplied = replyApplied,
+      )
+    slot.interactiveCommands.put(cmd)
+
+    val drained = slot.interactiveCommands.poll(1, TimeUnit.SECONDS)
+    assertSame("queue must round-trip the same instance, not a copy", cmd, drained)
+    val asReload = drained as InteractiveCommand.DispatchPreviewReload
+    assertSame(replyLatch, asReload.replyLatch)
+    assertSame(replyError, asReload.replyError)
+    assertSame(replyApplied, asReload.replyApplied)
+    assertNull("replyError defaults to null", asReload.replyError.get())
+    assertFalse("replyApplied defaults to false", asReload.replyApplied.get())
+  }
+
+  @Test
   fun dispatchLifecycleRoundTripsThroughTheBridge() {
     // Pin the cross-classloader contract for the new variant: only `java.*` types in the
     // payload, round-trips through `interactiveCommands` by reference (so the host's latch /

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
@@ -96,6 +96,22 @@ interface InteractiveSession : AutoCloseable {
   fun dispatchLifecycle(lifecycleEvent: String): Boolean = false
 
   /**
+   * Force a fresh composition: tear down the current composition slot and rebuild from scratch
+   * against the same composable function. Used by `record_preview`'s `preview.reload` script
+   * event to verify a screen recovers cleanly from a recompose-from-zero (`remember`,
+   * `rememberSaveable`, and `LaunchedEffect`-keyed work all reset).
+   *
+   * Returns `true` when the composition was rebuilt; `false` when the host doesn't support
+   * forced reloads (DesktopHost today). Throws when the rebuild itself failed.
+   *
+   * Note: this is a Compose-level reset, not an Android lifecycle round-trip. State preserved by
+   * `rememberSaveable` (bundle-backed) is also lost because the `key(...)` boundary that drives
+   * the rebuild invalidates the saveable-state call sites. For "state survives a config-change"
+   * audits use [dispatchLifecycle] (`pause` / `resume`) instead.
+   */
+  fun dispatchPreviewReload(): Boolean = false
+
+  /**
    * Render the current composition to a PNG and return the result. The implementation runs the
    * scene through enough frames to settle (typically two `scene.render()` calls — same heuristic as
    * the one-shot path) and encodes to disk at a stable path the daemon can publish via

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
@@ -300,22 +300,12 @@ object RecordingScriptDataExtensions {
             ),
           ),
       ),
-      DataExtensionDescriptor(
-        id = DataExtensionId("preview"),
-        displayName = "Preview script controls",
-        recordingScriptEvents =
-          listOf(
-            RecordingScriptEventDescriptor(
-              id = PREVIEW_RELOAD_EVENT,
-              displayName = "Reload preview",
-              summary = "Requests preview reload during a recording script.",
-            )
-          ),
-      ),
-      // `lifecycle.event` moved out — the Android backend wires `ActivityScenario.moveToState` via
-      // `LifecycleRecordingScriptEvents.descriptor` (advertised by `RobolectricHost`'s
-      // `recordingScriptEventDescriptors()`). Renderer-agnostic descriptors only carry roadmap
-      // entries that no host has wired yet.
+      // `preview.reload` and `lifecycle.event` both moved out of this list — the Android backend
+      // wires them via `PreviewReloadRecordingScriptEvents.descriptor` and
+      // `LifecycleRecordingScriptEvents.descriptor` respectively, advertised through
+      // `RobolectricHost.recordingScriptEventDescriptors()`. Renderer-agnostic descriptors only
+      // carry roadmap entries that no host has wired yet (today: just `state.save` /
+      // `state.restore`).
     )
 
   /**

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/extensions/RecordingScriptDataExtensionsTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/extensions/RecordingScriptDataExtensionsTest.kt
@@ -32,15 +32,14 @@ class RecordingScriptDataExtensionsTest {
   fun `roadmapDescriptors carry only the still-unwired script events`() {
     val roadmap = RecordingScriptDataExtensions.roadmapDescriptors
     val ids = roadmap.flatMap { it.recordingScriptEvents }.map { it.id }.toSet()
-    // `lifecycle.event` left this list when the Android backend wired
-    // `ActivityScenario.moveToState` — `RobolectricHost.recordingScriptEventDescriptors()` now
-    // advertises `LifecycleRecordingScriptEvents.descriptor` directly. The remaining entries
-    // (state save/restore, preview reload) wait for their dispatch.
+    // `lifecycle.event` and `preview.reload` left this list once the Android backend wired their
+    // dispatch — `RobolectricHost.recordingScriptEventDescriptors()` now advertises
+    // `LifecycleRecordingScriptEvents.descriptor` and `PreviewReloadRecordingScriptEvents.descriptor`
+    // directly. The only remaining unwired pair is state save/restore.
     assertEquals(
       setOf(
         RecordingScriptDataExtensions.STATE_SAVE_EVENT,
         RecordingScriptDataExtensions.STATE_RESTORE_EVENT,
-        RecordingScriptDataExtensions.PREVIEW_RELOAD_EVENT,
       ),
       ids,
     )

--- a/skills/compose-preview-review/design/AGENT_AUDITS.md
+++ b/skills/compose-preview-review/design/AGENT_AUDITS.md
@@ -516,12 +516,18 @@ payload evidence and the state/parameter path you found in code.
 
 ### State restoration and lifecycle audit
 
-> **Capability split.** `recording.probe` and `lifecycle.event` (Android-only — drives
-> `ActivityScenario.moveToState(...)` against the held rule's activity) are wired and
-> `record_preview` accepts them. `state.save` / `state.restore` and `preview.reload` are still
-> advertised as `supported = false` roadmap and rejected up front. The lifecycle event accepts
-> `pause` / `resume` / `stop` in v1 — `destroy` is rejected because moving the scenario to
-> DESTROYED would break subsequent renders.
+> **Capability split.** `recording.probe`, `lifecycle.event`, and `preview.reload` (all
+> Android-only) are wired and `record_preview` accepts them. `lifecycle.event` drives
+> `ActivityScenario.moveToState(...)` against the held rule's activity (accepts `pause` /
+> `resume` / `stop` — `destroy` is rejected). `preview.reload` forces a fresh composition by
+> tearing down the held content under its `key(...)` boundary and rebuilding (`remember` and
+> `rememberSaveable` state both reset). `state.save` / `state.restore` are still advertised as
+> `supported = false` roadmap and rejected up front.
+>
+> **Choose `lifecycle.event` vs `preview.reload`.** Use `lifecycle.event:pause` then `:resume`
+> when verifying that state survives a configuration change — `rememberSaveable` is preserved.
+> Use `preview.reload` when verifying the screen handles a cold composition — both `remember`
+> and `rememberSaveable` reset.
 
 First check the daemon's advertised extension events:
 
@@ -568,6 +574,25 @@ Check:
   the click state was lost across pause-resume).
 - Once `state.save` / `state.restore` ship as `supported: true`, extend this audit with named
   checkpoint pairs for explicit save/restore verification.
+
+**Cold-composition variant.** Replace the `pause`+`resume` pair with `preview.reload` to verify
+the screen recovers cleanly from a recompose-from-zero (`remember` and `rememberSaveable` both
+reset). A regression that lost `rememberSaveable` state under reload but not under pause-resume
+is the kind of thing this variant catches:
+
+```json
+{
+  "tool": "record_preview",
+  "arguments": {
+    "uri": "compose-preview://workspace/_app/com.example.StatefulPreview",
+    "events": [
+      { "tMs": 0,   "kind": "click", "pixelX": 120, "pixelY": 40 },
+      { "tMs": 200, "kind": "preview.reload" },
+      { "tMs": 200, "kind": "recording.probe", "label": "after-reload" }
+    ]
+  }
+}
+```
 
 ### Accessibility-driven interaction audit
 


### PR DESCRIPTION
## Summary

Forces a fresh composition by tearing down the held content under its `key(...)` boundary and rebuilding from scratch. `remember` and `rememberSaveable` state both reset — useful for audits that verify a screen handles a cold composition. Distinct from `lifecycle.event:pause`+`:resume` (which preserves `rememberSaveable` across the round-trip).

Wired as a self-contained extension following the lifecycle pattern from #741:

- **`InteractiveSession.dispatchPreviewReload(): Boolean`** — new method, default `false`. `DesktopHost` inherits the no-op; `AndroidInteractiveSession` overrides to enqueue a new `InteractiveCommand.DispatchPreviewReload` envelope (parameterless — the held composition is implicit).
- **Sandbox dispatch** (`RobolectricHost`) — wraps the held `setContent` body in `key(reloadCounter.intValue) { ... }` where `reloadCounter` is a `mutableIntStateOf(0)` local to the per-stream `evaluate()`. The new `DispatchPreviewReload` arm increments the counter under `runOnUiThread`, which Compose detects as a key change → tears down the slot table → rebuilds. Settle window + `waitForIdle()` afterwards so subsequent inputs / renders observe the rebuilt state.
- **`PreviewReloadRecordingScriptEvents`** (new, `:daemon:android`) — owns the `preview` data-extension descriptor with one `RecordingScriptEventDescriptor` (`preview.reload`, `supported = true`). Reuses `RecordingScriptDataExtensions.PREVIEW_RELOAD_EVENT` as the wire-name id so older clients hit the same string.
- **Recording session** (`AndroidRecordingSession.buildScriptHandlers`) — registers the `preview.reload` handler that calls `interactive.dispatchPreviewReload()` and surfaces applied / unsupported evidence.
- **Host-derived advertisement** — `RobolectricHost.recordingScriptEventDescriptors()` now returns `[recordingDescriptor, lifecycleDescriptor, previewReloadDescriptor]`. The `preview` descriptor is removed from `RecordingScriptDataExtensions.roadmapDescriptors` (only `state.save` / `state.restore` remain there).

`AGENT_AUDITS.md`'s state-restoration audit gains a "cold-composition variant" example that uses `preview.reload` plus a note on when to pick reload vs pause-resume:

> Use `lifecycle.event:pause` then `:resume` when verifying that state survives a configuration change — `rememberSaveable` is preserved. Use `preview.reload` when verifying the screen handles a cold composition — both `remember` and `rememberSaveable` reset.

Builds on:
- #720 (registry-based dispatch)
- #722 (host-derived supported descriptors)
- #741 (`lifecycle.event` — same shape as this PR)

## Test plan

- [ ] `./gradlew :daemon:core:check :daemon:android:check :data-render-core:check` (couldn't run locally — sandbox network blocks JDK 17 install; CI is the verification path)
- [ ] CI: `format`, `test` jobs green
- [ ] `PreviewReloadRecordingScriptEventsTest` (new) pins descriptor shape + wire-name alignment with the renderer-agnostic constant.
- [ ] `AndroidRecordingSessionTest` (new cases): happy-path routes through `dispatchPreviewReload` with applied evidence; miss-path surfaces a specific unsupported reason mentioning reload-counter wiring.
- [ ] `InteractiveCommandTest` (new case): cross-classloader contract for `DispatchPreviewReload`.
- [ ] `RecordingScriptDataExtensionsTest` (updated): roadmap shrunk to just `state.save` / `state.restore`.
- [ ] Manual smoke (post-merge, on an a11y-enabled Android daemon): a `record_preview` script with `click → preview.reload → recording.probe` against a `remember`-backed counter shows the count reset to zero on the post-reload frame.

## Follow-ups

The roadmap is down to one item now:
- `state.save` / `state.restore` — the principled multi-checkpoint model needs a way to inject a saved-state `Bundle` into a fresh activity, which `ActivityScenario` doesn't accept directly. The pragmatic alternative is `state.recreate` calling `scenario.recreate()` (Android's automatic save+restore round-trip) — collapses save+restore into one event but exercises the actual save/restore code path. Decide which model when audits start asking for it.

Plus the 7 a11y actions without a clean `SemanticsActions` equivalent (`clearFocus`, `accessibilityFocus`, `clearAccessibilityFocus`, `select`, `clearSelection`, `nextAtGranularity`, `previousAtGranularity`) — land if/when Compose grows the matching semantic.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8qJtJESJvS4yoTB9PKtRF)_