### PR TITLE
feat(daemon): wire state.recreate via SaveableStateRegistry snapshot+restore

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidInteractiveSession.kt
@@ -337,6 +337,36 @@ internal constructor(
     return replyApplied.get()
   }
 
+  /**
+   * Override of [InteractiveSession.dispatchStateRecreate]. Enqueues a
+   * [InteractiveCommand.DispatchStateRecreate] envelope; the sandbox-side loop snapshots the
+   * `SaveableStateRegistry`, increments a recreate counter, and Compose rebuilds the slot table
+   * with the snapshot restored.
+   */
+  override fun dispatchStateRecreate(): Boolean {
+    if (closed) return false
+    lastUsedAtMs.set(System.currentTimeMillis())
+    val replyLatch = CountDownLatch(1)
+    val replyError = AtomicReference<Throwable?>(null)
+    val replyApplied = AtomicBoolean(false)
+    slot.interactiveCommands.put(
+      InteractiveCommand.DispatchStateRecreate(
+        streamId = streamId,
+        replyLatch = replyLatch,
+        replyError = replyError,
+        replyApplied = replyApplied,
+      )
+    )
+    if (!replyLatch.await(DISPATCH_TIMEOUT_SEC, TimeUnit.SECONDS)) {
+      error(
+        "AndroidInteractiveSession.dispatchStateRecreate timed out after " +
+          "${DISPATCH_TIMEOUT_SEC}s for stream '$streamId'. Held-rule loop may be stuck."
+      )
+    }
+    replyError.get()?.let { throw it }
+    return replyApplied.get()
+  }
+
   override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult {
     check(!closed) { "AndroidInteractiveSession.render() called after close()" }
     lastUsedAtMs.set(System.currentTimeMillis())

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -275,6 +275,10 @@ class AndroidRecordingSession(
         // Preview reload — `preview.reload` forces a fresh composition via the held rule's
         // `key(...)` reload counter. See [PreviewReloadRecordingScriptEvents].
         put(PreviewReloadRecordingScriptEvents.PREVIEW_RELOAD_EVENT, previewReloadHandler())
+        // State recreate — Compose-level save+restore round-trip. Distinct from preview.reload:
+        // `rememberSaveable` is preserved via the SaveableStateRegistry snapshot/restore.
+        // See [StateRecreateRecordingScriptEvents].
+        put(StateRecreateRecordingScriptEvents.STATE_RECREATE_EVENT, stateRecreateHandler())
       }
     )
 
@@ -356,6 +360,32 @@ class AndroidRecordingSession(
         unsupportedEvidence(
           event,
           "host did not apply preview reload; held composition may be missing a reload counter",
+        )
+      }
+    }
+
+  /**
+   * Handler for `state.recreate` — forces a Compose-level save+restore round-trip via
+   * `interactive.dispatchStateRecreate()`. The Robolectric sandbox snapshots the current
+   * `SaveableStateRegistry`, increments a recreate counter, and rebuilds the slot table with the
+   * snapshot restored. `rememberSaveable` survives; `remember` resets.
+   *
+   * Reports `unsupported` when the host can't dispatch recreate (interactive returned `false`,
+   * e.g. on a backend without the SaveableStateRegistry bridge wired).
+   */
+  private fun stateRecreateHandler(): RecordingScriptEventHandler =
+    RecordingScriptEventHandler { event, _ ->
+      val applied = interactive.dispatchStateRecreate()
+      if (applied) {
+        appliedEvidence(
+          event,
+          "rememberSaveable state snapshotted and restored across a key(...) recreate",
+        )
+      } else {
+        unsupportedEvidence(
+          event,
+          "host did not apply state recreate; held composition may be missing the " +
+            "SaveableStateRegistry bridge",
         )
       }
     }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -200,6 +200,8 @@ open class RobolectricHost(
    *   held rule's activity.
    * - `preview.reload` (Android-only today) — forces a fresh composition via the held rule's
    *   `key(...)` reload counter.
+   * - `state.recreate` (Android-only today) — Compose-level save+restore round-trip via the
+   *   held rule's `SaveableStateRegistry` bridge.
    *
    * The a11y action descriptors live in `:data-a11y-connector` and are concatenated into
    * `dataExtensions` by `DaemonMain` only when the a11y preview extension is enabled, so they
@@ -213,6 +215,7 @@ open class RobolectricHost(
         RecordingScriptDataExtensions.recordingDescriptor,
         LifecycleRecordingScriptEvents.descriptor,
         PreviewReloadRecordingScriptEvents.descriptor,
+        StateRecreateRecordingScriptEvents.descriptor,
       )
     else emptyList()
 
@@ -1547,17 +1550,50 @@ open class RobolectricHost(
             // Lives here (not as a class-level field) because the held composition is local to
             // this `evaluate()` invocation; one reload counter per stream.
             val reloadCounter = androidx.compose.runtime.mutableIntStateOf(0)
+            // `state.recreate` uses a sibling pattern but PRESERVES `rememberSaveable` across the
+            // rebuild. The flow:
+            //   1. Snapshot the current `SaveableStateRegistry` via `performSave()`,
+            //      stash into `recreateSavedState`.
+            //   2. Increment `recreateGeneration`. The wrapping `key(...)` rebuilds; the inner
+            //      `remember(generation) { SaveableStateRegistry(restoredValues = ...) }`
+            //      seeds a new registry from the stash.
+            //   3. `rememberSaveable` reads the restored values from the new registry.
+            // `recreateRegistryRef` exposes the live registry to the command handler (which runs
+            // outside Compose). The `SideEffect` below updates it on every (re)composition.
+            val recreateGeneration = androidx.compose.runtime.mutableIntStateOf(0)
+            val recreateSavedState =
+              androidx.compose.runtime.mutableStateOf<Map<String, List<Any?>>>(emptyMap())
+            val recreateRegistryRef =
+              java.util.concurrent.atomic.AtomicReference<
+                androidx.compose.runtime.saveable.SaveableStateRegistry?
+              >(null)
             setupTrace.section("compose:setContent") {
               rule.setContent {
                 androidx.compose.runtime.key(reloadCounter.intValue) {
-                  androidx.compose.runtime.CompositionLocalProvider(
-                    androidx.compose.ui.platform.LocalInspectionMode provides
-                      (start.inspectionMode ?: false)
-                  ) {
-                    androidx.compose.foundation.layout.Box(
-                      modifier = androidx.compose.ui.Modifier.fillMaxSize()
+                  androidx.compose.runtime.key(recreateGeneration.intValue) {
+                    val parentRegistry =
+                      androidx.compose.runtime.saveable.LocalSaveableStateRegistry.current
+                    val recreateRegistry =
+                      androidx.compose.runtime.remember(recreateGeneration.intValue) {
+                        androidx.compose.runtime.saveable.SaveableStateRegistry(
+                          restoredValues = recreateSavedState.value,
+                          canBeSaved = { parentRegistry?.canBeSaved(it) ?: true },
+                        )
+                      }
+                    androidx.compose.runtime.SideEffect {
+                      recreateRegistryRef.set(recreateRegistry)
+                    }
+                    androidx.compose.runtime.CompositionLocalProvider(
+                      androidx.compose.ui.platform.LocalInspectionMode provides
+                        (start.inspectionMode ?: false),
+                      androidx.compose.runtime.saveable.LocalSaveableStateRegistry provides
+                        recreateRegistry,
                     ) {
-                      InvokeHeldComposable(composableMethod)
+                      androidx.compose.foundation.layout.Box(
+                        modifier = androidx.compose.ui.Modifier.fillMaxSize()
+                      ) {
+                        InvokeHeldComposable(composableMethod)
+                      }
                     }
                   }
                 }
@@ -1675,6 +1711,27 @@ open class RobolectricHost(
                     // Settle window — Compose has to detect the key change, dispose the old
                     // slot table, and run the new composition's first frame before subsequent
                     // inputs / renders observe the rebuilt state.
+                    rule.mainClock.advanceTimeBy(HELD_CAPTURE_ADVANCE_MS)
+                    rule.waitForIdle()
+                    cmd.replyApplied.set(true)
+                  } catch (t: Throwable) {
+                    cmd.replyError.set(t)
+                  } finally {
+                    cmd.replyLatch.countDown()
+                  }
+                }
+                is InteractiveCommand.DispatchStateRecreate -> {
+                  try {
+                    rule.runOnUiThread {
+                      // Snapshot the current registry, stash it, then bump the generation to
+                      // trigger a key-driven rebuild that initializes a fresh registry from the
+                      // stash. `performSave` returns null when nothing has registered (empty
+                      // composition); treat that as an empty map so the rebuild's
+                      // `restoredValues` parameter is always well-defined.
+                      val current = recreateRegistryRef.get()
+                      recreateSavedState.value = current?.performSave().orEmpty()
+                      recreateGeneration.intValue++
+                    }
                     rule.mainClock.advanceTimeBy(HELD_CAPTURE_ADVANCE_MS)
                     rule.waitForIdle()
                     cmd.replyApplied.set(true)

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/StateRecreateRecordingScriptEvents.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/StateRecreateRecordingScriptEvents.kt
@@ -1,0 +1,60 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescriptor
+
+/**
+ * State-recreate `record_preview` script event. One descriptor — `state.recreate` — that snapshots
+ * the current `SaveableStateRegistry`, tears down the held composition under a `key(...)`
+ * boundary, and rebuilds with the snapshot restored. Same audit signal as an Android
+ * `ActivityScenario.recreate()` (verifies state survives a teardown) but lives entirely at the
+ * Compose level so it doesn't depend on `onSaveInstanceState`/onCreate plumbing.
+ *
+ * **Distinct from the other state-shaped events:**
+ * - `lifecycle.event` (`pause`/`resume`/`stop`) — drives the activity lifecycle without
+ *   destroying it. `rememberSaveable` AND `remember` both survive.
+ * - `preview.reload` — full cold composition. Both `remember` and `rememberSaveable` reset.
+ * - `state.recreate` — the middle ground. `rememberSaveable` survives via a snapshot/restore
+ *   round-trip; `remember` resets.
+ *
+ * **Distinct from `state.save` / `state.restore` (still roadmap).** The named-checkpoint pair
+ * lets agents save multiple bundles and restore any one. `state.recreate` is the simpler
+ * single-event "round-trip" primitive — it's enough for the most common audit case ("does this
+ * preview survive a recreate?") without the multi-bundle stash machinery.
+ *
+ * Why this lives in `:daemon:android` (mirroring [LifecycleRecordingScriptEvents] and
+ * [PreviewReloadRecordingScriptEvents]): the `SaveableStateRegistry` bridge needs the held rule
+ * machinery, which is Robolectric-only today.
+ *
+ * **Status:** the descriptor ships with `supported = true`. Hosts that wire the
+ * `SaveableStateRegistry` bridge (today: only [RobolectricHost]) advertise it from
+ * `recordingScriptEventDescriptors()`.
+ */
+object StateRecreateRecordingScriptEvents {
+
+  /** Wire-name id. New constant — distinct from `state.save` / `state.restore` (still roadmap). */
+  const val STATE_RECREATE_EVENT: String = "state.recreate"
+
+  val descriptor: DataExtensionDescriptor =
+    DataExtensionDescriptor(
+      id = DataExtensionId("state.recreate"),
+      displayName = "State recreate (Compose-level save+restore)",
+      recordingScriptEvents =
+        listOf(
+          RecordingScriptEventDescriptor(
+            id = STATE_RECREATE_EVENT,
+            displayName = "Recreate composition",
+            summary =
+              "Snapshots the current `SaveableStateRegistry` via `performSave()`, tears down " +
+                "the held composition under a `key(...)` boundary, and rebuilds with the " +
+                "snapshot restored. `rememberSaveable` survives; `remember` resets. Same audit " +
+                "signal as `ActivityScenario.recreate()` but Compose-level.",
+            supported = true,
+          )
+        ),
+    )
+
+  /** Convenience for the host's `recordingScriptEventDescriptors()` override. */
+  val descriptors: List<DataExtensionDescriptor> = listOf(descriptor)
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/bridge/DaemonHostBridge.kt
@@ -511,4 +511,27 @@ sealed interface InteractiveCommand {
     val replyError: AtomicReference<Throwable?>,
     val replyApplied: AtomicBoolean,
   ) : InteractiveCommand
+
+  /**
+   * Force a Compose-level save+restore round-trip — exercise the `rememberSaveable` path
+   * without depending on Android's `onSaveInstanceState` / `onCreate(savedInstanceState)`. Used
+   * by `record_preview`'s `state.recreate` script event for "verify state survives a recreate"
+   * audits.
+   *
+   * The sandbox-side handler snapshots the current `SaveableStateRegistry` via `performSave()`,
+   * stashes it, then increments a recreate counter that the wrapping `key(...)` block reads.
+   * The new composition initializes a fresh `SaveableStateRegistry` from the stashed map, so
+   * `rememberSaveable` reads see the saved values. `remember` state is lost (same as a real
+   * activity recreate).
+   *
+   * No payload — the recreate target is implicit (the held composition this stream is driving).
+   * `replyApplied` reports success (`true`) or that the host doesn't carry the bridge wiring
+   * (`false`). Throwables ride [replyError].
+   */
+  data class DispatchStateRecreate(
+    override val streamId: String,
+    val replyLatch: CountDownLatch,
+    val replyError: AtomicReference<Throwable?>,
+    val replyApplied: AtomicBoolean,
+  ) : InteractiveCommand
 }

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
@@ -836,6 +836,114 @@ class AndroidRecordingSessionTest {
   }
 
   @Test
+  fun stateRecreateRoutesThroughDispatchStateRecreate() {
+    // Happy path for the new `state.recreate` registry entry: handler calls
+    // `interactive.dispatchStateRecreate()` and reports `applied` evidence with a message
+    // describing the snapshot+restore round-trip.
+    val framesDir = tempFolder.newFolder("state-recreate-frames")
+    val encodedDir = tempFolder.newFolder("state-recreate-encoded")
+    val sourcePng = File(tempFolder.newFolder("state-recreate-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    val interactive = RecordingDeltaSession(sourcePng).apply { stateRecreateResult = true }
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-state-recreate",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    try {
+      session.postScript(
+        listOf(
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = StateRecreateRecordingScriptEvents.STATE_RECREATE_EVENT,
+          )
+        )
+      )
+      val result = session.stop()
+
+      assertEquals(
+        "state.recreate must route through dispatchStateRecreate, not pointer/reload dispatch",
+        0,
+        interactive.dispatchCount,
+      )
+      assertEquals(0, interactive.previewReloadCount)
+      assertEquals(1, interactive.stateRecreateCount)
+      assertEquals(1, result.scriptEvents.size)
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.APPLIED,
+        result.scriptEvents[0].status,
+      )
+      val message = result.scriptEvents[0].message ?: ""
+      assertTrue(
+        "evidence must mention the rememberSaveable snapshot/restore round-trip; got '$message'",
+        message.contains("rememberSaveable") && message.contains("recreate"),
+      )
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
+  fun stateRecreateReportsUnsupportedWhenHostCannotRecreate() {
+    // When `dispatchStateRecreate` returns false (no SaveableStateRegistry bridge wired), the
+    // handler must surface a specific unsupported reason naming the bridge.
+    val framesDir = tempFolder.newFolder("state-recreate-miss-frames")
+    val encodedDir = tempFolder.newFolder("state-recreate-miss-encoded")
+    val sourcePng = File(tempFolder.newFolder("state-recreate-miss-source"), "source.png")
+    ImageIO.write(
+      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
+      "png",
+      sourcePng,
+    )
+    val interactive = RecordingDeltaSession(sourcePng).apply { stateRecreateResult = false }
+    val session =
+      AndroidRecordingSession(
+        previewId = INTERACTIVE_PREVIEW_ID,
+        recordingId = "test-rec-state-recreate-miss",
+        fps = FPS,
+        scale = 1.0f,
+        interactive = interactive,
+        framesDir = framesDir,
+        encodedDir = encodedDir,
+      )
+
+    try {
+      session.postScript(
+        listOf(
+          RecordingScriptEvent(
+            tMs = 0L,
+            kind = StateRecreateRecordingScriptEvents.STATE_RECREATE_EVENT,
+          )
+        )
+      )
+      val result = session.stop()
+
+      assertEquals(1, interactive.stateRecreateCount)
+      assertEquals(
+        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.UNSUPPORTED,
+        result.scriptEvents[0].status,
+      )
+      val message = result.scriptEvents[0].message ?: ""
+      assertTrue(
+        "miss diagnostic must mention the SaveableStateRegistry bridge; got '$message'",
+        message.contains("SaveableStateRegistry"),
+      )
+    } finally {
+      session.close()
+    }
+  }
+
+  @Test
   fun scriptedClickFlipsStateAndProducesFrames() {
     val outputDir = tempFolder.newFolder("recording-renders")
     val recordingsRoot = tempFolder.newFolder("recordings-root")
@@ -1129,6 +1237,21 @@ class AndroidRecordingSessionTest {
       previewReloadCount++
       val override = previewReloadResult
       return override ?: super.dispatchPreviewReload()
+    }
+
+    var stateRecreateCount: Int = 0
+
+    /**
+     * When non-null, [dispatchStateRecreate] returns this value verbatim and increments
+     * [stateRecreateCount]. When null (the default), the inherited interface-level default
+     * (`return false`) is used so existing tests don't have to opt in.
+     */
+    var stateRecreateResult: Boolean? = null
+
+    override fun dispatchStateRecreate(): Boolean {
+      stateRecreateCount++
+      val override = stateRecreateResult
+      return override ?: super.dispatchStateRecreate()
     }
 
     override fun render(requestId: Long, advanceTimeMs: Long?): RenderResult {

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/StateRecreateRecordingScriptEventsTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/StateRecreateRecordingScriptEventsTest.kt
@@ -1,0 +1,54 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [StateRecreateRecordingScriptEvents] — the host-owned descriptor that
+ * `RobolectricHost.recordingScriptEventDescriptors()` advertises as `supported = true` for the
+ * `state.recreate` script event. Distinct from the still-roadmap `state.save` / `state.restore`
+ * pair (the principled multi-checkpoint model) — `state.recreate` is the simpler single-event
+ * round-trip primitive.
+ */
+class StateRecreateRecordingScriptEventsTest {
+
+  @Test
+  fun `descriptor advertises state recreate with supported = true`() {
+    val descriptor = StateRecreateRecordingScriptEvents.descriptor
+    assertEquals("state.recreate", descriptor.id.value)
+    val events = descriptor.recordingScriptEvents
+    assertEquals(1, events.size)
+    val recreate = events.single()
+    assertEquals(StateRecreateRecordingScriptEvents.STATE_RECREATE_EVENT, recreate.id)
+    assertTrue(
+      "state.recreate must advertise supported = true so record_preview accepts it on Android",
+      recreate.supported,
+    )
+  }
+
+  @Test
+  fun `wire-name id is distinct from state save and state restore`() {
+    // `state.recreate` is its own primitive — collapsing save+restore into one round-trip event.
+    // The roadmap `state.save` / `state.restore` constants advertise the future named-checkpoint
+    // model and must keep their own ids.
+    assertNotEquals(
+      StateRecreateRecordingScriptEvents.STATE_RECREATE_EVENT,
+      RecordingScriptDataExtensions.STATE_SAVE_EVENT,
+    )
+    assertNotEquals(
+      StateRecreateRecordingScriptEvents.STATE_RECREATE_EVENT,
+      RecordingScriptDataExtensions.STATE_RESTORE_EVENT,
+    )
+  }
+
+  @Test
+  fun `descriptors convenience list wraps the single descriptor`() {
+    assertEquals(
+      listOf(StateRecreateRecordingScriptEvents.descriptor),
+      StateRecreateRecordingScriptEvents.descriptors,
+    )
+  }
+}

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/InteractiveCommandTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/bridge/InteractiveCommandTest.kt
@@ -151,6 +151,35 @@ class InteractiveCommandTest {
   }
 
   @Test
+  fun dispatchStateRecreateRoundTripsThroughTheBridge() {
+    // Pin the cross-classloader contract for the new variant: only `java.*` types in the
+    // payload, round-trips through `interactiveCommands` by reference. Parameterless — the
+    // recreate target is the held composition this stream is driving.
+    DaemonHostBridge.reset()
+    val slot = DaemonHostBridge.slot(0)
+    val replyLatch = CountDownLatch(1)
+    val replyError = AtomicReference<Throwable?>(null)
+    val replyApplied = AtomicBoolean(false)
+    val cmd =
+      InteractiveCommand.DispatchStateRecreate(
+        streamId = "stream-A",
+        replyLatch = replyLatch,
+        replyError = replyError,
+        replyApplied = replyApplied,
+      )
+    slot.interactiveCommands.put(cmd)
+
+    val drained = slot.interactiveCommands.poll(1, TimeUnit.SECONDS)
+    assertSame("queue must round-trip the same instance, not a copy", cmd, drained)
+    val asRecreate = drained as InteractiveCommand.DispatchStateRecreate
+    assertSame(replyLatch, asRecreate.replyLatch)
+    assertSame(replyError, asRecreate.replyError)
+    assertSame(replyApplied, asRecreate.replyApplied)
+    assertNull("replyError defaults to null", asRecreate.replyError.get())
+    assertFalse("replyApplied defaults to false", asRecreate.replyApplied.get())
+  }
+
+  @Test
   fun dispatchPreviewReloadRoundTripsThroughTheBridge() {
     // Pin the cross-classloader contract for the new variant: only `java.*` types in the
     // payload, round-trips through `interactiveCommands` by reference. No event-specific fields

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
@@ -112,6 +112,25 @@ interface InteractiveSession : AutoCloseable {
   fun dispatchPreviewReload(): Boolean = false
 
   /**
+   * Force a Compose-level save+restore round-trip: snapshot `rememberSaveable` state from the
+   * current composition, tear it down under a `key(...)` boundary, and rebuild with the snapshot
+   * restored. Same audit signal as an Android `ActivityScenario.recreate()` — verifies state
+   * survives a teardown — but lives entirely at the Compose level so it doesn't depend on the
+   * activity's `onSaveInstanceState`/onCreate path.
+   *
+   * Returns `true` when the recreate fired; `false` when the host doesn't have the
+   * `SaveableStateRegistry` bridge wired (DesktopHost today). Throws when the rebuild itself
+   * failed.
+   *
+   * Note: `remember` state is lost across the boundary (same as a real recreate);
+   * `rememberSaveable` survives via the snapshot/restore. Use [dispatchPreviewReload] when you
+   * want a true cold composition (both `remember` and `rememberSaveable` reset). Use
+   * [dispatchLifecycle] (`pause` / `resume`) when you want a real Android lifecycle round-trip
+   * with the activity intact.
+   */
+  fun dispatchStateRecreate(): Boolean = false
+
+  /**
    * Render the current composition to a PNG and return the result. The implementation runs the
    * scene through enough frames to settle (typically two `scene.render()` calls — same heuristic as
    * the one-shot path) and encodes to disk at a stable path the daemon can publish via

--- a/skills/compose-preview-review/design/AGENT_AUDITS.md
+++ b/skills/compose-preview-review/design/AGENT_AUDITS.md
@@ -516,18 +516,26 @@ payload evidence and the state/parameter path you found in code.
 
 ### State restoration and lifecycle audit
 
-> **Capability split.** `recording.probe`, `lifecycle.event`, and `preview.reload` (all
-> Android-only) are wired and `record_preview` accepts them. `lifecycle.event` drives
-> `ActivityScenario.moveToState(...)` against the held rule's activity (accepts `pause` /
-> `resume` / `stop` — `destroy` is rejected). `preview.reload` forces a fresh composition by
-> tearing down the held content under its `key(...)` boundary and rebuilding (`remember` and
-> `rememberSaveable` state both reset). `state.save` / `state.restore` are still advertised as
-> `supported = false` roadmap and rejected up front.
+> **Capability split.** `recording.probe`, `lifecycle.event`, `preview.reload`, and
+> `state.recreate` (all Android-only) are wired and `record_preview` accepts them.
+> `lifecycle.event` drives `ActivityScenario.moveToState(...)` against the held rule's activity
+> (accepts `pause` / `resume` / `stop` — `destroy` is rejected). `preview.reload` forces a fresh
+> composition by tearing down under a `key(...)` boundary (`remember` and `rememberSaveable`
+> both reset). `state.recreate` is the middle ground — a Compose-level save+restore via the
+> `SaveableStateRegistry` (`rememberSaveable` survives, `remember` resets). The named-checkpoint
+> pair `state.save` / `state.restore` is still advertised as `supported = false` roadmap and
+> rejected up front.
 >
-> **Choose `lifecycle.event` vs `preview.reload`.** Use `lifecycle.event:pause` then `:resume`
-> when verifying that state survives a configuration change — `rememberSaveable` is preserved.
-> Use `preview.reload` when verifying the screen handles a cold composition — both `remember`
-> and `rememberSaveable` reset.
+> **Choose `lifecycle.event` vs `state.recreate` vs `preview.reload`:**
+>
+> - `lifecycle.event:pause` then `:resume` — verifies state survives an Android configuration
+>   change. The activity is intact across the round-trip; `remember` and `rememberSaveable`
+>   both survive.
+> - `state.recreate` — verifies state survives a recreate. The composition is torn down and
+>   rebuilt; `rememberSaveable` is restored from a snapshot, `remember` resets. Same audit
+>   signal as a real `ActivityScenario.recreate()` but Compose-level only.
+> - `preview.reload` — verifies the screen handles a cold composition. Both `remember` and
+>   `rememberSaveable` reset.
 
 First check the daemon's advertised extension events:
 
@@ -593,6 +601,32 @@ is the kind of thing this variant catches:
   }
 }
 ```
+
+**Recreate variant.** Use `state.recreate` to exercise the `rememberSaveable` save+restore
+path without depending on the activity lifecycle — verifies the saved-state side of state
+preservation in isolation. Useful when the lifecycle path is unavailable or you want a tighter
+test of just the saveable path:
+
+```json
+{
+  "tool": "record_preview",
+  "arguments": {
+    "uri": "compose-preview://workspace/_app/com.example.StatefulPreview",
+    "events": [
+      { "tMs": 0,   "kind": "click", "pixelX": 120, "pixelY": 40 },
+      { "tMs": 200, "kind": "state.recreate" },
+      { "tMs": 200, "kind": "recording.probe", "label": "after-recreate" }
+    ]
+  }
+}
+```
+
+A `rememberSaveable`-backed counter that survives `state.recreate` but resets under
+`preview.reload` is correctly wired; one that resets under both is missing the saveable
+configuration; one that resets under `state.recreate` but survives `lifecycle.event:pause`+
+`:resume` is suspect — the activity-level path is preserving state the saveable registry
+isn't, which usually points to retained-instance bookkeeping that won't survive a real config
+change.
 
 ### Accessibility-driven interaction audit
 


### PR DESCRIPTION
## Summary

Forces a Compose-level save+restore round-trip: snapshot the current `SaveableStateRegistry`, tear down the held composition under a `key(...)` boundary, rebuild with the snapshot restored. Same audit signal as an Android `ActivityScenario.recreate()` (verifies state survives a recreate) but lives entirely at the Compose level so it doesn't depend on `onSaveInstanceState`/onCreate plumbing. `rememberSaveable` survives, `remember` resets — the middle ground between `lifecycle.event:pause`+`:resume` (everything survives) and `preview.reload` (everything resets).

Wired as a self-contained extension following the lifecycle / preview.reload pattern from #741 / #742:

- **`InteractiveSession.dispatchStateRecreate(): Boolean`** — new method, default `false`. `DesktopHost` inherits the no-op; `AndroidInteractiveSession` overrides to enqueue a new parameterless `InteractiveCommand.DispatchStateRecreate` envelope.
- **Sandbox bridge** (`RobolectricHost`) — wraps the held `setContent` body in nested `key(reloadCounter) { key(recreateGeneration) { ... } }` boundaries so reload and recreate invalidate independently. The recreate boundary installs its own `SaveableStateRegistry` (provided via `LocalSaveableStateRegistry`), seeded from a stashed snapshot. The new `DispatchStateRecreate` arm calls `registry.performSave()` to capture current `rememberSaveable` state, stashes it, then increments `recreateGeneration` — the rebuild's `remember(generation) { SaveableStateRegistry(restoredValues = stash) }` reads the snapshot and `rememberSaveable` reads see the restored values.
- **`StateRecreateRecordingScriptEvents`** (new, `:daemon:android`) — owns a `state.recreate` data-extension descriptor (`supported = true`). New wire-name id (`state.recreate`) — distinct from the still-roadmap `state.save` / `state.restore` pair, which advertises the future named-checkpoint model.
- **Recording session** (`AndroidRecordingSession.buildScriptHandlers`) — registers the `state.recreate` handler that calls `interactive.dispatchStateRecreate()` and surfaces applied / unsupported evidence with a specific reason naming the SaveableStateRegistry bridge.
- **Host-derived advertisement** — `RobolectricHost.recordingScriptEventDescriptors()` now returns `[recordingDescriptor, lifecycle, previewReload, stateRecreate]`. The renderer-agnostic roadmap stays at `state.save` / `state.restore` only (the principled named-checkpoint model — separate primitive).

Builds on:
- #720 (registry-based dispatch)
- #722 (host-derived supported descriptors)
- #741 (`lifecycle.event` — sibling pattern)
- #742 (`preview.reload` — sibling pattern, sets up the `key(...)` infrastructure this PR extends)

## Test plan

- [ ] `./gradlew :daemon:core:check :daemon:android:check` (couldn't run locally — sandbox network blocks JDK 17 install; CI is the verification path)
- [ ] CI: `format`, `test` jobs green
- [ ] `StateRecreateRecordingScriptEventsTest` (new) pins descriptor shape + wire-name distinctness.
- [ ] `AndroidRecordingSessionTest` (new cases): happy-path routes through `dispatchStateRecreate` with applied evidence; miss-path surfaces a specific unsupported reason mentioning the SaveableStateRegistry bridge.
- [ ] `InteractiveCommandTest` (new case): cross-classloader contract for `DispatchStateRecreate`.
- [ ] Manual smoke (post-merge, on an a11y-enabled Android daemon): a `record_preview` script with `click → state.recreate → recording.probe` against a `rememberSaveable`-backed counter shows the count survives. Same script with `preview.reload` instead shows the count reset.

## Roadmap shape after this PR

The recording-script surface is now:

**Wired (15 ids):** 7 input kinds, `recording.probe`, 12 `a11y.action.*`, `lifecycle.event` (pause/resume/stop), `preview.reload`, `state.recreate`.

**Roadmap (9 ids):**
- `state.save` / `state.restore` — the principled multi-checkpoint Bundle pair. Different primitive than `state.recreate`; lands when audits actually need named checkpoints.
- 7 a11y actions Compose doesn't expose as `SemanticsActions` (`clearFocus`, `accessibilityFocus`, `clearAccessibilityFocus`, `select`, `clearSelection`, `nextAtGranularity`, `previousAtGranularity`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8qJtJESJvS4yoTB9PKtRF)_