### PR TITLE
refactor(lifecycle): split lifecycle.event into per-state event ids

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -268,10 +268,13 @@ class AndroidRecordingSession(
         for (action in A11Y_SEMANTIC_ACTIONS) {
           put("a11y.action.$action", a11ySemanticsActionHandler(action))
         }
-        // Lifecycle dispatch — `lifecycle.event` reads `lifecycleEvent` payload and routes
-        // through `interactive.dispatchLifecycle(...)` → `ActivityScenario.moveToState(...)`.
-        // See [LifecycleRecordingScriptEvents] for the descriptor + state mapping.
-        put(LifecycleRecordingScriptEvents.LIFECYCLE_EVENT, lifecycleEventHandler())
+        // Lifecycle dispatch — one event id per state transition (`lifecycle.pause` /
+        // `lifecycle.resume` / `lifecycle.stop`). Each routes through
+        // `interactive.dispatchLifecycle(...)` → `ActivityScenario.moveToState(...)`. See
+        // [LifecycleRecordingScriptEvents] for the descriptor + state mapping.
+        put(LifecycleRecordingScriptEvents.LIFECYCLE_PAUSE_EVENT, lifecycleEventHandler("pause"))
+        put(LifecycleRecordingScriptEvents.LIFECYCLE_RESUME_EVENT, lifecycleEventHandler("resume"))
+        put(LifecycleRecordingScriptEvents.LIFECYCLE_STOP_EVENT, lifecycleEventHandler("stop"))
         // Preview reload — `preview.reload` forces a fresh composition via the held rule's
         // `key(...)` reload counter. See [PreviewReloadRecordingScriptEvents].
         put(PreviewReloadRecordingScriptEvents.PREVIEW_RELOAD_EVENT, previewReloadHandler())
@@ -459,40 +462,27 @@ class AndroidRecordingSession(
     }
 
   /**
-   * Handler for `lifecycle.event` — reads `event.lifecycleEvent` (the wire-name string) and
-   * forwards to `interactive.dispatchLifecycle(...)`. The Robolectric sandbox maps the string to
-   * a `Lifecycle.State` and calls `ActivityScenario.moveToState(...)`.
+   * Handler factory for the three `lifecycle.*` event ids — each registry entry pre-binds the
+   * lifecycle target ("pause" / "resume" / "stop") at registration time so the dispatch body
+   * doesn't re-parse a payload field. Forwards to `interactive.dispatchLifecycle(...)`; the
+   * Robolectric sandbox maps the string to a `Lifecycle.State` and calls
+   * `ActivityScenario.moveToState(...)`.
    *
-   * Reports `unsupported` (with a specific reason) when the event payload omits the
-   * `lifecycleEvent` field, when the named transition isn't in the v1 supported set
-   * ([LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS]), or when the host can't
-   * dispatch lifecycle (interactive returned `false`).
+   * Reports `unsupported` only when the host couldn't apply the transition (interactive
+   * returned `false` — typically because it has no ActivityScenario). Validation of the
+   * transition name happened up front: the registry only carries the three wired ids, so
+   * unknown lifecycle.* kinds are rejected at MCP via the descriptor's closed set.
    */
-  private fun lifecycleEventHandler(): RecordingScriptEventHandler =
+  private fun lifecycleEventHandler(target: String): RecordingScriptEventHandler =
     RecordingScriptEventHandler { event, _ ->
-      val lifecycleEvent = event.lifecycleEvent
-      if (lifecycleEvent.isNullOrBlank()) {
-        return@RecordingScriptEventHandler unsupportedEvidence(
-          event,
-          "${event.kind} requires a non-blank 'lifecycleEvent' (one of " +
-            "${LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS.sorted()})",
-        )
-      }
-      if (lifecycleEvent !in LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS) {
-        return@RecordingScriptEventHandler unsupportedEvidence(
-          event,
-          "lifecycleEvent '$lifecycleEvent' is not supported (one of " +
-            "${LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS.sorted()})",
-        )
-      }
-      val applied = interactive.dispatchLifecycle(lifecycleEvent)
+      val applied = interactive.dispatchLifecycle(target)
       if (applied) {
-        appliedEvidence(event, "lifecycle transition '$lifecycleEvent' fired on the held activity")
+        appliedEvidence(event, "lifecycle transition '$target' fired on the held activity")
       } else {
         unsupportedEvidence(
           event,
-          "host did not apply lifecycle transition '$lifecycleEvent'; held composition may be " +
-            "missing an ActivityScenario",
+          "host did not apply lifecycle transition '$target'; held composition may be missing " +
+            "an ActivityScenario",
         )
       }
     }

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/LifecycleRecordingScriptEvents.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/LifecycleRecordingScriptEvents.kt
@@ -9,31 +9,43 @@ import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescripto
  * [`compose-preview-review/design/AGENT_AUDITS.md`](../../../../../../skills/compose-preview-review/design/AGENT_AUDITS.md)
  * § "State restoration and lifecycle audit".
  *
- * One descriptor — `lifecycle.event` — that drives `ActivityScenario.moveToState(...)` on the
- * held rule's activity. The wire payload's `lifecycleEvent` field selects the target state:
- * `"pause"` → STARTED, `"resume"` → RESUMED, `"stop"` → CREATED. `"destroy"` is intentionally
- * not part of v1 — moving to DESTROYED mid-recording would tear down the scenario and break
- * subsequent renders.
+ * Three event ids — `lifecycle.pause`, `lifecycle.resume`, `lifecycle.stop` — each driving
+ * `ActivityScenario.moveToState(...)` on the held rule's activity:
+ *
+ * - `lifecycle.pause` → `Lifecycle.State.STARTED` (activity goes through onPause)
+ * - `lifecycle.resume` → `Lifecycle.State.RESUMED` (activity goes through onResume)
+ * - `lifecycle.stop` → `Lifecycle.State.CREATED` (activity goes through onPause + onStop)
+ *
+ * **Why three ids instead of one `lifecycle.event` with a `lifecycleEvent` payload.** Per-state
+ * ids let the MCP validator reject unknown transitions at the kind level (no special payload
+ * check needed), make the surface self-documenting in `list_data_products`, and align with
+ * `a11y.action.*` / `state.*` / `preview.*` shapes — every other extension uses kind-level
+ * discrimination.
+ *
+ * `"destroy"` is intentionally NOT one of the ids — moving to DESTROYED mid-recording would tear
+ * down the scenario and break subsequent renders. If we wire it in a future PR it would land as
+ * `lifecycle.destroy`.
  *
  * Why this lives in `:daemon:android` and not in a `:data-lifecycle-connector` module like the
  * a11y descriptors do: lifecycle has no data products (no per-render JSON / overlay PNG), so
  * there's no separate Android-only data module to colocate with. The dispatch end is in
  * [RobolectricHost.SandboxRunner.performLifecycleTransition]; the descriptor end lives next to
  * it.
- *
- * **Status:** the single descriptor ships with `supported = true`. Hosts that can dispatch
- * lifecycle (today: only [RobolectricHost]) advertise it from `recordingScriptEventDescriptors()`;
- * hosts without an Android lifecycle owner (DesktopHost) skip it entirely. The roadmap entries
- * (`state.save` / `state.restore` / `preview.reload`) stay in
- * `RecordingScriptDataExtensions.roadmapDescriptors` until their dispatch lands.
  */
 object LifecycleRecordingScriptEvents {
 
-  /** Wire-name id matching `RecordingScriptDataExtensions.LIFECYCLE_EVENT`. */
-  const val LIFECYCLE_EVENT: String = "lifecycle.event"
+  /** `lifecycle.pause` → `Lifecycle.State.STARTED`. Drives `onPause`. */
+  const val LIFECYCLE_PAUSE_EVENT: String = "lifecycle.pause"
 
-  /** Recognised values for [RecordingScriptEvent.lifecycleEvent]. `"destroy"` deliberately not in v1. */
-  val SUPPORTED_LIFECYCLE_EVENTS: Set<String> = setOf("pause", "resume", "stop")
+  /** `lifecycle.resume` → `Lifecycle.State.RESUMED`. Drives `onResume`. */
+  const val LIFECYCLE_RESUME_EVENT: String = "lifecycle.resume"
+
+  /** `lifecycle.stop` → `Lifecycle.State.CREATED`. Drives `onPause` + `onStop`. */
+  const val LIFECYCLE_STOP_EVENT: String = "lifecycle.stop"
+
+  /** All wired lifecycle event ids. */
+  val WIRED_EVENTS: Set<String> =
+    setOf(LIFECYCLE_PAUSE_EVENT, LIFECYCLE_RESUME_EVENT, LIFECYCLE_STOP_EVENT)
 
   val descriptor: DataExtensionDescriptor =
     DataExtensionDescriptor(
@@ -42,15 +54,29 @@ object LifecycleRecordingScriptEvents {
       recordingScriptEvents =
         listOf(
           RecordingScriptEventDescriptor(
-            id = LIFECYCLE_EVENT,
-            displayName = "Lifecycle event",
+            id = LIFECYCLE_PAUSE_EVENT,
+            displayName = "Pause",
             summary =
-              "Drives the held activity through the named lifecycle transition via " +
-                "ActivityScenario.moveToState. `lifecycleEvent` payload selects the target: " +
-                "'pause' → STARTED, 'resume' → RESUMED, 'stop' → CREATED. " +
-                "'destroy' is rejected (would break subsequent renders).",
+              "Moves the held activity to Lifecycle.State.STARTED via " +
+                "ActivityScenario.moveToState. Drives `onPause` on the way.",
             supported = true,
-          )
+          ),
+          RecordingScriptEventDescriptor(
+            id = LIFECYCLE_RESUME_EVENT,
+            displayName = "Resume",
+            summary =
+              "Moves the held activity to Lifecycle.State.RESUMED via " +
+                "ActivityScenario.moveToState. Drives `onResume` on the way.",
+            supported = true,
+          ),
+          RecordingScriptEventDescriptor(
+            id = LIFECYCLE_STOP_EVENT,
+            displayName = "Stop",
+            summary =
+              "Moves the held activity to Lifecycle.State.CREATED via " +
+                "ActivityScenario.moveToState. Drives `onPause` + `onStop` on the way.",
+            supported = true,
+          ),
         ),
     )
 

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
@@ -555,12 +555,10 @@ class AndroidRecordingSessionTest {
   }
 
   @Test
-  fun lifecycleEventRoutesThroughDispatchLifecycle() {
-    // Happy path for the new `lifecycle.event` registry entry: the handler reads
-    // `event.lifecycleEvent`, calls `interactive.dispatchLifecycle(...)`, and reports `applied`
-    // evidence with a message naming the transition. Pin every supported transition in one go so
-    // adding a new entry to `LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS` without
-    // updating the handler short-circuit is caught here.
+  fun lifecycleEventsRouteThroughDispatchLifecycle() {
+    // Pin every wired lifecycle id (`lifecycle.pause` / `lifecycle.resume` / `lifecycle.stop`):
+    // each registry entry pre-binds its target at registration time, so dispatch routes through
+    // `interactive.dispatchLifecycle("pause"|"resume"|"stop")` regardless of the event payload.
     val framesDir = tempFolder.newFolder("lifecycle-frames")
     val encodedDir = tempFolder.newFolder("lifecycle-encoded")
     val sourcePng = File(tempFolder.newFolder("lifecycle-source"), "source.png")
@@ -582,38 +580,32 @@ class AndroidRecordingSessionTest {
       )
 
     try {
+      val ids =
+        listOf(
+          LifecycleRecordingScriptEvents.LIFECYCLE_PAUSE_EVENT to "pause",
+          LifecycleRecordingScriptEvents.LIFECYCLE_RESUME_EVENT to "resume",
+          LifecycleRecordingScriptEvents.LIFECYCLE_STOP_EVENT to "stop",
+        )
       session.postScript(
-        LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS.sorted().map { transition ->
-          RecordingScriptEvent(
-            tMs = 0L,
-            kind = LifecycleRecordingScriptEvents.LIFECYCLE_EVENT,
-            lifecycleEvent = transition,
-          )
-        }
+        ids.map { (kind, _) -> RecordingScriptEvent(tMs = 0L, kind = kind) }
       )
       val result = session.stop()
 
-      // Every transition in the supported set routed through dispatchLifecycle in order.
-      assertEquals(
-        LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS.sorted(),
-        interactive.lifecycleCalls,
-      )
-      // None went through pointer or semantics dispatch.
+      // Each id routed through dispatchLifecycle with the matching pre-bound target string.
+      assertEquals(ids.map { it.second }, interactive.lifecycleCalls)
       assertEquals(0, interactive.dispatchCount)
       assertTrue(interactive.semanticsActionCalls.isEmpty())
-      // Every event reported applied with the transition named in the message.
-      val supported = LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS.sorted()
-      supported.forEachIndexed { index, transition ->
+      ids.forEachIndexed { index, (kind, target) ->
         val evidence = result.scriptEvents[index]
         assertEquals(
-          "evidence for lifecycle.event '$transition' must be applied",
+          "evidence for $kind must be applied",
           ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.APPLIED,
           evidence.status,
         )
         val message = evidence.message ?: ""
         assertTrue(
-          "evidence message must name the lifecycle transition '$transition'; got '$message'",
-          message.contains("'$transition'"),
+          "evidence message must name the lifecycle target '$target'; got '$message'",
+          message.contains("'$target'"),
         )
       }
     } finally {
@@ -622,23 +614,24 @@ class AndroidRecordingSessionTest {
   }
 
   @Test
-  fun lifecycleEventReportsUnsupportedForBlankPayload() {
-    // `kind = "lifecycle.event"` without a `lifecycleEvent` payload short-circuits BEFORE
-    // touching `interactive.dispatchLifecycle` — we know the agent has nothing meaningful for the
-    // host to do, so we surface a precise unsupported reason naming the supported set.
-    val framesDir = tempFolder.newFolder("lifecycle-blank-frames")
-    val encodedDir = tempFolder.newFolder("lifecycle-blank-encoded")
-    val sourcePng = File(tempFolder.newFolder("lifecycle-blank-source"), "source.png")
+  fun lifecycleEventReportsUnsupportedWhenHostCannotDispatch() {
+    // When `dispatchLifecycle` returns false (e.g. host has no ActivityScenario), the handler
+    // surfaces a specific unsupported reason naming the target. There's no kind-level
+    // misconfiguration to check anymore — the registry only carries the three wired ids; unknown
+    // `lifecycle.*` kinds are rejected at MCP via the descriptor closed set.
+    val framesDir = tempFolder.newFolder("lifecycle-miss-frames")
+    val encodedDir = tempFolder.newFolder("lifecycle-miss-encoded")
+    val sourcePng = File(tempFolder.newFolder("lifecycle-miss-source"), "source.png")
     ImageIO.write(
       java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
       "png",
       sourcePng,
     )
-    val interactive = RecordingDeltaSession(sourcePng)
+    val interactive = RecordingDeltaSession(sourcePng).apply { lifecycleResult = false }
     val session =
       AndroidRecordingSession(
         previewId = INTERACTIVE_PREVIEW_ID,
-        recordingId = "test-rec-lifecycle-blank",
+        recordingId = "test-rec-lifecycle-miss",
         fps = FPS,
         scale = 1.0f,
         interactive = interactive,
@@ -649,78 +642,24 @@ class AndroidRecordingSessionTest {
     try {
       session.postScript(
         listOf(
-          RecordingScriptEvent(tMs = 0L, kind = LifecycleRecordingScriptEvents.LIFECYCLE_EVENT)
+          RecordingScriptEvent(tMs = 0L, kind = LifecycleRecordingScriptEvents.LIFECYCLE_PAUSE_EVENT)
         )
       )
       val result = session.stop()
 
-      assertTrue(
-        "blank payload must short-circuit before dispatchLifecycle",
-        interactive.lifecycleCalls.isEmpty(),
-      )
+      assertEquals(listOf("pause"), interactive.lifecycleCalls)
       assertEquals(
         ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.UNSUPPORTED,
         result.scriptEvents[0].status,
       )
       val message = result.scriptEvents[0].message ?: ""
       assertTrue(
-        "diagnostic must list the supported transitions; got '$message'",
-        message.contains("pause") && message.contains("resume") && message.contains("stop"),
+        "miss diagnostic must mention the target transition; got '$message'",
+        message.contains("'pause'"),
       )
-    } finally {
-      session.close()
-    }
-  }
-
-  @Test
-  fun lifecycleEventReportsUnsupportedForUnknownTransition() {
-    // `lifecycleEvent: "destroy"` (and any other string outside the supported set) is rejected up
-    // front — destroy specifically is documented as v2 because it would tear down the scenario
-    // and break subsequent renders.
-    val framesDir = tempFolder.newFolder("lifecycle-destroy-frames")
-    val encodedDir = tempFolder.newFolder("lifecycle-destroy-encoded")
-    val sourcePng = File(tempFolder.newFolder("lifecycle-destroy-source"), "source.png")
-    ImageIO.write(
-      java.awt.image.BufferedImage(8, 8, java.awt.image.BufferedImage.TYPE_INT_ARGB),
-      "png",
-      sourcePng,
-    )
-    val interactive = RecordingDeltaSession(sourcePng)
-    val session =
-      AndroidRecordingSession(
-        previewId = INTERACTIVE_PREVIEW_ID,
-        recordingId = "test-rec-lifecycle-destroy",
-        fps = FPS,
-        scale = 1.0f,
-        interactive = interactive,
-        framesDir = framesDir,
-        encodedDir = encodedDir,
-      )
-
-    try {
-      session.postScript(
-        listOf(
-          RecordingScriptEvent(
-            tMs = 0L,
-            kind = LifecycleRecordingScriptEvents.LIFECYCLE_EVENT,
-            lifecycleEvent = "destroy",
-          )
-        )
-      )
-      val result = session.stop()
-
       assertTrue(
-        "unsupported transition must short-circuit before dispatchLifecycle",
-        interactive.lifecycleCalls.isEmpty(),
-      )
-      assertEquals(
-        ee.schimke.composeai.daemon.protocol.RecordingScriptEventStatus.UNSUPPORTED,
-        result.scriptEvents[0].status,
-      )
-      val message = result.scriptEvents[0].message ?: ""
-      assertTrue(
-        "diagnostic must mention the rejected transition name; got '$message'",
-        message.contains("'destroy'"),
+        "miss diagnostic must point at the missing ActivityScenario; got '$message'",
+        message.contains("ActivityScenario"),
       )
     } finally {
       session.close()

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/LifecycleRecordingScriptEventsTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/LifecycleRecordingScriptEventsTest.kt
@@ -1,7 +1,6 @@
 package ee.schimke.composeai.daemon
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -9,33 +8,42 @@ import org.junit.Test
  * Pins [LifecycleRecordingScriptEvents] — the Android-only lifecycle-driven script-event
  * descriptor that `RobolectricHost` advertises from `recordingScriptEventDescriptors()`.
  *
- * The split between supported transitions and roadmap (`destroy`) is also pinned in
- * [AndroidRecordingSessionTest] via `lifecycleEventReportsUnsupportedForUnknownTransition`; this
- * test keeps the descriptor side honest.
+ * Each supported transition has its own event id (`lifecycle.pause` / `lifecycle.resume` /
+ * `lifecycle.stop`) so the MCP validator can reject unknown transitions at the kind level. The
+ * dispatch routing is pinned in [AndroidRecordingSessionTest]; this test keeps the descriptor
+ * side honest.
  */
 class LifecycleRecordingScriptEventsTest {
 
   @Test
-  fun `descriptor advertises lifecycle event with supported = true`() {
+  fun `descriptor advertises one lifecycle event id per wired transition`() {
     val descriptor = LifecycleRecordingScriptEvents.descriptor
     assertEquals("lifecycle", descriptor.id.value)
-    val events = descriptor.recordingScriptEvents
-    assertEquals(1, events.size)
-    val lifecycleEvent = events.single()
-    assertEquals(LifecycleRecordingScriptEvents.LIFECYCLE_EVENT, lifecycleEvent.id)
+    val ids = descriptor.recordingScriptEvents.map { it.id }.toSet()
+    assertEquals(
+      setOf(
+        LifecycleRecordingScriptEvents.LIFECYCLE_PAUSE_EVENT,
+        LifecycleRecordingScriptEvents.LIFECYCLE_RESUME_EVENT,
+        LifecycleRecordingScriptEvents.LIFECYCLE_STOP_EVENT,
+      ),
+      ids,
+    )
+    val allSupported = descriptor.recordingScriptEvents.all { it.supported }
     assertTrue(
-      "lifecycle.event must advertise supported = true so record_preview accepts it on Android",
-      lifecycleEvent.supported,
+      "every wired lifecycle event id must advertise supported = true",
+      allSupported,
     )
   }
 
   @Test
-  fun `supported transitions cover pause resume stop without destroy`() {
-    val supported = LifecycleRecordingScriptEvents.SUPPORTED_LIFECYCLE_EVENTS
-    assertEquals(setOf("pause", "resume", "stop"), supported)
-    assertFalse(
+  fun `wired event set covers pause resume stop without destroy`() {
+    assertEquals(
+      setOf("lifecycle.pause", "lifecycle.resume", "lifecycle.stop"),
+      LifecycleRecordingScriptEvents.WIRED_EVENTS,
+    )
+    assertTrue(
       "destroy must stay out of v1 — moving the scenario to DESTROYED breaks subsequent renders",
-      "destroy" in supported,
+      "lifecycle.destroy" !in LifecycleRecordingScriptEvents.WIRED_EVENTS,
     )
   }
 

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/protocol/Messages.kt
@@ -1023,7 +1023,14 @@ data class RecordingScriptEvent(
   val label: String? = null,
   /** Agent-supplied checkpoint id for save/restore state markers. */
   val checkpointId: String? = null,
-  /** Lifecycle transition name for `kind = lifecycle`, e.g. `resume`, `pause`, or `destroy`. */
+  /**
+   * Vestigial after compose-ai-tools#754: the legacy `kind = "lifecycle.event"` /
+   * `lifecycleEvent: <transition>` shape was split into per-id events (`lifecycle.pause` /
+   * `lifecycle.resume` / `lifecycle.stop`), so no handler reads this field anymore. Retained on
+   * the wire as a free-form passthrough — agents that set it for trace context still see it
+   * round-trip into [RecordingScriptEvidence.lifecycleEvent]. Future cleanup may remove the
+   * field entirely.
+   */
   val lifecycleEvent: String? = null,
   /** Optional free-form tags copied into script evidence. */
   val tags: List<String> = emptyList(),

--- a/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
+++ b/data/render/core/src/main/kotlin/ee/schimke/composeai/data/render/extensions/DataExtensionPlan.kt
@@ -253,7 +253,6 @@ object RecordingScriptDataExtensions {
   const val STATE_SAVE_EVENT: String = "state.save"
   const val STATE_RESTORE_EVENT: String = "state.restore"
   const val PREVIEW_RELOAD_EVENT: String = "preview.reload"
-  const val LIFECYCLE_EVENT: String = "lifecycle.event"
 
   /**
    * `recording.probe` descriptor with `supported = true`. Returned from each

--- a/skills/compose-preview-review/design/AGENT_AUDITS.md
+++ b/skills/compose-preview-review/design/AGENT_AUDITS.md
@@ -516,13 +516,13 @@ payload evidence and the state/parameter path you found in code.
 
 ### State restoration and lifecycle audit
 
-> **Capability split.** `recording.probe`, `lifecycle.event`, `preview.reload`, `state.recreate`,
-> `state.save`, and `state.restore` (all Android-only) are wired and `record_preview` accepts
-> them.
+> **Capability split.** `recording.probe`, `lifecycle.pause` / `lifecycle.resume` /
+> `lifecycle.stop`, `preview.reload`, `state.recreate`, `state.save`, and `state.restore` (all
+> Android-only) are wired and `record_preview` accepts them.
 >
 > **Choose between the state-shaped events:**
 >
-> - `lifecycle.event:pause` then `:resume` — verifies state survives an Android configuration
+> - `lifecycle.pause` then `lifecycle.resume` — verifies state survives an Android configuration
 >   change. The activity is intact across the round-trip; `remember` and `rememberSaveable`
 >   both survive.
 > - `state.recreate` — single-event round-trip. The composition is torn down and rebuilt;
@@ -557,8 +557,8 @@ lifecycle round-trip:
     "uri": "compose-preview://workspace/_app/com.example.StatefulPreview",
     "events": [
       { "tMs": 0,   "kind": "click", "pixelX": 120, "pixelY": 40 },
-      { "tMs": 200, "kind": "lifecycle.event", "lifecycleEvent": "pause" },
-      { "tMs": 200, "kind": "lifecycle.event", "lifecycleEvent": "resume" },
+      { "tMs": 200, "kind": "lifecycle.pause" },
+      { "tMs": 200, "kind": "lifecycle.resume" },
       { "tMs": 200, "kind": "recording.probe", "label": "after-resume" }
     ]
   }
@@ -572,8 +572,8 @@ events; that tests timing luck instead of state-survival semantics.
 
 Check:
 
-- `list_data_products` advertises `recording.probe` and `lifecycle.event` with `supported: true`
-  on the daemon under test.
+- `list_data_products` advertises `recording.probe`, `lifecycle.pause`, and `lifecycle.resume`
+  with `supported: true` on the daemon under test.
 - The recording metadata's `scriptEvents` for both lifecycle events report `status: "applied"`
   (each handler emits a message naming the transition).
 - Input events that should change state produce changed frames before the lifecycle round-trip
@@ -648,10 +648,10 @@ test of just the saveable path:
 
 A `rememberSaveable`-backed counter that survives `state.recreate` but resets under
 `preview.reload` is correctly wired; one that resets under both is missing the saveable
-configuration; one that resets under `state.recreate` but survives `lifecycle.event:pause`+
-`:resume` is suspect — the activity-level path is preserving state the saveable registry
-isn't, which usually points to retained-instance bookkeeping that won't survive a real config
-change.
+configuration; one that resets under `state.recreate` but survives `lifecycle.pause` +
+`lifecycle.resume` is suspect — the activity-level path is preserving state the saveable
+registry isn't, which usually points to retained-instance bookkeeping that won't survive a
+real config change.
 
 ### Accessibility-driven interaction audit
 


### PR DESCRIPTION
## Summary

Re-targets #755 to `main` (was previously merged into the `agent/a11y-merge-roadmap-into-supported` branch instead of main). Branch rebased onto `origin/main` so it stands alone — the a11y descriptor merge from #754 is unaffected.

The legacy shape `{ "kind": "lifecycle.event", "lifecycleEvent": "pause" }` is a payload-discriminated union dressed up as one event id — every other extension (`a11y.action.*`, `state.*`, `preview.*`) uses kind-level discrimination. Aligns lifecycle with the rest by splitting into three ids:

- `lifecycle.pause`   → `Lifecycle.State.STARTED` (drives `onPause`)
- `lifecycle.resume`  → `Lifecycle.State.RESUMED` (drives `onResume`)
- `lifecycle.stop`    → `Lifecycle.State.CREATED` (drives `onPause` + `onStop`)

`destroy` stays out (moving the scenario to DESTROYED mid-recording would tear it down). If we wire it later it lands as `lifecycle.destroy`.

## Wins

- The MCP validator rejects unknown `lifecycle.*` kinds at the descriptor closed-set check; no separate payload check needed inside the daemon.
- `list_data_products` shows three distinct events agents can use (self-documenting).
- The handler's three-stage payload-validation chain (blank → unsupported, unknown → unsupported, host-rejected → unsupported) collapses to one (host-rejected → unsupported).
- The `RecordingScriptEvent.lifecycleEvent` payload field becomes vestigial — retained as free-form passthrough metadata for now (round-trips into evidence) and documented for future removal.

## Mechanical changes

- `LifecycleRecordingScriptEvents` advertises three events instead of one. `LIFECYCLE_PAUSE_EVENT` / `LIFECYCLE_RESUME_EVENT` / `LIFECYCLE_STOP_EVENT` replace the single `LIFECYCLE_EVENT`. `WIRED_EVENTS` replaces `SUPPORTED_LIFECYCLE_EVENTS`.
- `AndroidRecordingSession.buildScriptHandlers` registers three handlers via a shared factory `lifecycleEventHandler(target)` — each entry pre-binds its target string so the dispatch body doesn't re-parse a payload field.
- `RecordingScriptDataExtensions.LIFECYCLE_EVENT` constant deleted (no callers).
- `RecordingScriptEvent.lifecycleEvent` KDoc updated to flag its vestigial status.
- `LifecycleRecordingScriptEventsTest` rewritten to pin the three-event descriptor.
- `AndroidRecordingSessionTest` lifecycle cases collapsed: happy path iterates the three wired ids and asserts each routes through `dispatchLifecycle` with its pre-bound target; miss-path asserts the host-rejected diagnostic. The two payload-level rejection tests disappear because there's no payload field anymore.
- `AGENT_AUDITS.md`'s state-restoration audit updated to use `lifecycle.pause` / `lifecycle.resume` in the example.

## Wire-format change

Yes — `kind: "lifecycle.event"` is no longer recognised. Agents using the old shape will get a `validateRecordingScriptKinds` rejection up front. The audit doc shows the new shape; no in-flight clients depend on the old one.

## Test plan

- [ ] `./gradlew :daemon:core:check :daemon:android:check :data-render-core:check` (couldn't run locally — sandbox network blocks JDK 17 install; CI is the verification path)
- [ ] CI: `format`, `test` jobs green
- [ ] `LifecycleRecordingScriptEventsTest` (rewritten): three test cases pin the new shape.
- [ ] `AndroidRecordingSessionTest` (collapsed cases): two test cases pin the dispatch routing.
- [ ] Manual smoke (post-merge): `record_preview` with `kind: "lifecycle.pause"` against an a11y-enabled Android daemon produces `applied` evidence; `kind: "lifecycle.event"` is rejected at MCP up front.

## Follow-ups

PR #3 in the chain — promote input events (`click`, `pointerDown`, etc.) into one-or-more `input.*` extensions. Removes the last special-case branch from the validator.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8qJtJESJvS4yoTB9PKtRF)_