### PR TITLE
refactor(a11y): typed context keys for OverlayExtension; drop legacy attributes

### DIFF
--- a/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityPostCapturePipeline.kt
+++ b/data/a11y/connector/src/main/kotlin/ee/schimke/composeai/daemon/AccessibilityPostCapturePipeline.kt
@@ -5,15 +5,19 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionPlanner
 import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
 import ee.schimke.composeai.data.render.extensions.DataProductKey
 import ee.schimke.composeai.data.render.extensions.DataProductStore
+import ee.schimke.composeai.data.render.extensions.ExtensionContextData
+import ee.schimke.composeai.data.render.extensions.ExtensionContextValue
 import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
 import ee.schimke.composeai.data.render.extensions.PlannedDataExtension
 import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
 import ee.schimke.composeai.data.render.extensions.RecordingDataProductStore
 import ee.schimke.composeai.data.render.extensions.RenderDensity
 import ee.schimke.composeai.data.render.extensions.RenderImageArtifact
+import ee.schimke.composeai.data.render.extensions.provides
 import ee.schimke.composeai.renderer.AccessibilityDataProducts
 import ee.schimke.composeai.renderer.AccessibilityFindingsPayload
 import ee.schimke.composeai.renderer.AccessibilityHierarchyPayload
+import ee.schimke.composeai.renderer.OverlayContextKeys
 import ee.schimke.composeai.renderer.OverlayExtension
 import ee.schimke.composeai.renderer.TouchTargetsExtension
 import java.io.File
@@ -39,7 +43,6 @@ fun runAccessibilityPostCapturePipeline(
   imageArtifact: RenderImageArtifact? = null,
   outputDirectory: File? = null,
   isRound: Boolean = false,
-  attributes: Map<String, Any?> = emptyMap(),
   extensions: List<PlannedDataExtension> = AccessibilityPostCaptureExtensions.defaults,
   target: DataExtensionTarget? = DataExtensionTarget.Android,
 ): DataProductStore {
@@ -49,14 +52,11 @@ fun runAccessibilityPostCapturePipeline(
   store.put(CommonDataProducts.Density, RenderDensity(density))
   imageArtifact?.let { store.put(CommonDataProducts.ImageArtifact, it) }
 
-  // Merge caller attributes with the OverlayExtension contract slots — caller wins on conflict so
-  // tests can override. Folding outputDirectory + isRound into a typed product later (see
-  // RenderDataDirectory / RenderDeviceShape follow-up) lets us drop these named slots.
-  val mergedAttributes = buildMap<String, Any?> {
-    if (outputDirectory != null) put(OverlayExtension.OUTPUT_DIRECTORY_ATTRIBUTE, outputDirectory)
-    put(OverlayExtension.IS_ROUND_ATTRIBUTE, isRound)
-    putAll(attributes)
+  val contextValues = buildList<ExtensionContextValue<*>> {
+    if (outputDirectory != null) add(OverlayContextKeys.OutputDirectory provides outputDirectory)
+    add(OverlayContextKeys.IsRound provides isRound)
   }
+  val contextData = ExtensionContextData.of(*contextValues.toTypedArray())
 
   val initialProducts =
     buildSet<DataProductKey<*>> {
@@ -101,7 +101,7 @@ fun runAccessibilityPostCapturePipeline(
           previewId = previewId,
           renderMode = null,
           products = store.scopedFor(ext),
-          attributes = mergedAttributes,
+          data = contextData,
         )
       )
     } catch (t: Throwable) {

--- a/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/OverlayExtension.kt
+++ b/data/a11y/core/src/main/kotlin/ee/schimke/composeai/renderer/OverlayExtension.kt
@@ -7,6 +7,7 @@ import ee.schimke.composeai.data.render.extensions.DataExtensionId
 import ee.schimke.composeai.data.render.extensions.DataExtensionPhase
 import ee.schimke.composeai.data.render.extensions.DataExtensionTarget
 import ee.schimke.composeai.data.render.extensions.DataProductKey
+import ee.schimke.composeai.data.render.extensions.ExtensionContextKey
 import ee.schimke.composeai.data.render.extensions.ExtensionPostCaptureContext
 import ee.schimke.composeai.data.render.extensions.PostCaptureProcessor
 import java.io.File
@@ -18,9 +19,9 @@ import java.io.File
  * planner's target filter selects exactly one provider per platform.
  *
  * Inputs: hierarchy, ATF findings, captured image. Output: [AccessibilityOverlayArtifact] pointing
- * at the written PNG. The output directory and round-clip flag are passed via `attributes` (see
- * [OUTPUT_DIRECTORY_ATTRIBUTE], [IS_ROUND_ATTRIBUTE]) — those are render-host-controlled paths
- * rather than typed products so the extension itself stays a pure consumer of the typed graph.
+ * at the written PNG. The output directory and round-clip flag are render-host-controlled values,
+ * not typed products, so they flow through [OverlayContextKeys] on the post-capture context's
+ * `data` channel. The extension itself stays a pure consumer of the typed graph.
  */
 class OverlayExtension : PostCaptureProcessor {
   override val id: DataExtensionId = DataExtensionId(EXTENSION_ID)
@@ -40,10 +41,8 @@ class OverlayExtension : PostCaptureProcessor {
     val hierarchy = context.products.require(AccessibilityDataProducts.Hierarchy)
     val findings = context.products.require(AccessibilityDataProducts.Atf)
     val image = context.products.require(CommonDataProducts.ImageArtifact)
-    val outputDir =
-      context.attributes[OUTPUT_DIRECTORY_ATTRIBUTE] as? File
-        ?: error("OverlayExtension requires '$OUTPUT_DIRECTORY_ATTRIBUTE' in attributes.")
-    val isRound = context.attributes[IS_ROUND_ATTRIBUTE] as? Boolean ?: false
+    val outputDir = context.require(OverlayContextKeys.OutputDirectory)
+    val isRound = context.get(OverlayContextKeys.IsRound) ?: false
     val sourcePng = File(image.path)
     val destPng = outputDir.resolve(OVERLAY_FILE_NAME)
     val written =
@@ -62,8 +61,19 @@ class OverlayExtension : PostCaptureProcessor {
 
   companion object {
     const val EXTENSION_ID: String = "a11y-overlay"
-    const val OUTPUT_DIRECTORY_ATTRIBUTE: String = "a11y-overlay.outputDirectory"
-    const val IS_ROUND_ATTRIBUTE: String = "a11y-overlay.isRound"
     const val OVERLAY_FILE_NAME: String = "a11y-overlay.png"
   }
+}
+
+/**
+ * Typed keys [OverlayExtension] reads from [ExtensionPostCaptureContext.data]. The render host
+ * populates them when invoking the post-capture pipeline; they're not products because the values
+ * (output directory, device round-clip flag) come from host configuration, not from another
+ * extension.
+ */
+object OverlayContextKeys {
+  val OutputDirectory: ExtensionContextKey<File> =
+    ExtensionContextKey(name = "a11y-overlay.outputDirectory", type = File::class.java)
+  val IsRound: ExtensionContextKey<Boolean> =
+    ExtensionContextKey(name = "a11y-overlay.isRound", type = Boolean::class.javaObjectType)
 }

--- a/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/OverlayExtensionTest.kt
+++ b/data/a11y/core/src/test/kotlin/ee/schimke/composeai/renderer/OverlayExtensionTest.kt
@@ -31,7 +31,7 @@ class OverlayExtensionTest {
   }
 
   @Test
-  fun failsLoudlyWhenOutputDirectoryAttributeMissing() {
+  fun failsLoudlyWhenOutputDirectoryContextValueMissing() {
     val store = RecordingDataProductStore()
     store.put(AccessibilityDataProducts.Hierarchy, AccessibilityHierarchyPayload(emptyList()))
     store.put(AccessibilityDataProducts.Atf, AccessibilityFindingsPayload(emptyList()))
@@ -50,7 +50,7 @@ class OverlayExtensionTest {
       }
     assertTrue(
       ex.message!!,
-      ex.message!!.contains(OverlayExtension.OUTPUT_DIRECTORY_ATTRIBUTE),
+      ex.message!!.contains(OverlayContextKeys.OutputDirectory.name),
     )
   }
 

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/PostCaptureProcessor.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/PostCaptureProcessor.kt
@@ -6,10 +6,8 @@ package ee.schimke.composeai.data.render.extensions
  * write declared outputs through [products], which the executor scopes to the extension's
  * `inputs`/`outputs` set so contract violations fail loudly at runtime.
  *
- * Non-product context inputs the host hands to extensions go through [data] (typed
- * [ExtensionContextKey] entries) for new extensions. The legacy [attributes] map is kept for
- * back-compat with extensions that haven't migrated to typed keys yet (overlay attribute slots in
- * particular); prefer [data] in new code.
+ * Non-product context inputs the host hands to extensions go through [data] as typed
+ * [ExtensionContextKey] entries.
  */
 data class ExtensionPostCaptureContext(
   val extensionId: DataExtensionId,
@@ -17,7 +15,6 @@ data class ExtensionPostCaptureContext(
   val renderMode: String?,
   val products: DataProductStore,
   val data: ExtensionContextData = ExtensionContextData.Empty,
-  val attributes: Map<String, Any?> = emptyMap(),
 ) {
   fun <T : Any> get(key: ExtensionContextKey<T>): T? = data.get(key)
 


### PR DESCRIPTION
## Summary

`OverlayExtension` was the last production extension reading from the stringly-keyed `attributes: Map<String, Any?>` escape hatch on `ExtensionPostCaptureContext`. This:

- Migrates the two reads (`OUTPUT_DIRECTORY_ATTRIBUTE`, `IS_ROUND_ATTRIBUTE`) to typed `ExtensionContextKey<File>` / `ExtensionContextKey<Boolean>` exposed as `OverlayContextKeys.OutputDirectory` / `OverlayContextKeys.IsRound`. Same pattern as `AccessibilityHierarchyContextKeys.ViewRoot` (introduced in #739) and `:data-a11y-hierarchy-android` (#724).
- Updates `AccessibilityPostCapturePipeline` to populate `data: ExtensionContextData` instead of `attributes: Map`. Drops the now-unused `attributes` parameter (no production caller or test threaded values through it).
- Deletes the `attributes: Map<String, Any?>` field from `ExtensionPostCaptureContext` entirely. The post-capture context's only stringly-typed escape hatch is gone.
- The existing fail-loudly-on-missing-output-directory test is preserved — it now asserts against `OverlayContextKeys.OutputDirectory.name` (the `ExtensionContextData.require` error path includes the key name).

```kotlin
class OverlayExtension : PostCaptureProcessor {
  override fun process(context: ExtensionPostCaptureContext) {
    // ... typed product reads ...
    val outputDir = context.require(OverlayContextKeys.OutputDirectory)
    val isRound = context.get(OverlayContextKeys.IsRound) ?: false
    // ...
  }
}

object OverlayContextKeys {
  val OutputDirectory: ExtensionContextKey<File> =
    ExtensionContextKey(name = "a11y-overlay.outputDirectory", type = File::class.java)
  val IsRound: ExtensionContextKey<Boolean> =
    ExtensionContextKey(name = "a11y-overlay.isRound", type = Boolean::class.javaObjectType)
}
```

After this lands, all three production `PostCaptureProcessor` implementations (`AccessibilityHierarchyExtension`, `TouchTargetsExtension`, `OverlayExtension`) read non-product context inputs exclusively through typed keys, and `ExtensionPostCaptureContext` has no untyped channel left.

## Out of scope (future work)

- Compose-side `ExtensionComposeContext` and `ExtensionFrameContext` still carry their own `attributes: Map<String, Any?>` field — currently unread by any production extension (only docstring example mentions it). Worth removing in a separate PR; the context shape and migration story differ.
- `ExtensionFrameSequence.extras: Map<String, Any?>` and `ImageFrameTransformInput.extras` are output payload (frame-driver→image-transform), not host-input context — different problem, different PR.
- Migrating filesystem APIs (`java.io.File` → `okio.Path` / `java.nio.file.Path`) tracked in #759.

## Test plan

- [x] `./gradlew :data-a11y-core:test :data-a11y-connector:test :data-render-core:test` — green.
- [x] `./gradlew :daemon:android:compileDebugKotlin :renderer-android:compileDebugKotlin` — green.
- [x] `./gradlew ktfmtCheckAll` — green.