### PR TITLE
ci: publish all subprojects via root-level task abbreviation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,59 +95,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
+          # See the comment in snapshot.yml's publish step: root-level abbreviation fans out
+          # to every subproject applying `composeai.maven-publishing`; `:gradle-plugin` is an
+          # includeBuild and needs an explicit address.
           ./gradlew \
             :gradle-plugin:publishAllPublicationsToGitHubPackagesRepository \
-            :data-a11y-core:publishAllPublicationsToGitHubPackagesRepository \
-            :data-a11y-connector:publishAllPublicationsToGitHubPackagesRepository \
-            :data-fonts-core:publishAllPublicationsToGitHubPackagesRepository \
-            :data-fonts-connector:publishAllPublicationsToGitHubPackagesRepository \
-            :data-history-connector:publishAllPublicationsToGitHubPackagesRepository \
-            :data-layoutinspector-core:publishAllPublicationsToGitHubPackagesRepository \
-            :data-layoutinspector-connector:publishAllPublicationsToGitHubPackagesRepository \
-            :data-recomposition-connector:publishAllPublicationsToGitHubPackagesRepository \
-            :data-render-compose:publishAllPublicationsToGitHubPackagesRepository \
-            :data-render-core:publishAllPublicationsToGitHubPackagesRepository \
-            :data-render-connector:publishAllPublicationsToGitHubPackagesRepository \
-            :data-resources-core:publishAllPublicationsToGitHubPackagesRepository \
-            :data-resources-connector:publishAllPublicationsToGitHubPackagesRepository \
-            :data-scroll-core:publishAllPublicationsToGitHubPackagesRepository \
-            :data-strings-core:publishAllPublicationsToGitHubPackagesRepository \
-            :data-strings-connector:publishAllPublicationsToGitHubPackagesRepository \
-            :data-theme-connector:publishAllPublicationsToGitHubPackagesRepository \
-            :renderer-android:publishAllPublicationsToGitHubPackagesRepository \
-            :preview-annotations:publishAllPublicationsToGitHubPackagesRepository \
-            :daemon:core:publishAllPublicationsToGitHubPackagesRepository \
-            :daemon:desktop:publishAllPublicationsToGitHubPackagesRepository \
-            :daemon:android:publishAllPublicationsToGitHubPackagesRepository
+            publishAllPublicationsToGitHubPackagesRepository
       - name: Publish plugin, renderer-android, data-*, preview-annotations, daemon-* to Maven Central
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         run: |
+          # See the comment in snapshot.yml's publish step: root-level abbreviation fans out
+          # to every subproject applying `composeai.maven-publishing`; `:gradle-plugin` is an
+          # includeBuild and needs an explicit address.
           ./gradlew \
             :gradle-plugin:publishAndReleaseToMavenCentral \
-            :data-a11y-core:publishAndReleaseToMavenCentral \
-            :data-a11y-connector:publishAndReleaseToMavenCentral \
-            :data-fonts-core:publishAndReleaseToMavenCentral \
-            :data-fonts-connector:publishAndReleaseToMavenCentral \
-            :data-history-connector:publishAndReleaseToMavenCentral \
-            :data-layoutinspector-core:publishAndReleaseToMavenCentral \
-            :data-layoutinspector-connector:publishAndReleaseToMavenCentral \
-            :data-recomposition-connector:publishAndReleaseToMavenCentral \
-            :data-render-compose:publishAndReleaseToMavenCentral \
-            :data-render-core:publishAndReleaseToMavenCentral \
-            :data-render-connector:publishAndReleaseToMavenCentral \
-            :data-resources-core:publishAndReleaseToMavenCentral \
-            :data-resources-connector:publishAndReleaseToMavenCentral \
-            :data-scroll-core:publishAndReleaseToMavenCentral \
-            :data-strings-core:publishAndReleaseToMavenCentral \
-            :data-strings-connector:publishAndReleaseToMavenCentral \
-            :data-theme-connector:publishAndReleaseToMavenCentral \
-            :renderer-android:publishAndReleaseToMavenCentral \
-            :preview-annotations:publishAndReleaseToMavenCentral \
-            :daemon:core:publishAndReleaseToMavenCentral \
-            :daemon:desktop:publishAndReleaseToMavenCentral \
-            :daemon:android:publishAndReleaseToMavenCentral
+            publishAndReleaseToMavenCentral
 
   build-cli:
     runs-on: ubuntu-latest

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -85,30 +85,14 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         run: |
-          ./gradlew \
-            :gradle-plugin:publishToMavenCentral \
-            :data-a11y-core:publishToMavenCentral \
-            :data-a11y-connector:publishToMavenCentral \
-            :data-fonts-core:publishToMavenCentral \
-            :data-fonts-connector:publishToMavenCentral \
-            :data-history-connector:publishToMavenCentral \
-            :data-layoutinspector-core:publishToMavenCentral \
-            :data-layoutinspector-connector:publishToMavenCentral \
-            :data-recomposition-connector:publishToMavenCentral \
-            :data-render-compose:publishToMavenCentral \
-            :data-render-core:publishToMavenCentral \
-            :data-render-connector:publishToMavenCentral \
-            :data-resources-core:publishToMavenCentral \
-            :data-resources-connector:publishToMavenCentral \
-            :data-scroll-core:publishToMavenCentral \
-            :data-strings-core:publishToMavenCentral \
-            :data-strings-connector:publishToMavenCentral \
-            :data-theme-connector:publishToMavenCentral \
-            :renderer-android:publishToMavenCentral \
-            :preview-annotations:publishToMavenCentral \
-            :daemon:core:publishToMavenCentral \
-            :daemon:desktop:publishToMavenCentral \
-            :daemon:android:publishToMavenCentral
+          # Root-level `publishToMavenCentral` (no `:` prefix) fans out to every subproject that
+          # registered the task — i.e. every module applying the `composeai.maven-publishing`
+          # convention plugin. `:gradle-plugin` is an `includeBuild` (composite build), so root
+          # abbreviation doesn't reach it; address it explicitly. This avoids the hand-curated
+          # publish list that previously drifted out of sync (PR #724 added
+          # `:data-a11y-hierarchy-android` here but missed adding it to this list, leaving
+          # consumers' `renderer-android` POM resolution broken at snapshot time).
+          ./gradlew :gradle-plugin:publishToMavenCentral publishToMavenCentral
           # Note: `--no-configuration-cache` is incompatible with
           # `org.gradle.unsafe.isolated-projects=true` set in gradle.properties
           # (Gradle fails with "Configuration Cache cannot be disabled when


### PR DESCRIPTION
## Bug

CI snapshot publish was failing for any consumer fetching `renderer-android:0.1.0-SNAPSHOT`:

```
Could not find ee.schimke.composeai:data-a11y-hierarchy-android:0.1.0-SNAPSHOT.
Required by:
    project ':app' > ee.schimke.composeai:renderer-android:0.1.0-SNAPSHOT
```

Root cause: `:renderer-android`'s POM declares a transitive dep on `:data-a11y-hierarchy-android` (added by #724 as the platform-specific hierarchy producer), and that module configures `composeai.maven-publishing` correctly — but the snapshot/release workflows each carried a hand-curated list of `:<module>:publish<Task>` invocations and #724 never extended those lists. The artifact was never uploaded.

## Fix

Drop the hand-curated lists in favour of root-level task abbreviation:

```sh
./gradlew :gradle-plugin:publishToMavenCentral publishToMavenCentral
```

Gradle's root-level `publishToMavenCentral` (no `:` prefix) fans out to every subproject that registered the task — exactly the set of modules applying `composeai.maven-publishing`. Verified via `--dry-run` that the dynamic invocation picks up all 24 publishing-configured modules:

```
$ ./gradlew :gradle-plugin:publishToMavenCentral publishToMavenCentral --dry-run | grep -cE :publishToMavenCentral
24
```

`:gradle-plugin` is an `includeBuild` (composite build); root abbreviation doesn't reach included builds, so it stays explicit. Same pattern applied to all three workflow steps:
- `snapshot.yml` `publishToMavenCentral`
- `release.yml` `publishAllPublicationsToGitHubPackagesRepository`
- `release.yml` `publishAndReleaseToMavenCentral`

Net diff: -84 lines across both workflows. Future modules that apply `composeai.maven-publishing` are picked up automatically — no separate workflow edit needed alongside the `build.gradle.kts` change.

## Test plan

- [x] `./gradlew :gradle-plugin:publishToMavenCentral publishToMavenCentral --dry-run` — fans out to 24 unique tasks (matches `composeai.maven-publishing` count).
- [x] `./gradlew :gradle-plugin:publishAllPublicationsToGitHubPackagesRepository publishAllPublicationsToGitHubPackagesRepository --dry-run` — 24 unique tasks.
- [x] `./gradlew :gradle-plugin:publishAndReleaseToMavenCentral publishAndReleaseToMavenCentral --dry-run` — 24 unique tasks.
- [ ] CI snapshot run after merge confirms `data-a11y-hierarchy-android` lands in `central.sonatype.com/repository/maven-snapshots/`.