### PR TITLE
fix(vscode): hide icon-button[hidden] in the focus-mode toolbar

### DIFF
--- a/vscode-extension/media/preview.css
+++ b/vscode-extension/media/preview.css
@@ -289,6 +289,15 @@ body {
     font-size: inherit;
 }
 
+/* `.icon-button` and the UA `[hidden]` rule both have specificity 0,1,0,
+   and the author rule wins by cascade order — so setting `.hidden = true`
+   alone leaves the button visible. Bump specificity here so the focus-mode
+   toolbar's gated buttons (diff HEAD/main, launch on device, a11y overlay,
+   recording, stop-interactive when no live target) actually hide. */
+.icon-button[hidden] {
+    display: none;
+}
+
 .icon-button:hover:not(:disabled) {
     background: var(--toolbar-hover);
 }


### PR DESCRIPTION
## Summary

`composePreview.earlyFeatures.enabled = false` was *supposed* to hide the focus-mode toolbar's diff/launch-device/a11y/recording icons, but they kept showing — same image you flagged today.

Root cause: CSS specificity. The user-agent `[hidden] { display: none }` rule (specificity 0,1,0) ties with `.icon-button { display: inline-flex }` (also 0,1,0) and loses on cascade order, so `applyEarlyFeatureVisibility`'s `btnDiffHead.hidden = true` writes the attribute but doesn't change what's painted. Latent bug since the original imperative panel — masked because `btnLaunchDevice` wasn't gated. #748 added it to the gated set and exposed the issue.

Fix is one rule: `.icon-button[hidden] { display: none }` (specificity 0,2,0) wins over both. This was meant to ride along with #758 but didn't make the squash-merge — fresh PR.

Affected buttons:
- `#btn-diff-head` / `#btn-diff-main` (the git-compare and source-control icons in your screenshot)
- `#btn-launch-device` (device-mobile)
- `#btn-a11y-overlay` (eye)
- `#btn-recording` (record-keys)
- `#btn-stop-interactive` (debug-stop, when no live preview is active)

The `<select>` and `focus-controls` / `focus-inspector` / `compile-errors` containers already have their own `[hidden]` rules, so this only touches `.icon-button`.

## Test plan

- [x] `npm run compile`
- [x] `npm run format:check`
- [x] `npm test` — 320 unit tests green
- [ ] In the panel, with `composePreview.earlyFeatures.enabled = false` and the layout set to Focus, only `← 1/N → Live ✕` should be in the toolbar (plus the stop-live square when a card is live). With it on, the diff/launch/a11y/recording icons reappear.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4faFnbtRFv3GsS2E6USuA)_