### PR TITLE
Consolidate Gradle build tasks and improve daemon configuration

### DIFF
--- a/gradle-plugin/gradle.properties
+++ b/gradle-plugin/gradle.properties
@@ -1,3 +1,6 @@
+# Must match the root's `org.gradle.jvmargs` so a single Gradle daemon serves both roots.
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.parallel=true
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=fail
 org.gradle.caching=true

--- a/vscode-extension/.vscode/tasks.json
+++ b/vscode-extension/.vscode/tasks.json
@@ -26,8 +26,8 @@
             "command": "../gradlew",
             "args": [
                 "-p",
-                "../gradle-plugin",
-                "publishToMavenLocal"
+                "..",
+                ":gradle-plugin:publishToMavenLocal"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -47,6 +47,27 @@
                 "-p",
                 "..",
                 "publishToMavenLocal"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "group": "build",
+            "presentation": {
+                "reveal": "always",
+                "panel": "dedicated"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "gradle: F5 publish + install",
+            "type": "shell",
+            "command": "../gradlew",
+            "args": [
+                "-p",
+                "..",
+                "publishToMavenLocal",
+                ":gradle-plugin:publishToMavenLocal",
+                ":cli:installDist"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -108,10 +129,8 @@
             "dependsOrder": "sequence",
             "dependsOn": [
                 "npm: compile",
-                "gradle: publish plugin to mavenLocal",
-                "gradle: publish runtime artifacts to mavenLocal",
+                "gradle: F5 publish + install",
                 "extension: prepare artifact folder",
-                "gradle: install CLI dist",
                 "meshcore: install CLI"
             ],
             "group": {


### PR DESCRIPTION
## Summary
This PR consolidates multiple Gradle build tasks into a single unified task and improves Gradle daemon configuration for better build consistency across the workspace.

## Key Changes

- **Unified build task**: Combined "gradle: publish plugin to mavenLocal", "gradle: publish runtime artifacts to mavenLocal", and "gradle: install CLI dist" into a single "gradle: F5 publish + install" task that executes all three operations sequentially
- **Fixed Gradle path resolution**: Updated the publish plugin task to use relative path `..` with the full task path `:gradle-plugin:publishToMavenLocal` instead of `-p ../gradle-plugin`, ensuring correct execution from the vscode-extension directory
- **Gradle daemon configuration**: Added JVM arguments and parallel execution settings to `gradle-plugin/gradle.properties` to match the root project's configuration, ensuring a single Gradle daemon serves both build roots and improving build performance
- **Simplified F5 workflow**: Updated the "extension: prepare artifact" task dependencies to use the new consolidated task, reducing complexity and improving maintainability

## Implementation Details

The new consolidated task executes the following in sequence:
1. `publishToMavenLocal` - publishes runtime artifacts
2. `:gradle-plugin:publishToMavenLocal` - publishes the Gradle plugin
3. `:cli:installDist` - installs the CLI distribution

The Gradle daemon configuration ensures consistent JVM memory allocation (2GB) and UTF-8 encoding across both the root and gradle-plugin builds, preventing potential issues from mismatched configurations.

https://claude.ai/code/session_01FbdgNXK9wiLJeXGikgZwRk