### PR TITLE
refactor(input): promote input events into input.touch / input.keyboard / input.rsb extensions

### DIFF
--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSession.kt
@@ -246,13 +246,28 @@ class AndroidRecordingSession(
   private fun buildScriptHandlers(): RecordingScriptHandlerRegistry =
     RecordingScriptHandlerRegistry(
       buildMap {
-        put("click", interactiveDispatchHandler(InteractiveInputKind.CLICK))
-        put("pointerDown", interactiveDispatchHandler(InteractiveInputKind.POINTER_DOWN))
-        put("pointerMove", interactiveDispatchHandler(InteractiveInputKind.POINTER_MOVE))
-        put("pointerUp", interactiveDispatchHandler(InteractiveInputKind.POINTER_UP))
-        put("rotaryScroll", interactiveDispatchHandler(InteractiveInputKind.ROTARY_SCROLL))
-        put("keyDown", androidUnsupported("keyDown"))
-        put("keyUp", androidUnsupported("keyUp"))
+        put(
+          InputTouchRecordingScriptEvents.CLICK_EVENT,
+          interactiveDispatchHandler(InteractiveInputKind.CLICK),
+        )
+        put(
+          InputTouchRecordingScriptEvents.POINTER_DOWN_EVENT,
+          interactiveDispatchHandler(InteractiveInputKind.POINTER_DOWN),
+        )
+        put(
+          InputTouchRecordingScriptEvents.POINTER_MOVE_EVENT,
+          interactiveDispatchHandler(InteractiveInputKind.POINTER_MOVE),
+        )
+        put(
+          InputTouchRecordingScriptEvents.POINTER_UP_EVENT,
+          interactiveDispatchHandler(InteractiveInputKind.POINTER_UP),
+        )
+        put(
+          InputRsbRecordingScriptEvents.ROTARY_SCROLL_EVENT,
+          interactiveDispatchHandler(InteractiveInputKind.ROTARY_SCROLL),
+        )
+        put(InputKeyboardRecordingScriptEvents.KEY_DOWN_EVENT, androidUnsupported("keyDown"))
+        put(InputKeyboardRecordingScriptEvents.KEY_UP_EVENT, androidUnsupported("keyUp"))
         put(RecordingScriptDataExtensions.PROBE_EVENT, RecordingScriptEventHandler { e, _ ->
           appliedEvidence(e, "probe marker reached")
         })

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/InputRsbRecordingScriptEvents.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/InputRsbRecordingScriptEvents.kt
@@ -1,0 +1,44 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescriptor
+
+/**
+ * Rotary side-button (RSB) `record_preview` script events for Wear previews. One descriptor —
+ * `input.rsb` — advertising `input.rotaryScroll` as `supported = true` on the Android host.
+ *
+ * Lives in `:daemon:android` because RSB dispatch is Wear/Android-only — the held-rule loop's
+ * native `MotionEvent.SOURCE_ROTARY_ENCODER + ACTION_SCROLL` path doesn't have a desktop
+ * equivalent (`ImageComposeScene` exposes `sendPointerEvent` but no rotary channel). Only
+ * `RobolectricHost.recordingScriptEventDescriptors()` advertises this descriptor; desktop
+ * daemons skip it.
+ *
+ * The companion touch / keyboard descriptors live in `:daemon:core` since both backends share
+ * those contracts.
+ */
+object InputRsbRecordingScriptEvents {
+
+  const val ROTARY_SCROLL_EVENT: String = "input.rotaryScroll"
+
+  val descriptor: DataExtensionDescriptor =
+    DataExtensionDescriptor(
+      id = DataExtensionId("input.rsb"),
+      displayName = "Rotary side-button input",
+      recordingScriptEvents =
+        listOf(
+          RecordingScriptEventDescriptor(
+            id = ROTARY_SCROLL_EVENT,
+            displayName = "Rotary scroll",
+            summary =
+              "Synthesises a SOURCE_ROTARY_ENCODER MotionEvent and dispatches it to the focused " +
+                "Compose view. `scrollDeltaY` payload carries the wheel delta (positive = " +
+                "wheel-down). Wear-only — desktop daemons don't advertise this descriptor.",
+            supported = true,
+          )
+        ),
+    )
+
+  /** Convenience for the host's `recordingScriptEventDescriptors()` override. */
+  val descriptors: List<DataExtensionDescriptor> = listOf(descriptor)
+}

--- a/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
+++ b/daemon/android/src/main/kotlin/ee/schimke/composeai/daemon/RobolectricHost.kt
@@ -197,11 +197,13 @@ open class RobolectricHost(
    * dispatch:
    *
    * - `recording.probe` (renderer-agnostic) — the in-script timeline marker.
-   * - `lifecycle.event` (Android-only) — drives `ActivityScenario.moveToState(...)` against the
-   *   held rule's activity.
+   * - `input.touch` (renderer-agnostic) — pointer events through the held-rule loop.
+   * - `input.keyboard` (renderer-agnostic) — roadmap on every host; key dispatch isn't wired.
+   * - `input.rsb` (Android-only) — rotary side-button scroll on Wear previews.
+   * - `lifecycle.{pause,resume,stop}` (Android-only) — `ActivityScenario.moveToState(...)`.
    * - `preview.reload` (Android-only today) — forces a fresh composition via the held rule's
    *   `key(...)` reload counter.
-   * - `state.recreate` (Android-only today) — Compose-level save+restore round-trip via the
+   * - `state.{recreate,save,restore}` (Android-only today) — Compose-level save/restore via the
    *   held rule's `SaveableStateRegistry` bridge.
    *
    * The a11y action descriptors live in `:data-a11y-connector` and are concatenated into
@@ -214,6 +216,9 @@ open class RobolectricHost(
     if (supportsRecording)
       listOf(
         RecordingScriptDataExtensions.recordingDescriptor,
+        InputTouchRecordingScriptEvents.descriptor,
+        InputKeyboardRecordingScriptEvents.descriptor,
+        InputRsbRecordingScriptEvents.descriptor,
         LifecycleRecordingScriptEvents.descriptor,
         PreviewReloadRecordingScriptEvents.descriptor,
         StateRecordingScriptEvents.descriptor,

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/AndroidRecordingSessionTest.kt
@@ -68,7 +68,7 @@ class AndroidRecordingSessionTest {
       listOf(
         RecordingScriptEvent(
           tMs = 67L,
-          kind = "click",
+          kind = "input.click",
           pixelX = 4,
           pixelY = 4,
         )
@@ -86,7 +86,7 @@ class AndroidRecordingSessionTest {
   fun liveRecordingRoutesQueuedInputThroughTheSameRegistryAsScripted() {
     // Live mode used to call a separate `dispatchLiveInput` ladder; now both paths funnel through
     // `scriptHandlers.dispatch(...)`. Pin that the click in `liveInputs` reaches the same
-    // `interactive.dispatch(InteractiveInputParams)` call the scripted `kind = "click"` handler
+    // `interactive.dispatch(InteractiveInputParams)` call the scripted `kind = "input.click"` handler
     // makes — verifying the wireName translation + registry routing without standing up a real
     // Robolectric sandbox.
     val framesDir = tempFolder.newFolder("live-registry-frames")
@@ -200,7 +200,7 @@ class AndroidRecordingSessionTest {
           listOf(
             RecordingScriptEvent(
               tMs = 0L,
-              kind = "click",
+              kind = "input.click",
               pixelX = 1,
               pixelY = 1,
             )
@@ -280,7 +280,7 @@ class AndroidRecordingSessionTest {
         listOf(
           RecordingScriptEvent(
             tMs = 0L,
-            kind = "click",
+            kind = "input.click",
             pixelX = 1,
             pixelY = 1,
           ),
@@ -1118,7 +1118,7 @@ class AndroidRecordingSessionTest {
           listOf(
             RecordingScriptEvent(
               tMs = 67L,
-              kind = "click",
+              kind = "input.click",
               pixelX = INTERACTIVE_WIDTH_PX / 2,
               pixelY = INTERACTIVE_HEIGHT_PX / 2,
             )

--- a/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/InputRsbRecordingScriptEventsTest.kt
+++ b/daemon/android/src/test/kotlin/ee/schimke/composeai/daemon/InputRsbRecordingScriptEventsTest.kt
@@ -1,0 +1,35 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [InputRsbRecordingScriptEvents] — the Wear-only rotary side-button descriptor that
+ * `RobolectricHost` advertises (and `DesktopHost` doesn't). The matching wire-name id is also
+ * advertised through `INTERACTIVE_INPUT_KIND_BY_WIRE_NAME` so the typed live-mode dispatch path
+ * resolves to the same string.
+ */
+class InputRsbRecordingScriptEventsTest {
+
+  @Test
+  fun `descriptor advertises rotary scroll as supported`() {
+    val descriptor = InputRsbRecordingScriptEvents.descriptor
+    assertEquals("input.rsb", descriptor.id.value)
+    assertEquals(1, descriptor.recordingScriptEvents.size)
+    val rotary = descriptor.recordingScriptEvents.single()
+    assertEquals(InputRsbRecordingScriptEvents.ROTARY_SCROLL_EVENT, rotary.id)
+    assertTrue(
+      "input.rotaryScroll must advertise supported = true on the Wear-capable host",
+      rotary.supported,
+    )
+  }
+
+  @Test
+  fun `descriptors convenience list wraps the single descriptor`() {
+    assertEquals(
+      listOf(InputRsbRecordingScriptEvents.descriptor),
+      InputRsbRecordingScriptEvents.descriptors,
+    )
+  }
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputKeyboardRecordingScriptEvents.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputKeyboardRecordingScriptEvents.kt
@@ -1,0 +1,50 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescriptor
+
+/**
+ * Keyboard `record_preview` script events. One descriptor — `input.keyboard` — advertising
+ * `input.keyDown` and `input.keyUp` as **roadmap** (`supported = false`) on every host today.
+ * Desktop's `ImageComposeScene.sendKeyEvent` and Android's held-rule
+ * `KeyEvent.dispatchKeyEvent` are both wirable but neither is implemented yet — the existing
+ * input handlers register these as unsupported so the wire shape is documented while the
+ * dispatch side remains a follow-up.
+ *
+ * Lives in `:daemon:core` because the descriptor is renderer-agnostic — both backends will
+ * eventually advertise it from `recordingScriptEventDescriptors()` with `supported = true` once
+ * dispatch lands.
+ */
+object InputKeyboardRecordingScriptEvents {
+
+  const val KEY_DOWN_EVENT: String = "input.keyDown"
+  const val KEY_UP_EVENT: String = "input.keyUp"
+
+  val descriptor: DataExtensionDescriptor =
+    DataExtensionDescriptor(
+      id = DataExtensionId("input.keyboard"),
+      displayName = "Keyboard input",
+      recordingScriptEvents =
+        listOf(
+          RecordingScriptEventDescriptor(
+            id = KEY_DOWN_EVENT,
+            displayName = "Key down",
+            summary =
+              "Reserved for keyboard dispatch. Wire shape carries `keyCode`; daemon-side " +
+                "dispatch (Skiko `sendKeyEvent` on desktop, held-rule key event on Android) is " +
+                "a follow-up — both backends register this as unsupported today.",
+            supported = false,
+          ),
+          RecordingScriptEventDescriptor(
+            id = KEY_UP_EVENT,
+            displayName = "Key up",
+            summary = "Counterpart to keyDown; same dispatch follow-up.",
+            supported = false,
+          ),
+        ),
+    )
+
+  /** Convenience for the host's `recordingScriptEventDescriptors()` override. */
+  val descriptors: List<DataExtensionDescriptor> = listOf(descriptor)
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputTouchRecordingScriptEvents.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/InputTouchRecordingScriptEvents.kt
@@ -1,0 +1,77 @@
+package ee.schimke.composeai.daemon
+
+import ee.schimke.composeai.data.render.extensions.DataExtensionDescriptor
+import ee.schimke.composeai.data.render.extensions.DataExtensionId
+import ee.schimke.composeai.data.render.extensions.RecordingScriptEventDescriptor
+
+/**
+ * Touch / pointer-input `record_preview` script events. One descriptor — `input.touch` —
+ * advertising the four pointer-shaped event ids both backends dispatch:
+ *
+ * - `input.click` — Press → render-tick → Release at the same image-natural pixel position.
+ *   `Modifier.clickable {}` and primary-button-filtered tap-gesture detectors fire.
+ * - `input.pointerDown` — `PointerEventType.Press` only.
+ * - `input.pointerMove` — `PointerEventType.Move` with the primary button held.
+ * - `input.pointerUp` — `PointerEventType.Release`.
+ *
+ * Lives in `:daemon:core` because both `DesktopHost` and `RobolectricHost` dispatch this
+ * extension. Each host advertises the same descriptor from `recordingScriptEventDescriptors()`;
+ * the dispatch end is host-specific (Skiko `sendPointerEvent` on desktop, the held-rule's
+ * pointer pipeline on Android), but the descriptor advertisement is uniform.
+ *
+ * **Why split from `input.keyboard` and `input.rsb`.** Per-axis splits let each host advertise
+ * the exact subset it dispatches: desktop carries `input.touch` + `input.keyboard` (latter as
+ * roadmap); RobolectricHost carries `input.touch` + `input.keyboard` + `input.rsb`. One blanket
+ * `input` extension would force per-host descriptor variants with different `supported` flags
+ * — the per-axis split keeps the descriptors uniform across hosts and the per-host advertisement
+ * trivially additive.
+ */
+object InputTouchRecordingScriptEvents {
+
+  const val CLICK_EVENT: String = "input.click"
+  const val POINTER_DOWN_EVENT: String = "input.pointerDown"
+  const val POINTER_MOVE_EVENT: String = "input.pointerMove"
+  const val POINTER_UP_EVENT: String = "input.pointerUp"
+
+  /** All wired touch event ids. */
+  val WIRED_EVENTS: Set<String> =
+    setOf(CLICK_EVENT, POINTER_DOWN_EVENT, POINTER_MOVE_EVENT, POINTER_UP_EVENT)
+
+  val descriptor: DataExtensionDescriptor =
+    DataExtensionDescriptor(
+      id = DataExtensionId("input.touch"),
+      displayName = "Touch / pointer input",
+      recordingScriptEvents =
+        listOf(
+          RecordingScriptEventDescriptor(
+            id = CLICK_EVENT,
+            displayName = "Click",
+            summary =
+              "Press → render-tick → Release at the same image-natural pixel position. " +
+                "`Modifier.clickable {}` and primary-button-filtered tap-gesture detectors fire.",
+            supported = true,
+          ),
+          RecordingScriptEventDescriptor(
+            id = POINTER_DOWN_EVENT,
+            displayName = "Pointer down",
+            summary = "PointerEventType.Press at the supplied pixelX/pixelY.",
+            supported = true,
+          ),
+          RecordingScriptEventDescriptor(
+            id = POINTER_MOVE_EVENT,
+            displayName = "Pointer move",
+            summary = "PointerEventType.Move with the primary button held.",
+            supported = true,
+          ),
+          RecordingScriptEventDescriptor(
+            id = POINTER_UP_EVENT,
+            displayName = "Pointer up",
+            summary = "PointerEventType.Release at the supplied pixelX/pixelY.",
+            supported = true,
+          ),
+        ),
+    )
+
+  /** Convenience for the host's `recordingScriptEventDescriptors()` override. */
+  val descriptors: List<DataExtensionDescriptor> = listOf(descriptor)
+}

--- a/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
+++ b/daemon/core/src/main/kotlin/ee/schimke/composeai/daemon/RecordingSession.kt
@@ -131,24 +131,26 @@ fun String.toInteractiveInputKindOrNull(): InteractiveInputKind? =
   INTERACTIVE_INPUT_KIND_BY_WIRE_NAME[this]
 
 /**
- * Wire-name table for [InteractiveInputKind]. Single source of truth shared by the daemon's
- * recording sessions ([toInteractiveInputKindOrNull]) and the MCP server's `record_preview`
- * validator. Adding a new enum constant + wire name extends both call sites automatically — there's
- * no separate hard-coded set to keep in sync.
+ * Wire-name table for [InteractiveInputKind]. Single source of truth for the recording-script
+ * `kind` strings these enum values map to — used by the live-mode tick loops' `wireName()`
+ * synthesis and the registry's per-kind handler lookup.
+ *
+ * Naming follows the per-extension `<extension>.<event>` convention: `input.click`,
+ * `input.pointerDown`, etc. Three input extensions advertise these ids — see
+ * `InputTouchRecordingScriptEvents`, `InputKeyboardRecordingScriptEvents`, and
+ * `InputRsbRecordingScriptEvents`. The MCP `validateRecordingScriptKinds` checks every kind
+ * against the daemon's advertised set — no special-case branch for input kinds anymore.
  */
 val INTERACTIVE_INPUT_KIND_BY_WIRE_NAME: Map<String, InteractiveInputKind> =
   mapOf(
-    "click" to InteractiveInputKind.CLICK,
-    "pointerDown" to InteractiveInputKind.POINTER_DOWN,
-    "pointerMove" to InteractiveInputKind.POINTER_MOVE,
-    "pointerUp" to InteractiveInputKind.POINTER_UP,
-    "rotaryScroll" to InteractiveInputKind.ROTARY_SCROLL,
-    "keyDown" to InteractiveInputKind.KEY_DOWN,
-    "keyUp" to InteractiveInputKind.KEY_UP,
+    "input.click" to InteractiveInputKind.CLICK,
+    "input.pointerDown" to InteractiveInputKind.POINTER_DOWN,
+    "input.pointerMove" to InteractiveInputKind.POINTER_MOVE,
+    "input.pointerUp" to InteractiveInputKind.POINTER_UP,
+    "input.rotaryScroll" to InteractiveInputKind.ROTARY_SCROLL,
+    "input.keyDown" to InteractiveInputKind.KEY_DOWN,
+    "input.keyUp" to InteractiveInputKind.KEY_UP,
   )
-
-/** Wire-name set derived from [INTERACTIVE_INPUT_KIND_BY_WIRE_NAME]. */
-val INTERACTIVE_INPUT_KIND_WIRE_NAMES: Set<String> = INTERACTIVE_INPUT_KIND_BY_WIRE_NAME.keys
 
 /**
  * Reverse lookup — typed [InteractiveInputKind] back to its wire-name string. Used by live-mode

--- a/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InputRecordingScriptEventsTest.kt
+++ b/daemon/core/src/test/kotlin/ee/schimke/composeai/daemon/InputRecordingScriptEventsTest.kt
@@ -1,0 +1,90 @@
+package ee.schimke.composeai.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins [InputTouchRecordingScriptEvents] and [InputKeyboardRecordingScriptEvents] — the
+ * renderer-agnostic input-event descriptors that hosts advertise from
+ * `recordingScriptEventDescriptors()`. The Wear-only `input.rsb` extension is pinned in its own
+ * Android-side test (`InputRsbRecordingScriptEventsTest`).
+ *
+ * The wire-name strings here also have to match the keys of [INTERACTIVE_INPUT_KIND_BY_WIRE_NAME]
+ * so the live-mode `RecordingInputParams` synthesis path translates the typed
+ * [InteractiveInputKind] enum to the same id the descriptor advertises.
+ */
+class InputRecordingScriptEventsTest {
+
+  @Test
+  fun `input touch advertises four pointer events as supported`() {
+    val descriptor = InputTouchRecordingScriptEvents.descriptor
+    assertEquals("input.touch", descriptor.id.value)
+    val ids = descriptor.recordingScriptEvents.map { it.id }.toSet()
+    assertEquals(
+      setOf(
+        InputTouchRecordingScriptEvents.CLICK_EVENT,
+        InputTouchRecordingScriptEvents.POINTER_DOWN_EVENT,
+        InputTouchRecordingScriptEvents.POINTER_MOVE_EVENT,
+        InputTouchRecordingScriptEvents.POINTER_UP_EVENT,
+      ),
+      ids,
+    )
+    val allSupported = descriptor.recordingScriptEvents.all { it.supported }
+    assertTrue(
+      "every input.touch entry must advertise supported = true on every host that advertises this",
+      allSupported,
+    )
+  }
+
+  @Test
+  fun `input touch wire-name set is the public WIRED_EVENTS`() {
+    assertEquals(
+      InputTouchRecordingScriptEvents.descriptor.recordingScriptEvents.map { it.id }.toSet(),
+      InputTouchRecordingScriptEvents.WIRED_EVENTS,
+    )
+  }
+
+  @Test
+  fun `input keyboard advertises both keys as roadmap`() {
+    val descriptor = InputKeyboardRecordingScriptEvents.descriptor
+    assertEquals("input.keyboard", descriptor.id.value)
+    val ids = descriptor.recordingScriptEvents.map { it.id }.toSet()
+    assertEquals(
+      setOf(
+        InputKeyboardRecordingScriptEvents.KEY_DOWN_EVENT,
+        InputKeyboardRecordingScriptEvents.KEY_UP_EVENT,
+      ),
+      ids,
+    )
+    val anySupported = descriptor.recordingScriptEvents.any { it.supported }
+    assertFalse(
+      "input.keyboard must stay supported = false until key dispatch lands on either backend",
+      anySupported,
+    )
+  }
+
+  @Test
+  fun `wire-name table aligns with input descriptor ids for every typed enum`() {
+    // Live mode synthesises a recording-script event from a typed `RecordingInputParams` via
+    // `kind.wireName()`. Each enum entry must map to a wire-name string the descriptor side
+    // also advertises — otherwise the registry's lookup misses and the event silently falls
+    // through to the unsupported branch.
+    val advertisedTouchIds = InputTouchRecordingScriptEvents.WIRED_EVENTS
+    val advertisedKeyboardIds =
+      InputKeyboardRecordingScriptEvents.descriptor.recordingScriptEvents
+        .map { it.id }
+        .toSet()
+    // input.rotaryScroll is advertised by the Android-only `input.rsb` extension; check it via
+    // the wire-name table without depending on the Android module here.
+    val rotaryWireName = "input.rotaryScroll"
+    val totalWireNames = advertisedTouchIds + advertisedKeyboardIds + rotaryWireName
+    assertEquals(
+      "every InteractiveInputKind enum must have a matching wire name advertised by an input " +
+        "extension",
+      InteractiveInputKind.entries.map { it.wireName() }.toSet(),
+      totalWireNames,
+    )
+  }
+}

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopHost.kt
@@ -153,13 +153,23 @@ open class DesktopHost(
         }
 
   /**
-   * `recording.probe` is the only extension event [DesktopRecordingSession] dispatches today; click
-   * / pointer kinds are built-in inputs, not extensions. The descriptor is empty when the host
-   * can't actually allocate a session ([supportsRecording] = false) so agents don't see supported =
-   * true on a daemon that would reject `recording/start` anyway.
+   * Script-event descriptors this host's [DesktopRecordingSession] dispatches:
+   *
+   * - `recording.probe` — timeline marker.
+   * - `input.touch` — click + pointer up/down/move via `ImageComposeScene.sendPointerEvent`.
+   * - `input.keyboard` — advertised as roadmap (supported = false); key dispatch isn't wired.
+   *
+   * `input.rsb` is Wear-only and lives on `RobolectricHost`; desktop daemons skip it. The empty
+   * list when [supportsRecording] is `false` mirrors the `supportedRecordingFormats` shape so
+   * agents don't see supported = true on a daemon that would reject `recording/start` anyway.
    */
   override fun recordingScriptEventDescriptors(): List<DataExtensionDescriptor> =
-    if (supportsRecording) listOf(RecordingScriptDataExtensions.recordingDescriptor)
+    if (supportsRecording)
+      listOf(
+        RecordingScriptDataExtensions.recordingDescriptor,
+        InputTouchRecordingScriptEvents.descriptor,
+        InputKeyboardRecordingScriptEvents.descriptor,
+      )
     else emptyList()
 
   /**

--- a/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
+++ b/daemon/desktop/src/main/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSession.kt
@@ -274,13 +274,22 @@ class DesktopRecordingSession(
   private fun buildScriptHandlers(): RecordingScriptHandlerRegistry =
     RecordingScriptHandlerRegistry(
       buildMap {
-        put("click", clickHandler())
-        put("pointerDown", pointerHandler(PointerEventType.Press))
-        put("pointerMove", pointerHandler(PointerEventType.Move))
-        put("pointerUp", pointerHandler(PointerEventType.Release))
-        put("rotaryScroll", desktopUnsupported("rotary scroll"))
-        put("keyDown", desktopUnsupported("keyDown"))
-        put("keyUp", desktopUnsupported("keyUp"))
+        put(InputTouchRecordingScriptEvents.CLICK_EVENT, clickHandler())
+        put(
+          InputTouchRecordingScriptEvents.POINTER_DOWN_EVENT,
+          pointerHandler(PointerEventType.Press),
+        )
+        put(
+          InputTouchRecordingScriptEvents.POINTER_MOVE_EVENT,
+          pointerHandler(PointerEventType.Move),
+        )
+        put(
+          InputTouchRecordingScriptEvents.POINTER_UP_EVENT,
+          pointerHandler(PointerEventType.Release),
+        )
+        put("input.rotaryScroll", desktopUnsupported("rotary scroll"))
+        put(InputKeyboardRecordingScriptEvents.KEY_DOWN_EVENT, desktopUnsupported("keyDown"))
+        put(InputKeyboardRecordingScriptEvents.KEY_UP_EVENT, desktopUnsupported("keyUp"))
         put(
           RecordingScriptDataExtensions.PROBE_EVENT,
           RecordingScriptEventHandler { e, _ -> appliedEvidence(e, "probe marker reached") },

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopHostTest.kt
@@ -108,19 +108,19 @@ class DesktopHostTest {
   }
 
   /**
-   * With a resolver wired, `recordingScriptEventDescriptors()` advertises only `recording.probe`
-   * (supported = true). Roadmap descriptors stay out of the host contribution — they're appended
-   * separately by DaemonMain.
+   * With a resolver wired, `recordingScriptEventDescriptors()` advertises three extensions:
+   * `recording` (probe, supported), `input.touch` (4 pointer events, supported), and
+   * `input.keyboard` (2 key events, roadmap). The Wear-only `input.rsb` lives on the Android
+   * host; desktop daemons skip it.
    */
   @Test
-  fun recordingScriptEventDescriptorsAdvertiseProbeWhenResolverPresent() {
+  fun recordingScriptEventDescriptorsAdvertiseSupportedExtensions() {
     val descriptors = DesktopHost(previewSpecResolver = { null }).recordingScriptEventDescriptors()
-    assertEquals(1, descriptors.size)
-    val recording = descriptors.single()
-    assertEquals("recording", recording.id.value)
-    assertEquals(1, recording.recordingScriptEvents.size)
-    val probe = recording.recordingScriptEvents.single()
-    assertEquals("recording.probe", probe.id)
-    assertTrue("desktop must advertise recording.probe as supported", probe.supported)
+    val advertisedExtensionIds = descriptors.map { it.id.value }.toSet()
+    assertEquals(setOf("recording", "input.touch", "input.keyboard"), advertisedExtensionIds)
+    assertTrue(
+      "input.rsb is Wear-only and must NOT appear on the desktop host",
+      "input.rsb" !in advertisedExtensionIds,
+    )
   }
 }

--- a/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
+++ b/daemon/desktop/src/test/kotlin/ee/schimke/composeai/daemon/DesktopRecordingSessionTest.kt
@@ -95,13 +95,13 @@ class DesktopRecordingSessionTest {
           listOf(
             RecordingScriptEvent(
               tMs = 0L,
-              kind = "click",
+              kind = "input.click",
               pixelX = COMPONENT_WIDTH_PX / 2,
               pixelY = COMPONENT_HEIGHT_PX / 2,
             ),
             RecordingScriptEvent(
               tMs = 500L,
-              kind = "click",
+              kind = "input.click",
               pixelX = COMPONENT_WIDTH_PX / 2,
               pixelY = COMPONENT_HEIGHT_PX / 2,
             ),
@@ -226,7 +226,7 @@ class DesktopRecordingSessionTest {
           listOf(
             RecordingScriptEvent(
               tMs = 0L,
-              kind = "click",
+              kind = "input.click",
               pixelX = COMPONENT_WIDTH_PX / 2,
               pixelY = COMPONENT_HEIGHT_PX / 2,
             )
@@ -315,13 +315,13 @@ class DesktopRecordingSessionTest {
           listOf(
             RecordingScriptEvent(
               tMs = 0L,
-              kind = "click",
+              kind = "input.click",
               pixelX = COMPONENT_WIDTH_PX / 2,
               pixelY = COMPONENT_HEIGHT_PX / 2,
             ),
             RecordingScriptEvent(
               tMs = 200L,
-              kind = "click",
+              kind = "input.click",
               pixelX = COMPONENT_WIDTH_PX / 2,
               pixelY = COMPONENT_HEIGHT_PX / 2,
             ),
@@ -525,7 +525,9 @@ class DesktopRecordingSessionTest {
         )
       try {
         val thrown =
-          runCatching { session.postScript(listOf(RecordingScriptEvent(tMs = 0L, kind = "click"))) }
+          runCatching {
+            session.postScript(listOf(RecordingScriptEvent(tMs = 0L, kind = "input.click")))
+          }
             .exceptionOrNull()
         assertTrue(
           "postScript on a live session must throw IllegalStateException; got ${thrown?.javaClass}",

--- a/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
+++ b/mcp/src/main/kotlin/ee/schimke/composeai/mcp/DaemonMcpServer.kt
@@ -1,6 +1,5 @@
 package ee.schimke.composeai.mcp
 
-import ee.schimke.composeai.daemon.INTERACTIVE_INPUT_KIND_WIRE_NAMES
 import ee.schimke.composeai.daemon.protocol.ChangeType
 import ee.schimke.composeai.daemon.protocol.FileKind
 import ee.schimke.composeai.daemon.protocol.Material3ThemeOverrides
@@ -1128,7 +1127,7 @@ class DaemonMcpServer(
                     "type":"object",
                     "properties":{
                       "tMs":{"type":"integer","description":"Virtual time offset from recording/start, in milliseconds. Must be ≥ 0."},
-                      "kind":{"type":"string","description":"Input event kind (`click`, `pointerDown`, `pointerMove`, `pointerUp`, `rotaryScroll`, `keyDown`, `keyUp`) or a namespaced data-extension script event id the daemon advertises with `supported = true` — `recording.probe` is the only one wired today; `state.save`, `state.restore`, `lifecycle.event`, and `preview.reload` appear in `list_data_products` as roadmap entries (`supported = false`) and are rejected up front by record_preview."},
+                      "kind":{"type":"string","description":"Namespaced script-event id from `list_data_products`. Every event — input (`input.click`, `input.pointerDown`, `input.rotaryScroll`, …), accessibility actions (`a11y.action.click`, …), lifecycle (`lifecycle.pause`/`resume`/`stop`), state (`state.recreate`/`save`/`restore`), `preview.reload`, `recording.probe` — is advertised in the daemon's `dataExtensions[].recordingScriptEvents[]`. Only entries with `supported = true` are accepted; `supported = false` entries are roadmap and rejected up front."},
                       "pixelX":{"type":"integer","description":"X coord in image-natural pixel space (the preview's own widthPx)."},
                       "pixelY":{"type":"integer","description":"Y coord in image-natural pixel space."},
                       "scrollDeltaY":{"type":"number","description":"For 'rotaryScroll'."},
@@ -2633,28 +2632,27 @@ class DaemonMcpServer(
     }
 
   /**
-   * Per-event closed-set validation against the resolved daemon's advertised capabilities.
+   * Per-event closed-set validation against the resolved daemon's advertised capabilities. Every
+   * recording-script event id (input + extension events alike) is checked against
+   * `ServerCapabilities.dataExtensions[].recordingScriptEvents[]`:
    *
-   * Events fall into two buckets:
-   * 1. **Input kinds** — `click`, `pointerDown`, `pointerMove`, `pointerUp`, `rotaryScroll`,
-   *    `keyDown`, `keyUp`. Sourced from [INTERACTIVE_INPUT_KIND_WIRE_NAMES] (the same enum
-   *    [InteractiveInputKind] the daemon dispatches against). Always accepted at the MCP layer; the
-   *    daemon's recording session decides what to actually do with each (e.g. desktop returns
-   *    `unsupported` for `keyDown` until key dispatch lands).
-   * 2. **Extension events** — namespaced ids advertised in
-   *    `ServerCapabilities.dataExtensions[].recordingScriptEvents[]`. We accept only those flagged
-   *    `supported = true` by the daemon. Advertising an event with `supported = false` is the
-   *    daemon's roadmap signal — agents see it via `list_data_products` so they know what's
-   *    planned, but the script wrapper rejects it up front rather than letting the agent watch a
-   *    quiet `unsupported` evidence trail come back. (The daemon-side fallback that emits
-   *    `unsupported` evidence stays in place as defense-in-depth for older MCP servers + direct
-   *    daemon clients.)
+   * - **`supported = true`** — accepted; the daemon will dispatch.
+   * - **`supported = false`** — rejected with a precise diagnostic that points at
+   *   `list_data_products` so the agent sees the roadmap shape rather than a quiet `unsupported`
+   *   evidence trail. (The daemon-side fallback that emits `unsupported` evidence stays in
+   *   place as defense-in-depth for older MCP servers + direct daemon clients.)
+   * - **Not advertised** — rejected with "not advertised by this daemon".
+   *
+   * Input kinds (`input.click`, `input.pointerDown`, …) are advertised through
+   * `InputTouchRecordingScriptEvents` / `InputKeyboardRecordingScriptEvents` /
+   * `InputRsbRecordingScriptEvents` — same code path as every other extension. No special-case
+   * branch.
    */
   private fun validateRecordingScriptKinds(
     events: List<RecordingScriptEvent>,
     daemon: SupervisedDaemon,
   ): List<String> {
-    val supportedExtensionEventIds =
+    val supportedEventIds =
       daemon.dataExtensionDescriptors
         .flatMap { it.recordingScriptEvents }
         .filter { it.supported }
@@ -2668,15 +2666,13 @@ class DaemonMcpServer(
         .toSet()
     return events.mapIndexedNotNull { index, event ->
       when {
-        event.kind in INTERACTIVE_INPUT_KIND_WIRE_NAMES -> null
-        event.kind in supportedExtensionEventIds -> null
+        event.kind in supportedEventIds -> null
         event.kind in advertisedButUnsupported ->
-          "event[$index] extension script event '${event.kind}' is advertised by this daemon but " +
-            "not yet implemented (supported=false); list_data_products to inspect the roadmap"
+          "event[$index] script event '${event.kind}' is advertised by this daemon but not yet " +
+            "implemented (supported=false); list_data_products to inspect the roadmap"
         else ->
-          "event[$index] kind '${event.kind}' is not a recognised input event " +
-            "(${INTERACTIVE_INPUT_KIND_WIRE_NAMES.sorted()}) and not advertised by this daemon as " +
-            "an extension event"
+          "event[$index] kind '${event.kind}' is not advertised by this daemon. Call " +
+            "list_data_products to see the available script-event ids."
       }
     }
   }

--- a/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
+++ b/mcp/src/test/kotlin/ee/schimke/composeai/mcp/DaemonMcpServerTest.kt
@@ -895,7 +895,8 @@ class DaemonMcpServerTest {
       d.recordingEncodedBytes = cannedApngBytes
       d.recordingEncodeDir = recordingsDir
       d.advertisedDataExtensions =
-        ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions.descriptors
+        ee.schimke.composeai.data.render.extensions.RecordingScriptDataExtensions.descriptors +
+          ee.schimke.composeai.daemon.InputTouchRecordingScriptEvents.descriptor
       d.recordingStopResult =
         ee.schimke.composeai.daemon.protocol.RecordingStopResult(
           frameCount = 16,
@@ -937,7 +938,7 @@ class DaemonMcpServerTest {
             add(
               buildJsonObject {
                 put("tMs", 0)
-                put("kind", "click")
+                put("kind", "input.click")
                 put("pixelX", 120)
                 put("pixelY", 40)
               }
@@ -945,7 +946,7 @@ class DaemonMcpServerTest {
             add(
               buildJsonObject {
                 put("tMs", 500)
-                put("kind", "click")
+                put("kind", "input.click")
                 put("pixelX", 120)
                 put("pixelY", 40)
               }
@@ -983,7 +984,7 @@ class DaemonMcpServerTest {
     assertThat(scriptCall).isNotNull()
     assertThat(scriptCall!!.events).hasSize(3)
     assertThat(scriptCall.events[0].tMs).isEqualTo(0L)
-    assertThat(scriptCall.events[0].kind).isEqualTo("click")
+    assertThat(scriptCall.events[0].kind).isEqualTo("input.click")
     assertThat(scriptCall.events[0].pixelX).isEqualTo(120)
     assertThat(scriptCall.events[0].pixelY).isEqualTo(40)
     assertThat(scriptCall.events[1].tMs).isEqualTo(500L)
@@ -1089,7 +1090,7 @@ class DaemonMcpServerTest {
             add(
               buildJsonObject {
                 put("tMs", 0)
-                put("kind", "scroll") // not a recognised InteractiveInputKind
+                put("kind", "scroll") // not a wire-name id any extension advertises
                 put("pixelX", 10)
                 put("pixelY", 10)
               }
@@ -1099,8 +1100,8 @@ class DaemonMcpServerTest {
       )
     assertThat(resp.isError()).isTrue()
     val msg = resp.firstTextContent()
-    assertThat(msg).contains("kind 'scroll' is not a recognised input event")
-    assertThat(msg).contains("not advertised by this daemon")
+    assertThat(msg).contains("kind 'scroll' is not advertised by this daemon")
+    assertThat(msg).contains("list_data_products")
     // No daemon-side recording session should have been allocated when validation fails.
     assertThat(daemon.recordingStarts).isEmpty()
   }
@@ -1227,6 +1228,8 @@ class DaemonMcpServerTest {
     val recordingsDir = tmp.newFolder("mp4-recordings-out")
     factory.daemonConfigurer = { d ->
       d.advertisedRecordingFormats = listOf("apng", "mp4", "webm")
+      d.advertisedDataExtensions =
+        listOf(ee.schimke.composeai.daemon.InputTouchRecordingScriptEvents.descriptor)
       d.recordingEncodeDir = recordingsDir
       // Tiny canned payload — content doesn't matter for the wire-shape assertion.
       d.recordingEncodedBytes =
@@ -1261,7 +1264,7 @@ class DaemonMcpServerTest {
             add(
               buildJsonObject {
                 put("tMs", 0)
-                put("kind", "click")
+                put("kind", "input.click")
                 put("pixelX", 10)
                 put("pixelY", 10)
               }

--- a/skills/compose-preview-review/design/AGENT_AUDITS.md
+++ b/skills/compose-preview-review/design/AGENT_AUDITS.md
@@ -556,7 +556,7 @@ lifecycle round-trip:
   "arguments": {
     "uri": "compose-preview://workspace/_app/com.example.StatefulPreview",
     "events": [
-      { "tMs": 0,   "kind": "click", "pixelX": 120, "pixelY": 40 },
+      { "tMs": 0,   "kind": "input.click", "pixelX": 120, "pixelY": 40 },
       { "tMs": 200, "kind": "lifecycle.pause" },
       { "tMs": 200, "kind": "lifecycle.resume" },
       { "tMs": 200, "kind": "recording.probe", "label": "after-resume" }
@@ -593,7 +593,7 @@ is the kind of thing this variant catches:
   "arguments": {
     "uri": "compose-preview://workspace/_app/com.example.StatefulPreview",
     "events": [
-      { "tMs": 0,   "kind": "click", "pixelX": 120, "pixelY": 40 },
+      { "tMs": 0,   "kind": "input.click", "pixelX": 120, "pixelY": 40 },
       { "tMs": 200, "kind": "preview.reload" },
       { "tMs": 200, "kind": "recording.probe", "label": "after-reload" }
     ]
@@ -611,9 +611,9 @@ A, verify return-trip behaves correctly:
   "arguments": {
     "uri": "compose-preview://workspace/_app/com.example.StatefulPreview",
     "events": [
-      { "tMs": 0,   "kind": "click", "pixelX": 120, "pixelY": 40 },
+      { "tMs": 0,   "kind": "input.click", "pixelX": 120, "pixelY": 40 },
       { "tMs": 100, "kind": "state.save", "checkpointId": "after-first-click" },
-      { "tMs": 200, "kind": "click", "pixelX": 120, "pixelY": 40 },
+      { "tMs": 200, "kind": "input.click", "pixelX": 120, "pixelY": 40 },
       { "tMs": 300, "kind": "state.save", "checkpointId": "after-second-click" },
       { "tMs": 400, "kind": "state.restore", "checkpointId": "after-first-click" },
       { "tMs": 400, "kind": "recording.probe", "label": "after-restore-to-first" }
@@ -638,7 +638,7 @@ test of just the saveable path:
   "arguments": {
     "uri": "compose-preview://workspace/_app/com.example.StatefulPreview",
     "events": [
-      { "tMs": 0,   "kind": "click", "pixelX": 120, "pixelY": 40 },
+      { "tMs": 0,   "kind": "input.click", "pixelX": 120, "pixelY": 40 },
       { "tMs": 200, "kind": "state.recreate" },
       { "tMs": 200, "kind": "recording.probe", "label": "after-recreate" }
     ]

--- a/skills/compose-preview-review/scripts/run-agent-audit-samples.py
+++ b/skills/compose-preview-review/scripts/run-agent-audit-samples.py
@@ -529,7 +529,7 @@ def test_mcp_data_products() -> None:
                 "events": [
                     {
                         "tMs": 0,
-                        "kind": "click",
+                        "kind": "input.click",
                         "pixelX": 48,
                         "pixelY": 24,
                     },

--- a/skills/compose-preview/design/CAPTURE_MODES.md
+++ b/skills/compose-preview/design/CAPTURE_MODES.md
@@ -129,8 +129,8 @@ enough to define the recording duration:
   "scale": 1.0,
   "format": "apng",
   "events": [
-    { "tMs": 0, "kind": "pointerDown", "pixelX": 227, "pixelY": 227 },
-    { "tMs": 1200, "kind": "pointerUp", "pixelX": 227, "pixelY": 227 }
+    { "tMs": 0, "kind": "input.pointerDown", "pixelX": 227, "pixelY": 227 },
+    { "tMs": 1200, "kind": "input.pointerUp", "pixelX": 227, "pixelY": 227 }
   ]
 }
 ```
@@ -145,7 +145,7 @@ front (compose-ai-tools#714).
 {
   "uri": "compose-preview://<workspace>/<module>/<preview>",
   "events": [
-    { "tMs": 0, "kind": "click", "pixelX": 120, "pixelY": 40 },
+    { "tMs": 0, "kind": "input.click", "pixelX": 120, "pixelY": 40 },
     { "tMs": 200, "kind": "recording.probe", "label": "after-click" }
   ]
 }


### PR DESCRIPTION
## Summary

Third of three model-cleanup PRs (alongside #754 and #760, both targeting main). Closes the last hard-coded special-case in the recording-script model. The 7 input kinds (`click`, `pointerDown`, `pointerMove`, `pointerUp`, `rotaryScroll`, `keyDown`, `keyUp`) used to live outside the extension framework — `INTERACTIVE_INPUT_KIND_WIRE_NAMES` was a hand-rolled set checked separately by `validateRecordingScriptKinds`. After this PR they're just three more extensions advertised via `recordingScriptEventDescriptors()`, and the validator's special branch goes away.

## Three input extensions, applicability per host

| Extension | Events | Desktop | Android |
|-----------|--------|---------|---------|
| `input.touch` | `click`, `pointerDown`, `pointerMove`, `pointerUp` | supported | supported |
| `input.keyboard` | `keyDown`, `keyUp` | roadmap | roadmap |
| `input.rsb` | `rotaryScroll` | (skipped) | supported |

`InputTouchRecordingScriptEvents` and `InputKeyboardRecordingScriptEvents` live in `:daemon:core` because both backends share their contracts. `InputRsbRecordingScriptEvents` lives in `:daemon:android` because RSB dispatch is Wear/Android-only — `ImageComposeScene` has no rotary channel.

## Wire-format change

Every input wire id gets the `input.<event>` namespace:

| Before  | After |
|---------|-------|
| `click` | `input.click` |
| `pointerDown` | `input.pointerDown` |
| `pointerMove` | `input.pointerMove` |
| `pointerUp` | `input.pointerUp` |
| `rotaryScroll` | `input.rotaryScroll` |
| `keyDown` | `input.keyDown` |
| `keyUp` | `input.keyUp` |

Symmetric with every other extension's `<extension>.<event>` shape. **The `interactive/input` and `recording/input` notification wires (typed `InteractiveInputKind` enum with `@SerialName`) keep their existing values** — only the recording-script `kind: String` shape changes. Two distinct wires, two distinct conventions.

## Mechanical changes

- `INTERACTIVE_INPUT_KIND_BY_WIRE_NAME` map keys flip from `"click"` → `"input.click"` etc. `INTERACTIVE_INPUT_KIND_WIRE_NAMES` deleted (no callers after the validator change).
- `validateRecordingScriptKinds` collapses to a two-bucket check: `supported = true` advertised → accept, `supported = false` advertised → reject with roadmap diagnostic, anything else → reject with `list_data_products` pointer. No special-case for input kinds.
- `DesktopHost.recordingScriptEventDescriptors()` returns `[recording, input.touch, input.keyboard]`. `RobolectricHost.recordingScriptEventDescriptors()` adds `input.rsb` plus the existing lifecycle/preview/state extensions.
- `DesktopRecordingSession.buildScriptHandlers` and `AndroidRecordingSession.buildScriptHandlers` register handlers under the new wire-name keys (constants from the input descriptor objects).
- The `record_preview` tool schema description rewritten to explain the new uniform shape.
- Tests pin: input descriptor shapes (touch supported, keyboard roadmap, rsb Wear-only), wire-name table alignment with each enum value, MCP validator diagnostic phrasing for unknown kinds. Existing tests that sent `kind = "click"` etc. updated to `kind = "input.click"`, and the MCP fake daemon's `advertisedDataExtensions` includes `input.touch` so those events pass the new closed-set check.
- Audit doc + driver script + CAPTURE_MODES.md examples updated to use the new wire ids.

## Test plan

- [ ] `./gradlew :daemon:core:check :daemon:android:check :daemon:desktop:check :data-render-core:check :mcp:check` (couldn't run locally — sandbox network blocks JDK 17 install; CI is the verification path)
- [ ] CI: `format`, `test` jobs green
- [ ] `InputRecordingScriptEventsTest` (new): touch supported / keyboard roadmap shapes; the wire-name table covers every `InteractiveInputKind` enum value through the descriptor union.
- [ ] `InputRsbRecordingScriptEventsTest` (new): rsb Wear-only shape.
- [ ] `DesktopHostTest` (updated): `recordingScriptEventDescriptors()` returns exactly `{recording, input.touch, input.keyboard}` — no `input.rsb` on desktop.
- [ ] `DesktopRecordingSessionTest` / `AndroidRecordingSessionTest` (updated wire ids): existing dispatch coverage continues to pass against the new keys.
- [ ] `DaemonMcpServerTest`'s start-script-stop-encode + mp4 cases updated to advertise `input.touch` and send `input.click`.
- [ ] Manual smoke (post-merge): `record_preview` with `kind: "input.click"` against an a11y-enabled Android daemon produces `applied` evidence; `kind: "click"` is rejected at MCP up front (now requires the `input.` prefix).

## Where this lands in the chain

After this lands the recording-script model is fully extension-shaped — every event id is advertised through `dataExtensions[].recordingScriptEvents[]` with a per-event `supported` flag, and the MCP validator filters by exactly that. No hand-rolled allowlists, no per-extension special cases.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J8qJtJESJvS4yoTB9PKtRF)_