### PR TITLE
refactor(vscode): lift preview-grid + interactive input out of behavior.ts

### DIFF
--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -13,6 +13,8 @@
 // queries below resolve.
 
 import { getVsCodeApi } from "../shared/vscode";
+import { PreviewGrid } from "./components/PreviewGrid";
+import { attachInteractiveInputHandlers } from "./interactiveInput";
 import { previewStore } from "./previewStore";
 
 export function setupPreviewBehavior(
@@ -30,7 +32,7 @@ export function setupPreviewBehavior(
     const earlyFeatures = (): boolean =>
         previewStore.getState().earlyFeaturesEnabled;
 
-    const grid = document.getElementById("preview-grid");
+    const grid = document.getElementById("preview-grid") as PreviewGrid;
     const focusInspector = document.getElementById("focus-inspector");
     // `<message-banner>` owns the status strip; we use a typed-ish handle
     // to call setMessage / read its current owner from the few cases that
@@ -117,6 +119,16 @@ export function setupPreviewBehavior(
     const moduleInteractiveSupported = new Map();
     const interactivePreviewIds = new Set();
     const recordingPreviewIds = new Set();
+
+    // Config for the interactive-input pointer machine. The predicate
+    // unifies live/recording state — both forward pointer/wheel input
+    // to the daemon — so the module doesn't need direct access to
+    // either Set.
+    const interactiveInputConfig = {
+        isLive: (id) =>
+            interactivePreviewIds.has(id) || recordingPreviewIds.has(id),
+        vscode,
+    };
 
     // Restore layout preference
     if (
@@ -371,7 +383,8 @@ export function setupPreviewBehavior(
             container.appendChild(btn);
         }
         const img = container.querySelector("img");
-        if (img) ensureInteractiveInputHandlers(card, img);
+        if (img)
+            attachInteractiveInputHandlers(card, img, interactiveInputConfig);
     }
 
     function stopAllInteractive() {
@@ -439,7 +452,12 @@ export function setupPreviewBehavior(
         if (turnOn) {
             interactivePreviewIds.add(previewId);
             const img = card.querySelector(".image-container img");
-            if (img) ensureInteractiveInputHandlers(card, img);
+            if (img)
+                attachInteractiveInputHandlers(
+                    card,
+                    img,
+                    interactiveInputConfig,
+                );
         } else {
             interactivePreviewIds.delete(previewId);
         }
@@ -473,7 +491,12 @@ export function setupPreviewBehavior(
             recordingPreviewIds.clear();
             recordingPreviewIds.add(previewId);
             const img = card.querySelector(".image-container img");
-            if (img) ensureInteractiveInputHandlers(card, img);
+            if (img)
+                attachInteractiveInputHandlers(
+                    card,
+                    img,
+                    interactiveInputConfig,
+                );
         } else {
             recordingPreviewIds.delete(previewId);
         }
@@ -499,215 +522,8 @@ export function setupPreviewBehavior(
         setInteractiveForCard(card, shift);
     }
 
-    // Idempotent attach. Adds pointer listeners to the live card's image and a capture-phase
-    // wheel listener to the whole card exactly once; flagged via dataset so a second
-    // updateImage on the same element doesn't stack listeners. The handlers go inert the
-    // moment live mode exits, so non-live cards never consume input.
-    function ensureInteractiveInputHandlers(card, img) {
-        const previewId = card.dataset.previewId;
-        const shouldHandle =
-            !!previewId &&
-            (interactivePreviewIds.has(previewId) ||
-                recordingPreviewIds.has(previewId));
-        if (shouldHandle && card.dataset.interactiveWheelBound !== "1") {
-            card.dataset.interactiveWheelBound = "1";
-            card.addEventListener(
-                "wheel",
-                (evt) => {
-                    const id = card.dataset.previewId;
-                    if (
-                        !id ||
-                        (!interactivePreviewIds.has(id) &&
-                            !recordingPreviewIds.has(id))
-                    )
-                        return;
-                    // Live previews own wheel input while the cursor is inside the card. If the
-                    // wheel lands on preview pixels, forward it as rotary scroll; if it lands on
-                    // the card chrome, still consume it so enthusiastic scrolling cannot bubble to
-                    // the list and push the live preview out of view.
-                    const currentImg = card.querySelector(
-                        "img.preview-image, img.preview-gif, img",
-                    );
-                    const point =
-                        currentImg && eventInsideElement(currentImg, evt)
-                            ? imagePoint(currentImg, evt)
-                            : null;
-                    if (currentImg && point) {
-                        postInteractiveInput(
-                            id,
-                            currentImg,
-                            "rotaryScroll",
-                            point,
-                            evt.deltaY,
-                        );
-                    }
-                    evt.preventDefault();
-                    evt.stopImmediatePropagation();
-                },
-                { passive: false, capture: true },
-            );
-        }
-        if (shouldHandle && img.dataset.interactiveBound !== "1") {
-            img.dataset.interactiveBound = "1";
-            const state = {
-                pointerId: null,
-                start: null,
-                last: null,
-                dragging: false,
-                sentDown: false,
-            };
-            img.addEventListener("pointerdown", (evt) => {
-                const id = card.dataset.previewId;
-                if (
-                    !id ||
-                    (!interactivePreviewIds.has(id) &&
-                        !recordingPreviewIds.has(id))
-                )
-                    return;
-                if (evt.button !== 0 && evt.button !== 2) return;
-                state.pointerId = evt.pointerId;
-                state.start = imagePoint(img, evt);
-                state.last = state.start;
-                state.dragging = false;
-                state.sentDown = false;
-                img.setPointerCapture?.(evt.pointerId);
-                evt.preventDefault();
-                evt.stopPropagation();
-            });
-            img.addEventListener("pointermove", (evt) => {
-                const id = card.dataset.previewId;
-                if (
-                    !id ||
-                    (!interactivePreviewIds.has(id) &&
-                        !recordingPreviewIds.has(id))
-                )
-                    return;
-                if (state.pointerId !== evt.pointerId || !state.start) return;
-                const next = imagePoint(img, evt);
-                if (!next) return;
-                const dx = next.clientX - state.start.clientX;
-                const dy = next.clientY - state.start.clientY;
-                if (!state.dragging && Math.hypot(dx, dy) >= 4) {
-                    state.dragging = true;
-                }
-                if (state.dragging) {
-                    if (!state.sentDown) {
-                        postInteractiveInput(
-                            id,
-                            img,
-                            "pointerDown",
-                            state.start,
-                        );
-                        state.sentDown = true;
-                    }
-                    postInteractiveInput(id, img, "pointerMove", next);
-                    state.last = next;
-                    evt.preventDefault();
-                    evt.stopPropagation();
-                }
-            });
-            img.addEventListener("pointerup", (evt) => {
-                const id = card.dataset.previewId;
-                if (
-                    !id ||
-                    (!interactivePreviewIds.has(id) &&
-                        !recordingPreviewIds.has(id))
-                )
-                    return;
-                if (state.pointerId !== evt.pointerId || !state.start) return;
-                const point = imagePoint(img, evt) || state.last || state.start;
-                if (state.dragging) {
-                    if (!state.sentDown) {
-                        postInteractiveInput(
-                            id,
-                            img,
-                            "pointerDown",
-                            state.start,
-                        );
-                    }
-                    postInteractiveInput(id, img, "pointerUp", point);
-                } else {
-                    postInteractiveInput(id, img, "click", point);
-                }
-                img.releasePointerCapture?.(evt.pointerId);
-                state.pointerId = null;
-                state.start = null;
-                state.last = null;
-                state.dragging = false;
-                state.sentDown = false;
-                evt.preventDefault();
-                evt.stopPropagation();
-            });
-            img.addEventListener("pointercancel", (evt) => {
-                if (state.pointerId !== evt.pointerId) return;
-                img.releasePointerCapture?.(evt.pointerId);
-                state.pointerId = null;
-                state.start = null;
-                state.last = null;
-                state.dragging = false;
-                state.sentDown = false;
-            });
-            img.addEventListener("contextmenu", (evt) => {
-                const id = card.dataset.previewId;
-                if (
-                    !id ||
-                    (!interactivePreviewIds.has(id) &&
-                        !recordingPreviewIds.has(id))
-                )
-                    return;
-                evt.preventDefault();
-                evt.stopPropagation();
-            });
-        }
-    }
-
-    function imagePoint(img, evt) {
-        // Image-natural pixel coords — same space the daemon's renderer
-        // works in. The webview's offsetX/Y is in CSS pixels of the
-        // displayed image; scale by the displayed/natural ratio to
-        // recover the pixel the user actually clicked.
-        const natW = img.naturalWidth || 0;
-        const natH = img.naturalHeight || 0;
-        const rect = img.getBoundingClientRect();
-        if (!natW || !natH || rect.width === 0 || rect.height === 0)
-            return null;
-        const clientX = evt.clientX - rect.left;
-        const clientY = evt.clientY - rect.top;
-        const pixelX = Math.round(clientX * (natW / rect.width));
-        const pixelY = Math.round(clientY * (natH / rect.height));
-        return {
-            clientX,
-            clientY,
-            pixelX: Math.max(0, Math.min(natW - 1, pixelX)),
-            pixelY: Math.max(0, Math.min(natH - 1, pixelY)),
-        };
-    }
-
-    function eventInsideElement(el, evt) {
-        const rect = el.getBoundingClientRect();
-        return (
-            evt.clientX >= rect.left &&
-            evt.clientX <= rect.right &&
-            evt.clientY >= rect.top &&
-            evt.clientY <= rect.bottom
-        );
-    }
-
-    function postInteractiveInput(previewId, img, kind, point, scrollDeltaY) {
-        const natW = img.naturalWidth || 0;
-        const natH = img.naturalHeight || 0;
-        if (!point || !natW || !natH) return;
-        vscode.postMessage({
-            command: "recordInteractiveInput",
-            previewId,
-            kind,
-            pixelX: point.pixelX,
-            pixelY: point.pixelY,
-            imageWidth: natW,
-            imageHeight: natH,
-            scrollDeltaY,
-        });
-    }
+    // Pointer + wheel state machine for live previews lives in
+    // `./interactiveInput.ts` — see `attachInteractiveInputHandlers`.
 
     // Document-level Left/Right in focus mode steps between cards. The
     // animated-carousel frame-controls handler stops propagation so
@@ -746,16 +562,9 @@ export function setupPreviewBehavior(
     }
 
     function applyFilters() {
-        const fnVal = filterToolbar.getFunctionValue();
-        const grpVal = filterToolbar.getGroupValue();
-
-        let visibleCount = 0;
-        document.querySelectorAll(".preview-card").forEach((card) => {
-            const show =
-                (fnVal === "all" || card.dataset.function === fnVal) &&
-                (grpVal === "all" || card.dataset.group === grpVal);
-            card.classList.toggle("filtered-out", !show);
-            if (show) visibleCount++;
+        const visibleCount = grid.applyFilters({
+            fn: filterToolbar.getFunctionValue(),
+            group: filterToolbar.getGroupValue(),
         });
 
         // Only own the message when we have a filter-specific thing to
@@ -795,14 +604,12 @@ export function setupPreviewBehavior(
     }
 
     function getVisibleCards() {
-        return Array.from(document.querySelectorAll(".preview-card")).filter(
-            (c) => !c.classList.contains("filtered-out"),
-        );
+        return grid.getVisibleCards();
     }
 
     function applyLayout() {
         const mode = filterToolbar.getLayoutValue();
-        grid.className = "preview-grid layout-" + mode;
+        grid.setLayoutMode(mode);
         focusControls.hidden = mode !== "focus";
 
         if (mode === "focus") {
@@ -815,25 +622,13 @@ export function setupPreviewBehavior(
             }
             if (focusIndex >= visible.length) focusIndex = visible.length - 1;
             if (focusIndex < 0) focusIndex = 0;
-            // Hide all non-focused cards
-            document.querySelectorAll(".preview-card").forEach((card) => {
-                card.classList.remove("focused");
-            });
-            visible.forEach((card, i) => {
-                card.classList.toggle("hidden-by-focus", i !== focusIndex);
-            });
-            if (visible[focusIndex]) {
-                visible[focusIndex].classList.add("focused");
-            }
+            grid.applyFocusVisibility(visible[focusIndex]);
             focusPosition.textContent = focusIndex + 1 + " / " + visible.length;
             btnPrev.disabled = focusIndex === 0;
             btnNext.disabled = focusIndex === visible.length - 1;
             renderFocusInspector(visible[focusIndex]);
         } else {
-            // Clear focus classes for other layouts
-            document.querySelectorAll(".preview-card").forEach((card) => {
-                card.classList.remove("focused", "hidden-by-focus");
-            });
+            grid.applyFocusVisibility(null);
             renderFocusInspector(null);
         }
         document
@@ -1734,7 +1529,7 @@ export function setupPreviewBehavior(
         // Single-click on the image enters LIVE for this preview (in any
         // layout — focus, grid, flow, column). The first click toggles
         // interactive on; subsequent clicks while LIVE forward as pointer
-        // events to the daemon (handled by ensureInteractiveInputHandlers
+        // events to the daemon (handled by attachInteractiveInputHandlers
         // attached via updateImage). The handler is on the container, not
         // the <img>, so clicks land before the image renders too. Modifier-
         // aware: Shift+click follows the multi-stream semantics from
@@ -1946,7 +1741,7 @@ export function setupPreviewBehavior(
                 ";base64," +
                 capture.imageData;
             img.className = "fade-in";
-            ensureInteractiveInputHandlers(card, img);
+            attachInteractiveInputHandlers(card, img, interactiveInputConfig);
             if (capture.errorMessage || capture.renderError) {
                 container.appendChild(
                     buildErrorPanel(
@@ -2529,7 +2324,7 @@ export function setupPreviewBehavior(
         // than a sequence of independent renders. See INTERACTIVE.md § 3.
         const isLive = interactivePreviewIds.has(previewId);
         img.className = isLive ? "live-frame" : "fade-in";
-        ensureInteractiveInputHandlers(card, img);
+        attachInteractiveInputHandlers(card, img, interactiveInputConfig);
 
         if (caps) updateFrameIndicator(card);
 

--- a/vscode-extension/src/webview/preview/components/CompileErrorsBanner.ts
+++ b/vscode-extension/src/webview/preview/components/CompileErrorsBanner.ts
@@ -16,6 +16,7 @@ import { customElement, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import type { CompileError } from "../../shared/types";
 import { getVsCodeApi } from "../../shared/vscode";
+import { PreviewGrid } from "./PreviewGrid";
 
 interface SetCompileErrorsMessage {
     command: "setCompileErrors";
@@ -65,12 +66,15 @@ export class CompileErrorsBanner extends LitElement {
 
     protected updated(): void {
         // Cross-component side effect: dim the preview grid while the
-        // banner is showing. Mirrors the imperative `grid.classList.add(
-        // 'compile-stale')` / `grid.classList.remove('compile-stale')`
-        // calls in the previous `setCompileErrors` / `clearCompileErrors`.
-        const grid = document.getElementById("preview-grid");
-        if (!grid) return;
-        grid.classList.toggle("compile-stale", this.errors.length > 0);
+        // banner is showing. The grid owns its own class list (incl. the
+        // layout-X modifier), so we hand it the desired flag rather than
+        // toggling the class directly — matches the imperative
+        // `setCompileErrors` / `clearCompileErrors` behaviour but goes
+        // through the typed component API.
+        const grid = document.querySelector("preview-grid");
+        if (grid instanceof PreviewGrid) {
+            grid.setCompileStale(this.errors.length > 0);
+        }
     }
 
     protected render(): TemplateResult {

--- a/vscode-extension/src/webview/preview/components/PreviewGrid.ts
+++ b/vscode-extension/src/webview/preview/components/PreviewGrid.ts
@@ -1,0 +1,142 @@
+// `<preview-grid>` — typed wrapper around the imperative card grid.
+//
+// First step of the preview-grid migration. The cards themselves are
+// still imperative `<div class="preview-card">` elements created by
+// `behavior.ts` (`createCard` / `updateCardMetadata` / `renderPreviews`),
+// so this element does NOT manage its own light-DOM children; it just
+// surfaces the typed methods that used to be free-standing `grid.X`
+// calls in `behavior.ts` and the cross-component reach-in from
+// `<compile-errors-banner>`. A future commit can lift `<preview-card>`
+// itself, at which point this element will start owning the children
+// reactively.
+//
+// Concretely, this owns:
+//
+//  - The class list on the host (`preview-grid layout-X`, plus the
+//    `compile-stale` modifier).
+//  - The DOM walks that used to live in `applyFilters` / `applyLayout`
+//    / `getVisibleCards` — exposed as typed methods so callers don't
+//    have to repeat the `.preview-card` / `.filtered-out` / `.focused`
+//    selectors verbatim.
+//
+// We intentionally extend `HTMLElement`, not `LitElement`: the host's
+// children are imperative and Lit's render cycle would clobber them.
+// All state (layout mode, compile-stale flag) is set via explicit
+// method calls — no reactive `@state` needed.
+//
+// Light DOM keeps `media/preview.css` rules targeting `.preview-grid`,
+// `.preview-card`, etc. applying unchanged.
+
+export type LayoutMode = "grid" | "flow" | "column" | "focus";
+
+export interface FilterValues {
+    fn: string;
+    group: string;
+}
+
+export class PreviewGrid extends HTMLElement {
+    private layoutMode: LayoutMode = "grid";
+    private compileStale = false;
+
+    connectedCallback(): void {
+        this.applyClasses();
+    }
+
+    /** Set the layout mode and update the host class list. */
+    setLayoutMode(mode: LayoutMode): void {
+        this.layoutMode = mode;
+        this.applyClasses();
+    }
+
+    getLayoutMode(): LayoutMode {
+        return this.layoutMode;
+    }
+
+    /** Toggle the `compile-stale` modifier — called by
+     *  `<compile-errors-banner>` while the banner is visible. */
+    setCompileStale(stale: boolean): void {
+        if (this.compileStale === stale) return;
+        this.compileStale = stale;
+        this.applyClasses();
+    }
+
+    /** Cards in DOM order, regardless of filter state. */
+    getCards(): HTMLElement[] {
+        return Array.from(this.querySelectorAll<HTMLElement>(".preview-card"));
+    }
+
+    /** Cards currently visible (i.e. not filtered out). */
+    getVisibleCards(): HTMLElement[] {
+        return this.getCards().filter(
+            (c) => !c.classList.contains("filtered-out"),
+        );
+    }
+
+    /** Find a card by its `data-preview-id`. */
+    findCard(previewId: string): HTMLElement | null {
+        return this.querySelector<HTMLElement>(
+            `.preview-card[data-preview-id="${cssEscape(previewId)}"]`,
+        );
+    }
+
+    /**
+     * DOM walk that used to live in `applyFilters`. Toggles the
+     * `filtered-out` class on each card based on the function/group
+     * picks and returns how many ended up visible — callers use that
+     * count to decide whether to surface the "no matches" banner.
+     */
+    applyFilters(filters: FilterValues): number {
+        const { fn, group } = filters;
+        let visibleCount = 0;
+        for (const card of this.getCards()) {
+            const cardFn = card.dataset.function ?? "";
+            const cardGroup = card.dataset.group ?? "";
+            const show =
+                (fn === "all" || cardFn === fn) &&
+                (group === "all" || cardGroup === group);
+            card.classList.toggle("filtered-out", !show);
+            if (show) visibleCount++;
+        }
+        return visibleCount;
+    }
+
+    /**
+     * Mark a single visible card as focused and hide the others —
+     * the focus-mode class management formerly inlined in
+     * `applyLayout`. Pass `null` to clear all focus classes (used
+     * when leaving focus mode or when the visible set is empty).
+     */
+    applyFocusVisibility(focused: HTMLElement | null): void {
+        const visible = this.getVisibleCards();
+        if (focused === null) {
+            for (const card of this.getCards()) {
+                card.classList.remove("focused", "hidden-by-focus");
+            }
+            return;
+        }
+        for (const card of this.getCards()) {
+            card.classList.remove("focused");
+        }
+        for (const card of visible) {
+            card.classList.toggle("hidden-by-focus", card !== focused);
+        }
+        focused.classList.add("focused");
+    }
+
+    private applyClasses(): void {
+        const tokens = ["preview-grid", `layout-${this.layoutMode}`];
+        if (this.compileStale) tokens.push("compile-stale");
+        this.className = tokens.join(" ");
+    }
+}
+
+// CSS.escape isn't universally typed in older lib targets and isn't
+// available in the Node/test environment some webview tests run in.
+// previewIds in this codebase come from the discovery pipeline and use
+// a stable `[A-Za-z0-9._$-]` alphabet, but we still escape defensively
+// because they're used as attribute selectors in `findCard`.
+function cssEscape(value: string): string {
+    return value.replace(/(["\\])/g, "\\$1");
+}
+
+customElements.define("preview-grid", PreviewGrid);

--- a/vscode-extension/src/webview/preview/interactiveInput.ts
+++ b/vscode-extension/src/webview/preview/interactiveInput.ts
@@ -1,0 +1,265 @@
+// Pointer + wheel state machine for live (interactive) previews.
+//
+// Lifted verbatim from `behavior.ts` (`ensureInteractiveInputHandlers`,
+// `imagePoint`, `eventInsideElement`, `postInteractiveInput`) so the
+// pointer logic stops needing `@ts-nocheck`. Behaviour is unchanged:
+// pointer down / move / up / cancel / context-menu on the live image,
+// plus a capture-phase wheel listener on the whole card that maps
+// vertical deltas to rotary scroll. Listeners are idempotent — flagged
+// via `dataset.interactiveBound` / `dataset.interactiveWheelBound` so
+// re-attaching on subsequent `updateImage` calls doesn't stack
+// duplicates.
+//
+// The handlers stay attached after a card leaves live mode. They go
+// inert because every event re-checks the `isLive` predicate — so a
+// non-live card swallows nothing. We deliberately don't tear handlers
+// down because live can be re-entered without producing a fresh `<img>`
+// (e.g. the same image element survives a single-target → re-toggle
+// cycle), and re-binding would race with in-flight pointer captures.
+//
+// Coordinates the daemon expects are image-natural pixel space — the
+// same space the renderer paints in. The CSS-pixel offsets the browser
+// gives us are scaled by the displayed/natural ratio in `imagePoint`.
+// See docs/daemon/INTERACTIVE.md §§ 3, 6, 7.
+
+import type { VsCodeApi } from "../shared/vscode";
+
+export interface ImagePoint {
+    clientX: number;
+    clientY: number;
+    pixelX: number;
+    pixelY: number;
+}
+
+export interface InteractiveInputConfig {
+    /**
+     * Predicate keyed on a card's `data-preview-id`. Returns true when
+     * the card should currently consume pointer/wheel input — i.e. it
+     * is in the `interactivePreviewIds` set OR the `recordingPreviewIds`
+     * set. Both states forward input to the daemon.
+     *
+     * The predicate is called on every event, so non-live cards
+     * naturally pass events through.
+     */
+    isLive(previewId: string): boolean;
+    vscode: VsCodeApi<unknown>;
+}
+
+export function attachInteractiveInputHandlers(
+    card: HTMLElement,
+    img: HTMLImageElement,
+    config: InteractiveInputConfig,
+): void {
+    const previewId = card.dataset.previewId;
+    if (!previewId) return;
+    if (!config.isLive(previewId)) return;
+
+    if (card.dataset.interactiveWheelBound !== "1") {
+        card.dataset.interactiveWheelBound = "1";
+        card.addEventListener(
+            "wheel",
+            (evt) => {
+                const id = card.dataset.previewId;
+                if (!id || !config.isLive(id)) return;
+                // Live previews own wheel input while the cursor is inside the card. If the
+                // wheel lands on preview pixels, forward it as rotary scroll; if it lands on
+                // the card chrome, still consume it so enthusiastic scrolling cannot bubble to
+                // the list and push the live preview out of view.
+                const currentImg = card.querySelector<HTMLImageElement>(
+                    "img.preview-image, img.preview-gif, img",
+                );
+                const point =
+                    currentImg && eventInsideElement(currentImg, evt)
+                        ? imagePoint(currentImg, evt)
+                        : null;
+                if (currentImg && point) {
+                    postInteractiveInput(
+                        config.vscode,
+                        id,
+                        currentImg,
+                        "rotaryScroll",
+                        point,
+                        evt.deltaY,
+                    );
+                }
+                evt.preventDefault();
+                evt.stopImmediatePropagation();
+            },
+            { passive: false, capture: true },
+        );
+    }
+
+    if (img.dataset.interactiveBound === "1") return;
+    img.dataset.interactiveBound = "1";
+
+    interface PointerState {
+        pointerId: number | null;
+        start: ImagePoint | null;
+        last: ImagePoint | null;
+        dragging: boolean;
+        sentDown: boolean;
+    }
+    const state: PointerState = {
+        pointerId: null,
+        start: null,
+        last: null,
+        dragging: false,
+        sentDown: false,
+    };
+
+    img.addEventListener("pointerdown", (evt) => {
+        const id = card.dataset.previewId;
+        if (!id || !config.isLive(id)) return;
+        if (evt.button !== 0 && evt.button !== 2) return;
+        state.pointerId = evt.pointerId;
+        state.start = imagePoint(img, evt);
+        state.last = state.start;
+        state.dragging = false;
+        state.sentDown = false;
+        img.setPointerCapture?.(evt.pointerId);
+        evt.preventDefault();
+        evt.stopPropagation();
+    });
+
+    img.addEventListener("pointermove", (evt) => {
+        const id = card.dataset.previewId;
+        if (!id || !config.isLive(id)) return;
+        if (state.pointerId !== evt.pointerId || !state.start) return;
+        const next = imagePoint(img, evt);
+        if (!next) return;
+        const dx = next.clientX - state.start.clientX;
+        const dy = next.clientY - state.start.clientY;
+        if (!state.dragging && Math.hypot(dx, dy) >= 4) {
+            state.dragging = true;
+        }
+        if (state.dragging) {
+            if (!state.sentDown) {
+                postInteractiveInput(
+                    config.vscode,
+                    id,
+                    img,
+                    "pointerDown",
+                    state.start,
+                );
+                state.sentDown = true;
+            }
+            postInteractiveInput(config.vscode, id, img, "pointerMove", next);
+            state.last = next;
+            evt.preventDefault();
+            evt.stopPropagation();
+        }
+    });
+
+    img.addEventListener("pointerup", (evt) => {
+        const id = card.dataset.previewId;
+        if (!id || !config.isLive(id)) return;
+        if (state.pointerId !== evt.pointerId || !state.start) return;
+        const point = imagePoint(img, evt) || state.last || state.start;
+        if (state.dragging) {
+            if (!state.sentDown) {
+                postInteractiveInput(
+                    config.vscode,
+                    id,
+                    img,
+                    "pointerDown",
+                    state.start,
+                );
+            }
+            postInteractiveInput(config.vscode, id, img, "pointerUp", point);
+        } else {
+            postInteractiveInput(config.vscode, id, img, "click", point);
+        }
+        img.releasePointerCapture?.(evt.pointerId);
+        state.pointerId = null;
+        state.start = null;
+        state.last = null;
+        state.dragging = false;
+        state.sentDown = false;
+        evt.preventDefault();
+        evt.stopPropagation();
+    });
+
+    img.addEventListener("pointercancel", (evt) => {
+        if (state.pointerId !== evt.pointerId) return;
+        img.releasePointerCapture?.(evt.pointerId);
+        state.pointerId = null;
+        state.start = null;
+        state.last = null;
+        state.dragging = false;
+        state.sentDown = false;
+    });
+
+    img.addEventListener("contextmenu", (evt) => {
+        const id = card.dataset.previewId;
+        if (!id || !config.isLive(id)) return;
+        evt.preventDefault();
+        evt.stopPropagation();
+    });
+}
+
+function imagePoint(
+    img: HTMLImageElement,
+    evt: { clientX: number; clientY: number },
+): ImagePoint | null {
+    // Image-natural pixel coords — same space the daemon's renderer
+    // works in. The webview's offsetX/Y is in CSS pixels of the
+    // displayed image; scale by the displayed/natural ratio to recover
+    // the pixel the user actually clicked.
+    const natW = img.naturalWidth || 0;
+    const natH = img.naturalHeight || 0;
+    const rect = img.getBoundingClientRect();
+    if (!natW || !natH || rect.width === 0 || rect.height === 0) return null;
+    const clientX = evt.clientX - rect.left;
+    const clientY = evt.clientY - rect.top;
+    const pixelX = Math.round(clientX * (natW / rect.width));
+    const pixelY = Math.round(clientY * (natH / rect.height));
+    return {
+        clientX,
+        clientY,
+        pixelX: Math.max(0, Math.min(natW - 1, pixelX)),
+        pixelY: Math.max(0, Math.min(natH - 1, pixelY)),
+    };
+}
+
+function eventInsideElement(
+    el: Element,
+    evt: { clientX: number; clientY: number },
+): boolean {
+    const rect = el.getBoundingClientRect();
+    return (
+        evt.clientX >= rect.left &&
+        evt.clientX <= rect.right &&
+        evt.clientY >= rect.top &&
+        evt.clientY <= rect.bottom
+    );
+}
+
+type InteractiveInputKind =
+    | "click"
+    | "pointerDown"
+    | "pointerMove"
+    | "pointerUp"
+    | "rotaryScroll";
+
+function postInteractiveInput(
+    vscode: VsCodeApi<unknown>,
+    previewId: string,
+    img: HTMLImageElement,
+    kind: InteractiveInputKind,
+    point: ImagePoint | null,
+    scrollDeltaY?: number,
+): void {
+    const natW = img.naturalWidth || 0;
+    const natH = img.naturalHeight || 0;
+    if (!point || !natW || !natH) return;
+    vscode.postMessage({
+        command: "recordInteractiveInput",
+        previewId,
+        kind,
+        pixelX: point.pixelX,
+        pixelY: point.pixelY,
+        imageWidth: natW,
+        imageHeight: natH,
+        scrollDeltaY,
+    });
+}

--- a/vscode-extension/src/webview/preview/main.ts
+++ b/vscode-extension/src/webview/preview/main.ts
@@ -14,6 +14,7 @@ import { setupPreviewBehavior } from "./behavior";
 import "./components/CompileErrorsBanner";
 import "./components/FilterToolbar";
 import "./components/MessageBanner";
+import "./components/PreviewGrid";
 import "./components/ProgressBar";
 
 @customElement("preview-app")
@@ -155,12 +156,11 @@ export class PreviewApp extends LitElement {
                     <i class="codicon codicon-close" aria-hidden="true"></i>
                 </button>
             </div>
-            <div
+            <preview-grid
                 id="preview-grid"
-                class="preview-grid"
                 role="list"
                 aria-label="Preview cards"
-            ></div>
+            ></preview-grid>
             <div
                 id="focus-inspector"
                 class="focus-inspector"


### PR DESCRIPTION
First slice of #767. Two well-bounded pieces lifted out of `vscode-extension/src/webview/preview/behavior.ts` (which is `@ts-nocheck`):

## Summary

- New `<preview-grid>` custom element (`components/PreviewGrid.ts`) owning:
  - the host class list (`preview-grid layout-X` plus the `compile-stale` modifier),
  - the DOM walks that used to live in `applyFilters` / `applyLayout` / `getVisibleCards`, exposed as typed methods (`applyFilters`, `applyFocusVisibility`, `getVisibleCards`, `getCards`, `findCard`).
  Cards remain imperative `<div class="preview-card">` — the element is a typed wrapper, not a reactive child renderer, so `behavior.ts`'s `appendChild` / `insertBefore` paths keep working unchanged. `<compile-errors-banner>`'s cross-component `getElementById` reach-in now goes through `grid.setCompileStale(...)`.
- New `interactiveInput.ts` typed module owning the pointer + wheel state machine (`attachInteractiveInputHandlers`). Replaces the `@ts-nocheck`-shielded `ensureInteractiveInputHandlers` / `imagePoint` / `eventInsideElement` / `postInteractiveInput` quartet — semantics unchanged, just typed. Caller passes an `isLive` predicate so the module doesn't need direct access to `interactivePreviewIds` / `recordingPreviewIds`.

`behavior.ts` shrinks from 3208 to 3003 lines (~205 LOC) and drops zero behaviour. Lifting `<preview-card>` itself is the next slice.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 320/320 passing
- [x] `npm run format:check` clean
- [ ] Manual smoke: open the preview panel against the sample workspace, exercise filter dropdowns, layout switcher (grid/flow/column/focus), enter LIVE on a focused card and verify pointer + wheel input still reach the daemon, trigger a compile error and verify the grid dims via `compile-stale`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTv9gnHTdY5MzDfGdnSpBn)_