### PR TITLE
fix(vscode): pin webview esbuild to tsconfig.webview.json

### DIFF
--- a/vscode-extension/esbuild.webview.mjs
+++ b/vscode-extension/esbuild.webview.mjs
@@ -15,6 +15,15 @@ const common = {
     legalComments: "none",
     define: { "process.env.NODE_ENV": '"production"' },
     minify: !watch,
+    // Without this, esbuild falls back to the project-root tsconfig.json
+    // (the host config — no `experimentalDecorators`) and compiles the
+    // Lit `@customElement` / `@state()` decorators as TC39 standard
+    // decorators. Lit 3 supports both modes but the source uses the
+    // experimental syntax (plain class fields, no `accessor` keyword), so
+    // mismatched compilation silently breaks element registration and
+    // `@state` reactivity — the panel renders blank. Pinning the webview
+    // tsconfig keeps the bundle in experimental-decorator mode.
+    tsconfig: resolve(root, "tsconfig.webview.json"),
 };
 
 const entries = [


### PR DESCRIPTION
## Summary

Webview panel was rendering blank after #748 because esbuild was compiling Lit's `@customElement` / `@state()` decorators as TC39 standard (not as TypeScript-experimental), so element registration silently failed.

## Root cause

`esbuild.webview.mjs` didn't pass a `tsconfig` option, so esbuild fell back to the project-root `tsconfig.json` — the host-side config — which has no `experimentalDecorators`. Lit 3 supports both decorator modes, but the webview source uses experimental syntax (plain class fields, no `accessor` keyword), and that mismatches the TC39 helper esbuild emits. Result: `<preview-app>` never registered as a custom element, so the entire panel body stayed empty (no toolbar, no message banner, no progress strip).

The host-side log had no errors — the failure was inside the webview JS execution, only visible in the Webview Developer Tools console as `<preview-app>` and friends never connecting.

## Fix

One line in `esbuild.webview.mjs`:

```js
tsconfig: resolve(root, "tsconfig.webview.json"),
```

Confirmed by inspecting the bundle prelude: the TC39 helper array
```
["class","method","getter","setter","accessor","field","value","get","set"]
```
is gone, replaced by the classic TypeScript experimental-decorators `__decorate` helper. Bundles also slightly smaller: preview.js 79.9 → 77.5 KB, history.js 31.4 → 29.5 KB.

## Test plan

- [x] `npm run compile`
- [x] `npm run format:check`
- [x] `npm test` — 320 unit tests green
- [ ] **F5 the extension and confirm the panel actually renders** — toolbar, "Loading Compose previews…" placeholder, then the cards once a Kotlin file is opened. This is the regression we're fixing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4faFnbtRFv3GsS2E6USuA)_