### PR TITLE
chore: ktfmtFormatAll across daemon-core and data-render-core

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
@@ -50,8 +50,9 @@ interface InteractiveSession : AutoCloseable {
   fun dispatch(input: InteractiveInputParams)
 
   /**
-   * Accessibility-driven dispatch: resolve a node by its visible content description and invoke
-   * the named [`SemanticsActions`](https://developer.android.com/reference/kotlin/androidx/compose/ui/semantics/SemanticsActions)
+   * Accessibility-driven dispatch: resolve a node by its visible content description and invoke the
+   * named
+   * [`SemanticsActions`](https://developer.android.com/reference/kotlin/androidx/compose/ui/semantics/SemanticsActions)
    * action against it — same path a screen reader would walk. Used by `record_preview`'s
    * `a11y.action.*` script events.
    *
@@ -84,8 +85,8 @@ interface InteractiveSession : AutoCloseable {
    * event isn't one the host recognises (caller surfaces unsupported evidence with a specific
    * reason). Throws when the transition itself failed — same propagation shape as [dispatch].
    *
-   * Default returns `false` so hosts without an Android lifecycle owner cleanly surface
-   * "no lifecycle dispatch available" without blowing up the session.
+   * Default returns `false` so hosts without an Android lifecycle owner cleanly surface "no
+   * lifecycle dispatch available" without blowing up the session.
    *
    * @param lifecycleEvent transition name on the wire — `"pause"`, `"resume"`, `"stop"`. The
    *   implementation maps each to the matching `Lifecycle.State` and calls
@@ -97,17 +98,17 @@ interface InteractiveSession : AutoCloseable {
 
   /**
    * Force a fresh composition: tear down the current composition slot and rebuild from scratch
-   * against the same composable function. Used by `record_preview`'s `preview.reload` script
-   * event to verify a screen recovers cleanly from a recompose-from-zero (`remember`,
-   * `rememberSaveable`, and `LaunchedEffect`-keyed work all reset).
+   * against the same composable function. Used by `record_preview`'s `preview.reload` script event
+   * to verify a screen recovers cleanly from a recompose-from-zero (`remember`, `rememberSaveable`,
+   * and `LaunchedEffect`-keyed work all reset).
    *
-   * Returns `true` when the composition was rebuilt; `false` when the host doesn't support
-   * forced reloads (DesktopHost today). Throws when the rebuild itself failed.
+   * Returns `true` when the composition was rebuilt; `false` when the host doesn't support forced
+   * reloads (DesktopHost today). Throws when the rebuild itself failed.
    *
    * Note: this is a Compose-level reset, not an Android lifecycle round-trip. State preserved by
-   * `rememberSaveable` (bundle-backed) is also lost because the `key(...)` boundary that drives
-   * the rebuild invalidates the saveable-state call sites. For "state survives a config-change"
-   * audits use [dispatchLifecycle] (`pause` / `resume`) instead.
+   * `rememberSaveable` (bundle-backed) is also lost because the `key(...)` boundary that drives the
+   * rebuild invalidates the saveable-state call sites. For "state survives a config-change" audits
+   * use [dispatchLifecycle] (`pause` / `resume`) instead.
    */
   fun dispatchPreviewReload(): Boolean = false
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
@@ -160,6 +160,7 @@ val INTERACTIVE_INPUT_KIND_WIRE_NAMES: Set<String> = INTERACTIVE_INPUT_KIND_BY_W
 private val INTERACTIVE_INPUT_KIND_TO_WIRE_NAME: Map<InteractiveInputKind, String> =
   INTERACTIVE_INPUT_KIND_BY_WIRE_NAME.entries.associate { (wire, kind) -> kind to wire }
 
-/** Wire-name string for an [InteractiveInputKind] (the reverse of [toInteractiveInputKindOrNull]). */
-fun InteractiveInputKind.wireName(): String =
-  INTERACTIVE_INPUT_KIND_TO_WIRE_NAME.getValue(this)
+/**
+ * Wire-name string for an [InteractiveInputKind] (the reverse of [toInteractiveInputKindOrNull]).
+ */
+fun InteractiveInputKind.wireName(): String = INTERACTIVE_INPUT_KIND_TO_WIRE_NAME.getValue(this)

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1033,8 +1033,8 @@ data class RecordingScriptEvent(
    * `Icon(contentDescription = "Save")`). The handler resolves this against the held composition's
    * semantics tree and dispatches the corresponding `SemanticsActions` action — same lookup a
    * screen reader would perform. Ignored for input/probe/state/lifecycle events. Future a11y
-   * matchers (visible text, role, tag) will land as sibling fields rather than a generic params
-   * map so per-action validation stays typed end-to-end.
+   * matchers (visible text, role, tag) will land as sibling fields rather than a generic params map
+   * so per-action validation stays typed end-to-end.
    */
   val nodeContentDescription: String? = null,
 )

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
@@ -299,7 +299,7 @@ object RecordingScriptDataExtensions {
               summary = "Requests restoration from a saved-state checkpoint.",
             ),
           ),
-      ),
+      )
       // `preview.reload` and `lifecycle.event` both moved out of this list — the Android backend
       // wires them via `PreviewReloadRecordingScriptEvents.descriptor` and
       // `LifecycleRecordingScriptEvents.descriptor` respectively, advertised through

--- a/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/extensions/RecordingScriptDataExtensionsTest.kt
+++ b/data/render/core/src/test/kotlin/ee/schimke/composeai/data/render/extensions/RecordingScriptDataExtensionsTest.kt
@@ -34,7 +34,8 @@ class RecordingScriptDataExtensionsTest {
     val ids = roadmap.flatMap { it.recordingScriptEvents }.map { it.id }.toSet()
     // `lifecycle.event` and `preview.reload` left this list once the Android backend wired their
     // dispatch — `RobolectricHost.recordingScriptEventDescriptors()` now advertises
-    // `LifecycleRecordingScriptEvents.descriptor` and `PreviewReloadRecordingScriptEvents.descriptor`
+    // `LifecycleRecordingScriptEvents.descriptor` and
+    // `PreviewReloadRecordingScriptEvents.descriptor`
     // directly. The only remaining unwired pair is state save/restore.
     assertEquals(
       setOf(


### PR DESCRIPTION
## Summary

Five files on `main` fail `./gradlew ktfmtCheckAll` and so block any unrelated commit through the pre-commit hook:

- `daemon/core/src/main/kotlin/.../InteractiveSession.kt`
- `daemon/core/src/main/kotlin/.../RecordingSession.kt`
- `daemon/core/src/main/kotlin/.../protocol/Messages.kt`
- `data/render/core/src/main/kotlin/.../extensions/DataExtensionPlan.kt`
- `data/render/core/src/test/kotlin/.../extensions/RecordingScriptDataExtensionsTest.kt`

Pure cosmetic — output of `./gradlew ktfmtFormatAll`. No behavioural change. Same pattern as #723.

## Test plan

- [x] `./gradlew ktfmtCheckAll` — green.