### PR TITLE
chore: ktfmtFormatMain on InteractiveSession.kt

### DIFF
--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InteractiveSession.kt
@@ -142,10 +142,10 @@ interface InteractiveSession : AutoCloseable {
   fun dispatchStateSave(checkpointId: String): Boolean = false
 
   /**
-   * Look up the bundle stashed by an earlier [dispatchStateSave] with matching [checkpointId]
-   * and rebuild the held composition with it restored. Returns `true` when the restore fired,
-   * `false` when no checkpoint with that id has been saved (caller surfaces unsupported
-   * evidence). Throws when the rebuild itself failed.
+   * Look up the bundle stashed by an earlier [dispatchStateSave] with matching [checkpointId] and
+   * rebuild the held composition with it restored. Returns `true` when the restore fired, `false`
+   * when no checkpoint with that id has been saved (caller surfaces unsupported evidence). Throws
+   * when the rebuild itself failed.
    */
   fun dispatchStateRestore(checkpointId: String): Boolean = false
 


### PR DESCRIPTION
## Summary

`InteractiveSession.kt`'s KDoc paragraph for `dispatchStateRestore` is wrapped one column shorter than ktfmt's project line-length budget. `:daemon:core:ktfmtCheckMain` fails on `main`; formatting the file reflows the paragraph by one column.

Same shape as #747 — pre-commit hook gating any commit through `:daemon:core` until this lands.

## Test plan

- [x] `./gradlew :daemon:core:ktfmtCheckMain` — green.