### PR TITLE
refactor(vscode): lift pure card helpers + error panel out of behavior.ts

### DIFF
--- a/vscode-extension/src/webview/preview/behavior.ts
+++ b/vscode-extension/src/webview/preview/behavior.ts
@@ -19,8 +19,18 @@ import {
     buildA11yOverlay,
     ensureHierarchyOverlay,
 } from "./a11yOverlay";
+import {
+    buildTooltip,
+    buildVariantLabel,
+    isAnimatedPreview,
+    isWearPreview,
+    mimeFor,
+    parseBounds,
+    sanitizeId,
+} from "./cardData";
 import { PreviewGrid } from "./components/PreviewGrid";
 import { showDiffOverlay, type DiffMode } from "./diffOverlay";
+import { buildErrorPanel } from "./errorPanel";
 import { attachInteractiveInputHandlers } from "./interactiveInput";
 import { previewStore } from "./previewStore";
 import { ViewportTracker } from "./viewportTracker";
@@ -1113,41 +1123,12 @@ export function setupPreviewBehavior(
     // `<filter-toolbar>`'s reactive state retains `fnValue` / `grpValue`
     // when only `fnOptions` / `grpOptions` change.
 
-    function sanitizeId(id) {
-        return id.replace(/[^a-zA-Z0-9_-]/g, "_");
-    }
-
-    // Data-URL MIME for a preview image, derived from its renderOutput
-    // extension. @ScrollingPreview(GIF) captures land at .gif; all
-    // other captures are PNG. Browsers sniff magic bytes and would
-    // actually render a GIF served as image/png — but declaring the
-    // right type matters for the webview's img fallback/accessibility
-    // paths and avoids a console warning when saving the preview.
-    function mimeFor(renderOutput) {
-        return typeof renderOutput === "string" &&
-            renderOutput.toLowerCase().endsWith(".gif")
-            ? "image/gif"
-            : "image/png";
-    }
-
     // Per-preview carousel runtime state — imageData / errorMessage per
     // capture. Populated from updateImage / setImageError messages so
     // prev/next navigation can swap the visible <img> without a fresh
     // extension round-trip.
     // Map<previewId, [{ label, imageData, errorMessage }]>
     const cardCaptures = new Map();
-
-    // Preview is shown with a carousel when it has >1 capture or a single
-    // capture with a non-null dimension (e.g. an explicit 500ms snapshot).
-    function isAnimatedPreview(p) {
-        const caps = p.captures;
-        if (caps.length > 1) return true;
-        if (caps.length === 1) {
-            const c = caps[0];
-            return c.advanceTimeMillis != null || c.scroll != null;
-        }
-        return false;
-    }
 
     function createCard(p) {
         const animated = isAnimatedPreview(p);
@@ -1360,83 +1341,6 @@ export function setupPreviewBehavior(
         showFrame(card, next);
     }
 
-    /**
-     * Build the error overlay DOM for a failing capture. When
-     * renderError is non-null the panel has structured detail:
-     * exception class, message, a clickable file:line frame, and a
-     * collapsible stack trace. Otherwise it falls back to the plain
-     * one-line message (the case for renderers that don't yet
-     * produce a sidecar, or when the sidecar was unreadable).
-     *
-     * Click on the frame button posts an openSourceFile message;
-     * the extension resolves the stack-trace basename to an
-     * absolute path via workspace.findFiles. The disclosure for
-     * the full trace is a native details element -- no JS state
-     * to manage, browser handles the toggle.
-     */
-    function buildErrorPanel(message, renderError, className) {
-        const panel = document.createElement("div");
-        panel.className = "error-message render-error";
-        panel.setAttribute("role", "alert");
-        if (!renderError) {
-            panel.textContent = message || "";
-            return panel;
-        }
-        const cls =
-            (renderError.exception || "").split(".").pop() ||
-            renderError.exception ||
-            "Error";
-        const head = document.createElement("div");
-        head.className = "render-error-class";
-        head.textContent = cls;
-        panel.appendChild(head);
-
-        if (renderError.message) {
-            const msg = document.createElement("div");
-            msg.className = "render-error-msg";
-            msg.textContent = renderError.message;
-            panel.appendChild(msg);
-        }
-
-        const frame = renderError.topAppFrame;
-        if (frame && frame.file) {
-            const link = document.createElement("button");
-            link.className = "render-error-frame";
-            link.type = "button";
-            const fnSuffix = frame.function ? " in " + frame.function : "";
-            const lineSuffix = frame.line > 0 ? ":" + frame.line : "";
-            link.textContent = frame.file + lineSuffix + fnSuffix;
-            link.title = "Open " + frame.file + lineSuffix;
-            link.addEventListener("click", () => {
-                vscode.postMessage({
-                    command: "openSourceFile",
-                    fileName: frame.file,
-                    line: frame.line,
-                    // className lets the extension disambiguate same-
-                    // named files across modules — when the throw is
-                    // in this preview's own file, the class-derived
-                    // path matches and we pick the right one without
-                    // a workspace-wide first-hit guess.
-                    className: className || undefined,
-                });
-            });
-            panel.appendChild(link);
-        }
-
-        if (renderError.stackTrace) {
-            const details = document.createElement("details");
-            details.className = "render-error-stack";
-            const summary = document.createElement("summary");
-            summary.textContent = "Stack trace";
-            details.appendChild(summary);
-            const pre = document.createElement("pre");
-            pre.textContent = renderError.stackTrace;
-            details.appendChild(pre);
-            panel.appendChild(details);
-        }
-        return panel;
-    }
-
     function showFrame(card, index) {
         const caps = cardCaptures.get(card.dataset.previewId);
         if (!caps) return;
@@ -1466,6 +1370,7 @@ export function setupPreviewBehavior(
             if (capture.errorMessage || capture.renderError) {
                 container.appendChild(
                     buildErrorPanel(
+                        vscode,
                         capture.errorMessage,
                         capture.renderError,
                         card.dataset.className,
@@ -1597,57 +1502,6 @@ export function setupPreviewBehavior(
             // earlyFeatures off mid-session.
             existingOverlay.remove();
         }
-    }
-
-    // Compact single-line variant summary rendered in a persistent badge
-    // on each card. Longer-form info still lives in the hover tooltip
-    // (buildTooltip) — here we only surface what distinguishes siblings:
-    // name/group/device first, then dimensions, non-default fontScale,
-    // uiMode. Skips redundant bits (e.g. no "1.0×" for default font).
-    function buildVariantLabel(p) {
-        const parts = [];
-        const primary =
-            p.params.name || p.params.group || shortDevice(p.params.device);
-        if (primary) parts.push(primary);
-        if (p.params.widthDp && p.params.heightDp) {
-            parts.push(p.params.widthDp + "\u00D7" + p.params.heightDp);
-        }
-        if (p.params.fontScale && p.params.fontScale !== 1.0) {
-            parts.push(p.params.fontScale + "\u00D7");
-        }
-        if (p.params.uiMode) parts.push("uiMode " + p.params.uiMode);
-        if (p.params.locale) parts.push(p.params.locale);
-        return parts.join(" \u00B7 ");
-    }
-
-    function shortDevice(d) {
-        if (!d) return "";
-        return d.replace(/^id:/, "").replace(/_/g, " ");
-    }
-
-    function isWearPreview(p) {
-        const device = (p.params.device || "").toLowerCase();
-        if (device.includes("wear")) return true;
-        const w = p.params.widthDp || 0;
-        const h = p.params.heightDp || 0;
-        return w > 0 && h > 0 && w === h && w <= 260;
-    }
-
-    function buildTooltip(p) {
-        const base = "Open source: " + p.className + "." + p.functionName;
-        const parts = [];
-        if (p.params.name) parts.push(p.params.name);
-        if (p.params.device) parts.push(p.params.device);
-        if (p.params.widthDp && p.params.heightDp) {
-            parts.push(p.params.widthDp + "\u00D7" + p.params.heightDp + "dp");
-        }
-        if (p.params.fontScale && p.params.fontScale !== 1.0) {
-            parts.push("font " + p.params.fontScale + "\u00D7");
-        }
-        if (p.params.uiMode) parts.push("uiMode=" + p.params.uiMode);
-        if (p.params.locale) parts.push(p.params.locale);
-        if (p.params.group) parts.push("group: " + p.params.group);
-        return parts.length ? base + "\\n" + parts.join(" \u00B7 ") : base;
     }
 
     // Scale image containers so preview variants at different device sizes
@@ -2267,6 +2121,7 @@ export function setupPreviewBehavior(
                     }
                     container.appendChild(
                         buildErrorPanel(
+                            vscode,
                             msg.message,
                             renderError,
                             errCard.dataset.className,

--- a/vscode-extension/src/webview/preview/cardData.ts
+++ b/vscode-extension/src/webview/preview/cardData.ts
@@ -1,0 +1,137 @@
+// Pure data helpers for the preview-card surface.
+//
+// Lifted verbatim from `behavior.ts` so the per-card label / tooltip /
+// shape derivations stop being shielded by `@ts-nocheck` and stop
+// depending on any closed-over state in `setupPreviewBehavior`. None
+// of these reach into the DOM or the vscode handle.
+
+import type { PreviewInfo } from "../shared/types";
+
+/** DOM-safe id derived from a preview id. Used as the `id` of the
+ *  card element (`preview-${sanitizeId(p.id)}`) so callers can find
+ *  it via `getElementById` even when the underlying preview id has
+ *  characters that would be invalid in CSS / HTML id attributes. */
+export function sanitizeId(id: string): string {
+    return id.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+/**
+ * Data-URL MIME for a preview image, derived from its `renderOutput`
+ * extension. `@ScrollingPreview(GIF)` captures land at `.gif`; all
+ * other captures are PNG. Browsers sniff magic bytes and would
+ * actually render a GIF served as `image/png` — but declaring the
+ * right type matters for the webview's `<img>` fallback /
+ * accessibility paths and avoids a console warning when saving the
+ * preview.
+ */
+export function mimeFor(renderOutput: string | null | undefined): string {
+    return typeof renderOutput === "string" &&
+        renderOutput.toLowerCase().endsWith(".gif")
+        ? "image/gif"
+        : "image/png";
+}
+
+/**
+ * A preview is shown with a carousel when it has more than one
+ * capture, or a single capture with a non-null dimension (e.g. an
+ * explicit 500ms snapshot or a scroll capture).
+ */
+export function isAnimatedPreview(p: PreviewInfo): boolean {
+    const caps = p.captures;
+    if (caps.length > 1) return true;
+    if (caps.length === 1) {
+        const c = caps[0];
+        return c.advanceTimeMillis != null || c.scroll != null;
+    }
+    return false;
+}
+
+/**
+ * Compact one-line label shown as the variant badge on each card.
+ * Longer-form info still lives in the hover tooltip ([buildTooltip])
+ * — here we only surface what distinguishes siblings: name / group /
+ * device first, then dimensions, non-default fontScale, uiMode.
+ * Skips redundant bits (e.g. no `1.0×` for default font).
+ */
+export function buildVariantLabel(p: PreviewInfo): string {
+    const parts: string[] = [];
+    const primary =
+        p.params.name || p.params.group || shortDevice(p.params.device);
+    if (primary) parts.push(primary);
+    if (p.params.widthDp && p.params.heightDp) {
+        parts.push(p.params.widthDp + "×" + p.params.heightDp);
+    }
+    if (p.params.fontScale && p.params.fontScale !== 1.0) {
+        parts.push(p.params.fontScale + "×");
+    }
+    if (p.params.uiMode) parts.push("uiMode " + p.params.uiMode);
+    if (p.params.locale) parts.push(p.params.locale);
+    return parts.join(" · ");
+}
+
+export function shortDevice(d: string | null | undefined): string {
+    if (!d) return "";
+    return d.replace(/^id:/, "").replace(/_/g, " ");
+}
+
+/**
+ * Heuristic for "this preview is for a Wear OS surface." Trips on an
+ * explicit `wear` device id or a square preview at or under 260dp —
+ * which catches the standard Wear sizes (192dp small round, 227dp
+ * large round, 240dp square) without requiring the device id to be
+ * set.
+ */
+export function isWearPreview(p: PreviewInfo): boolean {
+    const device = (p.params.device || "").toLowerCase();
+    if (device.includes("wear")) return true;
+    const w = p.params.widthDp || 0;
+    const h = p.params.heightDp || 0;
+    return w > 0 && h > 0 && w === h && w <= 260;
+}
+
+/**
+ * Hover tooltip for the card title button — `Open source: <FQN>`,
+ * followed by a `·`-separated digest of the preview's parameters.
+ */
+export function buildTooltip(p: PreviewInfo): string {
+    const base = "Open source: " + p.className + "." + p.functionName;
+    const parts: string[] = [];
+    if (p.params.name) parts.push(p.params.name);
+    if (p.params.device) parts.push(p.params.device);
+    if (p.params.widthDp && p.params.heightDp) {
+        parts.push(p.params.widthDp + "×" + p.params.heightDp + "dp");
+    }
+    if (p.params.fontScale && p.params.fontScale !== 1.0) {
+        parts.push("font " + p.params.fontScale + "×");
+    }
+    if (p.params.uiMode) parts.push("uiMode=" + p.params.uiMode);
+    if (p.params.locale) parts.push(p.params.locale);
+    if (p.params.group) parts.push("group: " + p.params.group);
+    return parts.length ? base + "\\n" + parts.join(" · ") : base;
+}
+
+export interface ParsedBounds {
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+}
+
+/**
+ * Parse an `AccessibilityFinding.boundsInScreen` / `AccessibilityNode.
+ * boundsInScreen` string of the form `"left,top,right,bottom"` (in
+ * source-bitmap pixels) into numeric bounds. Returns `null` for
+ * malformed input — overlay paint code skips the finding rather than
+ * dropping zero/NaN boxes onto the image.
+ */
+export function parseBounds(s: string | null | undefined): ParsedBounds | null {
+    if (!s) return null;
+    const parts = s.split(",").map((x) => parseInt(x.trim(), 10));
+    if (parts.length !== 4 || parts.some(isNaN)) return null;
+    return {
+        left: parts[0],
+        top: parts[1],
+        right: parts[2],
+        bottom: parts[3],
+    };
+}

--- a/vscode-extension/src/webview/preview/errorPanel.ts
+++ b/vscode-extension/src/webview/preview/errorPanel.ts
@@ -1,0 +1,92 @@
+// Per-card render-error panel.
+//
+// Lifted verbatim from `behavior.ts`'s `buildErrorPanel`. Returns a
+// detached DOM element so callers (currently `behavior.ts`'s `showFrame`
+// / per-capture error handling) can `appendChild` it to the appropriate
+// container. Once `<preview-card>` lands as a Lit element this file's
+// shape will likely flip into a `TemplateResult`-returning helper or a
+// `<render-error-panel>` Lit child — the structure is already
+// self-contained, so the conversion is mechanical.
+//
+// When `renderError` is non-null the panel has structured detail:
+// exception class, message, a clickable `file:line` frame, and a
+// collapsible stack trace. Otherwise it falls back to the plain
+// one-line message (the case for renderers that don't yet produce a
+// sidecar, or when the sidecar was unreadable).
+//
+// Click on the frame button posts an `openSourceFile` message; the
+// extension resolves the stack-trace basename to an absolute path via
+// `workspace.findFiles`. The disclosure for the full trace is a
+// native `<details>` — no JS state to manage, the browser handles the
+// toggle.
+
+import type { PreviewRenderError } from "../shared/types";
+import type { VsCodeApi } from "../shared/vscode";
+
+export function buildErrorPanel(
+    vscode: VsCodeApi<unknown>,
+    message: string | null | undefined,
+    renderError: PreviewRenderError | null | undefined,
+    className: string | null | undefined,
+): HTMLElement {
+    const panel = document.createElement("div");
+    panel.className = "error-message render-error";
+    panel.setAttribute("role", "alert");
+    if (!renderError) {
+        panel.textContent = message || "";
+        return panel;
+    }
+    const cls =
+        (renderError.exception || "").split(".").pop() ||
+        renderError.exception ||
+        "Error";
+    const head = document.createElement("div");
+    head.className = "render-error-class";
+    head.textContent = cls;
+    panel.appendChild(head);
+
+    if (renderError.message) {
+        const msg = document.createElement("div");
+        msg.className = "render-error-msg";
+        msg.textContent = renderError.message;
+        panel.appendChild(msg);
+    }
+
+    const frame = renderError.topAppFrame;
+    if (frame && frame.file) {
+        const link = document.createElement("button");
+        link.className = "render-error-frame";
+        link.type = "button";
+        const fnSuffix = frame.function ? " in " + frame.function : "";
+        const lineSuffix = frame.line > 0 ? ":" + frame.line : "";
+        link.textContent = frame.file + lineSuffix + fnSuffix;
+        link.title = "Open " + frame.file + lineSuffix;
+        link.addEventListener("click", () => {
+            vscode.postMessage({
+                command: "openSourceFile",
+                fileName: frame.file,
+                line: frame.line,
+                // className lets the extension disambiguate same-named
+                // files across modules — when the throw is in this
+                // preview's own file, the class-derived path matches
+                // and we pick the right one without a workspace-wide
+                // first-hit guess.
+                className: className || undefined,
+            });
+        });
+        panel.appendChild(link);
+    }
+
+    if (renderError.stackTrace) {
+        const details = document.createElement("details");
+        details.className = "render-error-stack";
+        const summary = document.createElement("summary");
+        summary.textContent = "Stack trace";
+        details.appendChild(summary);
+        const pre = document.createElement("pre");
+        pre.textContent = renderError.stackTrace;
+        details.appendChild(pre);
+        panel.appendChild(details);
+    }
+    return panel;
+}


### PR DESCRIPTION
Groundwork for the eventual `<preview-card>` migration in #767. Two new typed modules with verbatim semantics:

## Summary

- `cardData.ts` — pure data helpers: `sanitizeId`, `mimeFor`, `isAnimatedPreview`, `buildVariantLabel`, `shortDevice`, `isWearPreview`, `buildTooltip`, `parseBounds`. No DOM, no vscode handle — straight `PreviewInfo` → `string` / `boolean` / `ParsedBounds`. Was previously eight `function foo(...) {}` blocks inside `setupPreviewBehavior` shielded by `@ts-nocheck`.
- `errorPanel.ts` — `buildErrorPanel(vscode, message, renderError, className)` returns the detached error-overlay DOM. Caller hands in the vscode handle so the module stays untouched-by-closure.

`behavior.ts` shrinks from 3208 → 3051 lines (−157 LOC). No behaviour change.

This stacks logically on #769 but is built from `main`, so the two PRs can land in either order.

## Test plan

- [x] `npm run compile` clean (host + webview)
- [x] `npm test` — 320/320 passing
- [x] `npm run format:check` clean
- [ ] Manual smoke: open the preview panel, force a preview render error (e.g. a `@Preview` that throws) and verify the structured error overlay still appears with class name, message, clickable file:line frame, and stack-trace disclosure.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PTv9gnHTdY5MzDfGdnSpBn)_