### PR TITLE
refactor(a11y): merge a11y.roadmap into a single a11y descriptor with mixed supported flags

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -263,8 +263,9 @@ class AndroidRecordingSession(
         // evidence with a specific reason. The action arm in
         // [RobolectricHost.performSemanticsActionByContentDescription] does the actual lookup +
         // invoke. Action ids without a clean equivalent (`accessibilityFocus`, `clearFocus`,
-        // `select`, granularity navigation) stay in
-        // `AccessibilityRecordingScriptEvents.roadmapDescriptors` and are rejected at MCP.
+        // `select`, granularity navigation) appear alongside the wired ones in
+        // `AccessibilityRecordingScriptEvents.descriptor` with `supported = false` and are
+        // rejected at MCP.
         for (action in A11Y_SEMANTIC_ACTIONS) {
           put("a11y.action.$action", a11ySemanticsActionHandler(action))
         }
@@ -696,8 +697,9 @@ class AndroidRecordingSession(
 
   companion object {
     /**
-     * `actionKind` strings advertised under `AccessibilityRecordingScriptEvents.supportedDescriptors`
-     * — each registers in [scriptHandlers] as `a11y.action.<kind>` and fans out to a `when` arm in
+     * `actionKind` strings advertised as `supported = true` under
+     * `AccessibilityRecordingScriptEvents.descriptor` — each registers in [scriptHandlers] as
+     * `a11y.action.<kind>` and fans out to a `when` arm in
      * [RobolectricHost.performSemanticsActionByContentDescription]. Adding a new entry requires
      * three coordinated edits: (a) the descriptor in [AccessibilityRecordingScriptEvents], (b)
      * this list, (c) the matching arm in `performSemanticsActionByContentDescription`. Test

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/DaemonMain.kt
@@ -337,24 +337,22 @@ fun main(args: Array<String>) {
       incrementalDiscovery = incrementalDiscovery,
       historyManager = historyManager,
       dataProducts = dataProducts,
-      // dataExtensions composition (per-extension halves):
-      //   - host.recordingScriptEventDescriptors()  → supported, renderer-agnostic (probe)
-      //   - AccessibilityRecordingScriptEvents.supportedDescriptors  → supported, a11y-only
-      //     (today: a11y.action.click). Wired only when the a11y preview extension is enabled
-      //     so a non-a11y daemon doesn't advertise an action it can't dispatch.
-      //   - RecordingScriptDataExtensions.roadmapDescriptors  → roadmap, renderer-agnostic
-      //     (state.save / state.restore / lifecycle.event / preview.reload, all supported = false)
-      //   - AccessibilityRecordingScriptEvents.roadmapDescriptors  → roadmap, a11y-only
-      //     (the other 18 a11y.action.* ids, supported = false)
-      // `record_preview` rejects roadmap kinds up front via `validateRecordingScriptKinds`.
+      // dataExtensions composition:
+      //   - host.recordingScriptEventDescriptors()  → host-wired extensions
+      //     (recording.probe + lifecycle + preview.reload + state.{recreate,save,restore})
+      //   - AccessibilityRecordingScriptEvents.descriptor  → the `a11y` extension. Single
+      //     descriptor carrying all 19 actions; 12 are supported = true, 7 are supported = false.
+      //     Wired only when the a11y preview extension is enabled so a non-a11y daemon doesn't
+      //     advertise actions it can't dispatch.
+      //   - RecordingScriptDataExtensions.roadmapDescriptors  → renderer-agnostic roadmap
+      //     (currently empty; new entries land here when an event has a renderer-agnostic
+      //     dispatch story but no host has wired it yet).
+      // `record_preview`'s validateRecordingScriptKinds filters by per-event `supported` flag.
       dataExtensions =
         host.recordingScriptEventDescriptors() +
-          (if (a11yPreviewExtensionEnabled)
-            AccessibilityRecordingScriptEvents.supportedDescriptors
+          (if (a11yPreviewExtensionEnabled) AccessibilityRecordingScriptEvents.descriptors
           else emptyList()) +
-          RecordingScriptDataExtensions.roadmapDescriptors +
-          (if (a11yPreviewExtensionEnabled) AccessibilityRecordingScriptEvents.roadmapDescriptors
-          else emptyList()),
+          RecordingScriptDataExtensions.roadmapDescriptors,
       previewExtensions = previewExtensions,
     )
   server.run()

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -1932,8 +1932,9 @@ open class RobolectricHost(
      * `scrollForward` is "advance the dominant scroll axis" (today: vertical; horizontal-only
      * scrollers should use `scrollLeft` / `scrollRight` directly until we read the node's scroll
      * axis ranges). Action kinds without a clean SemanticsActions equivalent
-     * (`accessibilityFocus`, `clearFocus`, `select`, granularity navigation) stay in
-     * `AccessibilityRecordingScriptEvents.roadmapDescriptors` and are rejected by MCP up front.
+     * (`accessibilityFocus`, `clearFocus`, `select`, granularity navigation) appear in
+     * `AccessibilityRecordingScriptEvents.descriptor` with `supported = false` and are rejected
+     * by MCP up front.
      */
     private fun performSemanticsActionByContentDescription(
       rule:

--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEvents.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEvents.kt
@@ -7,27 +7,28 @@ import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescripto
 /**
  * Accessibility-driven `record_preview` script events — see
  * [`compose-preview-review/design/AGENT_AUDITS.md`](../../../../../../skills/compose-preview-review/design/AGENT_AUDITS.md)
- * § "Accessibility-driven interaction audit" (planned).
+ * § "Accessibility-driven interaction audit".
  *
  * Each id maps to one [`AccessibilityNodeInfo`](https://developer.android.com/reference/android/view/accessibility/AccessibilityNodeInfo)
- * action constant. An `a11y.action.<name>` event in a recording script means "find the node
- * identified by `params` (today: `nodeId` from the most recent `a11y/hierarchy` payload — content-
- * description / semantics-tag matching is a follow-up) and dispatch the corresponding accessibility
- * action through `AccessibilityNodeInfo.performAction(...)`."
+ * action constant. An `a11y.action.<name>` event in a recording script means "find the node by its
+ * `nodeContentDescription` payload and dispatch the corresponding accessibility action against it"
+ * — same path `AccessibilityNodeInfo.performAction(...)` walks via TalkBack.
  *
- * Why these belong on a separate descriptor and not on `RecordingScriptDataExtensions` in
+ * Why this lives in `:data-a11y-connector` and not in `RecordingScriptDataExtensions` in
  * `:data-render-core`: a11y dispatch is Android-only (TalkBack-equivalent semantics drive these
  * actions) and lives in the a11y module pair. Desktop daemons don't advertise this descriptor at
- * all. The wiring point is `:daemon:android`'s [DaemonMain], which concatenates this list onto the
- * base recording-script descriptors when `a11y` is enabled — same gate as the a11y preview-
- * extension publishers.
+ * all. The wiring point is `:daemon:android`'s [DaemonMain], which appends [descriptor] to the
+ * daemon's `dataExtensions` when the a11y preview extension is enabled — same gate as the a11y
+ * preview-extension publishers.
  *
- * **Status:** [supportedDescriptors] today carries `a11y.action.click` only — wired end-to-end
- * through `AndroidInteractiveSession.dispatchSemanticsAction` →
- * `RobolectricHost.performSemanticsActionByContentDescription` →
- * `SemanticsActions.OnClick.action.invoke()`. [roadmapDescriptors] carries the other 18 actions
- * with `supported = false`; the MCP layer rejects them up front, and each lands one-by-one as
- * its sandbox-side `when` arm + handler factory ships.
+ * **Single descriptor, mixed support.** All 19 a11y actions live in one
+ * `DataExtensionDescriptor(id = "a11y", ...)`. Each event carries its own `supported` flag —
+ * 12 wired ids ride on `SemanticsActions` constants and report `supported = true`; the remaining 7
+ * (`clearFocus`, `accessibilityFocus`, `clearAccessibilityFocus`, `select`, `clearSelection`,
+ * `nextAtGranularity`, `previousAtGranularity`) report `supported = false` because Compose
+ * doesn't expose a clean `SemanticsActions` equivalent today. Agents calling `list_data_products`
+ * see one `a11y` extension with the full surface; the per-event flag is the source of truth for
+ * "can `record_preview` accept this kind right now."
  */
 object AccessibilityRecordingScriptEvents {
 
@@ -53,182 +54,148 @@ object AccessibilityRecordingScriptEvents {
   const val ACTION_PREVIOUS_AT_GRANULARITY: String = "a11y.action.previousAtGranularity"
 
   /**
-   * Currently-wired a11y actions. Each `recording.scriptEvents[*].id` here corresponds to a
-   * `when` arm in `RobolectricHost.performSemanticsActionByContentDescription` plus a registry
-   * entry in `AndroidRecordingSession.A11Y_SEMANTIC_ACTIONS`. The handler resolves a node by
-   * `hasContentDescription(...)` and invokes the matching `SemanticsActions` constant — same
-   * path `AccessibilityNodeInfo.performAction(...)` walks via TalkBack.
+   * Single `a11y` data-extension descriptor advertising all 19 actions. Wired ids appear with
+   * `supported = true`; the remaining 7 carry `supported = false` so agents see the full
+   * accessibility action surface (planned + shipped) in one extension entry.
    *
-   * The 6 scroll variants all ride on `SemanticsActions.ScrollBy(dx, dy)`: `scrollForward` /
+   * Each `supported = true` entry corresponds to a `when` arm in
+   * `RobolectricHost.performSemanticsActionByContentDescription` plus a registry entry in
+   * `AndroidRecordingSession.A11Y_SEMANTIC_ACTIONS`. To wire a new action, flip its
+   * [supportedEvent] / [unsupportedEvent] call below and add the matching arm + registry entry.
+   *
+   * The 6 scroll variants ride on `SemanticsActions.ScrollBy(dx, dy)`: `scrollForward` /
    * `scrollDown` push y forward by one viewport-height, `scrollBackward` / `scrollUp` push y
    * backward, `scrollLeft` / `scrollRight` push x. Horizontal scrollers should use the explicit
-   * left/right ids; the forward/backward pair is vertical-axis-first. Future iteration could
-   * read the node's scroll-axis ranges and pick the dominant axis automatically.
-   */
-  val supportedDescriptors: List<DataExtensionDescriptor> =
-    listOf(
-      DataExtensionDescriptor(
-        id = DataExtensionId("a11y"),
-        displayName = "Accessibility script actions",
-        recordingScriptEvents =
-          listOf(
-            supportedEvent(
-              ACTION_CLICK,
-              "Click",
-              "Performs ACTION_CLICK on the targeted accessibility node via SemanticsActions.OnClick.",
-            ),
-            supportedEvent(
-              ACTION_LONG_CLICK,
-              "Long click",
-              "Performs ACTION_LONG_CLICK on the targeted accessibility node via SemanticsActions.OnLongClick.",
-            ),
-            supportedEvent(
-              ACTION_FOCUS,
-              "Focus",
-              "Performs ACTION_FOCUS on the targeted node via SemanticsActions.RequestFocus.",
-            ),
-            supportedEvent(
-              ACTION_EXPAND,
-              "Expand",
-              "Performs ACTION_EXPAND on the targeted node via SemanticsActions.Expand.",
-            ),
-            supportedEvent(
-              ACTION_COLLAPSE,
-              "Collapse",
-              "Performs ACTION_COLLAPSE on the targeted node via SemanticsActions.Collapse.",
-            ),
-            supportedEvent(
-              ACTION_DISMISS,
-              "Dismiss",
-              "Performs ACTION_DISMISS on the targeted node via SemanticsActions.Dismiss.",
-            ),
-            supportedEvent(
-              ACTION_SCROLL_FORWARD,
-              "Scroll forward",
-              "Scrolls the targeted scrollable forward by one viewport-height via " +
-                "SemanticsActions.ScrollBy(0, +height). Vertical-axis primary; for horizontal " +
-                "scrollers use scrollLeft/scrollRight directly.",
-            ),
-            supportedEvent(
-              ACTION_SCROLL_BACKWARD,
-              "Scroll backward",
-              "Scrolls the targeted scrollable backward by one viewport-height via " +
-                "SemanticsActions.ScrollBy(0, -height). Vertical-axis primary.",
-            ),
-            supportedEvent(
-              ACTION_SCROLL_UP,
-              "Scroll up",
-              "Scrolls the targeted scrollable up by one viewport-height via SemanticsActions.ScrollBy(0, -height).",
-            ),
-            supportedEvent(
-              ACTION_SCROLL_DOWN,
-              "Scroll down",
-              "Scrolls the targeted scrollable down by one viewport-height via SemanticsActions.ScrollBy(0, +height).",
-            ),
-            supportedEvent(
-              ACTION_SCROLL_LEFT,
-              "Scroll left",
-              "Scrolls the targeted scrollable left by one viewport-width via SemanticsActions.ScrollBy(-width, 0).",
-            ),
-            supportedEvent(
-              ACTION_SCROLL_RIGHT,
-              "Scroll right",
-              "Scrolls the targeted scrollable right by one viewport-width via SemanticsActions.ScrollBy(+width, 0).",
-            ),
-          ),
-      )
-    )
-
-  /**
-   * Roadmap a11y action descriptors — `supported = false`. These don't have a clean
-   * `SemanticsActions` equivalent in Compose:
+   * left/right ids; the forward/backward pair is vertical-axis-first.
    *
+   * The unsupported entries each carry a per-event reason in their `summary`:
    * - `clearFocus` — Compose doesn't expose a `ClearFocus` semantic (focus is owned by the
    *   FocusManager; releasing focus is internal).
    * - `accessibilityFocus` / `clearAccessibilityFocus` — TalkBack-internal screen-reader focus,
-   *   not a user-invokable action on Compose nodes.
+   *   not a user-invokable Compose semantic.
    * - `select` / `clearSelection` — Compose's `Selected` semantic is state, not action; toggling
    *   typically happens through `OnClick`. No `SetSelected` semantic action exists.
    * - `nextAtGranularity` / `previousAtGranularity` — text-cursor navigation needs a granularity
    *   argument and ties into `SetSelection`; sketching the right wire shape is its own design
    *   pass.
-   *
-   * `record_preview` rejects these up front via `validateRecordingScriptKinds`. Each lands when
-   * Compose grows the matching semantic action OR we wire a direct `AccessibilityNodeInfo`
-   * fallback path for the ones it never will.
    */
-  val roadmapDescriptors: List<DataExtensionDescriptor> =
-    listOf(
-      DataExtensionDescriptor(
-        id = DataExtensionId("a11y.roadmap"),
-        displayName = "Accessibility script actions (roadmap)",
-        recordingScriptEvents =
-          listOf(
-            event(
-              ACTION_CLEAR_FOCUS,
-              "Clear focus",
-              "Releases focus from the targeted node. No SemanticsActions equivalent today; " +
-                "tracked as roadmap.",
-            ),
-            event(
-              ACTION_ACCESSIBILITY_FOCUS,
-              "Accessibility focus",
-              "TalkBack-internal screen-reader focus action; not a user-invokable Compose " +
-                "semantic. Tracked as roadmap.",
-            ),
-            event(
-              ACTION_CLEAR_ACCESSIBILITY_FOCUS,
-              "Clear accessibility focus",
-              "TalkBack-internal counterpart to accessibilityFocus. Tracked as roadmap.",
-            ),
-            event(
-              ACTION_SELECT,
-              "Select",
-              "Marks the targeted node as selected. Compose's `Selected` semantic is state, " +
-                "not an action; tracked as roadmap until a `SetSelected` semantic ships.",
-            ),
-            event(
-              ACTION_CLEAR_SELECTION,
-              "Clear selection",
-              "Counterpart to select; tracked as roadmap.",
-            ),
-            event(
-              ACTION_NEXT_AT_GRANULARITY,
-              "Next at movement granularity",
-              "Text-cursor navigation by character/word/paragraph. Needs a granularity " +
-                "argument; wire shape TBD. Tracked as roadmap.",
-            ),
-            event(
-              ACTION_PREVIOUS_AT_GRANULARITY,
-              "Previous at movement granularity",
-              "Counterpart to nextAtGranularity; tracked as roadmap.",
-            ),
+  val descriptor: DataExtensionDescriptor =
+    DataExtensionDescriptor(
+      id = DataExtensionId("a11y"),
+      displayName = "Accessibility script actions",
+      recordingScriptEvents =
+        listOf(
+          // --- Wired (supported = true) ---
+          supportedEvent(
+            ACTION_CLICK,
+            "Click",
+            "Performs ACTION_CLICK on the targeted accessibility node via SemanticsActions.OnClick.",
           ),
-      )
+          supportedEvent(
+            ACTION_LONG_CLICK,
+            "Long click",
+            "Performs ACTION_LONG_CLICK on the targeted accessibility node via SemanticsActions.OnLongClick.",
+          ),
+          supportedEvent(
+            ACTION_FOCUS,
+            "Focus",
+            "Performs ACTION_FOCUS on the targeted node via SemanticsActions.RequestFocus.",
+          ),
+          supportedEvent(
+            ACTION_EXPAND,
+            "Expand",
+            "Performs ACTION_EXPAND on the targeted node via SemanticsActions.Expand.",
+          ),
+          supportedEvent(
+            ACTION_COLLAPSE,
+            "Collapse",
+            "Performs ACTION_COLLAPSE on the targeted node via SemanticsActions.Collapse.",
+          ),
+          supportedEvent(
+            ACTION_DISMISS,
+            "Dismiss",
+            "Performs ACTION_DISMISS on the targeted node via SemanticsActions.Dismiss.",
+          ),
+          supportedEvent(
+            ACTION_SCROLL_FORWARD,
+            "Scroll forward",
+            "Scrolls the targeted scrollable forward by one viewport-height via " +
+              "SemanticsActions.ScrollBy(0, +height). Vertical-axis primary; for horizontal " +
+              "scrollers use scrollLeft/scrollRight directly.",
+          ),
+          supportedEvent(
+            ACTION_SCROLL_BACKWARD,
+            "Scroll backward",
+            "Scrolls the targeted scrollable backward by one viewport-height via " +
+              "SemanticsActions.ScrollBy(0, -height). Vertical-axis primary.",
+          ),
+          supportedEvent(
+            ACTION_SCROLL_UP,
+            "Scroll up",
+            "Scrolls the targeted scrollable up by one viewport-height via SemanticsActions.ScrollBy(0, -height).",
+          ),
+          supportedEvent(
+            ACTION_SCROLL_DOWN,
+            "Scroll down",
+            "Scrolls the targeted scrollable down by one viewport-height via SemanticsActions.ScrollBy(0, +height).",
+          ),
+          supportedEvent(
+            ACTION_SCROLL_LEFT,
+            "Scroll left",
+            "Scrolls the targeted scrollable left by one viewport-width via SemanticsActions.ScrollBy(-width, 0).",
+          ),
+          supportedEvent(
+            ACTION_SCROLL_RIGHT,
+            "Scroll right",
+            "Scrolls the targeted scrollable right by one viewport-width via SemanticsActions.ScrollBy(+width, 0).",
+          ),
+          // --- Roadmap (supported = false) ---
+          unsupportedEvent(
+            ACTION_CLEAR_FOCUS,
+            "Clear focus",
+            "Releases focus from the targeted node. No SemanticsActions equivalent today; " +
+              "tracked as roadmap.",
+          ),
+          unsupportedEvent(
+            ACTION_ACCESSIBILITY_FOCUS,
+            "Accessibility focus",
+            "TalkBack-internal screen-reader focus action; not a user-invokable Compose " +
+              "semantic. Tracked as roadmap.",
+          ),
+          unsupportedEvent(
+            ACTION_CLEAR_ACCESSIBILITY_FOCUS,
+            "Clear accessibility focus",
+            "TalkBack-internal counterpart to accessibilityFocus. Tracked as roadmap.",
+          ),
+          unsupportedEvent(
+            ACTION_SELECT,
+            "Select",
+            "Marks the targeted node as selected. Compose's `Selected` semantic is state, not " +
+              "an action; tracked as roadmap until a `SetSelected` semantic ships.",
+          ),
+          unsupportedEvent(
+            ACTION_CLEAR_SELECTION,
+            "Clear selection",
+            "Counterpart to select; tracked as roadmap.",
+          ),
+          unsupportedEvent(
+            ACTION_NEXT_AT_GRANULARITY,
+            "Next at movement granularity",
+            "Text-cursor navigation by character/word/paragraph. Needs a granularity argument; " +
+              "wire shape TBD. Tracked as roadmap.",
+          ),
+          unsupportedEvent(
+            ACTION_PREVIOUS_AT_GRANULARITY,
+            "Previous at movement granularity",
+            "Counterpart to nextAtGranularity; tracked as roadmap.",
+          ),
+        ),
     )
 
-  /**
-   * Combined list ([supportedDescriptors] + [roadmapDescriptors]) for callers that want to
-   * advertise the full a11y action surface in one go. New code should prefer the split lists so
-   * supported / roadmap halves can flow through the host-derived dataExtensions composition
-   * without re-flagging supported flags.
-   */
-  val descriptors: List<DataExtensionDescriptor> = supportedDescriptors + roadmapDescriptors
+  /** Convenience for the host wiring point — the daemon's `dataExtensions` takes a list. */
+  val descriptors: List<DataExtensionDescriptor> = listOf(descriptor)
 
-  /** Roadmap descriptor — `supported = false`. */
-  private fun event(
-    id: String,
-    displayName: String,
-    summary: String,
-  ): RecordingScriptEventDescriptor =
-    RecordingScriptEventDescriptor(
-      id = id,
-      displayName = displayName,
-      summary = summary,
-      supported = false,
-    )
-
-  /** Wired descriptor — `supported = true`; matches an entry in `AndroidRecordingSession.A11Y_SEMANTIC_ACTIONS`. */
+  /** Wired event — `supported = true`; matches an entry in `AndroidRecordingSession.A11Y_SEMANTIC_ACTIONS`. */
   private fun supportedEvent(
     id: String,
     displayName: String,
@@ -239,5 +206,18 @@ object AccessibilityRecordingScriptEvents {
       displayName = displayName,
       summary = summary,
       supported = true,
+    )
+
+  /** Roadmap event — `supported = false`. */
+  private fun unsupportedEvent(
+    id: String,
+    displayName: String,
+    summary: String,
+  ): RecordingScriptEventDescriptor =
+    RecordingScriptEventDescriptor(
+      id = id,
+      displayName = displayName,
+      summary = summary,
+      supported = false,
     )
 }

--- a/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEventsTest.kt
+++ b/data/a11y/connector/src/test/kotlin/ee/schimke/composeai/daemon/AccessibilityRecordingScriptEventsTest.kt
@@ -1,24 +1,49 @@
 package ee.schimke.composeai.daemon
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Pins the supported/roadmap split of [AccessibilityRecordingScriptEvents] — Android `DaemonMain`
- * composes the daemon's `dataExtensions` capability from these two halves, and `record_preview`'s
- * `validateRecordingScriptKinds` filters by the `supported` flag. The split must stay honest:
- * supported descriptors carry the kinds wired to a real `RobolectricHost.performSemanticsAction*`
- * arm, roadmap descriptors are everything else.
+ * Pins the single `a11y` descriptor's shape — `record_preview`'s `validateRecordingScriptKinds`
+ * filters by per-event `supported` flag, so the wired/unwired split is event-level rather than
+ * descriptor-level.
  */
 class AccessibilityRecordingScriptEventsTest {
 
   @Test
-  fun `supportedDescriptors carry the wired a11y action ids`() {
-    val supported = AccessibilityRecordingScriptEvents.supportedDescriptors
-    val supportedIds = supported.flatMap { it.recordingScriptEvents }.map { it.id }.toSet()
-    val expectedSupportedIds =
+  fun `descriptor advertises a11y as one extension with all 19 actions`() {
+    val descriptor = AccessibilityRecordingScriptEvents.descriptor
+    assertEquals("a11y", descriptor.id.value)
+    val ids = descriptor.recordingScriptEvents.map { it.id }.toSet()
+    val expectedIds =
+      setOf(
+        AccessibilityRecordingScriptEvents.ACTION_CLICK,
+        AccessibilityRecordingScriptEvents.ACTION_LONG_CLICK,
+        AccessibilityRecordingScriptEvents.ACTION_FOCUS,
+        AccessibilityRecordingScriptEvents.ACTION_EXPAND,
+        AccessibilityRecordingScriptEvents.ACTION_COLLAPSE,
+        AccessibilityRecordingScriptEvents.ACTION_DISMISS,
+        AccessibilityRecordingScriptEvents.ACTION_SCROLL_FORWARD,
+        AccessibilityRecordingScriptEvents.ACTION_SCROLL_BACKWARD,
+        AccessibilityRecordingScriptEvents.ACTION_SCROLL_UP,
+        AccessibilityRecordingScriptEvents.ACTION_SCROLL_DOWN,
+        AccessibilityRecordingScriptEvents.ACTION_SCROLL_LEFT,
+        AccessibilityRecordingScriptEvents.ACTION_SCROLL_RIGHT,
+        AccessibilityRecordingScriptEvents.ACTION_CLEAR_FOCUS,
+        AccessibilityRecordingScriptEvents.ACTION_ACCESSIBILITY_FOCUS,
+        AccessibilityRecordingScriptEvents.ACTION_CLEAR_ACCESSIBILITY_FOCUS,
+        AccessibilityRecordingScriptEvents.ACTION_SELECT,
+        AccessibilityRecordingScriptEvents.ACTION_CLEAR_SELECTION,
+        AccessibilityRecordingScriptEvents.ACTION_NEXT_AT_GRANULARITY,
+        AccessibilityRecordingScriptEvents.ACTION_PREVIOUS_AT_GRANULARITY,
+      )
+    assertEquals(expectedIds, ids)
+  }
+
+  @Test
+  fun `wired actions advertise supported = true`() {
+    val expectedSupported =
       setOf(
         AccessibilityRecordingScriptEvents.ACTION_CLICK,
         AccessibilityRecordingScriptEvents.ACTION_LONG_CLICK,
@@ -33,19 +58,21 @@ class AccessibilityRecordingScriptEventsTest {
         AccessibilityRecordingScriptEvents.ACTION_SCROLL_LEFT,
         AccessibilityRecordingScriptEvents.ACTION_SCROLL_RIGHT,
       )
-    assertEquals(expectedSupportedIds, supportedIds)
-    val allSupported = supported.flatMap { it.recordingScriptEvents }.all { it.supported }
-    assertTrue(
-      "every entry in supportedDescriptors must be supported = true so record_preview accepts it",
-      allSupported,
-    )
+    val actuallySupported =
+      AccessibilityRecordingScriptEvents.descriptor.recordingScriptEvents
+        .filter { it.supported }
+        .map { it.id }
+        .toSet()
+    assertEquals(expectedSupported, actuallySupported)
   }
 
   @Test
-  fun `roadmapDescriptors carry the actions without a clean SemanticsActions equivalent`() {
-    val roadmap = AccessibilityRecordingScriptEvents.roadmapDescriptors
-    val roadmapIds = roadmap.flatMap { it.recordingScriptEvents }.map { it.id }.toSet()
-    val expectedRoadmapIds =
+  fun `unwired actions advertise supported = false alongside the wired ones`() {
+    // Roadmap actions appear in the same descriptor with `supported = false` so agents calling
+    // `list_data_products` see the full a11y action surface in one extension entry. The wired /
+    // unwired distinction is per-event, not per-descriptor — there's no separate `a11y.roadmap`
+    // extension.
+    val expectedRoadmap =
       setOf(
         AccessibilityRecordingScriptEvents.ACTION_CLEAR_FOCUS,
         AccessibilityRecordingScriptEvents.ACTION_ACCESSIBILITY_FOCUS,
@@ -55,21 +82,23 @@ class AccessibilityRecordingScriptEventsTest {
         AccessibilityRecordingScriptEvents.ACTION_NEXT_AT_GRANULARITY,
         AccessibilityRecordingScriptEvents.ACTION_PREVIOUS_AT_GRANULARITY,
       )
-    assertEquals(expectedRoadmapIds, roadmapIds)
-    val anySupported = roadmap.flatMap { it.recordingScriptEvents }.any { it.supported }
-    assertFalse(
-      "roadmap descriptors must all be supported = false; flip them into the supportedDescriptors " +
-        "list when a real handler arm lands",
-      anySupported,
-    )
+    val actuallyUnsupported =
+      AccessibilityRecordingScriptEvents.descriptor.recordingScriptEvents
+        .filterNot { it.supported }
+        .map { it.id }
+        .toSet()
+    assertEquals(expectedRoadmap, actuallyUnsupported)
   }
 
   @Test
-  fun `legacy descriptors aggregate is supportedDescriptors plus roadmap`() {
+  fun `descriptors convenience list wraps the single descriptor`() {
     assertEquals(
-      AccessibilityRecordingScriptEvents.supportedDescriptors +
-        AccessibilityRecordingScriptEvents.roadmapDescriptors,
+      listOf(AccessibilityRecordingScriptEvents.descriptor),
       AccessibilityRecordingScriptEvents.descriptors,
+    )
+    assertTrue(
+      "descriptors list must contain exactly the one a11y descriptor",
+      AccessibilityRecordingScriptEvents.descriptors.size == 1,
     )
   }
 }


### PR DESCRIPTION
## Summary

First of three model-cleanup PRs. Agents calling `list_data_products` previously saw two separate `dataExtensions` entries — `a11y` (12 wired actions, `supported = true`) and `a11y.roadmap` (7 unwired actions, `supported = false`). That implied they were distinct extensions when they're actually one accessibility surface with a wired/unwired split at the event level. The `RecordingScriptEventDescriptor.supported` flag already encodes that split per event, so two extension descriptors was redundant.

This merges them into one `DataExtensionDescriptor(id = "a11y", ...)` carrying all 19 events — 12 marked `supported = true`, 7 marked `supported = false`. `list_data_products` now shows one a11y extension with the full action surface; `record_preview`'s `validateRecordingScriptKinds` filters by per-event `supported` flag exactly the same way.

## Changes

- `AccessibilityRecordingScriptEvents.supportedDescriptors` and `roadmapDescriptors` collapse into `descriptor` (single) plus `descriptors` (the host-wiring convenience list with one entry).
- Android `DaemonMain` composition simplifies from four lines (host + a11y-supported + renderer-agnostic-roadmap + a11y-roadmap) to three (host + a11y + renderer-agnostic-roadmap).
- `AccessibilityRecordingScriptEventsTest` rewritten to pin the single-descriptor shape: every expected id present, the wired-12 set carries `supported = true`, the unwired-7 set carries `supported = false`, descriptors-list is one entry.

**No wire-format change** — event ids unchanged. The `record_preview` accept/reject behaviour is identical because the validator already keys on per-event `supported`. Only the descriptor structure flattens.

## Test plan

- [ ] `./gradlew :data-a11y-connector:check :daemon:android:check :mcp:check` (couldn't run locally — sandbox network blocks JDK 17 install; CI is the verification path)
- [ ] CI: `format`, `test` jobs green
- [ ] `AccessibilityRecordingScriptEventsTest` (rewritten): four cases pin the descriptor shape, the supported set, the unsupported set, and the convenience-list size.
- [ ] Manual smoke (post-merge): `list_data_products` against an a11y-enabled Android daemon shows exactly one `a11y` extension entry with 19 events; the previously-rejected 7 ids (e.g. `a11y.action.clearFocus`) still get rejected up front by `record_preview`.

## Follow-ups (this is PR 1 of 3)

The remaining model-cleanups:

2. **Split `lifecycle.event` into `lifecycle.pause` / `lifecycle.resume` / `lifecycle.stop`.** Today it's one event id with a `lifecycleEvent` payload — payload-discriminated union. Separate ids would let the MCP validator reject unknown transitions at the kind level and align lifecycle with `a11y.action.*` / `state.*` / `preview.*` shapes. Wire-format change.

3. **Promote input events into one or more `input.*` extensions.** The 7 input kinds (`click`, `pointerDown`, `pointerMove`, `pointerUp`, `rotaryScroll`, `keyDown`, `keyUp`) are still hard-coded outside the extension model — special-cased in `INTERACTIVE_INPUT_KIND_WIRE_NAMES` and the MCP validator. Promoting them removes the last special-case branch and completes the original "everything is an extension" design goal. Largest of the three.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8qJtJESJvS4yoTB9PKtRF)_