### PR TITLE
fix(daemon-android): import getOrNull for SemanticsConfiguration

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.reflect.getDeclaredComposableMethod
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasRequestFocusAction


### PR DESCRIPTION
## Summary

`RobolectricHost.kt` lines 1879 and 1935 call `target.config.getOrNull(...)` — that's the `androidx.compose.ui.semantics.getOrNull` extension function on `SemanticsConfiguration`, which needs an explicit import. Without it, `:daemon:android:compileDebugKotlin` fails on `main` with:

```
e: RobolectricHost.kt:1879:47 Unresolved reference 'getOrNull'.
e: RobolectricHost.kt:1935:47 Unresolved reference 'getOrNull'.
```

Other call sites import the extension correctly (e.g. `data/scroll/core/.../ScrollDriver.kt:6`, `data/strings/connector/.../I18nTranslationsDataProduct.kt:4`). The omission was introduced by 7876d19 (#738) when the SemanticsActions dispatchers were wired in.

## Test plan

- [x] `./gradlew :daemon:android:compileDebugKotlin` — green (red on `main` without the import).