### PR TITLE
test(plugin): scaffold Android functional-test infrastructure (#733)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,3 +39,38 @@ tasks.register("ktfmtFormatAll") {
   dependsOn(gradle.includedBuild("gradle-plugin").task(":ktfmtFormat"))
   allprojects.forEach { dependsOn(it.taskPath("ktfmtFormat")) }
 }
+
+// Convenience entrypoint for issue #733's `AccessibilityAndroidFunctionalTest`. The test runs
+// against the AAR resolved from `~/.m2`, so the renderer-android AAR + every transitively-pulled
+// internal module must land in mavenLocal before `:gradle-plugin:functionalTest`. Wiring it
+// from the *parent* build (rather than from inside the gradle-plugin included build) lets the
+// child stay decoupled — the `dependsOn` chain only flows parent → child, the standard
+// direction.
+//
+// The publish set is the closure of renderer-android's compile/runtime project deps:
+//   :renderer-android
+//     api :data-a11y-core
+//       api :data-render-core
+//     implementation :data-render-core
+//     implementation :data-scroll-core
+//       api :data-render-core
+//       api :data-render-compose
+//         api :data-render-core
+val androidFunctionalTestPublishTargets =
+  listOf(
+    ":renderer-android",
+    ":data-a11y-core",
+    ":data-render-core",
+    ":data-render-compose",
+    ":data-scroll-core",
+  )
+
+tasks.register("functionalTestWithAndroid") {
+  group = "verification"
+  description =
+    "Publishes renderer-android (+ transitive internal modules) to mavenLocal, then runs " +
+      "gradle-plugin's functionalTest (including the Android-flavour " +
+      "AccessibilityAndroidFunctionalTest)."
+  androidFunctionalTestPublishTargets.forEach { dependsOn("$it:publishToMavenLocal") }
+  dependsOn(gradle.includedBuild("gradle-plugin").task(":functionalTest"))
+}

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
   id("composeai.maven-publishing")
   `java-gradle-plugin`
@@ -52,14 +54,113 @@ val functionalTestRuntimeOnly by configurations.getting {
   extendsFrom(configurations.testRuntimeOnly.get())
 }
 
+// `withPluginClasspath()` reads from `pluginUnderTestMetadata.pluginClasspath`, which by default
+// is just `sourceSets.main.runtimeClasspath`. AGP is `compileOnly` at the main level (so it
+// stays out of the published plugin JAR) — that means `AndroidComponentsExtension` is not
+// reachable from the plugin's classloader at functional-test time, and
+// `AndroidPreviewSupport.configure` throws `NoClassDefFoundError` the moment a synthetic
+// project applies `com.android.library`.
+//
+// Pull in **only the AGP API artifacts** (`gradle-api` + transitive `gradle-common-api` /
+// `gradle-settings-api`), not the full `gradle` runtime. The runtime jar drags in
+// `kotlin-gradle-plugin:2.2.10` plus its bundled Kotlin compiler, which then collides with the
+// `kotlin-compose-compiler-plugin-embeddable:2.3.21` the synthetic project resolves through its
+// own plugin block — TestKit puts both classes on the same classloader hierarchy and Kotlin
+// trips with "language version 2.0 incompatible with ComposeComponentRegistrar". The API jar
+// alone carries the AndroidComponentsExtension / Variant / CommonExtension / SingleArtifact
+// types that `AndroidPreviewSupport` reaches for; the synthetic project still gets the full
+// AGP runtime through its own `id("com.android.library")` plugin block.
+val agpForFunctionalTest by configurations.creating {
+  isCanBeResolved = true
+  isCanBeConsumed = false
+}
+
+dependencies {
+  // Mark non-transitive: even `gradle-api` drags in `kotlin-stdlib:2.2.10`, and any Kotlin
+  // version other than the one the synthetic project's compose-compiler-plugin was built for
+  // (`2.3.21`) trips "language version 2.0 incompatible with ComposeComponentRegistrar". The
+  // bare `gradle-api`, `gradle-common-api`, and `gradle-settings-api` jars carry the AGP types
+  // the plugin reaches for; we add the three explicit coords below so all referenced classes
+  // resolve without dragging Kotlin transitively.
+  agpForFunctionalTest("com.android.tools.build:gradle-api:${libs.versions.agp.get()}") {
+    isTransitive = false
+  }
+  agpForFunctionalTest("com.android.tools.build:gradle-common-api:${libs.versions.agp.get()}") {
+    isTransitive = false
+  }
+  agpForFunctionalTest("com.android.tools.build:gradle-settings-api:${libs.versions.agp.get()}") {
+    isTransitive = false
+  }
+}
+
+tasks.named<org.gradle.plugin.devel.tasks.PluginUnderTestMetadata>("pluginUnderTestMetadata") {
+  pluginClasspath.from(agpForFunctionalTest)
+}
+
 val functionalTestTask =
   tasks.register<Test>("functionalTest") {
     testClassesDirs = functionalTest.output.classesDirs
     classpath = functionalTest.runtimeClasspath
     useJUnit()
+
+    // `AccessibilityAndroidFunctionalTest` exercises the full external-consumer Android render
+    // path: synthetic `com.android.library` project + AGP + Robolectric + the plugin's
+    // auto-injected `ee.schimke.composeai:renderer-android:<plugin-version>` Maven coordinate.
+    // The synthetic project's `dependencyResolutionManagement.repositories { mavenLocal() }`
+    // catches the AAR. The test `assumeTrue`s out cleanly when the AAR isn't in `~/.m2`, so
+    // the default `:gradle-plugin:check` stays fast — the caller (CI / dev) is expected to run
+    // `./gradlew :renderer-android:publishToMavenLocal` first when they want the Android-flavour
+    // coverage.
+    //
+    // We don't `dependsOn(":renderer-android:publishToMavenLocal")` here because `:gradle-plugin`
+    // is an `includeBuild`, and cross-build task dependencies on the *parent* build would have
+    // to flow the other direction (parent → child). The skip-and-document model keeps the
+    // included-build boundary clean.
+
+    // Surface the host's `~/.m2/repository`, the plugin's compile-time version, and the Android
+    // SDK location (for synthetic-project `local.properties`) to the test JVM.
+    systemProperty(
+      "ee.schimke.composeai.functionalTest.mavenLocal",
+      providers.systemProperty("user.home").map { "$it/.m2/repository" }.get(),
+    )
+    systemProperty("ee.schimke.composeai.functionalTest.pluginVersion", project.version.toString())
+    // Resolve sdk.dir from `ANDROID_HOME` (CI) or `local.properties` (dev). Empty string when
+    // neither is set — the test then `assumeFalse`s out so devs without an SDK don't see a hard
+    // failure.
+    systemProperty("ee.schimke.composeai.functionalTest.androidSdkDir", resolveAndroidSdk(rootDir))
   }
 
 tasks.check { dependsOn(functionalTestTask) }
+
+/**
+ * Reads the Android SDK location from `ANDROID_HOME`, `ANDROID_SDK_ROOT`, or the host project's
+ * `local.properties` (the same precedence AGP itself uses). Returns an empty string when none are
+ * set so the functional test can `assumeFalse` it out cleanly on dev environments without an SDK
+ * installed.
+ */
+fun resolveAndroidSdk(rootDir: java.io.File): String {
+  System.getenv("ANDROID_HOME")
+    ?.takeIf { it.isNotBlank() }
+    ?.let {
+      return it
+    }
+  System.getenv("ANDROID_SDK_ROOT")
+    ?.takeIf { it.isNotBlank() }
+    ?.let {
+      return it
+    }
+  val localProps = rootDir.resolve("local.properties")
+  if (localProps.exists()) {
+    val props = Properties().apply { localProps.inputStream().use { load(it) } }
+    props
+      .getProperty("sdk.dir")
+      ?.takeIf { it.isNotBlank() }
+      ?.let {
+        return it
+      }
+  }
+  return ""
+}
 
 // Bake the plugin's own version into a resource so it can resolve a matching
 // `renderer-android` AAR at runtime for external consumers (who apply the

--- a/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AccessibilityAndroidFunctionalTest.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/ee/schimke/composeai/plugin/AccessibilityAndroidFunctionalTest.kt
@@ -1,0 +1,280 @@
+package ee.schimke.composeai.plugin
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assume.assumeTrue
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+/**
+ * End-to-end functional coverage for the **standard** accessibility pipeline on the
+ * `com.android.library` path: synthetic project + AGP + Robolectric + the plugin's auto-injected
+ * `ee.schimke.composeai:renderer-android:<plugin-version>` AAR (resolved from `~/.m2/repository`
+ * after the host build's `:renderer-android:publishToMavenLocal` pre-step).
+ *
+ * Issue #733. Companion to [AccessibilityFunctionalTest], which pins the CMP-side manifest wiring
+ * without booting Robolectric.
+ *
+ * Asserts the `:renderAllPreviews` artefact set the CLI's `A11yCommand` reads:
+ * - `build/compose-previews/accessibility.json` — top-level aggregated report.
+ * - `build/compose-previews/accessibility-per-preview/<className>.<funcName>_<variant>.json`.
+ * - `build/compose-previews/renders/<previewId>.a11y.png` — annotated overlay PNG.
+ *
+ * The four typed `a11y-atf.json` / `a11y-hierarchy.json` / `a11y-touchTargets.json` /
+ * `a11y-overlay.png` files described in earlier draft scoping notes are **daemon-mode-only**:
+ * `:daemon:android`'s `RenderEngine` is the only caller of
+ * `AccessibilityDataProducer.writeArtifacts`. The standard `RobolectricRenderTest` calls
+ * `AccessibilityChecker.writePerPreviewReport` instead. Daemon-mode coverage is a separate
+ * follow-up — needs daemon JVM + stdio JSON-RPC + lifecycle scaffolding.
+ *
+ * Skipped (`Assume.assumeTrue`) when no Android SDK is reachable via `ANDROID_HOME` /
+ * `ANDROID_SDK_ROOT` / host `local.properties` — keeps dev environments without an Android SDK
+ * green.
+ *
+ * **`@Ignore`d in the initial commit.** The infrastructure (`agpForFunctionalTest` config piped
+ * into `pluginUnderTestMetadata.pluginClasspath`, `functionalTestWithAndroid` aggregator task that
+ * pre-publishes the AAR closure to mavenLocal, `assumeTrue` guards) is in place, but the plugin
+ * itself fails to apply under TestKit because `withPluginClasspath()` and the synthetic project's
+ * `id("com.android.library")` end up loading AGP twice on different classloaders.
+ * `extensions.getByType(AndroidComponentsExtension::class.java)` then can't see the
+ * `LibraryAndroidComponentsExtension` the synthetic project registered — same FQN, two `Class`
+ * objects. Resolving that needs publishing the plugin itself to mavenLocal and dropping
+ * `withPluginClasspath()` so both plugins share one classloader hierarchy. Tracked in issue #733.
+ */
+@Ignore("Requires plugin-classloader-split fix; see kdoc above + #733")
+class AccessibilityAndroidFunctionalTest {
+
+  @get:Rule val tempDir = TemporaryFolder()
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private val mavenLocal: String =
+    System.getProperty("ee.schimke.composeai.functionalTest.mavenLocal", "")
+
+  private val pluginVersion: String =
+    System.getProperty("ee.schimke.composeai.functionalTest.pluginVersion", "")
+
+  private val androidSdkDir: String =
+    System.getProperty("ee.schimke.composeai.functionalTest.androidSdkDir", "")
+
+  private fun createTestProject(): File {
+    val projectDir = tempDir.root
+
+    File(projectDir, "settings.gradle.kts")
+      .writeText(
+        """
+        pluginManagement {
+            repositories {
+                gradlePluginPortal()
+                google()
+                mavenLocal()
+                mavenCentral()
+            }
+        }
+        dependencyResolutionManagement {
+            repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+            repositories {
+                google()
+                mavenLocal()
+                mavenCentral()
+            }
+        }
+        rootProject.name = "test-a11y-android"
+        """
+          .trimIndent()
+      )
+
+    // AGP reads `local.properties` from the project root for `sdk.dir`. `ANDROID_HOME` would also
+    // work but `GradleRunner` doesn't propagate the parent's environment by default — writing
+    // the file is the most portable signal.
+    File(projectDir, "local.properties").writeText("sdk.dir=$androidSdkDir\n")
+
+    File(projectDir, "build.gradle.kts")
+      .writeText(
+        """
+        plugins {
+            // AGP 9.x bundles its own Kotlin compilation; the standalone
+            // `org.jetbrains.kotlin.android` plugin is gone (and applying it now hard-errors).
+            id("com.android.library") version "9.2.0"
+            id("org.jetbrains.kotlin.plugin.compose") version "2.3.21"
+            id("ee.schimke.composeai.preview")
+        }
+
+        android {
+            namespace = "ee.schimke.composeai.functionaltest.a11y"
+            compileSdk = 36
+            defaultConfig { minSdk = 24 }
+            buildFeatures { compose = true }
+            compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+            }
+            // `RobolectricRenderTest` reads the merged manifest + Compose theme through
+            // Robolectric's resource loader; without this flag the synthetic project's
+            // resources don't end up on the test classpath.
+            testOptions { unitTests.isIncludeAndroidResources = true }
+        }
+
+        kotlin {
+            jvmToolchain(17)
+        }
+
+        dependencies {
+            implementation(platform("androidx.compose:compose-bom:2026.04.01"))
+            implementation("androidx.compose.ui:ui")
+            implementation("androidx.compose.ui:ui-tooling-preview")
+            implementation("androidx.compose.material3:material3")
+            implementation("androidx.compose.foundation:foundation")
+            debugImplementation("androidx.compose.ui:ui-tooling")
+        }
+
+        composePreview {
+            previewExtensions { a11y { enableAllChecks() } }
+        }
+        """
+          .trimIndent()
+      )
+
+    File(projectDir, "gradle.properties")
+      .writeText(
+        """
+        org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+        # Robolectric workers need the same heap as the host build's samples.
+        # `:renderer-android` AAR resolution + classes.jar zipTree expansion is light, but
+        # Compose BOM transitives push the dep graph into multi-hundred-artefact territory.
+        android.useAndroidX=true
+        """
+          .trimIndent()
+      )
+
+    val srcDir = File(projectDir, "src/main/kotlin/ee/schimke/composeai/functionaltest/a11y")
+    srcDir.mkdirs()
+    File(srcDir, "BadButtonPreview.kt")
+      .writeText(
+        """
+        package ee.schimke.composeai.functionaltest.a11y
+
+        import androidx.compose.foundation.layout.size
+        import androidx.compose.material3.Button
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.tooling.preview.Preview
+        import androidx.compose.ui.unit.dp
+
+        /**
+         * Deliberately-broken preview: a Material Button with no content description and a
+         * 20x20dp size. `AccessibilityChecker.analyze` should flag it for `TouchTargetSize`
+         * (below 48dp) and `SpeakableText` (no accessible label). Mirrors the
+         * `BadButtonPreview` fixture in `:samples:android` — same shape, same expected
+         * findings, kept self-contained here so the functional test is reproducible.
+         */
+        @Preview(name = "Bad Button", showBackground = true, backgroundColor = 0xFFFFFFFF)
+        @Composable
+        fun BadButtonPreview() {
+            Button(onClick = {}, modifier = Modifier.size(20.dp)) {}
+        }
+        """
+          .trimIndent()
+      )
+
+    return projectDir
+  }
+
+  private fun runner(projectDir: File): GradleRunner =
+    GradleRunner.create()
+      .withProjectDir(projectDir)
+      .withPluginClasspath()
+      // No `withArguments()` here — call sites add task names + flags. The shared bits go
+      // through `commonArgs`.
+      .forwardOutput()
+
+  /**
+   * Args common to every test invocation here. Just `--stacktrace` so the (frequent, AGP-related)
+   * config failures are debuggable from CI logs without a re-run. Gradle 9 removed `--no-daemon`
+   * (TestKit uses an embedded daemon anyway) and the configuration cache is fine here — the
+   * synthetic project rewrites its build script per-test, which invalidates the cache cleanly.
+   */
+  private fun commonArgs(vararg tasks: String): Array<String> = arrayOf(*tasks, "--stacktrace")
+
+  @Test
+  fun `renderAllPreviews produces the standard a11y artefact set`() {
+    assumeTrue(
+      "Skipping: no mavenLocal path passed via system property",
+      mavenLocal.isNotBlank() && File(mavenLocal).isDirectory,
+    )
+    assumeTrue(
+      "Skipping: plugin version not surfaced via system property",
+      pluginVersion.isNotBlank(),
+    )
+    assumeTrue(
+      "Skipping: no Android SDK reachable via ANDROID_HOME / local.properties",
+      androidSdkDir.isNotBlank() && File(androidSdkDir).isDirectory,
+    )
+    // Sanity: the host build must have published the matching renderer-android AAR before this
+    // test starts (functionalTestTask `dependsOn(":renderer-android:publishToMavenLocal")`).
+    val rendererAar =
+      File(mavenLocal, "ee/schimke/composeai/renderer-android/$pluginVersion")
+        .listFiles { f -> f.extension == "aar" }
+        ?.firstOrNull()
+    assumeTrue(
+      "Skipping: renderer-android-$pluginVersion.aar not in mavenLocal " +
+        "(did `:renderer-android:publishToMavenLocal` run?)",
+      rendererAar != null,
+    )
+
+    val projectDir = createTestProject()
+
+    val result = runner(projectDir).withArguments(*commonArgs("renderAllPreviews")).build()
+
+    assertThat(result.task(":renderPreviews")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+
+    // 1. Manifest pointer (sanity vs. AccessibilityFunctionalTest's CMP-side coverage).
+    //    Reuses the plugin's `PreviewManifest` shape since it's on the functional-test classpath.
+    val manifestFile = File(projectDir, "build/compose-previews/previews.json")
+    assertThat(manifestFile.exists()).isTrue()
+    val manifest = json.decodeFromString(PreviewManifest.serializer(), manifestFile.readText())
+    assertThat(manifest.accessibilityReport).isEqualTo("accessibility.json")
+
+    // 2. Aggregated `accessibility.json`. Walked through `JsonObject` rather than a typed DTO:
+    //    the producer-side `AccessibilityReport` type lives in `:data-a11y-core` (not on the
+    //    functional-test classpath), and re-declaring a copy here would collide with the
+    //    plugin's `PreviewManifest`-shaped neighbour at the package level. Walking the tree
+    //    keeps the assertion close to the on-disk shape — the contract the CLI / VS Code
+    //    extension / MCP agents all key off.
+    val reportFile = File(projectDir, "build/compose-previews/accessibility.json")
+    assertThat(reportFile.exists()).isTrue()
+    val report = json.parseToJsonElement(reportFile.readText()).jsonObject
+    val entries = report["entries"]?.jsonArray ?: error("accessibility.json missing entries")
+    assertThat(entries).isNotEmpty()
+    val badButton =
+      entries
+        .map { it.jsonObject }
+        .firstOrNull { it["previewId"]?.jsonPrimitive?.content?.contains("BadButton") == true }
+    assertThat(badButton).isNotNull()
+    val findings = badButton!!["findings"]?.jsonArray ?: error("BadButton entry missing findings")
+    assertThat(findings).isNotEmpty()
+
+    // 3. Per-preview JSON sidecars exist (used by VS Code's preview drawer for
+    //    deep-link-by-preview-id navigation).
+    val perPreviewDir = File(projectDir, "build/compose-previews/accessibility-per-preview")
+    assertThat(perPreviewDir.exists()).isTrue()
+    assertThat(perPreviewDir.listFiles { f -> f.extension == "json" }?.isNotEmpty() ?: false)
+      .isTrue()
+
+    // 4. Annotated overlay PNG. The annotated path is recorded relative to `accessibility.json`'s
+    //    parent directory; resolve and assert it exists with non-zero size.
+    val annotated = badButton["annotatedPath"]?.jsonPrimitive?.content
+    assertThat(annotated).isNotNull()
+    val annotatedFile = reportFile.parentFile.resolve(annotated!!).canonicalFile
+    assertThat(annotatedFile.exists()).isTrue()
+    assertThat(annotatedFile.length()).isGreaterThan(0L)
+  }
+}


### PR DESCRIPTION
## Summary

Lays down the build-side plumbing for a Robolectric-driven `AccessibilityAndroidFunctionalTest` (issue #733). Stops short of an executable test — flagged `@Ignore` with a kdoc explaining the classloader-split blocker — so the infra lands as a reviewable checkpoint while the follow-up work can be done in a focused PR.

## What lands

- **Root `functionalTestWithAndroid` aggregator task** that pre-publishes the renderer-android AAR closure (`:renderer-android`, `:data-a11y-core`, `:data-render-core`, `:data-render-compose`, `:data-scroll-core`) to mavenLocal before invoking `:gradle-plugin:functionalTest`. Wired in the parent build so the dependency only flows parent → child, keeping the gradle-plugin included build decoupled.
- **`agpForFunctionalTest` resolvable configuration** in `gradle-plugin/build.gradle.kts`, fed into `pluginUnderTestMetadata.pluginClasspath` so AGP types are reachable from the plugin's classloader at functional-test time. Limited to the AGP API artefacts (`gradle-api` / `gradle-common-api` / `gradle-settings-api`, non-transitive) so the bundled `kotlin-gradle-plugin` doesn't drag a Kotlin compiler that conflicts with the synthetic project's compose-compiler resolution.
- **System properties on `:gradle-plugin:functionalTest`** for `mavenLocal`, plugin version, and Android SDK directory. The test reads these and `Assume.assumeTrue`s out cleanly when the SDK / AAR aren't present, so dev environments without an Android SDK stay green.
- **`AccessibilityAndroidFunctionalTest` skeleton** with the synthetic Android-library project, a deliberately-broken `BadButtonPreview` fixture, and assertions for the standard a11y artefact set (`accessibility.json`, per-preview JSON sidecars, `<previewId>.a11y.png` overlay). Currently `@Ignore`d — see the kdoc + #733 for the blocker described below.

## What still needs to land before the test can run

The plugin under test and AGP both end up loaded twice in the TestKit classloader hierarchy — once via `withPluginClasspath()`, once via the synthetic project's `id("com.android.library")` plugin block. Same-FQN classes from different loaders fail identity comparisons — `extensions.getByType(AndroidComponentsExtension::class.java)` doesn't match the registered `LibraryAndroidComponentsExtension`.

Fix: drop `withPluginClasspath()`, publish `:gradle-plugin` itself to mavenLocal as part of the same pre-step, and have the synthetic project resolve our plugin via `pluginManagement.repositories.mavenLocal()` — so both plugins share one classloader. Tracked as the next step on issue #733.

## Test plan

- [x] `./gradlew :gradle-plugin:functionalTest` green (the new test class is `@Ignore`d; the existing CMP-flavoured tests still pass).
- [x] `./gradlew ktfmtCheckAll` clean.
- [ ] CI run on this PR.

Closes none of #733 yet — this is the checkpoint commit.
